### PR TITLE
feat: model network interface configuration

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -9,6 +9,7 @@ pub mod machine;
 pub mod memory;
 pub mod metrics;
 pub mod mmio;
+pub mod network;
 pub mod serial;
 pub mod startup;
 pub mod virtio_mmio;

--- a/crates/runtime/src/network.rs
+++ b/crates/runtime/src/network.rs
@@ -421,11 +421,15 @@ mod tests {
     #[test]
     fn rejects_invalid_guest_mac_addresses_without_echoing_them() {
         for invalid in [
+            "",
+            ":",
             "12:34:56:78:9a",
             "12:34:56:78:9a:bc:de",
+            "12::56:78:9a:bc",
             "12:34:56:78:9a:b",
             "12:34:56:78:9a:bbb",
             "12:34:56:78:9a:xx",
+            "12:34:56:78:9a:bc ",
             "123456789abc",
         ] {
             let err = validate(input().with_guest_mac(invalid))
@@ -441,7 +445,9 @@ mod tests {
                 err.to_string(),
                 "network guest_mac must be six colon-separated hex octets"
             );
-            assert!(!err.to_string().contains(invalid));
+            if !invalid.is_empty() {
+                assert!(!err.to_string().contains(invalid));
+            }
         }
     }
 

--- a/crates/runtime/src/network.rs
+++ b/crates/runtime/src/network.rs
@@ -1,0 +1,500 @@
+//! Backend-neutral network-interface configuration model.
+
+use std::fmt;
+use std::str::FromStr;
+
+const MAC_ADDRESS_LEN: usize = 6;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkInterfaceConfigInput {
+    path_iface_id: String,
+    body_iface_id: String,
+    host_dev_name: String,
+    guest_mac: Option<String>,
+    mtu_configured: bool,
+    rx_rate_limiter_configured: bool,
+    tx_rate_limiter_configured: bool,
+}
+
+impl NetworkInterfaceConfigInput {
+    pub fn new(
+        path_iface_id: impl Into<String>,
+        body_iface_id: impl Into<String>,
+        host_dev_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            path_iface_id: path_iface_id.into(),
+            body_iface_id: body_iface_id.into(),
+            host_dev_name: host_dev_name.into(),
+            guest_mac: None,
+            mtu_configured: false,
+            rx_rate_limiter_configured: false,
+            tx_rate_limiter_configured: false,
+        }
+    }
+
+    pub fn path_iface_id(&self) -> &str {
+        &self.path_iface_id
+    }
+
+    pub fn body_iface_id(&self) -> &str {
+        &self.body_iface_id
+    }
+
+    pub fn host_dev_name(&self) -> &str {
+        &self.host_dev_name
+    }
+
+    pub fn guest_mac(&self) -> Option<&str> {
+        self.guest_mac.as_deref()
+    }
+
+    pub const fn mtu_configured(&self) -> bool {
+        self.mtu_configured
+    }
+
+    pub const fn rx_rate_limiter_configured(&self) -> bool {
+        self.rx_rate_limiter_configured
+    }
+
+    pub const fn tx_rate_limiter_configured(&self) -> bool {
+        self.tx_rate_limiter_configured
+    }
+
+    pub fn with_guest_mac(mut self, guest_mac: impl Into<String>) -> Self {
+        self.guest_mac = Some(guest_mac.into());
+        self
+    }
+
+    pub const fn with_mtu_configured(mut self) -> Self {
+        self.mtu_configured = true;
+        self
+    }
+
+    pub const fn with_rx_rate_limiter_configured(mut self) -> Self {
+        self.rx_rate_limiter_configured = true;
+        self
+    }
+
+    pub const fn with_tx_rate_limiter_configured(mut self) -> Self {
+        self.tx_rate_limiter_configured = true;
+        self
+    }
+
+    pub fn validate(self) -> Result<NetworkInterfaceConfig, NetworkInterfaceConfigError> {
+        NetworkInterfaceConfig::try_from(self)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkInterfaceConfig {
+    iface_id: String,
+    host_dev_name: String,
+    guest_mac: Option<GuestMacAddress>,
+}
+
+impl NetworkInterfaceConfig {
+    pub fn iface_id(&self) -> &str {
+        &self.iface_id
+    }
+
+    pub fn host_dev_name(&self) -> &str {
+        &self.host_dev_name
+    }
+
+    pub const fn guest_mac(&self) -> Option<GuestMacAddress> {
+        self.guest_mac
+    }
+}
+
+impl TryFrom<NetworkInterfaceConfigInput> for NetworkInterfaceConfig {
+    type Error = NetworkInterfaceConfigError;
+
+    fn try_from(input: NetworkInterfaceConfigInput) -> Result<Self, Self::Error> {
+        validate_interface_id(InterfaceIdSource::Path, &input.path_iface_id)?;
+        validate_interface_id(InterfaceIdSource::Body, &input.body_iface_id)?;
+        if input.path_iface_id != input.body_iface_id {
+            return Err(NetworkInterfaceConfigError::MismatchedInterfaceId {
+                path_iface_id: input.path_iface_id,
+                body_iface_id: input.body_iface_id,
+            });
+        }
+
+        if input.host_dev_name.is_empty() {
+            return Err(NetworkInterfaceConfigError::EmptyHostDeviceName);
+        }
+
+        if input.mtu_configured {
+            return Err(NetworkInterfaceConfigError::UnsupportedMtu);
+        }
+        if input.rx_rate_limiter_configured {
+            return Err(NetworkInterfaceConfigError::UnsupportedRxRateLimiter);
+        }
+        if input.tx_rate_limiter_configured {
+            return Err(NetworkInterfaceConfigError::UnsupportedTxRateLimiter);
+        }
+
+        let guest_mac = input
+            .guest_mac
+            .map(|guest_mac| GuestMacAddress::from_str(&guest_mac))
+            .transpose()?;
+
+        Ok(Self {
+            iface_id: input.path_iface_id,
+            host_dev_name: input.host_dev_name,
+            guest_mac,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GuestMacAddress {
+    bytes: [u8; MAC_ADDRESS_LEN],
+}
+
+impl GuestMacAddress {
+    pub const fn from_bytes(bytes: [u8; MAC_ADDRESS_LEN]) -> Self {
+        Self { bytes }
+    }
+
+    pub const fn octets(self) -> [u8; MAC_ADDRESS_LEN] {
+        self.bytes
+    }
+}
+
+impl fmt::Display for GuestMacAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let [first, second, third, fourth, fifth, sixth] = self.bytes;
+        write!(
+            f,
+            "{first:02x}:{second:02x}:{third:02x}:{fourth:02x}:{fifth:02x}:{sixth:02x}"
+        )
+    }
+}
+
+impl FromStr for GuestMacAddress {
+    type Err = NetworkInterfaceConfigError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let mut parts = value.split(':');
+        let mut bytes = [0_u8; MAC_ADDRESS_LEN];
+
+        for byte in &mut bytes {
+            let Some(part) = parts.next() else {
+                return Err(NetworkInterfaceConfigError::InvalidGuestMacAddress {
+                    guest_mac: value.to_string(),
+                });
+            };
+            if part.len() != 2 {
+                return Err(NetworkInterfaceConfigError::InvalidGuestMacAddress {
+                    guest_mac: value.to_string(),
+                });
+            }
+            *byte = u8::from_str_radix(part, 16).map_err(|_| {
+                NetworkInterfaceConfigError::InvalidGuestMacAddress {
+                    guest_mac: value.to_string(),
+                }
+            })?;
+        }
+
+        if parts.next().is_some() {
+            return Err(NetworkInterfaceConfigError::InvalidGuestMacAddress {
+                guest_mac: value.to_string(),
+            });
+        }
+
+        Ok(Self { bytes })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InterfaceIdSource {
+    Path,
+    Body,
+}
+
+impl fmt::Display for InterfaceIdSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Path => f.write_str("path iface_id"),
+            Self::Body => f.write_str("body iface_id"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NetworkInterfaceConfigError {
+    EmptyInterfaceId {
+        source: InterfaceIdSource,
+    },
+    InvalidInterfaceId {
+        source: InterfaceIdSource,
+        iface_id: String,
+    },
+    MismatchedInterfaceId {
+        path_iface_id: String,
+        body_iface_id: String,
+    },
+    EmptyHostDeviceName,
+    InvalidGuestMacAddress {
+        guest_mac: String,
+    },
+    UnsupportedMtu,
+    UnsupportedRxRateLimiter,
+    UnsupportedTxRateLimiter,
+}
+
+impl fmt::Display for NetworkInterfaceConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyInterfaceId { source } => write!(f, "{source} must not be empty"),
+            Self::InvalidInterfaceId { source, .. } => {
+                write!(
+                    f,
+                    "{source} must contain only alphanumeric characters or '_'"
+                )
+            }
+            Self::MismatchedInterfaceId { .. } => {
+                f.write_str("path iface_id must match body iface_id")
+            }
+            Self::EmptyHostDeviceName => f.write_str("network host_dev_name must not be empty"),
+            Self::InvalidGuestMacAddress { .. } => {
+                f.write_str("network guest_mac must be six colon-separated hex octets")
+            }
+            Self::UnsupportedMtu => f.write_str("network mtu is not supported"),
+            Self::UnsupportedRxRateLimiter => {
+                f.write_str("network rx_rate_limiter is not supported")
+            }
+            Self::UnsupportedTxRateLimiter => {
+                f.write_str("network tx_rate_limiter is not supported")
+            }
+        }
+    }
+}
+
+impl std::error::Error for NetworkInterfaceConfigError {}
+
+fn validate_interface_id(
+    source: InterfaceIdSource,
+    iface_id: &str,
+) -> Result<(), NetworkInterfaceConfigError> {
+    if iface_id.is_empty() {
+        return Err(NetworkInterfaceConfigError::EmptyInterfaceId { source });
+    }
+
+    if !iface_id
+        .chars()
+        .all(|character| character == '_' || character.is_alphanumeric())
+    {
+        return Err(NetworkInterfaceConfigError::InvalidInterfaceId {
+            source,
+            iface_id: iface_id.to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::{
+        GuestMacAddress, InterfaceIdSource, NetworkInterfaceConfig, NetworkInterfaceConfigError,
+        NetworkInterfaceConfigInput,
+    };
+
+    fn input() -> NetworkInterfaceConfigInput {
+        NetworkInterfaceConfigInput::new("eth0", "eth0", "tap0")
+    }
+
+    fn validate(
+        input: NetworkInterfaceConfigInput,
+    ) -> Result<NetworkInterfaceConfig, NetworkInterfaceConfigError> {
+        input.validate()
+    }
+
+    #[test]
+    fn accepts_minimal_network_interface_config() {
+        let config = validate(input()).expect("minimal network config should be valid");
+
+        assert_eq!(config.iface_id(), "eth0");
+        assert_eq!(config.host_dev_name(), "tap0");
+        assert_eq!(config.guest_mac(), None);
+    }
+
+    #[test]
+    fn accepts_network_interface_config_with_guest_mac() {
+        let config = validate(input().with_guest_mac("12:34:56:78:9a:BC"))
+            .expect("network config with guest MAC should be valid");
+
+        let guest_mac = config.guest_mac().expect("guest MAC should be stored");
+        assert_eq!(guest_mac.octets(), [0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc]);
+        assert_eq!(guest_mac.to_string(), "12:34:56:78:9a:bc");
+    }
+
+    #[test]
+    fn accepts_firecracker_id_character_set() {
+        let id = "net_\u{00e9}1";
+        let config = validate(NetworkInterfaceConfigInput::new(id, id, "tap0"))
+            .expect("Firecracker-compatible network id should be valid");
+
+        assert_eq!(config.iface_id(), id);
+    }
+
+    #[test]
+    fn rejects_empty_interface_ids() {
+        assert_eq!(
+            validate(NetworkInterfaceConfigInput::new("", "eth0", "tap0")),
+            Err(NetworkInterfaceConfigError::EmptyInterfaceId {
+                source: InterfaceIdSource::Path,
+            })
+        );
+        assert_eq!(
+            validate(NetworkInterfaceConfigInput::new("eth0", "", "tap0")),
+            Err(NetworkInterfaceConfigError::EmptyInterfaceId {
+                source: InterfaceIdSource::Body,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_interface_ids_without_echoing_them() {
+        let invalid = "bad/id\nsecret";
+        let err = validate(NetworkInterfaceConfigInput::new(invalid, invalid, "tap0"))
+            .expect_err("invalid path id should fail");
+
+        assert_eq!(
+            err,
+            NetworkInterfaceConfigError::InvalidInterfaceId {
+                source: InterfaceIdSource::Path,
+                iface_id: invalid.to_string(),
+            }
+        );
+        assert_eq!(
+            err.to_string(),
+            "path iface_id must contain only alphanumeric characters or '_'"
+        );
+        assert!(!err.to_string().contains(invalid));
+
+        let err = validate(NetworkInterfaceConfigInput::new("eth0", invalid, "tap0"))
+            .expect_err("invalid body id should fail");
+        assert_eq!(
+            err,
+            NetworkInterfaceConfigError::InvalidInterfaceId {
+                source: InterfaceIdSource::Body,
+                iface_id: invalid.to_string(),
+            }
+        );
+        assert_eq!(
+            err.to_string(),
+            "body iface_id must contain only alphanumeric characters or '_'"
+        );
+        assert!(!err.to_string().contains(invalid));
+    }
+
+    #[test]
+    fn rejects_mismatched_interface_ids_without_echoing_them() {
+        let err = validate(NetworkInterfaceConfigInput::new("eth0", "eth1", "tap0"))
+            .expect_err("mismatched ids should fail");
+
+        assert_eq!(
+            err,
+            NetworkInterfaceConfigError::MismatchedInterfaceId {
+                path_iface_id: "eth0".to_string(),
+                body_iface_id: "eth1".to_string(),
+            }
+        );
+        assert_eq!(err.to_string(), "path iface_id must match body iface_id");
+        assert!(!err.to_string().contains("eth1"));
+    }
+
+    #[test]
+    fn rejects_empty_host_device_name_without_echoing_values() {
+        let err = validate(NetworkInterfaceConfigInput::new("eth0", "eth0", ""))
+            .expect_err("empty host device name should fail");
+
+        assert_eq!(err, NetworkInterfaceConfigError::EmptyHostDeviceName);
+        assert_eq!(err.to_string(), "network host_dev_name must not be empty");
+    }
+
+    #[test]
+    fn rejects_invalid_guest_mac_addresses_without_echoing_them() {
+        for invalid in [
+            "12:34:56:78:9a",
+            "12:34:56:78:9a:bc:de",
+            "12:34:56:78:9a:b",
+            "12:34:56:78:9a:bbb",
+            "12:34:56:78:9a:xx",
+            "123456789abc",
+        ] {
+            let err = validate(input().with_guest_mac(invalid))
+                .expect_err("invalid guest MAC should fail");
+
+            assert_eq!(
+                err,
+                NetworkInterfaceConfigError::InvalidGuestMacAddress {
+                    guest_mac: invalid.to_string(),
+                }
+            );
+            assert_eq!(
+                err.to_string(),
+                "network guest_mac must be six colon-separated hex octets"
+            );
+            assert!(!err.to_string().contains(invalid));
+        }
+    }
+
+    #[test]
+    fn guest_mac_address_parses_and_displays_normalized_lowercase() {
+        let mac = GuestMacAddress::from_str("12:34:56:78:9a:BC").expect("guest MAC should parse");
+
+        assert_eq!(mac.octets(), [0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc]);
+        assert_eq!(mac.to_string(), "12:34:56:78:9a:bc");
+        assert_eq!(
+            GuestMacAddress::from_bytes([0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa]).to_string(),
+            "ff:ee:dd:cc:bb:aa"
+        );
+    }
+
+    #[test]
+    fn rejects_deferred_fields() {
+        assert_eq!(
+            validate(input().with_mtu_configured()),
+            Err(NetworkInterfaceConfigError::UnsupportedMtu)
+        );
+        assert_eq!(
+            validate(input().with_rx_rate_limiter_configured()),
+            Err(NetworkInterfaceConfigError::UnsupportedRxRateLimiter)
+        );
+        assert_eq!(
+            validate(input().with_tx_rate_limiter_configured()),
+            Err(NetworkInterfaceConfigError::UnsupportedTxRateLimiter)
+        );
+    }
+
+    #[test]
+    fn network_interface_config_input_exposes_firecracker_shape() {
+        let input = input()
+            .with_guest_mac("12:34:56:78:9a:bc")
+            .with_mtu_configured()
+            .with_rx_rate_limiter_configured()
+            .with_tx_rate_limiter_configured();
+
+        assert_eq!(input.path_iface_id(), "eth0");
+        assert_eq!(input.body_iface_id(), "eth0");
+        assert_eq!(input.host_dev_name(), "tap0");
+        assert_eq!(input.guest_mac(), Some("12:34:56:78:9a:bc"));
+        assert!(input.mtu_configured());
+        assert!(input.rx_rate_limiter_configured());
+        assert!(input.tx_rate_limiter_configured());
+    }
+
+    #[test]
+    fn network_interface_config_errors_display_without_sources() {
+        let err = NetworkInterfaceConfigError::UnsupportedRxRateLimiter;
+
+        assert_eq!(err.to_string(), "network rx_rate_limiter is not supported");
+        assert!(std::error::Error::source(&err).is_none());
+    }
+}

--- a/crates/runtime/src/network.rs
+++ b/crates/runtime/src/network.rs
@@ -190,6 +190,11 @@ impl FromStr for GuestMacAddress {
                     guest_mac: value.to_string(),
                 });
             }
+            if !part.as_bytes().iter().all(u8::is_ascii_hexdigit) {
+                return Err(NetworkInterfaceConfigError::InvalidGuestMacAddress {
+                    guest_mac: value.to_string(),
+                });
+            }
             *byte = u8::from_str_radix(part, 16).map_err(|_| {
                 NetworkInterfaceConfigError::InvalidGuestMacAddress {
                     guest_mac: value.to_string(),
@@ -429,6 +434,7 @@ mod tests {
             "12:34:56:78:9a:b",
             "12:34:56:78:9a:bbb",
             "12:34:56:78:9a:xx",
+            "+1:34:56:78:9a:bc",
             "12:34:56:78:9a:bc ",
             "123456789abc",
         ] {

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -13,7 +13,8 @@ configuration storage, pre-boot `PUT /metrics` output configuration, pre-boot `P
 physical address and aarch64 DRAM layout/access primitives, arm64 boot
 placement helpers, internal boot-source validation and arm64 kernel/initrd
 payload loading, an internal Firecracker-shaped drive configuration validation
-model, a host-file backing access layer, internal configured block-device
+model, an internal Firecracker-shaped network interface configuration
+validation model, a host-file backing access layer, internal configured block-device
 preparation and MMIO registration helpers, an internal virtio-block
 config-space capacity model, an internal virtio-block request parser, single-request
 executor, queue dispatcher, MMIO queue-state bridge, resettable activation
@@ -222,7 +223,7 @@ compatibility targets.
 | `PUT` | `/logger` | supported target; minimal subset implemented | Stores process logger configuration before boot, opens `log_path` with nonblocking output semantics when provided, accepts optional Firecracker-shaped level/show/module fields, and omits logger state from `GET /vm/config` because it is not guest configuration. Full internal log routing remains deferred. |
 | `PATCH` | `/machine-config` | deferred | Partial updates belong with later state and validation rules. |
 | `PUT` | `/cpu-config` | deferred | Needs HVF CPU feature design with VM and boot work in #8 and #10. |
-| `PUT` | `/network-interfaces/{iface_id}` | deferred | Tied to virtio network work in #14. |
+| `PUT` | `/network-interfaces/{iface_id}` | deferred; internal model implemented | Public API behavior is tied to virtio network work in #14. The runtime has an internal Firecracker-shaped configuration validation model only. |
 | `PUT` | `/vsock` | deferred | Tied to virtio vsock work in #15. |
 | `GET`, `PUT`, `PATCH` | `/mmds` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/mmds/config` | deferred | Tied to MMDS work in #16. |
@@ -268,6 +269,12 @@ exist.
 | `PUT /drives/{drive_id}` | `io_engine` | optional when `Sync`; rejected when `Async` | The internal model accepts omitted/default `Sync` and rejects `Async`; `Async` is tied to Linux io_uring and does not directly map to the first macOS target. |
 | `PUT /drives/{drive_id}` | `socket` | optional when absent or `null`; deferred when set | The internal model rejects configured sockets; vhost-user-block is outside the first tier. |
 | `PUT /drives/{drive_id}` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
+| `PUT /network-interfaces/{iface_id}` | path `iface_id` | required; internal model only | The internal model validates this as nonempty alphanumeric or `_`, matching Firecracker's `checked_id` rule. Public API parsing remains deferred. |
+| `PUT /network-interfaces/{iface_id}` | body `iface_id` | required; internal model only | The internal model requires this to match the path `iface_id`. |
+| `PUT /network-interfaces/{iface_id}` | `host_dev_name` | required; internal model only | The internal model rejects empty values without opening host networking resources. macOS packet backend selection remains deferred. |
+| `PUT /network-interfaces/{iface_id}` | `guest_mac` | optional; internal model only | The internal model accepts six colon-separated two-hex-digit octets and normalizes display to lowercase hex. Duplicate MAC validation requires future multi-interface state. |
+| `PUT /network-interfaces/{iface_id}` | `mtu` | deferred when configured | The internal model rejects configured MTU values until virtio-net feature negotiation and backend behavior exist. |
+| `PUT /network-interfaces/{iface_id}` | `rx_rate_limiter`, `tx_rate_limiter` | deferred when configured | The internal model rejects configured network rate limiters until virtio-net rate limiting behavior exists. |
 | `PUT /metrics` | `metrics_path` | required | Host path to the metrics output file or FIFO. The runtime opens it as per-process observability state and redacts path details from API-facing open errors. |
 | `PUT /metrics` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
 | `PUT /logger` | `log_path` | optional | Host path to the logger output file or FIFO. When present, the runtime opens it as per-process observability state and redacts path details from API-facing open errors. When omitted, the existing sink is left unchanged. |
@@ -487,6 +494,22 @@ request execution. It rejects non-regular backing paths before data I/O and
 rejects read-only writes before mutating the file. Backing errors also avoid
 echoing `path_on_host`. This host-file opening path is internal and not invoked
 by public drive configuration yet.
+
+## Internal Network Interface Configuration
+
+The runtime crate has an internal, Firecracker-shaped network interface
+configuration model for future virtio-net work. It validates path and body
+`iface_id` values as nonempty alphanumeric strings with `_`, requires the two
+IDs to match, requires a nonempty `host_dev_name`, and accepts optional
+`guest_mac` values only when they are six colon-separated two-hex-digit octets.
+Displayed validation errors avoid echoing invalid IDs, host device names, and
+MAC strings.
+
+The internal model rejects configured `mtu`, `rx_rate_limiter`, and
+`tx_rate_limiter` fields as unsupported. It does not open host networking
+resources, choose a macOS packet backend, validate duplicate MAC addresses
+across multiple devices, expose public API behavior, or add the configuration to
+`GET /vm/config` yet.
 
 The runtime crate can prepare owned internal block-device resources from a
 validated list of stored drive configs. Preparation opens each backing file,

--- a/docs/security.md
+++ b/docs/security.md
@@ -124,6 +124,7 @@ Use unique paths for:
 - metrics files or FIFOs
 - logger files or FIFOs
 - writable block backing files
+- future host network devices or sockets
 - temporary test files
 
 Each process owns its own VMM controller state and observability sinks. There is
@@ -139,7 +140,9 @@ The current scaffold does not implement:
 - a Firecracker-jailer replacement
 - privilege dropping
 - host resource brokering
-- network, vsock, MMDS, or snapshot containment
+- network, vsock, MMDS, or snapshot containment; the current internal network
+  interface model validates configuration strings only and does not open host
+  networking resources
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy
 


### PR DESCRIPTION
## Summary

- Add a runtime-only Firecracker-shaped network interface configuration model.
- Validate interface IDs, host device names, optional guest MAC addresses, and explicitly unsupported deferred fields.
- Document that public network API behavior and macOS packet backend work remain deferred.

## Scope exclusions

- Does not add public `PUT /network-interfaces/{iface_id}` API parsing or VMM state storage.
- Does not expose network configuration through `GET /vm/config`.
- Does not implement virtio-net queues, duplicate MAC validation across stored devices, rate limiting, MTU behavior, or a macOS packet backend.

Closes #246

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-hvf-tests.sh`
