### PR TITLE
feat: serve version endpoint over API socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,12 +6,18 @@ version = 4
 name = "bangbang"
 version = "0.1.0"
 dependencies = [
+ "bangbang-api",
  "bangbang-hvf",
 ]
 
 [[package]]
 name = "bangbang-api"
 version = "0.1.0"
+dependencies = [
+ "httparse",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "bangbang-hvf"
@@ -23,3 +29,105 @@ dependencies = [
 [[package]]
 name = "bangbang-runtime"
 version = "0.1.0"
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.1.0"
 dependencies = [
  "bangbang-api",
  "bangbang-hvf",
+ "libc",
  "signal-hook",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.1.0"
 dependencies = [
  "bangbang-api",
  "bangbang-hvf",
+ "signal-hook",
 ]
 
 [[package]]
@@ -30,6 +31,16 @@ name = "bangbang-runtime"
 version = "0.1.0"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +51,12 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "memchr"
@@ -108,6 +125,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +160,21 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,6 @@ name = "bangbang-api"
 version = "0.1.0"
 dependencies = [
  "httparse",
- "serde",
  "serde_json",
 ]
 
@@ -73,7 +72,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
- "serde_derive",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The response body is Firecracker-shaped JSON:
 
 - `0`: help or version completed successfully, or the API server exited without error.
 - `153`: startup argument parsing or validation failed. This matches Firecracker's argument-parsing exit code.
-- `1`: non-argument process failure, including API socket bind or I/O failures.
+- `1`: non-argument process failure, including API socket bind or accept failures.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ cargo run -p bangbang -- --api-sock /tmp/bangbang.socket --id demo-1
 
 `bangbang` binds the configured socket path, serves `GET /version`, and stays running until `SIGINT` or `SIGTERM` requests shutdown. Unsupported Firecracker process options such as `--config-file`, `--no-api`, seccomp, logging, metrics, snapshot, MMDS, and PCI flags are rejected instead of ignored.
 
+The API socket is an unauthenticated local control interface. Filesystem
+permissions on the socket path and parent directory are the access-control
+boundary, so use a private directory or restrictive umask on multi-user hosts.
+
 Query the first supported endpoint:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 bangbang is a Rust VMM project for macOS hosts. The public control plane is intended to stay compatible with the Firecracker HTTP API over a Unix domain socket, while the VM backend is built on Apple's Hypervisor.framework.
 
-This repository is currently a scaffold. It defines crate boundaries, Firecracker-compatible API endpoint names, an initial process startup CLI, a backend trait, and the smallest Hypervisor.framework VM create/destroy wrapper.
+This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a backend trait, and the smallest Hypervisor.framework VM create/destroy wrapper.
 
 See [Firecracker Compatibility Scope](docs/firecracker-compatibility.md) for the intended compatibility target and current limitations.
 
 ## Layout
 
 ```text
-crates/api        Firecracker-compatible API endpoint names
+crates/api        Firecracker-compatible API request and response surface
 crates/runtime    Backend-neutral VM trait and error type
 crates/hvf        Hypervisor.framework backend skeleton
 crates/bangbang   VMM process entrypoint and startup CLI
@@ -17,34 +17,45 @@ crates/bangbang   VMM process entrypoint and startup CLI
 
 ## Current Scope
 
-The first target is Apple Silicon macOS. The current scaffold intentionally does not include:
+The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /version` only. It intentionally does not include:
 
-- an API server
-- API socket binding or listener cleanup
-- JSON request/response models
+- API endpoints beyond `GET /version`
+- JSON request body models
 - guest memory mapping
 - vCPU creation or a run loop
 - kernel loading
 
 ## Process CLI
 
-The `bangbang` executable accepts the first process-lifecycle arguments:
+The `bangbang` executable accepts the first process-lifecycle arguments and starts the API socket server:
 
 ```sh
 cargo run -p bangbang -- --api-sock /tmp/bangbang.socket --id demo-1
 ```
 
-- `--api-sock <PATH>` records the intended Unix socket path. The default is `/tmp/bangbang.socket`.
+- `--api-sock <PATH>` sets the Unix socket path for the API server. The default is `/tmp/bangbang.socket`.
 - `--id <ID>` records the microVM identifier. The default is `anonymous-instance`.
 - `--help`, `-h`, `--version`, and `-V` are supported.
 
-These arguments are parsed and validated only. `bangbang` does not bind the socket or serve the API yet. Unsupported Firecracker process options such as `--config-file`, `--no-api`, seccomp, logging, metrics, snapshot, MMDS, and PCI flags are rejected instead of ignored.
+`bangbang` binds the configured socket path, serves `GET /version`, and stays running. Unsupported Firecracker process options such as `--config-file`, `--no-api`, seccomp, logging, metrics, snapshot, MMDS, and PCI flags are rejected instead of ignored.
+
+Query the first supported endpoint:
+
+```sh
+curl --unix-socket /tmp/bangbang.socket http://localhost/version
+```
+
+The response body is Firecracker-shaped JSON:
+
+```json
+{"firecracker_version":"0.1.0"}
+```
 
 ## Exit Status
 
-- `0`: help, version, or parser-only startup completed successfully.
+- `0`: help or version completed successfully, or the API server exited without error.
 - `153`: startup argument parsing or validation failed. This matches Firecracker's argument-parsing exit code.
-- `1`: reserved for future non-argument process failures; the current scaffold has no such failure path.
+- `1`: non-argument process failure, including API socket bind or I/O failures.
 
 ## Build
 
@@ -53,7 +64,7 @@ cargo check
 cargo test
 ```
 
-Run the VMM process skeleton:
+Run the VMM process skeleton and API server:
 
 ```sh
 cargo run -p bangbang

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cargo run -p bangbang -- --api-sock /tmp/bangbang.socket --id demo-1
 - `--id <ID>` records the microVM identifier. The default is `anonymous-instance`.
 - `--help`, `-h`, `--version`, and `-V` are supported.
 
-`bangbang` binds the configured socket path, serves `GET /version`, and stays running. Unsupported Firecracker process options such as `--config-file`, `--no-api`, seccomp, logging, metrics, snapshot, MMDS, and PCI flags are rejected instead of ignored.
+`bangbang` binds the configured socket path, serves `GET /version`, and stays running until `SIGINT` or `SIGTERM` requests shutdown. Unsupported Firecracker process options such as `--config-file`, `--no-api`, seccomp, logging, metrics, snapshot, MMDS, and PCI flags are rejected instead of ignored.
 
 Query the first supported endpoint:
 

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
+httparse = "1.10.1"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
 
 [lints]
 workspace = true

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -6,7 +6,6 @@ repository.workspace = true
 
 [dependencies]
 httparse = "1.10.1"
-serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 
 [lints]

--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -134,16 +134,16 @@ pub fn parse_request(bytes: &[u8]) -> Result<ApiRequest, RequestError> {
         return Err(RequestError::PayloadTooLarge);
     }
 
-    let (method, path, header_len, content_length) = parse_request_head(bytes)?;
+    let (method, path, header_len, request_body) = parse_request_head(bytes)?;
     let body = bytes
         .get(header_len..)
         .ok_or(RequestError::MalformedRequest)?;
 
-    if body.len() != content_length {
+    if body.len() != request_body.content_length() {
         return Err(RequestError::MalformedRequest);
     }
 
-    if method == "GET" && content_length > 0 {
+    if method == "GET" && request_body.is_present() {
         return Err(RequestError::GetRequestBody);
     }
 
@@ -167,10 +167,14 @@ pub fn request_total_len(bytes: &[u8]) -> Result<Option<usize>, RequestError> {
         httparse::Status::Complete(header_len) => header_len,
         httparse::Status::Partial => return Ok(None),
     };
-    let content_length = content_length(request.headers)?;
+    let body = request_body(request.headers)?;
+
+    if body.has_unsupported_encoding() {
+        return Err(RequestError::MalformedRequest);
+    }
 
     let total_len = header_len
-        .checked_add(content_length)
+        .checked_add(body.content_length())
         .ok_or(RequestError::PayloadTooLarge)?;
 
     if total_len > HTTP_MAX_PAYLOAD_SIZE {
@@ -180,7 +184,7 @@ pub fn request_total_len(bytes: &[u8]) -> Result<Option<usize>, RequestError> {
     Ok(Some(total_len))
 }
 
-fn parse_request_head(bytes: &[u8]) -> Result<(&str, &str, usize, usize), RequestError> {
+fn parse_request_head(bytes: &[u8]) -> Result<(&str, &str, usize, RequestBody), RequestError> {
     let mut headers = [httparse::EMPTY_HEADER; MAX_HEADERS];
     let mut request = httparse::Request::new(&mut headers);
 
@@ -194,33 +198,57 @@ fn parse_request_head(bytes: &[u8]) -> Result<(&str, &str, usize, usize), Reques
 
     let method = request.method.ok_or(RequestError::MalformedRequest)?;
     let path = request.path.ok_or(RequestError::MalformedRequest)?;
-    let content_length = content_length(request.headers)?;
+    let body = request_body(request.headers)?;
 
-    Ok((method, path, header_len, content_length))
+    Ok((method, path, header_len, body))
 }
 
-fn content_length(headers: &[httparse::Header<'_>]) -> Result<usize, RequestError> {
-    let mut content_length = None;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RequestBody {
+    content_length: usize,
+    transfer_encoding: bool,
+}
 
-    for header in headers {
-        if !header.name.eq_ignore_ascii_case("Content-Length") {
-            continue;
-        }
-
-        if content_length.is_some() {
-            return Err(RequestError::MalformedRequest);
-        }
-
-        let value =
-            std::str::from_utf8(header.value).map_err(|_| RequestError::MalformedRequest)?;
-        let parsed = value
-            .trim()
-            .parse::<usize>()
-            .map_err(|_| RequestError::MalformedRequest)?;
-        content_length = Some(parsed);
+impl RequestBody {
+    const fn content_length(self) -> usize {
+        self.content_length
     }
 
-    Ok(content_length.unwrap_or(0))
+    const fn has_unsupported_encoding(self) -> bool {
+        self.transfer_encoding
+    }
+
+    const fn is_present(self) -> bool {
+        self.content_length > 0 || self.transfer_encoding
+    }
+}
+
+fn request_body(headers: &[httparse::Header<'_>]) -> Result<RequestBody, RequestError> {
+    let mut content_length = None;
+    let mut transfer_encoding = false;
+
+    for header in headers {
+        if header.name.eq_ignore_ascii_case("Content-Length") {
+            if content_length.is_some() {
+                return Err(RequestError::MalformedRequest);
+            }
+
+            let value =
+                std::str::from_utf8(header.value).map_err(|_| RequestError::MalformedRequest)?;
+            let parsed = value
+                .trim()
+                .parse::<usize>()
+                .map_err(|_| RequestError::MalformedRequest)?;
+            content_length = Some(parsed);
+        } else if header.name.eq_ignore_ascii_case("Transfer-Encoding") {
+            transfer_encoding = true;
+        }
+    }
+
+    Ok(RequestBody {
+        content_length: content_length.unwrap_or(0),
+        transfer_encoding,
+    })
 }
 
 impl From<ApiRequest> for Endpoint {
@@ -251,6 +279,23 @@ mod tests {
             b"GET /version HTTP/1.1\r\nContent-Length: 2\r\nContent-Type: application/json\r\n\r\n{}";
 
         assert_eq!(parse_request(request), Err(RequestError::GetRequestBody));
+    }
+
+    #[test]
+    fn rejects_get_version_with_transfer_encoding_body() {
+        let request = b"GET /version HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n";
+
+        assert_eq!(parse_request(request), Err(RequestError::GetRequestBody));
+    }
+
+    #[test]
+    fn total_len_rejects_unsupported_transfer_encoding() {
+        let request = b"GET /version HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n";
+
+        assert_eq!(
+            request_total_len(request),
+            Err(RequestError::MalformedRequest)
+        );
     }
 
     #[test]

--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -1,0 +1,327 @@
+use std::fmt;
+
+use serde::Serialize;
+
+use crate::route::Endpoint;
+use crate::HTTP_MAX_PAYLOAD_SIZE;
+
+const MAX_HEADERS: usize = 32;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApiRequest {
+    GetVersion,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RequestError {
+    GetRequestBody,
+    InvalidPathMethod,
+    MalformedRequest,
+    PayloadTooLarge,
+}
+
+impl RequestError {
+    pub fn fault_message(&self) -> &'static str {
+        match self {
+            Self::GetRequestBody => "GET request cannot have a body.",
+            Self::InvalidPathMethod => "Invalid request method and/or path.",
+            Self::MalformedRequest => "Malformed HTTP request.",
+            Self::PayloadTooLarge => "HTTP request payload exceeds the configured limit.",
+        }
+    }
+}
+
+impl fmt::Display for RequestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.fault_message())
+    }
+}
+
+impl std::error::Error for RequestError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusCode {
+    Ok,
+    BadRequest,
+}
+
+impl StatusCode {
+    pub const fn as_u16(self) -> u16 {
+        match self {
+            Self::Ok => 200,
+            Self::BadRequest => 400,
+        }
+    }
+
+    const fn reason_phrase(self) -> &'static str {
+        match self {
+            Self::Ok => "OK",
+            Self::BadRequest => "Bad Request",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpResponse {
+    status: StatusCode,
+    body: String,
+}
+
+impl HttpResponse {
+    pub fn version(version: &str) -> Self {
+        #[derive(Serialize)]
+        struct VersionResponse<'a> {
+            firecracker_version: &'a str,
+        }
+
+        let body = serde_json::to_string(&VersionResponse {
+            firecracker_version: version,
+        })
+        .expect("serializing version response should not fail");
+
+        Self {
+            status: StatusCode::Ok,
+            body,
+        }
+    }
+
+    pub fn fault(message: &str) -> Self {
+        #[derive(Serialize)]
+        struct FaultMessage<'a> {
+            fault_message: &'a str,
+        }
+
+        let body = serde_json::to_string(&FaultMessage {
+            fault_message: message,
+        })
+        .expect("serializing fault response should not fail");
+
+        Self {
+            status: StatusCode::BadRequest,
+            body,
+        }
+    }
+
+    pub const fn status(&self) -> StatusCode {
+        self.status
+    }
+
+    pub fn body(&self) -> &str {
+        &self.body
+    }
+
+    pub fn to_http_bytes(&self) -> Vec<u8> {
+        format!(
+            "HTTP/1.1 {} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            self.status.as_u16(),
+            self.status.reason_phrase(),
+            self.body.len(),
+            self.body
+        )
+        .into_bytes()
+    }
+}
+
+pub fn handle_request_bytes(bytes: &[u8], version: &str) -> HttpResponse {
+    match parse_request(bytes) {
+        Ok(ApiRequest::GetVersion) => HttpResponse::version(version),
+        Err(err) => HttpResponse::fault(err.fault_message()),
+    }
+}
+
+pub fn parse_request(bytes: &[u8]) -> Result<ApiRequest, RequestError> {
+    if bytes.len() > HTTP_MAX_PAYLOAD_SIZE {
+        return Err(RequestError::PayloadTooLarge);
+    }
+
+    let (method, path, header_len, content_length) = parse_request_head(bytes)?;
+    let body = bytes
+        .get(header_len..)
+        .ok_or(RequestError::MalformedRequest)?;
+
+    if body.len() != content_length {
+        return Err(RequestError::MalformedRequest);
+    }
+
+    if method == "GET" && content_length > 0 {
+        return Err(RequestError::GetRequestBody);
+    }
+
+    match (method, path) {
+        ("GET", "/version") => Ok(ApiRequest::GetVersion),
+        _ => Err(RequestError::InvalidPathMethod),
+    }
+}
+
+pub fn request_total_len(bytes: &[u8]) -> Result<Option<usize>, RequestError> {
+    if bytes.len() > HTTP_MAX_PAYLOAD_SIZE {
+        return Err(RequestError::PayloadTooLarge);
+    }
+
+    let mut headers = [httparse::EMPTY_HEADER; MAX_HEADERS];
+    let mut request = httparse::Request::new(&mut headers);
+    let status = request
+        .parse(bytes)
+        .map_err(|_| RequestError::MalformedRequest)?;
+    let header_len = match status {
+        httparse::Status::Complete(header_len) => header_len,
+        httparse::Status::Partial => return Ok(None),
+    };
+    let content_length = content_length(request.headers)?;
+
+    let total_len = header_len
+        .checked_add(content_length)
+        .ok_or(RequestError::PayloadTooLarge)?;
+
+    if total_len > HTTP_MAX_PAYLOAD_SIZE {
+        return Err(RequestError::PayloadTooLarge);
+    }
+
+    Ok(Some(total_len))
+}
+
+fn parse_request_head(bytes: &[u8]) -> Result<(&str, &str, usize, usize), RequestError> {
+    let mut headers = [httparse::EMPTY_HEADER; MAX_HEADERS];
+    let mut request = httparse::Request::new(&mut headers);
+
+    let status = request
+        .parse(bytes)
+        .map_err(|_| RequestError::MalformedRequest)?;
+    let header_len = match status {
+        httparse::Status::Complete(header_len) => header_len,
+        httparse::Status::Partial => return Err(RequestError::MalformedRequest),
+    };
+
+    let method = request.method.ok_or(RequestError::MalformedRequest)?;
+    let path = request.path.ok_or(RequestError::MalformedRequest)?;
+    let content_length = content_length(request.headers)?;
+
+    Ok((method, path, header_len, content_length))
+}
+
+fn content_length(headers: &[httparse::Header<'_>]) -> Result<usize, RequestError> {
+    let mut content_length = None;
+
+    for header in headers {
+        if !header.name.eq_ignore_ascii_case("Content-Length") {
+            continue;
+        }
+
+        if content_length.is_some() {
+            return Err(RequestError::MalformedRequest);
+        }
+
+        let value =
+            std::str::from_utf8(header.value).map_err(|_| RequestError::MalformedRequest)?;
+        let parsed = value
+            .trim()
+            .parse::<usize>()
+            .map_err(|_| RequestError::MalformedRequest)?;
+        content_length = Some(parsed);
+    }
+
+    Ok(content_length.unwrap_or(0))
+}
+
+impl From<ApiRequest> for Endpoint {
+    fn from(request: ApiRequest) -> Self {
+        match request {
+            ApiRequest::GetVersion => Self::Version,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VERSION: &str = "0.1.0";
+
+    #[test]
+    fn parses_get_version() {
+        let request = b"GET /version HTTP/1.1\r\nHost: localhost\r\n\r\n";
+
+        assert_eq!(parse_request(request), Ok(ApiRequest::GetVersion));
+        assert_eq!(request_total_len(request), Ok(Some(request.len())));
+    }
+
+    #[test]
+    fn rejects_get_version_with_body() {
+        let request =
+            b"GET /version HTTP/1.1\r\nContent-Length: 2\r\nContent-Type: application/json\r\n\r\n{}";
+
+        assert_eq!(parse_request(request), Err(RequestError::GetRequestBody));
+    }
+
+    #[test]
+    fn rejects_unsupported_method() {
+        let request = b"PUT /version HTTP/1.1\r\nContent-Length: 0\r\n\r\n";
+
+        assert_eq!(parse_request(request), Err(RequestError::InvalidPathMethod));
+    }
+
+    #[test]
+    fn rejects_unsupported_path() {
+        let request = b"GET / HTTP/1.1\r\n\r\n";
+
+        assert_eq!(parse_request(request), Err(RequestError::InvalidPathMethod));
+    }
+
+    #[test]
+    fn rejects_malformed_request() {
+        let request = b"not-http\r\n\r\n";
+
+        assert_eq!(parse_request(request), Err(RequestError::MalformedRequest));
+    }
+
+    #[test]
+    fn rejects_incomplete_body() {
+        let request = b"GET /version HTTP/1.1\r\nContent-Length: 2\r\n\r\n{";
+
+        assert_eq!(parse_request(request), Err(RequestError::MalformedRequest));
+    }
+
+    #[test]
+    fn rejects_request_over_payload_limit() {
+        let request = vec![b'a'; HTTP_MAX_PAYLOAD_SIZE + 1];
+
+        assert_eq!(parse_request(&request), Err(RequestError::PayloadTooLarge));
+    }
+
+    #[test]
+    fn response_body_contains_firecracker_version() {
+        let response = HttpResponse::version(VERSION);
+
+        assert_eq!(response.status(), StatusCode::Ok);
+        assert_eq!(response.body(), r#"{"firecracker_version":"0.1.0"}"#);
+    }
+
+    #[test]
+    fn fault_body_contains_fault_message() {
+        let response = HttpResponse::fault("message");
+
+        assert_eq!(response.status(), StatusCode::BadRequest);
+        assert_eq!(response.body(), r#"{"fault_message":"message"}"#);
+    }
+
+    #[test]
+    fn response_bytes_include_http_headers() {
+        let response = HttpResponse::version(VERSION);
+        let bytes = response.to_http_bytes();
+        let text = std::str::from_utf8(&bytes).expect("response should be utf-8");
+
+        assert!(text.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(text.contains("Content-Type: application/json\r\n"));
+        assert!(text.contains(&format!("Content-Length: {}\r\n", response.body().len())));
+        assert!(text.ends_with(r#"{"firecracker_version":"0.1.0"}"#));
+    }
+
+    #[test]
+    fn handles_request_bytes_as_response() {
+        let response =
+            handle_request_bytes(b"GET /version HTTP/1.1\r\nHost: localhost\r\n\r\n", VERSION);
+
+        assert_eq!(response.status(), StatusCode::Ok);
+        assert_eq!(response.body(), r#"{"firecracker_version":"0.1.0"}"#);
+    }
+}

--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -1,7 +1,5 @@
 use std::fmt;
 
-use serde::Serialize;
-
 use crate::route::Endpoint;
 use crate::HTTP_MAX_PAYLOAD_SIZE;
 
@@ -69,15 +67,7 @@ pub struct HttpResponse {
 
 impl HttpResponse {
     pub fn version(version: &str) -> Self {
-        #[derive(Serialize)]
-        struct VersionResponse<'a> {
-            firecracker_version: &'a str,
-        }
-
-        let body = serde_json::to_string(&VersionResponse {
-            firecracker_version: version,
-        })
-        .expect("serializing version response should not fail");
+        let body = serde_json::json!({ "firecracker_version": version }).to_string();
 
         Self {
             status: StatusCode::Ok,
@@ -86,15 +76,7 @@ impl HttpResponse {
     }
 
     pub fn fault(message: &str) -> Self {
-        #[derive(Serialize)]
-        struct FaultMessage<'a> {
-            fault_message: &'a str,
-        }
-
-        let body = serde_json::to_string(&FaultMessage {
-            fault_message: message,
-        })
-        .expect("serializing fault response should not fail");
+        let body = serde_json::json!({ "fault_message": message }).to_string();
 
         Self {
             status: StatusCode::BadRequest,

--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -309,6 +309,14 @@ mod tests {
     }
 
     #[test]
+    fn parses_get_version_with_zero_content_length() {
+        let request = b"GET /version HTTP/1.1\r\nContent-Length:\t0 \r\n\r\n";
+
+        assert_eq!(parse_request(request), Ok(ApiRequest::GetVersion));
+        assert_eq!(request_total_len(request), Ok(Some(request.len())));
+    }
+
+    #[test]
     fn rejects_get_version_with_transfer_encoding_body() {
         let request = b"GET /version HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n";
 
@@ -365,6 +373,17 @@ mod tests {
     }
 
     #[test]
+    fn rejects_duplicate_content_length() {
+        let request = b"GET /version HTTP/1.1\r\nContent-Length: 0\r\nContent-Length: 0\r\n\r\n";
+
+        assert_eq!(parse_request(request), Err(RequestError::MalformedRequest));
+        assert_eq!(
+            request_total_len(request),
+            Err(RequestError::MalformedRequest)
+        );
+    }
+
+    #[test]
     fn rejects_declared_content_length_over_payload_limit() {
         let request = format!(
             "GET /version HTTP/1.1\r\nContent-Length: {}\r\n\r\n",
@@ -377,6 +396,18 @@ mod tests {
         );
         assert_eq!(
             request_total_len(request.as_bytes()),
+            Err(RequestError::PayloadTooLarge)
+        );
+    }
+
+    #[test]
+    fn rejects_declared_content_length_over_usize() {
+        let request =
+            b"GET /version HTTP/1.1\r\nContent-Length: 999999999999999999999999999999\r\n\r\n";
+
+        assert_eq!(parse_request(request), Err(RequestError::PayloadTooLarge));
+        assert_eq!(
+            request_total_len(request),
             Err(RequestError::PayloadTooLarge)
         );
     }

--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -121,11 +121,17 @@ pub fn parse_request(bytes: &[u8]) -> Result<ApiRequest, RequestError> {
         .get(header_len..)
         .ok_or(RequestError::MalformedRequest)?;
 
+    if request_body.has_unsupported_encoding() {
+        return Err(RequestError::MalformedRequest);
+    }
+
+    checked_request_len(header_len, request_body.content_length())?;
+
     if body.len() != request_body.content_length() {
         return Err(RequestError::MalformedRequest);
     }
 
-    if method == "GET" && request_body.is_present() {
+    if method == "GET" && request_body.has_content() {
         return Err(RequestError::GetRequestBody);
     }
 
@@ -155,15 +161,10 @@ pub fn request_total_len(bytes: &[u8]) -> Result<Option<usize>, RequestError> {
         return Err(RequestError::MalformedRequest);
     }
 
-    let total_len = header_len
-        .checked_add(body.content_length())
-        .ok_or(RequestError::PayloadTooLarge)?;
-
-    if total_len > HTTP_MAX_PAYLOAD_SIZE {
-        return Err(RequestError::PayloadTooLarge);
-    }
-
-    Ok(Some(total_len))
+    Ok(Some(checked_request_len(
+        header_len,
+        body.content_length(),
+    )?))
 }
 
 fn parse_request_head(bytes: &[u8]) -> Result<(&str, &str, usize, RequestBody), RequestError> {
@@ -200,8 +201,8 @@ impl RequestBody {
         self.transfer_encoding
     }
 
-    const fn is_present(self) -> bool {
-        self.content_length > 0 || self.transfer_encoding
+    const fn has_content(self) -> bool {
+        self.content_length > 0
     }
 }
 
@@ -215,13 +216,7 @@ fn request_body(headers: &[httparse::Header<'_>]) -> Result<RequestBody, Request
                 return Err(RequestError::MalformedRequest);
             }
 
-            let value =
-                std::str::from_utf8(header.value).map_err(|_| RequestError::MalformedRequest)?;
-            let parsed = value
-                .trim()
-                .parse::<usize>()
-                .map_err(|_| RequestError::MalformedRequest)?;
-            content_length = Some(parsed);
+            content_length = Some(parse_content_length(header.value)?);
         } else if header.name.eq_ignore_ascii_case("Transfer-Encoding") {
             transfer_encoding = true;
         }
@@ -231,6 +226,56 @@ fn request_body(headers: &[httparse::Header<'_>]) -> Result<RequestBody, Request
         content_length: content_length.unwrap_or(0),
         transfer_encoding,
     })
+}
+
+fn parse_content_length(value: &[u8]) -> Result<usize, RequestError> {
+    let value = trim_http_optional_whitespace(value);
+    if value.is_empty() {
+        return Err(RequestError::MalformedRequest);
+    }
+
+    let mut parsed = 0usize;
+    for byte in value {
+        if !byte.is_ascii_digit() {
+            return Err(RequestError::MalformedRequest);
+        }
+
+        parsed = parsed
+            .checked_mul(10)
+            .and_then(|parsed| parsed.checked_add(usize::from(byte - b'0')))
+            .ok_or(RequestError::PayloadTooLarge)?;
+    }
+
+    Ok(parsed)
+}
+
+fn trim_http_optional_whitespace(value: &[u8]) -> &[u8] {
+    let start = value
+        .iter()
+        .position(|&byte| !is_http_optional_whitespace(byte))
+        .unwrap_or(value.len());
+    let end = value
+        .iter()
+        .rposition(|&byte| !is_http_optional_whitespace(byte))
+        .map_or(start, |index| index + 1);
+
+    &value[start..end]
+}
+
+const fn is_http_optional_whitespace(byte: u8) -> bool {
+    matches!(byte, b' ' | b'\t')
+}
+
+fn checked_request_len(header_len: usize, content_length: usize) -> Result<usize, RequestError> {
+    let total_len = header_len
+        .checked_add(content_length)
+        .ok_or(RequestError::PayloadTooLarge)?;
+
+    if total_len > HTTP_MAX_PAYLOAD_SIZE {
+        return Err(RequestError::PayloadTooLarge);
+    }
+
+    Ok(total_len)
 }
 
 impl From<ApiRequest> for Endpoint {
@@ -267,7 +312,7 @@ mod tests {
     fn rejects_get_version_with_transfer_encoding_body() {
         let request = b"GET /version HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n";
 
-        assert_eq!(parse_request(request), Err(RequestError::GetRequestBody));
+        assert_eq!(parse_request(request), Err(RequestError::MalformedRequest));
     }
 
     #[test]
@@ -306,6 +351,34 @@ mod tests {
         let request = b"GET /version HTTP/1.1\r\nContent-Length: 2\r\n\r\n{";
 
         assert_eq!(parse_request(request), Err(RequestError::MalformedRequest));
+    }
+
+    #[test]
+    fn rejects_non_digit_content_length() {
+        let request = b"GET /version HTTP/1.1\r\nContent-Length: +0\r\n\r\n";
+
+        assert_eq!(parse_request(request), Err(RequestError::MalformedRequest));
+        assert_eq!(
+            request_total_len(request),
+            Err(RequestError::MalformedRequest)
+        );
+    }
+
+    #[test]
+    fn rejects_declared_content_length_over_payload_limit() {
+        let request = format!(
+            "GET /version HTTP/1.1\r\nContent-Length: {}\r\n\r\n",
+            HTTP_MAX_PAYLOAD_SIZE + 1
+        );
+
+        assert_eq!(
+            parse_request(request.as_bytes()),
+            Err(RequestError::PayloadTooLarge)
+        );
+        assert_eq!(
+            request_total_len(request.as_bytes()),
+            Err(RequestError::PayloadTooLarge)
+        );
     }
 
     #[test]

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1,3 +1,7 @@
-//! Firecracker-compatible API names.
+//! Firecracker-compatible API surface.
 
+pub mod http;
 pub mod route;
+
+/// Firecracker's default maximum accepted HTTP request size.
+pub const HTTP_MAX_PAYLOAD_SIZE: usize = 51_200;

--- a/crates/bangbang/Cargo.toml
+++ b/crates/bangbang/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 [dependencies]
 bangbang-api = { path = "../api" }
 bangbang-hvf = { path = "../hvf" }
+libc = "0.2"
 signal-hook = "0.3"
 
 [lints]

--- a/crates/bangbang/Cargo.toml
+++ b/crates/bangbang/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
+bangbang-api = { path = "../api" }
 bangbang-hvf = { path = "../hvf" }
 
 [lints]

--- a/crates/bangbang/Cargo.toml
+++ b/crates/bangbang/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 [dependencies]
 bangbang-api = { path = "../api" }
 bangbang-hvf = { path = "../hvf" }
+signal-hook = "0.3"
 
 [lints]
 workspace = true

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -1,9 +1,11 @@
+use std::ffi::{CString, OsString};
 use std::fs;
 use std::io::{Read, Write};
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use bangbang_api::http::{handle_request_bytes, request_total_len, HttpResponse, RequestError};
 use bangbang_api::HTTP_MAX_PAYLOAD_SIZE;
@@ -54,8 +56,11 @@ impl ApiServer {
             return Err(ApiServerError::SocketPathExists);
         }
 
-        let listener = UnixListener::bind(path).map_err(|err| ApiServerError::Bind(err.kind()))?;
-        let socket_guard = SocketGuard::new(path)?;
+        let (listener, metadata) = bind_unpublished_socket(path)?;
+        publish_socket_path(&metadata.path, path).inspect_err(|_| {
+            let _ = fs::remove_file(&metadata.path);
+        })?;
+        let socket_guard = SocketGuard::new(path, metadata);
 
         Ok(Self {
             listener,
@@ -82,6 +87,13 @@ impl ApiServer {
 }
 
 #[derive(Debug)]
+struct BoundSocketMetadata {
+    path: PathBuf,
+    dev: u64,
+    ino: u64,
+}
+
+#[derive(Debug)]
 struct SocketGuard {
     path: PathBuf,
     dev: u64,
@@ -89,27 +101,20 @@ struct SocketGuard {
 }
 
 impl SocketGuard {
-    fn new(path: &Path) -> Result<Self, ApiServerError> {
-        let metadata =
-            fs::symlink_metadata(path).map_err(|err| ApiServerError::SocketMetadata(err.kind()))?;
-
-        if !metadata.file_type().is_socket() {
-            return Err(ApiServerError::SocketPathIsNotSocket);
-        }
-
-        Ok(Self {
+    fn new(path: &Path, metadata: BoundSocketMetadata) -> Self {
+        Self {
             path: path.to_path_buf(),
-            dev: metadata.dev(),
-            ino: metadata.ino(),
-        })
+            dev: metadata.dev,
+            ino: metadata.ino,
+        }
     }
 
     fn owns_current_path(&self) -> bool {
-        let Ok(metadata) = fs::symlink_metadata(&self.path) else {
+        let Ok(metadata) = socket_path_metadata(&self.path) else {
             return false;
         };
 
-        metadata.file_type().is_socket() && metadata.dev() == self.dev && metadata.ino() == self.ino
+        metadata.dev() == self.dev && metadata.ino() == self.ino
     }
 }
 
@@ -119,6 +124,107 @@ impl Drop for SocketGuard {
             let _ = fs::remove_file(&self.path);
         }
     }
+}
+
+fn socket_path_metadata(path: &Path) -> Result<fs::Metadata, ApiServerError> {
+    let metadata =
+        fs::symlink_metadata(path).map_err(|err| ApiServerError::SocketMetadata(err.kind()))?;
+
+    if !metadata.file_type().is_socket() {
+        return Err(ApiServerError::SocketPathIsNotSocket);
+    }
+
+    Ok(metadata)
+}
+
+fn bind_unpublished_socket(
+    path: &Path,
+) -> Result<(UnixListener, BoundSocketMetadata), ApiServerError> {
+    for attempt in 0..16 {
+        let temp_path = temporary_socket_path(path, attempt);
+        let listener = match UnixListener::bind(&temp_path) {
+            Ok(listener) => listener,
+            Err(err)
+                if matches!(
+                    err.kind(),
+                    std::io::ErrorKind::AddrInUse | std::io::ErrorKind::AlreadyExists
+                ) =>
+            {
+                continue;
+            }
+            Err(err) => return Err(ApiServerError::Bind(err.kind())),
+        };
+        let metadata = match socket_path_metadata(&temp_path) {
+            Ok(metadata) => metadata,
+            Err(err) => {
+                let _ = fs::remove_file(&temp_path);
+                return Err(err);
+            }
+        };
+
+        return Ok((
+            listener,
+            BoundSocketMetadata {
+                path: temp_path,
+                dev: metadata.dev(),
+                ino: metadata.ino(),
+            },
+        ));
+    }
+
+    Err(ApiServerError::Bind(std::io::ErrorKind::AlreadyExists))
+}
+
+fn temporary_socket_path(path: &Path, attempt: u8) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+
+    let mut temp_name = OsString::from(".bb.");
+    temp_name.push(format!("{}.{}.{}.sock", std::process::id(), nanos, attempt));
+
+    path.with_file_name(temp_name)
+}
+
+#[cfg(target_os = "macos")]
+fn publish_socket_path(from: &Path, to: &Path) -> Result<(), ApiServerError> {
+    use std::os::raw::{c_char, c_int, c_uint};
+
+    const RENAME_EXCL: c_uint = 0x0000_0004;
+
+    unsafe extern "C" {
+        fn renamex_np(from: *const c_char, to: *const c_char, flags: c_uint) -> c_int;
+    }
+
+    let from = path_to_cstring(from)?;
+    let to = path_to_cstring(to)?;
+    // SAFETY: both pointers come from live `CString` values and are valid
+    // NUL-terminated paths for the duration of this call.
+    let result = unsafe { renamex_np(from.as_ptr(), to.as_ptr(), RENAME_EXCL) };
+    if result == 0 {
+        return Ok(());
+    }
+
+    let kind = std::io::Error::last_os_error().kind();
+    if kind == std::io::ErrorKind::AlreadyExists {
+        Err(ApiServerError::SocketPathExists)
+    } else {
+        Err(ApiServerError::Bind(kind))
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn publish_socket_path(from: &Path, to: &Path) -> Result<(), ApiServerError> {
+    if path_exists_without_following_links(to)? {
+        return Err(ApiServerError::SocketPathExists);
+    }
+
+    fs::rename(from, to).map_err(|err| ApiServerError::Bind(err.kind()))
+}
+
+fn path_to_cstring(path: &Path) -> Result<CString, ApiServerError> {
+    CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| ApiServerError::Bind(std::io::ErrorKind::InvalidInput))
 }
 
 fn path_exists_without_following_links(path: &Path) -> Result<bool, ApiServerError> {
@@ -355,6 +461,28 @@ mod tests {
             .file_type()
             .is_symlink());
 
+        fs::remove_file(path).expect("fixture should clean up");
+    }
+
+    #[test]
+    fn publish_does_not_replace_existing_socket_path() {
+        let path = unique_socket_path("publish-race");
+        let temp_path = unique_socket_path("publish-temp");
+        let temp_listener = UnixListener::bind(&temp_path).expect("temporary listener should bind");
+        fs::write(&path, "replacement").expect("replacement should be written");
+
+        let err = publish_socket_path(&temp_path, &path)
+            .expect_err("publishing over an existing path should fail");
+
+        assert_eq!(err, ApiServerError::SocketPathExists);
+        assert_eq!(
+            fs::read_to_string(&path).expect("replacement should remain"),
+            "replacement"
+        );
+        assert!(temp_path.exists());
+
+        drop(temp_listener);
+        fs::remove_file(temp_path).expect("temporary socket should clean up");
         fs::remove_file(path).expect("fixture should clean up");
     }
 

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -5,13 +5,15 @@ use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
 use bangbang_api::http::{handle_request_bytes, request_total_len, HttpResponse, RequestError};
 use bangbang_api::HTTP_MAX_PAYLOAD_SIZE;
 
 const READ_CHUNK_SIZE: usize = 4096;
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
+static NEXT_TEMP_SOCKET_ID: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum ApiServerError {
@@ -140,8 +142,8 @@ fn socket_path_metadata(path: &Path) -> Result<fs::Metadata, ApiServerError> {
 fn bind_unpublished_socket(
     path: &Path,
 ) -> Result<(UnixListener, BoundSocketMetadata), ApiServerError> {
-    for attempt in 0..16 {
-        let temp_path = temporary_socket_path(path, attempt);
+    for _ in 0..16 {
+        let temp_path = temporary_socket_path(path);
         let listener = match UnixListener::bind(&temp_path) {
             Ok(listener) => listener,
             Err(err)
@@ -175,13 +177,10 @@ fn bind_unpublished_socket(
     Err(ApiServerError::Bind(std::io::ErrorKind::AlreadyExists))
 }
 
-fn temporary_socket_path(path: &Path, attempt: u8) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |duration| duration.as_nanos());
-
+fn temporary_socket_path(path: &Path) -> PathBuf {
+    let id = NEXT_TEMP_SOCKET_ID.fetch_add(1, Ordering::Relaxed);
     let mut temp_name = OsString::from(".bb.");
-    temp_name.push(format!("{}.{}.{}.sock", std::process::id(), nanos, attempt));
+    temp_name.push(format!("{}.{}", std::process::id(), id));
 
     path.with_file_name(temp_name)
 }
@@ -328,6 +327,31 @@ mod tests {
             .expect("system clock should be after unix epoch")
             .as_nanos();
         env::temp_dir().join(format!("bb-{name}-{}-{nanos}.sock", std::process::id()))
+    }
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let path = PathBuf::from("/tmp").join(format!("bb-{name}-{}-{nanos}", std::process::id()));
+        fs::create_dir(&path).expect("fixture directory should be created");
+        path
+    }
+
+    fn temporary_socket_entries(dir: &Path) -> Vec<PathBuf> {
+        let prefix = format!(".bb.{}.", std::process::id());
+        let mut paths = fs::read_dir(dir)
+            .expect("fixture directory should be readable")
+            .filter_map(|entry| {
+                let entry = entry.expect("fixture directory entry should be readable");
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                name.starts_with(&prefix).then(|| entry.path())
+            })
+            .collect::<Vec<_>>();
+        paths.sort();
+        paths
     }
 
     #[test]
@@ -492,7 +516,8 @@ mod tests {
     fn concurrent_binds_allow_only_one_owner() {
         const ATTEMPTS: usize = 8;
 
-        let path = unique_socket_path("concurrent");
+        let dir = unique_temp_dir("concurrent");
+        let path = dir.join("api.sock");
         let start = Arc::new(Barrier::new(ATTEMPTS));
         let finish = Arc::new(Barrier::new(ATTEMPTS));
         let handles = (0..ATTEMPTS)
@@ -504,12 +529,15 @@ mod tests {
                 thread::spawn(move || {
                     start.wait();
                     let result = ApiServer::bind(&path);
-                    let outcome = match &result {
-                        Ok(_) => Ok(()),
-                        Err(err) => Err(err),
-                    };
+                    let outcome = (
+                        result.is_ok(),
+                        matches!(
+                            result.as_ref().err(),
+                            Some(ApiServerError::SocketPathExists)
+                        ),
+                    );
                     finish.wait();
-                    outcome.map_err(|err| matches!(err, ApiServerError::SocketPathExists))
+                    outcome
                 })
             })
             .collect::<Vec<_>>();
@@ -519,15 +547,18 @@ mod tests {
             .map(|handle| handle.join().expect("bind thread should not panic"))
             .collect::<Vec<_>>();
 
-        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(results.iter().filter(|(is_ok, _)| *is_ok).count(), 1);
         assert_eq!(
             results
                 .iter()
-                .filter(|result| matches!(result, Err(true)))
+                .filter(|(_, is_path_exists)| *is_path_exists)
                 .count(),
             ATTEMPTS - 1
         );
         assert!(!path.exists());
+        assert_eq!(temporary_socket_entries(&dir), Vec::<PathBuf>::new());
+
+        fs::remove_dir(dir).expect("fixture directory should clean up");
     }
 
     #[test]

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -6,7 +6,7 @@ use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::os::unix::io::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use bangbang_api::http::{handle_request_bytes, request_total_len, HttpResponse, RequestError};
@@ -77,7 +77,6 @@ impl ApiServer {
     pub(crate) fn run_until(
         &self,
         version: &str,
-        shutdown_requested: &AtomicBool,
         shutdown_wakeup: &mut UnixStream,
     ) -> Result<(), ApiServerError> {
         self.listener
@@ -88,10 +87,6 @@ impl ApiServer {
             .map_err(|err| ApiServerError::Connection(err.kind()))?;
 
         loop {
-            if shutdown_requested.load(Ordering::Relaxed) {
-                return Ok(());
-            }
-
             wait_for_listener_or_shutdown(&self.listener, shutdown_wakeup)?;
             if drain_shutdown_wakeup(shutdown_wakeup)? {
                 return Ok(());
@@ -641,15 +636,11 @@ mod tests {
     fn run_until_cleans_socket_after_shutdown_request() {
         let path = unique_socket_path("shutdown");
         let server = ApiServer::bind(&path).expect("server should bind");
-        let shutdown_requested = Arc::new(AtomicBool::new(false));
-        let run_shutdown_requested = Arc::clone(&shutdown_requested);
         let (mut shutdown_reader, mut shutdown_writer) =
             UnixStream::pair().expect("shutdown stream pair should be created");
         let mut client = UnixStream::connect(&path).expect("client should connect");
 
-        let handle = thread::spawn(move || {
-            server.run_until(VERSION, &run_shutdown_requested, &mut shutdown_reader)
-        });
+        let handle = thread::spawn(move || server.run_until(VERSION, &mut shutdown_reader));
 
         client
             .write_all(b"GET /version HTTP/1.1\r\nHost: localhost\r\n\r\n")
@@ -659,7 +650,6 @@ mod tests {
         client
             .read_to_string(&mut response)
             .expect("client should read response");
-        shutdown_requested.store(true, Ordering::Relaxed);
         shutdown_writer
             .write_all(b"x")
             .expect("shutdown wakeup should be written");
@@ -676,15 +666,10 @@ mod tests {
     fn run_until_cleans_idle_socket_after_shutdown_request() {
         let path = unique_socket_path("idle-shutdown");
         let server = ApiServer::bind(&path).expect("server should bind");
-        let shutdown_requested = Arc::new(AtomicBool::new(false));
-        let run_shutdown_requested = Arc::clone(&shutdown_requested);
         let (mut shutdown_reader, mut shutdown_writer) =
             UnixStream::pair().expect("shutdown stream pair should be created");
-        let handle = thread::spawn(move || {
-            server.run_until(VERSION, &run_shutdown_requested, &mut shutdown_reader)
-        });
+        let handle = thread::spawn(move || server.run_until(VERSION, &mut shutdown_reader));
 
-        shutdown_requested.store(true, Ordering::Relaxed);
         shutdown_writer
             .write_all(b"x")
             .expect("shutdown wakeup should be written");

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -136,6 +136,10 @@ fn wait_for_listener_or_shutdown(
     ];
 
     loop {
+        for poll_fd in &mut poll_fds {
+            poll_fd.revents = 0;
+        }
+
         // SAFETY: `poll_fds` points to two initialized `pollfd` values and
         // remains valid for the duration of the call. The timeout is infinite.
         let result = unsafe { libc::poll(poll_fds.as_mut_ptr(), poll_fds.len() as _, -1) };
@@ -158,14 +162,10 @@ fn drain_shutdown_wakeup(shutdown_wakeup: &mut UnixStream) -> Result<bool, ApiSe
         match shutdown_wakeup.read(&mut buffer) {
             Ok(0) => return Ok(true),
             Ok(_) => drained = true,
-            Err(err)
-                if matches!(
-                    err.kind(),
-                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::Interrupted
-                ) =>
-            {
+            Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock) => {
                 return Ok(drained);
             }
+            Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
             Err(err) => return Err(ApiServerError::Connection(err.kind())),
         }
     }
@@ -226,7 +226,7 @@ fn bind_unpublished_socket(
     path: &Path,
 ) -> Result<(UnixListener, BoundSocketMetadata), ApiServerError> {
     for _ in 0..16 {
-        let temp_path = temporary_socket_path(path);
+        let temp_path = next_temporary_socket_path(path);
         let listener = match UnixListener::bind(&temp_path) {
             Ok(listener) => listener,
             Err(err)
@@ -260,8 +260,21 @@ fn bind_unpublished_socket(
     Err(ApiServerError::Bind(std::io::ErrorKind::AlreadyExists))
 }
 
-fn temporary_socket_path(path: &Path) -> PathBuf {
-    let id = NEXT_TEMP_SOCKET_ID.fetch_add(1, Ordering::Relaxed);
+fn next_temporary_socket_path(path: &Path) -> PathBuf {
+    next_temporary_socket_path_from(path, &NEXT_TEMP_SOCKET_ID)
+}
+
+fn next_temporary_socket_path_from(path: &Path, next_id: &AtomicU64) -> PathBuf {
+    loop {
+        let id = next_id.fetch_add(1, Ordering::Relaxed);
+        let temp_path = temporary_socket_path(path, id);
+        if temp_path != path {
+            return temp_path;
+        }
+    }
+}
+
+fn temporary_socket_path(path: &Path, id: u64) -> PathBuf {
     let mut temp_name = OsString::from(".bb.");
     temp_name.push(format!("{}.{}", std::process::id(), id));
 
@@ -445,6 +458,22 @@ mod tests {
             .collect::<Vec<_>>();
         paths.sort();
         paths
+    }
+
+    #[test]
+    fn temporary_socket_path_skips_requested_path_collision() {
+        let id = 7;
+        let path = PathBuf::from("/tmp").join(format!(".bb.{}.{}", std::process::id(), id));
+        let next_id = AtomicU64::new(id);
+
+        let temp_path = next_temporary_socket_path_from(&path, &next_id);
+
+        assert_ne!(temp_path, path);
+        assert_eq!(
+            temp_path,
+            PathBuf::from("/tmp").join(format!(".bb.{}.{}", std::process::id(), id + 1))
+        );
+        assert_eq!(next_id.load(Ordering::Relaxed), id + 2);
     }
 
     #[test]

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -23,6 +23,7 @@ pub(crate) enum ApiServerError {
     Connection(std::io::ErrorKind),
     SocketMetadata(std::io::ErrorKind),
     SocketPathCheck(std::io::ErrorKind),
+    SocketPathChanged,
     SocketPathExists,
     SocketPathIsNotSocket,
 }
@@ -37,6 +38,7 @@ impl std::fmt::Display for ApiServerError {
                 write!(f, "failed to inspect bound API socket: {kind:?}")
             }
             Self::SocketPathCheck(kind) => write!(f, "failed to check API socket path: {kind:?}"),
+            Self::SocketPathChanged => f.write_str("API socket path changed during bind"),
             Self::SocketPathExists => f.write_str("API socket path already exists"),
             Self::SocketPathIsNotSocket => f.write_str("bound API path is not a socket"),
         }
@@ -61,9 +63,10 @@ impl ApiServer {
 
         let (listener, metadata) = bind_unpublished_socket(path)?;
         publish_socket_path(&metadata.path, path).inspect_err(|_| {
-            let _ = fs::remove_file(&metadata.path);
+            remove_socket_path_if_owned(&metadata.path, metadata.dev, metadata.ino);
         })?;
         let socket_guard = SocketGuard::new(path, metadata);
+        ensure_socket_path_owner(path, socket_guard.dev, socket_guard.ino)?;
 
         Ok(Self {
             listener,
@@ -195,11 +198,7 @@ impl SocketGuard {
     }
 
     fn owns_current_path(&self) -> bool {
-        let Ok(metadata) = socket_path_metadata(&self.path) else {
-            return false;
-        };
-
-        metadata.dev() == self.dev && metadata.ino() == self.ino
+        socket_path_is_owned(&self.path, self.dev, self.ino).unwrap_or(false)
     }
 }
 
@@ -239,13 +238,7 @@ fn bind_unpublished_socket(
             }
             Err(err) => return Err(ApiServerError::Bind(err.kind())),
         };
-        let metadata = match socket_path_metadata(&temp_path) {
-            Ok(metadata) => metadata,
-            Err(err) => {
-                let _ = fs::remove_file(&temp_path);
-                return Err(err);
-            }
-        };
+        let metadata = socket_path_metadata(&temp_path)?;
 
         return Ok((
             listener,
@@ -279,6 +272,26 @@ fn temporary_socket_path(path: &Path, id: u64) -> PathBuf {
     temp_name.push(format!("{}.{}", std::process::id(), id));
 
     path.with_file_name(temp_name)
+}
+
+fn ensure_socket_path_owner(path: &Path, dev: u64, ino: u64) -> Result<(), ApiServerError> {
+    if socket_path_is_owned(path, dev, ino)? {
+        Ok(())
+    } else {
+        Err(ApiServerError::SocketPathChanged)
+    }
+}
+
+fn remove_socket_path_if_owned(path: &Path, dev: u64, ino: u64) {
+    if socket_path_is_owned(path, dev, ino).unwrap_or(false) {
+        let _ = fs::remove_file(path);
+    }
+}
+
+fn socket_path_is_owned(path: &Path, dev: u64, ino: u64) -> Result<bool, ApiServerError> {
+    let metadata = socket_path_metadata(path)?;
+
+    Ok(metadata.dev() == dev && metadata.ino() == ino)
 }
 
 #[cfg(target_os = "macos")]
@@ -474,6 +487,46 @@ mod tests {
             PathBuf::from("/tmp").join(format!(".bb.{}.{}", std::process::id(), id + 1))
         );
         assert_eq!(next_id.load(Ordering::Relaxed), id + 2);
+    }
+
+    #[test]
+    fn socket_path_cleanup_keeps_replaced_path() {
+        let path = unique_socket_path("cln");
+        let listener = UnixListener::bind(&path).expect("temporary listener should bind");
+        let metadata = socket_path_metadata(&path).expect("temporary listener path should exist");
+
+        fs::remove_file(&path).expect("temporary socket path should be removable");
+        fs::write(&path, "replacement").expect("replacement should be written");
+
+        remove_socket_path_if_owned(&path, metadata.dev(), metadata.ino());
+
+        assert_eq!(
+            fs::read_to_string(&path).expect("replacement should remain"),
+            "replacement"
+        );
+
+        drop(listener);
+        fs::remove_file(path).expect("fixture should clean up");
+    }
+
+    #[test]
+    fn socket_path_owner_check_rejects_replaced_socket() {
+        let path = unique_socket_path("own");
+        let listener = UnixListener::bind(&path).expect("temporary listener should bind");
+        let metadata = socket_path_metadata(&path).expect("temporary listener path should exist");
+
+        fs::remove_file(&path).expect("temporary socket path should be removable");
+        let replacement =
+            UnixListener::bind(&path).expect("replacement listener should bind same path");
+
+        let err = ensure_socket_path_owner(&path, metadata.dev(), metadata.ino())
+            .expect_err("replaced socket should not be owned");
+
+        assert_eq!(err, ApiServerError::SocketPathChanged);
+
+        drop(listener);
+        drop(replacement);
+        fs::remove_file(path).expect("fixture should clean up");
     }
 
     #[test]

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -340,6 +340,16 @@ fn handle_connection(stream: &mut UnixStream, version: &str) -> Result<(), ApiSe
 
 fn read_request(stream: &mut UnixStream, timeout: Duration) -> Result<RequestRead, ApiServerError> {
     let deadline = Instant::now() + timeout;
+    let mut now = Instant::now;
+
+    read_request_until(stream, deadline, &mut now)
+}
+
+fn read_request_until(
+    stream: &mut UnixStream,
+    deadline: Instant,
+    now: &mut impl FnMut() -> Instant,
+) -> Result<RequestRead, ApiServerError> {
     let mut request = Vec::new();
     let mut chunk = [0; READ_CHUNK_SIZE];
 
@@ -360,7 +370,7 @@ fn read_request(stream: &mut UnixStream, timeout: Duration) -> Result<RequestRea
         }
 
         let read_len = chunk.len().min(remaining);
-        let Some(read_timeout) = deadline.checked_duration_since(Instant::now()) else {
+        let Some(read_timeout) = deadline.checked_duration_since(now()) else {
             return Ok(RequestRead::Complete(request));
         };
         if read_timeout.is_zero() {
@@ -398,7 +408,7 @@ mod tests {
     use std::os::unix::net::UnixStream;
     use std::sync::{Arc, Barrier};
     use std::thread;
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     use super::*;
 
@@ -593,7 +603,18 @@ mod tests {
             .write_all(partial_request)
             .expect("client should write partial request");
 
-        let request = read_request(&mut server, Duration::from_millis(1))
+        let start = Instant::now();
+        let deadline = start + Duration::from_secs(1);
+        let mut first_now = true;
+        let mut now = || {
+            if std::mem::replace(&mut first_now, false) {
+                start
+            } else {
+                deadline + Duration::from_nanos(1)
+            }
+        };
+
+        let request = read_request_until(&mut server, deadline, &mut now)
             .expect("read timeout should not fail");
 
         assert_eq!(request, RequestRead::Complete(partial_request.to_vec()));

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -314,6 +314,8 @@ mod tests {
     use std::env;
     use std::io::{Read, Write};
     use std::os::unix::net::UnixStream;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use super::*;
@@ -484,6 +486,48 @@ mod tests {
         drop(temp_listener);
         fs::remove_file(temp_path).expect("temporary socket should clean up");
         fs::remove_file(path).expect("fixture should clean up");
+    }
+
+    #[test]
+    fn concurrent_binds_allow_only_one_owner() {
+        const ATTEMPTS: usize = 8;
+
+        let path = unique_socket_path("concurrent");
+        let start = Arc::new(Barrier::new(ATTEMPTS));
+        let finish = Arc::new(Barrier::new(ATTEMPTS));
+        let handles = (0..ATTEMPTS)
+            .map(|_| {
+                let path = path.clone();
+                let start = Arc::clone(&start);
+                let finish = Arc::clone(&finish);
+
+                thread::spawn(move || {
+                    start.wait();
+                    let result = ApiServer::bind(&path);
+                    let outcome = match &result {
+                        Ok(_) => Ok(()),
+                        Err(err) => Err(err),
+                    };
+                    finish.wait();
+                    outcome.map_err(|err| matches!(err, ApiServerError::SocketPathExists))
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let results = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("bind thread should not panic"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| matches!(result, Err(true)))
+                .count(),
+            ATTEMPTS - 1
+        );
+        assert!(!path.exists());
     }
 
     #[test]

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -6,6 +6,7 @@ use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::thread;
 use std::time::{Duration, Instant};
 
 use bangbang_api::http::{handle_request_bytes, request_total_len, HttpResponse, RequestError};
@@ -13,6 +14,7 @@ use bangbang_api::HTTP_MAX_PAYLOAD_SIZE;
 
 const READ_CHUNK_SIZE: usize = 4096;
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
+const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(100);
 static NEXT_TEMP_SOCKET_ID: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, PartialEq, Eq)]
@@ -75,6 +77,10 @@ impl ApiServer {
         version: &str,
         shutdown_requested: &AtomicBool,
     ) -> Result<(), ApiServerError> {
+        self.listener
+            .set_nonblocking(true)
+            .map_err(|err| ApiServerError::Accept(err.kind()))?;
+
         loop {
             if shutdown_requested.load(Ordering::Relaxed) {
                 return Ok(());
@@ -82,6 +88,9 @@ impl ApiServer {
 
             match self.serve_next(version) {
                 Ok(()) => {}
+                Err(ApiServerError::Accept(std::io::ErrorKind::WouldBlock)) => {
+                    thread::sleep(ACCEPT_RETRY_DELAY);
+                }
                 Err(ApiServerError::Accept(std::io::ErrorKind::Interrupted)) => {}
                 Err(err) => return Err(err),
             }
@@ -330,7 +339,7 @@ mod tests {
     use std::os::unix::net::UnixStream;
     use std::sync::{Arc, Barrier};
     use std::thread;
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     use super::*;
 
@@ -476,13 +485,39 @@ mod tests {
             .read_to_string(&mut response)
             .expect("client should read response");
         shutdown_requested.store(true, Ordering::Relaxed);
-        let _ = UnixStream::connect(&path);
 
         assert_eq!(
             handle.join().expect("server thread should not panic"),
             Ok(())
         );
         assert!(response.contains(r#"{"firecracker_version":"0.1.0"}"#));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn run_until_cleans_idle_socket_after_shutdown_request() {
+        let path = unique_socket_path("idle-shutdown");
+        let server = ApiServer::bind(&path).expect("server should bind");
+        let shutdown_requested = Arc::new(AtomicBool::new(false));
+        let run_shutdown_requested = Arc::clone(&shutdown_requested);
+        let handle = thread::spawn(move || server.run_until(VERSION, &run_shutdown_requested));
+
+        shutdown_requested.store(true, Ordering::Relaxed);
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while !handle.is_finished() && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        if !handle.is_finished() {
+            let _ = UnixStream::connect(&path);
+            let _ = handle.join();
+            panic!("server should exit without an external socket wake");
+        }
+
+        assert_eq!(
+            handle.join().expect("server thread should not panic"),
+            Ok(())
+        );
         assert!(!path.exists());
     }
 

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -3,11 +3,13 @@ use std::io::{Read, Write};
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use bangbang_api::http::{handle_request_bytes, request_total_len, HttpResponse, RequestError};
 use bangbang_api::HTTP_MAX_PAYLOAD_SIZE;
 
 const READ_CHUNK_SIZE: usize = 4096;
+const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum ApiServerError {
@@ -76,7 +78,9 @@ impl ApiServer {
             .accept()
             .map_err(|err| ApiServerError::Accept(err.kind()))?;
 
-        handle_connection(&mut stream, version)
+        let _ = handle_connection(&mut stream, version);
+
+        Ok(())
     }
 }
 
@@ -127,6 +131,13 @@ enum RequestRead {
 }
 
 fn handle_connection(stream: &mut UnixStream, version: &str) -> Result<(), ApiServerError> {
+    stream
+        .set_read_timeout(Some(CONNECTION_TIMEOUT))
+        .map_err(|err| ApiServerError::Connection(err.kind()))?;
+    stream
+        .set_write_timeout(Some(CONNECTION_TIMEOUT))
+        .map_err(|err| ApiServerError::Connection(err.kind()))?;
+
     let response = match read_request(stream)? {
         RequestRead::Complete(request) => handle_request_bytes(&request, version),
         RequestRead::TooLarge => HttpResponse::fault(RequestError::PayloadTooLarge.fault_message()),
@@ -158,9 +169,18 @@ fn read_request(stream: &mut UnixStream) -> Result<RequestRead, ApiServerError> 
         }
 
         let read_len = chunk.len().min(remaining);
-        let bytes_read = stream
-            .read(&mut chunk[..read_len])
-            .map_err(|err| ApiServerError::Connection(err.kind()))?;
+        let bytes_read = match stream.read(&mut chunk[..read_len]) {
+            Ok(bytes_read) => bytes_read,
+            Err(err)
+                if matches!(
+                    err.kind(),
+                    std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
+                ) =>
+            {
+                return Ok(RequestRead::Complete(request));
+            }
+            Err(err) => return Err(ApiServerError::Connection(err.kind())),
+        };
 
         if bytes_read == 0 {
             return Ok(RequestRead::Complete(request));
@@ -235,6 +255,22 @@ mod tests {
 
         assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
         assert!(response.contains(r#"{"fault_message":"Invalid request method and/or path."}"#));
+    }
+
+    #[test]
+    fn client_disconnect_does_not_fail_server() {
+        let path = unique_socket_path("disconnect");
+        let server = ApiServer::bind(&path).expect("server should bind");
+        let mut client = UnixStream::connect(&path).expect("client should connect");
+
+        client
+            .write_all(b"GET /version HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .expect("client should write request");
+        drop(client);
+
+        server
+            .serve_next(VERSION)
+            .expect("client disconnect should not fail server");
     }
 
     #[test]

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -99,8 +99,7 @@ impl ApiServer {
 
             match self.serve_next(version) {
                 Ok(()) => {}
-                Err(ApiServerError::Accept(std::io::ErrorKind::WouldBlock)) => {}
-                Err(ApiServerError::Accept(std::io::ErrorKind::Interrupted)) => {}
+                Err(ApiServerError::Accept(kind)) if is_transient_accept_error(kind) => {}
                 Err(err) => return Err(err),
             }
         }
@@ -119,6 +118,15 @@ impl ApiServer {
 
         Ok(())
     }
+}
+
+fn is_transient_accept_error(kind: std::io::ErrorKind) -> bool {
+    matches!(
+        kind,
+        std::io::ErrorKind::WouldBlock
+            | std::io::ErrorKind::Interrupted
+            | std::io::ErrorKind::ConnectionAborted
+    )
 }
 
 fn wait_for_listener_or_shutdown(
@@ -487,6 +495,18 @@ mod tests {
             PathBuf::from("/tmp").join(format!(".bb.{}.{}", std::process::id(), id + 1))
         );
         assert_eq!(next_id.load(Ordering::Relaxed), id + 2);
+    }
+
+    #[test]
+    fn classifies_transient_accept_errors() {
+        assert!(is_transient_accept_error(std::io::ErrorKind::WouldBlock));
+        assert!(is_transient_accept_error(std::io::ErrorKind::Interrupted));
+        assert!(is_transient_accept_error(
+            std::io::ErrorKind::ConnectionAborted
+        ));
+        assert!(!is_transient_accept_error(
+            std::io::ErrorKind::PermissionDenied
+        ));
     }
 
     #[test]

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -1,0 +1,285 @@
+use std::fs;
+use std::io::{Read, Write};
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+
+use bangbang_api::http::{handle_request_bytes, request_total_len, HttpResponse, RequestError};
+use bangbang_api::HTTP_MAX_PAYLOAD_SIZE;
+
+const READ_CHUNK_SIZE: usize = 4096;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ApiServerError {
+    Accept(std::io::ErrorKind),
+    Bind(std::io::ErrorKind),
+    Connection(std::io::ErrorKind),
+    SocketMetadata(std::io::ErrorKind),
+    SocketPathCheck(std::io::ErrorKind),
+    SocketPathExists,
+    SocketPathIsNotSocket,
+}
+
+impl std::fmt::Display for ApiServerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Accept(kind) => write!(f, "failed to accept API connection: {kind:?}"),
+            Self::Bind(kind) => write!(f, "failed to bind API socket: {kind:?}"),
+            Self::Connection(kind) => write!(f, "API connection I/O failed: {kind:?}"),
+            Self::SocketMetadata(kind) => {
+                write!(f, "failed to inspect bound API socket: {kind:?}")
+            }
+            Self::SocketPathCheck(kind) => write!(f, "failed to check API socket path: {kind:?}"),
+            Self::SocketPathExists => f.write_str("API socket path already exists"),
+            Self::SocketPathIsNotSocket => f.write_str("bound API path is not a socket"),
+        }
+    }
+}
+
+impl std::error::Error for ApiServerError {}
+
+#[derive(Debug)]
+pub(crate) struct ApiServer {
+    listener: UnixListener,
+    _socket_guard: SocketGuard,
+}
+
+impl ApiServer {
+    pub(crate) fn bind(path: impl AsRef<Path>) -> Result<Self, ApiServerError> {
+        let path = path.as_ref();
+
+        if path
+            .try_exists()
+            .map_err(|err| ApiServerError::SocketPathCheck(err.kind()))?
+        {
+            return Err(ApiServerError::SocketPathExists);
+        }
+
+        let listener = UnixListener::bind(path).map_err(|err| ApiServerError::Bind(err.kind()))?;
+        let socket_guard = SocketGuard::new(path)?;
+
+        Ok(Self {
+            listener,
+            _socket_guard: socket_guard,
+        })
+    }
+
+    pub(crate) fn run(&self, version: &str) -> Result<(), ApiServerError> {
+        loop {
+            self.serve_next(version)?;
+        }
+    }
+
+    fn serve_next(&self, version: &str) -> Result<(), ApiServerError> {
+        let (mut stream, _) = self
+            .listener
+            .accept()
+            .map_err(|err| ApiServerError::Accept(err.kind()))?;
+
+        handle_connection(&mut stream, version)
+    }
+}
+
+#[derive(Debug)]
+struct SocketGuard {
+    path: PathBuf,
+    dev: u64,
+    ino: u64,
+}
+
+impl SocketGuard {
+    fn new(path: &Path) -> Result<Self, ApiServerError> {
+        let metadata =
+            fs::metadata(path).map_err(|err| ApiServerError::SocketMetadata(err.kind()))?;
+
+        if !metadata.file_type().is_socket() {
+            return Err(ApiServerError::SocketPathIsNotSocket);
+        }
+
+        Ok(Self {
+            path: path.to_path_buf(),
+            dev: metadata.dev(),
+            ino: metadata.ino(),
+        })
+    }
+
+    fn owns_current_path(&self) -> bool {
+        let Ok(metadata) = fs::metadata(&self.path) else {
+            return false;
+        };
+
+        metadata.file_type().is_socket() && metadata.dev() == self.dev && metadata.ino() == self.ino
+    }
+}
+
+impl Drop for SocketGuard {
+    fn drop(&mut self) {
+        if self.owns_current_path() {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RequestRead {
+    Complete(Vec<u8>),
+    TooLarge,
+}
+
+fn handle_connection(stream: &mut UnixStream, version: &str) -> Result<(), ApiServerError> {
+    let response = match read_request(stream)? {
+        RequestRead::Complete(request) => handle_request_bytes(&request, version),
+        RequestRead::TooLarge => HttpResponse::fault(RequestError::PayloadTooLarge.fault_message()),
+    };
+
+    stream
+        .write_all(&response.to_http_bytes())
+        .map_err(|err| ApiServerError::Connection(err.kind()))
+}
+
+fn read_request(stream: &mut UnixStream) -> Result<RequestRead, ApiServerError> {
+    let mut request = Vec::new();
+    let mut chunk = [0; READ_CHUNK_SIZE];
+
+    loop {
+        match request_total_len(&request) {
+            Ok(Some(total_len)) if request.len() >= total_len => {
+                request.truncate(total_len);
+                return Ok(RequestRead::Complete(request));
+            }
+            Ok(Some(_)) | Ok(None) => {}
+            Err(RequestError::PayloadTooLarge) => return Ok(RequestRead::TooLarge),
+            Err(_) => return Ok(RequestRead::Complete(request)),
+        }
+
+        let remaining = HTTP_MAX_PAYLOAD_SIZE.saturating_sub(request.len());
+        if remaining == 0 {
+            return Ok(RequestRead::TooLarge);
+        }
+
+        let read_len = chunk.len().min(remaining);
+        let bytes_read = stream
+            .read(&mut chunk[..read_len])
+            .map_err(|err| ApiServerError::Connection(err.kind()))?;
+
+        if bytes_read == 0 {
+            return Ok(RequestRead::Complete(request));
+        }
+
+        request.extend_from_slice(&chunk[..bytes_read]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::io::{Read, Write};
+    use std::os::unix::net::UnixStream;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    const VERSION: &str = "0.1.0";
+
+    fn unique_socket_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        env::temp_dir().join(format!(
+            "bangbang-{name}-{}-{nanos}.socket",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn serves_version_over_unix_socket() {
+        let path = unique_socket_path("version");
+        let server = ApiServer::bind(&path).expect("server should bind");
+        let mut client = UnixStream::connect(&path).expect("client should connect");
+
+        client
+            .write_all(b"GET /version HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .expect("client should write request");
+        server
+            .serve_next(VERSION)
+            .expect("server should handle one request");
+
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("client should read response");
+
+        assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(response.contains("Content-Type: application/json\r\n"));
+        assert!(response.contains(r#"{"firecracker_version":"0.1.0"}"#));
+    }
+
+    #[test]
+    fn returns_fault_for_unsupported_path() {
+        let path = unique_socket_path("fault");
+        let server = ApiServer::bind(&path).expect("server should bind");
+        let mut client = UnixStream::connect(&path).expect("client should connect");
+
+        client
+            .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .expect("client should write request");
+        server
+            .serve_next(VERSION)
+            .expect("server should handle one request");
+
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("client should read response");
+
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        assert!(response.contains(r#"{"fault_message":"Invalid request method and/or path."}"#));
+    }
+
+    #[test]
+    fn fails_when_socket_path_exists_without_deleting_it() {
+        let path = unique_socket_path("exists");
+        fs::write(&path, "existing file").expect("fixture file should be written");
+
+        let err = ApiServer::bind(&path).expect_err("existing path should fail");
+
+        assert_eq!(err, ApiServerError::SocketPathExists);
+        assert_eq!(
+            fs::read_to_string(&path).expect("existing file should remain"),
+            "existing file"
+        );
+
+        fs::remove_file(path).expect("fixture should clean up");
+    }
+
+    #[test]
+    fn removes_owned_socket_on_drop() {
+        let path = unique_socket_path("cleanup");
+        let server = ApiServer::bind(&path).expect("server should bind");
+
+        assert!(path.exists());
+
+        drop(server);
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn does_not_remove_replaced_socket_path_on_drop() {
+        let path = unique_socket_path("replaced");
+        let server = ApiServer::bind(&path).expect("server should bind");
+
+        fs::remove_file(&path).expect("socket path should be removable");
+        fs::write(&path, "replacement").expect("replacement file should be written");
+
+        drop(server);
+
+        assert_eq!(
+            fs::read_to_string(&path).expect("replacement should remain"),
+            "replacement"
+        );
+
+        fs::remove_file(path).expect("fixture should clean up");
+    }
+}

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -50,10 +50,7 @@ impl ApiServer {
     pub(crate) fn bind(path: impl AsRef<Path>) -> Result<Self, ApiServerError> {
         let path = path.as_ref();
 
-        if path
-            .try_exists()
-            .map_err(|err| ApiServerError::SocketPathCheck(err.kind()))?
-        {
+        if path_exists_without_following_links(path)? {
             return Err(ApiServerError::SocketPathExists);
         }
 
@@ -94,7 +91,7 @@ struct SocketGuard {
 impl SocketGuard {
     fn new(path: &Path) -> Result<Self, ApiServerError> {
         let metadata =
-            fs::metadata(path).map_err(|err| ApiServerError::SocketMetadata(err.kind()))?;
+            fs::symlink_metadata(path).map_err(|err| ApiServerError::SocketMetadata(err.kind()))?;
 
         if !metadata.file_type().is_socket() {
             return Err(ApiServerError::SocketPathIsNotSocket);
@@ -108,7 +105,7 @@ impl SocketGuard {
     }
 
     fn owns_current_path(&self) -> bool {
-        let Ok(metadata) = fs::metadata(&self.path) else {
+        let Ok(metadata) = fs::symlink_metadata(&self.path) else {
             return false;
         };
 
@@ -121,6 +118,14 @@ impl Drop for SocketGuard {
         if self.owns_current_path() {
             let _ = fs::remove_file(&self.path);
         }
+    }
+}
+
+fn path_exists_without_following_links(path: &Path) -> Result<bool, ApiServerError> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(ApiServerError::SocketPathCheck(err.kind())),
     }
 }
 
@@ -206,10 +211,7 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .expect("system clock should be after unix epoch")
             .as_nanos();
-        env::temp_dir().join(format!(
-            "bangbang-{name}-{}-{nanos}.socket",
-            std::process::id()
-        ))
+        env::temp_dir().join(format!("bb-{name}-{}-{nanos}.sock", std::process::id()))
     }
 
     #[test]
@@ -258,6 +260,33 @@ mod tests {
     }
 
     #[test]
+    fn returns_fault_for_request_over_payload_limit() {
+        let path = unique_socket_path("limit");
+        let server = ApiServer::bind(&path).expect("server should bind");
+        let mut client = UnixStream::connect(&path).expect("client should connect");
+        let request = format!(
+            "GET /version HTTP/1.1\r\nContent-Length: {}\r\n\r\n",
+            HTTP_MAX_PAYLOAD_SIZE + 1
+        );
+
+        client
+            .write_all(request.as_bytes())
+            .expect("client should write request");
+        server
+            .serve_next(VERSION)
+            .expect("server should handle one request");
+
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("client should read response");
+
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        assert!(response
+            .contains(r#"{"fault_message":"HTTP request payload exceeds the configured limit."}"#));
+    }
+
+    #[test]
     fn client_disconnect_does_not_fail_server() {
         let path = unique_socket_path("disconnect");
         let server = ApiServer::bind(&path).expect("server should bind");
@@ -285,6 +314,23 @@ mod tests {
             fs::read_to_string(&path).expect("existing file should remain"),
             "existing file"
         );
+
+        fs::remove_file(path).expect("fixture should clean up");
+    }
+
+    #[test]
+    fn fails_when_socket_path_is_broken_symlink_without_deleting_it() {
+        let path = unique_socket_path("symlink");
+        let target = unique_socket_path("missing-target");
+        std::os::unix::fs::symlink(&target, &path).expect("fixture symlink should be created");
+
+        let err = ApiServer::bind(&path).expect_err("existing symlink path should fail");
+
+        assert_eq!(err, ApiServerError::SocketPathExists);
+        assert!(fs::symlink_metadata(&path)
+            .expect("symlink should remain")
+            .file_type()
+            .is_symlink());
 
         fs::remove_file(path).expect("fixture should clean up");
     }

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -3,7 +3,7 @@ use std::io::{Read, Write};
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use bangbang_api::http::{handle_request_bytes, request_total_len, HttpResponse, RequestError};
 use bangbang_api::HTTP_MAX_PAYLOAD_SIZE;
@@ -137,13 +137,10 @@ enum RequestRead {
 
 fn handle_connection(stream: &mut UnixStream, version: &str) -> Result<(), ApiServerError> {
     stream
-        .set_read_timeout(Some(CONNECTION_TIMEOUT))
-        .map_err(|err| ApiServerError::Connection(err.kind()))?;
-    stream
         .set_write_timeout(Some(CONNECTION_TIMEOUT))
         .map_err(|err| ApiServerError::Connection(err.kind()))?;
 
-    let response = match read_request(stream)? {
+    let response = match read_request(stream, CONNECTION_TIMEOUT)? {
         RequestRead::Complete(request) => handle_request_bytes(&request, version),
         RequestRead::TooLarge => HttpResponse::fault(RequestError::PayloadTooLarge.fault_message()),
     };
@@ -153,7 +150,8 @@ fn handle_connection(stream: &mut UnixStream, version: &str) -> Result<(), ApiSe
         .map_err(|err| ApiServerError::Connection(err.kind()))
 }
 
-fn read_request(stream: &mut UnixStream) -> Result<RequestRead, ApiServerError> {
+fn read_request(stream: &mut UnixStream, timeout: Duration) -> Result<RequestRead, ApiServerError> {
+    let deadline = Instant::now() + timeout;
     let mut request = Vec::new();
     let mut chunk = [0; READ_CHUNK_SIZE];
 
@@ -174,6 +172,16 @@ fn read_request(stream: &mut UnixStream) -> Result<RequestRead, ApiServerError> 
         }
 
         let read_len = chunk.len().min(remaining);
+        let Some(read_timeout) = deadline.checked_duration_since(Instant::now()) else {
+            return Ok(RequestRead::Complete(request));
+        };
+        if read_timeout.is_zero() {
+            return Ok(RequestRead::Complete(request));
+        }
+        stream
+            .set_read_timeout(Some(read_timeout))
+            .map_err(|err| ApiServerError::Connection(err.kind()))?;
+
         let bytes_read = match stream.read(&mut chunk[..read_len]) {
             Ok(bytes_read) => bytes_read,
             Err(err)
@@ -200,7 +208,7 @@ mod tests {
     use std::env;
     use std::io::{Read, Write};
     use std::os::unix::net::UnixStream;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use super::*;
 
@@ -300,6 +308,21 @@ mod tests {
         server
             .serve_next(VERSION)
             .expect("client disconnect should not fail server");
+    }
+
+    #[test]
+    fn request_read_timeout_applies_to_total_request() {
+        let (mut client, mut server) = UnixStream::pair().expect("stream pair should be created");
+        let partial_request = b"GET /version HTTP/1.1\r\n";
+
+        client
+            .write_all(partial_request)
+            .expect("client should write partial request");
+
+        let request = read_request(&mut server, Duration::from_millis(10))
+            .expect("read timeout should not fail");
+
+        assert_eq!(request, RequestRead::Complete(partial_request.to_vec()));
     }
 
     #[test]

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -3,10 +3,10 @@ use std::fs;
 use std::io::{Read, Write};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
+use std::os::unix::io::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::thread;
 use std::time::{Duration, Instant};
 
 use bangbang_api::http::{handle_request_bytes, request_total_len, HttpResponse, RequestError};
@@ -14,7 +14,6 @@ use bangbang_api::HTTP_MAX_PAYLOAD_SIZE;
 
 const READ_CHUNK_SIZE: usize = 4096;
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
-const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(100);
 static NEXT_TEMP_SOCKET_ID: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, PartialEq, Eq)]
@@ -76,21 +75,28 @@ impl ApiServer {
         &self,
         version: &str,
         shutdown_requested: &AtomicBool,
+        shutdown_wakeup: &mut UnixStream,
     ) -> Result<(), ApiServerError> {
         self.listener
             .set_nonblocking(true)
             .map_err(|err| ApiServerError::Accept(err.kind()))?;
+        shutdown_wakeup
+            .set_nonblocking(true)
+            .map_err(|err| ApiServerError::Connection(err.kind()))?;
 
         loop {
             if shutdown_requested.load(Ordering::Relaxed) {
                 return Ok(());
             }
 
+            wait_for_listener_or_shutdown(&self.listener, shutdown_wakeup)?;
+            if drain_shutdown_wakeup(shutdown_wakeup)? {
+                return Ok(());
+            }
+
             match self.serve_next(version) {
                 Ok(()) => {}
-                Err(ApiServerError::Accept(std::io::ErrorKind::WouldBlock)) => {
-                    thread::sleep(ACCEPT_RETRY_DELAY);
-                }
+                Err(ApiServerError::Accept(std::io::ErrorKind::WouldBlock)) => {}
                 Err(ApiServerError::Accept(std::io::ErrorKind::Interrupted)) => {}
                 Err(err) => return Err(err),
             }
@@ -109,6 +115,59 @@ impl ApiServer {
         let _ = handle_connection(&mut stream, version);
 
         Ok(())
+    }
+}
+
+fn wait_for_listener_or_shutdown(
+    listener: &UnixListener,
+    shutdown_wakeup: &UnixStream,
+) -> Result<(), ApiServerError> {
+    let mut poll_fds = [
+        libc::pollfd {
+            fd: listener.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        },
+        libc::pollfd {
+            fd: shutdown_wakeup.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        },
+    ];
+
+    loop {
+        // SAFETY: `poll_fds` points to two initialized `pollfd` values and
+        // remains valid for the duration of the call. The timeout is infinite.
+        let result = unsafe { libc::poll(poll_fds.as_mut_ptr(), poll_fds.len() as _, -1) };
+        if result > 0 {
+            return Ok(());
+        }
+
+        let kind = std::io::Error::last_os_error().kind();
+        if kind != std::io::ErrorKind::Interrupted {
+            return Err(ApiServerError::Accept(kind));
+        }
+    }
+}
+
+fn drain_shutdown_wakeup(shutdown_wakeup: &mut UnixStream) -> Result<bool, ApiServerError> {
+    let mut drained = false;
+    let mut buffer = [0; 64];
+
+    loop {
+        match shutdown_wakeup.read(&mut buffer) {
+            Ok(0) => return Ok(true),
+            Ok(_) => drained = true,
+            Err(err)
+                if matches!(
+                    err.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::Interrupted
+                ) =>
+            {
+                return Ok(drained);
+            }
+            Err(err) => return Err(ApiServerError::Connection(err.kind())),
+        }
     }
 }
 
@@ -339,7 +398,7 @@ mod tests {
     use std::os::unix::net::UnixStream;
     use std::sync::{Arc, Barrier};
     use std::thread;
-    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use super::*;
 
@@ -472,9 +531,13 @@ mod tests {
         let server = ApiServer::bind(&path).expect("server should bind");
         let shutdown_requested = Arc::new(AtomicBool::new(false));
         let run_shutdown_requested = Arc::clone(&shutdown_requested);
+        let (mut shutdown_reader, mut shutdown_writer) =
+            UnixStream::pair().expect("shutdown stream pair should be created");
         let mut client = UnixStream::connect(&path).expect("client should connect");
 
-        let handle = thread::spawn(move || server.run_until(VERSION, &run_shutdown_requested));
+        let handle = thread::spawn(move || {
+            server.run_until(VERSION, &run_shutdown_requested, &mut shutdown_reader)
+        });
 
         client
             .write_all(b"GET /version HTTP/1.1\r\nHost: localhost\r\n\r\n")
@@ -485,6 +548,9 @@ mod tests {
             .read_to_string(&mut response)
             .expect("client should read response");
         shutdown_requested.store(true, Ordering::Relaxed);
+        shutdown_writer
+            .write_all(b"x")
+            .expect("shutdown wakeup should be written");
 
         assert_eq!(
             handle.join().expect("server thread should not panic"),
@@ -500,19 +566,16 @@ mod tests {
         let server = ApiServer::bind(&path).expect("server should bind");
         let shutdown_requested = Arc::new(AtomicBool::new(false));
         let run_shutdown_requested = Arc::clone(&shutdown_requested);
-        let handle = thread::spawn(move || server.run_until(VERSION, &run_shutdown_requested));
+        let (mut shutdown_reader, mut shutdown_writer) =
+            UnixStream::pair().expect("shutdown stream pair should be created");
+        let handle = thread::spawn(move || {
+            server.run_until(VERSION, &run_shutdown_requested, &mut shutdown_reader)
+        });
 
         shutdown_requested.store(true, Ordering::Relaxed);
-        let deadline = Instant::now() + Duration::from_secs(1);
-        while !handle.is_finished() && Instant::now() < deadline {
-            thread::sleep(Duration::from_millis(10));
-        }
-
-        if !handle.is_finished() {
-            let _ = UnixStream::connect(&path);
-            let _ = handle.join();
-            panic!("server should exit without an external socket wake");
-        }
+        shutdown_writer
+            .write_all(b"x")
+            .expect("shutdown wakeup should be written");
 
         assert_eq!(
             handle.join().expect("server thread should not panic"),
@@ -522,7 +585,7 @@ mod tests {
     }
 
     #[test]
-    fn request_read_timeout_applies_to_total_request() {
+    fn request_read_timeout_returns_partial_request_after_expired_deadline() {
         let (mut client, mut server) = UnixStream::pair().expect("stream pair should be created");
         let partial_request = b"GET /version HTTP/1.1\r\n";
 
@@ -530,7 +593,7 @@ mod tests {
             .write_all(partial_request)
             .expect("client should write partial request");
 
-        let request = read_request(&mut server, Duration::from_millis(10))
+        let request = read_request(&mut server, Duration::from_millis(1))
             .expect("read timeout should not fail");
 
         assert_eq!(request, RequestRead::Complete(partial_request.to_vec()));

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -5,7 +5,7 @@ use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use bangbang_api::http::{handle_request_bytes, request_total_len, HttpResponse, RequestError};
@@ -70,9 +70,21 @@ impl ApiServer {
         })
     }
 
-    pub(crate) fn run(&self, version: &str) -> Result<(), ApiServerError> {
+    pub(crate) fn run_until(
+        &self,
+        version: &str,
+        shutdown_requested: &AtomicBool,
+    ) -> Result<(), ApiServerError> {
         loop {
-            self.serve_next(version)?;
+            if shutdown_requested.load(Ordering::Relaxed) {
+                return Ok(());
+            }
+
+            match self.serve_next(version) {
+                Ok(()) => {}
+                Err(ApiServerError::Accept(std::io::ErrorKind::Interrupted)) => {}
+                Err(err) => return Err(err),
+            }
         }
     }
 
@@ -81,6 +93,9 @@ impl ApiServer {
             .listener
             .accept()
             .map_err(|err| ApiServerError::Accept(err.kind()))?;
+        stream
+            .set_nonblocking(false)
+            .map_err(|err| ApiServerError::Connection(err.kind()))?;
 
         let _ = handle_connection(&mut stream, version);
 
@@ -440,6 +455,35 @@ mod tests {
         server
             .serve_next(VERSION)
             .expect("client disconnect should not fail server");
+    }
+
+    #[test]
+    fn run_until_cleans_socket_after_shutdown_request() {
+        let path = unique_socket_path("shutdown");
+        let server = ApiServer::bind(&path).expect("server should bind");
+        let shutdown_requested = Arc::new(AtomicBool::new(false));
+        let run_shutdown_requested = Arc::clone(&shutdown_requested);
+        let mut client = UnixStream::connect(&path).expect("client should connect");
+
+        let handle = thread::spawn(move || server.run_until(VERSION, &run_shutdown_requested));
+
+        client
+            .write_all(b"GET /version HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .expect("client should write request");
+
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("client should read response");
+        shutdown_requested.store(true, Ordering::Relaxed);
+        let _ = UnixStream::connect(&path);
+
+        assert_eq!(
+            handle.join().expect("server thread should not panic"),
+            Ok(())
+        );
+        assert!(response.contains(r#"{"firecracker_version":"0.1.0"}"#));
+        assert!(!path.exists());
     }
 
     #[test]

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::ffi::OsString;
 use std::fmt;
 use std::os::unix::io::IntoRawFd;
 use std::os::unix::net::UnixStream;
@@ -51,7 +52,7 @@ fn main() -> ExitCode {
 }
 
 fn run() -> Result<(), ProcessError> {
-    let args = parse_process_args(env::args().skip(1))?;
+    let args = parse_process_args(env::args_os().skip(1))?;
 
     match args.command {
         Command::Help => {
@@ -88,9 +89,9 @@ fn run() -> Result<(), ProcessError> {
 
 fn parse_process_args<I>(args: I) -> Result<Args, ProcessError>
 where
-    I: IntoIterator<Item = String>,
+    I: IntoIterator<Item = OsString>,
 {
-    Args::parse(args).map_err(ProcessError::ArgumentParsing)
+    Args::parse_os(args).map_err(ProcessError::ArgumentParsing)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -226,6 +227,32 @@ impl Default for StartupConfig {
 }
 
 impl Args {
+    fn parse_os<I>(args: I) -> Result<Self, String>
+    where
+        I: IntoIterator<Item = OsString>,
+    {
+        let args = args.into_iter().collect::<Vec<_>>();
+
+        if args.iter().any(|arg| arg == "--help" || arg == "-h") {
+            return Ok(Self {
+                command: Command::Help,
+            });
+        }
+
+        if args.iter().any(|arg| arg == "--version" || arg == "-V") {
+            return Ok(Self {
+                command: Command::Version,
+            });
+        }
+
+        let args = args
+            .into_iter()
+            .map(os_arg_into_string)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Self::parse(args)
+    }
+
     fn parse<I>(args: I) -> Result<Self, String>
     where
         I: IntoIterator<Item = String>,
@@ -292,6 +319,11 @@ impl Args {
             command: Command::Run(config),
         })
     }
+}
+
+fn os_arg_into_string(arg: OsString) -> Result<String, String> {
+    arg.into_string()
+        .map_err(|_| "invalid argument: arguments must be valid UTF-8".to_string())
 }
 
 fn print_help() {
@@ -366,6 +398,9 @@ fn unsupported_equals_syntax(arg: &str) -> Option<&'static str> {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
     use super::{
         parse_process_args, ApiServerError, Args, Command, ProcessError, ProcessExitCode,
         StartupConfig, DEFAULT_API_SOCK_PATH, DEFAULT_INSTANCE_ID, MAX_INSTANCE_ID_LEN,
@@ -411,7 +446,7 @@ mod tests {
 
     #[test]
     fn parse_process_args_wraps_parser_errors() {
-        let err = parse_process_args(["--unknown=/tmp/secret".to_string()])
+        let err = parse_process_args([OsString::from("--unknown=/tmp/secret")])
             .expect_err("process arg parsing should fail");
 
         assert_eq!(
@@ -419,6 +454,22 @@ mod tests {
             ProcessError::ArgumentParsing("unknown argument: --unknown".to_string())
         );
         assert_eq!(err.exit_code(), ProcessExitCode::ArgumentParsing);
+    }
+
+    #[test]
+    fn parse_os_help_arg_ignores_non_utf8_args() {
+        let args = Args::parse_os([OsString::from("--help"), OsString::from_vec(vec![0xff])])
+            .expect("help should bypass parsing");
+
+        assert_eq!(args.command, Command::Help);
+    }
+
+    #[test]
+    fn rejects_non_utf8_process_arg() {
+        let err =
+            Args::parse_os([OsString::from_vec(vec![0xff])]).expect_err("non-utf8 arg should fail");
+
+        assert_eq!(err, "invalid argument: arguments must be valid UTF-8");
     }
 
     #[test]

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -1,11 +1,17 @@
 use std::env;
 use std::fmt;
+use std::os::unix::net::UnixStream;
 use std::process::ExitCode;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
 
 mod api_server;
 
 use api_server::{ApiServer, ApiServerError};
 use bangbang_hvf::HvfBackend;
+use signal_hook::consts::signal::{SIGINT, SIGTERM};
+use signal_hook::iterator::{Handle as SignalHandle, Signals};
 
 const DEFAULT_API_SOCK_PATH: &str = "/tmp/bangbang.socket";
 const DEFAULT_INSTANCE_ID: &str = "anonymous-instance";
@@ -64,10 +70,11 @@ fn run() -> Result<(), ProcessError> {
                 HvfBackend::is_supported_target()
             );
 
+            let shutdown_signal = ShutdownSignal::install(config.api_sock.clone())?;
             let server = ApiServer::bind(&config.api_sock).map_err(ProcessError::ApiServer)?;
             println!("status: API server listening; VM startup is not implemented yet");
             server
-                .run(env!("CARGO_PKG_VERSION"))
+                .run_until(env!("CARGO_PKG_VERSION"), shutdown_signal.requested())
                 .map_err(ProcessError::ApiServer)?;
         }
     }
@@ -102,6 +109,7 @@ impl ProcessExitCode {
 enum ProcessError {
     ApiServer(ApiServerError),
     ArgumentParsing(String),
+    SignalHandler(std::io::ErrorKind),
 }
 
 impl ProcessError {
@@ -109,6 +117,7 @@ impl ProcessError {
         match self {
             Self::ApiServer(_) => ProcessExitCode::ProcessFailure,
             Self::ArgumentParsing(_) => ProcessExitCode::ArgumentParsing,
+            Self::SignalHandler(_) => ProcessExitCode::ProcessFailure,
         }
     }
 }
@@ -118,11 +127,59 @@ impl fmt::Display for ProcessError {
         match self {
             Self::ApiServer(err) => write!(f, "API server error: {err}"),
             Self::ArgumentParsing(message) => f.write_str(message),
+            Self::SignalHandler(kind) => {
+                write!(f, "failed to register shutdown signal handler: {kind:?}")
+            }
         }
     }
 }
 
 impl std::error::Error for ProcessError {}
+
+#[derive(Debug)]
+struct ShutdownSignal {
+    requested: Arc<AtomicBool>,
+    signal_handle: SignalHandle,
+    signal_thread: Option<thread::JoinHandle<()>>,
+}
+
+impl ShutdownSignal {
+    fn install(api_sock: String) -> Result<Self, ProcessError> {
+        let requested = Arc::new(AtomicBool::new(false));
+        let thread_requested = Arc::clone(&requested);
+        let mut signals = Signals::new([SIGINT, SIGTERM])
+            .map_err(|err| ProcessError::SignalHandler(err.kind()))?;
+        let signal_handle = signals.handle();
+        let signal_thread = thread::spawn(move || {
+            if signals.forever().next().is_some() {
+                thread_requested.store(true, Ordering::Relaxed);
+                let _ = UnixStream::connect(api_sock);
+            }
+        });
+
+        Ok(Self {
+            requested,
+            signal_handle,
+            signal_thread: Some(signal_thread),
+        })
+    }
+
+    fn requested(&self) -> &AtomicBool {
+        &self.requested
+    }
+}
+
+impl Drop for ShutdownSignal {
+    fn drop(&mut self) {
+        let should_join = !self.requested.load(Ordering::Relaxed);
+        self.signal_handle.close();
+        if should_join {
+            if let Some(signal_thread) = self.signal_thread.take() {
+                let _ = signal_thread.join();
+            }
+        }
+    }
+}
 
 #[derive(Debug, PartialEq, Eq)]
 struct Args {

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -2,6 +2,9 @@ use std::env;
 use std::fmt;
 use std::process::ExitCode;
 
+mod api_server;
+
+use api_server::{ApiServer, ApiServerError};
 use bangbang_hvf::HvfBackend;
 
 const DEFAULT_API_SOCK_PATH: &str = "/tmp/bangbang.socket";
@@ -54,13 +57,18 @@ fn run() -> Result<(), ProcessError> {
             println!("bangbang {}", env!("CARGO_PKG_VERSION"));
             return Ok(());
         }
-        Command::Run(_) => {
+        Command::Run(config) => {
             println!("bangbang {}", env!("CARGO_PKG_VERSION"));
             println!(
                 "hvf target supported: {}",
                 HvfBackend::is_supported_target()
             );
-            println!("status: startup arguments parsed; API server and VM startup are not implemented yet");
+
+            let server = ApiServer::bind(&config.api_sock).map_err(ProcessError::ApiServer)?;
+            println!("status: API server listening; VM startup is not implemented yet");
+            server
+                .run(env!("CARGO_PKG_VERSION"))
+                .map_err(ProcessError::ApiServer)?;
         }
     }
 
@@ -76,6 +84,7 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ProcessExitCode {
+    ProcessFailure = 1,
     ArgumentParsing = 153,
 }
 
@@ -91,12 +100,14 @@ impl ProcessExitCode {
 
 #[derive(Debug, PartialEq, Eq)]
 enum ProcessError {
+    ApiServer(ApiServerError),
     ArgumentParsing(String),
 }
 
 impl ProcessError {
     fn exit_code(&self) -> ProcessExitCode {
         match self {
+            Self::ApiServer(_) => ProcessExitCode::ProcessFailure,
             Self::ArgumentParsing(_) => ProcessExitCode::ArgumentParsing,
         }
     }
@@ -105,6 +116,7 @@ impl ProcessError {
 impl fmt::Display for ProcessError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::ApiServer(err) => write!(f, "API server error: {err}"),
             Self::ArgumentParsing(message) => f.write_str(message),
         }
     }
@@ -210,7 +222,7 @@ impl Args {
 
 fn print_help() {
     println!(
-        "bangbang {}\n\nUsage:\n  bangbang [OPTIONS]\n\nOptions:\n      --api-sock <PATH>  Record API socket path for future API server support [default: {}]\n      --id <ID>          MicroVM unique identifier [default: {}]\n  -V, --version          Print version\n  -h, --help             Print help\n\nCurrent scope:\n  Parses startup configuration only; no API server or VM startup is implemented yet.",
+        "bangbang {}\n\nUsage:\n  bangbang [OPTIONS]\n\nOptions:\n      --api-sock <PATH>  Unix domain socket path for the API server [default: {}]\n      --id <ID>          MicroVM unique identifier [default: {}]\n  -V, --version          Print version\n  -h, --help             Print help\n\nCurrent scope:\n  Serves GET /version over the API socket; VM startup is not implemented yet.",
         env!("CARGO_PKG_VERSION"),
         DEFAULT_API_SOCK_PATH,
         DEFAULT_INSTANCE_ID
@@ -281,8 +293,8 @@ fn unsupported_equals_syntax(arg: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_process_args, Args, Command, ProcessError, ProcessExitCode, StartupConfig,
-        DEFAULT_API_SOCK_PATH, DEFAULT_INSTANCE_ID, MAX_INSTANCE_ID_LEN,
+        parse_process_args, ApiServerError, Args, Command, ProcessError, ProcessExitCode,
+        StartupConfig, DEFAULT_API_SOCK_PATH, DEFAULT_INSTANCE_ID, MAX_INSTANCE_ID_LEN,
     };
 
     fn parse(args: &[&str]) -> Result<Args, String> {
@@ -298,7 +310,15 @@ mod tests {
 
     #[test]
     fn process_exit_code_value_matches_argument_parsing_contract() {
+        assert_eq!(ProcessExitCode::ProcessFailure.value(), 1);
         assert_eq!(ProcessExitCode::ArgumentParsing.value(), 153);
+    }
+
+    #[test]
+    fn api_server_error_maps_to_process_failure_exit_code() {
+        let err = ProcessError::ApiServer(ApiServerError::SocketPathExists);
+
+        assert_eq!(err.exit_code(), ProcessExitCode::ProcessFailure);
     }
 
     #[test]

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -1,16 +1,15 @@
 use std::env;
 use std::fmt;
 use std::process::ExitCode;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use std::thread;
 
 mod api_server;
 
 use api_server::{ApiServer, ApiServerError};
 use bangbang_hvf::HvfBackend;
 use signal_hook::consts::signal::{SIGINT, SIGTERM};
-use signal_hook::iterator::{Handle as SignalHandle, Signals};
+use signal_hook::{flag, low_level, SigId};
 
 const DEFAULT_API_SOCK_PATH: &str = "/tmp/bangbang.socket";
 const DEFAULT_INSTANCE_ID: &str = "anonymous-instance";
@@ -138,27 +137,25 @@ impl std::error::Error for ProcessError {}
 #[derive(Debug)]
 struct ShutdownSignal {
     requested: Arc<AtomicBool>,
-    signal_handle: SignalHandle,
-    signal_thread: Option<thread::JoinHandle<()>>,
+    signal_ids: [SigId; 2],
 }
 
 impl ShutdownSignal {
     fn install() -> Result<Self, ProcessError> {
         let requested = Arc::new(AtomicBool::new(false));
-        let thread_requested = Arc::clone(&requested);
-        let mut signals = Signals::new([SIGINT, SIGTERM])
+        let sigint = flag::register(SIGINT, Arc::clone(&requested))
             .map_err(|err| ProcessError::SignalHandler(err.kind()))?;
-        let signal_handle = signals.handle();
-        let signal_thread = thread::spawn(move || {
-            if signals.forever().next().is_some() {
-                thread_requested.store(true, Ordering::Relaxed);
+        let sigterm = match flag::register(SIGTERM, Arc::clone(&requested)) {
+            Ok(sigterm) => sigterm,
+            Err(err) => {
+                low_level::unregister(sigint);
+                return Err(ProcessError::SignalHandler(err.kind()));
             }
-        });
+        };
 
         Ok(Self {
             requested,
-            signal_handle,
-            signal_thread: Some(signal_thread),
+            signal_ids: [sigint, sigterm],
         })
     }
 
@@ -169,9 +166,8 @@ impl ShutdownSignal {
 
 impl Drop for ShutdownSignal {
     fn drop(&mut self) {
-        self.signal_handle.close();
-        if let Some(signal_thread) = self.signal_thread.take() {
-            let _ = signal_thread.join();
+        for signal_id in self.signal_ids {
+            low_level::unregister(signal_id);
         }
     }
 }

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -1,6 +1,5 @@
 use std::env;
 use std::fmt;
-use std::os::unix::net::UnixStream;
 use std::process::ExitCode;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -70,7 +69,7 @@ fn run() -> Result<(), ProcessError> {
                 HvfBackend::is_supported_target()
             );
 
-            let shutdown_signal = ShutdownSignal::install(config.api_sock.clone())?;
+            let shutdown_signal = ShutdownSignal::install()?;
             let server = ApiServer::bind(&config.api_sock).map_err(ProcessError::ApiServer)?;
             println!("status: API server listening; VM startup is not implemented yet");
             server
@@ -144,7 +143,7 @@ struct ShutdownSignal {
 }
 
 impl ShutdownSignal {
-    fn install(api_sock: String) -> Result<Self, ProcessError> {
+    fn install() -> Result<Self, ProcessError> {
         let requested = Arc::new(AtomicBool::new(false));
         let thread_requested = Arc::clone(&requested);
         let mut signals = Signals::new([SIGINT, SIGTERM])
@@ -153,7 +152,6 @@ impl ShutdownSignal {
         let signal_thread = thread::spawn(move || {
             if signals.forever().next().is_some() {
                 thread_requested.store(true, Ordering::Relaxed);
-                let _ = UnixStream::connect(api_sock);
             }
         });
 

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -171,12 +171,9 @@ impl ShutdownSignal {
 
 impl Drop for ShutdownSignal {
     fn drop(&mut self) {
-        let should_join = !self.requested.load(Ordering::Relaxed);
         self.signal_handle.close();
-        if should_join {
-            if let Some(signal_thread) = self.signal_thread.take() {
-                let _ = signal_thread.join();
-            }
+        if let Some(signal_thread) = self.signal_thread.take() {
+            let _ = signal_thread.join();
         }
     }
 }

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -1,15 +1,16 @@
 use std::env;
 use std::fmt;
+use std::os::unix::io::IntoRawFd;
+use std::os::unix::net::UnixStream;
 use std::process::ExitCode;
 use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 
 mod api_server;
 
 use api_server::{ApiServer, ApiServerError};
 use bangbang_hvf::HvfBackend;
 use signal_hook::consts::signal::{SIGINT, SIGTERM};
-use signal_hook::{flag, low_level, SigId};
+use signal_hook::{low_level, SigId};
 
 const DEFAULT_API_SOCK_PATH: &str = "/tmp/bangbang.socket";
 const DEFAULT_INSTANCE_ID: &str = "anonymous-instance";
@@ -68,11 +69,16 @@ fn run() -> Result<(), ProcessError> {
                 HvfBackend::is_supported_target()
             );
 
-            let shutdown_signal = ShutdownSignal::install()?;
+            let mut shutdown_signal = ShutdownSignal::install()?;
             let server = ApiServer::bind(&config.api_sock).map_err(ProcessError::ApiServer)?;
             println!("status: API server listening; VM startup is not implemented yet");
+            let (shutdown_requested, shutdown_wakeup) = shutdown_signal.parts();
             server
-                .run_until(env!("CARGO_PKG_VERSION"), shutdown_signal.requested())
+                .run_until(
+                    env!("CARGO_PKG_VERSION"),
+                    shutdown_requested,
+                    shutdown_wakeup,
+                )
                 .map_err(ProcessError::ApiServer)?;
         }
     }
@@ -136,31 +142,51 @@ impl std::error::Error for ProcessError {}
 
 #[derive(Debug)]
 struct ShutdownSignal {
-    requested: Arc<AtomicBool>,
+    requested: AtomicBool,
+    wakeup_reader: UnixStream,
     signal_ids: [SigId; 2],
 }
 
 impl ShutdownSignal {
     fn install() -> Result<Self, ProcessError> {
-        let requested = Arc::new(AtomicBool::new(false));
-        let sigint = flag::register(SIGINT, Arc::clone(&requested))
-            .map_err(|err| ProcessError::SignalHandler(err.kind()))?;
-        let sigterm = match flag::register(SIGTERM, Arc::clone(&requested)) {
+        let requested = AtomicBool::new(false);
+        let (wakeup_reader, wakeup_writer) =
+            UnixStream::pair().map_err(|err| ProcessError::SignalHandler(err.kind()))?;
+        let sigint = register_signal_wakeup(SIGINT, &wakeup_writer)?;
+        let sigterm = match register_signal_wakeup(SIGTERM, &wakeup_writer) {
             Ok(sigterm) => sigterm,
             Err(err) => {
                 low_level::unregister(sigint);
-                return Err(ProcessError::SignalHandler(err.kind()));
+                return Err(err);
             }
         };
 
         Ok(Self {
             requested,
+            wakeup_reader,
             signal_ids: [sigint, sigterm],
         })
     }
 
-    fn requested(&self) -> &AtomicBool {
-        &self.requested
+    fn parts(&mut self) -> (&AtomicBool, &mut UnixStream) {
+        (&self.requested, &mut self.wakeup_reader)
+    }
+}
+
+fn register_signal_wakeup(signal: i32, wakeup_writer: &UnixStream) -> Result<SigId, ProcessError> {
+    let wakeup_fd = wakeup_writer
+        .try_clone()
+        .map_err(|err| ProcessError::SignalHandler(err.kind()))?
+        .into_raw_fd();
+
+    match low_level::pipe::register_raw(signal, wakeup_fd) {
+        Ok(signal_id) => Ok(signal_id),
+        Err(err) => {
+            // SAFETY: `wakeup_fd` came from `UnixStream::into_raw_fd` and has
+            // not been handed to a registered signal action on this error path.
+            let _ = unsafe { libc::close(wakeup_fd) };
+            Err(ProcessError::SignalHandler(err.kind()))
+        }
     }
 }
 

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -4,7 +4,6 @@ use std::fmt;
 use std::os::unix::io::IntoRawFd;
 use std::os::unix::net::UnixStream;
 use std::process::ExitCode;
-use std::sync::atomic::AtomicBool;
 
 mod api_server;
 
@@ -73,13 +72,9 @@ fn run() -> Result<(), ProcessError> {
             let mut shutdown_signal = ShutdownSignal::install()?;
             let server = ApiServer::bind(&config.api_sock).map_err(ProcessError::ApiServer)?;
             println!("status: API server listening; VM startup is not implemented yet");
-            let (shutdown_requested, shutdown_wakeup) = shutdown_signal.parts();
+            let shutdown_wakeup = shutdown_signal.wakeup_reader();
             server
-                .run_until(
-                    env!("CARGO_PKG_VERSION"),
-                    shutdown_requested,
-                    shutdown_wakeup,
-                )
+                .run_until(env!("CARGO_PKG_VERSION"), shutdown_wakeup)
                 .map_err(ProcessError::ApiServer)?;
         }
     }
@@ -143,14 +138,12 @@ impl std::error::Error for ProcessError {}
 
 #[derive(Debug)]
 struct ShutdownSignal {
-    requested: AtomicBool,
     wakeup_reader: UnixStream,
     signal_ids: [SigId; 2],
 }
 
 impl ShutdownSignal {
     fn install() -> Result<Self, ProcessError> {
-        let requested = AtomicBool::new(false);
         let (wakeup_reader, wakeup_writer) =
             UnixStream::pair().map_err(|err| ProcessError::SignalHandler(err.kind()))?;
         let sigint = register_signal_wakeup(SIGINT, &wakeup_writer)?;
@@ -163,14 +156,13 @@ impl ShutdownSignal {
         };
 
         Ok(Self {
-            requested,
             wakeup_reader,
             signal_ids: [sigint, sigterm],
         })
     }
 
-    fn parts(&mut self) -> (&AtomicBool, &mut UnixStream) {
-        (&self.requested, &mut self.wakeup_reader)
+    fn wakeup_reader(&mut self) -> &mut UnixStream {
+        &mut self.wakeup_reader
     }
 }
 

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -41,11 +41,12 @@ compatibility decision expands the CLI parser.
 
 CLI values are untrusted input. Current validation rejects invalid IDs, empty
 socket paths, and socket paths containing control characters. API startup also
-fails if the configured socket path already exists. Socket cleanup only removes
-the socket inode created by the current process during normal shutdown; signal
-handling and forced-termination cleanup are not implemented yet. Process CLI
-parsing stays outside the future VM/vCPU fast path and should add only trivial
-startup overhead. Error and status output avoid echoing path-like CLI values.
+fails if the configured socket path already exists. Socket cleanup removes the
+socket inode created by the current process during normal shutdown and handled
+`SIGINT`/`SIGTERM` shutdown; uncatchable forced termination such as `SIGKILL`
+can still leave a stale socket path behind. Process CLI parsing stays outside
+the future VM/vCPU fast path and should add only trivial startup overhead. Error
+and status output avoid echoing path-like CLI values.
 
 ### Process Exit Status
 
@@ -53,7 +54,7 @@ The current executable uses a small process exit status contract:
 
 | Exit status | Current meaning | Compatibility notes |
 | --- | --- | --- |
-| `0` | Help or version completed successfully, or the API server exited without error. | Matches Firecracker's success status. |
+| `0` | Help or version completed successfully, or the API server exited without error, including handled `SIGINT`/`SIGTERM` shutdown. | Matches Firecracker's success status. |
 | `153` | Startup argument parsing or validation failed. | Matches Firecracker's `ArgParsing` exit code. |
 | `1` | API socket bind or accept failure. | Used for non-argument process failures before more specific Firecracker-compatible process errors exist. Per-connection read/write errors do not terminate the API server. |
 

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -44,9 +44,12 @@ socket paths, and socket paths containing control characters. API startup also
 fails if the configured socket path already exists. Socket cleanup removes the
 socket inode created by the current process during normal shutdown and handled
 `SIGINT`/`SIGTERM` shutdown; uncatchable forced termination such as `SIGKILL`
-can still leave a stale socket path behind. Process CLI parsing stays outside
-the future VM/vCPU fast path and should add only trivial startup overhead. Error
-and status output avoid echoing path-like CLI values.
+can still leave a stale socket path behind. The API socket is unauthenticated;
+filesystem permissions on the socket path and parent directory are the current
+access-control boundary. Operators should use a private socket directory or a
+restrictive umask on multi-user hosts. Process CLI parsing stays outside the
+future VM/vCPU fast path and should add only trivial startup overhead. Error and
+status output avoid echoing path-like CLI values.
 
 ### Process Exit Status
 

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -2,13 +2,13 @@
 
 This document describes bangbang's intended Firecracker compatibility scope. It
 is a planning reference for future API, VMM, and backend work; it does not mean
-the current scaffold implements the listed API behavior.
+the current scaffold implements all listed API behavior.
 
-The current repository defines crate boundaries, endpoint names, a
-backend-neutral VM trait, a minimal Hypervisor.framework VM create/destroy
-wrapper, and an initial process startup argument model. There is no API server,
-Unix socket listener, JSON request/response model, guest memory mapping, vCPU
-loop, or kernel loading yet.
+The current repository defines crate boundaries, endpoint names, a minimal
+HTTP-over-Unix-socket API server for `GET /version`, a backend-neutral VM
+trait, a minimal Hypervisor.framework VM create/destroy wrapper, and an initial
+process startup argument model. There is no broader API request body model,
+guest memory mapping, vCPU loop, or kernel loading yet.
 
 ## Firecracker Model Alignment
 
@@ -23,14 +23,14 @@ transitions, but this document only defines the initial scope.
 ## Process Startup CLI
 
 The current `bangbang` executable parses only the first process-lifecycle
-arguments. Parsing records startup configuration but does not bind a Unix
-socket, start an API server, load a configuration file, or start a guest.
+arguments and starts the first API socket surface. It binds a Unix socket and
+serves `GET /version`, but does not load a configuration file or start a guest.
 
 | Argument | Current behavior | Compatibility notes |
 | --- | --- | --- |
-| `--api-sock <PATH>` | parsed and stored | Firecracker defaults to `/run/firecracker.socket`; bangbang defaults to `/tmp/bangbang.socket` because macOS does not normally provide `/run`. This is an intentional host-platform difference. |
+| `--api-sock <PATH>` | binds the API Unix socket | Firecracker defaults to `/run/firecracker.socket`; bangbang defaults to `/tmp/bangbang.socket` because macOS does not normally provide `/run`. This is an intentional host-platform difference. |
 | `--id <ID>` | parsed and stored | Defaults to Firecracker's `anonymous-instance`. IDs must be 1 to 64 bytes and contain only alphanumeric characters or `-`, matching the Firecracker `v1.16.0` validator policy. |
-| `--help`, `-h` | prints help | Help describes the current parser-only scope. |
+| `--help`, `-h` | prints help | Help describes the current API socket scope. |
 | `--version`, `-V` | prints version | `-V` is retained from the existing bangbang scaffold. |
 | `--config-file`, `--no-api` | rejected | Deferred until VM configuration models and no-API startup behavior exist. |
 | seccomp, logger, metrics, snapshot, MMDS, boot timer, payload-size, and PCI process flags | rejected | These Firecracker options are Linux-specific, observability-related, or tied to later capability work. They must not be accepted as no-op compatibility shims. |
@@ -39,13 +39,13 @@ Only the Firecracker-style `--arg value` form is supported for the initial
 startup arguments. The `--arg=value` form is rejected until a separate
 compatibility decision expands the CLI parser.
 
-CLI values are untrusted input. Current validation is intentionally string-only:
-it rejects invalid IDs, empty socket paths, and socket paths containing control
-characters, but performs no filesystem creation, canonicalization, deletion,
-socket binding, permission checks, or VM work. Those checks belong with later
-socket lifecycle and API server work. Process CLI parsing stays outside the
-future VM/vCPU fast path and should add only trivial startup overhead. Error and
-status output avoid echoing path-like CLI values.
+CLI values are untrusted input. Current validation rejects invalid IDs, empty
+socket paths, and socket paths containing control characters. API startup also
+fails if the configured socket path already exists. Socket cleanup only removes
+the socket inode created by the current process during normal shutdown; signal
+handling and forced-termination cleanup are not implemented yet. Process CLI
+parsing stays outside the future VM/vCPU fast path and should add only trivial
+startup overhead. Error and status output avoid echoing path-like CLI values.
 
 ### Process Exit Status
 
@@ -53,9 +53,9 @@ The current executable uses a small process exit status contract:
 
 | Exit status | Current meaning | Compatibility notes |
 | --- | --- | --- |
-| `0` | Help, version, or parser-only startup completed successfully. | Matches Firecracker's success status. |
+| `0` | Help or version completed successfully, or the API server exited without error. | Matches Firecracker's success status. |
 | `153` | Startup argument parsing or validation failed. | Matches Firecracker's `ArgParsing` exit code. |
-| `1` | Reserved for future non-argument process failures. | The current scaffold has no such failure path yet. |
+| `1` | API socket bind, accept, or connection failure. | Used for non-argument process failures before more specific Firecracker-compatible process errors exist. |
 
 Firecracker also defines bad-configuration and signal-specific exit codes.
 bangbang does not expose those until the corresponding configuration loading,
@@ -94,8 +94,9 @@ before changing this reference.
 
 ## Support Level Vocabulary
 
-The current scaffold still implements no HTTP API behavior. The support levels
-below describe compatibility targets for future API work:
+The current scaffold implements only `GET /version` over HTTP on a Unix domain
+socket. The support levels below describe compatibility targets for future API
+work:
 
 - supported target: planned for the first boot-oriented API implementation
 - planned later: expected to be compatible later, but outside the first tier
@@ -117,12 +118,13 @@ deny unknown fields.
 ## Endpoint Compatibility Matrix
 
 The first planned compatibility tier is the smallest boot-oriented API surface.
-This matrix does not imply that the current scaffold implements the endpoints.
+Rows marked as implemented describe current behavior; the rest describe planned
+compatibility targets.
 
 | Method | Endpoint | Support level | Scope notes |
 | --- | --- | --- | --- |
 | `GET` | `/` | supported target | Describe the microVM instance. |
-| `GET` | `/version` | supported target | Report the VMM version with a Firecracker-shaped body. |
+| `GET` | `/version` | supported target; implemented first | Report the VMM version with a Firecracker-shaped body. |
 | `GET` | `/vm/config` | supported target | Return the full VM configuration once configuration models exist. |
 | `GET` | `/machine-config` | supported target | Return machine configuration and defaults. |
 | `PUT` | `/machine-config` | supported target | Configure vCPU and memory settings before boot. |
@@ -192,9 +194,9 @@ setup, memory size, and block device I/O when those surfaces are implemented.
 
 ## API State and Response Policy
 
-The current scaffold still implements no HTTP API behavior. The policy below is
-the first compatibility target for future request parsing, VMM action mapping,
-state validation, and golden API tests.
+The current scaffold implements the first HTTP API behavior for `GET /version`.
+The policy below is the compatibility target for future request parsing, VMM
+action mapping, state validation, and golden API tests.
 
 ### Initial API State Model
 
@@ -215,7 +217,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | Operation | Pre-boot behavior | Runtime behavior | Notes |
 | --- | --- | --- | --- |
 | `GET /` | supported target; `200` JSON | supported target; `200` JSON | Response state should reflect the current microVM state. |
-| `GET /version` | supported target; `200` JSON | supported target; `200` JSON | Body should use Firecracker's `firecracker_version` field shape. |
+| `GET /version` | implemented; `200` JSON | implemented; `200` JSON | Body uses Firecracker's `firecracker_version` field shape. |
 | `GET /vm/config` | supported target; `200` JSON | supported target; `200` JSON | Returns the accumulated or active VM configuration once models exist. |
 | `GET /machine-config` | supported target; `200` JSON | supported target; `200` JSON | Returns machine configuration and defaulted values. |
 | `PUT /machine-config` | supported target; `204` empty response on success | unsupported after start; `400` `fault_message` | Pre-boot-only configuration. |
@@ -241,6 +243,12 @@ Future API work should use `fault_message` consistently where Firecracker does.
 Exact message strings should be covered by golden tests once the API parser and
 VMM action model exist, but this document only defines the initial status/body
 shape.
+
+The initial API implementation uses Firecracker's default `51200` byte HTTP
+request payload limit. The `--http-api-max-payload-size` process argument
+remains rejected until configurable payload limits are introduced explicitly.
+Invalid path and method errors use the Firecracker `fault_message` body shape
+but intentionally avoid echoing path-like request values.
 
 API request bodies, path identifiers, and host resource paths are untrusted
 input. Future implementations must validate them before mutating VMM state and

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -249,6 +249,8 @@ request payload limit. The `--http-api-max-payload-size` process argument
 remains rejected until configurable payload limits are introduced explicitly.
 Invalid path and method errors use the Firecracker `fault_message` body shape
 but intentionally avoid echoing path-like request values.
+The initial blocking API server also uses a short per-connection timeout so an
+incomplete request cannot hold the single server loop indefinitely.
 
 API request bodies, path identifiers, and host resource paths are untrusted
 input. Future implementations must validate them before mutating VMM state and

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -55,7 +55,7 @@ The current executable uses a small process exit status contract:
 | --- | --- | --- |
 | `0` | Help or version completed successfully, or the API server exited without error. | Matches Firecracker's success status. |
 | `153` | Startup argument parsing or validation failed. | Matches Firecracker's `ArgParsing` exit code. |
-| `1` | API socket bind, accept, or connection failure. | Used for non-argument process failures before more specific Firecracker-compatible process errors exist. |
+| `1` | API socket bind or accept failure. | Used for non-argument process failures before more specific Firecracker-compatible process errors exist. Per-connection read/write errors do not terminate the API server. |
 
 Firecracker also defines bad-configuration and signal-specific exit codes.
 bangbang does not expose those until the corresponding configuration loading,


### PR DESCRIPTION
## Summary

- add a minimal Firecracker-shaped HTTP API layer for `GET /version`
- bind `--api-sock` as a Unix domain socket and serve one request per connection
- add socket safety tests for existing paths, normal cleanup, and replaced paths
- update README and compatibility docs for the new API socket behavior

Closes #43.

## Validation

```sh
cargo fmt --all -- --check
cargo check
cargo test
cargo clippy --all-targets -- -D warnings
```

Manual smoke:

```sh
cargo run -p bangbang -- --api-sock <tmp-socket>
curl --unix-socket <tmp-socket> http://localhost/version
```

Returned:

```json
{"firecracker_version":"0.1.0"}
```

## Scope Notes

- Only `GET /version` is implemented.
- VM state, VMM action channels, other API endpoints, signal handling, and concurrent serving remain out of scope.
