### PR TITLE
feat: add VMM control model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.1.0"
 dependencies = [
  "bangbang-api",
  "bangbang-hvf",
+ "bangbang-runtime",
  "libc",
  "signal-hook",
 ]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 bangbang is a Rust VMM project for macOS hosts. The public control plane is intended to stay compatible with the Firecracker HTTP API over a Unix domain socket, while the VM backend is built on Apple's Hypervisor.framework.
 
-This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a backend trait, and the smallest Hypervisor.framework VM create/destroy wrapper.
+This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, and the smallest Hypervisor.framework VM create/destroy wrapper.
 
 See [Firecracker Compatibility Scope](docs/firecracker-compatibility.md) for the intended compatibility target and current limitations.
 See [Pull Request Review Guidelines](docs/review-guidelines.md) for the project-specific review standard.
@@ -18,7 +18,7 @@ crates/bangbang   VMM process entrypoint and startup CLI
 
 ## Current Scope
 
-The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /version` only. It intentionally does not include:
+The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /version` only, routed through a minimal read-only VMM action model. It intentionally does not include:
 
 - API endpoints beyond `GET /version`
 - JSON request body models

--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -104,13 +104,6 @@ impl HttpResponse {
     }
 }
 
-pub fn handle_request_bytes(bytes: &[u8], version: &str) -> HttpResponse {
-    match parse_request(bytes) {
-        Ok(ApiRequest::GetVersion) => HttpResponse::version(version),
-        Err(err) => HttpResponse::fault(err.fault_message()),
-    }
-}
-
 pub fn parse_request(bytes: &[u8]) -> Result<ApiRequest, RequestError> {
     if bytes.len() > HTTP_MAX_PAYLOAD_SIZE {
         return Err(RequestError::PayloadTooLarge);
@@ -445,14 +438,5 @@ mod tests {
         assert!(text.contains("Content-Type: application/json\r\n"));
         assert!(text.contains(&format!("Content-Length: {}\r\n", response.body().len())));
         assert!(text.ends_with(r#"{"firecracker_version":"0.1.0"}"#));
-    }
-
-    #[test]
-    fn handles_request_bytes_as_response() {
-        let response =
-            handle_request_bytes(b"GET /version HTTP/1.1\r\nHost: localhost\r\n\r\n", VERSION);
-
-        assert_eq!(response.status(), StatusCode::Ok);
-        assert_eq!(response.body(), r#"{"firecracker_version":"0.1.0"}"#);
     }
 }

--- a/crates/bangbang/Cargo.toml
+++ b/crates/bangbang/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 [dependencies]
 bangbang-api = { path = "../api" }
 bangbang-hvf = { path = "../hvf" }
+bangbang-runtime = { path = "../runtime" }
 libc = "0.2"
 signal-hook = "0.3"
 

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -9,8 +9,11 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-use bangbang_api::http::{handle_request_bytes, request_total_len, HttpResponse, RequestError};
+use bangbang_api::http::{
+    parse_request, request_total_len, ApiRequest, HttpResponse, RequestError,
+};
 use bangbang_api::HTTP_MAX_PAYLOAD_SIZE;
+use bangbang_runtime::{VmmAction, VmmController, VmmData};
 
 const READ_CHUNK_SIZE: usize = 4096;
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
@@ -76,7 +79,7 @@ impl ApiServer {
 
     pub(crate) fn run_until(
         &self,
-        version: &str,
+        vmm: &mut VmmController,
         shutdown_wakeup: &mut UnixStream,
     ) -> Result<(), ApiServerError> {
         self.listener
@@ -92,7 +95,7 @@ impl ApiServer {
                 return Ok(());
             }
 
-            match self.serve_next(version) {
+            match self.serve_next(vmm) {
                 Ok(()) => {}
                 Err(ApiServerError::Accept(kind)) if is_transient_accept_error(kind) => {}
                 Err(err) => return Err(err),
@@ -100,7 +103,7 @@ impl ApiServer {
         }
     }
 
-    fn serve_next(&self, version: &str) -> Result<(), ApiServerError> {
+    fn serve_next(&self, vmm: &mut VmmController) -> Result<(), ApiServerError> {
         let (mut stream, _) = self
             .listener
             .accept()
@@ -109,7 +112,7 @@ impl ApiServer {
             .set_nonblocking(false)
             .map_err(|err| ApiServerError::Connection(err.kind()))?;
 
-        let _ = handle_connection(&mut stream, version);
+        let _ = handle_connection(&mut stream, vmm);
 
         Ok(())
     }
@@ -352,19 +355,49 @@ enum RequestRead {
     TooLarge,
 }
 
-fn handle_connection(stream: &mut UnixStream, version: &str) -> Result<(), ApiServerError> {
+fn handle_connection(
+    stream: &mut UnixStream,
+    vmm: &mut VmmController,
+) -> Result<(), ApiServerError> {
     stream
         .set_write_timeout(Some(CONNECTION_TIMEOUT))
         .map_err(|err| ApiServerError::Connection(err.kind()))?;
 
     let response = match read_request(stream, CONNECTION_TIMEOUT)? {
-        RequestRead::Complete(request) => handle_request_bytes(&request, version),
+        RequestRead::Complete(request) => handle_request_bytes(&request, vmm),
         RequestRead::TooLarge => HttpResponse::fault(RequestError::PayloadTooLarge.fault_message()),
     };
 
     stream
         .write_all(&response.to_http_bytes())
         .map_err(|err| ApiServerError::Connection(err.kind()))
+}
+
+fn handle_request_bytes(bytes: &[u8], vmm: &mut VmmController) -> HttpResponse {
+    match parse_request(bytes) {
+        Ok(request) => handle_api_request(request, vmm),
+        Err(err) => HttpResponse::fault(err.fault_message()),
+    }
+}
+
+fn handle_api_request(request: ApiRequest, vmm: &mut VmmController) -> HttpResponse {
+    match request {
+        ApiRequest::GetVersion => handle_vmm_data(
+            vmm.handle_action(VmmAction::GetVmmVersion),
+            "version request returned unexpected VMM data.",
+        ),
+    }
+}
+
+fn handle_vmm_data(
+    result: Result<VmmData, bangbang_runtime::VmmActionError>,
+    unexpected_message: &str,
+) -> HttpResponse {
+    match result {
+        Ok(VmmData::VmmVersion(version)) => HttpResponse::version(&version),
+        Ok(VmmData::InstanceInformation(_)) => HttpResponse::fault(unexpected_message),
+        Err(err) => HttpResponse::fault(&err.to_string()),
+    }
 }
 
 fn read_request(stream: &mut UnixStream, timeout: Duration) -> Result<RequestRead, ApiServerError> {
@@ -443,6 +476,10 @@ mod tests {
 
     const VERSION: &str = "0.1.0";
 
+    fn test_controller() -> VmmController {
+        VmmController::new("demo-1", VERSION, "bangbang")
+    }
+
     fn unique_socket_path(name: &str) -> PathBuf {
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -505,6 +542,19 @@ mod tests {
     }
 
     #[test]
+    fn dispatches_version_request_through_vmm_controller() {
+        let mut vmm = VmmController::new("demo-1", "9.9.9", "bangbang");
+
+        let response = handle_request_bytes(
+            b"GET /version HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            &mut vmm,
+        );
+
+        assert_eq!(response.status(), bangbang_api::http::StatusCode::Ok);
+        assert_eq!(response.body(), r#"{"firecracker_version":"9.9.9"}"#);
+    }
+
+    #[test]
     fn socket_path_cleanup_keeps_replaced_path() {
         let path = unique_socket_path("cln");
         let listener = UnixListener::bind(&path).expect("temporary listener should bind");
@@ -553,8 +603,9 @@ mod tests {
         client
             .write_all(b"GET /version HTTP/1.1\r\nHost: localhost\r\n\r\n")
             .expect("client should write request");
+        let mut vmm = test_controller();
         server
-            .serve_next(VERSION)
+            .serve_next(&mut vmm)
             .expect("server should handle one request");
 
         let mut response = String::new();
@@ -576,8 +627,9 @@ mod tests {
         client
             .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
             .expect("client should write request");
+        let mut vmm = test_controller();
         server
-            .serve_next(VERSION)
+            .serve_next(&mut vmm)
             .expect("server should handle one request");
 
         let mut response = String::new();
@@ -602,8 +654,9 @@ mod tests {
         client
             .write_all(request.as_bytes())
             .expect("client should write request");
+        let mut vmm = test_controller();
         server
-            .serve_next(VERSION)
+            .serve_next(&mut vmm)
             .expect("server should handle one request");
 
         let mut response = String::new();
@@ -627,8 +680,9 @@ mod tests {
             .expect("client should write request");
         drop(client);
 
+        let mut vmm = test_controller();
         server
-            .serve_next(VERSION)
+            .serve_next(&mut vmm)
             .expect("client disconnect should not fail server");
     }
 
@@ -640,7 +694,10 @@ mod tests {
             UnixStream::pair().expect("shutdown stream pair should be created");
         let mut client = UnixStream::connect(&path).expect("client should connect");
 
-        let handle = thread::spawn(move || server.run_until(VERSION, &mut shutdown_reader));
+        let handle = thread::spawn(move || {
+            let mut vmm = test_controller();
+            server.run_until(&mut vmm, &mut shutdown_reader)
+        });
 
         client
             .write_all(b"GET /version HTTP/1.1\r\nHost: localhost\r\n\r\n")
@@ -668,7 +725,10 @@ mod tests {
         let server = ApiServer::bind(&path).expect("server should bind");
         let (mut shutdown_reader, mut shutdown_writer) =
             UnixStream::pair().expect("shutdown stream pair should be created");
-        let handle = thread::spawn(move || server.run_until(VERSION, &mut shutdown_reader));
+        let handle = thread::spawn(move || {
+            let mut vmm = test_controller();
+            server.run_until(&mut vmm, &mut shutdown_reader)
+        });
 
         shutdown_writer
             .write_all(b"x")

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -9,11 +9,13 @@ mod api_server;
 
 use api_server::{ApiServer, ApiServerError};
 use bangbang_hvf::HvfBackend;
+use bangbang_runtime::VmmController;
 use signal_hook::consts::signal::{SIGINT, SIGTERM};
 use signal_hook::{low_level, SigId};
 
 const DEFAULT_API_SOCK_PATH: &str = "/tmp/bangbang.socket";
 const DEFAULT_INSTANCE_ID: &str = "anonymous-instance";
+const APP_NAME: &str = "bangbang";
 const MIN_INSTANCE_ID_LEN: usize = 1;
 const MAX_INSTANCE_ID_LEN: usize = 64;
 const UNSUPPORTED_FIRECRACKER_ARGS: &[&str] = &[
@@ -71,10 +73,11 @@ fn run() -> Result<(), ProcessError> {
 
             let mut shutdown_signal = ShutdownSignal::install()?;
             let server = ApiServer::bind(&config.api_sock).map_err(ProcessError::ApiServer)?;
+            let mut vmm = VmmController::new(config.id, env!("CARGO_PKG_VERSION"), APP_NAME);
             println!("status: API server listening; VM startup is not implemented yet");
             let shutdown_wakeup = shutdown_signal.wakeup_reader();
             server
-                .run_until(env!("CARGO_PKG_VERSION"), shutdown_wakeup)
+                .run_until(&mut vmm, shutdown_wakeup)
                 .map_err(ProcessError::ApiServer)?;
         }
     }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -2,6 +2,133 @@
 
 use std::fmt;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum InstanceState {
+    #[default]
+    NotStarted,
+    Running,
+    Paused,
+}
+
+impl fmt::Display for InstanceState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotStarted => f.write_str("Not started"),
+            Self::Running => f.write_str("Running"),
+            Self::Paused => f.write_str("Paused"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstanceInfo {
+    pub id: String,
+    pub state: InstanceState,
+    pub vmm_version: String,
+    pub app_name: String,
+}
+
+impl InstanceInfo {
+    pub fn new(
+        id: impl Into<String>,
+        state: InstanceState,
+        vmm_version: impl Into<String>,
+        app_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            state,
+            vmm_version: vmm_version.into(),
+            app_name: app_name.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VmmAction {
+    GetVmmVersion,
+    GetVmInstanceInfo,
+}
+
+impl VmmAction {
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::GetVmmVersion => "GetVmmVersion",
+            Self::GetVmInstanceInfo => "GetVmInstanceInfo",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VmmData {
+    VmmVersion(String),
+    InstanceInformation(InstanceInfo),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VmmActionError {
+    UnsupportedAction(&'static str),
+    UnsupportedState {
+        action: &'static str,
+        state: InstanceState,
+    },
+}
+
+impl fmt::Display for VmmActionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedAction(action) => {
+                write!(f, "The requested operation is not supported: {action}")
+            }
+            Self::UnsupportedState { action, state } => {
+                write!(
+                    f,
+                    "The requested operation is not supported in {state} state: {action}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for VmmActionError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VmmController {
+    instance_info: InstanceInfo,
+}
+
+impl VmmController {
+    pub fn new(
+        instance_id: impl Into<String>,
+        vmm_version: impl Into<String>,
+        app_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            instance_info: InstanceInfo::new(
+                instance_id,
+                InstanceState::NotStarted,
+                vmm_version,
+                app_name,
+            ),
+        }
+    }
+
+    pub fn instance_info(&self) -> &InstanceInfo {
+        &self.instance_info
+    }
+
+    pub fn handle_action(&mut self, action: VmmAction) -> Result<VmmData, VmmActionError> {
+        match action {
+            VmmAction::GetVmmVersion => {
+                Ok(VmmData::VmmVersion(self.instance_info.vmm_version.clone()))
+            }
+            VmmAction::GetVmInstanceInfo => {
+                Ok(VmmData::InstanceInformation(self.instance_info.clone()))
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BackendError {
     Unsupported(&'static str),
@@ -26,7 +153,83 @@ pub trait VmBackend: fmt::Debug {
 
 #[cfg(test)]
 mod tests {
-    use super::BackendError;
+    use super::{BackendError, InstanceState, VmmAction, VmmActionError, VmmController, VmmData};
+
+    #[test]
+    fn displays_not_started_state() {
+        assert_eq!(InstanceState::NotStarted.to_string(), "Not started");
+    }
+
+    #[test]
+    fn displays_running_state() {
+        assert_eq!(InstanceState::Running.to_string(), "Running");
+    }
+
+    #[test]
+    fn displays_paused_state() {
+        assert_eq!(InstanceState::Paused.to_string(), "Paused");
+    }
+
+    #[test]
+    fn controller_initializes_instance_info() {
+        let controller = VmmController::new("demo-1", "0.1.0", "bangbang");
+
+        let info = controller.instance_info();
+        assert_eq!(info.id, "demo-1");
+        assert_eq!(info.state, InstanceState::NotStarted);
+        assert_eq!(info.vmm_version, "0.1.0");
+        assert_eq!(info.app_name, "bangbang");
+    }
+
+    #[test]
+    fn handles_get_vmm_version() {
+        let mut controller = VmmController::new("demo-1", "0.1.0", "bangbang");
+
+        assert_eq!(
+            controller.handle_action(VmmAction::GetVmmVersion),
+            Ok(VmmData::VmmVersion("0.1.0".to_string()))
+        );
+    }
+
+    #[test]
+    fn handles_get_vm_instance_info() {
+        let mut controller = VmmController::new("demo-1", "0.1.0", "bangbang");
+
+        let data = controller
+            .handle_action(VmmAction::GetVmInstanceInfo)
+            .expect("instance info should be returned");
+
+        let VmmData::InstanceInformation(info) = data else {
+            panic!("expected instance info");
+        };
+        assert_eq!(info.id, "demo-1");
+        assert_eq!(info.state, InstanceState::NotStarted);
+        assert_eq!(info.vmm_version, "0.1.0");
+        assert_eq!(info.app_name, "bangbang");
+    }
+
+    #[test]
+    fn displays_unsupported_action_error() {
+        let err = VmmActionError::UnsupportedAction(VmmAction::GetVmInstanceInfo.name());
+
+        assert_eq!(
+            err.to_string(),
+            "The requested operation is not supported: GetVmInstanceInfo"
+        );
+    }
+
+    #[test]
+    fn displays_unsupported_state_error() {
+        let err = VmmActionError::UnsupportedState {
+            action: VmmAction::GetVmmVersion.name(),
+            state: InstanceState::Running,
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "The requested operation is not supported in Running state: GetVmmVersion"
+        );
+    }
 
     #[test]
     fn displays_unsupported_error() {

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -6,9 +6,10 @@ the current scaffold implements all listed API behavior.
 
 The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /version`, a backend-neutral VM
-trait, a minimal Hypervisor.framework VM create/destroy wrapper, and an initial
-process startup argument model. There is no broader API request body model,
-guest memory mapping, vCPU loop, or kernel loading yet.
+trait, a minimal read-only VMM action/data model, a minimal
+Hypervisor.framework VM create/destroy wrapper, and an initial process startup
+argument model. There is no broader API request body model, guest memory
+mapping, vCPU loop, or kernel loading yet.
 
 ## Firecracker Model Alignment
 
@@ -17,8 +18,10 @@ manages one microVM. Future API work should keep the control plane outside the
 guest execution fast path.
 
 The intended public control plane is Firecracker-style HTTP over a Unix domain
-socket. API requests should eventually map to explicit VMM actions and VM state
-transitions, but this document only defines the initial scope.
+socket. The implemented `GET /version` request already maps through a minimal
+internal VMM action/data boundary. Future API requests should map to explicit
+VMM actions and VM state transitions, but this document only defines the
+initial scope.
 
 ## Process Startup CLI
 
@@ -205,6 +208,11 @@ setup, memory size, and block device I/O when those surfaces are implemented.
 The current scaffold implements the first HTTP API behavior for `GET /version`.
 The policy below is the compatibility target for future request parsing, VMM
 action mapping, state validation, and golden API tests.
+
+The implemented `GET /version` path currently flows through the minimal
+read-only VMM action model as `GetVmmVersion` and returns VMM version data.
+The internal instance information state model also exists for future `GET /`,
+but `GET /` itself is not implemented yet.
 
 ### Initial API State Model
 


### PR DESCRIPTION
## Summary

- Add a minimal runtime VMM control model for instance state, instance info, read-only actions, response data, and action errors.
- Route the existing `GET /version` path through `bangbang-runtime` while keeping `bangbang-api` focused on parsing and response formatting.
- Update README and Firecracker compatibility docs to describe the internal action boundary without claiming new public endpoints.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`

Closes #51
