### PR TITLE
feat: add HVF GIC boot metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 bangbang is a Rust VMM project for macOS hosts. The public control plane is intended to stay compatible with the Firecracker HTTP API over a Unix domain socket, while the VM backend is built on Apple's Hypervisor.framework.
 
-This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, a backend-neutral guest address/layout model, anonymous guest memory allocation and byte access, arm64 boot placement helpers, internal boot-source validation with arm64 kernel/initrd payload loading, and the smallest Hypervisor.framework VM, guest memory map/unmap ownership, current-thread vCPU lifecycle, typed exit surface, register wrappers, and cancellable vCPU runner skeleton.
+This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, a backend-neutral guest address/layout model, anonymous guest memory allocation and byte access, arm64 boot placement helpers, internal boot-source validation with arm64 kernel/initrd payload loading, and the smallest Hypervisor.framework VM, GIC boot metadata, guest memory map/unmap ownership, current-thread vCPU lifecycle, typed exit surface, register wrappers, and cancellable vCPU runner skeleton.
 
 See [Firecracker Compatibility Scope](docs/firecracker-compatibility.md) for the intended compatibility target and current limitations.
 See [Pull Request Review Guidelines](docs/review-guidelines.md) for the project-specific review standard.
@@ -18,13 +18,13 @@ crates/bangbang   VMM process entrypoint and startup CLI
 
 ## Current Scope
 
-The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. The runtime crate defines guest physical address, range, and aarch64 DRAM layout primitives, can allocate owned anonymous host memory for validated page-aligned guest memory layouts, can safely read/write byte slices by guest address, exposes the first arm64 kernel/FDT/initrd placement helpers, and can internally validate a Firecracker-shaped boot source before loading a supported arm64 Linux `Image` kernel plus optional non-empty initrd into guest memory. The HVF crate can create/destroy a process VM, map/unmap allocated guest memory with backend-owned cleanup, create/destroy one current-thread vCPU handle, define typed HVF exit snapshots, get/set a narrow set of vCPU registers, and start a thread-owned runner that can cancel a single `hv_vcpu_run` step. It intentionally does not include:
+The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. The runtime crate defines guest physical address, range, and aarch64 DRAM layout primitives, can allocate owned anonymous host memory for validated page-aligned guest memory layouts, can safely read/write byte slices by guest address, exposes the first arm64 kernel/FDT/initrd placement helpers, and can internally validate a Firecracker-shaped boot source before loading a supported arm64 Linux `Image` kernel plus optional non-empty initrd into guest memory. The HVF crate can create/destroy a process VM, create macOS 15+ GIC v3 boot metadata without MSI/ITS, map/unmap allocated guest memory with backend-owned cleanup, create/destroy one current-thread vCPU handle, define typed HVF exit snapshots, get/set a narrow set of vCPU registers, and start a thread-owned runner that can cancel a single `hv_vcpu_run` step. It intentionally does not include:
 
 - API endpoints beyond `GET /` and `GET /version`
 - public JSON request body models for machine config, boot source, drives, or actions
 - public `/boot-source` behavior
 - command-line or FDT writes into guest memory
-- configured guest execution, continuous vCPU run loops, MMIO/device emulation, or boot register setup
+- interrupt injection, configured guest execution, continuous vCPU run loops, MMIO/device emulation, or boot register setup
 
 ## Process CLI
 
@@ -83,7 +83,7 @@ cargo test -p bangbang-hvf --lib --all-features --locked
 ```
 
 On macOS Apple Silicon hosts, `bangbang-hvf` contains real HVF lifecycle,
-guest memory mapping, and runner smoke tests in
+GIC creation, guest memory mapping, and runner smoke tests in
 `crates/hvf/tests/hvf_lifecycle.rs`. The tests are not ignored; run the signed
 test wrapper so host or entitlement failures fail the test run:
 

--- a/crates/hvf/src/backend.rs
+++ b/crates/hvf/src/backend.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use bangbang_runtime::memory::GuestMemory;
 use bangbang_runtime::{BackendError, VmBackend};
 
+use crate::gic::{HvfGicCreator, HvfGicError, HvfGicMetadata, RealHvfGicCreator};
 use crate::memory::{
     HvfGuestMemoryMapping, HvfGuestMemoryMappingError, HvfMemoryMapper, HvfMemoryPermissions,
     RealHvfMemoryMapper,
@@ -12,12 +13,18 @@ use crate::vcpu::HvfVcpu;
 
 const VM_NOT_CREATED_FOR_MEMORY_MESSAGE: &str = "VM must be created before mapping guest memory";
 const GUEST_MEMORY_ALREADY_MAPPED_MESSAGE: &str = "guest memory is already mapped";
+const VM_NOT_CREATED_FOR_GIC_MESSAGE: &str = "VM must be created before creating a GIC";
+const GIC_ALREADY_CREATED_MESSAGE: &str = "GIC is already created";
+const VCPU_TOPOLOGY_ALREADY_STARTED_MESSAGE: &str = "GIC must be created before creating vCPUs";
 
 #[derive(Debug)]
 pub struct HvfBackend {
     vm_created: bool,
     guest_memory: Option<HvfGuestMemoryMapping>,
+    gic: Option<HvfGicMetadata>,
+    vcpu_topology_started: bool,
     memory_mapper: Arc<dyn HvfMemoryMapper>,
+    gic_creator: Arc<dyn HvfGicCreator>,
 }
 
 impl Default for HvfBackend {
@@ -25,7 +32,10 @@ impl Default for HvfBackend {
         Self {
             vm_created: false,
             guest_memory: None,
+            gic: None,
+            vcpu_topology_started: false,
             memory_mapper: Arc::new(RealHvfMemoryMapper),
+            gic_creator: Arc::new(RealHvfGicCreator),
         }
     }
 }
@@ -60,6 +70,20 @@ impl HvfBackend {
         Ok(())
     }
 
+    pub fn create_gic(&mut self) -> Result<&HvfGicMetadata, HvfGicError> {
+        if !Self::is_supported_target() {
+            return Err(HvfGicError::Unsupported(
+                crate::ffi::UNSUPPORTED_TARGET_MESSAGE,
+            ));
+        }
+
+        self.create_gic_with_configured_creator()
+    }
+
+    pub fn gic_metadata(&self) -> Option<&HvfGicMetadata> {
+        self.gic.as_ref()
+    }
+
     #[cfg(test)]
     fn has_guest_memory_mapping(&self) -> bool {
         self.guest_memory
@@ -80,10 +104,11 @@ impl HvfBackend {
             ));
         }
 
+        self.vcpu_topology_started = true;
         HvfVcpu::new(self)
     }
 
-    pub fn start_vcpu_runner(&self) -> Result<HvfVcpuRunner<'_>, HvfVcpuRunnerError> {
+    pub fn start_vcpu_runner(&mut self) -> Result<HvfVcpuRunner<'_>, HvfVcpuRunnerError> {
         if !Self::is_supported_target() {
             return Err(BackendError::Unsupported(crate::ffi::UNSUPPORTED_TARGET_MESSAGE).into());
         }
@@ -95,7 +120,36 @@ impl HvfBackend {
             .into());
         }
 
+        self.vcpu_topology_started = true;
         HvfVcpuRunner::new(self)
+    }
+
+    fn create_gic_with_configured_creator(&mut self) -> Result<&HvfGicMetadata, HvfGicError> {
+        if !self.vm_created {
+            return Err(HvfGicError::InvalidState(VM_NOT_CREATED_FOR_GIC_MESSAGE));
+        }
+
+        if self.gic.is_some() {
+            return Err(HvfGicError::InvalidState(GIC_ALREADY_CREATED_MESSAGE));
+        }
+
+        if self.vcpu_topology_started {
+            return Err(HvfGicError::InvalidState(
+                VCPU_TOPOLOGY_ALREADY_STARTED_MESSAGE,
+            ));
+        }
+
+        let metadata = self.gic_creator.create_gic()?;
+        self.gic = Some(metadata);
+
+        self.gic
+            .as_ref()
+            .ok_or(HvfGicError::InvalidState("created GIC metadata is missing"))
+    }
+
+    fn clear_vm_owned_state(&mut self) {
+        self.gic = None;
+        self.vcpu_topology_started = false;
     }
 
     fn map_guest_memory_with_configured_mapper(
@@ -139,7 +193,22 @@ impl HvfBackend {
         Self {
             vm_created: false,
             guest_memory: None,
+            gic: None,
+            vcpu_topology_started: false,
             memory_mapper,
+            gic_creator: Arc::new(RealHvfGicCreator),
+        }
+    }
+
+    #[cfg(test)]
+    fn new_with_gic_creator(gic_creator: Arc<dyn HvfGicCreator>) -> Self {
+        Self {
+            vm_created: false,
+            guest_memory: None,
+            gic: None,
+            vcpu_topology_started: false,
+            memory_mapper: Arc::new(RealHvfMemoryMapper),
+            gic_creator,
         }
     }
 }
@@ -161,6 +230,7 @@ impl VmBackend for HvfBackend {
                 .map_err(|err| BackendError::Hypervisor(err.to_string()))?;
             crate::ffi::destroy_vm()?;
             self.vm_created = false;
+            self.clear_vm_owned_state();
         }
         Ok(())
     }
@@ -178,6 +248,7 @@ impl Drop for HvfBackend {
             }
             let vm_destroyed = crate::ffi::destroy_vm().is_ok();
             self.vm_created = false;
+            self.clear_vm_owned_state();
 
             if vm_destroyed && let Some(mapping) = mapping_after_failed_unmap {
                 mapping.release_after_vm_destroy();
@@ -217,6 +288,31 @@ mod tests {
         host_page_size().expect("host page size should be available for tests")
     }
 
+    fn gic_metadata() -> crate::gic::HvfGicMetadata {
+        crate::gic::HvfGicMetadata {
+            distributor: crate::gic::HvfGicRegion {
+                base: 0x3fff_0000,
+                size: 0x1_0000,
+            },
+            redistributor: crate::gic::HvfGicRedistributor {
+                region: crate::gic::HvfGicRegion {
+                    base: 0x3ffd_0000,
+                    size: 0x2_0000,
+                },
+                single_redistributor_size: 0x2_0000,
+            },
+            spi_interrupt_range: crate::gic::HvfGicInterruptRange {
+                base: 32,
+                count: 96,
+            },
+            timer_interrupts: crate::gic::HvfGicTimerInterrupts {
+                el1_virtual_timer_intid: 27,
+                el1_physical_timer_intid: 30,
+            },
+            msi: None,
+        }
+    }
+
     #[test]
     fn supported_target_matches_compile_target() {
         assert_eq!(
@@ -247,7 +343,7 @@ mod tests {
 
     #[test]
     fn start_vcpu_runner_before_vm_reports_state_or_target_error() {
-        let backend = HvfBackend::new();
+        let mut backend = HvfBackend::new();
         let err = backend
             .start_vcpu_runner()
             .expect_err("starting a vCPU runner before VM creation should fail");
@@ -267,6 +363,90 @@ mod tests {
                 ))
             );
         }
+    }
+
+    #[test]
+    fn create_gic_before_vm_reports_state_error_without_calling_creator() {
+        let creator = Arc::new(RecordingGicCreator::with_metadata(gic_metadata()));
+        let mut backend = HvfBackend::new_with_gic_creator(creator.clone());
+
+        assert_eq!(
+            backend.create_gic_with_configured_creator(),
+            Err(crate::gic::HvfGicError::InvalidState(
+                super::VM_NOT_CREATED_FOR_GIC_MESSAGE
+            ))
+        );
+        assert_eq!(creator.create_count(), 0);
+        assert_eq!(backend.gic_metadata(), None);
+    }
+
+    #[test]
+    fn duplicate_gic_creation_is_rejected_without_calling_creator_again() {
+        let creator = Arc::new(RecordingGicCreator::with_metadata(gic_metadata()));
+        let mut backend = HvfBackend::new_with_gic_creator(creator.clone());
+        backend.vm_created = true;
+
+        assert_eq!(
+            backend.create_gic_with_configured_creator(),
+            Ok(&gic_metadata())
+        );
+        assert_eq!(
+            backend.create_gic_with_configured_creator(),
+            Err(crate::gic::HvfGicError::InvalidState(
+                super::GIC_ALREADY_CREATED_MESSAGE
+            ))
+        );
+        assert_eq!(creator.create_count(), 1);
+        assert_eq!(backend.gic_metadata(), Some(&gic_metadata()));
+    }
+
+    #[test]
+    fn failed_gic_creation_does_not_store_metadata() {
+        let creator = Arc::new(RecordingGicCreator::with_error(
+            crate::gic::HvfGicError::Backend(BackendError::Hypervisor(
+                "injected GIC failure".to_string(),
+            )),
+        ));
+        let mut backend = HvfBackend::new_with_gic_creator(creator.clone());
+        backend.vm_created = true;
+
+        assert_eq!(
+            backend.create_gic_with_configured_creator(),
+            Err(crate::gic::HvfGicError::Backend(BackendError::Hypervisor(
+                "injected GIC failure".to_string()
+            )))
+        );
+        assert_eq!(creator.create_count(), 1);
+        assert_eq!(backend.gic_metadata(), None);
+    }
+
+    #[test]
+    fn gic_creation_after_vcpu_topology_started_is_rejected() {
+        let creator = Arc::new(RecordingGicCreator::with_metadata(gic_metadata()));
+        let mut backend = HvfBackend::new_with_gic_creator(creator.clone());
+        backend.vm_created = true;
+        backend.vcpu_topology_started = true;
+
+        assert_eq!(
+            backend.create_gic_with_configured_creator(),
+            Err(crate::gic::HvfGicError::InvalidState(
+                super::VCPU_TOPOLOGY_ALREADY_STARTED_MESSAGE
+            ))
+        );
+        assert_eq!(creator.create_count(), 0);
+        assert_eq!(backend.gic_metadata(), None);
+    }
+
+    #[test]
+    fn clearing_vm_owned_state_removes_gic_metadata_and_topology_flag() {
+        let mut backend = HvfBackend::new();
+        backend.gic = Some(gic_metadata());
+        backend.vcpu_topology_started = true;
+
+        backend.clear_vm_owned_state();
+
+        assert_eq!(backend.gic_metadata(), None);
+        assert!(!backend.vcpu_topology_started);
     }
 
     #[test]
@@ -469,5 +649,44 @@ mod tests {
         maps: usize,
         unmaps: usize,
         fail_unmap: bool,
+    }
+
+    #[derive(Debug)]
+    struct RecordingGicCreator {
+        result: Result<crate::gic::HvfGicMetadata, crate::gic::HvfGicError>,
+        create_count: Mutex<usize>,
+    }
+
+    impl RecordingGicCreator {
+        fn with_metadata(metadata: crate::gic::HvfGicMetadata) -> Self {
+            Self {
+                result: Ok(metadata),
+                create_count: Mutex::new(0),
+            }
+        }
+
+        fn with_error(error: crate::gic::HvfGicError) -> Self {
+            Self {
+                result: Err(error),
+                create_count: Mutex::new(0),
+            }
+        }
+
+        fn create_count(&self) -> usize {
+            *self
+                .create_count
+                .lock()
+                .expect("create count lock should not be poisoned")
+        }
+    }
+
+    impl crate::gic::HvfGicCreator for RecordingGicCreator {
+        fn create_gic(&self) -> Result<crate::gic::HvfGicMetadata, crate::gic::HvfGicError> {
+            *self
+                .create_count
+                .lock()
+                .expect("create count lock should not be poisoned") += 1;
+            self.result.clone()
+        }
     }
 }

--- a/crates/hvf/src/backend.rs
+++ b/crates/hvf/src/backend.rs
@@ -572,6 +572,20 @@ mod tests {
         );
     }
 
+    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+    #[test]
+    fn unsupported_target_rejects_gic_creation() {
+        let mut backend = HvfBackend::new();
+
+        assert_eq!(
+            backend.create_gic(),
+            Err(crate::gic::HvfGicError::Unsupported(
+                crate::ffi::UNSUPPORTED_TARGET_MESSAGE
+            ))
+        );
+        assert_eq!(backend.gic_metadata(), None);
+    }
+
     #[derive(Debug)]
     struct RecordingMapper {
         state: Mutex<RecordingMapperState>,

--- a/crates/hvf/src/backend.rs
+++ b/crates/hvf/src/backend.rs
@@ -104,8 +104,9 @@ impl HvfBackend {
             ));
         }
 
+        let vcpu = HvfVcpu::new()?;
         self.vcpu_topology_started = true;
-        HvfVcpu::new(self)
+        Ok(vcpu)
     }
 
     pub fn start_vcpu_runner(&mut self) -> Result<HvfVcpuRunner<'_>, HvfVcpuRunnerError> {
@@ -120,8 +121,9 @@ impl HvfBackend {
             .into());
         }
 
+        let runner = HvfVcpuRunner::new()?;
         self.vcpu_topology_started = true;
-        HvfVcpuRunner::new(self)
+        Ok(runner)
     }
 
     fn create_gic_with_configured_creator(&mut self) -> Result<&HvfGicMetadata, HvfGicError> {

--- a/crates/hvf/src/gic.rs
+++ b/crates/hvf/src/gic.rs
@@ -13,6 +13,7 @@ const DYNAMIC_SYMBOL_SIZE_MISMATCH_MESSAGE: &str =
 
 const HV_GIC_INT_EL1_VIRTUAL_TIMER: u16 = 27;
 const HV_GIC_INT_EL1_PHYSICAL_TIMER: u16 = 30;
+const FIRST_SPI_INTID: u32 = 32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HvfGicRegion {
@@ -279,6 +280,7 @@ fn metadata_from_parameters(parameters: HvfGicParameters) -> Result<HvfGicMetada
             value: parameters.redistributor_size,
         });
     }
+    validate_spi_interrupt_range(parameters.spi_interrupt_range)?;
 
     let distributor = aligned_region_below(
         "distributor",
@@ -330,6 +332,29 @@ fn validate_parameter(
     } else {
         Err(HvfGicError::InvalidParameter { name, value })
     }
+}
+
+fn validate_spi_interrupt_range(range: HvfGicInterruptRange) -> Result<(), HvfGicError> {
+    if range.base < FIRST_SPI_INTID {
+        return Err(HvfGicError::InvalidParameter {
+            name: "spi_interrupt_range.base",
+            value: u64::from(range.base),
+        });
+    }
+    if range.count == 0 {
+        return Err(HvfGicError::InvalidParameter {
+            name: "spi_interrupt_range.count",
+            value: 0,
+        });
+    }
+    if range.base.checked_add(range.count).is_none() {
+        return Err(HvfGicError::InvalidParameter {
+            name: "spi_interrupt_range.end_exclusive",
+            value: u64::from(range.base) + u64::from(range.count),
+        });
+    }
+
+    Ok(())
 }
 
 fn aligned_region_below(
@@ -893,6 +918,60 @@ mod tests {
             HvfGicError::InvalidParameter {
                 name: "redistributor_size",
                 value: 0x2_0000,
+            }
+        );
+    }
+
+    #[test]
+    fn metadata_rejects_non_spi_interrupt_range_base() {
+        let err = metadata_from_parameters(HvfGicParameters {
+            spi_interrupt_range: HvfGicInterruptRange { base: 31, count: 1 },
+            ..default_parameters()
+        })
+        .expect_err("SPI range base below the first SPI INTID should fail");
+
+        assert_eq!(
+            err,
+            HvfGicError::InvalidParameter {
+                name: "spi_interrupt_range.base",
+                value: 31,
+            }
+        );
+    }
+
+    #[test]
+    fn metadata_rejects_zero_spi_interrupt_count_before_config_creation() {
+        let api = FakeGicApi::new(HvfGicParameters {
+            spi_interrupt_range: HvfGicInterruptRange { base: 32, count: 0 },
+            ..default_parameters()
+        });
+
+        assert_eq!(
+            create_gic_with_api(&api),
+            Err(HvfGicError::InvalidParameter {
+                name: "spi_interrupt_range.count",
+                value: 0,
+            })
+        );
+        assert!(!api.created_config());
+    }
+
+    #[test]
+    fn metadata_rejects_spi_interrupt_range_overflow() {
+        let err = metadata_from_parameters(HvfGicParameters {
+            spi_interrupt_range: HvfGicInterruptRange {
+                base: u32::MAX,
+                count: 2,
+            },
+            ..default_parameters()
+        })
+        .expect_err("SPI range end should not overflow");
+
+        assert_eq!(
+            err,
+            HvfGicError::InvalidParameter {
+                name: "spi_interrupt_range.end_exclusive",
+                value: u64::from(u32::MAX) + 2,
             }
         );
     }

--- a/crates/hvf/src/gic.rs
+++ b/crates/hvf/src/gic.rs
@@ -1,0 +1,1169 @@
+//! HVF GIC v3 creation and metadata for later boot/FDT setup.
+
+use std::fmt;
+
+use bangbang_runtime::BackendError;
+
+const GIC_REQUIRES_MACOS_15_MESSAGE: &str =
+    "Hypervisor.framework GIC APIs require macOS 15.0 or newer";
+const MMIO32_MEM_START: u64 = 1 << 30;
+const DRAM_MEM_START: u64 = bangbang_runtime::memory::aarch64::DRAM_MEM_START;
+const DYNAMIC_SYMBOL_SIZE_MISMATCH_MESSAGE: &str =
+    "function pointer size does not match a dynamic symbol pointer";
+
+const HV_GIC_INT_EL1_VIRTUAL_TIMER: u16 = 27;
+const HV_GIC_INT_EL1_PHYSICAL_TIMER: u16 = 30;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HvfGicRegion {
+    pub base: u64,
+    pub size: u64,
+}
+
+impl HvfGicRegion {
+    pub const fn end_exclusive(self) -> u64 {
+        self.base.saturating_add(self.size)
+    }
+
+    const fn overlaps(self, other: Self) -> bool {
+        self.base < other.end_exclusive() && other.base < self.end_exclusive()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HvfGicInterruptRange {
+    pub base: u32,
+    pub count: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HvfGicTimerInterrupts {
+    pub el1_virtual_timer_intid: u32,
+    pub el1_physical_timer_intid: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HvfGicRedistributor {
+    pub region: HvfGicRegion,
+    pub single_redistributor_size: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HvfGicMsiMetadata {
+    pub region: HvfGicRegion,
+    pub interrupt_range: HvfGicInterruptRange,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HvfGicMetadata {
+    pub distributor: HvfGicRegion,
+    pub redistributor: HvfGicRedistributor,
+    pub spi_interrupt_range: HvfGicInterruptRange,
+    pub timer_interrupts: HvfGicTimerInterrupts,
+    pub msi: Option<HvfGicMsiMetadata>,
+}
+
+impl HvfGicMetadata {
+    pub const FDT_COMPATIBILITY: &'static str = "arm,gic-v3";
+    pub const FDT_INTERRUPT_CELLS: u32 = 3;
+    pub const FDT_MAINTENANCE_IRQ: u32 = 9;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HvfGicError {
+    Backend(BackendError),
+    Unsupported(&'static str),
+    InvalidState(&'static str),
+    MissingSymbol(&'static str),
+    ConfigCreateFailed,
+    InvalidParameter {
+        name: &'static str,
+        value: u64,
+    },
+    AddressUnderflow {
+        region: &'static str,
+        limit: u64,
+        size: u64,
+    },
+    UnalignedAddress {
+        region: &'static str,
+        address: u64,
+        alignment: u64,
+    },
+    RegionOverlap {
+        first: &'static str,
+        second: &'static str,
+    },
+    RegionOverlapsDram {
+        region: &'static str,
+        end_exclusive: u64,
+        dram_start: u64,
+    },
+}
+
+impl fmt::Display for HvfGicError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Backend(source) => write!(f, "{source}"),
+            Self::Unsupported(message) => write!(f, "unsupported GIC setup: {message}"),
+            Self::InvalidState(message) => write!(f, "invalid GIC state: {message}"),
+            Self::MissingSymbol(symbol) => write!(
+                f,
+                "Hypervisor.framework GIC symbol {symbol} is unavailable; macOS 15.0 or newer is required"
+            ),
+            Self::ConfigCreateFailed => {
+                f.write_str("failed to create Hypervisor.framework GIC configuration")
+            }
+            Self::InvalidParameter { name, value } => {
+                write!(
+                    f,
+                    "invalid Hypervisor.framework GIC parameter {name}={value}"
+                )
+            }
+            Self::AddressUnderflow {
+                region,
+                limit,
+                size,
+            } => write!(
+                f,
+                "GIC {region} region of {size} bytes cannot fit below 0x{limit:x}"
+            ),
+            Self::UnalignedAddress {
+                region,
+                address,
+                alignment,
+            } => write!(
+                f,
+                "GIC {region} base 0x{address:x} is not aligned to {alignment} bytes"
+            ),
+            Self::RegionOverlap { first, second } => {
+                write!(f, "GIC {first} region overlaps {second} region")
+            }
+            Self::RegionOverlapsDram {
+                region,
+                end_exclusive,
+                dram_start,
+            } => write!(
+                f,
+                "GIC {region} region ending at 0x{end_exclusive:x} overlaps DRAM starting at 0x{dram_start:x}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for HvfGicError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Backend(source) => Some(source),
+            Self::Unsupported(_)
+            | Self::InvalidState(_)
+            | Self::MissingSymbol(_)
+            | Self::ConfigCreateFailed
+            | Self::InvalidParameter { .. }
+            | Self::AddressUnderflow { .. }
+            | Self::UnalignedAddress { .. }
+            | Self::RegionOverlap { .. }
+            | Self::RegionOverlapsDram { .. } => None,
+        }
+    }
+}
+
+impl From<BackendError> for HvfGicError {
+    fn from(source: BackendError) -> Self {
+        Self::Backend(source)
+    }
+}
+
+pub(crate) trait HvfGicCreator: fmt::Debug + Send + Sync {
+    fn create_gic(&self) -> Result<HvfGicMetadata, HvfGicError>;
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct RealHvfGicCreator;
+
+#[derive(Debug, Clone, Copy)]
+struct HvfGicParameters {
+    distributor_size: u64,
+    distributor_alignment: u64,
+    redistributor_region_size: u64,
+    redistributor_size: u64,
+    redistributor_alignment: u64,
+    spi_interrupt_range: HvfGicInterruptRange,
+    timer_interrupts: HvfGicTimerInterrupts,
+}
+
+trait HvfGicApi {
+    type Config;
+
+    fn distributor_size(&self) -> Result<u64, HvfGicError>;
+    fn distributor_alignment(&self) -> Result<u64, HvfGicError>;
+    fn redistributor_region_size(&self) -> Result<u64, HvfGicError>;
+    fn redistributor_size(&self) -> Result<u64, HvfGicError>;
+    fn redistributor_alignment(&self) -> Result<u64, HvfGicError>;
+    fn spi_interrupt_range(&self) -> Result<HvfGicInterruptRange, HvfGicError>;
+    fn intid(&self, interrupt: u16) -> Result<u32, HvfGicError>;
+    fn create_config(&self) -> Result<Self::Config, HvfGicError>;
+    fn set_distributor_base(&self, config: &mut Self::Config, base: u64)
+    -> Result<(), HvfGicError>;
+    fn set_redistributor_base(
+        &self,
+        config: &mut Self::Config,
+        base: u64,
+    ) -> Result<(), HvfGicError>;
+    fn create_gic(&self, config: &Self::Config) -> Result<(), HvfGicError>;
+    fn release_config(&self, config: Self::Config);
+}
+
+impl HvfGicCreator for RealHvfGicCreator {
+    fn create_gic(&self) -> Result<HvfGicMetadata, HvfGicError> {
+        create_real_gic()
+    }
+}
+
+fn create_gic_with_api(api: &impl HvfGicApi) -> Result<HvfGicMetadata, HvfGicError> {
+    let parameters = query_parameters(api)?;
+    let metadata = metadata_from_parameters(parameters)?;
+    let mut config = GicConfigGuard::new(api)?;
+
+    api.set_distributor_base(config.config_mut()?, metadata.distributor.base)?;
+    api.set_redistributor_base(config.config_mut()?, metadata.redistributor.region.base)?;
+    api.create_gic(config.config()?)?;
+
+    Ok(metadata)
+}
+
+fn query_parameters(api: &impl HvfGicApi) -> Result<HvfGicParameters, HvfGicError> {
+    Ok(HvfGicParameters {
+        distributor_size: api.distributor_size()?,
+        distributor_alignment: api.distributor_alignment()?,
+        redistributor_region_size: api.redistributor_region_size()?,
+        redistributor_size: api.redistributor_size()?,
+        redistributor_alignment: api.redistributor_alignment()?,
+        spi_interrupt_range: api.spi_interrupt_range()?,
+        timer_interrupts: HvfGicTimerInterrupts {
+            el1_virtual_timer_intid: api.intid(HV_GIC_INT_EL1_VIRTUAL_TIMER)?,
+            el1_physical_timer_intid: api.intid(HV_GIC_INT_EL1_PHYSICAL_TIMER)?,
+        },
+    })
+}
+
+fn metadata_from_parameters(parameters: HvfGicParameters) -> Result<HvfGicMetadata, HvfGicError> {
+    validate_parameter(
+        "distributor_size",
+        parameters.distributor_size,
+        ParameterRule::NonZero,
+    )?;
+    validate_parameter(
+        "distributor_base_alignment",
+        parameters.distributor_alignment,
+        ParameterRule::PowerOfTwo,
+    )?;
+    validate_parameter(
+        "redistributor_region_size",
+        parameters.redistributor_region_size,
+        ParameterRule::NonZero,
+    )?;
+    validate_parameter(
+        "redistributor_size",
+        parameters.redistributor_size,
+        ParameterRule::NonZero,
+    )?;
+    validate_parameter(
+        "redistributor_base_alignment",
+        parameters.redistributor_alignment,
+        ParameterRule::PowerOfTwo,
+    )?;
+    if parameters.redistributor_size > parameters.redistributor_region_size {
+        return Err(HvfGicError::InvalidParameter {
+            name: "redistributor_size",
+            value: parameters.redistributor_size,
+        });
+    }
+
+    let distributor = aligned_region_below(
+        "distributor",
+        MMIO32_MEM_START,
+        parameters.distributor_size,
+        parameters.distributor_alignment,
+    )?;
+    let redistributor = aligned_region_below(
+        "redistributor",
+        distributor.base,
+        parameters.redistributor_region_size,
+        parameters.redistributor_alignment,
+    )?;
+
+    validate_regions_do_not_overlap("distributor", distributor, "redistributor", redistributor)?;
+    validate_region_below_dram("distributor", distributor)?;
+    validate_region_below_dram("redistributor", redistributor)?;
+
+    Ok(HvfGicMetadata {
+        distributor,
+        redistributor: HvfGicRedistributor {
+            region: redistributor,
+            single_redistributor_size: parameters.redistributor_size,
+        },
+        spi_interrupt_range: parameters.spi_interrupt_range,
+        timer_interrupts: parameters.timer_interrupts,
+        msi: None,
+    })
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ParameterRule {
+    NonZero,
+    PowerOfTwo,
+}
+
+fn validate_parameter(
+    name: &'static str,
+    value: u64,
+    rule: ParameterRule,
+) -> Result<(), HvfGicError> {
+    let valid = match rule {
+        ParameterRule::NonZero => value != 0,
+        ParameterRule::PowerOfTwo => value != 0 && value.is_power_of_two(),
+    };
+
+    if valid {
+        Ok(())
+    } else {
+        Err(HvfGicError::InvalidParameter { name, value })
+    }
+}
+
+fn aligned_region_below(
+    region: &'static str,
+    limit: u64,
+    size: u64,
+    alignment: u64,
+) -> Result<HvfGicRegion, HvfGicError> {
+    let Some(unadjusted_base) = limit.checked_sub(size) else {
+        return Err(HvfGicError::AddressUnderflow {
+            region,
+            limit,
+            size,
+        });
+    };
+
+    let base = unadjusted_base & !(alignment - 1);
+    let Some(end_exclusive) = base.checked_add(size) else {
+        return Err(HvfGicError::AddressUnderflow {
+            region,
+            limit,
+            size,
+        });
+    };
+    if end_exclusive > limit {
+        return Err(HvfGicError::AddressUnderflow {
+            region,
+            limit,
+            size,
+        });
+    }
+    if !base.is_multiple_of(alignment) {
+        return Err(HvfGicError::UnalignedAddress {
+            region,
+            address: base,
+            alignment,
+        });
+    }
+
+    Ok(HvfGicRegion { base, size })
+}
+
+fn validate_regions_do_not_overlap(
+    first_name: &'static str,
+    first: HvfGicRegion,
+    second_name: &'static str,
+    second: HvfGicRegion,
+) -> Result<(), HvfGicError> {
+    if first.overlaps(second) {
+        Err(HvfGicError::RegionOverlap {
+            first: first_name,
+            second: second_name,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_region_below_dram(
+    region_name: &'static str,
+    region: HvfGicRegion,
+) -> Result<(), HvfGicError> {
+    if region.end_exclusive() > DRAM_MEM_START {
+        Err(HvfGicError::RegionOverlapsDram {
+            region: region_name,
+            end_exclusive: region.end_exclusive(),
+            dram_start: DRAM_MEM_START,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+struct GicConfigGuard<'api, Api: HvfGicApi + ?Sized> {
+    api: &'api Api,
+    config: Option<Api::Config>,
+}
+
+impl<'api, Api: HvfGicApi + ?Sized> GicConfigGuard<'api, Api> {
+    fn new(api: &'api Api) -> Result<Self, HvfGicError> {
+        Ok(Self {
+            config: Some(api.create_config()?),
+            api,
+        })
+    }
+
+    fn config(&self) -> Result<&Api::Config, HvfGicError> {
+        self.config.as_ref().ok_or(HvfGicError::InvalidState(
+            "GIC config has already been released",
+        ))
+    }
+
+    fn config_mut(&mut self) -> Result<&mut Api::Config, HvfGicError> {
+        self.config.as_mut().ok_or(HvfGicError::InvalidState(
+            "GIC config has already been released",
+        ))
+    }
+}
+
+impl<Api: HvfGicApi + ?Sized> Drop for GicConfigGuard<'_, Api> {
+    fn drop(&mut self) {
+        if let Some(config) = self.config.take() {
+            self.api.release_config(config);
+        }
+    }
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn create_real_gic() -> Result<HvfGicMetadata, HvfGicError> {
+    let api = LoadedHvfGicApi::load()?;
+    create_gic_with_api(&api)
+}
+
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+fn create_real_gic() -> Result<HvfGicMetadata, HvfGicError> {
+    Err(HvfGicError::Unsupported(
+        crate::ffi::UNSUPPORTED_TARGET_MESSAGE,
+    ))
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+mod dynamic {
+    use std::ffi::{CStr, c_void};
+    use std::fmt;
+    use std::mem;
+    use std::ptr::NonNull;
+
+    use super::{DYNAMIC_SYMBOL_SIZE_MISMATCH_MESSAGE, HvfGicError, HvfGicInterruptRange};
+
+    type HvReturn = i32;
+    type HvGicConfig = NonNull<c_void>;
+    type HvGicConfigCreate = unsafe extern "C" fn() -> *mut c_void;
+    type HvGicSetBase = unsafe extern "C" fn(*mut c_void, u64) -> HvReturn;
+    type HvGicCreate = unsafe extern "C" fn(*mut c_void) -> HvReturn;
+    type HvGicGetSize = unsafe extern "C" fn(*mut usize) -> HvReturn;
+    type HvGicGetSpiRange = unsafe extern "C" fn(*mut u32, *mut u32) -> HvReturn;
+    type HvGicGetIntid = unsafe extern "C" fn(u16, *mut u32) -> HvReturn;
+    type OsRelease = unsafe extern "C" fn(*mut c_void);
+
+    const HYPERVISOR_FRAMEWORK_PATH: &CStr =
+        c"/System/Library/Frameworks/Hypervisor.framework/Hypervisor";
+
+    pub(super) struct LoadedHvfGicApi {
+        _library: DynamicLibrary,
+        symbols: HvfGicSymbols,
+    }
+
+    struct DynamicLibrary {
+        handle: NonNull<c_void>,
+    }
+
+    #[derive(Clone, Copy)]
+    struct HvfGicSymbols {
+        config_create: HvGicConfigCreate,
+        config_set_distributor_base: HvGicSetBase,
+        config_set_redistributor_base: HvGicSetBase,
+        create: HvGicCreate,
+        get_distributor_size: HvGicGetSize,
+        get_distributor_base_alignment: HvGicGetSize,
+        get_redistributor_region_size: HvGicGetSize,
+        get_redistributor_size: HvGicGetSize,
+        get_redistributor_base_alignment: HvGicGetSize,
+        get_spi_interrupt_range: HvGicGetSpiRange,
+        get_intid: HvGicGetIntid,
+        os_release: OsRelease,
+    }
+
+    impl LoadedHvfGicApi {
+        pub(super) fn load() -> Result<Self, HvfGicError> {
+            let library = DynamicLibrary::open(HYPERVISOR_FRAMEWORK_PATH)?;
+            let symbols = HvfGicSymbols::load(library.handle())?;
+
+            Ok(Self {
+                _library: library,
+                symbols,
+            })
+        }
+
+        fn get_size(
+            &self,
+            function: HvGicGetSize,
+            operation: &'static str,
+        ) -> Result<u64, HvfGicError> {
+            let mut value = 0usize;
+            // SAFETY: `value` is a valid out-pointer for the duration of the call.
+            unsafe { crate::ffi::check(function(&mut value), operation)? };
+
+            u64::try_from(value).map_err(|_| HvfGicError::InvalidParameter {
+                name: operation,
+                value: u64::MAX,
+            })
+        }
+    }
+
+    impl fmt::Debug for LoadedHvfGicApi {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("LoadedHvfGicApi").finish_non_exhaustive()
+        }
+    }
+
+    impl DynamicLibrary {
+        fn open(path: &CStr) -> Result<Self, HvfGicError> {
+            // SAFETY: `path` is a NUL-terminated static framework path.
+            let handle = unsafe { libc::dlopen(path.as_ptr(), libc::RTLD_LAZY | libc::RTLD_LOCAL) };
+            let handle = NonNull::new(handle).ok_or(HvfGicError::Unsupported(
+                super::GIC_REQUIRES_MACOS_15_MESSAGE,
+            ))?;
+
+            Ok(Self { handle })
+        }
+
+        fn handle(&self) -> NonNull<c_void> {
+            self.handle
+        }
+    }
+
+    impl Drop for DynamicLibrary {
+        fn drop(&mut self) {
+            // SAFETY: `handle` was returned by `dlopen` and is closed exactly once here.
+            unsafe {
+                let _ = libc::dlclose(self.handle.as_ptr());
+            }
+        }
+    }
+
+    impl fmt::Debug for DynamicLibrary {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("DynamicLibrary")
+                .field("handle", &self.handle)
+                .finish()
+        }
+    }
+
+    impl HvfGicSymbols {
+        fn load(library: NonNull<c_void>) -> Result<Self, HvfGicError> {
+            Ok(Self {
+                config_create: load_symbol(
+                    library,
+                    c"hv_gic_config_create",
+                    "hv_gic_config_create",
+                )?,
+                config_set_distributor_base: load_symbol(
+                    library,
+                    c"hv_gic_config_set_distributor_base",
+                    "hv_gic_config_set_distributor_base",
+                )?,
+                config_set_redistributor_base: load_symbol(
+                    library,
+                    c"hv_gic_config_set_redistributor_base",
+                    "hv_gic_config_set_redistributor_base",
+                )?,
+                create: load_symbol(library, c"hv_gic_create", "hv_gic_create")?,
+                get_distributor_size: load_symbol(
+                    library,
+                    c"hv_gic_get_distributor_size",
+                    "hv_gic_get_distributor_size",
+                )?,
+                get_distributor_base_alignment: load_symbol(
+                    library,
+                    c"hv_gic_get_distributor_base_alignment",
+                    "hv_gic_get_distributor_base_alignment",
+                )?,
+                get_redistributor_region_size: load_symbol(
+                    library,
+                    c"hv_gic_get_redistributor_region_size",
+                    "hv_gic_get_redistributor_region_size",
+                )?,
+                get_redistributor_size: load_symbol(
+                    library,
+                    c"hv_gic_get_redistributor_size",
+                    "hv_gic_get_redistributor_size",
+                )?,
+                get_redistributor_base_alignment: load_symbol(
+                    library,
+                    c"hv_gic_get_redistributor_base_alignment",
+                    "hv_gic_get_redistributor_base_alignment",
+                )?,
+                get_spi_interrupt_range: load_symbol(
+                    library,
+                    c"hv_gic_get_spi_interrupt_range",
+                    "hv_gic_get_spi_interrupt_range",
+                )?,
+                get_intid: load_symbol(library, c"hv_gic_get_intid", "hv_gic_get_intid")?,
+                os_release: load_symbol(
+                    NonNull::new(libc::RTLD_DEFAULT)
+                        .ok_or(HvfGicError::MissingSymbol("os_release"))?,
+                    c"os_release",
+                    "os_release",
+                )?,
+            })
+        }
+    }
+
+    fn load_symbol<T: Copy>(
+        handle: NonNull<c_void>,
+        name: &CStr,
+        symbol_name: &'static str,
+    ) -> Result<T, HvfGicError> {
+        if mem::size_of::<T>() != mem::size_of::<*mut c_void>() {
+            return Err(HvfGicError::InvalidState(
+                DYNAMIC_SYMBOL_SIZE_MISMATCH_MESSAGE,
+            ));
+        }
+
+        // SAFETY: `handle` comes from `dlopen` or `RTLD_DEFAULT`, and `name`
+        // is a NUL-terminated static symbol name.
+        let symbol = unsafe { libc::dlsym(handle.as_ptr(), name.as_ptr()) };
+        if symbol.is_null() {
+            return Err(HvfGicError::MissingSymbol(symbol_name));
+        }
+
+        // SAFETY: The caller picks `T` to match the requested symbol's C
+        // function type. Function pointers and dynamic symbol pointers have
+        // the same representation on this target, checked above.
+        Ok(unsafe { mem::transmute_copy::<*mut c_void, T>(&symbol) })
+    }
+
+    impl super::HvfGicApi for LoadedHvfGicApi {
+        type Config = HvGicConfig;
+
+        fn distributor_size(&self) -> Result<u64, HvfGicError> {
+            self.get_size(
+                self.symbols.get_distributor_size,
+                "hv_gic_get_distributor_size",
+            )
+        }
+
+        fn distributor_alignment(&self) -> Result<u64, HvfGicError> {
+            self.get_size(
+                self.symbols.get_distributor_base_alignment,
+                "hv_gic_get_distributor_base_alignment",
+            )
+        }
+
+        fn redistributor_region_size(&self) -> Result<u64, HvfGicError> {
+            self.get_size(
+                self.symbols.get_redistributor_region_size,
+                "hv_gic_get_redistributor_region_size",
+            )
+        }
+
+        fn redistributor_size(&self) -> Result<u64, HvfGicError> {
+            self.get_size(
+                self.symbols.get_redistributor_size,
+                "hv_gic_get_redistributor_size",
+            )
+        }
+
+        fn redistributor_alignment(&self) -> Result<u64, HvfGicError> {
+            self.get_size(
+                self.symbols.get_redistributor_base_alignment,
+                "hv_gic_get_redistributor_base_alignment",
+            )
+        }
+
+        fn spi_interrupt_range(&self) -> Result<HvfGicInterruptRange, HvfGicError> {
+            let mut base = 0;
+            let mut count = 0;
+            // SAFETY: `base` and `count` are valid out-pointers for the duration of the call.
+            unsafe {
+                crate::ffi::check(
+                    (self.symbols.get_spi_interrupt_range)(&mut base, &mut count),
+                    "hv_gic_get_spi_interrupt_range",
+                )?
+            };
+
+            Ok(HvfGicInterruptRange { base, count })
+        }
+
+        fn intid(&self, interrupt: u16) -> Result<u32, HvfGicError> {
+            let mut intid = 0;
+            // SAFETY: `intid` is a valid out-pointer for the duration of the call.
+            unsafe {
+                crate::ffi::check(
+                    (self.symbols.get_intid)(interrupt, &mut intid),
+                    "hv_gic_get_intid",
+                )?
+            };
+
+            Ok(intid)
+        }
+
+        fn create_config(&self) -> Result<Self::Config, HvfGicError> {
+            // SAFETY: Creates a new retained GIC config object per Hypervisor.framework.
+            let config = unsafe { (self.symbols.config_create)() };
+            NonNull::new(config).ok_or(HvfGicError::ConfigCreateFailed)
+        }
+
+        fn set_distributor_base(
+            &self,
+            config: &mut Self::Config,
+            base: u64,
+        ) -> Result<(), HvfGicError> {
+            // SAFETY: `config` is a live GIC config object owned by the guard.
+            unsafe {
+                crate::ffi::check(
+                    (self.symbols.config_set_distributor_base)(config.as_ptr(), base),
+                    "hv_gic_config_set_distributor_base",
+                )?
+            };
+            Ok(())
+        }
+
+        fn set_redistributor_base(
+            &self,
+            config: &mut Self::Config,
+            base: u64,
+        ) -> Result<(), HvfGicError> {
+            // SAFETY: `config` is a live GIC config object owned by the guard.
+            unsafe {
+                crate::ffi::check(
+                    (self.symbols.config_set_redistributor_base)(config.as_ptr(), base),
+                    "hv_gic_config_set_redistributor_base",
+                )?
+            };
+            Ok(())
+        }
+
+        fn create_gic(&self, config: &Self::Config) -> Result<(), HvfGicError> {
+            // SAFETY: The VM is live, and `config` has valid distributor and
+            // redistributor bases configured before this call.
+            unsafe { crate::ffi::check((self.symbols.create)(config.as_ptr()), "hv_gic_create")? };
+            Ok(())
+        }
+
+        fn release_config(&self, config: Self::Config) {
+            // SAFETY: `config` is a retained OS object created by
+            // `hv_gic_config_create` and is released exactly once by the guard.
+            unsafe {
+                (self.symbols.os_release)(config.as_ptr());
+            }
+        }
+    }
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+use dynamic::LoadedHvfGicApi;
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use bangbang_runtime::BackendError;
+
+    use super::{
+        GicConfigGuard, HV_GIC_INT_EL1_PHYSICAL_TIMER, HV_GIC_INT_EL1_VIRTUAL_TIMER, HvfGicApi,
+        HvfGicError, HvfGicInterruptRange, HvfGicMetadata, HvfGicParameters, HvfGicRegion,
+        HvfGicTimerInterrupts, create_gic_with_api, metadata_from_parameters,
+    };
+
+    const DIST_SIZE: u64 = 0x1_0000;
+    const REDIST_REGION_SIZE: u64 = 0x2_0000;
+    const REDIST_SIZE: u64 = 0x2_0000;
+    const ALIGNMENT: u64 = 0x1_0000;
+
+    #[test]
+    fn metadata_places_gic_regions_below_mmio32_start() {
+        let metadata = metadata_from_parameters(default_parameters())
+            .expect("default GIC parameters should produce metadata");
+
+        assert_eq!(
+            metadata.distributor,
+            HvfGicRegion {
+                base: 0x3fff_0000,
+                size: DIST_SIZE
+            }
+        );
+        assert_eq!(
+            metadata.redistributor.region,
+            HvfGicRegion {
+                base: 0x3ffd_0000,
+                size: REDIST_REGION_SIZE
+            }
+        );
+        assert_eq!(
+            metadata.redistributor.single_redistributor_size,
+            REDIST_SIZE
+        );
+        assert_eq!(
+            metadata.spi_interrupt_range,
+            HvfGicInterruptRange {
+                base: 32,
+                count: 96
+            }
+        );
+        assert_eq!(
+            metadata.timer_interrupts,
+            HvfGicTimerInterrupts {
+                el1_virtual_timer_intid: 27,
+                el1_physical_timer_intid: 30,
+            }
+        );
+        assert_eq!(metadata.msi, None);
+        assert_eq!(HvfGicMetadata::FDT_COMPATIBILITY, "arm,gic-v3");
+        assert_eq!(HvfGicMetadata::FDT_INTERRUPT_CELLS, 3);
+        assert_eq!(HvfGicMetadata::FDT_MAINTENANCE_IRQ, 9);
+    }
+
+    #[test]
+    fn metadata_aligns_regions_down_to_sdk_alignment() {
+        let parameters = HvfGicParameters {
+            distributor_size: 0x1_1000,
+            redistributor_region_size: 0x2_1000,
+            ..default_parameters()
+        };
+
+        let metadata =
+            metadata_from_parameters(parameters).expect("unaligned sizes should align bases down");
+
+        assert_eq!(metadata.distributor.base, 0x3ffe_0000);
+        assert_eq!(metadata.distributor.end_exclusive(), 0x3fff_1000);
+        assert_eq!(metadata.redistributor.region.base, 0x3ffb_0000);
+        assert_eq!(metadata.redistributor.region.end_exclusive(), 0x3ffd_1000);
+    }
+
+    #[test]
+    fn metadata_rejects_zero_sizes_before_config_creation() {
+        let api = FakeGicApi::new(HvfGicParameters {
+            distributor_size: 0,
+            ..default_parameters()
+        });
+
+        assert_eq!(
+            create_gic_with_api(&api),
+            Err(HvfGicError::InvalidParameter {
+                name: "distributor_size",
+                value: 0,
+            })
+        );
+        assert!(!api.created_config());
+    }
+
+    #[test]
+    fn metadata_rejects_non_power_of_two_alignment() {
+        let err = metadata_from_parameters(HvfGicParameters {
+            redistributor_alignment: 3,
+            ..default_parameters()
+        })
+        .expect_err("non-power-of-two alignment should fail");
+
+        assert_eq!(
+            err,
+            HvfGicError::InvalidParameter {
+                name: "redistributor_base_alignment",
+                value: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn metadata_rejects_redistributor_size_larger_than_region() {
+        let err = metadata_from_parameters(HvfGicParameters {
+            redistributor_region_size: 0x1_0000,
+            redistributor_size: 0x2_0000,
+            ..default_parameters()
+        })
+        .expect_err("single redistributor larger than total region should fail");
+
+        assert_eq!(
+            err,
+            HvfGicError::InvalidParameter {
+                name: "redistributor_size",
+                value: 0x2_0000,
+            }
+        );
+    }
+
+    #[test]
+    fn metadata_rejects_region_that_cannot_fit_below_mmio32() {
+        let err = metadata_from_parameters(HvfGicParameters {
+            redistributor_region_size: 0x4000_0000,
+            ..default_parameters()
+        })
+        .expect_err("redistributor region should not fit below distributor");
+
+        assert_eq!(
+            err,
+            HvfGicError::AddressUnderflow {
+                region: "redistributor",
+                limit: 0x3fff_0000,
+                size: 0x4000_0000,
+            }
+        );
+    }
+
+    #[test]
+    fn create_gic_configures_hvf_before_returning_metadata() {
+        let api = FakeGicApi::default();
+
+        let metadata = create_gic_with_api(&api).expect("GIC should be created");
+
+        assert_eq!(metadata.distributor.base, 0x3fff_0000);
+        assert_eq!(
+            api.calls(),
+            vec![
+                "hv_gic_get_distributor_size",
+                "hv_gic_get_distributor_base_alignment",
+                "hv_gic_get_redistributor_region_size",
+                "hv_gic_get_redistributor_size",
+                "hv_gic_get_redistributor_base_alignment",
+                "hv_gic_get_spi_interrupt_range",
+                "hv_gic_get_intid",
+                "hv_gic_get_intid",
+                "hv_gic_config_create",
+                "hv_gic_config_set_distributor_base",
+                "hv_gic_config_set_redistributor_base",
+                "hv_gic_create",
+                "os_release",
+            ]
+        );
+        assert_eq!(api.released_configs(), vec![1]);
+    }
+
+    #[test]
+    fn create_gic_releases_config_after_set_failure() {
+        let api = FakeGicApi::default().with_failure("hv_gic_config_set_redistributor_base");
+
+        assert_eq!(
+            create_gic_with_api(&api),
+            Err(HvfGicError::Backend(BackendError::Hypervisor(
+                "injected hv_gic_config_set_redistributor_base failure".to_string()
+            )))
+        );
+        assert_eq!(
+            api.calls(),
+            vec![
+                "hv_gic_get_distributor_size",
+                "hv_gic_get_distributor_base_alignment",
+                "hv_gic_get_redistributor_region_size",
+                "hv_gic_get_redistributor_size",
+                "hv_gic_get_redistributor_base_alignment",
+                "hv_gic_get_spi_interrupt_range",
+                "hv_gic_get_intid",
+                "hv_gic_get_intid",
+                "hv_gic_config_create",
+                "hv_gic_config_set_distributor_base",
+                "hv_gic_config_set_redistributor_base",
+                "os_release",
+            ]
+        );
+    }
+
+    #[test]
+    fn config_guard_releases_on_drop() {
+        let api = FakeGicApi::default();
+
+        {
+            let _guard = GicConfigGuard::new(&api).expect("config should be created");
+        }
+
+        assert_eq!(api.calls(), vec!["hv_gic_config_create", "os_release"]);
+    }
+
+    fn default_parameters() -> HvfGicParameters {
+        HvfGicParameters {
+            distributor_size: DIST_SIZE,
+            distributor_alignment: ALIGNMENT,
+            redistributor_region_size: REDIST_REGION_SIZE,
+            redistributor_size: REDIST_SIZE,
+            redistributor_alignment: ALIGNMENT,
+            spi_interrupt_range: HvfGicInterruptRange {
+                base: 32,
+                count: 96,
+            },
+            timer_interrupts: HvfGicTimerInterrupts {
+                el1_virtual_timer_intid: 27,
+                el1_physical_timer_intid: 30,
+            },
+        }
+    }
+
+    #[derive(Debug)]
+    struct FakeGicApi {
+        parameters: HvfGicParameters,
+        state: Mutex<FakeGicApiState>,
+    }
+
+    impl Default for FakeGicApi {
+        fn default() -> Self {
+            Self::new(default_parameters())
+        }
+    }
+
+    impl FakeGicApi {
+        fn new(parameters: HvfGicParameters) -> Self {
+            Self {
+                parameters,
+                state: Mutex::new(FakeGicApiState {
+                    calls: Vec::new(),
+                    next_config: 1,
+                    released_configs: Vec::new(),
+                    failure: None,
+                    created_config: false,
+                }),
+            }
+        }
+
+        fn with_failure(self, failure: &'static str) -> Self {
+            self.state
+                .lock()
+                .expect("fake GIC API state should be lockable")
+                .failure = Some(failure);
+            self
+        }
+
+        fn calls(&self) -> Vec<&'static str> {
+            self.state
+                .lock()
+                .expect("fake GIC API state should be lockable")
+                .calls
+                .clone()
+        }
+
+        fn released_configs(&self) -> Vec<u64> {
+            self.state
+                .lock()
+                .expect("fake GIC API state should be lockable")
+                .released_configs
+                .clone()
+        }
+
+        fn created_config(&self) -> bool {
+            self.state
+                .lock()
+                .expect("fake GIC API state should be lockable")
+                .created_config
+        }
+
+        fn record(&self, call: &'static str) -> Result<(), HvfGicError> {
+            let mut state = self
+                .state
+                .lock()
+                .expect("fake GIC API state should be lockable");
+            state.calls.push(call);
+
+            if state.failure == Some(call) {
+                Err(HvfGicError::Backend(BackendError::Hypervisor(format!(
+                    "injected {call} failure"
+                ))))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    impl HvfGicApi for FakeGicApi {
+        type Config = u64;
+
+        fn distributor_size(&self) -> Result<u64, HvfGicError> {
+            self.record("hv_gic_get_distributor_size")?;
+            Ok(self.parameters.distributor_size)
+        }
+
+        fn distributor_alignment(&self) -> Result<u64, HvfGicError> {
+            self.record("hv_gic_get_distributor_base_alignment")?;
+            Ok(self.parameters.distributor_alignment)
+        }
+
+        fn redistributor_region_size(&self) -> Result<u64, HvfGicError> {
+            self.record("hv_gic_get_redistributor_region_size")?;
+            Ok(self.parameters.redistributor_region_size)
+        }
+
+        fn redistributor_size(&self) -> Result<u64, HvfGicError> {
+            self.record("hv_gic_get_redistributor_size")?;
+            Ok(self.parameters.redistributor_size)
+        }
+
+        fn redistributor_alignment(&self) -> Result<u64, HvfGicError> {
+            self.record("hv_gic_get_redistributor_base_alignment")?;
+            Ok(self.parameters.redistributor_alignment)
+        }
+
+        fn spi_interrupt_range(&self) -> Result<HvfGicInterruptRange, HvfGicError> {
+            self.record("hv_gic_get_spi_interrupt_range")?;
+            Ok(self.parameters.spi_interrupt_range)
+        }
+
+        fn intid(&self, interrupt: u16) -> Result<u32, HvfGicError> {
+            self.record("hv_gic_get_intid")?;
+            match interrupt {
+                HV_GIC_INT_EL1_VIRTUAL_TIMER => {
+                    Ok(self.parameters.timer_interrupts.el1_virtual_timer_intid)
+                }
+                HV_GIC_INT_EL1_PHYSICAL_TIMER => {
+                    Ok(self.parameters.timer_interrupts.el1_physical_timer_intid)
+                }
+                _ => Err(HvfGicError::InvalidParameter {
+                    name: "interrupt",
+                    value: u64::from(interrupt),
+                }),
+            }
+        }
+
+        fn create_config(&self) -> Result<Self::Config, HvfGicError> {
+            self.record("hv_gic_config_create")?;
+            let mut state = self
+                .state
+                .lock()
+                .expect("fake GIC API state should be lockable");
+            let config = state.next_config;
+            state.next_config += 1;
+            state.created_config = true;
+            Ok(config)
+        }
+
+        fn set_distributor_base(&self, _: &mut Self::Config, _: u64) -> Result<(), HvfGicError> {
+            self.record("hv_gic_config_set_distributor_base")
+        }
+
+        fn set_redistributor_base(&self, _: &mut Self::Config, _: u64) -> Result<(), HvfGicError> {
+            self.record("hv_gic_config_set_redistributor_base")
+        }
+
+        fn create_gic(&self, _: &Self::Config) -> Result<(), HvfGicError> {
+            self.record("hv_gic_create")
+        }
+
+        fn release_config(&self, config: Self::Config) {
+            let mut state = self
+                .state
+                .lock()
+                .expect("fake GIC API state should be lockable");
+            state.calls.push("os_release");
+            state.released_configs.push(config);
+        }
+    }
+
+    #[derive(Debug)]
+    struct FakeGicApiState {
+        calls: Vec<&'static str>,
+        next_config: u64,
+        released_configs: Vec<u64>,
+        failure: Option<&'static str>,
+        created_config: bool,
+    }
+}

--- a/crates/hvf/src/gic.rs
+++ b/crates/hvf/src/gic.rs
@@ -13,6 +13,7 @@ const DYNAMIC_SYMBOL_SIZE_MISMATCH_MESSAGE: &str =
 
 const HV_GIC_INT_EL1_VIRTUAL_TIMER: u16 = 27;
 const HV_GIC_INT_EL1_PHYSICAL_TIMER: u16 = 30;
+const FIRST_PPI_INTID: u32 = 16;
 const FIRST_SPI_INTID: u32 = 32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -281,6 +282,7 @@ fn metadata_from_parameters(parameters: HvfGicParameters) -> Result<HvfGicMetada
         });
     }
     validate_spi_interrupt_range(parameters.spi_interrupt_range)?;
+    validate_timer_interrupts(parameters.timer_interrupts)?;
 
     let distributor = aligned_region_below(
         "distributor",
@@ -355,6 +357,30 @@ fn validate_spi_interrupt_range(range: HvfGicInterruptRange) -> Result<(), HvfGi
     }
 
     Ok(())
+}
+
+fn validate_timer_interrupts(timers: HvfGicTimerInterrupts) -> Result<(), HvfGicError> {
+    validate_ppi_intid("el1_virtual_timer_intid", timers.el1_virtual_timer_intid)?;
+    validate_ppi_intid("el1_physical_timer_intid", timers.el1_physical_timer_intid)?;
+    if timers.el1_virtual_timer_intid == timers.el1_physical_timer_intid {
+        return Err(HvfGicError::InvalidParameter {
+            name: "timer_interrupts",
+            value: u64::from(timers.el1_virtual_timer_intid),
+        });
+    }
+
+    Ok(())
+}
+
+fn validate_ppi_intid(name: &'static str, intid: u32) -> Result<(), HvfGicError> {
+    if (FIRST_PPI_INTID..FIRST_SPI_INTID).contains(&intid) {
+        Ok(())
+    } else {
+        Err(HvfGicError::InvalidParameter {
+            name,
+            value: u64::from(intid),
+        })
+    }
 }
 
 fn aligned_region_below(
@@ -1017,6 +1043,66 @@ mod tests {
             HvfGicError::InvalidParameter {
                 name: "spi_interrupt_range.end_exclusive",
                 value: u64::from(u32::MAX) + 2,
+            }
+        );
+    }
+
+    #[test]
+    fn metadata_rejects_non_ppi_timer_interrupts_before_config_creation() {
+        let api = FakeGicApi::new(HvfGicParameters {
+            timer_interrupts: HvfGicTimerInterrupts {
+                el1_virtual_timer_intid: 15,
+                ..default_parameters().timer_interrupts
+            },
+            ..default_parameters()
+        });
+
+        assert_eq!(
+            create_gic_with_api(&api),
+            Err(HvfGicError::InvalidParameter {
+                name: "el1_virtual_timer_intid",
+                value: 15,
+            })
+        );
+        assert!(!api.created_config());
+    }
+
+    #[test]
+    fn metadata_rejects_timer_interrupts_in_spi_range() {
+        let err = metadata_from_parameters(HvfGicParameters {
+            timer_interrupts: HvfGicTimerInterrupts {
+                el1_physical_timer_intid: 32,
+                ..default_parameters().timer_interrupts
+            },
+            ..default_parameters()
+        })
+        .expect_err("timer interrupt INTIDs should be PPIs");
+
+        assert_eq!(
+            err,
+            HvfGicError::InvalidParameter {
+                name: "el1_physical_timer_intid",
+                value: 32,
+            }
+        );
+    }
+
+    #[test]
+    fn metadata_rejects_duplicate_timer_interrupts() {
+        let err = metadata_from_parameters(HvfGicParameters {
+            timer_interrupts: HvfGicTimerInterrupts {
+                el1_virtual_timer_intid: 27,
+                el1_physical_timer_intid: 27,
+            },
+            ..default_parameters()
+        })
+        .expect_err("timer interrupt INTIDs should be distinct");
+
+        assert_eq!(
+            err,
+            HvfGicError::InvalidParameter {
+                name: "timer_interrupts",
+                value: 27,
             }
         );
     }

--- a/crates/hvf/src/gic.rs
+++ b/crates/hvf/src/gic.rs
@@ -1183,6 +1183,37 @@ mod tests {
     }
 
     #[test]
+    fn create_gic_releases_config_after_create_failure() {
+        let api = FakeGicApi::default().with_failure("hv_gic_create");
+
+        assert_eq!(
+            create_gic_with_api(&api),
+            Err(HvfGicError::Backend(BackendError::Hypervisor(
+                "injected hv_gic_create failure".to_string()
+            )))
+        );
+        assert_eq!(
+            api.calls(),
+            vec![
+                "hv_gic_get_distributor_size",
+                "hv_gic_get_distributor_base_alignment",
+                "hv_gic_get_redistributor_region_size",
+                "hv_gic_get_redistributor_size",
+                "hv_gic_get_redistributor_base_alignment",
+                "hv_gic_get_spi_interrupt_range",
+                "hv_gic_get_intid",
+                "hv_gic_get_intid",
+                "hv_gic_config_create",
+                "hv_gic_config_set_distributor_base",
+                "hv_gic_config_set_redistributor_base",
+                "hv_gic_create",
+                "os_release",
+            ]
+        );
+        assert_eq!(api.released_configs(), vec![1]);
+    }
+
+    #[test]
     fn config_guard_releases_on_drop() {
         let api = FakeGicApi::default();
 

--- a/crates/hvf/src/gic.rs
+++ b/crates/hvf/src/gic.rs
@@ -788,6 +788,51 @@ mod dynamic {
             }
         }
     }
+
+    #[cfg(test)]
+    mod tests {
+        use std::ffi::c_void;
+        use std::ptr::NonNull;
+
+        use super::load_symbol;
+        use crate::gic::{DYNAMIC_SYMBOL_SIZE_MISMATCH_MESSAGE, HvfGicError};
+
+        fn default_symbols() -> NonNull<c_void> {
+            NonNull::new(libc::RTLD_DEFAULT).expect("RTLD_DEFAULT should be non-null")
+        }
+
+        #[test]
+        fn load_symbol_reports_missing_symbol() {
+            type MissingSymbol = unsafe extern "C" fn();
+
+            let err = load_symbol::<MissingSymbol>(
+                default_symbols(),
+                c"bangbang_hvf_missing_test_symbol",
+                "bangbang_hvf_missing_test_symbol",
+            )
+            .expect_err("missing dynamic symbol should fail");
+
+            assert_eq!(
+                err,
+                HvfGicError::MissingSymbol("bangbang_hvf_missing_test_symbol")
+            );
+        }
+
+        #[test]
+        fn load_symbol_rejects_size_mismatch() {
+            let err = load_symbol::<u8>(
+                default_symbols(),
+                c"bangbang_hvf_missing_test_symbol",
+                "bangbang_hvf_missing_test_symbol",
+            )
+            .expect_err("non-pointer-sized symbol type should fail before dlsym");
+
+            assert_eq!(
+                err,
+                HvfGicError::InvalidState(DYNAMIC_SYMBOL_SIZE_MISMATCH_MESSAGE)
+            );
+        }
+    }
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -3,12 +3,17 @@
 mod backend;
 mod exit;
 mod ffi;
+mod gic;
 mod memory;
 mod runner;
 mod vcpu;
 
 pub use backend::HvfBackend;
 pub use exit::{HvfExceptionExit, HvfVcpuExit};
+pub use gic::{
+    HvfGicError, HvfGicInterruptRange, HvfGicMetadata, HvfGicMsiMetadata, HvfGicRedistributor,
+    HvfGicRegion, HvfGicTimerInterrupts,
+};
 pub use memory::{HvfGuestMemoryMappingError, HvfGuestMemoryUnmapFailure, HvfMemoryPermissions};
 pub use runner::{HvfVcpuRunner, HvfVcpuRunnerError};
 pub use vcpu::{HvfRegister, HvfSystemRegister, HvfVcpu};

--- a/crates/hvf/src/runner.rs
+++ b/crates/hvf/src/runner.rs
@@ -123,7 +123,7 @@ impl RunnerVcpu for RealRunnerVcpu {
 }
 
 impl<'vm> HvfVcpuRunner<'vm> {
-    pub(crate) fn new(_: &'vm HvfBackend) -> Result<Self, HvfVcpuRunnerError> {
+    pub(crate) fn new() -> Result<Self, HvfVcpuRunnerError> {
         Self::from_started(
             spawn_runner_thread(RealRunnerVcpu::create)?,
             real_cancel_vcpu(),

--- a/crates/hvf/src/vcpu.rs
+++ b/crates/hvf/src/vcpu.rs
@@ -176,7 +176,7 @@ impl fmt::Debug for HvfVcpuOwner {
 }
 
 impl<'vm> HvfVcpu<'vm> {
-    pub(crate) fn new(_: &'vm mut HvfBackend) -> Result<Self, BackendError> {
+    pub(crate) fn new() -> Result<Self, BackendError> {
         Ok(Self {
             owner: HvfVcpuOwner::new()?,
             _vm: PhantomData,

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -62,6 +62,31 @@ fn creates_hvf_gic_before_vcpu() {
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 #[test]
+fn rejects_hvf_gic_after_vcpu_creation() {
+    use bangbang_hvf::{HvfBackend, HvfGicError};
+    use bangbang_runtime::VmBackend;
+
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let mut backend = HvfBackend::new();
+
+    backend.create_vm().expect("VM should be created");
+    {
+        let mut vcpu = backend.create_vcpu().expect("vCPU should be created");
+        vcpu.destroy().expect("vCPU should be destroyed");
+    }
+    assert_eq!(
+        backend
+            .create_gic()
+            .expect_err("GIC creation after vCPU creation should fail"),
+        HvfGicError::InvalidState("GIC must be created before creating vCPUs")
+    );
+    backend.destroy_vm().expect("VM should be destroyed");
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
 fn cancels_runner_before_first_run() {
     use bangbang_hvf::{HvfBackend, HvfVcpuExit};
     use bangbang_runtime::VmBackend;

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -36,6 +36,32 @@ fn creates_and_destroys_hvf_vcpu() {
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 #[test]
+fn creates_hvf_gic_before_vcpu() {
+    use bangbang_hvf::{HvfBackend, HvfGicMetadata};
+    use bangbang_runtime::VmBackend;
+
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let mut backend = HvfBackend::new();
+
+    backend.create_vm().expect("VM should be created");
+    let metadata = *backend.create_gic().expect("GIC should be created");
+    assert_eq!(metadata.msi, None);
+    assert_eq!(HvfGicMetadata::FDT_COMPATIBILITY, "arm,gic-v3");
+    assert!(metadata.distributor.size > 0);
+    assert!(metadata.redistributor.region.size > 0);
+    {
+        let mut vcpu = backend
+            .create_vcpu()
+            .expect("vCPU should be created after GIC");
+        vcpu.destroy().expect("vCPU should be destroyed");
+    }
+    backend.destroy_vm().expect("VM should be destroyed");
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
 fn cancels_runner_before_first_run() {
     use bangbang_hvf::{HvfBackend, HvfVcpuExit};
     use bangbang_runtime::VmBackend;

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -12,11 +12,12 @@ placement helpers, internal boot-source validation and arm64 kernel/initrd
 payload loading, a minimal
 Hypervisor.framework VM create/destroy wrapper, a current-thread HVF vCPU
 create/destroy wrapper, typed HVF exit surface, narrow vCPU register wrappers,
-anonymous guest memory allocation for validated runtime layouts, HVF guest
-memory map/unmap ownership for allocated regions, and an initial process
-startup argument model. There is no broader API request body model, guest
-execution, vCPU run loop, MMIO/device emulation, boot register setup, FDT
-generation, or public boot-source API behavior yet.
+internal macOS 15+ HVF GIC v3 boot metadata without MSI/ITS, anonymous guest
+memory allocation for validated runtime layouts, HVF guest memory map/unmap
+ownership for allocated regions, and an initial process startup argument model.
+There is no broader API request body model, guest execution, vCPU run loop,
+interrupt injection, MMIO/device emulation, boot register setup, FDT generation,
+or public boot-source API behavior yet.
 
 ## Firecracker Model Alignment
 
@@ -289,9 +290,18 @@ backend-owned mapping owner consumes the `GuestMemory` allocation, unmaps mapped
 regions on explicit unmap, partial failure, drop, and VM destruction, and keeps
 cleanup local to the backend instance.
 
+On macOS 15.0 or newer, the HVF backend can create a GIC v3 device after VM
+creation and before vCPU creation. It dynamically resolves the macOS 15 GIC
+symbols so older hosts can return structured unsupported errors instead of
+failing at process load time. The backend exposes internal boot metadata for the
+future FDT path: distributor and redistributor regions below the 1 GiB MMIO32
+boundary, the supported SPI range, timer interrupt IDs, and the `arm,gic-v3`
+compatibility shape. MSI/ITS metadata is intentionally absent until a later
+device path needs it.
+
 This still is not bootable guest RAM. bangbang does not write FDT payloads, wire
-`mem_size_mib` into public startup behavior, configure boot registers, or start
-a guest. Later API and startup work still needs to decide whether an oversized
+`mem_size_mib` into public startup behavior, inject interrupts, configure boot
+registers, or start a guest. Later API and startup work still needs to decide whether an oversized
 `mem_size_mib` request should be rejected before layout construction or should
 preserve Firecracker's architecture-helper truncation behavior.
 


### PR DESCRIPTION
## Summary

- Add an HVF GIC v3 setup layer that dynamically resolves macOS 15+ GIC symbols and releases the config object with RAII.
- Wire GIC creation into `HvfBackend` after VM creation and before vCPU topology creation, exposing internal metadata for later FDT generation.
- Document the current GIC scope: no MSI/ITS, FDT generation, interrupt injection, MMIO devices, boot registers, or guest run yet.

## Scope Exclusions

- No MSI/ITS configuration.
- No FDT byte generation or public boot API wiring.
- No interrupt injection or guest execution loop changes.

Closes #81

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-hvf-tests.sh`
- `git diff --check`
