### PR TITLE
feat: derive vmnet config from host device name

### DIFF
--- a/crates/bangbang/src/host_network/vmnet.rs
+++ b/crates/bangbang/src/host_network/vmnet.rs
@@ -25,6 +25,10 @@ pub const VMNET_TOO_MANY_PACKETS_VALUE: u32 = 1008;
 pub const VMNET_SHARING_SERVICE_BUSY_VALUE: u32 = 1009;
 pub const VMNET_NOT_AUTHORIZED_VALUE: u32 = 1010;
 
+pub const VMNET_HOST_DEVICE_NAME_HOST: &str = "vmnet:host";
+pub const VMNET_HOST_DEVICE_NAME_SHARED: &str = "vmnet:shared";
+pub const VMNET_HOST_DEVICE_NAME_BRIDGED_PREFIX: &str = "vmnet:bridged:";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VmnetMode {
     Host,
@@ -198,6 +202,18 @@ impl VmnetInterfaceConfig {
         }
     }
 
+    pub fn from_host_dev_name(host_dev_name: &str) -> Result<Self, VmnetHostDeviceNameConfigError> {
+        match host_dev_name {
+            VMNET_HOST_DEVICE_NAME_HOST => Ok(Self::host()),
+            VMNET_HOST_DEVICE_NAME_SHARED => Ok(Self::shared()),
+            name => match name.strip_prefix(VMNET_HOST_DEVICE_NAME_BRIDGED_PREFIX) {
+                Some(interface_name) => Self::bridged(interface_name)
+                    .map_err(|source| VmnetHostDeviceNameConfigError::BridgedInterface { source }),
+                None => Err(VmnetHostDeviceNameConfigError::UnsupportedHostDeviceName),
+            },
+        }
+    }
+
     pub fn bridged(interface_name: impl Into<String>) -> Result<Self, VmnetInterfaceConfigError> {
         let interface_name = interface_name.into();
         if interface_name.is_empty() {
@@ -219,6 +235,34 @@ impl VmnetInterfaceConfig {
 
     pub fn bridged_interface_name(&self) -> Option<&str> {
         self.bridged_interface_name.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VmnetHostDeviceNameConfigError {
+    UnsupportedHostDeviceName,
+    BridgedInterface { source: VmnetInterfaceConfigError },
+}
+
+impl fmt::Display for VmnetHostDeviceNameConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedHostDeviceName => f.write_str(
+                "unsupported vmnet host_dev_name; expected vmnet:host, vmnet:shared, or vmnet:bridged:<interface>",
+            ),
+            Self::BridgedInterface { source } => {
+                write!(f, "invalid vmnet bridged host_dev_name: {source}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VmnetHostDeviceNameConfigError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::UnsupportedHostDeviceName => None,
+            Self::BridgedInterface { source } => Some(source),
+        }
     }
 }
 
@@ -1180,12 +1224,12 @@ mod tests {
 
     use super::{
         OwnedVmnetInterface, StartedVmnetInterface, VMNET_BRIDGED_MODE_VALUE,
-        VMNET_HOST_MODE_VALUE, VMNET_SHARED_MODE_VALUE, VmnetError, VmnetInterfaceBackend,
-        VmnetInterfaceConfig, VmnetInterfaceConfigError, VmnetInterfaceDescriptor,
-        VmnetInterfaceDescriptorError, VmnetInterfaceLifecycle, VmnetInterfaceStartError,
-        VmnetMode, VmnetOperation, VmnetPacketCountExpectation, VmnetPacketDescriptor,
-        VmnetPacketDescriptorError, VmnetPacketIoBackend, VmnetPacketIoError, VmnetReadPacket,
-        VmnetStatus, VmnetSystemApi, VmnetWritePacket,
+        VMNET_HOST_MODE_VALUE, VMNET_SHARED_MODE_VALUE, VmnetError, VmnetHostDeviceNameConfigError,
+        VmnetInterfaceBackend, VmnetInterfaceConfig, VmnetInterfaceConfigError,
+        VmnetInterfaceDescriptor, VmnetInterfaceDescriptorError, VmnetInterfaceLifecycle,
+        VmnetInterfaceStartError, VmnetMode, VmnetOperation, VmnetPacketCountExpectation,
+        VmnetPacketDescriptor, VmnetPacketDescriptorError, VmnetPacketIoBackend,
+        VmnetPacketIoError, VmnetReadPacket, VmnetStatus, VmnetSystemApi, VmnetWritePacket,
     };
 
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2246,6 +2290,89 @@ mod tests {
         assert_eq!(shared.bridged_interface_name(), None);
         assert_eq!(bridged.mode(), VmnetMode::Bridged);
         assert_eq!(bridged.bridged_interface_name(), Some("en0"));
+    }
+
+    #[test]
+    fn vmnet_host_dev_name_maps_host_mode() {
+        let config = VmnetInterfaceConfig::from_host_dev_name("vmnet:host")
+            .expect("host host_dev_name should map");
+
+        assert_eq!(config.mode(), VmnetMode::Host);
+        assert_eq!(config.bridged_interface_name(), None);
+    }
+
+    #[test]
+    fn vmnet_host_dev_name_maps_shared_mode() {
+        let config = VmnetInterfaceConfig::from_host_dev_name("vmnet:shared")
+            .expect("shared host_dev_name should map");
+
+        assert_eq!(config.mode(), VmnetMode::Shared);
+        assert_eq!(config.bridged_interface_name(), None);
+    }
+
+    #[test]
+    fn vmnet_host_dev_name_maps_bridged_mode() {
+        let config = VmnetInterfaceConfig::from_host_dev_name("vmnet:bridged:en0")
+            .expect("bridged host_dev_name should map");
+
+        assert_eq!(config.mode(), VmnetMode::Bridged);
+        assert_eq!(config.bridged_interface_name(), Some("en0"));
+    }
+
+    #[test]
+    fn vmnet_host_dev_name_rejects_unsupported_bare_name() {
+        let error = VmnetInterfaceConfig::from_host_dev_name("tap0")
+            .expect_err("bare host_dev_name should be rejected by vmnet mapping");
+
+        assert_eq!(
+            error,
+            VmnetHostDeviceNameConfigError::UnsupportedHostDeviceName
+        );
+        assert!(error.source().is_none());
+        assert_eq!(
+            error.to_string(),
+            "unsupported vmnet host_dev_name; expected vmnet:host, vmnet:shared, or vmnet:bridged:<interface>"
+        );
+    }
+
+    #[test]
+    fn vmnet_host_dev_name_rejects_empty_bridged_interface() {
+        let error = VmnetInterfaceConfig::from_host_dev_name("vmnet:bridged:")
+            .expect_err("empty bridged interface should be rejected");
+
+        assert_eq!(
+            error,
+            VmnetHostDeviceNameConfigError::BridgedInterface {
+                source: VmnetInterfaceConfigError::EmptyBridgedInterfaceName
+            }
+        );
+        assert_eq!(
+            error
+                .source()
+                .expect("bridged error should expose source")
+                .to_string(),
+            "vmnet bridged interface name must not be empty"
+        );
+    }
+
+    #[test]
+    fn vmnet_host_dev_name_rejects_interior_nul_bridged_interface() {
+        let error = VmnetInterfaceConfig::from_host_dev_name("vmnet:bridged:en\0")
+            .expect_err("interior NUL bridged interface should be rejected");
+
+        assert_eq!(
+            error,
+            VmnetHostDeviceNameConfigError::BridgedInterface {
+                source: VmnetInterfaceConfigError::InteriorNulInBridgedInterfaceName
+            }
+        );
+        assert_eq!(
+            error
+                .source()
+                .expect("bridged error should expose source")
+                .to_string(),
+            "vmnet bridged interface name must not contain NUL bytes"
+        );
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -532,8 +532,12 @@ host device names, and MAC strings.
 
 The internal model rejects configured `mtu`, `rx_rate_limiter`, and
 `tx_rate_limiter` fields as unsupported. It does not open host networking
-resources or choose a macOS packet backend. Stored network interface configs are
-returned from `GET /vm/config` in the `network-interfaces` array.
+resources. Stored network interface configs are returned from `GET /vm/config`
+in the `network-interfaces` array. For future macOS vmnet startup, the process
+crate has an internal mapping boundary that interprets `host_dev_name` values
+`vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` as vmnet host,
+shared, and bridged configurations. That mapping is not applied by the public
+API storage path yet, so other nonempty names are still accepted before boot.
 
 ## Internal Vsock Configuration
 
@@ -591,12 +595,15 @@ backend start/stop ownership, packet `iovec` layout, single-packet system
 `vmnet_read`/`vmnet_write` wrappers, count validation, owned cleanup models,
 an internal virtio-net packet I/O adapter that copies TX guest-memory payload
 segments into vmnet writes and caches one vmnet RX packet until consumed, and a
-prebuilt adapter provider keyed by configured interface ID. These boundaries
-are not connected to the default process provider.
+prebuilt adapter provider keyed by configured interface ID. It also defines an
+internal `host_dev_name` mapping for `vmnet:host`, `vmnet:shared`, and
+`vmnet:bridged:<interface>`. These boundaries are not connected to the default
+process provider.
 The default process provider uses a no-op TX sink and an empty RX source, so
 current boot sessions still do not open host networking resources or provide
 user-visible packet ingress or egress. These helpers do not advertise MTU,
-choose a live host packet backend, or connect packets to the host network.
+choose a live host packet backend during startup, or connect packets to the host
+network.
 
 The runtime crate can prepare owned internal block-device resources from a
 validated list of stored drive configs. Preparation opens each backing file,

--- a/docs/security.md
+++ b/docs/security.md
@@ -161,8 +161,10 @@ The current scaffold does not implement:
   packet descriptor, single-packet system read/write backend boundaries, and an
   internal virtio-net adapter that can move packets between vmnet and the
   runtime packet traits for future host networking, plus an internal provider
-  that can select prebuilt adapters by configured interface ID, but these
-  boundaries are not connected to process startup and bangbang startup does not call
+  that can select prebuilt adapters by configured interface ID and an internal
+  `host_dev_name` mapping for `vmnet:host`, `vmnet:shared`, and
+  `vmnet:bridged:<interface>`, but these boundaries are not connected to
+  process startup and bangbang startup does not call
   `vmnet_start_interface`, `vmnet_stop_interface`, `vmnet_read`, or
   `vmnet_write`. The default provider is a no-op TX sink plus an empty RX source
   and bangbang still does not open host networking resources. The current vsock


### PR DESCRIPTION
## Summary

- add an internal `host_dev_name` to `VmnetInterfaceConfig` mapping for explicit `vmnet:` syntax
- reject unsupported and malformed vmnet host device names with structured errors
- cover host, shared, bridged, unsupported, empty bridged, and interior-NUL bridged cases in unit tests
- document that the mapping exists but is not applied by API storage or default startup yet

## Scope Exclusions

- Does not change `PUT /network-interfaces/{iface_id}` storage validation or response behavior.
- Does not start or stop vmnet interfaces during process startup.
- Does not replace the default no-op network packet provider.
- Does not add real host networking, callbacks, entitlements, or connectivity tests.

Closes #313

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test -p bangbang --all-features --locked vmnet`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
