### PR TITLE
feat: add cancellable HVF vCPU runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 bangbang is a Rust VMM project for macOS hosts. The public control plane is intended to stay compatible with the Firecracker HTTP API over a Unix domain socket, while the VM backend is built on Apple's Hypervisor.framework.
 
-This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, and the smallest Hypervisor.framework VM, current-thread vCPU lifecycle, typed exit surface, and register wrappers.
+This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, and the smallest Hypervisor.framework VM, current-thread vCPU lifecycle, typed exit surface, register wrappers, and cancellable vCPU runner skeleton.
 
 See [Firecracker Compatibility Scope](docs/firecracker-compatibility.md) for the intended compatibility target and current limitations.
 See [Pull Request Review Guidelines](docs/review-guidelines.md) for the project-specific review standard.
@@ -18,12 +18,12 @@ crates/bangbang   VMM process entrypoint and startup CLI
 
 ## Current Scope
 
-The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. The HVF crate can create/destroy a process VM, create/destroy one current-thread vCPU handle, define typed HVF exit snapshots for future run-loop work, and get/set a narrow set of vCPU registers for lifecycle smoke testing. It intentionally does not include:
+The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. The HVF crate can create/destroy a process VM, create/destroy one current-thread vCPU handle, define typed HVF exit snapshots, get/set a narrow set of vCPU registers, and start a thread-owned runner that can cancel a single `hv_vcpu_run` step. It intentionally does not include:
 
 - API endpoints beyond `GET /` and `GET /version`
 - JSON request body models
 - guest memory mapping
-- guest execution, vCPU run loops, MMIO/device emulation, or boot register setup
+- configured guest execution, continuous vCPU run loops, MMIO/device emulation, or boot register setup
 - kernel loading
 
 ## Process CLI
@@ -82,15 +82,16 @@ cargo test --workspace --all-targets --all-features --locked --exclude bangbang-
 cargo test -p bangbang-hvf --lib --all-features --locked
 ```
 
-On macOS Apple Silicon hosts, `bangbang-hvf` contains a real HVF lifecycle smoke
-test in `crates/hvf/tests/hvf_lifecycle.rs`. The test is not ignored; run the
-signed test wrapper so host or entitlement failures fail the test run:
+On macOS Apple Silicon hosts, `bangbang-hvf` contains real HVF lifecycle and
+runner smoke tests in `crates/hvf/tests/hvf_lifecycle.rs`. The tests are not
+ignored; run the signed test wrapper so host or entitlement failures fail the
+test run:
 
 ```sh
 scripts/run-hvf-tests.sh
 ```
 
-Hosted macOS CI may build and sign the lifecycle test without executing it when
+Hosted macOS CI may build and sign the HVF tests without executing them when
 Hypervisor.framework is unavailable:
 
 ```sh

--- a/crates/hvf/src/backend.rs
+++ b/crates/hvf/src/backend.rs
@@ -1,5 +1,6 @@
 use bangbang_runtime::{BackendError, VmBackend};
 
+use crate::runner::{HvfVcpuRunner, HvfVcpuRunnerError};
 use crate::vcpu::HvfVcpu;
 
 #[derive(Debug, Default)]
@@ -30,6 +31,21 @@ impl HvfBackend {
         }
 
         HvfVcpu::new(self)
+    }
+
+    pub fn start_vcpu_runner(&self) -> Result<HvfVcpuRunner<'_>, HvfVcpuRunnerError> {
+        if !Self::is_supported_target() {
+            return Err(BackendError::Unsupported(crate::ffi::UNSUPPORTED_TARGET_MESSAGE).into());
+        }
+
+        if !self.vm_created {
+            return Err(BackendError::InvalidState(
+                "VM must be created before starting a vCPU runner",
+            )
+            .into());
+        }
+
+        HvfVcpuRunner::new(self)
     }
 }
 
@@ -92,6 +108,30 @@ mod tests {
             assert_eq!(
                 err,
                 BackendError::Unsupported(crate::ffi::UNSUPPORTED_TARGET_MESSAGE)
+            );
+        }
+    }
+
+    #[test]
+    fn start_vcpu_runner_before_vm_reports_state_or_target_error() {
+        let backend = HvfBackend::new();
+        let err = backend
+            .start_vcpu_runner()
+            .expect_err("starting a vCPU runner before VM creation should fail");
+
+        if HvfBackend::is_supported_target() {
+            assert_eq!(
+                err,
+                crate::runner::HvfVcpuRunnerError::Backend(BackendError::InvalidState(
+                    "VM must be created before starting a vCPU runner"
+                ))
+            );
+        } else {
+            assert_eq!(
+                err,
+                crate::runner::HvfVcpuRunnerError::Backend(BackendError::Unsupported(
+                    crate::ffi::UNSUPPORTED_TARGET_MESSAGE
+                ))
             );
         }
     }

--- a/crates/hvf/src/ffi.rs
+++ b/crates/hvf/src/ffi.rs
@@ -96,6 +96,8 @@ mod imp {
         pub fn hv_vcpu_set_reg(vcpu: HvVcpu, reg: HvReg, value: u64) -> HvReturn;
         pub fn hv_vcpu_get_sys_reg(vcpu: HvVcpu, reg: HvSysReg, value: *mut u64) -> HvReturn;
         pub fn hv_vcpu_set_sys_reg(vcpu: HvVcpu, reg: HvSysReg, value: u64) -> HvReturn;
+        pub fn hv_vcpu_run(vcpu: HvVcpu) -> HvReturn;
+        pub fn hv_vcpus_exit(vcpus: *mut HvVcpu, vcpu_count: u32) -> HvReturn;
     }
 
     fn hv_return_name(code: HvReturn) -> Option<&'static str> {
@@ -162,6 +164,25 @@ mod imp {
         // SAFETY: The caller owns this current-thread vCPU handle and guarantees it has not
         // already been destroyed.
         unsafe { check(hv_vcpu_destroy(vcpu), "hv_vcpu_destroy") }
+    }
+
+    pub fn run_vcpu(vcpu: HvVcpu) -> Result<(), BackendError> {
+        // SAFETY: The caller owns this current-thread vCPU handle.
+        unsafe { check(hv_vcpu_run(vcpu), "hv_vcpu_run") }
+    }
+
+    pub fn exit_vcpus(vcpus: &mut [HvVcpu]) -> Result<(), BackendError> {
+        let vcpu_count = u32::try_from(vcpus.len())
+            .map_err(|_| BackendError::InvalidState("too many vCPUs to exit"))?;
+
+        // SAFETY: `vcpus.as_mut_ptr()` is valid for `vcpu_count` elements for the duration of
+        // the call, and HVF only uses the ids to request asynchronous exits.
+        unsafe {
+            check(
+                hv_vcpus_exit(vcpus.as_mut_ptr(), vcpu_count),
+                "hv_vcpus_exit",
+            )
+        }
     }
 
     pub fn get_reg(vcpu: HvVcpu, reg: HvReg) -> Result<u64, BackendError> {
@@ -257,6 +278,14 @@ mod imp {
 
     pub fn destroy_vcpu(_: HvVcpu) -> Result<(), BackendError> {
         Ok(())
+    }
+
+    pub fn run_vcpu(_: HvVcpu) -> Result<(), BackendError> {
+        Err(BackendError::Unsupported(UNSUPPORTED_TARGET_MESSAGE))
+    }
+
+    pub fn exit_vcpus(_: &mut [HvVcpu]) -> Result<(), BackendError> {
+        Err(BackendError::Unsupported(UNSUPPORTED_TARGET_MESSAGE))
     }
 
     pub fn get_reg(_: HvVcpu, _: HvReg) -> Result<u64, BackendError> {

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -3,8 +3,10 @@
 mod backend;
 mod exit;
 mod ffi;
+mod runner;
 mod vcpu;
 
 pub use backend::HvfBackend;
 pub use exit::{HvfExceptionExit, HvfVcpuExit};
+pub use runner::{HvfVcpuRunner, HvfVcpuRunnerError};
 pub use vcpu::{HvfRegister, HvfSystemRegister, HvfVcpu};

--- a/crates/hvf/src/runner.rs
+++ b/crates/hvf/src/runner.rs
@@ -1,0 +1,552 @@
+use std::fmt;
+use std::marker::PhantomData;
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::thread::{self, JoinHandle};
+
+use bangbang_runtime::BackendError;
+
+use crate::backend::HvfBackend;
+use crate::exit::HvfVcpuExit;
+use crate::vcpu::HvfVcpuOwner;
+
+const RUNNER_SHUT_DOWN_MESSAGE: &str = "vCPU runner is shut down";
+const RUNNER_STATE_POISONED_MESSAGE: &str = "vCPU runner state lock is poisoned";
+const COMMAND_CHANNEL_CLOSED_MESSAGE: &str = "vCPU runner command channel is closed";
+const RESPONSE_CHANNEL_CLOSED_MESSAGE: &str = "vCPU runner response channel is closed";
+
+type CancelVcpu = Arc<dyn Fn(crate::ffi::HvVcpu) -> Result<(), BackendError> + Send + Sync>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HvfVcpuRunnerError {
+    Backend(BackendError),
+    InvalidState(&'static str),
+    ThreadSpawn(String),
+    ChannelClosed(&'static str),
+    ThreadPanicked,
+}
+
+impl fmt::Display for HvfVcpuRunnerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Backend(err) => write!(f, "{err}"),
+            Self::InvalidState(message) => write!(f, "invalid vCPU runner state: {message}"),
+            Self::ThreadSpawn(message) => {
+                write!(f, "failed to spawn vCPU runner thread: {message}")
+            }
+            Self::ChannelClosed(message) => write!(f, "vCPU runner channel closed: {message}"),
+            Self::ThreadPanicked => f.write_str("vCPU runner thread panicked"),
+        }
+    }
+}
+
+impl std::error::Error for HvfVcpuRunnerError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Backend(err) => Some(err),
+            Self::InvalidState(_)
+            | Self::ThreadSpawn(_)
+            | Self::ChannelClosed(_)
+            | Self::ThreadPanicked => None,
+        }
+    }
+}
+
+impl From<BackendError> for HvfVcpuRunnerError {
+    fn from(err: BackendError) -> Self {
+        Self::Backend(err)
+    }
+}
+
+pub struct HvfVcpuRunner<'vm> {
+    command_sender: mpsc::Sender<RunnerCommand>,
+    vcpu: crate::ffi::HvVcpu,
+    cancel_vcpu: CancelVcpu,
+    state: Mutex<RunnerHandleState>,
+    _vm: PhantomData<&'vm HvfBackend>,
+}
+
+#[derive(Debug)]
+struct RunnerHandleState {
+    thread: Option<JoinHandle<()>>,
+    shutting_down: bool,
+    in_flight_runs: usize,
+}
+
+enum RunnerCommand {
+    RunOnce {
+        response_sender: mpsc::Sender<Result<HvfVcpuExit, HvfVcpuRunnerError>>,
+    },
+    Shutdown {
+        response_sender: mpsc::Sender<Result<(), HvfVcpuRunnerError>>,
+    },
+}
+
+struct StartedRunner {
+    command_sender: mpsc::Sender<RunnerCommand>,
+    vcpu: crate::ffi::HvVcpu,
+    thread: JoinHandle<()>,
+}
+
+trait RunnerVcpu {
+    fn raw_vcpu(&self) -> Result<crate::ffi::HvVcpu, BackendError>;
+    fn run_once(&mut self) -> Result<HvfVcpuExit, BackendError>;
+    fn destroy(&mut self) -> Result<(), BackendError>;
+}
+
+struct RealRunnerVcpu {
+    owner: HvfVcpuOwner,
+}
+
+impl RealRunnerVcpu {
+    fn create() -> Result<Self, BackendError> {
+        Ok(Self {
+            owner: HvfVcpuOwner::new()?,
+        })
+    }
+}
+
+impl RunnerVcpu for RealRunnerVcpu {
+    fn raw_vcpu(&self) -> Result<crate::ffi::HvVcpu, BackendError> {
+        self.owner.raw_vcpu()
+    }
+
+    fn run_once(&mut self) -> Result<HvfVcpuExit, BackendError> {
+        self.owner.run_once()
+    }
+
+    fn destroy(&mut self) -> Result<(), BackendError> {
+        self.owner.destroy()
+    }
+}
+
+impl<'vm> HvfVcpuRunner<'vm> {
+    pub(crate) fn new(_: &'vm HvfBackend) -> Result<Self, HvfVcpuRunnerError> {
+        Self::from_started(
+            spawn_runner_thread(RealRunnerVcpu::create)?,
+            real_cancel_vcpu(),
+        )
+    }
+
+    pub fn run_once(&self) -> Result<HvfVcpuExit, HvfVcpuRunnerError> {
+        let (response_sender, response_receiver) = mpsc::channel();
+        let command_sender = self.prepare_run_once()?;
+        let _in_flight_run = InFlightRun::new(&self.state);
+
+        if command_sender
+            .send(RunnerCommand::RunOnce { response_sender })
+            .is_err()
+        {
+            return Err(HvfVcpuRunnerError::ChannelClosed(
+                COMMAND_CHANNEL_CLOSED_MESSAGE,
+            ));
+        }
+
+        response_receiver
+            .recv()
+            .map_err(|_| HvfVcpuRunnerError::ChannelClosed(RESPONSE_CHANNEL_CLOSED_MESSAGE))?
+    }
+
+    pub fn cancel(&self) -> Result<(), HvfVcpuRunnerError> {
+        self.ensure_thread_exists()?;
+        self.cancel_vcpu()
+    }
+
+    pub fn shutdown(&self) -> Result<(), HvfVcpuRunnerError> {
+        let (command_sender, should_cancel) = match self.prepare_shutdown() {
+            Ok(prepared_shutdown) => prepared_shutdown,
+            Err(HvfVcpuRunnerError::InvalidState(RUNNER_SHUT_DOWN_MESSAGE)) => return Ok(()),
+            Err(err) => return Err(err),
+        };
+
+        if should_cancel {
+            self.cancel_vcpu()?;
+        }
+
+        let (response_sender, response_receiver) = mpsc::channel();
+        let send_result = command_sender
+            .send(RunnerCommand::Shutdown { response_sender })
+            .map_err(|_| HvfVcpuRunnerError::ChannelClosed(COMMAND_CHANNEL_CLOSED_MESSAGE));
+
+        let thread = self.take_thread()?;
+
+        let response_result = match send_result {
+            Ok(()) => response_receiver
+                .recv()
+                .map_err(|_| HvfVcpuRunnerError::ChannelClosed(RESPONSE_CHANNEL_CLOSED_MESSAGE))?,
+            Err(err) => Err(err),
+        };
+        let join_result = join_runner_thread(thread);
+
+        first_error(response_result, join_result)
+    }
+
+    fn from_started(
+        started: StartedRunner,
+        cancel_vcpu: CancelVcpu,
+    ) -> Result<Self, HvfVcpuRunnerError> {
+        Ok(Self {
+            command_sender: started.command_sender,
+            vcpu: started.vcpu,
+            cancel_vcpu,
+            state: Mutex::new(RunnerHandleState {
+                thread: Some(started.thread),
+                shutting_down: false,
+                in_flight_runs: 0,
+            }),
+            _vm: PhantomData,
+        })
+    }
+
+    fn prepare_run_once(&self) -> Result<mpsc::Sender<RunnerCommand>, HvfVcpuRunnerError> {
+        let mut state = self.lock_state()?;
+        if state.thread.is_none() || state.shutting_down {
+            return Err(HvfVcpuRunnerError::InvalidState(RUNNER_SHUT_DOWN_MESSAGE));
+        }
+
+        state.in_flight_runs =
+            state
+                .in_flight_runs
+                .checked_add(1)
+                .ok_or(HvfVcpuRunnerError::InvalidState(
+                    "too many in-flight vCPU runs",
+                ))?;
+
+        Ok(self.command_sender.clone())
+    }
+
+    fn prepare_shutdown(&self) -> Result<(mpsc::Sender<RunnerCommand>, bool), HvfVcpuRunnerError> {
+        let mut state = self.lock_state()?;
+        if state.thread.is_none() {
+            return Err(HvfVcpuRunnerError::InvalidState(RUNNER_SHUT_DOWN_MESSAGE));
+        }
+
+        state.shutting_down = true;
+
+        Ok((self.command_sender.clone(), state.in_flight_runs > 0))
+    }
+
+    fn ensure_thread_exists(&self) -> Result<(), HvfVcpuRunnerError> {
+        let state = self.lock_state()?;
+        if state.thread.is_none() {
+            return Err(HvfVcpuRunnerError::InvalidState(RUNNER_SHUT_DOWN_MESSAGE));
+        }
+        Ok(())
+    }
+
+    fn cancel_vcpu(&self) -> Result<(), HvfVcpuRunnerError> {
+        (self.cancel_vcpu)(self.vcpu).map_err(HvfVcpuRunnerError::Backend)
+    }
+
+    fn take_thread(&self) -> Result<Option<JoinHandle<()>>, HvfVcpuRunnerError> {
+        Ok(self.lock_state()?.thread.take())
+    }
+
+    fn lock_state(&self) -> Result<MutexGuard<'_, RunnerHandleState>, HvfVcpuRunnerError> {
+        self.state
+            .lock()
+            .map_err(|_| HvfVcpuRunnerError::InvalidState(RUNNER_STATE_POISONED_MESSAGE))
+    }
+}
+
+impl Drop for HvfVcpuRunner<'_> {
+    fn drop(&mut self) {
+        let _ = self.shutdown();
+    }
+}
+
+impl fmt::Debug for HvfVcpuRunner<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = self.state.lock().map(|state| {
+            (
+                state.thread.is_some(),
+                state.shutting_down,
+                state.in_flight_runs,
+            )
+        });
+
+        match state {
+            Ok((active, shutting_down, in_flight_runs)) => f
+                .debug_struct("HvfVcpuRunner")
+                .field("active", &active)
+                .field("shutting_down", &shutting_down)
+                .field("in_flight_runs", &in_flight_runs)
+                .finish_non_exhaustive(),
+            Err(_) => f
+                .debug_struct("HvfVcpuRunner")
+                .field("state", &RUNNER_STATE_POISONED_MESSAGE)
+                .finish_non_exhaustive(),
+        }
+    }
+}
+
+struct InFlightRun<'state> {
+    state: &'state Mutex<RunnerHandleState>,
+}
+
+impl<'state> InFlightRun<'state> {
+    fn new(state: &'state Mutex<RunnerHandleState>) -> Self {
+        Self { state }
+    }
+}
+
+impl Drop for InFlightRun<'_> {
+    fn drop(&mut self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.in_flight_runs = state.in_flight_runs.saturating_sub(1);
+        }
+    }
+}
+
+fn real_cancel_vcpu() -> CancelVcpu {
+    Arc::new(|vcpu| {
+        let mut vcpus = [vcpu];
+        crate::ffi::exit_vcpus(&mut vcpus)
+    })
+}
+
+fn spawn_runner_thread<C, V>(create_vcpu: C) -> Result<StartedRunner, HvfVcpuRunnerError>
+where
+    C: FnOnce() -> Result<V, BackendError> + Send + 'static,
+    V: RunnerVcpu + 'static,
+{
+    let (command_sender, command_receiver) = mpsc::channel();
+    let (startup_sender, startup_receiver) = mpsc::channel();
+    let thread = thread::Builder::new()
+        .name("bangbang-hvf-vcpu".to_string())
+        .spawn(move || run_runner_thread(command_receiver, startup_sender, create_vcpu))
+        .map_err(|err| HvfVcpuRunnerError::ThreadSpawn(err.to_string()))?;
+
+    match startup_receiver
+        .recv()
+        .map_err(|_| HvfVcpuRunnerError::ChannelClosed(RESPONSE_CHANNEL_CLOSED_MESSAGE))?
+    {
+        Ok(vcpu) => Ok(StartedRunner {
+            command_sender,
+            vcpu,
+            thread,
+        }),
+        Err(err) => {
+            join_runner_thread(Some(thread))?;
+            Err(err)
+        }
+    }
+}
+
+fn run_runner_thread<C, V>(
+    command_receiver: mpsc::Receiver<RunnerCommand>,
+    startup_sender: mpsc::Sender<Result<crate::ffi::HvVcpu, HvfVcpuRunnerError>>,
+    create_vcpu: C,
+) where
+    C: FnOnce() -> Result<V, BackendError>,
+    V: RunnerVcpu,
+{
+    let mut vcpu = match create_vcpu() {
+        Ok(vcpu) => vcpu,
+        Err(err) => {
+            let _ = startup_sender.send(Err(HvfVcpuRunnerError::Backend(err)));
+            return;
+        }
+    };
+
+    let vcpu_id = match vcpu.raw_vcpu() {
+        Ok(vcpu_id) => vcpu_id,
+        Err(err) => {
+            let _ = startup_sender.send(Err(HvfVcpuRunnerError::Backend(err)));
+            return;
+        }
+    };
+
+    if startup_sender.send(Ok(vcpu_id)).is_err() {
+        return;
+    }
+
+    while let Ok(command) = command_receiver.recv() {
+        match command {
+            RunnerCommand::RunOnce { response_sender } => {
+                let result = vcpu.run_once().map_err(HvfVcpuRunnerError::Backend);
+                let _ = response_sender.send(result);
+            }
+            RunnerCommand::Shutdown { response_sender } => {
+                let result = vcpu.destroy().map_err(HvfVcpuRunnerError::Backend);
+                let _ = response_sender.send(result);
+                return;
+            }
+        }
+    }
+}
+
+fn join_runner_thread(thread: Option<JoinHandle<()>>) -> Result<(), HvfVcpuRunnerError> {
+    if let Some(thread) = thread {
+        thread
+            .join()
+            .map_err(|_| HvfVcpuRunnerError::ThreadPanicked)?;
+    }
+
+    Ok(())
+}
+
+fn first_error(
+    first: Result<(), HvfVcpuRunnerError>,
+    second: Result<(), HvfVcpuRunnerError>,
+) -> Result<(), HvfVcpuRunnerError> {
+    match first {
+        Ok(()) => second,
+        Err(err) => Err(err),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, mpsc};
+    use std::thread;
+
+    use bangbang_runtime::BackendError;
+
+    use super::{CancelVcpu, HvfVcpuRunner, HvfVcpuRunnerError, RunnerVcpu, spawn_runner_thread};
+    use crate::exit::HvfVcpuExit;
+
+    struct FakeVcpu {
+        entered_run_sender: mpsc::Sender<()>,
+        release_run_receiver: mpsc::Receiver<Result<HvfVcpuExit, BackendError>>,
+        destroyed_sender: mpsc::Sender<()>,
+    }
+
+    impl RunnerVcpu for FakeVcpu {
+        fn raw_vcpu(&self) -> Result<crate::ffi::HvVcpu, BackendError> {
+            Ok(7)
+        }
+
+        fn run_once(&mut self) -> Result<HvfVcpuExit, BackendError> {
+            self.entered_run_sender
+                .send(())
+                .map_err(|_| BackendError::InvalidState("fake run entry receiver closed"))?;
+            self.release_run_receiver
+                .recv()
+                .map_err(|_| BackendError::InvalidState("fake run release sender closed"))?
+        }
+
+        fn destroy(&mut self) -> Result<(), BackendError> {
+            self.destroyed_sender
+                .send(())
+                .map_err(|_| BackendError::InvalidState("fake destroy receiver closed"))
+        }
+    }
+
+    fn fake_cancel_vcpu(
+        release_run_sender: mpsc::Sender<Result<HvfVcpuExit, BackendError>>,
+    ) -> CancelVcpu {
+        Arc::new(move |_| {
+            release_run_sender
+                .send(Ok(HvfVcpuExit::Canceled))
+                .map_err(|_| BackendError::InvalidState("fake run release receiver closed"))
+        })
+    }
+
+    fn start_fake_runner() -> (
+        HvfVcpuRunner<'static>,
+        mpsc::Receiver<()>,
+        mpsc::Receiver<()>,
+    ) {
+        let (entered_run_sender, entered_run_receiver) = mpsc::channel();
+        let (release_run_sender, release_run_receiver) = mpsc::channel();
+        let (destroyed_sender, destroyed_receiver) = mpsc::channel();
+        let cancel_vcpu = fake_cancel_vcpu(release_run_sender);
+        let started = spawn_runner_thread(move || {
+            Ok(FakeVcpu {
+                entered_run_sender,
+                release_run_receiver,
+                destroyed_sender,
+            })
+        })
+        .expect("fake runner should start");
+
+        (
+            HvfVcpuRunner::from_started(started, cancel_vcpu).expect("runner should be created"),
+            entered_run_receiver,
+            destroyed_receiver,
+        )
+    }
+
+    #[test]
+    fn cancel_unblocks_in_flight_run() {
+        let (runner, entered_run_receiver, destroyed_receiver) = start_fake_runner();
+
+        thread::scope(|scope| {
+            let run = scope.spawn(|| runner.run_once());
+            entered_run_receiver
+                .recv()
+                .expect("runner should enter fake run");
+
+            runner.cancel().expect("cancel should release fake run");
+
+            assert_eq!(
+                run.join().expect("run thread should join"),
+                Ok(HvfVcpuExit::Canceled)
+            );
+        });
+
+        runner.shutdown().expect("runner should shut down");
+        destroyed_receiver
+            .recv()
+            .expect("fake vCPU should be destroyed");
+    }
+
+    #[test]
+    fn shutdown_cancels_in_flight_run_and_joins_thread() {
+        let (runner, entered_run_receiver, destroyed_receiver) = start_fake_runner();
+
+        thread::scope(|scope| {
+            let run = scope.spawn(|| runner.run_once());
+            entered_run_receiver
+                .recv()
+                .expect("runner should enter fake run");
+
+            runner.shutdown().expect("shutdown should cancel fake run");
+
+            assert_eq!(
+                run.join().expect("run thread should join"),
+                Ok(HvfVcpuExit::Canceled)
+            );
+        });
+
+        destroyed_receiver
+            .recv()
+            .expect("fake vCPU should be destroyed");
+        runner
+            .shutdown()
+            .expect("repeated shutdown should be idempotent");
+    }
+
+    #[test]
+    fn run_after_shutdown_reports_invalid_state() {
+        let (runner, _, destroyed_receiver) = start_fake_runner();
+
+        runner.shutdown().expect("runner should shut down");
+        destroyed_receiver
+            .recv()
+            .expect("fake vCPU should be destroyed");
+
+        assert_eq!(
+            runner.run_once(),
+            Err(HvfVcpuRunnerError::InvalidState(
+                super::RUNNER_SHUT_DOWN_MESSAGE
+            ))
+        );
+    }
+
+    #[test]
+    fn startup_error_is_returned_to_caller() {
+        let result = spawn_runner_thread(|| {
+            Err::<FakeVcpu, BackendError>(BackendError::InvalidState("fake startup failed"))
+        });
+        let Err(err) = result else {
+            panic!("startup error should be returned");
+        };
+
+        assert_eq!(
+            err,
+            HvfVcpuRunnerError::Backend(BackendError::InvalidState("fake startup failed"))
+        );
+    }
+}

--- a/crates/hvf/src/runner.rs
+++ b/crates/hvf/src/runner.rs
@@ -345,10 +345,17 @@ where
         .spawn(move || run_runner_thread(command_receiver, startup_sender, create_vcpu))
         .map_err(|err| HvfVcpuRunnerError::ThreadSpawn(err.to_string()))?;
 
-    match startup_receiver
-        .recv()
-        .map_err(|_| HvfVcpuRunnerError::ChannelClosed(RESPONSE_CHANNEL_CLOSED_MESSAGE))?
-    {
+    let startup_result = match startup_receiver.recv() {
+        Ok(startup_result) => startup_result,
+        Err(_) => {
+            join_runner_thread(Some(thread))?;
+            return Err(HvfVcpuRunnerError::ChannelClosed(
+                RESPONSE_CHANNEL_CLOSED_MESSAGE,
+            ));
+        }
+    };
+
+    match startup_result {
         Ok(vcpu) => Ok(StartedRunner {
             command_sender,
             vcpu,
@@ -739,5 +746,17 @@ mod tests {
             err,
             HvfVcpuRunnerError::Backend(BackendError::InvalidState("fake startup failed"))
         );
+    }
+
+    #[test]
+    fn startup_panic_is_joined_and_returned_to_caller() {
+        let result = spawn_runner_thread(|| -> Result<FakeVcpu, BackendError> {
+            panic!("fake startup panic");
+        });
+        let Err(err) = result else {
+            panic!("startup panic should be returned");
+        };
+
+        assert_eq!(err, HvfVcpuRunnerError::ThreadPanicked);
     }
 }

--- a/crates/hvf/src/runner.rs
+++ b/crates/hvf/src/runner.rs
@@ -11,6 +11,7 @@ use crate::exit::HvfVcpuExit;
 use crate::vcpu::HvfVcpuOwner;
 
 const RUNNER_SHUT_DOWN_MESSAGE: &str = "vCPU runner is shut down";
+const RUNNER_SHUTTING_DOWN_MESSAGE: &str = "vCPU runner shutdown is already in progress";
 const RUN_IN_FLIGHT_MESSAGE: &str = "vCPU runner already has a run in flight";
 const RUNNER_STATE_POISONED_MESSAGE: &str = "vCPU runner state lock is poisoned";
 const COMMAND_CHANNEL_CLOSED_MESSAGE: &str = "vCPU runner command channel is closed";
@@ -139,7 +140,7 @@ impl<'vm> HvfVcpuRunner<'vm> {
     }
 
     pub fn cancel(&self) -> Result<(), HvfVcpuRunnerError> {
-        self.ensure_thread_exists()?;
+        self.prepare_cancel()?;
         self.cancel_vcpu()
     }
 
@@ -219,8 +220,13 @@ impl<'vm> HvfVcpuRunner<'vm> {
 
     fn prepare_shutdown(&self) -> Result<(mpsc::Sender<RunnerCommand>, bool), HvfVcpuRunnerError> {
         let mut state = self.lock_state()?;
-        if state.thread.is_none() || state.shutting_down {
+        if state.thread.is_none() {
             return Err(HvfVcpuRunnerError::InvalidState(RUNNER_SHUT_DOWN_MESSAGE));
+        }
+        if state.shutting_down {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                RUNNER_SHUTTING_DOWN_MESSAGE,
+            ));
         }
 
         state.shutting_down = true;
@@ -234,10 +240,15 @@ impl<'vm> HvfVcpuRunner<'vm> {
         }
     }
 
-    fn ensure_thread_exists(&self) -> Result<(), HvfVcpuRunnerError> {
+    fn prepare_cancel(&self) -> Result<(), HvfVcpuRunnerError> {
         let state = self.lock_state()?;
         if state.thread.is_none() {
             return Err(HvfVcpuRunnerError::InvalidState(RUNNER_SHUT_DOWN_MESSAGE));
+        }
+        if state.shutting_down {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                RUNNER_SHUTTING_DOWN_MESSAGE,
+            ));
         }
         Ok(())
     }
@@ -527,7 +538,7 @@ mod tests {
     }
 
     #[test]
-    fn prepared_shutdown_rejects_second_shutdown_command() {
+    fn shutdown_in_progress_rejects_second_shutdown_command_and_cancel() {
         let (runner, _, destroyed_receiver) = start_fake_runner();
         let (command_sender, should_cancel) = runner
             .prepare_shutdown()
@@ -540,7 +551,19 @@ mod tests {
         };
         assert_eq!(
             err,
-            HvfVcpuRunnerError::InvalidState(super::RUNNER_SHUT_DOWN_MESSAGE)
+            HvfVcpuRunnerError::InvalidState(super::RUNNER_SHUTTING_DOWN_MESSAGE)
+        );
+        assert_eq!(
+            runner.shutdown(),
+            Err(HvfVcpuRunnerError::InvalidState(
+                super::RUNNER_SHUTTING_DOWN_MESSAGE
+            ))
+        );
+        assert_eq!(
+            runner.cancel(),
+            Err(HvfVcpuRunnerError::InvalidState(
+                super::RUNNER_SHUTTING_DOWN_MESSAGE
+            ))
         );
 
         let (response_sender, response_receiver) = mpsc::channel();

--- a/crates/hvf/src/runner.rs
+++ b/crates/hvf/src/runner.rs
@@ -150,8 +150,9 @@ impl<'vm> HvfVcpuRunner<'vm> {
             Err(err) => return Err(err),
         };
 
-        if should_cancel {
-            self.cancel_vcpu()?;
+        if should_cancel && let Err(err) = self.cancel_vcpu() {
+            self.cancel_shutdown();
+            return Err(err);
         }
 
         let (response_sender, response_receiver) = mpsc::channel();
@@ -218,13 +219,19 @@ impl<'vm> HvfVcpuRunner<'vm> {
 
     fn prepare_shutdown(&self) -> Result<(mpsc::Sender<RunnerCommand>, bool), HvfVcpuRunnerError> {
         let mut state = self.lock_state()?;
-        if state.thread.is_none() {
+        if state.thread.is_none() || state.shutting_down {
             return Err(HvfVcpuRunnerError::InvalidState(RUNNER_SHUT_DOWN_MESSAGE));
         }
 
         state.shutting_down = true;
 
         Ok((self.command_sender.clone(), state.in_flight_runs > 0))
+    }
+
+    fn cancel_shutdown(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.shutting_down = false;
+        }
     }
 
     fn ensure_thread_exists(&self) -> Result<(), HvfVcpuRunnerError> {
@@ -517,6 +524,41 @@ mod tests {
         runner
             .shutdown()
             .expect("repeated shutdown should be idempotent");
+    }
+
+    #[test]
+    fn prepared_shutdown_rejects_second_shutdown_command() {
+        let (runner, _, destroyed_receiver) = start_fake_runner();
+        let (command_sender, should_cancel) = runner
+            .prepare_shutdown()
+            .expect("first shutdown should be prepared");
+
+        assert!(!should_cancel);
+
+        let Err(err) = runner.prepare_shutdown() else {
+            panic!("second shutdown should not be prepared");
+        };
+        assert_eq!(
+            err,
+            HvfVcpuRunnerError::InvalidState(super::RUNNER_SHUT_DOWN_MESSAGE)
+        );
+
+        let (response_sender, response_receiver) = mpsc::channel();
+        command_sender
+            .send(super::RunnerCommand::Shutdown { response_sender })
+            .expect("shutdown command should be sent");
+        let thread = runner
+            .take_thread()
+            .expect("runner state should be lockable");
+        let response = response_receiver
+            .recv()
+            .expect("shutdown response should be sent");
+
+        assert_eq!(response, Ok(()));
+        super::join_runner_thread(thread).expect("runner thread should join");
+        destroyed_receiver
+            .recv()
+            .expect("fake vCPU should be destroyed");
     }
 
     #[test]

--- a/crates/hvf/src/runner.rs
+++ b/crates/hvf/src/runner.rs
@@ -140,7 +140,9 @@ impl<'vm> HvfVcpuRunner<'vm> {
     }
 
     pub fn cancel(&self) -> Result<(), HvfVcpuRunnerError> {
-        let _state = self.prepare_cancel()?;
+        // Keep the state lock until the HVF exit request returns so shutdown
+        // cannot destroy the vCPU while cancellation uses its raw id.
+        let _state_guard = self.prepare_cancel()?;
         self.cancel_vcpu()
     }
 

--- a/crates/hvf/src/runner.rs
+++ b/crates/hvf/src/runner.rs
@@ -174,7 +174,7 @@ impl<'vm> HvfVcpuRunner<'vm> {
         let join_result = join_runner_thread(thread);
         self.finish_shutdown();
 
-        first_error(response_result, join_result)
+        shutdown_result(response_result, join_result)
     }
 
     fn from_started(
@@ -421,13 +421,14 @@ fn join_runner_thread(thread: Option<JoinHandle<()>>) -> Result<(), HvfVcpuRunne
     Ok(())
 }
 
-fn first_error(
+fn shutdown_result(
     first: Result<(), HvfVcpuRunnerError>,
     second: Result<(), HvfVcpuRunnerError>,
 ) -> Result<(), HvfVcpuRunnerError> {
-    match first {
-        Ok(()) => second,
-        Err(err) => Err(err),
+    match (first, second) {
+        (_, Err(HvfVcpuRunnerError::ThreadPanicked)) => Err(HvfVcpuRunnerError::ThreadPanicked),
+        (Err(err), _) => Err(err),
+        (Ok(()), result) => result,
     }
 }
 
@@ -447,6 +448,8 @@ mod tests {
         destroyed_sender: mpsc::Sender<()>,
     }
 
+    struct PanicOnRunVcpu;
+
     impl RunnerVcpu for FakeVcpu {
         fn raw_vcpu(&self) -> Result<crate::ffi::HvVcpu, BackendError> {
             Ok(7)
@@ -465,6 +468,20 @@ mod tests {
             self.destroyed_sender
                 .send(())
                 .map_err(|_| BackendError::InvalidState("fake destroy receiver closed"))
+        }
+    }
+
+    impl RunnerVcpu for PanicOnRunVcpu {
+        fn raw_vcpu(&self) -> Result<crate::ffi::HvVcpu, BackendError> {
+            Ok(7)
+        }
+
+        fn run_once(&mut self) -> Result<HvfVcpuExit, BackendError> {
+            panic!("fake run panic");
+        }
+
+        fn destroy(&mut self) -> Result<(), BackendError> {
+            Ok(())
         }
     }
 
@@ -758,5 +775,21 @@ mod tests {
         };
 
         assert_eq!(err, HvfVcpuRunnerError::ThreadPanicked);
+    }
+
+    #[test]
+    fn shutdown_reports_thread_panic_after_started_runner_exits() {
+        let started =
+            spawn_runner_thread(|| Ok(PanicOnRunVcpu)).expect("panic runner should start");
+        let runner = HvfVcpuRunner::from_started(started, Arc::new(|_| Ok(())))
+            .expect("runner should be created");
+
+        assert_eq!(
+            runner.run_once(),
+            Err(HvfVcpuRunnerError::ChannelClosed(
+                super::RESPONSE_CHANNEL_CLOSED_MESSAGE
+            ))
+        );
+        assert_eq!(runner.shutdown(), Err(HvfVcpuRunnerError::ThreadPanicked));
     }
 }

--- a/crates/hvf/src/runner.rs
+++ b/crates/hvf/src/runner.rs
@@ -11,6 +11,7 @@ use crate::exit::HvfVcpuExit;
 use crate::vcpu::HvfVcpuOwner;
 
 const RUNNER_SHUT_DOWN_MESSAGE: &str = "vCPU runner is shut down";
+const RUN_IN_FLIGHT_MESSAGE: &str = "vCPU runner already has a run in flight";
 const RUNNER_STATE_POISONED_MESSAGE: &str = "vCPU runner state lock is poisoned";
 const COMMAND_CHANNEL_CLOSED_MESSAGE: &str = "vCPU runner command channel is closed";
 const RESPONSE_CHANNEL_CLOSED_MESSAGE: &str = "vCPU runner response channel is closed";
@@ -203,14 +204,11 @@ impl<'vm> HvfVcpuRunner<'vm> {
         if state.thread.is_none() || state.shutting_down {
             return Err(HvfVcpuRunnerError::InvalidState(RUNNER_SHUT_DOWN_MESSAGE));
         }
+        if state.in_flight_runs > 0 {
+            return Err(HvfVcpuRunnerError::InvalidState(RUN_IN_FLIGHT_MESSAGE));
+        }
 
-        state.in_flight_runs =
-            state
-                .in_flight_runs
-                .checked_add(1)
-                .ok_or(HvfVcpuRunnerError::InvalidState(
-                    "too many in-flight vCPU runs",
-                ))?;
+        state.in_flight_runs = 1;
 
         Ok(self.command_sender.clone())
     }
@@ -516,6 +514,36 @@ mod tests {
         runner
             .shutdown()
             .expect("repeated shutdown should be idempotent");
+    }
+
+    #[test]
+    fn concurrent_run_once_is_rejected() {
+        let (runner, entered_run_receiver, destroyed_receiver) = start_fake_runner();
+
+        thread::scope(|scope| {
+            let run = scope.spawn(|| runner.run_once());
+            entered_run_receiver
+                .recv()
+                .expect("runner should enter fake run");
+
+            assert_eq!(
+                runner.run_once(),
+                Err(HvfVcpuRunnerError::InvalidState(
+                    super::RUN_IN_FLIGHT_MESSAGE
+                ))
+            );
+
+            runner.cancel().expect("cancel should release fake run");
+            assert_eq!(
+                run.join().expect("run thread should join"),
+                Ok(HvfVcpuExit::Canceled)
+            );
+        });
+
+        runner.shutdown().expect("runner should shut down");
+        destroyed_receiver
+            .recv()
+            .expect("fake vCPU should be destroyed");
     }
 
     #[test]

--- a/crates/hvf/src/runner.rs
+++ b/crates/hvf/src/runner.rs
@@ -131,17 +131,7 @@ impl<'vm> HvfVcpuRunner<'vm> {
 
     pub fn run_once(&self) -> Result<HvfVcpuExit, HvfVcpuRunnerError> {
         let (response_sender, response_receiver) = mpsc::channel();
-        let command_sender = self.prepare_run_once()?;
-        let _in_flight_run = InFlightRun::new(&self.state);
-
-        if command_sender
-            .send(RunnerCommand::RunOnce { response_sender })
-            .is_err()
-        {
-            return Err(HvfVcpuRunnerError::ChannelClosed(
-                COMMAND_CHANNEL_CLOSED_MESSAGE,
-            ));
-        }
+        let _in_flight_run = self.start_run_once(response_sender)?;
 
         response_receiver
             .recv()
@@ -199,7 +189,10 @@ impl<'vm> HvfVcpuRunner<'vm> {
         })
     }
 
-    fn prepare_run_once(&self) -> Result<mpsc::Sender<RunnerCommand>, HvfVcpuRunnerError> {
+    fn start_run_once(
+        &self,
+        response_sender: mpsc::Sender<Result<HvfVcpuExit, HvfVcpuRunnerError>>,
+    ) -> Result<InFlightRun<'_>, HvfVcpuRunnerError> {
         let mut state = self.lock_state()?;
         if state.thread.is_none() || state.shutting_down {
             return Err(HvfVcpuRunnerError::InvalidState(RUNNER_SHUT_DOWN_MESSAGE));
@@ -209,8 +202,18 @@ impl<'vm> HvfVcpuRunner<'vm> {
         }
 
         state.in_flight_runs = 1;
+        if self
+            .command_sender
+            .send(RunnerCommand::RunOnce { response_sender })
+            .is_err()
+        {
+            state.in_flight_runs = 0;
+            return Err(HvfVcpuRunnerError::ChannelClosed(
+                COMMAND_CHANNEL_CLOSED_MESSAGE,
+            ));
+        }
 
-        Ok(self.command_sender.clone())
+        Ok(InFlightRun::new(&self.state))
     }
 
     fn prepare_shutdown(&self) -> Result<(mpsc::Sender<RunnerCommand>, bool), HvfVcpuRunnerError> {

--- a/crates/hvf/src/runner.rs
+++ b/crates/hvf/src/runner.rs
@@ -140,7 +140,7 @@ impl<'vm> HvfVcpuRunner<'vm> {
     }
 
     pub fn cancel(&self) -> Result<(), HvfVcpuRunnerError> {
-        self.prepare_cancel()?;
+        let _state = self.prepare_cancel()?;
         self.cancel_vcpu()
     }
 
@@ -170,6 +170,7 @@ impl<'vm> HvfVcpuRunner<'vm> {
             Err(err) => Err(err),
         };
         let join_result = join_runner_thread(thread);
+        self.finish_shutdown();
 
         first_error(response_result, join_result)
     }
@@ -220,13 +221,13 @@ impl<'vm> HvfVcpuRunner<'vm> {
 
     fn prepare_shutdown(&self) -> Result<(mpsc::Sender<RunnerCommand>, bool), HvfVcpuRunnerError> {
         let mut state = self.lock_state()?;
-        if state.thread.is_none() {
-            return Err(HvfVcpuRunnerError::InvalidState(RUNNER_SHUT_DOWN_MESSAGE));
-        }
         if state.shutting_down {
             return Err(HvfVcpuRunnerError::InvalidState(
                 RUNNER_SHUTTING_DOWN_MESSAGE,
             ));
+        }
+        if state.thread.is_none() {
+            return Err(HvfVcpuRunnerError::InvalidState(RUNNER_SHUT_DOWN_MESSAGE));
         }
 
         state.shutting_down = true;
@@ -240,7 +241,13 @@ impl<'vm> HvfVcpuRunner<'vm> {
         }
     }
 
-    fn prepare_cancel(&self) -> Result<(), HvfVcpuRunnerError> {
+    fn finish_shutdown(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.shutting_down = false;
+        }
+    }
+
+    fn prepare_cancel(&self) -> Result<MutexGuard<'_, RunnerHandleState>, HvfVcpuRunnerError> {
         let state = self.lock_state()?;
         if state.thread.is_none() {
             return Err(HvfVcpuRunnerError::InvalidState(RUNNER_SHUT_DOWN_MESSAGE));
@@ -250,7 +257,7 @@ impl<'vm> HvfVcpuRunner<'vm> {
                 RUNNER_SHUTTING_DOWN_MESSAGE,
             ));
         }
-        Ok(())
+        Ok(state)
     }
 
     fn cancel_vcpu(&self) -> Result<(), HvfVcpuRunnerError> {
@@ -417,7 +424,7 @@ fn first_error(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, mpsc};
+    use std::sync::{Arc, Condvar, Mutex, mpsc};
     use std::thread;
 
     use bangbang_runtime::BackendError;
@@ -471,6 +478,28 @@ mod tests {
         let (release_run_sender, release_run_receiver) = mpsc::channel();
         let (destroyed_sender, destroyed_receiver) = mpsc::channel();
         let cancel_vcpu = fake_cancel_vcpu(release_run_sender);
+        start_fake_runner_with_cancel(
+            cancel_vcpu,
+            entered_run_sender,
+            release_run_receiver,
+            destroyed_sender,
+            entered_run_receiver,
+            destroyed_receiver,
+        )
+    }
+
+    fn start_fake_runner_with_cancel(
+        cancel_vcpu: CancelVcpu,
+        entered_run_sender: mpsc::Sender<()>,
+        release_run_receiver: mpsc::Receiver<Result<HvfVcpuExit, BackendError>>,
+        destroyed_sender: mpsc::Sender<()>,
+        entered_run_receiver: mpsc::Receiver<()>,
+        destroyed_receiver: mpsc::Receiver<()>,
+    ) -> (
+        HvfVcpuRunner<'static>,
+        mpsc::Receiver<()>,
+        mpsc::Receiver<()>,
+    ) {
         let started = spawn_runner_thread(move || {
             Ok(FakeVcpu {
                 entered_run_sender,
@@ -485,6 +514,60 @@ mod tests {
             entered_run_receiver,
             destroyed_receiver,
         )
+    }
+
+    #[test]
+    fn cancel_holds_runner_state_until_hvf_exit_request_returns() {
+        let (entered_run_sender, entered_run_receiver) = mpsc::channel();
+        let (_release_run_sender, release_run_receiver) = mpsc::channel();
+        let (destroyed_sender, destroyed_receiver) = mpsc::channel();
+        let (entered_cancel_sender, entered_cancel_receiver) = mpsc::channel();
+        let release_cancel = Arc::new((Mutex::new(false), Condvar::new()));
+        let cancel_release_for_runner = Arc::clone(&release_cancel);
+        let cancel_vcpu = Arc::new(move |_| {
+            entered_cancel_sender
+                .send(())
+                .map_err(|_| BackendError::InvalidState("fake cancel entry receiver closed"))?;
+            let (released, released_changed) = &*cancel_release_for_runner;
+            let mut released = released
+                .lock()
+                .map_err(|_| BackendError::InvalidState("fake cancel release lock poisoned"))?;
+            while !*released {
+                released = released_changed
+                    .wait(released)
+                    .map_err(|_| BackendError::InvalidState("fake cancel release lock poisoned"))?;
+            }
+            Ok(())
+        });
+        let (runner, _, destroyed_receiver) = start_fake_runner_with_cancel(
+            cancel_vcpu,
+            entered_run_sender,
+            release_run_receiver,
+            destroyed_sender,
+            entered_run_receiver,
+            destroyed_receiver,
+        );
+
+        thread::scope(|scope| {
+            let cancel = scope.spawn(|| runner.cancel());
+            entered_cancel_receiver
+                .recv()
+                .expect("cancel should enter fake HVF exit request");
+
+            assert!(runner.state.try_lock().is_err());
+
+            let (released, released_changed) = &*release_cancel;
+            *released
+                .lock()
+                .expect("fake cancel release lock should be lockable") = true;
+            released_changed.notify_one();
+            assert_eq!(cancel.join().expect("cancel thread should join"), Ok(()));
+        });
+
+        runner.shutdown().expect("runner should shut down");
+        destroyed_receiver
+            .recv()
+            .expect("fake vCPU should be destroyed");
     }
 
     #[test]
@@ -565,20 +648,30 @@ mod tests {
                 super::RUNNER_SHUTTING_DOWN_MESSAGE
             ))
         );
+        let thread = runner
+            .take_thread()
+            .expect("runner state should be lockable");
+        assert_eq!(
+            runner.shutdown(),
+            Err(HvfVcpuRunnerError::InvalidState(
+                super::RUNNER_SHUTTING_DOWN_MESSAGE
+            ))
+        );
 
         let (response_sender, response_receiver) = mpsc::channel();
         command_sender
             .send(super::RunnerCommand::Shutdown { response_sender })
             .expect("shutdown command should be sent");
-        let thread = runner
-            .take_thread()
-            .expect("runner state should be lockable");
         let response = response_receiver
             .recv()
             .expect("shutdown response should be sent");
 
         assert_eq!(response, Ok(()));
         super::join_runner_thread(thread).expect("runner thread should join");
+        runner.finish_shutdown();
+        runner
+            .shutdown()
+            .expect("completed shutdown should be idempotent");
         destroyed_receiver
             .recv()
             .expect("fake vCPU should be destroyed");

--- a/crates/hvf/src/runner.rs
+++ b/crates/hvf/src/runner.rs
@@ -647,6 +647,68 @@ mod tests {
     }
 
     #[test]
+    fn shutdown_cancel_error_keeps_in_flight_run_and_allows_retry() {
+        let (entered_run_sender, entered_run_receiver) = mpsc::channel();
+        let (release_run_sender, release_run_receiver) = mpsc::channel();
+        let (destroyed_sender, destroyed_receiver) = mpsc::channel();
+        let fail_next_cancel = Arc::new(Mutex::new(true));
+        let fail_next_cancel_for_runner = Arc::clone(&fail_next_cancel);
+        let cancel_vcpu = Arc::new(move |_| {
+            let mut fail_next = fail_next_cancel_for_runner
+                .lock()
+                .map_err(|_| BackendError::InvalidState("fake cancel state lock poisoned"))?;
+            if *fail_next {
+                *fail_next = false;
+                return Err(BackendError::InvalidState("fake cancel failed"));
+            }
+
+            release_run_sender
+                .send(Ok(HvfVcpuExit::Canceled))
+                .map_err(|_| BackendError::InvalidState("fake run release receiver closed"))
+        });
+        let (runner, entered_run_receiver, destroyed_receiver) = start_fake_runner_with_cancel(
+            cancel_vcpu,
+            entered_run_sender,
+            release_run_receiver,
+            destroyed_sender,
+            entered_run_receiver,
+            destroyed_receiver,
+        );
+
+        thread::scope(|scope| {
+            let run = scope.spawn(|| runner.run_once());
+            entered_run_receiver
+                .recv()
+                .expect("runner should enter fake run");
+
+            assert_eq!(
+                runner.shutdown(),
+                Err(HvfVcpuRunnerError::Backend(BackendError::InvalidState(
+                    "fake cancel failed"
+                )))
+            );
+            assert_eq!(
+                runner.run_once(),
+                Err(HvfVcpuRunnerError::InvalidState(
+                    super::RUN_IN_FLIGHT_MESSAGE
+                ))
+            );
+
+            runner
+                .shutdown()
+                .expect("shutdown retry should cancel and join fake run");
+            assert_eq!(
+                run.join().expect("run thread should join"),
+                Ok(HvfVcpuExit::Canceled)
+            );
+        });
+
+        destroyed_receiver
+            .recv()
+            .expect("fake vCPU should be destroyed");
+    }
+
+    #[test]
     fn shutdown_in_progress_rejects_second_shutdown_command_and_cancel() {
         let (runner, _, destroyed_receiver) = start_fake_runner();
         let (command_sender, should_cancel) = runner

--- a/crates/hvf/src/vcpu.rs
+++ b/crates/hvf/src/vcpu.rs
@@ -83,7 +83,7 @@ impl HvfVcpuOwner {
     }
 
     pub(crate) fn run_once(&mut self) -> Result<HvfVcpuExit, BackendError> {
-        let vcpu = self.raw_vcpu()?;
+        let vcpu = self.prepare_run()?;
 
         crate::ffi::run_vcpu(vcpu)?;
         self.mark_exit_available()?;
@@ -133,6 +133,12 @@ impl HvfVcpuOwner {
     fn mark_exit_available(&mut self) -> Result<(), BackendError> {
         self.handle_mut()?.exit_available = true;
         Ok(())
+    }
+
+    fn prepare_run(&mut self) -> Result<crate::ffi::HvVcpu, BackendError> {
+        let handle = self.handle_mut()?;
+        handle.exit_available = false;
+        Ok(handle.vcpu)
     }
 
     fn handle(&self) -> Result<&HvfVcpuHandle, BackendError> {
@@ -230,6 +236,17 @@ mod tests {
     };
     use crate::exit::{HvfExceptionExit, HvfVcpuExit};
 
+    fn fake_vcpu_owner(exit: *mut crate::ffi::HvVcpuExit, exit_available: bool) -> HvfVcpuOwner {
+        HvfVcpuOwner {
+            handle: Some(HvfVcpuHandle {
+                vcpu: 7,
+                exit,
+                exit_available,
+            }),
+            _not_send_sync: PhantomData::<Rc<()>>,
+        }
+    }
+
     fn raw_exit(reason: u32) -> crate::ffi::HvVcpuExit {
         crate::ffi::HvVcpuExit {
             reason,
@@ -246,14 +263,7 @@ mod tests {
         exit_available: bool,
     ) -> ManuallyDrop<HvfVcpu<'static>> {
         ManuallyDrop::new(HvfVcpu {
-            owner: HvfVcpuOwner {
-                handle: Some(HvfVcpuHandle {
-                    vcpu: 7,
-                    exit,
-                    exit_available,
-                }),
-                _not_send_sync: PhantomData::<Rc<()>>,
-            },
+            owner: fake_vcpu_owner(exit, exit_available),
             _vm: PhantomData,
             _not_send_sync: PhantomData::<Rc<()>>,
         })
@@ -295,6 +305,18 @@ mod tests {
 
         assert_eq!(
             vcpu.exit_snapshot(),
+            Err(BackendError::InvalidState(NO_VCPU_EXIT_MESSAGE))
+        );
+    }
+
+    #[test]
+    fn prepare_run_clears_stale_exit_snapshot() {
+        let mut exit = raw_exit(crate::ffi::HV_EXIT_REASON_EXCEPTION);
+        let mut owner = ManuallyDrop::new(fake_vcpu_owner(ptr::addr_of_mut!(exit), true));
+
+        assert_eq!(owner.prepare_run(), Ok(7));
+        assert_eq!(
+            owner.exit_snapshot(),
             Err(BackendError::InvalidState(NO_VCPU_EXIT_MESSAGE))
         );
     }

--- a/crates/hvf/src/vcpu.rs
+++ b/crates/hvf/src/vcpu.rs
@@ -47,6 +47,7 @@ pub struct HvfVcpu<'vm> {
 
 pub(crate) struct HvfVcpuOwner {
     handle: Option<HvfVcpuHandle>,
+    _not_send_sync: PhantomData<Rc<()>>,
 }
 
 struct HvfVcpuHandle {
@@ -65,6 +66,7 @@ impl HvfVcpuOwner {
                 exit: created.exit,
                 exit_available: false,
             }),
+            _not_send_sync: PhantomData,
         })
     }
 
@@ -250,6 +252,7 @@ mod tests {
                     exit,
                     exit_available,
                 }),
+                _not_send_sync: PhantomData::<Rc<()>>,
             },
             _vm: PhantomData,
             _not_send_sync: PhantomData::<Rc<()>>,
@@ -299,7 +302,10 @@ mod tests {
     #[test]
     fn exit_snapshot_rejects_destroyed_vcpu() {
         let vcpu = HvfVcpu {
-            owner: HvfVcpuOwner { handle: None },
+            owner: HvfVcpuOwner {
+                handle: None,
+                _not_send_sync: PhantomData::<Rc<()>>,
+            },
             _vm: PhantomData,
             _not_send_sync: PhantomData::<Rc<()>>,
         };
@@ -313,7 +319,10 @@ mod tests {
     #[test]
     fn register_access_rejects_destroyed_vcpu() {
         let mut vcpu = HvfVcpu {
-            owner: HvfVcpuOwner { handle: None },
+            owner: HvfVcpuOwner {
+                handle: None,
+                _not_send_sync: PhantomData::<Rc<()>>,
+            },
             _vm: PhantomData,
             _not_send_sync: PhantomData::<Rc<()>>,
         };

--- a/crates/hvf/src/vcpu.rs
+++ b/crates/hvf/src/vcpu.rs
@@ -40,9 +40,13 @@ impl HvfSystemRegister {
 }
 
 pub struct HvfVcpu<'vm> {
-    handle: Option<HvfVcpuHandle>,
+    owner: HvfVcpuOwner,
     _vm: PhantomData<&'vm mut HvfBackend>,
     _not_send_sync: PhantomData<Rc<()>>,
+}
+
+pub(crate) struct HvfVcpuOwner {
+    handle: Option<HvfVcpuHandle>,
 }
 
 struct HvfVcpuHandle {
@@ -51,8 +55,8 @@ struct HvfVcpuHandle {
     exit_available: bool,
 }
 
-impl<'vm> HvfVcpu<'vm> {
-    pub(crate) fn new(_: &'vm mut HvfBackend) -> Result<Self, BackendError> {
+impl HvfVcpuOwner {
+    pub(crate) fn new() -> Result<Self, BackendError> {
         let created = crate::ffi::create_vcpu()?;
 
         Ok(Self {
@@ -61,16 +65,30 @@ impl<'vm> HvfVcpu<'vm> {
                 exit: created.exit,
                 exit_available: false,
             }),
-            _vm: PhantomData,
-            _not_send_sync: PhantomData,
         })
     }
 
-    pub fn destroy(&mut self) -> Result<(), BackendError> {
-        self.destroy_inner()
+    pub(crate) fn raw_vcpu(&self) -> Result<crate::ffi::HvVcpu, BackendError> {
+        Ok(self.handle()?.vcpu)
     }
 
-    pub fn exit_snapshot(&self) -> Result<HvfVcpuExit, BackendError> {
+    pub(crate) fn destroy(&mut self) -> Result<(), BackendError> {
+        if let Some(handle) = &self.handle {
+            crate::ffi::destroy_vcpu(handle.vcpu)?;
+            self.handle = None;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn run_once(&mut self) -> Result<HvfVcpuExit, BackendError> {
+        let vcpu = self.raw_vcpu()?;
+
+        crate::ffi::run_vcpu(vcpu)?;
+        self.mark_exit_available()?;
+        self.exit_snapshot()
+    }
+
+    pub(crate) fn exit_snapshot(&self) -> Result<HvfVcpuExit, BackendError> {
         let handle = self.handle()?;
         if !handle.exit_available {
             return Err(BackendError::InvalidState(NO_VCPU_EXIT_MESSAGE));
@@ -83,24 +101,36 @@ impl<'vm> HvfVcpu<'vm> {
         Ok(HvfVcpuExit::from_raw(raw_exit))
     }
 
-    pub fn get_register(&self, register: HvfRegister) -> Result<u64, BackendError> {
+    pub(crate) fn get_register(&self, register: HvfRegister) -> Result<u64, BackendError> {
         crate::ffi::get_reg(self.handle()?.vcpu, register.raw())
     }
 
-    pub fn set_register(&mut self, register: HvfRegister, value: u64) -> Result<(), BackendError> {
+    pub(crate) fn set_register(
+        &mut self,
+        register: HvfRegister,
+        value: u64,
+    ) -> Result<(), BackendError> {
         crate::ffi::set_reg(self.handle()?.vcpu, register.raw(), value)
     }
 
-    pub fn get_system_register(&self, register: HvfSystemRegister) -> Result<u64, BackendError> {
+    pub(crate) fn get_system_register(
+        &self,
+        register: HvfSystemRegister,
+    ) -> Result<u64, BackendError> {
         crate::ffi::get_sys_reg(self.handle()?.vcpu, register.raw())
     }
 
-    pub fn set_system_register(
+    pub(crate) fn set_system_register(
         &mut self,
         register: HvfSystemRegister,
         value: u64,
     ) -> Result<(), BackendError> {
         crate::ffi::set_sys_reg(self.handle()?.vcpu, register.raw(), value)
+    }
+
+    fn mark_exit_available(&mut self) -> Result<(), BackendError> {
+        self.handle_mut()?.exit_available = true;
+        Ok(())
     }
 
     fn handle(&self) -> Result<&HvfVcpuHandle, BackendError> {
@@ -109,36 +139,76 @@ impl<'vm> HvfVcpu<'vm> {
             .ok_or(BackendError::InvalidState(DESTROYED_VCPU_MESSAGE))
     }
 
-    fn destroy_inner(&mut self) -> Result<(), BackendError> {
-        if let Some(handle) = &self.handle {
-            crate::ffi::destroy_vcpu(handle.vcpu)?;
-            self.handle = None;
-        }
-        Ok(())
+    fn handle_mut(&mut self) -> Result<&mut HvfVcpuHandle, BackendError> {
+        self.handle
+            .as_mut()
+            .ok_or(BackendError::InvalidState(DESTROYED_VCPU_MESSAGE))
     }
 }
 
-impl Drop for HvfVcpu<'_> {
+impl Drop for HvfVcpuOwner {
     fn drop(&mut self) {
-        let _ = self.destroy_inner();
+        let _ = self.destroy();
+    }
+}
+
+impl fmt::Debug for HvfVcpuOwner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (active, has_exit_pointer, exit_available) = match &self.handle {
+            Some(handle) => (true, !handle.exit.is_null(), handle.exit_available),
+            None => (false, false, false),
+        };
+
+        f.debug_struct("HvfVcpuOwner")
+            .field("active", &active)
+            .field("has_exit_pointer", &has_exit_pointer)
+            .field("exit_available", &exit_available)
+            .finish()
+    }
+}
+
+impl<'vm> HvfVcpu<'vm> {
+    pub(crate) fn new(_: &'vm mut HvfBackend) -> Result<Self, BackendError> {
+        Ok(Self {
+            owner: HvfVcpuOwner::new()?,
+            _vm: PhantomData,
+            _not_send_sync: PhantomData,
+        })
+    }
+
+    pub fn destroy(&mut self) -> Result<(), BackendError> {
+        self.owner.destroy()
+    }
+
+    pub fn exit_snapshot(&self) -> Result<HvfVcpuExit, BackendError> {
+        self.owner.exit_snapshot()
+    }
+
+    pub fn get_register(&self, register: HvfRegister) -> Result<u64, BackendError> {
+        self.owner.get_register(register)
+    }
+
+    pub fn set_register(&mut self, register: HvfRegister, value: u64) -> Result<(), BackendError> {
+        self.owner.set_register(register, value)
+    }
+
+    pub fn get_system_register(&self, register: HvfSystemRegister) -> Result<u64, BackendError> {
+        self.owner.get_system_register(register)
+    }
+
+    pub fn set_system_register(
+        &mut self,
+        register: HvfSystemRegister,
+        value: u64,
+    ) -> Result<(), BackendError> {
+        self.owner.set_system_register(register, value)
     }
 }
 
 impl fmt::Debug for HvfVcpu<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (vcpu, has_exit_pointer, exit_available) = match &self.handle {
-            Some(handle) => (
-                Some(handle.vcpu),
-                !handle.exit.is_null(),
-                handle.exit_available,
-            ),
-            None => (None, false, false),
-        };
-
         f.debug_struct("HvfVcpu")
-            .field("vcpu", &vcpu)
-            .field("has_exit_pointer", &has_exit_pointer)
-            .field("exit_available", &exit_available)
+            .field("owner", &self.owner)
             .finish_non_exhaustive()
     }
 }
@@ -154,7 +224,7 @@ mod tests {
 
     use super::{
         DESTROYED_VCPU_MESSAGE, HvfRegister, HvfSystemRegister, HvfVcpu, HvfVcpuHandle,
-        NO_VCPU_EXIT_MESSAGE,
+        HvfVcpuOwner, NO_VCPU_EXIT_MESSAGE,
     };
     use crate::exit::{HvfExceptionExit, HvfVcpuExit};
 
@@ -174,11 +244,13 @@ mod tests {
         exit_available: bool,
     ) -> ManuallyDrop<HvfVcpu<'static>> {
         ManuallyDrop::new(HvfVcpu {
-            handle: Some(HvfVcpuHandle {
-                vcpu: 7,
-                exit,
-                exit_available,
-            }),
+            owner: HvfVcpuOwner {
+                handle: Some(HvfVcpuHandle {
+                    vcpu: 7,
+                    exit,
+                    exit_available,
+                }),
+            },
             _vm: PhantomData,
             _not_send_sync: PhantomData::<Rc<()>>,
         })
@@ -227,7 +299,7 @@ mod tests {
     #[test]
     fn exit_snapshot_rejects_destroyed_vcpu() {
         let vcpu = HvfVcpu {
-            handle: None,
+            owner: HvfVcpuOwner { handle: None },
             _vm: PhantomData,
             _not_send_sync: PhantomData::<Rc<()>>,
         };
@@ -241,7 +313,7 @@ mod tests {
     #[test]
     fn register_access_rejects_destroyed_vcpu() {
         let mut vcpu = HvfVcpu {
-            handle: None,
+            owner: HvfVcpuOwner { handle: None },
             _vm: PhantomData,
             _not_send_sync: PhantomData::<Rc<()>>,
         };

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -28,6 +28,29 @@ fn creates_and_destroys_hvf_vcpu() {
     backend.destroy_vm().expect("VM should be destroyed");
 }
 
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn cancels_runner_before_first_run() {
+    use bangbang_hvf::{HvfBackend, HvfVcpuExit};
+    use bangbang_runtime::VmBackend;
+
+    let mut backend = HvfBackend::new();
+
+    backend.create_vm().expect("VM should be created");
+    {
+        let runner = backend
+            .start_vcpu_runner()
+            .expect("vCPU runner should start");
+        runner.cancel().expect("runner should accept cancellation");
+        assert_eq!(
+            runner.run_once().expect("runner should return an exit"),
+            HvfVcpuExit::Canceled
+        );
+        runner.shutdown().expect("runner should shut down");
+    }
+    backend.destroy_vm().expect("VM should be destroyed");
+}
+
 #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 #[test]
 fn requires_macos_apple_silicon() {

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -1,10 +1,16 @@
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+static HVF_LIFECYCLE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 #[test]
 fn creates_and_destroys_hvf_vcpu() {
     use bangbang_hvf::{HvfBackend, HvfRegister};
     use bangbang_runtime::BackendError;
     use bangbang_runtime::VmBackend;
 
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
     let mut backend = HvfBackend::new();
 
     backend.create_vm().expect("VM should be created");
@@ -34,6 +40,9 @@ fn cancels_runner_before_first_run() {
     use bangbang_hvf::{HvfBackend, HvfVcpuExit};
     use bangbang_runtime::VmBackend;
 
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
     let mut backend = HvfBackend::new();
 
     backend.create_vm().expect("VM should be created");

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -312,11 +312,17 @@ macOS design work instead of direct implementation:
 - HVF vCPU handles are thread-affine: creation, register access, run, and
   destroy operations must happen on the owning thread. The current vCPU wrapper
   covers current-thread lifecycle, typed exit surface, and narrow register
-  access only; future run-loop work should use a thread-owned runner.
+  access. The current runner skeleton creates a vCPU on a dedicated thread,
+  supports one cancellable `hv_vcpu_run` step at a time, and shuts down by
+  canceling and joining the runner thread.
 - HVF exit snapshots preserve Hypervisor.framework reasons such as canceled,
-  exception, virtual timer activation, and unknown after a future run wrapper
-  marks exit data available. They are not yet produced by guest execution or
-  decoded into MMIO, timer, device, or runtime events.
+  exception, virtual timer activation, and unknown after a run wrapper marks
+  exit data available. They are not yet decoded into MMIO, timer, device, or
+  runtime events.
+- Firecracker's full paused/resumed microVM loop is not implemented yet.
+  bangbang's runner is only the HVF ownership and cancellation primitive needed
+  before guest memory, interrupt, timer, and device work can build the real run
+  loop.
 - Linux seccomp, jailer, cgroups, and namespaces do not directly apply.
 - Linux TAP-based networking needs a macOS-specific design.
 - Snapshot and device behavior may differ when backed by HVF.


### PR DESCRIPTION
Closes #62

## Summary

- add HVF wrappers for `hv_vcpu_run` and `hv_vcpus_exit`
- add a thread-owned `HvfVcpuRunner` with `run_once`, `cancel`, and explicit `shutdown`
- reuse the existing typed `HvfVcpuExit` surface for runner exits
- cover cancellation/shutdown behavior with unit tests and signed HVF smoke coverage
- update README and compatibility docs for the runner skeleton and remaining non-goals

## Scope exclusions

- no guest memory mapping, Linux boot setup, MMIO/device emulation, or continuous run loop
- no public `PUT /actions` or `InstanceStart` behavior
- no backend-neutral runtime vCPU abstraction yet

## Verification

```sh
cargo fmt --all -- --check
cargo check --workspace --all-targets --all-features --locked
cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
cargo test -p bangbang-hvf --lib --all-features --locked
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
scripts/run-hvf-tests.sh
```
