### PR TITLE
feat: serve instance info endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ crates/bangbang   VMM process entrypoint and startup CLI
 
 ## Current Scope
 
-The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /version` only, routed through a minimal read-only VMM action model. It intentionally does not include:
+The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. It intentionally does not include:
 
-- API endpoints beyond `GET /version`
+- API endpoints beyond `GET /` and `GET /version`
 - JSON request body models
 - guest memory mapping
 - vCPU creation or a run loop
@@ -38,19 +38,29 @@ cargo run -p bangbang -- --api-sock /tmp/bangbang.socket --id demo-1
 - `--id <ID>` records the microVM identifier. IDs must be 1 to 64 bytes and contain only ASCII alphanumeric characters or `-`. The default is `anonymous-instance`.
 - `--help`, `-h`, `--version`, and `-V` are supported.
 
-`bangbang` binds the configured socket path, serves `GET /version`, and stays running until `SIGINT` or `SIGTERM` requests shutdown. Unsupported Firecracker process options such as `--config-file`, `--no-api`, seccomp, logging, metrics, snapshot, MMDS, and PCI flags are rejected instead of ignored.
+`bangbang` binds the configured socket path, serves `GET /` and `GET /version`, and stays running until `SIGINT` or `SIGTERM` requests shutdown. Unsupported Firecracker process options such as `--config-file`, `--no-api`, seccomp, logging, metrics, snapshot, MMDS, and PCI flags are rejected instead of ignored.
 
 The API socket is an unauthenticated local control interface. Filesystem
 permissions on the socket path and parent directory are the access-control
 boundary, so use a private directory or restrictive umask on multi-user hosts.
 
-Query the first supported endpoint:
+Query the supported read-only endpoints:
+
+```sh
+curl --unix-socket /tmp/bangbang.socket http://localhost/
+```
+
+The instance info response is Firecracker-shaped JSON:
+
+```json
+{"app_name":"bangbang","id":"demo-1","state":"Not started","vmm_version":"0.1.0"}
+```
 
 ```sh
 curl --unix-socket /tmp/bangbang.socket http://localhost/version
 ```
 
-The response body is Firecracker-shaped JSON:
+The version response body is Firecracker-shaped JSON:
 
 ```json
 {"firecracker_version":"0.1.0"}

--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -7,6 +7,7 @@ const MAX_HEADERS: usize = 32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApiRequest {
+    GetInstanceInfo,
     GetVersion,
 }
 
@@ -66,6 +67,21 @@ pub struct HttpResponse {
 }
 
 impl HttpResponse {
+    pub fn instance_info(id: &str, state: &str, vmm_version: &str, app_name: &str) -> Self {
+        let body = serde_json::json!({
+            "app_name": app_name,
+            "id": id,
+            "state": state,
+            "vmm_version": vmm_version,
+        })
+        .to_string();
+
+        Self {
+            status: StatusCode::Ok,
+            body,
+        }
+    }
+
     pub fn version(version: &str) -> Self {
         let body = serde_json::json!({ "firecracker_version": version }).to_string();
 
@@ -129,6 +145,7 @@ pub fn parse_request(bytes: &[u8]) -> Result<ApiRequest, RequestError> {
     }
 
     match (method, path) {
+        ("GET", "/") => Ok(ApiRequest::GetInstanceInfo),
         ("GET", "/version") => Ok(ApiRequest::GetVersion),
         _ => Err(RequestError::InvalidPathMethod),
     }
@@ -274,6 +291,7 @@ fn checked_request_len(header_len: usize, content_length: usize) -> Result<usize
 impl From<ApiRequest> for Endpoint {
     fn from(request: ApiRequest) -> Self {
         match request {
+            ApiRequest::GetInstanceInfo => Self::DescribeInstance,
             ApiRequest::GetVersion => Self::Version,
         }
     }
@@ -284,6 +302,30 @@ mod tests {
     use super::*;
 
     const VERSION: &str = "0.1.0";
+
+    #[test]
+    fn parses_get_instance_info() {
+        let request = b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
+
+        assert_eq!(parse_request(request), Ok(ApiRequest::GetInstanceInfo));
+        assert_eq!(request_total_len(request), Ok(Some(request.len())));
+    }
+
+    #[test]
+    fn rejects_get_instance_info_with_body() {
+        let request =
+            b"GET / HTTP/1.1\r\nContent-Length: 2\r\nContent-Type: application/json\r\n\r\n{}";
+
+        assert_eq!(parse_request(request), Err(RequestError::GetRequestBody));
+    }
+
+    #[test]
+    fn parses_get_instance_info_with_zero_content_length() {
+        let request = b"GET / HTTP/1.1\r\nContent-Length:\t0 \r\n\r\n";
+
+        assert_eq!(parse_request(request), Ok(ApiRequest::GetInstanceInfo));
+        assert_eq!(request_total_len(request), Ok(Some(request.len())));
+    }
 
     #[test]
     fn parses_get_version() {
@@ -335,7 +377,7 @@ mod tests {
 
     #[test]
     fn rejects_unsupported_path() {
-        let request = b"GET / HTTP/1.1\r\n\r\n";
+        let request = b"GET /unknown HTTP/1.1\r\n\r\n";
 
         assert_eq!(parse_request(request), Err(RequestError::InvalidPathMethod));
     }
@@ -421,6 +463,24 @@ mod tests {
     }
 
     #[test]
+    fn response_body_contains_instance_info() {
+        let response = HttpResponse::instance_info("demo-1", "Not started", VERSION, "bangbang");
+        let body: serde_json::Value =
+            serde_json::from_str(response.body()).expect("body should be JSON");
+
+        assert_eq!(response.status(), StatusCode::Ok);
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "app_name": "bangbang",
+                "id": "demo-1",
+                "state": "Not started",
+                "vmm_version": "0.1.0",
+            })
+        );
+    }
+
+    #[test]
     fn fault_body_contains_fault_message() {
         let response = HttpResponse::fault("message");
 
@@ -438,5 +498,14 @@ mod tests {
         assert!(text.contains("Content-Type: application/json\r\n"));
         assert!(text.contains(&format!("Content-Length: {}\r\n", response.body().len())));
         assert!(text.ends_with(r#"{"firecracker_version":"0.1.0"}"#));
+    }
+
+    #[test]
+    fn api_request_converts_to_endpoint() {
+        assert_eq!(
+            Endpoint::from(ApiRequest::GetInstanceInfo),
+            Endpoint::DescribeInstance
+        );
+        assert_eq!(Endpoint::from(ApiRequest::GetVersion), Endpoint::Version);
     }
 }

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -382,20 +382,32 @@ fn handle_request_bytes(bytes: &[u8], vmm: &mut VmmController) -> HttpResponse {
 
 fn handle_api_request(request: ApiRequest, vmm: &mut VmmController) -> HttpResponse {
     match request {
-        ApiRequest::GetVersion => handle_vmm_data(
-            vmm.handle_action(VmmAction::GetVmmVersion),
-            "version request returned unexpected VMM data.",
-        ),
+        ApiRequest::GetInstanceInfo => {
+            handle_instance_info(vmm.handle_action(VmmAction::GetVmInstanceInfo))
+        }
+        ApiRequest::GetVersion => handle_vmm_version(vmm.handle_action(VmmAction::GetVmmVersion)),
     }
 }
 
-fn handle_vmm_data(
-    result: Result<VmmData, bangbang_runtime::VmmActionError>,
-    unexpected_message: &str,
-) -> HttpResponse {
+fn handle_vmm_version(result: Result<VmmData, bangbang_runtime::VmmActionError>) -> HttpResponse {
     match result {
         Ok(VmmData::VmmVersion(version)) => HttpResponse::version(&version),
-        Ok(VmmData::InstanceInformation(_)) => HttpResponse::fault(unexpected_message),
+        Ok(VmmData::InstanceInformation(_)) => {
+            HttpResponse::fault("version request returned unexpected VMM data.")
+        }
+        Err(err) => HttpResponse::fault(&err.to_string()),
+    }
+}
+
+fn handle_instance_info(result: Result<VmmData, bangbang_runtime::VmmActionError>) -> HttpResponse {
+    match result {
+        Ok(VmmData::InstanceInformation(info)) => {
+            let state = info.state.to_string();
+            HttpResponse::instance_info(&info.id, &state, &info.vmm_version, &info.app_name)
+        }
+        Ok(VmmData::VmmVersion(_)) => {
+            HttpResponse::fault("instance info request returned unexpected VMM data.")
+        }
         Err(err) => HttpResponse::fault(&err.to_string()),
     }
 }
@@ -555,6 +567,19 @@ mod tests {
     }
 
     #[test]
+    fn dispatches_instance_info_request_through_vmm_controller() {
+        let mut vmm = VmmController::new("demo-9", "9.9.9", "bangbang");
+
+        let response = handle_request_bytes(b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n", &mut vmm);
+
+        assert_eq!(response.status(), bangbang_api::http::StatusCode::Ok);
+        assert!(response.body().contains(r#""id":"demo-9""#));
+        assert!(response.body().contains(r#""state":"Not started""#));
+        assert!(response.body().contains(r#""vmm_version":"9.9.9""#));
+        assert!(response.body().contains(r#""app_name":"bangbang""#));
+    }
+
+    #[test]
     fn socket_path_cleanup_keeps_replaced_path() {
         let path = unique_socket_path("cln");
         let listener = UnixListener::bind(&path).expect("temporary listener should bind");
@@ -619,13 +644,40 @@ mod tests {
     }
 
     #[test]
+    fn serves_instance_info_over_unix_socket() {
+        let path = unique_socket_path("instance-info");
+        let server = ApiServer::bind(&path).expect("server should bind");
+        let mut client = UnixStream::connect(&path).expect("client should connect");
+
+        client
+            .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .expect("client should write request");
+        let mut vmm = test_controller();
+        server
+            .serve_next(&mut vmm)
+            .expect("server should handle one request");
+
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("client should read response");
+
+        assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(response.contains("Content-Type: application/json\r\n"));
+        assert!(response.contains(r#""id":"demo-1""#));
+        assert!(response.contains(r#""state":"Not started""#));
+        assert!(response.contains(r#""vmm_version":"0.1.0""#));
+        assert!(response.contains(r#""app_name":"bangbang""#));
+    }
+
+    #[test]
     fn returns_fault_for_unsupported_path() {
         let path = unique_socket_path("fault");
         let server = ApiServer::bind(&path).expect("server should bind");
         let mut client = UnixStream::connect(&path).expect("client should connect");
 
         client
-            .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .write_all(b"GET /unknown HTTP/1.1\r\nHost: localhost\r\n\r\n")
             .expect("client should write request");
         let mut vmm = test_controller();
         server

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -323,7 +323,7 @@ fn os_arg_into_string(arg: OsString) -> Result<String, String> {
 
 fn print_help() {
     println!(
-        "bangbang {}\n\nUsage:\n  bangbang [OPTIONS]\n\nOptions:\n      --api-sock <PATH>  Unix domain socket path for the API server [default: {}]\n      --id <ID>          MicroVM unique identifier [default: {}]\n                         Accepts 1-64 bytes, ASCII alphanumeric or '-'\n  -V, --version          Print version\n  -h, --help             Print help\n\nCurrent scope:\n  Serves GET /version over the API socket; VM startup is not implemented yet.",
+        "bangbang {}\n\nUsage:\n  bangbang [OPTIONS]\n\nOptions:\n      --api-sock <PATH>  Unix domain socket path for the API server [default: {}]\n      --id <ID>          MicroVM unique identifier [default: {}]\n                         Accepts 1-64 bytes, ASCII alphanumeric or '-'\n  -V, --version          Print version\n  -h, --help             Print help\n\nCurrent scope:\n  Serves GET / and GET /version over the API socket; VM startup is not implemented yet.",
         env!("CARGO_PKG_VERSION"),
         DEFAULT_API_SOCK_PATH,
         DEFAULT_INSTANCE_ID

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -5,7 +5,7 @@ is a planning reference for future API, VMM, and backend work; it does not mean
 the current scaffold implements all listed API behavior.
 
 The current repository defines crate boundaries, endpoint names, a minimal
-HTTP-over-Unix-socket API server for `GET /version`, a backend-neutral VM
+HTTP-over-Unix-socket API server for `GET /` and `GET /version`, a backend-neutral VM
 trait, a minimal read-only VMM action/data model, a minimal
 Hypervisor.framework VM create/destroy wrapper, and an initial process startup
 argument model. There is no broader API request body model, guest memory
@@ -18,16 +18,17 @@ manages one microVM. Future API work should keep the control plane outside the
 guest execution fast path.
 
 The intended public control plane is Firecracker-style HTTP over a Unix domain
-socket. The implemented `GET /version` request already maps through a minimal
-internal VMM action/data boundary. Future API requests should map to explicit
-VMM actions and VM state transitions, but this document only defines the
-initial scope.
+socket. The implemented `GET /` and `GET /version` requests already map
+through a minimal internal VMM action/data boundary. Future API requests should
+map to explicit VMM actions and VM state transitions, but this document only
+defines the initial scope.
 
 ## Process Startup CLI
 
 The current `bangbang` executable parses only the first process-lifecycle
 arguments and starts the first API socket surface. It binds a Unix socket and
-serves `GET /version`, but does not load a configuration file or start a guest.
+serves `GET /` and `GET /version`, but does not load a configuration file or
+start a guest.
 
 | Argument | Current behavior | Compatibility notes |
 | --- | --- | --- |
@@ -105,9 +106,9 @@ before changing this reference.
 
 ## Support Level Vocabulary
 
-The current scaffold implements only `GET /version` over HTTP on a Unix domain
-socket. The support levels below describe compatibility targets for future API
-work:
+The current scaffold implements only `GET /` and `GET /version` over HTTP on a
+Unix domain socket. The support levels below describe compatibility targets for
+future API work:
 
 - supported target: planned for the first boot-oriented API implementation
 - planned later: expected to be compatible later, but outside the first tier
@@ -134,8 +135,8 @@ compatibility targets.
 
 | Method | Endpoint | Support level | Scope notes |
 | --- | --- | --- | --- |
-| `GET` | `/` | supported target | Describe the microVM instance. |
-| `GET` | `/version` | supported target; implemented first | Report the VMM version with a Firecracker-shaped body. |
+| `GET` | `/` | supported target; implemented | Describe the microVM instance. The current state remains `Not started` until startup behavior exists. |
+| `GET` | `/version` | supported target; implemented | Report the VMM version with a Firecracker-shaped body. |
 | `GET` | `/vm/config` | supported target | Return the full VM configuration once configuration models exist. |
 | `GET` | `/machine-config` | supported target | Return machine configuration and defaults. |
 | `PUT` | `/machine-config` | supported target | Configure vCPU and memory settings before boot. |
@@ -205,14 +206,16 @@ setup, memory size, and block device I/O when those surfaces are implemented.
 
 ## API State and Response Policy
 
-The current scaffold implements the first HTTP API behavior for `GET /version`.
+The current scaffold implements the first HTTP API behavior for `GET /` and
+`GET /version`.
 The policy below is the compatibility target for future request parsing, VMM
 action mapping, state validation, and golden API tests.
 
 The implemented `GET /version` path currently flows through the minimal
 read-only VMM action model as `GetVmmVersion` and returns VMM version data.
-The internal instance information state model also exists for future `GET /`,
-but `GET /` itself is not implemented yet.
+The implemented `GET /` path flows through the same boundary as
+`GetVmInstanceInfo` and returns Firecracker-shaped instance information. The
+state currently remains `Not started` until real startup behavior exists.
 
 ### Initial API State Model
 
@@ -232,7 +235,7 @@ The first API implementation should model the same broad stages as Firecracker:
 
 | Operation | Pre-boot behavior | Runtime behavior | Notes |
 | --- | --- | --- | --- |
-| `GET /` | supported target; `200` JSON | supported target; `200` JSON | Response state should reflect the current microVM state. |
+| `GET /` | implemented; `200` JSON | implemented; `200` JSON | Response state should reflect the current microVM state. It currently remains `Not started` until startup behavior exists. |
 | `GET /version` | implemented; `200` JSON | implemented; `200` JSON | Body uses Firecracker's `firecracker_version` field shape. |
 | `GET /vm/config` | supported target; `200` JSON | supported target; `200` JSON | Returns the accumulated or active VM configuration once models exist. |
 | `GET /machine-config` | supported target; `200` JSON | supported target; `200` JSON | Returns machine configuration and defaulted values. |


### PR DESCRIPTION
## Summary

- add Firecracker-compatible `GET /` parsing and instance info response formatting
- dispatch `GET /` through `VmmAction::GetVmInstanceInfo`
- update README and compatibility docs for the newly supported read-only endpoint

Closes #53

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
