### PR TITLE
docs: add testing guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Use Rust 2024 edition style and `rustfmt` defaults. Keep modules small and align
 
 Library package names use the `bangbang-*` pattern even when their directory names are shorter, such as `crates/hvf` for `bangbang-hvf`. The executable package is `bangbang` in `crates/bangbang`.
 
-Workspace lints deny Rust warnings, strict rustdoc issues, and selected Clippy lints. Keep test-only Clippy exceptions in `clippy.toml` instead of adding broad inline `allow` attributes.
+Workspace lints deny Rust warnings, strict rustdoc issues, and selected Clippy lints. Keep test-only Clippy exceptions in `clippy.toml` instead of adding broad inline `allow` attributes, except for integration-test helper exceptions documented in `docs/testing.md`.
 
 Unsafe code must stay isolated behind small FFI wrappers, with `SAFETY:` comments explaining each unsafe call.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository is currently a scaffold. It defines crate boundaries, an initial
 
 See [Firecracker Compatibility Scope](docs/firecracker-compatibility.md) for the intended compatibility target and current limitations.
 See [macOS Host Security Model](docs/security.md) for the current host trust boundary and security limitations.
+See [Testing Guide](docs/testing.md) for test layering, integration-test rules, and local verification commands.
 See [Pull Request Review Guidelines](docs/review-guidelines.md) for the project-specific review standard.
 
 ## Layout
@@ -209,6 +210,7 @@ integration, and CLI observability flags remain deferred.
 ## Build
 
 Requires the latest stable Rust toolchain.
+See [Testing Guide](docs/testing.md) for when to add unit tests, normal integration tests, or signed HVF integration tests.
 
 ```sh
 cargo check --workspace --all-targets --all-features --locked

--- a/docs/review-guidelines.md
+++ b/docs/review-guidelines.md
@@ -120,6 +120,10 @@ overflow behavior when introduced.
 
 ## Test Expectations
 
+Use `docs/testing.md` as the contributor-facing testing guide. Reviewers should
+apply that document when deciding whether a change needs unit coverage, a new
+normal integration test, or a signed HVF integration test.
+
 Unit tests live next to the code they exercise under each crate's `src/` tree.
 Test public behavior where practical, and add narrower unit tests for parsing,
 error formatting, state transitions, FFI wrappers, and edge cases.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,140 @@
+# Testing Guide
+
+This document defines how to add and run tests in bangbang. Prefer tests that
+exercise project behavior through the narrowest public boundary that still
+proves the change.
+
+## Test Layers
+
+Use unit tests for small, deterministic logic. Place them next to the code they
+exercise under each crate's `src/` tree with Rust's built-in `#[test]`
+framework. Unit tests are the right fit for parsers, error formatting, state
+transitions, range checks, request validation, and backend-neutral helpers.
+The `clippy.toml` test exceptions allow `expect`, `unwrap`, `panic`, and
+indexing in `#[test]` bodies, but they do not cover ordinary helper functions in
+integration-test crates. If an integration test needs those test-only patterns
+in helpers, add a file-scoped allow at the top of that test file:
+
+```rust
+#![allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unwrap_used
+)]
+```
+
+Keep these allows scoped to test files, and do not use them in production code.
+
+Use normal Rust integration tests when behavior crosses a crate or process
+boundary but does not require Hypervisor.framework entitlements. Put these under
+the owning crate's `tests/` directory. A PR may start by adding a new
+integration test to pin the intended behavior before changing implementation,
+especially for CLI, API, filesystem, or cross-crate workflows. The final PR
+must leave the new test passing in the documented command set.
+
+Use HVF integration tests for behavior that creates HVF VMs, vCPUs, GIC state,
+mapped guest memory, signed test binaries, or guest boot execution. These tests
+live in `crates/hvf/tests/` and must run through
+`scripts/run-integration-tests.sh` so the binaries are signed with the
+`com.apple.security.hypervisor` entitlement. Do not add real HVF tests to the
+unsigned workspace test path.
+
+## What To Cover
+
+For CLI and API changes, cover successful requests, unknown options or fields,
+empty values, duplicate values, malformed inputs, exit codes, HTTP status codes,
+and Firecracker-shaped response bodies.
+
+For host filesystem paths, cover missing paths, directories, unsupported file
+types, redacted error messages, cleanup ownership, and failure atomicity. A
+failed operation should not partially mutate accepted configuration, guest
+memory, or host resources.
+
+For guest memory, address, and range logic, cover exact-fit success, one-past
+failure, overflow failure, overlapping ranges, and no-partial-mutation behavior.
+
+For process, socket, and multi-bangbang behavior, cover unique resource names,
+stale socket handling, shutdown cleanup, replacement races, and concurrent runs
+where practical.
+
+For HVF and FFI code, cover resource creation and destruction, platform gating,
+error translation, unsupported exits or registers, cancellation, and cleanup
+after partial setup failure.
+
+## Stability Rules
+
+Avoid arbitrary sleeps, fixed polling delays, and timeout increases that hide
+races. Prefer explicit state, bounded channels, owned handles, temporary
+directories, and public completion signals.
+
+Tests must not share fixed global paths. Use unique temporary files or
+directories and verify cleanup when ownership matters. Multiple tests and
+multiple `bangbang` processes should not interfere unless the test is explicitly
+checking conflict behavior.
+
+Do not ignore HVF tests on hosts that support HVF. If an HVF test cannot run on
+hosted CI, use the signed integration runner with `--allow-unsupported` so CI
+still validates artifact preparation, compilation, and signing before skipping
+execution on unsupported runners.
+
+## Running Tests
+
+Run the standard workspace checks before opening or updating a PR:
+
+```sh
+cargo fmt --all -- --check
+cargo check --workspace --all-targets --all-features --locked
+cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
+cargo test -p bangbang-hvf --lib --all-features --locked
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
+```
+
+Run signed HVF integration tests on macOS Apple Silicon without
+`--allow-unsupported`:
+
+```sh
+scripts/run-integration-tests.sh
+```
+
+Run one signed integration test target when the change is narrower:
+
+```sh
+scripts/run-integration-tests.sh --test hvf_lifecycle
+scripts/run-integration-tests.sh --test guest_boot
+```
+
+Hosted macOS CI may use:
+
+```sh
+scripts/run-integration-tests.sh --allow-unsupported
+```
+
+That option is for CI-style build/sign validation on runners that cannot
+execute HVF. Local Apple Silicon verification should omit it so unsupported or
+misconfigured hosts fail.
+
+## Guest Boot Artifacts
+
+Guest boot tests use the pinned Firecracker arm64 kernel and a deterministic
+tiny initrd. The integration runner prepares both when `guest_boot` is selected.
+To prepare only the kernel cache, run:
+
+```sh
+scripts/fetch-firecracker-kernel.sh
+```
+
+The default cache lives under `.tmp/guest-artifacts`. Set
+`BANGBANG_GUEST_ARTIFACTS_DIR` to use a different cache root.
+
+## PR Expectations
+
+Bug fixes should include a regression test unless the behavior cannot be tested
+practically in the current scaffold. New public behavior should be tested
+through the public CLI, API, crate, filesystem, or HVF boundary that users or
+future code will rely on.
+
+List only verification commands that were actually run on the reviewed head. If
+a command is intentionally skipped, explain why it does not add useful signal
+for the PR.


### PR DESCRIPTION
## Summary
- Add `docs/testing.md` with repository-specific test layering and coverage guidance.
- Document when to add unit tests, normal integration tests, and signed HVF integration tests.
- Link the testing guide from `README.md` and `docs/review-guidelines.md`.
- Clarify `AGENTS.md` Clippy guidance for integration-test helper exceptions.

## Scope
- Documentation only.
- No test or runtime behavior changes.

## Verification
- `git diff --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
