### PR TITLE
chore: migrate workspace to Rust 2024 edition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,15 @@ jobs:
 
       - name: Install Rust
         run: |
+          rustup toolchain install 1.85.0 --profile minimal
           rustup toolchain install stable --profile minimal --component clippy --component rustfmt --target aarch64-apple-darwin
           rustup default stable
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+
+      - name: Check MSRV
+        run: cargo +1.85.0 check --workspace --all-targets --all-features --locked
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Use these commands before opening or updating a pull request. For local or self-
 
 ## Coding Style & Naming Conventions
 
-Use Rust 2021 edition style and `rustfmt` defaults. Keep modules small and aligned with crate boundaries. Public names should describe stable concepts, not future plans; for example, prefer explicit names like `is_supported_target()` when checking compile-target support only.
+Use Rust 2024 edition style and `rustfmt` defaults. Keep modules small and aligned with crate boundaries. Public names should describe stable concepts, not future plans; for example, prefer explicit names like `is_supported_target()` when checking compile-target support only.
 
 Library package names use the `bangbang-*` pattern even when their directory names are shorter, such as `crates/hvf` for `bangbang-hvf`. The executable package is `bangbang` in `crates/bangbang`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Unit tests live next to the code they exercise under each crate’s `src/` tree.
 ## Build, Test, and Development Commands
 
 - `cargo fmt --all -- --check`: verify Rust formatting.
+- `cargo +1.85.0 check --workspace --all-targets --all-features --locked`: verify the declared minimum Rust toolchain.
 - `cargo check --workspace --all-targets --all-features --locked`: type-check the full workspace using the committed lockfile.
 - `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`: run non-HVF tests with all targets and features enabled.
 - `cargo test -p bangbang-hvf --lib --all-features --locked`: run unsigned HVF unit tests.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "3"
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.85"
 repository = "https://github.com/seven332/bangbang"
 
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/seven332/bangbang"
 
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
     "crates/runtime",
     "crates/bangbang",
 ]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ The version response body is Firecracker-shaped JSON:
 
 ## Build
 
+Requires Rust 1.85 or newer for the Rust 2024 edition.
+
 ```sh
 cargo check --workspace --all-targets --all-features --locked
 cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bangbang-api"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 [dependencies]

--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
-use crate::route::Endpoint;
 use crate::HTTP_MAX_PAYLOAD_SIZE;
+use crate::route::Endpoint;
 
 const MAX_HEADERS: usize = 32;
 

--- a/crates/bangbang/Cargo.toml
+++ b/crates/bangbang/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bangbang"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 [dependencies]

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -9,10 +9,10 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-use bangbang_api::http::{
-    parse_request, request_total_len, ApiRequest, HttpResponse, RequestError,
-};
 use bangbang_api::HTTP_MAX_PAYLOAD_SIZE;
+use bangbang_api::http::{
+    ApiRequest, HttpResponse, RequestError, parse_request, request_total_len,
+};
 use bangbang_runtime::{VmmAction, VmmController, VmmData};
 
 const READ_CHUNK_SIZE: usize = 4096;
@@ -717,8 +717,11 @@ mod tests {
             .expect("client should read response");
 
         assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
-        assert!(response
-            .contains(r#"{"fault_message":"HTTP request payload exceeds the configured limit."}"#));
+        assert!(
+            response.contains(
+                r#"{"fault_message":"HTTP request payload exceeds the configured limit."}"#
+            )
+        );
     }
 
     #[test]
@@ -844,10 +847,12 @@ mod tests {
         let err = ApiServer::bind(&path).expect_err("existing symlink path should fail");
 
         assert_eq!(err, ApiServerError::SocketPathExists);
-        assert!(fs::symlink_metadata(&path)
-            .expect("symlink should remain")
-            .file_type()
-            .is_symlink());
+        assert!(
+            fs::symlink_metadata(&path)
+                .expect("symlink should remain")
+                .file_type()
+                .is_symlink()
+        );
 
         fs::remove_file(path).expect("fixture should clean up");
     }

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -11,7 +11,7 @@ use api_server::{ApiServer, ApiServerError};
 use bangbang_hvf::HvfBackend;
 use bangbang_runtime::VmmController;
 use signal_hook::consts::signal::{SIGINT, SIGTERM};
-use signal_hook::{low_level, SigId};
+use signal_hook::{SigId, low_level};
 
 const DEFAULT_API_SOCK_PATH: &str = "/tmp/bangbang.socket";
 const DEFAULT_INSTANCE_ID: &str = "anonymous-instance";
@@ -397,8 +397,8 @@ mod tests {
     use std::os::unix::ffi::OsStringExt;
 
     use super::{
-        parse_process_args, ApiServerError, Args, Command, ProcessError, ProcessExitCode,
-        StartupConfig, DEFAULT_API_SOCK_PATH, DEFAULT_INSTANCE_ID, MAX_INSTANCE_ID_LEN,
+        ApiServerError, Args, Command, DEFAULT_API_SOCK_PATH, DEFAULT_INSTANCE_ID,
+        MAX_INSTANCE_ID_LEN, ProcessError, ProcessExitCode, StartupConfig, parse_process_args,
     };
 
     fn parse(args: &[&str]) -> Result<Args, String> {

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -295,18 +295,23 @@ impl Args {
                     id_seen = true;
                     index += 2;
                 }
-                other if let Some(name) = unsupported_firecracker_arg(other) => {
-                    return Err(format!("unsupported Firecracker argument: --{name}"));
+                other => {
+                    if let Some(name) = unsupported_firecracker_arg(other) {
+                        return Err(format!("unsupported Firecracker argument: --{name}"));
+                    }
+
+                    if let Some(name) = unsupported_equals_syntax(other) {
+                        return Err(format!(
+                            "unsupported argument syntax for --{name}; use --{name} <VALUE>"
+                        ));
+                    }
+
+                    if other.starts_with('-') {
+                        return Err(format!("unknown argument: {}", display_arg_name(other)));
+                    }
+
+                    return Err("unexpected positional argument".to_string());
                 }
-                other if let Some(name) = unsupported_equals_syntax(other) => {
-                    return Err(format!(
-                        "unsupported argument syntax for --{name}; use --{name} <VALUE>"
-                    ));
-                }
-                other if other.starts_with('-') => {
-                    return Err(format!("unknown argument: {}", display_arg_name(other)));
-                }
-                _ => return Err("unexpected positional argument".to_string()),
             }
         }
 

--- a/crates/hvf/Cargo.toml
+++ b/crates/hvf/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bangbang-hvf"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 [dependencies]

--- a/crates/hvf/src/ffi.rs
+++ b/crates/hvf/src/ffi.rs
@@ -83,7 +83,7 @@ mod imp {
     const HV_UNSUPPORTED: HvReturn = 0xfae9400fu32 as HvReturn;
 
     #[link(name = "Hypervisor", kind = "framework")]
-    extern "C" {
+    unsafe extern "C" {
         pub fn hv_vm_create(config: HvVmConfig) -> HvReturn;
         pub fn hv_vm_destroy() -> HvReturn;
         pub fn hv_vcpu_create(
@@ -201,7 +201,7 @@ mod imp {
 
     #[cfg(test)]
     mod tests {
-        use super::{check, HV_BAD_ARGUMENT, HV_DENIED, HV_UNSUPPORTED};
+        use super::{HV_BAD_ARGUMENT, HV_DENIED, HV_UNSUPPORTED, check};
 
         #[test]
         fn check_displays_named_hv_return() {

--- a/crates/hvf/src/vcpu.rs
+++ b/crates/hvf/src/vcpu.rs
@@ -153,7 +153,7 @@ mod tests {
     use bangbang_runtime::BackendError;
 
     use super::{
-        HvfRegister, HvfSystemRegister, HvfVcpu, HvfVcpuHandle, DESTROYED_VCPU_MESSAGE,
+        DESTROYED_VCPU_MESSAGE, HvfRegister, HvfSystemRegister, HvfVcpu, HvfVcpuHandle,
         NO_VCPU_EXIT_MESSAGE,
     };
     use crate::exit::{HvfExceptionExit, HvfVcpuExit};

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bangbang-runtime"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 [dependencies]


### PR DESCRIPTION
## Summary

- migrate the workspace package edition from Rust 2021 to Rust 2024
- align the virtual workspace resolver with Rust 2024's resolver 3 behavior
- declare Rust 1.85 as the workspace minimum toolchain and document it in the README/contributor guide
- add CI coverage for the declared Rust 1.85 MSRV
- keep argument parsing syntax compatible with the declared Rust 1.85 MSRV
- apply the required `unsafe extern "C"` FFI syntax and rustfmt output for the new edition

## Verification

```sh
cargo +1.85.0 check --workspace --all-targets --all-features --locked
cargo fmt --all -- --check
cargo check --workspace --all-targets --all-features --locked
cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
cargo test -p bangbang-hvf --lib --all-features --locked
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
scripts/run-hvf-tests.sh
```
