### PR TITLE
feat: add HVF vCPU lifecycle wrappers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   rust:
     name: rust
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 15
 
     steps:
@@ -39,7 +39,29 @@ jobs:
         run: cargo check --workspace --all-targets --all-features --locked
 
       - name: Run tests
-        run: cargo test --workspace --all-targets --all-features --locked
+        run: cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
+
+      - name: Run signed HVF smoke test
+        run: |
+          TEST_BIN=$(cargo test -p bangbang-hvf --all-targets --all-features --locked --no-run --message-format=json \
+            | sed -n 's/.*"executable":"\([^"]*bangbang_hvf-[^"]*\)".*/\1/p' \
+            | tail -1)
+          test -n "$TEST_BIN"
+
+          ENTITLEMENTS=$(mktemp "${TMPDIR:-/tmp}/bangbang-hvf-entitlements.XXXXXX")
+          cat > "$ENTITLEMENTS" <<'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>com.apple.security.hypervisor</key>
+            <true/>
+          </dict>
+          </plist>
+          EOF
+
+          codesign --force --sign - --entitlements "$ENTITLEMENTS" "$TEST_BIN"
+          "$TEST_BIN"
 
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,26 +42,7 @@ jobs:
         run: cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
 
       - name: Run signed HVF smoke test
-        run: |
-          TEST_BIN=$(cargo test -p bangbang-hvf --all-targets --all-features --locked --no-run --message-format=json \
-            | sed -n 's/.*"executable":"\([^"]*bangbang_hvf-[^"]*\)".*/\1/p' \
-            | tail -1)
-          test -n "$TEST_BIN"
-
-          ENTITLEMENTS=$(mktemp "${TMPDIR:-/tmp}/bangbang-hvf-entitlements.XXXXXX")
-          cat > "$ENTITLEMENTS" <<'EOF'
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-            <key>com.apple.security.hypervisor</key>
-            <true/>
-          </dict>
-          </plist>
-          EOF
-
-          codesign --force --sign - --entitlements "$ENTITLEMENTS" "$TEST_BIN"
-          "$TEST_BIN"
+        run: scripts/run-hvf-tests.sh
 
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
 
+      - name: Run HVF unit tests
+        run: cargo test -p bangbang-hvf --lib --all-features --locked
+
       - name: Run signed HVF smoke test
         run: scripts/run-hvf-tests.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Run HVF unit tests
         run: cargo test -p bangbang-hvf --lib --all-features --locked
 
-      - name: Run signed HVF smoke test
-        run: scripts/run-hvf-tests.sh
+      - name: Build and sign HVF smoke test
+        run: scripts/run-hvf-tests.sh --allow-unsupported
 
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup toolchain install stable --profile minimal --component clippy --component rustfmt
+          rustup toolchain install stable --profile minimal --component clippy --component rustfmt --target aarch64-apple-darwin
           rustup default stable
 
       - name: Cache Rust dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,10 +20,10 @@ Unit tests live next to the code they exercise under each crate’s `src/` tree.
 - `cargo test -p bangbang-hvf --lib --all-features --locked`: run unsigned HVF unit tests.
 - `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`: run lint checks with warnings treated as errors.
 - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`: build documentation without dependency docs.
-- `scripts/run-hvf-tests.sh`: sign and run HVF integration tests on macOS Apple Silicon.
+- `scripts/run-hvf-tests.sh`: sign and run HVF integration tests on macOS Apple Silicon; use `--allow-unsupported` only for CI runners that cannot execute HVF.
 - `cargo run -p bangbang`: run the current VMM process skeleton.
 
-Use these commands before opening or updating a pull request. HVF lifecycle tests should fail rather than be ignored when the host cannot run them.
+Use these commands before opening or updating a pull request. For local or self-hosted HVF verification, run `scripts/run-hvf-tests.sh` without `--allow-unsupported` so unsupported hosts fail instead of being ignored.
 
 ## Coding Style & Naming Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,10 @@ Unit tests live next to the code they exercise under each crate’s `src/` tree.
 - `cargo fmt --all -- --check`: verify Rust formatting.
 - `cargo check --workspace --all-targets --all-features --locked`: type-check the full workspace using the committed lockfile.
 - `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`: run non-HVF tests with all targets and features enabled.
+- `cargo test -p bangbang-hvf --lib --all-features --locked`: run unsigned HVF unit tests.
 - `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`: run lint checks with warnings treated as errors.
 - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`: build documentation without dependency docs.
-- `scripts/run-hvf-tests.sh`: sign and run `bangbang-hvf` tests on macOS Apple Silicon.
+- `scripts/run-hvf-tests.sh`: sign and run HVF integration tests on macOS Apple Silicon.
 - `cargo run -p bangbang`: run the current VMM process skeleton.
 
 Use these commands before opening or updating a pull request. HVF lifecycle tests should fail rather than be ignored when the host cannot run them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,12 +16,12 @@ Unit tests live next to the code they exercise under each crate’s `src/` tree.
 
 - `cargo fmt --all -- --check`: verify Rust formatting.
 - `cargo check --workspace --all-targets --all-features --locked`: type-check the full workspace using the committed lockfile.
-- `cargo test --workspace --all-targets --all-features --locked`: run all unit and doc tests with all targets and features enabled.
+- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`: run non-HVF tests with all targets and features enabled.
 - `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`: run lint checks with warnings treated as errors.
 - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`: build documentation without dependency docs.
 - `cargo run -p bangbang`: run the current VMM process skeleton.
 
-Use these commands before opening or updating a pull request.
+Use these commands before opening or updating a pull request. On macOS Apple Silicon, also sign and run the `bangbang-hvf` test binary as described in `README.md`; HVF lifecycle tests should fail rather than be ignored when the host cannot run them.
 
 ## Coding Style & Naming Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Unsafe code must stay isolated behind small FFI wrappers, with `SAFETY:` comment
 
 Use Rust’s built-in test framework with `#[test]`. Add focused unit tests for argument parsing, error formatting, and backend state transitions as those surfaces grow. Test names should describe behavior, such as `parse_help_arg` or `displays_hypervisor_error`.
 
-Do not add integration tests that require creating real Hypervisor.framework VMs until the runtime can gate them clearly by platform and privileges.
+Real Hypervisor.framework integration tests must stay in `crates/hvf/tests/` and run through `scripts/run-hvf-tests.sh` so the test binary is signed and unsupported hosts are handled explicitly. Do not run or add real HVF integration tests through the unsigned workspace test path.
 
 ## Commit & Pull Request Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,10 @@ Unit tests live next to the code they exercise under each crate’s `src/` tree.
 - `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`: run non-HVF tests with all targets and features enabled.
 - `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`: run lint checks with warnings treated as errors.
 - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`: build documentation without dependency docs.
+- `scripts/run-hvf-tests.sh`: sign and run `bangbang-hvf` tests on macOS Apple Silicon.
 - `cargo run -p bangbang`: run the current VMM process skeleton.
 
-Use these commands before opening or updating a pull request. On macOS Apple Silicon, also sign and run the `bangbang-hvf` test binary as described in `README.md`; HVF lifecycle tests should fail rather than be ignored when the host cannot run them.
+Use these commands before opening or updating a pull request. HVF lifecycle tests should fail rather than be ignored when the host cannot run them.
 
 ## Coding Style & Naming Conventions
 

--- a/README.md
+++ b/README.md
@@ -80,27 +80,11 @@ cargo test --workspace --all-targets --all-features --locked --exclude bangbang-
 ```
 
 On macOS Apple Silicon hosts, `bangbang-hvf` contains a real HVF lifecycle smoke
-test. The test is not ignored; sign the test binary with the Hypervisor
-entitlement and run it directly:
+test. The test is not ignored; run the signed test wrapper so host or
+entitlement failures fail the test run:
 
 ```sh
-TEST_BIN=$(cargo test -p bangbang-hvf --all-targets --all-features --locked --no-run --message-format=json \
-  | sed -n 's/.*"executable":"\([^"]*bangbang_hvf-[^"]*\)".*/\1/p' \
-  | tail -1)
-test -n "$TEST_BIN"
-ENTITLEMENTS=$(mktemp "${TMPDIR:-/tmp}/bangbang-hvf-entitlements.XXXXXX")
-cat > "$ENTITLEMENTS" <<'EOF'
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>com.apple.security.hypervisor</key>
-  <true/>
-</dict>
-</plist>
-EOF
-codesign --force --sign - --entitlements "$ENTITLEMENTS" "$TEST_BIN"
-"$TEST_BIN"
+scripts/run-hvf-tests.sh
 ```
 
 Run the VMM process skeleton and API server:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 bangbang is a Rust VMM project for macOS hosts. The public control plane is intended to stay compatible with the Firecracker HTTP API over a Unix domain socket, while the VM backend is built on Apple's Hypervisor.framework.
 
-This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, and the smallest Hypervisor.framework VM create/destroy wrapper.
+This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, and the smallest Hypervisor.framework VM and current-thread vCPU create/destroy wrappers.
 
 See [Firecracker Compatibility Scope](docs/firecracker-compatibility.md) for the intended compatibility target and current limitations.
 See [Pull Request Review Guidelines](docs/review-guidelines.md) for the project-specific review standard.
@@ -18,12 +18,12 @@ crates/bangbang   VMM process entrypoint and startup CLI
 
 ## Current Scope
 
-The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. It intentionally does not include:
+The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. The HVF crate can create/destroy a process VM and create/destroy one current-thread vCPU handle for lifecycle smoke testing. It intentionally does not include:
 
 - API endpoints beyond `GET /` and `GET /version`
 - JSON request body models
 - guest memory mapping
-- vCPU creation or a run loop
+- vCPU register setup, exit handling, or a run loop
 - kernel loading
 
 ## Process CLI
@@ -77,6 +77,29 @@ The version response body is Firecracker-shaped JSON:
 ```sh
 cargo check
 cargo test
+```
+
+On macOS Apple Silicon hosts, the ignored HVF lifecycle smoke test requires the
+test binary to be signed with the Hypervisor entitlement before running:
+
+```sh
+cargo test -p bangbang-hvf --no-run
+TEST_BIN=$(cargo test -p bangbang-hvf --no-run --message-format=json \
+  | sed -n 's/.*"executable":"\([^"]*bangbang_hvf-[^"]*\)".*/\1/p' \
+  | head -1)
+ENTITLEMENTS=$(mktemp "${TMPDIR:-/tmp}/bangbang-hvf-entitlements.XXXXXX")
+cat > "$ENTITLEMENTS" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.hypervisor</key>
+  <true/>
+</dict>
+</plist>
+EOF
+codesign --force --sign - --entitlements "$ENTITLEMENTS" "$TEST_BIN"
+BANGBANG_RUN_HVF_TESTS=1 "$TEST_BIN" --ignored
 ```
 
 Run the VMM process skeleton and API server:

--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ signed test wrapper so host or entitlement failures fail the test run:
 scripts/run-hvf-tests.sh
 ```
 
+Hosted macOS CI may build and sign the lifecycle test without executing it when
+Hypervisor.framework is unavailable:
+
+```sh
+scripts/run-hvf-tests.sh --allow-unsupported
+```
+
 Run the VMM process skeleton and API server:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -77,11 +77,12 @@ The version response body is Firecracker-shaped JSON:
 ```sh
 cargo check --workspace --all-targets --all-features --locked
 cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
+cargo test -p bangbang-hvf --lib --all-features --locked
 ```
 
 On macOS Apple Silicon hosts, `bangbang-hvf` contains a real HVF lifecycle smoke
-test. The test is not ignored; run the signed test wrapper so host or
-entitlement failures fail the test run:
+test in `crates/hvf/tests/hvf_lifecycle.rs`. The test is not ignored; run the
+signed test wrapper so host or entitlement failures fail the test run:
 
 ```sh
 scripts/run-hvf-tests.sh

--- a/README.md
+++ b/README.md
@@ -75,18 +75,19 @@ The version response body is Firecracker-shaped JSON:
 ## Build
 
 ```sh
-cargo check
-cargo test
+cargo check --workspace --all-targets --all-features --locked
+cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
 ```
 
-On macOS Apple Silicon hosts, the ignored HVF lifecycle smoke test requires the
-test binary to be signed with the Hypervisor entitlement before running:
+On macOS Apple Silicon hosts, `bangbang-hvf` contains a real HVF lifecycle smoke
+test. The test is not ignored; sign the test binary with the Hypervisor
+entitlement and run it directly:
 
 ```sh
-cargo test -p bangbang-hvf --no-run
-TEST_BIN=$(cargo test -p bangbang-hvf --no-run --message-format=json \
+TEST_BIN=$(cargo test -p bangbang-hvf --all-targets --all-features --locked --no-run --message-format=json \
   | sed -n 's/.*"executable":"\([^"]*bangbang_hvf-[^"]*\)".*/\1/p' \
-  | head -1)
+  | tail -1)
+test -n "$TEST_BIN"
 ENTITLEMENTS=$(mktemp "${TMPDIR:-/tmp}/bangbang-hvf-entitlements.XXXXXX")
 cat > "$ENTITLEMENTS" <<'EOF'
 <?xml version="1.0" encoding="UTF-8"?>
@@ -99,7 +100,7 @@ cat > "$ENTITLEMENTS" <<'EOF'
 </plist>
 EOF
 codesign --force --sign - --entitlements "$ENTITLEMENTS" "$TEST_BIN"
-BANGBANG_RUN_HVF_TESTS=1 "$TEST_BIN" --ignored
+"$TEST_BIN"
 ```
 
 Run the VMM process skeleton and API server:

--- a/crates/hvf/src/backend.rs
+++ b/crates/hvf/src/backend.rs
@@ -1,5 +1,7 @@
 use bangbang_runtime::{BackendError, VmBackend};
 
+use crate::vcpu::HvfVcpu;
+
 #[derive(Debug, Default)]
 pub struct HvfBackend {
     vm_created: bool,
@@ -12,6 +14,22 @@ impl HvfBackend {
 
     pub fn is_supported_target() -> bool {
         cfg!(all(target_os = "macos", target_arch = "aarch64"))
+    }
+
+    pub fn create_vcpu(&mut self) -> Result<HvfVcpu<'_>, BackendError> {
+        if !Self::is_supported_target() {
+            return Err(BackendError::Unsupported(
+                crate::ffi::UNSUPPORTED_TARGET_MESSAGE,
+            ));
+        }
+
+        if !self.vm_created {
+            return Err(BackendError::InvalidState(
+                "VM must be created before creating a vCPU",
+            ));
+        }
+
+        HvfVcpu::new(self)
     }
 }
 
@@ -41,5 +59,75 @@ impl Drop for HvfBackend {
             let _ = crate::ffi::destroy_vm();
             self.vm_created = false;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bangbang_runtime::{BackendError, VmBackend};
+
+    use super::HvfBackend;
+
+    #[test]
+    fn supported_target_matches_compile_target() {
+        assert_eq!(
+            HvfBackend::is_supported_target(),
+            cfg!(all(target_os = "macos", target_arch = "aarch64"))
+        );
+    }
+
+    #[test]
+    fn create_vcpu_before_vm_reports_state_or_target_error() {
+        let mut backend = HvfBackend::new();
+        let err = backend
+            .create_vcpu()
+            .expect_err("creating a vCPU before VM creation should fail");
+
+        if HvfBackend::is_supported_target() {
+            assert_eq!(
+                err,
+                BackendError::InvalidState("VM must be created before creating a vCPU")
+            );
+        } else {
+            assert_eq!(
+                err,
+                BackendError::Unsupported(crate::ffi::UNSUPPORTED_TARGET_MESSAGE)
+            );
+        }
+    }
+
+    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+    #[test]
+    fn unsupported_target_rejects_vm_creation() {
+        let mut backend = HvfBackend::new();
+
+        assert_eq!(
+            backend.create_vm(),
+            Err(BackendError::Unsupported(
+                crate::ffi::UNSUPPORTED_TARGET_MESSAGE
+            ))
+        );
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[test]
+    #[ignore = "requires a signed Hypervisor.framework entitlement on macOS Apple Silicon"]
+    fn creates_and_destroys_hvf_vcpu() {
+        if std::env::var("BANGBANG_RUN_HVF_TESTS").as_deref() != Ok("1") {
+            eprintln!(
+                "sign the test binary with com.apple.security.hypervisor and set \
+                 BANGBANG_RUN_HVF_TESTS=1 to run real HVF lifecycle smoke tests"
+            );
+            return;
+        }
+
+        let mut backend = HvfBackend::new();
+
+        backend.create_vm().expect("VM should be created");
+        {
+            let vcpu = backend.create_vcpu().expect("vCPU should be created");
+            vcpu.destroy().expect("vCPU should be destroyed");
+        }
+        backend.destroy_vm().expect("VM should be destroyed");
     }
 }

--- a/crates/hvf/src/backend.rs
+++ b/crates/hvf/src/backend.rs
@@ -111,16 +111,7 @@ mod tests {
 
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     #[test]
-    #[ignore = "requires a signed Hypervisor.framework entitlement on macOS Apple Silicon"]
     fn creates_and_destroys_hvf_vcpu() {
-        if std::env::var("BANGBANG_RUN_HVF_TESTS").as_deref() != Ok("1") {
-            eprintln!(
-                "sign the test binary with com.apple.security.hypervisor and set \
-                 BANGBANG_RUN_HVF_TESTS=1 to run real HVF lifecycle smoke tests"
-            );
-            return;
-        }
-
         let mut backend = HvfBackend::new();
 
         backend.create_vm().expect("VM should be created");

--- a/crates/hvf/src/backend.rs
+++ b/crates/hvf/src/backend.rs
@@ -64,7 +64,7 @@ impl Drop for HvfBackend {
 
 #[cfg(test)]
 mod tests {
-    use bangbang_runtime::{BackendError, VmBackend};
+    use bangbang_runtime::BackendError;
 
     use super::HvfBackend;
 
@@ -99,6 +99,8 @@ mod tests {
     #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
     #[test]
     fn unsupported_target_rejects_vm_creation() {
+        use bangbang_runtime::VmBackend;
+
         let mut backend = HvfBackend::new();
 
         assert_eq!(
@@ -107,18 +109,5 @@ mod tests {
                 crate::ffi::UNSUPPORTED_TARGET_MESSAGE
             ))
         );
-    }
-
-    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    #[test]
-    fn creates_and_destroys_hvf_vcpu() {
-        let mut backend = HvfBackend::new();
-
-        backend.create_vm().expect("VM should be created");
-        {
-            let vcpu = backend.create_vcpu().expect("vCPU should be created");
-            vcpu.destroy().expect("vCPU should be destroyed");
-        }
-        backend.destroy_vm().expect("VM should be destroyed");
     }
 }

--- a/crates/hvf/src/ffi.rs
+++ b/crates/hvf/src/ffi.rs
@@ -24,7 +24,7 @@ mod imp {
     const HV_FAULT: HvReturn = 0xfae94008u32 as HvReturn;
     const HV_UNSUPPORTED: HvReturn = 0xfae9400fu32 as HvReturn;
 
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Debug)]
     pub struct CreatedVcpu {
         pub vcpu: HvVcpu,
         pub exit: *mut HvVcpuExit,
@@ -146,7 +146,7 @@ mod imp {
     pub type HvVcpu = u64;
     pub type HvVcpuExit = c_void;
 
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Debug)]
     pub struct CreatedVcpu {
         pub vcpu: HvVcpu,
         pub exit: *mut HvVcpuExit,

--- a/crates/hvf/src/ffi.rs
+++ b/crates/hvf/src/ffi.rs
@@ -15,6 +15,14 @@ mod imp {
     pub type HvVcpuExit = c_void;
 
     pub const HV_SUCCESS: HvReturn = 0;
+    const HV_ERROR: HvReturn = 0xfae94001u32 as HvReturn;
+    const HV_BUSY: HvReturn = 0xfae94002u32 as HvReturn;
+    const HV_BAD_ARGUMENT: HvReturn = 0xfae94003u32 as HvReturn;
+    const HV_NO_RESOURCES: HvReturn = 0xfae94005u32 as HvReturn;
+    const HV_NO_DEVICE: HvReturn = 0xfae94006u32 as HvReturn;
+    const HV_DENIED: HvReturn = 0xfae94007u32 as HvReturn;
+    const HV_FAULT: HvReturn = 0xfae94008u32 as HvReturn;
+    const HV_UNSUPPORTED: HvReturn = 0xfae9400fu32 as HvReturn;
 
     #[derive(Debug, Clone, Copy)]
     pub struct CreatedVcpu {
@@ -34,12 +42,36 @@ mod imp {
         pub fn hv_vcpu_destroy(vcpu: HvVcpu) -> HvReturn;
     }
 
+    fn hv_return_name(code: HvReturn) -> Option<&'static str> {
+        match code {
+            HV_ERROR => Some("HV_ERROR"),
+            HV_BUSY => Some("HV_BUSY"),
+            HV_BAD_ARGUMENT => Some("HV_BAD_ARGUMENT"),
+            HV_NO_RESOURCES => Some("HV_NO_RESOURCES"),
+            HV_NO_DEVICE => Some("HV_NO_DEVICE"),
+            HV_DENIED => Some("HV_DENIED"),
+            HV_FAULT => Some("HV_FAULT"),
+            HV_UNSUPPORTED => Some("HV_UNSUPPORTED"),
+            _ => None,
+        }
+    }
+
+    fn format_hv_return(code: HvReturn) -> String {
+        let code = code as u32;
+
+        match hv_return_name(code as HvReturn) {
+            Some(name) => format!("{name} (hv_return_t=0x{code:08x})"),
+            None => format!("hv_return_t=0x{code:08x}"),
+        }
+    }
+
     pub fn check(code: HvReturn, operation: &'static str) -> Result<(), BackendError> {
         if code == HV_SUCCESS {
             Ok(())
         } else {
             Err(BackendError::Hypervisor(format!(
-                "{operation} failed with hv_return_t=0x{code:08x}"
+                "{operation} failed with {}",
+                format_hv_return(code)
             )))
         }
     }
@@ -74,6 +106,32 @@ mod imp {
         // SAFETY: The caller owns this current-thread vCPU handle and guarantees it has not
         // already been destroyed.
         unsafe { check(hv_vcpu_destroy(vcpu), "hv_vcpu_destroy") }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{check, HV_DENIED, HV_UNSUPPORTED};
+
+        #[test]
+        fn check_displays_named_hv_return() {
+            let err = check(HV_DENIED, "hv_vm_create").expect_err("HV_DENIED should fail");
+
+            assert_eq!(
+                err.to_string(),
+                "hypervisor error: hv_vm_create failed with HV_DENIED (hv_return_t=0xfae94007)"
+            );
+        }
+
+        #[test]
+        fn check_displays_unsupported_hv_return() {
+            let err =
+                check(HV_UNSUPPORTED, "hv_vm_create").expect_err("HV_UNSUPPORTED should fail");
+
+            assert_eq!(
+                err.to_string(),
+                "hypervisor error: hv_vm_create failed with HV_UNSUPPORTED (hv_return_t=0xfae9400f)"
+            );
+        }
     }
 }
 

--- a/crates/hvf/src/ffi.rs
+++ b/crates/hvf/src/ffi.rs
@@ -1,3 +1,6 @@
+pub(crate) const UNSUPPORTED_TARGET_MESSAGE: &str =
+    "Hypervisor.framework backend currently targets macOS on Apple Silicon";
+
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 mod imp {
     use std::ffi::c_void;
@@ -7,13 +10,28 @@ mod imp {
 
     pub type HvReturn = i32;
     pub type HvVmConfig = *mut c_void;
+    pub type HvVcpu = u64;
+    pub type HvVcpuConfig = *mut c_void;
+    pub type HvVcpuExit = c_void;
 
     pub const HV_SUCCESS: HvReturn = 0;
+
+    #[derive(Debug, Clone, Copy)]
+    pub struct CreatedVcpu {
+        pub vcpu: HvVcpu,
+        pub exit: *mut HvVcpuExit,
+    }
 
     #[link(name = "Hypervisor", kind = "framework")]
     extern "C" {
         pub fn hv_vm_create(config: HvVmConfig) -> HvReturn;
         pub fn hv_vm_destroy() -> HvReturn;
+        pub fn hv_vcpu_create(
+            vcpu: *mut HvVcpu,
+            exit: *mut *mut HvVcpuExit,
+            config: HvVcpuConfig,
+        ) -> HvReturn;
+        pub fn hv_vcpu_destroy(vcpu: HvVcpu) -> HvReturn;
     }
 
     pub fn check(code: HvReturn, operation: &'static str) -> Result<(), BackendError> {
@@ -35,19 +53,60 @@ mod imp {
         // SAFETY: Destroys the process-local VM after vCPUs have been destroyed.
         unsafe { check(hv_vm_destroy(), "hv_vm_destroy") }
     }
+
+    pub fn create_vcpu() -> Result<CreatedVcpu, BackendError> {
+        let mut vcpu = 0;
+        let mut exit = ptr::null_mut();
+
+        // SAFETY: The output pointers are valid for the duration of the call, and a null
+        // configuration requests the default vCPU configuration.
+        unsafe {
+            check(
+                hv_vcpu_create(&mut vcpu, &mut exit, ptr::null_mut()),
+                "hv_vcpu_create",
+            )?;
+        }
+
+        Ok(CreatedVcpu { vcpu, exit })
+    }
+
+    pub fn destroy_vcpu(vcpu: HvVcpu) -> Result<(), BackendError> {
+        // SAFETY: The caller owns this current-thread vCPU handle and guarantees it has not
+        // already been destroyed.
+        unsafe { check(hv_vcpu_destroy(vcpu), "hv_vcpu_destroy") }
+    }
 }
 
 #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 mod imp {
+    use std::ffi::c_void;
+
     use bangbang_runtime::BackendError;
 
+    use super::UNSUPPORTED_TARGET_MESSAGE;
+
+    pub type HvVcpu = u64;
+    pub type HvVcpuExit = c_void;
+
+    #[derive(Debug, Clone, Copy)]
+    pub struct CreatedVcpu {
+        pub vcpu: HvVcpu,
+        pub exit: *mut HvVcpuExit,
+    }
+
     pub fn create_vm() -> Result<(), BackendError> {
-        Err(BackendError::Unsupported(
-            "Hypervisor.framework backend currently targets macOS on Apple Silicon",
-        ))
+        Err(BackendError::Unsupported(UNSUPPORTED_TARGET_MESSAGE))
     }
 
     pub fn destroy_vm() -> Result<(), BackendError> {
+        Ok(())
+    }
+
+    pub fn create_vcpu() -> Result<CreatedVcpu, BackendError> {
+        Err(BackendError::Unsupported(UNSUPPORTED_TARGET_MESSAGE))
+    }
+
+    pub fn destroy_vcpu(_: HvVcpu) -> Result<(), BackendError> {
         Ok(())
     }
 }

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -2,5 +2,7 @@
 
 mod backend;
 mod ffi;
+mod vcpu;
 
 pub use backend::HvfBackend;
+pub use vcpu::HvfVcpu;

--- a/crates/hvf/src/vcpu.rs
+++ b/crates/hvf/src/vcpu.rs
@@ -25,7 +25,7 @@ impl<'vm> HvfVcpu<'vm> {
         })
     }
 
-    pub fn destroy(mut self) -> Result<(), BackendError> {
+    pub fn destroy(&mut self) -> Result<(), BackendError> {
         self.destroy_inner()
     }
 
@@ -33,6 +33,7 @@ impl<'vm> HvfVcpu<'vm> {
         if let Some(vcpu) = self.vcpu {
             crate::ffi::destroy_vcpu(vcpu)?;
             self.vcpu = None;
+            self.exit = std::ptr::null_mut();
         }
         Ok(())
     }

--- a/crates/hvf/src/vcpu.rs
+++ b/crates/hvf/src/vcpu.rs
@@ -12,7 +12,6 @@ pub struct HvfVcpu<'vm> {
     _not_send_sync: PhantomData<Rc<()>>,
 }
 
-#[derive(Clone, Copy)]
 struct HvfVcpuHandle {
     vcpu: crate::ffi::HvVcpu,
     exit: *mut crate::ffi::HvVcpuExit,
@@ -37,9 +36,11 @@ impl<'vm> HvfVcpu<'vm> {
     }
 
     fn destroy_inner(&mut self) -> Result<(), BackendError> {
-        if let Some(handle) = self.handle {
-            crate::ffi::destroy_vcpu(handle.vcpu)?;
-            self.handle = None;
+        if let Some(handle) = self.handle.take() {
+            if let Err(err) = crate::ffi::destroy_vcpu(handle.vcpu) {
+                self.handle = Some(handle);
+                return Err(err);
+            }
         }
         Ok(())
     }
@@ -53,7 +54,7 @@ impl Drop for HvfVcpu<'_> {
 
 impl fmt::Debug for HvfVcpu<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (vcpu, has_exit) = match self.handle {
+        let (vcpu, has_exit) = match &self.handle {
             Some(handle) => (Some(handle.vcpu), !handle.exit.is_null()),
             None => (None, false),
         };

--- a/crates/hvf/src/vcpu.rs
+++ b/crates/hvf/src/vcpu.rs
@@ -7,10 +7,15 @@ use bangbang_runtime::BackendError;
 use crate::backend::HvfBackend;
 
 pub struct HvfVcpu<'vm> {
-    vcpu: Option<crate::ffi::HvVcpu>,
-    exit: *mut crate::ffi::HvVcpuExit,
+    handle: Option<HvfVcpuHandle>,
     _vm: PhantomData<&'vm mut HvfBackend>,
     _not_send_sync: PhantomData<Rc<()>>,
+}
+
+#[derive(Clone, Copy)]
+struct HvfVcpuHandle {
+    vcpu: crate::ffi::HvVcpu,
+    exit: *mut crate::ffi::HvVcpuExit,
 }
 
 impl<'vm> HvfVcpu<'vm> {
@@ -18,8 +23,10 @@ impl<'vm> HvfVcpu<'vm> {
         let created = crate::ffi::create_vcpu()?;
 
         Ok(Self {
-            vcpu: Some(created.vcpu),
-            exit: created.exit,
+            handle: Some(HvfVcpuHandle {
+                vcpu: created.vcpu,
+                exit: created.exit,
+            }),
             _vm: PhantomData,
             _not_send_sync: PhantomData,
         })
@@ -30,10 +37,9 @@ impl<'vm> HvfVcpu<'vm> {
     }
 
     fn destroy_inner(&mut self) -> Result<(), BackendError> {
-        if let Some(vcpu) = self.vcpu {
-            crate::ffi::destroy_vcpu(vcpu)?;
-            self.vcpu = None;
-            self.exit = std::ptr::null_mut();
+        if let Some(handle) = self.handle {
+            crate::ffi::destroy_vcpu(handle.vcpu)?;
+            self.handle = None;
         }
         Ok(())
     }
@@ -47,9 +53,14 @@ impl Drop for HvfVcpu<'_> {
 
 impl fmt::Debug for HvfVcpu<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (vcpu, has_exit) = match self.handle {
+            Some(handle) => (Some(handle.vcpu), !handle.exit.is_null()),
+            None => (None, false),
+        };
+
         f.debug_struct("HvfVcpu")
-            .field("vcpu", &self.vcpu)
-            .field("has_exit", &(!self.exit.is_null()))
+            .field("vcpu", &vcpu)
+            .field("has_exit", &has_exit)
             .finish_non_exhaustive()
     }
 }

--- a/crates/hvf/src/vcpu.rs
+++ b/crates/hvf/src/vcpu.rs
@@ -1,0 +1,53 @@
+use std::fmt;
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+use bangbang_runtime::BackendError;
+
+use crate::backend::HvfBackend;
+
+pub struct HvfVcpu<'vm> {
+    vcpu: Option<crate::ffi::HvVcpu>,
+    exit: *mut crate::ffi::HvVcpuExit,
+    _vm: PhantomData<&'vm mut HvfBackend>,
+    _not_send_sync: PhantomData<Rc<()>>,
+}
+
+impl<'vm> HvfVcpu<'vm> {
+    pub(crate) fn new(_: &'vm mut HvfBackend) -> Result<Self, BackendError> {
+        let created = crate::ffi::create_vcpu()?;
+
+        Ok(Self {
+            vcpu: Some(created.vcpu),
+            exit: created.exit,
+            _vm: PhantomData,
+            _not_send_sync: PhantomData,
+        })
+    }
+
+    pub fn destroy(mut self) -> Result<(), BackendError> {
+        self.destroy_inner()
+    }
+
+    fn destroy_inner(&mut self) -> Result<(), BackendError> {
+        if let Some(vcpu) = self.vcpu.take() {
+            crate::ffi::destroy_vcpu(vcpu)?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for HvfVcpu<'_> {
+    fn drop(&mut self) {
+        let _ = self.destroy_inner();
+    }
+}
+
+impl fmt::Debug for HvfVcpu<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HvfVcpu")
+            .field("vcpu", &self.vcpu)
+            .field("has_exit", &(!self.exit.is_null()))
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/hvf/src/vcpu.rs
+++ b/crates/hvf/src/vcpu.rs
@@ -36,11 +36,9 @@ impl<'vm> HvfVcpu<'vm> {
     }
 
     fn destroy_inner(&mut self) -> Result<(), BackendError> {
-        if let Some(handle) = self.handle.take() {
-            if let Err(err) = crate::ffi::destroy_vcpu(handle.vcpu) {
-                self.handle = Some(handle);
-                return Err(err);
-            }
+        if let Some(handle) = &self.handle {
+            crate::ffi::destroy_vcpu(handle.vcpu)?;
+            self.handle = None;
         }
         Ok(())
     }

--- a/crates/hvf/src/vcpu.rs
+++ b/crates/hvf/src/vcpu.rs
@@ -30,8 +30,9 @@ impl<'vm> HvfVcpu<'vm> {
     }
 
     fn destroy_inner(&mut self) -> Result<(), BackendError> {
-        if let Some(vcpu) = self.vcpu.take() {
+        if let Some(vcpu) = self.vcpu {
             crate::ffi::destroy_vcpu(vcpu)?;
+            self.vcpu = None;
         }
         Ok(())
     }

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -10,10 +10,6 @@ fn creates_and_destroys_hvf_vcpu() {
     {
         let mut vcpu = backend.create_vcpu().expect("vCPU should be created");
         vcpu.destroy().expect("vCPU should be destroyed");
-        assert_eq!(
-            format!("{vcpu:?}"),
-            "HvfVcpu { vcpu: None, has_exit: false, .. }"
-        );
         vcpu.destroy()
             .expect("destroyed vCPU should remain destroyed");
     }

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -8,8 +8,14 @@ fn creates_and_destroys_hvf_vcpu() {
 
     backend.create_vm().expect("VM should be created");
     {
-        let vcpu = backend.create_vcpu().expect("vCPU should be created");
+        let mut vcpu = backend.create_vcpu().expect("vCPU should be created");
         vcpu.destroy().expect("vCPU should be destroyed");
+        assert_eq!(
+            format!("{vcpu:?}"),
+            "HvfVcpu { vcpu: None, has_exit: false, .. }"
+        );
+        vcpu.destroy()
+            .expect("destroyed vCPU should remain destroyed");
     }
     backend.destroy_vm().expect("VM should be destroyed");
 }

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -1,0 +1,21 @@
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn creates_and_destroys_hvf_vcpu() {
+    use bangbang_hvf::HvfBackend;
+    use bangbang_runtime::VmBackend;
+
+    let mut backend = HvfBackend::new();
+
+    backend.create_vm().expect("VM should be created");
+    {
+        let vcpu = backend.create_vcpu().expect("vCPU should be created");
+        vcpu.destroy().expect("vCPU should be destroyed");
+    }
+    backend.destroy_vm().expect("VM should be destroyed");
+}
+
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+#[test]
+fn requires_macos_apple_silicon() {
+    panic!("signed HVF lifecycle tests require macOS Apple Silicon");
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -132,6 +132,7 @@ impl VmmController {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BackendError {
     Unsupported(&'static str),
+    InvalidState(&'static str),
     Hypervisor(String),
 }
 
@@ -139,6 +140,7 @@ impl fmt::Display for BackendError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Unsupported(message) => write!(f, "unsupported backend: {message}"),
+            Self::InvalidState(message) => write!(f, "invalid backend state: {message}"),
             Self::Hypervisor(message) => write!(f, "hypervisor error: {message}"),
         }
     }
@@ -238,6 +240,16 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "unsupported backend: macOS on Apple Silicon required"
+        );
+    }
+
+    #[test]
+    fn displays_invalid_state_error() {
+        let err = BackendError::InvalidState("VM must be created before creating a vCPU");
+
+        assert_eq!(
+            err.to_string(),
+            "invalid backend state: VM must be created before creating a vCPU"
         );
     }
 

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -327,9 +327,10 @@ surface:
 - unit tests for parsing, configuration, and state transitions
 - golden tests for Firecracker-shaped API responses once the API exists
 - real HVF tests on macOS Apple Silicon through `scripts/run-hvf-tests.sh`,
-  which signs the `bangbang-hvf` test binary with the
-  `com.apple.security.hypervisor` entitlement before running it; HVF lifecycle
-  tests should fail instead of being ignored when the host cannot run them
+  which signs the `bangbang-hvf` integration test with the
+  `com.apple.security.hypervisor` entitlement before running it; the script
+  fails when the host cannot run HVF tests unless CI explicitly uses
+  `--allow-unsupported` after build/sign validation
 - boot smoke tests once kernel loading and vCPU execution exist
 
 ## Security and Performance Scope

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -7,9 +7,10 @@ the current scaffold implements all listed API behavior.
 The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /` and `GET /version`, a backend-neutral VM
 trait, a minimal read-only VMM action/data model, a minimal
-Hypervisor.framework VM create/destroy wrapper, and an initial process startup
-argument model. There is no broader API request body model, guest memory
-mapping, vCPU loop, or kernel loading yet.
+Hypervisor.framework VM create/destroy wrapper, a current-thread HVF vCPU
+create/destroy wrapper, and an initial process startup argument model. There is
+no broader API request body model, guest memory mapping, vCPU register setup,
+exit handling, run loop, or kernel loading yet.
 
 ## Firecracker Model Alignment
 
@@ -307,6 +308,10 @@ macOS design work instead of direct implementation:
 
 - KVM-specific VM and vCPU operations need HVF equivalents rather than direct
   KVM ioctl usage.
+- HVF vCPU handles are thread-affine: creation, register access, run, and
+  destroy operations must happen on the owning thread. The initial vCPU wrapper
+  covers create/destroy lifecycle only; future run-loop work should use a
+  thread-owned runner.
 - Linux seccomp, jailer, cgroups, and namespaces do not directly apply.
 - Linux TAP-based networking needs a macOS-specific design.
 - Snapshot and device behavior may differ when backed by HVF.
@@ -321,7 +326,10 @@ surface:
 
 - unit tests for parsing, configuration, and state transitions
 - golden tests for Firecracker-shaped API responses once the API exists
-- platform-gated tests for HVF behavior
+- platform-gated or ignored tests for HVF behavior, such as
+  signing the `bangbang-hvf` test binary with the
+  `com.apple.security.hypervisor` entitlement and running it with
+  `BANGBANG_RUN_HVF_TESTS=1` on macOS Apple Silicon
 - boot smoke tests once kernel loading and vCPU execution exist
 
 ## Security and Performance Scope

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -326,10 +326,10 @@ surface:
 
 - unit tests for parsing, configuration, and state transitions
 - golden tests for Firecracker-shaped API responses once the API exists
-- platform-gated or ignored tests for HVF behavior, such as
-  signing the `bangbang-hvf` test binary with the
-  `com.apple.security.hypervisor` entitlement and running it with
-  `BANGBANG_RUN_HVF_TESTS=1` on macOS Apple Silicon
+- real HVF tests on macOS Apple Silicon, with the `bangbang-hvf` test binary
+  signed using the `com.apple.security.hypervisor` entitlement before running;
+  HVF lifecycle tests should fail instead of being ignored when the host cannot
+  run them
 - boot smoke tests once kernel loading and vCPU execution exist
 
 ## Security and Performance Scope

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -326,10 +326,10 @@ surface:
 
 - unit tests for parsing, configuration, and state transitions
 - golden tests for Firecracker-shaped API responses once the API exists
-- real HVF tests on macOS Apple Silicon, with the `bangbang-hvf` test binary
-  signed using the `com.apple.security.hypervisor` entitlement before running;
-  HVF lifecycle tests should fail instead of being ignored when the host cannot
-  run them
+- real HVF tests on macOS Apple Silicon through `scripts/run-hvf-tests.sh`,
+  which signs the `bangbang-hvf` test binary with the
+  `com.apple.security.hypervisor` entitlement before running it; HVF lifecycle
+  tests should fail instead of being ignored when the host cannot run them
 - boot smoke tests once kernel loading and vCPU execution exist
 
 ## Security and Performance Scope

--- a/docs/review-guidelines.md
+++ b/docs/review-guidelines.md
@@ -27,9 +27,8 @@ cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
 ```
 
-On macOS Apple Silicon, also sign and run the `bangbang-hvf` test binary as
-shown in `README.md`. HVF lifecycle tests should not be skipped or ignored when
-they are in scope for the PR.
+On macOS Apple Silicon, also run `scripts/run-hvf-tests.sh`. HVF lifecycle tests
+should not be skipped or ignored when they are in scope for the PR.
 
 Reviewers should confirm the PR body lists the checks that were run. If any
 command is intentionally skipped, the PR should explain why the skipped command

--- a/docs/review-guidelines.md
+++ b/docs/review-guidelines.md
@@ -22,10 +22,14 @@ Run the repository checks before opening or updating a pull request:
 ```sh
 cargo fmt --all -- --check
 cargo check --workspace --all-targets --all-features --locked
-cargo test --workspace --all-targets --all-features --locked
+cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
 cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
 ```
+
+On macOS Apple Silicon, also sign and run the `bangbang-hvf` test binary as
+shown in `README.md`. HVF lifecycle tests should not be skipped or ignored when
+they are in scope for the PR.
 
 Reviewers should confirm the PR body lists the checks that were run. If any
 command is intentionally skipped, the PR should explain why the skipped command

--- a/docs/review-guidelines.md
+++ b/docs/review-guidelines.md
@@ -23,12 +23,14 @@ Run the repository checks before opening or updating a pull request:
 cargo fmt --all -- --check
 cargo check --workspace --all-targets --all-features --locked
 cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
+cargo test -p bangbang-hvf --lib --all-features --locked
 cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
 ```
 
-On macOS Apple Silicon, also run `scripts/run-hvf-tests.sh`. HVF lifecycle tests
-should not be skipped or ignored when they are in scope for the PR.
+On macOS Apple Silicon, also run `scripts/run-hvf-tests.sh` for signed HVF
+integration tests under `crates/hvf/tests/`. HVF lifecycle tests should not be
+skipped or ignored when they are in scope for the PR.
 
 Reviewers should confirm the PR body lists the checks that were run. If any
 command is intentionally skipped, the PR should explain why the skipped command

--- a/docs/review-guidelines.md
+++ b/docs/review-guidelines.md
@@ -30,7 +30,9 @@ RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --lock
 
 On macOS Apple Silicon, also run `scripts/run-hvf-tests.sh` for signed HVF
 integration tests under `crates/hvf/tests/`. HVF lifecycle tests should not be
-skipped or ignored when they are in scope for the PR.
+skipped or ignored on hosts that support HVF. Hosted CI may use
+`scripts/run-hvf-tests.sh --allow-unsupported` to validate build/sign behavior
+without executing HVF when the runner does not support it.
 
 Reviewers should confirm the PR body lists the checks that were run. If any
 command is intentionally skipped, the PR should explain why the skipped command

--- a/scripts/run-hvf-tests.sh
+++ b/scripts/run-hvf-tests.sh
@@ -67,6 +67,8 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 1
 fi
 
+target_triple="aarch64-apple-darwin"
+
 entitlements="$tmp_dir/hvf-entitlements.plist"
 cat > "$entitlements" <<'EOF'
 <?xml version="1.0" encoding="UTF-8"?>
@@ -80,7 +82,15 @@ cat > "$entitlements" <<'EOF'
 EOF
 
 cargo_messages="$tmp_dir/cargo-test.json"
-cargo test -p bangbang-hvf --test hvf_lifecycle --all-features --locked --no-run --message-format=json > "$cargo_messages"
+cargo test \
+  -p bangbang-hvf \
+  --test hvf_lifecycle \
+  --all-features \
+  --locked \
+  --target "$target_triple" \
+  --no-run \
+  --message-format=json \
+  > "$cargo_messages"
 
 test_bins_file="$tmp_dir/test-bins"
 python3 - "$cargo_messages" > "$test_bins_file" <<'PY'

--- a/scripts/run-hvf-tests.sh
+++ b/scripts/run-hvf-tests.sh
@@ -12,7 +12,8 @@ Options:
   --allow-unsupported  Exit 0 instead of 1 when the host cannot run HVF tests.
   -h, --help           Show this help.
 
-Any arguments after -- are passed to the signed Rust test binary.
+Arguments after -- are passed to the signed Rust test binary, except
+--test-threads because the wrapper always runs HVF tests with one test thread.
 EOF
 }
 
@@ -41,6 +42,17 @@ while [[ "$#" -gt 0 ]]; do
   esac
   shift
 done
+
+if [[ "${#test_args[@]}" -gt 0 ]]; then
+  for test_arg in "${test_args[@]}"; do
+    case "$test_arg" in
+      --test-threads | --test-threads=*)
+        echo "scripts/run-hvf-tests.sh controls --test-threads and always uses 1" >&2
+        exit 2
+        ;;
+    esac
+  done
+fi
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"

--- a/scripts/run-hvf-tests.sh
+++ b/scripts/run-hvf-tests.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if [[ "$(uname -s)" != "Darwin" || "$(uname -m)" != "arm64" ]]; then
+  echo "bangbang-hvf tests require macOS Apple Silicon; found $(uname -s) $(uname -m)" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/bangbang-hvf-tests.XXXXXX")"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+entitlements="$tmp_dir/hvf-entitlements.plist"
+cat > "$entitlements" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.hypervisor</key>
+  <true/>
+</dict>
+</plist>
+EOF
+
+cargo_messages="$tmp_dir/cargo-test.json"
+cargo test -p bangbang-hvf --all-targets --all-features --locked --no-run --message-format=json > "$cargo_messages"
+
+test_bins=()
+while IFS= read -r test_bin; do
+  if [[ -n "$test_bin" ]]; then
+    test_bins+=("$test_bin")
+  fi
+done < <(sed -n 's/.*"executable":"\([^"]*bangbang_hvf-[^"]*\)".*/\1/p' "$cargo_messages")
+
+if [[ "${#test_bins[@]}" -eq 0 ]]; then
+  echo "failed to locate bangbang-hvf test executable" >&2
+  exit 1
+fi
+
+for test_bin in "${test_bins[@]}"; do
+  codesign --force --sign - --entitlements "$entitlements" "$test_bin"
+  "$test_bin" "$@"
+done

--- a/scripts/run-hvf-tests.sh
+++ b/scripts/run-hvf-tests.sh
@@ -108,11 +108,6 @@ if [[ "$hv_disable" == "1" ]]; then
   finish_unsupported "Hypervisor.framework is disabled on this host"
 fi
 
-hv_vmm_present="$(sysctl -n kern.hv_vmm_present 2>/dev/null || true)"
-if [[ "$hv_vmm_present" == "1" ]]; then
-  finish_unsupported "nested Hypervisor.framework execution is not available on this virtualized host"
-fi
-
 for test_bin in "${signed_test_bins[@]}"; do
   if [[ "${#test_args[@]}" -eq 0 ]]; then
     "$test_bin" --test-threads=1

--- a/scripts/run-hvf-tests.sh
+++ b/scripts/run-hvf-tests.sh
@@ -1,16 +1,66 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<'EOF'
+Usage: scripts/run-hvf-tests.sh [--allow-unsupported] [-- TEST_ARGS...]
+
+Build and sign the bangbang-hvf lifecycle integration test, then run it when
+the host supports Hypervisor.framework VM creation.
+
+Options:
+  --allow-unsupported  Exit 0 instead of 1 when the host cannot run HVF tests.
+  -h, --help           Show this help.
+
+Any arguments after -- are passed to the signed Rust test binary.
+EOF
+}
+
+allow_unsupported=false
+test_args=()
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --allow-unsupported)
+      allow_unsupported=true
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      test_args+=("$@")
+      break
+      ;;
+    *)
+      test_args+=("$1")
+      ;;
+  esac
+  shift
+done
+
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-if [[ "$(uname -s)" != "Darwin" || "$(uname -m)" != "arm64" ]]; then
-  echo "bangbang-hvf tests require macOS Apple Silicon; found $(uname -s) $(uname -m)" >&2
-  exit 1
-fi
-
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/bangbang-hvf-tests.XXXXXX")"
 trap 'rm -rf "$tmp_dir"' EXIT
+
+finish_unsupported() {
+  local message="$1"
+
+  if [[ "$allow_unsupported" == true ]]; then
+    echo "$message; skipping signed HVF lifecycle test"
+    exit 0
+  fi
+
+  echo "$message" >&2
+  exit 1
+}
+
+if [[ "$(uname -s)" != "Darwin" || "$(uname -m)" != "arm64" ]]; then
+  finish_unsupported "bangbang-hvf tests require macOS Apple Silicon; found $(uname -s) $(uname -m)"
+fi
 
 entitlements="$tmp_dir/hvf-entitlements.plist"
 cat > "$entitlements" <<'EOF'
@@ -25,7 +75,7 @@ cat > "$entitlements" <<'EOF'
 EOF
 
 cargo_messages="$tmp_dir/cargo-test.json"
-cargo test -p bangbang-hvf --test hvf_lifecycle --all-features --locked --no-run --message-format=json > "$cargo_messages"
+cargo test --target-dir "$tmp_dir/target" -p bangbang-hvf --test hvf_lifecycle --all-features --locked --no-run --message-format=json > "$cargo_messages"
 
 test_bins=()
 while IFS= read -r test_bin; do
@@ -41,5 +91,27 @@ fi
 
 for test_bin in "${test_bins[@]}"; do
   codesign --force --sign - --entitlements "$entitlements" "$test_bin"
-  "$test_bin" --test-threads=1 "$@"
+done
+
+hv_support="$(sysctl -n kern.hv_support 2>/dev/null || sysctl -n kern.hv.supported 2>/dev/null || true)"
+if [[ "$hv_support" != "1" ]]; then
+  finish_unsupported "Hypervisor.framework is not supported by this host"
+fi
+
+hv_disable="$(sysctl -n kern.hv_disable 2>/dev/null || true)"
+if [[ "$hv_disable" == "1" ]]; then
+  finish_unsupported "Hypervisor.framework is disabled on this host"
+fi
+
+hv_vmm_present="$(sysctl -n kern.hv_vmm_present 2>/dev/null || true)"
+if [[ "$hv_vmm_present" == "1" ]]; then
+  finish_unsupported "nested Hypervisor.framework execution is not available on this virtualized host"
+fi
+
+for test_bin in "${test_bins[@]}"; do
+  if [[ "${#test_args[@]}" -eq 0 ]]; then
+    "$test_bin" --test-threads=1
+  else
+    "$test_bin" --test-threads=1 "${test_args[@]}"
+  fi
 done

--- a/scripts/run-hvf-tests.sh
+++ b/scripts/run-hvf-tests.sh
@@ -34,7 +34,9 @@ while [[ "$#" -gt 0 ]]; do
       break
       ;;
     *)
-      test_args+=("$1")
+      echo "unknown argument before --: $1" >&2
+      usage >&2
+      exit 2
       ;;
   esac
   shift

--- a/scripts/run-hvf-tests.sh
+++ b/scripts/run-hvf-tests.sh
@@ -25,21 +25,21 @@ cat > "$entitlements" <<'EOF'
 EOF
 
 cargo_messages="$tmp_dir/cargo-test.json"
-cargo test -p bangbang-hvf --all-targets --all-features --locked --no-run --message-format=json > "$cargo_messages"
+cargo test -p bangbang-hvf --test hvf_lifecycle --all-features --locked --no-run --message-format=json > "$cargo_messages"
 
 test_bins=()
 while IFS= read -r test_bin; do
   if [[ -n "$test_bin" ]]; then
     test_bins+=("$test_bin")
   fi
-done < <(sed -n 's/.*"executable":"\([^"]*bangbang_hvf-[^"]*\)".*/\1/p' "$cargo_messages")
+done < <(sed -n 's/.*"executable":"\([^"]*\)".*/\1/p' "$cargo_messages")
 
 if [[ "${#test_bins[@]}" -eq 0 ]]; then
-  echo "failed to locate bangbang-hvf test executable" >&2
+  echo "failed to locate bangbang-hvf lifecycle test executable" >&2
   exit 1
 fi
 
 for test_bin in "${test_bins[@]}"; do
   codesign --force --sign - --entitlements "$entitlements" "$test_bin"
-  "$test_bin" "$@"
+  "$test_bin" --test-threads=1 "$@"
 done

--- a/scripts/run-hvf-tests.sh
+++ b/scripts/run-hvf-tests.sh
@@ -62,6 +62,11 @@ if [[ "$(uname -s)" != "Darwin" || "$(uname -m)" != "arm64" ]]; then
   finish_unsupported "bangbang-hvf tests require macOS Apple Silicon; found $(uname -s) $(uname -m)"
 fi
 
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required to parse cargo test JSON output" >&2
+  exit 1
+fi
+
 entitlements="$tmp_dir/hvf-entitlements.plist"
 cat > "$entitlements" <<'EOF'
 <?xml version="1.0" encoding="UTF-8"?>
@@ -77,12 +82,33 @@ EOF
 cargo_messages="$tmp_dir/cargo-test.json"
 cargo test -p bangbang-hvf --test hvf_lifecycle --all-features --locked --no-run --message-format=json > "$cargo_messages"
 
+test_bins_file="$tmp_dir/test-bins"
+python3 - "$cargo_messages" > "$test_bins_file" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as messages:
+    for line in messages:
+        message = json.loads(line)
+        target = message.get("target", {})
+        executable = message.get("executable")
+
+        if (
+            message.get("reason") == "compiler-artifact"
+            and executable is not None
+            and target.get("name") == "hvf_lifecycle"
+            and "test" in target.get("kind", [])
+        ):
+            sys.stdout.write(executable)
+            sys.stdout.write("\0")
+PY
+
 test_bins=()
-while IFS= read -r test_bin; do
+while IFS= read -r -d "" test_bin; do
   if [[ -n "$test_bin" ]]; then
     test_bins+=("$test_bin")
   fi
-done < <(sed -n 's/.*"executable":"\([^"]*\)".*/\1/p' "$cargo_messages")
+done < "$test_bins_file"
 
 if [[ "${#test_bins[@]}" -eq 0 ]]; then
   echo "failed to locate bangbang-hvf lifecycle test executable" >&2

--- a/scripts/run-hvf-tests.sh
+++ b/scripts/run-hvf-tests.sh
@@ -58,8 +58,11 @@ finish_unsupported() {
   exit 1
 }
 
-if [[ "$(uname -s)" != "Darwin" || "$(uname -m)" != "arm64" ]]; then
-  finish_unsupported "bangbang-hvf tests require macOS Apple Silicon; found $(uname -s) $(uname -m)"
+host_os="$(uname -s)"
+host_arch="$(uname -m)"
+
+if [[ "$host_os" != "Darwin" ]]; then
+  finish_unsupported "bangbang-hvf tests require macOS; found $host_os $host_arch"
 fi
 
 if ! command -v python3 >/dev/null 2>&1; then
@@ -133,6 +136,10 @@ for index in "${!test_bins[@]}"; do
   codesign --force --sign - --entitlements "$entitlements" "$signed_test_bin"
   signed_test_bins+=("$signed_test_bin")
 done
+
+if [[ "$host_arch" != "arm64" ]]; then
+  finish_unsupported "bangbang-hvf tests require Apple Silicon; found $host_os $host_arch"
+fi
 
 hv_support="$(sysctl -n kern.hv_support 2>/dev/null || sysctl -n kern.hv.supported 2>/dev/null || true)"
 if [[ "$hv_support" != "1" ]]; then

--- a/scripts/run-hvf-tests.sh
+++ b/scripts/run-hvf-tests.sh
@@ -75,7 +75,7 @@ cat > "$entitlements" <<'EOF'
 EOF
 
 cargo_messages="$tmp_dir/cargo-test.json"
-cargo test --target-dir "$tmp_dir/target" -p bangbang-hvf --test hvf_lifecycle --all-features --locked --no-run --message-format=json > "$cargo_messages"
+cargo test -p bangbang-hvf --test hvf_lifecycle --all-features --locked --no-run --message-format=json > "$cargo_messages"
 
 test_bins=()
 while IFS= read -r test_bin; do
@@ -89,8 +89,13 @@ if [[ "${#test_bins[@]}" -eq 0 ]]; then
   exit 1
 fi
 
-for test_bin in "${test_bins[@]}"; do
-  codesign --force --sign - --entitlements "$entitlements" "$test_bin"
+signed_test_bins=()
+for index in "${!test_bins[@]}"; do
+  test_bin="${test_bins[$index]}"
+  signed_test_bin="$tmp_dir/$(basename "$test_bin").$index"
+  cp "$test_bin" "$signed_test_bin"
+  codesign --force --sign - --entitlements "$entitlements" "$signed_test_bin"
+  signed_test_bins+=("$signed_test_bin")
 done
 
 hv_support="$(sysctl -n kern.hv_support 2>/dev/null || sysctl -n kern.hv.supported 2>/dev/null || true)"
@@ -108,7 +113,7 @@ if [[ "$hv_vmm_present" == "1" ]]; then
   finish_unsupported "nested Hypervisor.framework execution is not available on this virtualized host"
 fi
 
-for test_bin in "${test_bins[@]}"; do
+for test_bin in "${signed_test_bins[@]}"; do
   if [[ "${#test_args[@]}" -eq 0 ]]; then
     "$test_bin" --test-threads=1
   else


### PR DESCRIPTION
## Summary

- Add minimal HVF vCPU create/destroy FFI and an owning `HvfVcpu<'_>` RAII wrapper.
- Keep vCPU handles tied to a mutable `HvfBackend` borrow and non-`Send`/non-`Sync` so active handles cannot be moved across threads.
- Keep owning vCPU handles non-`Copy`, make explicit vCPU destroy retryable on Hypervisor.framework errors, clear the cached handle only after successful destroy, and keep repeated destroy after success idempotent.
- Add `BackendError::InvalidState` for lifecycle ordering errors and keep unsupported targets returning clear unsupported errors.
- Add `scripts/run-hvf-tests.sh` to build, sign, and run the real HVF lifecycle integration test when the host supports HVF.
- Document the unsigned HVF unit test path, signed HVF integration test path, and remaining out-of-scope work.

## CI note

Hosted macOS CI runs `scripts/run-hvf-tests.sh --allow-unsupported`, which still builds and signs `crates/hvf/tests/hvf_lifecycle.rs` but exits successfully without executing the test when the runner does not support Hypervisor.framework VM creation. Local or self-hosted Apple Silicon verification should run `scripts/run-hvf-tests.sh` without `--allow-unsupported` so unsupported hosts fail.

## Scope exclusions

- No `hv_vcpu_run`, exit handling, register setup, guest memory mapping, vCPU runner threads, or `InstanceStart` wiring.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `rustup toolchain install stable --profile minimal --component clippy --component rustfmt --target aarch64-apple-darwin --no-update`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `scripts/run-hvf-tests.sh` (`1 passed; 0 failed; 0 ignored` locally)
- `CARGO_BUILD_TARGET=x86_64-apple-darwin scripts/run-hvf-tests.sh` (`1 passed; 0 failed; 0 ignored`; script still builds/runs `aarch64-apple-darwin`)
- `scripts/run-hvf-tests.sh --allow-unsupported` (`1 passed; 0 failed; 0 ignored` locally on supported HVF host)
- `scripts/run-hvf-tests.sh --allow-unsupported -- --list` passes through to the signed test binary
- `scripts/run-hvf-tests.sh --help` exits 0, `scripts/run-hvf-tests.sh --allow-unsuported` exits 2, and `scripts/run-hvf-tests.sh -- --help` passes help through to the signed test binary
- `scripts/run-hvf-tests.sh -- --test-threads=2` and `scripts/run-hvf-tests.sh -- --test-threads 2` exit 2 before build/sign; empty test-arg runs still work under macOS Bash `set -u`
- Simulated Darwin x86_64 host: script builds/signs first; default exits 1, `--allow-unsupported` exits 0 without executing HVF
- Simulated unsupported host: `scripts/run-hvf-tests.sh` exits 1, `scripts/run-hvf-tests.sh --allow-unsupported` exits 0 after build/sign
- Simulated disabled HVF host: `scripts/run-hvf-tests.sh --allow-unsupported` exits 0 after build/sign without executing HVF
- Simulated cargo JSON parser input with escaped quotes/newlines and non-test executable artifacts; parser keeps only the `hvf_lifecycle` test executable
- Simulated missing `hvf_lifecycle` artifact and malformed cargo JSON both fail instead of reporting success
- Verified SDK FFI types for `hv_return_t`, `hv_vcpu_t`, `hv_vcpu_create`, `hv_vcpu_destroy`, and `hv_vm_destroy`
- Verified safe Rust rejects `destroy_vm()` while an `HvfVcpu` borrow is live
- `bash -n scripts/run-hvf-tests.sh`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`

Closes #55
