### PR TITLE
feat: add process exit status model

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ cargo run -p bangbang -- --api-sock /tmp/bangbang.socket --id demo-1
 
 These arguments are parsed and validated only. `bangbang` does not bind the socket or serve the API yet. Unsupported Firecracker process options such as `--config-file`, `--no-api`, seccomp, logging, metrics, snapshot, MMDS, and PCI flags are rejected instead of ignored.
 
+## Exit Status
+
+- `0`: help, version, or parser-only startup completed successfully.
+- `153`: startup argument parsing or validation failed. This matches Firecracker's argument-parsing exit code.
+- `1`: reserved for future non-argument process failures; the current scaffold has no such failure path.
+
 ## Build
 
 ```sh

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::fmt;
 use std::process::ExitCode;
 
 use bangbang_hvf::HvfBackend;
@@ -34,14 +35,15 @@ fn main() -> ExitCode {
     match run() {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
+            let exit_code = err.exit_code().into_exit_code();
             eprintln!("bangbang: {err}");
-            ExitCode::from(1)
+            exit_code
         }
     }
 }
 
-fn run() -> Result<(), String> {
-    let args = Args::parse(env::args().skip(1))?;
+fn run() -> Result<(), ProcessError> {
+    let args = parse_process_args(env::args().skip(1))?;
 
     match args.command {
         Command::Help => {
@@ -64,6 +66,51 @@ fn run() -> Result<(), String> {
 
     Ok(())
 }
+
+fn parse_process_args<I>(args: I) -> Result<Args, ProcessError>
+where
+    I: IntoIterator<Item = String>,
+{
+    Args::parse(args).map_err(ProcessError::ArgumentParsing)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProcessExitCode {
+    ArgumentParsing = 153,
+}
+
+impl ProcessExitCode {
+    const fn value(self) -> u8 {
+        self as u8
+    }
+
+    fn into_exit_code(self) -> ExitCode {
+        ExitCode::from(self.value())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ProcessError {
+    ArgumentParsing(String),
+}
+
+impl ProcessError {
+    fn exit_code(&self) -> ProcessExitCode {
+        match self {
+            Self::ArgumentParsing(_) => ProcessExitCode::ArgumentParsing,
+        }
+    }
+}
+
+impl fmt::Display for ProcessError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ArgumentParsing(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for ProcessError {}
 
 #[derive(Debug, PartialEq, Eq)]
 struct Args {
@@ -234,8 +281,8 @@ fn unsupported_equals_syntax(arg: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::{
-        Args, Command, StartupConfig, DEFAULT_API_SOCK_PATH, DEFAULT_INSTANCE_ID,
-        MAX_INSTANCE_ID_LEN,
+        parse_process_args, Args, Command, ProcessError, ProcessExitCode, StartupConfig,
+        DEFAULT_API_SOCK_PATH, DEFAULT_INSTANCE_ID, MAX_INSTANCE_ID_LEN,
     };
 
     fn parse(args: &[&str]) -> Result<Args, String> {
@@ -247,6 +294,37 @@ mod tests {
             Command::Run(config) => Ok(config),
             command => Err(format!("expected run command, got {command:?}")),
         }
+    }
+
+    #[test]
+    fn process_exit_code_value_matches_argument_parsing_contract() {
+        assert_eq!(ProcessExitCode::ArgumentParsing.value(), 153);
+    }
+
+    #[test]
+    fn argument_parse_error_maps_to_argument_parsing_exit_code() {
+        let err = ProcessError::ArgumentParsing("unknown argument: --unknown".to_string());
+
+        assert_eq!(err.exit_code(), ProcessExitCode::ArgumentParsing);
+    }
+
+    #[test]
+    fn process_error_display_preserves_parser_message() {
+        let err = ProcessError::ArgumentParsing("unknown argument: --unknown".to_string());
+
+        assert_eq!(err.to_string(), "unknown argument: --unknown");
+    }
+
+    #[test]
+    fn parse_process_args_wraps_parser_errors() {
+        let err = parse_process_args(["--unknown=/tmp/secret".to_string()])
+            .expect_err("process arg parsing should fail");
+
+        assert_eq!(
+            err,
+            ProcessError::ArgumentParsing("unknown argument: --unknown".to_string())
+        );
+        assert_eq!(err.exit_code(), ProcessExitCode::ArgumentParsing);
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -47,6 +47,20 @@ socket lifecycle and API server work. Process CLI parsing stays outside the
 future VM/vCPU fast path and should add only trivial startup overhead. Error and
 status output avoid echoing path-like CLI values.
 
+### Process Exit Status
+
+The current executable uses a small process exit status contract:
+
+| Exit status | Current meaning | Compatibility notes |
+| --- | --- | --- |
+| `0` | Help, version, or parser-only startup completed successfully. | Matches Firecracker's success status. |
+| `153` | Startup argument parsing or validation failed. | Matches Firecracker's `ArgParsing` exit code. |
+| `1` | Reserved for future non-argument process failures. | The current scaffold has no such failure path yet. |
+
+Firecracker also defines bad-configuration and signal-specific exit codes.
+bangbang does not expose those until the corresponding configuration loading,
+signal handling, API server, or VM runtime behavior exists.
+
 ## Compatibility Baseline
 
 bangbang's first Firecracker compatibility baseline is the upstream


### PR DESCRIPTION
## Summary

- Add a typed process error boundary for `bangbang` startup failures.
- Map startup argument parsing and validation failures to Firecracker's argument parsing exit code `153`.
- Document the current exit status contract and keep future socket/API/VM/signal behavior out of scope.

## Scope Notes

This PR does not add API socket binding, API server startup, `--config-file`, `--no-api`, signal handling, VM creation, guest memory, vCPU, or boot behavior.

Closes #41

## Validation

```sh
cargo fmt --all -- --check
cargo check
cargo test
cargo clippy --all-targets -- -D warnings
cargo run -q -p bangbang -- --api-sock /tmp/bangbang.socket --id demo-1
cargo run -q -p bangbang -- --unknown=/tmp/secret
cargo run -q -p bangbang -- /tmp/secret.img
cargo run -q -p bangbang -- --config-file=/tmp/secret.json
```

The three argument-error smoke checks exited with status `153`; the successful parser-only startup exited with status `0`.
