### PR TITLE
feat: add anonymous guest memory allocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,9 @@ dependencies = [
 [[package]]
 name = "bangbang-runtime"
 version = "0.1.0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "errno"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 bangbang is a Rust VMM project for macOS hosts. The public control plane is intended to stay compatible with the Firecracker HTTP API over a Unix domain socket, while the VM backend is built on Apple's Hypervisor.framework.
 
-This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, a backend-neutral guest address/layout model, and the smallest Hypervisor.framework VM, current-thread vCPU lifecycle, typed exit surface, register wrappers, and cancellable vCPU runner skeleton.
+This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, a backend-neutral guest address/layout model, anonymous guest memory allocation, and the smallest Hypervisor.framework VM, current-thread vCPU lifecycle, typed exit surface, register wrappers, and cancellable vCPU runner skeleton.
 
 See [Firecracker Compatibility Scope](docs/firecracker-compatibility.md) for the intended compatibility target and current limitations.
 See [Pull Request Review Guidelines](docs/review-guidelines.md) for the project-specific review standard.
@@ -18,11 +18,11 @@ crates/bangbang   VMM process entrypoint and startup CLI
 
 ## Current Scope
 
-The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. The runtime crate defines guest physical address, range, and aarch64 DRAM layout primitives. The HVF crate can create/destroy a process VM, create/destroy one current-thread vCPU handle, define typed HVF exit snapshots, get/set a narrow set of vCPU registers, and start a thread-owned runner that can cancel a single `hv_vcpu_run` step. It intentionally does not include:
+The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. The runtime crate defines guest physical address, range, and aarch64 DRAM layout primitives, and can allocate owned anonymous host memory for validated page-aligned guest memory layouts. The HVF crate can create/destroy a process VM, create/destroy one current-thread vCPU handle, define typed HVF exit snapshots, get/set a narrow set of vCPU registers, and start a thread-owned runner that can cancel a single `hv_vcpu_run` step. It intentionally does not include:
 
 - API endpoints beyond `GET /` and `GET /version`
 - JSON request body models
-- guest memory allocation or HVF mapping
+- HVF guest memory mapping
 - configured guest execution, continuous vCPU run loops, MMIO/device emulation, or boot register setup
 - kernel loading
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
+libc = "0.2"
 
 [lints]
 workspace = true

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -757,6 +757,17 @@ mod tests {
     }
 
     #[test]
+    fn guest_memory_layout_rejects_duplicate_start_ranges() {
+        let previous = range(0x1000, 0x1000);
+        let next = range(0x1000, 0x1000);
+
+        assert_eq!(
+            GuestMemoryLayout::new(vec![previous, next]),
+            Err(GuestMemoryError::OverlappingRange { previous, next })
+        );
+    }
+
+    #[test]
     fn aarch64_dram_layout_rejects_zero_requested_size() {
         assert_eq!(aarch64::dram_layout(0), Err(GuestMemoryError::EmptyLayout));
     }
@@ -950,6 +961,30 @@ mod tests {
         ));
         assert_eq!(mapper.maps, 0);
         assert_eq!(drop_count.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn guest_memory_rejects_invalid_host_page_size_before_allocation() {
+        let layout = GuestMemoryLayout::new(vec![range(0, PAGE_SIZE)])
+            .expect("page-aligned layout should be valid");
+
+        for page_size in [0, 3] {
+            let drop_count = Arc::new(AtomicUsize::new(0));
+            let mut mapper = CountingMapper {
+                maps: 0,
+                drop_count: Arc::clone(&drop_count),
+            };
+
+            let err = GuestMemory::allocate_with_mapper(&layout, page_size, &mut mapper)
+                .expect_err("invalid host page size should fail before allocation");
+
+            assert!(matches!(
+                err,
+                GuestMemoryAllocationError::InvalidHostPageSize
+            ));
+            assert_eq!(mapper.maps, 0);
+            assert_eq!(drop_count.load(Ordering::Relaxed), 0);
+        }
     }
 
     #[test]

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -1008,6 +1008,28 @@ mod tests {
     }
 
     #[test]
+    fn guest_memory_drop_releases_all_regions() {
+        let page_size = host_page_size().expect("host page size should be available for tests");
+        let layout = GuestMemoryLayout::new(vec![range(0, page_size), range(page_size, page_size)])
+            .expect("page-aligned layout should be valid");
+        let drop_count = Arc::new(AtomicUsize::new(0));
+        let mut mapper = CountingMapper {
+            maps: 0,
+            drop_count: Arc::clone(&drop_count),
+        };
+
+        let memory = GuestMemory::allocate_with_mapper(&layout, page_size, &mut mapper)
+            .expect("guest memory allocation should succeed");
+
+        assert_eq!(mapper.maps, 2);
+        assert_eq!(drop_count.load(Ordering::Relaxed), 0);
+
+        drop(memory);
+
+        assert_eq!(drop_count.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
     fn guest_memory_partial_allocation_failure_drops_previous_regions() {
         let page_size = host_page_size().expect("host page size should be available for tests");
         let layout = GuestMemoryLayout::new(vec![range(0, page_size), range(page_size, page_size)])

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -1,4 +1,12 @@
+use std::ffi::c_void;
 use std::fmt;
+use std::io;
+use std::ptr::{self, NonNull};
+
+#[cfg(test)]
+use std::cell::Cell;
+#[cfg(test)]
+use std::rc::Rc;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GuestAddress(u64);
@@ -143,6 +151,133 @@ impl GuestMemoryLayout {
     }
 }
 
+#[derive(Debug)]
+pub struct GuestMemory {
+    regions: Vec<GuestMemoryRegion>,
+}
+
+impl GuestMemory {
+    pub fn allocate(layout: &GuestMemoryLayout) -> Result<Self, GuestMemoryAllocationError> {
+        let page_size = host_page_size()?;
+        let mut mapper = SystemAnonymousMapper;
+
+        Self::allocate_with_mapper(layout, page_size, &mut mapper)
+    }
+
+    fn allocate_with_mapper(
+        layout: &GuestMemoryLayout,
+        page_size: u64,
+        mapper: &mut impl AnonymousMapper,
+    ) -> Result<Self, GuestMemoryAllocationError> {
+        let ranges = validated_allocation_ranges(layout, page_size)?;
+        let mut regions = Vec::with_capacity(ranges.len());
+
+        for (range, host_size) in ranges {
+            regions.push(GuestMemoryRegion {
+                range,
+                mapping: mapper.map(host_size)?,
+            });
+        }
+
+        Ok(Self { regions })
+    }
+
+    pub fn regions(&self) -> &[GuestMemoryRegion] {
+        &self.regions
+    }
+
+    pub fn total_size(&self) -> u64 {
+        self.regions
+            .iter()
+            .map(|region| region.range().size())
+            .sum::<u64>()
+    }
+}
+
+pub struct GuestMemoryRegion {
+    range: GuestMemoryRange,
+    mapping: AnonymousMapping,
+}
+
+impl GuestMemoryRegion {
+    pub const fn range(&self) -> GuestMemoryRange {
+        self.range
+    }
+
+    pub fn host_address(&self) -> NonNull<c_void> {
+        self.mapping.address()
+    }
+
+    pub const fn host_size(&self) -> usize {
+        self.mapping.size()
+    }
+}
+
+impl fmt::Debug for GuestMemoryRegion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GuestMemoryRegion")
+            .field("range", &self.range)
+            .field("host_size", &self.mapping.size())
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug)]
+pub enum GuestMemoryAllocationError {
+    InvalidLayout(GuestMemoryError),
+    InvalidHostPageSize,
+    SizeTooLarge { range: GuestMemoryRange },
+    AnonymousMmapFailed { size: usize, source: io::Error },
+    AnonymousMmapReturnedNull { size: usize },
+}
+
+impl fmt::Display for GuestMemoryAllocationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidLayout(source) => {
+                write!(f, "invalid guest memory layout for allocation: {source}")
+            }
+            Self::InvalidHostPageSize => f.write_str("host page size is unavailable or invalid"),
+            Self::SizeTooLarge { range } => {
+                write!(
+                    f,
+                    "guest memory range {range} is too large to allocate on this host"
+                )
+            }
+            Self::AnonymousMmapFailed { size, source } => {
+                write!(
+                    f,
+                    "failed to allocate anonymous guest memory mapping of {size} bytes: {source}"
+                )
+            }
+            Self::AnonymousMmapReturnedNull { size } => {
+                write!(
+                    f,
+                    "anonymous guest memory mapping of {size} bytes returned a null address"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for GuestMemoryAllocationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidLayout(source) => Some(source),
+            Self::AnonymousMmapFailed { source, .. } => Some(source),
+            Self::InvalidHostPageSize
+            | Self::SizeTooLarge { .. }
+            | Self::AnonymousMmapReturnedNull { .. } => None,
+        }
+    }
+}
+
+impl From<GuestMemoryError> for GuestMemoryAllocationError {
+    fn from(source: GuestMemoryError) -> Self {
+        Self::InvalidLayout(source)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GuestMemoryError {
     EmptyLayout,
@@ -265,9 +400,165 @@ fn validate_alignment(alignment: u64) -> Result<(), GuestMemoryError> {
     }
 }
 
+fn validated_allocation_ranges(
+    layout: &GuestMemoryLayout,
+    page_size: u64,
+) -> Result<Vec<(GuestMemoryRange, usize)>, GuestMemoryAllocationError> {
+    validate_host_page_size(page_size)?;
+
+    let mut ranges = Vec::with_capacity(layout.ranges().len());
+    for range in layout.ranges().iter().copied() {
+        range.validate_alignment(page_size)?;
+        let host_size = usize::try_from(range.size())
+            .map_err(|_| GuestMemoryAllocationError::SizeTooLarge { range })?;
+        ranges.push((range, host_size));
+    }
+
+    Ok(ranges)
+}
+
+fn host_page_size() -> Result<u64, GuestMemoryAllocationError> {
+    // SAFETY: `sysconf(_SC_PAGESIZE)` has no pointer arguments and does not
+    // require process-local invariants from Rust.
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    let page_size =
+        u64::try_from(page_size).map_err(|_| GuestMemoryAllocationError::InvalidHostPageSize)?;
+
+    validate_host_page_size(page_size)?;
+    Ok(page_size)
+}
+
+fn validate_host_page_size(page_size: u64) -> Result<(), GuestMemoryAllocationError> {
+    if page_size == 0 || !page_size.is_power_of_two() {
+        Err(GuestMemoryAllocationError::InvalidHostPageSize)
+    } else {
+        Ok(())
+    }
+}
+
+trait AnonymousMapper {
+    fn map(&mut self, size: usize) -> Result<AnonymousMapping, GuestMemoryAllocationError>;
+}
+
+#[derive(Debug)]
+struct SystemAnonymousMapper;
+
+impl AnonymousMapper for SystemAnonymousMapper {
+    fn map(&mut self, size: usize) -> Result<AnonymousMapping, GuestMemoryAllocationError> {
+        AnonymousMapping::map(size)
+    }
+}
+
+struct AnonymousMapping {
+    address: NonNull<c_void>,
+    size: usize,
+    kind: AnonymousMappingKind,
+}
+
+impl AnonymousMapping {
+    fn map(size: usize) -> Result<Self, GuestMemoryAllocationError> {
+        // SAFETY: The call requests a new private anonymous read/write mapping.
+        // `size` was validated from a non-empty guest memory range before this
+        // function is called. No aliasing Rust reference is created here.
+        let address = unsafe {
+            libc::mmap(
+                ptr::null_mut(),
+                size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANON,
+                -1,
+                0,
+            )
+        };
+
+        if address == libc::MAP_FAILED {
+            return Err(GuestMemoryAllocationError::AnonymousMmapFailed {
+                size,
+                source: io::Error::last_os_error(),
+            });
+        }
+
+        let Some(address) = NonNull::new(address) else {
+            // SAFETY: `mmap` reported success, so the returned address and size
+            // describe a live mapping even if the address is null.
+            unsafe {
+                let _ = libc::munmap(address, size);
+            }
+
+            return Err(GuestMemoryAllocationError::AnonymousMmapReturnedNull { size });
+        };
+
+        Ok(Self {
+            address,
+            size,
+            kind: AnonymousMappingKind::System,
+        })
+    }
+
+    #[cfg(test)]
+    fn test_mapping(size: usize, drop_count: Rc<Cell<usize>>) -> Self {
+        Self {
+            address: NonNull::<u8>::dangling().cast(),
+            size,
+            kind: AnonymousMappingKind::Test { drop_count },
+        }
+    }
+
+    const fn address(&self) -> NonNull<c_void> {
+        self.address
+    }
+
+    const fn size(&self) -> usize {
+        self.size
+    }
+}
+
+impl fmt::Debug for AnonymousMapping {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AnonymousMapping")
+            .field("size", &self.size)
+            .field("kind", &self.kind)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug)]
+enum AnonymousMappingKind {
+    System,
+    #[cfg(test)]
+    Test {
+        drop_count: Rc<Cell<usize>>,
+    },
+}
+
+impl Drop for AnonymousMapping {
+    fn drop(&mut self) {
+        match &self.kind {
+            AnonymousMappingKind::System => {
+                // SAFETY: `AnonymousMapping::map` stores only successful mmap
+                // results, and each `AnonymousMapping` owns exactly one mapping.
+                unsafe {
+                    let _ = libc::munmap(self.address.as_ptr(), self.size);
+                }
+            }
+            #[cfg(test)]
+            AnonymousMappingKind::Test { drop_count } => {
+                drop_count.set(drop_count.get() + 1);
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{GuestAddress, GuestMemoryError, GuestMemoryLayout, GuestMemoryRange, aarch64};
+    use std::cell::Cell;
+    use std::io;
+    use std::rc::Rc;
+
+    use super::{
+        AnonymousMapper, AnonymousMapping, GuestAddress, GuestMemory, GuestMemoryAllocationError,
+        GuestMemoryError, GuestMemoryLayout, GuestMemoryRange, aarch64, host_page_size,
+    };
 
     const PAGE_SIZE: u64 = 4096;
 
@@ -515,5 +806,147 @@ mod tests {
             range.end_exclusive().raw_value() <= aarch64::MMIO64_MEM_START
                 || range.start().raw_value() >= aarch64::FIRST_ADDR_PAST_64BITS_MMIO
         }));
+    }
+
+    #[test]
+    fn guest_memory_allocates_small_layout() {
+        let page_size = host_page_size().expect("host page size should be available for tests");
+        let layout = GuestMemoryLayout::new(vec![range(0, page_size)])
+            .expect("page-aligned layout should be valid");
+
+        let memory =
+            GuestMemory::allocate(&layout).expect("guest memory allocation should succeed");
+        let region = memory
+            .regions()
+            .first()
+            .expect("guest memory should contain one region");
+        let page_size_usize =
+            usize::try_from(page_size).expect("host page size should fit in usize");
+
+        assert_eq!(memory.regions().len(), 1);
+        assert_eq!(memory.total_size(), page_size);
+        assert_eq!(region.range(), range(0, page_size));
+        assert_eq!(region.host_size(), page_size_usize);
+        assert_eq!(region.host_address().as_ptr() as usize % page_size_usize, 0);
+
+        let byte = region.host_address().as_ptr().cast::<u8>();
+        // SAFETY: `region` owns a live read/write anonymous mapping of at
+        // least one byte for the duration of this test.
+        unsafe {
+            byte.write(0xab);
+            assert_eq!(byte.read(), 0xab);
+        }
+    }
+
+    #[test]
+    fn guest_memory_rejects_unaligned_layout_before_allocation() {
+        let page_size = host_page_size().expect("host page size should be available for tests");
+        let unaligned_range = range(page_size, page_size - 1);
+        let layout =
+            GuestMemoryLayout::new(vec![unaligned_range]).expect("layout ordering should be valid");
+        let drop_count = Rc::new(Cell::new(0));
+        let mut mapper = CountingMapper {
+            maps: 0,
+            drop_count: Rc::clone(&drop_count),
+        };
+
+        let err = GuestMemory::allocate_with_mapper(&layout, page_size, &mut mapper)
+            .expect_err("unaligned allocation should fail");
+
+        assert!(matches!(
+            err,
+            GuestMemoryAllocationError::InvalidLayout(GuestMemoryError::UnalignedRange {
+                range,
+                alignment,
+            }) if range == unaligned_range && alignment == page_size
+        ));
+        assert_eq!(mapper.maps, 0);
+        assert_eq!(drop_count.get(), 0);
+    }
+
+    #[test]
+    fn guest_memory_allocations_are_independent() {
+        let page_size = host_page_size().expect("host page size should be available for tests");
+        let layout = GuestMemoryLayout::new(vec![range(0, page_size)])
+            .expect("page-aligned layout should be valid");
+
+        let first = GuestMemory::allocate(&layout).expect("first allocation should succeed");
+        let second = GuestMemory::allocate(&layout).expect("second allocation should succeed");
+        let first_region = first
+            .regions()
+            .first()
+            .expect("first allocation should contain one region");
+        let second_region = second
+            .regions()
+            .first()
+            .expect("second allocation should contain one region");
+
+        assert_eq!(first_region.range(), second_region.range());
+        assert_ne!(first_region.host_address(), second_region.host_address());
+    }
+
+    #[test]
+    fn guest_memory_partial_allocation_failure_drops_previous_regions() {
+        let page_size = host_page_size().expect("host page size should be available for tests");
+        let layout = GuestMemoryLayout::new(vec![range(0, page_size), range(page_size, page_size)])
+            .expect("page-aligned layout should be valid");
+        let drop_count = Rc::new(Cell::new(0));
+        let mut mapper = FailingMapper {
+            maps: 0,
+            fail_on: 2,
+            drop_count: Rc::clone(&drop_count),
+        };
+
+        let err = GuestMemory::allocate_with_mapper(&layout, page_size, &mut mapper)
+            .expect_err("second region allocation should fail");
+
+        assert!(matches!(
+            err,
+            GuestMemoryAllocationError::AnonymousMmapFailed { size, .. }
+                if size == usize::try_from(page_size).expect("page size should fit usize")
+        ));
+        assert_eq!(mapper.maps, 2);
+        assert_eq!(drop_count.get(), 1);
+    }
+
+    #[derive(Debug)]
+    struct CountingMapper {
+        maps: usize,
+        drop_count: Rc<Cell<usize>>,
+    }
+
+    impl AnonymousMapper for CountingMapper {
+        fn map(&mut self, size: usize) -> Result<AnonymousMapping, GuestMemoryAllocationError> {
+            self.maps += 1;
+            Ok(AnonymousMapping::test_mapping(
+                size,
+                Rc::clone(&self.drop_count),
+            ))
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingMapper {
+        maps: usize,
+        fail_on: usize,
+        drop_count: Rc<Cell<usize>>,
+    }
+
+    impl AnonymousMapper for FailingMapper {
+        fn map(&mut self, size: usize) -> Result<AnonymousMapping, GuestMemoryAllocationError> {
+            self.maps += 1;
+
+            if self.maps == self.fail_on {
+                return Err(GuestMemoryAllocationError::AnonymousMmapFailed {
+                    size,
+                    source: io::Error::from_raw_os_error(libc::ENOMEM),
+                });
+            }
+
+            Ok(AnonymousMapping::test_mapping(
+                size,
+                Rc::clone(&self.drop_count),
+            ))
+        }
     }
 }

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -584,9 +584,11 @@ impl Drop for AnonymousMapping {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::io;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread;
 
     use super::{
         AnonymousMapper, AnonymousMapping, GuestAddress, GuestMemory, GuestMemoryAllocationError,
@@ -969,6 +971,35 @@ mod tests {
 
         assert_eq!(first_region.range(), second_region.range());
         assert_ne!(first_region.host_address(), second_region.host_address());
+    }
+
+    #[test]
+    fn guest_memory_allocations_are_independent_across_threads() {
+        let page_size = host_page_size().expect("host page size should be available for tests");
+        let handles = (0..4)
+            .map(|_| {
+                thread::spawn(move || {
+                    let layout = GuestMemoryLayout::new(vec![range(0, page_size)])
+                        .expect("page-aligned layout should be valid");
+
+                    GuestMemory::allocate(&layout).expect("guest memory allocation should succeed")
+                })
+            })
+            .collect::<Vec<_>>();
+        let memories = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("allocation thread should not panic"))
+            .collect::<Vec<_>>();
+        let mut host_addresses = HashSet::new();
+
+        for memory in &memories {
+            let region = memory
+                .regions()
+                .first()
+                .expect("guest memory should contain one region");
+            assert_eq!(region.range(), range(0, page_size));
+            assert!(host_addresses.insert(region.host_address()));
+        }
     }
 
     #[test]

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -465,7 +465,7 @@ impl AnonymousMapping {
                 ptr::null_mut(),
                 size,
                 libc::PROT_READ | libc::PROT_WRITE,
-                libc::MAP_PRIVATE | libc::MAP_ANON,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_NORESERVE,
                 -1,
                 0,
             )
@@ -852,6 +852,32 @@ mod tests {
 
         let err = GuestMemory::allocate_with_mapper(&layout, page_size, &mut mapper)
             .expect_err("unaligned allocation should fail");
+
+        assert!(matches!(
+            err,
+            GuestMemoryAllocationError::InvalidLayout(GuestMemoryError::UnalignedRange {
+                range,
+                alignment,
+            }) if range == unaligned_range && alignment == page_size
+        ));
+        assert_eq!(mapper.maps, 0);
+        assert_eq!(drop_count.get(), 0);
+    }
+
+    #[test]
+    fn guest_memory_validates_all_ranges_before_allocation() {
+        let page_size = host_page_size().expect("host page size should be available for tests");
+        let unaligned_range = range(page_size, page_size - 1);
+        let layout = GuestMemoryLayout::new(vec![range(0, page_size), unaligned_range])
+            .expect("layout ordering should be valid");
+        let drop_count = Rc::new(Cell::new(0));
+        let mut mapper = CountingMapper {
+            maps: 0,
+            drop_count: Rc::clone(&drop_count),
+        };
+
+        let err = GuestMemory::allocate_with_mapper(&layout, page_size, &mut mapper)
+            .expect_err("unaligned second range should fail before allocation");
 
         assert!(matches!(
             err,

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -586,8 +586,8 @@ impl Drop for AnonymousMapping {
 mod tests {
     use std::collections::HashSet;
     use std::io;
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier};
     use std::thread;
 
     use super::{
@@ -976,9 +976,14 @@ mod tests {
     #[test]
     fn guest_memory_allocations_are_independent_across_threads() {
         let page_size = host_page_size().expect("host page size should be available for tests");
-        let handles = (0..4)
+        let thread_count = 4;
+        let start = Arc::new(Barrier::new(thread_count));
+        let handles = (0..thread_count)
             .map(|_| {
+                let start = Arc::clone(&start);
                 thread::spawn(move || {
+                    start.wait();
+
                     let layout = GuestMemoryLayout::new(vec![range(0, page_size)])
                         .expect("page-aligned layout should be valid");
 

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -1030,6 +1030,25 @@ mod tests {
     }
 
     #[test]
+    fn guest_memory_drop_releases_regions_after_thread_move() {
+        let page_size = host_page_size().expect("host page size should be available for tests");
+        let layout = GuestMemoryLayout::new(vec![range(0, page_size), range(page_size, page_size)])
+            .expect("page-aligned layout should be valid");
+        let drop_count = Arc::new(AtomicUsize::new(0));
+        let mut mapper = CountingMapper {
+            maps: 0,
+            drop_count: Arc::clone(&drop_count),
+        };
+        let memory = GuestMemory::allocate_with_mapper(&layout, page_size, &mut mapper)
+            .expect("guest memory allocation should succeed");
+
+        let handle = thread::spawn(move || drop(memory));
+
+        handle.join().expect("drop thread should not panic");
+        assert_eq!(drop_count.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
     fn guest_memory_partial_allocation_failure_drops_previous_regions() {
         let page_size = host_page_size().expect("host page size should be available for tests");
         let layout = GuestMemoryLayout::new(vec![range(0, page_size), range(page_size, page_size)])

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -5,9 +5,9 @@ use std::io;
 use std::ptr::{self, NonNull};
 
 #[cfg(test)]
-use std::cell::Cell;
+use std::sync::Arc;
 #[cfg(test)]
-use std::rc::Rc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GuestAddress(u64);
@@ -478,6 +478,16 @@ struct AnonymousMapping {
     kind: AnonymousMappingKind,
 }
 
+// SAFETY: `AnonymousMapping` owns a process-local mmap region. Moving ownership
+// to another thread does not invalidate the mapping, and `munmap` may run from
+// any thread when the owner is dropped.
+unsafe impl Send for AnonymousMapping {}
+
+// SAFETY: Shared references expose only copyable metadata and a raw pointer.
+// Safe Rust cannot mutate the mapped bytes through this type, and unsafe users
+// must uphold the usual raw-pointer aliasing and lifetime requirements.
+unsafe impl Sync for AnonymousMapping {}
+
 impl AnonymousMapping {
     fn map(size: usize) -> Result<Self, GuestMemoryAllocationError> {
         // SAFETY: The call requests a new private anonymous read/write mapping.
@@ -519,7 +529,7 @@ impl AnonymousMapping {
     }
 
     #[cfg(test)]
-    fn test_mapping(size: usize, drop_count: Rc<Cell<usize>>) -> Self {
+    fn test_mapping(size: usize, drop_count: Arc<AtomicUsize>) -> Self {
         Self {
             address: NonNull::<u8>::dangling().cast(),
             size,
@@ -550,7 +560,7 @@ enum AnonymousMappingKind {
     System,
     #[cfg(test)]
     Test {
-        drop_count: Rc<Cell<usize>>,
+        drop_count: Arc<AtomicUsize>,
     },
 }
 
@@ -566,7 +576,7 @@ impl Drop for AnonymousMapping {
             }
             #[cfg(test)]
             AnonymousMappingKind::Test { drop_count } => {
-                drop_count.set(drop_count.get() + 1);
+                drop_count.fetch_add(1, Ordering::Relaxed);
             }
         }
     }
@@ -574,9 +584,9 @@ impl Drop for AnonymousMapping {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::Cell;
     use std::io;
-    use std::rc::Rc;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::{
         AnonymousMapper, AnonymousMapping, GuestAddress, GuestMemory, GuestMemoryAllocationError,
@@ -862,6 +872,14 @@ mod tests {
     }
 
     #[test]
+    fn guest_memory_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+
+        assert_send_sync::<GuestMemory>();
+        assert_send_sync::<super::GuestMemoryRegion>();
+    }
+
+    #[test]
     fn guest_memory_debug_omits_host_address() {
         let page_size = host_page_size().expect("host page size should be available for tests");
         let layout = GuestMemoryLayout::new(vec![range(0, page_size)])
@@ -886,10 +904,10 @@ mod tests {
         let unaligned_range = range(page_size, page_size - 1);
         let layout =
             GuestMemoryLayout::new(vec![unaligned_range]).expect("layout ordering should be valid");
-        let drop_count = Rc::new(Cell::new(0));
+        let drop_count = Arc::new(AtomicUsize::new(0));
         let mut mapper = CountingMapper {
             maps: 0,
-            drop_count: Rc::clone(&drop_count),
+            drop_count: Arc::clone(&drop_count),
         };
 
         let err = GuestMemory::allocate_with_mapper(&layout, page_size, &mut mapper)
@@ -903,7 +921,7 @@ mod tests {
             }) if range == unaligned_range && alignment == page_size
         ));
         assert_eq!(mapper.maps, 0);
-        assert_eq!(drop_count.get(), 0);
+        assert_eq!(drop_count.load(Ordering::Relaxed), 0);
     }
 
     #[test]
@@ -912,10 +930,10 @@ mod tests {
         let unaligned_range = range(page_size, page_size - 1);
         let layout = GuestMemoryLayout::new(vec![range(0, page_size), unaligned_range])
             .expect("layout ordering should be valid");
-        let drop_count = Rc::new(Cell::new(0));
+        let drop_count = Arc::new(AtomicUsize::new(0));
         let mut mapper = CountingMapper {
             maps: 0,
-            drop_count: Rc::clone(&drop_count),
+            drop_count: Arc::clone(&drop_count),
         };
 
         let err = GuestMemory::allocate_with_mapper(&layout, page_size, &mut mapper)
@@ -929,7 +947,7 @@ mod tests {
             }) if range == unaligned_range && alignment == page_size
         ));
         assert_eq!(mapper.maps, 0);
-        assert_eq!(drop_count.get(), 0);
+        assert_eq!(drop_count.load(Ordering::Relaxed), 0);
     }
 
     #[test]
@@ -958,11 +976,11 @@ mod tests {
         let page_size = host_page_size().expect("host page size should be available for tests");
         let layout = GuestMemoryLayout::new(vec![range(0, page_size), range(page_size, page_size)])
             .expect("page-aligned layout should be valid");
-        let drop_count = Rc::new(Cell::new(0));
+        let drop_count = Arc::new(AtomicUsize::new(0));
         let mut mapper = FailingMapper {
             maps: 0,
             fail_on: 2,
-            drop_count: Rc::clone(&drop_count),
+            drop_count: Arc::clone(&drop_count),
         };
 
         let err = GuestMemory::allocate_with_mapper(&layout, page_size, &mut mapper)
@@ -974,13 +992,13 @@ mod tests {
                 if size == usize::try_from(page_size).expect("page size should fit usize")
         ));
         assert_eq!(mapper.maps, 2);
-        assert_eq!(drop_count.get(), 1);
+        assert_eq!(drop_count.load(Ordering::Relaxed), 1);
     }
 
     #[derive(Debug)]
     struct CountingMapper {
         maps: usize,
-        drop_count: Rc<Cell<usize>>,
+        drop_count: Arc<AtomicUsize>,
     }
 
     impl AnonymousMapper for CountingMapper {
@@ -988,7 +1006,7 @@ mod tests {
             self.maps += 1;
             Ok(AnonymousMapping::test_mapping(
                 size,
-                Rc::clone(&self.drop_count),
+                Arc::clone(&self.drop_count),
             ))
         }
     }
@@ -997,7 +1015,7 @@ mod tests {
     struct FailingMapper {
         maps: usize,
         fail_on: usize,
-        drop_count: Rc<Cell<usize>>,
+        drop_count: Arc<AtomicUsize>,
     }
 
     impl AnonymousMapper for FailingMapper {
@@ -1013,7 +1031,7 @@ mod tests {
 
             Ok(AnonymousMapping::test_mapping(
                 size,
-                Rc::clone(&self.drop_count),
+                Arc::clone(&self.drop_count),
             ))
         }
     }

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -1,3 +1,4 @@
+use std::collections::TryReserveError;
 use std::ffi::c_void;
 use std::fmt;
 use std::io;
@@ -169,10 +170,16 @@ impl GuestMemory {
         page_size: u64,
         mapper: &mut impl AnonymousMapper,
     ) -> Result<Self, GuestMemoryAllocationError> {
-        let ranges = validated_allocation_ranges(layout, page_size)?;
-        let mut regions = Vec::with_capacity(ranges.len());
+        validate_allocation_ranges(layout, page_size)?;
+        let mut regions = Vec::new();
+        regions
+            .try_reserve_exact(layout.ranges().len())
+            .map_err(
+                |source| GuestMemoryAllocationError::RegionMetadataAllocationFailed { source },
+            )?;
 
-        for (range, host_size) in ranges {
+        for range in layout.ranges().iter().copied() {
+            let host_size = allocation_host_size(range)?;
             regions.push(GuestMemoryRegion {
                 range,
                 mapping: mapper.map(host_size)?,
@@ -227,6 +234,7 @@ pub enum GuestMemoryAllocationError {
     InvalidLayout(GuestMemoryError),
     InvalidHostPageSize,
     SizeTooLarge { range: GuestMemoryRange },
+    RegionMetadataAllocationFailed { source: TryReserveError },
     AnonymousMmapFailed { size: usize, source: io::Error },
     AnonymousMmapReturnedNull { size: usize },
 }
@@ -242,6 +250,12 @@ impl fmt::Display for GuestMemoryAllocationError {
                 write!(
                     f,
                     "guest memory range {range} is too large to allocate on this host"
+                )
+            }
+            Self::RegionMetadataAllocationFailed { source } => {
+                write!(
+                    f,
+                    "failed to reserve guest memory region metadata: {source}"
                 )
             }
             Self::AnonymousMmapFailed { size, source } => {
@@ -264,6 +278,7 @@ impl std::error::Error for GuestMemoryAllocationError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::InvalidLayout(source) => Some(source),
+            Self::RegionMetadataAllocationFailed { source } => Some(source),
             Self::AnonymousMmapFailed { source, .. } => Some(source),
             Self::InvalidHostPageSize
             | Self::SizeTooLarge { .. }
@@ -400,21 +415,29 @@ fn validate_alignment(alignment: u64) -> Result<(), GuestMemoryError> {
     }
 }
 
-fn validated_allocation_ranges(
+fn validate_allocation_ranges(
     layout: &GuestMemoryLayout,
     page_size: u64,
-) -> Result<Vec<(GuestMemoryRange, usize)>, GuestMemoryAllocationError> {
+) -> Result<(), GuestMemoryAllocationError> {
     validate_host_page_size(page_size)?;
 
-    let mut ranges = Vec::with_capacity(layout.ranges().len());
     for range in layout.ranges().iter().copied() {
-        range.validate_alignment(page_size)?;
-        let host_size = usize::try_from(range.size())
-            .map_err(|_| GuestMemoryAllocationError::SizeTooLarge { range })?;
-        ranges.push((range, host_size));
+        validate_allocation_range(range, page_size)?;
     }
 
-    Ok(ranges)
+    Ok(())
+}
+
+fn validate_allocation_range(
+    range: GuestMemoryRange,
+    page_size: u64,
+) -> Result<usize, GuestMemoryAllocationError> {
+    range.validate_alignment(page_size)?;
+    allocation_host_size(range)
+}
+
+fn allocation_host_size(range: GuestMemoryRange) -> Result<usize, GuestMemoryAllocationError> {
+    usize::try_from(range.size()).map_err(|_| GuestMemoryAllocationError::SizeTooLarge { range })
 }
 
 fn host_page_size() -> Result<u64, GuestMemoryAllocationError> {
@@ -836,6 +859,25 @@ mod tests {
             byte.write(0xab);
             assert_eq!(byte.read(), 0xab);
         }
+    }
+
+    #[test]
+    fn guest_memory_debug_omits_host_address() {
+        let page_size = host_page_size().expect("host page size should be available for tests");
+        let layout = GuestMemoryLayout::new(vec![range(0, page_size)])
+            .expect("page-aligned layout should be valid");
+        let memory =
+            GuestMemory::allocate(&layout).expect("guest memory allocation should succeed");
+        let region = memory
+            .regions()
+            .first()
+            .expect("guest memory should contain one region");
+        let host_address = format!("{:p}", region.host_address().as_ptr());
+
+        let debug = format!("{memory:?}");
+
+        assert!(!debug.contains(&host_address));
+        assert!(debug.contains("host_size"));
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -10,9 +10,10 @@ trait, a minimal read-only VMM action/data model, backend-neutral guest
 physical address and aarch64 DRAM layout primitives, a minimal
 Hypervisor.framework VM create/destroy wrapper, a current-thread HVF vCPU
 create/destroy wrapper, typed HVF exit surface, narrow vCPU register wrappers,
-and an initial process startup argument model. There is no broader API request
-body model, guest memory allocation or HVF mapping, guest execution, vCPU run
-loop, MMIO/device emulation, boot register setup, or kernel loading yet.
+anonymous guest memory allocation for validated runtime layouts, and an initial
+process startup argument model. There is no broader API request body model, HVF
+guest memory mapping, guest execution, vCPU run loop, MMIO/device emulation,
+boot register setup, or kernel loading yet.
 
 ## Firecracker Model Alignment
 
@@ -212,7 +213,8 @@ setup, memory size, and block device I/O when those surfaces are implemented.
 The runtime crate models the backend-neutral guest physical address space used
 by later allocation, HVF mapping, boot, and device work. The current model
 contains guest physical addresses, checked RAM ranges, ordered non-overlapping
-layouts, and the first aarch64 DRAM layout helper.
+layouts, the first aarch64 DRAM layout helper, and owned anonymous host memory
+allocation for validated page-aligned layouts.
 
 The aarch64 layout helper follows Firecracker's `v1.16.0` ARM layout shape:
 
@@ -222,11 +224,19 @@ The aarch64 layout helper follows Firecracker's `v1.16.0` ARM layout shape:
 - zero requested memory is rejected by the layout helper
 - requests above the architectural maximum are capped inside the layout model
 
-This is only an address-space model. It does not allocate host memory, map
-memory into Hypervisor.framework, write kernel/initrd/FDT payloads, or start a
-guest. Later API and startup work still needs to decide whether an oversized
-`mem_size_mib` request should be rejected before layout construction or should
-preserve Firecracker's architecture-helper truncation behavior.
+The allocation model creates one anonymous read/write private host memory
+mapping for each validated guest RAM range and releases the mappings with
+runtime ownership cleanup. It preserves each guest range with its host mapping
+for later HVF map/unmap work. It does not use Firecracker's `vm-memory` crate;
+future device-memory, dirty-tracking, snapshot, or file-backed-memory work
+should evaluate the right abstraction from its concrete requirements.
+
+This still is not executable guest RAM. The runtime does not map allocated
+memory into Hypervisor.framework, write kernel/initrd/FDT payloads, wire
+`mem_size_mib` into public startup behavior, or start a guest. Later API and
+startup work still needs to decide whether an oversized `mem_size_mib` request
+should be rejected before layout construction or should preserve Firecracker's
+architecture-helper truncation behavior.
 
 ## API State and Response Policy
 


### PR DESCRIPTION
## Summary

- Add `bangbang-runtime` guest memory ownership backed by anonymous read/write `mmap` regions.
- Validate host page alignment before allocation, return typed errors, and clean up partial allocations through RAII drop behavior.
- Document that anonymous guest memory allocation now exists, while HVF mapping and public startup wiring remain out of scope.

Closes #66.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-hvf-tests.sh --allow-unsupported`