### PR TITLE
feat: add vmnet lifecycle boundary

### DIFF
--- a/crates/bangbang/src/host_network.rs
+++ b/crates/bangbang/src/host_network.rs
@@ -1,1 +1,3 @@
+//! Internal host-network backend boundaries.
+
 pub mod vmnet;

--- a/crates/bangbang/src/host_network.rs
+++ b/crates/bangbang/src/host_network.rs
@@ -1,0 +1,1 @@
+pub mod vmnet;

--- a/crates/bangbang/src/host_network/vmnet.rs
+++ b/crates/bangbang/src/host_network/vmnet.rs
@@ -1,0 +1,507 @@
+use std::fmt;
+
+pub const VMNET_HOST_MODE_VALUE: u32 = 1000;
+pub const VMNET_SHARED_MODE_VALUE: u32 = 1001;
+pub const VMNET_BRIDGED_MODE_VALUE: u32 = 1002;
+
+pub const VMNET_SUCCESS_VALUE: u32 = 1000;
+pub const VMNET_FAILURE_VALUE: u32 = 1001;
+pub const VMNET_MEM_FAILURE_VALUE: u32 = 1002;
+pub const VMNET_INVALID_ARGUMENT_VALUE: u32 = 1003;
+pub const VMNET_SETUP_INCOMPLETE_VALUE: u32 = 1004;
+pub const VMNET_INVALID_ACCESS_VALUE: u32 = 1005;
+pub const VMNET_PACKET_TOO_BIG_VALUE: u32 = 1006;
+pub const VMNET_BUFFER_EXHAUSTED_VALUE: u32 = 1007;
+pub const VMNET_TOO_MANY_PACKETS_VALUE: u32 = 1008;
+pub const VMNET_SHARING_SERVICE_BUSY_VALUE: u32 = 1009;
+pub const VMNET_NOT_AUTHORIZED_VALUE: u32 = 1010;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VmnetMode {
+    Host,
+    Shared,
+    Bridged,
+}
+
+impl VmnetMode {
+    pub const fn raw_value(self) -> u32 {
+        match self {
+            Self::Host => VMNET_HOST_MODE_VALUE,
+            Self::Shared => VMNET_SHARED_MODE_VALUE,
+            Self::Bridged => VMNET_BRIDGED_MODE_VALUE,
+        }
+    }
+}
+
+impl fmt::Display for VmnetMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Host => "host",
+            Self::Shared => "shared",
+            Self::Bridged => "bridged",
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VmnetStatus {
+    Success,
+    Failure,
+    MemoryFailure,
+    InvalidArgument,
+    SetupIncomplete,
+    InvalidAccess,
+    PacketTooBig,
+    BufferExhausted,
+    TooManyPackets,
+    SharingServiceBusy,
+    NotAuthorized,
+    Unknown(u32),
+}
+
+impl VmnetStatus {
+    pub const fn from_raw(value: u32) -> Self {
+        match value {
+            VMNET_SUCCESS_VALUE => Self::Success,
+            VMNET_FAILURE_VALUE => Self::Failure,
+            VMNET_MEM_FAILURE_VALUE => Self::MemoryFailure,
+            VMNET_INVALID_ARGUMENT_VALUE => Self::InvalidArgument,
+            VMNET_SETUP_INCOMPLETE_VALUE => Self::SetupIncomplete,
+            VMNET_INVALID_ACCESS_VALUE => Self::InvalidAccess,
+            VMNET_PACKET_TOO_BIG_VALUE => Self::PacketTooBig,
+            VMNET_BUFFER_EXHAUSTED_VALUE => Self::BufferExhausted,
+            VMNET_TOO_MANY_PACKETS_VALUE => Self::TooManyPackets,
+            VMNET_SHARING_SERVICE_BUSY_VALUE => Self::SharingServiceBusy,
+            VMNET_NOT_AUTHORIZED_VALUE => Self::NotAuthorized,
+            value => Self::Unknown(value),
+        }
+    }
+
+    pub const fn raw_value(self) -> u32 {
+        match self {
+            Self::Success => VMNET_SUCCESS_VALUE,
+            Self::Failure => VMNET_FAILURE_VALUE,
+            Self::MemoryFailure => VMNET_MEM_FAILURE_VALUE,
+            Self::InvalidArgument => VMNET_INVALID_ARGUMENT_VALUE,
+            Self::SetupIncomplete => VMNET_SETUP_INCOMPLETE_VALUE,
+            Self::InvalidAccess => VMNET_INVALID_ACCESS_VALUE,
+            Self::PacketTooBig => VMNET_PACKET_TOO_BIG_VALUE,
+            Self::BufferExhausted => VMNET_BUFFER_EXHAUSTED_VALUE,
+            Self::TooManyPackets => VMNET_TOO_MANY_PACKETS_VALUE,
+            Self::SharingServiceBusy => VMNET_SHARING_SERVICE_BUSY_VALUE,
+            Self::NotAuthorized => VMNET_NOT_AUTHORIZED_VALUE,
+            Self::Unknown(value) => value,
+        }
+    }
+
+    const fn name(self) -> Option<&'static str> {
+        match self {
+            Self::Success => Some("VMNET_SUCCESS"),
+            Self::Failure => Some("VMNET_FAILURE"),
+            Self::MemoryFailure => Some("VMNET_MEM_FAILURE"),
+            Self::InvalidArgument => Some("VMNET_INVALID_ARGUMENT"),
+            Self::SetupIncomplete => Some("VMNET_SETUP_INCOMPLETE"),
+            Self::InvalidAccess => Some("VMNET_INVALID_ACCESS"),
+            Self::PacketTooBig => Some("VMNET_PACKET_TOO_BIG"),
+            Self::BufferExhausted => Some("VMNET_BUFFER_EXHAUSTED"),
+            Self::TooManyPackets => Some("VMNET_TOO_MANY_PACKETS"),
+            Self::SharingServiceBusy => Some("VMNET_SHARING_SERVICE_BUSY"),
+            Self::NotAuthorized => Some("VMNET_NOT_AUTHORIZED"),
+            Self::Unknown(_) => None,
+        }
+    }
+}
+
+impl fmt::Display for VmnetStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.name() {
+            Some(name) => write!(f, "{name} (vmnet_return_t={})", self.raw_value()),
+            None => write!(f, "vmnet_return_t={}", self.raw_value()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VmnetOperation {
+    StartInterface,
+    StopInterface,
+    ReadPackets,
+    WritePackets,
+}
+
+impl fmt::Display for VmnetOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::StartInterface => "vmnet_start_interface",
+            Self::StopInterface => "vmnet_stop_interface",
+            Self::ReadPackets => "vmnet_read",
+            Self::WritePackets => "vmnet_write",
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VmnetError {
+    operation: VmnetOperation,
+    status: VmnetStatus,
+}
+
+impl VmnetError {
+    pub const fn new(operation: VmnetOperation, status: VmnetStatus) -> Self {
+        Self { operation, status }
+    }
+
+    pub const fn operation(&self) -> VmnetOperation {
+        self.operation
+    }
+
+    pub const fn status(&self) -> VmnetStatus {
+        self.status
+    }
+}
+
+impl fmt::Display for VmnetError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} failed with {}", self.operation, self.status)
+    }
+}
+
+impl std::error::Error for VmnetError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VmnetInterfaceConfig {
+    mode: VmnetMode,
+    bridged_interface_name: Option<String>,
+}
+
+impl VmnetInterfaceConfig {
+    pub const fn host() -> Self {
+        Self {
+            mode: VmnetMode::Host,
+            bridged_interface_name: None,
+        }
+    }
+
+    pub const fn shared() -> Self {
+        Self {
+            mode: VmnetMode::Shared,
+            bridged_interface_name: None,
+        }
+    }
+
+    pub fn bridged(interface_name: impl Into<String>) -> Result<Self, VmnetInterfaceConfigError> {
+        let interface_name = interface_name.into();
+        if interface_name.is_empty() {
+            return Err(VmnetInterfaceConfigError::EmptyBridgedInterfaceName);
+        }
+
+        Ok(Self {
+            mode: VmnetMode::Bridged,
+            bridged_interface_name: Some(interface_name),
+        })
+    }
+
+    pub const fn mode(&self) -> VmnetMode {
+        self.mode
+    }
+
+    pub fn bridged_interface_name(&self) -> Option<&str> {
+        self.bridged_interface_name.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VmnetInterfaceConfigError {
+    EmptyBridgedInterfaceName,
+}
+
+impl fmt::Display for VmnetInterfaceConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyBridgedInterfaceName => {
+                f.write_str("vmnet bridged interface name must not be empty")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VmnetInterfaceConfigError {}
+
+pub trait VmnetInterfaceLifecycle: fmt::Debug + Send + 'static {
+    type Interface: fmt::Debug + Send + 'static;
+
+    fn start_interface(
+        &mut self,
+        config: &VmnetInterfaceConfig,
+    ) -> Result<Self::Interface, VmnetError>;
+
+    fn stop_interface(&mut self, interface: &mut Self::Interface) -> Result<(), VmnetError>;
+}
+
+#[derive(Debug)]
+pub struct OwnedVmnetInterface<L>
+where
+    L: VmnetInterfaceLifecycle,
+{
+    lifecycle: L,
+    interface: Option<L::Interface>,
+}
+
+impl<L> OwnedVmnetInterface<L>
+where
+    L: VmnetInterfaceLifecycle,
+{
+    pub fn start(mut lifecycle: L, config: &VmnetInterfaceConfig) -> Result<Self, VmnetError> {
+        let interface = lifecycle.start_interface(config)?;
+
+        Ok(Self {
+            lifecycle,
+            interface: Some(interface),
+        })
+    }
+
+    pub const fn is_started(&self) -> bool {
+        self.interface.is_some()
+    }
+
+    pub fn stop(&mut self) -> Result<(), VmnetError> {
+        if let Some(interface) = self.interface.as_mut() {
+            self.lifecycle.stop_interface(interface)?;
+            self.interface = None;
+        }
+
+        Ok(())
+    }
+}
+
+impl<L> Drop for OwnedVmnetInterface<L>
+where
+    L: VmnetInterfaceLifecycle,
+{
+    fn drop(&mut self) {
+        match self.stop() {
+            Ok(()) | Err(_) => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::{
+        OwnedVmnetInterface, VMNET_BRIDGED_MODE_VALUE, VMNET_HOST_MODE_VALUE,
+        VMNET_SHARED_MODE_VALUE, VmnetError, VmnetInterfaceConfig, VmnetInterfaceConfigError,
+        VmnetInterfaceLifecycle, VmnetMode, VmnetOperation, VmnetStatus,
+    };
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct RecordedVmnetInterface {
+        id: u64,
+    }
+
+    #[derive(Debug, Clone)]
+    struct RecordingVmnetLifecycle {
+        events: Arc<Mutex<Vec<String>>>,
+        start_status: Option<VmnetStatus>,
+        stop_status: Option<VmnetStatus>,
+    }
+
+    impl RecordingVmnetLifecycle {
+        fn new() -> Self {
+            Self {
+                events: Arc::new(Mutex::new(Vec::new())),
+                start_status: None,
+                stop_status: None,
+            }
+        }
+
+        fn with_start_status(mut self, status: VmnetStatus) -> Self {
+            self.start_status = Some(status);
+            self
+        }
+
+        fn with_stop_status(mut self, status: VmnetStatus) -> Self {
+            self.stop_status = Some(status);
+            self
+        }
+
+        fn events(&self) -> Arc<Mutex<Vec<String>>> {
+            Arc::clone(&self.events)
+        }
+    }
+
+    impl VmnetInterfaceLifecycle for RecordingVmnetLifecycle {
+        type Interface = RecordedVmnetInterface;
+
+        fn start_interface(
+            &mut self,
+            config: &VmnetInterfaceConfig,
+        ) -> Result<Self::Interface, VmnetError> {
+            push_event(&self.events, format!("start:{}", config.mode()));
+            if let Some(status) = self.start_status {
+                return Err(VmnetError::new(VmnetOperation::StartInterface, status));
+            }
+
+            Ok(RecordedVmnetInterface { id: 7 })
+        }
+
+        fn stop_interface(&mut self, interface: &mut Self::Interface) -> Result<(), VmnetError> {
+            push_event(&self.events, format!("stop:{}", interface.id));
+            if let Some(status) = self.stop_status {
+                return Err(VmnetError::new(VmnetOperation::StopInterface, status));
+            }
+
+            Ok(())
+        }
+    }
+
+    fn push_event(events: &Arc<Mutex<Vec<String>>>, event: String) {
+        match events.lock() {
+            Ok(mut guard) => guard.push(event),
+            Err(poisoned) => poisoned.into_inner().push(event),
+        }
+    }
+
+    fn recorded_events(events: &Arc<Mutex<Vec<String>>>) -> Vec<String> {
+        match events.lock() {
+            Ok(guard) => guard.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }
+    }
+
+    #[test]
+    fn vmnet_modes_match_sdk_values() {
+        assert_eq!(VmnetMode::Host.raw_value(), VMNET_HOST_MODE_VALUE);
+        assert_eq!(VmnetMode::Shared.raw_value(), VMNET_SHARED_MODE_VALUE);
+        assert_eq!(VmnetMode::Bridged.raw_value(), VMNET_BRIDGED_MODE_VALUE);
+        assert_eq!(VmnetMode::Host.to_string(), "host");
+        assert_eq!(VmnetMode::Shared.to_string(), "shared");
+        assert_eq!(VmnetMode::Bridged.to_string(), "bridged");
+    }
+
+    #[test]
+    fn vmnet_status_maps_known_and_unknown_values() {
+        assert_eq!(VmnetStatus::from_raw(1000), VmnetStatus::Success);
+        assert_eq!(VmnetStatus::from_raw(1010), VmnetStatus::NotAuthorized);
+        assert_eq!(VmnetStatus::from_raw(9000), VmnetStatus::Unknown(9000));
+        assert_eq!(
+            VmnetStatus::NotAuthorized.to_string(),
+            "VMNET_NOT_AUTHORIZED (vmnet_return_t=1010)"
+        );
+        assert_eq!(
+            VmnetStatus::Unknown(9000).to_string(),
+            "vmnet_return_t=9000"
+        );
+    }
+
+    #[test]
+    fn vmnet_error_includes_operation_and_status() {
+        let error = VmnetError::new(VmnetOperation::ReadPackets, VmnetStatus::BufferExhausted);
+
+        assert_eq!(error.operation(), VmnetOperation::ReadPackets);
+        assert_eq!(error.status(), VmnetStatus::BufferExhausted);
+        assert_eq!(
+            error.to_string(),
+            "vmnet_read failed with VMNET_BUFFER_EXHAUSTED (vmnet_return_t=1007)"
+        );
+    }
+
+    #[test]
+    fn vmnet_interface_config_models_modes() {
+        let host = VmnetInterfaceConfig::host();
+        let shared = VmnetInterfaceConfig::shared();
+        let bridged = VmnetInterfaceConfig::bridged("en0").expect("bridged config should validate");
+
+        assert_eq!(host.mode(), VmnetMode::Host);
+        assert_eq!(host.bridged_interface_name(), None);
+        assert_eq!(shared.mode(), VmnetMode::Shared);
+        assert_eq!(shared.bridged_interface_name(), None);
+        assert_eq!(bridged.mode(), VmnetMode::Bridged);
+        assert_eq!(bridged.bridged_interface_name(), Some("en0"));
+    }
+
+    #[test]
+    fn bridged_config_rejects_empty_interface_name() {
+        let error = VmnetInterfaceConfig::bridged("")
+            .expect_err("empty bridged interface should be rejected");
+
+        assert_eq!(error, VmnetInterfaceConfigError::EmptyBridgedInterfaceName);
+        assert_eq!(
+            error.to_string(),
+            "vmnet bridged interface name must not be empty"
+        );
+    }
+
+    #[test]
+    fn owned_interface_starts_and_stops_once() {
+        let lifecycle = RecordingVmnetLifecycle::new();
+        let event_log = lifecycle.events();
+        let config = VmnetInterfaceConfig::host();
+        let mut interface = OwnedVmnetInterface::start(lifecycle, &config)
+            .expect("owned vmnet interface should start");
+
+        assert!(interface.is_started());
+        interface.stop().expect("owned vmnet interface should stop");
+        assert!(!interface.is_started());
+        interface.stop().expect("second stop should be a no-op");
+
+        assert_eq!(recorded_events(&event_log), ["start:host", "stop:7"]);
+    }
+
+    #[test]
+    fn owned_interface_drop_stops_started_interface() {
+        let lifecycle = RecordingVmnetLifecycle::new();
+        let event_log = lifecycle.events();
+        let config = VmnetInterfaceConfig::shared();
+
+        {
+            let _interface = OwnedVmnetInterface::start(lifecycle, &config)
+                .expect("owned vmnet interface should start");
+        }
+
+        assert_eq!(recorded_events(&event_log), ["start:shared", "stop:7"]);
+    }
+
+    #[test]
+    fn owned_interface_start_failure_does_not_create_owner() {
+        let lifecycle =
+            RecordingVmnetLifecycle::new().with_start_status(VmnetStatus::InvalidAccess);
+        let event_log = lifecycle.events();
+        let config = VmnetInterfaceConfig::host();
+        let error = OwnedVmnetInterface::start(lifecycle, &config)
+            .expect_err("start failure should return an error");
+
+        assert_eq!(error.operation(), VmnetOperation::StartInterface);
+        assert_eq!(error.status(), VmnetStatus::InvalidAccess);
+        assert_eq!(recorded_events(&event_log), ["start:host"]);
+    }
+
+    #[test]
+    fn failed_stop_keeps_interface_started_for_retry() {
+        let lifecycle =
+            RecordingVmnetLifecycle::new().with_stop_status(VmnetStatus::SetupIncomplete);
+        let event_log = lifecycle.events();
+        let config = VmnetInterfaceConfig::host();
+        let mut interface = OwnedVmnetInterface::start(lifecycle, &config)
+            .expect("owned vmnet interface should start");
+        let error = interface
+            .stop()
+            .expect_err("failed stop should return an error");
+
+        assert_eq!(error.operation(), VmnetOperation::StopInterface);
+        assert_eq!(error.status(), VmnetStatus::SetupIncomplete);
+        assert!(interface.is_started());
+        assert_eq!(recorded_events(&event_log), ["start:host", "stop:7"]);
+    }
+
+    #[test]
+    fn vmnet_write_operation_displays_name() {
+        let error = VmnetError::new(VmnetOperation::WritePackets, VmnetStatus::PacketTooBig);
+
+        assert_eq!(
+            error.to_string(),
+            "vmnet_write failed with VMNET_PACKET_TOO_BIG (vmnet_return_t=1006)"
+        );
+    }
+}

--- a/crates/bangbang/src/host_network/vmnet.rs
+++ b/crates/bangbang/src/host_network/vmnet.rs
@@ -1,3 +1,5 @@
+//! vmnet lifecycle boundary types for future macOS host networking.
+
 use std::fmt;
 
 pub const VMNET_HOST_MODE_VALUE: u32 = 1000;

--- a/crates/bangbang/src/host_network/vmnet.rs
+++ b/crates/bangbang/src/host_network/vmnet.rs
@@ -498,6 +498,26 @@ mod tests {
     }
 
     #[test]
+    fn drop_retries_cleanup_after_failed_explicit_stop() {
+        let lifecycle =
+            RecordingVmnetLifecycle::new().with_stop_status(VmnetStatus::SetupIncomplete);
+        let event_log = lifecycle.events();
+        let config = VmnetInterfaceConfig::host();
+
+        {
+            let mut interface = OwnedVmnetInterface::start(lifecycle, &config)
+                .expect("owned vmnet interface should start");
+
+            let _ = interface.stop();
+        }
+
+        assert_eq!(
+            recorded_events(&event_log),
+            ["start:host", "stop:7", "stop:7"]
+        );
+    }
+
+    #[test]
     fn vmnet_write_operation_displays_name() {
         let error = VmnetError::new(VmnetOperation::WritePackets, VmnetStatus::PacketTooBig);
 

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -6,6 +6,7 @@ use std::os::unix::net::UnixStream;
 use std::process::ExitCode;
 
 mod api_server;
+#[doc(hidden)]
 pub mod host_network;
 mod vmm;
 

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -6,6 +6,7 @@ use std::os::unix::net::UnixStream;
 use std::process::ExitCode;
 
 mod api_server;
+pub mod host_network;
 mod vmm;
 
 use api_server::{ApiServer, ApiServerError};

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -7,6 +7,7 @@ use std::process::ExitCode;
 
 mod api_server;
 #[doc(hidden)]
+#[cfg(target_os = "macos")]
 pub mod host_network;
 mod vmm;
 

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -8,7 +8,7 @@ The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /`, `GET /version`,
 `GET /vm/config`, `GET /machine-config`, pre-boot `PUT /machine-config`
 configuration storage, pre-boot `PUT /boot-source` configuration storage, pre-boot `PUT /drives/{drive_id}`
-configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, an internal vmnet lifecycle boundary model for future macOS host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
+configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet lifecycle boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
 `InstanceStart` preflight, transactional startup executor, and successful-start state transition helpers, backend-neutral guest
 physical address and aarch64 DRAM layout/access primitives, arm64 boot
 placement helpers, internal boot-source validation and arm64 kernel/initrd
@@ -550,9 +550,9 @@ internal packet source, copies a zeroed 12-byte virtio-net header plus packet
 payload into validated guest-writable RX buffers, publishes used-ring
 completions with the written length, preserves malformed-buffer and
 partial-dispatch metadata, and marks queue interrupt status when RX buffers
-complete. The process crate also defines an internal vmnet lifecycle boundary
-with vmnet mode, status, operation error, configuration, and owned cleanup
-models for a later macOS host backend. This boundary is not connected to the
+complete. On macOS, the process crate also defines an internal vmnet lifecycle
+boundary with vmnet mode, status, operation error, configuration, and owned
+cleanup models for a later host backend. This boundary is not connected to the
 default process provider. The default process provider uses a no-op TX sink and
 an empty RX source, so current boot sessions still do not open host networking
 resources or provide user-visible packet ingress or egress. These helpers do not

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -8,7 +8,7 @@ The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /`, `GET /version`,
 `GET /vm/config`, `GET /machine-config`, pre-boot `PUT /machine-config`
 configuration storage, pre-boot `PUT /boot-source` configuration storage, pre-boot `PUT /drives/{drive_id}`
-configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a backend-neutral VM trait, a minimal VMM action/data model with internal
+configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, an internal vmnet lifecycle boundary model for future macOS host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
 `InstanceStart` preflight, transactional startup executor, and successful-start state transition helpers, backend-neutral guest
 physical address and aarch64 DRAM layout/access primitives, arm64 boot
 placement helpers, internal boot-source validation and arm64 kernel/initrd
@@ -550,10 +550,14 @@ internal packet source, copies a zeroed 12-byte virtio-net header plus packet
 payload into validated guest-writable RX buffers, publishes used-ring
 completions with the written length, preserves malformed-buffer and
 partial-dispatch metadata, and marks queue interrupt status when RX buffers
-complete. The default process provider uses a no-op TX sink and an empty RX
-source, so current boot sessions still do not open host networking resources or
-provide user-visible packet ingress or egress. These helpers do not advertise
-MTU, choose a host packet backend, or connect packets to the host network.
+complete. The process crate also defines an internal vmnet lifecycle boundary
+with vmnet mode, status, operation error, configuration, and owned cleanup
+models for a later macOS host backend. This boundary is not connected to the
+default process provider. The default process provider uses a no-op TX sink and
+an empty RX source, so current boot sessions still do not open host networking
+resources or provide user-visible packet ingress or egress. These helpers do not
+advertise MTU, create a vmnet interface, choose a live host packet backend, or
+connect packets to the host network.
 
 The runtime crate can prepare owned internal block-device resources from a
 validated list of stored drive configs. Preparation opens each backing file,

--- a/docs/security.md
+++ b/docs/security.md
@@ -152,9 +152,10 @@ The current scaffold does not implement:
   virtio-net notification dispatch can parse guest TX descriptor metadata and
   pass validated TX frame payloads to injected packet I/O selected per configured
   interface, and can copy injected RX packet bytes into validated guest RX
-  buffers through the same boundary. The process-owned HVF boot loop can use
-  that injected boundary, but the default provider is a no-op TX sink plus an
-  empty RX source and bangbang still does not open host networking resources
+  buffers through the same boundary. The process crate has an internal vmnet
+  lifecycle boundary for future macOS host networking, but it is not connected to
+  process startup. The default provider is a no-op TX sink plus an empty RX
+  source and bangbang still does not open host networking resources
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -152,9 +152,9 @@ The current scaffold does not implement:
   virtio-net notification dispatch can parse guest TX descriptor metadata and
   pass validated TX frame payloads to injected packet I/O selected per configured
   interface, and can copy injected RX packet bytes into validated guest RX
-  buffers through the same boundary. The process crate has an internal vmnet
-  lifecycle boundary for future macOS host networking, but it is not connected to
-  process startup. The default provider is a no-op TX sink plus an empty RX
+  buffers through the same boundary. On macOS, the process crate has an internal
+  vmnet lifecycle boundary for future host networking, but it is not connected
+  to process startup. The default provider is a no-op TX sink plus an empty RX
   source and bangbang still does not open host networking resources
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy


### PR DESCRIPTION
Closes #295

## Summary
- Add a `host_network::vmnet` boundary for vmnet modes, return statuses, operation errors, interface config, and owned lifecycle cleanup.
- Cover lifecycle ownership with fake-backed unit tests, including start failure, explicit stop, drop cleanup, and retryable stop failure.
- Document that this is an internal backend boundary only and does not enable host networking or open vmnet resources.

## Out Of Scope
- No `vmnet.framework` FFI calls, Objective-C block/dispatch/xpc integration, or vmnet entitlement work.
- No packet read/write connection to virtio-net TX/RX queues.
- No default `InstanceStart` behavior change and no public network API shape change.

## Verification
- cargo fmt --all -- --check
- cargo check --workspace --all-targets --all-features --locked
- cargo test -p bangbang --all-features --locked host_network::vmnet -- --nocapture
- cargo clippy -p bangbang --all-targets --all-features --locked -- -D warnings
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- git diff --check
- git diff --cached --check
