### PR TITLE
feat: add guest memory boot access

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 bangbang is a Rust VMM project for macOS hosts. The public control plane is intended to stay compatible with the Firecracker HTTP API over a Unix domain socket, while the VM backend is built on Apple's Hypervisor.framework.
 
-This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, a backend-neutral guest address/layout model, anonymous guest memory allocation, and the smallest Hypervisor.framework VM, guest memory map/unmap ownership, current-thread vCPU lifecycle, typed exit surface, register wrappers, and cancellable vCPU runner skeleton.
+This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, a backend-neutral guest address/layout model, anonymous guest memory allocation and byte access, arm64 boot placement helpers, and the smallest Hypervisor.framework VM, guest memory map/unmap ownership, current-thread vCPU lifecycle, typed exit surface, register wrappers, and cancellable vCPU runner skeleton.
 
 See [Firecracker Compatibility Scope](docs/firecracker-compatibility.md) for the intended compatibility target and current limitations.
 See [Pull Request Review Guidelines](docs/review-guidelines.md) for the project-specific review standard.
@@ -18,7 +18,7 @@ crates/bangbang   VMM process entrypoint and startup CLI
 
 ## Current Scope
 
-The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. The runtime crate defines guest physical address, range, and aarch64 DRAM layout primitives, and can allocate owned anonymous host memory for validated page-aligned guest memory layouts. The HVF crate can create/destroy a process VM, map/unmap allocated guest memory with backend-owned cleanup, create/destroy one current-thread vCPU handle, define typed HVF exit snapshots, get/set a narrow set of vCPU registers, and start a thread-owned runner that can cancel a single `hv_vcpu_run` step. It intentionally does not include:
+The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. The runtime crate defines guest physical address, range, and aarch64 DRAM layout primitives, can allocate owned anonymous host memory for validated page-aligned guest memory layouts, can safely read/write byte slices by guest address, and exposes the first arm64 kernel/FDT/initrd placement helpers. The HVF crate can create/destroy a process VM, map/unmap allocated guest memory with backend-owned cleanup, create/destroy one current-thread vCPU handle, define typed HVF exit snapshots, get/set a narrow set of vCPU registers, and start a thread-owned runner that can cancel a single `hv_vcpu_run` step. It intentionally does not include:
 
 - API endpoints beyond `GET /` and `GET /version`
 - JSON request body models

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -1378,6 +1378,28 @@ mod tests {
     }
 
     #[test]
+    fn guest_memory_access_rejects_unmapped_hole_without_partial_read() {
+        let page_size = host_page_size().expect("host page size should be available for tests");
+        let mut memory =
+            allocate_memory(vec![range(0, page_size), range(2 * page_size, page_size)]);
+        let address = GuestAddress::new(page_size - 1);
+        let access_range = range(page_size - 1, 2);
+        let mut destination = [0x55, 0x66];
+
+        memory
+            .write_slice(&[0xaa], address)
+            .expect("single-byte write before hole should succeed");
+
+        assert_eq!(
+            memory.read_slice(address, &mut destination),
+            Err(GuestMemoryAccessError::UnmappedRange {
+                range: access_range
+            })
+        );
+        assert_eq!(destination, [0x55, 0x66]);
+    }
+
+    #[test]
     fn guest_memory_access_spans_adjacent_ranges() {
         let page_size = host_page_size().expect("host page size should be available for tests");
         let mut memory = allocate_memory(vec![range(0, page_size), range(page_size, page_size)]);

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -1355,6 +1355,22 @@ mod tests {
     }
 
     #[test]
+    fn guest_memory_read_rejects_address_overflow_without_mutating_destination() {
+        let page_size = host_page_size().expect("host page size should be available for tests");
+        let memory = allocate_memory(vec![range(0, page_size)]);
+        let mut destination = [0x55];
+
+        assert_eq!(
+            memory.read_slice(GuestAddress::new(u64::MAX), &mut destination),
+            Err(GuestMemoryAccessError::AddressOverflow {
+                start: GuestAddress::new(u64::MAX),
+                size: 1
+            })
+        );
+        assert_eq!(destination, [0x55]);
+    }
+
+    #[test]
     fn guest_memory_access_rejects_unmapped_hole_without_partial_write() {
         let page_size = host_page_size().expect("host page size should be available for tests");
         let mut memory =

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -1363,6 +1363,47 @@ mod tests {
     }
 
     #[test]
+    fn displays_guest_memory_access_errors() {
+        let access_range = range(0x1000, 0x20);
+
+        assert_eq!(
+            GuestMemoryAccessError::SizeTooLarge { size: 7 }.to_string(),
+            "guest memory access size 7 bytes is too large to represent"
+        );
+        assert_eq!(
+            GuestMemoryAccessError::AddressOverflow {
+                start: GuestAddress::new(0xffff),
+                size: 2
+            }
+            .to_string(),
+            "guest memory access overflows address space: start=0xffff, size=2"
+        );
+        assert_eq!(
+            GuestMemoryAccessError::UnmappedRange {
+                range: access_range
+            }
+            .to_string(),
+            "guest memory access range [0x1000..0x1020) (32 bytes) is not fully mapped"
+        );
+        assert_eq!(
+            GuestMemoryAccessError::SegmentOffsetTooLarge {
+                range: access_range,
+                offset: 5
+            }
+            .to_string(),
+            "guest memory access offset 5 in range [0x1000..0x1020) (32 bytes) is too large for this host"
+        );
+        assert_eq!(
+            GuestMemoryAccessError::SegmentSizeTooLarge {
+                range: access_range,
+                size: 6
+            }
+            .to_string(),
+            "guest memory access segment of 6 bytes in range [0x1000..0x1020) (32 bytes) is too large for this host"
+        );
+    }
+
+    #[test]
     fn guest_memory_read_rejects_address_overflow_without_mutating_destination() {
         let page_size = host_page_size().expect("host page size should be available for tests");
         let memory = allocate_memory(vec![range(0, page_size)]);

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -252,8 +252,8 @@ impl GuestMemory {
 
     pub fn read_slice(
         &self,
-        guest_address: GuestAddress,
         destination: &mut [u8],
+        guest_address: GuestAddress,
     ) -> Result<(), GuestMemoryAccessError> {
         let Some(range) = access_range(guest_address, destination.len())? else {
             return Ok(());
@@ -1302,7 +1302,7 @@ mod tests {
             .write_slice(&source, address)
             .expect("guest memory write should succeed");
         memory
-            .read_slice(address, &mut destination)
+            .read_slice(&mut destination, address)
             .expect("guest memory read should succeed");
 
         assert_eq!(destination, source);
@@ -1320,7 +1320,7 @@ mod tests {
             .write_slice(&source, address)
             .expect("guest memory write ending at range boundary should succeed");
         memory
-            .read_slice(address, &mut destination)
+            .read_slice(&mut destination, address)
             .expect("guest memory read ending at range boundary should succeed");
 
         assert_eq!(destination, source);
@@ -1336,7 +1336,7 @@ mod tests {
             .write_slice(&[], GuestAddress::new(u64::MAX))
             .expect("zero-length write should not validate address");
         memory
-            .read_slice(GuestAddress::new(u64::MAX), &mut destination)
+            .read_slice(&mut destination, GuestAddress::new(u64::MAX))
             .expect("zero-length read should not validate address");
     }
 
@@ -1361,7 +1361,7 @@ mod tests {
         let mut destination = [0x55];
 
         assert_eq!(
-            memory.read_slice(GuestAddress::new(u64::MAX), &mut destination),
+            memory.read_slice(&mut destination, GuestAddress::new(u64::MAX)),
             Err(GuestMemoryAccessError::AddressOverflow {
                 start: GuestAddress::new(u64::MAX),
                 size: 1
@@ -1387,7 +1387,7 @@ mod tests {
 
         let mut byte = [0xff];
         memory
-            .read_slice(address, &mut byte)
+            .read_slice(&mut byte, address)
             .expect("single-byte read before hole should still succeed");
 
         assert_eq!(byte, [0]);
@@ -1407,7 +1407,7 @@ mod tests {
             .expect("single-byte write before hole should succeed");
 
         assert_eq!(
-            memory.read_slice(address, &mut destination),
+            memory.read_slice(&mut destination, address),
             Err(GuestMemoryAccessError::UnmappedRange {
                 range: access_range
             })
@@ -1427,7 +1427,7 @@ mod tests {
             .write_slice(&source, address)
             .expect("guest memory write should cross adjacent ranges");
         memory
-            .read_slice(address, &mut destination)
+            .read_slice(&mut destination, address)
             .expect("guest memory read should cross adjacent ranges");
 
         assert_eq!(destination, source);

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -1234,6 +1234,14 @@ mod tests {
     }
 
     #[test]
+    fn aarch64_initrd_load_address_returns_none_when_rounded_size_overflows() {
+        let layout = aarch64::dram_layout(aarch64::FDT_MAX_SIZE + PAGE_SIZE)
+            .expect("fdt layout should be valid");
+
+        assert_eq!(aarch64::initrd_load_address(&layout, u64::MAX), Ok(None));
+    }
+
+    #[test]
     fn guest_memory_allocates_small_layout() {
         let page_size = host_page_size().expect("host page size should be available for tests");
         let layout = GuestMemoryLayout::new(vec![range(0, page_size)])
@@ -1368,6 +1376,31 @@ mod tests {
             })
         );
         assert_eq!(destination, [0x55]);
+    }
+
+    #[test]
+    fn guest_memory_access_rejects_fully_unmapped_ranges_without_partial_read() {
+        let page_size = host_page_size().expect("host page size should be available for tests");
+        let mut memory = allocate_memory(vec![range(page_size, page_size)]);
+
+        for address in [GuestAddress::new(0), GuestAddress::new(2 * page_size)] {
+            let access_range = range(address.raw_value(), 1);
+            let mut destination = [0x55];
+
+            assert_eq!(
+                memory.write_slice(&[0xaa], address),
+                Err(GuestMemoryAccessError::UnmappedRange {
+                    range: access_range
+                })
+            );
+            assert_eq!(
+                memory.read_slice(&mut destination, address),
+                Err(GuestMemoryAccessError::UnmappedRange {
+                    range: access_range
+                })
+            );
+            assert_eq!(destination, [0x55]);
+        }
     }
 
     #[test]

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -237,10 +237,10 @@ impl GuestMemory {
             // SAFETY: `validate_mapped_range` proved the whole requested guest
             // range is backed by live mappings. `access_segment` bounds this
             // segment to `region`, and the destination pointer is within that
-            // mapping. The safe API provides no way to alias `source` with the
-            // private anonymous mapping mutably.
+            // mapping. `ptr::copy` permits overlap if `source` was derived from
+            // the same guest mapping through a raw host pointer.
             unsafe {
-                ptr::copy_nonoverlapping(source_segment.as_ptr(), destination, segment.size);
+                ptr::copy(source_segment.as_ptr(), destination, segment.size);
             }
 
             remaining = next_remaining;
@@ -283,9 +283,10 @@ impl GuestMemory {
             // SAFETY: `validate_mapped_range` proved the whole requested guest
             // range is backed by live mappings. `access_segment` bounds this
             // segment to `region`, and the source pointer is within that
-            // mapping. The destination is a caller-provided mutable slice.
+            // mapping. `ptr::copy` permits overlap if `destination` was derived
+            // from the same guest mapping through a raw host pointer.
             unsafe {
-                ptr::copy_nonoverlapping(source, destination_segment.as_mut_ptr(), segment.size);
+                ptr::copy(source, destination_segment.as_mut_ptr(), segment.size);
             }
 
             remaining = next_remaining;

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -84,6 +84,10 @@ impl GuestMemoryRange {
         self.end_exclusive.0 == other.start.0 || other.end_exclusive.0 == self.start.0
     }
 
+    pub const fn contains(self, address: GuestAddress) -> bool {
+        self.start.0 <= address.0 && address.0 < self.end_exclusive.0
+    }
+
     pub fn validate_alignment(self, alignment: u64) -> Result<(), GuestMemoryError> {
         validate_alignment(alignment)?;
 
@@ -199,6 +203,117 @@ impl GuestMemory {
             .map(|region| region.range().size())
             .sum::<u64>()
     }
+
+    pub fn write_slice(
+        &mut self,
+        source: &[u8],
+        guest_address: GuestAddress,
+    ) -> Result<(), GuestMemoryAccessError> {
+        let Some(range) = access_range(guest_address, source.len())? else {
+            return Ok(());
+        };
+
+        self.validate_mapped_range(range)?;
+
+        let mut remaining = source;
+        let mut current = range.start();
+        for region in &mut self.regions {
+            if remaining.is_empty() {
+                break;
+            }
+            if region.range().end_exclusive() <= current {
+                continue;
+            }
+
+            let segment = access_segment(region, current, range.end_exclusive())?;
+            let (source_segment, next_remaining) = remaining.split_at(segment.size);
+            let destination = region
+                .mapping
+                .address()
+                .as_ptr()
+                .cast::<u8>()
+                .wrapping_add(segment.offset);
+
+            // SAFETY: `validate_mapped_range` proved the whole requested guest
+            // range is backed by live mappings. `access_segment` bounds this
+            // segment to `region`, and the destination pointer is within that
+            // mapping. The safe API provides no way to alias `source` with the
+            // private anonymous mapping mutably.
+            unsafe {
+                ptr::copy_nonoverlapping(source_segment.as_ptr(), destination, segment.size);
+            }
+
+            remaining = next_remaining;
+            current = advance_address(current, segment.size)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn read_slice(
+        &self,
+        guest_address: GuestAddress,
+        destination: &mut [u8],
+    ) -> Result<(), GuestMemoryAccessError> {
+        let Some(range) = access_range(guest_address, destination.len())? else {
+            return Ok(());
+        };
+
+        self.validate_mapped_range(range)?;
+
+        let mut remaining = destination;
+        let mut current = range.start();
+        for region in &self.regions {
+            if remaining.is_empty() {
+                break;
+            }
+            if region.range().end_exclusive() <= current {
+                continue;
+            }
+
+            let segment = access_segment(region, current, range.end_exclusive())?;
+            let (destination_segment, next_remaining) = remaining.split_at_mut(segment.size);
+            let source = region
+                .mapping
+                .address()
+                .as_ptr()
+                .cast::<u8>()
+                .wrapping_add(segment.offset);
+
+            // SAFETY: `validate_mapped_range` proved the whole requested guest
+            // range is backed by live mappings. `access_segment` bounds this
+            // segment to `region`, and the source pointer is within that
+            // mapping. The destination is a caller-provided mutable slice.
+            unsafe {
+                ptr::copy_nonoverlapping(source, destination_segment.as_mut_ptr(), segment.size);
+            }
+
+            remaining = next_remaining;
+            current = advance_address(current, segment.size)?;
+        }
+
+        Ok(())
+    }
+
+    fn validate_mapped_range(&self, range: GuestMemoryRange) -> Result<(), GuestMemoryAccessError> {
+        let mut current = range.start();
+        for region in &self.regions {
+            if region.range().end_exclusive() <= current {
+                continue;
+            }
+            if !region.range().contains(current) {
+                return Err(GuestMemoryAccessError::UnmappedRange { range });
+            }
+
+            let segment = access_segment(region, current, range.end_exclusive())?;
+            current = advance_address(current, segment.size)?;
+            if current == range.end_exclusive() {
+                return Ok(());
+            }
+        }
+
+        Err(GuestMemoryAccessError::UnmappedRange { range })
+    }
 }
 
 pub struct GuestMemoryRegion {
@@ -294,6 +409,64 @@ impl From<GuestMemoryError> for GuestMemoryAllocationError {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuestMemoryAccessError {
+    SizeTooLarge {
+        size: usize,
+    },
+    AddressOverflow {
+        start: GuestAddress,
+        size: u64,
+    },
+    UnmappedRange {
+        range: GuestMemoryRange,
+    },
+    SegmentOffsetTooLarge {
+        range: GuestMemoryRange,
+        offset: u64,
+    },
+    SegmentSizeTooLarge {
+        range: GuestMemoryRange,
+        size: u64,
+    },
+}
+
+impl fmt::Display for GuestMemoryAccessError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SizeTooLarge { size } => {
+                write!(
+                    f,
+                    "guest memory access size {size} bytes is too large to represent"
+                )
+            }
+            Self::AddressOverflow { start, size } => {
+                write!(
+                    f,
+                    "guest memory access overflows address space: start={start}, size={size}"
+                )
+            }
+            Self::UnmappedRange { range } => {
+                write!(f, "guest memory access range {range} is not fully mapped")
+            }
+            Self::SegmentOffsetTooLarge { range, offset } => {
+                write!(
+                    f,
+                    "guest memory access offset {offset} in range {range} is too large for this host"
+                )
+            }
+            Self::SegmentSizeTooLarge { range, size } => {
+                write!(
+                    f,
+                    "guest memory access segment of {size} bytes in range {range} is too large for this host"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for GuestMemoryAccessError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GuestMemoryError {
     EmptyLayout,
     EmptyRange {
@@ -368,6 +541,11 @@ pub mod aarch64 {
 
     pub const DRAM_MEM_START: u64 = 0x8000_0000;
     pub const DRAM_MEM_MAX_SIZE: u64 = 0x00FF_8000_0000;
+    pub const SYSTEM_MEM_START: u64 = DRAM_MEM_START;
+    pub const SYSTEM_MEM_SIZE: u64 = 0x20_0000;
+    pub const CMDLINE_MAX_SIZE: usize = 2048;
+    pub const FDT_MAX_SIZE: u64 = 0x20_0000;
+    pub const GUEST_PAGE_SIZE: u64 = 4096;
     pub const MMIO64_MEM_START: u64 = 256 << 30;
     pub const MMIO64_MEM_SIZE: u64 = 256 << 30;
     pub const FIRST_ADDR_PAST_64BITS_MMIO: u64 = MMIO64_MEM_START + MMIO64_MEM_SIZE;
@@ -405,6 +583,125 @@ pub mod aarch64 {
 
         GuestMemoryLayout::new(ranges)
     }
+
+    pub const fn kernel_load_address() -> GuestAddress {
+        GuestAddress::new(SYSTEM_MEM_START + SYSTEM_MEM_SIZE)
+    }
+
+    pub fn fdt_address(layout: &GuestMemoryLayout) -> Result<GuestAddress, GuestMemoryError> {
+        let first_range = first_range(layout)?;
+        let candidate = match first_range
+            .end_exclusive()
+            .raw_value()
+            .checked_sub(FDT_MAX_SIZE)
+        {
+            Some(address) => GuestAddress::new(address),
+            None => return Ok(first_range.start()),
+        };
+
+        if first_range.contains(candidate) {
+            Ok(candidate)
+        } else {
+            Ok(first_range.start())
+        }
+    }
+
+    pub fn initrd_load_address(
+        layout: &GuestMemoryLayout,
+        initrd_size: u64,
+    ) -> Result<Option<GuestAddress>, GuestMemoryError> {
+        let fdt_address = fdt_address(layout)?;
+        let Some(rounded_size) = align_up(initrd_size, GUEST_PAGE_SIZE) else {
+            return Ok(None);
+        };
+        let Some(load_address) = fdt_address.raw_value().checked_sub(rounded_size) else {
+            return Ok(None);
+        };
+        let load_address = GuestAddress::new(load_address);
+
+        if first_range(layout)?.contains(load_address) {
+            Ok(Some(load_address))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn first_range(layout: &GuestMemoryLayout) -> Result<GuestMemoryRange, GuestMemoryError> {
+        layout
+            .ranges()
+            .first()
+            .copied()
+            .ok_or(GuestMemoryError::EmptyLayout)
+    }
+
+    const fn align_up(value: u64, alignment: u64) -> Option<u64> {
+        if alignment == 0 || !alignment.is_power_of_two() {
+            return None;
+        }
+
+        let mask = alignment - 1;
+        match value.checked_add(mask) {
+            Some(rounded) => Some(rounded & !mask),
+            None => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GuestMemorySegment {
+    offset: usize,
+    size: usize,
+}
+
+fn access_range(
+    start: GuestAddress,
+    size: usize,
+) -> Result<Option<GuestMemoryRange>, GuestMemoryAccessError> {
+    if size == 0 {
+        return Ok(None);
+    }
+
+    let size = u64::try_from(size).map_err(|_| GuestMemoryAccessError::SizeTooLarge { size })?;
+    let end_exclusive = start
+        .checked_add(size)
+        .ok_or(GuestMemoryAccessError::AddressOverflow { start, size })?;
+
+    Ok(Some(GuestMemoryRange {
+        start,
+        size,
+        end_exclusive,
+    }))
+}
+
+fn access_segment(
+    region: &GuestMemoryRegion,
+    current: GuestAddress,
+    end: GuestAddress,
+) -> Result<GuestMemorySegment, GuestMemoryAccessError> {
+    let range = region.range();
+    let offset = current.raw_value() - range.start().raw_value();
+    let offset = usize::try_from(offset)
+        .map_err(|_| GuestMemoryAccessError::SegmentOffsetTooLarge { range, offset })?;
+    let size = (range.end_exclusive().raw_value() - current.raw_value())
+        .min(end.raw_value() - current.raw_value());
+    let size = usize::try_from(size)
+        .map_err(|_| GuestMemoryAccessError::SegmentSizeTooLarge { range, size })?;
+
+    Ok(GuestMemorySegment { offset, size })
+}
+
+fn advance_address(
+    address: GuestAddress,
+    offset: usize,
+) -> Result<GuestAddress, GuestMemoryAccessError> {
+    let size =
+        u64::try_from(offset).map_err(|_| GuestMemoryAccessError::SizeTooLarge { size: offset })?;
+    address
+        .checked_add(size)
+        .ok_or(GuestMemoryAccessError::AddressOverflow {
+            start: address,
+            size,
+        })
 }
 
 fn validate_alignment(alignment: u64) -> Result<(), GuestMemoryError> {
@@ -591,8 +888,9 @@ mod tests {
     use std::thread;
 
     use super::{
-        AnonymousMapper, AnonymousMapping, GuestAddress, GuestMemory, GuestMemoryAllocationError,
-        GuestMemoryError, GuestMemoryLayout, GuestMemoryRange, aarch64, host_page_size,
+        AnonymousMapper, AnonymousMapping, GuestAddress, GuestMemory, GuestMemoryAccessError,
+        GuestMemoryAllocationError, GuestMemoryError, GuestMemoryLayout, GuestMemoryRange, aarch64,
+        host_page_size,
     };
 
     const PAGE_SIZE: u64 = 4096;
@@ -600,6 +898,13 @@ mod tests {
     fn range(start: u64, size: u64) -> GuestMemoryRange {
         GuestMemoryRange::new(GuestAddress::new(start), size)
             .expect("range should be valid for test")
+    }
+
+    fn allocate_memory(ranges: Vec<GuestMemoryRange>) -> GuestMemory {
+        let layout =
+            GuestMemoryLayout::new(ranges).expect("guest memory layout should be valid for test");
+
+        GuestMemory::allocate(&layout).expect("guest memory allocation should succeed")
     }
 
     #[test]
@@ -855,6 +1160,79 @@ mod tests {
     }
 
     #[test]
+    fn aarch64_boot_constants_match_firecracker_layout() {
+        assert_eq!(aarch64::SYSTEM_MEM_START, aarch64::DRAM_MEM_START);
+        assert_eq!(aarch64::SYSTEM_MEM_SIZE, 0x20_0000);
+        assert_eq!(aarch64::CMDLINE_MAX_SIZE, 2048);
+        assert_eq!(aarch64::FDT_MAX_SIZE, 0x20_0000);
+        assert_eq!(aarch64::GUEST_PAGE_SIZE, 4096);
+    }
+
+    #[test]
+    fn aarch64_kernel_load_address_follows_system_memory() {
+        assert_eq!(
+            aarch64::kernel_load_address(),
+            GuestAddress::new(aarch64::DRAM_MEM_START + aarch64::SYSTEM_MEM_SIZE)
+        );
+    }
+
+    #[test]
+    fn aarch64_fdt_address_uses_dram_start_for_small_or_equal_memory() {
+        for size in [aarch64::FDT_MAX_SIZE - PAGE_SIZE, aarch64::FDT_MAX_SIZE] {
+            let layout =
+                aarch64::dram_layout(size).expect("small fdt layout should be valid for test");
+
+            assert_eq!(
+                aarch64::fdt_address(&layout),
+                Ok(GuestAddress::new(aarch64::DRAM_MEM_START))
+            );
+        }
+    }
+
+    #[test]
+    fn aarch64_fdt_address_reserves_last_fdt_window_for_larger_memory() {
+        let layout = aarch64::dram_layout(aarch64::FDT_MAX_SIZE + PAGE_SIZE)
+            .expect("large fdt layout should be valid");
+
+        assert_eq!(
+            aarch64::fdt_address(&layout),
+            Ok(GuestAddress::new(aarch64::DRAM_MEM_START + PAGE_SIZE))
+        );
+    }
+
+    #[test]
+    fn aarch64_initrd_load_address_aligns_before_fdt() {
+        let layout = aarch64::dram_layout(aarch64::FDT_MAX_SIZE + (4 * PAGE_SIZE))
+            .expect("initrd layout should be valid");
+
+        assert_eq!(
+            aarch64::initrd_load_address(&layout, PAGE_SIZE + 1),
+            Ok(Some(GuestAddress::new(
+                aarch64::DRAM_MEM_START + (2 * PAGE_SIZE)
+            )))
+        );
+    }
+
+    #[test]
+    fn aarch64_initrd_load_address_returns_fdt_address_for_empty_payload() {
+        let layout =
+            aarch64::dram_layout(aarch64::FDT_MAX_SIZE).expect("fdt-only layout should be valid");
+
+        assert_eq!(
+            aarch64::initrd_load_address(&layout, 0),
+            Ok(Some(GuestAddress::new(aarch64::DRAM_MEM_START)))
+        );
+    }
+
+    #[test]
+    fn aarch64_initrd_load_address_returns_none_without_space() {
+        let layout =
+            aarch64::dram_layout(aarch64::FDT_MAX_SIZE).expect("fdt-only layout should be valid");
+
+        assert_eq!(aarch64::initrd_load_address(&layout, 1), Ok(None));
+    }
+
+    #[test]
     fn guest_memory_allocates_small_layout() {
         let page_size = host_page_size().expect("host page size should be available for tests");
         let layout = GuestMemoryLayout::new(vec![range(0, page_size)])
@@ -909,6 +1287,139 @@ mod tests {
 
         assert!(!debug.contains(&host_address));
         assert!(debug.contains("host_size"));
+    }
+
+    #[test]
+    fn guest_memory_write_and_read_slice_round_trip() {
+        let page_size = host_page_size().expect("host page size should be available for tests");
+        let mut memory = allocate_memory(vec![range(page_size, page_size)]);
+        let address = GuestAddress::new(page_size + 128);
+        let source = [0xde, 0xad, 0xbe, 0xef];
+        let mut destination = [0; 4];
+
+        memory
+            .write_slice(&source, address)
+            .expect("guest memory write should succeed");
+        memory
+            .read_slice(address, &mut destination)
+            .expect("guest memory read should succeed");
+
+        assert_eq!(destination, source);
+    }
+
+    #[test]
+    fn guest_memory_access_accepts_exact_end_boundary() {
+        let page_size = host_page_size().expect("host page size should be available for tests");
+        let mut memory = allocate_memory(vec![range(0, page_size)]);
+        let source = [1, 2, 3, 4];
+        let address = GuestAddress::new(page_size - u64::try_from(source.len()).unwrap());
+        let mut destination = [0; 4];
+
+        memory
+            .write_slice(&source, address)
+            .expect("guest memory write ending at range boundary should succeed");
+        memory
+            .read_slice(address, &mut destination)
+            .expect("guest memory read ending at range boundary should succeed");
+
+        assert_eq!(destination, source);
+    }
+
+    #[test]
+    fn guest_memory_access_treats_zero_length_as_noop() {
+        let page_size = host_page_size().expect("host page size should be available for tests");
+        let mut memory = allocate_memory(vec![range(0, page_size)]);
+        let mut destination: [u8; 0] = [];
+
+        memory
+            .write_slice(&[], GuestAddress::new(u64::MAX))
+            .expect("zero-length write should not validate address");
+        memory
+            .read_slice(GuestAddress::new(u64::MAX), &mut destination)
+            .expect("zero-length read should not validate address");
+    }
+
+    #[test]
+    fn guest_memory_access_rejects_address_overflow() {
+        let page_size = host_page_size().expect("host page size should be available for tests");
+        let mut memory = allocate_memory(vec![range(0, page_size)]);
+
+        assert_eq!(
+            memory.write_slice(&[0], GuestAddress::new(u64::MAX)),
+            Err(GuestMemoryAccessError::AddressOverflow {
+                start: GuestAddress::new(u64::MAX),
+                size: 1
+            })
+        );
+    }
+
+    #[test]
+    fn guest_memory_access_rejects_unmapped_hole_without_partial_write() {
+        let page_size = host_page_size().expect("host page size should be available for tests");
+        let mut memory =
+            allocate_memory(vec![range(0, page_size), range(2 * page_size, page_size)]);
+        let address = GuestAddress::new(page_size - 1);
+        let access_range = range(page_size - 1, 2);
+
+        assert_eq!(
+            memory.write_slice(&[0xaa, 0xbb], address),
+            Err(GuestMemoryAccessError::UnmappedRange {
+                range: access_range
+            })
+        );
+
+        let mut byte = [0xff];
+        memory
+            .read_slice(address, &mut byte)
+            .expect("single-byte read before hole should still succeed");
+
+        assert_eq!(byte, [0]);
+    }
+
+    #[test]
+    fn guest_memory_access_spans_adjacent_ranges() {
+        let page_size = host_page_size().expect("host page size should be available for tests");
+        let mut memory = allocate_memory(vec![range(0, page_size), range(page_size, page_size)]);
+        let source = [0x11, 0x22];
+        let address = GuestAddress::new(page_size - 1);
+        let mut destination = [0; 2];
+
+        memory
+            .write_slice(&source, address)
+            .expect("guest memory write should cross adjacent ranges");
+        memory
+            .read_slice(address, &mut destination)
+            .expect("guest memory read should cross adjacent ranges");
+
+        assert_eq!(destination, source);
+    }
+
+    #[test]
+    fn guest_memory_access_validation_rejects_aarch64_mmio64_gap() {
+        let size_before_gap = aarch64::MMIO64_MEM_START - aarch64::DRAM_MEM_START;
+        let layout = aarch64::dram_layout(size_before_gap + PAGE_SIZE)
+            .expect("split aarch64 layout should be valid");
+        let drop_count = Arc::new(AtomicUsize::new(0));
+        let mut mapper = CountingMapper {
+            maps: 0,
+            drop_count: Arc::clone(&drop_count),
+        };
+        let memory = GuestMemory::allocate_with_mapper(&layout, PAGE_SIZE, &mut mapper)
+            .expect("fake guest memory allocation should succeed");
+        let access_range = range(aarch64::MMIO64_MEM_START - 1, 2);
+
+        assert_eq!(
+            memory.validate_mapped_range(access_range),
+            Err(GuestMemoryAccessError::UnmappedRange {
+                range: access_range
+            })
+        );
+        assert_eq!(mapper.maps, 2);
+        assert_eq!(drop_count.load(Ordering::Relaxed), 0);
+
+        drop(memory);
+
+        assert_eq!(drop_count.load(Ordering::Relaxed), 2);
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -236,7 +236,7 @@ evaluate the right abstraction from its concrete requirements.
 
 Guest memory byte access validates the whole requested guest address range
 before copying. Overflow, unmapped holes, and the aarch64 MMIO64 gap fail
-without a partial write, while zero-length reads and writes are no-ops. This
+without partial copies, while zero-length reads and writes are no-ops. This
 gives later boot-loading code a safe runtime-owned path for copying kernel,
 initrd, command line, and FDT bytes without exposing additional raw host-memory
 pointers.

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -7,7 +7,8 @@ the current scaffold implements all listed API behavior.
 The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /` and `GET /version`, a backend-neutral VM
 trait, a minimal read-only VMM action/data model, backend-neutral guest
-physical address and aarch64 DRAM layout primitives, a minimal
+physical address and aarch64 DRAM layout/access primitives, arm64 boot
+placement helpers, a minimal
 Hypervisor.framework VM create/destroy wrapper, a current-thread HVF vCPU
 create/destroy wrapper, typed HVF exit surface, narrow vCPU register wrappers,
 anonymous guest memory allocation for validated runtime layouts, HVF guest
@@ -214,8 +215,9 @@ setup, memory size, and block device I/O when those surfaces are implemented.
 The runtime crate models the backend-neutral guest physical address space used
 by later allocation, HVF mapping, boot, and device work. The current model
 contains guest physical addresses, checked RAM ranges, ordered non-overlapping
-layouts, the first aarch64 DRAM layout helper, and owned anonymous host memory
-allocation for validated page-aligned layouts.
+layouts, the first aarch64 DRAM layout and boot placement helpers, safe byte
+slice access by guest address, and owned anonymous host memory allocation for
+validated page-aligned layouts.
 
 The aarch64 layout helper follows Firecracker's `v1.16.0` ARM layout shape:
 
@@ -231,6 +233,21 @@ runtime ownership cleanup. It preserves each guest range with its host mapping
 for HVF map/unmap work. It does not use Firecracker's `vm-memory` crate; future
 device-memory, dirty-tracking, snapshot, or file-backed-memory work should
 evaluate the right abstraction from its concrete requirements.
+
+Guest memory byte access validates the whole requested guest address range
+before copying. Overflow, unmapped holes, and the aarch64 MMIO64 gap fail
+without a partial write, while zero-length reads and writes are no-ops. This
+gives later boot-loading code a safe runtime-owned path for copying kernel,
+initrd, command line, and FDT bytes without exposing additional raw host-memory
+pointers.
+
+The first arm64 placement helpers match Firecracker's published aarch64 layout
+shape: system memory occupies the first 2 MiB of DRAM, the kernel load address
+starts at `0x8020_0000`, command lines are capped at 2048 bytes, the FDT window
+is 2 MiB at the end of the first DRAM range when there is room, and initrd
+placement is page-aligned immediately before the FDT window when it fits. A
+zero-byte initrd resolves to the FDT address, matching Firecracker's helper
+behavior.
 
 The HVF backend can map allocated guest memory regions into an existing
 Hypervisor.framework VM with read/write/execute guest RAM permissions. The

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -243,10 +243,10 @@ pointers.
 
 The first arm64 placement helpers match Firecracker's published aarch64 layout
 shape: system memory occupies the first 2 MiB of DRAM, the kernel load address
-starts at `0x8020_0000`, command lines are capped at 2048 bytes, the FDT window
-is 2 MiB at the end of the first DRAM range when there is room, and initrd
-placement is page-aligned immediately before the FDT window when it fits. A
-zero-byte initrd resolves to the FDT address, matching Firecracker's helper
+starts at `0x8020_0000`, the command-line size constant is 2048 bytes, the FDT
+window is 2 MiB at the end of the first DRAM range when there is room, and
+initrd placement is page-aligned immediately before the FDT window when it fits.
+A zero-byte initrd resolves to the FDT address, matching Firecracker's helper
 behavior.
 
 The HVF backend can map allocated guest memory regions into an existing


### PR DESCRIPTION
## Summary
- add safe guest memory byte-slice read/write APIs with full-range validation before copying
- add Firecracker-aligned arm64 kernel, FDT, command line, and initrd placement helpers
- document the new runtime scope and guest memory compatibility behavior

Closes #71

## Verification
- cargo fmt --all -- --check
- cargo check --workspace --all-targets --all-features --locked
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- scripts/run-hvf-tests.sh --allow-unsupported