### PR TITLE
fix: restrict instance ids to ascii

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cargo run -p bangbang -- --api-sock /tmp/bangbang.socket --id demo-1
 ```
 
 - `--api-sock <PATH>` sets the Unix socket path for the API server. The default is `/tmp/bangbang.socket`.
-- `--id <ID>` records the microVM identifier. The default is `anonymous-instance`.
+- `--id <ID>` records the microVM identifier. IDs must be 1 to 64 bytes and contain only ASCII alphanumeric characters or `-`. The default is `anonymous-instance`.
 - `--help`, `-h`, `--version`, and `-V` are supported.
 
 `bangbang` binds the configured socket path, serves `GET /version`, and stays running until `SIGINT` or `SIGTERM` requests shutdown. Unsupported Firecracker process options such as `--config-file`, `--no-api`, seccomp, logging, metrics, snapshot, MMDS, and PCI flags are rejected instead of ignored.

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -635,6 +635,17 @@ mod tests {
     }
 
     #[test]
+    fn rejects_multibyte_id_over_max_length_by_bytes() {
+        let id = "é".repeat(MAX_INSTANCE_ID_LEN / 2 + 1);
+        let err = Args::parse(["--id".to_string(), id]).expect_err("long id should fail");
+
+        assert_eq!(
+            err,
+            "invalid --id: invalid length 66; length must be between 1 and 64"
+        );
+    }
+
+    #[test]
     fn rejects_unsupported_firecracker_config_file_arg() {
         let err = parse(&["--config-file", "vm.json"]).expect_err("unsupported arg should fail");
 

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -320,7 +320,7 @@ fn os_arg_into_string(arg: OsString) -> Result<String, String> {
 
 fn print_help() {
     println!(
-        "bangbang {}\n\nUsage:\n  bangbang [OPTIONS]\n\nOptions:\n      --api-sock <PATH>  Unix domain socket path for the API server [default: {}]\n      --id <ID>          MicroVM unique identifier: 1-64 bytes, ASCII alphanumeric or '-' [default: {}]\n  -V, --version          Print version\n  -h, --help             Print help\n\nCurrent scope:\n  Serves GET /version over the API socket; VM startup is not implemented yet.",
+        "bangbang {}\n\nUsage:\n  bangbang [OPTIONS]\n\nOptions:\n      --api-sock <PATH>  Unix domain socket path for the API server [default: {}]\n      --id <ID>          MicroVM unique identifier [default: {}]\n                         Accepts 1-64 bytes, ASCII alphanumeric or '-'\n  -V, --version          Print version\n  -h, --help             Print help\n\nCurrent scope:\n  Serves GET /version over the API socket; VM startup is not implemented yet.",
         env!("CARGO_PKG_VERSION"),
         DEFAULT_API_SOCK_PATH,
         DEFAULT_INSTANCE_ID

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -357,7 +357,7 @@ fn validate_instance_id(id: &str) -> Result<(), String> {
     }
 
     for (position, ch) in id.chars().enumerate() {
-        if !(ch == '-' || ch.is_alphanumeric()) {
+        if !(ch == '-' || ch.is_ascii_alphanumeric()) {
             return Err(format!(
                 "invalid --id: invalid character {ch:?} at position {position}"
             ));
@@ -614,6 +614,13 @@ mod tests {
         let err = parse(&["--id", "vm:1"]).expect_err("colon id should fail");
 
         assert_eq!(err, "invalid --id: invalid character ':' at position 2");
+    }
+
+    #[test]
+    fn rejects_id_with_non_ascii_alphanumeric() {
+        let err = parse(&["--id", "vmé1"]).expect_err("non-ascii id should fail");
+
+        assert_eq!(err, "invalid --id: invalid character 'é' at position 2");
     }
 
     #[test]

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -320,7 +320,7 @@ fn os_arg_into_string(arg: OsString) -> Result<String, String> {
 
 fn print_help() {
     println!(
-        "bangbang {}\n\nUsage:\n  bangbang [OPTIONS]\n\nOptions:\n      --api-sock <PATH>  Unix domain socket path for the API server [default: {}]\n      --id <ID>          MicroVM unique identifier [default: {}]\n  -V, --version          Print version\n  -h, --help             Print help\n\nCurrent scope:\n  Serves GET /version over the API socket; VM startup is not implemented yet.",
+        "bangbang {}\n\nUsage:\n  bangbang [OPTIONS]\n\nOptions:\n      --api-sock <PATH>  Unix domain socket path for the API server [default: {}]\n      --id <ID>          MicroVM unique identifier: 1-64 bytes, ASCII alphanumeric or '-' [default: {}]\n  -V, --version          Print version\n  -h, --help             Print help\n\nCurrent scope:\n  Serves GET /version over the API socket; VM startup is not implemented yet.",
         env!("CARGO_PKG_VERSION"),
         DEFAULT_API_SOCK_PATH,
         DEFAULT_INSTANCE_ID
@@ -618,9 +618,15 @@ mod tests {
 
     #[test]
     fn rejects_id_with_non_ascii_alphanumeric() {
-        let err = parse(&["--id", "vmé1"]).expect_err("non-ascii id should fail");
+        const NON_ASCII_ALPHANUMERIC: char = '\u{e9}';
 
-        assert_eq!(err, "invalid --id: invalid character 'é' at position 2");
+        let id = format!("vm{NON_ASCII_ALPHANUMERIC}1");
+        let err = Args::parse(["--id".to_string(), id]).expect_err("non-ascii id should fail");
+
+        assert_eq!(
+            err,
+            format!("invalid --id: invalid character {NON_ASCII_ALPHANUMERIC:?} at position 2")
+        );
     }
 
     #[test]
@@ -636,7 +642,7 @@ mod tests {
 
     #[test]
     fn rejects_multibyte_id_over_max_length_by_bytes() {
-        let id = "é".repeat(MAX_INSTANCE_ID_LEN / 2 + 1);
+        let id = "\u{e9}".repeat(MAX_INSTANCE_ID_LEN / 2 + 1);
         let err = Args::parse(["--id".to_string(), id]).expect_err("long id should fail");
 
         assert_eq!(

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -29,7 +29,7 @@ serves `GET /version`, but does not load a configuration file or start a guest.
 | Argument | Current behavior | Compatibility notes |
 | --- | --- | --- |
 | `--api-sock <PATH>` | binds the API Unix socket | Firecracker defaults to `/run/firecracker.socket`; bangbang defaults to `/tmp/bangbang.socket` because macOS does not normally provide `/run`. This is an intentional host-platform difference. |
-| `--id <ID>` | parsed and stored | Defaults to Firecracker's `anonymous-instance`. IDs must be 1 to 64 bytes and contain only alphanumeric characters or `-`, matching the Firecracker `v1.16.0` validator policy. |
+| `--id <ID>` | parsed and stored | Defaults to Firecracker's `anonymous-instance`. IDs must be 1 to 64 bytes and contain only ASCII alphanumeric characters or `-`. |
 | `--help`, `-h` | prints help | Help describes the current API socket scope. |
 | `--version`, `-V` | prints version | `-V` is retained from the existing bangbang scaffold. |
 | `--config-file`, `--no-api` | rejected | Deferred until VM configuration models and no-API startup behavior exist. |

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -35,6 +35,10 @@ serves `GET /version`, but does not load a configuration file or start a guest.
 | `--config-file`, `--no-api` | rejected | Deferred until VM configuration models and no-API startup behavior exist. |
 | seccomp, logger, metrics, snapshot, MMDS, boot timer, payload-size, and PCI process flags | rejected | These Firecracker options are Linux-specific, observability-related, or tied to later capability work. They must not be accepted as no-op compatibility shims. |
 
+bangbang intentionally treats `--id` alphanumeric characters as ASCII only.
+This is stricter than Firecracker `v1.16.0`'s Rust validator, which accepts
+Unicode alphanumeric characters.
+
 Only the Firecracker-style `--arg value` form is supported for the initial
 startup arguments. The `--arg=value` form is rejected until a separate
 compatibility decision expands the CLI parser.


### PR DESCRIPTION
## Summary

- Restrict `--id` validation to ASCII alphanumeric characters plus `-`.
- Add regression tests for rejecting non-ASCII alphanumeric IDs and preserving byte-based length limits for multibyte IDs.
- Update `--help`, README, and Firecracker compatibility docs to state the ASCII policy and intentional divergence explicitly.

## Compatibility Notes

This intentionally follows #45's ASCII-only acceptance criteria. Firecracker `v1.16.0` uses Rust's Unicode-aware `char::is_alphanumeric()` for instance ID validation, so this PR documents bangbang's stricter current policy.

## Verification

- `cargo run -p bangbang -- --help`
- `cargo test -p bangbang rejects_id_with_non_ascii_alphanumeric --locked`
- `cargo test -p bangbang rejects_multibyte_id_over_max_length_by_bytes --locked`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`

Closes #45
