### PR TITLE
feat: add HVF guest memory mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ name = "bangbang-hvf"
 version = "0.1.0"
 dependencies = [
  "bangbang-runtime",
+ "libc",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ cargo test --workspace --all-targets --all-features --locked --exclude bangbang-
 cargo test -p bangbang-hvf --lib --all-features --locked
 ```
 
-On macOS Apple Silicon hosts, `bangbang-hvf` contains real HVF lifecycle and
-runner smoke tests in `crates/hvf/tests/hvf_lifecycle.rs`. The tests are not
-ignored; run the signed test wrapper so host or entitlement failures fail the
-test run:
+On macOS Apple Silicon hosts, `bangbang-hvf` contains real HVF lifecycle,
+guest memory mapping, and runner smoke tests in
+`crates/hvf/tests/hvf_lifecycle.rs`. The tests are not ignored; run the signed
+test wrapper so host or entitlement failures fail the test run:
 
 ```sh
 scripts/run-hvf-tests.sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 bangbang is a Rust VMM project for macOS hosts. The public control plane is intended to stay compatible with the Firecracker HTTP API over a Unix domain socket, while the VM backend is built on Apple's Hypervisor.framework.
 
-This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, a backend-neutral guest address/layout model, anonymous guest memory allocation, and the smallest Hypervisor.framework VM, current-thread vCPU lifecycle, typed exit surface, register wrappers, and cancellable vCPU runner skeleton.
+This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, a backend-neutral guest address/layout model, anonymous guest memory allocation, and the smallest Hypervisor.framework VM, guest memory map/unmap ownership, current-thread vCPU lifecycle, typed exit surface, register wrappers, and cancellable vCPU runner skeleton.
 
 See [Firecracker Compatibility Scope](docs/firecracker-compatibility.md) for the intended compatibility target and current limitations.
 See [Pull Request Review Guidelines](docs/review-guidelines.md) for the project-specific review standard.
@@ -18,11 +18,10 @@ crates/bangbang   VMM process entrypoint and startup CLI
 
 ## Current Scope
 
-The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. The runtime crate defines guest physical address, range, and aarch64 DRAM layout primitives, and can allocate owned anonymous host memory for validated page-aligned guest memory layouts. The HVF crate can create/destroy a process VM, create/destroy one current-thread vCPU handle, define typed HVF exit snapshots, get/set a narrow set of vCPU registers, and start a thread-owned runner that can cancel a single `hv_vcpu_run` step. It intentionally does not include:
+The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. The runtime crate defines guest physical address, range, and aarch64 DRAM layout primitives, and can allocate owned anonymous host memory for validated page-aligned guest memory layouts. The HVF crate can create/destroy a process VM, map/unmap allocated guest memory with backend-owned cleanup, create/destroy one current-thread vCPU handle, define typed HVF exit snapshots, get/set a narrow set of vCPU registers, and start a thread-owned runner that can cancel a single `hv_vcpu_run` step. It intentionally does not include:
 
 - API endpoints beyond `GET /` and `GET /version`
 - JSON request body models
-- HVF guest memory mapping
 - configured guest execution, continuous vCPU run loops, MMIO/device emulation, or boot register setup
 - kernel loading
 

--- a/crates/hvf/Cargo.toml
+++ b/crates/hvf/Cargo.toml
@@ -6,6 +6,7 @@ repository.workspace = true
 
 [dependencies]
 bangbang-runtime = { path = "../runtime" }
+libc = "0.2"
 
 [lints]
 workspace = true

--- a/crates/hvf/src/backend.rs
+++ b/crates/hvf/src/backend.rs
@@ -168,11 +168,19 @@ impl VmBackend for HvfBackend {
 impl Drop for HvfBackend {
     fn drop(&mut self) {
         if self.vm_created {
-            if let Some(mut mapping) = self.guest_memory.take() {
-                let _ = mapping.unmap_all();
+            let mut mapping_after_failed_unmap = None;
+
+            if let Some(mut mapping) = self.guest_memory.take()
+                && mapping.unmap_all().is_err()
+            {
+                mapping_after_failed_unmap = Some(mapping);
             }
-            let _ = crate::ffi::destroy_vm();
+            let vm_destroyed = crate::ffi::destroy_vm().is_ok();
             self.vm_created = false;
+
+            if vm_destroyed && let Some(mapping) = mapping_after_failed_unmap {
+                mapping.release_after_vm_destroy();
+            }
         }
     }
 }

--- a/crates/hvf/src/backend.rs
+++ b/crates/hvf/src/backend.rs
@@ -338,6 +338,42 @@ mod tests {
         assert_eq!(mapper.unmap_count(), 1);
     }
 
+    #[test]
+    fn unmap_guest_memory_keeps_active_mapping_when_unmap_fails() {
+        let page_size = page_size();
+        let mapper = Arc::new(RecordingMapper::default());
+        let mut backend = HvfBackend::new_with_memory_mapper(mapper.clone());
+        backend.vm_created = true;
+
+        backend
+            .map_guest_memory_with_configured_mapper(
+                memory_for_ranges(vec![range(0, page_size)]),
+                HvfMemoryPermissions::GUEST_RAM,
+            )
+            .expect("guest memory mapping should succeed");
+
+        mapper.set_fail_unmap(true);
+        let err = backend
+            .unmap_guest_memory()
+            .expect_err("failed unmap should be reported");
+
+        assert!(matches!(
+            err,
+            crate::memory::HvfGuestMemoryMappingError::UnmapFailed { failures }
+                if failures.len() == 1
+        ));
+        assert!(backend.has_guest_memory_mapping());
+        assert_eq!(mapper.unmap_count(), 1);
+
+        mapper.set_fail_unmap(false);
+        backend
+            .unmap_guest_memory()
+            .expect("retry should clear retained mapping");
+
+        assert!(!backend.has_guest_memory_mapping());
+        assert_eq!(mapper.unmap_count(), 2);
+    }
+
     #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
     #[test]
     fn unsupported_target_rejects_vm_creation() {
@@ -353,12 +389,28 @@ mod tests {
         );
     }
 
-    #[derive(Debug, Default)]
+    #[derive(Debug)]
     struct RecordingMapper {
         state: Mutex<RecordingMapperState>,
     }
 
+    impl Default for RecordingMapper {
+        fn default() -> Self {
+            Self::new(false)
+        }
+    }
+
     impl RecordingMapper {
+        fn new(fail_unmap: bool) -> Self {
+            Self {
+                state: Mutex::new(RecordingMapperState {
+                    maps: 0,
+                    unmaps: 0,
+                    fail_unmap,
+                }),
+            }
+        }
+
         fn map_count(&self) -> usize {
             self.state
                 .lock()
@@ -371,6 +423,13 @@ mod tests {
                 .lock()
                 .expect("state lock should not be poisoned")
                 .unmaps
+        }
+
+        fn set_fail_unmap(&self, fail_unmap: bool) {
+            self.state
+                .lock()
+                .expect("state lock should not be poisoned")
+                .fail_unmap = fail_unmap;
         }
     }
 
@@ -388,10 +447,18 @@ mod tests {
         }
 
         fn unmap_region(&self, _: HvfMappedGuestMemoryRegion) -> Result<(), BackendError> {
-            self.state
+            let mut state = self
+                .state
                 .lock()
-                .expect("state lock should not be poisoned")
-                .unmaps += 1;
+                .expect("state lock should not be poisoned");
+            state.unmaps += 1;
+
+            if state.fail_unmap {
+                return Err(BackendError::Hypervisor(
+                    "injected unmap failure".to_string(),
+                ));
+            }
+
             Ok(())
         }
     }
@@ -400,5 +467,6 @@ mod tests {
     struct RecordingMapperState {
         maps: usize,
         unmaps: usize,
+        fail_unmap: bool,
     }
 }

--- a/crates/hvf/src/backend.rs
+++ b/crates/hvf/src/backend.rs
@@ -1,11 +1,33 @@
+use std::sync::Arc;
+
+use bangbang_runtime::memory::GuestMemory;
 use bangbang_runtime::{BackendError, VmBackend};
 
+use crate::memory::{
+    HvfGuestMemoryMapping, HvfGuestMemoryMappingError, HvfMemoryMapper, HvfMemoryPermissions,
+    RealHvfMemoryMapper,
+};
 use crate::runner::{HvfVcpuRunner, HvfVcpuRunnerError};
 use crate::vcpu::HvfVcpu;
 
-#[derive(Debug, Default)]
+const VM_NOT_CREATED_FOR_MEMORY_MESSAGE: &str = "VM must be created before mapping guest memory";
+const GUEST_MEMORY_ALREADY_MAPPED_MESSAGE: &str = "guest memory is already mapped";
+
+#[derive(Debug)]
 pub struct HvfBackend {
     vm_created: bool,
+    guest_memory: Option<HvfGuestMemoryMapping>,
+    memory_mapper: Arc<dyn HvfMemoryMapper>,
+}
+
+impl Default for HvfBackend {
+    fn default() -> Self {
+        Self {
+            vm_created: false,
+            guest_memory: None,
+            memory_mapper: Arc::new(RealHvfMemoryMapper),
+        }
+    }
 }
 
 impl HvfBackend {
@@ -15,6 +37,33 @@ impl HvfBackend {
 
     pub fn is_supported_target() -> bool {
         cfg!(all(target_os = "macos", target_arch = "aarch64"))
+    }
+
+    pub fn map_guest_memory(
+        &mut self,
+        memory: GuestMemory,
+        permissions: HvfMemoryPermissions,
+    ) -> Result<(), HvfGuestMemoryMappingError> {
+        if !Self::is_supported_target() {
+            return Err(BackendError::Unsupported(crate::ffi::UNSUPPORTED_TARGET_MESSAGE).into());
+        }
+
+        self.map_guest_memory_with_configured_mapper(memory, permissions)
+    }
+
+    pub fn unmap_guest_memory(&mut self) -> Result<(), HvfGuestMemoryMappingError> {
+        if let Some(mapping) = self.guest_memory.as_mut() {
+            mapping.unmap_all()?;
+        }
+
+        self.guest_memory = None;
+        Ok(())
+    }
+
+    pub fn has_guest_memory_mapping(&self) -> bool {
+        self.guest_memory
+            .as_ref()
+            .is_some_and(HvfGuestMemoryMapping::has_mapped_regions)
     }
 
     pub fn create_vcpu(&mut self) -> Result<HvfVcpu<'_>, BackendError> {
@@ -47,6 +96,51 @@ impl HvfBackend {
 
         HvfVcpuRunner::new(self)
     }
+
+    fn map_guest_memory_with_configured_mapper(
+        &mut self,
+        memory: GuestMemory,
+        permissions: HvfMemoryPermissions,
+    ) -> Result<(), HvfGuestMemoryMappingError> {
+        if !self.vm_created {
+            return Err(HvfGuestMemoryMappingError::InvalidState(
+                VM_NOT_CREATED_FOR_MEMORY_MESSAGE,
+            ));
+        }
+
+        if self.guest_memory.is_some() {
+            return Err(HvfGuestMemoryMappingError::InvalidState(
+                GUEST_MEMORY_ALREADY_MAPPED_MESSAGE,
+            ));
+        }
+
+        match HvfGuestMemoryMapping::map_with_mapper(
+            memory,
+            permissions,
+            Arc::clone(&self.memory_mapper),
+        ) {
+            Ok(mapping) => {
+                self.guest_memory = Some(mapping);
+                Ok(())
+            }
+            Err(failed_mapping) => {
+                if failed_mapping.mapping.has_mapped_regions() {
+                    self.guest_memory = Some(failed_mapping.mapping);
+                }
+
+                Err(failed_mapping.error)
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn new_with_memory_mapper(memory_mapper: Arc<dyn HvfMemoryMapper>) -> Self {
+        Self {
+            vm_created: false,
+            guest_memory: None,
+            memory_mapper,
+        }
+    }
 }
 
 impl VmBackend for HvfBackend {
@@ -62,6 +156,8 @@ impl VmBackend for HvfBackend {
 
     fn destroy_vm(&mut self) -> Result<(), BackendError> {
         if self.vm_created {
+            self.unmap_guest_memory()
+                .map_err(|err| BackendError::Hypervisor(err.to_string()))?;
             crate::ffi::destroy_vm()?;
             self.vm_created = false;
         }
@@ -72,6 +168,9 @@ impl VmBackend for HvfBackend {
 impl Drop for HvfBackend {
     fn drop(&mut self) {
         if self.vm_created {
+            if let Some(mut mapping) = self.guest_memory.take() {
+                let _ = mapping.unmap_all();
+            }
             let _ = crate::ffi::destroy_vm();
             self.vm_created = false;
         }
@@ -80,9 +179,34 @@ impl Drop for HvfBackend {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
     use bangbang_runtime::BackendError;
+    use bangbang_runtime::memory::{
+        GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange,
+    };
 
     use super::HvfBackend;
+    use crate::memory::{
+        HvfMappedGuestMemoryRegion, HvfMemoryMapRequest, HvfMemoryMapper, HvfMemoryPermissions,
+        host_page_size,
+    };
+
+    fn range(start: u64, size: u64) -> GuestMemoryRange {
+        GuestMemoryRange::new(GuestAddress::new(start), size)
+            .expect("guest memory range should be valid for test")
+    }
+
+    fn memory_for_ranges(ranges: Vec<GuestMemoryRange>) -> GuestMemory {
+        let layout =
+            GuestMemoryLayout::new(ranges).expect("guest memory layout should be valid for test");
+
+        GuestMemory::allocate(&layout).expect("guest memory allocation should succeed")
+    }
+
+    fn page_size() -> u64 {
+        host_page_size().expect("host page size should be available for tests")
+    }
 
     #[test]
     fn supported_target_matches_compile_target() {
@@ -136,6 +260,76 @@ mod tests {
         }
     }
 
+    #[test]
+    fn map_guest_memory_before_vm_reports_state_error() {
+        let page_size = page_size();
+        let mut backend = HvfBackend::new_with_memory_mapper(Arc::new(RecordingMapper::default()));
+        let memory = memory_for_ranges(vec![range(0, page_size)]);
+
+        let err = backend
+            .map_guest_memory_with_configured_mapper(memory, HvfMemoryPermissions::GUEST_RAM)
+            .expect_err("mapping guest memory before VM creation should fail");
+
+        assert!(matches!(
+            err,
+            crate::memory::HvfGuestMemoryMappingError::InvalidState(
+                super::VM_NOT_CREATED_FOR_MEMORY_MESSAGE
+            )
+        ));
+    }
+
+    #[test]
+    fn duplicate_guest_memory_mapping_is_rejected() {
+        let page_size = page_size();
+        let mapper = Arc::new(RecordingMapper::default());
+        let mut backend = HvfBackend::new_with_memory_mapper(mapper.clone());
+        backend.vm_created = true;
+
+        backend
+            .map_guest_memory_with_configured_mapper(
+                memory_for_ranges(vec![range(0, page_size)]),
+                HvfMemoryPermissions::GUEST_RAM,
+            )
+            .expect("first guest memory mapping should succeed");
+        let err = backend
+            .map_guest_memory_with_configured_mapper(
+                memory_for_ranges(vec![range(0, page_size)]),
+                HvfMemoryPermissions::GUEST_RAM,
+            )
+            .expect_err("second guest memory mapping should fail");
+
+        assert!(matches!(
+            err,
+            crate::memory::HvfGuestMemoryMappingError::InvalidState(
+                super::GUEST_MEMORY_ALREADY_MAPPED_MESSAGE
+            )
+        ));
+        assert!(backend.has_guest_memory_mapping());
+        assert_eq!(mapper.map_count(), 1);
+    }
+
+    #[test]
+    fn unmap_guest_memory_clears_active_mapping() {
+        let page_size = page_size();
+        let mapper = Arc::new(RecordingMapper::default());
+        let mut backend = HvfBackend::new_with_memory_mapper(mapper.clone());
+        backend.vm_created = true;
+
+        backend
+            .map_guest_memory_with_configured_mapper(
+                memory_for_ranges(vec![range(0, page_size)]),
+                HvfMemoryPermissions::GUEST_RAM,
+            )
+            .expect("guest memory mapping should succeed");
+
+        backend
+            .unmap_guest_memory()
+            .expect("guest memory should unmap cleanly");
+
+        assert!(!backend.has_guest_memory_mapping());
+        assert_eq!(mapper.unmap_count(), 1);
+    }
+
     #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
     #[test]
     fn unsupported_target_rejects_vm_creation() {
@@ -149,5 +343,54 @@ mod tests {
                 crate::ffi::UNSUPPORTED_TARGET_MESSAGE
             ))
         );
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingMapper {
+        state: Mutex<RecordingMapperState>,
+    }
+
+    impl RecordingMapper {
+        fn map_count(&self) -> usize {
+            self.state
+                .lock()
+                .expect("state lock should not be poisoned")
+                .maps
+        }
+
+        fn unmap_count(&self) -> usize {
+            self.state
+                .lock()
+                .expect("state lock should not be poisoned")
+                .unmaps
+        }
+    }
+
+    impl HvfMemoryMapper for RecordingMapper {
+        fn map_region(
+            &self,
+            _: HvfMemoryMapRequest,
+            _: HvfMemoryPermissions,
+        ) -> Result<(), BackendError> {
+            self.state
+                .lock()
+                .expect("state lock should not be poisoned")
+                .maps += 1;
+            Ok(())
+        }
+
+        fn unmap_region(&self, _: HvfMappedGuestMemoryRegion) -> Result<(), BackendError> {
+            self.state
+                .lock()
+                .expect("state lock should not be poisoned")
+                .unmaps += 1;
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingMapperState {
+        maps: usize,
+        unmaps: usize,
     }
 }

--- a/crates/hvf/src/backend.rs
+++ b/crates/hvf/src/backend.rs
@@ -60,7 +60,8 @@ impl HvfBackend {
         Ok(())
     }
 
-    pub fn has_guest_memory_mapping(&self) -> bool {
+    #[cfg(test)]
+    fn has_guest_memory_mapping(&self) -> bool {
         self.guest_memory
             .as_ref()
             .is_some_and(HvfGuestMemoryMapping::has_mapped_regions)

--- a/crates/hvf/src/ffi.rs
+++ b/crates/hvf/src/ffi.rs
@@ -3,8 +3,13 @@ pub(crate) const UNSUPPORTED_TARGET_MESSAGE: &str =
 
 pub(crate) type HvVcpu = u64;
 pub(crate) type HvExitReason = u32;
+pub(crate) type HvMemoryFlags = u64;
 pub(crate) type HvReg = u32;
 pub(crate) type HvSysReg = u16;
+
+pub(crate) const HV_MEMORY_READ: HvMemoryFlags = 1 << 0;
+pub(crate) const HV_MEMORY_WRITE: HvMemoryFlags = 1 << 1;
+pub(crate) const HV_MEMORY_EXEC: HvMemoryFlags = 1 << 2;
 
 pub(crate) const HV_EXIT_REASON_CANCELED: HvExitReason = 0;
 pub(crate) const HV_EXIT_REASON_EXCEPTION: HvExitReason = 1;
@@ -63,10 +68,11 @@ pub(crate) unsafe fn copy_vcpu_exit(
 mod imp {
     use std::ffi::c_void;
     use std::ptr;
+    use std::ptr::NonNull;
 
     use bangbang_runtime::BackendError;
 
-    use super::{CreatedVcpu, HvReg, HvSysReg, HvVcpu, HvVcpuExit};
+    use super::{CreatedVcpu, HvMemoryFlags, HvReg, HvSysReg, HvVcpu, HvVcpuExit};
 
     pub type HvReturn = i32;
     pub type HvVmConfig = *mut c_void;
@@ -86,6 +92,13 @@ mod imp {
     unsafe extern "C" {
         pub fn hv_vm_create(config: HvVmConfig) -> HvReturn;
         pub fn hv_vm_destroy() -> HvReturn;
+        pub fn hv_vm_map(
+            addr: *mut c_void,
+            ipa: u64,
+            size: usize,
+            flags: HvMemoryFlags,
+        ) -> HvReturn;
+        pub fn hv_vm_unmap(ipa: u64, size: usize) -> HvReturn;
         pub fn hv_vcpu_create(
             vcpu: *mut HvVcpu,
             exit: *mut *mut HvVcpuExit,
@@ -142,6 +155,28 @@ mod imp {
     pub fn destroy_vm() -> Result<(), BackendError> {
         // SAFETY: Destroys the process-local VM after vCPUs have been destroyed.
         unsafe { check(hv_vm_destroy(), "hv_vm_destroy") }
+    }
+
+    pub fn map_memory(
+        host_address: NonNull<c_void>,
+        guest_address: u64,
+        size: usize,
+        flags: HvMemoryFlags,
+    ) -> Result<(), BackendError> {
+        // SAFETY: The caller validates page alignment, region size, and VM lifecycle before
+        // mapping this userspace address into the process-local HVF VM.
+        unsafe {
+            check(
+                hv_vm_map(host_address.as_ptr(), guest_address, size, flags),
+                "hv_vm_map",
+            )
+        }
+    }
+
+    pub fn unmap_memory(guest_address: u64, size: usize) -> Result<(), BackendError> {
+        // SAFETY: The caller owns a previously mapped guest physical range for the live
+        // process-local HVF VM and guarantees the range is page aligned.
+        unsafe { check(hv_vm_unmap(guest_address, size), "hv_vm_unmap") }
     }
 
     pub fn create_vcpu() -> Result<CreatedVcpu, BackendError> {
@@ -260,9 +295,12 @@ mod imp {
 
 #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 mod imp {
+    use std::ffi::c_void;
+    use std::ptr::NonNull;
+
     use bangbang_runtime::BackendError;
 
-    use super::{CreatedVcpu, HvReg, HvSysReg, HvVcpu, UNSUPPORTED_TARGET_MESSAGE};
+    use super::{CreatedVcpu, HvMemoryFlags, HvReg, HvSysReg, HvVcpu, UNSUPPORTED_TARGET_MESSAGE};
 
     pub fn create_vm() -> Result<(), BackendError> {
         Err(BackendError::Unsupported(UNSUPPORTED_TARGET_MESSAGE))
@@ -270,6 +308,19 @@ mod imp {
 
     pub fn destroy_vm() -> Result<(), BackendError> {
         Ok(())
+    }
+
+    pub fn map_memory(
+        _: NonNull<c_void>,
+        _: u64,
+        _: usize,
+        _: HvMemoryFlags,
+    ) -> Result<(), BackendError> {
+        Err(BackendError::Unsupported(UNSUPPORTED_TARGET_MESSAGE))
+    }
+
+    pub fn unmap_memory(_: u64, _: usize) -> Result<(), BackendError> {
+        Err(BackendError::Unsupported(UNSUPPORTED_TARGET_MESSAGE))
     }
 
     pub fn create_vcpu() -> Result<CreatedVcpu, BackendError> {

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -9,6 +9,9 @@ mod vcpu;
 
 pub use backend::HvfBackend;
 pub use exit::{HvfExceptionExit, HvfVcpuExit};
-pub use memory::{HvfGuestMemoryMapping, HvfGuestMemoryMappingError, HvfMemoryPermissions};
+pub use memory::{
+    HvfGuestMemoryMapping, HvfGuestMemoryMappingError, HvfGuestMemoryUnmapFailure,
+    HvfMemoryPermissions,
+};
 pub use runner::{HvfVcpuRunner, HvfVcpuRunnerError};
 pub use vcpu::{HvfRegister, HvfSystemRegister, HvfVcpu};

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -9,9 +9,6 @@ mod vcpu;
 
 pub use backend::HvfBackend;
 pub use exit::{HvfExceptionExit, HvfVcpuExit};
-pub use memory::{
-    HvfGuestMemoryMapping, HvfGuestMemoryMappingError, HvfGuestMemoryUnmapFailure,
-    HvfMemoryPermissions,
-};
+pub use memory::{HvfGuestMemoryMappingError, HvfGuestMemoryUnmapFailure, HvfMemoryPermissions};
 pub use runner::{HvfVcpuRunner, HvfVcpuRunnerError};
 pub use vcpu::{HvfRegister, HvfSystemRegister, HvfVcpu};

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -3,10 +3,12 @@
 mod backend;
 mod exit;
 mod ffi;
+mod memory;
 mod runner;
 mod vcpu;
 
 pub use backend::HvfBackend;
 pub use exit::{HvfExceptionExit, HvfVcpuExit};
+pub use memory::{HvfGuestMemoryMapping, HvfGuestMemoryMappingError, HvfMemoryPermissions};
 pub use runner::{HvfVcpuRunner, HvfVcpuRunnerError};
 pub use vcpu::{HvfRegister, HvfSystemRegister, HvfVcpu};

--- a/crates/hvf/src/memory.rs
+++ b/crates/hvf/src/memory.rs
@@ -42,7 +42,7 @@ impl HvfMemoryPermissions {
         Self { bits }
     }
 
-    pub const fn bits(self) -> crate::ffi::HvMemoryFlags {
+    pub(crate) const fn bits(self) -> crate::ffi::HvMemoryFlags {
         self.bits
     }
 
@@ -229,21 +229,13 @@ impl HvfGuestMemoryUnmapFailure {
 }
 
 #[derive(Debug)]
-pub struct HvfGuestMemoryMapping {
+pub(crate) struct HvfGuestMemoryMapping {
     memory: Option<GuestMemory>,
     mapped_regions: Vec<HvfMappedGuestMemoryRegion>,
     mapper: Arc<dyn HvfMemoryMapper>,
 }
 
 impl HvfGuestMemoryMapping {
-    pub fn mapped_region_count(&self) -> usize {
-        self.mapped_regions.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.mapped_regions.is_empty()
-    }
-
     pub(crate) fn map_with_mapper(
         memory: GuestMemory,
         permissions: HvfMemoryPermissions,
@@ -702,7 +694,7 @@ mod tests {
         )
         .expect("guest memory mapping should succeed");
 
-        assert_eq!(mapping.mapped_region_count(), 2);
+        assert_eq!(mapping.mapped_regions.len(), 2);
         let maps = mapper.maps();
         let mut mapped_ranges = maps.iter().map(|(request, _)| request.range);
         assert_eq!(mapped_ranges.next(), Some(range(0, page_size)));

--- a/crates/hvf/src/memory.rs
+++ b/crates/hvf/src/memory.rs
@@ -1,0 +1,879 @@
+use std::collections::TryReserveError;
+use std::ffi::c_void;
+use std::fmt;
+use std::ptr::NonNull;
+use std::sync::Arc;
+
+use bangbang_runtime::BackendError;
+use bangbang_runtime::memory::{GuestMemory, GuestMemoryRange, GuestMemoryRegion};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HvfMemoryPermissions {
+    bits: crate::ffi::HvMemoryFlags,
+}
+
+impl HvfMemoryPermissions {
+    pub const READ: Self = Self {
+        bits: crate::ffi::HV_MEMORY_READ,
+    };
+    pub const WRITE: Self = Self {
+        bits: crate::ffi::HV_MEMORY_WRITE,
+    };
+    pub const EXECUTE: Self = Self {
+        bits: crate::ffi::HV_MEMORY_EXEC,
+    };
+    pub const GUEST_RAM: Self = Self {
+        bits: crate::ffi::HV_MEMORY_READ | crate::ffi::HV_MEMORY_WRITE | crate::ffi::HV_MEMORY_EXEC,
+    };
+
+    pub const fn new(read: bool, write: bool, execute: bool) -> Self {
+        let mut bits = 0;
+
+        if read {
+            bits |= crate::ffi::HV_MEMORY_READ;
+        }
+        if write {
+            bits |= crate::ffi::HV_MEMORY_WRITE;
+        }
+        if execute {
+            bits |= crate::ffi::HV_MEMORY_EXEC;
+        }
+
+        Self { bits }
+    }
+
+    pub const fn bits(self) -> crate::ffi::HvMemoryFlags {
+        self.bits
+    }
+
+    const fn is_empty(self) -> bool {
+        self.bits == 0
+    }
+}
+
+impl Default for HvfMemoryPermissions {
+    fn default() -> Self {
+        Self::GUEST_RAM
+    }
+}
+
+#[derive(Debug)]
+pub enum HvfGuestMemoryMappingError {
+    Backend(BackendError),
+    InvalidState(&'static str),
+    EmptyGuestMemory,
+    EmptyPermissions,
+    InvalidHostPageSize,
+    SizeTooLarge {
+        range: GuestMemoryRange,
+    },
+    UnalignedGuestRange {
+        range: GuestMemoryRange,
+        alignment: u64,
+    },
+    UnalignedHostAddress {
+        range: GuestMemoryRange,
+        alignment: usize,
+    },
+    UnalignedHostSize {
+        range: GuestMemoryRange,
+        host_size: usize,
+        alignment: usize,
+    },
+    HostSizeMismatch {
+        range: GuestMemoryRange,
+        host_size: usize,
+        expected_size: usize,
+    },
+    MappingMetadataAllocationFailed {
+        source: TryReserveError,
+    },
+    MapFailed {
+        range: GuestMemoryRange,
+        source: BackendError,
+        cleanup_failures: Vec<HvfGuestMemoryUnmapFailure>,
+    },
+    UnmapFailed {
+        failures: Vec<HvfGuestMemoryUnmapFailure>,
+    },
+}
+
+impl fmt::Display for HvfGuestMemoryMappingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Backend(source) => write!(f, "{source}"),
+            Self::InvalidState(message) => {
+                write!(f, "invalid guest memory mapping state: {message}")
+            }
+            Self::EmptyGuestMemory => f.write_str("guest memory must contain at least one region"),
+            Self::EmptyPermissions => f.write_str("guest memory permissions must not be empty"),
+            Self::InvalidHostPageSize => f.write_str("host page size is unavailable or invalid"),
+            Self::SizeTooLarge { range } => {
+                write!(
+                    f,
+                    "guest memory range {range} is too large to map on this host"
+                )
+            }
+            Self::UnalignedGuestRange { range, alignment } => {
+                write!(
+                    f,
+                    "guest memory range {range} is not aligned to {alignment} bytes"
+                )
+            }
+            Self::UnalignedHostAddress { range, alignment } => {
+                write!(
+                    f,
+                    "host address for guest memory range {range} is not aligned to {alignment} bytes"
+                )
+            }
+            Self::UnalignedHostSize {
+                range,
+                host_size,
+                alignment,
+            } => {
+                write!(
+                    f,
+                    "host mapping for guest memory range {range} has size {host_size}, which is not aligned to {alignment} bytes"
+                )
+            }
+            Self::HostSizeMismatch {
+                range,
+                host_size,
+                expected_size,
+            } => {
+                write!(
+                    f,
+                    "host mapping for guest memory range {range} has size {host_size}, expected {expected_size}"
+                )
+            }
+            Self::MappingMetadataAllocationFailed { source } => {
+                write!(
+                    f,
+                    "failed to reserve guest memory mapping metadata: {source}"
+                )
+            }
+            Self::MapFailed {
+                range,
+                source,
+                cleanup_failures,
+            } => {
+                if cleanup_failures.is_empty() {
+                    write!(f, "failed to map guest memory range {range}: {source}")
+                } else {
+                    write!(
+                        f,
+                        "failed to map guest memory range {range}: {source}; also failed to unmap {} previously mapped region(s)",
+                        cleanup_failures.len()
+                    )
+                }
+            }
+            Self::UnmapFailed { failures } => {
+                write!(
+                    f,
+                    "failed to unmap {} guest memory region(s)",
+                    failures.len()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for HvfGuestMemoryMappingError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Backend(source) | Self::MapFailed { source, .. } => Some(source),
+            Self::MappingMetadataAllocationFailed { source } => Some(source),
+            Self::UnmapFailed { failures } => failures
+                .first()
+                .map(|failure| &failure.source as &(dyn std::error::Error + 'static)),
+            Self::InvalidState(_)
+            | Self::EmptyGuestMemory
+            | Self::EmptyPermissions
+            | Self::InvalidHostPageSize
+            | Self::SizeTooLarge { .. }
+            | Self::UnalignedGuestRange { .. }
+            | Self::UnalignedHostAddress { .. }
+            | Self::UnalignedHostSize { .. }
+            | Self::HostSizeMismatch { .. } => None,
+        }
+    }
+}
+
+impl From<BackendError> for HvfGuestMemoryMappingError {
+    fn from(source: BackendError) -> Self {
+        Self::Backend(source)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HvfGuestMemoryUnmapFailure {
+    range: GuestMemoryRange,
+    source: BackendError,
+}
+
+impl HvfGuestMemoryUnmapFailure {
+    pub const fn range(&self) -> GuestMemoryRange {
+        self.range
+    }
+
+    pub const fn source(&self) -> &BackendError {
+        &self.source
+    }
+}
+
+#[derive(Debug)]
+pub struct HvfGuestMemoryMapping {
+    memory: Option<GuestMemory>,
+    mapped_regions: Vec<HvfMappedGuestMemoryRegion>,
+    mapper: Arc<dyn HvfMemoryMapper>,
+}
+
+impl HvfGuestMemoryMapping {
+    pub fn mapped_region_count(&self) -> usize {
+        self.mapped_regions.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.mapped_regions.is_empty()
+    }
+
+    pub(crate) fn map_with_mapper(
+        memory: GuestMemory,
+        permissions: HvfMemoryPermissions,
+        mapper: Arc<dyn HvfMemoryMapper>,
+    ) -> Result<Self, Box<FailedGuestMemoryMapping>> {
+        let mut mapping = Self {
+            memory: Some(memory),
+            mapped_regions: Vec::new(),
+            mapper,
+        };
+
+        match mapping.map_all(permissions) {
+            Ok(()) => Ok(mapping),
+            Err(error) => Err(Box::new(FailedGuestMemoryMapping { mapping, error })),
+        }
+    }
+
+    pub(crate) fn unmap_all(&mut self) -> Result<(), HvfGuestMemoryMappingError> {
+        let failures = self.unmap_mapped_regions();
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(HvfGuestMemoryMappingError::UnmapFailed { failures })
+        }
+    }
+
+    pub(crate) fn has_mapped_regions(&self) -> bool {
+        !self.mapped_regions.is_empty()
+    }
+
+    fn map_all(
+        &mut self,
+        permissions: HvfMemoryPermissions,
+    ) -> Result<(), HvfGuestMemoryMappingError> {
+        let memory = self
+            .memory
+            .as_ref()
+            .ok_or(HvfGuestMemoryMappingError::InvalidState(
+                "guest memory owner is missing",
+            ))?;
+        let requests = validated_map_requests(memory, permissions)?;
+        self.mapped_regions
+            .try_reserve_exact(requests.len())
+            .map_err(
+                |source| HvfGuestMemoryMappingError::MappingMetadataAllocationFailed { source },
+            )?;
+
+        for request in requests {
+            let mapped_region = request.mapped_region();
+            if let Err(source) = self.mapper.map_region(request, permissions) {
+                let cleanup_failures = self.unmap_mapped_regions();
+                return Err(HvfGuestMemoryMappingError::MapFailed {
+                    range: request.range,
+                    source,
+                    cleanup_failures,
+                });
+            }
+
+            self.mapped_regions.push(mapped_region);
+        }
+
+        Ok(())
+    }
+
+    fn unmap_mapped_regions(&mut self) -> Vec<HvfGuestMemoryUnmapFailure> {
+        let mut failures = Vec::new();
+        let mut remaining_regions = Vec::new();
+
+        while let Some(mapped_region) = self.mapped_regions.pop() {
+            if let Err(source) = self.mapper.unmap_region(mapped_region) {
+                failures.push(HvfGuestMemoryUnmapFailure {
+                    range: mapped_region.range,
+                    source,
+                });
+                remaining_regions.push(mapped_region);
+            }
+        }
+
+        while let Some(mapped_region) = remaining_regions.pop() {
+            self.mapped_regions.push(mapped_region);
+        }
+
+        failures
+    }
+}
+
+impl Drop for HvfGuestMemoryMapping {
+    fn drop(&mut self) {
+        if self.unmap_all().is_err()
+            && let Some(memory) = self.memory.take()
+        {
+            std::mem::forget(memory);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct FailedGuestMemoryMapping {
+    pub(crate) mapping: HvfGuestMemoryMapping,
+    pub(crate) error: HvfGuestMemoryMappingError,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct HvfMemoryMapRequest {
+    range: GuestMemoryRange,
+    host_address: usize,
+    guest_address: u64,
+    size: usize,
+}
+
+impl HvfMemoryMapRequest {
+    const fn mapped_region(self) -> HvfMappedGuestMemoryRegion {
+        HvfMappedGuestMemoryRegion {
+            range: self.range,
+            guest_address: self.guest_address,
+            size: self.size,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct HvfMappedGuestMemoryRegion {
+    range: GuestMemoryRange,
+    guest_address: u64,
+    size: usize,
+}
+
+pub(crate) trait HvfMemoryMapper: fmt::Debug + Send + Sync {
+    fn map_region(
+        &self,
+        request: HvfMemoryMapRequest,
+        permissions: HvfMemoryPermissions,
+    ) -> Result<(), BackendError>;
+
+    fn unmap_region(&self, mapped_region: HvfMappedGuestMemoryRegion) -> Result<(), BackendError>;
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct RealHvfMemoryMapper;
+
+impl HvfMemoryMapper for RealHvfMemoryMapper {
+    fn map_region(
+        &self,
+        request: HvfMemoryMapRequest,
+        permissions: HvfMemoryPermissions,
+    ) -> Result<(), BackendError> {
+        let host_address = NonNull::<c_void>::new(request.host_address as *mut c_void).ok_or(
+            BackendError::InvalidState("validated guest memory host address is null"),
+        )?;
+
+        crate::ffi::map_memory(
+            host_address,
+            request.guest_address,
+            request.size,
+            permissions.bits(),
+        )
+    }
+
+    fn unmap_region(&self, mapped_region: HvfMappedGuestMemoryRegion) -> Result<(), BackendError> {
+        crate::ffi::unmap_memory(mapped_region.guest_address, mapped_region.size)
+    }
+}
+
+fn validated_map_requests(
+    memory: &GuestMemory,
+    permissions: HvfMemoryPermissions,
+) -> Result<Vec<HvfMemoryMapRequest>, HvfGuestMemoryMappingError> {
+    if permissions.is_empty() {
+        return Err(HvfGuestMemoryMappingError::EmptyPermissions);
+    }
+
+    if memory.regions().is_empty() {
+        return Err(HvfGuestMemoryMappingError::EmptyGuestMemory);
+    }
+
+    let page_size = host_page_size()?;
+    let mut requests = Vec::new();
+    requests
+        .try_reserve_exact(memory.regions().len())
+        .map_err(|source| HvfGuestMemoryMappingError::MappingMetadataAllocationFailed { source })?;
+
+    for region in memory.regions() {
+        requests.push(validated_region_map_request(region, page_size)?);
+    }
+
+    Ok(requests)
+}
+
+fn validated_region_map_request(
+    region: &GuestMemoryRegion,
+    page_size: u64,
+) -> Result<HvfMemoryMapRequest, HvfGuestMemoryMappingError> {
+    validate_map_request(
+        region.range(),
+        region.host_address().as_ptr() as usize,
+        region.host_size(),
+        page_size,
+    )
+}
+
+fn validate_map_request(
+    range: GuestMemoryRange,
+    host_address: usize,
+    host_size: usize,
+    page_size: u64,
+) -> Result<HvfMemoryMapRequest, HvfGuestMemoryMappingError> {
+    validate_host_page_size(page_size)?;
+    let alignment =
+        usize::try_from(page_size).map_err(|_| HvfGuestMemoryMappingError::InvalidHostPageSize)?;
+
+    if range.validate_alignment(page_size).is_err() {
+        return Err(HvfGuestMemoryMappingError::UnalignedGuestRange {
+            range,
+            alignment: page_size,
+        });
+    }
+
+    let size = usize::try_from(range.size())
+        .map_err(|_| HvfGuestMemoryMappingError::SizeTooLarge { range })?;
+
+    if host_size != size {
+        return Err(HvfGuestMemoryMappingError::HostSizeMismatch {
+            range,
+            host_size,
+            expected_size: size,
+        });
+    }
+
+    if !host_size.is_multiple_of(alignment) {
+        return Err(HvfGuestMemoryMappingError::UnalignedHostSize {
+            range,
+            host_size,
+            alignment,
+        });
+    }
+
+    if !host_address.is_multiple_of(alignment) {
+        return Err(HvfGuestMemoryMappingError::UnalignedHostAddress { range, alignment });
+    }
+
+    Ok(HvfMemoryMapRequest {
+        range,
+        host_address,
+        guest_address: range.start().raw_value(),
+        size,
+    })
+}
+
+pub(crate) fn host_page_size() -> Result<u64, HvfGuestMemoryMappingError> {
+    // SAFETY: `sysconf(_SC_PAGESIZE)` has no pointer arguments and does not
+    // require process-local invariants from Rust.
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    let page_size =
+        u64::try_from(page_size).map_err(|_| HvfGuestMemoryMappingError::InvalidHostPageSize)?;
+
+    validate_host_page_size(page_size)?;
+    Ok(page_size)
+}
+
+fn validate_host_page_size(page_size: u64) -> Result<(), HvfGuestMemoryMappingError> {
+    if page_size == 0 || !page_size.is_power_of_two() {
+        Err(HvfGuestMemoryMappingError::InvalidHostPageSize)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use bangbang_runtime::memory::{
+        GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange,
+    };
+
+    use super::{
+        HvfGuestMemoryMapping, HvfGuestMemoryMappingError, HvfMappedGuestMemoryRegion,
+        HvfMemoryMapRequest, HvfMemoryMapper, HvfMemoryPermissions, host_page_size,
+        validate_map_request,
+    };
+    use crate::memory::FailedGuestMemoryMapping;
+
+    fn range(start: u64, size: u64) -> GuestMemoryRange {
+        GuestMemoryRange::new(GuestAddress::new(start), size)
+            .expect("guest memory range should be valid for test")
+    }
+
+    fn memory_for_ranges(ranges: Vec<GuestMemoryRange>) -> GuestMemory {
+        let layout =
+            GuestMemoryLayout::new(ranges).expect("guest memory layout should be valid for test");
+
+        GuestMemory::allocate(&layout).expect("guest memory allocation should succeed")
+    }
+
+    fn page_size() -> u64 {
+        host_page_size().expect("host page size should be available for tests")
+    }
+
+    #[test]
+    fn permission_bits_match_hvf_flags() {
+        assert_eq!(
+            HvfMemoryPermissions::READ.bits(),
+            crate::ffi::HV_MEMORY_READ
+        );
+        assert_eq!(
+            HvfMemoryPermissions::WRITE.bits(),
+            crate::ffi::HV_MEMORY_WRITE
+        );
+        assert_eq!(
+            HvfMemoryPermissions::EXECUTE.bits(),
+            crate::ffi::HV_MEMORY_EXEC
+        );
+        assert_eq!(
+            HvfMemoryPermissions::new(true, true, true),
+            HvfMemoryPermissions::GUEST_RAM
+        );
+        assert_eq!(
+            HvfMemoryPermissions::default(),
+            HvfMemoryPermissions::GUEST_RAM
+        );
+    }
+
+    #[test]
+    fn validate_map_request_rejects_unaligned_guest_range() {
+        let page_size = page_size();
+        let guest_range = range(page_size, page_size - 1);
+
+        let err = validate_map_request(
+            guest_range,
+            usize::try_from(page_size).expect("page size should fit usize"),
+            usize::try_from(page_size - 1).expect("range size should fit usize"),
+            page_size,
+        )
+        .expect_err("unaligned guest range should be rejected");
+
+        assert!(matches!(
+            err,
+            HvfGuestMemoryMappingError::UnalignedGuestRange { range, alignment }
+                if range == guest_range && alignment == page_size
+        ));
+    }
+
+    #[test]
+    fn validate_map_request_rejects_unaligned_host_address() {
+        let page_size = page_size();
+        let alignment = usize::try_from(page_size).expect("page size should fit usize");
+        let guest_range = range(0, page_size);
+
+        let err = validate_map_request(guest_range, alignment / 2, alignment, page_size)
+            .expect_err("unaligned host address should be rejected");
+
+        assert!(matches!(
+            err,
+            HvfGuestMemoryMappingError::UnalignedHostAddress { range, alignment: error_alignment }
+                if range == guest_range && error_alignment == alignment
+        ));
+    }
+
+    #[test]
+    fn validate_map_request_rejects_host_size_mismatch() {
+        let page_size = page_size();
+        let alignment = usize::try_from(page_size).expect("page size should fit usize");
+        let guest_range = range(0, page_size);
+
+        let err = validate_map_request(guest_range, alignment, alignment * 2, page_size)
+            .expect_err("host size mismatch should be rejected");
+
+        assert!(matches!(
+            err,
+            HvfGuestMemoryMappingError::HostSizeMismatch {
+                range,
+                host_size,
+                expected_size,
+            } if range == guest_range && host_size == alignment * 2 && expected_size == alignment
+        ));
+    }
+
+    #[test]
+    fn mapping_rejects_empty_permissions_before_map_calls() {
+        let page_size = page_size();
+        let memory = memory_for_ranges(vec![range(0, page_size)]);
+        let mapper = Arc::new(RecordingMapper::default());
+
+        let failure = HvfGuestMemoryMapping::map_with_mapper(
+            memory,
+            HvfMemoryPermissions::new(false, false, false),
+            mapper.clone(),
+        )
+        .expect_err("empty permissions should be rejected");
+
+        assert!(matches!(
+            failure.error,
+            HvfGuestMemoryMappingError::EmptyPermissions
+        ));
+        assert_eq!(mapper.map_count(), 0);
+        assert_eq!(mapper.unmap_count(), 0);
+    }
+
+    #[test]
+    fn mapping_maps_regions_and_drop_unmaps_in_reverse_order() {
+        let page_size = page_size();
+        let memory = memory_for_ranges(vec![range(0, page_size), range(page_size, page_size)]);
+        let mapper = Arc::new(RecordingMapper::default());
+
+        let mapping = HvfGuestMemoryMapping::map_with_mapper(
+            memory,
+            HvfMemoryPermissions::GUEST_RAM,
+            mapper.clone(),
+        )
+        .expect("guest memory mapping should succeed");
+
+        assert_eq!(mapping.mapped_region_count(), 2);
+        let maps = mapper.maps();
+        let mut mapped_ranges = maps.iter().map(|(request, _)| request.range);
+        assert_eq!(mapped_ranges.next(), Some(range(0, page_size)));
+        assert_eq!(mapped_ranges.next(), Some(range(page_size, page_size)));
+        assert_eq!(mapped_ranges.next(), None);
+
+        drop(mapping);
+
+        let unmaps = mapper.unmaps();
+        let mut unmapped_ranges = unmaps.iter().map(|mapped_region| mapped_region.range);
+        assert_eq!(unmapped_ranges.next(), Some(range(page_size, page_size)));
+        assert_eq!(unmapped_ranges.next(), Some(range(0, page_size)));
+        assert_eq!(unmapped_ranges.next(), None);
+    }
+
+    #[test]
+    fn partial_map_failure_unmaps_previously_mapped_regions() {
+        let page_size = page_size();
+        let memory = memory_for_ranges(vec![range(0, page_size), range(page_size, page_size)]);
+        let failed_range = range(page_size, page_size);
+        let mapper = Arc::new(RecordingMapper::new(Some(2), false));
+
+        let failure = HvfGuestMemoryMapping::map_with_mapper(
+            memory,
+            HvfMemoryPermissions::GUEST_RAM,
+            mapper.clone(),
+        )
+        .expect_err("second map should fail");
+
+        assert!(matches!(
+            failure.error,
+            HvfGuestMemoryMappingError::MapFailed {
+                range,
+                cleanup_failures,
+                ..
+            } if range == failed_range && cleanup_failures.is_empty()
+        ));
+        assert!(!failure.mapping.has_mapped_regions());
+        assert_eq!(mapper.map_count(), 2);
+
+        let unmaps = mapper.unmaps();
+        let mut unmapped_ranges = unmaps.iter().map(|mapped_region| mapped_region.range);
+        assert_eq!(unmapped_ranges.next(), Some(range(0, page_size)));
+        assert_eq!(unmapped_ranges.next(), None);
+    }
+
+    #[test]
+    fn partial_map_failure_retains_regions_when_cleanup_fails() {
+        let page_size = page_size();
+        let memory = memory_for_ranges(vec![range(0, page_size), range(page_size, page_size)]);
+        let failed_range = range(page_size, page_size);
+        let mapper = Arc::new(RecordingMapper::new(Some(2), true));
+
+        let failure = HvfGuestMemoryMapping::map_with_mapper(
+            memory,
+            HvfMemoryPermissions::GUEST_RAM,
+            mapper.clone(),
+        )
+        .expect_err("second map should fail");
+
+        assert!(matches!(
+            failure.error,
+            HvfGuestMemoryMappingError::MapFailed {
+                range,
+                cleanup_failures,
+                ..
+            } if range == failed_range && cleanup_failures.len() == 1
+        ));
+        assert!(failure.mapping.has_mapped_regions());
+        assert_eq!(mapper.map_count(), 2);
+        assert_eq!(mapper.unmap_count(), 1);
+    }
+
+    #[test]
+    fn explicit_unmap_keeps_failed_regions_for_retry() {
+        let page_size = page_size();
+        let memory = memory_for_ranges(vec![range(0, page_size)]);
+        let mapper = Arc::new(RecordingMapper::new(None, true));
+        let mut mapping = HvfGuestMemoryMapping::map_with_mapper(
+            memory,
+            HvfMemoryPermissions::GUEST_RAM,
+            mapper.clone(),
+        )
+        .expect("guest memory mapping should succeed");
+
+        let err = mapping
+            .unmap_all()
+            .expect_err("first unmap should report failure");
+
+        assert!(matches!(
+            err,
+            HvfGuestMemoryMappingError::UnmapFailed { failures } if failures.len() == 1
+        ));
+        assert!(mapping.has_mapped_regions());
+
+        mapper.set_fail_unmap(false);
+        mapping
+            .unmap_all()
+            .expect("second unmap should clean up retained region");
+
+        assert!(!mapping.has_mapped_regions());
+        assert_eq!(mapper.unmap_count(), 2);
+    }
+
+    #[derive(Debug)]
+    struct RecordingMapper {
+        state: Mutex<RecordingMapperState>,
+    }
+
+    impl Default for RecordingMapper {
+        fn default() -> Self {
+            Self::new(None, false)
+        }
+    }
+
+    impl RecordingMapper {
+        fn new(fail_map_on: Option<usize>, fail_unmap: bool) -> Self {
+            Self {
+                state: Mutex::new(RecordingMapperState {
+                    maps: Vec::new(),
+                    unmaps: Vec::new(),
+                    fail_map_on,
+                    fail_unmap,
+                }),
+            }
+        }
+
+        fn map_count(&self) -> usize {
+            self.state
+                .lock()
+                .expect("state lock should not be poisoned")
+                .maps
+                .len()
+        }
+
+        fn unmap_count(&self) -> usize {
+            self.state
+                .lock()
+                .expect("state lock should not be poisoned")
+                .unmaps
+                .len()
+        }
+
+        fn maps(&self) -> Vec<(HvfMemoryMapRequest, HvfMemoryPermissions)> {
+            self.state
+                .lock()
+                .expect("state lock should not be poisoned")
+                .maps
+                .clone()
+        }
+
+        fn unmaps(&self) -> Vec<HvfMappedGuestMemoryRegion> {
+            self.state
+                .lock()
+                .expect("state lock should not be poisoned")
+                .unmaps
+                .clone()
+        }
+
+        fn set_fail_unmap(&self, fail_unmap: bool) {
+            self.state
+                .lock()
+                .expect("state lock should not be poisoned")
+                .fail_unmap = fail_unmap;
+        }
+    }
+
+    impl HvfMemoryMapper for RecordingMapper {
+        fn map_region(
+            &self,
+            request: HvfMemoryMapRequest,
+            permissions: HvfMemoryPermissions,
+        ) -> Result<(), bangbang_runtime::BackendError> {
+            let mut state = self
+                .state
+                .lock()
+                .expect("state lock should not be poisoned");
+            state.maps.push((request, permissions));
+
+            if state.fail_map_on == Some(state.maps.len()) {
+                return Err(bangbang_runtime::BackendError::Hypervisor(
+                    "injected map failure".to_string(),
+                ));
+            }
+
+            Ok(())
+        }
+
+        fn unmap_region(
+            &self,
+            mapped_region: HvfMappedGuestMemoryRegion,
+        ) -> Result<(), bangbang_runtime::BackendError> {
+            let mut state = self
+                .state
+                .lock()
+                .expect("state lock should not be poisoned");
+            state.unmaps.push(mapped_region);
+
+            if state.fail_unmap {
+                return Err(bangbang_runtime::BackendError::Hypervisor(
+                    "injected unmap failure".to_string(),
+                ));
+            }
+
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingMapperState {
+        maps: Vec<(HvfMemoryMapRequest, HvfMemoryPermissions)>,
+        unmaps: Vec<HvfMappedGuestMemoryRegion>,
+        fail_map_on: Option<usize>,
+        fail_unmap: bool,
+    }
+
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    #[test]
+    fn mapping_owner_is_send_and_sync() {
+        assert_send_sync::<HvfGuestMemoryMapping>();
+    }
+
+    #[test]
+    fn failed_mapping_keeps_owner_for_cleanup_review() {
+        assert_send_sync::<FailedGuestMemoryMapping>();
+    }
+}

--- a/crates/hvf/src/memory.rs
+++ b/crates/hvf/src/memory.rs
@@ -267,6 +267,12 @@ impl HvfGuestMemoryMapping {
         !self.mapped_regions.is_empty()
     }
 
+    // HVF destroys guest mappings with the VM. Use this only after `hv_vm_destroy`
+    // succeeds following an earlier unmap failure.
+    pub(crate) fn release_after_vm_destroy(mut self) {
+        self.mapped_regions.clear();
+    }
+
     fn map_all(
         &mut self,
         permissions: HvfMemoryPermissions,
@@ -751,6 +757,23 @@ mod tests {
 
         assert!(!mapping.has_mapped_regions());
         assert_eq!(mapper.unmap_count(), 2);
+    }
+
+    #[test]
+    fn release_after_vm_destroy_does_not_unmap_again() {
+        let page_size = page_size();
+        let memory = memory_for_ranges(vec![range(0, page_size)]);
+        let mapper = Arc::new(RecordingMapper::default());
+        let mapping = HvfGuestMemoryMapping::map_with_mapper(
+            memory,
+            HvfMemoryPermissions::GUEST_RAM,
+            mapper.clone(),
+        )
+        .expect("guest memory mapping should succeed");
+
+        mapping.release_after_vm_destroy();
+
+        assert_eq!(mapper.unmap_count(), 0);
     }
 
     #[derive(Debug)]

--- a/crates/hvf/src/memory.rs
+++ b/crates/hvf/src/memory.rs
@@ -75,6 +75,9 @@ pub enum HvfGuestMemoryMappingError {
         range: GuestMemoryRange,
         alignment: usize,
     },
+    NullHostAddress {
+        range: GuestMemoryRange,
+    },
     UnalignedHostSize {
         range: GuestMemoryRange,
         host_size: usize,
@@ -125,6 +128,9 @@ impl fmt::Display for HvfGuestMemoryMappingError {
                     f,
                     "host address for guest memory range {range} is not aligned to {alignment} bytes"
                 )
+            }
+            Self::NullHostAddress { range } => {
+                write!(f, "host address for guest memory range {range} is null")
             }
             Self::UnalignedHostSize {
                 range,
@@ -193,6 +199,7 @@ impl std::error::Error for HvfGuestMemoryMappingError {
             | Self::SizeTooLarge { .. }
             | Self::UnalignedGuestRange { .. }
             | Self::UnalignedHostAddress { .. }
+            | Self::NullHostAddress { .. }
             | Self::UnalignedHostSize { .. }
             | Self::HostSizeMismatch { .. } => None,
         }
@@ -463,12 +470,8 @@ fn validate_map_request(
     let size = usize::try_from(range.size())
         .map_err(|_| HvfGuestMemoryMappingError::SizeTooLarge { range })?;
 
-    if host_size != size {
-        return Err(HvfGuestMemoryMappingError::HostSizeMismatch {
-            range,
-            host_size,
-            expected_size: size,
-        });
+    if host_address == 0 {
+        return Err(HvfGuestMemoryMappingError::NullHostAddress { range });
     }
 
     if !host_size.is_multiple_of(alignment) {
@@ -476,6 +479,14 @@ fn validate_map_request(
             range,
             host_size,
             alignment,
+        });
+    }
+
+    if host_size != size {
+        return Err(HvfGuestMemoryMappingError::HostSizeMismatch {
+            range,
+            host_size,
+            expected_size: size,
         });
     }
 
@@ -598,6 +609,43 @@ mod tests {
             err,
             HvfGuestMemoryMappingError::UnalignedHostAddress { range, alignment: error_alignment }
                 if range == guest_range && error_alignment == alignment
+        ));
+    }
+
+    #[test]
+    fn validate_map_request_rejects_null_host_address() {
+        let page_size = page_size();
+        let alignment = usize::try_from(page_size).expect("page size should fit usize");
+        let guest_range = range(0, page_size);
+
+        let err = validate_map_request(guest_range, 0, alignment, page_size)
+            .expect_err("null host address should be rejected");
+
+        assert!(matches!(
+            err,
+            HvfGuestMemoryMappingError::NullHostAddress { range } if range == guest_range
+        ));
+    }
+
+    #[test]
+    fn validate_map_request_rejects_unaligned_host_size() {
+        let page_size = page_size();
+        let alignment = usize::try_from(page_size).expect("page size should fit usize");
+        let guest_range = range(0, page_size);
+        let host_size = alignment + 1;
+
+        let err = validate_map_request(guest_range, alignment, host_size, page_size)
+            .expect_err("unaligned host size should be rejected");
+
+        assert!(matches!(
+            err,
+            HvfGuestMemoryMappingError::UnalignedHostSize {
+                range,
+                host_size: error_host_size,
+                alignment: error_alignment,
+            } if range == guest_range
+                && error_host_size == host_size
+                && error_alignment == alignment
         ));
     }
 

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -60,6 +60,41 @@ fn cancels_runner_before_first_run() {
     backend.destroy_vm().expect("VM should be destroyed");
 }
 
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn maps_guest_memory_and_unmaps_before_destroying_vm() {
+    use bangbang_hvf::{HvfBackend, HvfMemoryPermissions};
+    use bangbang_runtime::VmBackend;
+    use bangbang_runtime::memory::{GuestMemory, aarch64};
+
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let mut backend = HvfBackend::new();
+    let layout = aarch64::dram_layout(host_page_size().expect("host page size should be valid"))
+        .expect("guest memory layout should be valid");
+    let memory = GuestMemory::allocate(&layout).expect("guest memory allocation should succeed");
+
+    backend.create_vm().expect("VM should be created");
+    backend
+        .map_guest_memory(memory, HvfMemoryPermissions::GUEST_RAM)
+        .expect("guest memory should be mapped");
+    assert!(backend.has_guest_memory_mapping());
+    backend
+        .destroy_vm()
+        .expect("VM destruction should unmap guest memory first");
+    assert!(!backend.has_guest_memory_mapping());
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn host_page_size() -> Result<u64, std::num::TryFromIntError> {
+    // SAFETY: `sysconf(_SC_PAGESIZE)` has no pointer arguments and does not
+    // require process-local invariants from Rust.
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+
+    u64::try_from(page_size)
+}
+
 #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 #[test]
 fn requires_macos_apple_silicon() {

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -79,11 +79,12 @@ fn maps_guest_memory_and_unmaps_before_destroying_vm() {
     backend
         .map_guest_memory(memory, HvfMemoryPermissions::GUEST_RAM)
         .expect("guest memory should be mapped");
-    assert!(backend.has_guest_memory_mapping());
+    backend
+        .unmap_guest_memory()
+        .expect("guest memory should be unmapped");
     backend
         .destroy_vm()
-        .expect("VM destruction should unmap guest memory first");
-    assert!(!backend.has_guest_memory_mapping());
+        .expect("VM should be destroyed after guest memory unmap");
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -80,11 +80,8 @@ fn maps_guest_memory_and_unmaps_before_destroying_vm() {
         .map_guest_memory(memory, HvfMemoryPermissions::GUEST_RAM)
         .expect("guest memory should be mapped");
     backend
-        .unmap_guest_memory()
-        .expect("guest memory should be unmapped");
-    backend
         .destroy_vm()
-        .expect("VM should be destroyed after guest memory unmap");
+        .expect("VM destruction should unmap guest memory first");
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -10,10 +10,11 @@ trait, a minimal read-only VMM action/data model, backend-neutral guest
 physical address and aarch64 DRAM layout primitives, a minimal
 Hypervisor.framework VM create/destroy wrapper, a current-thread HVF vCPU
 create/destroy wrapper, typed HVF exit surface, narrow vCPU register wrappers,
-anonymous guest memory allocation for validated runtime layouts, and an initial
-process startup argument model. There is no broader API request body model, HVF
-guest memory mapping, guest execution, vCPU run loop, MMIO/device emulation,
-boot register setup, or kernel loading yet.
+anonymous guest memory allocation for validated runtime layouts, HVF guest
+memory map/unmap ownership for allocated regions, and an initial process
+startup argument model. There is no broader API request body model, guest
+execution, vCPU run loop, MMIO/device emulation, boot register setup, or kernel
+loading yet.
 
 ## Firecracker Model Alignment
 
@@ -227,16 +228,21 @@ The aarch64 layout helper follows Firecracker's `v1.16.0` ARM layout shape:
 The allocation model creates one anonymous read/write private host memory
 mapping for each validated guest RAM range and releases the mappings with
 runtime ownership cleanup. It preserves each guest range with its host mapping
-for later HVF map/unmap work. It does not use Firecracker's `vm-memory` crate;
-future device-memory, dirty-tracking, snapshot, or file-backed-memory work
-should evaluate the right abstraction from its concrete requirements.
+for HVF map/unmap work. It does not use Firecracker's `vm-memory` crate; future
+device-memory, dirty-tracking, snapshot, or file-backed-memory work should
+evaluate the right abstraction from its concrete requirements.
 
-This still is not executable guest RAM. The runtime does not map allocated
-memory into Hypervisor.framework, write kernel/initrd/FDT payloads, wire
-`mem_size_mib` into public startup behavior, or start a guest. Later API and
-startup work still needs to decide whether an oversized `mem_size_mib` request
-should be rejected before layout construction or should preserve Firecracker's
-architecture-helper truncation behavior.
+The HVF backend can map allocated guest memory regions into an existing
+Hypervisor.framework VM with read/write/execute guest RAM permissions. The
+backend-owned mapping owner consumes the `GuestMemory` allocation, unmaps mapped
+regions on explicit unmap, partial failure, drop, and VM destruction, and keeps
+cleanup local to the backend instance.
+
+This still is not bootable guest RAM. bangbang does not write
+kernel/initrd/FDT payloads, wire `mem_size_mib` into public startup behavior,
+or start a guest. Later API and startup work still needs to decide whether an
+oversized `mem_size_mib` request should be rejected before layout construction
+or should preserve Firecracker's architecture-helper truncation behavior.
 
 ## API State and Response Policy
 
@@ -341,6 +347,9 @@ macOS design work instead of direct implementation:
 
 - KVM-specific VM and vCPU operations need HVF equivalents rather than direct
   KVM ioctl usage.
+- HVF guest RAM is mapped with a backend-owned owner that holds the anonymous
+  host allocation until unmap or VM destruction. It does not yet load payloads,
+  expose device memory helpers, or start guest execution.
 - HVF vCPU handles are thread-affine: creation, register access, run, and
   destroy operations must happen on the owning thread. The current vCPU wrapper
   covers current-thread lifecycle, typed exit surface, and narrow register


### PR DESCRIPTION
## Summary

- add HVF `hv_vm_map`/`hv_vm_unmap` wrappers and guest RAM permission handling
- add backend-owned guest memory mapping ownership that consumes `GuestMemory` and unmaps on explicit unmap, partial failure, drop, and VM destroy
- add unit coverage for validation, duplicate mapping, partial cleanup, and retryable unmap failures, plus signed HVF integration coverage
- update README and Firecracker compatibility docs for mapped HVF guest RAM and remaining startup limitations

Closes #68

## Scope exclusions

- does not wire `mem_size_mib` into public startup
- does not load kernel/initrd/FDT payloads
- does not start guest execution or add a vCPU run loop/device emulation
- does not add `hv_vm_protect`, dirty tracking, huge pages, or file-backed memory

## Verification

```sh
cargo fmt --all -- --check
cargo check --workspace --all-targets --all-features --locked
cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
cargo test -p bangbang-hvf --lib --all-features --locked
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
scripts/run-hvf-tests.sh
```
