### PR TITLE
feat: prepare virtio-vsock device resource

### DIFF
--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -570,12 +570,12 @@ mod tests {
 
     #[test]
     fn prepared_vsock_device_preserves_config_and_inactive_device() {
-        let config = valid_vsock_config(42, "./relative-vsock.sock");
+        let config = valid_vsock_config(u32::MAX, "./relative-vsock.sock");
         let prepared = PreparedVsockDevice::from_config(&config);
 
-        assert_eq!(prepared.guest_cid(), 42);
+        assert_eq!(prepared.guest_cid(), u32::MAX);
         assert_eq!(prepared.uds_path(), Path::new("./relative-vsock.sock"));
-        assert_eq!(prepared.config_space().guest_cid(), 42);
+        assert_eq!(prepared.config_space().guest_cid(), u64::from(u32::MAX));
         assert!(!prepared.device().is_activated());
     }
 
@@ -598,19 +598,18 @@ mod tests {
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system time should be after Unix epoch")
             .as_nanos();
-        let path = std::env::temp_dir()
-            .join(format!(
-                "bangbang-vsock-missing-parent-{}-{unique}",
-                std::process::id(),
-            ))
-            .join("v.sock");
-        let config = valid_vsock_config(8, path.to_string_lossy().into_owned());
+        let socket_path = format!(
+            "bangbang-vsock-missing-parent-{}-{unique}/v.sock",
+            std::process::id(),
+        );
+        let path = Path::new(&socket_path);
+        let config = valid_vsock_config(8, socket_path.clone());
 
         assert!(!path.exists());
 
         let prepared = PreparedVsockDevice::from_config(&config);
 
-        assert_eq!(prepared.uds_path(), path.as_path());
+        assert_eq!(prepared.uds_path(), path);
         assert!(!path.exists());
     }
 

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -274,6 +274,50 @@ impl VirtioMmioDeviceActivationHandler for VirtioVsockDevice {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreparedVsockDevice {
+    guest_cid: u32,
+    uds_path: PathBuf,
+    config_space: VirtioVsockConfigSpace,
+    device: VirtioVsockDevice,
+}
+
+impl PreparedVsockDevice {
+    pub fn from_config(config: &VsockConfig) -> Self {
+        Self {
+            guest_cid: config.guest_cid(),
+            uds_path: config.uds_path().to_path_buf(),
+            config_space: VirtioVsockConfigSpace::new(u64::from(config.guest_cid())),
+            device: VirtioVsockDevice::new(),
+        }
+    }
+
+    pub const fn guest_cid(&self) -> u32 {
+        self.guest_cid
+    }
+
+    pub fn uds_path(&self) -> &Path {
+        &self.uds_path
+    }
+
+    pub const fn config_space(&self) -> VirtioVsockConfigSpace {
+        self.config_space
+    }
+
+    pub const fn device(&self) -> &VirtioVsockDevice {
+        &self.device
+    }
+
+    pub fn into_parts(self) -> (u32, PathBuf, VirtioVsockConfigSpace, VirtioVsockDevice) {
+        (
+            self.guest_cid,
+            self.uds_path,
+            self.config_space,
+            self.device,
+        )
+    }
+}
+
 pub fn virtio_vsock_mmio_handler(
     guest_cid: u32,
 ) -> Result<VirtioVsockMmioHandler, VirtioMmioRegisterHandlerError> {
@@ -317,7 +361,7 @@ mod tests {
     };
 
     use super::{
-        MIN_GUEST_CID, VIRTIO_FEATURE_IN_ORDER, VIRTIO_FEATURE_VERSION_1,
+        MIN_GUEST_CID, PreparedVsockDevice, VIRTIO_FEATURE_IN_ORDER, VIRTIO_FEATURE_VERSION_1,
         VIRTIO_RING_FEATURE_EVENT_IDX, VIRTIO_VSOCK_CONFIG_GUEST_CID_SIZE, VIRTIO_VSOCK_DEVICE_ID,
         VIRTIO_VSOCK_EVENT_QUEUE_INDEX, VIRTIO_VSOCK_QUEUE_COUNT, VIRTIO_VSOCK_QUEUE_SIZE,
         VIRTIO_VSOCK_QUEUE_SIZES, VIRTIO_VSOCK_RX_QUEUE_INDEX, VIRTIO_VSOCK_TX_QUEUE_INDEX,
@@ -335,6 +379,10 @@ mod tests {
 
     fn validate(input: VsockConfigInput) -> Result<super::VsockConfig, VsockConfigError> {
         input.validate()
+    }
+
+    fn valid_vsock_config(guest_cid: u32, uds_path: impl Into<String>) -> super::VsockConfig {
+        validate(VsockConfigInput::new(guest_cid, uds_path)).expect("valid config")
     }
 
     fn virtio_mmio_access(offset: u64, len: u64) -> MmioAccess {
@@ -518,6 +566,52 @@ mod tests {
     #[test]
     fn errors_have_no_sources() {
         assert!(VsockConfigError::EmptySocketPath.source().is_none());
+    }
+
+    #[test]
+    fn prepared_vsock_device_preserves_config_and_inactive_device() {
+        let config = valid_vsock_config(42, "./relative-vsock.sock");
+        let prepared = PreparedVsockDevice::from_config(&config);
+
+        assert_eq!(prepared.guest_cid(), 42);
+        assert_eq!(prepared.uds_path(), Path::new("./relative-vsock.sock"));
+        assert_eq!(prepared.config_space().guest_cid(), 42);
+        assert!(!prepared.device().is_activated());
+    }
+
+    #[test]
+    fn prepared_vsock_device_into_parts_consumes_owned_resource() {
+        let config = valid_vsock_config(7, "relative-vsock.sock");
+        let prepared = PreparedVsockDevice::from_config(&config);
+
+        let (guest_cid, uds_path, config_space, device) = prepared.into_parts();
+
+        assert_eq!(guest_cid, 7);
+        assert_eq!(uds_path.as_path(), Path::new("relative-vsock.sock"));
+        assert_eq!(config_space.guest_cid(), 7);
+        assert!(!device.is_activated());
+    }
+
+    #[test]
+    fn prepared_vsock_device_does_not_touch_missing_socket_path() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after Unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir()
+            .join(format!(
+                "bangbang-vsock-missing-parent-{}-{unique}",
+                std::process::id(),
+            ))
+            .join("v.sock");
+        let config = valid_vsock_config(8, path.to_string_lossy().into_owned());
+
+        assert!(!path.exists());
+
+        let prepared = PreparedVsockDevice::from_config(&config);
+
+        assert_eq!(prepared.uds_path(), path.as_path());
+        assert!(!path.exists());
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -8,7 +8,7 @@ The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /`, `GET /version`,
 `GET /vm/config`, `GET /machine-config`, pre-boot `PUT /machine-config`
 configuration storage, pre-boot `PUT /boot-source` configuration storage, pre-boot `PUT /drives/{drive_id}`
-configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space and inert MMIO handler skeleton, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
+configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, prepared device resource, and inert MMIO handler skeleton, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
 `InstanceStart` preflight, transactional startup executor, and successful-start state transition helpers, backend-neutral guest
 physical address and aarch64 DRAM layout/access primitives, arm64 boot
 placement helpers, internal boot-source validation and arm64 kernel/initrd
@@ -233,7 +233,7 @@ compatibility targets.
 | `PATCH` | `/machine-config` | deferred | Partial updates belong with later state and validation rules. |
 | `PUT` | `/cpu-config` | deferred | Needs HVF CPU feature design with VM and boot work in #8 and #10. |
 | `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores up to 16 initial virtio-net configurations before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the interface count before opening vmnet resources, then selects vmnet packet I/O only for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names; unsupported names fail startup before `Running` is committed. Internal network notification dispatch can route each configured interface through selected packet I/O, parse TX descriptors through a packet sink boundary, and copy injected RX packets into guest buffers through a packet source boundary. Public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
-| `PUT` | `/vsock` | supported target; configuration storage implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. An internal virtio-vsock config-space and inert MMIO handler skeleton exists, but startup attachment, queue data movement, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
+| `PUT` | `/vsock` | supported target; configuration storage implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. An internal virtio-vsock prepared resource, config-space, and inert MMIO handler skeleton exist, but startup attachment, queue data movement, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
 | `GET`, `PUT`, `PATCH` | `/mmds` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/mmds/config` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/snapshot/create`, `/snapshot/load` | deferred | Tied to snapshot and restore work in #19. |
@@ -559,13 +559,16 @@ and is returned from `GET /vm/config` as `vsock` with `guest_cid` and
 `uds_path`; the deprecated input-only `vsock_id` is omitted. The current model
 does not open, bind, connect, unlink, or create the configured `uds_path`.
 
-The runtime crate has an internal virtio-vsock config-space and inert MMIO
-handler skeleton. It uses the virtio device id `19`, three 256-entry RX, TX, and
-event queues, Firecracker's `VERSION_1`, `IN_ORDER`, and `EVENT_IDX` feature
-bits, and a guest-CID config field that supports Firecracker-shaped 8-byte and
-4-byte-half reads. Config writes are rejected. Startup FDT attachment, prepared
-resources, queue activation beyond inert state, packet formats, host Unix socket
-backend behavior, CID routing, and data movement remain deferred.
+The runtime crate has an internal virtio-vsock prepared resource, config-space,
+and inert MMIO handler skeleton. It uses the virtio device id `19`, three
+256-entry RX, TX, and event queues, Firecracker's `VERSION_1`, `IN_ORDER`, and
+`EVENT_IDX` feature bits, and a guest-CID config field that supports
+Firecracker-shaped 8-byte and 4-byte-half reads. Config writes are rejected.
+The prepared resource preserves the validated guest CID, socket path,
+config-space, and inactive device state without touching host socket resources.
+Startup FDT attachment, MMIO registration, queue activation beyond inert state,
+packet formats, host Unix socket backend behavior, CID routing, and data
+movement remain deferred.
 
 The runtime crate also has the first backend-neutral virtio-net config-space,
 activation, TX frame parser, RX buffer parser, prepared device resources, and
@@ -1019,7 +1022,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | `PUT /boot-source` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; host paths are opened during startup preparation. Host path errors must avoid leaking sensitive path details. |
 | `PUT /drives/{drive_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; startup preparation opens backing files and registers initial block MMIO devices. Runtime hotplug remains deferred. |
 | `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records up to 16 validated pre-boot configs without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the count before opening vmnet packet I/O for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names and fails before `Running` for unsupported names. Internal network notification dispatch can route each interface through selected packet I/O, complete TX descriptor heads through a packet sink boundary, and write injected RX packets into guest buffers through a packet source boundary. Public packet movement, PATCH, and DELETE remain deferred. |
-| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Internal virtio-vsock config-space and inert MMIO handler skeleton exist, but startup attachment, host socket backend behavior, CID routing, data movement, PATCH, and DELETE remain deferred. |
+| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Internal virtio-vsock prepared resource, config-space, and inert MMIO handler skeleton exist, but startup attachment, host socket backend behavior, CID routing, data movement, PATCH, and DELETE remain deferred. |
 | `PUT /metrics` | implemented; `204` empty response on successful output initialization | unsupported after start; `400` `fault_message` | Metrics output is process observability state, not guest configuration. Duplicate initialization fails. |
 | `PUT /logger` | implemented; `204` empty response on successful pre-boot configuration | unsupported after start; `400` `fault_message` | Logger output is process observability state, not guest configuration. Repeated pre-boot requests update provided fields; full log routing remains deferred. |
 | `PUT /actions` with `InstanceStart` | process-routed; `204` after successful owned HVF startup with internal boot run-loop worker across bounded step windows or `400` preflight/preparation fault | unsupported after start; `400` `fault_message` | Commits `Running` only after the owned HVF boot-session worker with internal serial capture is retained. The worker keeps internal active, terminal-outcome, or error status; public run-loop control and public serial streaming remain deferred. |
@@ -1070,7 +1073,7 @@ Their eventual support level should follow the endpoint matrix:
   I/O selection for supported `host_dev_name` forms
 - virtio-vsock startup attachment, host Unix socket backend behavior, CID
   routing, and data movement beyond pre-boot `/vsock` configuration storage and
-  the internal config-space/MMIO handler skeleton
+  the internal prepared resource/config-space/MMIO handler skeleton
 - snapshots
 - MMDS
 - balloon devices and balloon statistics

--- a/docs/security.md
+++ b/docs/security.md
@@ -171,11 +171,12 @@ The current scaffold does not implement:
   sink plus empty RX source, and still lacks a macOS sandbox, host resource
   broker, connectivity policy, and live vmnet integration proof. The current
   vsock API path validates and stores `guest_cid` plus `uds_path` before boot.
-  The runtime crate has an internal virtio-vsock config-space and inert MMIO
-  handler skeleton that exposes only the configured guest CID through bounded
-  config reads. It does not open, bind, connect, unlink, or create `uds_path`,
-  does not attach a guest-visible startup device, and does not implement host
-  Unix socket backend behavior, CID routing, or data movement
+  The runtime crate has an internal virtio-vsock prepared resource, config-space,
+  and inert MMIO handler skeleton that preserve the configured socket path and
+  expose only the configured guest CID through bounded config reads. Preparation
+  does not open, bind, connect, unlink, or create `uds_path`, does not attach a
+  guest-visible startup device, and does not implement host Unix socket backend
+  behavior, CID routing, or data movement
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy
 


### PR DESCRIPTION
## Summary

- Add an internal `PreparedVsockDevice` built from validated `VsockConfig`.
- Preserve guest CID, `uds_path`, config-space, and inactive device state for later startup/MMIO work.
- Document that preparation still does not touch host Unix socket resources or attach a guest-visible device.

Closes #323

## Scope

Out of scope for this PR: MMIO registration, startup/FDT attachment, host Unix socket backend behavior, CID routing, packet formats, queue dispatch, data movement, runtime updates, PATCH, DELETE, and public `/vsock` API changes.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p bangbang-runtime vsock --all-features --locked`
- `cargo check -p bangbang-runtime --all-targets --all-features --locked`
- `cargo clippy -p bangbang-runtime --all-targets --all-features --locked -- -D warnings`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
