### PR TITLE
feat: add virtio-vsock device skeleton

### DIFF
--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -535,11 +535,12 @@ mod tests {
     fn virtio_vsock_config_space_reports_firecracker_feature_bits() {
         let config = VirtioVsockConfigSpace::new(3);
         let features = config.available_features();
+        let expected_features = (1_u64 << VIRTIO_FEATURE_VERSION_1)
+            | (1_u64 << VIRTIO_FEATURE_IN_ORDER)
+            | (1_u64 << VIRTIO_RING_FEATURE_EVENT_IDX);
 
         assert_eq!(config.guest_cid(), 3);
-        assert_ne!(features & (1_u64 << VIRTIO_FEATURE_VERSION_1), 0);
-        assert_ne!(features & (1_u64 << VIRTIO_FEATURE_IN_ORDER), 0);
-        assert_ne!(features & (1_u64 << VIRTIO_RING_FEATURE_EVENT_IDX), 0);
+        assert_eq!(features, expected_features);
     }
 
     #[test]

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -184,9 +184,10 @@ impl VirtioMmioDeviceConfigHandler for VirtioVsockConfigSpace {
         &self,
         access: VirtioMmioDeviceConfigAccess,
     ) -> Result<MmioAccessBytes, VirtioMmioDeviceConfigError> {
-        let [b0, b1, b2, b3, b4, b5, b6, b7] = self.guest_cid_bytes();
+        let bytes = self.guest_cid_bytes();
+        let [b0, b1, b2, b3, b4, b5, b6, b7] = bytes;
         match (access.offset(), access.len()) {
-            (0, 8) => MmioAccessBytes::new(&self.guest_cid_bytes()),
+            (0, 8) => MmioAccessBytes::new(&bytes),
             (0, 4) => MmioAccessBytes::new(&[b0, b1, b2, b3]),
             (4, 4) => MmioAccessBytes::new(&[b4, b5, b6, b7]),
             _ => {
@@ -579,6 +580,24 @@ mod tests {
         assert!(matches!(
             err,
             VirtioMmioRegisterHandlerError::UnsupportedDeviceConfigRead { offset: 2, len: 4 }
+        ));
+
+        let err = handler
+            .read_access(device_config_access(8, 1))
+            .expect_err("past-end config read should fail");
+
+        assert!(matches!(
+            err,
+            VirtioMmioRegisterHandlerError::UnsupportedDeviceConfigRead { offset: 8, len: 1 }
+        ));
+
+        let err = handler
+            .read_access(device_config_access(4, 8))
+            .expect_err("straddling config read should fail");
+
+        assert!(matches!(
+            err,
+            VirtioMmioRegisterHandlerError::UnsupportedDeviceConfigRead { offset: 4, len: 8 }
         ));
     }
 

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -312,7 +312,8 @@ mod tests {
         VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DRIVER,
         VIRTIO_DEVICE_STATUS_DRIVER_OK, VIRTIO_DEVICE_STATUS_FEATURES_OK,
         VIRTIO_DEVICE_STATUS_INIT, VIRTIO_MMIO_DEVICE_CONFIG_OFFSET,
-        VIRTIO_MMIO_DEVICE_WINDOW_SIZE, VirtioMmioRegister, VirtioMmioRegisterHandlerError,
+        VIRTIO_MMIO_DEVICE_WINDOW_SIZE, VirtioMmioDeviceActivation, VirtioMmioDeviceRegisters,
+        VirtioMmioQueueRegisters, VirtioMmioRegister, VirtioMmioRegisterHandlerError,
     };
 
     use super::{
@@ -698,5 +699,25 @@ mod tests {
         ));
         assert!(!handler.is_device_activated());
         assert!(!handler.activation_handler().is_activated());
+    }
+
+    #[test]
+    fn virtio_vsock_device_rejects_unexpected_queue_count() {
+        let registers = VirtioMmioDeviceRegisters::new(VIRTIO_VSOCK_DEVICE_ID, 0);
+        let queues =
+            VirtioMmioQueueRegisters::new(&[VIRTIO_VSOCK_QUEUE_SIZE, VIRTIO_VSOCK_QUEUE_SIZE])
+                .expect("short queue table should build");
+        let activation = VirtioMmioDeviceActivation::new(&registers, &queues);
+        let mut device = VirtioVsockDevice::new();
+
+        let err = device
+            .activate_vsock(activation)
+            .expect_err("unexpected queue count should fail activation");
+
+        assert_eq!(
+            err.to_string(),
+            "virtio-mmio device activation handler failed: virtio-vsock expected 3 queues, got 2"
+        );
+        assert!(!device.is_activated());
     }
 }

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -3,7 +3,31 @@
 use std::fmt;
 use std::path::{Path, PathBuf};
 
+use crate::mmio::{MmioAccessBytes, MmioAccessBytesError, MmioHandlerError};
+use crate::virtio_mmio::{
+    VirtioMmioDeviceActivation, VirtioMmioDeviceActivationError, VirtioMmioDeviceActivationHandler,
+    VirtioMmioDeviceConfigAccess, VirtioMmioDeviceConfigError, VirtioMmioDeviceConfigHandler,
+    VirtioMmioRegisterHandler, VirtioMmioRegisterHandlerError,
+};
+
 pub const MIN_GUEST_CID: u32 = 3;
+pub const VIRTIO_VSOCK_DEVICE_ID: u32 = 19;
+pub const VIRTIO_VSOCK_RX_QUEUE_INDEX: usize = 0;
+pub const VIRTIO_VSOCK_TX_QUEUE_INDEX: usize = 1;
+pub const VIRTIO_VSOCK_EVENT_QUEUE_INDEX: usize = 2;
+pub const VIRTIO_VSOCK_QUEUE_COUNT: usize = 3;
+pub const VIRTIO_VSOCK_QUEUE_SIZE: u16 = 256;
+pub const VIRTIO_VSOCK_QUEUE_SIZES: [u16; VIRTIO_VSOCK_QUEUE_COUNT] =
+    [VIRTIO_VSOCK_QUEUE_SIZE; VIRTIO_VSOCK_QUEUE_COUNT];
+pub const VIRTIO_VSOCK_CONFIG_GUEST_CID_SIZE: usize = 8;
+pub const VIRTIO_RING_FEATURE_EVENT_IDX: u32 = 29;
+pub const VIRTIO_FEATURE_VERSION_1: u32 = 32;
+pub const VIRTIO_FEATURE_IN_ORDER: u32 = 35;
+
+const VIRTIO_VSOCK_QUEUE_INDEXES: [u32; VIRTIO_VSOCK_QUEUE_COUNT] = [0, 1, 2];
+
+pub type VirtioVsockMmioHandler =
+    VirtioMmioRegisterHandler<VirtioVsockConfigSpace, VirtioVsockDevice>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VsockConfigInput {
@@ -130,6 +154,148 @@ impl fmt::Display for VsockConfigError {
 
 impl std::error::Error for VsockConfigError {}
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VirtioVsockConfigSpace {
+    guest_cid: u64,
+}
+
+impl VirtioVsockConfigSpace {
+    pub const fn new(guest_cid: u64) -> Self {
+        Self { guest_cid }
+    }
+
+    pub const fn guest_cid(self) -> u64 {
+        self.guest_cid
+    }
+
+    pub const fn available_features(self) -> u64 {
+        virtio_feature_bit(VIRTIO_FEATURE_VERSION_1)
+            | virtio_feature_bit(VIRTIO_FEATURE_IN_ORDER)
+            | virtio_feature_bit(VIRTIO_RING_FEATURE_EVENT_IDX)
+    }
+
+    const fn guest_cid_bytes(self) -> [u8; VIRTIO_VSOCK_CONFIG_GUEST_CID_SIZE] {
+        self.guest_cid.to_le_bytes()
+    }
+}
+
+impl VirtioMmioDeviceConfigHandler for VirtioVsockConfigSpace {
+    fn read_device_config(
+        &self,
+        access: VirtioMmioDeviceConfigAccess,
+    ) -> Result<MmioAccessBytes, VirtioMmioDeviceConfigError> {
+        let [b0, b1, b2, b3, b4, b5, b6, b7] = self.guest_cid_bytes();
+        match (access.offset(), access.len()) {
+            (0, 8) => MmioAccessBytes::new(&self.guest_cid_bytes()),
+            (0, 4) => MmioAccessBytes::new(&[b0, b1, b2, b3]),
+            (4, 4) => MmioAccessBytes::new(&[b4, b5, b6, b7]),
+            _ => {
+                return Err(VirtioMmioDeviceConfigError::UnsupportedRead {
+                    offset: access.offset(),
+                    len: access.len(),
+                });
+            }
+        }
+        .map_err(config_bytes_error)
+    }
+
+    fn write_device_config(
+        &mut self,
+        access: VirtioMmioDeviceConfigAccess,
+        _data: MmioAccessBytes,
+    ) -> Result<(), VirtioMmioDeviceConfigError> {
+        Err(VirtioMmioDeviceConfigError::UnsupportedWrite {
+            offset: access.offset(),
+            len: access.len(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct VirtioVsockDevice {
+    activated: bool,
+}
+
+impl VirtioVsockDevice {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub const fn is_activated(&self) -> bool {
+        self.activated
+    }
+
+    pub fn activate_vsock(
+        &mut self,
+        activation: VirtioMmioDeviceActivation<'_>,
+    ) -> Result<(), VirtioMmioDeviceActivationError> {
+        if activation.queue_count() != VIRTIO_VSOCK_QUEUE_COUNT {
+            return Err(MmioHandlerError::new(format!(
+                "virtio-vsock expected {VIRTIO_VSOCK_QUEUE_COUNT} queues, got {}",
+                activation.queue_count()
+            ))
+            .into());
+        }
+
+        for queue_index in VIRTIO_VSOCK_QUEUE_INDEXES {
+            let queue = activation.queue(queue_index).map_err(|source| {
+                MmioHandlerError::new(format!(
+                    "failed to read virtio-vsock queue {queue_index}: {source}"
+                ))
+            })?;
+            if !queue.ready() || queue.size() == 0 {
+                return Err(MmioHandlerError::new(format!(
+                    "virtio-vsock queue {queue_index} must be configured and ready before activation"
+                ))
+                .into());
+            }
+        }
+
+        self.activated = true;
+        Ok(())
+    }
+
+    pub fn reset(&mut self) {
+        self.activated = false;
+    }
+}
+
+impl VirtioMmioDeviceActivationHandler for VirtioVsockDevice {
+    fn activate(
+        &mut self,
+        activation: VirtioMmioDeviceActivation<'_>,
+    ) -> Result<(), VirtioMmioDeviceActivationError> {
+        self.activate_vsock(activation)
+    }
+
+    fn reset(&mut self) {
+        VirtioVsockDevice::reset(self);
+    }
+}
+
+pub fn virtio_vsock_mmio_handler(
+    guest_cid: u32,
+) -> Result<VirtioVsockMmioHandler, VirtioMmioRegisterHandlerError> {
+    let config = VirtioVsockConfigSpace::new(u64::from(guest_cid));
+    VirtioMmioRegisterHandler::with_device_config_and_activation(
+        VIRTIO_VSOCK_DEVICE_ID,
+        config.available_features(),
+        &VIRTIO_VSOCK_QUEUE_SIZES,
+        config,
+        VirtioVsockDevice::new(),
+    )
+}
+
+const fn virtio_feature_bit(feature: u32) -> u64 {
+    1_u64 << feature
+}
+
+fn config_bytes_error(source: MmioAccessBytesError) -> VirtioMmioDeviceConfigError {
+    VirtioMmioDeviceConfigError::Handler {
+        source: MmioHandlerError::new(format!("virtio-vsock config access bytes failed: {source}")),
+    }
+}
+
 fn has_control_character(value: &str) -> bool {
     value.chars().any(char::is_control)
 }
@@ -139,10 +305,126 @@ mod tests {
     use std::error::Error as _;
     use std::path::Path;
 
-    use super::{MIN_GUEST_CID, VsockConfigError, VsockConfigInput};
+    use crate::memory::GuestAddress;
+    use crate::mmio::{MmioAccess, MmioAccessBytes, MmioBus, MmioRegionId};
+    use crate::virtio_mmio::{
+        VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DRIVER,
+        VIRTIO_DEVICE_STATUS_DRIVER_OK, VIRTIO_DEVICE_STATUS_FEATURES_OK,
+        VIRTIO_DEVICE_STATUS_INIT, VIRTIO_MMIO_DEVICE_CONFIG_OFFSET,
+        VIRTIO_MMIO_DEVICE_WINDOW_SIZE, VirtioMmioRegister, VirtioMmioRegisterHandlerError,
+    };
+
+    use super::{
+        MIN_GUEST_CID, VIRTIO_FEATURE_IN_ORDER, VIRTIO_FEATURE_VERSION_1,
+        VIRTIO_RING_FEATURE_EVENT_IDX, VIRTIO_VSOCK_CONFIG_GUEST_CID_SIZE, VIRTIO_VSOCK_DEVICE_ID,
+        VIRTIO_VSOCK_EVENT_QUEUE_INDEX, VIRTIO_VSOCK_QUEUE_COUNT, VIRTIO_VSOCK_QUEUE_SIZE,
+        VIRTIO_VSOCK_QUEUE_SIZES, VIRTIO_VSOCK_RX_QUEUE_INDEX, VIRTIO_VSOCK_TX_QUEUE_INDEX,
+        VirtioVsockConfigSpace, VirtioVsockDevice, VirtioVsockMmioHandler, VsockConfigError,
+        VsockConfigInput, virtio_vsock_mmio_handler,
+    };
+
+    const TEST_MMIO_BASE: u64 = 0x1000_0000;
+    const QUEUE_CONFIG_STATUS: u32 = VIRTIO_DEVICE_STATUS_ACKNOWLEDGE
+        | VIRTIO_DEVICE_STATUS_DRIVER
+        | VIRTIO_DEVICE_STATUS_FEATURES_OK;
+    const DRIVER_OK_STATUS: u32 = QUEUE_CONFIG_STATUS | VIRTIO_DEVICE_STATUS_DRIVER_OK;
+    const TEST_QUEUE_ADDRESS_BASE: u64 = 0x1000;
+    const TEST_QUEUE_ADDRESS_STRIDE: u64 = 0x1000;
 
     fn validate(input: VsockConfigInput) -> Result<super::VsockConfig, VsockConfigError> {
         input.validate()
+    }
+
+    fn virtio_mmio_access(offset: u64, len: u64) -> MmioAccess {
+        let mut bus = MmioBus::new();
+        bus.insert(
+            MmioRegionId::new(1),
+            GuestAddress::new(TEST_MMIO_BASE),
+            VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+        )
+        .expect("virtio-mmio region should insert");
+        bus.lookup(GuestAddress::new(TEST_MMIO_BASE + offset), len)
+            .expect("virtio-mmio access should resolve")
+    }
+
+    fn device_config_access(offset: u64, len: u64) -> MmioAccess {
+        virtio_mmio_access(VIRTIO_MMIO_DEVICE_CONFIG_OFFSET + offset, len)
+    }
+
+    fn read_config(handler: &VirtioVsockMmioHandler, offset: u64, len: u64) -> Vec<u8> {
+        handler
+            .read_access(device_config_access(offset, len))
+            .expect("vsock config read should succeed")
+            .as_slice()
+            .to_vec()
+    }
+
+    fn advance_handler_to_features_ok(handler: &mut VirtioVsockMmioHandler) {
+        handler
+            .write_register(VirtioMmioRegister::Status, VIRTIO_DEVICE_STATUS_ACKNOWLEDGE)
+            .expect("status should accept ACKNOWLEDGE");
+        handler
+            .write_register(
+                VirtioMmioRegister::Status,
+                VIRTIO_DEVICE_STATUS_ACKNOWLEDGE | VIRTIO_DEVICE_STATUS_DRIVER,
+            )
+            .expect("status should accept DRIVER");
+        handler
+            .write_register(VirtioMmioRegister::Status, QUEUE_CONFIG_STATUS)
+            .expect("status should accept FEATURES_OK");
+    }
+
+    fn guest_address_low(address: GuestAddress) -> u32 {
+        u32::try_from(address.raw_value()).expect("test guest address should fit in low half")
+    }
+
+    fn configure_vsock_queues(handler: &mut VirtioVsockMmioHandler) {
+        for queue_index in 0..VIRTIO_VSOCK_QUEUE_COUNT {
+            let queue_index_u32 = u32::try_from(queue_index).expect("queue index should fit");
+            let queue_base =
+                TEST_QUEUE_ADDRESS_BASE + u64::from(queue_index_u32) * TEST_QUEUE_ADDRESS_STRIDE;
+            handler
+                .write_register(VirtioMmioRegister::QueueSel, queue_index_u32)
+                .expect("queue select should write");
+            handler
+                .write_register(
+                    VirtioMmioRegister::QueueNum,
+                    u32::from(VIRTIO_VSOCK_QUEUE_SIZE),
+                )
+                .expect("queue size should write");
+            handler
+                .write_register(
+                    VirtioMmioRegister::QueueDescLow,
+                    guest_address_low(GuestAddress::new(queue_base)),
+                )
+                .expect("queue descriptor table should write");
+            handler
+                .write_register(
+                    VirtioMmioRegister::QueueDriverLow,
+                    guest_address_low(GuestAddress::new(queue_base + 0x200)),
+                )
+                .expect("queue driver ring should write");
+            handler
+                .write_register(
+                    VirtioMmioRegister::QueueDeviceLow,
+                    guest_address_low(GuestAddress::new(queue_base + 0x400)),
+                )
+                .expect("queue device ring should write");
+            handler
+                .write_register(VirtioMmioRegister::QueueReady, 1)
+                .expect("queue ready should write");
+        }
+    }
+
+    fn vsock_handler_for_config(config: VirtioVsockConfigSpace) -> VirtioVsockMmioHandler {
+        VirtioVsockMmioHandler::with_device_config_and_activation(
+            VIRTIO_VSOCK_DEVICE_ID,
+            config.available_features(),
+            &VIRTIO_VSOCK_QUEUE_SIZES,
+            config,
+            VirtioVsockDevice::new(),
+        )
+        .expect("vsock handler should build")
     }
 
     #[test]
@@ -234,5 +516,167 @@ mod tests {
     #[test]
     fn errors_have_no_sources() {
         assert!(VsockConfigError::EmptySocketPath.source().is_none());
+    }
+
+    #[test]
+    fn virtio_vsock_constants_match_firecracker_shape() {
+        assert_eq!(VIRTIO_VSOCK_DEVICE_ID, 19);
+        assert_eq!(VIRTIO_VSOCK_RX_QUEUE_INDEX, 0);
+        assert_eq!(VIRTIO_VSOCK_TX_QUEUE_INDEX, 1);
+        assert_eq!(VIRTIO_VSOCK_EVENT_QUEUE_INDEX, 2);
+        assert_eq!(VIRTIO_VSOCK_QUEUE_COUNT, 3);
+        assert_eq!(VIRTIO_VSOCK_QUEUE_SIZE, 256);
+        assert_eq!(VIRTIO_VSOCK_QUEUE_SIZES, [256, 256, 256]);
+        assert_eq!(VIRTIO_VSOCK_CONFIG_GUEST_CID_SIZE, 8);
+    }
+
+    #[test]
+    fn virtio_vsock_config_space_reports_firecracker_feature_bits() {
+        let config = VirtioVsockConfigSpace::new(3);
+        let features = config.available_features();
+
+        assert_eq!(config.guest_cid(), 3);
+        assert_ne!(features & (1_u64 << VIRTIO_FEATURE_VERSION_1), 0);
+        assert_ne!(features & (1_u64 << VIRTIO_FEATURE_IN_ORDER), 0);
+        assert_ne!(features & (1_u64 << VIRTIO_RING_FEATURE_EVENT_IDX), 0);
+    }
+
+    #[test]
+    fn virtio_vsock_config_space_reads_guest_cid_as_u64() {
+        let config = VirtioVsockConfigSpace::new(0x1122_3344_5566_7788);
+        let handler = vsock_handler_for_config(config);
+
+        assert_eq!(
+            read_config(&handler, 0, 8),
+            0x1122_3344_5566_7788_u64.to_le_bytes().to_vec()
+        );
+    }
+
+    #[test]
+    fn virtio_vsock_config_space_reads_guest_cid_halves() {
+        let config = VirtioVsockConfigSpace::new(0x1122_3344_5566_7788);
+        let handler = vsock_handler_for_config(config);
+
+        assert_eq!(
+            read_config(&handler, 0, 4),
+            0x5566_7788_u32.to_le_bytes().to_vec()
+        );
+        assert_eq!(
+            read_config(&handler, 4, 4),
+            0x1122_3344_u32.to_le_bytes().to_vec()
+        );
+    }
+
+    #[test]
+    fn virtio_vsock_config_space_rejects_unsupported_reads() {
+        let config = VirtioVsockConfigSpace::new(3);
+        let handler = vsock_handler_for_config(config);
+
+        let err = handler
+            .read_access(device_config_access(2, 4))
+            .expect_err("unsupported config read should fail");
+
+        assert!(matches!(
+            err,
+            VirtioMmioRegisterHandlerError::UnsupportedDeviceConfigRead { offset: 2, len: 4 }
+        ));
+    }
+
+    #[test]
+    fn virtio_vsock_config_space_rejects_writes() {
+        let mut handler = virtio_vsock_mmio_handler(3).expect("vsock handler should build");
+        handler
+            .write_register(VirtioMmioRegister::Status, VIRTIO_DEVICE_STATUS_ACKNOWLEDGE)
+            .expect("status should accept ACKNOWLEDGE");
+        handler
+            .write_register(
+                VirtioMmioRegister::Status,
+                VIRTIO_DEVICE_STATUS_ACKNOWLEDGE | VIRTIO_DEVICE_STATUS_DRIVER,
+            )
+            .expect("status should accept DRIVER");
+
+        let err = handler
+            .write_access(
+                device_config_access(0, 4),
+                MmioAccessBytes::new(&0_u32.to_le_bytes()).expect("test bytes should fit"),
+            )
+            .expect_err("vsock config write should fail");
+
+        assert!(matches!(
+            err,
+            VirtioMmioRegisterHandlerError::UnsupportedDeviceConfigWrite { offset: 0, len: 4 }
+        ));
+    }
+
+    #[test]
+    fn virtio_vsock_mmio_handler_uses_device_id_and_queue_shape() {
+        let mut handler = virtio_vsock_mmio_handler(42).expect("vsock handler should build");
+
+        assert_eq!(
+            handler
+                .read_register(VirtioMmioRegister::DeviceId)
+                .expect("device id should read"),
+            VIRTIO_VSOCK_DEVICE_ID
+        );
+        assert_eq!(
+            handler.queue_registers().queue_count(),
+            VIRTIO_VSOCK_QUEUE_COUNT
+        );
+
+        for queue_index in 0..VIRTIO_VSOCK_QUEUE_COUNT {
+            handler
+                .write_register(
+                    VirtioMmioRegister::QueueSel,
+                    u32::try_from(queue_index).expect("queue index should fit"),
+                )
+                .expect("queue select should write");
+            assert_eq!(
+                handler
+                    .read_register(VirtioMmioRegister::QueueNumMax)
+                    .expect("queue max should read"),
+                u32::from(VIRTIO_VSOCK_QUEUE_SIZE)
+            );
+        }
+    }
+
+    #[test]
+    fn virtio_vsock_device_activates_and_resets_through_handler() {
+        let mut handler = virtio_vsock_mmio_handler(3).expect("vsock handler should build");
+
+        assert!(!handler.is_device_activated());
+        assert!(!handler.activation_handler().is_activated());
+
+        advance_handler_to_features_ok(&mut handler);
+        configure_vsock_queues(&mut handler);
+        handler
+            .write_register(VirtioMmioRegister::Status, DRIVER_OK_STATUS)
+            .expect("DRIVER_OK should activate vsock device");
+
+        assert!(handler.is_device_activated());
+        assert!(handler.activation_handler().is_activated());
+
+        handler
+            .write_register(VirtioMmioRegister::Status, VIRTIO_DEVICE_STATUS_INIT)
+            .expect("status reset should succeed");
+
+        assert!(!handler.is_device_activated());
+        assert!(!handler.activation_handler().is_activated());
+    }
+
+    #[test]
+    fn virtio_vsock_device_rejects_driver_ok_before_queues_are_ready() {
+        let mut handler = virtio_vsock_mmio_handler(3).expect("vsock handler should build");
+        advance_handler_to_features_ok(&mut handler);
+
+        let err = handler
+            .write_register(VirtioMmioRegister::Status, DRIVER_OK_STATUS)
+            .expect_err("unready queues should reject DRIVER_OK");
+
+        assert!(matches!(
+            err,
+            VirtioMmioRegisterHandlerError::DeviceActivation { .. }
+        ));
+        assert!(!handler.is_device_activated());
+        assert!(!handler.activation_handler().is_activated());
     }
 }

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -8,7 +8,7 @@ The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /`, `GET /version`,
 `GET /vm/config`, `GET /machine-config`, pre-boot `PUT /machine-config`
 configuration storage, pre-boot `PUT /boot-source` configuration storage, pre-boot `PUT /drives/{drive_id}`
-configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
+configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space and inert MMIO handler skeleton, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
 `InstanceStart` preflight, transactional startup executor, and successful-start state transition helpers, backend-neutral guest
 physical address and aarch64 DRAM layout/access primitives, arm64 boot
 placement helpers, internal boot-source validation and arm64 kernel/initrd
@@ -233,7 +233,7 @@ compatibility targets.
 | `PATCH` | `/machine-config` | deferred | Partial updates belong with later state and validation rules. |
 | `PUT` | `/cpu-config` | deferred | Needs HVF CPU feature design with VM and boot work in #8 and #10. |
 | `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores up to 16 initial virtio-net configurations before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the interface count before opening vmnet resources, then selects vmnet packet I/O only for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names; unsupported names fail startup before `Running` is committed. Internal network notification dispatch can route each configured interface through selected packet I/O, parse TX descriptors through a packet sink boundary, and copy injected RX packets into guest buffers through a packet source boundary. Public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
-| `PUT` | `/vsock` | supported target; configuration storage implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Virtio-vsock device emulation, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
+| `PUT` | `/vsock` | supported target; configuration storage implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. An internal virtio-vsock config-space and inert MMIO handler skeleton exists, but startup attachment, queue data movement, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
 | `GET`, `PUT`, `PATCH` | `/mmds` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/mmds/config` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/snapshot/create`, `/snapshot/load` | deferred | Tied to snapshot and restore work in #19. |
@@ -557,9 +557,15 @@ Displayed validation errors avoid echoing configured socket paths.
 Stored vsock configuration replaces any previous pre-boot vsock configuration
 and is returned from `GET /vm/config` as `vsock` with `guest_cid` and
 `uds_path`; the deprecated input-only `vsock_id` is omitted. The current model
-does not open, bind, connect, unlink, or create the configured `uds_path`;
-virtio-vsock device emulation, host Unix socket backend behavior, CID routing,
-and data movement remain deferred.
+does not open, bind, connect, unlink, or create the configured `uds_path`.
+
+The runtime crate has an internal virtio-vsock config-space and inert MMIO
+handler skeleton. It uses the virtio device id `19`, three 256-entry RX, TX, and
+event queues, Firecracker's `VERSION_1`, `IN_ORDER`, and `EVENT_IDX` feature
+bits, and a guest-CID config field that supports Firecracker-shaped 8-byte and
+4-byte-half reads. Config writes are rejected. Startup FDT attachment, prepared
+resources, queue activation beyond inert state, packet formats, host Unix socket
+backend behavior, CID routing, and data movement remain deferred.
 
 The runtime crate also has the first backend-neutral virtio-net config-space,
 activation, TX frame parser, RX buffer parser, prepared device resources, and
@@ -1013,7 +1019,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | `PUT /boot-source` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; host paths are opened during startup preparation. Host path errors must avoid leaking sensitive path details. |
 | `PUT /drives/{drive_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; startup preparation opens backing files and registers initial block MMIO devices. Runtime hotplug remains deferred. |
 | `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records up to 16 validated pre-boot configs without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the count before opening vmnet packet I/O for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names and fails before `Running` for unsupported names. Internal network notification dispatch can route each interface through selected packet I/O, complete TX descriptor heads through a packet sink boundary, and write injected RX packets into guest buffers through a packet source boundary. Public packet movement, PATCH, and DELETE remain deferred. |
-| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Virtio-vsock device emulation, host socket backend behavior, CID routing, data movement, PATCH, and DELETE remain deferred. |
+| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Internal virtio-vsock config-space and inert MMIO handler skeleton exist, but startup attachment, host socket backend behavior, CID routing, data movement, PATCH, and DELETE remain deferred. |
 | `PUT /metrics` | implemented; `204` empty response on successful output initialization | unsupported after start; `400` `fault_message` | Metrics output is process observability state, not guest configuration. Duplicate initialization fails. |
 | `PUT /logger` | implemented; `204` empty response on successful pre-boot configuration | unsupported after start; `400` `fault_message` | Logger output is process observability state, not guest configuration. Repeated pre-boot requests update provided fields; full log routing remains deferred. |
 | `PUT /actions` with `InstanceStart` | process-routed; `204` after successful owned HVF startup with internal boot run-loop worker across bounded step windows or `400` preflight/preparation fault | unsupported after start; `400` `fault_message` | Commits `Running` only after the owned HVF boot-session worker with internal serial capture is retained. The worker keeps internal active, terminal-outcome, or error status; public run-loop control and public serial streaming remain deferred. |
@@ -1062,8 +1068,9 @@ Their eventual support level should follow the endpoint matrix:
   parser, prepared device resources, MMIO registration, startup FDT metadata,
   TX/RX notification dispatch metadata helpers, and startup-time vmnet packet
   I/O selection for supported `host_dev_name` forms
-- virtio-vsock device emulation, host Unix socket backend behavior, CID routing,
-  and data movement beyond pre-boot `/vsock` configuration storage
+- virtio-vsock startup attachment, host Unix socket backend behavior, CID
+  routing, and data movement beyond pre-boot `/vsock` configuration storage and
+  the internal config-space/MMIO handler skeleton
 - snapshots
 - MMDS
 - balloon devices and balloon statistics

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -352,8 +352,8 @@ pre-boot-only guest configuration section. Valid requests replace the stored
 vsock config and return `204 No Content`; invalid requests fail without
 mutating previous vsock state. The current response reports `guest_cid` and
 `uds_path` while omitting the accepted deprecated `vsock_id`, matching
-Firecracker's effective config output. It does not create a virtio-vsock device,
-open host socket resources, route CIDs, or move data.
+Firecracker's effective config output. It does not attach a guest-visible
+virtio-vsock device, open host socket resources, route CIDs, or move data.
 `SendCtrlAltDel` is rejected at parse time for the first aarch64 target.
 
 Future implementation PRs should derive unit or golden tests from these tables.

--- a/docs/security.md
+++ b/docs/security.md
@@ -170,9 +170,12 @@ The current scaffold does not implement:
   interfaces use the supported names, keeps no-network startup on a no-op TX
   sink plus empty RX source, and still lacks a macOS sandbox, host resource
   broker, connectivity policy, and live vmnet integration proof. The current
-  vsock API path validates and stores
-  `guest_cid` plus `uds_path` before boot, but it does not implement a
-  virtio-vsock device or host Unix socket backend
+  vsock API path validates and stores `guest_cid` plus `uds_path` before boot.
+  The runtime crate has an internal virtio-vsock config-space and inert MMIO
+  handler skeleton that exposes only the configured guest CID through bounded
+  config reads. It does not open, bind, connect, unlink, or create `uds_path`,
+  does not attach a guest-visible startup device, and does not implement host
+  Unix socket backend behavior, CID routing, or data movement
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy
 


### PR DESCRIPTION
## Summary
- Add Firecracker-shaped virtio-vsock constants, config space, and inert MMIO handler skeleton in `bangbang-runtime`.
- Require all three vsock queues to be configured and ready before inert activation succeeds.
- Document that startup attachment, host Unix socket backend behavior, CID routing, and data movement remain deferred.

Closes #321

## Validation
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
