### PR TITLE
feat: add arm64 FDT generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,8 +33,16 @@ dependencies = [
 name = "bangbang-runtime"
 version = "0.1.0"
 dependencies = [
+ "device_tree",
  "libc",
+ "vm-fdt",
 ]
+
+[[package]]
+name = "device_tree"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18f717c5c7c2e3483feb64cccebd077245ad6d19007c2db0fd341d38595353c"
 
 [[package]]
 name = "errno"
@@ -166,6 +174,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "vm-fdt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e21282841a059bb62627ce8441c491f09603622cd5a21c43bfedc85a2952f23"
 
 [[package]]
 name = "windows-link"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 bangbang is a Rust VMM project for macOS hosts. The public control plane is intended to stay compatible with the Firecracker HTTP API over a Unix domain socket, while the VM backend is built on Apple's Hypervisor.framework.
 
-This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, a backend-neutral guest address/layout model, anonymous guest memory allocation and byte access, arm64 boot placement helpers, internal boot-source validation with arm64 kernel/initrd payload loading, and the smallest Hypervisor.framework VM, GIC boot metadata, guest memory map/unmap ownership, current-thread vCPU lifecycle, typed exit surface, register wrappers, and cancellable vCPU runner skeleton.
+This repository is currently a scaffold. It defines crate boundaries, an initial Firecracker-compatible API socket, a process startup CLI, a minimal internal VMM action model, a backend trait, a backend-neutral guest address/layout model, anonymous guest memory allocation and byte access, arm64 boot placement helpers, internal boot-source validation with arm64 kernel/initrd payload loading, minimal arm64 FDT generation and guest-memory writes, and the smallest Hypervisor.framework VM, GIC boot metadata, guest memory map/unmap ownership, current-thread vCPU lifecycle, typed exit surface, register wrappers, and cancellable vCPU runner skeleton.
 
 See [Firecracker Compatibility Scope](docs/firecracker-compatibility.md) for the intended compatibility target and current limitations.
 See [Pull Request Review Guidelines](docs/review-guidelines.md) for the project-specific review standard.
@@ -18,12 +18,12 @@ crates/bangbang   VMM process entrypoint and startup CLI
 
 ## Current Scope
 
-The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. The runtime crate defines guest physical address, range, and aarch64 DRAM layout primitives, can allocate owned anonymous host memory for validated page-aligned guest memory layouts, can safely read/write byte slices by guest address, exposes the first arm64 kernel/FDT/initrd placement helpers, and can internally validate a Firecracker-shaped boot source before loading a supported arm64 Linux `Image` kernel plus optional non-empty initrd into guest memory. The HVF crate can create/destroy a process VM, create macOS 15+ GIC v3 boot metadata without MSI/ITS, map/unmap allocated guest memory with backend-owned cleanup, create/destroy one current-thread vCPU handle, define typed HVF exit snapshots, get/set a narrow set of vCPU registers, and start a thread-owned runner that can cancel a single `hv_vcpu_run` step. It intentionally does not include:
+The first target is Apple Silicon macOS. The current scaffold includes HTTP over a Unix domain socket for `GET /` and `GET /version`, routed through a minimal read-only VMM action model. The runtime crate defines guest physical address, range, and aarch64 DRAM layout primitives, can allocate owned anonymous host memory for validated page-aligned guest memory layouts, can safely read/write byte slices by guest address, exposes the first arm64 kernel/FDT/initrd placement helpers, can internally validate a Firecracker-shaped boot source before loading a supported arm64 Linux `Image` kernel plus optional non-empty initrd into guest memory, and can build/write a minimal Firecracker-shaped arm64 FDT from loaded boot metadata and backend-neutral interrupt-controller metadata. The HVF crate can create/destroy a process VM, create macOS 15+ GIC v3 boot metadata without MSI/ITS, convert that metadata for the runtime FDT path, map/unmap allocated guest memory with backend-owned cleanup, create/destroy one current-thread vCPU handle, define typed HVF exit snapshots, get/set a narrow set of vCPU registers, and start a thread-owned runner that can cancel a single `hv_vcpu_run` step. It intentionally does not include:
 
 - API endpoints beyond `GET /` and `GET /version`
 - public JSON request body models for machine config, boot source, drives, or actions
 - public `/boot-source` behavior
-- command-line or FDT writes into guest memory
+- public command-line or FDT configuration behavior
 - interrupt injection, configured guest execution, continuous vCPU run loops, MMIO/device emulation, or boot register setup
 
 ## Process CLI

--- a/crates/hvf/src/gic.rs
+++ b/crates/hvf/src/gic.rs
@@ -1078,6 +1078,29 @@ mod tests {
     }
 
     #[test]
+    fn metadata_timer_conversion_rejects_publicly_constructed_duplicate_intids() {
+        let mut metadata = metadata_from_parameters(default_parameters())
+            .expect("default GIC parameters should produce metadata");
+        metadata.timer_interrupts = HvfGicTimerInterrupts {
+            el1_virtual_timer_intid: 27,
+            el1_physical_timer_intid: 27,
+        };
+
+        let err = metadata
+            .arm64_fdt_timer_interrupts()
+            .expect_err("duplicate timer INTIDs should fail conversion");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::DuplicatePpi {
+                first: "non_secure_physical_timer",
+                second: "virtual_timer",
+                value: 11,
+            }
+        );
+    }
+
+    #[test]
     fn metadata_aligns_regions_down_to_sdk_alignment() {
         let parameters = HvfGicParameters {
             distributor_size: 0x1_1000,

--- a/crates/hvf/src/gic.rs
+++ b/crates/hvf/src/gic.rs
@@ -3,6 +3,10 @@
 use std::fmt;
 
 use bangbang_runtime::BackendError;
+use bangbang_runtime::fdt::{
+    Arm64FdtError, Arm64FdtGic, Arm64FdtInterruptRange, Arm64FdtMsi, Arm64FdtRegion,
+    Arm64FdtTimerInterrupts,
+};
 
 const GIC_REQUIRES_MACOS_15_MESSAGE: &str =
     "Hypervisor.framework GIC APIs require macOS 15.0 or newer";
@@ -69,6 +73,51 @@ impl HvfGicMetadata {
     pub const FDT_COMPATIBILITY: &'static str = "arm,gic-v3";
     pub const FDT_INTERRUPT_CELLS: u32 = 3;
     pub const FDT_MAINTENANCE_IRQ: u32 = 9;
+
+    pub fn arm64_fdt_gic(&self) -> Arm64FdtGic {
+        Arm64FdtGic {
+            distributor: self.distributor.into(),
+            redistributor: self.redistributor.region.into(),
+            compatibility: Self::FDT_COMPATIBILITY,
+            interrupt_cells: Self::FDT_INTERRUPT_CELLS,
+            maintenance_irq: Self::FDT_MAINTENANCE_IRQ,
+            msi: self.msi.map(Into::into),
+        }
+    }
+
+    pub fn arm64_fdt_timer_interrupts(&self) -> Result<Arm64FdtTimerInterrupts, Arm64FdtError> {
+        Arm64FdtTimerInterrupts::from_el1_timer_intids(
+            self.timer_interrupts.el1_virtual_timer_intid,
+            self.timer_interrupts.el1_physical_timer_intid,
+        )
+    }
+}
+
+impl From<HvfGicRegion> for Arm64FdtRegion {
+    fn from(region: HvfGicRegion) -> Self {
+        Self {
+            base: region.base,
+            size: region.size,
+        }
+    }
+}
+
+impl From<HvfGicInterruptRange> for Arm64FdtInterruptRange {
+    fn from(range: HvfGicInterruptRange) -> Self {
+        Self {
+            base: range.base,
+            count: range.count,
+        }
+    }
+}
+
+impl From<HvfGicMsiMetadata> for Arm64FdtMsi {
+    fn from(metadata: HvfGicMsiMetadata) -> Self {
+        Self {
+            region: metadata.region.into(),
+            interrupt_range: metadata.interrupt_range.into(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -869,11 +918,16 @@ mod tests {
     use std::sync::Mutex;
 
     use bangbang_runtime::BackendError;
+    use bangbang_runtime::fdt::{
+        ARM64_FDT_HYPERVISOR_TIMER_PPI, ARM64_FDT_NON_SECURE_PHYSICAL_TIMER_PPI,
+        ARM64_FDT_SECURE_PHYSICAL_TIMER_PPI, ARM64_FDT_VIRTUAL_TIMER_PPI, Arm64FdtError,
+        Arm64FdtInterruptRange, Arm64FdtMsi, Arm64FdtRegion, Arm64FdtTimerInterrupts,
+    };
 
     use super::{
         GicConfigGuard, HV_GIC_INT_EL1_PHYSICAL_TIMER, HV_GIC_INT_EL1_VIRTUAL_TIMER, HvfGicApi,
-        HvfGicError, HvfGicInterruptRange, HvfGicMetadata, HvfGicParameters, HvfGicRegion,
-        HvfGicTimerInterrupts, create_gic_with_api, metadata_from_parameters,
+        HvfGicError, HvfGicInterruptRange, HvfGicMetadata, HvfGicMsiMetadata, HvfGicParameters,
+        HvfGicRegion, HvfGicTimerInterrupts, create_gic_with_api, metadata_from_parameters,
     };
 
     const DIST_SIZE: u64 = 0x1_0000;
@@ -922,6 +976,105 @@ mod tests {
         assert_eq!(HvfGicMetadata::FDT_COMPATIBILITY, "arm,gic-v3");
         assert_eq!(HvfGicMetadata::FDT_INTERRUPT_CELLS, 3);
         assert_eq!(HvfGicMetadata::FDT_MAINTENANCE_IRQ, 9);
+    }
+
+    #[test]
+    fn metadata_converts_to_arm64_fdt_gic_input() {
+        let metadata = metadata_from_parameters(default_parameters())
+            .expect("default GIC parameters should produce metadata");
+
+        let fdt_gic = metadata.arm64_fdt_gic();
+
+        assert_eq!(
+            fdt_gic.distributor,
+            Arm64FdtRegion {
+                base: 0x3fff_0000,
+                size: DIST_SIZE,
+            }
+        );
+        assert_eq!(
+            fdt_gic.redistributor,
+            Arm64FdtRegion {
+                base: 0x3ffd_0000,
+                size: REDIST_REGION_SIZE,
+            }
+        );
+        assert_eq!(fdt_gic.compatibility, "arm,gic-v3");
+        assert_eq!(fdt_gic.interrupt_cells, 3);
+        assert_eq!(fdt_gic.maintenance_irq, 9);
+        assert_eq!(fdt_gic.msi, None);
+    }
+
+    #[test]
+    fn metadata_converts_optional_msi_to_arm64_fdt_input() {
+        let mut metadata = metadata_from_parameters(default_parameters())
+            .expect("default GIC parameters should produce metadata");
+        metadata.msi = Some(HvfGicMsiMetadata {
+            region: HvfGicRegion {
+                base: 0x3ffc_0000,
+                size: 0x1_0000,
+            },
+            interrupt_range: HvfGicInterruptRange {
+                base: 128,
+                count: 32,
+            },
+        });
+
+        assert_eq!(
+            metadata.arm64_fdt_gic().msi,
+            Some(Arm64FdtMsi {
+                region: Arm64FdtRegion {
+                    base: 0x3ffc_0000,
+                    size: 0x1_0000,
+                },
+                interrupt_range: Arm64FdtInterruptRange {
+                    base: 128,
+                    count: 32,
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn metadata_converts_hvf_timer_intids_to_fdt_ppis() {
+        let metadata = metadata_from_parameters(default_parameters())
+            .expect("default GIC parameters should produce metadata");
+
+        let timers = metadata
+            .arm64_fdt_timer_interrupts()
+            .expect("validated HVF timer INTIDs should map to FDT PPIs");
+
+        assert_eq!(
+            timers,
+            Arm64FdtTimerInterrupts {
+                secure_physical: ARM64_FDT_SECURE_PHYSICAL_TIMER_PPI,
+                non_secure_physical: ARM64_FDT_NON_SECURE_PHYSICAL_TIMER_PPI,
+                virtual_timer: ARM64_FDT_VIRTUAL_TIMER_PPI,
+                hypervisor: ARM64_FDT_HYPERVISOR_TIMER_PPI,
+            }
+        );
+    }
+
+    #[test]
+    fn metadata_timer_conversion_rejects_publicly_constructed_non_ppi_intids() {
+        let mut metadata = metadata_from_parameters(default_parameters())
+            .expect("default GIC parameters should produce metadata");
+        metadata.timer_interrupts = HvfGicTimerInterrupts {
+            el1_virtual_timer_intid: 15,
+            el1_physical_timer_intid: 30,
+        };
+
+        let err = metadata
+            .arm64_fdt_timer_interrupts()
+            .expect_err("non-PPI timer INTID should fail conversion");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::InvalidPpiIntid {
+                name: "el1_virtual_timer_intid",
+                intid: 15,
+            }
+        );
     }
 
     #[test]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -6,6 +6,10 @@ repository.workspace = true
 
 [dependencies]
 libc = "0.2"
+vm-fdt = "0.3.0"
+
+[dev-dependencies]
+device_tree = "1.1.0"
 
 [lints]
 workspace = true

--- a/crates/runtime/src/fdt.rs
+++ b/crates/runtime/src/fdt.rs
@@ -17,6 +17,7 @@ const SIZE_CELLS: u32 = 2;
 const CPU_ADDRESS_CELLS: u32 = 2;
 const CPU_SIZE_CELLS: u32 = 0;
 const CPU_REG_MASK: u64 = 0x7f_ffff;
+const MAX_ARM64_FDT_CPUS: usize = 32;
 const GIC_FDT_IRQ_TYPE_PPI: u32 = 1;
 const IRQ_TYPE_LEVEL_HIGH: u32 = 4;
 const FIRST_PPI_INTID: u32 = 16;
@@ -124,6 +125,10 @@ pub struct Arm64FdtGuestMemoryWrite {
 #[derive(Debug, PartialEq, Eq)]
 pub enum Arm64FdtError {
     MissingCpu,
+    TooManyCpus {
+        count: usize,
+        max: usize,
+    },
     DuplicateCpuReg {
         first_index: usize,
         second_index: usize,
@@ -140,13 +145,28 @@ pub enum Arm64FdtError {
         actual: GuestAddress,
         expected: GuestAddress,
     },
-    InitrdEndOverflow {
-        address: GuestAddress,
-        size: u64,
+    InvalidInitrdRange {
+        source: GuestMemoryError,
+    },
+    InitrdNotInGuestMemory {
+        range: GuestMemoryRange,
+    },
+    InitrdOverlapsFdt {
+        end_exclusive: GuestAddress,
+        fdt_address: GuestAddress,
     },
     InvalidGicRegion {
         name: &'static str,
         region: Arm64FdtRegion,
+    },
+    GicRegionsOverlap {
+        first: &'static str,
+        second: &'static str,
+    },
+    GicRegionOverlapsMemory {
+        name: &'static str,
+        region: Arm64FdtRegion,
+        memory_range: GuestMemoryRange,
     },
     InvalidGicInterruptCells {
         value: u32,
@@ -186,6 +206,9 @@ impl fmt::Display for Arm64FdtError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::MissingCpu => f.write_str("arm64 FDT requires at least one CPU"),
+            Self::TooManyCpus { count, max } => {
+                write!(f, "arm64 FDT supports at most {max} CPUs, got {count}")
+            }
             Self::DuplicateCpuReg {
                 first_index,
                 second_index,
@@ -208,13 +231,35 @@ impl fmt::Display for Arm64FdtError {
                 f,
                 "arm64 FDT guest memory must start at {expected}, got {actual}"
             ),
-            Self::InitrdEndOverflow { address, size } => write!(
+            Self::InvalidInitrdRange { source } => {
+                write!(f, "invalid arm64 FDT initrd range: {source}")
+            }
+            Self::InitrdNotInGuestMemory { range } => write!(
                 f,
-                "initrd FDT end address overflows: start={address}, size={size}"
+                "arm64 FDT initrd range {range} is not fully inside guest memory advertised to the guest"
+            ),
+            Self::InitrdOverlapsFdt {
+                end_exclusive,
+                fdt_address,
+            } => write!(
+                f,
+                "arm64 FDT initrd end address {end_exclusive} overlaps reserved FDT address {fdt_address}"
             ),
             Self::InvalidGicRegion { name, region } => write!(
                 f,
                 "invalid arm64 FDT GIC {name} region: base=0x{:x}, size={}",
+                region.base, region.size
+            ),
+            Self::GicRegionsOverlap { first, second } => {
+                write!(f, "arm64 FDT GIC {first} region overlaps {second} region")
+            }
+            Self::GicRegionOverlapsMemory {
+                name,
+                region,
+                memory_range,
+            } => write!(
+                f,
+                "arm64 FDT GIC {name} region base=0x{:x}, size={} overlaps guest memory range {memory_range}",
                 region.base, region.size
             ),
             Self::InvalidGicInterruptCells { value } => {
@@ -261,14 +306,19 @@ impl std::error::Error for Arm64FdtError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::InvalidLayout { source } => Some(source),
+            Self::InvalidInitrdRange { source } => Some(source),
             Self::CreateFdt { source } => Some(source),
             Self::GuestMemoryWrite { source } => Some(source),
             Self::MissingCpu
+            | Self::TooManyCpus { .. }
             | Self::DuplicateCpuReg { .. }
             | Self::NoGuestMemoryAfterSystemArea { .. }
             | Self::InvalidDramStart { .. }
-            | Self::InitrdEndOverflow { .. }
+            | Self::InitrdNotInGuestMemory { .. }
+            | Self::InitrdOverlapsFdt { .. }
             | Self::InvalidGicRegion { .. }
+            | Self::GicRegionsOverlap { .. }
+            | Self::GicRegionOverlapsMemory { .. }
             | Self::InvalidGicInterruptCells { .. }
             | Self::InvalidPpi { .. }
             | Self::DuplicatePpi { .. }
@@ -322,19 +372,19 @@ fn validate_config(config: &Arm64FdtConfig<'_>) -> Result<(), Arm64FdtError> {
     if config.vcpu_mpidrs.is_empty() {
         return Err(Arm64FdtError::MissingCpu);
     }
+    if config.vcpu_mpidrs.len() > MAX_ARM64_FDT_CPUS {
+        return Err(Arm64FdtError::TooManyCpus {
+            count: config.vcpu_mpidrs.len(),
+            max: MAX_ARM64_FDT_CPUS,
+        });
+    }
 
     validate_cpu_regs(config.vcpu_mpidrs)?;
     memory_reg_cells(config.layout)?;
-    validate_gic(config.gic)?;
+    validate_gic(config.layout, config.gic)?;
     validate_timer(config.timer)?;
     if let Some(initrd) = config.boot.initrd {
-        initrd
-            .address
-            .checked_add(initrd.size)
-            .ok_or(Arm64FdtError::InitrdEndOverflow {
-                address: initrd.address,
-                size: initrd.size,
-            })?;
+        validate_initrd(config.layout, initrd)?;
     }
 
     Ok(())
@@ -403,14 +453,7 @@ fn create_chosen_node(
     fdt.property_string("bootargs", boot.command_line)?;
 
     if let Some(initrd) = boot.initrd {
-        let initrd_end =
-            initrd
-                .address
-                .checked_add(initrd.size)
-                .ok_or(Arm64FdtError::InitrdEndOverflow {
-                    address: initrd.address,
-                    size: initrd.size,
-                })?;
+        let initrd_end = initrd_range(initrd)?.end_exclusive();
         fdt.property_u64("linux,initrd-start", initrd.address.raw_value())?;
         fdt.property_u64("linux,initrd-end", initrd_end.raw_value())?;
     }
@@ -519,9 +562,77 @@ fn memory_reg_cells(layout: &GuestMemoryLayout) -> Result<Vec<u64>, Arm64FdtErro
     Ok(cells)
 }
 
-fn validate_gic(gic: Arm64FdtGic) -> Result<(), Arm64FdtError> {
-    validate_gic_region("distributor", gic.distributor)?;
-    validate_gic_region("redistributor", gic.redistributor)?;
+fn validate_initrd(layout: &GuestMemoryLayout, initrd: LoadedInitrd) -> Result<(), Arm64FdtError> {
+    let range = initrd_range(initrd)?;
+    if !is_range_in_guest_memory_node(layout, range)? {
+        return Err(Arm64FdtError::InitrdNotInGuestMemory { range });
+    }
+
+    let fdt_address =
+        aarch64::fdt_address(layout).map_err(|source| Arm64FdtError::InvalidLayout { source })?;
+    if range.end_exclusive() > fdt_address {
+        return Err(Arm64FdtError::InitrdOverlapsFdt {
+            end_exclusive: range.end_exclusive(),
+            fdt_address,
+        });
+    }
+
+    Ok(())
+}
+
+fn initrd_range(initrd: LoadedInitrd) -> Result<GuestMemoryRange, Arm64FdtError> {
+    GuestMemoryRange::new(initrd.address, initrd.size)
+        .map_err(|source| Arm64FdtError::InvalidInitrdRange { source })
+}
+
+fn is_range_in_guest_memory_node(
+    layout: &GuestMemoryLayout,
+    range: GuestMemoryRange,
+) -> Result<bool, Arm64FdtError> {
+    for (range_index, memory_range) in layout.ranges().iter().copied().enumerate() {
+        let start = if range_index == 0 {
+            memory_range
+                .start()
+                .checked_add(aarch64::SYSTEM_MEM_SIZE)
+                .ok_or(Arm64FdtError::InvalidLayout {
+                    source: GuestMemoryError::AddressOverflow {
+                        start: memory_range.start(),
+                        size: aarch64::SYSTEM_MEM_SIZE,
+                    },
+                })?
+        } else {
+            memory_range.start()
+        };
+
+        if start <= range.start() && range.end_exclusive() <= memory_range.end_exclusive() {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn validate_gic(layout: &GuestMemoryLayout, gic: Arm64FdtGic) -> Result<(), Arm64FdtError> {
+    let distributor = validate_gic_region("distributor", gic.distributor)?;
+    let redistributor = validate_gic_region("redistributor", gic.redistributor)?;
+    validate_gic_regions_do_not_overlap(
+        "distributor",
+        distributor,
+        "redistributor",
+        redistributor,
+    )?;
+    validate_gic_region_does_not_overlap_memory(
+        layout,
+        "distributor",
+        gic.distributor,
+        distributor,
+    )?;
+    validate_gic_region_does_not_overlap_memory(
+        layout,
+        "redistributor",
+        gic.redistributor,
+        redistributor,
+    )?;
 
     if gic.interrupt_cells != 3 {
         return Err(Arm64FdtError::InvalidGicInterruptCells {
@@ -538,12 +649,47 @@ fn validate_gic(gic: Arm64FdtGic) -> Result<(), Arm64FdtError> {
     Ok(())
 }
 
-fn validate_gic_region(name: &'static str, region: Arm64FdtRegion) -> Result<(), Arm64FdtError> {
-    if region.size == 0 || region.base.checked_add(region.size).is_none() {
-        Err(Arm64FdtError::InvalidGicRegion { name, region })
+fn validate_gic_region(
+    name: &'static str,
+    region: Arm64FdtRegion,
+) -> Result<GuestMemoryRange, Arm64FdtError> {
+    GuestMemoryRange::new(GuestAddress::new(region.base), region.size)
+        .map_err(|_| Arm64FdtError::InvalidGicRegion { name, region })
+}
+
+fn validate_gic_regions_do_not_overlap(
+    first_name: &'static str,
+    first: GuestMemoryRange,
+    second_name: &'static str,
+    second: GuestMemoryRange,
+) -> Result<(), Arm64FdtError> {
+    if first.overlaps(second) {
+        Err(Arm64FdtError::GicRegionsOverlap {
+            first: first_name,
+            second: second_name,
+        })
     } else {
         Ok(())
     }
+}
+
+fn validate_gic_region_does_not_overlap_memory(
+    layout: &GuestMemoryLayout,
+    name: &'static str,
+    region: Arm64FdtRegion,
+    gic_range: GuestMemoryRange,
+) -> Result<(), Arm64FdtError> {
+    for memory_range in layout.ranges().iter().copied() {
+        if gic_range.overlaps(memory_range) {
+            return Err(Arm64FdtError::GicRegionOverlapsMemory {
+                name,
+                region,
+                memory_range,
+            });
+        }
+    }
+
+    Ok(())
 }
 
 fn validate_timer(timer: Arm64FdtTimerInterrupts) -> Result<(), Arm64FdtError> {
@@ -741,6 +887,78 @@ mod tests {
     }
 
     #[test]
+    fn rejects_empty_initrd_range() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let address = GuestAddress::new(aarch64::DRAM_MEM_START + aarch64::SYSTEM_MEM_SIZE);
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: Some(LoadedInitrd { address, size: 0 }),
+            },
+        );
+
+        let err = build_arm64_fdt(&config).expect_err("empty initrd range should fail");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::InvalidInitrdRange {
+                source: GuestMemoryError::EmptyRange { start: address },
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_initrd_outside_guest_memory_node() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let range = GuestMemoryRange::new(GuestAddress::new(aarch64::DRAM_MEM_START), 0x1000)
+            .expect("test initrd range should be valid");
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: Some(LoadedInitrd {
+                    address: range.start(),
+                    size: range.size(),
+                }),
+            },
+        );
+
+        let err =
+            build_arm64_fdt(&config).expect_err("initrd outside advertised memory should fail");
+
+        assert_eq!(err, Arm64FdtError::InitrdNotInGuestMemory { range });
+    }
+
+    #[test]
+    fn rejects_initrd_overlapping_fdt() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let fdt_address = aarch64::fdt_address(&layout).expect("FDT address should resolve");
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: Some(LoadedInitrd {
+                    address: fdt_address,
+                    size: 1,
+                }),
+            },
+        );
+
+        let err = build_arm64_fdt(&config).expect_err("initrd overlapping FDT should fail");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::InitrdOverlapsFdt {
+                end_exclusive: fdt_address
+                    .checked_add(1)
+                    .expect("test initrd end should not overflow"),
+                fdt_address,
+            }
+        );
+    }
+
+    #[test]
     fn memory_node_excludes_reserved_system_area() {
         let layout = test_layout(TEST_MEMORY_SIZE);
         let config = test_config(
@@ -818,6 +1036,70 @@ mod tests {
         );
         assert_eq!(prop_u32_cells(intc, "interrupts"), vec![1, 9, 4]);
         assert!(intc.children.is_empty());
+    }
+
+    #[test]
+    fn rejects_overlapping_gic_regions() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let config = Arm64FdtConfig {
+            gic: Arm64FdtGic {
+                redistributor: Arm64FdtRegion {
+                    base: 0x3ffe_0000,
+                    size: 0x2_0000,
+                },
+                ..test_gic()
+            },
+            ..test_config(
+                &layout,
+                Arm64FdtBootInfo {
+                    command_line: "panic=1",
+                    initrd: None,
+                },
+            )
+        };
+
+        let err = build_arm64_fdt(&config).expect_err("overlapping GIC regions should fail");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::GicRegionsOverlap {
+                first: "distributor",
+                second: "redistributor",
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_gic_region_overlapping_guest_memory() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let region = Arm64FdtRegion {
+            base: aarch64::DRAM_MEM_START,
+            size: 0x1000,
+        };
+        let config = Arm64FdtConfig {
+            gic: Arm64FdtGic {
+                distributor: region,
+                ..test_gic()
+            },
+            ..test_config(
+                &layout,
+                Arm64FdtBootInfo {
+                    command_line: "panic=1",
+                    initrd: None,
+                },
+            )
+        };
+
+        let err = build_arm64_fdt(&config).expect_err("GIC region overlapping memory should fail");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::GicRegionOverlapsMemory {
+                name: "distributor",
+                region,
+                memory_range: layout.ranges()[0],
+            }
+        );
     }
 
     #[test]
@@ -1099,6 +1381,32 @@ mod tests {
         let err = build_arm64_fdt(&config).expect_err("missing CPU should fail");
 
         assert_eq!(err, Arm64FdtError::MissingCpu);
+    }
+
+    #[test]
+    fn rejects_too_many_cpus() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let mpidrs: Vec<u64> = (0..=MAX_ARM64_FDT_CPUS as u64).collect();
+        let config = Arm64FdtConfig {
+            vcpu_mpidrs: &mpidrs,
+            ..test_config(
+                &layout,
+                Arm64FdtBootInfo {
+                    command_line: "panic=1",
+                    initrd: None,
+                },
+            )
+        };
+
+        let err = build_arm64_fdt(&config).expect_err("too many CPUs should fail");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::TooManyCpus {
+                count: MAX_ARM64_FDT_CPUS + 1,
+                max: MAX_ARM64_FDT_CPUS,
+            }
+        );
     }
 
     #[test]

--- a/crates/runtime/src/fdt.rs
+++ b/crates/runtime/src/fdt.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use vm_fdt::{Error as VmFdtError, FdtWriter};
 
-use crate::boot::{LoadedBootSource, LoadedInitrd};
+use crate::boot::{BootCommandLineError, LoadedBootSource, LoadedInitrd};
 use crate::memory::{
     GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryError, GuestMemoryLayout,
     GuestMemoryRange, aarch64,
@@ -146,6 +146,12 @@ pub enum Arm64FdtError {
         actual: GuestAddress,
         expected: GuestAddress,
     },
+    GuestMemoryOverlapsMmio64 {
+        range: GuestMemoryRange,
+    },
+    InvalidCommandLine {
+        source: BootCommandLineError,
+    },
     InvalidInitrdRange {
         source: GuestMemoryError,
     },
@@ -236,6 +242,13 @@ impl fmt::Display for Arm64FdtError {
                 f,
                 "arm64 FDT guest memory must start at {expected}, got {actual}"
             ),
+            Self::GuestMemoryOverlapsMmio64 { range } => write!(
+                f,
+                "arm64 FDT guest memory range {range} overlaps the aarch64 MMIO64 gap"
+            ),
+            Self::InvalidCommandLine { source } => {
+                write!(f, "invalid arm64 FDT command line: {source}")
+            }
             Self::InvalidInitrdRange { source } => {
                 write!(f, "invalid arm64 FDT initrd range: {source}")
             }
@@ -315,6 +328,7 @@ impl std::error::Error for Arm64FdtError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::InvalidLayout { source } => Some(source),
+            Self::InvalidCommandLine { source } => Some(source),
             Self::InvalidInitrdRange { source } => Some(source),
             Self::CreateFdt { source } => Some(source),
             Self::GuestMemoryWrite { source } => Some(source),
@@ -323,6 +337,7 @@ impl std::error::Error for Arm64FdtError {
             | Self::DuplicateCpuReg { .. }
             | Self::NoGuestMemoryAfterSystemArea { .. }
             | Self::InvalidDramStart { .. }
+            | Self::GuestMemoryOverlapsMmio64 { .. }
             | Self::InitrdNotInGuestMemory { .. }
             | Self::InitrdOverlapsFdt { .. }
             | Self::InvalidGicRegion { .. }
@@ -391,6 +406,7 @@ fn validate_config(config: &Arm64FdtConfig<'_>) -> Result<(), Arm64FdtError> {
 
     validate_cpu_regs(config.vcpu_mpidrs)?;
     memory_reg_cells(config.layout)?;
+    validate_command_line(config.boot.command_line)?;
     validate_gic(config.layout, config.gic)?;
     validate_timer(config.timer)?;
     validate_gic_timer_ppis(config.gic, config.timer)?;
@@ -418,6 +434,36 @@ fn validate_cpu_regs(mpidrs: &[u64]) -> Result<(), Arm64FdtError> {
                 });
             }
         }
+    }
+
+    Ok(())
+}
+
+fn validate_command_line(command_line: &str) -> Result<(), Arm64FdtError> {
+    if command_line.as_bytes().contains(&0) {
+        return Err(Arm64FdtError::InvalidCommandLine {
+            source: BootCommandLineError::ContainsNul,
+        });
+    }
+
+    let size_with_nul =
+        command_line
+            .len()
+            .checked_add(1)
+            .ok_or(Arm64FdtError::InvalidCommandLine {
+                source: BootCommandLineError::TooLarge {
+                    size_with_nul: usize::MAX,
+                    max_size: aarch64::CMDLINE_MAX_SIZE,
+                },
+            })?;
+
+    if size_with_nul > aarch64::CMDLINE_MAX_SIZE {
+        return Err(Arm64FdtError::InvalidCommandLine {
+            source: BootCommandLineError::TooLarge {
+                size_with_nul,
+                max_size: aarch64::CMDLINE_MAX_SIZE,
+            },
+        });
     }
 
     Ok(())
@@ -540,6 +586,7 @@ fn create_psci_node(fdt: &mut FdtWriter) -> Result<(), Arm64FdtError> {
 
 fn memory_reg_cells(layout: &GuestMemoryLayout) -> Result<Vec<u64>, Arm64FdtError> {
     let mut cells = Vec::with_capacity(layout.ranges().len().saturating_mul(2));
+    let mmio64_gap = mmio64_gap_range()?;
     for (range_index, range) in layout.ranges().iter().copied().enumerate() {
         if range_index == 0 {
             if range.start().raw_value() != aarch64::SYSTEM_MEM_START {
@@ -554,6 +601,7 @@ fn memory_reg_cells(layout: &GuestMemoryLayout) -> Result<Vec<u64>, Arm64FdtErro
                     system_size: aarch64::SYSTEM_MEM_SIZE,
                 });
             }
+            validate_memory_range_excludes_mmio64_gap(range, mmio64_gap)?;
             let start = range.start().checked_add(aarch64::SYSTEM_MEM_SIZE).ok_or(
                 Arm64FdtError::InvalidLayout {
                     source: GuestMemoryError::AddressOverflow {
@@ -565,12 +613,32 @@ fn memory_reg_cells(layout: &GuestMemoryLayout) -> Result<Vec<u64>, Arm64FdtErro
             cells.push(start.raw_value());
             cells.push(range.size() - aarch64::SYSTEM_MEM_SIZE);
         } else {
+            validate_memory_range_excludes_mmio64_gap(range, mmio64_gap)?;
             cells.push(range.start().raw_value());
             cells.push(range.size());
         }
     }
 
     Ok(cells)
+}
+
+fn mmio64_gap_range() -> Result<GuestMemoryRange, Arm64FdtError> {
+    GuestMemoryRange::new(
+        GuestAddress::new(aarch64::MMIO64_MEM_START),
+        aarch64::MMIO64_MEM_SIZE,
+    )
+    .map_err(|source| Arm64FdtError::InvalidLayout { source })
+}
+
+fn validate_memory_range_excludes_mmio64_gap(
+    range: GuestMemoryRange,
+    mmio64_gap: GuestMemoryRange,
+) -> Result<(), Arm64FdtError> {
+    if range.overlaps(mmio64_gap) {
+        Err(Arm64FdtError::GuestMemoryOverlapsMmio64 { range })
+    } else {
+        Ok(())
+    }
 }
 
 fn validate_initrd(layout: &GuestMemoryLayout, initrd: LoadedInitrd) -> Result<(), Arm64FdtError> {
@@ -929,6 +997,71 @@ mod tests {
     }
 
     #[test]
+    fn accepts_command_line_at_fdt_limit() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let command_line = "x".repeat(aarch64::CMDLINE_MAX_SIZE - 1);
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: &command_line,
+                initrd: None,
+            },
+        );
+
+        let bytes = build_arm64_fdt(&config).expect("max-sized command line should fit");
+        let tree = DeviceTree::load(&bytes).expect("FDT should parse");
+        let chosen = required_node(&tree, "/chosen");
+
+        assert_eq!(chosen.prop_str("bootargs").unwrap(), command_line);
+    }
+
+    #[test]
+    fn rejects_oversized_command_line() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let command_line = "x".repeat(aarch64::CMDLINE_MAX_SIZE);
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: &command_line,
+                initrd: None,
+            },
+        );
+
+        let err = build_arm64_fdt(&config).expect_err("oversized command line should fail");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::InvalidCommandLine {
+                source: BootCommandLineError::TooLarge {
+                    size_with_nul: aarch64::CMDLINE_MAX_SIZE + 1,
+                    max_size: aarch64::CMDLINE_MAX_SIZE,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_command_line_with_nul() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1\0debug",
+                initrd: None,
+            },
+        );
+
+        let err = build_arm64_fdt(&config).expect_err("NUL command line should fail");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::InvalidCommandLine {
+                source: BootCommandLineError::ContainsNul,
+            }
+        );
+    }
+
+    #[test]
     fn rejects_empty_initrd_range() {
         let layout = test_layout(TEST_MEMORY_SIZE);
         let address = GuestAddress::new(aarch64::DRAM_MEM_START + aarch64::SYSTEM_MEM_SIZE);
@@ -1022,6 +1155,38 @@ mod tests {
                 aarch64::DRAM_MEM_START + aarch64::SYSTEM_MEM_SIZE,
                 TEST_MEMORY_SIZE - aarch64::SYSTEM_MEM_SIZE,
             ]
+        );
+    }
+
+    #[test]
+    fn rejects_memory_range_overlapping_mmio64_gap() {
+        let first_range = GuestMemoryRange::new(
+            GuestAddress::new(aarch64::DRAM_MEM_START),
+            aarch64::SYSTEM_MEM_SIZE + aarch64::GUEST_PAGE_SIZE,
+        )
+        .expect("first memory range should be valid");
+        let mmio64_range = GuestMemoryRange::new(
+            GuestAddress::new(aarch64::MMIO64_MEM_START),
+            aarch64::GUEST_PAGE_SIZE,
+        )
+        .expect("MMIO64-overlapping test range should be valid");
+        let layout = GuestMemoryLayout::new(vec![first_range, mmio64_range])
+            .expect("test layout should be valid");
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: None,
+            },
+        );
+
+        let err = build_arm64_fdt(&config).expect_err("MMIO64 gap RAM should fail");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::GuestMemoryOverlapsMmio64 {
+                range: mmio64_range,
+            }
         );
     }
 
@@ -1281,12 +1446,11 @@ mod tests {
 
     #[test]
     fn rejects_oversized_generated_fdt() {
-        let layout = test_layout(TEST_MEMORY_SIZE);
-        let command_line = "x".repeat(aarch64::FDT_MAX_SIZE as usize + 1);
+        let layout = oversized_fdt_layout();
         let config = test_config(
             &layout,
             Arm64FdtBootInfo {
-                command_line: &command_line,
+                command_line: "panic=1",
                 initrd: None,
             },
         );
@@ -1597,6 +1761,27 @@ mod tests {
 
     fn test_layout(size: u64) -> GuestMemoryLayout {
         aarch64::dram_layout(size).expect("test layout should be valid")
+    }
+
+    fn oversized_fdt_layout() -> GuestMemoryLayout {
+        let mut ranges = Vec::new();
+        let mut start = aarch64::DRAM_MEM_START;
+        let first_range_size = aarch64::SYSTEM_MEM_SIZE + aarch64::GUEST_PAGE_SIZE;
+        ranges.push(
+            GuestMemoryRange::new(GuestAddress::new(start), first_range_size)
+                .expect("oversized FDT first range should be valid"),
+        );
+        start += first_range_size;
+
+        for _ in 0..(aarch64::FDT_MAX_SIZE / 16 + 1) {
+            ranges.push(
+                GuestMemoryRange::new(GuestAddress::new(start), 1)
+                    .expect("oversized FDT memory range should be valid"),
+            );
+            start += 1;
+        }
+
+        GuestMemoryLayout::new(ranges).expect("oversized FDT layout should be valid")
     }
 
     fn test_config<'a>(

--- a/crates/runtime/src/fdt.rs
+++ b/crates/runtime/src/fdt.rs
@@ -765,16 +765,22 @@ fn validate_initrd(layout: &GuestMemoryLayout, initrd: LoadedInitrd) -> Result<(
         return Err(Arm64FdtError::InitrdNotInGuestMemory { range });
     }
 
-    let fdt_address =
-        aarch64::fdt_address(layout).map_err(|source| Arm64FdtError::InvalidLayout { source })?;
-    if range.end_exclusive() > fdt_address {
+    let fdt_range = fdt_reserved_range(layout)?;
+    if range.overlaps(fdt_range) {
         return Err(Arm64FdtError::InitrdOverlapsFdt {
             end_exclusive: range.end_exclusive(),
-            fdt_address,
+            fdt_address: fdt_range.start(),
         });
     }
 
     Ok(())
+}
+
+fn fdt_reserved_range(layout: &GuestMemoryLayout) -> Result<GuestMemoryRange, Arm64FdtError> {
+    let address =
+        aarch64::fdt_address(layout).map_err(|source| Arm64FdtError::InvalidLayout { source })?;
+    GuestMemoryRange::new(address, aarch64::FDT_MAX_SIZE)
+        .map_err(|source| Arm64FdtError::InvalidLayout { source })
 }
 
 fn initrd_range(initrd: LoadedInitrd) -> Result<GuestMemoryRange, Arm64FdtError> {
@@ -1248,6 +1254,37 @@ mod tests {
                     .expect("test initrd end should not overflow"),
                 fdt_address,
             }
+        );
+    }
+
+    #[test]
+    fn accepts_initrd_in_later_dram_range_after_fdt_window() {
+        let layout = aarch64::dram_layout(aarch64::MMIO64_MEM_START - aarch64::DRAM_MEM_START + 1)
+            .expect("split layout should be valid");
+        let second_range = layout.ranges()[1];
+        let initrd = LoadedInitrd {
+            address: second_range.start(),
+            size: second_range.size(),
+        };
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: Some(initrd),
+            },
+        );
+
+        let bytes = build_arm64_fdt(&config).expect("later-range initrd should not overlap FDT");
+        let tree = DeviceTree::load(&bytes).expect("FDT should parse");
+        let chosen = required_node(&tree, "/chosen");
+
+        assert_eq!(
+            chosen.prop_u64("linux,initrd-start").unwrap(),
+            second_range.start().raw_value()
+        );
+        assert_eq!(
+            chosen.prop_u64("linux,initrd-end").unwrap(),
+            second_range.end_exclusive().raw_value()
         );
     }
 

--- a/crates/runtime/src/fdt.rs
+++ b/crates/runtime/src/fdt.rs
@@ -101,7 +101,7 @@ impl Arm64FdtTimerInterrupts {
         el1_virtual_timer_intid: u32,
         el1_physical_timer_intid: u32,
     ) -> Result<Self, Arm64FdtError> {
-        Ok(Self {
+        let timer = Self {
             secure_physical: ARM64_FDT_SECURE_PHYSICAL_TIMER_PPI,
             non_secure_physical: ppi_from_intid(
                 "el1_physical_timer_intid",
@@ -109,7 +109,9 @@ impl Arm64FdtTimerInterrupts {
             )?,
             virtual_timer: ppi_from_intid("el1_virtual_timer_intid", el1_virtual_timer_intid)?,
             hypervisor: ARM64_FDT_HYPERVISOR_TIMER_PPI,
-        })
+        };
+        validate_timer(timer)?;
+        Ok(timer)
     }
 }
 
@@ -129,6 +131,10 @@ pub enum Arm64FdtError {
         first_range: GuestMemoryRange,
         system_size: u64,
     },
+    InvalidDramStart {
+        actual: GuestAddress,
+        expected: GuestAddress,
+    },
     InitrdEndOverflow {
         address: GuestAddress,
         size: u64,
@@ -142,6 +148,11 @@ pub enum Arm64FdtError {
     },
     InvalidPpi {
         name: &'static str,
+        value: u32,
+    },
+    DuplicatePpi {
+        first: &'static str,
+        second: &'static str,
         value: u32,
     },
     InvalidPpiIntid {
@@ -175,6 +186,10 @@ impl fmt::Display for Arm64FdtError {
                 f,
                 "guest memory first range {first_range} does not leave RAM after the reserved {system_size} byte system area"
             ),
+            Self::InvalidDramStart { actual, expected } => write!(
+                f,
+                "arm64 FDT guest memory must start at {expected}, got {actual}"
+            ),
             Self::InitrdEndOverflow { address, size } => write!(
                 f,
                 "initrd FDT end address overflows: start={address}, size={size}"
@@ -193,6 +208,14 @@ impl fmt::Display for Arm64FdtError {
                     "arm64 FDT {name} PPI value must be below 16, got {value}"
                 )
             }
+            Self::DuplicatePpi {
+                first,
+                second,
+                value,
+            } => write!(
+                f,
+                "arm64 FDT timer PPIs must be distinct: {first} and {second} both use {value}"
+            ),
             Self::InvalidPpiIntid { name, intid } => write!(
                 f,
                 "arm64 FDT {name} INTID must be in the PPI range [16, 32), got {intid}"
@@ -220,10 +243,12 @@ impl std::error::Error for Arm64FdtError {
             Self::GuestMemoryWrite { source } => Some(source),
             Self::MissingCpu
             | Self::NoGuestMemoryAfterSystemArea { .. }
+            | Self::InvalidDramStart { .. }
             | Self::InitrdEndOverflow { .. }
             | Self::InvalidGicRegion { .. }
             | Self::InvalidGicInterruptCells { .. }
             | Self::InvalidPpi { .. }
+            | Self::DuplicatePpi { .. }
             | Self::InvalidPpiIntid { .. }
             | Self::UnsupportedMsi
             | Self::FdtTooLarge { .. } => None,
@@ -411,6 +436,12 @@ fn memory_reg_cells(layout: &GuestMemoryLayout) -> Result<Vec<u64>, Arm64FdtErro
     let mut cells = Vec::with_capacity(layout.ranges().len().saturating_mul(2));
     for (range_index, range) in layout.ranges().iter().copied().enumerate() {
         if range_index == 0 {
+            if range.start().raw_value() != aarch64::SYSTEM_MEM_START {
+                return Err(Arm64FdtError::InvalidDramStart {
+                    actual: range.start(),
+                    expected: GuestAddress::new(aarch64::SYSTEM_MEM_START),
+                });
+            }
             if range.size() <= aarch64::SYSTEM_MEM_SIZE {
                 return Err(Arm64FdtError::NoGuestMemoryAfterSystemArea {
                     first_range: range,
@@ -468,6 +499,7 @@ fn validate_timer(timer: Arm64FdtTimerInterrupts) -> Result<(), Arm64FdtError> {
     validate_ppi("non_secure_physical_timer", timer.non_secure_physical)?;
     validate_ppi("virtual_timer", timer.virtual_timer)?;
     validate_ppi("hypervisor_timer", timer.hypervisor)?;
+    validate_distinct_timer_ppis(timer)?;
     Ok(())
 }
 
@@ -477,6 +509,29 @@ fn validate_ppi(name: &'static str, value: u32) -> Result<(), Arm64FdtError> {
     } else {
         Err(Arm64FdtError::InvalidPpi { name, value })
     }
+}
+
+fn validate_distinct_timer_ppis(timer: Arm64FdtTimerInterrupts) -> Result<(), Arm64FdtError> {
+    let values = [
+        ("secure_physical_timer", timer.secure_physical),
+        ("non_secure_physical_timer", timer.non_secure_physical),
+        ("virtual_timer", timer.virtual_timer),
+        ("hypervisor_timer", timer.hypervisor),
+    ];
+
+    for (left_index, (left_name, left_value)) in values.iter().copied().enumerate() {
+        for (right_name, right_value) in values.iter().copied().skip(left_index + 1) {
+            if left_value == right_value {
+                return Err(Arm64FdtError::DuplicatePpi {
+                    first: left_name,
+                    second: right_name,
+                    value: left_value,
+                });
+            }
+        }
+    }
+
+    Ok(())
 }
 
 fn ppi_from_intid(name: &'static str, intid: u32) -> Result<u32, Arm64FdtError> {
@@ -887,6 +942,32 @@ mod tests {
     }
 
     #[test]
+    fn rejects_layout_that_does_not_start_at_arm64_dram_start() {
+        let start = GuestAddress::new(aarch64::DRAM_MEM_START + aarch64::GUEST_PAGE_SIZE);
+        let layout = GuestMemoryLayout::new(vec![
+            GuestMemoryRange::new(start, TEST_MEMORY_SIZE).expect("test range should be valid"),
+        ])
+        .expect("test layout should be valid");
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: None,
+            },
+        );
+
+        let err = build_arm64_fdt(&config).expect_err("unexpected DRAM start should fail");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::InvalidDramStart {
+                actual: start,
+                expected: GuestAddress::new(aarch64::SYSTEM_MEM_START),
+            }
+        );
+    }
+
+    #[test]
     fn rejects_missing_cpus() {
         let layout = test_layout(TEST_MEMORY_SIZE);
         let config = Arm64FdtConfig {
@@ -906,6 +987,37 @@ mod tests {
     }
 
     #[test]
+    fn rejects_duplicate_timer_ppis() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let config = Arm64FdtConfig {
+            timer: Arm64FdtTimerInterrupts {
+                secure_physical: 13,
+                non_secure_physical: 13,
+                virtual_timer: 11,
+                hypervisor: 10,
+            },
+            ..test_config(
+                &layout,
+                Arm64FdtBootInfo {
+                    command_line: "panic=1",
+                    initrd: None,
+                },
+            )
+        };
+
+        let err = build_arm64_fdt(&config).expect_err("duplicate timer PPI should fail");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::DuplicatePpi {
+                first: "secure_physical_timer",
+                second: "non_secure_physical_timer",
+                value: 13,
+            }
+        );
+    }
+
+    #[test]
     fn rejects_invalid_timer_intids() {
         let err = Arm64FdtTimerInterrupts::from_el1_timer_intids(15, 30)
             .expect_err("non-PPI virtual timer INTID should fail");
@@ -915,6 +1027,21 @@ mod tests {
             Arm64FdtError::InvalidPpiIntid {
                 name: "el1_virtual_timer_intid",
                 intid: 15,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_timer_intids() {
+        let err = Arm64FdtTimerInterrupts::from_el1_timer_intids(27, 27)
+            .expect_err("duplicate timer INTIDs should fail after PPI mapping");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::DuplicatePpi {
+                first: "non_secure_physical_timer",
+                second: "virtual_timer",
+                value: 11,
             }
         );
     }

--- a/crates/runtime/src/fdt.rs
+++ b/crates/runtime/src/fdt.rs
@@ -18,6 +18,7 @@ const CPU_ADDRESS_CELLS: u32 = 2;
 const CPU_SIZE_CELLS: u32 = 0;
 const CPU_REG_MASK: u64 = 0x7f_ffff;
 const MAX_ARM64_FDT_CPUS: usize = 32;
+const GIC_COMPATIBILITY: &str = "arm,gic-v3";
 const GIC_FDT_IRQ_TYPE_PPI: u32 = 1;
 const IRQ_TYPE_LEVEL_HIGH: u32 = 4;
 const FIRST_PPI_INTID: u32 = 16;
@@ -168,6 +169,10 @@ pub enum Arm64FdtError {
         region: Arm64FdtRegion,
         memory_range: GuestMemoryRange,
     },
+    InvalidGicCompatibility {
+        value: &'static str,
+        expected: &'static str,
+    },
     InvalidGicInterruptCells {
         value: u32,
     },
@@ -262,6 +267,10 @@ impl fmt::Display for Arm64FdtError {
                 "arm64 FDT GIC {name} region base=0x{:x}, size={} overlaps guest memory range {memory_range}",
                 region.base, region.size
             ),
+            Self::InvalidGicCompatibility { value, expected } => write!(
+                f,
+                "arm64 FDT GIC compatible must be {expected}, got {value}"
+            ),
             Self::InvalidGicInterruptCells { value } => {
                 write!(f, "arm64 FDT GIC #interrupt-cells must be 3, got {value}")
             }
@@ -277,7 +286,7 @@ impl fmt::Display for Arm64FdtError {
                 value,
             } => write!(
                 f,
-                "arm64 FDT timer PPIs must be distinct: {first} and {second} both use {value}"
+                "arm64 FDT PPIs must be distinct: {first} and {second} both use {value}"
             ),
             Self::InvalidPpiIntid { name, intid } => write!(
                 f,
@@ -319,6 +328,7 @@ impl std::error::Error for Arm64FdtError {
             | Self::InvalidGicRegion { .. }
             | Self::GicRegionsOverlap { .. }
             | Self::GicRegionOverlapsMemory { .. }
+            | Self::InvalidGicCompatibility { .. }
             | Self::InvalidGicInterruptCells { .. }
             | Self::InvalidPpi { .. }
             | Self::DuplicatePpi { .. }
@@ -383,6 +393,7 @@ fn validate_config(config: &Arm64FdtConfig<'_>) -> Result<(), Arm64FdtError> {
     memory_reg_cells(config.layout)?;
     validate_gic(config.layout, config.gic)?;
     validate_timer(config.timer)?;
+    validate_gic_timer_ppis(config.gic, config.timer)?;
     if let Some(initrd) = config.boot.initrd {
         validate_initrd(config.layout, initrd)?;
     }
@@ -634,6 +645,13 @@ fn validate_gic(layout: &GuestMemoryLayout, gic: Arm64FdtGic) -> Result<(), Arm6
         redistributor,
     )?;
 
+    if gic.compatibility != GIC_COMPATIBILITY {
+        return Err(Arm64FdtError::InvalidGicCompatibility {
+            value: gic.compatibility,
+            expected: GIC_COMPATIBILITY,
+        });
+    }
+
     if gic.interrupt_cells != 3 {
         return Err(Arm64FdtError::InvalidGicInterruptCells {
             value: gic.interrupt_cells,
@@ -644,6 +662,30 @@ fn validate_gic(layout: &GuestMemoryLayout, gic: Arm64FdtGic) -> Result<(), Arm6
 
     if gic.msi.is_some() {
         return Err(Arm64FdtError::UnsupportedMsi);
+    }
+
+    Ok(())
+}
+
+fn validate_gic_timer_ppis(
+    gic: Arm64FdtGic,
+    timer: Arm64FdtTimerInterrupts,
+) -> Result<(), Arm64FdtError> {
+    let timer_ppis = [
+        ("secure_physical_timer", timer.secure_physical),
+        ("non_secure_physical_timer", timer.non_secure_physical),
+        ("virtual_timer", timer.virtual_timer),
+        ("hypervisor_timer", timer.hypervisor),
+    ];
+
+    for (timer_name, timer_ppi) in timer_ppis {
+        if gic.maintenance_irq == timer_ppi {
+            return Err(Arm64FdtError::DuplicatePpi {
+                first: "maintenance_irq",
+                second: timer_name,
+                value: timer_ppi,
+            });
+        }
     }
 
     Ok(())
@@ -1103,6 +1145,63 @@ mod tests {
     }
 
     #[test]
+    fn rejects_unexpected_gic_compatibility() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let config = Arm64FdtConfig {
+            gic: Arm64FdtGic {
+                compatibility: "arm,gic-v2",
+                ..test_gic()
+            },
+            ..test_config(
+                &layout,
+                Arm64FdtBootInfo {
+                    command_line: "panic=1",
+                    initrd: None,
+                },
+            )
+        };
+
+        let err = build_arm64_fdt(&config).expect_err("unexpected GIC compatible should fail");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::InvalidGicCompatibility {
+                value: "arm,gic-v2",
+                expected: GIC_COMPATIBILITY,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_gic_maintenance_irq_reusing_timer_ppi() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let config = Arm64FdtConfig {
+            gic: Arm64FdtGic {
+                maintenance_irq: ARM64_FDT_SECURE_PHYSICAL_TIMER_PPI,
+                ..test_gic()
+            },
+            ..test_config(
+                &layout,
+                Arm64FdtBootInfo {
+                    command_line: "panic=1",
+                    initrd: None,
+                },
+            )
+        };
+
+        let err = build_arm64_fdt(&config).expect_err("reused maintenance PPI should fail");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::DuplicatePpi {
+                first: "maintenance_irq",
+                second: "secure_physical_timer",
+                value: ARM64_FDT_SECURE_PHYSICAL_TIMER_PPI,
+            }
+        );
+    }
+
+    #[test]
     fn timer_node_uses_firecracker_ppi_cells() {
         let layout = test_layout(TEST_MEMORY_SIZE);
         let config = test_config(
@@ -1523,7 +1622,7 @@ mod tests {
                 base: 0x3ffd_0000,
                 size: 0x2_0000,
             },
-            compatibility: "arm,gic-v3",
+            compatibility: GIC_COMPATIBILITY,
             interrupt_cells: 3,
             maintenance_irq: 9,
             msi: None,

--- a/crates/runtime/src/fdt.rs
+++ b/crates/runtime/src/fdt.rs
@@ -23,6 +23,8 @@ const GIC_FDT_IRQ_TYPE_PPI: u32 = 1;
 const IRQ_TYPE_LEVEL_HIGH: u32 = 4;
 const FIRST_PPI_INTID: u32 = 16;
 const FIRST_SPI_INTID: u32 = 32;
+const MEMORY_REG_CELLS_PER_RANGE: usize = 2;
+const MEMORY_REG_CELL_SIZE: usize = 8;
 
 pub const ARM64_FDT_SECURE_PHYSICAL_TIMER_PPI: u32 = 13;
 pub const ARM64_FDT_NON_SECURE_PHYSICAL_TIMER_PPI: u32 = 14;
@@ -585,7 +587,10 @@ fn create_psci_node(fdt: &mut FdtWriter) -> Result<(), Arm64FdtError> {
 }
 
 fn memory_reg_cells(layout: &GuestMemoryLayout) -> Result<Vec<u64>, Arm64FdtError> {
-    let mut cells = Vec::with_capacity(layout.ranges().len().saturating_mul(2));
+    let cell_count = memory_reg_cell_count(layout)?;
+    validate_fdt_size(memory_reg_size_lower_bound(cell_count)?)?;
+
+    let mut cells = Vec::with_capacity(cell_count);
     let mmio64_gap = mmio64_gap_range()?;
     for (range_index, range) in layout.ranges().iter().copied().enumerate() {
         if range_index == 0 {
@@ -620,6 +625,26 @@ fn memory_reg_cells(layout: &GuestMemoryLayout) -> Result<Vec<u64>, Arm64FdtErro
     }
 
     Ok(cells)
+}
+
+fn memory_reg_cell_count(layout: &GuestMemoryLayout) -> Result<usize, Arm64FdtError> {
+    layout
+        .ranges()
+        .len()
+        .checked_mul(MEMORY_REG_CELLS_PER_RANGE)
+        .ok_or(Arm64FdtError::FdtTooLarge {
+            size: usize::MAX,
+            max_size: aarch64::FDT_MAX_SIZE,
+        })
+}
+
+fn memory_reg_size_lower_bound(cell_count: usize) -> Result<usize, Arm64FdtError> {
+    cell_count
+        .checked_mul(MEMORY_REG_CELL_SIZE)
+        .ok_or(Arm64FdtError::FdtTooLarge {
+            size: usize::MAX,
+            max_size: aarch64::FDT_MAX_SIZE,
+        })
 }
 
 fn mmio64_gap_range() -> Result<GuestMemoryRange, Arm64FdtError> {
@@ -1457,13 +1482,13 @@ mod tests {
 
         let err = build_arm64_fdt(&config).expect_err("oversized generated FDT should fail");
 
-        assert!(matches!(
+        assert_eq!(
             err,
             Arm64FdtError::FdtTooLarge {
+                size: layout.ranges().len() * MEMORY_REG_CELLS_PER_RANGE * MEMORY_REG_CELL_SIZE,
                 max_size: aarch64::FDT_MAX_SIZE,
-                ..
             }
-        ));
+        );
     }
 
     #[test]

--- a/crates/runtime/src/fdt.rs
+++ b/crates/runtime/src/fdt.rs
@@ -167,6 +167,11 @@ pub enum Arm64FdtError {
         size: usize,
         max_size: u64,
     },
+    GuestMemoryLayoutMismatch {
+        range_index: usize,
+        expected: Option<GuestMemoryRange>,
+        actual: Option<GuestMemoryRange>,
+    },
     GuestMemoryWrite {
         source: GuestMemoryAccessError,
     },
@@ -228,6 +233,10 @@ impl fmt::Display for Arm64FdtError {
                     "arm64 FDT size {size} bytes exceeds reserved {max_size} byte window"
                 )
             }
+            Self::GuestMemoryLayoutMismatch { range_index, .. } => write!(
+                f,
+                "arm64 FDT guest memory layout does not match allocated memory at range {range_index}"
+            ),
             Self::GuestMemoryWrite { source } => {
                 write!(f, "failed to write arm64 FDT into guest memory: {source}")
             }
@@ -251,7 +260,8 @@ impl std::error::Error for Arm64FdtError {
             | Self::DuplicatePpi { .. }
             | Self::InvalidPpiIntid { .. }
             | Self::UnsupportedMsi
-            | Self::FdtTooLarge { .. } => None,
+            | Self::FdtTooLarge { .. }
+            | Self::GuestMemoryLayoutMismatch { .. } => None,
         }
     }
 }
@@ -289,6 +299,7 @@ pub fn write_arm64_fdt(
     config: &Arm64FdtConfig<'_>,
     memory: &mut GuestMemory,
 ) -> Result<Arm64FdtGuestMemoryWrite, Arm64FdtError> {
+    validate_guest_memory_matches_layout(config.layout, memory)?;
     let bytes = build_arm64_fdt(config)?;
     write_arm64_fdt_bytes(config.layout, memory, &bytes)
 }
@@ -569,6 +580,29 @@ fn write_arm64_fdt_bytes(
         address,
         size: bytes.len(),
     })
+}
+
+fn validate_guest_memory_matches_layout(
+    layout: &GuestMemoryLayout,
+    memory: &GuestMemory,
+) -> Result<(), Arm64FdtError> {
+    let layout_ranges = layout.ranges();
+    let memory_regions = memory.regions();
+    let range_count = layout_ranges.len().max(memory_regions.len());
+
+    for range_index in 0..range_count {
+        let expected = layout_ranges.get(range_index).copied();
+        let actual = memory_regions.get(range_index).map(|region| region.range());
+        if expected != actual {
+            return Err(Arm64FdtError::GuestMemoryLayoutMismatch {
+                range_index,
+                expected,
+                actual,
+            });
+        }
+    }
+
+    Ok(())
 }
 
 fn size_as_u64(size: usize) -> u64 {
@@ -878,16 +912,15 @@ mod tests {
     }
 
     #[test]
-    fn rejects_unbacked_guest_memory_write_without_partial_mutation() {
+    fn rejects_mismatched_guest_memory_layout_without_partial_mutation() {
         let layout = test_layout(TEST_MEMORY_SIZE);
-        let memory_layout = GuestMemoryLayout::new(vec![
-            GuestMemoryRange::new(
-                GuestAddress::new(aarch64::DRAM_MEM_START),
-                aarch64::FDT_MAX_SIZE,
-            )
-            .expect("mapped prefix should be valid"),
-        ])
-        .expect("mapped prefix layout should be valid");
+        let memory_range = GuestMemoryRange::new(
+            GuestAddress::new(aarch64::DRAM_MEM_START),
+            aarch64::FDT_MAX_SIZE,
+        )
+        .expect("mapped prefix should be valid");
+        let memory_layout = GuestMemoryLayout::new(vec![memory_range])
+            .expect("mapped prefix layout should be valid");
         let mut memory =
             GuestMemory::allocate(&memory_layout).expect("mapped prefix should allocate");
         let mut before = vec![0; 16];
@@ -902,15 +935,56 @@ mod tests {
             },
         );
 
-        let err =
-            write_arm64_fdt(&config, &mut memory).expect_err("unbacked FDT write should fail");
+        let err = write_arm64_fdt(&config, &mut memory)
+            .expect_err("mismatched guest memory layout should fail before write");
 
-        assert!(matches!(
+        assert_eq!(
+            err,
+            Arm64FdtError::GuestMemoryLayoutMismatch {
+                range_index: 0,
+                expected: Some(layout.ranges()[0]),
+                actual: Some(memory_range),
+            }
+        );
+        let mut after = vec![0; before.len()];
+        memory
+            .read_slice(&mut after, GuestAddress::new(aarch64::DRAM_MEM_START))
+            .expect("mapped prefix should remain readable");
+        assert_eq!(after, before);
+    }
+
+    #[test]
+    fn raw_fdt_write_rejects_unbacked_guest_memory_without_partial_mutation() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let fdt_address = aarch64::fdt_address(&layout).expect("FDT address should resolve");
+        let memory_layout = GuestMemoryLayout::new(vec![
+            GuestMemoryRange::new(
+                GuestAddress::new(aarch64::DRAM_MEM_START),
+                aarch64::FDT_MAX_SIZE,
+            )
+            .expect("mapped prefix should be valid"),
+        ])
+        .expect("mapped prefix layout should be valid");
+        let mut memory =
+            GuestMemory::allocate(&memory_layout).expect("mapped prefix should allocate");
+        let mut before = vec![0; 16];
+        memory
+            .read_slice(&mut before, GuestAddress::new(aarch64::DRAM_MEM_START))
+            .expect("initial bytes should read");
+        let bytes = vec![0xa5; 256];
+
+        let err = write_arm64_fdt_bytes(&layout, &mut memory, &bytes)
+            .expect_err("unbacked raw FDT write should fail");
+
+        assert_eq!(
             err,
             Arm64FdtError::GuestMemoryWrite {
-                source: GuestMemoryAccessError::UnmappedRange { .. }
+                source: GuestMemoryAccessError::UnmappedRange {
+                    range: GuestMemoryRange::new(fdt_address, 256)
+                        .expect("FDT write range should be valid"),
+                },
             }
-        ));
+        );
         let mut after = vec![0; before.len()];
         memory
             .read_slice(&mut after, GuestAddress::new(aarch64::DRAM_MEM_START))

--- a/crates/runtime/src/fdt.rs
+++ b/crates/runtime/src/fdt.rs
@@ -148,6 +148,10 @@ pub enum Arm64FdtError {
         actual: GuestAddress,
         expected: GuestAddress,
     },
+    GuestMemoryTooLarge {
+        size: u64,
+        max_size: u64,
+    },
     GuestMemoryOverlapsMmio64 {
         range: GuestMemoryRange,
     },
@@ -244,6 +248,10 @@ impl fmt::Display for Arm64FdtError {
                 f,
                 "arm64 FDT guest memory must start at {expected}, got {actual}"
             ),
+            Self::GuestMemoryTooLarge { size, max_size } => write!(
+                f,
+                "arm64 FDT guest memory size {size} bytes exceeds {max_size} byte aarch64 maximum"
+            ),
             Self::GuestMemoryOverlapsMmio64 { range } => write!(
                 f,
                 "arm64 FDT guest memory range {range} overlaps the aarch64 MMIO64 gap"
@@ -339,6 +347,7 @@ impl std::error::Error for Arm64FdtError {
             | Self::DuplicateCpuReg { .. }
             | Self::NoGuestMemoryAfterSystemArea { .. }
             | Self::InvalidDramStart { .. }
+            | Self::GuestMemoryTooLarge { .. }
             | Self::GuestMemoryOverlapsMmio64 { .. }
             | Self::InitrdNotInGuestMemory { .. }
             | Self::InitrdOverlapsFdt { .. }
@@ -408,6 +417,7 @@ fn validate_config(config: &Arm64FdtConfig<'_>) -> Result<(), Arm64FdtError> {
 
     validate_cpu_regs(config.vcpu_mpidrs)?;
     memory_reg_cells(config.layout)?;
+    validate_guest_memory_size(config.layout)?;
     validate_command_line(config.boot.command_line)?;
     validate_gic(config.layout, config.gic)?;
     validate_timer(config.timer)?;
@@ -625,6 +635,27 @@ fn memory_reg_cells(layout: &GuestMemoryLayout) -> Result<Vec<u64>, Arm64FdtErro
     }
 
     Ok(cells)
+}
+
+fn validate_guest_memory_size(layout: &GuestMemoryLayout) -> Result<(), Arm64FdtError> {
+    let mut size = 0u64;
+    for range in layout.ranges().iter().copied() {
+        size = size
+            .checked_add(range.size())
+            .ok_or(Arm64FdtError::GuestMemoryTooLarge {
+                size: u64::MAX,
+                max_size: aarch64::DRAM_MEM_MAX_SIZE,
+            })?;
+    }
+
+    if size > aarch64::DRAM_MEM_MAX_SIZE {
+        Err(Arm64FdtError::GuestMemoryTooLarge {
+            size,
+            max_size: aarch64::DRAM_MEM_MAX_SIZE,
+        })
+    } else {
+        Ok(())
+    }
 }
 
 fn memory_reg_cell_count(layout: &GuestMemoryLayout) -> Result<usize, Arm64FdtError> {
@@ -1211,6 +1242,39 @@ mod tests {
             err,
             Arm64FdtError::GuestMemoryOverlapsMmio64 {
                 range: mmio64_range,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_memory_larger_than_arm64_dram_max() {
+        let first_size = aarch64::MMIO64_MEM_START - aarch64::DRAM_MEM_START;
+        let second_size = aarch64::DRAM_MEM_MAX_SIZE - first_size + 1;
+        let first_range =
+            GuestMemoryRange::new(GuestAddress::new(aarch64::DRAM_MEM_START), first_size)
+                .expect("first max-size test range should be valid");
+        let second_range = GuestMemoryRange::new(
+            GuestAddress::new(aarch64::FIRST_ADDR_PAST_64BITS_MMIO),
+            second_size,
+        )
+        .expect("second max-size test range should be valid");
+        let layout = GuestMemoryLayout::new(vec![first_range, second_range])
+            .expect("oversized aarch64 layout should be structurally valid");
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: None,
+            },
+        );
+
+        let err = build_arm64_fdt(&config).expect_err("oversized guest memory should fail");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::GuestMemoryTooLarge {
+                size: aarch64::DRAM_MEM_MAX_SIZE + 1,
+                max_size: aarch64::DRAM_MEM_MAX_SIZE,
             }
         );
     }

--- a/crates/runtime/src/fdt.rs
+++ b/crates/runtime/src/fdt.rs
@@ -1,0 +1,986 @@
+//! Minimal arm64 Flattened Device Tree generation for guest boot metadata.
+
+use std::fmt;
+
+use vm_fdt::{Error as VmFdtError, FdtWriter};
+
+use crate::boot::{LoadedBootSource, LoadedInitrd};
+use crate::memory::{
+    GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryError, GuestMemoryLayout,
+    GuestMemoryRange, aarch64,
+};
+
+const ROOT_COMPATIBILITY: &str = "linux,dummy-virt";
+const GIC_PHANDLE: u32 = 1;
+const ADDRESS_CELLS: u32 = 2;
+const SIZE_CELLS: u32 = 2;
+const CPU_ADDRESS_CELLS: u32 = 2;
+const CPU_SIZE_CELLS: u32 = 0;
+const CPU_REG_MASK: u64 = 0x7f_ffff;
+const GIC_FDT_IRQ_TYPE_PPI: u32 = 1;
+const IRQ_TYPE_LEVEL_HIGH: u32 = 4;
+const FIRST_PPI_INTID: u32 = 16;
+const FIRST_SPI_INTID: u32 = 32;
+
+pub const ARM64_FDT_SECURE_PHYSICAL_TIMER_PPI: u32 = 13;
+pub const ARM64_FDT_NON_SECURE_PHYSICAL_TIMER_PPI: u32 = 14;
+pub const ARM64_FDT_VIRTUAL_TIMER_PPI: u32 = 11;
+pub const ARM64_FDT_HYPERVISOR_TIMER_PPI: u32 = 10;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Arm64FdtBootInfo<'a> {
+    pub command_line: &'a str,
+    pub initrd: Option<LoadedInitrd>,
+}
+
+impl<'a> From<&'a LoadedBootSource> for Arm64FdtBootInfo<'a> {
+    fn from(source: &'a LoadedBootSource) -> Self {
+        Self {
+            command_line: source.command_line.as_str(),
+            initrd: source.initrd,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Arm64FdtConfig<'a> {
+    pub layout: &'a GuestMemoryLayout,
+    pub boot: Arm64FdtBootInfo<'a>,
+    pub vcpu_mpidrs: &'a [u64],
+    pub gic: Arm64FdtGic,
+    pub timer: Arm64FdtTimerInterrupts,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Arm64FdtRegion {
+    pub base: u64,
+    pub size: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Arm64FdtInterruptRange {
+    pub base: u32,
+    pub count: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Arm64FdtMsi {
+    pub region: Arm64FdtRegion,
+    pub interrupt_range: Arm64FdtInterruptRange,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Arm64FdtGic {
+    pub distributor: Arm64FdtRegion,
+    pub redistributor: Arm64FdtRegion,
+    pub compatibility: &'static str,
+    pub interrupt_cells: u32,
+    pub maintenance_irq: u32,
+    pub msi: Option<Arm64FdtMsi>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Arm64FdtTimerInterrupts {
+    pub secure_physical: u32,
+    pub non_secure_physical: u32,
+    pub virtual_timer: u32,
+    pub hypervisor: u32,
+}
+
+impl Arm64FdtTimerInterrupts {
+    pub const fn firecracker_default() -> Self {
+        Self {
+            secure_physical: ARM64_FDT_SECURE_PHYSICAL_TIMER_PPI,
+            non_secure_physical: ARM64_FDT_NON_SECURE_PHYSICAL_TIMER_PPI,
+            virtual_timer: ARM64_FDT_VIRTUAL_TIMER_PPI,
+            hypervisor: ARM64_FDT_HYPERVISOR_TIMER_PPI,
+        }
+    }
+
+    pub fn from_el1_timer_intids(
+        el1_virtual_timer_intid: u32,
+        el1_physical_timer_intid: u32,
+    ) -> Result<Self, Arm64FdtError> {
+        Ok(Self {
+            secure_physical: ARM64_FDT_SECURE_PHYSICAL_TIMER_PPI,
+            non_secure_physical: ppi_from_intid(
+                "el1_physical_timer_intid",
+                el1_physical_timer_intid,
+            )?,
+            virtual_timer: ppi_from_intid("el1_virtual_timer_intid", el1_virtual_timer_intid)?,
+            hypervisor: ARM64_FDT_HYPERVISOR_TIMER_PPI,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Arm64FdtGuestMemoryWrite {
+    pub address: GuestAddress,
+    pub size: usize,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Arm64FdtError {
+    MissingCpu,
+    InvalidLayout {
+        source: GuestMemoryError,
+    },
+    NoGuestMemoryAfterSystemArea {
+        first_range: GuestMemoryRange,
+        system_size: u64,
+    },
+    InitrdEndOverflow {
+        address: GuestAddress,
+        size: u64,
+    },
+    InvalidGicRegion {
+        name: &'static str,
+        region: Arm64FdtRegion,
+    },
+    InvalidGicInterruptCells {
+        value: u32,
+    },
+    InvalidPpi {
+        name: &'static str,
+        value: u32,
+    },
+    InvalidPpiIntid {
+        name: &'static str,
+        intid: u32,
+    },
+    UnsupportedMsi,
+    CreateFdt {
+        source: VmFdtError,
+    },
+    FdtTooLarge {
+        size: usize,
+        max_size: u64,
+    },
+    GuestMemoryWrite {
+        source: GuestMemoryAccessError,
+    },
+}
+
+impl fmt::Display for Arm64FdtError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingCpu => f.write_str("arm64 FDT requires at least one CPU"),
+            Self::InvalidLayout { source } => {
+                write!(f, "invalid arm64 FDT memory layout: {source}")
+            }
+            Self::NoGuestMemoryAfterSystemArea {
+                first_range,
+                system_size,
+            } => write!(
+                f,
+                "guest memory first range {first_range} does not leave RAM after the reserved {system_size} byte system area"
+            ),
+            Self::InitrdEndOverflow { address, size } => write!(
+                f,
+                "initrd FDT end address overflows: start={address}, size={size}"
+            ),
+            Self::InvalidGicRegion { name, region } => write!(
+                f,
+                "invalid arm64 FDT GIC {name} region: base=0x{:x}, size={}",
+                region.base, region.size
+            ),
+            Self::InvalidGicInterruptCells { value } => {
+                write!(f, "arm64 FDT GIC #interrupt-cells must be 3, got {value}")
+            }
+            Self::InvalidPpi { name, value } => {
+                write!(
+                    f,
+                    "arm64 FDT {name} PPI value must be below 16, got {value}"
+                )
+            }
+            Self::InvalidPpiIntid { name, intid } => write!(
+                f,
+                "arm64 FDT {name} INTID must be in the PPI range [16, 32), got {intid}"
+            ),
+            Self::UnsupportedMsi => f.write_str("arm64 FDT MSI/ITS nodes are not supported yet"),
+            Self::CreateFdt { source } => write!(f, "failed to create arm64 FDT: {source}"),
+            Self::FdtTooLarge { size, max_size } => {
+                write!(
+                    f,
+                    "arm64 FDT size {size} bytes exceeds reserved {max_size} byte window"
+                )
+            }
+            Self::GuestMemoryWrite { source } => {
+                write!(f, "failed to write arm64 FDT into guest memory: {source}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for Arm64FdtError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidLayout { source } => Some(source),
+            Self::CreateFdt { source } => Some(source),
+            Self::GuestMemoryWrite { source } => Some(source),
+            Self::MissingCpu
+            | Self::NoGuestMemoryAfterSystemArea { .. }
+            | Self::InitrdEndOverflow { .. }
+            | Self::InvalidGicRegion { .. }
+            | Self::InvalidGicInterruptCells { .. }
+            | Self::InvalidPpi { .. }
+            | Self::InvalidPpiIntid { .. }
+            | Self::UnsupportedMsi
+            | Self::FdtTooLarge { .. } => None,
+        }
+    }
+}
+
+impl From<VmFdtError> for Arm64FdtError {
+    fn from(source: VmFdtError) -> Self {
+        Self::CreateFdt { source }
+    }
+}
+
+pub fn build_arm64_fdt(config: &Arm64FdtConfig<'_>) -> Result<Vec<u8>, Arm64FdtError> {
+    validate_config(config)?;
+
+    let mut fdt = FdtWriter::new()?;
+    let root = fdt.begin_node("")?;
+    fdt.property_string("compatible", ROOT_COMPATIBILITY)?;
+    fdt.property_u32("#address-cells", ADDRESS_CELLS)?;
+    fdt.property_u32("#size-cells", SIZE_CELLS)?;
+    fdt.property_u32("interrupt-parent", GIC_PHANDLE)?;
+
+    create_cpu_nodes(&mut fdt, config.vcpu_mpidrs)?;
+    create_memory_node(&mut fdt, config.layout)?;
+    create_chosen_node(&mut fdt, config.boot)?;
+    create_gic_node(&mut fdt, config.gic)?;
+    create_timer_node(&mut fdt, config.timer)?;
+    create_psci_node(&mut fdt)?;
+
+    fdt.end_node(root)?;
+    let bytes = fdt.finish()?;
+    validate_fdt_size(bytes.len())?;
+    Ok(bytes)
+}
+
+pub fn write_arm64_fdt(
+    config: &Arm64FdtConfig<'_>,
+    memory: &mut GuestMemory,
+) -> Result<Arm64FdtGuestMemoryWrite, Arm64FdtError> {
+    let bytes = build_arm64_fdt(config)?;
+    write_arm64_fdt_bytes(config.layout, memory, &bytes)
+}
+
+fn validate_config(config: &Arm64FdtConfig<'_>) -> Result<(), Arm64FdtError> {
+    if config.vcpu_mpidrs.is_empty() {
+        return Err(Arm64FdtError::MissingCpu);
+    }
+
+    memory_reg_cells(config.layout)?;
+    validate_gic(config.gic)?;
+    validate_timer(config.timer)?;
+    if let Some(initrd) = config.boot.initrd {
+        initrd
+            .address
+            .checked_add(initrd.size)
+            .ok_or(Arm64FdtError::InitrdEndOverflow {
+                address: initrd.address,
+                size: initrd.size,
+            })?;
+    }
+
+    Ok(())
+}
+
+fn create_cpu_nodes(fdt: &mut FdtWriter, mpidrs: &[u64]) -> Result<(), Arm64FdtError> {
+    let cpus = fdt.begin_node("cpus")?;
+    fdt.property_u32("#address-cells", CPU_ADDRESS_CELLS)?;
+    fdt.property_u32("#size-cells", CPU_SIZE_CELLS)?;
+
+    for (cpu_index, mpidr) in mpidrs.iter().copied().enumerate() {
+        let cpu = fdt.begin_node(&format!("cpu@{cpu_index:x}"))?;
+        fdt.property_string("device_type", "cpu")?;
+        fdt.property_string("compatible", "arm,arm-v8")?;
+        fdt.property_string("enable-method", "psci")?;
+        fdt.property_u64("reg", mpidr & CPU_REG_MASK)?;
+        fdt.end_node(cpu)?;
+    }
+
+    fdt.end_node(cpus)?;
+    Ok(())
+}
+
+fn create_memory_node(
+    fdt: &mut FdtWriter,
+    layout: &GuestMemoryLayout,
+) -> Result<(), Arm64FdtError> {
+    let memory = fdt.begin_node("memory@ram")?;
+    fdt.property_string("device_type", "memory")?;
+    fdt.property_array_u64("reg", &memory_reg_cells(layout)?)?;
+    fdt.end_node(memory)?;
+    Ok(())
+}
+
+fn create_chosen_node(
+    fdt: &mut FdtWriter,
+    boot: Arm64FdtBootInfo<'_>,
+) -> Result<(), Arm64FdtError> {
+    let chosen = fdt.begin_node("chosen")?;
+    fdt.property_string("bootargs", boot.command_line)?;
+
+    if let Some(initrd) = boot.initrd {
+        let initrd_end =
+            initrd
+                .address
+                .checked_add(initrd.size)
+                .ok_or(Arm64FdtError::InitrdEndOverflow {
+                    address: initrd.address,
+                    size: initrd.size,
+                })?;
+        fdt.property_u64("linux,initrd-start", initrd.address.raw_value())?;
+        fdt.property_u64("linux,initrd-end", initrd_end.raw_value())?;
+    }
+
+    fdt.end_node(chosen)?;
+    Ok(())
+}
+
+fn create_gic_node(fdt: &mut FdtWriter, gic: Arm64FdtGic) -> Result<(), Arm64FdtError> {
+    let interrupt = fdt.begin_node("intc")?;
+    fdt.property_string("compatible", gic.compatibility)?;
+    fdt.property_null("interrupt-controller")?;
+    fdt.property_u32("#interrupt-cells", gic.interrupt_cells)?;
+    fdt.property_array_u64(
+        "reg",
+        &[
+            gic.distributor.base,
+            gic.distributor.size,
+            gic.redistributor.base,
+            gic.redistributor.size,
+        ],
+    )?;
+    fdt.property_phandle(GIC_PHANDLE)?;
+    fdt.property_u32("#address-cells", ADDRESS_CELLS)?;
+    fdt.property_u32("#size-cells", SIZE_CELLS)?;
+    fdt.property_null("ranges")?;
+    fdt.property_array_u32(
+        "interrupts",
+        &[
+            GIC_FDT_IRQ_TYPE_PPI,
+            gic.maintenance_irq,
+            IRQ_TYPE_LEVEL_HIGH,
+        ],
+    )?;
+    fdt.end_node(interrupt)?;
+    Ok(())
+}
+
+fn create_timer_node(
+    fdt: &mut FdtWriter,
+    timer: Arm64FdtTimerInterrupts,
+) -> Result<(), Arm64FdtError> {
+    let interrupts = [
+        GIC_FDT_IRQ_TYPE_PPI,
+        timer.secure_physical,
+        IRQ_TYPE_LEVEL_HIGH,
+        GIC_FDT_IRQ_TYPE_PPI,
+        timer.non_secure_physical,
+        IRQ_TYPE_LEVEL_HIGH,
+        GIC_FDT_IRQ_TYPE_PPI,
+        timer.virtual_timer,
+        IRQ_TYPE_LEVEL_HIGH,
+        GIC_FDT_IRQ_TYPE_PPI,
+        timer.hypervisor,
+        IRQ_TYPE_LEVEL_HIGH,
+    ];
+
+    let timer_node = fdt.begin_node("timer")?;
+    fdt.property_string("compatible", "arm,armv8-timer")?;
+    fdt.property_null("always-on")?;
+    fdt.property_array_u32("interrupts", &interrupts)?;
+    fdt.end_node(timer_node)?;
+    Ok(())
+}
+
+fn create_psci_node(fdt: &mut FdtWriter) -> Result<(), Arm64FdtError> {
+    let psci = fdt.begin_node("psci")?;
+    fdt.property_string("compatible", "arm,psci-0.2")?;
+    fdt.property_string("method", "hvc")?;
+    fdt.end_node(psci)?;
+    Ok(())
+}
+
+fn memory_reg_cells(layout: &GuestMemoryLayout) -> Result<Vec<u64>, Arm64FdtError> {
+    let mut cells = Vec::with_capacity(layout.ranges().len().saturating_mul(2));
+    for (range_index, range) in layout.ranges().iter().copied().enumerate() {
+        if range_index == 0 {
+            if range.size() <= aarch64::SYSTEM_MEM_SIZE {
+                return Err(Arm64FdtError::NoGuestMemoryAfterSystemArea {
+                    first_range: range,
+                    system_size: aarch64::SYSTEM_MEM_SIZE,
+                });
+            }
+            let start = range.start().checked_add(aarch64::SYSTEM_MEM_SIZE).ok_or(
+                Arm64FdtError::InvalidLayout {
+                    source: GuestMemoryError::AddressOverflow {
+                        start: range.start(),
+                        size: aarch64::SYSTEM_MEM_SIZE,
+                    },
+                },
+            )?;
+            cells.push(start.raw_value());
+            cells.push(range.size() - aarch64::SYSTEM_MEM_SIZE);
+        } else {
+            cells.push(range.start().raw_value());
+            cells.push(range.size());
+        }
+    }
+
+    Ok(cells)
+}
+
+fn validate_gic(gic: Arm64FdtGic) -> Result<(), Arm64FdtError> {
+    validate_gic_region("distributor", gic.distributor)?;
+    validate_gic_region("redistributor", gic.redistributor)?;
+
+    if gic.interrupt_cells != 3 {
+        return Err(Arm64FdtError::InvalidGicInterruptCells {
+            value: gic.interrupt_cells,
+        });
+    }
+
+    validate_ppi("maintenance_irq", gic.maintenance_irq)?;
+
+    if gic.msi.is_some() {
+        return Err(Arm64FdtError::UnsupportedMsi);
+    }
+
+    Ok(())
+}
+
+fn validate_gic_region(name: &'static str, region: Arm64FdtRegion) -> Result<(), Arm64FdtError> {
+    if region.size == 0 || region.base.checked_add(region.size).is_none() {
+        Err(Arm64FdtError::InvalidGicRegion { name, region })
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_timer(timer: Arm64FdtTimerInterrupts) -> Result<(), Arm64FdtError> {
+    validate_ppi("secure_physical_timer", timer.secure_physical)?;
+    validate_ppi("non_secure_physical_timer", timer.non_secure_physical)?;
+    validate_ppi("virtual_timer", timer.virtual_timer)?;
+    validate_ppi("hypervisor_timer", timer.hypervisor)?;
+    Ok(())
+}
+
+fn validate_ppi(name: &'static str, value: u32) -> Result<(), Arm64FdtError> {
+    if value < FIRST_PPI_INTID {
+        Ok(())
+    } else {
+        Err(Arm64FdtError::InvalidPpi { name, value })
+    }
+}
+
+fn ppi_from_intid(name: &'static str, intid: u32) -> Result<u32, Arm64FdtError> {
+    if (FIRST_PPI_INTID..FIRST_SPI_INTID).contains(&intid) {
+        Ok(intid - FIRST_PPI_INTID)
+    } else {
+        Err(Arm64FdtError::InvalidPpiIntid { name, intid })
+    }
+}
+
+fn validate_fdt_size(size: usize) -> Result<(), Arm64FdtError> {
+    if size_as_u64(size) > aarch64::FDT_MAX_SIZE {
+        Err(Arm64FdtError::FdtTooLarge {
+            size,
+            max_size: aarch64::FDT_MAX_SIZE,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+fn write_arm64_fdt_bytes(
+    layout: &GuestMemoryLayout,
+    memory: &mut GuestMemory,
+    bytes: &[u8],
+) -> Result<Arm64FdtGuestMemoryWrite, Arm64FdtError> {
+    validate_fdt_size(bytes.len())?;
+    let address =
+        aarch64::fdt_address(layout).map_err(|source| Arm64FdtError::InvalidLayout { source })?;
+    memory
+        .write_slice(bytes, address)
+        .map_err(|source| Arm64FdtError::GuestMemoryWrite { source })?;
+
+    Ok(Arm64FdtGuestMemoryWrite {
+        address,
+        size: bytes.len(),
+    })
+}
+
+fn size_as_u64(size: usize) -> u64 {
+    u64::try_from(size).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use device_tree::{DeviceTree, Node};
+
+    use super::*;
+
+    const TEST_MEMORY_SIZE: u64 = aarch64::SYSTEM_MEM_SIZE + aarch64::FDT_MAX_SIZE + 0x40_0000;
+    const TEST_INITRD_ADDRESS: GuestAddress =
+        GuestAddress::new(aarch64::DRAM_MEM_START + 0x30_0000);
+    const TEST_INITRD_SIZE: u64 = 0x1000;
+    const TEST_VCPU_MPIDRS: &[u64] = &[0];
+
+    #[test]
+    fn builds_minimal_firecracker_shaped_fdt_with_initrd() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "console=ttyAMA0 reboot=k",
+                initrd: Some(test_initrd()),
+            },
+        );
+
+        let bytes = build_arm64_fdt(&config).expect("FDT should be built");
+        let tree = DeviceTree::load(&bytes).expect("FDT should parse");
+
+        assert_eq!(
+            tree.root.prop_str("compatible").unwrap(),
+            ROOT_COMPATIBILITY
+        );
+        assert_eq!(tree.root.prop_u32("#address-cells").unwrap(), 2);
+        assert_eq!(tree.root.prop_u32("#size-cells").unwrap(), 2);
+        assert_eq!(tree.root.prop_u32("interrupt-parent").unwrap(), GIC_PHANDLE);
+
+        let root_children: Vec<&str> = tree
+            .root
+            .children
+            .iter()
+            .map(|child| child.name.as_str())
+            .collect();
+        assert_eq!(
+            root_children,
+            ["cpus", "memory@ram", "chosen", "intc", "timer", "psci"]
+        );
+
+        let cpu = required_node(&tree, "/cpus/cpu@0");
+        assert_eq!(cpu.prop_str("device_type").unwrap(), "cpu");
+        assert_eq!(cpu.prop_str("compatible").unwrap(), "arm,arm-v8");
+        assert_eq!(cpu.prop_str("enable-method").unwrap(), "psci");
+        assert_eq!(cpu.prop_u64("reg").unwrap(), 0);
+
+        let chosen = required_node(&tree, "/chosen");
+        assert_eq!(
+            chosen.prop_str("bootargs").unwrap(),
+            "console=ttyAMA0 reboot=k"
+        );
+        assert_eq!(
+            chosen.prop_u64("linux,initrd-start").unwrap(),
+            TEST_INITRD_ADDRESS.raw_value()
+        );
+        assert_eq!(
+            chosen.prop_u64("linux,initrd-end").unwrap(),
+            TEST_INITRD_ADDRESS.raw_value() + TEST_INITRD_SIZE
+        );
+
+        let psci = required_node(&tree, "/psci");
+        assert_eq!(psci.prop_str("compatible").unwrap(), "arm,psci-0.2");
+        assert_eq!(psci.prop_str("method").unwrap(), "hvc");
+    }
+
+    #[test]
+    fn omits_initrd_properties_when_initrd_is_not_loaded() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: None,
+            },
+        );
+
+        let bytes = build_arm64_fdt(&config).expect("FDT should be built");
+        let tree = DeviceTree::load(&bytes).expect("FDT should parse");
+        let chosen = required_node(&tree, "/chosen");
+
+        assert_eq!(chosen.prop_str("bootargs").unwrap(), "panic=1");
+        assert!(!chosen.has_prop("linux,initrd-start"));
+        assert!(!chosen.has_prop("linux,initrd-end"));
+    }
+
+    #[test]
+    fn memory_node_excludes_reserved_system_area() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: None,
+            },
+        );
+
+        let bytes = build_arm64_fdt(&config).expect("FDT should be built");
+        let tree = DeviceTree::load(&bytes).expect("FDT should parse");
+        let memory = required_node(&tree, "/memory@ram");
+        let reg = prop_u64_cells(memory, "reg");
+
+        assert_eq!(
+            reg,
+            vec![
+                aarch64::DRAM_MEM_START + aarch64::SYSTEM_MEM_SIZE,
+                TEST_MEMORY_SIZE - aarch64::SYSTEM_MEM_SIZE,
+            ]
+        );
+    }
+
+    #[test]
+    fn memory_node_keeps_later_dram_ranges() {
+        let layout = aarch64::dram_layout(aarch64::MMIO64_MEM_START - aarch64::DRAM_MEM_START + 1)
+            .expect("split layout should be valid");
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: None,
+            },
+        );
+
+        let bytes = build_arm64_fdt(&config).expect("FDT should be built");
+        let tree = DeviceTree::load(&bytes).expect("FDT should parse");
+        let memory = required_node(&tree, "/memory@ram");
+
+        assert_eq!(
+            prop_u64_cells(memory, "reg"),
+            vec![
+                aarch64::DRAM_MEM_START + aarch64::SYSTEM_MEM_SIZE,
+                aarch64::MMIO64_MEM_START - aarch64::DRAM_MEM_START - aarch64::SYSTEM_MEM_SIZE,
+                aarch64::FIRST_ADDR_PAST_64BITS_MMIO,
+                1,
+            ]
+        );
+    }
+
+    #[test]
+    fn gic_node_uses_metadata_without_msi_child() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: None,
+            },
+        );
+
+        let bytes = build_arm64_fdt(&config).expect("FDT should be built");
+        let tree = DeviceTree::load(&bytes).expect("FDT should parse");
+        let intc = required_node(&tree, "/intc");
+
+        assert_eq!(intc.prop_str("compatible").unwrap(), "arm,gic-v3");
+        assert!(intc.has_prop("interrupt-controller"));
+        assert_eq!(intc.prop_u32("#interrupt-cells").unwrap(), 3);
+        assert_eq!(intc.prop_u32("phandle").unwrap(), GIC_PHANDLE);
+        assert!(intc.has_prop("ranges"));
+        assert_eq!(
+            prop_u64_cells(intc, "reg"),
+            vec![0x3fff_0000, 0x1_0000, 0x3ffd_0000, 0x2_0000]
+        );
+        assert_eq!(prop_u32_cells(intc, "interrupts"), vec![1, 9, 4]);
+        assert!(intc.children.is_empty());
+    }
+
+    #[test]
+    fn timer_node_uses_firecracker_ppi_cells() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: None,
+            },
+        );
+
+        let bytes = build_arm64_fdt(&config).expect("FDT should be built");
+        let tree = DeviceTree::load(&bytes).expect("FDT should parse");
+        let timer = required_node(&tree, "/timer");
+
+        assert_eq!(timer.prop_str("compatible").unwrap(), "arm,armv8-timer");
+        assert!(timer.has_prop("always-on"));
+        assert_eq!(
+            prop_u32_cells(timer, "interrupts"),
+            vec![1, 13, 4, 1, 14, 4, 1, 11, 4, 1, 10, 4]
+        );
+    }
+
+    #[test]
+    fn writes_fdt_to_reserved_guest_memory_address() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let mut memory = GuestMemory::allocate(&layout).expect("guest memory should allocate");
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: None,
+            },
+        );
+
+        let write = write_arm64_fdt(&config, &mut memory).expect("FDT should write");
+
+        assert_eq!(
+            write.address,
+            aarch64::fdt_address(&layout).expect("FDT address should resolve")
+        );
+        assert!(size_as_u64(write.size) <= aarch64::FDT_MAX_SIZE);
+
+        let mut read_back = vec![0; write.size];
+        memory
+            .read_slice(&mut read_back, write.address)
+            .expect("written FDT should be readable");
+        DeviceTree::load(&read_back).expect("written FDT should parse");
+    }
+
+    #[test]
+    fn rejects_oversized_fdt_before_guest_memory_write() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let mut memory = GuestMemory::allocate(&layout).expect("guest memory should allocate");
+        let address = aarch64::fdt_address(&layout).expect("FDT address should resolve");
+        let mut before = vec![0; 16];
+        memory
+            .read_slice(&mut before, address)
+            .expect("initial FDT bytes should read");
+        let oversized = vec![0; aarch64::FDT_MAX_SIZE as usize + 1];
+
+        let err = write_arm64_fdt_bytes(&layout, &mut memory, &oversized)
+            .expect_err("oversized FDT should fail");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::FdtTooLarge {
+                size: oversized.len(),
+                max_size: aarch64::FDT_MAX_SIZE,
+            }
+        );
+        let mut after = vec![0; before.len()];
+        memory
+            .read_slice(&mut after, address)
+            .expect("FDT bytes should remain readable");
+        assert_eq!(after, before);
+    }
+
+    #[test]
+    fn rejects_oversized_generated_fdt() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let command_line = "x".repeat(aarch64::FDT_MAX_SIZE as usize + 1);
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: &command_line,
+                initrd: None,
+            },
+        );
+
+        let err = build_arm64_fdt(&config).expect_err("oversized generated FDT should fail");
+
+        assert!(matches!(
+            err,
+            Arm64FdtError::FdtTooLarge {
+                max_size: aarch64::FDT_MAX_SIZE,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_msi_metadata_until_its_node_is_supported() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let config = Arm64FdtConfig {
+            gic: Arm64FdtGic {
+                msi: Some(Arm64FdtMsi {
+                    region: Arm64FdtRegion {
+                        base: 0x3ffc_0000,
+                        size: 0x1_0000,
+                    },
+                    interrupt_range: Arm64FdtInterruptRange {
+                        base: 128,
+                        count: 32,
+                    },
+                }),
+                ..test_gic()
+            },
+            ..test_config(
+                &layout,
+                Arm64FdtBootInfo {
+                    command_line: "panic=1",
+                    initrd: None,
+                },
+            )
+        };
+
+        let err = build_arm64_fdt(&config).expect_err("MSI should be explicit unsupported work");
+
+        assert_eq!(err, Arm64FdtError::UnsupportedMsi);
+    }
+
+    #[test]
+    fn rejects_unbacked_guest_memory_write_without_partial_mutation() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let memory_layout = GuestMemoryLayout::new(vec![
+            GuestMemoryRange::new(
+                GuestAddress::new(aarch64::DRAM_MEM_START),
+                aarch64::FDT_MAX_SIZE,
+            )
+            .expect("mapped prefix should be valid"),
+        ])
+        .expect("mapped prefix layout should be valid");
+        let mut memory =
+            GuestMemory::allocate(&memory_layout).expect("mapped prefix should allocate");
+        let mut before = vec![0; 16];
+        memory
+            .read_slice(&mut before, GuestAddress::new(aarch64::DRAM_MEM_START))
+            .expect("initial bytes should read");
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: None,
+            },
+        );
+
+        let err =
+            write_arm64_fdt(&config, &mut memory).expect_err("unbacked FDT write should fail");
+
+        assert!(matches!(
+            err,
+            Arm64FdtError::GuestMemoryWrite {
+                source: GuestMemoryAccessError::UnmappedRange { .. }
+            }
+        ));
+        let mut after = vec![0; before.len()];
+        memory
+            .read_slice(&mut after, GuestAddress::new(aarch64::DRAM_MEM_START))
+            .expect("mapped prefix should remain readable");
+        assert_eq!(after, before);
+    }
+
+    #[test]
+    fn rejects_memory_without_ram_after_system_area() {
+        let layout = test_layout(aarch64::SYSTEM_MEM_SIZE);
+        let first_range = layout.ranges()[0];
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: None,
+            },
+        );
+
+        let err = build_arm64_fdt(&config).expect_err("tiny memory should fail");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::NoGuestMemoryAfterSystemArea {
+                first_range,
+                system_size: aarch64::SYSTEM_MEM_SIZE,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_missing_cpus() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let config = Arm64FdtConfig {
+            vcpu_mpidrs: &[],
+            ..test_config(
+                &layout,
+                Arm64FdtBootInfo {
+                    command_line: "panic=1",
+                    initrd: None,
+                },
+            )
+        };
+
+        let err = build_arm64_fdt(&config).expect_err("missing CPU should fail");
+
+        assert_eq!(err, Arm64FdtError::MissingCpu);
+    }
+
+    #[test]
+    fn rejects_invalid_timer_intids() {
+        let err = Arm64FdtTimerInterrupts::from_el1_timer_intids(15, 30)
+            .expect_err("non-PPI virtual timer INTID should fail");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::InvalidPpiIntid {
+                name: "el1_virtual_timer_intid",
+                intid: 15,
+            }
+        );
+    }
+
+    fn test_layout(size: u64) -> GuestMemoryLayout {
+        aarch64::dram_layout(size).expect("test layout should be valid")
+    }
+
+    fn test_config<'a>(
+        layout: &'a GuestMemoryLayout,
+        boot: Arm64FdtBootInfo<'a>,
+    ) -> Arm64FdtConfig<'a> {
+        Arm64FdtConfig {
+            layout,
+            boot,
+            vcpu_mpidrs: TEST_VCPU_MPIDRS,
+            gic: test_gic(),
+            timer: Arm64FdtTimerInterrupts::firecracker_default(),
+        }
+    }
+
+    const fn test_gic() -> Arm64FdtGic {
+        Arm64FdtGic {
+            distributor: Arm64FdtRegion {
+                base: 0x3fff_0000,
+                size: 0x1_0000,
+            },
+            redistributor: Arm64FdtRegion {
+                base: 0x3ffd_0000,
+                size: 0x2_0000,
+            },
+            compatibility: "arm,gic-v3",
+            interrupt_cells: 3,
+            maintenance_irq: 9,
+            msi: None,
+        }
+    }
+
+    const fn test_initrd() -> LoadedInitrd {
+        LoadedInitrd {
+            address: TEST_INITRD_ADDRESS,
+            size: TEST_INITRD_SIZE,
+        }
+    }
+
+    fn required_node<'a>(tree: &'a DeviceTree, path: &str) -> &'a Node {
+        tree.find(path).expect("node should exist")
+    }
+
+    fn prop_u32_cells(node: &Node, name: &str) -> Vec<u32> {
+        node.prop_raw(name)
+            .expect("property should exist")
+            .chunks_exact(4)
+            .map(|chunk| u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+            .collect()
+    }
+
+    fn prop_u64_cells(node: &Node, name: &str) -> Vec<u64> {
+        node.prop_raw(name)
+            .expect("property should exist")
+            .chunks_exact(8)
+            .map(|chunk| {
+                u64::from_be_bytes([
+                    chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],
+                ])
+            })
+            .collect()
+    }
+}

--- a/crates/runtime/src/fdt.rs
+++ b/crates/runtime/src/fdt.rs
@@ -152,6 +152,11 @@ pub enum Arm64FdtError {
         size: u64,
         max_size: u64,
     },
+    UnexpectedDramLayout {
+        range_index: usize,
+        expected: Option<GuestMemoryRange>,
+        actual: Option<GuestMemoryRange>,
+    },
     GuestMemoryOverlapsMmio64 {
         range: GuestMemoryRange,
     },
@@ -252,6 +257,10 @@ impl fmt::Display for Arm64FdtError {
                 f,
                 "arm64 FDT guest memory size {size} bytes exceeds {max_size} byte aarch64 maximum"
             ),
+            Self::UnexpectedDramLayout { range_index, .. } => write!(
+                f,
+                "arm64 FDT guest memory layout does not match the aarch64 DRAM layout at range {range_index}"
+            ),
             Self::GuestMemoryOverlapsMmio64 { range } => write!(
                 f,
                 "arm64 FDT guest memory range {range} overlaps the aarch64 MMIO64 gap"
@@ -348,6 +357,7 @@ impl std::error::Error for Arm64FdtError {
             | Self::NoGuestMemoryAfterSystemArea { .. }
             | Self::InvalidDramStart { .. }
             | Self::GuestMemoryTooLarge { .. }
+            | Self::UnexpectedDramLayout { .. }
             | Self::GuestMemoryOverlapsMmio64 { .. }
             | Self::InitrdNotInGuestMemory { .. }
             | Self::InitrdOverlapsFdt { .. }
@@ -417,7 +427,8 @@ fn validate_config(config: &Arm64FdtConfig<'_>) -> Result<(), Arm64FdtError> {
 
     validate_cpu_regs(config.vcpu_mpidrs)?;
     memory_reg_cells(config.layout)?;
-    validate_guest_memory_size(config.layout)?;
+    let guest_memory_size = validate_guest_memory_size(config.layout)?;
+    validate_aarch64_dram_layout(config.layout, guest_memory_size)?;
     validate_command_line(config.boot.command_line)?;
     validate_gic(config.layout, config.gic)?;
     validate_timer(config.timer)?;
@@ -637,7 +648,7 @@ fn memory_reg_cells(layout: &GuestMemoryLayout) -> Result<Vec<u64>, Arm64FdtErro
     Ok(cells)
 }
 
-fn validate_guest_memory_size(layout: &GuestMemoryLayout) -> Result<(), Arm64FdtError> {
+fn validate_guest_memory_size(layout: &GuestMemoryLayout) -> Result<u64, Arm64FdtError> {
     let mut size = 0u64;
     for range in layout.ranges().iter().copied() {
         size = size
@@ -654,8 +665,33 @@ fn validate_guest_memory_size(layout: &GuestMemoryLayout) -> Result<(), Arm64Fdt
             max_size: aarch64::DRAM_MEM_MAX_SIZE,
         })
     } else {
-        Ok(())
+        Ok(size)
     }
+}
+
+fn validate_aarch64_dram_layout(
+    layout: &GuestMemoryLayout,
+    size: u64,
+) -> Result<(), Arm64FdtError> {
+    let expected_layout =
+        aarch64::dram_layout(size).map_err(|source| Arm64FdtError::InvalidLayout { source })?;
+    let actual_ranges = layout.ranges();
+    let expected_ranges = expected_layout.ranges();
+    let range_count = actual_ranges.len().max(expected_ranges.len());
+
+    for range_index in 0..range_count {
+        let expected = expected_ranges.get(range_index).copied();
+        let actual = actual_ranges.get(range_index).copied();
+        if expected != actual {
+            return Err(Arm64FdtError::UnexpectedDramLayout {
+                range_index,
+                expected,
+                actual,
+            });
+        }
+    }
+
+    Ok(())
 }
 
 fn memory_reg_cell_count(layout: &GuestMemoryLayout) -> Result<usize, Arm64FdtError> {
@@ -1275,6 +1311,44 @@ mod tests {
             Arm64FdtError::GuestMemoryTooLarge {
                 size: aarch64::DRAM_MEM_MAX_SIZE + 1,
                 max_size: aarch64::DRAM_MEM_MAX_SIZE,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_sparse_memory_layout() {
+        let first_range = GuestMemoryRange::new(
+            GuestAddress::new(aarch64::DRAM_MEM_START),
+            aarch64::SYSTEM_MEM_SIZE + aarch64::GUEST_PAGE_SIZE,
+        )
+        .expect("first sparse test range should be valid");
+        let second_range = GuestMemoryRange::new(
+            GuestAddress::new(
+                aarch64::DRAM_MEM_START + aarch64::SYSTEM_MEM_SIZE + (2 * aarch64::GUEST_PAGE_SIZE),
+            ),
+            aarch64::GUEST_PAGE_SIZE,
+        )
+        .expect("second sparse test range should be valid");
+        let layout = GuestMemoryLayout::new(vec![first_range, second_range])
+            .expect("sparse layout should be structurally valid");
+        let expected_layout = aarch64::dram_layout(layout.total_size())
+            .expect("expected dense aarch64 layout should be valid");
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: None,
+            },
+        );
+
+        let err = build_arm64_fdt(&config).expect_err("sparse memory layout should fail");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::UnexpectedDramLayout {
+                range_index: 0,
+                expected: Some(expected_layout.ranges()[0]),
+                actual: Some(first_range),
             }
         );
     }

--- a/crates/runtime/src/fdt.rs
+++ b/crates/runtime/src/fdt.rs
@@ -382,8 +382,13 @@ impl From<VmFdtError> for Arm64FdtError {
     }
 }
 
+#[derive(Debug)]
+struct ValidatedArm64FdtConfig {
+    memory_reg_cells: Vec<u64>,
+}
+
 pub fn build_arm64_fdt(config: &Arm64FdtConfig<'_>) -> Result<Vec<u8>, Arm64FdtError> {
-    validate_config(config)?;
+    let validated = validate_config(config)?;
 
     let mut fdt = FdtWriter::new()?;
     let root = fdt.begin_node("")?;
@@ -393,7 +398,7 @@ pub fn build_arm64_fdt(config: &Arm64FdtConfig<'_>) -> Result<Vec<u8>, Arm64FdtE
     fdt.property_u32("interrupt-parent", GIC_PHANDLE)?;
 
     create_cpu_nodes(&mut fdt, config.vcpu_mpidrs)?;
-    create_memory_node(&mut fdt, config.layout)?;
+    create_memory_node(&mut fdt, &validated.memory_reg_cells)?;
     create_chosen_node(&mut fdt, config.boot)?;
     create_gic_node(&mut fdt, config.gic)?;
     create_timer_node(&mut fdt, config.timer)?;
@@ -414,7 +419,7 @@ pub fn write_arm64_fdt(
     write_arm64_fdt_bytes(config.layout, memory, &bytes)
 }
 
-fn validate_config(config: &Arm64FdtConfig<'_>) -> Result<(), Arm64FdtError> {
+fn validate_config(config: &Arm64FdtConfig<'_>) -> Result<ValidatedArm64FdtConfig, Arm64FdtError> {
     if config.vcpu_mpidrs.is_empty() {
         return Err(Arm64FdtError::MissingCpu);
     }
@@ -426,9 +431,8 @@ fn validate_config(config: &Arm64FdtConfig<'_>) -> Result<(), Arm64FdtError> {
     }
 
     validate_cpu_regs(config.vcpu_mpidrs)?;
-    memory_reg_cells(config.layout)?;
-    let guest_memory_size = validate_guest_memory_size(config.layout)?;
-    validate_aarch64_dram_layout(config.layout, guest_memory_size)?;
+    validate_memory_layout(config.layout)?;
+    let memory_reg_cells = memory_reg_cells(config.layout)?;
     validate_command_line(config.boot.command_line)?;
     validate_gic(config.layout, config.gic)?;
     validate_timer(config.timer)?;
@@ -437,7 +441,7 @@ fn validate_config(config: &Arm64FdtConfig<'_>) -> Result<(), Arm64FdtError> {
         validate_initrd(config.layout, initrd)?;
     }
 
-    Ok(())
+    Ok(ValidatedArm64FdtConfig { memory_reg_cells })
 }
 
 fn validate_cpu_regs(mpidrs: &[u64]) -> Result<(), Arm64FdtError> {
@@ -497,12 +501,13 @@ fn create_cpu_nodes(fdt: &mut FdtWriter, mpidrs: &[u64]) -> Result<(), Arm64FdtE
     fdt.property_u32("#address-cells", CPU_ADDRESS_CELLS)?;
     fdt.property_u32("#size-cells", CPU_SIZE_CELLS)?;
 
-    for (cpu_index, mpidr) in mpidrs.iter().copied().enumerate() {
-        let cpu = fdt.begin_node(&format!("cpu@{cpu_index:x}"))?;
+    for mpidr in mpidrs.iter().copied() {
+        let reg = cpu_reg(mpidr);
+        let cpu = fdt.begin_node(&format!("cpu@{reg:x}"))?;
         fdt.property_string("device_type", "cpu")?;
         fdt.property_string("compatible", "arm,arm-v8")?;
         fdt.property_string("enable-method", "psci")?;
-        fdt.property_u64("reg", cpu_reg(mpidr))?;
+        fdt.property_u64("reg", reg)?;
         fdt.end_node(cpu)?;
     }
 
@@ -514,13 +519,10 @@ const fn cpu_reg(mpidr: u64) -> u64 {
     mpidr & CPU_REG_MASK
 }
 
-fn create_memory_node(
-    fdt: &mut FdtWriter,
-    layout: &GuestMemoryLayout,
-) -> Result<(), Arm64FdtError> {
+fn create_memory_node(fdt: &mut FdtWriter, reg_cells: &[u64]) -> Result<(), Arm64FdtError> {
     let memory = fdt.begin_node("memory@ram")?;
     fdt.property_string("device_type", "memory")?;
-    fdt.property_array_u64("reg", &memory_reg_cells(layout)?)?;
+    fdt.property_array_u64("reg", reg_cells)?;
     fdt.end_node(memory)?;
     Ok(())
 }
@@ -607,11 +609,19 @@ fn create_psci_node(fdt: &mut FdtWriter) -> Result<(), Arm64FdtError> {
     Ok(())
 }
 
-fn memory_reg_cells(layout: &GuestMemoryLayout) -> Result<Vec<u64>, Arm64FdtError> {
-    let cell_count = memory_reg_cell_count(layout)?;
-    validate_fdt_size(memory_reg_size_lower_bound(cell_count)?)?;
+fn validate_memory_layout(layout: &GuestMemoryLayout) -> Result<(), Arm64FdtError> {
+    validate_memory_reg_size(layout)?;
+    validate_memory_ranges(layout)?;
+    let guest_memory_size = validate_guest_memory_size(layout)?;
+    validate_aarch64_dram_layout(layout, guest_memory_size)
+}
 
-    let mut cells = Vec::with_capacity(cell_count);
+fn validate_memory_reg_size(layout: &GuestMemoryLayout) -> Result<(), Arm64FdtError> {
+    let cell_count = memory_reg_cell_count(layout)?;
+    validate_fdt_size(memory_reg_size_lower_bound(cell_count)?)
+}
+
+fn validate_memory_ranges(layout: &GuestMemoryLayout) -> Result<(), Arm64FdtError> {
     let mmio64_gap = mmio64_gap_range()?;
     for (range_index, range) in layout.ranges().iter().copied().enumerate() {
         if range_index == 0 {
@@ -627,7 +637,18 @@ fn memory_reg_cells(layout: &GuestMemoryLayout) -> Result<Vec<u64>, Arm64FdtErro
                     system_size: aarch64::SYSTEM_MEM_SIZE,
                 });
             }
-            validate_memory_range_excludes_mmio64_gap(range, mmio64_gap)?;
+        }
+
+        validate_memory_range_excludes_mmio64_gap(range, mmio64_gap)?;
+    }
+
+    Ok(())
+}
+
+fn memory_reg_cells(layout: &GuestMemoryLayout) -> Result<Vec<u64>, Arm64FdtError> {
+    let mut cells = Vec::with_capacity(memory_reg_cell_count(layout)?);
+    for (range_index, range) in layout.ranges().iter().copied().enumerate() {
+        if range_index == 0 {
             let start = range.start().checked_add(aarch64::SYSTEM_MEM_SIZE).ok_or(
                 Arm64FdtError::InvalidLayout {
                     source: GuestMemoryError::AddressOverflow {
@@ -637,9 +658,14 @@ fn memory_reg_cells(layout: &GuestMemoryLayout) -> Result<Vec<u64>, Arm64FdtErro
                 },
             )?;
             cells.push(start.raw_value());
-            cells.push(range.size() - aarch64::SYSTEM_MEM_SIZE);
+            let size = range.size().checked_sub(aarch64::SYSTEM_MEM_SIZE).ok_or(
+                Arm64FdtError::NoGuestMemoryAfterSystemArea {
+                    first_range: range,
+                    system_size: aarch64::SYSTEM_MEM_SIZE,
+                },
+            )?;
+            cells.push(size);
         } else {
-            validate_memory_range_excludes_mmio64_gap(range, mmio64_gap)?;
             cells.push(range.start().raw_value());
             cells.push(range.size());
         }
@@ -1860,6 +1886,35 @@ mod tests {
                 reg: 0,
             }
         );
+    }
+
+    #[test]
+    fn cpu_node_names_use_cpu_reg_values() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let mpidrs = [0, 2];
+        let config = Arm64FdtConfig {
+            vcpu_mpidrs: &mpidrs,
+            ..test_config(
+                &layout,
+                Arm64FdtBootInfo {
+                    command_line: "panic=1",
+                    initrd: None,
+                },
+            )
+        };
+
+        let bytes = build_arm64_fdt(&config).expect("FDT should be built");
+        let tree = DeviceTree::load(&bytes).expect("FDT should parse");
+
+        assert_eq!(
+            required_node(&tree, "/cpus/cpu@0").prop_u64("reg").unwrap(),
+            0
+        );
+        assert_eq!(
+            required_node(&tree, "/cpus/cpu@2").prop_u64("reg").unwrap(),
+            2
+        );
+        assert!(tree.find("/cpus/cpu@1").is_none());
     }
 
     #[test]

--- a/crates/runtime/src/fdt.rs
+++ b/crates/runtime/src/fdt.rs
@@ -124,6 +124,11 @@ pub struct Arm64FdtGuestMemoryWrite {
 #[derive(Debug, PartialEq, Eq)]
 pub enum Arm64FdtError {
     MissingCpu,
+    DuplicateCpuReg {
+        first_index: usize,
+        second_index: usize,
+        reg: u64,
+    },
     InvalidLayout {
         source: GuestMemoryError,
     },
@@ -181,6 +186,14 @@ impl fmt::Display for Arm64FdtError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::MissingCpu => f.write_str("arm64 FDT requires at least one CPU"),
+            Self::DuplicateCpuReg {
+                first_index,
+                second_index,
+                reg,
+            } => write!(
+                f,
+                "arm64 FDT CPU reg values must be distinct: CPU {first_index} and CPU {second_index} both use 0x{reg:x}"
+            ),
             Self::InvalidLayout { source } => {
                 write!(f, "invalid arm64 FDT memory layout: {source}")
             }
@@ -251,6 +264,7 @@ impl std::error::Error for Arm64FdtError {
             Self::CreateFdt { source } => Some(source),
             Self::GuestMemoryWrite { source } => Some(source),
             Self::MissingCpu
+            | Self::DuplicateCpuReg { .. }
             | Self::NoGuestMemoryAfterSystemArea { .. }
             | Self::InvalidDramStart { .. }
             | Self::InitrdEndOverflow { .. }
@@ -309,6 +323,7 @@ fn validate_config(config: &Arm64FdtConfig<'_>) -> Result<(), Arm64FdtError> {
         return Err(Arm64FdtError::MissingCpu);
     }
 
+    validate_cpu_regs(config.vcpu_mpidrs)?;
     memory_reg_cells(config.layout)?;
     validate_gic(config.gic)?;
     validate_timer(config.timer)?;
@@ -325,6 +340,28 @@ fn validate_config(config: &Arm64FdtConfig<'_>) -> Result<(), Arm64FdtError> {
     Ok(())
 }
 
+fn validate_cpu_regs(mpidrs: &[u64]) -> Result<(), Arm64FdtError> {
+    for (first_index, first_reg) in mpidrs.iter().copied().map(cpu_reg).enumerate() {
+        for (second_index, second_reg) in mpidrs
+            .iter()
+            .copied()
+            .map(cpu_reg)
+            .enumerate()
+            .skip(first_index + 1)
+        {
+            if first_reg == second_reg {
+                return Err(Arm64FdtError::DuplicateCpuReg {
+                    first_index,
+                    second_index,
+                    reg: first_reg,
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
 fn create_cpu_nodes(fdt: &mut FdtWriter, mpidrs: &[u64]) -> Result<(), Arm64FdtError> {
     let cpus = fdt.begin_node("cpus")?;
     fdt.property_u32("#address-cells", CPU_ADDRESS_CELLS)?;
@@ -335,12 +372,16 @@ fn create_cpu_nodes(fdt: &mut FdtWriter, mpidrs: &[u64]) -> Result<(), Arm64FdtE
         fdt.property_string("device_type", "cpu")?;
         fdt.property_string("compatible", "arm,arm-v8")?;
         fdt.property_string("enable-method", "psci")?;
-        fdt.property_u64("reg", mpidr & CPU_REG_MASK)?;
+        fdt.property_u64("reg", cpu_reg(mpidr))?;
         fdt.end_node(cpu)?;
     }
 
     fdt.end_node(cpus)?;
     Ok(())
+}
+
+const fn cpu_reg(mpidr: u64) -> u64 {
+    mpidr & CPU_REG_MASK
 }
 
 fn create_memory_node(
@@ -1058,6 +1099,33 @@ mod tests {
         let err = build_arm64_fdt(&config).expect_err("missing CPU should fail");
 
         assert_eq!(err, Arm64FdtError::MissingCpu);
+    }
+
+    #[test]
+    fn rejects_duplicate_cpu_reg_values() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let mpidrs = [0, CPU_REG_MASK + 1];
+        let config = Arm64FdtConfig {
+            vcpu_mpidrs: &mpidrs,
+            ..test_config(
+                &layout,
+                Arm64FdtBootInfo {
+                    command_line: "panic=1",
+                    initrd: None,
+                },
+            )
+        };
+
+        let err = build_arm64_fdt(&config).expect_err("duplicate CPU reg should fail");
+
+        assert_eq!(
+            err,
+            Arm64FdtError::DuplicateCpuReg {
+                first_index: 0,
+                second_index: 1,
+                reg: 0,
+            }
+        );
     }
 
     #[test]

--- a/crates/runtime/src/fdt.rs
+++ b/crates/runtime/src/fdt.rs
@@ -280,7 +280,7 @@ impl fmt::Display for Arm64FdtError {
                 fdt_address,
             } => write!(
                 f,
-                "arm64 FDT initrd end address {end_exclusive} overlaps reserved FDT address {fdt_address}"
+                "arm64 FDT initrd range ending at {end_exclusive} overlaps reserved FDT window starting at {fdt_address}"
             ),
             Self::InvalidGicRegion { name, region } => write!(
                 f,
@@ -1254,6 +1254,16 @@ mod tests {
                     .expect("test initrd end should not overflow"),
                 fdt_address,
             }
+        );
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "arm64 FDT initrd range ending at {} overlaps reserved FDT window starting at {}",
+                fdt_address
+                    .checked_add(1)
+                    .expect("test initrd end should not overflow"),
+                fdt_address
+            )
         );
     }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,6 +1,7 @@
 //! Backend-neutral VM runtime boundary.
 
 pub mod boot;
+pub mod fdt;
 pub mod memory;
 
 use std::fmt;

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -12,12 +12,13 @@ placement helpers, internal boot-source validation and arm64 kernel/initrd
 payload loading, a minimal
 Hypervisor.framework VM create/destroy wrapper, a current-thread HVF vCPU
 create/destroy wrapper, typed HVF exit surface, narrow vCPU register wrappers,
-internal macOS 15+ HVF GIC v3 boot metadata without MSI/ITS, anonymous guest
-memory allocation for validated runtime layouts, HVF guest memory map/unmap
-ownership for allocated regions, and an initial process startup argument model.
+internal macOS 15+ HVF GIC v3 boot metadata without MSI/ITS, minimal internal
+arm64 FDT generation and guest-memory writes, anonymous guest memory allocation
+for validated runtime layouts, HVF guest memory map/unmap ownership for
+allocated regions, and an initial process startup argument model.
 There is no broader API request body model, guest execution, vCPU run loop,
-interrupt injection, MMIO/device emulation, boot register setup, FDT generation,
-or public boot-source API behavior yet.
+interrupt injection, MMIO/device emulation, boot register setup, or public
+boot-source API behavior yet.
 
 ## Firecracker Model Alignment
 
@@ -264,8 +265,9 @@ command-line parsing shape: leading and trailing boot/init-argument whitespace
 is trimmed, the first unquoted ` -- ` separates init args, and the normalized
 bytes must fit in the 2048-byte aarch64 command-line capacity including the
 trailing NUL byte. Embedded NUL bytes and init args without boot args are
-rejected. The validated bytes are retained for later FDT work, but this scaffold
-still does not write a command line into guest memory.
+rejected. The validated command-line text is now available to the internal FDT
+builder as the `chosen.bootargs` property, but this remains internal and is not
+wired to public API behavior yet.
 
 The internal loader supports the arm64 Linux `Image` header shape used by
 Firecracker's aarch64 boot path. It validates the Image magic, text offset, and
@@ -284,6 +286,27 @@ does not expose new raw host-memory pointers. Direct `linux-loader`/`vm-memory`
 integration is deferred until the project decides whether to add a narrow
 adapter or adopt `vm-memory` more broadly.
 
+## Internal arm64 FDT Generation
+
+The runtime crate can build a minimal Firecracker-shaped arm64 FDT using the
+same `vm-fdt` writer crate that Firecracker uses. The generated tree currently
+contains root properties, CPU data, memory, chosen, timer, PSCI, and GIC nodes.
+It intentionally omits serial, RTC, virtio, PCI, vmgenid, vmclock, and other
+device nodes until the corresponding emulation paths exist.
+
+The memory node excludes the first 2 MiB system area from the first DRAM range
+and preserves later DRAM ranges from the runtime layout. The chosen node carries
+boot arguments and optional initrd start/end properties from loaded boot-source
+metadata. The GIC node consumes backend-neutral distributor and redistributor
+metadata, advertises `arm,gic-v3`, and does not emit an ITS/MSI child while the
+HVF metadata has no MSI support.
+
+FDT bytes are built before guest memory is touched, checked against the reserved
+2 MiB FDT window, and then copied with `GuestMemory::write_slice` at the
+aarch64 FDT address. Oversized, overflowing, or unbacked writes fail before a
+partial copy. The write result records the FDT guest address and byte size for
+future boot-register setup.
+
 The HVF backend can map allocated guest memory regions into an existing
 Hypervisor.framework VM with read/write/execute guest RAM permissions. The
 backend-owned mapping owner consumes the `GuestMemory` allocation, unmaps mapped
@@ -296,12 +319,14 @@ symbols so older hosts can return structured unsupported errors instead of
 failing at process load time. The backend exposes internal boot metadata for the
 future FDT path: distributor and redistributor regions below the 1 GiB MMIO32
 boundary, the supported SPI range, timer interrupt IDs, and the `arm,gic-v3`
-compatibility shape. MSI/ITS metadata is intentionally absent until a later
+compatibility shape. HVF timer INTIDs are converted to FDT PPI cells for the
+runtime timer node, and MSI/ITS metadata is intentionally absent until a later
 device path needs it.
 
-This still is not bootable guest RAM. bangbang does not write FDT payloads, wire
-`mem_size_mib` into public startup behavior, inject interrupts, configure boot
-registers, or start a guest. Later API and startup work still needs to decide whether an oversized
+This still is not bootable guest RAM. bangbang can now write an internal FDT
+payload, but it does not wire `mem_size_mib` into public startup behavior,
+inject interrupts, configure boot registers, emulate devices, or start a guest.
+Later API and startup work still needs to decide whether an oversized
 `mem_size_mib` request should be rejected before layout construction or should
 preserve Firecracker's architecture-helper truncation behavior.
 

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -295,9 +295,12 @@ It intentionally omits serial, RTC, virtio, PCI, vmgenid, vmclock, and other
 device nodes until the corresponding emulation paths exist.
 
 The memory node excludes the first 2 MiB system area from the first DRAM range
-and preserves later DRAM ranges from the runtime layout. The chosen node carries
-boot arguments and optional initrd start/end properties from loaded boot-source
-metadata. The GIC node consumes backend-neutral distributor and redistributor
+and preserves later DRAM ranges from the runtime layout, but rejects ranges that
+overlap the aarch64 MMIO64 gap. The chosen node carries boot arguments and
+optional initrd start/end properties from loaded boot-source metadata. Direct
+FDT configuration still validates that `bootargs` fits in the 2048-byte aarch64
+command-line capacity including the trailing NUL byte and contains no embedded
+NUL bytes. The GIC node consumes backend-neutral distributor and redistributor
 metadata, advertises `arm,gic-v3`, and does not emit an ITS/MSI child while the
 HVF metadata has no MSI support. The FDT builder rejects empty or oversized CPU
 sets, duplicate CPU `reg` values, initrd ranges outside guest-advertised memory

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -300,6 +300,8 @@ configuration must match the aarch64 DRAM layout helper for its total guest RAM
 size. Sparse layouts, ranges overlapping the aarch64 MMIO64 gap, and total RAM
 beyond the aarch64 maximum are rejected. The chosen node carries boot arguments
 and optional initrd start/end properties from loaded boot-source metadata.
+Firecracker's `rng-seed` and `linux,pci-probe-only` chosen properties are
+deferred until guest startup and device work need them.
 Direct FDT configuration still validates that `bootargs` fits in the 2048-byte
 aarch64 command-line capacity including the trailing NUL byte and contains no
 embedded NUL bytes. The GIC node consumes backend-neutral distributor and

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -299,7 +299,10 @@ and preserves later DRAM ranges from the runtime layout. The chosen node carries
 boot arguments and optional initrd start/end properties from loaded boot-source
 metadata. The GIC node consumes backend-neutral distributor and redistributor
 metadata, advertises `arm,gic-v3`, and does not emit an ITS/MSI child while the
-HVF metadata has no MSI support.
+HVF metadata has no MSI support. The FDT builder rejects empty or oversized CPU
+sets, duplicate CPU `reg` values, initrd ranges outside guest-advertised memory
+or overlapping the reserved FDT address, and GIC MMIO regions that are invalid,
+overlap each other, or overlap guest RAM.
 
 FDT writes first reject mismatches between the layout used to describe guest RAM
 and the allocated guest memory object. FDT bytes are then built before guest

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -313,8 +313,10 @@ FDT writes first reject mismatches between the layout used to describe guest RAM
 and the allocated guest memory object. FDT bytes are then built before guest
 memory is touched, checked against the reserved 2 MiB FDT window, and copied
 with `GuestMemory::write_slice` at the aarch64 FDT address. Oversized,
-overflowing, or unbacked writes fail before a partial copy. The write result
-records the FDT guest address and byte size for future boot-register setup.
+overflowing, or unbacked writes fail before a partial copy. Memory layouts whose
+memory `reg` property alone cannot fit in the FDT window are rejected before FDT
+construction. The write result records the FDT guest address and byte size for
+future boot-register setup.
 
 The HVF backend can map allocated guest memory regions into an existing
 Hypervisor.framework VM with read/write/execute guest RAM permissions. The

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -296,18 +296,18 @@ device nodes until the corresponding emulation paths exist.
 
 The memory node excludes the first 2 MiB system area from the first DRAM range
 and preserves later DRAM ranges from the runtime layout, but rejects ranges that
-overlap the aarch64 MMIO64 gap. The chosen node carries boot arguments and
-optional initrd start/end properties from loaded boot-source metadata. Direct
-FDT configuration still validates that `bootargs` fits in the 2048-byte aarch64
-command-line capacity including the trailing NUL byte and contains no embedded
-NUL bytes. The GIC node consumes backend-neutral distributor and redistributor
-metadata, advertises `arm,gic-v3`, and does not emit an ITS/MSI child while the
-HVF metadata has no MSI support. The FDT builder rejects empty or oversized CPU
-sets, duplicate CPU `reg` values, initrd ranges outside guest-advertised memory
-or overlapping the reserved FDT address, and GIC MMIO regions that are invalid,
-overlap each other, or overlap guest RAM. It also rejects unexpected GIC
-compatibility strings and PPI collisions between the GIC maintenance interrupt
-and timer interrupts.
+overlap the aarch64 MMIO64 gap or push total guest RAM beyond the aarch64
+maximum. The chosen node carries boot arguments and optional initrd start/end
+properties from loaded boot-source metadata. Direct FDT configuration still
+validates that `bootargs` fits in the 2048-byte aarch64 command-line capacity
+including the trailing NUL byte and contains no embedded NUL bytes. The GIC node
+consumes backend-neutral distributor and redistributor metadata, advertises
+`arm,gic-v3`, and does not emit an ITS/MSI child while the HVF metadata has no
+MSI support. The FDT builder rejects empty or oversized CPU sets, duplicate CPU
+`reg` values, initrd ranges outside guest-advertised memory or overlapping the
+reserved FDT address, and GIC MMIO regions that are invalid, overlap each other,
+or overlap guest RAM. It also rejects unexpected GIC compatibility strings and
+PPI collisions between the GIC maintenance interrupt and timer interrupts.
 
 FDT writes first reject mismatches between the layout used to describe guest RAM
 and the allocated guest memory object. FDT bytes are then built before guest

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -301,11 +301,12 @@ metadata. The GIC node consumes backend-neutral distributor and redistributor
 metadata, advertises `arm,gic-v3`, and does not emit an ITS/MSI child while the
 HVF metadata has no MSI support.
 
-FDT bytes are built before guest memory is touched, checked against the reserved
-2 MiB FDT window, and then copied with `GuestMemory::write_slice` at the
-aarch64 FDT address. Oversized, overflowing, or unbacked writes fail before a
-partial copy. The write result records the FDT guest address and byte size for
-future boot-register setup.
+FDT writes first reject mismatches between the layout used to describe guest RAM
+and the allocated guest memory object. FDT bytes are then built before guest
+memory is touched, checked against the reserved 2 MiB FDT window, and copied
+with `GuestMemory::write_slice` at the aarch64 FDT address. Oversized,
+overflowing, or unbacked writes fail before a partial copy. The write result
+records the FDT guest address and byte size for future boot-register setup.
 
 The HVF backend can map allocated guest memory regions into an existing
 Hypervisor.framework VM with read/write/execute guest RAM permissions. The

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -302,7 +302,9 @@ metadata, advertises `arm,gic-v3`, and does not emit an ITS/MSI child while the
 HVF metadata has no MSI support. The FDT builder rejects empty or oversized CPU
 sets, duplicate CPU `reg` values, initrd ranges outside guest-advertised memory
 or overlapping the reserved FDT address, and GIC MMIO regions that are invalid,
-overlap each other, or overlap guest RAM.
+overlap each other, or overlap guest RAM. It also rejects unexpected GIC
+compatibility strings and PPI collisions between the GIC maintenance interrupt
+and timer interrupts.
 
 FDT writes first reject mismatches between the layout used to describe guest RAM
 and the allocated guest memory object. FDT bytes are then built before guest

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -306,7 +306,7 @@ embedded NUL bytes. The GIC node consumes backend-neutral distributor and
 redistributor metadata, advertises `arm,gic-v3`, and does not emit an ITS/MSI
 child while the HVF metadata has no MSI support. The FDT builder rejects empty
 or oversized CPU sets, duplicate CPU `reg` values, initrd ranges outside
-guest-advertised memory or overlapping the reserved FDT address, and GIC MMIO
+guest-advertised memory or overlapping the reserved FDT window, and GIC MMIO
 regions that are invalid, overlap each other, or overlap guest RAM. It also
 rejects unexpected GIC compatibility strings and PPI collisions between the GIC
 maintenance interrupt and timer interrupts.

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -295,19 +295,21 @@ It intentionally omits serial, RTC, virtio, PCI, vmgenid, vmclock, and other
 device nodes until the corresponding emulation paths exist.
 
 The memory node excludes the first 2 MiB system area from the first DRAM range
-and preserves later DRAM ranges from the runtime layout, but rejects ranges that
-overlap the aarch64 MMIO64 gap or push total guest RAM beyond the aarch64
-maximum. The chosen node carries boot arguments and optional initrd start/end
-properties from loaded boot-source metadata. Direct FDT configuration still
-validates that `bootargs` fits in the 2048-byte aarch64 command-line capacity
-including the trailing NUL byte and contains no embedded NUL bytes. The GIC node
-consumes backend-neutral distributor and redistributor metadata, advertises
-`arm,gic-v3`, and does not emit an ITS/MSI child while the HVF metadata has no
-MSI support. The FDT builder rejects empty or oversized CPU sets, duplicate CPU
-`reg` values, initrd ranges outside guest-advertised memory or overlapping the
-reserved FDT address, and GIC MMIO regions that are invalid, overlap each other,
-or overlap guest RAM. It also rejects unexpected GIC compatibility strings and
-PPI collisions between the GIC maintenance interrupt and timer interrupts.
+and preserves later DRAM ranges from the runtime layout, but direct FDT
+configuration must match the aarch64 DRAM layout helper for its total guest RAM
+size. Sparse layouts, ranges overlapping the aarch64 MMIO64 gap, and total RAM
+beyond the aarch64 maximum are rejected. The chosen node carries boot arguments
+and optional initrd start/end properties from loaded boot-source metadata.
+Direct FDT configuration still validates that `bootargs` fits in the 2048-byte
+aarch64 command-line capacity including the trailing NUL byte and contains no
+embedded NUL bytes. The GIC node consumes backend-neutral distributor and
+redistributor metadata, advertises `arm,gic-v3`, and does not emit an ITS/MSI
+child while the HVF metadata has no MSI support. The FDT builder rejects empty
+or oversized CPU sets, duplicate CPU `reg` values, initrd ranges outside
+guest-advertised memory or overlapping the reserved FDT address, and GIC MMIO
+regions that are invalid, overlap each other, or overlap guest RAM. It also
+rejects unexpected GIC compatibility strings and PPI collisions between the GIC
+maintenance interrupt and timer interrupts.
 
 FDT writes first reject mismatches between the layout used to describe guest RAM
 and the allocated guest memory object. FDT bytes are then built before guest


### PR DESCRIPTION
## Summary

- Add a backend-neutral arm64 FDT builder/writer in `bangbang-runtime` using `vm-fdt`.
- Generate root, CPU, memory, chosen, timer, PSCI, and GIC nodes, then write the DTB through `GuestMemory::write_slice` at the reserved FDT address.
- Add HVF GIC metadata conversion for runtime FDT input, including timer INTID-to-PPI mapping.
- Update README and compatibility docs to describe the new internal FDT capability while keeping boot registers, devices, interrupts, and guest execution out of scope.

Closes #83

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-hvf-tests.sh`
