### PR TITLE
feat: add vmnet xpc descriptor boundary

### DIFF
--- a/crates/bangbang/src/host_network/vmnet.rs
+++ b/crates/bangbang/src/host_network/vmnet.rs
@@ -1,6 +1,8 @@
 //! vmnet lifecycle boundary types for future macOS host networking.
 
+use std::ffi::{CString, c_char, c_void};
 use std::fmt;
+use std::ptr::{self, NonNull};
 
 pub const VMNET_HOST_MODE_VALUE: u32 = 1000;
 pub const VMNET_SHARED_MODE_VALUE: u32 = 1001;
@@ -196,6 +198,9 @@ impl VmnetInterfaceConfig {
         if interface_name.is_empty() {
             return Err(VmnetInterfaceConfigError::EmptyBridgedInterfaceName);
         }
+        if interface_name.as_bytes().contains(&0) {
+            return Err(VmnetInterfaceConfigError::InteriorNulInBridgedInterfaceName);
+        }
 
         Ok(Self {
             mode: VmnetMode::Bridged,
@@ -215,6 +220,7 @@ impl VmnetInterfaceConfig {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VmnetInterfaceConfigError {
     EmptyBridgedInterfaceName,
+    InteriorNulInBridgedInterfaceName,
 }
 
 impl fmt::Display for VmnetInterfaceConfigError {
@@ -223,11 +229,172 @@ impl fmt::Display for VmnetInterfaceConfigError {
             Self::EmptyBridgedInterfaceName => {
                 f.write_str("vmnet bridged interface name must not be empty")
             }
+            Self::InteriorNulInBridgedInterfaceName => {
+                f.write_str("vmnet bridged interface name must not contain NUL bytes")
+            }
         }
     }
 }
 
 impl std::error::Error for VmnetInterfaceConfigError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VmnetInterfaceDescriptorError {
+    CreateDictionaryFailed,
+    InteriorNulInBridgedInterfaceName,
+    MissingVmnetKey(&'static str),
+}
+
+impl fmt::Display for VmnetInterfaceDescriptorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CreateDictionaryFailed => {
+                f.write_str("failed to create vmnet interface descriptor")
+            }
+            Self::InteriorNulInBridgedInterfaceName => {
+                f.write_str("vmnet bridged interface name must not contain NUL bytes")
+            }
+            Self::MissingVmnetKey(key) => write!(f, "vmnet key symbol {key} is null"),
+        }
+    }
+}
+
+impl std::error::Error for VmnetInterfaceDescriptorError {}
+
+#[derive(Debug)]
+pub struct VmnetInterfaceDescriptor {
+    dictionary: OwnedXpcObject,
+}
+
+impl VmnetInterfaceDescriptor {
+    pub fn new(config: &VmnetInterfaceConfig) -> Result<Self, VmnetInterfaceDescriptorError> {
+        let dictionary = OwnedXpcObject::dictionary()
+            .ok_or(VmnetInterfaceDescriptorError::CreateDictionaryFailed)?;
+        let operation_mode_key = vmnet_operation_mode_key()?;
+
+        // SAFETY: `dictionary` owns a live XPC dictionary, `operation_mode_key`
+        // is a non-null vmnet SDK key, and primitive uint64 insertion does not
+        // borrow data after the call returns.
+        unsafe {
+            xpc::xpc_dictionary_set_uint64(
+                dictionary.as_ptr(),
+                operation_mode_key,
+                u64::from(config.mode().raw_value()),
+            );
+        }
+
+        if let Some(interface_name) = config.bridged_interface_name() {
+            let interface_name = CString::new(interface_name)
+                .map_err(|_| VmnetInterfaceDescriptorError::InteriorNulInBridgedInterfaceName)?;
+            let shared_interface_name_key = vmnet_shared_interface_name_key()?;
+
+            // SAFETY: `dictionary` owns a live XPC dictionary,
+            // `shared_interface_name_key` is a non-null vmnet SDK key, and the
+            // bridged interface name is a valid C string for the duration of the call.
+            unsafe {
+                xpc::xpc_dictionary_set_string(
+                    dictionary.as_ptr(),
+                    shared_interface_name_key,
+                    interface_name.as_ptr(),
+                );
+            }
+        }
+
+        Ok(Self { dictionary })
+    }
+
+    pub fn as_raw_xpc_object(&self) -> *mut c_void {
+        self.dictionary.as_ptr()
+    }
+}
+
+#[derive(Debug)]
+struct OwnedXpcObject {
+    object: NonNull<c_void>,
+}
+
+impl OwnedXpcObject {
+    fn dictionary() -> Option<Self> {
+        // SAFETY: `xpc_dictionary_create` permits null key and value arrays
+        // when `count` is zero, creating an empty retained dictionary object.
+        let object = unsafe { xpc::xpc_dictionary_create(ptr::null(), ptr::null(), 0) };
+
+        NonNull::new(object).map(|object| Self { object })
+    }
+
+    fn as_ptr(&self) -> xpc::XpcObject {
+        self.object.as_ptr()
+    }
+}
+
+impl Drop for OwnedXpcObject {
+    fn drop(&mut self) {
+        // SAFETY: `object` came from an XPC create function and this owner is
+        // non-clone, so this is the single matching release.
+        unsafe {
+            xpc::xpc_release(self.object.as_ptr());
+        }
+    }
+}
+
+fn vmnet_operation_mode_key() -> Result<*const c_char, VmnetInterfaceDescriptorError> {
+    // SAFETY: The symbol is provided by vmnet.framework when this macOS-gated
+    // module is linked. The null check below prevents passing a null key to XPC.
+    let key = unsafe { xpc::VMNET_OPERATION_MODE_KEY };
+    if key.is_null() {
+        Err(VmnetInterfaceDescriptorError::MissingVmnetKey(
+            "vmnet_operation_mode_key",
+        ))
+    } else {
+        Ok(key)
+    }
+}
+
+fn vmnet_shared_interface_name_key() -> Result<*const c_char, VmnetInterfaceDescriptorError> {
+    // SAFETY: The symbol is provided by vmnet.framework when this macOS-gated
+    // module is linked. The null check below prevents passing a null key to XPC.
+    let key = unsafe { xpc::VMNET_SHARED_INTERFACE_NAME_KEY };
+    if key.is_null() {
+        Err(VmnetInterfaceDescriptorError::MissingVmnetKey(
+            "vmnet_shared_interface_name_key",
+        ))
+    } else {
+        Ok(key)
+    }
+}
+
+mod xpc {
+    use std::ffi::{c_char, c_void};
+
+    pub type XpcObject = *mut c_void;
+
+    unsafe extern "C" {
+        pub fn xpc_dictionary_create(
+            keys: *const *const c_char,
+            values: *const XpcObject,
+            count: usize,
+        ) -> XpcObject;
+        pub fn xpc_dictionary_set_uint64(xdict: XpcObject, key: *const c_char, value: u64);
+        pub fn xpc_dictionary_set_string(
+            xdict: XpcObject,
+            key: *const c_char,
+            string: *const c_char,
+        );
+        #[cfg(test)]
+        pub fn xpc_dictionary_get_uint64(xdict: XpcObject, key: *const c_char) -> u64;
+        #[cfg(test)]
+        pub fn xpc_dictionary_get_string(xdict: XpcObject, key: *const c_char) -> *const c_char;
+        pub fn xpc_release(object: XpcObject);
+    }
+
+    #[link(name = "vmnet", kind = "framework")]
+    unsafe extern "C" {
+        #[link_name = "vmnet_operation_mode_key"]
+        pub static VMNET_OPERATION_MODE_KEY: *const c_char;
+        #[link_name = "vmnet_shared_interface_name_key"]
+        pub static VMNET_SHARED_INTERFACE_NAME_KEY: *const c_char;
+    }
+}
 
 pub trait VmnetInterfaceLifecycle: fmt::Debug + Send + 'static {
     type Interface: fmt::Debug + Send + 'static;
@@ -289,12 +456,13 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::CStr;
     use std::sync::{Arc, Mutex};
 
     use super::{
         OwnedVmnetInterface, VMNET_BRIDGED_MODE_VALUE, VMNET_HOST_MODE_VALUE,
         VMNET_SHARED_MODE_VALUE, VmnetError, VmnetInterfaceConfig, VmnetInterfaceConfigError,
-        VmnetInterfaceLifecycle, VmnetMode, VmnetOperation, VmnetStatus,
+        VmnetInterfaceDescriptor, VmnetInterfaceLifecycle, VmnetMode, VmnetOperation, VmnetStatus,
     };
 
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -372,6 +540,37 @@ mod tests {
         }
     }
 
+    fn descriptor_mode(descriptor: &VmnetInterfaceDescriptor) -> u64 {
+        let key = super::vmnet_operation_mode_key().expect("vmnet mode key should be available");
+
+        // SAFETY: The descriptor owns a live XPC dictionary, and the key comes
+        // from the vmnet SDK symbol wrapper.
+        unsafe { super::xpc::xpc_dictionary_get_uint64(descriptor.dictionary.as_ptr(), key) }
+    }
+
+    fn descriptor_bridged_interface_name(descriptor: &VmnetInterfaceDescriptor) -> Option<String> {
+        let key = super::vmnet_shared_interface_name_key()
+            .expect("vmnet shared interface name key should be available");
+
+        // SAFETY: The descriptor owns a live XPC dictionary, and the key comes
+        // from the vmnet SDK symbol wrapper. XPC owns the returned C string.
+        let value =
+            unsafe { super::xpc::xpc_dictionary_get_string(descriptor.dictionary.as_ptr(), key) };
+
+        if value.is_null() {
+            None
+        } else {
+            // SAFETY: XPC returns either null or a valid null-terminated C string
+            // for the lifetime of the dictionary.
+            Some(
+                unsafe { CStr::from_ptr(value) }
+                    .to_str()
+                    .expect("bridged interface name should be valid UTF-8")
+                    .to_string(),
+            )
+        }
+    }
+
     #[test]
     fn vmnet_modes_match_sdk_values() {
         assert_eq!(VmnetMode::Host.raw_value(), VMNET_HOST_MODE_VALUE);
@@ -432,6 +631,63 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "vmnet bridged interface name must not be empty"
+        );
+    }
+
+    #[test]
+    fn bridged_config_rejects_interior_nul_interface_name() {
+        let error = VmnetInterfaceConfig::bridged("en\0")
+            .expect_err("interior NUL bridged interface should be rejected");
+
+        assert_eq!(
+            error,
+            VmnetInterfaceConfigError::InteriorNulInBridgedInterfaceName
+        );
+        assert_eq!(
+            error.to_string(),
+            "vmnet bridged interface name must not contain NUL bytes"
+        );
+    }
+
+    #[test]
+    fn vmnet_interface_descriptor_models_host_mode() {
+        let config = VmnetInterfaceConfig::host();
+        let descriptor =
+            VmnetInterfaceDescriptor::new(&config).expect("host descriptor should be created");
+
+        assert_eq!(
+            descriptor_mode(&descriptor),
+            u64::from(VMNET_HOST_MODE_VALUE)
+        );
+        assert_eq!(descriptor_bridged_interface_name(&descriptor), None);
+    }
+
+    #[test]
+    fn vmnet_interface_descriptor_models_shared_mode() {
+        let config = VmnetInterfaceConfig::shared();
+        let descriptor =
+            VmnetInterfaceDescriptor::new(&config).expect("shared descriptor should be created");
+
+        assert_eq!(
+            descriptor_mode(&descriptor),
+            u64::from(VMNET_SHARED_MODE_VALUE)
+        );
+        assert_eq!(descriptor_bridged_interface_name(&descriptor), None);
+    }
+
+    #[test]
+    fn vmnet_interface_descriptor_models_bridged_mode() {
+        let config = VmnetInterfaceConfig::bridged("en0").expect("bridged config should validate");
+        let descriptor =
+            VmnetInterfaceDescriptor::new(&config).expect("bridged descriptor should be created");
+
+        assert_eq!(
+            descriptor_mode(&descriptor),
+            u64::from(VMNET_BRIDGED_MODE_VALUE)
+        );
+        assert_eq!(
+            descriptor_bridged_interface_name(&descriptor),
+            Some("en0".to_string())
         );
     }
 

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -8,7 +8,7 @@ The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /`, `GET /version`,
 `GET /vm/config`, `GET /machine-config`, pre-boot `PUT /machine-config`
 configuration storage, pre-boot `PUT /boot-source` configuration storage, pre-boot `PUT /drives/{drive_id}`
-configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet lifecycle boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
+configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor and lifecycle boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
 `InstanceStart` preflight, transactional startup executor, and successful-start state transition helpers, backend-neutral guest
 physical address and aarch64 DRAM layout/access primitives, arm64 boot
 placement helpers, internal boot-source validation and arm64 kernel/initrd
@@ -550,14 +550,14 @@ internal packet source, copies a zeroed 12-byte virtio-net header plus packet
 payload into validated guest-writable RX buffers, publishes used-ring
 completions with the written length, preserves malformed-buffer and
 partial-dispatch metadata, and marks queue interrupt status when RX buffers
-complete. On macOS, the process crate also defines an internal vmnet lifecycle
-boundary with vmnet mode, status, operation error, configuration, and owned
-cleanup models for a later host backend. This boundary is not connected to the
-default process provider. The default process provider uses a no-op TX sink and
-an empty RX source, so current boot sessions still do not open host networking
-resources or provide user-visible packet ingress or egress. These helpers do not
-advertise MTU, create a vmnet interface, choose a live host packet backend, or
-connect packets to the host network.
+complete. On macOS, the process crate also defines an internal vmnet descriptor
+and lifecycle boundary with vmnet mode, status, operation error, XPC descriptor
+configuration, and owned cleanup models for a later host backend. This boundary
+is not connected to the default process provider. The default process provider
+uses a no-op TX sink and an empty RX source, so current boot sessions still do
+not open host networking resources or provide user-visible packet ingress or
+egress. These helpers do not advertise MTU, start a vmnet interface, choose a
+live host packet backend, or connect packets to the host network.
 
 The runtime crate can prepare owned internal block-device resources from a
 validated list of stored drive configs. Preparation opens each backing file,

--- a/docs/security.md
+++ b/docs/security.md
@@ -153,9 +153,9 @@ The current scaffold does not implement:
   pass validated TX frame payloads to injected packet I/O selected per configured
   interface, and can copy injected RX packet bytes into validated guest RX
   buffers through the same boundary. On macOS, the process crate has an internal
-  vmnet lifecycle boundary for future host networking, but it is not connected
-  to process startup. The default provider is a no-op TX sink plus an empty RX
-  source and bangbang still does not open host networking resources
+  vmnet descriptor and lifecycle boundary for future host networking, but it is
+  not connected to process startup. The default provider is a no-op TX sink plus
+  an empty RX source and bangbang still does not open host networking resources
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy
 


### PR DESCRIPTION
Closes #297

## Summary
- Add an owned `VmnetInterfaceDescriptor` that builds a vmnet `interface_desc` XPC dictionary from `VmnetInterfaceConfig`.
- Bind only the minimum macOS XPC APIs and vmnet key symbols needed for descriptor construction and test readback.
- Reject interior-NUL bridged interface names before XPC string conversion.
- Document that bangbang now has a vmnet descriptor/lifecycle boundary only, with no vmnet start, packet movement, or default networking behavior change.

## Out Of Scope
- No `vmnet_start_interface` or `vmnet_stop_interface` calls.
- No Objective-C block, dispatch queue, entitlement, or signing changes.
- No connection between vmnet read/write and virtio-net TX/RX queues.
- No public Firecracker network API shape change.

## Verification
- cargo fmt --all -- --check
- cargo check --workspace --all-targets --all-features --locked
- cargo test -p bangbang --all-features --locked host_network::vmnet -- --nocapture
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- git diff --check
- git diff --cached --check

Signed integration tests were not run because this PR does not create HVF or vmnet host resources.
