### PR TITLE
chore: enforce strict workspace lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,15 +26,11 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup toolchain install 1.85.0 --profile minimal
           rustup toolchain install stable --profile minimal --component clippy --component rustfmt --target aarch64-apple-darwin
           rustup default stable
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
-
-      - name: Check MSRV
-        run: cargo +1.85.0 check --workspace --all-targets --all-features --locked
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,6 @@ Unit tests live next to the code they exercise under each crate’s `src/` tree.
 ## Build, Test, and Development Commands
 
 - `cargo fmt --all -- --check`: verify Rust formatting.
-- `cargo +1.85.0 check --workspace --all-targets --all-features --locked`: verify the declared minimum Rust toolchain.
 - `cargo check --workspace --all-targets --all-features --locked`: type-check the full workspace using the committed lockfile.
 - `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`: run non-HVF tests with all targets and features enabled.
 - `cargo test -p bangbang-hvf --lib --all-features --locked`: run unsigned HVF unit tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ Use Rust 2024 edition style and `rustfmt` defaults. Keep modules small and align
 
 Library package names use the `bangbang-*` pattern even when their directory names are shorter, such as `crates/hvf` for `bangbang-hvf`. The executable package is `bangbang` in `crates/bangbang`.
 
+Workspace lints deny Rust warnings, strict rustdoc issues, and selected Clippy lints. Keep test-only Clippy exceptions in `clippy.toml` instead of adding broad inline `allow` attributes.
+
 Unsafe code must stay isolated behind small FFI wrappers, with `SAFETY:` comments explaining each unsafe call.
 
 ## Testing Guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@ Use these commands before opening or updating a pull request. For local or self-
 
 ## Coding Style & Naming Conventions
 
+Use the latest stable Rust toolchain; this repository does not declare an MSRV.
+
 Use Rust 2024 edition style and `rustfmt` defaults. Keep modules small and aligned with crate boundaries. Public names should describe stable concepts, not future plans; for example, prefer explicit names like `is_supported_target()` when checking compile-target support only.
 
 Library package names use the `bangbang-*` pattern even when their directory names are shorter, such as `crates/hvf` for `bangbang-hvf`. The executable package is `bangbang` in `crates/bangbang`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ resolver = "3"
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
 repository = "https://github.com/seven332/bangbang"
 
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,26 @@ rust-version = "1.85"
 repository = "https://github.com/seven332/bangbang"
 
 [workspace.lints.rust]
-missing_debug_implementations = "warn"
+missing_debug_implementations = "deny"
+warnings = "deny"
 
+[workspace.lints.rustdoc]
+bare_urls = "deny"
+broken_intra_doc_links = "deny"
+invalid_codeblock_attributes = "deny"
+invalid_html_tags = "deny"
+invalid_rust_codeblocks = "deny"
+private_intra_doc_links = "deny"
+redundant_explicit_links = "deny"
+
+# Test-specific exceptions live in clippy.toml.
 [workspace.lints.clippy]
-undocumented_unsafe_blocks = "warn"
+all = "deny"
+expect_used = "deny"
+indexing_slicing = "deny"
+panic = "deny"
+todo = "deny"
+undocumented_unsafe_blocks = "deny"
+unimplemented = "deny"
+unreachable = "deny"
+unwrap_used = "deny"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The version response body is Firecracker-shaped JSON:
 
 ## Build
 
-Requires Rust 1.85 or newer for the Rust 2024 edition.
+Requires the latest stable Rust toolchain.
 
 ```sh
 cargo check --workspace --all-targets --all-features --locked

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+allow-expect-in-tests = true
+allow-indexing-slicing-in-tests = true
+allow-panic-in-tests = true
+allow-unwrap-in-tests = true

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -2,7 +2,6 @@
 name = "bangbang-api"
 version.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 repository.workspace = true
 
 [dependencies]

--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -260,16 +260,23 @@ fn parse_content_length(value: &[u8]) -> Result<usize, RequestError> {
 }
 
 fn trim_http_optional_whitespace(value: &[u8]) -> &[u8] {
-    let start = value
-        .iter()
-        .position(|&byte| !is_http_optional_whitespace(byte))
-        .unwrap_or(value.len());
-    let end = value
-        .iter()
-        .rposition(|&byte| !is_http_optional_whitespace(byte))
-        .map_or(start, |index| index + 1);
+    let mut value = value;
 
-    &value[start..end]
+    while let Some((&byte, rest)) = value.split_first() {
+        if !is_http_optional_whitespace(byte) {
+            break;
+        }
+        value = rest;
+    }
+
+    while let Some((&byte, rest)) = value.split_last() {
+        if !is_http_optional_whitespace(byte) {
+            break;
+        }
+        value = rest;
+    }
+
+    value
 }
 
 const fn is_http_optional_whitespace(byte: u8) -> bool {

--- a/crates/bangbang/Cargo.toml
+++ b/crates/bangbang/Cargo.toml
@@ -2,7 +2,6 @@
 name = "bangbang"
 version.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 repository.workspace = true
 
 [dependencies]

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -454,7 +454,10 @@ fn read_request_until(
             .set_read_timeout(Some(read_timeout))
             .map_err(|err| ApiServerError::Connection(err.kind()))?;
 
-        let bytes_read = match stream.read(&mut chunk[..read_len]) {
+        let read_buffer = chunk
+            .get_mut(..read_len)
+            .ok_or(ApiServerError::Connection(std::io::ErrorKind::InvalidInput))?;
+        let bytes_read = match stream.read(read_buffer) {
             Ok(bytes_read) => bytes_read,
             Err(err)
                 if matches!(
@@ -471,7 +474,10 @@ fn read_request_until(
             return Ok(RequestRead::Complete(request));
         }
 
-        request.extend_from_slice(&chunk[..bytes_read]);
+        let bytes = chunk
+            .get(..bytes_read)
+            .ok_or(ApiServerError::Connection(std::io::ErrorKind::InvalidInput))?;
+        request.extend_from_slice(bytes);
     }
 }
 

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -271,9 +271,7 @@ impl Args {
         let mut id_seen = false;
         let mut index = 0;
 
-        while index < args.len() {
-            let arg = &args[index];
-
+        while let Some(arg) = args.get(index) {
             match arg.as_str() {
                 "--api-sock" => {
                     if api_sock_seen {

--- a/crates/hvf/Cargo.toml
+++ b/crates/hvf/Cargo.toml
@@ -2,7 +2,6 @@
 name = "bangbang-hvf"
 version.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 repository.workspace = true
 
 [dependencies]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -2,7 +2,6 @@
 name = "bangbang-runtime"
 version.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 repository.workspace = true
 
 [dependencies]


### PR DESCRIPTION
Closes #60


## Summary
- deny workspace Rust warnings, rustdoc documentation issues, and stricter Clippy lints
- add `clippy.toml` test-only exceptions for unwrap, expect, panic, and indexing/slicing
- remove production indexing/slicing patterns that would violate the new lint policy
- rely on the latest stable Rust toolchain instead of declaring an MSRV
- document the lint and stable-toolchain policy in the contributor guide and README


## Verification
```sh
cargo fmt --all -- --check
cargo check --workspace --all-targets --all-features --locked
cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
cargo test -p bangbang-hvf --lib --all-features --locked
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
scripts/run-hvf-tests.sh
```
