### PR TITLE
feat: dispatch virtio-net tx notifications

### DIFF
--- a/crates/runtime/src/network.rs
+++ b/crates/runtime/src/network.rs
@@ -4661,6 +4661,50 @@ mod tests {
     }
 
     #[test]
+    fn virtio_network_notifications_empty_tx_queue_has_no_interrupt() {
+        let mut memory = tx_frame_memory();
+        let mut handler = network_activation_handler();
+
+        configure_network_handler_queues(&mut handler);
+        activate_network_handler(&mut handler);
+        handler
+            .write_register(
+                VirtioMmioRegister::QueueNotify,
+                VIRTIO_NET_TX_QUEUE_INDEX
+                    .try_into()
+                    .expect("TX queue index should fit"),
+            )
+            .expect("TX notification should write");
+
+        let notification = handler
+            .dispatch_network_queue_notifications(&mut memory)
+            .expect("empty TX queue notification should dispatch as no-op");
+
+        assert_eq!(
+            notification.drained_notifications(),
+            [VIRTIO_NET_TX_QUEUE_INDEX]
+        );
+        assert!(!notification.needs_queue_interrupt());
+        let dispatch = notification
+            .tx_queue_dispatch()
+            .expect("TX dispatch summary should be present");
+        assert_eq!(dispatch.processed_frames(), 0);
+        assert_eq!(dispatch.successful_frames(), 0);
+        assert_eq!(dispatch.parse_failures(), 0);
+        assert!(dispatch.frames().is_empty());
+        assert!(!dispatch.needs_queue_interrupt());
+        assert_eq!(read_interrupt_status(&handler), 0);
+        assert!(handler.pending_queue_notifications().is_empty());
+        let active_tx_queue = handler
+            .activation_handler()
+            .active_tx_dispatch_queue()
+            .expect("TX dispatch queue should remain active");
+        assert_eq!(active_tx_queue.available_ring().next_avail(), 0);
+        assert_eq!(active_tx_queue.used_ring().next_used(), 0);
+        assert_eq!(read_tx_used_index(&memory), 0);
+    }
+
+    #[test]
     fn virtio_network_notifications_record_tx_parse_failure_and_complete_used_ring() {
         let mut memory = tx_frame_memory();
         let mut handler = network_activation_handler();

--- a/crates/runtime/src/network.rs
+++ b/crates/runtime/src/network.rs
@@ -4,6 +4,7 @@ use std::collections::TryReserveError;
 use std::fmt;
 use std::str::FromStr;
 
+use crate::interrupt::DeviceInterruptKind;
 use crate::memory::{
     GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryError, GuestMemoryRange,
 };
@@ -17,7 +18,10 @@ use crate::virtio_mmio::{
     VirtioMmioDeviceConfigHandler, VirtioMmioQueueRegisterError, VirtioMmioQueueState,
     VirtioMmioRegisterHandler, VirtioMmioRegisterHandlerError,
 };
-use crate::virtio_queue::{VirtqueueDescriptor, VirtqueueDescriptorChain};
+use crate::virtio_queue::{
+    VirtqueueAvailableRing, VirtqueueAvailableRingError, VirtqueueDescriptor,
+    VirtqueueDescriptorChain, VirtqueueUsedRing, VirtqueueUsedRingError,
+};
 
 const MAC_ADDRESS_LEN: usize = 6;
 pub const VIRTIO_NET_DEVICE_ID: u32 = 1;
@@ -799,7 +803,7 @@ impl std::error::Error for VirtioNetworkRxBufferParseError {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct VirtioNetworkDevice {
     active_rx_queue: Option<VirtioMmioQueueState>,
-    active_tx_queue: Option<VirtioMmioQueueState>,
+    active_tx_queue: Option<VirtioNetworkTxQueue>,
 }
 
 impl VirtioNetworkDevice {
@@ -815,8 +819,14 @@ impl VirtioNetworkDevice {
         self.active_rx_queue
     }
 
-    pub const fn active_tx_queue(&self) -> Option<VirtioMmioQueueState> {
+    pub fn active_tx_queue(&self) -> Option<VirtioMmioQueueState> {
         self.active_tx_queue
+            .as_ref()
+            .map(VirtioNetworkTxQueue::queue_state)
+    }
+
+    pub const fn active_tx_dispatch_queue(&self) -> Option<&VirtioNetworkTxQueue> {
+        self.active_tx_queue.as_ref()
     }
 
     pub fn activate_network(
@@ -829,8 +839,15 @@ impl VirtioNetworkDevice {
 
         let active_rx_queue =
             active_network_queue_state(activation, VIRTIO_NET_RX_QUEUE_INDEX_U32)?;
-        let active_tx_queue =
-            active_network_queue_state(activation, VIRTIO_NET_TX_QUEUE_INDEX_U32)?;
+        let active_tx_queue = active_network_queue_state(activation, VIRTIO_NET_TX_QUEUE_INDEX_U32)
+            .and_then(|queue| {
+                VirtioNetworkTxQueue::from_mmio_queue_state(queue).map_err(|source| {
+                    VirtioNetworkDeviceActivationError::TxQueueBuild {
+                        queue_index: VIRTIO_NET_TX_QUEUE_INDEX_U32,
+                        source,
+                    }
+                })
+            })?;
 
         self.active_rx_queue = Some(active_rx_queue);
         self.active_tx_queue = Some(active_tx_queue);
@@ -845,11 +862,13 @@ impl VirtioNetworkDevice {
 
     fn dispatch_drained_queue_notifications(
         &mut self,
+        memory: &mut GuestMemory,
         drained_notifications: Vec<usize>,
     ) -> Result<VirtioNetworkDeviceNotificationDispatch, VirtioNetworkDeviceNotificationError> {
         if drained_notifications.is_empty() {
             return Ok(VirtioNetworkDeviceNotificationDispatch::new(
                 drained_notifications,
+                None,
             ));
         }
 
@@ -868,27 +887,336 @@ impl VirtioNetworkDevice {
             });
         }
 
-        match drained_notifications.first().copied() {
-            Some(queue_index) => Err(
+        if drained_notifications
+            .iter()
+            .copied()
+            .any(|queue_index| queue_index == VIRTIO_NET_RX_QUEUE_INDEX)
+        {
+            return Err(
                 VirtioNetworkDeviceNotificationError::UnsupportedQueueExecution {
                     drained_notifications,
-                    queue_index,
+                    queue_index: VIRTIO_NET_RX_QUEUE_INDEX,
                 },
-            ),
-            None => Ok(VirtioNetworkDeviceNotificationDispatch::new(
+            );
+        }
+
+        let Some(queue) = self.active_tx_queue.as_mut() else {
+            return Err(VirtioNetworkDeviceNotificationError::Inactive {
                 drained_notifications,
+            });
+        };
+
+        match queue.dispatch(memory) {
+            Ok(dispatch) => Ok(VirtioNetworkDeviceNotificationDispatch::new(
+                drained_notifications,
+                Some(dispatch),
             )),
+            Err(source) => Err(VirtioNetworkDeviceNotificationError::TxQueueDispatch {
+                drained_notifications,
+                source,
+            }),
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VirtioNetworkTxQueue {
+    queue_state: VirtioMmioQueueState,
+    available: VirtqueueAvailableRing,
+    used: VirtqueueUsedRing,
+}
+
+impl VirtioNetworkTxQueue {
+    pub fn from_mmio_queue_state(
+        queue: VirtioMmioQueueState,
+    ) -> Result<Self, VirtioNetworkTxQueueBuildError> {
+        if !queue.ready() {
+            return Err(VirtioNetworkTxQueueBuildError::QueueNotReady);
+        }
+
+        let available = VirtqueueAvailableRing::new(
+            queue.descriptor_table(),
+            queue.driver_ring(),
+            queue.size(),
+        )
+        .map_err(|source| VirtioNetworkTxQueueBuildError::AvailableRing { source })?;
+        let used = VirtqueueUsedRing::new(queue.device_ring(), queue.size())
+            .map_err(|source| VirtioNetworkTxQueueBuildError::UsedRing { source })?;
+
+        Ok(Self {
+            queue_state: queue,
+            available,
+            used,
+        })
+    }
+
+    pub const fn queue_state(&self) -> VirtioMmioQueueState {
+        self.queue_state
+    }
+
+    pub const fn available_ring(&self) -> &VirtqueueAvailableRing {
+        &self.available
+    }
+
+    pub const fn used_ring(&self) -> &VirtqueueUsedRing {
+        &self.used
+    }
+
+    pub fn dispatch(
+        &mut self,
+        memory: &mut GuestMemory,
+    ) -> Result<VirtioNetworkTxQueueDispatch, VirtioNetworkTxQueueDispatchError> {
+        let mut dispatch =
+            VirtioNetworkTxQueueDispatch::with_capacity(self.available.queue_size())?;
+        while let Some(chain) = match self.available.pop_descriptor_chain(memory) {
+            Ok(chain) => chain,
+            Err(source) => {
+                return Err(VirtioNetworkTxQueueDispatchError::AvailableRing {
+                    completed_dispatch: Box::new(dispatch),
+                    source,
+                });
+            }
+        } {
+            let descriptor_head = match descriptor_chain_head(&chain) {
+                Some(descriptor_head) => descriptor_head,
+                None => {
+                    return Err(VirtioNetworkTxQueueDispatchError::EmptyDescriptorChain {
+                        completed_dispatch: Box::new(dispatch),
+                    });
+                }
+            };
+            let outcome = match VirtioNetworkTxFrame::parse(memory, &chain) {
+                Ok(frame) => VirtioNetworkTxQueueDispatchOutcome::Ok(frame),
+                Err(source) => VirtioNetworkTxQueueDispatchOutcome::ParseError(source),
+            };
+            if let Err(source) = self.used.publish_used_element(memory, descriptor_head, 0) {
+                return Err(VirtioNetworkTxQueueDispatchError::UsedRing {
+                    completed_dispatch: Box::new(dispatch),
+                    descriptor_head,
+                    bytes_written_to_guest: 0,
+                    source,
+                });
+            }
+            dispatch.record(outcome);
+        }
+
+        Ok(dispatch)
+    }
+}
+
+#[derive(Debug)]
+pub enum VirtioNetworkTxQueueBuildError {
+    QueueNotReady,
+    AvailableRing { source: VirtqueueAvailableRingError },
+    UsedRing { source: VirtqueueUsedRingError },
+}
+
+impl fmt::Display for VirtioNetworkTxQueueBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::QueueNotReady => f.write_str("virtio-net TX queue is not ready"),
+            Self::AvailableRing { source } => {
+                write!(f, "failed to build virtio-net TX available ring: {source}")
+            }
+            Self::UsedRing { source } => {
+                write!(f, "failed to build virtio-net TX used ring: {source}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VirtioNetworkTxQueueBuildError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::AvailableRing { source } => Some(source),
+            Self::UsedRing { source } => Some(source),
+            Self::QueueNotReady => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct VirtioNetworkTxQueueDispatch {
+    processed_frames: usize,
+    successful_frames: usize,
+    parse_failures: usize,
+    frames: Vec<VirtioNetworkTxFrame>,
+    first_parse_failure: Option<VirtioNetworkTxFrameParseError>,
+}
+
+impl VirtioNetworkTxQueueDispatch {
+    fn with_capacity(queue_size: u16) -> Result<Self, VirtioNetworkTxQueueDispatchError> {
+        let mut frames = Vec::new();
+        frames
+            .try_reserve_exact(usize::from(queue_size))
+            .map_err(
+                |source| VirtioNetworkTxQueueDispatchError::FrameMetadataAllocation { source },
+            )?;
+
+        Ok(Self {
+            processed_frames: 0,
+            successful_frames: 0,
+            parse_failures: 0,
+            frames,
+            first_parse_failure: None,
+        })
+    }
+
+    pub const fn processed_frames(&self) -> usize {
+        self.processed_frames
+    }
+
+    pub const fn successful_frames(&self) -> usize {
+        self.successful_frames
+    }
+
+    pub const fn parse_failures(&self) -> usize {
+        self.parse_failures
+    }
+
+    pub const fn first_parse_failure(&self) -> Option<&VirtioNetworkTxFrameParseError> {
+        self.first_parse_failure.as_ref()
+    }
+
+    pub fn frames(&self) -> &[VirtioNetworkTxFrame] {
+        &self.frames
+    }
+
+    pub const fn needs_queue_interrupt(&self) -> bool {
+        self.processed_frames != 0
+    }
+
+    fn record(&mut self, outcome: VirtioNetworkTxQueueDispatchOutcome) {
+        self.processed_frames += 1;
+        match outcome {
+            VirtioNetworkTxQueueDispatchOutcome::Ok(frame) => {
+                self.successful_frames += 1;
+                self.frames.push(frame);
+            }
+            VirtioNetworkTxQueueDispatchOutcome::ParseError(source) => {
+                self.parse_failures += 1;
+                if self.first_parse_failure.is_none() {
+                    self.first_parse_failure = Some(source);
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum VirtioNetworkTxQueueDispatchOutcome {
+    Ok(VirtioNetworkTxFrame),
+    ParseError(VirtioNetworkTxFrameParseError),
+}
+
+#[derive(Debug)]
+pub enum VirtioNetworkTxQueueDispatchError {
+    FrameMetadataAllocation {
+        source: TryReserveError,
+    },
+    AvailableRing {
+        completed_dispatch: Box<VirtioNetworkTxQueueDispatch>,
+        source: VirtqueueAvailableRingError,
+    },
+    EmptyDescriptorChain {
+        completed_dispatch: Box<VirtioNetworkTxQueueDispatch>,
+    },
+    UsedRing {
+        completed_dispatch: Box<VirtioNetworkTxQueueDispatch>,
+        descriptor_head: u16,
+        bytes_written_to_guest: u32,
+        source: VirtqueueUsedRingError,
+    },
+}
+
+impl VirtioNetworkTxQueueDispatchError {
+    pub const fn completed_dispatch(&self) -> Option<&VirtioNetworkTxQueueDispatch> {
+        match self {
+            Self::AvailableRing {
+                completed_dispatch, ..
+            }
+            | Self::EmptyDescriptorChain {
+                completed_dispatch, ..
+            }
+            | Self::UsedRing {
+                completed_dispatch, ..
+            } => Some(completed_dispatch),
+            Self::FrameMetadataAllocation { .. } => None,
+        }
+    }
+}
+
+impl fmt::Display for VirtioNetworkTxQueueDispatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::FrameMetadataAllocation { source } => {
+                write!(
+                    f,
+                    "failed to reserve virtio-net TX frame metadata: {source}"
+                )
+            }
+            Self::AvailableRing { source, .. } => {
+                write!(
+                    f,
+                    "failed to pop virtio-net TX available descriptor chain: {source}"
+                )
+            }
+            Self::EmptyDescriptorChain { .. } => {
+                f.write_str("virtio-net TX queue produced an empty descriptor chain")
+            }
+            Self::UsedRing {
+                descriptor_head,
+                bytes_written_to_guest,
+                source,
+                ..
+            } => {
+                write!(
+                    f,
+                    "failed to publish virtio-net TX used descriptor head {descriptor_head} with length {bytes_written_to_guest}: {source}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for VirtioNetworkTxQueueDispatchError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::FrameMetadataAllocation { source } => Some(source),
+            Self::AvailableRing { source, .. } => Some(source),
+            Self::UsedRing { source, .. } => Some(source),
+            Self::EmptyDescriptorChain { .. } => None,
+        }
+    }
+}
+
+fn descriptor_chain_head(chain: &VirtqueueDescriptorChain) -> Option<u16> {
+    chain
+        .descriptors()
+        .first()
+        .map(|descriptor| descriptor.index())
 }
 
 impl<C: VirtioMmioDeviceConfigHandler> VirtioMmioRegisterHandler<C, VirtioNetworkDevice> {
     pub fn dispatch_network_queue_notifications(
         &mut self,
+        memory: &mut GuestMemory,
     ) -> Result<VirtioNetworkDeviceNotificationDispatch, VirtioNetworkDeviceNotificationError> {
         let drained_notifications = self.take_pending_queue_notifications();
-        self.activation_handler_mut()
-            .dispatch_drained_queue_notifications(drained_notifications)
+        let dispatch = self
+            .activation_handler_mut()
+            .dispatch_drained_queue_notifications(memory, drained_notifications);
+        let needs_queue_interrupt = match &dispatch {
+            Ok(dispatch) => dispatch.needs_queue_interrupt(),
+            Err(error) => error
+                .completed_tx_dispatch()
+                .is_some_and(VirtioNetworkTxQueueDispatch::needs_queue_interrupt),
+        };
+        if needs_queue_interrupt {
+            self.mark_interrupt_pending(DeviceInterruptKind::Queue);
+        }
+
+        dispatch
     }
 }
 
@@ -1481,20 +1809,35 @@ impl std::error::Error for PreparedNetworkDeviceError {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct VirtioNetworkDeviceNotificationDispatch {
     drained_notifications: Vec<usize>,
+    tx_queue_dispatch: Option<VirtioNetworkTxQueueDispatch>,
 }
 
 impl VirtioNetworkDeviceNotificationDispatch {
-    const fn new(drained_notifications: Vec<usize>) -> Self {
+    const fn new(
+        drained_notifications: Vec<usize>,
+        tx_queue_dispatch: Option<VirtioNetworkTxQueueDispatch>,
+    ) -> Self {
         Self {
             drained_notifications,
+            tx_queue_dispatch,
         }
     }
 
     pub fn drained_notifications(&self) -> &[usize] {
         &self.drained_notifications
+    }
+
+    pub const fn tx_queue_dispatch(&self) -> Option<&VirtioNetworkTxQueueDispatch> {
+        self.tx_queue_dispatch.as_ref()
+    }
+
+    pub fn needs_queue_interrupt(&self) -> bool {
+        self.tx_queue_dispatch
+            .as_ref()
+            .is_some_and(VirtioNetworkTxQueueDispatch::needs_queue_interrupt)
     }
 }
 
@@ -1511,6 +1854,10 @@ pub enum VirtioNetworkDeviceNotificationError {
         drained_notifications: Vec<usize>,
         queue_index: usize,
     },
+    TxQueueDispatch {
+        drained_notifications: Vec<usize>,
+        source: VirtioNetworkTxQueueDispatchError,
+    },
 }
 
 impl VirtioNetworkDeviceNotificationError {
@@ -1526,7 +1873,20 @@ impl VirtioNetworkDeviceNotificationError {
             | Self::UnsupportedQueueExecution {
                 drained_notifications,
                 ..
+            }
+            | Self::TxQueueDispatch {
+                drained_notifications,
+                ..
             } => drained_notifications,
+        }
+    }
+
+    pub const fn completed_tx_dispatch(&self) -> Option<&VirtioNetworkTxQueueDispatch> {
+        match self {
+            Self::TxQueueDispatch { source, .. } => source.completed_dispatch(),
+            Self::Inactive { .. }
+            | Self::UnsupportedQueue { .. }
+            | Self::UnsupportedQueueExecution { .. } => None,
         }
     }
 }
@@ -1549,11 +1909,23 @@ impl fmt::Display for VirtioNetworkDeviceNotificationError {
                     "virtio-net queue {queue_index} notification execution is not supported"
                 )
             }
+            Self::TxQueueDispatch { source, .. } => {
+                write!(f, "failed to dispatch virtio-net TX queue: {source}")
+            }
         }
     }
 }
 
-impl std::error::Error for VirtioNetworkDeviceNotificationError {}
+impl std::error::Error for VirtioNetworkDeviceNotificationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::TxQueueDispatch { source, .. } => Some(source),
+            Self::Inactive { .. }
+            | Self::UnsupportedQueue { .. }
+            | Self::UnsupportedQueueExecution { .. } => None,
+        }
+    }
+}
 
 #[derive(Debug)]
 pub enum VirtioNetworkDeviceActivationError {
@@ -1561,6 +1933,10 @@ pub enum VirtioNetworkDeviceActivationError {
     QueueMetadata {
         queue_index: u32,
         source: VirtioMmioQueueRegisterError,
+    },
+    TxQueueBuild {
+        queue_index: u32,
+        source: VirtioNetworkTxQueueBuildError,
     },
     QueueNotReady {
         queue_index: u32,
@@ -1583,6 +1959,15 @@ impl fmt::Display for VirtioNetworkDeviceActivationError {
                     "failed to read virtio-net queue {queue_index} activation metadata: {source}"
                 )
             }
+            Self::TxQueueBuild {
+                queue_index,
+                source,
+            } => {
+                write!(
+                    f,
+                    "failed to activate virtio-net TX queue {queue_index}: {source}"
+                )
+            }
             Self::QueueNotReady { queue_index } => {
                 write!(f, "virtio-net queue {queue_index} is not ready")
             }
@@ -1597,6 +1982,7 @@ impl std::error::Error for VirtioNetworkDeviceActivationError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::QueueMetadata { source, .. } => Some(source),
+            Self::TxQueueBuild { source, .. } => Some(source),
             Self::AlreadyActive
             | Self::QueueNotReady { .. }
             | Self::QueueSizeNotConfigured { .. } => None,
@@ -2061,6 +2447,7 @@ fn validate_interface_id(
 mod tests {
     use std::str::FromStr;
 
+    use crate::interrupt::DeviceInterruptKind;
     use crate::memory::{GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange};
     use crate::mmio::{
         MmioAccess, MmioAccessBytes, MmioBus, MmioDispatchOutcome, MmioDispatcher, MmioOperation,
@@ -2091,7 +2478,7 @@ mod tests {
         VIRTIO_RING_FEATURE_EVENT_IDX, VirtioNetworkConfigSpace, VirtioNetworkDevice,
         VirtioNetworkDeviceActivationError, VirtioNetworkDeviceNotificationError,
         VirtioNetworkMmioHandler, VirtioNetworkRxBuffer, VirtioNetworkRxBufferParseError,
-        VirtioNetworkTxFrame, VirtioNetworkTxFrameParseError,
+        VirtioNetworkTxFrame, VirtioNetworkTxFrameParseError, VirtioNetworkTxQueueDispatchError,
     };
 
     const TEST_MMIO_BASE: GuestAddress = GuestAddress::new(0x1000);
@@ -2518,6 +2905,96 @@ mod tests {
 
         read_descriptor_chain(memory, TEST_TX_DESCRIPTOR_TABLE, TEST_QUEUE_SIZE, 0)
             .expect("TX descriptor chain should read")
+    }
+
+    fn write_guest_u16(memory: &mut GuestMemory, address: GuestAddress, value: u16) {
+        memory
+            .write_slice(&value.to_le_bytes(), address)
+            .expect("test u16 should write");
+    }
+
+    fn read_guest_u16(memory: &GuestMemory, address: GuestAddress) -> u16 {
+        let mut bytes = [0; 2];
+        memory
+            .read_slice(&mut bytes, address)
+            .expect("test u16 should read");
+        u16::from_le_bytes(bytes)
+    }
+
+    fn read_guest_u32(memory: &GuestMemory, address: GuestAddress) -> u32 {
+        let mut bytes = [0; 4];
+        memory
+            .read_slice(&mut bytes, address)
+            .expect("test u32 should read");
+        u32::from_le_bytes(bytes)
+    }
+
+    fn tx_available_ring_idx_address() -> GuestAddress {
+        TEST_TX_AVAILABLE_RING
+            .checked_add(2)
+            .expect("available ring idx address should not overflow")
+    }
+
+    fn tx_available_ring_entry_address(index: usize) -> GuestAddress {
+        TEST_TX_AVAILABLE_RING
+            .checked_add(
+                4 + u64::try_from(index).expect("test index should fit") * u64::from(2_u16),
+            )
+            .expect("available ring entry address should not overflow")
+    }
+
+    fn write_tx_available_heads(memory: &mut GuestMemory, heads: &[u16]) {
+        for (index, head) in heads.iter().copied().enumerate() {
+            write_guest_u16(memory, tx_available_ring_entry_address(index), head);
+        }
+        write_guest_u16(
+            memory,
+            tx_available_ring_idx_address(),
+            u16::try_from(heads.len()).expect("test available head count should fit"),
+        );
+    }
+
+    fn tx_used_ring_idx_address() -> GuestAddress {
+        TEST_TX_USED_RING
+            .checked_add(2)
+            .expect("used ring idx address should not overflow")
+    }
+
+    fn tx_used_ring_entry_address(index: usize) -> GuestAddress {
+        TEST_TX_USED_RING
+            .checked_add(4 + u64::try_from(index).expect("test index should fit") * 8)
+            .expect("used ring entry address should not overflow")
+    }
+
+    fn read_tx_used_index(memory: &GuestMemory) -> u16 {
+        read_guest_u16(memory, tx_used_ring_idx_address())
+    }
+
+    fn read_tx_used_element(memory: &GuestMemory, index: usize) -> (u32, u32) {
+        let address = tx_used_ring_entry_address(index);
+        let descriptor_head = read_guest_u32(memory, address);
+        let len = read_guest_u32(
+            memory,
+            address
+                .checked_add(4)
+                .expect("used ring len address should not overflow"),
+        );
+        (descriptor_head, len)
+    }
+
+    fn read_interrupt_status(handler: &VirtioNetworkMmioHandler) -> u32 {
+        handler
+            .read_register(VirtioMmioRegister::InterruptStatus)
+            .expect("interrupt status should read")
+    }
+
+    fn acknowledge_queue_interrupt(handler: &mut VirtioNetworkMmioHandler) {
+        handler
+            .write_register(
+                VirtioMmioRegister::InterruptAck,
+                DeviceInterruptKind::Queue.status().bits(),
+            )
+            .expect("queue interrupt should acknowledge");
     }
 
     fn parse_tx_frame(
@@ -4043,21 +4520,25 @@ mod tests {
 
     #[test]
     fn virtio_network_notifications_without_pending_work_are_noop() {
+        let mut memory = tx_frame_memory();
         let mut device = VirtioNetworkDevice::new();
 
         let dispatch = device
-            .dispatch_drained_queue_notifications(Vec::new())
+            .dispatch_drained_queue_notifications(&mut memory, Vec::new())
             .expect("empty notification drain should be a no-op");
 
         assert_eq!(dispatch.drained_notifications(), &[]);
+        assert!(dispatch.tx_queue_dispatch().is_none());
+        assert!(!dispatch.needs_queue_interrupt());
     }
 
     #[test]
     fn virtio_network_notifications_reject_inactive_device_with_drained_metadata() {
+        let mut memory = tx_frame_memory();
         let mut device = VirtioNetworkDevice::new();
 
         let error = device
-            .dispatch_drained_queue_notifications(vec![VIRTIO_NET_RX_QUEUE_INDEX])
+            .dispatch_drained_queue_notifications(&mut memory, vec![VIRTIO_NET_RX_QUEUE_INDEX])
             .expect_err("notification before activation should fail");
 
         assert!(matches!(
@@ -4069,11 +4550,13 @@ mod tests {
             error.to_string(),
             "virtio-net queue notification cannot be dispatched before activation"
         );
+        assert!(error.completed_tx_dispatch().is_none());
         assert!(std::error::Error::source(&error).is_none());
     }
 
     #[test]
     fn virtio_network_notifications_reject_unsupported_queue_execution_and_drain() {
+        let mut memory = tx_frame_memory();
         let mut handler = network_activation_handler();
 
         configure_network_handler_queues(&mut handler);
@@ -4096,7 +4579,7 @@ mod tests {
             .expect("TX notification should write");
 
         let error = handler
-            .dispatch_network_queue_notifications()
+            .dispatch_network_queue_notifications(&mut memory)
             .expect_err("network packet execution is not supported yet");
 
         match &error {
@@ -4109,11 +4592,242 @@ mod tests {
             error.drained_notifications(),
             &[VIRTIO_NET_RX_QUEUE_INDEX, VIRTIO_NET_TX_QUEUE_INDEX]
         );
+        assert!(error.completed_tx_dispatch().is_none());
+        assert_eq!(read_interrupt_status(&handler), 0);
         assert!(handler.pending_queue_notifications().is_empty());
     }
 
     #[test]
+    fn virtio_network_notifications_dispatch_tx_frame_and_mark_interrupt() {
+        let mut memory = tx_frame_memory();
+        let mut handler = network_activation_handler();
+
+        configure_network_handler_queues(&mut handler);
+        activate_network_handler(&mut handler);
+        write_tx_header(&mut memory, TEST_TX_HEADER);
+        tx_descriptor_chain(
+            &mut memory,
+            &[
+                TestDescriptor::readable(TEST_TX_HEADER, VIRTIO_NET_TX_HEADER_SIZE, Some(1)),
+                TestDescriptor::readable(TEST_TX_PAYLOAD, 4, None),
+            ],
+        );
+        write_tx_available_heads(&mut memory, &[0]);
+        handler
+            .write_register(
+                VirtioMmioRegister::QueueNotify,
+                VIRTIO_NET_TX_QUEUE_INDEX
+                    .try_into()
+                    .expect("TX queue index should fit"),
+            )
+            .expect("TX notification should write");
+
+        let notification = handler
+            .dispatch_network_queue_notifications(&mut memory)
+            .expect("TX queue notification should dispatch");
+
+        assert_eq!(
+            notification.drained_notifications(),
+            [VIRTIO_NET_TX_QUEUE_INDEX]
+        );
+        assert!(notification.needs_queue_interrupt());
+        let dispatch = notification
+            .tx_queue_dispatch()
+            .expect("TX dispatch summary should be present");
+        assert_eq!(dispatch.processed_frames(), 1);
+        assert_eq!(dispatch.successful_frames(), 1);
+        assert_eq!(dispatch.parse_failures(), 0);
+        assert!(dispatch.first_parse_failure().is_none());
+        assert!(dispatch.needs_queue_interrupt());
+        let frame = dispatch
+            .frames()
+            .first()
+            .expect("parsed TX frame should be recorded");
+        assert_eq!(frame.descriptor_head(), 0);
+        assert_eq!(frame.payload_len(), 4);
+        assert_eq!(
+            read_interrupt_status(&handler),
+            DeviceInterruptKind::Queue.status().bits()
+        );
+        assert!(handler.pending_queue_notifications().is_empty());
+        let active_tx_queue = handler
+            .activation_handler()
+            .active_tx_dispatch_queue()
+            .expect("TX dispatch queue should remain active");
+        assert_eq!(active_tx_queue.available_ring().next_avail(), 1);
+        assert_eq!(active_tx_queue.used_ring().next_used(), 1);
+        assert_eq!(read_tx_used_index(&memory), 1);
+        assert_eq!(read_tx_used_element(&memory, 0), (0, 0));
+    }
+
+    #[test]
+    fn virtio_network_notifications_record_tx_parse_failure_and_complete_used_ring() {
+        let mut memory = tx_frame_memory();
+        let mut handler = network_activation_handler();
+
+        configure_network_handler_queues(&mut handler);
+        activate_network_handler(&mut handler);
+        tx_descriptor_chain(
+            &mut memory,
+            &[TestDescriptor::readable(
+                TEST_TX_HEADER,
+                VIRTIO_NET_TX_HEADER_SIZE - 1,
+                None,
+            )],
+        );
+        write_tx_available_heads(&mut memory, &[0]);
+        handler
+            .write_register(
+                VirtioMmioRegister::QueueNotify,
+                VIRTIO_NET_TX_QUEUE_INDEX
+                    .try_into()
+                    .expect("TX queue index should fit"),
+            )
+            .expect("TX notification should write");
+
+        let notification = handler
+            .dispatch_network_queue_notifications(&mut memory)
+            .expect("malformed TX frame should still complete descriptor head");
+
+        assert_eq!(
+            notification.drained_notifications(),
+            [VIRTIO_NET_TX_QUEUE_INDEX]
+        );
+        let dispatch = notification
+            .tx_queue_dispatch()
+            .expect("TX dispatch summary should be present");
+        assert_eq!(dispatch.processed_frames(), 1);
+        assert_eq!(dispatch.successful_frames(), 0);
+        assert_eq!(dispatch.parse_failures(), 1);
+        assert!(matches!(
+            dispatch.first_parse_failure(),
+            Some(VirtioNetworkTxFrameParseError::HeaderDescriptorTooSmall {
+                index: 0,
+                len: 11,
+                min: 12,
+            })
+        ));
+        assert!(dispatch.frames().is_empty());
+        assert!(notification.needs_queue_interrupt());
+        assert_eq!(
+            read_interrupt_status(&handler),
+            DeviceInterruptKind::Queue.status().bits()
+        );
+        assert_eq!(read_tx_used_index(&memory), 1);
+        assert_eq!(read_tx_used_element(&memory, 0), (0, 0));
+    }
+
+    #[test]
+    fn virtio_network_notifications_do_not_redispatch_after_drain() {
+        let mut memory = tx_frame_memory();
+        let mut handler = network_activation_handler();
+
+        configure_network_handler_queues(&mut handler);
+        activate_network_handler(&mut handler);
+        write_tx_header(&mut memory, TEST_TX_HEADER);
+        tx_descriptor_chain(
+            &mut memory,
+            &[TestDescriptor::readable(
+                TEST_TX_HEADER,
+                VIRTIO_NET_TX_HEADER_SIZE + 4,
+                None,
+            )],
+        );
+        write_tx_available_heads(&mut memory, &[0]);
+        handler
+            .write_register(
+                VirtioMmioRegister::QueueNotify,
+                VIRTIO_NET_TX_QUEUE_INDEX
+                    .try_into()
+                    .expect("TX queue index should fit"),
+            )
+            .expect("TX notification should write");
+
+        let first = handler
+            .dispatch_network_queue_notifications(&mut memory)
+            .expect("first TX dispatch should succeed");
+        assert!(first.tx_queue_dispatch().is_some());
+        acknowledge_queue_interrupt(&mut handler);
+
+        let second = handler
+            .dispatch_network_queue_notifications(&mut memory)
+            .expect("second dispatch without notification should be a no-op");
+
+        assert_eq!(second.drained_notifications(), []);
+        assert!(second.tx_queue_dispatch().is_none());
+        assert!(!second.needs_queue_interrupt());
+        assert_eq!(read_interrupt_status(&handler), 0);
+        let active_tx_queue = handler
+            .activation_handler()
+            .active_tx_dispatch_queue()
+            .expect("TX dispatch queue should remain active");
+        assert_eq!(active_tx_queue.available_ring().next_avail(), 1);
+        assert_eq!(active_tx_queue.used_ring().next_used(), 1);
+        assert_eq!(read_tx_used_index(&memory), 1);
+    }
+
+    #[test]
+    fn virtio_network_notifications_preserve_partial_tx_dispatch_error() {
+        let mut memory = tx_frame_memory();
+        let mut handler = network_activation_handler();
+
+        configure_network_handler_queues(&mut handler);
+        activate_network_handler(&mut handler);
+        write_tx_header(&mut memory, TEST_TX_HEADER);
+        tx_descriptor_chain(
+            &mut memory,
+            &[TestDescriptor::readable(
+                TEST_TX_HEADER,
+                VIRTIO_NET_TX_HEADER_SIZE + 4,
+                None,
+            )],
+        );
+        write_tx_available_heads(&mut memory, &[0, TEST_QUEUE_SIZE]);
+        handler
+            .write_register(
+                VirtioMmioRegister::QueueNotify,
+                VIRTIO_NET_TX_QUEUE_INDEX
+                    .try_into()
+                    .expect("TX queue index should fit"),
+            )
+            .expect("TX notification should write");
+
+        let error = handler
+            .dispatch_network_queue_notifications(&mut memory)
+            .expect_err("invalid second TX head should fail after partial dispatch");
+
+        match &error {
+            VirtioNetworkDeviceNotificationError::TxQueueDispatch {
+                source: VirtioNetworkTxQueueDispatchError::AvailableRing { .. },
+                ..
+            } => {}
+            other => panic!("expected TX available-ring dispatch error, got {other:?}"),
+        }
+        assert_eq!(error.drained_notifications(), [VIRTIO_NET_TX_QUEUE_INDEX]);
+        let completed = error
+            .completed_tx_dispatch()
+            .expect("partial dispatch metadata should be preserved");
+        assert_eq!(completed.processed_frames(), 1);
+        assert_eq!(completed.successful_frames(), 1);
+        assert!(completed.needs_queue_interrupt());
+        assert_eq!(
+            read_interrupt_status(&handler),
+            DeviceInterruptKind::Queue.status().bits()
+        );
+        assert!(handler.pending_queue_notifications().is_empty());
+        let active_tx_queue = handler
+            .activation_handler()
+            .active_tx_dispatch_queue()
+            .expect("TX dispatch queue should remain active");
+        assert_eq!(active_tx_queue.available_ring().next_avail(), 1);
+        assert_eq!(active_tx_queue.used_ring().next_used(), 1);
+        assert_eq!(read_tx_used_index(&memory), 1);
+        assert_eq!(read_tx_used_element(&memory, 0), (0, 0));
+    }
+
+    #[test]
     fn virtio_network_notifications_reject_unsupported_queue_index() {
+        let mut memory = tx_frame_memory();
         let mut device = VirtioNetworkDevice::new();
         let registers = network_device_registers();
         let queues =
@@ -4123,7 +4837,7 @@ mod tests {
             .expect("network device should activate");
 
         let error = device
-            .dispatch_drained_queue_notifications(vec![2])
+            .dispatch_drained_queue_notifications(&mut memory, vec![2])
             .expect_err("unsupported queue index should fail");
 
         match &error {
@@ -4133,5 +4847,6 @@ mod tests {
             other => panic!("expected unsupported queue error, got {other:?}"),
         }
         assert_eq!(error.drained_notifications(), &[2]);
+        assert!(error.completed_tx_dispatch().is_none());
     }
 }

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -899,7 +899,8 @@ mod tests {
     };
     use crate::network::{
         NetworkInterfaceConfigInput, NetworkInterfaceConfigs, NetworkMmioDeviceRegistration,
-        NetworkMmioLayout, PreparedNetworkDevices,
+        NetworkMmioLayout, PreparedNetworkDevices, VIRTIO_NET_RX_QUEUE_INDEX,
+        VIRTIO_NET_TX_HEADER_SIZE, VIRTIO_NET_TX_QUEUE_INDEX,
     };
     use crate::serial::{
         SERIAL_MMIO_DEVICE_WINDOW_SIZE, SERIAL_TRANSMIT_REGISTER_OFFSET, SerialMmioDevice,
@@ -932,6 +933,9 @@ mod tests {
     const HEADER_ADDR: GuestAddress = GuestAddress::new(0x8043_0000);
     const DATA_ADDR: GuestAddress = GuestAddress::new(0x8044_0000);
     const STATUS_ADDR: GuestAddress = GuestAddress::new(0x8045_0000);
+    const TEST_RX_DESCRIPTOR_TABLE: GuestAddress = GuestAddress::new(0x8046_0000);
+    const TEST_RX_AVAILABLE_RING: GuestAddress = GuestAddress::new(0x8047_0000);
+    const TEST_RX_USED_RING: GuestAddress = GuestAddress::new(0x8048_0000);
     const TEST_AVAILABLE_RING_IDX_OFFSET: u64 = 2;
     const TEST_AVAILABLE_RING_RING_OFFSET: u64 = 4;
     const TEST_AVAILABLE_RING_ENTRY_SIZE: u64 = 2;
@@ -1200,6 +1204,65 @@ mod tests {
         }
     }
 
+    fn write_boot_network_mmio_u32(
+        runtime: &mut super::Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+        device_index: usize,
+        register: VirtioMmioRegister,
+        value: u32,
+    ) {
+        try_write_boot_network_mmio_u32(runtime, mmio_dispatcher, device_index, register, value)
+            .expect("network MMIO write should dispatch");
+    }
+
+    fn try_write_boot_network_mmio_u32(
+        runtime: &mut super::Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+        device_index: usize,
+        register: VirtioMmioRegister,
+        value: u32,
+    ) -> Result<MmioDispatchOutcome, crate::mmio::MmioDispatchError> {
+        let address = runtime.network_devices[device_index]
+            .registration
+            .address()
+            .checked_add(register.offset())
+            .expect("test MMIO address should not overflow");
+        let access = mmio_dispatcher
+            .lookup(address, 4)
+            .expect("network MMIO access should resolve");
+        let data = MmioAccessBytes::new(&value.to_le_bytes()).expect("u32 bytes should be valid");
+        mmio_dispatcher.dispatch(
+            MmioOperation::write(access, data).expect("u32 write operation should be valid"),
+        )
+    }
+
+    fn read_boot_network_mmio_u32(
+        runtime: &mut super::Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+        device_index: usize,
+        register: VirtioMmioRegister,
+    ) -> u32 {
+        let address = runtime.network_devices[device_index]
+            .registration
+            .address()
+            .checked_add(register.offset())
+            .expect("test MMIO address should not overflow");
+        let access = mmio_dispatcher
+            .lookup(address, 4)
+            .expect("network MMIO access should resolve");
+        let outcome = mmio_dispatcher
+            .dispatch(MmioOperation::read(access).expect("u32 read operation should be valid"))
+            .expect("network MMIO read should dispatch");
+        match outcome {
+            MmioDispatchOutcome::Read { data } => u32::from_le_bytes(
+                data.as_slice()
+                    .try_into()
+                    .expect("u32 read should return four bytes"),
+            ),
+            MmioDispatchOutcome::Write => panic!("read operation should not produce write outcome"),
+        }
+    }
+
     fn configure_boot_block_queue(
         runtime: &mut super::Arm64BootRuntimeResources,
         mmio_dispatcher: &mut MmioDispatcher,
@@ -1271,6 +1334,112 @@ mod tests {
         );
     }
 
+    fn configure_boot_network_queue(
+        runtime: &mut super::Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+        device_index: usize,
+        queue_index: usize,
+        descriptor_table: GuestAddress,
+        driver_ring: GuestAddress,
+        device_ring: GuestAddress,
+    ) {
+        write_boot_network_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            device_index,
+            VirtioMmioRegister::QueueSel,
+            u32::try_from(queue_index).expect("queue index should fit"),
+        );
+        write_boot_network_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            device_index,
+            VirtioMmioRegister::QueueNum,
+            u32::from(TEST_QUEUE_SIZE),
+        );
+        write_boot_network_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            device_index,
+            VirtioMmioRegister::QueueDescLow,
+            guest_address_low(descriptor_table),
+        );
+        write_boot_network_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            device_index,
+            VirtioMmioRegister::QueueDriverLow,
+            guest_address_low(driver_ring),
+        );
+        write_boot_network_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            device_index,
+            VirtioMmioRegister::QueueDeviceLow,
+            guest_address_low(device_ring),
+        );
+        write_boot_network_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            device_index,
+            VirtioMmioRegister::QueueReady,
+            1,
+        );
+    }
+
+    fn configure_boot_network_queues(
+        runtime: &mut super::Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+        device_index: usize,
+    ) {
+        write_boot_network_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            device_index,
+            VirtioMmioRegister::Status,
+            VIRTIO_DEVICE_STATUS_ACKNOWLEDGE,
+        );
+        write_boot_network_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            device_index,
+            VirtioMmioRegister::Status,
+            VIRTIO_DEVICE_STATUS_ACKNOWLEDGE | VIRTIO_DEVICE_STATUS_DRIVER,
+        );
+        write_boot_network_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            device_index,
+            VirtioMmioRegister::Status,
+            QUEUE_CONFIG_STATUS,
+        );
+        configure_boot_network_queue(
+            runtime,
+            mmio_dispatcher,
+            device_index,
+            VIRTIO_NET_RX_QUEUE_INDEX,
+            TEST_RX_DESCRIPTOR_TABLE,
+            TEST_RX_AVAILABLE_RING,
+            TEST_RX_USED_RING,
+        );
+        configure_boot_network_queue(
+            runtime,
+            mmio_dispatcher,
+            device_index,
+            VIRTIO_NET_TX_QUEUE_INDEX,
+            TEST_DESCRIPTOR_TABLE,
+            TEST_AVAILABLE_RING,
+            TEST_USED_RING,
+        );
+        write_boot_network_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            device_index,
+            VirtioMmioRegister::Status,
+            DRIVER_OK_STATUS,
+        );
+    }
+
     fn notify_boot_block_queue(
         runtime: &mut super::Arm64BootRuntimeResources,
         mmio_dispatcher: &mut MmioDispatcher,
@@ -1282,6 +1451,20 @@ mod tests {
             device_index,
             VirtioMmioRegister::QueueNotify,
             0,
+        );
+    }
+
+    fn notify_boot_network_tx_queue(
+        runtime: &mut super::Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+        device_index: usize,
+    ) {
+        write_boot_network_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            device_index,
+            VirtioMmioRegister::QueueNotify,
+            u32::try_from(VIRTIO_NET_TX_QUEUE_INDEX).expect("TX queue index should fit"),
         );
     }
 
@@ -1354,6 +1537,22 @@ mod tests {
             TestDescriptor::writable(STATUS_ADDR, VIRTIO_BLOCK_STATUS_SIZE, None),
         );
         write_available_heads(memory, &[0, TEST_QUEUE_SIZE]);
+    }
+
+    fn write_queued_tx_frame(memory: &mut crate::memory::GuestMemory) {
+        memory
+            .write_slice(&[0; VIRTIO_NET_TX_HEADER_SIZE as usize], HEADER_ADDR)
+            .expect("TX header should write");
+        memory
+            .write_slice(&[0x45, 0, 0, 0], DATA_ADDR)
+            .expect("TX payload should write");
+        write_descriptor(
+            memory,
+            0,
+            TestDescriptor::readable(HEADER_ADDR, VIRTIO_NET_TX_HEADER_SIZE, Some(1)),
+        );
+        write_descriptor(memory, 1, TestDescriptor::readable(DATA_ADDR, 4, None));
+        write_available_heads(memory, &[0]);
     }
 
     fn write_request_header(
@@ -1769,6 +1968,61 @@ mod tests {
         assert_eq!(dispatch.drained_notifications(), []);
         assert!(dispatch.tx_queue_dispatch().is_none());
         assert!(!device_dispatch.needs_queue_interrupt());
+    }
+
+    #[test]
+    fn boot_runtime_network_notification_dispatch_executes_tx_queue() {
+        let kernel = temp_file("kernel-network-tx-dispatch", &arm64_image());
+        let mut controller = controller_with_kernel(kernel.path());
+        add_network(&mut controller, "eth0", "tap0");
+        let config = Arm64BootResourceConfig {
+            network_interrupt_lines: &[line(33)],
+            ..valid_config(&[])
+        };
+        let resources = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+        let mut memory = parts.memory;
+        let mut mmio_dispatcher = parts.mmio_dispatcher;
+        let mut runtime = parts.runtime;
+        configure_boot_network_queues(&mut runtime, &mut mmio_dispatcher, 0);
+        write_queued_tx_frame(&mut memory);
+        notify_boot_network_tx_queue(&mut runtime, &mut mmio_dispatcher, 0);
+
+        let dispatches = runtime
+            .dispatch_network_queue_notifications(&mut memory, &mut mmio_dispatcher)
+            .expect("network dispatch result should allocate");
+
+        assert_eq!(dispatches.len(), 1);
+        assert!(dispatches.needs_queue_interrupt());
+        let device_dispatch = &dispatches.as_slice()[0];
+        assert_eq!(device_dispatch.device().registration.iface_id(), "eth0");
+        assert_eq!(device_dispatch.device().fdt_device.interrupt_line, line(33));
+        let dispatch = device_dispatch
+            .outcome()
+            .dispatched()
+            .expect("queued TX notification should dispatch");
+        assert_eq!(
+            dispatch.drained_notifications(),
+            [VIRTIO_NET_TX_QUEUE_INDEX]
+        );
+        let tx_dispatch = dispatch
+            .tx_queue_dispatch()
+            .expect("TX dispatch summary should be present");
+        assert_eq!(tx_dispatch.processed_frames(), 1);
+        assert_eq!(tx_dispatch.successful_frames(), 1);
+        assert_eq!(tx_dispatch.parse_failures(), 0);
+        assert_eq!(tx_dispatch.frames()[0].payload_len(), 4);
+        assert!(device_dispatch.needs_queue_interrupt());
+        assert_eq!(
+            read_boot_network_mmio_u32(
+                &mut runtime,
+                &mut mmio_dispatcher,
+                0,
+                VirtioMmioRegister::InterruptStatus
+            ),
+            DeviceInterruptKind::Queue.status().bits()
+        );
     }
 
     #[test]

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -26,7 +26,8 @@ use crate::mmio::{
 };
 use crate::network::{
     NetworkMmioDeviceRegistration, NetworkMmioLayout, NetworkMmioRegistrationError,
-    PreparedNetworkDeviceError, PreparedNetworkDevices,
+    PreparedNetworkDeviceError, PreparedNetworkDevices, VirtioNetworkDeviceNotificationDispatch,
+    VirtioNetworkDeviceNotificationError, VirtioNetworkMmioHandler,
 };
 use crate::serial::{SERIAL_MMIO_DEVICE_WINDOW_SIZE, SerialMmioDevice, SharedSerialOutputBuffer};
 
@@ -219,6 +220,129 @@ impl std::error::Error for Arm64BootBlockNotificationDispatchError {
     }
 }
 
+#[derive(Debug)]
+pub struct Arm64BootNetworkNotificationDispatches {
+    devices: Vec<Arm64BootNetworkNotificationDispatch>,
+}
+
+impl Arm64BootNetworkNotificationDispatches {
+    fn new(devices: Vec<Arm64BootNetworkNotificationDispatch>) -> Self {
+        Self { devices }
+    }
+
+    pub fn as_slice(&self) -> &[Arm64BootNetworkNotificationDispatch] {
+        &self.devices
+    }
+
+    pub fn into_vec(self) -> Vec<Arm64BootNetworkNotificationDispatch> {
+        self.devices
+    }
+
+    pub fn len(&self) -> usize {
+        self.devices.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.devices.is_empty()
+    }
+
+    pub fn needs_queue_interrupt(&self) -> bool {
+        self.devices
+            .iter()
+            .any(Arm64BootNetworkNotificationDispatch::needs_queue_interrupt)
+    }
+}
+
+#[derive(Debug)]
+pub struct Arm64BootNetworkNotificationDispatch {
+    device: Arm64BootNetworkDevice,
+    outcome: Arm64BootNetworkNotificationOutcome,
+}
+
+impl Arm64BootNetworkNotificationDispatch {
+    fn new(device: Arm64BootNetworkDevice, outcome: Arm64BootNetworkNotificationOutcome) -> Self {
+        Self { device, outcome }
+    }
+
+    pub const fn device(&self) -> &Arm64BootNetworkDevice {
+        &self.device
+    }
+
+    pub const fn outcome(&self) -> &Arm64BootNetworkNotificationOutcome {
+        &self.outcome
+    }
+
+    pub fn needs_queue_interrupt(&self) -> bool {
+        self.outcome.needs_queue_interrupt()
+    }
+}
+
+#[derive(Debug)]
+pub enum Arm64BootNetworkNotificationOutcome {
+    Dispatched(VirtioNetworkDeviceNotificationDispatch),
+    DispatchFailed(VirtioNetworkDeviceNotificationError),
+    HandlerLookupFailed(MmioHandlerLookupError),
+}
+
+impl Arm64BootNetworkNotificationOutcome {
+    pub fn needs_queue_interrupt(&self) -> bool {
+        match self {
+            Self::Dispatched(dispatch) => dispatch.needs_queue_interrupt(),
+            Self::DispatchFailed(source) => source
+                .completed_tx_dispatch()
+                .is_some_and(crate::network::VirtioNetworkTxQueueDispatch::needs_queue_interrupt),
+            Self::HandlerLookupFailed(_) => false,
+        }
+    }
+
+    pub const fn dispatched(&self) -> Option<&VirtioNetworkDeviceNotificationDispatch> {
+        match self {
+            Self::Dispatched(dispatch) => Some(dispatch),
+            Self::DispatchFailed(_) | Self::HandlerLookupFailed(_) => None,
+        }
+    }
+
+    pub const fn dispatch_error(&self) -> Option<&VirtioNetworkDeviceNotificationError> {
+        match self {
+            Self::DispatchFailed(source) => Some(source),
+            Self::Dispatched(_) | Self::HandlerLookupFailed(_) => None,
+        }
+    }
+
+    pub const fn handler_lookup_error(&self) -> Option<&MmioHandlerLookupError> {
+        match self {
+            Self::HandlerLookupFailed(source) => Some(source),
+            Self::Dispatched(_) | Self::DispatchFailed(_) => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Arm64BootNetworkNotificationDispatchError {
+    ResultAllocation { source: TryReserveError },
+}
+
+impl fmt::Display for Arm64BootNetworkNotificationDispatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ResultAllocation { source } => {
+                write!(
+                    f,
+                    "failed to allocate network notification results: {source}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for Arm64BootNetworkNotificationDispatchError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::ResultAllocation { source } => Some(source),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Arm64BootBlockDevice {
     pub registration: BlockMmioDeviceRegistration,
@@ -264,6 +388,34 @@ impl Arm64BootRuntimeResources {
         }
 
         Ok(Arm64BootBlockNotificationDispatches::new(devices))
+    }
+
+    pub fn dispatch_network_queue_notifications(
+        &mut self,
+        memory: &mut GuestMemory,
+        mmio_dispatcher: &mut MmioDispatcher,
+    ) -> Result<Arm64BootNetworkNotificationDispatches, Arm64BootNetworkNotificationDispatchError>
+    {
+        let mut devices = Vec::new();
+        devices
+            .try_reserve_exact(self.network_devices.len())
+            .map_err(
+                |source| Arm64BootNetworkNotificationDispatchError::ResultAllocation { source },
+            )?;
+
+        for device in self.network_devices.iter().cloned() {
+            let region_id = device.registration.region_id();
+            let outcome = match mmio_dispatcher.handler_mut::<VirtioNetworkMmioHandler>(region_id) {
+                Ok(handler) => match handler.dispatch_network_queue_notifications(memory) {
+                    Ok(dispatch) => Arm64BootNetworkNotificationOutcome::Dispatched(dispatch),
+                    Err(source) => Arm64BootNetworkNotificationOutcome::DispatchFailed(source),
+                },
+                Err(source) => Arm64BootNetworkNotificationOutcome::HandlerLookupFailed(source),
+            };
+            devices.push(Arm64BootNetworkNotificationDispatch::new(device, outcome));
+        }
+
+        Ok(Arm64BootNetworkNotificationDispatches::new(devices))
     }
 }
 
@@ -1562,6 +1714,98 @@ mod tests {
         assert!(dispatches.is_empty());
         assert_eq!(dispatches.len(), 0);
         assert!(!dispatches.needs_queue_interrupt());
+    }
+
+    #[test]
+    fn boot_runtime_network_notification_dispatch_accepts_empty_network_devices() {
+        let kernel = temp_file("kernel-empty-network-dispatch", &arm64_image());
+        let controller = controller_with_kernel(kernel.path());
+        let resources =
+            Arm64BootResources::assemble_from_controller(&controller, valid_config(&[]))
+                .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+        let mut memory = parts.memory;
+        let mut mmio_dispatcher = parts.mmio_dispatcher;
+        let mut runtime = parts.runtime;
+
+        let dispatches = runtime
+            .dispatch_network_queue_notifications(&mut memory, &mut mmio_dispatcher)
+            .expect("empty network dispatch result should allocate");
+
+        assert!(dispatches.is_empty());
+        assert_eq!(dispatches.len(), 0);
+        assert!(!dispatches.needs_queue_interrupt());
+    }
+
+    #[test]
+    fn boot_runtime_network_notification_dispatch_without_pending_notification_is_noop() {
+        let kernel = temp_file("kernel-network-noop-dispatch", &arm64_image());
+        let mut controller = controller_with_kernel(kernel.path());
+        add_network(&mut controller, "eth0", "tap0");
+        let config = Arm64BootResourceConfig {
+            network_interrupt_lines: &[line(33)],
+            ..valid_config(&[])
+        };
+        let resources = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+        let mut memory = parts.memory;
+        let mut mmio_dispatcher = parts.mmio_dispatcher;
+        let mut runtime = parts.runtime;
+
+        let dispatches = runtime
+            .dispatch_network_queue_notifications(&mut memory, &mut mmio_dispatcher)
+            .expect("network dispatch result should allocate");
+
+        assert_eq!(dispatches.len(), 1);
+        assert!(!dispatches.needs_queue_interrupt());
+        let device_dispatch = &dispatches.as_slice()[0];
+        assert_eq!(device_dispatch.device().registration.iface_id(), "eth0");
+        assert_eq!(device_dispatch.device().fdt_device.interrupt_line, line(33));
+        let dispatch = device_dispatch
+            .outcome()
+            .dispatched()
+            .expect("no pending notification should dispatch as no-op");
+        assert_eq!(dispatch.drained_notifications(), []);
+        assert!(dispatch.tx_queue_dispatch().is_none());
+        assert!(!device_dispatch.needs_queue_interrupt());
+    }
+
+    #[test]
+    fn boot_runtime_network_notification_dispatch_reports_missing_handler() {
+        let kernel = temp_file("kernel-network-missing-handler-dispatch", &arm64_image());
+        let mut controller = controller_with_kernel(kernel.path());
+        add_network(&mut controller, "eth0", "tap0");
+        let config = Arm64BootResourceConfig {
+            network_interrupt_lines: &[line(33)],
+            ..valid_config(&[])
+        };
+        let resources = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+        let mut memory = parts.memory;
+        let mut mmio_dispatcher = MmioDispatcher::new();
+        let mut runtime = parts.runtime;
+
+        let dispatches = runtime
+            .dispatch_network_queue_notifications(&mut memory, &mut mmio_dispatcher)
+            .expect("network dispatch result should allocate");
+
+        assert_eq!(dispatches.len(), 1);
+        assert!(!dispatches.needs_queue_interrupt());
+        let error = dispatches.as_slice()[0]
+            .outcome()
+            .handler_lookup_error()
+            .expect("missing network handler should be reported");
+        match error {
+            crate::mmio::MmioHandlerLookupError::MissingHandler { region_id } => {
+                assert_eq!(
+                    *region_id,
+                    runtime.network_devices[0].registration.region_id()
+                );
+            }
+            other => panic!("expected missing network handler, got {other:?}"),
+        }
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -14,7 +14,7 @@ physical address and aarch64 DRAM layout/access primitives, arm64 boot
 placement helpers, internal boot-source validation and arm64 kernel/initrd
 payload loading, an internal Firecracker-shaped drive configuration validation
 model, a Firecracker-shaped network interface configuration storage and
-validation model, internal virtio-net config-space, activation, TX frame parser, RX buffer parser, prepared device resources, MMIO registration helpers, and startup FDT attachment for inert virtio-net devices, a host-file backing access layer, internal configured block-device
+validation model, internal virtio-net config-space, activation, TX frame parser, RX buffer parser, prepared device resources, MMIO registration helpers, startup FDT attachment, and internal TX notification dispatch metadata for virtio-net devices, a host-file backing access layer, internal configured block-device
 preparation and MMIO registration helpers, an internal virtio-block
 config-space capacity model, an internal virtio-block request parser, single-request
 executor, queue dispatcher, MMIO queue-state bridge, resettable activation
@@ -39,8 +39,8 @@ available-ring read model, used-ring write model, and internal virtio-block
 queue construction, drain, resettable active queue ownership, and active queue
 notification dispatch helper with virtio-mmio queue interrupt-status updates
 for future device handlers, internal boot-resource assembly from stored VM
-configuration with optional serial plus block and inert network MMIO registration,
-boot-runtime block notification dispatch with per-device metadata, an internal backend-neutral
+configuration with optional serial plus block and network MMIO registration,
+boot-runtime block and network notification dispatch with per-device metadata, an internal backend-neutral
 interrupt line/status/trigger model, single-vCPU arm64 HVF
 boot-register setup, internal HVF single-vCPU arm64 boot-session preparation
 with a runner-compatible shared MMIO dispatcher, controlled mapped guest-memory
@@ -223,7 +223,7 @@ compatibility targets.
 | `PUT` | `/logger` | supported target; minimal subset implemented | Stores process logger configuration before boot, opens `log_path` with nonblocking output semantics when provided, accepts optional Firecracker-shaped level/show/module fields, and omits logger state from `GET /vm/config` because it is not guest configuration. Full internal log routing remains deferred. |
 | `PATCH` | `/machine-config` | deferred | Partial updates belong with later state and validation rules. |
 | `PUT` | `/cpu-config` | deferred | Needs HVF CPU feature design with VM and boot work in #8 and #10. |
-| `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores initial virtio-net configuration before boot without opening host networking resources. Startup preparation attaches configured interfaces as inert virtio-mmio devices in the MMIO dispatcher and guest FDT, but packet backend selection, packet queue execution, packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
+| `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores initial virtio-net configuration before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT, and internal TX notification dispatch can parse and complete TX descriptor heads. Packet backend selection, RX execution, packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
 | `PUT` | `/vsock` | deferred | Tied to virtio vsock work in #15. |
 | `GET`, `PUT`, `PATCH` | `/mmds` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/mmds/config` | deferred | Tied to MMDS work in #16. |
@@ -521,8 +521,8 @@ MMIO registration helpers. They define the
 Firecracker-shaped virtio network device id, RX/TX queue indexes, two queue
 sizes, the guest-MAC feature bit, a `VirtioMmioDeviceConfigHandler` for reading
 a configured guest MAC through the existing virtio-mmio register handler, a
-`DRIVER_OK` activation handler that validates and retains ready RX/TX queue
-metadata, an internal TX frame parser for the 12-byte virtio-net header plus
+`DRIVER_OK` activation handler that validates and retains ready RX queue
+metadata plus a dispatchable TX queue, an internal TX frame parser for the 12-byte virtio-net header plus
 guest-readable payload segments, and an internal RX buffer parser for
 guest-writable receive buffer segments with the current 1526-byte Firecracker
 non-merged-RX minimum. Preparation can build ordered owned resources from stored
@@ -532,10 +532,14 @@ prepared resources can be consumed into deterministic virtio-mmio regions and
 handlers in a fresh or existing internal `MmioDispatcher`, returning read-only
 registration metadata. Startup preparation can pair those registrations with
 caller-provided interrupt lines and write matching inert virtio-mmio descriptors
-into the guest FDT while preserving interface order and host device names. These
-helpers do not execute RX/TX queues, signal completed network queue interrupts,
-advertise MTU, choose a host packet backend, write packets into guest RX
-buffers, or move packets.
+into the guest FDT while preserving interface order and host device names.
+Internal network notification dispatch can drain pending TX queue notifications,
+walk the TX available ring, parse each descriptor chain into
+`VirtioNetworkTxFrame` metadata, publish used-ring completions with length 0,
+preserve parse and partial-dispatch errors, and mark queue interrupt status when
+descriptor heads complete. These helpers do not execute RX queues, advertise
+MTU, choose a host packet backend, write packets into guest RX buffers, or move
+packets.
 
 The runtime crate can prepare owned internal block-device resources from a
 validated list of stored drive configs. Preparation opens each backing file,
@@ -933,7 +937,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | `PUT /machine-config` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Pre-boot-only configuration. Stored values are applied during startup preparation. |
 | `PUT /boot-source` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; host paths are opened during startup preparation. Host path errors must avoid leaking sensitive path details. |
 | `PUT /drives/{drive_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; startup preparation opens backing files and registers initial block MMIO devices. Runtime hotplug remains deferred. |
-| `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening host networking resources. Startup preparation attaches configured interfaces as inert virtio-mmio devices in the MMIO dispatcher and guest FDT, while packet backend, virtio-net packet queue execution, packet movement, PATCH, and DELETE remain deferred. |
+| `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT, while internal TX notification dispatch can parse and complete TX descriptor heads. Packet backend, RX queue execution, packet movement, PATCH, and DELETE remain deferred. |
 | `PUT /metrics` | implemented; `204` empty response on successful output initialization | unsupported after start; `400` `fault_message` | Metrics output is process observability state, not guest configuration. Duplicate initialization fails. |
 | `PUT /logger` | implemented; `204` empty response on successful pre-boot configuration | unsupported after start; `400` `fault_message` | Logger output is process observability state, not guest configuration. Repeated pre-boot requests update provided fields; full log routing remains deferred. |
 | `PUT /actions` with `InstanceStart` | process-routed; `204` after successful owned HVF startup with internal boot run-loop worker across bounded step windows or `400` preflight/preparation fault | unsupported after start; `400` `fault_message` | Commits `Running` only after the owned HVF boot-session worker with internal serial capture is retained. The worker keeps internal active, terminal-outcome, or error status; public run-loop control and public serial streaming remain deferred. |
@@ -979,8 +983,8 @@ Their eventual support level should follow the endpoint matrix:
 
 - packet networking beyond pre-boot `network-interfaces` configuration storage
   and the internal virtio-net config-space, activation, TX frame parser, RX
-  buffer parser, prepared device resources, MMIO registration helpers, and
-  inert startup FDT attachment
+  buffer parser, prepared device resources, MMIO registration, startup FDT
+  metadata, and TX notification dispatch metadata helpers
 - vsock
 - snapshots
 - MMDS

--- a/docs/security.md
+++ b/docs/security.md
@@ -96,8 +96,9 @@ HVF; local HVF verification should fail when HVF is unavailable.
 ## Guest Data Exposure
 
 The guest is untrusted. vCPU execution, guest memory contents, virtqueue
-descriptor chains, MMIO accesses, block requests, and future device inputs must
-be validated before they affect host resources.
+descriptor chains, MMIO accesses, block requests, virtio-net TX descriptor
+metadata, and future device inputs must be validated before they affect host
+resources.
 Trapped system-register exits are guest-visible CPU behavior and must stay
 explicit. The current HVF runner emulates only the early-boot `OSDLR_EL1` and
 `OSLAR_EL1` OS lock RAZ/WI behavior needed by the pinned Firecracker kernel;
@@ -147,8 +148,9 @@ The current scaffold does not implement:
 - privilege dropping
 - host resource brokering
 - network, vsock, MMDS, or snapshot containment; the current network interface
-  configuration path validates and stores configuration strings only and does
-  not open host networking resources
+  configuration path validates and stores configuration strings, and internal
+  virtio-net TX notification dispatch parses guest descriptor metadata, but
+  bangbang still does not open host networking resources
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy
 


### PR DESCRIPTION
## Summary

- Add backend-neutral virtio-net TX queue dispatch from drained MMIO queue notifications.
- Parse TX descriptor chains into frame metadata, publish zero-length used-ring completions, and mark queue interrupts after completed descriptors.
- Add boot-runtime network notification dispatch metadata and update compatibility/security docs.

## Scope exclusions

- No host packet backend selection or host network resource opening.
- No RX queue execution or packet movement.
- No public run-loop integration beyond internal dispatch helpers.

Closes #281

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p bangbang-runtime --all-targets --all-features --locked`
- `cargo test -p bangbang-runtime --all-targets --all-features --locked`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
