### PR TITLE
feat: register virtio-vsock MMIO resource

### DIFF
--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -1010,6 +1010,52 @@ mod tests {
     }
 
     #[test]
+    fn prepared_vsock_device_rejects_invalid_mmio_layout_without_path_leak() {
+        let layout = VsockMmioLayout::new(GuestAddress::new(u64::MAX), MmioRegionId::new(4));
+        let err = prepared_vsock_device(13, "secret-vsock-path.sock")
+            .register_mmio(layout)
+            .expect_err("overflowing region should fail");
+
+        assert!(matches!(
+            err,
+            VsockMmioRegistrationError::InvalidRegion {
+                region_id,
+                address,
+                ..
+            } if region_id == MmioRegionId::new(4) && address == GuestAddress::new(u64::MAX)
+        ));
+        assert!(err.source().is_some());
+        assert!(!err.to_string().contains("secret-vsock-path"));
+    }
+
+    #[test]
+    fn prepared_vsock_device_rejects_duplicate_mmio_handler_without_path_leak() {
+        let layout = vsock_mmio_layout();
+        let mut dispatcher = MmioDispatcher::new();
+        dispatcher
+            .register_handler(
+                layout.region_id(),
+                virtio_vsock_mmio_handler(3).expect("existing handler should build"),
+            )
+            .expect("existing handler should register");
+
+        let err = prepared_vsock_device(14, "secret-vsock-path.sock")
+            .register_mmio_with_dispatcher(layout, dispatcher)
+            .expect_err("duplicate handler should fail");
+
+        assert!(matches!(
+            err,
+            VsockMmioRegistrationError::RegisterHandler {
+                guest_cid: 14,
+                region_id,
+                ..
+            } if region_id == layout.region_id()
+        ));
+        assert!(err.source().is_some());
+        assert!(!err.to_string().contains("secret-vsock-path"));
+    }
+
+    #[test]
     fn prepared_vsock_device_mmio_registration_does_not_touch_missing_socket_path() {
         let socket_path = unique_missing_socket_path();
         let path = Path::new(&socket_path);

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -3,11 +3,15 @@
 use std::fmt;
 use std::path::{Path, PathBuf};
 
-use crate::mmio::{MmioAccessBytes, MmioAccessBytesError, MmioHandlerError};
+use crate::memory::{GuestAddress, GuestMemoryError};
+use crate::mmio::{
+    MmioAccessBytes, MmioAccessBytesError, MmioBusError, MmioDispatchError, MmioDispatcher,
+    MmioHandlerError, MmioRegion, MmioRegionId,
+};
 use crate::virtio_mmio::{
-    VirtioMmioDeviceActivation, VirtioMmioDeviceActivationError, VirtioMmioDeviceActivationHandler,
-    VirtioMmioDeviceConfigAccess, VirtioMmioDeviceConfigError, VirtioMmioDeviceConfigHandler,
-    VirtioMmioRegisterHandler, VirtioMmioRegisterHandlerError,
+    VIRTIO_MMIO_DEVICE_WINDOW_SIZE, VirtioMmioDeviceActivation, VirtioMmioDeviceActivationError,
+    VirtioMmioDeviceActivationHandler, VirtioMmioDeviceConfigAccess, VirtioMmioDeviceConfigError,
+    VirtioMmioDeviceConfigHandler, VirtioMmioRegisterHandler, VirtioMmioRegisterHandlerError,
 };
 
 pub const MIN_GUEST_CID: u32 = 3;
@@ -316,6 +320,246 @@ impl PreparedVsockDevice {
             self.device,
         )
     }
+
+    pub fn register_mmio(
+        self,
+        layout: VsockMmioLayout,
+    ) -> Result<VsockMmioDevice, VsockMmioRegistrationError> {
+        VsockMmioDevice::from_prepared(self, layout)
+    }
+
+    pub fn register_mmio_with_dispatcher(
+        self,
+        layout: VsockMmioLayout,
+        dispatcher: MmioDispatcher,
+    ) -> Result<VsockMmioDevice, VsockMmioRegistrationError> {
+        VsockMmioDevice::from_prepared_with_dispatcher(self, layout, dispatcher)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VsockMmioLayout {
+    address: GuestAddress,
+    region_id: MmioRegionId,
+}
+
+impl VsockMmioLayout {
+    pub const fn new(address: GuestAddress, region_id: MmioRegionId) -> Self {
+        Self { address, region_id }
+    }
+
+    pub const fn address(self) -> GuestAddress {
+        self.address
+    }
+
+    pub const fn region_id(self) -> MmioRegionId {
+        self.region_id
+    }
+
+    fn region(self) -> Result<MmioRegion, VsockMmioRegistrationError> {
+        MmioRegion::new(self.region_id, self.address, VIRTIO_MMIO_DEVICE_WINDOW_SIZE).map_err(
+            |source| VsockMmioRegistrationError::InvalidRegion {
+                region_id: self.region_id,
+                address: self.address,
+                source,
+            },
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VsockMmioDeviceRegistration {
+    guest_cid: u32,
+    uds_path: PathBuf,
+    region: MmioRegion,
+}
+
+impl VsockMmioDeviceRegistration {
+    pub const fn guest_cid(&self) -> u32 {
+        self.guest_cid
+    }
+
+    pub fn uds_path(&self) -> &Path {
+        &self.uds_path
+    }
+
+    pub const fn region(&self) -> MmioRegion {
+        self.region
+    }
+
+    pub const fn region_id(&self) -> MmioRegionId {
+        self.region.id()
+    }
+
+    pub const fn address(&self) -> GuestAddress {
+        self.region.range().start()
+    }
+}
+
+#[derive(Debug)]
+pub struct VsockMmioDevice {
+    dispatcher: MmioDispatcher,
+    registration: VsockMmioDeviceRegistration,
+}
+
+impl VsockMmioDevice {
+    pub fn from_prepared(
+        prepared: PreparedVsockDevice,
+        layout: VsockMmioLayout,
+    ) -> Result<Self, VsockMmioRegistrationError> {
+        Self::from_prepared_with_dispatcher(prepared, layout, MmioDispatcher::new())
+    }
+
+    pub fn from_prepared_with_dispatcher(
+        prepared: PreparedVsockDevice,
+        layout: VsockMmioLayout,
+        dispatcher: MmioDispatcher,
+    ) -> Result<Self, VsockMmioRegistrationError> {
+        let region = layout.region()?;
+        let (guest_cid, uds_path, config_space, device) = prepared.into_parts();
+        let handler = VirtioMmioRegisterHandler::with_device_config_and_activation(
+            VIRTIO_VSOCK_DEVICE_ID,
+            config_space.available_features(),
+            &VIRTIO_VSOCK_QUEUE_SIZES,
+            config_space,
+            device,
+        )
+        .map_err(|source| VsockMmioRegistrationError::BuildHandler {
+            guest_cid,
+            region_id: layout.region_id(),
+            source,
+        })?;
+        let mut dispatcher = dispatcher;
+        let inserted_region = dispatcher
+            .insert_region(
+                layout.region_id(),
+                layout.address(),
+                VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+            )
+            .map_err(|source| VsockMmioRegistrationError::InsertRegion {
+                guest_cid,
+                region_id: layout.region_id(),
+                address: layout.address(),
+                source,
+            })?;
+        dispatcher
+            .register_handler(layout.region_id(), handler)
+            .map_err(|source| VsockMmioRegistrationError::RegisterHandler {
+                guest_cid,
+                region_id: layout.region_id(),
+                source,
+            })?;
+        debug_assert_eq!(inserted_region, region);
+
+        Ok(Self {
+            dispatcher,
+            registration: VsockMmioDeviceRegistration {
+                guest_cid,
+                uds_path,
+                region,
+            },
+        })
+    }
+
+    pub fn dispatcher(&self) -> &MmioDispatcher {
+        &self.dispatcher
+    }
+
+    pub fn dispatcher_mut(&mut self) -> &mut MmioDispatcher {
+        &mut self.dispatcher
+    }
+
+    pub const fn registration(&self) -> &VsockMmioDeviceRegistration {
+        &self.registration
+    }
+
+    pub fn into_parts(self) -> (MmioDispatcher, VsockMmioDeviceRegistration) {
+        (self.dispatcher, self.registration)
+    }
+}
+
+#[derive(Debug)]
+pub enum VsockMmioRegistrationError {
+    InvalidRegion {
+        region_id: MmioRegionId,
+        address: GuestAddress,
+        source: GuestMemoryError,
+    },
+    BuildHandler {
+        guest_cid: u32,
+        region_id: MmioRegionId,
+        source: VirtioMmioRegisterHandlerError,
+    },
+    InsertRegion {
+        guest_cid: u32,
+        region_id: MmioRegionId,
+        address: GuestAddress,
+        source: MmioBusError,
+    },
+    RegisterHandler {
+        guest_cid: u32,
+        region_id: MmioRegionId,
+        source: MmioDispatchError,
+    },
+}
+
+impl fmt::Display for VsockMmioRegistrationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRegion {
+                region_id,
+                address,
+                source,
+            } => {
+                write!(
+                    f,
+                    "invalid vsock MMIO region id={region_id} at {address}: {source}"
+                )
+            }
+            Self::BuildHandler {
+                guest_cid,
+                region_id,
+                source,
+            } => {
+                write!(
+                    f,
+                    "failed to build vsock MMIO handler for guest CID {guest_cid} region id={region_id}: {source}"
+                )
+            }
+            Self::InsertRegion {
+                guest_cid,
+                region_id,
+                address,
+                source,
+            } => {
+                write!(
+                    f,
+                    "failed to insert vsock MMIO region for guest CID {guest_cid} region id={region_id} at {address}: {source}"
+                )
+            }
+            Self::RegisterHandler {
+                guest_cid,
+                region_id,
+                source,
+            } => {
+                write!(
+                    f,
+                    "failed to register vsock MMIO handler for guest CID {guest_cid} region id={region_id}: {source}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for VsockMmioRegistrationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidRegion { source, .. } => Some(source),
+            Self::BuildHandler { source, .. } => Some(source),
+            Self::InsertRegion { source, .. } => Some(source),
+            Self::RegisterHandler { source, .. } => Some(source),
+        }
+    }
 }
 
 pub fn virtio_vsock_mmio_handler(
@@ -351,7 +595,10 @@ mod tests {
     use std::path::Path;
 
     use crate::memory::GuestAddress;
-    use crate::mmio::{MmioAccess, MmioAccessBytes, MmioBus, MmioRegionId};
+    use crate::mmio::{
+        MmioAccess, MmioAccessBytes, MmioBus, MmioDispatchOutcome, MmioDispatcher, MmioOperation,
+        MmioRegionId,
+    };
     use crate::virtio_mmio::{
         VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DRIVER,
         VIRTIO_DEVICE_STATUS_DRIVER_OK, VIRTIO_DEVICE_STATUS_FEATURES_OK,
@@ -366,7 +613,8 @@ mod tests {
         VIRTIO_VSOCK_EVENT_QUEUE_INDEX, VIRTIO_VSOCK_QUEUE_COUNT, VIRTIO_VSOCK_QUEUE_SIZE,
         VIRTIO_VSOCK_QUEUE_SIZES, VIRTIO_VSOCK_RX_QUEUE_INDEX, VIRTIO_VSOCK_TX_QUEUE_INDEX,
         VirtioVsockConfigSpace, VirtioVsockDevice, VirtioVsockMmioHandler, VsockConfigError,
-        VsockConfigInput, virtio_vsock_mmio_handler,
+        VsockConfigInput, VsockMmioDevice, VsockMmioLayout, VsockMmioRegistrationError,
+        virtio_vsock_mmio_handler,
     };
 
     const TEST_MMIO_BASE: u64 = 0x1000_0000;
@@ -383,6 +631,47 @@ mod tests {
 
     fn valid_vsock_config(guest_cid: u32, uds_path: impl Into<String>) -> super::VsockConfig {
         validate(VsockConfigInput::new(guest_cid, uds_path)).expect("valid config")
+    }
+
+    fn prepared_vsock_device(guest_cid: u32, uds_path: impl Into<String>) -> PreparedVsockDevice {
+        PreparedVsockDevice::from_config(&valid_vsock_config(guest_cid, uds_path))
+    }
+
+    fn unique_missing_socket_path() -> String {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after Unix epoch")
+            .as_nanos();
+        format!(
+            "bangbang-vsock-missing-parent-{}-{unique}/v.sock",
+            std::process::id(),
+        )
+    }
+
+    fn vsock_mmio_layout() -> VsockMmioLayout {
+        VsockMmioLayout::new(GuestAddress::new(TEST_MMIO_BASE), MmioRegionId::new(2))
+    }
+
+    fn read_registered_config(device: &mut VsockMmioDevice, offset: u64, len: u64) -> Vec<u8> {
+        let address = device
+            .registration()
+            .address()
+            .checked_add(VIRTIO_MMIO_DEVICE_CONFIG_OFFSET + offset)
+            .expect("test config address should not overflow");
+        let access = device
+            .dispatcher()
+            .lookup(address, len)
+            .expect("registered config access should resolve");
+        let operation = MmioOperation::read(access).expect("registered config read should build");
+        let outcome = device
+            .dispatcher_mut()
+            .dispatch(operation)
+            .expect("registered config read should dispatch");
+        let MmioDispatchOutcome::Read { data } = outcome else {
+            panic!("read operation should return read outcome");
+        };
+
+        data.as_slice().to_vec()
     }
 
     fn virtio_mmio_access(offset: u64, len: u64) -> MmioAccess {
@@ -594,14 +883,7 @@ mod tests {
 
     #[test]
     fn prepared_vsock_device_does_not_touch_missing_socket_path() {
-        let unique = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("system time should be after Unix epoch")
-            .as_nanos();
-        let socket_path = format!(
-            "bangbang-vsock-missing-parent-{}-{unique}/v.sock",
-            std::process::id(),
-        );
+        let socket_path = unique_missing_socket_path();
         let path = Path::new(&socket_path);
         let config = valid_vsock_config(8, socket_path.clone());
 
@@ -610,6 +892,135 @@ mod tests {
         let prepared = PreparedVsockDevice::from_config(&config);
 
         assert_eq!(prepared.uds_path(), path);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn prepared_vsock_device_registers_mmio_in_fresh_dispatcher() {
+        let mut device = prepared_vsock_device(42, "./v.sock")
+            .register_mmio(vsock_mmio_layout())
+            .expect("vsock device should register");
+        let registration = device.registration();
+
+        assert_eq!(registration.guest_cid(), 42);
+        assert_eq!(registration.uds_path(), Path::new("./v.sock"));
+        assert_eq!(registration.region_id(), MmioRegionId::new(2));
+        assert_eq!(registration.address(), GuestAddress::new(TEST_MMIO_BASE));
+        assert_eq!(
+            registration.region().range().size(),
+            VIRTIO_MMIO_DEVICE_WINDOW_SIZE
+        );
+        assert_eq!(device.dispatcher().regions(), &[registration.region()]);
+
+        let region_id = registration.region_id();
+        let handler = device
+            .dispatcher_mut()
+            .handler_mut::<VirtioVsockMmioHandler>(region_id)
+            .expect("registered vsock handler should be present");
+        assert!(!handler.is_device_activated());
+        assert!(!handler.activation_handler().is_activated());
+    }
+
+    #[test]
+    fn prepared_vsock_device_registers_mmio_in_existing_dispatcher() {
+        let mut dispatcher = MmioDispatcher::new();
+        let existing_region = dispatcher
+            .insert_region(
+                MmioRegionId::new(1),
+                GuestAddress::new(TEST_MMIO_BASE - VIRTIO_MMIO_DEVICE_WINDOW_SIZE),
+                VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+            )
+            .expect("existing region should insert");
+        let device = prepared_vsock_device(9, "./v.sock")
+            .register_mmio_with_dispatcher(vsock_mmio_layout(), dispatcher)
+            .expect("vsock device should register with existing dispatcher");
+
+        assert_eq!(device.dispatcher().regions().len(), 2);
+        assert!(device.dispatcher().regions().contains(&existing_region));
+        assert!(
+            device
+                .dispatcher()
+                .regions()
+                .contains(&device.registration().region())
+        );
+    }
+
+    #[test]
+    fn registered_vsock_mmio_dispatch_reads_guest_cid_config() {
+        let mut device = prepared_vsock_device(0x1122_3344, "./v.sock")
+            .register_mmio(vsock_mmio_layout())
+            .expect("vsock device should register");
+
+        assert_eq!(
+            read_registered_config(&mut device, 0, 8),
+            u64::from(0x1122_3344_u32).to_le_bytes().to_vec()
+        );
+        assert_eq!(
+            read_registered_config(&mut device, 0, 4),
+            0x1122_3344_u32.to_le_bytes().to_vec()
+        );
+        assert_eq!(
+            read_registered_config(&mut device, 4, 4),
+            0_u32.to_le_bytes().to_vec()
+        );
+    }
+
+    #[test]
+    fn registered_vsock_mmio_into_parts_consumes_owned_resource() {
+        let device = prepared_vsock_device(11, "relative-vsock.sock")
+            .register_mmio(vsock_mmio_layout())
+            .expect("vsock device should register");
+
+        let (dispatcher, registration) = device.into_parts();
+
+        assert_eq!(dispatcher.regions(), &[registration.region()]);
+        assert_eq!(registration.guest_cid(), 11);
+        assert_eq!(registration.uds_path(), Path::new("relative-vsock.sock"));
+    }
+
+    #[test]
+    fn prepared_vsock_device_rejects_overlapping_mmio_registration_without_path_leak() {
+        let mut dispatcher = MmioDispatcher::new();
+        dispatcher
+            .insert_region(
+                MmioRegionId::new(1),
+                GuestAddress::new(TEST_MMIO_BASE),
+                VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+            )
+            .expect("existing region should insert");
+
+        let layout = VsockMmioLayout::new(
+            GuestAddress::new(TEST_MMIO_BASE + 0x100),
+            MmioRegionId::new(3),
+        );
+        let err = prepared_vsock_device(12, "secret-vsock-path.sock")
+            .register_mmio_with_dispatcher(layout, dispatcher)
+            .expect_err("overlapping region should fail");
+
+        assert!(matches!(
+            err,
+            VsockMmioRegistrationError::InsertRegion {
+                guest_cid: 12,
+                region_id,
+                ..
+            } if region_id == MmioRegionId::new(3)
+        ));
+        assert!(err.source().is_some());
+        assert!(!err.to_string().contains("secret-vsock-path"));
+    }
+
+    #[test]
+    fn prepared_vsock_device_mmio_registration_does_not_touch_missing_socket_path() {
+        let socket_path = unique_missing_socket_path();
+        let path = Path::new(&socket_path);
+
+        assert!(!path.exists());
+
+        let device = prepared_vsock_device(13, socket_path.clone())
+            .register_mmio(vsock_mmio_layout())
+            .expect("vsock device should register");
+
+        assert_eq!(device.registration().uds_path(), path);
         assert!(!path.exists());
     }
 

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -8,7 +8,7 @@ The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /`, `GET /version`,
 `GET /vm/config`, `GET /machine-config`, pre-boot `PUT /machine-config`
 configuration storage, pre-boot `PUT /boot-source` configuration storage, pre-boot `PUT /drives/{drive_id}`
-configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, prepared device resource, and inert MMIO handler skeleton, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
+configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, prepared device resource, MMIO registration helper, and inert MMIO handler skeleton, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
 `InstanceStart` preflight, transactional startup executor, and successful-start state transition helpers, backend-neutral guest
 physical address and aarch64 DRAM layout/access primitives, arm64 boot
 placement helpers, internal boot-source validation and arm64 kernel/initrd
@@ -233,7 +233,7 @@ compatibility targets.
 | `PATCH` | `/machine-config` | deferred | Partial updates belong with later state and validation rules. |
 | `PUT` | `/cpu-config` | deferred | Needs HVF CPU feature design with VM and boot work in #8 and #10. |
 | `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores up to 16 initial virtio-net configurations before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the interface count before opening vmnet resources, then selects vmnet packet I/O only for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names; unsupported names fail startup before `Running` is committed. Internal network notification dispatch can route each configured interface through selected packet I/O, parse TX descriptors through a packet sink boundary, and copy injected RX packets into guest buffers through a packet source boundary. Public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
-| `PUT` | `/vsock` | supported target; configuration storage implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. An internal virtio-vsock prepared resource, config-space, and inert MMIO handler skeleton exist, but startup attachment, queue data movement, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
+| `PUT` | `/vsock` | supported target; configuration storage implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. An internal virtio-vsock prepared resource, MMIO registration helper, config-space, and inert MMIO handler skeleton exist, but startup attachment, queue data movement, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
 | `GET`, `PUT`, `PATCH` | `/mmds` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/mmds/config` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/snapshot/create`, `/snapshot/load` | deferred | Tied to snapshot and restore work in #19. |
@@ -559,16 +559,17 @@ and is returned from `GET /vm/config` as `vsock` with `guest_cid` and
 `uds_path`; the deprecated input-only `vsock_id` is omitted. The current model
 does not open, bind, connect, unlink, or create the configured `uds_path`.
 
-The runtime crate has an internal virtio-vsock prepared resource, config-space,
-and inert MMIO handler skeleton. It uses the virtio device id `19`, three
-256-entry RX, TX, and event queues, Firecracker's `VERSION_1`, `IN_ORDER`, and
-`EVENT_IDX` feature bits, and a guest-CID config field that supports
-Firecracker-shaped 8-byte and 4-byte-half reads. Config writes are rejected.
-The prepared resource preserves the validated guest CID, socket path,
-config-space, and inactive device state without touching host socket resources.
-Startup FDT attachment, MMIO registration, queue activation beyond inert state,
-packet formats, host Unix socket backend behavior, CID routing, and data
-movement remain deferred.
+The runtime crate has an internal virtio-vsock prepared resource, MMIO
+registration helper, config-space, and inert MMIO handler skeleton. It uses the
+virtio device id `19`, three 256-entry RX, TX, and event queues, Firecracker's
+`VERSION_1`, `IN_ORDER`, and `EVENT_IDX` feature bits, and a guest-CID config
+field that supports Firecracker-shaped 8-byte and 4-byte-half reads. Config
+writes are rejected. The prepared resource preserves the validated guest CID,
+socket path, config-space, and inactive device state, and the registration
+helper can consume it into a caller-provided internal MMIO dispatcher without
+touching host socket resources. Startup FDT attachment, startup resource
+assembly, queue activation beyond inert state, packet formats, host Unix socket
+backend behavior, CID routing, and data movement remain deferred.
 
 The runtime crate also has the first backend-neutral virtio-net config-space,
 activation, TX frame parser, RX buffer parser, prepared device resources, and
@@ -1022,7 +1023,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | `PUT /boot-source` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; host paths are opened during startup preparation. Host path errors must avoid leaking sensitive path details. |
 | `PUT /drives/{drive_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; startup preparation opens backing files and registers initial block MMIO devices. Runtime hotplug remains deferred. |
 | `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records up to 16 validated pre-boot configs without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the count before opening vmnet packet I/O for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names and fails before `Running` for unsupported names. Internal network notification dispatch can route each interface through selected packet I/O, complete TX descriptor heads through a packet sink boundary, and write injected RX packets into guest buffers through a packet source boundary. Public packet movement, PATCH, and DELETE remain deferred. |
-| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Internal virtio-vsock prepared resource, config-space, and inert MMIO handler skeleton exist, but startup attachment, host socket backend behavior, CID routing, data movement, PATCH, and DELETE remain deferred. |
+| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Internal virtio-vsock prepared resource, MMIO registration helper, config-space, and inert MMIO handler skeleton exist, but startup attachment, host socket backend behavior, CID routing, data movement, PATCH, and DELETE remain deferred. |
 | `PUT /metrics` | implemented; `204` empty response on successful output initialization | unsupported after start; `400` `fault_message` | Metrics output is process observability state, not guest configuration. Duplicate initialization fails. |
 | `PUT /logger` | implemented; `204` empty response on successful pre-boot configuration | unsupported after start; `400` `fault_message` | Logger output is process observability state, not guest configuration. Repeated pre-boot requests update provided fields; full log routing remains deferred. |
 | `PUT /actions` with `InstanceStart` | process-routed; `204` after successful owned HVF startup with internal boot run-loop worker across bounded step windows or `400` preflight/preparation fault | unsupported after start; `400` `fault_message` | Commits `Running` only after the owned HVF boot-session worker with internal serial capture is retained. The worker keeps internal active, terminal-outcome, or error status; public run-loop control and public serial streaming remain deferred. |
@@ -1073,7 +1074,8 @@ Their eventual support level should follow the endpoint matrix:
   I/O selection for supported `host_dev_name` forms
 - virtio-vsock startup attachment, host Unix socket backend behavior, CID
   routing, and data movement beyond pre-boot `/vsock` configuration storage and
-  the internal prepared resource/config-space/MMIO handler skeleton
+  the internal prepared resource/MMIO registration/config-space/MMIO handler
+  skeleton
 - snapshots
 - MMDS
 - balloon devices and balloon statistics

--- a/docs/security.md
+++ b/docs/security.md
@@ -171,12 +171,13 @@ The current scaffold does not implement:
   sink plus empty RX source, and still lacks a macOS sandbox, host resource
   broker, connectivity policy, and live vmnet integration proof. The current
   vsock API path validates and stores `guest_cid` plus `uds_path` before boot.
-  The runtime crate has an internal virtio-vsock prepared resource, config-space,
-  and inert MMIO handler skeleton that preserve the configured socket path and
-  expose only the configured guest CID through bounded config reads. Preparation
-  does not open, bind, connect, unlink, or create `uds_path`, does not attach a
-  guest-visible startup device, and does not implement host Unix socket backend
-  behavior, CID routing, or data movement
+  The runtime crate has an internal virtio-vsock prepared resource, MMIO
+  registration helper, config-space, and inert MMIO handler skeleton that
+  preserve the configured socket path and expose only the configured guest CID
+  through bounded config reads. Preparation and MMIO registration do not open,
+  bind, connect, unlink, or create `uds_path`, do not attach a guest-visible
+  startup device, and do not implement host Unix socket backend behavior, CID
+  routing, or data movement
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy
 


### PR DESCRIPTION
## Summary

- Add a singular runtime `VsockMmioDevice` registration boundary for prepared virtio-vsock devices.
- Register the owned config-space and inactive device state into a fresh or existing `MmioDispatcher` with read-only metadata for later startup/FDT work.
- Document that MMIO registration still does not touch host Unix socket resources or make vsock guest-visible at startup.

Closes #325

## Scope

Out of scope for this PR: collection wrappers, startup resource assembly, FDT attachment, interrupt allocation, guest-visible startup wiring, host Unix socket backend behavior, CID routing, packet formats, queue dispatch, data movement, runtime updates, PATCH, DELETE, and public `/vsock` API changes.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
