### PR TITLE
feat: add process startup argument model

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 bangbang is a Rust VMM project for macOS hosts. The public control plane is intended to stay compatible with the Firecracker HTTP API over a Unix domain socket, while the VM backend is built on Apple's Hypervisor.framework.
 
-This repository is currently a scaffold. It defines crate boundaries, Firecracker-compatible API endpoint names, a backend trait, and the smallest Hypervisor.framework VM create/destroy wrapper.
+This repository is currently a scaffold. It defines crate boundaries, Firecracker-compatible API endpoint names, an initial process startup CLI, a backend trait, and the smallest Hypervisor.framework VM create/destroy wrapper.
 
 See [Firecracker Compatibility Scope](docs/firecracker-compatibility.md) for the intended compatibility target and current limitations.
 
@@ -12,7 +12,7 @@ See [Firecracker Compatibility Scope](docs/firecracker-compatibility.md) for the
 crates/api        Firecracker-compatible API endpoint names
 crates/runtime    Backend-neutral VM trait and error type
 crates/hvf        Hypervisor.framework backend skeleton
-crates/bangbang   VMM process entrypoint skeleton
+crates/bangbang   VMM process entrypoint and startup CLI
 ```
 
 ## Current Scope

--- a/README.md
+++ b/README.md
@@ -20,10 +20,25 @@ crates/bangbang   VMM process entrypoint skeleton
 The first target is Apple Silicon macOS. The current scaffold intentionally does not include:
 
 - an API server
+- API socket binding or listener cleanup
 - JSON request/response models
 - guest memory mapping
 - vCPU creation or a run loop
 - kernel loading
+
+## Process CLI
+
+The `bangbang` executable accepts the first process-lifecycle arguments:
+
+```sh
+cargo run -p bangbang -- --api-sock /tmp/bangbang.socket --id demo-1
+```
+
+- `--api-sock <PATH>` records the intended Unix socket path. The default is `/tmp/bangbang.socket`.
+- `--id <ID>` records the microVM identifier. The default is `anonymous-instance`.
+- `--help`, `-h`, `--version`, and `-V` are supported.
+
+These arguments are parsed and validated only. `bangbang` does not bind the socket or serve the API yet. Unsupported Firecracker process options such as `--config-file`, `--no-api`, seccomp, logging, metrics, snapshot, MMDS, and PCI flags are rejected instead of ignored.
 
 ## Build
 

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -153,7 +153,7 @@ impl Args {
                 other if other.starts_with('-') => {
                     return Err(format!("unknown argument: {}", display_arg_name(other)));
                 }
-                other => return Err(format!("unexpected positional argument: {other}")),
+                _ => return Err("unexpected positional argument".to_string()),
             }
         }
 
@@ -471,6 +471,13 @@ mod tests {
     fn rejects_positional_arg() {
         let err = parse(&["image.bin"]).expect_err("positional args should fail");
 
-        assert_eq!(err, "unexpected positional argument: image.bin");
+        assert_eq!(err, "unexpected positional argument");
+    }
+
+    #[test]
+    fn rejects_positional_path_without_echoing_value() {
+        let err = parse(&["/tmp/secret.img"]).expect_err("positional args should fail");
+
+        assert_eq!(err, "unexpected positional argument");
     }
 }

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -281,6 +281,13 @@ mod tests {
     }
 
     #[test]
+    fn parse_version_arg_ignores_other_args() {
+        let args = parse(&["--version", "--unknown"]).expect("version should bypass parsing");
+
+        assert_eq!(args.command, Command::Version);
+    }
+
+    #[test]
     fn parse_short_version_arg() {
         let args = parse(&["-V"]).expect("short version arg should parse");
 
@@ -394,6 +401,16 @@ mod tests {
         let err = parse(&["--config-file", "vm.json"]).expect_err("unsupported arg should fail");
 
         assert_eq!(err, "unsupported Firecracker argument: --config-file");
+    }
+
+    #[test]
+    fn rejects_unsupported_firecracker_config_file_equals_arg() {
+        let err = parse(&["--config-file=vm.json"]).expect_err("unsupported arg should fail");
+
+        assert_eq!(
+            err,
+            "unsupported Firecracker argument: --config-file=vm.json"
+        );
     }
 
     #[test]

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -52,10 +52,8 @@ fn run() -> Result<(), String> {
             println!("bangbang {}", env!("CARGO_PKG_VERSION"));
             return Ok(());
         }
-        Command::Run(config) => {
+        Command::Run(_) => {
             println!("bangbang {}", env!("CARGO_PKG_VERSION"));
-            println!("id: {}", config.id);
-            println!("api socket: {}", config.api_sock);
             println!(
                 "hvf target supported: {}",
                 HvfBackend::is_supported_target()

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -3,6 +3,33 @@ use std::process::ExitCode;
 
 use bangbang_hvf::HvfBackend;
 
+const DEFAULT_API_SOCK_PATH: &str = "/tmp/bangbang.socket";
+const DEFAULT_INSTANCE_ID: &str = "anonymous-instance";
+const MIN_INSTANCE_ID_LEN: usize = 1;
+const MAX_INSTANCE_ID_LEN: usize = 64;
+const UNSUPPORTED_FIRECRACKER_ARGS: &[&str] = &[
+    "boot-timer",
+    "config-file",
+    "describe-snapshot",
+    "enable-pci",
+    "http-api-max-payload-size",
+    "level",
+    "log-path",
+    "metadata",
+    "metrics-path",
+    "mmds-size-limit",
+    "module",
+    "no-api",
+    "no-seccomp",
+    "parent-cpu-time-us",
+    "seccomp-filter",
+    "show-level",
+    "show-log-origin",
+    "snapshot-version",
+    "start-time-cpu-us",
+    "start-time-us",
+];
+
 fn main() -> ExitCode {
     match run() {
         Ok(()) => ExitCode::SUCCESS,
@@ -16,95 +43,395 @@ fn main() -> ExitCode {
 fn run() -> Result<(), String> {
     let args = Args::parse(env::args().skip(1))?;
 
-    if args.help {
-        print_help();
-        return Ok(());
+    match args.command {
+        Command::Help => {
+            print_help();
+            return Ok(());
+        }
+        Command::Version => {
+            println!("bangbang {}", env!("CARGO_PKG_VERSION"));
+            return Ok(());
+        }
+        Command::Run(config) => {
+            println!("bangbang {}", env!("CARGO_PKG_VERSION"));
+            println!("id: {}", config.id);
+            println!("api socket: {}", config.api_sock);
+            println!(
+                "hvf target supported: {}",
+                HvfBackend::is_supported_target()
+            );
+            println!("status: startup arguments parsed; API server and VM startup are not implemented yet");
+        }
     }
-
-    if args.version {
-        println!("bangbang {}", env!("CARGO_PKG_VERSION"));
-        return Ok(());
-    }
-
-    println!("bangbang {}", env!("CARGO_PKG_VERSION"));
-    println!(
-        "hvf target supported: {}",
-        HvfBackend::is_supported_target()
-    );
-    println!("status: first-PR scaffold only");
 
     Ok(())
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 struct Args {
-    help: bool,
-    version: bool,
+    command: Command,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Command {
+    Help,
+    Version,
+    Run(StartupConfig),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct StartupConfig {
+    api_sock: String,
+    id: String,
+}
+
+impl Default for StartupConfig {
+    fn default() -> Self {
+        Self {
+            api_sock: DEFAULT_API_SOCK_PATH.to_string(),
+            id: DEFAULT_INSTANCE_ID.to_string(),
+        }
+    }
 }
 
 impl Args {
     fn parse<I>(args: I) -> Result<Self, String>
     where
-        I: Iterator<Item = String>,
+        I: IntoIterator<Item = String>,
     {
-        let mut parsed = Self {
-            help: false,
-            version: false,
-        };
+        let args = args.into_iter().collect::<Vec<_>>();
 
-        for arg in args {
+        if args.iter().any(|arg| arg == "--help" || arg == "-h") {
+            return Ok(Self {
+                command: Command::Help,
+            });
+        }
+
+        if args.iter().any(|arg| arg == "--version" || arg == "-V") {
+            return Ok(Self {
+                command: Command::Version,
+            });
+        }
+
+        let mut config = StartupConfig::default();
+        let mut api_sock_seen = false;
+        let mut id_seen = false;
+        let mut index = 0;
+
+        while index < args.len() {
+            let arg = &args[index];
+
             match arg.as_str() {
-                "--version" | "-V" => parsed.version = true,
-                "--help" | "-h" => parsed.help = true,
-                other => return Err(format!("unknown argument: {other}")),
+                "--api-sock" => {
+                    if api_sock_seen {
+                        return Err("duplicate argument: --api-sock".to_string());
+                    }
+                    let value = take_value(&args, index, "--api-sock")?;
+                    validate_api_sock(&value)?;
+                    config.api_sock = value;
+                    api_sock_seen = true;
+                    index += 2;
+                }
+                "--id" => {
+                    if id_seen {
+                        return Err("duplicate argument: --id".to_string());
+                    }
+                    let value = take_value(&args, index, "--id")?;
+                    validate_instance_id(&value)?;
+                    config.id = value;
+                    id_seen = true;
+                    index += 2;
+                }
+                other if unsupported_firecracker_arg(other).is_some() => {
+                    return Err(format!("unsupported Firecracker argument: {other}"));
+                }
+                other if let Some(name) = unsupported_equals_syntax(other) => {
+                    return Err(format!(
+                        "unsupported argument syntax: {other}; use --{} <VALUE>",
+                        name
+                    ));
+                }
+                other if other.starts_with('-') => {
+                    return Err(format!("unknown argument: {other}"))
+                }
+                other => return Err(format!("unexpected positional argument: {other}")),
             }
         }
 
-        Ok(parsed)
+        Ok(Self {
+            command: Command::Run(config),
+        })
     }
 }
 
 fn print_help() {
     println!(
-        "bangbang {}\n\nUsage:\n  bangbang\n\nOptions:\n  -V, --version  Print version\n  -h, --help     Print help",
-        env!("CARGO_PKG_VERSION")
+        "bangbang {}\n\nUsage:\n  bangbang [OPTIONS]\n\nOptions:\n      --api-sock <PATH>  Record API socket path for future API server support [default: {}]\n      --id <ID>          MicroVM unique identifier [default: {}]\n  -V, --version          Print version\n  -h, --help             Print help\n\nCurrent scope:\n  Parses startup configuration only; no API server or VM startup is implemented yet.",
+        env!("CARGO_PKG_VERSION"),
+        DEFAULT_API_SOCK_PATH,
+        DEFAULT_INSTANCE_ID
     );
+}
+
+fn take_value(args: &[String], index: usize, name: &str) -> Result<String, String> {
+    args.get(index + 1)
+        .filter(|value| !value.starts_with("--"))
+        .cloned()
+        .ok_or_else(|| format!("missing value for {name}"))
+}
+
+fn validate_api_sock(api_sock: &str) -> Result<(), String> {
+    if api_sock.is_empty() {
+        return Err("invalid --api-sock: path must not be empty".to_string());
+    }
+
+    Ok(())
+}
+
+fn validate_instance_id(id: &str) -> Result<(), String> {
+    if !(MIN_INSTANCE_ID_LEN..=MAX_INSTANCE_ID_LEN).contains(&id.len()) {
+        return Err(format!(
+            "invalid --id: invalid length {}; length must be between {} and {}",
+            id.len(),
+            MIN_INSTANCE_ID_LEN,
+            MAX_INSTANCE_ID_LEN
+        ));
+    }
+
+    for (position, ch) in id.chars().enumerate() {
+        if !(ch == '-' || ch.is_alphanumeric()) {
+            return Err(format!(
+                "invalid --id: invalid character {ch:?} at position {position}"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn unsupported_firecracker_arg(arg: &str) -> Option<&str> {
+    let name = firecracker_arg_name(arg)?;
+    UNSUPPORTED_FIRECRACKER_ARGS.contains(&name).then_some(name)
+}
+
+fn firecracker_arg_name(arg: &str) -> Option<&str> {
+    let name = arg.strip_prefix("--")?;
+
+    Some(name.split_once('=').map_or(name, |(name, _)| name))
+}
+
+fn unsupported_equals_syntax(arg: &str) -> Option<&'static str> {
+    [("--api-sock=", "api-sock"), ("--id=", "id")]
+        .into_iter()
+        .find_map(|(prefix, name)| arg.starts_with(prefix).then_some(name))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Args;
+    use super::{
+        Args, Command, StartupConfig, DEFAULT_API_SOCK_PATH, DEFAULT_INSTANCE_ID,
+        MAX_INSTANCE_ID_LEN,
+    };
+
+    fn parse(args: &[&str]) -> Result<Args, String> {
+        Args::parse(args.iter().map(|arg| arg.to_string()))
+    }
+
+    fn parse_run(args: &[&str]) -> Result<StartupConfig, String> {
+        match parse(args)?.command {
+            Command::Run(config) => Ok(config),
+            command => Err(format!("expected run command, got {command:?}")),
+        }
+    }
 
     #[test]
-    fn parse_empty_args() {
-        let args = Args::parse([].into_iter()).expect("empty args should parse");
+    fn parse_empty_args_uses_defaults() {
+        let config = parse_run(&[]).expect("empty args should parse");
 
-        assert!(!args.help);
-        assert!(!args.version);
+        assert_eq!(config.api_sock, DEFAULT_API_SOCK_PATH);
+        assert_eq!(config.id, DEFAULT_INSTANCE_ID);
     }
 
     #[test]
     fn parse_help_arg() {
-        let args = Args::parse(["--help".to_string()].into_iter()).expect("help arg should parse");
+        let args = parse(&["--help"]).expect("help arg should parse");
 
-        assert!(args.help);
-        assert!(!args.version);
+        assert_eq!(args.command, Command::Help);
+    }
+
+    #[test]
+    fn parse_short_help_arg() {
+        let args = parse(&["-h"]).expect("short help arg should parse");
+
+        assert_eq!(args.command, Command::Help);
+    }
+
+    #[test]
+    fn parse_help_arg_ignores_other_args() {
+        let args = parse(&["--help", "--unknown"]).expect("help should bypass parsing");
+
+        assert_eq!(args.command, Command::Help);
     }
 
     #[test]
     fn parse_version_arg() {
-        let args =
-            Args::parse(["--version".to_string()].into_iter()).expect("version arg should parse");
+        let args = parse(&["--version"]).expect("version arg should parse");
 
-        assert!(!args.help);
-        assert!(args.version);
+        assert_eq!(args.command, Command::Version);
+    }
+
+    #[test]
+    fn parse_short_version_arg() {
+        let args = parse(&["-V"]).expect("short version arg should parse");
+
+        assert_eq!(args.command, Command::Version);
+    }
+
+    #[test]
+    fn parse_api_sock_arg() {
+        let config =
+            parse_run(&["--api-sock", "/tmp/custom.socket"]).expect("api socket arg should parse");
+
+        assert_eq!(config.api_sock, "/tmp/custom.socket");
+        assert_eq!(config.id, DEFAULT_INSTANCE_ID);
+    }
+
+    #[test]
+    fn parse_id_arg() {
+        let config = parse_run(&["--id", "demo-1"]).expect("id arg should parse");
+
+        assert_eq!(config.api_sock, DEFAULT_API_SOCK_PATH);
+        assert_eq!(config.id, "demo-1");
+    }
+
+    #[test]
+    fn parse_startup_args_together() {
+        let config = parse_run(&["--api-sock", "/tmp/custom.socket", "--id", "demo-1"])
+            .expect("startup args should parse");
+
+        assert_eq!(config.api_sock, "/tmp/custom.socket");
+        assert_eq!(config.id, "demo-1");
+    }
+
+    #[test]
+    fn rejects_missing_api_sock_value() {
+        let err = parse(&["--api-sock"]).expect_err("missing api socket value should fail");
+
+        assert_eq!(err, "missing value for --api-sock");
+    }
+
+    #[test]
+    fn rejects_missing_id_value() {
+        let err = parse(&["--id", "--api-sock"]).expect_err("missing id value should fail");
+
+        assert_eq!(err, "missing value for --id");
+    }
+
+    #[test]
+    fn rejects_duplicate_api_sock() {
+        let err = parse(&[
+            "--api-sock",
+            "/tmp/one.socket",
+            "--api-sock",
+            "/tmp/two.socket",
+        ])
+        .expect_err("duplicate api socket should fail");
+
+        assert_eq!(err, "duplicate argument: --api-sock");
+    }
+
+    #[test]
+    fn rejects_duplicate_id() {
+        let err = parse(&["--id", "one", "--id", "two"]).expect_err("duplicate id should fail");
+
+        assert_eq!(err, "duplicate argument: --id");
+    }
+
+    #[test]
+    fn rejects_empty_api_sock() {
+        let err = parse(&["--api-sock", ""]).expect_err("empty api socket should fail");
+
+        assert_eq!(err, "invalid --api-sock: path must not be empty");
+    }
+
+    #[test]
+    fn rejects_empty_id() {
+        let err = parse(&["--id", ""]).expect_err("empty id should fail");
+
+        assert_eq!(
+            err,
+            "invalid --id: invalid length 0; length must be between 1 and 64"
+        );
+    }
+
+    #[test]
+    fn rejects_id_with_underscore() {
+        let err = parse(&["--id", "vm_1"]).expect_err("underscore id should fail");
+
+        assert_eq!(err, "invalid --id: invalid character '_' at position 2");
+    }
+
+    #[test]
+    fn rejects_id_with_colon() {
+        let err = parse(&["--id", "vm:1"]).expect_err("colon id should fail");
+
+        assert_eq!(err, "invalid --id: invalid character ':' at position 2");
+    }
+
+    #[test]
+    fn rejects_id_over_max_length() {
+        let id = "a".repeat(MAX_INSTANCE_ID_LEN + 1);
+        let err = Args::parse(["--id".to_string(), id]).expect_err("long id should fail");
+
+        assert_eq!(
+            err,
+            "invalid --id: invalid length 65; length must be between 1 and 64"
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_firecracker_config_file_arg() {
+        let err = parse(&["--config-file", "vm.json"]).expect_err("unsupported arg should fail");
+
+        assert_eq!(err, "unsupported Firecracker argument: --config-file");
+    }
+
+    #[test]
+    fn rejects_unsupported_firecracker_no_api_arg() {
+        let err = parse(&["--no-api"]).expect_err("unsupported flag should fail");
+
+        assert_eq!(err, "unsupported Firecracker argument: --no-api");
+    }
+
+    #[test]
+    fn rejects_unsupported_firecracker_linux_arg() {
+        let err = parse(&["--no-seccomp"]).expect_err("unsupported Linux flag should fail");
+
+        assert_eq!(err, "unsupported Firecracker argument: --no-seccomp");
+    }
+
+    #[test]
+    fn rejects_unsupported_equals_syntax_for_supported_arg() {
+        let err =
+            parse(&["--api-sock=/tmp/bangbang.socket"]).expect_err("equals syntax should fail");
+
+        assert_eq!(
+            err,
+            "unsupported argument syntax: --api-sock=/tmp/bangbang.socket; use --api-sock <VALUE>"
+        );
     }
 
     #[test]
     fn rejects_unknown_arg() {
-        let err = Args::parse(["--api-sock".to_string()].into_iter())
-            .expect_err("unknown args should fail");
+        let err = parse(&["--unknown"]).expect_err("unknown args should fail");
 
-        assert_eq!(err, "unknown argument: --api-sock");
+        assert_eq!(err, "unknown argument: --unknown");
+    }
+
+    #[test]
+    fn rejects_positional_arg() {
+        let err = parse(&["image.bin"]).expect_err("positional args should fail");
+
+        assert_eq!(err, "unexpected positional argument: image.bin");
     }
 }

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -142,17 +142,16 @@ impl Args {
                     id_seen = true;
                     index += 2;
                 }
-                other if unsupported_firecracker_arg(other).is_some() => {
-                    return Err(format!("unsupported Firecracker argument: {other}"));
+                other if let Some(name) = unsupported_firecracker_arg(other) => {
+                    return Err(format!("unsupported Firecracker argument: --{name}"));
                 }
                 other if let Some(name) = unsupported_equals_syntax(other) => {
                     return Err(format!(
-                        "unsupported argument syntax: {other}; use --{} <VALUE>",
-                        name
+                        "unsupported argument syntax for --{name}; use --{name} <VALUE>"
                     ));
                 }
                 other if other.starts_with('-') => {
-                    return Err(format!("unknown argument: {other}"))
+                    return Err(format!("unknown argument: {}", display_arg_name(other)));
                 }
                 other => return Err(format!("unexpected positional argument: {other}")),
             }
@@ -183,6 +182,10 @@ fn take_value(args: &[String], index: usize, name: &str) -> Result<String, Strin
 fn validate_api_sock(api_sock: &str) -> Result<(), String> {
     if api_sock.is_empty() {
         return Err("invalid --api-sock: path must not be empty".to_string());
+    }
+
+    if api_sock.chars().any(char::is_control) {
+        return Err("invalid --api-sock: path must not contain control characters".to_string());
     }
 
     Ok(())
@@ -218,6 +221,10 @@ fn firecracker_arg_name(arg: &str) -> Option<&str> {
     let name = arg.strip_prefix("--")?;
 
     Some(name.split_once('=').map_or(name, |(name, _)| name))
+}
+
+fn display_arg_name(arg: &str) -> &str {
+    arg.split_once('=').map_or(arg, |(name, _)| name)
 }
 
 fn unsupported_equals_syntax(arg: &str) -> Option<&'static str> {
@@ -362,6 +369,17 @@ mod tests {
     }
 
     #[test]
+    fn rejects_api_sock_with_control_character() {
+        let err = parse(&["--api-sock", "/tmp/bangbang\n.socket"])
+            .expect_err("api socket with control character should fail");
+
+        assert_eq!(
+            err,
+            "invalid --api-sock: path must not contain control characters"
+        );
+    }
+
+    #[test]
     fn rejects_empty_id() {
         let err = parse(&["--id", ""]).expect_err("empty id should fail");
 
@@ -407,10 +425,7 @@ mod tests {
     fn rejects_unsupported_firecracker_config_file_equals_arg() {
         let err = parse(&["--config-file=vm.json"]).expect_err("unsupported arg should fail");
 
-        assert_eq!(
-            err,
-            "unsupported Firecracker argument: --config-file=vm.json"
-        );
+        assert_eq!(err, "unsupported Firecracker argument: --config-file");
     }
 
     #[test]
@@ -434,13 +449,20 @@ mod tests {
 
         assert_eq!(
             err,
-            "unsupported argument syntax: --api-sock=/tmp/bangbang.socket; use --api-sock <VALUE>"
+            "unsupported argument syntax for --api-sock; use --api-sock <VALUE>"
         );
     }
 
     #[test]
     fn rejects_unknown_arg() {
         let err = parse(&["--unknown"]).expect_err("unknown args should fail");
+
+        assert_eq!(err, "unknown argument: --unknown");
+    }
+
+    #[test]
+    fn rejects_unknown_equals_arg_without_echoing_value() {
+        let err = parse(&["--unknown=/tmp/secret"]).expect_err("unknown args should fail");
 
         assert_eq!(err, "unknown argument: --unknown");
     }

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -44,7 +44,8 @@ it rejects invalid IDs, empty socket paths, and socket paths containing control
 characters, but performs no filesystem creation, canonicalization, deletion,
 socket binding, permission checks, or VM work. Those checks belong with later
 socket lifecycle and API server work. Process CLI parsing stays outside the
-future VM/vCPU fast path and should add only trivial startup overhead.
+future VM/vCPU fast path and should add only trivial startup overhead. Error and
+status output avoid echoing path-like CLI values.
 
 ## Compatibility Baseline
 

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -4,10 +4,11 @@ This document describes bangbang's intended Firecracker compatibility scope. It
 is a planning reference for future API, VMM, and backend work; it does not mean
 the current scaffold implements the listed API behavior.
 
-The current repository only defines crate boundaries, endpoint names, a
-backend-neutral VM trait, and a minimal Hypervisor.framework VM create/destroy
-wrapper. There is no API server, JSON request/response model, `--api-sock`
-argument, guest memory mapping, vCPU loop, or kernel loading yet.
+The current repository defines crate boundaries, endpoint names, a
+backend-neutral VM trait, a minimal Hypervisor.framework VM create/destroy
+wrapper, and an initial process startup argument model. There is no API server,
+Unix socket listener, JSON request/response model, guest memory mapping, vCPU
+loop, or kernel loading yet.
 
 ## Firecracker Model Alignment
 
@@ -18,6 +19,32 @@ guest execution fast path.
 The intended public control plane is Firecracker-style HTTP over a Unix domain
 socket. API requests should eventually map to explicit VMM actions and VM state
 transitions, but this document only defines the initial scope.
+
+## Process Startup CLI
+
+The current `bangbang` executable parses only the first process-lifecycle
+arguments. Parsing records startup configuration but does not bind a Unix
+socket, start an API server, load a configuration file, or start a guest.
+
+| Argument | Current behavior | Compatibility notes |
+| --- | --- | --- |
+| `--api-sock <PATH>` | parsed and stored | Firecracker defaults to `/run/firecracker.socket`; bangbang defaults to `/tmp/bangbang.socket` because macOS does not normally provide `/run`. This is an intentional host-platform difference. |
+| `--id <ID>` | parsed and stored | Defaults to Firecracker's `anonymous-instance`. IDs must be 1 to 64 bytes and contain only alphanumeric characters or `-`, matching the Firecracker `v1.16.0` validator policy. |
+| `--help`, `-h` | prints help | Help describes the current parser-only scope. |
+| `--version`, `-V` | prints version | `-V` is retained from the existing bangbang scaffold. |
+| `--config-file`, `--no-api` | rejected | Deferred until VM configuration models and no-API startup behavior exist. |
+| seccomp, logger, metrics, snapshot, MMDS, boot timer, payload-size, and PCI process flags | rejected | These Firecracker options are Linux-specific, observability-related, or tied to later capability work. They must not be accepted as no-op compatibility shims. |
+
+Only the Firecracker-style `--arg value` form is supported for the initial
+startup arguments. The `--arg=value` form is rejected until a separate
+compatibility decision expands the CLI parser.
+
+CLI values are untrusted input. Current validation is intentionally string-only:
+it rejects invalid IDs and empty socket paths but performs no filesystem
+creation, canonicalization, deletion, socket binding, permission checks, or VM
+work. Those checks belong with later socket lifecycle and API server work.
+Process CLI parsing stays outside the future VM/vCPU fast path and should add
+only trivial startup overhead.
 
 ## Compatibility Baseline
 

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -40,11 +40,11 @@ startup arguments. The `--arg=value` form is rejected until a separate
 compatibility decision expands the CLI parser.
 
 CLI values are untrusted input. Current validation is intentionally string-only:
-it rejects invalid IDs and empty socket paths but performs no filesystem
-creation, canonicalization, deletion, socket binding, permission checks, or VM
-work. Those checks belong with later socket lifecycle and API server work.
-Process CLI parsing stays outside the future VM/vCPU fast path and should add
-only trivial startup overhead.
+it rejects invalid IDs, empty socket paths, and socket paths containing control
+characters, but performs no filesystem creation, canonicalization, deletion,
+socket binding, permission checks, or VM work. Those checks belong with later
+socket lifecycle and API server work. Process CLI parsing stays outside the
+future VM/vCPU fast path and should add only trivial startup overhead.
 
 ## Compatibility Baseline
 


### PR DESCRIPTION
## Summary

- Add a structured startup argument model for `bangbang` with `--api-sock` and `--id`.
- Validate Firecracker-compatible instance IDs and non-empty socket paths without filesystem side effects.
- Reject unsupported Firecracker process options explicitly and document the current parser-only scope.

## Scope Notes

This PR does not bind a Unix socket, start an API server, load config files, or start a guest. Startup arguments are parsed and validated only; status and error output avoid echoing path-like CLI values.

Closes #36
Closes #37
Closes #38
Closes #39

## Validation

```sh
cargo fmt --all -- --check
cargo check
cargo test
cargo clippy --all-targets -- -D warnings
cargo run -q -p bangbang -- --help
cargo run -q -p bangbang -- --api-sock /tmp/bangbang.socket --id demo-1
cargo run -q -p bangbang -- --config-file vm.json
```
