### PR TITLE
test: cache Firecracker guest kernel artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,15 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 
+      - name: Cache guest artifacts
+        uses: actions/cache@v6
+        with:
+          path: .tmp/guest-artifacts
+          key: guest-artifacts-firecracker-v1.15-aarch64-vmlinux-6.1.155-e3544b10603acbf3db492cb52e000d22ba202cb4b63b9add027565683e11c591
+
+      - name: Fetch Firecracker guest kernel
+        run: scripts/fetch-firecracker-kernel.sh
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 /codereviews/
+/.tmp/

--- a/README.md
+++ b/README.md
@@ -232,6 +232,20 @@ Hypervisor.framework is unavailable:
 scripts/run-hvf-tests.sh --allow-unsupported
 ```
 
+Prepare the pinned Firecracker arm64 Linux kernel artifact used by later guest
+boot smoke validation work:
+
+```sh
+scripts/fetch-firecracker-kernel.sh
+```
+
+The script verifies the pinned SHA-256 before reusing or installing the cached
+artifact. By default, it stores the kernel under
+`.tmp/guest-artifacts/firecracker-ci/v1.15/aarch64/vmlinux-6.1.155`. Set
+`BANGBANG_GUEST_ARTIFACTS_DIR` to use a different cache root. This command only
+prepares the kernel artifact; it does not start a guest or run the HVF boot
+smoke test.
+
 Run the VMM process skeleton and API server:
 
 ```sh

--- a/scripts/fetch-firecracker-kernel.sh
+++ b/scripts/fetch-firecracker-kernel.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/fetch-firecracker-kernel.sh
+
+Fetch and verify the pinned Firecracker arm64 Linux kernel artifact.
+
+Environment:
+  BANGBANG_GUEST_ARTIFACTS_DIR  Override the guest artifact cache root.
+EOF
+}
+
+if [[ "$#" -gt 0 ]]; then
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+firecracker_minor="v1.15"
+kernel_arch="aarch64"
+kernel_version="6.1.155"
+kernel_sha256="e3544b10603acbf3db492cb52e000d22ba202cb4b63b9add027565683e11c591"
+kernel_url="https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/${firecracker_minor}/${kernel_arch}/vmlinux-${kernel_version}"
+
+cache_root="${BANGBANG_GUEST_ARTIFACTS_DIR:-$repo_root/.tmp/guest-artifacts}"
+target_dir="${cache_root}/firecracker-ci/${firecracker_minor}/${kernel_arch}"
+target_path="${target_dir}/vmlinux-${kernel_version}"
+tmp_file=""
+
+cleanup() {
+  if [[ -n "$tmp_file" && -e "$tmp_file" ]]; then
+    rm -f "$tmp_file"
+  fi
+}
+trap cleanup EXIT
+
+hash_file() {
+  local path="$1"
+  local output
+
+  if command -v shasum >/dev/null 2>&1; then
+    output="$(shasum -a 256 "$path")"
+    printf '%s\n' "${output%% *}"
+    return
+  fi
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    output="$(sha256sum "$path")"
+    printf '%s\n' "${output%% *}"
+    return
+  fi
+
+  echo "shasum or sha256sum is required to verify guest artifacts" >&2
+  exit 1
+}
+
+verify_sha256() {
+  local path="$1"
+  local actual
+
+  actual="$(hash_file "$path")"
+  [[ "$actual" == "$kernel_sha256" ]]
+}
+
+if [[ -e "$target_path" && ! -f "$target_path" ]]; then
+  echo "cached kernel artifact path exists but is not a regular file: $target_path" >&2
+  exit 1
+fi
+
+if [[ -f "$target_path" ]]; then
+  if verify_sha256 "$target_path"; then
+    echo "using cached Firecracker kernel artifact: $target_path" >&2
+    printf '%s\n' "$target_path"
+    exit 0
+  fi
+
+  echo "cached Firecracker kernel artifact failed SHA-256 verification; redownloading" >&2
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required to fetch guest artifacts" >&2
+  exit 1
+fi
+
+mkdir -p "$target_dir"
+tmp_file="$(mktemp "${target_path}.download.XXXXXX")"
+
+echo "fetching Firecracker kernel artifact: $kernel_url" >&2
+curl \
+  --fail \
+  --location \
+  --show-error \
+  --silent \
+  --retry 3 \
+  --connect-timeout 10 \
+  --output "$tmp_file" \
+  "$kernel_url"
+
+if ! verify_sha256 "$tmp_file"; then
+  echo "downloaded Firecracker kernel artifact failed SHA-256 verification" >&2
+  exit 1
+fi
+
+chmod 0644 "$tmp_file"
+mv "$tmp_file" "$target_path"
+tmp_file=""
+
+printf '%s\n' "$target_path"


### PR DESCRIPTION
## Summary

- add `scripts/fetch-firecracker-kernel.sh` for the pinned Firecracker arm64 kernel artifact
- cache verified guest artifacts under `.tmp/guest-artifacts` and ignore `.tmp/` locally
- add hosted CI cache/fetch verification for the pinned guest kernel artifact
- document the artifact preparation command and cache override

## Scope exclusions

- Does not generate a tiny initrd.
- Does not start `bangbang` or run guest boot smoke validation.
- Does not require real HVF guest execution on GitHub-hosted macOS runners.

Closes #249.

## Verification

- `bash -n scripts/fetch-firecracker-kernel.sh`
- `scripts/fetch-firecracker-kernel.sh --help`
- fresh temporary-cache fetch with SHA-256 verification
- repeated temporary-cache fetch reuses the verified cached artifact
- corrupted temporary-cache artifact is rejected, redownloaded, and restored to the pinned SHA-256
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-hvf-tests.sh --allow-unsupported`
