### PR TITLE
feat: limit configured network interfaces

### DIFF
--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -27,6 +27,8 @@ use bangbang_runtime::machine::{
     MachineConfigHugePages as RuntimeMachineConfigHugePages, MachineConfigInput,
 };
 use bangbang_runtime::metrics::MetricsConfigInput;
+#[cfg(test)]
+use bangbang_runtime::network::MAX_NETWORK_INTERFACE_COUNT;
 use bangbang_runtime::network::{NetworkInterfaceConfig, NetworkInterfaceConfigInput};
 use bangbang_runtime::vsock::{VsockConfig, VsockConfigInput};
 use bangbang_runtime::{VmConfiguration, VmmAction, VmmData};
@@ -2005,6 +2007,61 @@ mod tests {
         assert_eq!(
             config.guest_mac().map(|guest_mac| guest_mac.to_string()),
             Some("12:34:56:78:9a:bc".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_fault_for_network_interface_count_over_limit_without_storing() {
+        let mut vmm = test_controller();
+
+        for index in 0..MAX_NETWORK_INTERFACE_COUNT {
+            let body = format!(r#"{{"iface_id":"eth{index}","host_dev_name":"tap{index}"}}"#);
+            let request = format!(
+                "PUT /network-interfaces/eth{index} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                body.len()
+            );
+            let response = handle_request_bytes(request.as_bytes(), &mut vmm);
+
+            assert_eq!(response.status(), bangbang_api::http::StatusCode::NoContent);
+        }
+
+        let path = unique_socket_path("net-limit");
+        let server = ApiServer::bind(&path).expect("server should bind");
+        let mut client = UnixStream::connect(&path).expect("client should connect");
+        let body = format!(
+            r#"{{"iface_id":"eth{MAX_NETWORK_INTERFACE_COUNT}","host_dev_name":"tap{MAX_NETWORK_INTERFACE_COUNT}"}}"#
+        );
+        let request = format!(
+            "PUT /network-interfaces/eth{MAX_NETWORK_INTERFACE_COUNT} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+
+        client
+            .write_all(request.as_bytes())
+            .expect("client should write request");
+        server
+            .serve_next(&mut vmm)
+            .expect("server should handle one request");
+
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("client should read response");
+
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        assert!(
+            response.contains(r#"{"fault_message":"network interface count exceeds maximum 16"}"#)
+        );
+
+        let data = vmm
+            .handle_action(VmmAction::GetVmConfig)
+            .expect("VM config should be returned");
+        let VmmData::VmConfiguration(config) = data else {
+            panic!("expected VM config");
+        };
+        assert_eq!(
+            config.network_interface_configs().len(),
+            MAX_NETWORK_INTERFACE_COUNT
         );
     }
 

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -14,9 +14,9 @@ use bangbang_runtime::block::BlockMmioLayout;
 use bangbang_runtime::memory::{GuestAddress, GuestMemory};
 use bangbang_runtime::mmio::MmioRegionId;
 use bangbang_runtime::network::{
-    NetworkInterfaceConfig, NetworkMmioLayout, VirtioNetworkRxPacket, VirtioNetworkRxPacketSource,
-    VirtioNetworkRxPacketSourceError, VirtioNetworkTxFrame, VirtioNetworkTxPacketSink,
-    VirtioNetworkTxPacketSinkError,
+    NetworkInterfaceConfig, NetworkInterfaceConfigError, NetworkMmioLayout, VirtioNetworkRxPacket,
+    VirtioNetworkRxPacketSource, VirtioNetworkRxPacketSourceError, VirtioNetworkTxFrame,
+    VirtioNetworkTxPacketSink, VirtioNetworkTxPacketSinkError, validate_network_interface_count,
 };
 use bangbang_runtime::serial::SharedSerialOutputBuffer;
 use bangbang_runtime::startup::{
@@ -266,6 +266,10 @@ impl ProcessNetworkPacketIoProvider {
     fn from_network_configs(
         configs: &[NetworkInterfaceConfig],
     ) -> Result<Self, ProcessNetworkPacketIoProviderBuildError> {
+        validate_network_interface_count(configs.len()).map_err(|source| {
+            ProcessNetworkPacketIoProviderBuildError::NetworkInterfaceCount { source }
+        })?;
+
         if configs.is_empty() {
             return Ok(Self::Noop(NoopProcessNetworkPacketIoProvider::default()));
         }
@@ -289,6 +293,9 @@ impl Arm64BootNetworkPacketIoProvider for ProcessNetworkPacketIoProvider {
 
 #[derive(Debug)]
 enum ProcessNetworkPacketIoProviderBuildError {
+    NetworkInterfaceCount {
+        source: NetworkInterfaceConfigError,
+    },
     HostDeviceName {
         iface_id: String,
         source: VmnetHostDeviceNameConfigError,
@@ -309,6 +316,9 @@ enum ProcessNetworkPacketIoProviderBuildError {
 impl fmt::Display for ProcessNetworkPacketIoProviderBuildError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::NetworkInterfaceCount { source } => {
+                write!(f, "unsupported network interface count: {source}")
+            }
             Self::HostDeviceName { iface_id, source } => {
                 write!(
                     f,
@@ -337,6 +347,7 @@ impl fmt::Display for ProcessNetworkPacketIoProviderBuildError {
 impl std::error::Error for ProcessNetworkPacketIoProviderBuildError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
+            Self::NetworkInterfaceCount { source } => Some(source),
             Self::HostDeviceName { source, .. } => Some(source),
             Self::Start { source, .. } => Some(source),
             Self::PacketIoBuild { source, .. } => Some(source),
@@ -373,6 +384,10 @@ where
     F: ProcessVmnetPacketIoBackendFactory,
     F::Backend: VmnetPacketIoBackend<Interface = <F::Backend as VmnetInterfaceBackend>::Interface>,
 {
+    validate_network_interface_count(configs.len()).map_err(|source| {
+        ProcessNetworkPacketIoProviderBuildError::NetworkInterfaceCount { source }
+    })?;
+
     let mut entries = Vec::new();
 
     for config in configs {
@@ -766,8 +781,9 @@ mod tests {
     use bangbang_runtime::interrupt::GuestInterruptLine;
     use bangbang_runtime::mmio::MmioRegion;
     use bangbang_runtime::network::{
-        NetworkInterfaceConfig, NetworkInterfaceConfigInput, NetworkInterfaceConfigs,
-        NetworkMmioLayout, PreparedNetworkDevices,
+        MAX_NETWORK_INTERFACE_COUNT, NetworkInterfaceConfig, NetworkInterfaceConfigError,
+        NetworkInterfaceConfigInput, NetworkInterfaceConfigs, NetworkMmioLayout,
+        PreparedNetworkDevices,
     };
     use bangbang_runtime::serial::{
         SERIAL_MMIO_DEVICE_WINDOW_SIZE, SerialOutput, SharedSerialOutputBuffer,
@@ -1245,6 +1261,17 @@ mod tests {
         network_configs.as_slice().to_vec()
     }
 
+    fn validated_network_configs(count: usize) -> Vec<NetworkInterfaceConfig> {
+        (0..count)
+            .map(|index| {
+                let iface_id = format!("eth{index}");
+                NetworkInterfaceConfigInput::new(iface_id.clone(), iface_id, "vmnet:shared")
+                    .validate()
+                    .expect("individual network config should validate")
+            })
+            .collect()
+    }
+
     fn test_boot_network_device() -> Arm64BootNetworkDevice {
         let mut configs = NetworkInterfaceConfigs::new();
         configs
@@ -1485,6 +1512,34 @@ mod tests {
     }
 
     #[test]
+    fn process_vmnet_packet_io_provider_rejects_over_limit_before_backend() {
+        let configs = validated_network_configs(MAX_NETWORK_INTERFACE_COUNT + 1);
+        let mut factory = RecordingVmnetPacketIoBackendFactory::default();
+        let event_log = factory.events();
+        let error = process_vmnet_packet_io_provider_from_configs(&configs, &mut factory)
+            .expect_err("over-limit network configs should fail provider construction");
+
+        match error {
+            ProcessNetworkPacketIoProviderBuildError::NetworkInterfaceCount { source } => {
+                assert_eq!(
+                    source,
+                    NetworkInterfaceConfigError::TooManyNetworkInterfaces {
+                        count: MAX_NETWORK_INTERFACE_COUNT + 1,
+                        max: MAX_NETWORK_INTERFACE_COUNT,
+                    }
+                );
+            }
+            ProcessNetworkPacketIoProviderBuildError::HostDeviceName { .. }
+            | ProcessNetworkPacketIoProviderBuildError::Start { .. }
+            | ProcessNetworkPacketIoProviderBuildError::PacketIoBuild { .. }
+            | ProcessNetworkPacketIoProviderBuildError::ProviderBuild { .. } => {
+                panic!("over-limit configs should fail before vmnet backend start");
+            }
+        }
+        assert!(recorded_events(&event_log).is_empty());
+    }
+
+    #[test]
     fn process_vmnet_packet_io_provider_rejects_unsupported_host_dev_name_before_backend() {
         let configs = network_configs([("eth0", "tap0")]);
         let mut factory = RecordingVmnetPacketIoBackendFactory::default();
@@ -1496,7 +1551,8 @@ mod tests {
             ProcessNetworkPacketIoProviderBuildError::HostDeviceName { iface_id, .. } => {
                 assert_eq!(iface_id, "eth0");
             }
-            ProcessNetworkPacketIoProviderBuildError::Start { .. }
+            ProcessNetworkPacketIoProviderBuildError::NetworkInterfaceCount { .. }
+            | ProcessNetworkPacketIoProviderBuildError::Start { .. }
             | ProcessNetworkPacketIoProviderBuildError::PacketIoBuild { .. }
             | ProcessNetworkPacketIoProviderBuildError::ProviderBuild { .. } => {
                 panic!("unsupported host_dev_name should fail before vmnet backend start");
@@ -1517,7 +1573,8 @@ mod tests {
             ProcessNetworkPacketIoProviderBuildError::HostDeviceName { iface_id, .. } => {
                 assert_eq!(iface_id, "eth1");
             }
-            ProcessNetworkPacketIoProviderBuildError::Start { .. }
+            ProcessNetworkPacketIoProviderBuildError::NetworkInterfaceCount { .. }
+            | ProcessNetworkPacketIoProviderBuildError::Start { .. }
             | ProcessNetworkPacketIoProviderBuildError::PacketIoBuild { .. }
             | ProcessNetworkPacketIoProviderBuildError::ProviderBuild { .. } => {
                 panic!("unsupported host_dev_name should be reported as config failure");

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -487,7 +487,10 @@ mod tests {
         logger::{LoggerConfigError, LoggerConfigInput, LoggerLevel},
         machine::{DEFAULT_MEM_SIZE_MIB, DEFAULT_VCPU_COUNT, MachineConfigInput},
         metrics::{MetricsConfigError, MetricsConfigInput},
-        network::{GuestMacAddress, NetworkInterfaceConfigError, NetworkInterfaceConfigInput},
+        network::{
+            GuestMacAddress, MAX_NETWORK_INTERFACE_COUNT, NetworkInterfaceConfigError,
+            NetworkInterfaceConfigInput,
+        },
         vsock::{MIN_GUEST_CID, VsockConfigError, VsockConfigInput},
     };
 
@@ -1827,6 +1830,43 @@ mod tests {
         assert_eq!(err.to_string(), "network guest_mac is already in use");
         assert_eq!(controller.network_interface_configs().len(), 1);
         assert_eq!(controller.network_interface_configs()[0].iface_id(), "eth0");
+    }
+
+    #[test]
+    fn put_network_interface_config_rejects_one_over_limit_without_mutating() {
+        let mut controller = VmmController::new("demo-1", "0.1.0", "bangbang");
+
+        for index in 0..MAX_NETWORK_INTERFACE_COUNT {
+            let iface_id = format!("eth{index}");
+            let host_dev_name = format!("tap{index}");
+            controller
+                .handle_action(VmmAction::PutNetworkInterface(
+                    NetworkInterfaceConfigInput::new(iface_id.clone(), iface_id, host_dev_name),
+                ))
+                .expect("network interface within limit should insert");
+        }
+
+        let iface_id = format!("eth{MAX_NETWORK_INTERFACE_COUNT}");
+        let host_dev_name = format!("tap{MAX_NETWORK_INTERFACE_COUNT}");
+        let err = controller
+            .handle_action(VmmAction::PutNetworkInterface(
+                NetworkInterfaceConfigInput::new(iface_id.clone(), iface_id, host_dev_name),
+            ))
+            .expect_err("one-over network interface should fail");
+
+        assert_eq!(
+            err,
+            VmmActionError::NetworkInterfaceConfig(
+                NetworkInterfaceConfigError::TooManyNetworkInterfaces {
+                    count: MAX_NETWORK_INTERFACE_COUNT + 1,
+                    max: MAX_NETWORK_INTERFACE_COUNT,
+                }
+            )
+        );
+        assert_eq!(
+            controller.network_interface_configs().len(),
+            MAX_NETWORK_INTERFACE_COUNT
+        );
     }
 
     #[test]

--- a/crates/runtime/src/network.rs
+++ b/crates/runtime/src/network.rs
@@ -38,6 +38,7 @@ pub const VIRTIO_FEATURE_VERSION_1: u32 = 32;
 pub const VIRTIO_NET_TX_HEADER_SIZE: u32 = 12;
 pub const VIRTIO_NET_MAX_BUFFER_SIZE: u64 = 65_562;
 pub const VIRTIO_NET_RX_MIN_BUFFER_SIZE: u64 = 1_526;
+pub const MAX_NETWORK_INTERFACE_COUNT: usize = 16;
 
 const VIRTIO_NET_RX_QUEUE_INDEX_U32: u32 = 0;
 const VIRTIO_NET_TX_QUEUE_INDEX_U32: u32 = 1;
@@ -206,6 +207,10 @@ impl NetworkInterfaceConfigs {
         input: NetworkInterfaceConfigInput,
     ) -> Result<(), NetworkInterfaceConfigError> {
         let config = input.validate()?;
+        let existing_index = self
+            .configs
+            .iter()
+            .position(|existing| existing.iface_id() == config.iface_id());
 
         if let Some(guest_mac) = config.guest_mac()
             && self.configs.iter().any(|existing| {
@@ -215,11 +220,11 @@ impl NetworkInterfaceConfigs {
             return Err(NetworkInterfaceConfigError::GuestMacAddressInUse { guest_mac });
         }
 
-        if let Some(index) = self
-            .configs
-            .iter()
-            .position(|existing| existing.iface_id() == config.iface_id())
-        {
+        if existing_index.is_none() {
+            validate_network_interface_count(self.configs.len().saturating_add(1))?;
+        }
+
+        if let Some(index) = existing_index {
             self.configs.remove(index);
         }
 
@@ -3391,6 +3396,10 @@ pub enum NetworkInterfaceConfigError {
     GuestMacAddressInUse {
         guest_mac: GuestMacAddress,
     },
+    TooManyNetworkInterfaces {
+        count: usize,
+        max: usize,
+    },
     UnsupportedMtu,
     UnsupportedRxRateLimiter,
     UnsupportedTxRateLimiter,
@@ -3414,6 +3423,9 @@ impl fmt::Display for NetworkInterfaceConfigError {
                 f.write_str("network guest_mac must be six colon-separated hex octets")
             }
             Self::GuestMacAddressInUse { .. } => f.write_str("network guest_mac is already in use"),
+            Self::TooManyNetworkInterfaces { max, .. } => {
+                write!(f, "network interface count exceeds maximum {max}")
+            }
             Self::UnsupportedMtu => f.write_str("network mtu is not supported"),
             Self::UnsupportedRxRateLimiter => {
                 f.write_str("network rx_rate_limiter is not supported")
@@ -3426,6 +3438,17 @@ impl fmt::Display for NetworkInterfaceConfigError {
 }
 
 impl std::error::Error for NetworkInterfaceConfigError {}
+
+pub fn validate_network_interface_count(count: usize) -> Result<(), NetworkInterfaceConfigError> {
+    if count > MAX_NETWORK_INTERFACE_COUNT {
+        return Err(NetworkInterfaceConfigError::TooManyNetworkInterfaces {
+            count,
+            max: MAX_NETWORK_INTERFACE_COUNT,
+        });
+    }
+
+    Ok(())
+}
 
 fn validate_interface_id(
     source: InterfaceIdSource,
@@ -3473,11 +3496,11 @@ mod tests {
     };
 
     use super::{
-        GuestMacAddress, InterfaceIdSource, NetworkInterfaceConfig, NetworkInterfaceConfigError,
-        NetworkInterfaceConfigInput, NetworkInterfaceConfigs, NetworkMmioDevices,
-        NetworkMmioLayout, NetworkMmioRegistrationError, PreparedNetworkDevices,
-        VIRTIO_FEATURE_VERSION_1, VIRTIO_NET_CONFIG_MAC_SIZE, VIRTIO_NET_DEVICE_ID,
-        VIRTIO_NET_F_MAC, VIRTIO_NET_MAX_BUFFER_SIZE, VIRTIO_NET_QUEUE_COUNT,
+        GuestMacAddress, InterfaceIdSource, MAX_NETWORK_INTERFACE_COUNT, NetworkInterfaceConfig,
+        NetworkInterfaceConfigError, NetworkInterfaceConfigInput, NetworkInterfaceConfigs,
+        NetworkMmioDevices, NetworkMmioLayout, NetworkMmioRegistrationError,
+        PreparedNetworkDevices, VIRTIO_FEATURE_VERSION_1, VIRTIO_NET_CONFIG_MAC_SIZE,
+        VIRTIO_NET_DEVICE_ID, VIRTIO_NET_F_MAC, VIRTIO_NET_MAX_BUFFER_SIZE, VIRTIO_NET_QUEUE_COUNT,
         VIRTIO_NET_QUEUE_SIZE, VIRTIO_NET_QUEUE_SIZES, VIRTIO_NET_RX_MIN_BUFFER_SIZE,
         VIRTIO_NET_RX_QUEUE_INDEX, VIRTIO_NET_TX_HEADER_SIZE, VIRTIO_NET_TX_QUEUE_INDEX,
         VIRTIO_RING_FEATURE_EVENT_IDX, VirtioNetworkConfigSpace, VirtioNetworkDevice,
@@ -3511,6 +3534,12 @@ mod tests {
 
     fn input() -> NetworkInterfaceConfigInput {
         NetworkInterfaceConfigInput::new("eth0", "eth0", "tap0")
+    }
+
+    fn numbered_input(index: usize) -> NetworkInterfaceConfigInput {
+        let iface_id = format!("eth{index}");
+        let host_dev_name = format!("tap{index}");
+        NetworkInterfaceConfigInput::new(iface_id.clone(), iface_id, host_dev_name)
     }
 
     fn validate(
@@ -4500,6 +4529,80 @@ mod tests {
         assert_eq!(err.to_string(), "network guest_mac is already in use");
         assert_eq!(configs.as_slice().len(), 1);
         assert_eq!(configs.as_slice()[0].iface_id(), "eth0");
+    }
+
+    #[test]
+    fn network_interface_configs_accept_exact_interface_count_limit() {
+        let mut configs = NetworkInterfaceConfigs::new();
+
+        for index in 0..MAX_NETWORK_INTERFACE_COUNT {
+            configs
+                .insert(numbered_input(index))
+                .expect("interface within limit should insert");
+        }
+
+        assert_eq!(configs.as_slice().len(), MAX_NETWORK_INTERFACE_COUNT);
+    }
+
+    #[test]
+    fn network_interface_configs_reject_one_over_limit_without_mutating() {
+        let mut configs = NetworkInterfaceConfigs::new();
+
+        for index in 0..MAX_NETWORK_INTERFACE_COUNT {
+            configs
+                .insert(numbered_input(index))
+                .expect("interface within limit should insert");
+        }
+
+        let err = configs
+            .insert(numbered_input(MAX_NETWORK_INTERFACE_COUNT))
+            .expect_err("one-over interface should fail");
+
+        assert_eq!(
+            err,
+            NetworkInterfaceConfigError::TooManyNetworkInterfaces {
+                count: MAX_NETWORK_INTERFACE_COUNT + 1,
+                max: MAX_NETWORK_INTERFACE_COUNT,
+            }
+        );
+        assert_eq!(
+            err.to_string(),
+            format!("network interface count exceeds maximum {MAX_NETWORK_INTERFACE_COUNT}")
+        );
+        assert_eq!(configs.as_slice().len(), MAX_NETWORK_INTERFACE_COUNT);
+        assert_eq!(
+            configs.as_slice()[MAX_NETWORK_INTERFACE_COUNT - 1].iface_id(),
+            format!("eth{}", MAX_NETWORK_INTERFACE_COUNT - 1)
+        );
+    }
+
+    #[test]
+    fn network_interface_configs_replace_existing_interface_at_limit() {
+        let mut configs = NetworkInterfaceConfigs::new();
+
+        for index in 0..MAX_NETWORK_INTERFACE_COUNT {
+            configs
+                .insert(numbered_input(index))
+                .expect("interface within limit should insert");
+        }
+
+        configs
+            .insert(NetworkInterfaceConfigInput::new(
+                "eth0",
+                "eth0",
+                "replacement",
+            ))
+            .expect("replacement at limit should insert");
+
+        assert_eq!(configs.as_slice().len(), MAX_NETWORK_INTERFACE_COUNT);
+        assert_eq!(
+            configs.as_slice()[MAX_NETWORK_INTERFACE_COUNT - 1].iface_id(),
+            "eth0"
+        );
+        assert_eq!(
+            configs.as_slice()[MAX_NETWORK_INTERFACE_COUNT - 1].host_dev_name(),
+            "replacement"
+        );
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -232,7 +232,7 @@ compatibility targets.
 | `PUT` | `/logger` | supported target; minimal subset implemented | Stores process logger configuration before boot, opens `log_path` with nonblocking output semantics when provided, accepts optional Firecracker-shaped level/show/module fields, and omits logger state from `GET /vm/config` because it is not guest configuration. Full internal log routing remains deferred. |
 | `PATCH` | `/machine-config` | deferred | Partial updates belong with later state and validation rules. |
 | `PUT` | `/cpu-config` | deferred | Needs HVF CPU feature design with VM and boot work in #8 and #10. |
-| `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores initial virtio-net configuration before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` selects vmnet packet I/O only for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names; unsupported names fail startup before `Running` is committed. Internal network notification dispatch can route each configured interface through selected packet I/O, parse TX descriptors through a packet sink boundary, and copy injected RX packets into guest buffers through a packet source boundary. Public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
+| `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores up to 16 initial virtio-net configurations before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the interface count before opening vmnet resources, then selects vmnet packet I/O only for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names; unsupported names fail startup before `Running` is committed. Internal network notification dispatch can route each configured interface through selected packet I/O, parse TX descriptors through a packet sink boundary, and copy injected RX packets into guest buffers through a packet source boundary. Public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
 | `PUT` | `/vsock` | supported target; configuration storage implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Virtio-vsock device emulation, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
 | `GET`, `PUT`, `PATCH` | `/mmds` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/mmds/config` | deferred | Tied to MMDS work in #16. |
@@ -280,7 +280,7 @@ exist.
 | `PUT /drives/{drive_id}` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
 | `PUT /network-interfaces/{iface_id}` | path `iface_id` | required | The API parser captures this value, and the internal model validates it as nonempty alphanumeric or `_`, matching Firecracker's `checked_id` rule. |
 | `PUT /network-interfaces/{iface_id}` | body `iface_id` | required | The API parser rejects requests where this does not match the path `iface_id`. |
-| `PUT /network-interfaces/{iface_id}` | `host_dev_name` | required | The API/VMM path records this value only after rejecting empty values; it does not open, stat, or otherwise touch host networking resources during configuration. `InstanceStart` later accepts only `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` for vmnet packet I/O startup. |
+| `PUT /network-interfaces/{iface_id}` | `host_dev_name` | required | The API/VMM path records this value only after rejecting empty values and enforcing the current 16-interface bangbang limit; it does not open, stat, or otherwise touch host networking resources during configuration. `InstanceStart` later accepts only `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` for vmnet packet I/O startup. |
 | `PUT /network-interfaces/{iface_id}` | `guest_mac` | optional | The internal model accepts six colon-separated two-hex-digit octets, normalizes display to lowercase hex, and rejects duplicate configured MAC addresses across different interface IDs. |
 | `PUT /network-interfaces/{iface_id}` | `mtu` | deferred when configured | The internal model rejects configured MTU values until virtio-net feature negotiation and backend behavior exist. |
 | `PUT /network-interfaces/{iface_id}` | `rx_rate_limiter`, `tx_rate_limiter` | deferred when configured | The internal model rejects configured network rate limiters until virtio-net rate limiting behavior exists. |
@@ -532,14 +532,17 @@ different interface IDs. Displayed validation errors avoid echoing invalid IDs,
 host device names, and MAC strings.
 
 The internal model rejects configured `mtu`, `rx_rate_limiter`, and
-`tx_rate_limiter` fields as unsupported. Configuration storage does not open
-host networking resources. Stored network interface configs are returned from
-`GET /vm/config` in the `network-interfaces` array. During `InstanceStart`, the
-process crate maps `host_dev_name` values `vmnet:host`, `vmnet:shared`, and
-`vmnet:bridged:<interface>` to vmnet host, shared, and bridged configurations
-and builds cleanup-owning packet I/O for each configured interface. Other
-nonempty names are still accepted before boot but fail startup before `Running`
-is committed.
+`tx_rate_limiter` fields as unsupported. bangbang currently limits stored
+network interfaces to 16. Firecracker `v1.16.0` does not publish a separate
+network-interface count limit; this is a macOS/HVF host-resource boundary for
+the current scaffold. Configuration storage does not open host networking
+resources. Stored network interface configs are returned from `GET /vm/config`
+in the `network-interfaces` array. During `InstanceStart`, the process crate
+revalidates the count before opening vmnet resources, maps `host_dev_name`
+values `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` to vmnet
+host, shared, and bridged configurations, and builds cleanup-owning packet I/O
+for each configured interface. Other nonempty names are still accepted before
+boot but fail startup before `Running` is committed.
 
 ## Internal Vsock Configuration
 
@@ -602,11 +605,11 @@ adapter that copies TX guest-memory payload segments into vmnet writes and
 caches one vmnet RX packet until consumed, and a prebuilt adapter provider keyed
 by configured interface ID. It also defines an internal `host_dev_name` mapping
 for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>`. Startup with
-configured network interfaces now opens vmnet resources through those supported
-forms and retains stop-on-drop cleanup. Startup without network interfaces still
-uses a no-op TX sink and an empty RX source. These helpers do not advertise MTU,
-support rate limiters, prove host connectivity, or provide public runtime packet
-movement.
+configured network interfaces revalidates the 16-interface limit before opening
+vmnet resources through those supported forms and retains stop-on-drop cleanup.
+Startup without network interfaces still uses a no-op TX sink and an empty RX
+source. These helpers do not advertise MTU, support rate limiters, prove host
+connectivity, or provide public runtime packet movement.
 
 The runtime crate can prepare owned internal block-device resources from a
 validated list of stored drive configs. Preparation opens each backing file,
@@ -1009,7 +1012,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | `PUT /machine-config` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Pre-boot-only configuration. Stored values are applied during startup preparation. |
 | `PUT /boot-source` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; host paths are opened during startup preparation. Host path errors must avoid leaking sensitive path details. |
 | `PUT /drives/{drive_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; startup preparation opens backing files and registers initial block MMIO devices. Runtime hotplug remains deferred. |
-| `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` opens vmnet packet I/O for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names and fails before `Running` for unsupported names. Internal network notification dispatch can route each interface through selected packet I/O, complete TX descriptor heads through a packet sink boundary, and write injected RX packets into guest buffers through a packet source boundary. Public packet movement, PATCH, and DELETE remain deferred. |
+| `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records up to 16 validated pre-boot configs without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the count before opening vmnet packet I/O for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names and fails before `Running` for unsupported names. Internal network notification dispatch can route each interface through selected packet I/O, complete TX descriptor heads through a packet sink boundary, and write injected RX packets into guest buffers through a packet source boundary. Public packet movement, PATCH, and DELETE remain deferred. |
 | `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Virtio-vsock device emulation, host socket backend behavior, CID routing, data movement, PATCH, and DELETE remain deferred. |
 | `PUT /metrics` | implemented; `204` empty response on successful output initialization | unsupported after start; `400` `fault_message` | Metrics output is process observability state, not guest configuration. Duplicate initialization fails. |
 | `PUT /logger` | implemented; `204` empty response on successful pre-boot configuration | unsupported after start; `400` `fault_message` | Logger output is process observability state, not guest configuration. Repeated pre-boot requests update provided fields; full log routing remains deferred. |

--- a/docs/security.md
+++ b/docs/security.md
@@ -164,11 +164,13 @@ The current scaffold does not implement:
   packets between vmnet and the runtime packet traits for future host
   networking, plus an internal provider that can select prebuilt adapters by
   configured interface ID and an internal `host_dev_name` mapping for
-  `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>`. Startup opens
-  vmnet resources only when configured interfaces use those supported names,
-  keeps no-network startup on a no-op TX sink plus empty RX source, and still
-  lacks a macOS sandbox, host resource broker, connectivity policy, and live
-  vmnet integration proof. The current vsock API path validates and stores
+  `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>`. The current
+  model stores at most 16 configured network interfaces. Startup revalidates
+  that limit before opening vmnet resources, opens them only when configured
+  interfaces use the supported names, keeps no-network startup on a no-op TX
+  sink plus empty RX source, and still lacks a macOS sandbox, host resource
+  broker, connectivity policy, and live vmnet integration proof. The current
+  vsock API path validates and stores
   `guest_cid` plus `uds_path` before boot, but it does not implement a
   virtio-vsock device or host Unix socket backend
 - complete production logging or metrics policy


### PR DESCRIPTION
## Summary

- Add a 16-interface configured network limit in `bangbang-runtime`.
- Revalidate network interface count before process startup opens vmnet packet I/O resources.
- Cover exact-limit, one-over, replacement-at-limit, and no-backend-start behavior, and document the macOS/HVF resource boundary.

Closes #319

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
