### PR TITLE
feat: add vmnet virtio packet adapter

### DIFF
--- a/crates/bangbang/src/host_network.rs
+++ b/crates/bangbang/src/host_network.rs
@@ -1,3 +1,4 @@
 //! Internal host-network backend boundaries.
 
+pub mod virtio_vmnet;
 pub mod vmnet;

--- a/crates/bangbang/src/host_network/virtio_vmnet.rs
+++ b/crates/bangbang/src/host_network/virtio_vmnet.rs
@@ -1,0 +1,899 @@
+//! Adapters between internal virtio-net packet traits and vmnet packet I/O.
+
+use std::collections::TryReserveError;
+use std::fmt;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use bangbang_runtime::memory::{GuestMemory, GuestMemoryAccessError};
+use bangbang_runtime::network::{
+    VIRTIO_NET_MAX_BUFFER_SIZE, VirtioNetworkRxPacket, VirtioNetworkRxPacketSource,
+    VirtioNetworkRxPacketSourceError, VirtioNetworkTxFrame, VirtioNetworkTxPacketSink,
+    VirtioNetworkTxPacketSinkError,
+};
+
+use crate::host_network::vmnet::{
+    VmnetPacketDescriptorError, VmnetPacketIoBackend, VmnetPacketIoError, VmnetReadPacket,
+    VmnetWritePacket,
+};
+
+pub const DEFAULT_VMNET_VIRTIO_NETWORK_RX_BUFFER_LEN: usize = VIRTIO_NET_MAX_BUFFER_SIZE as usize;
+
+#[derive(Debug)]
+pub enum VmnetVirtioNetworkPacketIoBuildError {
+    EmptyRxBuffer,
+    RxBufferAllocation { len: usize, source: TryReserveError },
+}
+
+impl fmt::Display for VmnetVirtioNetworkPacketIoBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyRxBuffer => f.write_str("vmnet virtio-net RX buffer must not be empty"),
+            Self::RxBufferAllocation { len, source } => {
+                write!(
+                    f,
+                    "failed to reserve vmnet virtio-net RX buffer of {len} bytes: {source}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for VmnetVirtioNetworkPacketIoBuildError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::RxBufferAllocation { source, .. } => Some(source),
+            Self::EmptyRxBuffer => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct VmnetVirtioNetworkPacketIo<B>
+where
+    B: VmnetPacketIoBackend,
+{
+    tx_sink: VmnetVirtioNetworkTxPacketSink<B>,
+    rx_source: VmnetVirtioNetworkRxPacketSource<B>,
+}
+
+impl<B> VmnetVirtioNetworkPacketIo<B>
+where
+    B: VmnetPacketIoBackend,
+{
+    pub fn new(
+        backend: B,
+        interface: B::Interface,
+    ) -> Result<Self, VmnetVirtioNetworkPacketIoBuildError> {
+        Self::with_rx_buffer_len(
+            backend,
+            interface,
+            DEFAULT_VMNET_VIRTIO_NETWORK_RX_BUFFER_LEN,
+        )
+    }
+
+    pub fn with_rx_buffer_len(
+        backend: B,
+        interface: B::Interface,
+        rx_buffer_len: usize,
+    ) -> Result<Self, VmnetVirtioNetworkPacketIoBuildError> {
+        let shared = Arc::new(Mutex::new(VmnetVirtioNetworkPacketIoState {
+            backend,
+            interface,
+        }));
+
+        Ok(Self {
+            tx_sink: VmnetVirtioNetworkTxPacketSink::new(Arc::clone(&shared)),
+            rx_source: VmnetVirtioNetworkRxPacketSource::new(shared, rx_buffer_len)?,
+        })
+    }
+
+    pub fn tx_sink(&mut self) -> &mut VmnetVirtioNetworkTxPacketSink<B> {
+        &mut self.tx_sink
+    }
+
+    pub fn rx_source(&mut self) -> &mut VmnetVirtioNetworkRxPacketSource<B> {
+        &mut self.rx_source
+    }
+}
+
+#[derive(Debug)]
+struct VmnetVirtioNetworkPacketIoState<B>
+where
+    B: VmnetPacketIoBackend,
+{
+    backend: B,
+    interface: B::Interface,
+}
+
+#[derive(Debug)]
+pub struct VmnetVirtioNetworkTxPacketSink<B>
+where
+    B: VmnetPacketIoBackend,
+{
+    shared: Arc<Mutex<VmnetVirtioNetworkPacketIoState<B>>>,
+}
+
+impl<B> VmnetVirtioNetworkTxPacketSink<B>
+where
+    B: VmnetPacketIoBackend,
+{
+    fn new(shared: Arc<Mutex<VmnetVirtioNetworkPacketIoState<B>>>) -> Self {
+        Self { shared }
+    }
+}
+
+impl<B> VirtioNetworkTxPacketSink for VmnetVirtioNetworkTxPacketSink<B>
+where
+    B: VmnetPacketIoBackend,
+{
+    fn transmit_frame(
+        &mut self,
+        memory: &GuestMemory,
+        frame: &VirtioNetworkTxFrame,
+    ) -> Result<(), VirtioNetworkTxPacketSinkError> {
+        let packet = copy_tx_frame_payload(memory, frame).map_err(tx_error)?;
+        let mut packet = VmnetWritePacket::new(&packet).map_err(tx_descriptor_error)?;
+        let mut state = lock_state_for_tx(&self.shared)?;
+        let VmnetVirtioNetworkPacketIoState { backend, interface } = &mut *state;
+
+        backend
+            .write_packet(interface, &mut packet)
+            .map_err(tx_vmnet_error)
+    }
+}
+
+#[derive(Debug)]
+pub struct VmnetVirtioNetworkRxPacketSource<B>
+where
+    B: VmnetPacketIoBackend,
+{
+    shared: Arc<Mutex<VmnetVirtioNetworkPacketIoState<B>>>,
+    read_buffer: Vec<u8>,
+    cached_packet_len: Option<usize>,
+}
+
+impl<B> VmnetVirtioNetworkRxPacketSource<B>
+where
+    B: VmnetPacketIoBackend,
+{
+    fn new(
+        shared: Arc<Mutex<VmnetVirtioNetworkPacketIoState<B>>>,
+        rx_buffer_len: usize,
+    ) -> Result<Self, VmnetVirtioNetworkPacketIoBuildError> {
+        if rx_buffer_len == 0 {
+            return Err(VmnetVirtioNetworkPacketIoBuildError::EmptyRxBuffer);
+        }
+
+        let mut read_buffer = Vec::new();
+        read_buffer
+            .try_reserve_exact(rx_buffer_len)
+            .map_err(
+                |source| VmnetVirtioNetworkPacketIoBuildError::RxBufferAllocation {
+                    len: rx_buffer_len,
+                    source,
+                },
+            )?;
+        read_buffer.resize(rx_buffer_len, 0);
+
+        Ok(Self {
+            shared,
+            read_buffer,
+            cached_packet_len: None,
+        })
+    }
+
+    fn cached_packet(&self) -> Option<VirtioNetworkRxPacket<'_>> {
+        let len = self.cached_packet_len?;
+        self.read_buffer.get(..len).map(VirtioNetworkRxPacket::new)
+    }
+}
+
+impl<B> VirtioNetworkRxPacketSource for VmnetVirtioNetworkRxPacketSource<B>
+where
+    B: VmnetPacketIoBackend,
+{
+    fn peek_packet(
+        &mut self,
+    ) -> Result<Option<VirtioNetworkRxPacket<'_>>, VirtioNetworkRxPacketSourceError> {
+        if self.cached_packet_len.is_some() {
+            return Ok(self.cached_packet());
+        }
+
+        let packet_len = {
+            let mut packet = VmnetReadPacket::new(&mut self.read_buffer).map_err(rx_error)?;
+            let mut state = lock_state_for_rx(&self.shared)?;
+            let VmnetVirtioNetworkPacketIoState { backend, interface } = &mut *state;
+
+            backend
+                .read_packet(interface, &mut packet)
+                .map_err(rx_vmnet_error)?
+        };
+        if let Some(len) = packet_len {
+            validate_rx_packet_len(len, self.read_buffer.len())?;
+        }
+
+        self.cached_packet_len = packet_len;
+        Ok(self.cached_packet())
+    }
+
+    fn consume_packet(&mut self) {
+        self.cached_packet_len = None;
+    }
+}
+
+#[derive(Debug)]
+enum VmnetVirtioNetworkTxCopyError {
+    PayloadLengthTooLarge {
+        len: u64,
+    },
+    PacketAllocation {
+        len: usize,
+        source: TryReserveError,
+    },
+    SegmentLengthTooLarge {
+        descriptor_index: u16,
+        len: u32,
+    },
+    SegmentRead {
+        descriptor_index: u16,
+        source: GuestMemoryAccessError,
+    },
+}
+
+impl fmt::Display for VmnetVirtioNetworkTxCopyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PayloadLengthTooLarge { len } => {
+                write!(
+                    f,
+                    "virtio-net TX payload length {len} does not fit host usize"
+                )
+            }
+            Self::PacketAllocation { len, source } => {
+                write!(
+                    f,
+                    "failed to reserve vmnet TX packet buffer of {len} bytes: {source}"
+                )
+            }
+            Self::SegmentLengthTooLarge {
+                descriptor_index,
+                len,
+            } => write!(
+                f,
+                "virtio-net TX payload descriptor {descriptor_index} length {len} does not fit host usize"
+            ),
+            Self::SegmentRead {
+                descriptor_index,
+                source,
+            } => write!(
+                f,
+                "failed to read virtio-net TX payload descriptor {descriptor_index}: {source}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for VmnetVirtioNetworkTxCopyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::PacketAllocation { source, .. } => Some(source),
+            Self::SegmentRead { source, .. } => Some(source),
+            Self::PayloadLengthTooLarge { .. } | Self::SegmentLengthTooLarge { .. } => None,
+        }
+    }
+}
+
+fn copy_tx_frame_payload(
+    memory: &GuestMemory,
+    frame: &VirtioNetworkTxFrame,
+) -> Result<Vec<u8>, VmnetVirtioNetworkTxCopyError> {
+    let packet_len = usize::try_from(frame.payload_len()).map_err(|_| {
+        VmnetVirtioNetworkTxCopyError::PayloadLengthTooLarge {
+            len: frame.payload_len(),
+        }
+    })?;
+    let mut packet = Vec::new();
+    packet.try_reserve_exact(packet_len).map_err(|source| {
+        VmnetVirtioNetworkTxCopyError::PacketAllocation {
+            len: packet_len,
+            source,
+        }
+    })?;
+
+    for segment in frame.payload_segments() {
+        let segment_len = usize::try_from(segment.len()).map_err(|_| {
+            VmnetVirtioNetworkTxCopyError::SegmentLengthTooLarge {
+                descriptor_index: segment.descriptor_index(),
+                len: segment.len(),
+            }
+        })?;
+        let start = packet.len();
+        let end = start.checked_add(segment_len).ok_or(
+            VmnetVirtioNetworkTxCopyError::PayloadLengthTooLarge {
+                len: frame.payload_len(),
+            },
+        )?;
+        packet.resize(end, 0);
+        let segment_buffer = packet.get_mut(start..end).ok_or(
+            VmnetVirtioNetworkTxCopyError::PayloadLengthTooLarge {
+                len: frame.payload_len(),
+            },
+        )?;
+        memory
+            .read_slice(segment_buffer, segment.address())
+            .map_err(|source| VmnetVirtioNetworkTxCopyError::SegmentRead {
+                descriptor_index: segment.descriptor_index(),
+                source,
+            })?;
+    }
+
+    Ok(packet)
+}
+
+fn lock_state_for_tx<B>(
+    shared: &Arc<Mutex<VmnetVirtioNetworkPacketIoState<B>>>,
+) -> Result<MutexGuard<'_, VmnetVirtioNetworkPacketIoState<B>>, VirtioNetworkTxPacketSinkError>
+where
+    B: VmnetPacketIoBackend,
+{
+    shared.lock().map_err(|_| {
+        VirtioNetworkTxPacketSinkError::new("vmnet virtio-net packet state lock poisoned during TX")
+    })
+}
+
+fn lock_state_for_rx<B>(
+    shared: &Arc<Mutex<VmnetVirtioNetworkPacketIoState<B>>>,
+) -> Result<MutexGuard<'_, VmnetVirtioNetworkPacketIoState<B>>, VirtioNetworkRxPacketSourceError>
+where
+    B: VmnetPacketIoBackend,
+{
+    shared.lock().map_err(|_| {
+        VirtioNetworkRxPacketSourceError::new(
+            "vmnet virtio-net packet state lock poisoned during RX",
+        )
+    })
+}
+
+fn tx_error(source: VmnetVirtioNetworkTxCopyError) -> VirtioNetworkTxPacketSinkError {
+    VirtioNetworkTxPacketSinkError::new(source.to_string())
+}
+
+fn tx_descriptor_error(source: VmnetPacketDescriptorError) -> VirtioNetworkTxPacketSinkError {
+    VirtioNetworkTxPacketSinkError::new(format!(
+        "failed to build vmnet TX packet descriptor: {source}"
+    ))
+}
+
+fn tx_vmnet_error(source: VmnetPacketIoError) -> VirtioNetworkTxPacketSinkError {
+    VirtioNetworkTxPacketSinkError::new(format!("vmnet TX packet write failed: {source}"))
+}
+
+fn rx_error(source: VmnetPacketDescriptorError) -> VirtioNetworkRxPacketSourceError {
+    VirtioNetworkRxPacketSourceError::new(format!(
+        "failed to build vmnet RX packet descriptor: {source}"
+    ))
+}
+
+fn rx_vmnet_error(source: VmnetPacketIoError) -> VirtioNetworkRxPacketSourceError {
+    VirtioNetworkRxPacketSourceError::new(format!("vmnet RX packet read failed: {source}"))
+}
+
+fn validate_rx_packet_len(
+    packet_len: usize,
+    buffer_len: usize,
+) -> Result<(), VirtioNetworkRxPacketSourceError> {
+    if packet_len <= buffer_len {
+        return Ok(());
+    }
+
+    Err(rx_vmnet_error(
+        VmnetPacketIoError::ReadPacketSizeExceedsBuffer {
+            packet_size: packet_len,
+            buffer_len,
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::ptr;
+    use std::sync::Arc;
+
+    use bangbang_runtime::memory::{
+        GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange,
+    };
+    use bangbang_runtime::network::{
+        VIRTIO_NET_TX_HEADER_SIZE, VirtioNetworkRxPacketSource, VirtioNetworkTxFrame,
+        VirtioNetworkTxPacketSink,
+    };
+    use bangbang_runtime::virtio_queue::{
+        VIRTQUEUE_DESC_F_NEXT, VIRTQUEUE_DESCRIPTOR_SIZE, read_descriptor_chain,
+    };
+
+    use super::{
+        VmnetPacketIoBackend, VmnetPacketIoError, VmnetReadPacket, VmnetVirtioNetworkPacketIo,
+        VmnetVirtioNetworkPacketIoBuildError, VmnetWritePacket,
+    };
+    use crate::host_network::vmnet::{VmnetOperation, VmnetPacketCountExpectation};
+
+    const DESCRIPTOR_TABLE: GuestAddress = GuestAddress::new(0x1000);
+    const HEADER_ADDRESS: GuestAddress = GuestAddress::new(0x2000);
+    const PAYLOAD_ADDRESS: GuestAddress = GuestAddress::new(0x3000);
+    const SECOND_PAYLOAD_ADDRESS: GuestAddress = GuestAddress::new(0x4000);
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct FakeInterface;
+
+    #[derive(Debug, Default)]
+    struct FakeVmnetPacketIoBackend {
+        write_error: Option<VmnetPacketIoError>,
+        read_results: VecDeque<Result<Option<Vec<u8>>, VmnetPacketIoError>>,
+        written_packets: Vec<Vec<u8>>,
+        read_calls: usize,
+        write_calls: usize,
+    }
+
+    impl FakeVmnetPacketIoBackend {
+        fn with_write_error(mut self, error: VmnetPacketIoError) -> Self {
+            self.write_error = Some(error);
+            self
+        }
+
+        fn with_read_result(mut self, result: Result<Option<Vec<u8>>, VmnetPacketIoError>) -> Self {
+            self.read_results.push_back(result);
+            self
+        }
+    }
+
+    impl VmnetPacketIoBackend for FakeVmnetPacketIoBackend {
+        type Interface = FakeInterface;
+
+        fn read_packet(
+            &mut self,
+            _interface: &mut Self::Interface,
+            packet: &mut VmnetReadPacket<'_>,
+        ) -> Result<Option<usize>, VmnetPacketIoError> {
+            self.read_calls += 1;
+            let Some(result) = self.read_results.pop_front() else {
+                return Ok(None);
+            };
+            let Some(bytes) = result? else {
+                return Ok(None);
+            };
+            let len = bytes.len();
+            assert!(len <= packet.iov().iov_len);
+
+            // SAFETY: `VmnetReadPacket` owns an iovec pointing at the live
+            // read buffer borrowed by the adapter for this synchronous call.
+            unsafe {
+                ptr::copy_nonoverlapping(bytes.as_ptr(), packet.iov().iov_base.cast::<u8>(), len);
+            }
+
+            Ok(Some(len))
+        }
+
+        fn write_packet(
+            &mut self,
+            _interface: &mut Self::Interface,
+            packet: &mut VmnetWritePacket<'_>,
+        ) -> Result<(), VmnetPacketIoError> {
+            self.write_calls += 1;
+            if let Some(error) = self.write_error.clone() {
+                return Err(error);
+            }
+
+            let descriptor = packet.as_raw_descriptor();
+            assert_eq!(descriptor.iov_count(), 1);
+            assert!(!descriptor.iov_ptr().is_null());
+
+            // SAFETY: `VmnetWritePacket` owns an iovec pointing at the packet
+            // bytes borrowed by the adapter for this synchronous call.
+            let iov = unsafe { &*descriptor.iov_ptr() };
+            // SAFETY: The iovec base and length were created from a live packet
+            // slice and are valid for this call.
+            let bytes =
+                unsafe { std::slice::from_raw_parts(iov.iov_base.cast::<u8>(), iov.iov_len) };
+            self.written_packets.push(bytes.to_vec());
+
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct OversizedReadBackend {
+        packet_len: usize,
+    }
+
+    impl VmnetPacketIoBackend for OversizedReadBackend {
+        type Interface = FakeInterface;
+
+        fn read_packet(
+            &mut self,
+            _interface: &mut Self::Interface,
+            _packet: &mut VmnetReadPacket<'_>,
+        ) -> Result<Option<usize>, VmnetPacketIoError> {
+            Ok(Some(self.packet_len))
+        }
+
+        fn write_packet(
+            &mut self,
+            _interface: &mut Self::Interface,
+            _packet: &mut VmnetWritePacket<'_>,
+        ) -> Result<(), VmnetPacketIoError> {
+            Ok(())
+        }
+    }
+
+    fn fake_interface() -> FakeInterface {
+        FakeInterface
+    }
+
+    fn tx_memory() -> GuestMemory {
+        let layout = GuestMemoryLayout::new(vec![
+            GuestMemoryRange::new(GuestAddress::new(0), 0x10_000)
+                .expect("test memory range should be valid"),
+        ])
+        .expect("test memory layout should be valid");
+
+        GuestMemory::allocate(&layout).expect("test guest memory should allocate")
+    }
+
+    fn write_descriptor(
+        memory: &mut GuestMemory,
+        index: u16,
+        address: GuestAddress,
+        len: u32,
+        flags: u16,
+        next: u16,
+    ) {
+        let descriptor_address = GuestAddress::new(
+            DESCRIPTOR_TABLE.raw_value() + (u64::from(index) * VIRTQUEUE_DESCRIPTOR_SIZE as u64),
+        );
+        let mut bytes = [0_u8; VIRTQUEUE_DESCRIPTOR_SIZE];
+        bytes[0..8].copy_from_slice(&address.raw_value().to_le_bytes());
+        bytes[8..12].copy_from_slice(&len.to_le_bytes());
+        bytes[12..14].copy_from_slice(&flags.to_le_bytes());
+        bytes[14..16].copy_from_slice(&next.to_le_bytes());
+        memory
+            .write_slice(&bytes, descriptor_address)
+            .expect("test descriptor should write");
+    }
+
+    fn tx_frame(
+        memory: &mut GuestMemory,
+        payloads: &[(&[u8], GuestAddress)],
+    ) -> VirtioNetworkTxFrame {
+        let header = [0_u8; VIRTIO_NET_TX_HEADER_SIZE as usize];
+        memory
+            .write_slice(&header, HEADER_ADDRESS)
+            .expect("test TX header should write");
+        write_descriptor(
+            memory,
+            0,
+            HEADER_ADDRESS,
+            VIRTIO_NET_TX_HEADER_SIZE,
+            VIRTQUEUE_DESC_F_NEXT,
+            1,
+        );
+
+        for (index, (payload, address)) in payloads.iter().enumerate() {
+            memory
+                .write_slice(payload, *address)
+                .expect("test TX payload should write");
+            let descriptor_index =
+                u16::try_from(index + 1).expect("test descriptor index should fit u16");
+            let next_index = descriptor_index
+                .checked_add(1)
+                .expect("test descriptor next index should fit u16");
+            let has_next = index + 1 < payloads.len();
+            let flags = if has_next { VIRTQUEUE_DESC_F_NEXT } else { 0 };
+            write_descriptor(
+                memory,
+                descriptor_index,
+                *address,
+                u32::try_from(payload.len()).expect("test payload length should fit u32"),
+                flags,
+                next_index,
+            );
+        }
+
+        let chain =
+            read_descriptor_chain(memory, DESCRIPTOR_TABLE, 8, 0).expect("test chain should read");
+        VirtioNetworkTxFrame::parse(memory, &chain).expect("test TX frame should parse")
+    }
+
+    fn packet_io(
+        backend: FakeVmnetPacketIoBackend,
+    ) -> VmnetVirtioNetworkPacketIo<FakeVmnetPacketIoBackend> {
+        VmnetVirtioNetworkPacketIo::with_rx_buffer_len(backend, fake_interface(), 2048)
+            .expect("packet I/O should build")
+    }
+
+    fn unexpected_count_error(operation: VmnetOperation) -> VmnetPacketIoError {
+        VmnetPacketIoError::UnexpectedPacketCount {
+            operation,
+            expected: VmnetPacketCountExpectation::One,
+            actual: 0,
+        }
+    }
+
+    #[test]
+    fn builds_packet_io_with_default_rx_buffer() {
+        let mut packet_io =
+            VmnetVirtioNetworkPacketIo::new(FakeVmnetPacketIoBackend::default(), fake_interface())
+                .expect("default packet I/O should build");
+
+        assert!(
+            packet_io
+                .rx_source()
+                .peek_packet()
+                .expect("peek should succeed")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn rejects_empty_rx_buffer() {
+        let error = VmnetVirtioNetworkPacketIo::with_rx_buffer_len(
+            FakeVmnetPacketIoBackend::default(),
+            fake_interface(),
+            0,
+        )
+        .expect_err("empty RX buffer should fail");
+
+        assert!(matches!(
+            error,
+            VmnetVirtioNetworkPacketIoBuildError::EmptyRxBuffer
+        ));
+    }
+
+    #[test]
+    fn tx_sink_writes_single_segment_payload() {
+        let mut memory = tx_memory();
+        let frame = tx_frame(&mut memory, &[(&[0xaa, 0xbb, 0xcc], PAYLOAD_ADDRESS)]);
+        let mut packet_io = packet_io(FakeVmnetPacketIoBackend::default());
+
+        packet_io
+            .tx_sink()
+            .transmit_frame(&memory, &frame)
+            .expect("TX should write vmnet packet");
+
+        let state = packet_io
+            .tx_sink()
+            .shared
+            .lock()
+            .expect("test state lock should succeed");
+        assert_eq!(state.backend.write_calls, 1);
+        assert_eq!(state.backend.written_packets, [vec![0xaa, 0xbb, 0xcc]]);
+    }
+
+    #[test]
+    fn tx_sink_writes_multi_segment_payload() {
+        let mut memory = tx_memory();
+        let frame = tx_frame(
+            &mut memory,
+            &[
+                (&[0xaa, 0xbb][..], PAYLOAD_ADDRESS),
+                (&[0xcc, 0xdd][..], SECOND_PAYLOAD_ADDRESS),
+            ],
+        );
+        let mut packet_io = packet_io(FakeVmnetPacketIoBackend::default());
+
+        packet_io
+            .tx_sink()
+            .transmit_frame(&memory, &frame)
+            .expect("TX should write vmnet packet");
+
+        let state = packet_io
+            .tx_sink()
+            .shared
+            .lock()
+            .expect("test state lock should succeed");
+        assert_eq!(
+            state.backend.written_packets,
+            [vec![0xaa, 0xbb, 0xcc, 0xdd]]
+        );
+    }
+
+    #[test]
+    fn tx_sink_reports_guest_memory_read_failure() {
+        let mut memory = tx_memory();
+        let frame = tx_frame(&mut memory, &[(&[0xaa, 0xbb], PAYLOAD_ADDRESS)]);
+        let unmapped_payload_layout = GuestMemoryLayout::new(vec![
+            GuestMemoryRange::new(GuestAddress::new(0x4000), 0x4000)
+                .expect("unmapped payload range should be valid"),
+        ])
+        .expect("unmapped payload layout should be valid");
+        let unmapped_payload_memory =
+            GuestMemory::allocate(&unmapped_payload_layout).expect("test memory should allocate");
+        let mut packet_io = packet_io(FakeVmnetPacketIoBackend::default());
+
+        let error = packet_io
+            .tx_sink()
+            .transmit_frame(&unmapped_payload_memory, &frame)
+            .expect_err("unmapped payload should fail");
+
+        assert!(
+            error
+                .message()
+                .contains("failed to read virtio-net TX payload descriptor 1")
+        );
+    }
+
+    #[test]
+    fn tx_sink_reports_vmnet_write_failure() {
+        let mut memory = tx_memory();
+        let frame = tx_frame(&mut memory, &[(&[0xaa], PAYLOAD_ADDRESS)]);
+        let backend = FakeVmnetPacketIoBackend::default()
+            .with_write_error(unexpected_count_error(VmnetOperation::WritePackets));
+        let mut packet_io = packet_io(backend);
+
+        let error = packet_io
+            .tx_sink()
+            .transmit_frame(&memory, &frame)
+            .expect_err("vmnet write failure should surface");
+
+        assert!(
+            error
+                .message()
+                .contains("vmnet TX packet write failed: vmnet_write returned packet count 0")
+        );
+    }
+
+    #[test]
+    fn rx_source_returns_none_when_vmnet_has_no_packet() {
+        let backend = FakeVmnetPacketIoBackend::default().with_read_result(Ok(None));
+        let mut packet_io = packet_io(backend);
+
+        assert!(
+            packet_io
+                .rx_source()
+                .peek_packet()
+                .expect("peek should succeed")
+                .is_none()
+        );
+        let state = packet_io
+            .rx_source()
+            .shared
+            .lock()
+            .expect("test state lock should succeed");
+        assert_eq!(state.backend.read_calls, 1);
+    }
+
+    #[test]
+    fn rx_source_caches_peeked_packet_until_consumed() {
+        let backend = FakeVmnetPacketIoBackend::default()
+            .with_read_result(Ok(Some(vec![0x11, 0x22])))
+            .with_read_result(Ok(Some(vec![0x33])));
+        let mut packet_io = packet_io(backend);
+
+        let first = packet_io
+            .rx_source()
+            .peek_packet()
+            .expect("first peek should succeed")
+            .expect("packet should be present");
+        assert_eq!(first.bytes(), &[0x11, 0x22]);
+        let second = packet_io
+            .rx_source()
+            .peek_packet()
+            .expect("second peek should succeed")
+            .expect("cached packet should still be present");
+        assert_eq!(second.bytes(), &[0x11, 0x22]);
+
+        let state = packet_io
+            .rx_source()
+            .shared
+            .lock()
+            .expect("test state lock should succeed");
+        assert_eq!(state.backend.read_calls, 1);
+    }
+
+    #[test]
+    fn rx_source_reads_next_packet_after_consume() {
+        let backend = FakeVmnetPacketIoBackend::default()
+            .with_read_result(Ok(Some(vec![0x11])))
+            .with_read_result(Ok(Some(vec![0x22])));
+        let mut packet_io = packet_io(backend);
+
+        let first = packet_io
+            .rx_source()
+            .peek_packet()
+            .expect("first peek should succeed")
+            .expect("first packet should be present");
+        assert_eq!(first.bytes(), &[0x11]);
+        packet_io.rx_source().consume_packet();
+        let second = packet_io
+            .rx_source()
+            .peek_packet()
+            .expect("second peek should succeed")
+            .expect("second packet should be present");
+        assert_eq!(second.bytes(), &[0x22]);
+    }
+
+    #[test]
+    fn rx_source_reports_vmnet_read_failure() {
+        let backend = FakeVmnetPacketIoBackend::default()
+            .with_read_result(Err(unexpected_count_error(VmnetOperation::ReadPackets)));
+        let mut packet_io = packet_io(backend);
+
+        let error = packet_io
+            .rx_source()
+            .peek_packet()
+            .expect_err("vmnet read failure should surface");
+
+        assert!(
+            error
+                .message()
+                .contains("vmnet RX packet read failed: vmnet_read returned packet count 0")
+        );
+    }
+
+    #[test]
+    fn rx_source_rejects_backend_packet_len_larger_than_buffer() {
+        let backend = OversizedReadBackend { packet_len: 2049 };
+        let mut packet_io =
+            VmnetVirtioNetworkPacketIo::with_rx_buffer_len(backend, fake_interface(), 2048)
+                .expect("packet I/O should build");
+
+        let error = packet_io
+            .rx_source()
+            .peek_packet()
+            .expect_err("oversized backend read should fail");
+
+        assert!(
+            error.message().contains(
+                "vmnet RX packet read failed: vmnet_read returned packet size 2049, larger than read buffer 2048"
+            )
+        );
+    }
+
+    #[test]
+    fn tx_sink_reports_poisoned_state_lock() {
+        let mut packet_io = packet_io(FakeVmnetPacketIoBackend::default());
+        let shared = Arc::clone(&packet_io.tx_sink().shared);
+        let _ = std::thread::spawn(move || {
+            let _guard = shared
+                .lock()
+                .expect("test lock should succeed before poison");
+            panic!("poison test lock");
+        })
+        .join();
+        let mut memory = tx_memory();
+        let frame = tx_frame(&mut memory, &[(&[0xaa], PAYLOAD_ADDRESS)]);
+
+        let error = packet_io
+            .tx_sink()
+            .transmit_frame(&memory, &frame)
+            .expect_err("poisoned lock should fail");
+
+        assert!(error.message().contains("state lock poisoned during TX"));
+    }
+
+    #[test]
+    fn rx_source_reports_poisoned_state_lock() {
+        let mut packet_io = packet_io(FakeVmnetPacketIoBackend::default());
+        let shared = Arc::clone(&packet_io.rx_source().shared);
+        let _ = std::thread::spawn(move || {
+            let _guard = shared
+                .lock()
+                .expect("test lock should succeed before poison");
+            panic!("poison test lock");
+        })
+        .join();
+
+        let error = packet_io
+            .rx_source()
+            .peek_packet()
+            .expect_err("poisoned lock should fail");
+
+        assert!(error.message().contains("state lock poisoned during RX"));
+    }
+
+    #[test]
+    fn packet_io_owner_exposes_distinct_tx_and_rx_handles() {
+        fn assert_send<T: Send>() {}
+
+        assert_send::<VmnetVirtioNetworkPacketIo<FakeVmnetPacketIoBackend>>();
+    }
+}

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -587,13 +587,14 @@ lifecycle, start owner, packet descriptor, and concrete system start/stop
 backend boundaries with vmnet mode, status, operation error, XPC descriptor
 configuration, retained dispatch queue ownership, completion-status mapping,
 backend start/stop ownership, packet `iovec` layout, single-packet system
-`vmnet_read`/`vmnet_write` wrappers, count validation, and owned cleanup models
-for a later host backend. These boundaries are not connected to the default
-process provider. The default process provider uses a no-op TX sink and an
-empty RX source, so current boot sessions still do not open host networking
-resources or provide user-visible packet ingress or egress. These helpers do
-not advertise MTU, choose a live host packet backend, or connect packets to the
-host network.
+`vmnet_read`/`vmnet_write` wrappers, count validation, owned cleanup models,
+and an internal virtio-net packet I/O adapter that copies TX guest-memory
+payload segments into vmnet writes and caches one vmnet RX packet until
+consumed. These boundaries are not connected to the default process provider.
+The default process provider uses a no-op TX sink and an empty RX source, so
+current boot sessions still do not open host networking resources or provide
+user-visible packet ingress or egress. These helpers do not advertise MTU,
+choose a live host packet backend, or connect packets to the host network.
 
 The runtime crate can prepare owned internal block-device resources from a
 validated list of stored drive configs. Preparation opens each backing file,

--- a/docs/security.md
+++ b/docs/security.md
@@ -158,12 +158,13 @@ The current scaffold does not implement:
   interface, and can copy injected RX packet bytes into validated guest RX
   buffers through the same boundary. On macOS, the process crate has internal
   vmnet descriptor, lifecycle, start owner, concrete system start/stop backend,
-  packet descriptor, and single-packet system read/write backend boundaries for
-  future host networking, but these boundaries are not connected to process
-  startup and bangbang startup does not call `vmnet_start_interface`,
-  `vmnet_stop_interface`, `vmnet_read`, or `vmnet_write`. The default provider
-  is a no-op TX sink plus an empty RX source and bangbang still does not open
-  host networking resources. The current vsock
+  packet descriptor, single-packet system read/write backend boundaries, and an
+  internal virtio-net adapter that can move packets between vmnet and the
+  runtime packet traits for future host networking, but these boundaries are not
+  connected to process startup and bangbang startup does not call
+  `vmnet_start_interface`, `vmnet_stop_interface`, `vmnet_read`, or
+  `vmnet_write`. The default provider is a no-op TX sink plus an empty RX source
+  and bangbang still does not open host networking resources. The current vsock
   API path validates and stores
   `guest_cid` plus `uds_path` before boot, but it does not implement a
   virtio-vsock device or host Unix socket backend


### PR DESCRIPTION
## Summary

- Add an internal `virtio_vmnet` host-network adapter that bridges `VmnetPacketIoBackend` to the runtime virtio-net TX sink and RX source traits.
- Copy TX payload segments from guest memory into owned vmnet write packets.
- Cache one vmnet RX packet between `peek_packet` and `consume_packet`, with error conversion for allocation, guest-memory, vmnet, lock, and invalid packet-length cases.
- Update compatibility and security docs to keep default startup scoped to no-op TX plus empty RX packet I/O.

## Scope Exclusions

- Does not start or stop vmnet interfaces for configured network devices.
- Does not replace the default process packet-I/O provider.
- Does not add vmnet callbacks, batching, host wakeups, entitlement changes, or real host connectivity tests.

Closes #309

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test -p bangbang --all-features --locked virtio_vmnet`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
