### PR TITLE
feat: wire vmnet packet io into startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Record a pre-boot network interface:
 curl --unix-socket /tmp/bangbang.socket \
   -X PUT http://localhost/network-interfaces/eth0 \
   -H 'Content-Type: application/json' \
-  -d '{"iface_id":"eth0","host_dev_name":"tap0","guest_mac":"12:34:56:78:9a:bc"}'
+  -d '{"iface_id":"eth0","host_dev_name":"vmnet:shared","guest_mac":"12:34:56:78:9a:bc"}'
 ```
 
 Record a pre-boot vsock configuration:

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -14,7 +14,7 @@ use bangbang_runtime::block::BlockMmioLayout;
 use bangbang_runtime::memory::{GuestAddress, GuestMemory};
 use bangbang_runtime::mmio::MmioRegionId;
 use bangbang_runtime::network::{
-    NetworkMmioLayout, VirtioNetworkRxPacket, VirtioNetworkRxPacketSource,
+    NetworkInterfaceConfig, NetworkMmioLayout, VirtioNetworkRxPacket, VirtioNetworkRxPacketSource,
     VirtioNetworkRxPacketSourceError, VirtioNetworkTxFrame, VirtioNetworkTxPacketSink,
     VirtioNetworkTxPacketSinkError,
 };
@@ -24,6 +24,16 @@ use bangbang_runtime::startup::{
     Arm64BootNetworkPacketIoProvider,
 };
 use bangbang_runtime::{BackendError, VmmAction, VmmActionError, VmmController, VmmData};
+
+use crate::host_network::virtio_vmnet::{
+    VmnetVirtioNetworkPacketIo, VmnetVirtioNetworkPacketIoBuildError,
+    VmnetVirtioNetworkPacketIoProvider, VmnetVirtioNetworkPacketIoProviderBuildError,
+    VmnetVirtioNetworkPacketIoProviderEntry,
+};
+use crate::host_network::vmnet::{
+    StartedVmnetPacketIoBackend, SystemVmnetInterfaceBackend, VmnetHostDeviceNameConfigError,
+    VmnetInterfaceBackend, VmnetInterfaceConfig, VmnetInterfaceStartError, VmnetPacketIoBackend,
+};
 
 #[cfg(test)]
 use bangbang_runtime::InstanceInfo;
@@ -181,16 +191,23 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
     type Session = HvfBootRunLoopSupervisor;
 
     fn start(&mut self, controller: &VmmController) -> Result<Self::Session, BackendError> {
+        let packet_io = ProcessNetworkPacketIoProvider::from_network_configs(
+            controller.network_interface_configs(),
+        )
+        .map_err(|err| {
+            BackendError::Hypervisor(format!(
+                "failed to build network packet I/O provider: {err}"
+            ))
+        })?;
         let session = OwnedHvfArm64BootSession::new(controller, self.boot_session_config())
             .map_err(|err| BackendError::Hypervisor(err.to_string()))?;
-        let session =
-            ProcessHvfBootSession::new(session, NoopProcessNetworkPacketIoProvider::default());
+        let session = ProcessHvfBootSession::new(session, packet_io);
         HvfBootRunLoopSupervisor::start(session, default_hvf_boot_run_loop_step_limit())
     }
 }
 
 pub(crate) type HvfBootRunLoopSupervisor = BootRunLoopSupervisor<
-    ProcessHvfBootSession<OwnedHvfArm64BootSession, NoopProcessNetworkPacketIoProvider>,
+    ProcessHvfBootSession<OwnedHvfArm64BootSession, ProcessNetworkPacketIoProvider>,
 >;
 
 pub(crate) struct ProcessHvfBootSession<S, P> {
@@ -233,6 +250,160 @@ impl Arm64BootNetworkPacketIoProvider for NoopProcessNetworkPacketIoProvider {
             &mut self.rx_source,
         ))
     }
+}
+
+type SystemStartedVmnetPacketIoBackend = StartedVmnetPacketIoBackend<SystemVmnetInterfaceBackend>;
+type SystemProcessVmnetPacketIoProvider =
+    VmnetVirtioNetworkPacketIoProvider<SystemStartedVmnetPacketIoBackend>;
+
+#[derive(Debug)]
+pub(crate) enum ProcessNetworkPacketIoProvider {
+    Noop(NoopProcessNetworkPacketIoProvider),
+    Vmnet(SystemProcessVmnetPacketIoProvider),
+}
+
+impl ProcessNetworkPacketIoProvider {
+    fn from_network_configs(
+        configs: &[NetworkInterfaceConfig],
+    ) -> Result<Self, ProcessNetworkPacketIoProviderBuildError> {
+        if configs.is_empty() {
+            return Ok(Self::Noop(NoopProcessNetworkPacketIoProvider::default()));
+        }
+
+        let mut factory = SystemProcessVmnetPacketIoBackendFactory;
+        process_vmnet_packet_io_provider_from_configs(configs, &mut factory).map(Self::Vmnet)
+    }
+}
+
+impl Arm64BootNetworkPacketIoProvider for ProcessNetworkPacketIoProvider {
+    fn packet_io(
+        &mut self,
+        device: &Arm64BootNetworkDevice,
+    ) -> Result<Arm64BootNetworkPacketIo<'_>, Arm64BootNetworkPacketIoError> {
+        match self {
+            Self::Noop(provider) => provider.packet_io(device),
+            Self::Vmnet(provider) => provider.packet_io(device),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ProcessNetworkPacketIoProviderBuildError {
+    HostDeviceName {
+        iface_id: String,
+        source: VmnetHostDeviceNameConfigError,
+    },
+    Start {
+        iface_id: String,
+        source: VmnetInterfaceStartError,
+    },
+    PacketIoBuild {
+        iface_id: String,
+        source: VmnetVirtioNetworkPacketIoBuildError,
+    },
+    ProviderBuild {
+        source: VmnetVirtioNetworkPacketIoProviderBuildError,
+    },
+}
+
+impl fmt::Display for ProcessNetworkPacketIoProviderBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::HostDeviceName { iface_id, source } => {
+                write!(
+                    f,
+                    "network interface {iface_id} has unsupported vmnet host device config: {source}"
+                )
+            }
+            Self::Start { iface_id, source } => {
+                write!(
+                    f,
+                    "failed to start vmnet packet I/O for interface {iface_id}: {source}"
+                )
+            }
+            Self::PacketIoBuild { iface_id, source } => {
+                write!(
+                    f,
+                    "failed to build vmnet packet I/O for interface {iface_id}: {source}"
+                )
+            }
+            Self::ProviderBuild { source } => {
+                write!(f, "failed to build vmnet packet I/O provider: {source}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ProcessNetworkPacketIoProviderBuildError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::HostDeviceName { source, .. } => Some(source),
+            Self::Start { source, .. } => Some(source),
+            Self::PacketIoBuild { source, .. } => Some(source),
+            Self::ProviderBuild { source } => Some(source),
+        }
+    }
+}
+
+trait ProcessVmnetPacketIoBackendFactory {
+    type Backend: VmnetInterfaceBackend;
+
+    fn new_backend(&mut self, iface_id: &str) -> Self::Backend;
+}
+
+#[derive(Debug, Default)]
+struct SystemProcessVmnetPacketIoBackendFactory;
+
+impl ProcessVmnetPacketIoBackendFactory for SystemProcessVmnetPacketIoBackendFactory {
+    type Backend = SystemVmnetInterfaceBackend;
+
+    fn new_backend(&mut self, _iface_id: &str) -> Self::Backend {
+        SystemVmnetInterfaceBackend::new()
+    }
+}
+
+fn process_vmnet_packet_io_provider_from_configs<F>(
+    configs: &[NetworkInterfaceConfig],
+    factory: &mut F,
+) -> Result<
+    VmnetVirtioNetworkPacketIoProvider<StartedVmnetPacketIoBackend<F::Backend>>,
+    ProcessNetworkPacketIoProviderBuildError,
+>
+where
+    F: ProcessVmnetPacketIoBackendFactory,
+    F::Backend: VmnetPacketIoBackend<Interface = <F::Backend as VmnetInterfaceBackend>::Interface>,
+{
+    let mut entries = Vec::new();
+
+    for config in configs {
+        let iface_id = config.iface_id();
+        let vmnet_config = VmnetInterfaceConfig::from_host_dev_name(config.host_dev_name())
+            .map_err(
+                |source| ProcessNetworkPacketIoProviderBuildError::HostDeviceName {
+                    iface_id: iface_id.to_string(),
+                    source,
+                },
+            )?;
+        let backend = factory.new_backend(iface_id);
+        let (backend, interface) = StartedVmnetPacketIoBackend::start(backend, &vmnet_config)
+            .map_err(|source| ProcessNetworkPacketIoProviderBuildError::Start {
+                iface_id: iface_id.to_string(),
+                source,
+            })?;
+        let packet_io = VmnetVirtioNetworkPacketIo::new(backend, interface).map_err(|source| {
+            ProcessNetworkPacketIoProviderBuildError::PacketIoBuild {
+                iface_id: iface_id.to_string(),
+                source,
+            }
+        })?;
+
+        entries.push(VmnetVirtioNetworkPacketIoProviderEntry::new(
+            iface_id, packet_io,
+        ));
+    }
+
+    VmnetVirtioNetworkPacketIoProvider::new(entries)
+        .map_err(|source| ProcessNetworkPacketIoProviderBuildError::ProviderBuild { source })
 }
 
 #[derive(Debug, Default)]
@@ -595,8 +766,8 @@ mod tests {
     use bangbang_runtime::interrupt::GuestInterruptLine;
     use bangbang_runtime::mmio::MmioRegion;
     use bangbang_runtime::network::{
-        NetworkInterfaceConfigInput, NetworkInterfaceConfigs, NetworkMmioLayout,
-        PreparedNetworkDevices,
+        NetworkInterfaceConfig, NetworkInterfaceConfigInput, NetworkInterfaceConfigs,
+        NetworkMmioLayout, PreparedNetworkDevices,
     };
     use bangbang_runtime::serial::{
         SERIAL_MMIO_DEVICE_WINDOW_SIZE, SerialOutput, SharedSerialOutputBuffer,
@@ -607,13 +778,21 @@ mod tests {
     };
     use bangbang_runtime::{BackendError, InstanceState, VmmAction, VmmActionError};
 
+    use crate::host_network::vmnet::{
+        VmnetError, VmnetInterfaceBackend, VmnetInterfaceConfig, VmnetInterfaceDescriptor,
+        VmnetInterfaceDescriptorError, VmnetOperation, VmnetPacketIoBackend, VmnetPacketIoError,
+        VmnetReadPacket, VmnetStatus, VmnetWritePacket,
+    };
+
     use super::{
         BootRunLoopControl, BootRunLoopSession, BootRunLoopSupervisor, BootRunLoopWorkerStatus,
         DEFAULT_HVF_BOOT_RUN_LOOP_STEP_LIMIT, DEFAULT_NETWORK_MMIO_BASE,
         DEFAULT_NETWORK_MMIO_REGION_ID, DEFAULT_SERIAL_MMIO_BASE, DEFAULT_SERIAL_MMIO_REGION_ID,
         EmptyProcessNetworkRxPacketSource, HvfInstanceStartExecutor, InstanceStartExecutor,
         NetworkPacketIoRunLoopSession, NoopProcessNetworkTxPacketSink, ProcessHvfBootSession,
-        ProcessVmm, default_hvf_boot_run_loop_step_limit, default_hvf_boot_session_config,
+        ProcessNetworkPacketIoProvider, ProcessNetworkPacketIoProviderBuildError, ProcessVmm,
+        ProcessVmnetPacketIoBackendFactory, default_hvf_boot_run_loop_step_limit,
+        default_hvf_boot_session_config, process_vmnet_packet_io_provider_from_configs,
     };
 
     static NEXT_TEMP_FILE_ID: AtomicU64 = AtomicU64::new(0);
@@ -937,6 +1116,135 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct RecordingVmnetInterface {
+        iface_id: String,
+    }
+
+    #[derive(Debug)]
+    struct RecordingVmnetPacketIoBackend {
+        iface_id: String,
+        events: Arc<Mutex<Vec<String>>>,
+        start_status: Option<VmnetStatus>,
+    }
+
+    impl VmnetInterfaceBackend for RecordingVmnetPacketIoBackend {
+        type Interface = RecordingVmnetInterface;
+
+        fn build_interface_descriptor(
+            &mut self,
+            config: &VmnetInterfaceConfig,
+        ) -> Result<VmnetInterfaceDescriptor, VmnetInterfaceDescriptorError> {
+            push_recorded_event(
+                &self.events,
+                format!("descriptor:{}:{}", self.iface_id, config.mode()),
+            );
+            VmnetInterfaceDescriptor::new(config)
+        }
+
+        fn start_interface(
+            &mut self,
+            _descriptor: &VmnetInterfaceDescriptor,
+        ) -> Result<Self::Interface, VmnetError> {
+            push_recorded_event(&self.events, format!("start:{}", self.iface_id));
+            if let Some(status) = self.start_status {
+                return Err(VmnetError::new(VmnetOperation::StartInterface, status));
+            }
+
+            Ok(RecordingVmnetInterface {
+                iface_id: self.iface_id.clone(),
+            })
+        }
+
+        fn stop_interface(&mut self, interface: &mut Self::Interface) -> Result<(), VmnetError> {
+            push_recorded_event(&self.events, format!("stop:{}", interface.iface_id));
+            Ok(())
+        }
+    }
+
+    impl VmnetPacketIoBackend for RecordingVmnetPacketIoBackend {
+        type Interface = RecordingVmnetInterface;
+
+        fn read_packet(
+            &mut self,
+            interface: &mut Self::Interface,
+            _packet: &mut VmnetReadPacket<'_>,
+        ) -> Result<Option<usize>, VmnetPacketIoError> {
+            push_recorded_event(&self.events, format!("read:{}", interface.iface_id));
+            Ok(None)
+        }
+
+        fn write_packet(
+            &mut self,
+            interface: &mut Self::Interface,
+            _packet: &mut VmnetWritePacket<'_>,
+        ) -> Result<(), VmnetPacketIoError> {
+            push_recorded_event(&self.events, format!("write:{}", interface.iface_id));
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingVmnetPacketIoBackendFactory {
+        events: Arc<Mutex<Vec<String>>>,
+        start_statuses: VecDeque<Option<VmnetStatus>>,
+    }
+
+    impl RecordingVmnetPacketIoBackendFactory {
+        fn events(&self) -> Arc<Mutex<Vec<String>>> {
+            Arc::clone(&self.events)
+        }
+
+        fn with_next_start_status(mut self, status: Option<VmnetStatus>) -> Self {
+            self.start_statuses.push_back(status);
+            self
+        }
+    }
+
+    impl ProcessVmnetPacketIoBackendFactory for RecordingVmnetPacketIoBackendFactory {
+        type Backend = RecordingVmnetPacketIoBackend;
+
+        fn new_backend(&mut self, iface_id: &str) -> Self::Backend {
+            push_recorded_event(&self.events, format!("backend:{iface_id}"));
+            RecordingVmnetPacketIoBackend {
+                iface_id: iface_id.to_string(),
+                events: Arc::clone(&self.events),
+                start_status: self.start_statuses.pop_front().unwrap_or(None),
+            }
+        }
+    }
+
+    fn push_recorded_event(events: &Arc<Mutex<Vec<String>>>, event: String) {
+        events
+            .lock()
+            .expect("recorded event log should lock")
+            .push(event);
+    }
+
+    fn recorded_events(events: &Arc<Mutex<Vec<String>>>) -> Vec<String> {
+        events
+            .lock()
+            .expect("recorded event log should lock")
+            .clone()
+    }
+
+    fn network_configs(
+        configs: impl IntoIterator<Item = (&'static str, &'static str)>,
+    ) -> Vec<NetworkInterfaceConfig> {
+        let mut network_configs = NetworkInterfaceConfigs::new();
+        for (iface_id, host_dev_name) in configs {
+            network_configs
+                .insert(NetworkInterfaceConfigInput::new(
+                    iface_id,
+                    iface_id,
+                    host_dev_name,
+                ))
+                .expect("network config should insert");
+        }
+
+        network_configs.as_slice().to_vec()
+    }
+
     fn test_boot_network_device() -> Arm64BootNetworkDevice {
         let mut configs = NetworkInterfaceConfigs::new();
         configs
@@ -1102,6 +1410,161 @@ mod tests {
                 .lock()
                 .expect("requested ifaces should lock"),
             ["eth0".to_string()]
+        );
+    }
+
+    #[test]
+    fn process_network_packet_io_provider_empty_configs_use_noop() {
+        let mut provider = ProcessNetworkPacketIoProvider::from_network_configs(&[])
+            .expect("empty network configs should build a no-op provider");
+
+        match &provider {
+            ProcessNetworkPacketIoProvider::Noop(_) => {}
+            ProcessNetworkPacketIoProvider::Vmnet(_) => {
+                panic!("empty network configs should not build a vmnet provider");
+            }
+        }
+        provider
+            .packet_io(&test_boot_network_device())
+            .expect("no-op provider should return packet I/O for any device");
+    }
+
+    #[test]
+    fn process_vmnet_packet_io_provider_starts_supported_configs() {
+        let configs = network_configs([("eth0", "vmnet:shared")]);
+        let mut factory = RecordingVmnetPacketIoBackendFactory::default();
+        let event_log = factory.events();
+
+        {
+            let mut provider =
+                process_vmnet_packet_io_provider_from_configs(&configs, &mut factory)
+                    .expect("supported vmnet configs should build provider");
+            provider
+                .packet_io(&test_boot_network_device())
+                .expect("provider should select packet I/O by iface id");
+        }
+
+        assert_eq!(
+            recorded_events(&event_log),
+            [
+                "backend:eth0".to_string(),
+                "descriptor:eth0:shared".to_string(),
+                "start:eth0".to_string(),
+                "stop:eth0".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn process_vmnet_packet_io_provider_rejects_unsupported_host_dev_name_before_backend() {
+        let configs = network_configs([("eth0", "tap0")]);
+        let mut factory = RecordingVmnetPacketIoBackendFactory::default();
+        let event_log = factory.events();
+        let error = process_vmnet_packet_io_provider_from_configs(&configs, &mut factory)
+            .expect_err("unsupported host_dev_name should fail provider construction");
+
+        match error {
+            ProcessNetworkPacketIoProviderBuildError::HostDeviceName { iface_id, .. } => {
+                assert_eq!(iface_id, "eth0");
+            }
+            ProcessNetworkPacketIoProviderBuildError::Start { .. }
+            | ProcessNetworkPacketIoProviderBuildError::PacketIoBuild { .. }
+            | ProcessNetworkPacketIoProviderBuildError::ProviderBuild { .. } => {
+                panic!("unsupported host_dev_name should fail before vmnet backend start");
+            }
+        }
+        assert!(recorded_events(&event_log).is_empty());
+    }
+
+    #[test]
+    fn process_vmnet_packet_io_provider_cleans_started_entries_after_later_failure() {
+        let configs = network_configs([("eth0", "vmnet:shared"), ("eth1", "tap1")]);
+        let mut factory = RecordingVmnetPacketIoBackendFactory::default();
+        let event_log = factory.events();
+        let error = process_vmnet_packet_io_provider_from_configs(&configs, &mut factory)
+            .expect_err("later unsupported config should fail provider construction");
+
+        match error {
+            ProcessNetworkPacketIoProviderBuildError::HostDeviceName { iface_id, .. } => {
+                assert_eq!(iface_id, "eth1");
+            }
+            ProcessNetworkPacketIoProviderBuildError::Start { .. }
+            | ProcessNetworkPacketIoProviderBuildError::PacketIoBuild { .. }
+            | ProcessNetworkPacketIoProviderBuildError::ProviderBuild { .. } => {
+                panic!("unsupported host_dev_name should be reported as config failure");
+            }
+        }
+        assert_eq!(
+            recorded_events(&event_log),
+            [
+                "backend:eth0".to_string(),
+                "descriptor:eth0:shared".to_string(),
+                "start:eth0".to_string(),
+                "stop:eth0".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn process_vmnet_packet_io_provider_start_failure_preserves_not_started_state() {
+        let mut controller = bangbang_runtime::VmmController::new("demo-1", "0.1.0", "bangbang");
+        controller
+            .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+                "/tmp/vmlinux",
+            )))
+            .expect("boot source should configure");
+        controller
+            .handle_action(VmmAction::PutNetworkInterface(
+                NetworkInterfaceConfigInput::new("eth0", "eth0", "vmnet:shared"),
+            ))
+            .expect("network config should insert");
+        let mut factory = RecordingVmnetPacketIoBackendFactory::default()
+            .with_next_start_status(Some(VmnetStatus::NotAuthorized));
+        let event_log = factory.events();
+        let error = controller
+            .start_instance_with(|controller| {
+                process_vmnet_packet_io_provider_from_configs(
+                    controller.network_interface_configs(),
+                    &mut factory,
+                )
+                .map(|_provider| ())
+                .map_err(|err| {
+                    BackendError::Hypervisor(format!(
+                        "failed to build network packet I/O provider: {err}"
+                    ))
+                })
+            })
+            .expect_err("vmnet start failure should fail InstanceStart");
+
+        match error {
+            VmmActionError::InstanceStart(BackendError::Hypervisor(message)) => {
+                assert!(message.contains("failed to start vmnet packet I/O for interface eth0"));
+            }
+            VmmActionError::InstanceStart(
+                BackendError::Unsupported(_) | BackendError::InvalidState(_),
+            )
+            | VmmActionError::UnsupportedAction(_)
+            | VmmActionError::UnsupportedState { .. }
+            | VmmActionError::MissingBootSource
+            | VmmActionError::BootSourceConfig(_)
+            | VmmActionError::DriveConfig(_)
+            | VmmActionError::LoggerConfig(_)
+            | VmmActionError::MachineConfig(_)
+            | VmmActionError::MetricsConfig(_)
+            | VmmActionError::MetricsFlush(_)
+            | VmmActionError::NetworkInterfaceConfig(_)
+            | VmmActionError::VsockConfig(_) => {
+                panic!("vmnet start failure should propagate as hypervisor startup error");
+            }
+        }
+        assert_eq!(controller.instance_info().state, InstanceState::NotStarted);
+        assert_eq!(
+            recorded_events(&event_log),
+            [
+                "backend:eth0".to_string(),
+                "descriptor:eth0:shared".to_string(),
+                "start:eth0".to_string(),
+            ]
         );
     }
 

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -1456,6 +1456,35 @@ mod tests {
     }
 
     #[test]
+    fn process_vmnet_packet_io_provider_maps_all_supported_host_dev_name_forms() {
+        let configs = network_configs([
+            ("eth0", "vmnet:host"),
+            ("eth1", "vmnet:shared"),
+            ("eth2", "vmnet:bridged:en0"),
+        ]);
+        let mut factory = RecordingVmnetPacketIoBackendFactory::default();
+        let event_log = factory.events();
+        let provider = process_vmnet_packet_io_provider_from_configs(&configs, &mut factory)
+            .expect("all supported vmnet host device names should build provider");
+
+        let events = recorded_events(&event_log);
+        assert!(events.iter().any(|event| event == "descriptor:eth0:host"));
+        assert!(events.iter().any(|event| event == "descriptor:eth1:shared"));
+        assert!(
+            events
+                .iter()
+                .any(|event| event == "descriptor:eth2:bridged")
+        );
+        drop(provider);
+
+        let events = recorded_events(&event_log);
+        for iface_id in ["eth0", "eth1", "eth2"] {
+            let expected = format!("stop:{iface_id}");
+            assert!(events.iter().any(|event| event == &expected));
+        }
+    }
+
+    #[test]
     fn process_vmnet_packet_io_provider_rejects_unsupported_host_dev_name_before_backend() {
         let configs = network_configs([("eth0", "tap0")]);
         let mut factory = RecordingVmnetPacketIoBackendFactory::default();

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -49,9 +49,10 @@ access, one-step runner-thread MMIO handling, a run-cancellation boundary, a
 virtual-timer-mask control boundary, a bounded internal boot-session run-loop
 pump, owned internal boot-session handle, process-level owned startup-session
 wiring with optional serial capture and boot run-loop supervision across bounded
-step windows with retained internal worker status, process-owned no-op
-virtio-net packet-I/O provider injection, an internal vmnet virtio-net packet
-I/O provider keyed by configured interface ID, boot block and virtio-net queue
+step windows with retained internal worker status, process-owned virtio-net
+packet-I/O provider selection with no-op fallback and vmnet-backed startup for
+configured interfaces, an internal vmnet virtio-net packet I/O provider keyed by
+configured interface ID, boot block and virtio-net queue
 interrupt signaling,
 virtual timer PPI assertion, per-controller metrics and logger output state, and an initial process startup argument model.
 There is no broader API request body model beyond the initial boot-source,
@@ -231,7 +232,7 @@ compatibility targets.
 | `PUT` | `/logger` | supported target; minimal subset implemented | Stores process logger configuration before boot, opens `log_path` with nonblocking output semantics when provided, accepts optional Firecracker-shaped level/show/module fields, and omits logger state from `GET /vm/config` because it is not guest configuration. Full internal log routing remains deferred. |
 | `PATCH` | `/machine-config` | deferred | Partial updates belong with later state and validation rules. |
 | `PUT` | `/cpu-config` | deferred | Needs HVF CPU feature design with VM and boot work in #8 and #10. |
-| `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores initial virtio-net configuration before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT, and internal network notification dispatch can route each configured interface through injected packet I/O, parse TX descriptors through a packet sink boundary, and copy injected RX packets into guest buffers through a packet source boundary. Host packet backend selection, public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
+| `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores initial virtio-net configuration before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` selects vmnet packet I/O only for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names; unsupported names fail startup before `Running` is committed. Internal network notification dispatch can route each configured interface through selected packet I/O, parse TX descriptors through a packet sink boundary, and copy injected RX packets into guest buffers through a packet source boundary. Public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
 | `PUT` | `/vsock` | supported target; configuration storage implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Virtio-vsock device emulation, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
 | `GET`, `PUT`, `PATCH` | `/mmds` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/mmds/config` | deferred | Tied to MMDS work in #16. |
@@ -279,7 +280,7 @@ exist.
 | `PUT /drives/{drive_id}` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
 | `PUT /network-interfaces/{iface_id}` | path `iface_id` | required | The API parser captures this value, and the internal model validates it as nonempty alphanumeric or `_`, matching Firecracker's `checked_id` rule. |
 | `PUT /network-interfaces/{iface_id}` | body `iface_id` | required | The API parser rejects requests where this does not match the path `iface_id`. |
-| `PUT /network-interfaces/{iface_id}` | `host_dev_name` | required | The API/VMM path records this value only after rejecting empty values; it does not open, stat, or otherwise touch host networking resources. macOS packet backend selection remains deferred. |
+| `PUT /network-interfaces/{iface_id}` | `host_dev_name` | required | The API/VMM path records this value only after rejecting empty values; it does not open, stat, or otherwise touch host networking resources during configuration. `InstanceStart` later accepts only `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` for vmnet packet I/O startup. |
 | `PUT /network-interfaces/{iface_id}` | `guest_mac` | optional | The internal model accepts six colon-separated two-hex-digit octets, normalizes display to lowercase hex, and rejects duplicate configured MAC addresses across different interface IDs. |
 | `PUT /network-interfaces/{iface_id}` | `mtu` | deferred when configured | The internal model rejects configured MTU values until virtio-net feature negotiation and backend behavior exist. |
 | `PUT /network-interfaces/{iface_id}` | `rx_rate_limiter`, `tx_rate_limiter` | deferred when configured | The internal model rejects configured network rate limiters until virtio-net rate limiting behavior exists. |
@@ -531,13 +532,14 @@ different interface IDs. Displayed validation errors avoid echoing invalid IDs,
 host device names, and MAC strings.
 
 The internal model rejects configured `mtu`, `rx_rate_limiter`, and
-`tx_rate_limiter` fields as unsupported. It does not open host networking
-resources. Stored network interface configs are returned from `GET /vm/config`
-in the `network-interfaces` array. For future macOS vmnet startup, the process
-crate has an internal mapping boundary that interprets `host_dev_name` values
-`vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` as vmnet host,
-shared, and bridged configurations. That mapping is not applied by the public
-API storage path yet, so other nonempty names are still accepted before boot.
+`tx_rate_limiter` fields as unsupported. Configuration storage does not open
+host networking resources. Stored network interface configs are returned from
+`GET /vm/config` in the `network-interfaces` array. During `InstanceStart`, the
+process crate maps `host_dev_name` values `vmnet:host`, `vmnet:shared`, and
+`vmnet:bridged:<interface>` to vmnet host, shared, and bridged configurations
+and builds cleanup-owning packet I/O for each configured interface. Other
+nonempty names are still accepted before boot but fail startup before `Running`
+is committed.
 
 ## Internal Vsock Configuration
 
@@ -577,8 +579,9 @@ into the guest FDT while preserving interface order and host device names.
 Internal network notification dispatch can drain pending TX and RX queue
 notifications and can choose injected packet I/O per configured interface at the
 boot-runtime boundary. The HVF boot-session wrapper can invoke that injected
-path, and process-owned startup wires the internal boot loop through a default
-no-op provider. TX dispatch walks the TX available ring, parses descriptor
+path. Process-owned startup uses a no-op provider when no network interfaces are
+configured and builds vmnet packet I/O for configured interfaces during
+`InstanceStart`. TX dispatch walks the TX available ring, parses descriptor
 chains into `VirtioNetworkTxFrame` metadata, publishes used-ring
 completions with length 0, delivers parsed frames to an injected internal packet
 sink, preserves parse, sink, and partial-dispatch errors, and marks queue
@@ -598,13 +601,12 @@ retaining vmnet stop-on-drop ownership, an internal virtio-net packet I/O
 adapter that copies TX guest-memory payload segments into vmnet writes and
 caches one vmnet RX packet until consumed, and a prebuilt adapter provider keyed
 by configured interface ID. It also defines an internal `host_dev_name` mapping
-for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>`. These
-boundaries are not connected to the default process provider.
-The default process provider uses a no-op TX sink and an empty RX source, so
-current boot sessions still do not open host networking resources or provide
-user-visible packet ingress or egress. These helpers do not advertise MTU,
-choose a live host packet backend during startup, or connect packets to the host
-network.
+for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>`. Startup with
+configured network interfaces now opens vmnet resources through those supported
+forms and retains stop-on-drop cleanup. Startup without network interfaces still
+uses a no-op TX sink and an empty RX source. These helpers do not advertise MTU,
+support rate limiters, prove host connectivity, or provide public runtime packet
+movement.
 
 The runtime crate can prepare owned internal block-device resources from a
 validated list of stored drive configs. Preparation opens each backing file,
@@ -1007,7 +1009,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | `PUT /machine-config` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Pre-boot-only configuration. Stored values are applied during startup preparation. |
 | `PUT /boot-source` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; host paths are opened during startup preparation. Host path errors must avoid leaking sensitive path details. |
 | `PUT /drives/{drive_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; startup preparation opens backing files and registers initial block MMIO devices. Runtime hotplug remains deferred. |
-| `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT, while internal network notification dispatch can route each interface through injected packet I/O, complete TX descriptor heads through a packet sink boundary, and write injected RX packets into guest buffers through a packet source boundary. Host packet backend, public packet movement, PATCH, and DELETE remain deferred. |
+| `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` opens vmnet packet I/O for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names and fails before `Running` for unsupported names. Internal network notification dispatch can route each interface through selected packet I/O, complete TX descriptor heads through a packet sink boundary, and write injected RX packets into guest buffers through a packet source boundary. Public packet movement, PATCH, and DELETE remain deferred. |
 | `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Virtio-vsock device emulation, host socket backend behavior, CID routing, data movement, PATCH, and DELETE remain deferred. |
 | `PUT /metrics` | implemented; `204` empty response on successful output initialization | unsupported after start; `400` `fault_message` | Metrics output is process observability state, not guest configuration. Duplicate initialization fails. |
 | `PUT /logger` | implemented; `204` empty response on successful pre-boot configuration | unsupported after start; `400` `fault_message` | Logger output is process observability state, not guest configuration. Repeated pre-boot requests update provided fields; full log routing remains deferred. |
@@ -1052,11 +1054,11 @@ and tested.
 The following Firecracker features are outside the first compatibility tier.
 Their eventual support level should follow the endpoint matrix:
 
-- packet networking beyond pre-boot `network-interfaces` configuration storage
-  and the internal virtio-net config-space, activation, TX frame parser, RX
-  buffer parser, prepared device resources, MMIO registration, startup FDT
-  metadata, TX/RX notification dispatch metadata helpers, injected no-op TX
-  packet sink boundary, and injected empty RX packet source boundary
+- packet networking beyond pre-boot `network-interfaces` configuration storage,
+  internal virtio-net config-space, activation, TX frame parser, RX buffer
+  parser, prepared device resources, MMIO registration, startup FDT metadata,
+  TX/RX notification dispatch metadata helpers, and startup-time vmnet packet
+  I/O selection for supported `host_dev_name` forms
 - virtio-vsock device emulation, host Unix socket backend behavior, CID routing,
   and data movement beyond pre-boot `/vsock` configuration storage
 - snapshots

--- a/docs/security.md
+++ b/docs/security.md
@@ -164,12 +164,11 @@ The current scaffold does not implement:
   packets between vmnet and the runtime packet traits for future host
   networking, plus an internal provider that can select prebuilt adapters by
   configured interface ID and an internal `host_dev_name` mapping for
-  `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>`, but these
-  boundaries are not connected to process startup and bangbang startup does not call
-  `vmnet_start_interface`, `vmnet_stop_interface`, `vmnet_read`, or
-  `vmnet_write`. The default provider is a no-op TX sink plus an empty RX source
-  and bangbang still does not open host networking resources. The current vsock
-  API path validates and stores
+  `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>`. Startup opens
+  vmnet resources only when configured interfaces use those supported names,
+  keeps no-network startup on a no-op TX sink plus empty RX source, and still
+  lacks a macOS sandbox, host resource broker, connectivity policy, and live
+  vmnet integration proof. The current vsock API path validates and stores
   `guest_cid` plus `uds_path` before boot, but it does not implement a
   virtio-vsock device or host Unix socket backend
 - complete production logging or metrics policy


### PR DESCRIPTION
## Summary

- Build a process-owned network packet I/O provider during `InstanceStart` from stored network configs.
- Keep no-network startup on the existing no-op provider, and select vmnet-backed packet I/O for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>`.
- Add fake-backed tests for supported construction, unsupported host device failure, start failure state preservation, and cleanup ownership.
- Update compatibility and security docs for startup-time vmnet selection and remaining limits.

## Scope Exclusions

- No public network PATCH, DELETE, or runtime update support.
- No live vmnet connectivity test or signed integration test.
- No API-time rejection for non-vmnet `host_dev_name` values before boot.
- No MTU, rate limiter, or backend selection beyond the supported vmnet forms.

Closes #317

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
