### PR TITLE
feat: model HVF vCPU exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 bangbang is a Rust VMM project for macOS hosts. The public control plane is intended to stay compatible with the Firecracker HTTP API over a Unix domain socket, while the VM backend is built on Apple's Hypervisor.framework.
 
-This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, and the smallest Hypervisor.framework VM and current-thread vCPU create/destroy wrappers.
+This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, and the smallest Hypervisor.framework VM, current-thread vCPU lifecycle, exit snapshot, and register wrappers.
 
 See [Firecracker Compatibility Scope](docs/firecracker-compatibility.md) for the intended compatibility target and current limitations.
 See [Pull Request Review Guidelines](docs/review-guidelines.md) for the project-specific review standard.
@@ -18,12 +18,12 @@ crates/bangbang   VMM process entrypoint and startup CLI
 
 ## Current Scope
 
-The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. The HVF crate can create/destroy a process VM and create/destroy one current-thread vCPU handle for lifecycle smoke testing. It intentionally does not include:
+The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. The HVF crate can create/destroy a process VM, create/destroy one current-thread vCPU handle, snapshot typed HVF exit data, and get/set a narrow set of vCPU registers for lifecycle smoke testing. It intentionally does not include:
 
 - API endpoints beyond `GET /` and `GET /version`
 - JSON request body models
 - guest memory mapping
-- vCPU register setup, exit handling, or a run loop
+- guest execution, vCPU run loops, MMIO/device emulation, or boot register setup
 - kernel loading
 
 ## Process CLI

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 bangbang is a Rust VMM project for macOS hosts. The public control plane is intended to stay compatible with the Firecracker HTTP API over a Unix domain socket, while the VM backend is built on Apple's Hypervisor.framework.
 
-This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, and the smallest Hypervisor.framework VM, current-thread vCPU lifecycle, exit snapshot, and register wrappers.
+This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, and the smallest Hypervisor.framework VM, current-thread vCPU lifecycle, typed exit surface, and register wrappers.
 
 See [Firecracker Compatibility Scope](docs/firecracker-compatibility.md) for the intended compatibility target and current limitations.
 See [Pull Request Review Guidelines](docs/review-guidelines.md) for the project-specific review standard.
@@ -18,7 +18,7 @@ crates/bangbang   VMM process entrypoint and startup CLI
 
 ## Current Scope
 
-The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. The HVF crate can create/destroy a process VM, create/destroy one current-thread vCPU handle, snapshot typed HVF exit data, and get/set a narrow set of vCPU registers for lifecycle smoke testing. It intentionally does not include:
+The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. The HVF crate can create/destroy a process VM, create/destroy one current-thread vCPU handle, define typed HVF exit snapshots for future run-loop work, and get/set a narrow set of vCPU registers for lifecycle smoke testing. It intentionally does not include:
 
 - API endpoints beyond `GET /` and `GET /version`
 - JSON request body models

--- a/crates/hvf/src/exit.rs
+++ b/crates/hvf/src/exit.rs
@@ -1,0 +1,96 @@
+//! Typed snapshots of Hypervisor.framework vCPU exits.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HvfExceptionExit {
+    pub syndrome: u64,
+    pub virtual_address: u64,
+    pub physical_address: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfVcpuExit {
+    Canceled,
+    Exception(HvfExceptionExit),
+    VtimerActivated,
+    Unknown { reason: u32 },
+}
+
+impl HvfVcpuExit {
+    pub(crate) fn from_raw(exit: crate::ffi::HvVcpuExit) -> Self {
+        match exit.reason {
+            crate::ffi::HV_EXIT_REASON_CANCELED => Self::Canceled,
+            crate::ffi::HV_EXIT_REASON_EXCEPTION => Self::Exception(HvfExceptionExit {
+                syndrome: exit.exception.syndrome,
+                virtual_address: exit.exception.virtual_address,
+                physical_address: exit.exception.physical_address,
+            }),
+            crate::ffi::HV_EXIT_REASON_VTIMER_ACTIVATED => Self::VtimerActivated,
+            crate::ffi::HV_EXIT_REASON_UNKNOWN => Self::Unknown {
+                reason: crate::ffi::HV_EXIT_REASON_UNKNOWN,
+            },
+            reason => Self::Unknown { reason },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HvfExceptionExit, HvfVcpuExit};
+
+    fn raw_exit(reason: u32) -> crate::ffi::HvVcpuExit {
+        crate::ffi::HvVcpuExit {
+            reason,
+            exception: crate::ffi::HvVcpuExitException {
+                syndrome: 0x11,
+                virtual_address: 0x22,
+                physical_address: 0x33,
+            },
+        }
+    }
+
+    #[test]
+    fn converts_canceled_exit() {
+        assert_eq!(
+            HvfVcpuExit::from_raw(raw_exit(crate::ffi::HV_EXIT_REASON_CANCELED)),
+            HvfVcpuExit::Canceled
+        );
+    }
+
+    #[test]
+    fn converts_exception_exit() {
+        assert_eq!(
+            HvfVcpuExit::from_raw(raw_exit(crate::ffi::HV_EXIT_REASON_EXCEPTION)),
+            HvfVcpuExit::Exception(HvfExceptionExit {
+                syndrome: 0x11,
+                virtual_address: 0x22,
+                physical_address: 0x33,
+            })
+        );
+    }
+
+    #[test]
+    fn converts_vtimer_activated_exit() {
+        assert_eq!(
+            HvfVcpuExit::from_raw(raw_exit(crate::ffi::HV_EXIT_REASON_VTIMER_ACTIVATED)),
+            HvfVcpuExit::VtimerActivated
+        );
+    }
+
+    #[test]
+    fn preserves_sdk_unknown_exit_reason() {
+        assert_eq!(
+            HvfVcpuExit::from_raw(raw_exit(crate::ffi::HV_EXIT_REASON_UNKNOWN)),
+            HvfVcpuExit::Unknown {
+                reason: crate::ffi::HV_EXIT_REASON_UNKNOWN
+            }
+        );
+    }
+
+    #[test]
+    fn preserves_future_unknown_exit_reason() {
+        assert_eq!(
+            HvfVcpuExit::from_raw(raw_exit(99)),
+            HvfVcpuExit::Unknown { reason: 99 }
+        );
+    }
+}

--- a/crates/hvf/src/ffi.rs
+++ b/crates/hvf/src/ffi.rs
@@ -41,7 +41,12 @@ pub(crate) struct CreatedVcpu {
     pub(crate) exit: *mut HvVcpuExit,
 }
 
-pub(crate) fn copy_vcpu_exit(
+/// # Safety
+///
+/// `exit` must point to initialized `HvVcpuExit` data belonging to a live
+/// current-thread vCPU whose latest `hv_vcpu_run` call has returned, or to
+/// test-owned memory with the same layout.
+pub(crate) unsafe fn copy_vcpu_exit(
     exit: *const HvVcpuExit,
 ) -> Result<HvVcpuExit, bangbang_runtime::BackendError> {
     if exit.is_null() {
@@ -50,10 +55,7 @@ pub(crate) fn copy_vcpu_exit(
         ));
     }
 
-    // SAFETY: The caller provides a non-null pointer to an initialized `HvVcpuExit`
-    // belonging to a live current-thread vCPU or to test-owned memory with the same
-    // layout. The raw struct is `Copy`, so this snapshots the current values without
-    // moving or retaining HVF-owned memory.
+    // SAFETY: The caller guarantees `exit` is valid for a read of `HvVcpuExit`.
     unsafe { Ok(*exit) }
 }
 

--- a/crates/hvf/src/ffi.rs
+++ b/crates/hvf/src/ffi.rs
@@ -1,6 +1,62 @@
 pub(crate) const UNSUPPORTED_TARGET_MESSAGE: &str =
     "Hypervisor.framework backend currently targets macOS on Apple Silicon";
 
+pub(crate) type HvVcpu = u64;
+pub(crate) type HvExitReason = u32;
+pub(crate) type HvReg = u32;
+pub(crate) type HvSysReg = u16;
+
+pub(crate) const HV_EXIT_REASON_CANCELED: HvExitReason = 0;
+pub(crate) const HV_EXIT_REASON_EXCEPTION: HvExitReason = 1;
+pub(crate) const HV_EXIT_REASON_VTIMER_ACTIVATED: HvExitReason = 2;
+pub(crate) const HV_EXIT_REASON_UNKNOWN: HvExitReason = 3;
+pub(crate) const HV_REG_X0: HvReg = 0;
+pub(crate) const HV_REG_X1: HvReg = 1;
+pub(crate) const HV_REG_X2: HvReg = 2;
+pub(crate) const HV_REG_X3: HvReg = 3;
+pub(crate) const HV_REG_PC: HvReg = 31;
+pub(crate) const HV_REG_CPSR: HvReg = 34;
+pub(crate) const HV_SYS_REG_SPSR_EL1: HvSysReg = 0xc200;
+pub(crate) const HV_SYS_REG_ELR_EL1: HvSysReg = 0xc201;
+pub(crate) const HV_SYS_REG_SP_EL1: HvSysReg = 0xe208;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct HvVcpuExitException {
+    pub(crate) syndrome: u64,
+    pub(crate) virtual_address: u64,
+    pub(crate) physical_address: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct HvVcpuExit {
+    pub(crate) reason: HvExitReason,
+    pub(crate) exception: HvVcpuExitException,
+}
+
+#[derive(Debug)]
+pub(crate) struct CreatedVcpu {
+    pub(crate) vcpu: HvVcpu,
+    pub(crate) exit: *mut HvVcpuExit,
+}
+
+pub(crate) fn copy_vcpu_exit(
+    exit: *const HvVcpuExit,
+) -> Result<HvVcpuExit, bangbang_runtime::BackendError> {
+    if exit.is_null() {
+        return Err(bangbang_runtime::BackendError::Hypervisor(
+            "hv_vcpu_exit_t pointer is null".to_string(),
+        ));
+    }
+
+    // SAFETY: The caller provides a non-null pointer to an initialized `HvVcpuExit`
+    // belonging to a live current-thread vCPU or to test-owned memory with the same
+    // layout. The raw struct is `Copy`, so this snapshots the current values without
+    // moving or retaining HVF-owned memory.
+    unsafe { Ok(*exit) }
+}
+
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 mod imp {
     use std::ffi::c_void;
@@ -8,11 +64,11 @@ mod imp {
 
     use bangbang_runtime::BackendError;
 
+    use super::{CreatedVcpu, HvReg, HvSysReg, HvVcpu, HvVcpuExit};
+
     pub type HvReturn = i32;
     pub type HvVmConfig = *mut c_void;
-    pub type HvVcpu = u64;
     pub type HvVcpuConfig = *mut c_void;
-    pub type HvVcpuExit = c_void;
 
     pub const HV_SUCCESS: HvReturn = 0;
     const HV_ERROR: HvReturn = 0xfae94001u32 as HvReturn;
@@ -24,12 +80,6 @@ mod imp {
     const HV_FAULT: HvReturn = 0xfae94008u32 as HvReturn;
     const HV_UNSUPPORTED: HvReturn = 0xfae9400fu32 as HvReturn;
 
-    #[derive(Debug)]
-    pub struct CreatedVcpu {
-        pub vcpu: HvVcpu,
-        pub exit: *mut HvVcpuExit,
-    }
-
     #[link(name = "Hypervisor", kind = "framework")]
     extern "C" {
         pub fn hv_vm_create(config: HvVmConfig) -> HvReturn;
@@ -40,6 +90,10 @@ mod imp {
             config: HvVcpuConfig,
         ) -> HvReturn;
         pub fn hv_vcpu_destroy(vcpu: HvVcpu) -> HvReturn;
+        pub fn hv_vcpu_get_reg(vcpu: HvVcpu, reg: HvReg, value: *mut u64) -> HvReturn;
+        pub fn hv_vcpu_set_reg(vcpu: HvVcpu, reg: HvReg, value: u64) -> HvReturn;
+        pub fn hv_vcpu_get_sys_reg(vcpu: HvVcpu, reg: HvSysReg, value: *mut u64) -> HvReturn;
+        pub fn hv_vcpu_set_sys_reg(vcpu: HvVcpu, reg: HvSysReg, value: u64) -> HvReturn;
     }
 
     fn hv_return_name(code: HvReturn) -> Option<&'static str> {
@@ -108,9 +162,44 @@ mod imp {
         unsafe { check(hv_vcpu_destroy(vcpu), "hv_vcpu_destroy") }
     }
 
+    pub fn get_reg(vcpu: HvVcpu, reg: HvReg) -> Result<u64, BackendError> {
+        let mut value = 0;
+
+        // SAFETY: The caller owns this current-thread vCPU handle, and `value` is a valid
+        // out-pointer for the duration of the call.
+        unsafe { check(hv_vcpu_get_reg(vcpu, reg, &mut value), "hv_vcpu_get_reg")? };
+
+        Ok(value)
+    }
+
+    pub fn set_reg(vcpu: HvVcpu, reg: HvReg, value: u64) -> Result<(), BackendError> {
+        // SAFETY: The caller owns this current-thread vCPU handle.
+        unsafe { check(hv_vcpu_set_reg(vcpu, reg, value), "hv_vcpu_set_reg") }
+    }
+
+    pub fn get_sys_reg(vcpu: HvVcpu, reg: HvSysReg) -> Result<u64, BackendError> {
+        let mut value = 0;
+
+        // SAFETY: The caller owns this current-thread vCPU handle, and `value` is a valid
+        // out-pointer for the duration of the call.
+        unsafe {
+            check(
+                hv_vcpu_get_sys_reg(vcpu, reg, &mut value),
+                "hv_vcpu_get_sys_reg",
+            )?
+        };
+
+        Ok(value)
+    }
+
+    pub fn set_sys_reg(vcpu: HvVcpu, reg: HvSysReg, value: u64) -> Result<(), BackendError> {
+        // SAFETY: The caller owns this current-thread vCPU handle.
+        unsafe { check(hv_vcpu_set_sys_reg(vcpu, reg, value), "hv_vcpu_set_sys_reg") }
+    }
+
     #[cfg(test)]
     mod tests {
-        use super::{check, HV_DENIED, HV_UNSUPPORTED};
+        use super::{check, HV_BAD_ARGUMENT, HV_DENIED, HV_UNSUPPORTED};
 
         #[test]
         fn check_displays_named_hv_return() {
@@ -132,25 +221,25 @@ mod imp {
                 "hypervisor error: hv_vm_create failed with HV_UNSUPPORTED (hv_return_t=0xfae9400f)"
             );
         }
+
+        #[test]
+        fn check_displays_register_operation_hv_return() {
+            let err =
+                check(HV_BAD_ARGUMENT, "hv_vcpu_get_reg").expect_err("HV_BAD_ARGUMENT should fail");
+
+            assert_eq!(
+                err.to_string(),
+                "hypervisor error: hv_vcpu_get_reg failed with HV_BAD_ARGUMENT (hv_return_t=0xfae94003)"
+            );
+        }
     }
 }
 
 #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 mod imp {
-    use std::ffi::c_void;
-
     use bangbang_runtime::BackendError;
 
-    use super::UNSUPPORTED_TARGET_MESSAGE;
-
-    pub type HvVcpu = u64;
-    pub type HvVcpuExit = c_void;
-
-    #[derive(Debug)]
-    pub struct CreatedVcpu {
-        pub vcpu: HvVcpu,
-        pub exit: *mut HvVcpuExit,
-    }
+    use super::{CreatedVcpu, HvReg, HvSysReg, HvVcpu, UNSUPPORTED_TARGET_MESSAGE};
 
     pub fn create_vm() -> Result<(), BackendError> {
         Err(BackendError::Unsupported(UNSUPPORTED_TARGET_MESSAGE))
@@ -167,6 +256,46 @@ mod imp {
     pub fn destroy_vcpu(_: HvVcpu) -> Result<(), BackendError> {
         Ok(())
     }
+
+    pub fn get_reg(_: HvVcpu, _: HvReg) -> Result<u64, BackendError> {
+        Err(BackendError::Unsupported(UNSUPPORTED_TARGET_MESSAGE))
+    }
+
+    pub fn set_reg(_: HvVcpu, _: HvReg, _: u64) -> Result<(), BackendError> {
+        Err(BackendError::Unsupported(UNSUPPORTED_TARGET_MESSAGE))
+    }
+
+    pub fn get_sys_reg(_: HvVcpu, _: HvSysReg) -> Result<u64, BackendError> {
+        Err(BackendError::Unsupported(UNSUPPORTED_TARGET_MESSAGE))
+    }
+
+    pub fn set_sys_reg(_: HvVcpu, _: HvSysReg, _: u64) -> Result<(), BackendError> {
+        Err(BackendError::Unsupported(UNSUPPORTED_TARGET_MESSAGE))
+    }
 }
 
-pub use imp::*;
+pub(crate) use imp::*;
+
+#[cfg(test)]
+mod tests {
+    use std::mem::{align_of, offset_of, size_of};
+
+    use super::{HvVcpuExit, HvVcpuExitException};
+
+    #[test]
+    fn vcpu_exit_layout_matches_hvf_sdk() {
+        assert_eq!(size_of::<HvVcpuExit>(), 32);
+        assert_eq!(align_of::<HvVcpuExit>(), 8);
+        assert_eq!(offset_of!(HvVcpuExit, reason), 0);
+        assert_eq!(offset_of!(HvVcpuExit, exception), 8);
+        assert_eq!(offset_of!(HvVcpuExit, exception.syndrome), 8);
+        assert_eq!(offset_of!(HvVcpuExit, exception.virtual_address), 16);
+        assert_eq!(offset_of!(HvVcpuExit, exception.physical_address), 24);
+    }
+
+    #[test]
+    fn vcpu_exit_exception_layout_matches_hvf_sdk() {
+        assert_eq!(size_of::<HvVcpuExitException>(), 24);
+        assert_eq!(align_of::<HvVcpuExitException>(), 8);
+    }
+}

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -1,8 +1,10 @@
 //! Hypervisor.framework backend.
 
 mod backend;
+mod exit;
 mod ffi;
 mod vcpu;
 
 pub use backend::HvfBackend;
-pub use vcpu::HvfVcpu;
+pub use exit::{HvfExceptionExit, HvfVcpuExit};
+pub use vcpu::{HvfRegister, HvfSystemRegister, HvfVcpu};

--- a/crates/hvf/src/vcpu.rs
+++ b/crates/hvf/src/vcpu.rs
@@ -8,6 +8,7 @@ use crate::backend::HvfBackend;
 use crate::exit::HvfVcpuExit;
 
 const DESTROYED_VCPU_MESSAGE: &str = "vCPU has already been destroyed";
+const NO_VCPU_EXIT_MESSAGE: &str = "vCPU has not exited yet";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct HvfRegister(u32);
@@ -47,6 +48,7 @@ pub struct HvfVcpu<'vm> {
 struct HvfVcpuHandle {
     vcpu: crate::ffi::HvVcpu,
     exit: *mut crate::ffi::HvVcpuExit,
+    exit_available: bool,
 }
 
 impl<'vm> HvfVcpu<'vm> {
@@ -57,6 +59,7 @@ impl<'vm> HvfVcpu<'vm> {
             handle: Some(HvfVcpuHandle {
                 vcpu: created.vcpu,
                 exit: created.exit,
+                exit_available: false,
             }),
             _vm: PhantomData,
             _not_send_sync: PhantomData,
@@ -68,7 +71,14 @@ impl<'vm> HvfVcpu<'vm> {
     }
 
     pub fn exit_snapshot(&self) -> Result<HvfVcpuExit, BackendError> {
-        let raw_exit = crate::ffi::copy_vcpu_exit(self.handle()?.exit)?;
+        let handle = self.handle()?;
+        if !handle.exit_available {
+            return Err(BackendError::InvalidState(NO_VCPU_EXIT_MESSAGE));
+        }
+
+        // SAFETY: `handle` belongs to this live current-thread vCPU, and
+        // `exit_available` is only set after HVF has produced exit data.
+        let raw_exit = unsafe { crate::ffi::copy_vcpu_exit(handle.exit)? };
 
         Ok(HvfVcpuExit::from_raw(raw_exit))
     }
@@ -116,14 +126,19 @@ impl Drop for HvfVcpu<'_> {
 
 impl fmt::Debug for HvfVcpu<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (vcpu, has_exit) = match &self.handle {
-            Some(handle) => (Some(handle.vcpu), !handle.exit.is_null()),
-            None => (None, false),
+        let (vcpu, has_exit_pointer, exit_available) = match &self.handle {
+            Some(handle) => (
+                Some(handle.vcpu),
+                !handle.exit.is_null(),
+                handle.exit_available,
+            ),
+            None => (None, false, false),
         };
 
         f.debug_struct("HvfVcpu")
             .field("vcpu", &vcpu)
-            .field("has_exit", &has_exit)
+            .field("has_exit_pointer", &has_exit_pointer)
+            .field("exit_available", &exit_available)
             .finish_non_exhaustive()
     }
 }
@@ -136,7 +151,10 @@ mod tests {
 
     use bangbang_runtime::BackendError;
 
-    use super::{HvfRegister, HvfSystemRegister, HvfVcpu, HvfVcpuHandle, DESTROYED_VCPU_MESSAGE};
+    use super::{
+        HvfRegister, HvfSystemRegister, HvfVcpu, HvfVcpuHandle, DESTROYED_VCPU_MESSAGE,
+        NO_VCPU_EXIT_MESSAGE,
+    };
     use crate::exit::{HvfExceptionExit, HvfVcpuExit};
 
     fn raw_exit(reason: u32) -> crate::ffi::HvVcpuExit {
@@ -150,9 +168,13 @@ mod tests {
         }
     }
 
-    fn fake_vcpu(exit: *mut crate::ffi::HvVcpuExit) -> HvfVcpu<'static> {
+    fn fake_vcpu(exit: *mut crate::ffi::HvVcpuExit, exit_available: bool) -> HvfVcpu<'static> {
         HvfVcpu {
-            handle: Some(HvfVcpuHandle { vcpu: 7, exit }),
+            handle: Some(HvfVcpuHandle {
+                vcpu: 7,
+                exit,
+                exit_available,
+            }),
             _vm: PhantomData,
             _not_send_sync: PhantomData::<Rc<()>>,
         }
@@ -161,7 +183,7 @@ mod tests {
     #[test]
     fn exit_snapshot_copies_raw_exit_data() {
         let mut exit = raw_exit(crate::ffi::HV_EXIT_REASON_EXCEPTION);
-        let mut vcpu = fake_vcpu(ptr::addr_of_mut!(exit));
+        let mut vcpu = fake_vcpu(ptr::addr_of_mut!(exit), true);
 
         assert_eq!(
             vcpu.exit_snapshot(),
@@ -177,7 +199,7 @@ mod tests {
 
     #[test]
     fn exit_snapshot_rejects_null_exit_pointer() {
-        let mut vcpu = fake_vcpu(ptr::null_mut());
+        let mut vcpu = fake_vcpu(ptr::null_mut(), true);
 
         let err = vcpu
             .exit_snapshot()
@@ -186,6 +208,19 @@ mod tests {
         assert_eq!(
             err,
             BackendError::Hypervisor("hv_vcpu_exit_t pointer is null".to_string())
+        );
+
+        vcpu.handle = None;
+    }
+
+    #[test]
+    fn exit_snapshot_rejects_unavailable_exit() {
+        let mut exit = raw_exit(crate::ffi::HV_EXIT_REASON_EXCEPTION);
+        let mut vcpu = fake_vcpu(ptr::addr_of_mut!(exit), false);
+
+        assert_eq!(
+            vcpu.exit_snapshot(),
+            Err(BackendError::InvalidState(NO_VCPU_EXIT_MESSAGE))
         );
 
         vcpu.handle = None;

--- a/crates/hvf/src/vcpu.rs
+++ b/crates/hvf/src/vcpu.rs
@@ -5,6 +5,38 @@ use std::rc::Rc;
 use bangbang_runtime::BackendError;
 
 use crate::backend::HvfBackend;
+use crate::exit::HvfVcpuExit;
+
+const DESTROYED_VCPU_MESSAGE: &str = "vCPU has already been destroyed";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HvfRegister(u32);
+
+impl HvfRegister {
+    pub const X0: Self = Self(crate::ffi::HV_REG_X0);
+    pub const X1: Self = Self(crate::ffi::HV_REG_X1);
+    pub const X2: Self = Self(crate::ffi::HV_REG_X2);
+    pub const X3: Self = Self(crate::ffi::HV_REG_X3);
+    pub const PC: Self = Self(crate::ffi::HV_REG_PC);
+    pub const CPSR: Self = Self(crate::ffi::HV_REG_CPSR);
+
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HvfSystemRegister(u16);
+
+impl HvfSystemRegister {
+    pub const SPSR_EL1: Self = Self(crate::ffi::HV_SYS_REG_SPSR_EL1);
+    pub const ELR_EL1: Self = Self(crate::ffi::HV_SYS_REG_ELR_EL1);
+    pub const SP_EL1: Self = Self(crate::ffi::HV_SYS_REG_SP_EL1);
+
+    pub const fn raw(self) -> u16 {
+        self.0
+    }
+}
 
 pub struct HvfVcpu<'vm> {
     handle: Option<HvfVcpuHandle>,
@@ -35,6 +67,38 @@ impl<'vm> HvfVcpu<'vm> {
         self.destroy_inner()
     }
 
+    pub fn exit_snapshot(&self) -> Result<HvfVcpuExit, BackendError> {
+        let raw_exit = crate::ffi::copy_vcpu_exit(self.handle()?.exit)?;
+
+        Ok(HvfVcpuExit::from_raw(raw_exit))
+    }
+
+    pub fn get_register(&self, register: HvfRegister) -> Result<u64, BackendError> {
+        crate::ffi::get_reg(self.handle()?.vcpu, register.raw())
+    }
+
+    pub fn set_register(&self, register: HvfRegister, value: u64) -> Result<(), BackendError> {
+        crate::ffi::set_reg(self.handle()?.vcpu, register.raw(), value)
+    }
+
+    pub fn get_system_register(&self, register: HvfSystemRegister) -> Result<u64, BackendError> {
+        crate::ffi::get_sys_reg(self.handle()?.vcpu, register.raw())
+    }
+
+    pub fn set_system_register(
+        &self,
+        register: HvfSystemRegister,
+        value: u64,
+    ) -> Result<(), BackendError> {
+        crate::ffi::set_sys_reg(self.handle()?.vcpu, register.raw(), value)
+    }
+
+    fn handle(&self) -> Result<&HvfVcpuHandle, BackendError> {
+        self.handle
+            .as_ref()
+            .ok_or(BackendError::InvalidState(DESTROYED_VCPU_MESSAGE))
+    }
+
     fn destroy_inner(&mut self) -> Result<(), BackendError> {
         if let Some(handle) = &self.handle {
             crate::ffi::destroy_vcpu(handle.vcpu)?;
@@ -61,5 +125,109 @@ impl fmt::Debug for HvfVcpu<'_> {
             .field("vcpu", &vcpu)
             .field("has_exit", &has_exit)
             .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::marker::PhantomData;
+    use std::ptr;
+    use std::rc::Rc;
+
+    use bangbang_runtime::BackendError;
+
+    use super::{HvfRegister, HvfSystemRegister, HvfVcpu, HvfVcpuHandle, DESTROYED_VCPU_MESSAGE};
+    use crate::exit::{HvfExceptionExit, HvfVcpuExit};
+
+    fn raw_exit(reason: u32) -> crate::ffi::HvVcpuExit {
+        crate::ffi::HvVcpuExit {
+            reason,
+            exception: crate::ffi::HvVcpuExitException {
+                syndrome: 0xabc,
+                virtual_address: 0xdef,
+                physical_address: 0x123,
+            },
+        }
+    }
+
+    fn fake_vcpu(exit: *mut crate::ffi::HvVcpuExit) -> HvfVcpu<'static> {
+        HvfVcpu {
+            handle: Some(HvfVcpuHandle { vcpu: 7, exit }),
+            _vm: PhantomData,
+            _not_send_sync: PhantomData::<Rc<()>>,
+        }
+    }
+
+    #[test]
+    fn exit_snapshot_copies_raw_exit_data() {
+        let mut exit = raw_exit(crate::ffi::HV_EXIT_REASON_EXCEPTION);
+        let mut vcpu = fake_vcpu(ptr::addr_of_mut!(exit));
+
+        assert_eq!(
+            vcpu.exit_snapshot(),
+            Ok(HvfVcpuExit::Exception(HvfExceptionExit {
+                syndrome: 0xabc,
+                virtual_address: 0xdef,
+                physical_address: 0x123,
+            }))
+        );
+
+        vcpu.handle = None;
+    }
+
+    #[test]
+    fn exit_snapshot_rejects_null_exit_pointer() {
+        let mut vcpu = fake_vcpu(ptr::null_mut());
+
+        let err = vcpu
+            .exit_snapshot()
+            .expect_err("null exit pointer should fail");
+
+        assert_eq!(
+            err,
+            BackendError::Hypervisor("hv_vcpu_exit_t pointer is null".to_string())
+        );
+
+        vcpu.handle = None;
+    }
+
+    #[test]
+    fn exit_snapshot_rejects_destroyed_vcpu() {
+        let vcpu = HvfVcpu {
+            handle: None,
+            _vm: PhantomData,
+            _not_send_sync: PhantomData::<Rc<()>>,
+        };
+
+        assert_eq!(
+            vcpu.exit_snapshot(),
+            Err(BackendError::InvalidState(DESTROYED_VCPU_MESSAGE))
+        );
+    }
+
+    #[test]
+    fn register_access_rejects_destroyed_vcpu() {
+        let vcpu = HvfVcpu {
+            handle: None,
+            _vm: PhantomData,
+            _not_send_sync: PhantomData::<Rc<()>>,
+        };
+
+        assert_eq!(
+            vcpu.get_register(HvfRegister::X0),
+            Err(BackendError::InvalidState(DESTROYED_VCPU_MESSAGE))
+        );
+        assert_eq!(
+            vcpu.set_register(HvfRegister::X0, 0),
+            Err(BackendError::InvalidState(DESTROYED_VCPU_MESSAGE))
+        );
+        assert_eq!(
+            vcpu.get_system_register(HvfSystemRegister::SP_EL1),
+            Err(BackendError::InvalidState(DESTROYED_VCPU_MESSAGE))
+        );
+        assert_eq!(
+            vcpu.set_system_register(HvfSystemRegister::SP_EL1, 0),
+            Err(BackendError::InvalidState(DESTROYED_VCPU_MESSAGE))
+        );
     }
 }

--- a/crates/hvf/src/vcpu.rs
+++ b/crates/hvf/src/vcpu.rs
@@ -87,7 +87,7 @@ impl<'vm> HvfVcpu<'vm> {
         crate::ffi::get_reg(self.handle()?.vcpu, register.raw())
     }
 
-    pub fn set_register(&self, register: HvfRegister, value: u64) -> Result<(), BackendError> {
+    pub fn set_register(&mut self, register: HvfRegister, value: u64) -> Result<(), BackendError> {
         crate::ffi::set_reg(self.handle()?.vcpu, register.raw(), value)
     }
 
@@ -96,7 +96,7 @@ impl<'vm> HvfVcpu<'vm> {
     }
 
     pub fn set_system_register(
-        &self,
+        &mut self,
         register: HvfSystemRegister,
         value: u64,
     ) -> Result<(), BackendError> {
@@ -146,6 +146,7 @@ impl fmt::Debug for HvfVcpu<'_> {
 #[cfg(test)]
 mod tests {
     use std::marker::PhantomData;
+    use std::mem::ManuallyDrop;
     use std::ptr;
     use std::rc::Rc;
 
@@ -168,8 +169,11 @@ mod tests {
         }
     }
 
-    fn fake_vcpu(exit: *mut crate::ffi::HvVcpuExit, exit_available: bool) -> HvfVcpu<'static> {
-        HvfVcpu {
+    fn fake_vcpu(
+        exit: *mut crate::ffi::HvVcpuExit,
+        exit_available: bool,
+    ) -> ManuallyDrop<HvfVcpu<'static>> {
+        ManuallyDrop::new(HvfVcpu {
             handle: Some(HvfVcpuHandle {
                 vcpu: 7,
                 exit,
@@ -177,13 +181,13 @@ mod tests {
             }),
             _vm: PhantomData,
             _not_send_sync: PhantomData::<Rc<()>>,
-        }
+        })
     }
 
     #[test]
     fn exit_snapshot_copies_raw_exit_data() {
         let mut exit = raw_exit(crate::ffi::HV_EXIT_REASON_EXCEPTION);
-        let mut vcpu = fake_vcpu(ptr::addr_of_mut!(exit), true);
+        let vcpu = fake_vcpu(ptr::addr_of_mut!(exit), true);
 
         assert_eq!(
             vcpu.exit_snapshot(),
@@ -193,13 +197,11 @@ mod tests {
                 physical_address: 0x123,
             }))
         );
-
-        vcpu.handle = None;
     }
 
     #[test]
     fn exit_snapshot_rejects_null_exit_pointer() {
-        let mut vcpu = fake_vcpu(ptr::null_mut(), true);
+        let vcpu = fake_vcpu(ptr::null_mut(), true);
 
         let err = vcpu
             .exit_snapshot()
@@ -209,21 +211,17 @@ mod tests {
             err,
             BackendError::Hypervisor("hv_vcpu_exit_t pointer is null".to_string())
         );
-
-        vcpu.handle = None;
     }
 
     #[test]
     fn exit_snapshot_rejects_unavailable_exit() {
         let mut exit = raw_exit(crate::ffi::HV_EXIT_REASON_EXCEPTION);
-        let mut vcpu = fake_vcpu(ptr::addr_of_mut!(exit), false);
+        let vcpu = fake_vcpu(ptr::addr_of_mut!(exit), false);
 
         assert_eq!(
             vcpu.exit_snapshot(),
             Err(BackendError::InvalidState(NO_VCPU_EXIT_MESSAGE))
         );
-
-        vcpu.handle = None;
     }
 
     #[test]
@@ -242,7 +240,7 @@ mod tests {
 
     #[test]
     fn register_access_rejects_destroyed_vcpu() {
-        let vcpu = HvfVcpu {
+        let mut vcpu = HvfVcpu {
             handle: None,
             _vm: PhantomData,
             _not_send_sync: PhantomData::<Rc<()>>,

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -1,7 +1,7 @@
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 #[test]
 fn creates_and_destroys_hvf_vcpu() {
-    use bangbang_hvf::HvfBackend;
+    use bangbang_hvf::{HvfBackend, HvfRegister};
     use bangbang_runtime::VmBackend;
 
     let mut backend = HvfBackend::new();
@@ -9,6 +9,13 @@ fn creates_and_destroys_hvf_vcpu() {
     backend.create_vm().expect("VM should be created");
     {
         let mut vcpu = backend.create_vcpu().expect("vCPU should be created");
+        vcpu.set_register(HvfRegister::X0, 0x1234)
+            .expect("vCPU register should be set");
+        assert_eq!(
+            vcpu.get_register(HvfRegister::X0)
+                .expect("vCPU register should be read"),
+            0x1234
+        );
         vcpu.destroy().expect("vCPU should be destroyed");
         vcpu.destroy()
             .expect("destroyed vCPU should remain destroyed");

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -2,6 +2,7 @@
 #[test]
 fn creates_and_destroys_hvf_vcpu() {
     use bangbang_hvf::{HvfBackend, HvfRegister};
+    use bangbang_runtime::BackendError;
     use bangbang_runtime::VmBackend;
 
     let mut backend = HvfBackend::new();
@@ -9,6 +10,10 @@ fn creates_and_destroys_hvf_vcpu() {
     backend.create_vm().expect("VM should be created");
     {
         let mut vcpu = backend.create_vcpu().expect("vCPU should be created");
+        assert_eq!(
+            vcpu.exit_snapshot(),
+            Err(BackendError::InvalidState("vCPU has not exited yet"))
+        );
         vcpu.set_register(HvfRegister::X0, 0x1234)
             .expect("vCPU register should be set");
         assert_eq!(

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -8,9 +8,10 @@ The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /` and `GET /version`, a backend-neutral VM
 trait, a minimal read-only VMM action/data model, a minimal
 Hypervisor.framework VM create/destroy wrapper, a current-thread HVF vCPU
-create/destroy wrapper, and an initial process startup argument model. There is
-no broader API request body model, guest memory mapping, vCPU register setup,
-exit handling, run loop, or kernel loading yet.
+create/destroy wrapper, typed HVF exit snapshots, narrow vCPU register wrappers,
+and an initial process startup argument model. There is no broader API request
+body model, guest memory mapping, guest execution, vCPU run loop, MMIO/device
+emulation, boot register setup, or kernel loading yet.
 
 ## Firecracker Model Alignment
 
@@ -309,9 +310,12 @@ macOS design work instead of direct implementation:
 - KVM-specific VM and vCPU operations need HVF equivalents rather than direct
   KVM ioctl usage.
 - HVF vCPU handles are thread-affine: creation, register access, run, and
-  destroy operations must happen on the owning thread. The initial vCPU wrapper
-  covers create/destroy lifecycle only; future run-loop work should use a
-  thread-owned runner.
+  destroy operations must happen on the owning thread. The current vCPU wrapper
+  covers current-thread lifecycle, typed exit snapshots, and narrow register
+  access only; future run-loop work should use a thread-owned runner.
+- HVF exit snapshots preserve Hypervisor.framework reasons such as canceled,
+  exception, virtual timer activation, and unknown. They are not yet decoded
+  into MMIO, timer, device, or runtime events.
 - Linux seccomp, jailer, cgroups, and namespaces do not directly apply.
 - Linux TAP-based networking needs a macOS-specific design.
 - Snapshot and device behavior may differ when backed by HVF.

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -8,7 +8,7 @@ The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /` and `GET /version`, a backend-neutral VM
 trait, a minimal read-only VMM action/data model, a minimal
 Hypervisor.framework VM create/destroy wrapper, a current-thread HVF vCPU
-create/destroy wrapper, typed HVF exit snapshots, narrow vCPU register wrappers,
+create/destroy wrapper, typed HVF exit surface, narrow vCPU register wrappers,
 and an initial process startup argument model. There is no broader API request
 body model, guest memory mapping, guest execution, vCPU run loop, MMIO/device
 emulation, boot register setup, or kernel loading yet.
@@ -311,11 +311,12 @@ macOS design work instead of direct implementation:
   KVM ioctl usage.
 - HVF vCPU handles are thread-affine: creation, register access, run, and
   destroy operations must happen on the owning thread. The current vCPU wrapper
-  covers current-thread lifecycle, typed exit snapshots, and narrow register
+  covers current-thread lifecycle, typed exit surface, and narrow register
   access only; future run-loop work should use a thread-owned runner.
 - HVF exit snapshots preserve Hypervisor.framework reasons such as canceled,
-  exception, virtual timer activation, and unknown. They are not yet decoded
-  into MMIO, timer, device, or runtime events.
+  exception, virtual timer activation, and unknown after a future run wrapper
+  marks exit data available. They are not yet produced by guest execution or
+  decoded into MMIO, timer, device, or runtime events.
 - Linux seccomp, jailer, cgroups, and namespaces do not directly apply.
 - Linux TAP-based networking needs a macOS-specific design.
 - Snapshot and device behavior may differ when backed by HVF.


### PR DESCRIPTION
## Summary

- add typed HVF vCPU exit modeling for canceled, exception, vtimer, and unknown reasons
- guard vCPU exit snapshots until a future `hv_vcpu_run` wrapper has produced exit data
- add narrow HVF register/system-register wrappers on the current-thread vCPU handle
- update HVF lifecycle smoke coverage and docs for the new exit/register surface

## Scope exclusions

- does not call `hv_vcpu_run`
- does not add a thread-owned vCPU runner or cancellation model
- does not introduce a backend-neutral runtime vCPU exit abstraction
- does not implement MMIO/device emulation, guest memory mapping, boot, or public startup behavior

Closes #57.

## Verification

```sh
cargo fmt --all -- --check
cargo check --workspace --all-targets --all-features --locked
cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
cargo test -p bangbang-hvf --lib --all-features --locked
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
scripts/run-hvf-tests.sh
scripts/run-hvf-tests.sh --allow-unsupported
```
