### PR TITLE
feat: route process network packet I/O

### DIFF
--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -11,10 +11,18 @@ use bangbang_hvf::{
     HvfVcpuRunnerError, OwnedHvfArm64BootSession,
 };
 use bangbang_runtime::block::BlockMmioLayout;
-use bangbang_runtime::memory::GuestAddress;
+use bangbang_runtime::memory::{GuestAddress, GuestMemory};
 use bangbang_runtime::mmio::MmioRegionId;
-use bangbang_runtime::network::NetworkMmioLayout;
+use bangbang_runtime::network::{
+    NetworkMmioLayout, VirtioNetworkRxPacket, VirtioNetworkRxPacketSource,
+    VirtioNetworkRxPacketSourceError, VirtioNetworkTxFrame, VirtioNetworkTxPacketSink,
+    VirtioNetworkTxPacketSinkError,
+};
 use bangbang_runtime::serial::SharedSerialOutputBuffer;
+use bangbang_runtime::startup::{
+    Arm64BootNetworkDevice, Arm64BootNetworkPacketIo, Arm64BootNetworkPacketIoError,
+    Arm64BootNetworkPacketIoProvider,
+};
 use bangbang_runtime::{BackendError, VmmAction, VmmActionError, VmmController, VmmData};
 
 #[cfg(test)]
@@ -175,11 +183,130 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
     fn start(&mut self, controller: &VmmController) -> Result<Self::Session, BackendError> {
         let session = OwnedHvfArm64BootSession::new(controller, self.boot_session_config())
             .map_err(|err| BackendError::Hypervisor(err.to_string()))?;
+        let session =
+            ProcessHvfBootSession::new(session, NoopProcessNetworkPacketIoProvider::default());
         HvfBootRunLoopSupervisor::start(session, default_hvf_boot_run_loop_step_limit())
     }
 }
 
-pub(crate) type HvfBootRunLoopSupervisor = BootRunLoopSupervisor<OwnedHvfArm64BootSession>;
+pub(crate) type HvfBootRunLoopSupervisor = BootRunLoopSupervisor<
+    ProcessHvfBootSession<OwnedHvfArm64BootSession, NoopProcessNetworkPacketIoProvider>,
+>;
+
+pub(crate) struct ProcessHvfBootSession<S, P> {
+    session: S,
+    packet_io: P,
+}
+
+impl<S, P> ProcessHvfBootSession<S, P> {
+    const fn new(session: S, packet_io: P) -> Self {
+        Self { session, packet_io }
+    }
+}
+
+impl<S, P> fmt::Debug for ProcessHvfBootSession<S, P>
+where
+    S: fmt::Debug,
+    P: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProcessHvfBootSession")
+            .field("session", &self.session)
+            .field("packet_io", &self.packet_io)
+            .finish()
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct NoopProcessNetworkPacketIoProvider {
+    tx_sink: NoopProcessNetworkTxPacketSink,
+    rx_source: EmptyProcessNetworkRxPacketSource,
+}
+
+impl Arm64BootNetworkPacketIoProvider for NoopProcessNetworkPacketIoProvider {
+    fn packet_io(
+        &mut self,
+        _device: &Arm64BootNetworkDevice,
+    ) -> Result<Arm64BootNetworkPacketIo<'_>, Arm64BootNetworkPacketIoError> {
+        Ok(Arm64BootNetworkPacketIo::new(
+            &mut self.tx_sink,
+            &mut self.rx_source,
+        ))
+    }
+}
+
+#[derive(Debug, Default)]
+struct NoopProcessNetworkTxPacketSink;
+
+impl VirtioNetworkTxPacketSink for NoopProcessNetworkTxPacketSink {
+    fn transmit_frame(
+        &mut self,
+        _memory: &GuestMemory,
+        _frame: &VirtioNetworkTxFrame,
+    ) -> Result<(), VirtioNetworkTxPacketSinkError> {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default)]
+struct EmptyProcessNetworkRxPacketSource;
+
+impl VirtioNetworkRxPacketSource for EmptyProcessNetworkRxPacketSource {
+    fn peek_packet(
+        &mut self,
+    ) -> Result<Option<VirtioNetworkRxPacket<'_>>, VirtioNetworkRxPacketSourceError> {
+        Ok(None)
+    }
+
+    fn consume_packet(&mut self) {}
+}
+
+pub(crate) trait NetworkPacketIoRunLoopSession: Send + 'static {
+    type Control: BootRunLoopControl;
+    type Error: fmt::Display + Send + 'static;
+    type Outcome: Clone + fmt::Debug + Send + 'static;
+
+    fn run_loop_control(&self) -> Self::Control;
+
+    fn run_loop_with_network_packet_io<P>(
+        &mut self,
+        stop_token: &<Self::Control as BootRunLoopControl>::StopToken,
+        max_steps: NonZeroUsize,
+        packet_io: &mut P,
+    ) -> Result<Self::Outcome, Self::Error>
+    where
+        P: Arm64BootNetworkPacketIoProvider;
+
+    fn should_continue_after_outcome(outcome: &Self::Outcome) -> bool;
+}
+
+impl NetworkPacketIoRunLoopSession for OwnedHvfArm64BootSession {
+    type Control = HvfArm64BootRunLoopControl;
+    type Error = HvfArm64BootRunLoopError;
+    type Outcome = HvfArm64BootRunLoopOutcome;
+
+    fn run_loop_control(&self) -> Self::Control {
+        OwnedHvfArm64BootSession::run_loop_control(self)
+    }
+
+    fn run_loop_with_network_packet_io<P>(
+        &mut self,
+        stop_token: &<Self::Control as BootRunLoopControl>::StopToken,
+        max_steps: NonZeroUsize,
+        packet_io: &mut P,
+    ) -> Result<Self::Outcome, Self::Error>
+    where
+        P: Arm64BootNetworkPacketIoProvider,
+    {
+        OwnedHvfArm64BootSession::run_loop_with_network_packet_io(
+            self, stop_token, max_steps, packet_io,
+        )
+    }
+
+    fn should_continue_after_outcome(outcome: &Self::Outcome) -> bool {
+        matches!(outcome, HvfArm64BootRunLoopOutcome::StepLimitReached { .. })
+    }
+}
 
 pub(crate) trait BootRunLoopControl: Clone + fmt::Debug + Send + Sync + 'static {
     type Error: fmt::Display + Send + 'static;
@@ -238,6 +365,33 @@ impl BootRunLoopSession for OwnedHvfArm64BootSession {
 
     fn should_continue_after_outcome(outcome: &Self::Outcome) -> bool {
         matches!(outcome, HvfArm64BootRunLoopOutcome::StepLimitReached { .. })
+    }
+}
+
+impl<S, P> BootRunLoopSession for ProcessHvfBootSession<S, P>
+where
+    S: NetworkPacketIoRunLoopSession,
+    P: Arm64BootNetworkPacketIoProvider + Send + 'static,
+{
+    type Control = S::Control;
+    type Error = S::Error;
+    type Outcome = S::Outcome;
+
+    fn run_loop_control(&self) -> Self::Control {
+        self.session.run_loop_control()
+    }
+
+    fn run_loop(
+        &mut self,
+        stop_token: &<Self::Control as BootRunLoopControl>::StopToken,
+        max_steps: NonZeroUsize,
+    ) -> Result<Self::Outcome, Self::Error> {
+        self.session
+            .run_loop_with_network_packet_io(stop_token, max_steps, &mut self.packet_io)
+    }
+
+    fn should_continue_after_outcome(outcome: &Self::Outcome) -> bool {
+        S::should_continue_after_outcome(outcome)
     }
 }
 
@@ -437,12 +591,19 @@ mod tests {
 
     use bangbang_runtime::block::{DriveConfigInput, DriveConfigs, PreparedBlockDevices};
     use bangbang_runtime::boot::BootSourceConfigInput;
+    use bangbang_runtime::fdt::{Arm64FdtRegion, Arm64FdtVirtioMmioDevice};
+    use bangbang_runtime::interrupt::GuestInterruptLine;
     use bangbang_runtime::mmio::MmioRegion;
     use bangbang_runtime::network::{
-        NetworkInterfaceConfigInput, NetworkInterfaceConfigs, PreparedNetworkDevices,
+        NetworkInterfaceConfigInput, NetworkInterfaceConfigs, NetworkMmioLayout,
+        PreparedNetworkDevices,
     };
     use bangbang_runtime::serial::{
         SERIAL_MMIO_DEVICE_WINDOW_SIZE, SerialOutput, SharedSerialOutputBuffer,
+    };
+    use bangbang_runtime::startup::{
+        Arm64BootNetworkDevice, Arm64BootNetworkPacketIo, Arm64BootNetworkPacketIoError,
+        Arm64BootNetworkPacketIoProvider,
     };
     use bangbang_runtime::{BackendError, InstanceState, VmmAction, VmmActionError};
 
@@ -450,8 +611,9 @@ mod tests {
         BootRunLoopControl, BootRunLoopSession, BootRunLoopSupervisor, BootRunLoopWorkerStatus,
         DEFAULT_HVF_BOOT_RUN_LOOP_STEP_LIMIT, DEFAULT_NETWORK_MMIO_BASE,
         DEFAULT_NETWORK_MMIO_REGION_ID, DEFAULT_SERIAL_MMIO_BASE, DEFAULT_SERIAL_MMIO_REGION_ID,
-        HvfInstanceStartExecutor, InstanceStartExecutor, ProcessVmm,
-        default_hvf_boot_run_loop_step_limit, default_hvf_boot_session_config,
+        EmptyProcessNetworkRxPacketSource, HvfInstanceStartExecutor, InstanceStartExecutor,
+        NetworkPacketIoRunLoopSession, NoopProcessNetworkTxPacketSink, ProcessHvfBootSession,
+        ProcessVmm, default_hvf_boot_run_loop_step_limit, default_hvf_boot_session_config,
     };
 
     static NEXT_TEMP_FILE_ID: AtomicU64 = AtomicU64::new(0);
@@ -702,6 +864,109 @@ mod tests {
         }
     }
 
+    struct FakeNetworkPacketIoRunLoopSession {
+        control: FakeRunLoopControl,
+        max_steps_sender: mpsc::Sender<usize>,
+    }
+
+    impl FakeNetworkPacketIoRunLoopSession {
+        const fn new(control: FakeRunLoopControl, max_steps_sender: mpsc::Sender<usize>) -> Self {
+            Self {
+                control,
+                max_steps_sender,
+            }
+        }
+    }
+
+    impl NetworkPacketIoRunLoopSession for FakeNetworkPacketIoRunLoopSession {
+        type Control = FakeRunLoopControl;
+        type Error = FakeRunLoopError;
+        type Outcome = FakeRunLoopOutcome;
+
+        fn run_loop_control(&self) -> Self::Control {
+            self.control.clone()
+        }
+
+        fn run_loop_with_network_packet_io<P>(
+            &mut self,
+            _stop_token: &<Self::Control as BootRunLoopControl>::StopToken,
+            max_steps: NonZeroUsize,
+            packet_io: &mut P,
+        ) -> Result<Self::Outcome, Self::Error>
+        where
+            P: Arm64BootNetworkPacketIoProvider,
+        {
+            let _ = self.max_steps_sender.send(max_steps.get());
+            packet_io
+                .packet_io(&test_boot_network_device())
+                .map_err(|_| FakeRunLoopError)?;
+            Ok(FakeRunLoopOutcome::Terminal)
+        }
+
+        fn should_continue_after_outcome(outcome: &Self::Outcome) -> bool {
+            matches!(outcome, FakeRunLoopOutcome::StepLimitReached)
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingProcessNetworkPacketIoProvider {
+        requested_ifaces: Arc<Mutex<Vec<String>>>,
+        tx_sink: NoopProcessNetworkTxPacketSink,
+        rx_source: EmptyProcessNetworkRxPacketSource,
+    }
+
+    impl RecordingProcessNetworkPacketIoProvider {
+        fn requested_ifaces(&self) -> Arc<Mutex<Vec<String>>> {
+            Arc::clone(&self.requested_ifaces)
+        }
+    }
+
+    impl Arm64BootNetworkPacketIoProvider for RecordingProcessNetworkPacketIoProvider {
+        fn packet_io(
+            &mut self,
+            device: &Arm64BootNetworkDevice,
+        ) -> Result<Arm64BootNetworkPacketIo<'_>, Arm64BootNetworkPacketIoError> {
+            self.requested_ifaces
+                .lock()
+                .expect("requested ifaces should lock")
+                .push(device.registration.iface_id().to_string());
+            Ok(Arm64BootNetworkPacketIo::new(
+                &mut self.tx_sink,
+                &mut self.rx_source,
+            ))
+        }
+    }
+
+    fn test_boot_network_device() -> Arm64BootNetworkDevice {
+        let mut configs = NetworkInterfaceConfigs::new();
+        configs
+            .insert(NetworkInterfaceConfigInput::new("eth0", "eth0", "tap0"))
+            .expect("test network config should insert");
+        let prepared = PreparedNetworkDevices::from_configs(&configs)
+            .expect("test network device should prepare");
+        let devices = prepared
+            .register_mmio(NetworkMmioLayout::new(
+                DEFAULT_NETWORK_MMIO_BASE,
+                DEFAULT_NETWORK_MMIO_REGION_ID,
+            ))
+            .expect("test network MMIO should register");
+        let (_dispatcher, mut registrations) = devices.into_parts();
+        let registration = registrations.remove(0);
+        let region = registration.region();
+
+        Arm64BootNetworkDevice {
+            registration,
+            fdt_device: Arm64FdtVirtioMmioDevice {
+                region: Arm64FdtRegion {
+                    base: region.range().start().raw_value(),
+                    size: region.range().size(),
+                },
+                interrupt_line: GuestInterruptLine::new(32)
+                    .expect("test interrupt line should be valid"),
+            },
+        }
+    }
+
     fn configured_vmm(starter: FakeStarter) -> ProcessVmm<FakeStarter> {
         let mut vmm = ProcessVmm::with_starter("demo-1", "0.1.0", "bangbang", starter);
         vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
@@ -805,6 +1070,38 @@ mod tests {
                 .registrations()
                 .iter()
                 .all(|network| !network.region().range().overlaps(serial_region.range()))
+        );
+    }
+
+    #[test]
+    fn process_hvf_boot_session_routes_run_loop_through_packet_io() {
+        let control = FakeRunLoopControl::default();
+        let stop_token = control.stop_token();
+        let (max_steps_sender, max_steps_receiver) = mpsc::channel();
+        let fake_session = FakeNetworkPacketIoRunLoopSession::new(control, max_steps_sender);
+        let provider = RecordingProcessNetworkPacketIoProvider::default();
+        let requested_ifaces = provider.requested_ifaces();
+        let mut session = ProcessHvfBootSession::new(fake_session, provider);
+
+        let result = session
+            .run_loop(
+                &stop_token,
+                NonZeroUsize::new(17).expect("test step limit should be nonzero"),
+            )
+            .expect("process HVF boot session should run");
+
+        assert_eq!(result, FakeRunLoopOutcome::Terminal);
+        assert_eq!(
+            max_steps_receiver
+                .recv()
+                .expect("fake session should receive step limit"),
+            17
+        );
+        assert_eq!(
+            *requested_ifaces
+                .lock()
+                .expect("requested ifaces should lock"),
+            ["eth0".to_string()]
         );
     }
 

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -562,6 +562,16 @@ impl OwnedHvfArm64BootSession {
         run_boot_session_loop(self, stop_token, max_steps)
     }
 
+    pub fn run_loop_with_network_packet_io(
+        &mut self,
+        stop_token: &HvfArm64BootRunLoopStopToken,
+        max_steps: NonZeroUsize,
+        packet_io: &mut impl Arm64BootNetworkPacketIoProvider,
+    ) -> Result<HvfArm64BootRunLoopOutcome, HvfArm64BootRunLoopError> {
+        let mut session = NetworkPacketIoBootSessionRunLoopSession::new(self, packet_io);
+        run_boot_session_loop(&mut session, stop_token, max_steps)
+    }
+
     pub fn run_loop_with_observer(
         &mut self,
         stop_token: &HvfArm64BootRunLoopStopToken,
@@ -679,6 +689,60 @@ impl BootSessionRunLoopSession for OwnedHvfArm64BootSession {
         HvfArm64BootNetworkNotificationDispatchError,
     > {
         self.dispatch_network_queue_notifications_and_signal_interrupts()
+    }
+}
+
+struct NetworkPacketIoBootSessionRunLoopSession<'session, 'packet_io, P>
+where
+    P: Arm64BootNetworkPacketIoProvider,
+{
+    session: &'session mut OwnedHvfArm64BootSession,
+    packet_io: &'packet_io mut P,
+}
+
+impl<'session, 'packet_io, P> NetworkPacketIoBootSessionRunLoopSession<'session, 'packet_io, P>
+where
+    P: Arm64BootNetworkPacketIoProvider,
+{
+    const fn new(
+        session: &'session mut OwnedHvfArm64BootSession,
+        packet_io: &'packet_io mut P,
+    ) -> Self {
+        Self { session, packet_io }
+    }
+}
+
+impl<P> BootSessionRunLoopSession for NetworkPacketIoBootSessionRunLoopSession<'_, '_, P>
+where
+    P: Arm64BootNetworkPacketIoProvider,
+{
+    fn run_loop_vcpu_step(&mut self) -> Result<HvfVcpuRunStepOutcome, HvfVcpuRunnerError> {
+        self.session.run_once_and_handle_mmio()
+    }
+
+    fn handle_run_loop_virtual_timer(&mut self) -> Result<(), HvfVcpuRunnerError> {
+        let intid = self.session.gic.timer_interrupts.el1_virtual_timer_intid;
+        self.session.runner.set_gic_ppi_pending(intid)
+    }
+
+    fn dispatch_run_loop_block_notifications(
+        &mut self,
+    ) -> Result<HvfArm64BootBlockNotificationDispatches, HvfArm64BootBlockNotificationDispatchError>
+    {
+        self.session
+            .dispatch_block_queue_notifications_and_signal_interrupts()
+    }
+
+    fn dispatch_run_loop_network_notifications(
+        &mut self,
+    ) -> Result<
+        HvfArm64BootNetworkNotificationDispatches,
+        HvfArm64BootNetworkNotificationDispatchError,
+    > {
+        self.session
+            .dispatch_network_queue_notifications_with_packet_io_and_signal_interrupts(
+                self.packet_io,
+            )
     }
 }
 

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -48,7 +48,10 @@ with a runner-compatible shared MMIO dispatcher, controlled mapped guest-memory
 access, one-step runner-thread MMIO handling, a run-cancellation boundary, a
 virtual-timer-mask control boundary, a bounded internal boot-session run-loop
 pump, owned internal boot-session handle, process-level owned startup-session
-wiring with optional serial capture and boot run-loop supervision across bounded step windows with retained internal worker status, boot block and virtio-net queue interrupt signaling,
+wiring with optional serial capture and boot run-loop supervision across bounded
+step windows with retained internal worker status, process-owned no-op
+virtio-net packet-I/O provider injection, boot block and virtio-net queue
+interrupt signaling,
 virtual timer PPI assertion, per-controller metrics and logger output state, and an initial process startup argument model.
 There is no broader API request body model beyond the initial boot-source,
 drive configuration, machine-configuration, metrics, logger, and actions bodies, public guest
@@ -537,9 +540,9 @@ into the guest FDT while preserving interface order and host device names.
 Internal network notification dispatch can drain pending TX and RX queue
 notifications and can choose injected packet I/O per configured interface at the
 boot-runtime boundary. The HVF boot-session wrapper can invoke that injected
-path while preserving the existing default no-op behavior. TX dispatch walks the
-TX available ring, parses descriptor chains into `VirtioNetworkTxFrame`
-metadata, publishes used-ring
+path, and process-owned startup wires the internal boot loop through a default
+no-op provider. TX dispatch walks the TX available ring, parses descriptor
+chains into `VirtioNetworkTxFrame` metadata, publishes used-ring
 completions with length 0, delivers parsed frames to an injected internal packet
 sink, preserves parse, sink, and partial-dispatch errors, and marks queue
 interrupt status when descriptor heads complete. RX dispatch uses an injected
@@ -547,10 +550,10 @@ internal packet source, copies a zeroed 12-byte virtio-net header plus packet
 payload into validated guest-writable RX buffers, publishes used-ring
 completions with the written length, preserves malformed-buffer and
 partial-dispatch metadata, and marks queue interrupt status when RX buffers
-complete. The default dispatch path uses a no-op TX sink and an empty RX source,
-so current boot sessions still do not open host networking resources or provide
-user-visible packet ingress or egress. These helpers do not advertise MTU,
-choose a host packet backend, or connect packets to the host network.
+complete. The default process provider uses a no-op TX sink and an empty RX
+source, so current boot sessions still do not open host networking resources or
+provide user-visible packet ingress or egress. These helpers do not advertise
+MTU, choose a host packet backend, or connect packets to the host network.
 
 The runtime crate can prepare owned internal block-device resources from a
 validated list of stored drive configs. Preparation opens each backing file,

--- a/docs/security.md
+++ b/docs/security.md
@@ -152,9 +152,9 @@ The current scaffold does not implement:
   virtio-net notification dispatch can parse guest TX descriptor metadata and
   pass validated TX frame payloads to injected packet I/O selected per configured
   interface, and can copy injected RX packet bytes into validated guest RX
-  buffers through the same boundary. The HVF boot-session wrapper can use that
-  injected boundary, but the default path is a no-op TX sink plus an empty RX
-  source and bangbang still does not open host networking resources
+  buffers through the same boundary. The process-owned HVF boot loop can use
+  that injected boundary, but the default provider is a no-op TX sink plus an
+  empty RX source and bangbang still does not open host networking resources
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy
 


### PR DESCRIPTION
Closes #293

## Summary
- Add an owned HVF run-loop entry point that dispatches network notifications through caller-provided packet I/O.
- Wrap the process-owned HVF boot session with a default no-op packet-I/O provider for `InstanceStart`.
- Cover the process wrapper path with a unit test that proves the provider is used.
- Update compatibility and security docs for the process-level injection boundary.

## Out Of Scope
- No vmnet, tap, bridged, NAT, or other real macOS host network backend is implemented.
- No public network PATCH, DELETE, MTU, rate limiting, or runtime hotplug behavior is added.

## Verification
- cargo fmt --all -- --check
- cargo check --workspace --all-targets --all-features --locked
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- git diff --check