### PR TITLE
feat: route boot virtio-net packet I/O

### DIFF
--- a/crates/runtime/src/network.rs
+++ b/crates/runtime/src/network.rs
@@ -992,7 +992,7 @@ impl VirtioNetworkDevice {
         &mut self,
         memory: &mut GuestMemory,
         drained_notifications: Vec<usize>,
-        tx_sink: &mut impl VirtioNetworkTxPacketSink,
+        tx_sink: &mut (impl VirtioNetworkTxPacketSink + ?Sized),
     ) -> Result<VirtioNetworkDeviceNotificationDispatch, VirtioNetworkDeviceNotificationError> {
         let mut rx_source = EmptyVirtioNetworkRxPacketSource;
         self.dispatch_drained_queue_notifications_with_packet_io(
@@ -1007,8 +1007,8 @@ impl VirtioNetworkDevice {
         &mut self,
         memory: &mut GuestMemory,
         drained_notifications: Vec<usize>,
-        tx_sink: &mut impl VirtioNetworkTxPacketSink,
-        rx_source: &mut impl VirtioNetworkRxPacketSource,
+        tx_sink: &mut (impl VirtioNetworkTxPacketSink + ?Sized),
+        rx_source: &mut (impl VirtioNetworkRxPacketSource + ?Sized),
     ) -> Result<VirtioNetworkDeviceNotificationDispatch, VirtioNetworkDeviceNotificationError> {
         if drained_notifications.is_empty() {
             return Ok(VirtioNetworkDeviceNotificationDispatch::new(
@@ -1146,7 +1146,7 @@ impl VirtioNetworkRxQueue {
     pub fn dispatch_with_source(
         &mut self,
         memory: &mut GuestMemory,
-        rx_source: &mut impl VirtioNetworkRxPacketSource,
+        rx_source: &mut (impl VirtioNetworkRxPacketSource + ?Sized),
     ) -> Result<VirtioNetworkRxQueueDispatch, VirtioNetworkRxQueueDispatchError> {
         let mut dispatch =
             VirtioNetworkRxQueueDispatch::with_capacity(self.available.queue_size())?;
@@ -1840,7 +1840,7 @@ impl VirtioNetworkTxQueue {
     pub fn dispatch_with_sink(
         &mut self,
         memory: &mut GuestMemory,
-        tx_sink: &mut impl VirtioNetworkTxPacketSink,
+        tx_sink: &mut (impl VirtioNetworkTxPacketSink + ?Sized),
     ) -> Result<VirtioNetworkTxQueueDispatch, VirtioNetworkTxQueueDispatchError> {
         let mut dispatch =
             VirtioNetworkTxQueueDispatch::with_capacity(self.available.queue_size())?;
@@ -2121,7 +2121,7 @@ impl<C: VirtioMmioDeviceConfigHandler> VirtioMmioRegisterHandler<C, VirtioNetwor
     pub fn dispatch_network_queue_notifications_with_tx_sink(
         &mut self,
         memory: &mut GuestMemory,
-        tx_sink: &mut impl VirtioNetworkTxPacketSink,
+        tx_sink: &mut (impl VirtioNetworkTxPacketSink + ?Sized),
     ) -> Result<VirtioNetworkDeviceNotificationDispatch, VirtioNetworkDeviceNotificationError> {
         let drained_notifications = self.take_pending_queue_notifications();
         let dispatch = self
@@ -2152,8 +2152,8 @@ impl<C: VirtioMmioDeviceConfigHandler> VirtioMmioRegisterHandler<C, VirtioNetwor
     pub fn dispatch_network_queue_notifications_with_packet_io(
         &mut self,
         memory: &mut GuestMemory,
-        tx_sink: &mut impl VirtioNetworkTxPacketSink,
-        rx_source: &mut impl VirtioNetworkRxPacketSource,
+        tx_sink: &mut (impl VirtioNetworkTxPacketSink + ?Sized),
+        rx_source: &mut (impl VirtioNetworkRxPacketSource + ?Sized),
     ) -> Result<VirtioNetworkDeviceNotificationDispatch, VirtioNetworkDeviceNotificationError> {
         let drained_notifications = self.take_pending_queue_notifications();
         let dispatch = self

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -2355,6 +2355,33 @@ mod tests {
     }
 
     #[test]
+    fn boot_runtime_network_packet_io_dispatch_accepts_empty_network_devices() {
+        let kernel = temp_file("kernel-empty-network-packet-io-dispatch", &arm64_image());
+        let controller = controller_with_kernel(kernel.path());
+        let resources =
+            Arm64BootResources::assemble_from_controller(&controller, valid_config(&[]))
+                .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+        let mut memory = parts.memory;
+        let mut mmio_dispatcher = parts.mmio_dispatcher;
+        let mut runtime = parts.runtime;
+        let mut provider = RecordingNetworkPacketIoProvider::default();
+
+        let dispatches = runtime
+            .dispatch_network_queue_notifications_with_packet_io(
+                &mut memory,
+                &mut mmio_dispatcher,
+                &mut provider,
+            )
+            .expect("empty network dispatch result should allocate");
+
+        assert!(dispatches.is_empty());
+        assert_eq!(dispatches.len(), 0);
+        assert!(!dispatches.needs_queue_interrupt());
+        assert!(provider.requested_ifaces.is_empty());
+    }
+
+    #[test]
     fn boot_runtime_network_notification_dispatch_without_pending_notification_is_noop() {
         let kernel = temp_file("kernel-network-noop-dispatch", &arm64_image());
         let mut controller = controller_with_kernel(kernel.path());

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -27,7 +27,8 @@ use crate::mmio::{
 use crate::network::{
     NetworkMmioDeviceRegistration, NetworkMmioLayout, NetworkMmioRegistrationError,
     PreparedNetworkDeviceError, PreparedNetworkDevices, VirtioNetworkDeviceNotificationDispatch,
-    VirtioNetworkDeviceNotificationError, VirtioNetworkMmioHandler,
+    VirtioNetworkDeviceNotificationError, VirtioNetworkMmioHandler, VirtioNetworkRxPacketSource,
+    VirtioNetworkTxPacketSink,
 };
 use crate::serial::{SERIAL_MMIO_DEVICE_WINDOW_SIZE, SerialMmioDevice, SharedSerialOutputBuffer};
 
@@ -282,6 +283,7 @@ pub enum Arm64BootNetworkNotificationOutcome {
     Dispatched(Box<VirtioNetworkDeviceNotificationDispatch>),
     DispatchFailed(VirtioNetworkDeviceNotificationError),
     HandlerLookupFailed(MmioHandlerLookupError),
+    PacketIoProviderFailed(Arm64BootNetworkPacketIoError),
 }
 
 impl Arm64BootNetworkNotificationOutcome {
@@ -295,31 +297,95 @@ impl Arm64BootNetworkNotificationOutcome {
                     crate::network::VirtioNetworkRxQueueDispatch::needs_queue_interrupt,
                 )
             }
-            Self::HandlerLookupFailed(_) => false,
+            Self::HandlerLookupFailed(_) | Self::PacketIoProviderFailed(_) => false,
         }
     }
 
     pub fn dispatched(&self) -> Option<&VirtioNetworkDeviceNotificationDispatch> {
         match self {
             Self::Dispatched(dispatch) => Some(dispatch.as_ref()),
-            Self::DispatchFailed(_) | Self::HandlerLookupFailed(_) => None,
+            Self::DispatchFailed(_)
+            | Self::HandlerLookupFailed(_)
+            | Self::PacketIoProviderFailed(_) => None,
         }
     }
 
     pub const fn dispatch_error(&self) -> Option<&VirtioNetworkDeviceNotificationError> {
         match self {
             Self::DispatchFailed(source) => Some(source),
-            Self::Dispatched(_) | Self::HandlerLookupFailed(_) => None,
+            Self::Dispatched(_)
+            | Self::HandlerLookupFailed(_)
+            | Self::PacketIoProviderFailed(_) => None,
         }
     }
 
     pub const fn handler_lookup_error(&self) -> Option<&MmioHandlerLookupError> {
         match self {
             Self::HandlerLookupFailed(source) => Some(source),
-            Self::Dispatched(_) | Self::DispatchFailed(_) => None,
+            Self::Dispatched(_) | Self::DispatchFailed(_) | Self::PacketIoProviderFailed(_) => None,
+        }
+    }
+
+    pub const fn packet_io_error(&self) -> Option<&Arm64BootNetworkPacketIoError> {
+        match self {
+            Self::PacketIoProviderFailed(source) => Some(source),
+            Self::Dispatched(_) | Self::DispatchFailed(_) | Self::HandlerLookupFailed(_) => None,
         }
     }
 }
+
+pub struct Arm64BootNetworkPacketIo<'a> {
+    tx_sink: &'a mut dyn VirtioNetworkTxPacketSink,
+    rx_source: &'a mut dyn VirtioNetworkRxPacketSource,
+}
+
+impl<'a> Arm64BootNetworkPacketIo<'a> {
+    pub fn new(
+        tx_sink: &'a mut dyn VirtioNetworkTxPacketSink,
+        rx_source: &'a mut dyn VirtioNetworkRxPacketSource,
+    ) -> Self {
+        Self { tx_sink, rx_source }
+    }
+}
+
+impl fmt::Debug for Arm64BootNetworkPacketIo<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Arm64BootNetworkPacketIo")
+            .finish_non_exhaustive()
+    }
+}
+
+pub trait Arm64BootNetworkPacketIoProvider {
+    fn packet_io(
+        &mut self,
+        device: &Arm64BootNetworkDevice,
+    ) -> Result<Arm64BootNetworkPacketIo<'_>, Arm64BootNetworkPacketIoError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Arm64BootNetworkPacketIoError {
+    message: String,
+}
+
+impl Arm64BootNetworkPacketIoError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for Arm64BootNetworkPacketIoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for Arm64BootNetworkPacketIoError {}
 
 #[derive(Debug)]
 pub enum Arm64BootNetworkNotificationDispatchError {
@@ -416,6 +482,64 @@ impl Arm64BootRuntimeResources {
                     }
                     Err(source) => Arm64BootNetworkNotificationOutcome::DispatchFailed(source),
                 },
+                Err(source) => Arm64BootNetworkNotificationOutcome::HandlerLookupFailed(source),
+            };
+            devices.push(Arm64BootNetworkNotificationDispatch::new(device, outcome));
+        }
+
+        Ok(Arm64BootNetworkNotificationDispatches::new(devices))
+    }
+
+    pub fn dispatch_network_queue_notifications_with_packet_io(
+        &mut self,
+        memory: &mut GuestMemory,
+        mmio_dispatcher: &mut MmioDispatcher,
+        packet_io: &mut impl Arm64BootNetworkPacketIoProvider,
+    ) -> Result<Arm64BootNetworkNotificationDispatches, Arm64BootNetworkNotificationDispatchError>
+    {
+        let mut devices = Vec::new();
+        devices
+            .try_reserve_exact(self.network_devices.len())
+            .map_err(
+                |source| Arm64BootNetworkNotificationDispatchError::ResultAllocation { source },
+            )?;
+
+        for device in self.network_devices.iter().cloned() {
+            let region_id = device.registration.region_id();
+            let outcome = match mmio_dispatcher.handler_mut::<VirtioNetworkMmioHandler>(region_id) {
+                Ok(handler) => {
+                    if !handler.has_pending_queue_notifications() {
+                        match handler.dispatch_network_queue_notifications(memory) {
+                            Ok(dispatch) => {
+                                Arm64BootNetworkNotificationOutcome::Dispatched(Box::new(dispatch))
+                            }
+                            Err(source) => {
+                                Arm64BootNetworkNotificationOutcome::DispatchFailed(source)
+                            }
+                        }
+                    } else {
+                        match packet_io.packet_io(&device) {
+                            Ok(packet_io) => {
+                                let Arm64BootNetworkPacketIo { tx_sink, rx_source } = packet_io;
+                                match handler.dispatch_network_queue_notifications_with_packet_io(
+                                    memory, tx_sink, rx_source,
+                                ) {
+                                    Ok(dispatch) => {
+                                        Arm64BootNetworkNotificationOutcome::Dispatched(Box::new(
+                                            dispatch,
+                                        ))
+                                    }
+                                    Err(source) => {
+                                        Arm64BootNetworkNotificationOutcome::DispatchFailed(source)
+                                    }
+                                }
+                            }
+                            Err(source) => {
+                                Arm64BootNetworkNotificationOutcome::PacketIoProviderFailed(source)
+                            }
+                        }
+                    }
+                }
                 Err(source) => Arm64BootNetworkNotificationOutcome::HandlerLookupFailed(source),
             };
             devices.push(Arm64BootNetworkNotificationDispatch::new(device, outcome));
@@ -876,6 +1000,7 @@ fn register_serial_mmio(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
     use std::fs::{self, OpenOptions};
     use std::io::Write;
     use std::path::{Path, PathBuf};
@@ -884,9 +1009,11 @@ mod tests {
     use device_tree::DeviceTree;
 
     use super::{
-        Arm64BootResourceConfig, Arm64BootResourceError, Arm64BootResources,
-        Arm64BootSerialDeviceConfig, Arm64BootSerialMmioRegistrationError, MIB,
-        arm64_boot_network_device_metadata, block_device_metadata,
+        Arm64BootNetworkNotificationOutcome, Arm64BootNetworkPacketIo,
+        Arm64BootNetworkPacketIoError, Arm64BootNetworkPacketIoProvider, Arm64BootResourceConfig,
+        Arm64BootResourceError, Arm64BootResources, Arm64BootSerialDeviceConfig,
+        Arm64BootSerialMmioRegistrationError, MIB, arm64_boot_network_device_metadata,
+        block_device_metadata,
     };
     use crate::VmmAction;
     use crate::block::{
@@ -905,8 +1032,10 @@ mod tests {
     };
     use crate::network::{
         NetworkInterfaceConfigInput, NetworkInterfaceConfigs, NetworkMmioDeviceRegistration,
-        NetworkMmioLayout, PreparedNetworkDevices, VIRTIO_NET_RX_QUEUE_INDEX,
-        VIRTIO_NET_TX_HEADER_SIZE, VIRTIO_NET_TX_QUEUE_INDEX,
+        NetworkMmioLayout, PreparedNetworkDevices, VIRTIO_NET_RX_MIN_BUFFER_SIZE,
+        VIRTIO_NET_RX_QUEUE_INDEX, VIRTIO_NET_TX_HEADER_SIZE, VIRTIO_NET_TX_QUEUE_INDEX,
+        VirtioNetworkRxPacket, VirtioNetworkRxPacketSource, VirtioNetworkRxPacketSourceError,
+        VirtioNetworkTxFrame, VirtioNetworkTxPacketSink, VirtioNetworkTxPacketSinkError,
     };
     use crate::serial::{
         SERIAL_MMIO_DEVICE_WINDOW_SIZE, SERIAL_TRANSMIT_REGISTER_OFFSET, SerialMmioDevice,
@@ -942,6 +1071,8 @@ mod tests {
     const TEST_RX_DESCRIPTOR_TABLE: GuestAddress = GuestAddress::new(0x8046_0000);
     const TEST_RX_AVAILABLE_RING: GuestAddress = GuestAddress::new(0x8047_0000);
     const TEST_RX_USED_RING: GuestAddress = GuestAddress::new(0x8048_0000);
+    const TEST_RX_BUFFER: GuestAddress = GuestAddress::new(0x8049_0000);
+    const TEST_NETWORK_QUEUE_DEVICE_STRIDE: u64 = 0x0010_0000;
     const TEST_AVAILABLE_RING_IDX_OFFSET: u64 = 2;
     const TEST_AVAILABLE_RING_RING_OFFSET: u64 = 4;
     const TEST_AVAILABLE_RING_ENTRY_SIZE: u64 = 2;
@@ -1398,6 +1529,20 @@ mod tests {
         mmio_dispatcher: &mut MmioDispatcher,
         device_index: usize,
     ) {
+        configure_boot_network_queues_with_layout(
+            runtime,
+            mmio_dispatcher,
+            device_index,
+            network_queue_layout(0),
+        );
+    }
+
+    fn configure_boot_network_queues_with_layout(
+        runtime: &mut super::Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+        device_index: usize,
+        layout: TestNetworkQueueLayout,
+    ) {
         write_boot_network_mmio_u32(
             runtime,
             mmio_dispatcher,
@@ -1424,18 +1569,18 @@ mod tests {
             mmio_dispatcher,
             device_index,
             VIRTIO_NET_RX_QUEUE_INDEX,
-            TEST_RX_DESCRIPTOR_TABLE,
-            TEST_RX_AVAILABLE_RING,
-            TEST_RX_USED_RING,
+            layout.rx_descriptor_table,
+            layout.rx_available_ring,
+            layout.rx_used_ring,
         );
         configure_boot_network_queue(
             runtime,
             mmio_dispatcher,
             device_index,
             VIRTIO_NET_TX_QUEUE_INDEX,
-            TEST_DESCRIPTOR_TABLE,
-            TEST_AVAILABLE_RING,
-            TEST_USED_RING,
+            layout.tx_descriptor_table,
+            layout.tx_available_ring,
+            layout.tx_used_ring,
         );
         write_boot_network_mmio_u32(
             runtime,
@@ -1471,6 +1616,20 @@ mod tests {
             device_index,
             VirtioMmioRegister::QueueNotify,
             u32::try_from(VIRTIO_NET_TX_QUEUE_INDEX).expect("TX queue index should fit"),
+        );
+    }
+
+    fn notify_boot_network_rx_queue(
+        runtime: &mut super::Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+        device_index: usize,
+    ) {
+        write_boot_network_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            device_index,
+            VirtioMmioRegister::QueueNotify,
+            u32::try_from(VIRTIO_NET_RX_QUEUE_INDEX).expect("RX queue index should fit"),
         );
     }
 
@@ -1514,6 +1673,147 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Default)]
+    struct RecordingTxPacketSink {
+        calls: usize,
+        packets: Vec<Vec<u8>>,
+    }
+
+    impl VirtioNetworkTxPacketSink for RecordingTxPacketSink {
+        fn transmit_frame(
+            &mut self,
+            memory: &crate::memory::GuestMemory,
+            frame: &VirtioNetworkTxFrame,
+        ) -> Result<(), VirtioNetworkTxPacketSinkError> {
+            self.calls += 1;
+            let payload_len = usize::try_from(frame.payload_len())
+                .expect("test TX payload length should fit in usize");
+            let mut packet = Vec::new();
+            packet
+                .try_reserve_exact(payload_len)
+                .expect("test packet allocation should succeed");
+            for segment in frame.payload_segments() {
+                let len =
+                    usize::try_from(segment.len()).expect("test TX segment should fit in usize");
+                let mut bytes = vec![0; len];
+                memory
+                    .read_slice(&mut bytes, segment.address())
+                    .expect("test TX segment should read");
+                packet.extend(bytes);
+            }
+            self.packets.push(packet);
+
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingRxPacketSource {
+        packets: VecDeque<Vec<u8>>,
+        peek_calls: usize,
+        consume_calls: usize,
+    }
+
+    impl RecordingRxPacketSource {
+        fn with_packets(packets: Vec<Vec<u8>>) -> Self {
+            Self {
+                packets: VecDeque::from(packets),
+                peek_calls: 0,
+                consume_calls: 0,
+            }
+        }
+    }
+
+    impl VirtioNetworkRxPacketSource for RecordingRxPacketSource {
+        fn peek_packet(
+            &mut self,
+        ) -> Result<Option<VirtioNetworkRxPacket<'_>>, VirtioNetworkRxPacketSourceError> {
+            self.peek_calls += 1;
+            Ok(self
+                .packets
+                .front()
+                .map(|packet| VirtioNetworkRxPacket::new(packet.as_slice())))
+        }
+
+        fn consume_packet(&mut self) {
+            self.consume_calls += 1;
+            let _ = self.packets.pop_front();
+        }
+    }
+
+    #[derive(Debug)]
+    struct RecordingNetworkPacketEndpoint {
+        iface_id: String,
+        tx_sink: RecordingTxPacketSink,
+        rx_source: RecordingRxPacketSource,
+    }
+
+    impl RecordingNetworkPacketEndpoint {
+        fn new(iface_id: &str, packets: Vec<Vec<u8>>) -> Self {
+            Self {
+                iface_id: iface_id.to_string(),
+                tx_sink: RecordingTxPacketSink::default(),
+                rx_source: RecordingRxPacketSource::with_packets(packets),
+            }
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingNetworkPacketIoProvider {
+        endpoints: Vec<RecordingNetworkPacketEndpoint>,
+        requested_ifaces: Vec<String>,
+        fail_iface: Option<String>,
+    }
+
+    impl RecordingNetworkPacketIoProvider {
+        fn with_endpoint(mut self, iface_id: &str, packets: Vec<Vec<u8>>) -> Self {
+            self.endpoints
+                .push(RecordingNetworkPacketEndpoint::new(iface_id, packets));
+            self
+        }
+
+        fn failing_for(mut self, iface_id: &str) -> Self {
+            self.fail_iface = Some(iface_id.to_string());
+            self
+        }
+
+        fn endpoint(&self, iface_id: &str) -> &RecordingNetworkPacketEndpoint {
+            self.endpoints
+                .iter()
+                .find(|endpoint| endpoint.iface_id == iface_id)
+                .expect("test endpoint should exist")
+        }
+    }
+
+    impl Arm64BootNetworkPacketIoProvider for RecordingNetworkPacketIoProvider {
+        fn packet_io(
+            &mut self,
+            device: &super::Arm64BootNetworkDevice,
+        ) -> Result<Arm64BootNetworkPacketIo<'_>, Arm64BootNetworkPacketIoError> {
+            let iface_id = device.registration.iface_id();
+            self.requested_ifaces.push(iface_id.to_string());
+            if self.fail_iface.as_deref() == Some(iface_id) {
+                return Err(Arm64BootNetworkPacketIoError::new(format!(
+                    "test packet I/O unavailable for interface {iface_id}"
+                )));
+            }
+
+            let endpoint = self
+                .endpoints
+                .iter_mut()
+                .find(|endpoint| endpoint.iface_id == iface_id)
+                .ok_or_else(|| {
+                    Arm64BootNetworkPacketIoError::new(format!(
+                        "missing test packet I/O for interface {iface_id}"
+                    ))
+                })?;
+            Ok(Arm64BootNetworkPacketIo::new(
+                &mut endpoint.tx_sink,
+                &mut endpoint.rx_source,
+            ))
+        }
+    }
+
     fn write_queued_read_request(memory: &mut crate::memory::GuestMemory) {
         write_request_header(memory, HEADER_ADDR, VIRTIO_BLOCK_REQUEST_TYPE_IN, 0);
         write_descriptor(
@@ -1546,19 +1846,60 @@ mod tests {
     }
 
     fn write_queued_tx_frame(memory: &mut crate::memory::GuestMemory) {
+        write_queued_tx_frame_at(
+            memory,
+            TEST_DESCRIPTOR_TABLE,
+            HEADER_ADDR,
+            DATA_ADDR,
+            &[0x45, 0, 0, 0],
+        );
+        write_available_heads(memory, &[0]);
+    }
+
+    fn write_queued_tx_frame_at(
+        memory: &mut crate::memory::GuestMemory,
+        descriptor_table: GuestAddress,
+        header_address: GuestAddress,
+        payload_address: GuestAddress,
+        payload: &[u8],
+    ) {
         memory
-            .write_slice(&[0; VIRTIO_NET_TX_HEADER_SIZE as usize], HEADER_ADDR)
+            .write_slice(&[0; VIRTIO_NET_TX_HEADER_SIZE as usize], header_address)
             .expect("TX header should write");
         memory
-            .write_slice(&[0x45, 0, 0, 0], DATA_ADDR)
+            .write_slice(payload, payload_address)
             .expect("TX payload should write");
-        write_descriptor(
+        write_descriptor_at(
             memory,
+            descriptor_table,
             0,
-            TestDescriptor::readable(HEADER_ADDR, VIRTIO_NET_TX_HEADER_SIZE, Some(1)),
+            TestDescriptor::readable(header_address, VIRTIO_NET_TX_HEADER_SIZE, Some(1)),
         );
-        write_descriptor(memory, 1, TestDescriptor::readable(DATA_ADDR, 4, None));
-        write_available_heads(memory, &[0]);
+        write_descriptor_at(
+            memory,
+            descriptor_table,
+            1,
+            TestDescriptor::readable(
+                payload_address,
+                u32::try_from(payload.len()).expect("test payload length should fit in u32"),
+                None,
+            ),
+        );
+    }
+
+    fn write_rx_buffer(memory: &mut crate::memory::GuestMemory, layout: TestNetworkQueueLayout) {
+        write_descriptor_at(
+            memory,
+            layout.rx_descriptor_table,
+            0,
+            TestDescriptor::writable(
+                layout.rx_buffer,
+                u32::try_from(VIRTIO_NET_RX_MIN_BUFFER_SIZE)
+                    .expect("test RX minimum should fit in u32"),
+                None,
+            ),
+        );
+        write_available_heads_at(memory, layout.rx_available_ring, &[0]);
     }
 
     fn write_request_header(
@@ -1582,6 +1923,15 @@ mod tests {
         index: u16,
         descriptor: TestDescriptor,
     ) {
+        write_descriptor_at(memory, TEST_DESCRIPTOR_TABLE, index, descriptor);
+    }
+
+    fn write_descriptor_at(
+        memory: &mut crate::memory::GuestMemory,
+        descriptor_table: GuestAddress,
+        index: u16,
+        descriptor: TestDescriptor,
+    ) {
         let mut bytes = [0; VIRTQUEUE_DESCRIPTOR_SIZE];
         let (address_bytes, tail) = bytes.split_at_mut(8);
         let (len_bytes, tail) = tail.split_at_mut(4);
@@ -1591,7 +1941,7 @@ mod tests {
         flags_bytes.copy_from_slice(&descriptor.flags.to_le_bytes());
         next_bytes.copy_from_slice(&descriptor.next.to_le_bytes());
 
-        let descriptor_address = TEST_DESCRIPTOR_TABLE
+        let descriptor_address = descriptor_table
             .checked_add(
                 u64::from(index)
                     * u64::try_from(VIRTQUEUE_DESCRIPTOR_SIZE).expect("descriptor size should fit"),
@@ -1620,14 +1970,17 @@ mod tests {
         bytes
     }
 
-    fn available_ring_idx_address() -> GuestAddress {
-        TEST_AVAILABLE_RING
+    fn available_ring_idx_address_at(available_ring: GuestAddress) -> GuestAddress {
+        available_ring
             .checked_add(TEST_AVAILABLE_RING_IDX_OFFSET)
             .expect("available idx address should not overflow")
     }
 
-    fn available_ring_entry_address(ring_index: u16) -> GuestAddress {
-        TEST_AVAILABLE_RING
+    fn available_ring_entry_address_at(
+        available_ring: GuestAddress,
+        ring_index: u16,
+    ) -> GuestAddress {
+        available_ring
             .checked_add(
                 TEST_AVAILABLE_RING_RING_OFFSET
                     + u64::from(ring_index) * TEST_AVAILABLE_RING_ENTRY_SIZE,
@@ -1636,10 +1989,19 @@ mod tests {
     }
 
     fn write_available_heads(memory: &mut crate::memory::GuestMemory, heads: &[u16]) {
+        write_available_heads_at(memory, TEST_AVAILABLE_RING, heads);
+    }
+
+    fn write_available_heads_at(
+        memory: &mut crate::memory::GuestMemory,
+        available_ring: GuestAddress,
+        heads: &[u16],
+    ) {
         for (ring_index, head) in heads.iter().copied().enumerate() {
             write_guest_u16(
                 memory,
-                available_ring_entry_address(
+                available_ring_entry_address_at(
+                    available_ring,
                     u16::try_from(ring_index).expect("test ring index should fit in u16"),
                 ),
                 head,
@@ -1647,9 +2009,59 @@ mod tests {
         }
         write_guest_u16(
             memory,
-            available_ring_idx_address(),
+            available_ring_idx_address_at(available_ring),
             u16::try_from(heads.len()).expect("test available length should fit in u16"),
         );
+    }
+
+    fn network_queue_layout(device_index: usize) -> TestNetworkQueueLayout {
+        let offset = u64::try_from(device_index)
+            .expect("test device index should fit in u64")
+            .checked_mul(TEST_NETWORK_QUEUE_DEVICE_STRIDE)
+            .expect("test queue offset should not overflow");
+
+        TestNetworkQueueLayout {
+            rx_descriptor_table: TEST_RX_DESCRIPTOR_TABLE
+                .checked_add(offset)
+                .expect("test RX descriptor table should not overflow"),
+            rx_available_ring: TEST_RX_AVAILABLE_RING
+                .checked_add(offset)
+                .expect("test RX available ring should not overflow"),
+            rx_used_ring: TEST_RX_USED_RING
+                .checked_add(offset)
+                .expect("test RX used ring should not overflow"),
+            rx_buffer: TEST_RX_BUFFER
+                .checked_add(offset)
+                .expect("test RX buffer should not overflow"),
+            tx_descriptor_table: TEST_DESCRIPTOR_TABLE
+                .checked_add(offset)
+                .expect("test TX descriptor table should not overflow"),
+            tx_available_ring: TEST_AVAILABLE_RING
+                .checked_add(offset)
+                .expect("test TX available ring should not overflow"),
+            tx_used_ring: TEST_USED_RING
+                .checked_add(offset)
+                .expect("test TX used ring should not overflow"),
+            tx_header: HEADER_ADDR
+                .checked_add(offset)
+                .expect("test TX header should not overflow"),
+            tx_payload: DATA_ADDR
+                .checked_add(offset)
+                .expect("test TX payload should not overflow"),
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct TestNetworkQueueLayout {
+        rx_descriptor_table: GuestAddress,
+        rx_available_ring: GuestAddress,
+        rx_used_ring: GuestAddress,
+        rx_buffer: GuestAddress,
+        tx_descriptor_table: GuestAddress,
+        tx_available_ring: GuestAddress,
+        tx_used_ring: GuestAddress,
+        tx_header: GuestAddress,
+        tx_payload: GuestAddress,
     }
 
     fn read_fdt(resources: &Arm64BootResources) -> DeviceTree {
@@ -1977,6 +2389,41 @@ mod tests {
     }
 
     #[test]
+    fn boot_runtime_network_notification_dispatch_with_packet_io_skips_provider_without_pending() {
+        let kernel = temp_file("kernel-network-packet-io-noop-dispatch", &arm64_image());
+        let mut controller = controller_with_kernel(kernel.path());
+        add_network(&mut controller, "eth0", "tap0");
+        let config = Arm64BootResourceConfig {
+            network_interrupt_lines: &[line(33)],
+            ..valid_config(&[])
+        };
+        let resources = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+        let mut memory = parts.memory;
+        let mut mmio_dispatcher = parts.mmio_dispatcher;
+        let mut runtime = parts.runtime;
+        let mut provider =
+            RecordingNetworkPacketIoProvider::default().with_endpoint("eth0", Vec::new());
+
+        let dispatches = runtime
+            .dispatch_network_queue_notifications_with_packet_io(
+                &mut memory,
+                &mut mmio_dispatcher,
+                &mut provider,
+            )
+            .expect("network dispatch result should allocate");
+
+        assert!(provider.requested_ifaces.is_empty());
+        let dispatch = dispatches.as_slice()[0]
+            .outcome()
+            .dispatched()
+            .expect("no pending notification should dispatch as no-op");
+        assert_eq!(dispatch.drained_notifications(), []);
+        assert!(!dispatches.needs_queue_interrupt());
+    }
+
+    #[test]
     fn boot_runtime_network_notification_dispatch_executes_tx_queue() {
         let kernel = temp_file("kernel-network-tx-dispatch", &arm64_image());
         let mut controller = controller_with_kernel(kernel.path());
@@ -2029,6 +2476,258 @@ mod tests {
             ),
             DeviceInterruptKind::Queue.status().bits()
         );
+    }
+
+    #[test]
+    fn boot_runtime_network_notification_dispatch_routes_packet_io_by_interface() {
+        let kernel = temp_file("kernel-network-packet-io-dispatch", &arm64_image());
+        let mut controller = controller_with_kernel(kernel.path());
+        add_network(&mut controller, "eth0", "tap0");
+        let config = Arm64BootResourceConfig {
+            network_interrupt_lines: &[line(33)],
+            ..valid_config(&[])
+        };
+        let resources = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+        let mut memory = parts.memory;
+        let mut mmio_dispatcher = parts.mmio_dispatcher;
+        let mut runtime = parts.runtime;
+        let layout = network_queue_layout(0);
+        configure_boot_network_queues_with_layout(&mut runtime, &mut mmio_dispatcher, 0, layout);
+        write_rx_buffer(&mut memory, layout);
+        write_queued_tx_frame_at(
+            &mut memory,
+            layout.tx_descriptor_table,
+            layout.tx_header,
+            layout.tx_payload,
+            &[0xde, 0xad, 0xbe, 0xef],
+        );
+        write_available_heads_at(&mut memory, layout.tx_available_ring, &[0]);
+        notify_boot_network_rx_queue(&mut runtime, &mut mmio_dispatcher, 0);
+        notify_boot_network_tx_queue(&mut runtime, &mut mmio_dispatcher, 0);
+        let mut provider = RecordingNetworkPacketIoProvider::default()
+            .with_endpoint("eth0", vec![vec![0xaa, 0xbb]]);
+
+        let dispatches = runtime
+            .dispatch_network_queue_notifications_with_packet_io(
+                &mut memory,
+                &mut mmio_dispatcher,
+                &mut provider,
+            )
+            .expect("network dispatch result should allocate");
+
+        assert_eq!(provider.requested_ifaces, ["eth0".to_string()]);
+        assert_eq!(dispatches.len(), 1);
+        assert!(dispatches.needs_queue_interrupt());
+        let dispatch = dispatches.as_slice()[0]
+            .outcome()
+            .dispatched()
+            .expect("network dispatch should complete");
+        assert_eq!(
+            dispatch.drained_notifications(),
+            [VIRTIO_NET_RX_QUEUE_INDEX, VIRTIO_NET_TX_QUEUE_INDEX]
+        );
+        let rx_dispatch = dispatch
+            .rx_queue_dispatch()
+            .expect("RX dispatch summary should be present");
+        assert_eq!(rx_dispatch.delivered_packets(), 1);
+        let tx_dispatch = dispatch
+            .tx_queue_dispatch()
+            .expect("TX dispatch summary should be present");
+        assert_eq!(tx_dispatch.processed_frames(), 1);
+        assert_eq!(tx_dispatch.sink_successful_frames(), 1);
+
+        let endpoint = provider.endpoint("eth0");
+        assert_eq!(endpoint.tx_sink.calls, 1);
+        assert_eq!(endpoint.tx_sink.packets, [vec![0xde, 0xad, 0xbe, 0xef]]);
+        assert_eq!(endpoint.rx_source.consume_calls, 1);
+        assert!(endpoint.rx_source.packets.is_empty());
+        let mut expected_rx_frame = vec![0; VIRTIO_NET_TX_HEADER_SIZE as usize];
+        expected_rx_frame.extend([0xaa, 0xbb]);
+        assert_eq!(
+            read_guest_bytes(&memory, layout.rx_buffer, expected_rx_frame.len()),
+            expected_rx_frame
+        );
+        assert_eq!(
+            read_boot_network_mmio_u32(
+                &mut runtime,
+                &mut mmio_dispatcher,
+                0,
+                VirtioMmioRegister::InterruptStatus
+            ),
+            DeviceInterruptKind::Queue.status().bits()
+        );
+    }
+
+    #[test]
+    fn boot_runtime_network_notification_dispatch_routes_multiple_interfaces_separately() {
+        let kernel = temp_file("kernel-network-packet-io-multiple", &arm64_image());
+        let mut controller = controller_with_kernel(kernel.path());
+        add_network(&mut controller, "eth0", "tap0");
+        add_network(&mut controller, "eth1", "tap1");
+        let config = Arm64BootResourceConfig {
+            network_interrupt_lines: &[line(33), line(34)],
+            ..valid_config(&[])
+        };
+        let resources = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+        let mut memory = parts.memory;
+        let mut mmio_dispatcher = parts.mmio_dispatcher;
+        let mut runtime = parts.runtime;
+        let first = network_queue_layout(0);
+        let second = network_queue_layout(1);
+        configure_boot_network_queues_with_layout(&mut runtime, &mut mmio_dispatcher, 0, first);
+        configure_boot_network_queues_with_layout(&mut runtime, &mut mmio_dispatcher, 1, second);
+        write_queued_tx_frame_at(
+            &mut memory,
+            first.tx_descriptor_table,
+            first.tx_header,
+            first.tx_payload,
+            &[0x10],
+        );
+        write_available_heads_at(&mut memory, first.tx_available_ring, &[0]);
+        write_queued_tx_frame_at(
+            &mut memory,
+            second.tx_descriptor_table,
+            second.tx_header,
+            second.tx_payload,
+            &[0x20, 0x21],
+        );
+        write_available_heads_at(&mut memory, second.tx_available_ring, &[0]);
+        notify_boot_network_tx_queue(&mut runtime, &mut mmio_dispatcher, 0);
+        notify_boot_network_tx_queue(&mut runtime, &mut mmio_dispatcher, 1);
+        let mut provider = RecordingNetworkPacketIoProvider::default()
+            .with_endpoint("eth0", Vec::new())
+            .with_endpoint("eth1", Vec::new());
+
+        let dispatches = runtime
+            .dispatch_network_queue_notifications_with_packet_io(
+                &mut memory,
+                &mut mmio_dispatcher,
+                &mut provider,
+            )
+            .expect("network dispatch result should allocate");
+
+        assert_eq!(
+            provider.requested_ifaces,
+            ["eth0".to_string(), "eth1".to_string()]
+        );
+        assert_eq!(dispatches.len(), 2);
+        assert!(dispatches.needs_queue_interrupt());
+        assert_eq!(provider.endpoint("eth0").tx_sink.packets, [vec![0x10]]);
+        assert_eq!(
+            provider.endpoint("eth1").tx_sink.packets,
+            [vec![0x20, 0x21]]
+        );
+        assert_eq!(provider.endpoint("eth0").tx_sink.calls, 1);
+        assert_eq!(provider.endpoint("eth1").tx_sink.calls, 1);
+    }
+
+    #[test]
+    fn boot_runtime_network_notification_dispatch_preserves_pending_on_packet_io_failure() {
+        let kernel = temp_file("kernel-network-packet-io-failure", &arm64_image());
+        let mut controller = controller_with_kernel(kernel.path());
+        add_network(&mut controller, "eth0", "tap0");
+        let config = Arm64BootResourceConfig {
+            network_interrupt_lines: &[line(33)],
+            ..valid_config(&[])
+        };
+        let resources = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+        let mut memory = parts.memory;
+        let mut mmio_dispatcher = parts.mmio_dispatcher;
+        let mut runtime = parts.runtime;
+        configure_boot_network_queues(&mut runtime, &mut mmio_dispatcher, 0);
+        write_queued_tx_frame(&mut memory);
+        notify_boot_network_tx_queue(&mut runtime, &mut mmio_dispatcher, 0);
+        let mut provider = RecordingNetworkPacketIoProvider::default().failing_for("eth0");
+
+        let failed = runtime
+            .dispatch_network_queue_notifications_with_packet_io(
+                &mut memory,
+                &mut mmio_dispatcher,
+                &mut provider,
+            )
+            .expect("network dispatch result should allocate");
+
+        assert!(!failed.needs_queue_interrupt());
+        match failed.as_slice()[0].outcome() {
+            Arm64BootNetworkNotificationOutcome::PacketIoProviderFailed(source) => {
+                assert_eq!(
+                    source.message(),
+                    "test packet I/O unavailable for interface eth0"
+                );
+            }
+            other => panic!("expected packet I/O provider failure, got {other:?}"),
+        }
+        assert_eq!(
+            read_boot_network_mmio_u32(
+                &mut runtime,
+                &mut mmio_dispatcher,
+                0,
+                VirtioMmioRegister::InterruptStatus
+            ),
+            0
+        );
+
+        let retried = runtime
+            .dispatch_network_queue_notifications(&mut memory, &mut mmio_dispatcher)
+            .expect("retry with default packet I/O should allocate");
+        let dispatch = retried.as_slice()[0]
+            .outcome()
+            .dispatched()
+            .expect("retry should dispatch preserved notification");
+        assert_eq!(
+            dispatch.drained_notifications(),
+            [VIRTIO_NET_TX_QUEUE_INDEX]
+        );
+        assert_eq!(
+            dispatch
+                .tx_queue_dispatch()
+                .expect("TX dispatch should be present")
+                .processed_frames(),
+            1
+        );
+        assert!(retried.needs_queue_interrupt());
+    }
+
+    #[test]
+    fn boot_runtime_network_notification_dispatch_skips_packet_io_when_handler_missing() {
+        let kernel = temp_file("kernel-network-packet-io-missing-handler", &arm64_image());
+        let mut controller = controller_with_kernel(kernel.path());
+        add_network(&mut controller, "eth0", "tap0");
+        let config = Arm64BootResourceConfig {
+            network_interrupt_lines: &[line(33)],
+            ..valid_config(&[])
+        };
+        let resources = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+        let mut memory = parts.memory;
+        let mut mmio_dispatcher = MmioDispatcher::new();
+        let mut runtime = parts.runtime;
+        let mut provider =
+            RecordingNetworkPacketIoProvider::default().with_endpoint("eth0", Vec::new());
+
+        let dispatches = runtime
+            .dispatch_network_queue_notifications_with_packet_io(
+                &mut memory,
+                &mut mmio_dispatcher,
+                &mut provider,
+            )
+            .expect("network dispatch result should allocate");
+
+        assert!(provider.requested_ifaces.is_empty());
+        assert!(
+            dispatches.as_slice()[0]
+                .outcome()
+                .handler_lookup_error()
+                .is_some()
+        );
+        assert!(!dispatches.needs_queue_interrupt());
     }
 
     #[test]

--- a/crates/runtime/src/virtio_mmio.rs
+++ b/crates/runtime/src/virtio_mmio.rs
@@ -964,6 +964,13 @@ impl VirtioMmioQueueNotificationRegisters {
             .collect()
     }
 
+    pub fn has_pending_queue_notifications(&self) -> bool {
+        self.pending_notifications
+            .iter()
+            .copied()
+            .any(|is_pending| is_pending)
+    }
+
     pub fn take_pending_queue_notifications(&mut self) -> Vec<usize> {
         let pending_notifications = self.pending_queue_notifications();
         self.reset();
@@ -1579,6 +1586,10 @@ impl<C: VirtioMmioDeviceConfigHandler, A: VirtioMmioDeviceActivationHandler>
 
     pub fn pending_queue_notifications(&self) -> Vec<usize> {
         self.queue_notifications.pending_queue_notifications()
+    }
+
+    pub fn has_pending_queue_notifications(&self) -> bool {
+        self.queue_notifications.has_pending_queue_notifications()
     }
 
     pub fn take_pending_queue_notifications(&mut self) -> Vec<usize> {
@@ -3990,6 +4001,7 @@ mod tests {
         let notifications =
             VirtioMmioQueueNotificationRegisters::new(2).expect("notifications should build");
         assert_eq!(notifications.queue_count(), 2);
+        assert!(!notifications.has_pending_queue_notifications());
         assert!(notifications.pending_queue_notifications().is_empty());
         assert_eq!(notifications.is_queue_notification_pending(0), Ok(false));
         assert_eq!(notifications.is_queue_notification_pending(1), Ok(false));
@@ -4017,8 +4029,10 @@ mod tests {
         assert_eq!(notifications.is_queue_notification_pending(0), Ok(true));
         assert_eq!(notifications.is_queue_notification_pending(1), Ok(false));
         assert_eq!(notifications.is_queue_notification_pending(2), Ok(true));
+        assert!(notifications.has_pending_queue_notifications());
         assert_eq!(notifications.pending_queue_notifications(), vec![0, 2]);
         assert_eq!(notifications.take_pending_queue_notifications(), vec![0, 2]);
+        assert!(!notifications.has_pending_queue_notifications());
         assert!(notifications.pending_queue_notifications().is_empty());
     }
 
@@ -4262,15 +4276,18 @@ mod tests {
         advance_handler_to_driver_ok(&mut handler).expect("handler should reach DRIVER_OK");
 
         assert_eq!(handler.is_queue_notification_pending(1), Ok(false));
+        assert!(!handler.has_pending_queue_notifications());
         assert!(handler.pending_queue_notifications().is_empty());
 
         write_register_u32(&mut handler, VirtioMmioRegister::QueueNotify.offset(), 1)
             .expect("queue notify should write");
 
         assert_eq!(handler.is_queue_notification_pending(1), Ok(true));
+        assert!(handler.has_pending_queue_notifications());
         assert_eq!(handler.pending_queue_notifications(), vec![1]);
         assert_eq!(handler.take_pending_queue_notifications(), vec![1]);
         assert_eq!(handler.is_queue_notification_pending(1), Ok(false));
+        assert!(!handler.has_pending_queue_notifications());
         assert!(handler.take_pending_queue_notifications().is_empty());
     }
 

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -223,7 +223,7 @@ compatibility targets.
 | `PUT` | `/logger` | supported target; minimal subset implemented | Stores process logger configuration before boot, opens `log_path` with nonblocking output semantics when provided, accepts optional Firecracker-shaped level/show/module fields, and omits logger state from `GET /vm/config` because it is not guest configuration. Full internal log routing remains deferred. |
 | `PATCH` | `/machine-config` | deferred | Partial updates belong with later state and validation rules. |
 | `PUT` | `/cpu-config` | deferred | Needs HVF CPU feature design with VM and boot work in #8 and #10. |
-| `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores initial virtio-net configuration before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT, and internal network notification dispatch can parse TX descriptors through an injected packet sink boundary and copy injected RX packets into guest buffers through an injected packet source boundary. Host packet backend selection, public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
+| `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores initial virtio-net configuration before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT, and internal network notification dispatch can route each configured interface through injected packet I/O, parse TX descriptors through a packet sink boundary, and copy injected RX packets into guest buffers through a packet source boundary. Host packet backend selection, public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
 | `PUT` | `/vsock` | deferred | Tied to virtio vsock work in #15. |
 | `GET`, `PUT`, `PATCH` | `/mmds` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/mmds/config` | deferred | Tied to MMDS work in #16. |
@@ -534,19 +534,20 @@ registration metadata. Startup preparation can pair those registrations with
 caller-provided interrupt lines and write matching inert virtio-mmio descriptors
 into the guest FDT while preserving interface order and host device names.
 Internal network notification dispatch can drain pending TX and RX queue
-notifications. TX dispatch walks the TX available ring, parses descriptor chains
-into `VirtioNetworkTxFrame` metadata, publishes used-ring completions with
-length 0, delivers parsed frames to an injected internal packet sink, preserves
-parse, sink, and partial-dispatch errors, and marks queue interrupt status when
-descriptor heads complete. RX dispatch uses an injected internal packet source,
-copies a zeroed 12-byte virtio-net header plus packet payload into validated
-guest-writable RX buffers, publishes used-ring completions with the written
-length, preserves malformed-buffer and partial-dispatch metadata, and marks
-queue interrupt status when RX buffers complete. The default dispatch path uses
-a no-op TX sink and an empty RX source, so current boot sessions still do not
-open host networking resources or provide user-visible packet ingress or egress.
-These helpers do not advertise MTU, choose a host packet backend, or connect
-packets to the host network.
+notifications and can choose injected packet I/O per configured interface at the
+boot-runtime boundary. TX dispatch walks the TX available ring, parses
+descriptor chains into `VirtioNetworkTxFrame` metadata, publishes used-ring
+completions with length 0, delivers parsed frames to an injected internal packet
+sink, preserves parse, sink, and partial-dispatch errors, and marks queue
+interrupt status when descriptor heads complete. RX dispatch uses an injected
+internal packet source, copies a zeroed 12-byte virtio-net header plus packet
+payload into validated guest-writable RX buffers, publishes used-ring
+completions with the written length, preserves malformed-buffer and
+partial-dispatch metadata, and marks queue interrupt status when RX buffers
+complete. The default dispatch path uses a no-op TX sink and an empty RX source,
+so current boot sessions still do not open host networking resources or provide
+user-visible packet ingress or egress. These helpers do not advertise MTU,
+choose a host packet backend, or connect packets to the host network.
 
 The runtime crate can prepare owned internal block-device resources from a
 validated list of stored drive configs. Preparation opens each backing file,
@@ -946,7 +947,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | `PUT /machine-config` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Pre-boot-only configuration. Stored values are applied during startup preparation. |
 | `PUT /boot-source` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; host paths are opened during startup preparation. Host path errors must avoid leaking sensitive path details. |
 | `PUT /drives/{drive_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; startup preparation opens backing files and registers initial block MMIO devices. Runtime hotplug remains deferred. |
-| `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT, while internal network notification dispatch can parse and complete TX descriptor heads through an injected packet sink boundary and write injected RX packets into guest buffers through an injected packet source boundary. Host packet backend, public packet movement, PATCH, and DELETE remain deferred. |
+| `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT, while internal network notification dispatch can route each interface through injected packet I/O, complete TX descriptor heads through a packet sink boundary, and write injected RX packets into guest buffers through a packet source boundary. Host packet backend, public packet movement, PATCH, and DELETE remain deferred. |
 | `PUT /metrics` | implemented; `204` empty response on successful output initialization | unsupported after start; `400` `fault_message` | Metrics output is process observability state, not guest configuration. Duplicate initialization fails. |
 | `PUT /logger` | implemented; `204` empty response on successful pre-boot configuration | unsupported after start; `400` `fault_message` | Logger output is process observability state, not guest configuration. Repeated pre-boot requests update provided fields; full log routing remains deferred. |
 | `PUT /actions` with `InstanceStart` | process-routed; `204` after successful owned HVF startup with internal boot run-loop worker across bounded step windows or `400` preflight/preparation fault | unsupported after start; `400` `fault_message` | Commits `Running` only after the owned HVF boot-session worker with internal serial capture is retained. The worker keeps internal active, terminal-outcome, or error status; public run-loop control and public serial streaming remain deferred. |

--- a/docs/security.md
+++ b/docs/security.md
@@ -150,10 +150,11 @@ The current scaffold does not implement:
 - network, vsock, MMDS, or snapshot containment; the current network interface
   configuration path validates and stores configuration strings, and internal
   virtio-net notification dispatch can parse guest TX descriptor metadata and
-  pass validated TX frame payloads to an injected packet sink, and can copy
-  injected RX packet bytes into validated guest RX buffers through an injected
-  packet source, but the default path is a no-op TX sink plus an empty RX source
-  and bangbang still does not open host networking resources
+  pass validated TX frame payloads to injected packet I/O selected per configured
+  interface, and can copy injected RX packet bytes into validated guest RX
+  buffers through the same boundary, but the default path is a no-op TX sink
+  plus an empty RX source and bangbang still does not open host networking
+  resources
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy
 


### PR DESCRIPTION
## Summary

- Add a boot-runtime virtio-net packet I/O provider boundary keyed by configured network interface metadata.
- Route pending boot network notifications through per-interface injected TX sinks and RX sources while preserving the existing no-op/empty default path.
- Add a no-allocation queue notification pending check and tests for default behavior, no-pending provider skipping, per-interface routing, multi-interface isolation, provider failure retry behavior, and missing-handler behavior.
- Update compatibility and security docs to describe the internal boundary while keeping host networking resources out of scope.

## Out of scope

- Opening or selecting a real macOS host networking backend.
- Public packet movement APIs, network hotplug, PATCH/DELETE, MTU, or rate limiting.

Closes #289

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`
