### PR TITLE
feat: add vsock configuration boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ curl --unix-socket /tmp/bangbang.socket \
   -d '{"iface_id":"eth0","host_dev_name":"tap0","guest_mac":"12:34:56:78:9a:bc"}'
 ```
 
+Record a pre-boot vsock configuration:
+
+```sh
+curl --unix-socket /tmp/bangbang.socket \
+  -X PUT http://localhost/vsock \
+  -H 'Content-Type: application/json' \
+  -d '{"guest_cid":3,"uds_path":"./v.sock"}'
+```
+
 Submit an `InstanceStart` action:
 
 ```sh

--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -26,6 +26,7 @@ pub enum ApiRequest {
     PutMachineConfig(Box<MachineConfigRequest>),
     PutMetrics(Box<MetricsConfigRequest>),
     PutNetworkInterface(Box<NetworkInterfaceConfigRequest>),
+    PutVsock(Box<VsockConfigRequest>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -372,6 +373,27 @@ impl NetworkInterfaceConfigRequest {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VsockConfigRequest {
+    vsock_id: Option<String>,
+    guest_cid: u32,
+    uds_path: String,
+}
+
+impl VsockConfigRequest {
+    pub fn vsock_id(&self) -> Option<&str> {
+        self.vsock_id.as_deref()
+    }
+
+    pub const fn guest_cid(&self) -> u32 {
+        self.guest_cid
+    }
+
+    pub fn uds_path(&self) -> &str {
+        &self.uds_path
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 pub enum DriveCacheType {
     Unsafe,
@@ -503,6 +525,7 @@ pub struct VmConfigResponse {
     boot_source: Option<BootSourceResponse>,
     drives: Vec<DriveConfigResponse>,
     network_interfaces: Vec<NetworkInterfaceConfigResponse>,
+    vsock: Option<VsockConfigResponse>,
 }
 
 impl VmConfigResponse {
@@ -511,12 +534,29 @@ impl VmConfigResponse {
         boot_source: Option<BootSourceResponse>,
         drives: Vec<DriveConfigResponse>,
         network_interfaces: Vec<NetworkInterfaceConfigResponse>,
+        vsock: Option<VsockConfigResponse>,
     ) -> Self {
         Self {
             machine_config,
             boot_source,
             drives,
             network_interfaces,
+            vsock,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VsockConfigResponse {
+    guest_cid: u32,
+    uds_path: String,
+}
+
+impl VsockConfigResponse {
+    pub fn new(guest_cid: u32, uds_path: impl Into<String>) -> Self {
+        Self {
+            guest_cid,
+            uds_path: uds_path.into(),
         }
     }
 }
@@ -554,6 +594,15 @@ struct NetworkInterfaceConfigRequestBody {
     rx_rate_limiter: Option<serde_json::Value>,
     #[serde(default)]
     tx_rate_limiter: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VsockConfigRequestBody {
+    #[serde(default)]
+    vsock_id: Option<String>,
+    guest_cid: u32,
+    uds_path: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -666,6 +715,9 @@ impl HttpResponse {
                     .collect(),
             ),
         );
+        if let Some(vsock) = &config.vsock {
+            body.insert("vsock".to_string(), vsock_config_response_value(vsock));
+        }
 
         Self {
             status: StatusCode::Ok,
@@ -806,6 +858,19 @@ fn network_interface_config_response_value(
     serde_json::Value::Object(body)
 }
 
+fn vsock_config_response_value(vsock: &VsockConfigResponse) -> serde_json::Value {
+    let mut body = serde_json::Map::new();
+    body.insert(
+        "guest_cid".to_string(),
+        serde_json::Value::Number(serde_json::Number::from(vsock.guest_cid)),
+    );
+    body.insert(
+        "uds_path".to_string(),
+        serde_json::Value::String(vsock.uds_path.clone()),
+    );
+    serde_json::Value::Object(body)
+}
+
 pub fn parse_request(bytes: &[u8]) -> Result<ApiRequest, RequestError> {
     if bytes.len() > HTTP_MAX_PAYLOAD_SIZE {
         return Err(RequestError::PayloadTooLarge);
@@ -854,6 +919,9 @@ pub fn parse_request(bytes: &[u8]) -> Result<ApiRequest, RequestError> {
     }
     if method == "PUT" && path == "/metrics" {
         return parse_metrics_config_request(body);
+    }
+    if method == "PUT" && path == "/vsock" {
+        return parse_vsock_config_request(body);
     }
 
     match (method, path) {
@@ -1024,6 +1092,17 @@ fn parse_metrics_config_request(body: &[u8]) -> Result<ApiRequest, RequestError>
 
     Ok(ApiRequest::PutMetrics(Box::new(MetricsConfigRequest {
         metrics_path: body.metrics_path,
+    })))
+}
+
+fn parse_vsock_config_request(body: &[u8]) -> Result<ApiRequest, RequestError> {
+    let body = serde_json::from_slice::<VsockConfigRequestBody>(body)
+        .map_err(|_| RequestError::MalformedRequest)?;
+
+    Ok(ApiRequest::PutVsock(Box::new(VsockConfigRequest {
+        vsock_id: body.vsock_id,
+        guest_cid: body.guest_cid,
+        uds_path: body.uds_path,
     })))
 }
 
@@ -1255,6 +1334,7 @@ impl From<ApiRequest> for Endpoint {
             ApiRequest::PutMachineConfig(_) => Self::MachineConfig,
             ApiRequest::PutMetrics(_) => Self::Metrics,
             ApiRequest::PutNetworkInterface(_) => Self::NetworkInterface,
+            ApiRequest::PutVsock(_) => Self::Vsock,
         }
     }
 }
@@ -1907,6 +1987,127 @@ mod tests {
         );
         assert_eq!(
             parse_request(&request_with_body("PUT", "/metrics/extra", "{}")),
+            Err(RequestError::InvalidPathMethod)
+        );
+    }
+
+    #[test]
+    fn parses_put_vsock_with_minimal_body() {
+        let body = r#"{
+            "guest_cid": 3,
+            "uds_path": "./v.sock"
+        }"#;
+        let request = request_with_body("PUT", "/vsock", body);
+
+        let parsed = parse_request(&request).expect("vsock request should parse");
+
+        let ApiRequest::PutVsock(config) = parsed else {
+            panic!("expected vsock request");
+        };
+        assert_eq!(config.vsock_id(), None);
+        assert_eq!(config.guest_cid(), 3);
+        assert_eq!(config.uds_path(), "./v.sock");
+        assert_eq!(request_total_len(&request), Ok(Some(request.len())));
+    }
+
+    #[test]
+    fn parses_put_vsock_with_deprecated_vsock_id() {
+        let body = r#"{
+            "vsock_id": "vsock0",
+            "guest_cid": 42,
+            "uds_path": "/tmp/v.sock"
+        }"#;
+        let request = request_with_body("PUT", "/vsock", body);
+
+        let parsed = parse_request(&request).expect("vsock request should parse");
+
+        let ApiRequest::PutVsock(config) = parsed else {
+            panic!("expected vsock request");
+        };
+        assert_eq!(config.vsock_id(), Some("vsock0"));
+        assert_eq!(config.guest_cid(), 42);
+        assert_eq!(config.uds_path(), "/tmp/v.sock");
+    }
+
+    #[test]
+    fn parses_put_vsock_with_null_vsock_id() {
+        let body = r#"{
+            "vsock_id": null,
+            "guest_cid": 3,
+            "uds_path": "./v.sock"
+        }"#;
+        let request = request_with_body("PUT", "/vsock", body);
+
+        let parsed = parse_request(&request).expect("vsock request should parse");
+
+        let ApiRequest::PutVsock(config) = parsed else {
+            panic!("expected vsock request");
+        };
+        assert_eq!(config.vsock_id(), None);
+    }
+
+    #[test]
+    fn rejects_put_vsock_missing_required_fields() {
+        assert_eq!(
+            parse_request(&request_with_body(
+                "PUT",
+                "/vsock",
+                r#"{"uds_path":"./v.sock"}"#,
+            )),
+            Err(RequestError::MalformedRequest)
+        );
+        assert_eq!(
+            parse_request(&request_with_body("PUT", "/vsock", r#"{"guest_cid":3}"#)),
+            Err(RequestError::MalformedRequest)
+        );
+    }
+
+    #[test]
+    fn rejects_put_vsock_unknown_field() {
+        let body = r#"{
+            "guest_cid": 3,
+            "uds_path": "./v.sock",
+            "unknown": true
+        }"#;
+        let request = request_with_body("PUT", "/vsock", body);
+
+        assert_eq!(parse_request(&request), Err(RequestError::MalformedRequest));
+    }
+
+    #[test]
+    fn rejects_put_vsock_invalid_field_type() {
+        for body in [
+            r#"{"guest_cid":"3","uds_path":"./v.sock"}"#,
+            r#"{"guest_cid":3,"uds_path":null}"#,
+            r#"{"guest_cid":3,"uds_path":["./v.sock"]}"#,
+            r#"{"vsock_id":1,"guest_cid":3,"uds_path":"./v.sock"}"#,
+        ] {
+            assert_eq!(
+                parse_request(&request_with_body("PUT", "/vsock", body)),
+                Err(RequestError::MalformedRequest)
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_put_vsock_empty_body() {
+        let request = request_with_body("PUT", "/vsock", "");
+
+        assert_eq!(parse_request(&request), Err(RequestError::MalformedRequest));
+    }
+
+    #[test]
+    fn rejects_unsupported_vsock_method_or_path() {
+        assert_eq!(
+            parse_request(b"GET /vsock HTTP/1.1\r\nHost: localhost\r\n\r\n"),
+            Err(RequestError::InvalidPathMethod)
+        );
+        assert_eq!(
+            parse_request(&request_with_body(
+                "PUT",
+                "/vsock/extra",
+                r#"{"guest_cid":3,"uds_path":"./v.sock"}"#,
+            )),
             Err(RequestError::InvalidPathMethod)
         );
     }
@@ -2601,6 +2802,7 @@ mod tests {
             None,
             Vec::new(),
             Vec::new(),
+            None,
         ));
         let body: serde_json::Value =
             serde_json::from_str(response.body()).expect("body should be JSON");
@@ -2622,6 +2824,7 @@ mod tests {
         );
         assert_eq!(body.get("boot-source"), None);
         assert_eq!(body.get("logger"), None);
+        assert_eq!(body.get("vsock"), None);
     }
 
     #[test]
@@ -2634,11 +2837,13 @@ mod tests {
                 .with_partuuid("0eaa91a0-01");
         let network_interface =
             NetworkInterfaceConfigResponse::new("eth0", "tap0").with_guest_mac("12:34:56:78:9a:bc");
+        let vsock = VsockConfigResponse::new(3, "./v.sock");
         let response = HttpResponse::vm_config(&VmConfigResponse::new(
             MachineConfigResponse::new(2, 256, false, false, "None"),
             Some(boot_source),
             vec![drive],
             vec![network_interface],
+            Some(vsock),
         ));
         let body: serde_json::Value =
             serde_json::from_str(response.body()).expect("body should be JSON");
@@ -2677,6 +2882,10 @@ mod tests {
                         "iface_id": "eth0",
                     },
                 ],
+                "vsock": {
+                    "guest_cid": 3,
+                    "uds_path": "./v.sock",
+                },
             })
         );
         assert_eq!(body.get("metrics"), None);
@@ -2696,6 +2905,7 @@ mod tests {
                 "Sync",
             )],
             vec![NetworkInterfaceConfigResponse::new("eth0", "tap0")],
+            Some(VsockConfigResponse::new(3, "./v.sock")),
         ));
         let body: serde_json::Value =
             serde_json::from_str(response.body()).expect("body should be JSON");
@@ -2722,6 +2932,17 @@ mod tests {
             .expect("one network interface should be returned");
         assert_eq!(network_interface.get("guest_mac"), None);
         assert_eq!(network_interface.get("rx_rate_limiter"), None);
+        assert_eq!(
+            body.get("vsock"),
+            Some(&serde_json::json!({
+                "guest_cid": 3,
+                "uds_path": "./v.sock",
+            }))
+        );
+        assert_eq!(
+            body.get("vsock").and_then(|vsock| vsock.get("vsock_id")),
+            None
+        );
     }
 
     #[test]
@@ -2841,5 +3062,14 @@ mod tests {
         .expect("network interface request should parse");
 
         assert_eq!(Endpoint::from(request), Endpoint::NetworkInterface);
+
+        let request = parse_request(&request_with_body(
+            "PUT",
+            "/vsock",
+            r#"{"guest_cid":3,"uds_path":"./v.sock"}"#,
+        ))
+        .expect("vsock request should parse");
+
+        assert_eq!(Endpoint::from(request), Endpoint::Vsock);
     }
 }

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -16,7 +16,8 @@ use bangbang_api::http::{
     DriveIoEngine as ApiDriveIoEngine, HttpResponse, LoggerConfigRequest,
     LoggerLevel as ApiLoggerLevel, MachineConfigRequest, MachineConfigResponse,
     MetricsConfigRequest, NetworkInterfaceConfigRequest, NetworkInterfaceConfigResponse,
-    RequestError, VmConfigResponse, parse_request, request_total_len,
+    RequestError, VmConfigResponse, VsockConfigRequest, VsockConfigResponse, parse_request,
+    request_total_len,
 };
 use bangbang_runtime::block::{DriveCacheType, DriveConfig, DriveConfigInput, DriveIoEngine};
 use bangbang_runtime::boot::{BootSourceConfig, BootSourceConfigInput};
@@ -27,6 +28,7 @@ use bangbang_runtime::machine::{
 };
 use bangbang_runtime::metrics::MetricsConfigInput;
 use bangbang_runtime::network::{NetworkInterfaceConfig, NetworkInterfaceConfigInput};
+use bangbang_runtime::vsock::{VsockConfig, VsockConfigInput};
 use bangbang_runtime::{VmConfiguration, VmmAction, VmmData};
 
 use crate::vmm::VmmRequestHandler;
@@ -429,6 +431,9 @@ fn handle_api_request(request: ApiRequest, vmm: &mut impl VmmRequestHandler) -> 
                 network_interface_config_input_from_request(config.as_ref()),
             )))
         }
+        ApiRequest::PutVsock(config) => handle_empty(vmm.handle_action(VmmAction::PutVsock(
+            vsock_config_input_from_request(config.as_ref()),
+        ))),
     }
 }
 
@@ -546,6 +551,9 @@ fn vm_config_response_from_runtime(config: &VmConfiguration) -> VmConfigResponse
             .iter()
             .map(network_interface_config_response_from_runtime)
             .collect(),
+        config
+            .vsock_config()
+            .map(vsock_config_response_from_runtime),
     )
 }
 
@@ -597,6 +605,10 @@ fn network_interface_config_response_from_runtime(
     }
 
     response
+}
+
+fn vsock_config_response_from_runtime(config: &VsockConfig) -> VsockConfigResponse {
+    VsockConfigResponse::new(config.guest_cid(), path_text(config.uds_path()))
 }
 
 fn path_text(path: &Path) -> String {
@@ -719,6 +731,15 @@ fn network_interface_config_input_from_request(
     }
     if config.tx_rate_limiter_configured() {
         input = input.with_tx_rate_limiter_configured();
+    }
+
+    input
+}
+
+fn vsock_config_input_from_request(config: &VsockConfigRequest) -> VsockConfigInput {
+    let mut input = VsockConfigInput::new(config.guest_cid(), config.uds_path());
+    if let Some(vsock_id) = config.vsock_id() {
+        input = input.with_vsock_id(vsock_id);
     }
 
     input
@@ -1035,6 +1056,7 @@ mod tests {
         );
         assert!(default_response.body().contains(r#""vcpu_count":1"#));
         assert!(!default_response.body().contains(r#""boot-source":"#));
+        assert!(!default_response.body().contains(r#""vsock":"#));
         assert_eq!(
             vmm.instance_info().state,
             bangbang_runtime::InstanceState::NotStarted
@@ -1094,6 +1116,20 @@ mod tests {
             bangbang_api::http::StatusCode::NoContent
         );
 
+        let vsock_body = r#"{
+            "vsock_id": "vsock0",
+            "guest_cid": 3,
+            "uds_path": "./v.sock"
+        }"#;
+        let vsock_request = format!(
+            "PUT /vsock HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{vsock_body}",
+            vsock_body.len()
+        );
+        assert_eq!(
+            handle_request_bytes(vsock_request.as_bytes(), &mut vmm).status(),
+            bangbang_api::http::StatusCode::NoContent
+        );
+
         let response = handle_request_bytes(
             b"GET /vm/config HTTP/1.1\r\nHost: localhost\r\n\r\n",
             &mut vmm,
@@ -1136,6 +1172,10 @@ mod tests {
                 .body()
                 .contains(r#""guest_mac":"12:34:56:78:9a:bc""#)
         );
+        assert!(response.body().contains(r#""vsock":"#));
+        assert!(response.body().contains(r#""guest_cid":3"#));
+        assert!(response.body().contains(r#""uds_path":"./v.sock""#));
+        assert!(!response.body().contains("vsock_id"));
         assert_eq!(
             vmm.instance_info().state,
             bangbang_runtime::InstanceState::NotStarted
@@ -1271,6 +1311,128 @@ mod tests {
         );
         assert_eq!(config.initrd_path(), None);
         assert_eq!(config.boot_args(), None);
+    }
+
+    #[test]
+    fn configures_vsock_over_unix_socket() {
+        let mut vmm = test_controller();
+        let path = unique_socket_path("vsock");
+        let server = ApiServer::bind(&path).expect("server should bind");
+        let mut client = UnixStream::connect(&path).expect("client should connect");
+        let body = r#"{
+            "guest_cid": 3,
+            "uds_path": "./v.sock"
+        }"#;
+        let request = format!(
+            "PUT /vsock HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+
+        client
+            .write_all(request.as_bytes())
+            .expect("client should write request");
+        server
+            .serve_next(&mut vmm)
+            .expect("server should handle one request");
+
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("client should read response");
+
+        assert!(response.starts_with("HTTP/1.1 204 No Content\r\n"));
+        assert!(response.contains("Content-Length: 0\r\n"));
+        let config_response = handle_request_bytes(
+            b"GET /vm/config HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            &mut vmm,
+        );
+        assert_eq!(config_response.status(), bangbang_api::http::StatusCode::Ok);
+        assert!(config_response.body().contains(r#""vsock":"#));
+        assert!(config_response.body().contains(r#""guest_cid":3"#));
+        assert!(config_response.body().contains(r#""uds_path":"./v.sock""#));
+    }
+
+    #[test]
+    fn returns_fault_for_invalid_vsock_without_mutating() {
+        let mut vmm = test_controller();
+        let original_body = r#"{"guest_cid":3,"uds_path":"./original.sock"}"#;
+        let original_request = format!(
+            "PUT /vsock HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{original_body}",
+            original_body.len()
+        );
+        assert_eq!(
+            handle_request_bytes(original_request.as_bytes(), &mut vmm).status(),
+            bangbang_api::http::StatusCode::NoContent
+        );
+
+        let invalid_body = r#"{"guest_cid":2,"uds_path":"/tmp/private-v.sock"}"#;
+        let invalid_request = format!(
+            "PUT /vsock HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{invalid_body}",
+            invalid_body.len()
+        );
+
+        let response = handle_request_bytes(invalid_request.as_bytes(), &mut vmm);
+
+        assert_eq!(
+            response.status(),
+            bangbang_api::http::StatusCode::BadRequest
+        );
+        assert_eq!(
+            response.body(),
+            r#"{"fault_message":"vsock guest_cid 2 is below minimum 3"}"#
+        );
+        assert!(!response.body().contains("/tmp/private-v.sock"));
+
+        let config_response = handle_request_bytes(
+            b"GET /vm/config HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            &mut vmm,
+        );
+        assert!(config_response.body().contains(r#""guest_cid":3"#));
+        assert!(
+            config_response
+                .body()
+                .contains(r#""uds_path":"./original.sock""#)
+        );
+        assert!(!config_response.body().contains("/tmp/private-v.sock"));
+    }
+
+    #[test]
+    fn rejects_vsock_after_start_without_creating_socket_path() {
+        let mut vmm = test_controller_with_starter(TestInstanceStarter::success());
+        let boot_body = r#"{"kernel_image_path":"/tmp/original-vmlinux"}"#;
+        let boot_request = format!(
+            "PUT /boot-source HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{boot_body}",
+            boot_body.len()
+        );
+        assert_eq!(
+            handle_request_bytes(boot_request.as_bytes(), &mut vmm).status(),
+            bangbang_api::http::StatusCode::NoContent
+        );
+        let start_response =
+            put_action_over_socket(&mut vmm, "start-before-vsock", "InstanceStart");
+        assert!(start_response.starts_with("HTTP/1.1 204 No Content\r\n"));
+
+        let uds_path = unique_socket_path("vsock-after-start");
+        let body = format!(
+            r#"{{"guest_cid":3,"uds_path":"{}"}}"#,
+            uds_path.to_string_lossy()
+        );
+        let request = format!(
+            "PUT /vsock HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+
+        let response = handle_request_bytes(request.as_bytes(), &mut vmm);
+
+        assert_eq!(
+            response.status(),
+            bangbang_api::http::StatusCode::BadRequest
+        );
+        assert_eq!(
+            response.body(),
+            r#"{"fault_message":"The requested operation is not supported in Running state: PutVsock"}"#
+        );
+        assert!(!uds_path.exists());
     }
 
     #[test]
@@ -1651,6 +1813,10 @@ mod tests {
                 .with_guest_mac("12:34:56:78:9a:bc"),
         ))
         .expect("network interface config should be stored");
+        vmm.handle_action(VmmAction::PutVsock(
+            VsockConfigInput::new(3, "./v.sock").with_vsock_id("vsock0"),
+        ))
+        .expect("vsock config should be stored");
 
         client
             .write_all(b"GET /vm/config HTTP/1.1\r\nHost: localhost\r\n\r\n")
@@ -1683,6 +1849,10 @@ mod tests {
         assert!(response.contains(r#""iface_id":"eth0""#));
         assert!(response.contains(r#""host_dev_name":"tap0""#));
         assert!(response.contains(r#""guest_mac":"12:34:56:78:9a:bc""#));
+        assert!(response.contains(r#""vsock":"#));
+        assert!(response.contains(r#""guest_cid":3"#));
+        assert!(response.contains(r#""uds_path":"./v.sock""#));
+        assert!(!response.contains("vsock_id"));
         assert_eq!(
             vmm.instance_info().state,
             bangbang_runtime::InstanceState::NotStarted

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -347,8 +347,9 @@ fn help_text() -> String {
             "Current scope:\n",
             "  Serves GET /, GET /version, GET /vm/config, GET /machine-config, ",
             "pre-boot PUT /machine-config, pre-boot PUT /boot-source, ",
-            "pre-boot PUT /drives/{{drive_id}}, pre-boot PUT /metrics, and ",
-            "pre-boot PUT /logger configuration storage over the API ",
+            "pre-boot PUT /drives/{{drive_id}}, pre-boot ",
+            "PUT /network-interfaces/{{iface_id}}, pre-boot PUT /vsock, ",
+            "pre-boot PUT /metrics, and pre-boot PUT /logger configuration storage over the API ",
             "socket; PUT /actions starts a process-owned HVF boot run-loop ",
             "worker across bounded step windows for InstanceStart, but public ",
             "run-loop control is not implemented yet."

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -14,6 +14,7 @@ pub mod serial;
 pub mod startup;
 pub mod virtio_mmio;
 pub mod virtio_queue;
+pub mod vsock;
 
 use std::fmt;
 
@@ -73,6 +74,7 @@ pub enum VmmAction {
     PutMetrics(metrics::MetricsConfigInput),
     PutDrive(block::DriveConfigInput),
     PutNetworkInterface(network::NetworkInterfaceConfigInput),
+    PutVsock(vsock::VsockConfigInput),
 }
 
 impl VmmAction {
@@ -90,6 +92,7 @@ impl VmmAction {
             Self::PutMetrics(_) => "PutMetrics",
             Self::PutDrive(_) => "PutDrive",
             Self::PutNetworkInterface(_) => "PutNetworkInterface",
+            Self::PutVsock(_) => "PutVsock",
         }
     }
 }
@@ -109,6 +112,7 @@ pub struct VmConfiguration {
     boot_source_config: Option<boot::BootSourceConfig>,
     drive_configs: Vec<block::DriveConfig>,
     network_interface_configs: Vec<network::NetworkInterfaceConfig>,
+    vsock_config: Option<vsock::VsockConfig>,
 }
 
 impl VmConfiguration {
@@ -117,12 +121,14 @@ impl VmConfiguration {
         boot_source_config: Option<boot::BootSourceConfig>,
         drive_configs: Vec<block::DriveConfig>,
         network_interface_configs: Vec<network::NetworkInterfaceConfig>,
+        vsock_config: Option<vsock::VsockConfig>,
     ) -> Self {
         Self {
             machine_config,
             boot_source_config,
             drive_configs,
             network_interface_configs,
+            vsock_config,
         }
     }
 
@@ -140,6 +146,10 @@ impl VmConfiguration {
 
     pub fn network_interface_configs(&self) -> &[network::NetworkInterfaceConfig] {
         &self.network_interface_configs
+    }
+
+    pub fn vsock_config(&self) -> Option<&vsock::VsockConfig> {
+        self.vsock_config.as_ref()
     }
 }
 
@@ -159,6 +169,7 @@ pub enum VmmActionError {
     MetricsConfig(metrics::MetricsConfigError),
     MetricsFlush(metrics::MetricsFlushError),
     NetworkInterfaceConfig(network::NetworkInterfaceConfigError),
+    VsockConfig(vsock::VsockConfigError),
 }
 
 impl fmt::Display for VmmActionError {
@@ -184,6 +195,7 @@ impl fmt::Display for VmmActionError {
             Self::MetricsConfig(err) => write!(f, "{err}"),
             Self::MetricsFlush(err) => write!(f, "{err}"),
             Self::NetworkInterfaceConfig(err) => write!(f, "{err}"),
+            Self::VsockConfig(err) => write!(f, "{err}"),
         }
     }
 }
@@ -199,6 +211,7 @@ impl std::error::Error for VmmActionError {
             Self::MetricsConfig(err) => Some(err),
             Self::MetricsFlush(err) => Some(err),
             Self::NetworkInterfaceConfig(err) => Some(err),
+            Self::VsockConfig(err) => Some(err),
             Self::MissingBootSource
             | Self::UnsupportedAction(_)
             | Self::UnsupportedState { .. } => None,
@@ -213,6 +226,7 @@ pub struct VmmController {
     boot_source_config: Option<boot::BootSourceConfig>,
     drive_configs: block::DriveConfigs,
     network_interface_configs: network::NetworkInterfaceConfigs,
+    vsock_config: Option<vsock::VsockConfig>,
     logger_state: logger::LoggerState,
     metrics_state: metrics::MetricsState,
 }
@@ -234,6 +248,7 @@ impl VmmController {
             boot_source_config: None,
             drive_configs: block::DriveConfigs::new(),
             network_interface_configs: network::NetworkInterfaceConfigs::new(),
+            vsock_config: None,
             logger_state: logger::LoggerState::default(),
             metrics_state: metrics::MetricsState::default(),
         }
@@ -251,6 +266,10 @@ impl VmmController {
         self.network_interface_configs.as_slice()
     }
 
+    pub fn vsock_config(&self) -> Option<&vsock::VsockConfig> {
+        self.vsock_config.as_ref()
+    }
+
     pub const fn machine_config(&self) -> machine::MachineConfig {
         self.machine_config
     }
@@ -265,6 +284,7 @@ impl VmmController {
             self.boot_source_config.clone(),
             self.drive_configs.as_slice().to_vec(),
             self.network_interface_configs.as_slice().to_vec(),
+            self.vsock_config.clone(),
         )
     }
 
@@ -409,6 +429,19 @@ impl VmmController {
 
                 Ok(VmmData::Empty)
             }
+            VmmAction::PutVsock(config) => {
+                if self.instance_info.state != InstanceState::NotStarted {
+                    return Err(VmmActionError::UnsupportedState {
+                        action: action_name,
+                        state: self.instance_info.state,
+                    });
+                }
+
+                let config = config.validate().map_err(VmmActionError::VsockConfig)?;
+                self.vsock_config = Some(config);
+
+                Ok(VmmData::Empty)
+            }
         }
     }
 }
@@ -455,6 +488,7 @@ mod tests {
         machine::{DEFAULT_MEM_SIZE_MIB, DEFAULT_VCPU_COUNT, MachineConfigInput},
         metrics::{MetricsConfigError, MetricsConfigInput},
         network::{GuestMacAddress, NetworkInterfaceConfigError, NetworkInterfaceConfigInput},
+        vsock::{MIN_GUEST_CID, VsockConfigError, VsockConfigInput},
     };
 
     fn drive_input(id: &str, path: &str, is_root_device: bool) -> DriveConfigInput {
@@ -463,6 +497,10 @@ mod tests {
 
     fn network_input(id: &str, host_dev_name: &str) -> NetworkInterfaceConfigInput {
         NetworkInterfaceConfigInput::new(id, id, host_dev_name)
+    }
+
+    fn vsock_input(guest_cid: u32, uds_path: &str) -> VsockConfigInput {
+        VsockConfigInput::new(guest_cid, uds_path)
     }
 
     fn boot_source_input(kernel_image_path: &str) -> BootSourceConfigInput {
@@ -523,6 +561,7 @@ mod tests {
         assert_eq!(controller.boot_source_config(), None);
         assert!(controller.drive_configs().is_empty());
         assert!(controller.network_interface_configs().is_empty());
+        assert_eq!(controller.vsock_config(), None);
     }
 
     #[test]
@@ -586,10 +625,12 @@ mod tests {
         assert_eq!(config.boot_source_config(), None);
         assert!(config.drive_configs().is_empty());
         assert!(config.network_interface_configs().is_empty());
+        assert_eq!(config.vsock_config(), None);
         assert_eq!(controller.instance_info().state, InstanceState::NotStarted);
         assert!(controller.boot_source_config().is_none());
         assert!(controller.drive_configs().is_empty());
         assert!(controller.network_interface_configs().is_empty());
+        assert!(controller.vsock_config().is_none());
     }
 
     #[test]
@@ -617,6 +658,11 @@ mod tests {
                 network_input("eth0", "tap0").with_guest_mac("12:34:56:78:9a:bc"),
             ))
             .expect("network interface config should be stored");
+        controller
+            .handle_action(VmmAction::PutVsock(
+                vsock_input(3, "./v.sock").with_vsock_id("vsock0"),
+            ))
+            .expect("vsock config should be stored");
 
         let data = controller
             .handle_action(VmmAction::GetVmConfig)
@@ -657,6 +703,12 @@ mod tests {
                 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc,
             ]))
         );
+        let vsock = config
+            .vsock_config()
+            .expect("vsock config should be present");
+        assert_eq!(vsock.vsock_id(), Some("vsock0"));
+        assert_eq!(vsock.guest_cid(), 3);
+        assert_eq!(vsock.uds_path(), Path::new("./v.sock"));
         assert_eq!(controller.instance_info().state, InstanceState::NotStarted);
     }
 
@@ -682,6 +734,7 @@ mod tests {
         assert!(config.boot_source_config().is_some());
         assert!(config.drive_configs().is_empty());
         assert!(config.network_interface_configs().is_empty());
+        assert_eq!(config.vsock_config(), None);
     }
 
     #[test]
@@ -696,6 +749,10 @@ mod tests {
         assert_eq!(
             VmmAction::PutNetworkInterface(network_input("eth0", "tap0")).name(),
             "PutNetworkInterface"
+        );
+        assert_eq!(
+            VmmAction::PutVsock(vsock_input(3, "./v.sock")).name(),
+            "PutVsock"
         );
     }
 
@@ -1814,6 +1871,99 @@ mod tests {
     }
 
     #[test]
+    fn handles_put_vsock_config() {
+        let mut controller = VmmController::new("demo-1", "0.1.0", "bangbang");
+
+        assert_eq!(
+            controller.handle_action(VmmAction::PutVsock(
+                vsock_input(MIN_GUEST_CID, "./v.sock").with_vsock_id("vsock0"),
+            )),
+            Ok(VmmData::Empty)
+        );
+
+        let config = controller
+            .vsock_config()
+            .expect("vsock config should be stored");
+        assert_eq!(config.vsock_id(), Some("vsock0"));
+        assert_eq!(config.guest_cid(), MIN_GUEST_CID);
+        assert_eq!(config.uds_path(), Path::new("./v.sock"));
+    }
+
+    #[test]
+    fn put_vsock_config_replaces_existing_config() {
+        let mut controller = VmmController::new("demo-1", "0.1.0", "bangbang");
+        controller
+            .handle_action(VmmAction::PutVsock(vsock_input(3, "/tmp/first.sock")))
+            .expect("initial vsock config should be stored");
+
+        controller
+            .handle_action(VmmAction::PutVsock(vsock_input(42, "/tmp/replaced.sock")))
+            .expect("replacement vsock config should be stored");
+
+        let config = controller
+            .vsock_config()
+            .expect("replacement config should be stored");
+        assert_eq!(config.vsock_id(), None);
+        assert_eq!(config.guest_cid(), 42);
+        assert_eq!(config.uds_path(), Path::new("/tmp/replaced.sock"));
+    }
+
+    #[test]
+    fn put_vsock_config_rejects_invalid_config_without_mutating() {
+        let mut controller = VmmController::new("demo-1", "0.1.0", "bangbang");
+        controller
+            .handle_action(VmmAction::PutVsock(vsock_input(3, "/tmp/original.sock")))
+            .expect("initial vsock config should be stored");
+
+        let err = controller
+            .handle_action(VmmAction::PutVsock(vsock_input(2, "/tmp/replacement.sock")))
+            .expect_err("invalid guest cid should fail");
+
+        assert_eq!(
+            err,
+            VmmActionError::VsockConfig(VsockConfigError::GuestCidTooSmall {
+                guest_cid: 2,
+                min: MIN_GUEST_CID,
+            })
+        );
+        assert_eq!(err.to_string(), "vsock guest_cid 2 is below minimum 3");
+        let config = controller
+            .vsock_config()
+            .expect("original config should remain stored");
+        assert_eq!(config.guest_cid(), 3);
+        assert_eq!(config.uds_path(), Path::new("/tmp/original.sock"));
+    }
+
+    #[test]
+    fn put_vsock_config_rejects_running_state_without_mutating() {
+        let mut controller = VmmController::new("demo-1", "0.1.0", "bangbang");
+        controller
+            .handle_action(VmmAction::PutVsock(vsock_input(3, "/tmp/original.sock")))
+            .expect("initial vsock config should be stored");
+        controller.instance_info.state = InstanceState::Running;
+
+        let err = controller
+            .handle_action(VmmAction::PutVsock(vsock_input(
+                42,
+                "/tmp/replacement.sock",
+            )))
+            .expect_err("running vsock config should fail");
+
+        assert_eq!(
+            err,
+            VmmActionError::UnsupportedState {
+                action: "PutVsock",
+                state: InstanceState::Running,
+            }
+        );
+        let config = controller
+            .vsock_config()
+            .expect("original config should remain stored");
+        assert_eq!(config.guest_cid(), 3);
+        assert_eq!(config.uds_path(), Path::new("/tmp/original.sock"));
+    }
+
+    #[test]
     fn displays_unsupported_action_error() {
         let err = VmmActionError::UnsupportedAction(VmmAction::GetVmInstanceInfo.name());
 
@@ -1852,6 +2002,14 @@ mod tests {
         let err = VmmActionError::DriveConfig(DriveConfigError::EmptyPathOnHost);
 
         assert_eq!(err.to_string(), "drive path_on_host must not be empty");
+        assert!(err.source().is_some());
+    }
+
+    #[test]
+    fn displays_vsock_config_error() {
+        let err = VmmActionError::VsockConfig(VsockConfigError::EmptySocketPath);
+
+        assert_eq!(err.to_string(), "vsock uds_path must not be empty");
         assert!(err.source().is_some());
     }
 

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -1,0 +1,238 @@
+//! Backend-neutral vsock configuration model.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+pub const MIN_GUEST_CID: u32 = 3;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VsockConfigInput {
+    vsock_id: Option<String>,
+    guest_cid: u32,
+    uds_path: String,
+}
+
+impl VsockConfigInput {
+    pub fn new(guest_cid: u32, uds_path: impl Into<String>) -> Self {
+        Self {
+            vsock_id: None,
+            guest_cid,
+            uds_path: uds_path.into(),
+        }
+    }
+
+    pub fn with_vsock_id(mut self, vsock_id: impl Into<String>) -> Self {
+        self.vsock_id = Some(vsock_id.into());
+        self
+    }
+
+    pub fn vsock_id(&self) -> Option<&str> {
+        self.vsock_id.as_deref()
+    }
+
+    pub const fn guest_cid(&self) -> u32 {
+        self.guest_cid
+    }
+
+    pub fn uds_path(&self) -> &str {
+        &self.uds_path
+    }
+
+    pub fn validate(self) -> Result<VsockConfig, VsockConfigError> {
+        VsockConfig::try_from(self)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VsockConfig {
+    vsock_id: Option<String>,
+    guest_cid: u32,
+    uds_path: PathBuf,
+}
+
+impl VsockConfig {
+    pub fn vsock_id(&self) -> Option<&str> {
+        self.vsock_id.as_deref()
+    }
+
+    pub const fn guest_cid(&self) -> u32 {
+        self.guest_cid
+    }
+
+    pub fn uds_path(&self) -> &Path {
+        &self.uds_path
+    }
+}
+
+impl TryFrom<VsockConfigInput> for VsockConfig {
+    type Error = VsockConfigError;
+
+    fn try_from(input: VsockConfigInput) -> Result<Self, Self::Error> {
+        if input.guest_cid < MIN_GUEST_CID {
+            return Err(VsockConfigError::GuestCidTooSmall {
+                guest_cid: input.guest_cid,
+                min: MIN_GUEST_CID,
+            });
+        }
+
+        if let Some(vsock_id) = input.vsock_id.as_deref() {
+            if vsock_id.is_empty() {
+                return Err(VsockConfigError::EmptyVsockId);
+            }
+            if has_control_character(vsock_id) {
+                return Err(VsockConfigError::InvalidVsockId {
+                    vsock_id: vsock_id.to_string(),
+                });
+            }
+        }
+
+        if input.uds_path.is_empty() {
+            return Err(VsockConfigError::EmptySocketPath);
+        }
+        if has_control_character(&input.uds_path) {
+            return Err(VsockConfigError::InvalidSocketPath);
+        }
+
+        Ok(Self {
+            vsock_id: input.vsock_id,
+            guest_cid: input.guest_cid,
+            uds_path: PathBuf::from(input.uds_path),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VsockConfigError {
+    GuestCidTooSmall { guest_cid: u32, min: u32 },
+    EmptyVsockId,
+    InvalidVsockId { vsock_id: String },
+    EmptySocketPath,
+    InvalidSocketPath,
+}
+
+impl fmt::Display for VsockConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::GuestCidTooSmall { guest_cid, min } => {
+                write!(f, "vsock guest_cid {guest_cid} is below minimum {min}")
+            }
+            Self::EmptyVsockId => f.write_str("vsock_id must not be empty"),
+            Self::InvalidVsockId { .. } => {
+                f.write_str("vsock_id must not contain control characters")
+            }
+            Self::EmptySocketPath => f.write_str("vsock uds_path must not be empty"),
+            Self::InvalidSocketPath => {
+                f.write_str("vsock uds_path must not contain control characters")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VsockConfigError {}
+
+fn has_control_character(value: &str) -> bool {
+    value.chars().any(char::is_control)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as _;
+    use std::path::Path;
+
+    use super::{MIN_GUEST_CID, VsockConfigError, VsockConfigInput};
+
+    fn validate(input: VsockConfigInput) -> Result<super::VsockConfig, VsockConfigError> {
+        input.validate()
+    }
+
+    #[test]
+    fn accepts_minimal_config() {
+        let config =
+            validate(VsockConfigInput::new(MIN_GUEST_CID, "./v.sock")).expect("valid config");
+
+        assert_eq!(config.vsock_id(), None);
+        assert_eq!(config.guest_cid(), MIN_GUEST_CID);
+        assert_eq!(config.uds_path(), Path::new("./v.sock"));
+    }
+
+    #[test]
+    fn accepts_optional_deprecated_vsock_id() {
+        let config = validate(VsockConfigInput::new(42, "/tmp/v.sock").with_vsock_id("vsock_0"))
+            .expect("valid config");
+
+        assert_eq!(config.vsock_id(), Some("vsock_0"));
+        assert_eq!(config.guest_cid(), 42);
+        assert_eq!(config.uds_path(), Path::new("/tmp/v.sock"));
+    }
+
+    #[test]
+    fn rejects_guest_cid_below_firecracker_minimum() {
+        let err = validate(VsockConfigInput::new(2, "/tmp/v.sock"))
+            .expect_err("small guest cid should fail");
+
+        assert_eq!(
+            err,
+            VsockConfigError::GuestCidTooSmall {
+                guest_cid: 2,
+                min: MIN_GUEST_CID,
+            }
+        );
+        assert_eq!(err.to_string(), "vsock guest_cid 2 is below minimum 3");
+    }
+
+    #[test]
+    fn rejects_empty_vsock_id() {
+        let err = validate(VsockConfigInput::new(3, "/tmp/v.sock").with_vsock_id(""))
+            .expect_err("empty id should fail");
+
+        assert_eq!(err, VsockConfigError::EmptyVsockId);
+        assert_eq!(err.to_string(), "vsock_id must not be empty");
+    }
+
+    #[test]
+    fn rejects_control_character_vsock_id_without_echoing_it() {
+        let invalid = "id\nsecret";
+        let err = validate(VsockConfigInput::new(3, "/tmp/v.sock").with_vsock_id(invalid))
+            .expect_err("control character id should fail");
+
+        assert_eq!(
+            err,
+            VsockConfigError::InvalidVsockId {
+                vsock_id: invalid.to_string(),
+            }
+        );
+        assert_eq!(
+            err.to_string(),
+            "vsock_id must not contain control characters"
+        );
+        assert!(!err.to_string().contains(invalid));
+    }
+
+    #[test]
+    fn rejects_empty_socket_path() {
+        let err =
+            validate(VsockConfigInput::new(3, "")).expect_err("empty socket path should fail");
+
+        assert_eq!(err, VsockConfigError::EmptySocketPath);
+        assert_eq!(err.to_string(), "vsock uds_path must not be empty");
+    }
+
+    #[test]
+    fn rejects_control_character_socket_path_without_echoing_it() {
+        let invalid = "/tmp/v.sock\nsecret";
+        let err = validate(VsockConfigInput::new(3, invalid))
+            .expect_err("control character socket path should fail");
+
+        assert_eq!(err, VsockConfigError::InvalidSocketPath);
+        assert_eq!(
+            err.to_string(),
+            "vsock uds_path must not contain control characters"
+        );
+        assert!(!err.to_string().contains(invalid));
+    }
+
+    #[test]
+    fn errors_have_no_sources() {
+        assert!(VsockConfigError::EmptySocketPath.source().is_none());
+    }
+}

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -8,7 +8,7 @@ The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /`, `GET /version`,
 `GET /vm/config`, `GET /machine-config`, pre-boot `PUT /machine-config`
 configuration storage, pre-boot `PUT /boot-source` configuration storage, pre-boot `PUT /drives/{drive_id}`
-configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
+configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
 `InstanceStart` preflight, transactional startup executor, and successful-start state transition helpers, backend-neutral guest
 physical address and aarch64 DRAM layout/access primitives, arm64 boot
 placement helpers, internal boot-source validation and arm64 kernel/initrd
@@ -54,7 +54,7 @@ virtio-net packet-I/O provider injection, boot block and virtio-net queue
 interrupt signaling,
 virtual timer PPI assertion, per-controller metrics and logger output state, and an initial process startup argument model.
 There is no broader API request body model beyond the initial boot-source,
-drive configuration, machine-configuration, metrics, logger, and actions bodies, public guest
+drive configuration, network-interface configuration, vsock configuration, machine-configuration, metrics, logger, and actions bodies, public guest
 execution beyond internal startup execution across bounded step windows, public run-loop control, complete interrupt
 delivery, including timer EOI/deactivation-driven unmasking,
 general HVF runner-loop notification scheduling, public serial output streaming,
@@ -87,6 +87,7 @@ The intended public control plane is Firecracker-style HTTP over a Unix domain
 socket. The implemented `GET /`, `GET /version`, `GET /vm/config`,
 `GET /machine-config`, pre-boot `PUT /machine-config`, pre-boot
 `PUT /boot-source`, pre-boot `PUT /drives/{drive_id}`, pre-boot
+`PUT /network-interfaces/{iface_id}`, pre-boot `PUT /vsock`, pre-boot
 `PUT /metrics`, pre-boot `PUT /logger`, and parsed `PUT /actions` requests
 already map through a minimal internal VMM action/data boundary. Validation
 rejects malformed boot-source and actions requests before VMM state mutation.
@@ -100,7 +101,8 @@ The current `bangbang` executable parses only the first process-lifecycle
 arguments and starts the first API socket surface. It binds a Unix socket and
 serves `GET /`, `GET /version`, `GET /vm/config`, `GET /machine-config`,
 pre-boot `PUT /machine-config`, pre-boot `PUT /boot-source` configuration storage, and
-pre-boot `PUT /drives/{drive_id}` configuration storage, pre-boot `PUT /metrics`
+pre-boot `PUT /drives/{drive_id}` configuration storage, pre-boot
+`PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage, pre-boot `PUT /metrics`
 output configuration, pre-boot `PUT /logger` output configuration, plus process-routed `PUT /actions` startup and metrics
 flush with an internal boot run-loop worker across bounded step windows or
 state/configuration faults, but does not load a configuration file or provide
@@ -184,7 +186,8 @@ before changing this reference.
 
 The current scaffold implements `GET /`, `GET /version`, `GET /vm/config`,
 `GET /machine-config`, pre-boot `PUT /machine-config` configuration storage, pre-boot
-`PUT /boot-source`, `PUT /drives/{drive_id}`, `PUT /metrics`, and `PUT /logger` configuration
+`PUT /boot-source`, `PUT /drives/{drive_id}`,
+`PUT /network-interfaces/{iface_id}`, `PUT /vsock`, `PUT /metrics`, and `PUT /logger` configuration
 storage over HTTP on a Unix domain socket, plus runtime `FlushMetrics` after
 successful startup. The support levels below describe compatibility targets for
 future API work:
@@ -228,7 +231,7 @@ compatibility targets.
 | `PATCH` | `/machine-config` | deferred | Partial updates belong with later state and validation rules. |
 | `PUT` | `/cpu-config` | deferred | Needs HVF CPU feature design with VM and boot work in #8 and #10. |
 | `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores initial virtio-net configuration before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT, and internal network notification dispatch can route each configured interface through injected packet I/O, parse TX descriptors through a packet sink boundary, and copy injected RX packets into guest buffers through a packet source boundary. Host packet backend selection, public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
-| `PUT` | `/vsock` | deferred | Tied to virtio vsock work in #15. |
+| `PUT` | `/vsock` | supported target; configuration storage implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Virtio-vsock device emulation, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
 | `GET`, `PUT`, `PATCH` | `/mmds` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/mmds/config` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/snapshot/create`, `/snapshot/load` | deferred | Tied to snapshot and restore work in #19. |
@@ -280,6 +283,10 @@ exist.
 | `PUT /network-interfaces/{iface_id}` | `mtu` | deferred when configured | The internal model rejects configured MTU values until virtio-net feature negotiation and backend behavior exist. |
 | `PUT /network-interfaces/{iface_id}` | `rx_rate_limiter`, `tx_rate_limiter` | deferred when configured | The internal model rejects configured network rate limiters until virtio-net rate limiting behavior exists. |
 | `PUT /network-interfaces/{iface_id}` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
+| `PUT /vsock` | `vsock_id` | optional and deprecated | Firecracker `v1.16.0` accepts this field but treats it as deprecated. The internal model accepts it when present and rejects empty or control-character values. `GET /vm/config` omits this deprecated field. |
+| `PUT /vsock` | `guest_cid` | required | Firecracker's published schema requires a 32-bit guest CID with minimum value `3`; smaller values are rejected before state mutation. |
+| `PUT /vsock` | `uds_path` | required | Host Unix socket path to use for the future backend. The current API/VMM path records this value only after rejecting empty paths and control characters. Relative paths remain accepted to match Firecracker's documented `./v.sock` examples. No file or socket is opened, bound, connected, unlinked, or created by this configuration path. |
+| `PUT /vsock` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
 | `PUT /metrics` | `metrics_path` | required | Host path to the metrics output file or FIFO. The runtime opens it as per-process observability state and redacts path details from API-facing open errors. |
 | `PUT /metrics` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
 | `PUT /logger` | `log_path` | optional | Host path to the logger output file or FIFO. When present, the runtime opens it as per-process observability state and redacts path details from API-facing open errors. When omitted, the existing sink is left unchanged. |
@@ -303,9 +310,10 @@ during `InstanceStart` startup.
 without side effects. It includes the stored/default `machine-config`, includes
 `boot-source` only after it is configured, and always includes a `drives` array
 for configured virtio-block drives plus a `network-interfaces` array for stored
-network interface configs. Unsupported Firecracker sections such as MMDS, vsock,
-balloon, snapshots, and hotplug are omitted until their configuration models
-exist. Metrics and logger output configuration are also omitted because they are
+network interface configs. It includes `vsock` only after `PUT /vsock` stores a
+valid configuration. Unsupported Firecracker sections such as MMDS, balloon,
+snapshots, and hotplug are omitted until their configuration models exist.
+Metrics and logger output configuration are also omitted because they are
 process observability state rather than guest configuration.
 
 The API and VMM state path implement the `PUT /boot-source` field policy above.
@@ -337,6 +345,13 @@ pre-boot-only per-process observability configuration. Repeated pre-boot
 requests update only the fields they provide. Runtime requests fail without
 opening a new output path. The configured logger sink is not wired into the
 process logging backend yet.
+The API and VMM state path implement the `PUT /vsock` field policy above as a
+pre-boot-only guest configuration section. Valid requests replace the stored
+vsock config and return `204 No Content`; invalid requests fail without
+mutating previous vsock state. The current response reports `guest_cid` and
+`uds_path` while omitting the accepted deprecated `vsock_id`, matching
+Firecracker's effective config output. It does not create a virtio-vsock device,
+open host socket resources, route CIDs, or move data.
 `SendCtrlAltDel` is rejected at parse time for the first aarch64 target.
 
 Future implementation PRs should derive unit or golden tests from these tables.
@@ -518,6 +533,23 @@ The internal model rejects configured `mtu`, `rx_rate_limiter`, and
 `tx_rate_limiter` fields as unsupported. It does not open host networking
 resources or choose a macOS packet backend. Stored network interface configs are
 returned from `GET /vm/config` in the `network-interfaces` array.
+
+## Internal Vsock Configuration
+
+The API and runtime crates implement pre-boot, Firecracker-shaped vsock
+configuration storage for future virtio-vsock work. The API parser accepts
+`PUT /vsock`, rejects unknown fields, and forwards the supported request shape
+through the VMM action boundary. The runtime requires `guest_cid >= 3`, accepts
+the deprecated optional `vsock_id` when it is nonempty and contains no control
+characters, and requires a nonempty `uds_path` with no control characters.
+Displayed validation errors avoid echoing configured socket paths.
+
+Stored vsock configuration replaces any previous pre-boot vsock configuration
+and is returned from `GET /vm/config` as `vsock` with `guest_cid` and
+`uds_path`; the deprecated input-only `vsock_id` is omitted. The current model
+does not open, bind, connect, unlink, or create the configured `uds_path`;
+virtio-vsock device emulation, host Unix socket backend behavior, CID routing,
+and data movement remain deferred.
 
 The runtime crate also has the first backend-neutral virtio-net config-space,
 activation, TX frame parser, RX buffer parser, prepared device resources, and
@@ -902,7 +934,8 @@ behavior.
 The current scaffold implements the first HTTP API behavior for `GET /`,
 `GET /version`, `GET /vm/config`, pre-boot `/machine-config` configuration
 storage, pre-boot `PUT /boot-source`, `PUT /drives/{drive_id}`, and
-`PUT /metrics` and `PUT /logger` configuration storage, plus
+`PUT /network-interfaces/{iface_id}`, `PUT /vsock`, and `PUT /metrics` and
+`PUT /logger` configuration storage, plus
 process-routed `PUT /actions` startup with a bounded internal boot run-loop
 worker and runtime metrics flush handling. The
 policy below is the compatibility target for future request parsing, VMM action
@@ -916,11 +949,13 @@ flow through `GetMachineConfig` and `PutMachineConfig` and read or replace
 stored machine configuration state. `GET /vm/config` flows through
 `GetVmConfig` and returns the supported accumulated configuration subset:
 `machine-config`, `boot-source` when configured, the `drives` array, and the
-`network-interfaces` array.
+`network-interfaces` array, plus `vsock` when configured.
 Observability state such as metrics and logger configuration is omitted. Unsupported top-level sections are omitted until their models exist. The implemented pre-boot drive path flows
 through `PutDrive` and records validated configuration state. The implemented
 pre-boot network-interface path flows through `PutNetworkInterface` and records
 validated configuration state without opening host networking resources. Parsed
+`/vsock` requests flow through `PutVsock` and replace validated vsock
+configuration state without opening host Unix socket resources. Parsed
 `/boot-source` requests flow through `PutBootSource` and replace stored
 boot-source configuration state. Parsed `/metrics` requests flow through
 `PutMetrics` and initialize per-process metrics output state that is not part of
@@ -961,6 +996,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | `PUT /boot-source` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; host paths are opened during startup preparation. Host path errors must avoid leaking sensitive path details. |
 | `PUT /drives/{drive_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; startup preparation opens backing files and registers initial block MMIO devices. Runtime hotplug remains deferred. |
 | `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT, while internal network notification dispatch can route each interface through injected packet I/O, complete TX descriptor heads through a packet sink boundary, and write injected RX packets into guest buffers through a packet source boundary. Host packet backend, public packet movement, PATCH, and DELETE remain deferred. |
+| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Virtio-vsock device emulation, host socket backend behavior, CID routing, data movement, PATCH, and DELETE remain deferred. |
 | `PUT /metrics` | implemented; `204` empty response on successful output initialization | unsupported after start; `400` `fault_message` | Metrics output is process observability state, not guest configuration. Duplicate initialization fails. |
 | `PUT /logger` | implemented; `204` empty response on successful pre-boot configuration | unsupported after start; `400` `fault_message` | Logger output is process observability state, not guest configuration. Repeated pre-boot requests update provided fields; full log routing remains deferred. |
 | `PUT /actions` with `InstanceStart` | process-routed; `204` after successful owned HVF startup with internal boot run-loop worker across bounded step windows or `400` preflight/preparation fault | unsupported after start; `400` `fault_message` | Commits `Running` only after the owned HVF boot-session worker with internal serial capture is retained. The worker keeps internal active, terminal-outcome, or error status; public run-loop control and public serial streaming remain deferred. |
@@ -1009,7 +1045,8 @@ Their eventual support level should follow the endpoint matrix:
   buffer parser, prepared device resources, MMIO registration, startup FDT
   metadata, TX/RX notification dispatch metadata helpers, injected no-op TX
   packet sink boundary, and injected empty RX packet source boundary
-- vsock
+- virtio-vsock device emulation, host Unix socket backend behavior, CID routing,
+  and data movement beyond pre-boot `/vsock` configuration storage
 - snapshots
 - MMDS
 - balloon devices and balloon statistics

--- a/docs/security.md
+++ b/docs/security.md
@@ -63,6 +63,9 @@ is resource-specific:
   Files are opened later during `InstanceStart`.
 - `/drives/{drive_id}` stores block backing paths during configuration. Backing
   files are opened later during `InstanceStart`.
+- `/vsock` stores the configured Unix socket path during configuration only.
+  The current implementation does not open, bind, connect, unlink, or create
+  that socket path.
 - `/metrics` opens the output path during pre-boot configuration and keeps a
   per-process metrics sink.
 - `/logger` opens `log_path` during pre-boot configuration when that field is
@@ -131,6 +134,7 @@ Use unique paths for:
 - metrics files or FIFOs
 - logger files or FIFOs
 - writable block backing files
+- configured vsock socket paths when future vsock backends start creating them
 - future host network devices or sockets
 - temporary test files
 
@@ -147,7 +151,7 @@ The current scaffold does not implement:
 - a Firecracker-jailer replacement
 - privilege dropping
 - host resource brokering
-- network, vsock, MMDS, or snapshot containment; the current network interface
+- network, MMDS, snapshot, or full vsock containment; the current network interface
   configuration path validates and stores configuration strings, and internal
   virtio-net notification dispatch can parse guest TX descriptor metadata and
   pass validated TX frame payloads to injected packet I/O selected per configured
@@ -158,7 +162,9 @@ The current scaffold does not implement:
   not include a concrete system vmnet backend or call `vmnet_start_interface`,
   `vmnet_stop_interface`, `vmnet_read`, or `vmnet_write`. The default provider
   is a no-op TX sink plus an empty RX source and bangbang still does not open
-  host networking resources
+  host networking resources. The current vsock API path validates and stores
+  `guest_cid` plus `uds_path` before boot, but it does not implement a
+  virtio-vsock device or host Unix socket backend
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy
 


### PR DESCRIPTION
## Summary

- Add Firecracker-shaped `PUT /vsock` parsing, runtime validation, and pre-boot VMM storage.
- Include configured vsock `guest_cid` and `uds_path` in `GET /vm/config` while accepting deprecated input-only `vsock_id`.
- Document that the current scope records configuration only and does not create, bind, connect, unlink, or open host socket resources.

## Scope Exclusions

- No virtio-vsock device emulation.
- No host Unix socket backend or socket resource ownership.
- No guest CID routing, data movement, hotplug, PATCH, or DELETE support.

Closes #303

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test -p bangbang-api --all-features --locked vsock`
- `cargo test -p bangbang-runtime --all-features --locked vsock`
- `cargo test -p bangbang --all-features --locked vsock`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
