### PR TITLE
feat: attach virtio-vsock to boot resources

### DIFF
--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -1402,14 +1402,17 @@ mod tests {
             block_devices
                 .registrations()
                 .iter()
-                .all(|registration| registration.region_id() != serial_region_id)
+                .all(|registration| registration.region_id() != serial_region_id
+                    && registration.region_id() != vsock_region.id())
         );
         assert!(
             network_devices
                 .registrations()
                 .iter()
-                .all(|registration| registration.region_id() != serial_region_id)
+                .all(|registration| registration.region_id() != serial_region_id
+                    && registration.region_id() != vsock_region.id())
         );
+        assert_ne!(vsock_region.id(), serial_region_id);
         assert!(block_devices.registrations().iter().all(|block| {
             network_devices
                 .registrations()

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -23,6 +23,7 @@ use bangbang_runtime::startup::{
     Arm64BootNetworkDevice, Arm64BootNetworkPacketIo, Arm64BootNetworkPacketIoError,
     Arm64BootNetworkPacketIoProvider,
 };
+use bangbang_runtime::vsock::VsockMmioLayout;
 use bangbang_runtime::{BackendError, VmmAction, VmmActionError, VmmController, VmmData};
 
 use crate::host_network::virtio_vmnet::{
@@ -48,6 +49,8 @@ const DEFAULT_BLOCK_MMIO_BASE: GuestAddress = GuestAddress::new(0x5000_0000);
 const DEFAULT_BLOCK_MMIO_REGION_ID: MmioRegionId = MmioRegionId::new(1);
 const DEFAULT_NETWORK_MMIO_BASE: GuestAddress = GuestAddress::new(0x6000_0000);
 const DEFAULT_NETWORK_MMIO_REGION_ID: MmioRegionId = MmioRegionId::new(1000);
+const DEFAULT_VSOCK_MMIO_BASE: GuestAddress = GuestAddress::new(0x7000_0000);
+const DEFAULT_VSOCK_MMIO_REGION_ID: MmioRegionId = MmioRegionId::new(2000);
 const DEFAULT_SERIAL_MMIO_BASE: GuestAddress = GuestAddress::new(0x4000_0000);
 const DEFAULT_SERIAL_MMIO_REGION_ID: MmioRegionId = MmioRegionId::new(0);
 const DEFAULT_HVF_BOOT_RUN_LOOP_STEP_LIMIT: usize = 1024;
@@ -757,6 +760,7 @@ fn default_hvf_boot_session_config(
     HvfArm64BootSessionConfig::new(
         BlockMmioLayout::new(DEFAULT_BLOCK_MMIO_BASE, DEFAULT_BLOCK_MMIO_REGION_ID),
         NetworkMmioLayout::new(DEFAULT_NETWORK_MMIO_BASE, DEFAULT_NETWORK_MMIO_REGION_ID),
+        VsockMmioLayout::new(DEFAULT_VSOCK_MMIO_BASE, DEFAULT_VSOCK_MMIO_REGION_ID),
     )
     .with_serial_device(HvfArm64BootSerialDeviceConfig::new(
         DEFAULT_SERIAL_MMIO_REGION_ID,
@@ -792,6 +796,7 @@ mod tests {
         Arm64BootNetworkDevice, Arm64BootNetworkPacketIo, Arm64BootNetworkPacketIoError,
         Arm64BootNetworkPacketIoProvider,
     };
+    use bangbang_runtime::virtio_mmio::VIRTIO_MMIO_DEVICE_WINDOW_SIZE;
     use bangbang_runtime::{BackendError, InstanceState, VmmAction, VmmActionError};
 
     use crate::host_network::vmnet::{
@@ -804,11 +809,12 @@ mod tests {
         BootRunLoopControl, BootRunLoopSession, BootRunLoopSupervisor, BootRunLoopWorkerStatus,
         DEFAULT_HVF_BOOT_RUN_LOOP_STEP_LIMIT, DEFAULT_NETWORK_MMIO_BASE,
         DEFAULT_NETWORK_MMIO_REGION_ID, DEFAULT_SERIAL_MMIO_BASE, DEFAULT_SERIAL_MMIO_REGION_ID,
-        EmptyProcessNetworkRxPacketSource, HvfInstanceStartExecutor, InstanceStartExecutor,
-        NetworkPacketIoRunLoopSession, NoopProcessNetworkTxPacketSink, ProcessHvfBootSession,
-        ProcessNetworkPacketIoProvider, ProcessNetworkPacketIoProviderBuildError, ProcessVmm,
-        ProcessVmnetPacketIoBackendFactory, default_hvf_boot_run_loop_step_limit,
-        default_hvf_boot_session_config, process_vmnet_packet_io_provider_from_configs,
+        DEFAULT_VSOCK_MMIO_BASE, DEFAULT_VSOCK_MMIO_REGION_ID, EmptyProcessNetworkRxPacketSource,
+        HvfInstanceStartExecutor, InstanceStartExecutor, NetworkPacketIoRunLoopSession,
+        NoopProcessNetworkTxPacketSink, ProcessHvfBootSession, ProcessNetworkPacketIoProvider,
+        ProcessNetworkPacketIoProviderBuildError, ProcessVmm, ProcessVmnetPacketIoBackendFactory,
+        default_hvf_boot_run_loop_step_limit, default_hvf_boot_session_config,
+        process_vmnet_packet_io_provider_from_configs,
     };
 
     static NEXT_TEMP_FILE_ID: AtomicU64 = AtomicU64::new(0);
@@ -1366,6 +1372,11 @@ mod tests {
             config.network_mmio_layout.base_region_id(),
             DEFAULT_NETWORK_MMIO_REGION_ID
         );
+        assert_eq!(config.vsock_mmio_layout.address(), DEFAULT_VSOCK_MMIO_BASE);
+        assert_eq!(
+            config.vsock_mmio_layout.region_id(),
+            DEFAULT_VSOCK_MMIO_REGION_ID
+        );
         let block_devices = PreparedBlockDevices::from_configs(&drives)
             .expect("block devices should prepare")
             .register_mmio(config.block_mmio_layout)
@@ -1374,6 +1385,12 @@ mod tests {
             .expect("network devices should prepare")
             .register_mmio(config.network_mmio_layout)
             .expect("network MMIO should register");
+        let vsock_region = MmioRegion::new(
+            config.vsock_mmio_layout.region_id(),
+            config.vsock_mmio_layout.address(),
+            VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+        )
+        .expect("vsock MMIO region should be valid");
         let serial_region = MmioRegion::new(
             serial_region_id,
             DEFAULT_SERIAL_MMIO_BASE,
@@ -1399,13 +1416,13 @@ mod tests {
                 .iter()
                 .all(|network| !block.region().range().overlaps(network.region().range()))
                 && !block.region().range().overlaps(serial_region.range())
+                && !block.region().range().overlaps(vsock_region.range())
         }));
-        assert!(
-            network_devices
-                .registrations()
-                .iter()
-                .all(|network| !network.region().range().overlaps(serial_region.range()))
-        );
+        assert!(network_devices.registrations().iter().all(|network| {
+            !network.region().range().overlaps(serial_region.range())
+                && !network.region().range().overlaps(vsock_region.range())
+        }));
+        assert!(!vsock_region.range().overlaps(serial_region.range()));
     }
 
     #[test]

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -23,6 +23,7 @@ use bangbang_runtime::startup::{
     Arm64BootResources, Arm64BootRuntimeResources,
     Arm64BootSerialDeviceConfig as RuntimeArm64BootSerialDeviceConfig,
 };
+use bangbang_runtime::vsock::VsockMmioLayout;
 use bangbang_runtime::{BackendError, VmBackend, VmmController};
 
 use crate::backend::HvfBackend;
@@ -42,6 +43,7 @@ const SINGLE_VCPU_COUNT: u8 = 1;
 pub struct HvfArm64BootSessionConfig {
     pub block_mmio_layout: BlockMmioLayout,
     pub network_mmio_layout: NetworkMmioLayout,
+    pub vsock_mmio_layout: VsockMmioLayout,
     pub serial_device: Option<HvfArm64BootSerialDeviceConfig>,
 }
 
@@ -49,10 +51,12 @@ impl HvfArm64BootSessionConfig {
     pub const fn new(
         block_mmio_layout: BlockMmioLayout,
         network_mmio_layout: NetworkMmioLayout,
+        vsock_mmio_layout: VsockMmioLayout,
     ) -> Self {
         Self {
             block_mmio_layout,
             network_mmio_layout,
+            vsock_mmio_layout,
             serial_device: None,
         }
     }
@@ -106,6 +110,7 @@ pub struct HvfArm64BootSession<'vm> {
     primary_mpidr: u64,
     block_interrupt_lines: Vec<GuestInterruptLine>,
     network_interrupt_lines: Vec<GuestInterruptLine>,
+    vsock_interrupt_line: Option<GuestInterruptLine>,
     serial_interrupt_line: Option<GuestInterruptLine>,
     boot_registers: HvfArm64BootRegisters,
 }
@@ -120,6 +125,7 @@ pub struct OwnedHvfArm64BootSession {
     primary_mpidr: u64,
     block_interrupt_lines: Vec<GuestInterruptLine>,
     network_interrupt_lines: Vec<GuestInterruptLine>,
+    vsock_interrupt_line: Option<GuestInterruptLine>,
     serial_interrupt_line: Option<GuestInterruptLine>,
     boot_registers: HvfArm64BootRegisters,
 }
@@ -299,6 +305,10 @@ impl HvfArm64BootSession<'_> {
         &self.network_interrupt_lines
     }
 
+    pub const fn vsock_interrupt_line(&self) -> Option<GuestInterruptLine> {
+        self.vsock_interrupt_line
+    }
+
     pub const fn serial_interrupt_line(&self) -> Option<GuestInterruptLine> {
         self.serial_interrupt_line
     }
@@ -472,6 +482,7 @@ impl OwnedHvfArm64BootSession {
             primary_mpidr: prepared.primary_mpidr,
             block_interrupt_lines: prepared.block_interrupt_lines,
             network_interrupt_lines: prepared.network_interrupt_lines,
+            vsock_interrupt_line: prepared.vsock_interrupt_line,
             serial_interrupt_line: prepared.serial_interrupt_line,
             boot_registers: prepared.boot_registers,
         })
@@ -532,6 +543,10 @@ impl OwnedHvfArm64BootSession {
 
     pub fn network_interrupt_lines(&self) -> &[GuestInterruptLine] {
         &self.network_interrupt_lines
+    }
+
+    pub const fn vsock_interrupt_line(&self) -> Option<GuestInterruptLine> {
+        self.vsock_interrupt_line
     }
 
     pub const fn serial_interrupt_line(&self) -> Option<GuestInterruptLine> {
@@ -1456,6 +1471,7 @@ impl std::error::Error for HvfArm64BootSessionError {
 pub enum HvfArm64BootInterruptLinePurpose {
     BlockDevice,
     NetworkDevice,
+    VsockDevice,
     SerialDevice,
 }
 
@@ -1464,6 +1480,7 @@ impl fmt::Display for HvfArm64BootInterruptLinePurpose {
         match self {
             Self::BlockDevice => f.write_str("block device"),
             Self::NetworkDevice => f.write_str("network device"),
+            Self::VsockDevice => f.write_str("vsock device"),
             Self::SerialDevice => f.write_str("serial device"),
         }
     }
@@ -1506,6 +1523,7 @@ struct PreparedHvfArm64BootSession<'vm> {
     primary_mpidr: u64,
     block_interrupt_lines: Vec<GuestInterruptLine>,
     network_interrupt_lines: Vec<GuestInterruptLine>,
+    vsock_interrupt_line: Option<GuestInterruptLine>,
     serial_interrupt_line: Option<GuestInterruptLine>,
     boot_registers: HvfArm64BootRegisters,
 }
@@ -1514,6 +1532,7 @@ struct PreparedHvfArm64BootSession<'vm> {
 struct HvfArm64BootInterruptLines {
     block: Vec<GuestInterruptLine>,
     network: Vec<GuestInterruptLine>,
+    vsock: Option<GuestInterruptLine>,
     serial: Option<GuestInterruptLine>,
 }
 
@@ -1544,6 +1563,7 @@ impl HvfBackend {
             primary_mpidr: prepared.primary_mpidr,
             block_interrupt_lines: prepared.block_interrupt_lines,
             network_interrupt_lines: prepared.network_interrupt_lines,
+            vsock_interrupt_line: prepared.vsock_interrupt_line,
             serial_interrupt_line: prepared.serial_interrupt_line,
             boot_registers: prepared.boot_registers,
         })
@@ -1569,6 +1589,7 @@ fn prepare_arm64_boot_session_parts<'vm>(
         &gic,
         controller.drive_configs().len(),
         controller.network_interface_configs().len(),
+        controller.vsock_config().is_some(),
         config.serial_device.is_some(),
     )?;
 
@@ -1593,6 +1614,8 @@ fn prepare_arm64_boot_session_parts<'vm>(
             block_interrupt_lines: &interrupt_lines.block,
             network_mmio_layout: config.network_mmio_layout,
             network_interrupt_lines: &interrupt_lines.network,
+            vsock_mmio_layout: config.vsock_mmio_layout,
+            vsock_interrupt_line: interrupt_lines.vsock,
         },
     )
     .map_err(|source| HvfArm64BootSessionError::AssembleResources { source })?;
@@ -1617,6 +1640,7 @@ fn prepare_arm64_boot_session_parts<'vm>(
         primary_mpidr,
         block_interrupt_lines: interrupt_lines.block,
         network_interrupt_lines: interrupt_lines.network,
+        vsock_interrupt_line: interrupt_lines.vsock,
         serial_interrupt_line: interrupt_lines.serial,
         boot_registers,
     })
@@ -1635,6 +1659,7 @@ fn allocate_interrupt_lines(
     gic: &HvfGicMetadata,
     block_device_count: usize,
     network_device_count: usize,
+    vsock_configured: bool,
     serial_configured: bool,
 ) -> Result<HvfArm64BootInterruptLines, HvfArm64BootSessionError> {
     let mut allocator = HvfGicInterruptLineAllocator::from_metadata(gic).map_err(|source| {
@@ -1671,6 +1696,17 @@ fn allocate_interrupt_lines(
         })?);
     }
 
+    let vsock = if vsock_configured {
+        Some(allocator.allocate().map_err(|source| {
+            HvfArm64BootSessionError::AllocateInterruptLine {
+                purpose: HvfArm64BootInterruptLinePurpose::VsockDevice,
+                source,
+            }
+        })?)
+    } else {
+        None
+    };
+
     let serial = if serial_configured {
         Some(allocator.allocate().map_err(|source| {
             HvfArm64BootSessionError::AllocateInterruptLine {
@@ -1685,6 +1721,7 @@ fn allocate_interrupt_lines(
     Ok(HvfArm64BootInterruptLines {
         block,
         network,
+        vsock,
         serial,
     })
 }
@@ -1738,6 +1775,7 @@ mod tests {
     use bangbang_runtime::virtio_queue::{
         VIRTQUEUE_DESC_F_NEXT, VIRTQUEUE_DESC_F_WRITE, VIRTQUEUE_DESCRIPTOR_SIZE,
     };
+    use bangbang_runtime::vsock::VsockMmioLayout;
 
     use super::{
         HvfArm64BootBlockNotificationDispatchError, HvfArm64BootInterruptLinePurpose,
@@ -2437,6 +2475,11 @@ mod tests {
                 MmioRegionId::new(50),
             ),
             network_interrupt_lines: network_lines,
+            vsock_mmio_layout: VsockMmioLayout::new(
+                GuestAddress::new(0x4000_6000),
+                MmioRegionId::new(90),
+            ),
+            vsock_interrupt_line: None,
         }
     }
 
@@ -4328,6 +4371,7 @@ mod tests {
         let config = HvfArm64BootSessionConfig::new(
             BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1)),
             network_layout,
+            VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
         )
         .with_serial_device(serial);
 
@@ -4354,27 +4398,43 @@ mod tests {
 
     #[test]
     fn interrupt_lines_allocate_blocks_before_network_before_serial() {
-        let lines = allocate_interrupt_lines(&gic_with_spi_range(32, 5), 2, 2, true)
+        let lines = allocate_interrupt_lines(&gic_with_spi_range(32, 6), 2, 2, true, true)
             .expect("interrupt lines should allocate");
 
         assert_eq!(line_values(&lines.block), vec![32, 33]);
         assert_eq!(line_values(&lines.network), vec![34, 35]);
-        assert_eq!(lines.serial.map(|line| line.raw_value()), Some(36));
+        assert_eq!(lines.vsock.map(|line| line.raw_value()), Some(36));
+        assert_eq!(lines.serial.map(|line| line.raw_value()), Some(37));
     }
 
     #[test]
     fn interrupt_lines_allocate_none_for_absent_serial() {
-        let lines = allocate_interrupt_lines(&gic_with_spi_range(40, 3), 2, 1, false)
+        let lines = allocate_interrupt_lines(&gic_with_spi_range(40, 3), 2, 1, false, false)
             .expect("interrupt lines should allocate");
 
         assert_eq!(line_values(&lines.block), vec![40, 41]);
         assert_eq!(line_values(&lines.network), vec![42]);
+        assert_eq!(lines.vsock, None);
         assert_eq!(lines.serial, None);
     }
 
     #[test]
+    fn interrupt_lines_report_vsock_exhaustion_with_purpose() {
+        let err = allocate_interrupt_lines(&gic_with_spi_range(32, 2), 1, 1, true, false)
+            .expect_err("vsock allocation should exhaust range");
+
+        assert!(matches!(
+            err,
+            HvfArm64BootSessionError::AllocateInterruptLine {
+                purpose: HvfArm64BootInterruptLinePurpose::VsockDevice,
+                ..
+            }
+        ));
+    }
+
+    #[test]
     fn interrupt_lines_report_serial_exhaustion_with_purpose() {
-        let err = allocate_interrupt_lines(&gic_with_spi_range(32, 2), 1, 1, true)
+        let err = allocate_interrupt_lines(&gic_with_spi_range(32, 3), 1, 1, true, true)
             .expect_err("serial allocation should exhaust range");
 
         assert!(matches!(
@@ -4388,7 +4448,7 @@ mod tests {
 
     #[test]
     fn interrupt_lines_report_network_exhaustion_with_purpose() {
-        let err = allocate_interrupt_lines(&gic_with_spi_range(32, 1), 1, 1, false)
+        let err = allocate_interrupt_lines(&gic_with_spi_range(32, 1), 1, 1, false, false)
             .expect_err("network allocation should exhaust range");
 
         assert!(matches!(
@@ -4402,7 +4462,7 @@ mod tests {
 
     #[test]
     fn interrupt_lines_reject_invalid_gic_range() {
-        let err = allocate_interrupt_lines(&gic_with_spi_range(31, 1), 0, 0, false)
+        let err = allocate_interrupt_lines(&gic_with_spi_range(31, 1), 0, 0, false, false)
             .expect_err("invalid SPI range should fail");
 
         assert!(matches!(

--- a/crates/hvf/tests/guest_boot.rs
+++ b/crates/hvf/tests/guest_boot.rs
@@ -22,6 +22,8 @@ const SERIAL_MMIO_BASE: u64 = 0x4000_0000;
 const BLOCK_MMIO_BASE: u64 = 0x5000_0000;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const NETWORK_MMIO_BASE: u64 = 0x6000_0000;
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const VSOCK_MMIO_BASE: u64 = 0x7000_0000;
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 #[test]
@@ -38,6 +40,7 @@ fn boots_firecracker_kernel_to_guest_marker() {
     use bangbang_runtime::mmio::MmioRegionId;
     use bangbang_runtime::network::NetworkMmioLayout;
     use bangbang_runtime::serial::SharedSerialOutputBuffer;
+    use bangbang_runtime::vsock::VsockMmioLayout;
     use bangbang_runtime::{VmmAction, VmmController};
 
     let _test_lock = GUEST_BOOT_TEST_LOCK
@@ -61,6 +64,7 @@ fn boots_firecracker_kernel_to_guest_marker() {
             GuestAddress::new(NETWORK_MMIO_BASE),
             MmioRegionId::new(1000),
         ),
+        VsockMmioLayout::new(GuestAddress::new(VSOCK_MMIO_BASE), MmioRegionId::new(2000)),
     )
     .with_serial_device(HvfArm64BootSerialDeviceConfig::new(
         MmioRegionId::new(0),

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -268,6 +268,7 @@ fn prepares_internal_hvf_arm64_boot_session() {
     use bangbang_runtime::memory::GuestAddress;
     use bangbang_runtime::mmio::MmioRegionId;
     use bangbang_runtime::network::NetworkMmioLayout;
+    use bangbang_runtime::vsock::VsockMmioLayout;
 
     let _test_lock = HVF_LIFECYCLE_TEST_LOCK
         .lock()
@@ -284,6 +285,7 @@ fn prepares_internal_hvf_arm64_boot_session() {
     let config = HvfArm64BootSessionConfig::new(
         BlockMmioLayout::new(GuestAddress::new(0x4000_0000), MmioRegionId::new(1)),
         NetworkMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1000)),
+        VsockMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(2000)),
     );
 
     let mut session = backend
@@ -363,6 +365,7 @@ fn prepares_owned_hvf_arm64_boot_session() {
     use bangbang_runtime::memory::GuestAddress;
     use bangbang_runtime::mmio::MmioRegionId;
     use bangbang_runtime::network::NetworkMmioLayout;
+    use bangbang_runtime::vsock::VsockMmioLayout;
 
     let _test_lock = HVF_LIFECYCLE_TEST_LOCK
         .lock()
@@ -379,6 +382,7 @@ fn prepares_owned_hvf_arm64_boot_session() {
     let config = HvfArm64BootSessionConfig::new(
         BlockMmioLayout::new(GuestAddress::new(0x4000_0000), MmioRegionId::new(1)),
         NetworkMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1000)),
+        VsockMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(2000)),
     );
 
     let mut session = OwnedHvfArm64BootSession::new(&controller, config.clone())
@@ -462,6 +466,7 @@ fn owned_hvf_arm64_boot_session_cleans_up_after_prepare_error() {
     use bangbang_runtime::mmio::MmioRegionId;
     use bangbang_runtime::network::NetworkMmioLayout;
     use bangbang_runtime::startup::Arm64BootResourceError;
+    use bangbang_runtime::vsock::VsockMmioLayout;
 
     let _test_lock = HVF_LIFECYCLE_TEST_LOCK
         .lock()
@@ -469,6 +474,7 @@ fn owned_hvf_arm64_boot_session_cleans_up_after_prepare_error() {
     let config = HvfArm64BootSessionConfig::new(
         BlockMmioLayout::new(GuestAddress::new(0x4000_0000), MmioRegionId::new(1)),
         NetworkMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1000)),
+        VsockMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(2000)),
     );
     let empty_controller = bangbang_runtime::VmmController::new("test", "0.1.0", "bangbang");
 
@@ -507,6 +513,7 @@ fn rejects_boot_session_on_existing_hvf_vm_without_destroying_it() {
     use bangbang_runtime::memory::GuestAddress;
     use bangbang_runtime::mmio::MmioRegionId;
     use bangbang_runtime::network::NetworkMmioLayout;
+    use bangbang_runtime::vsock::VsockMmioLayout;
 
     let _test_lock = HVF_LIFECYCLE_TEST_LOCK
         .lock()
@@ -521,6 +528,7 @@ fn rejects_boot_session_on_existing_hvf_vm_without_destroying_it() {
             HvfArm64BootSessionConfig::new(
                 BlockMmioLayout::new(GuestAddress::new(0x4000_0000), MmioRegionId::new(1)),
                 NetworkMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1000)),
+                VsockMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(2000)),
             ),
         )
         .expect_err("existing VM should be rejected");

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -31,6 +31,9 @@ use crate::network::{
     VirtioNetworkTxPacketSink,
 };
 use crate::serial::{SERIAL_MMIO_DEVICE_WINDOW_SIZE, SerialMmioDevice, SharedSerialOutputBuffer};
+use crate::vsock::{
+    PreparedVsockDevice, VsockMmioDeviceRegistration, VsockMmioLayout, VsockMmioRegistrationError,
+};
 
 const MIB: u64 = 1024 * 1024;
 
@@ -44,6 +47,8 @@ pub struct Arm64BootResourceConfig<'a> {
     pub block_interrupt_lines: &'a [GuestInterruptLine],
     pub network_mmio_layout: NetworkMmioLayout,
     pub network_interrupt_lines: &'a [GuestInterruptLine],
+    pub vsock_mmio_layout: VsockMmioLayout,
+    pub vsock_interrupt_line: Option<GuestInterruptLine>,
 }
 
 #[derive(Debug, Clone)]
@@ -81,6 +86,7 @@ pub struct Arm64BootResources {
     pub serial_device: Option<Arm64BootSerialDevice>,
     pub block_devices: Vec<Arm64BootBlockDevice>,
     pub network_devices: Vec<Arm64BootNetworkDevice>,
+    pub vsock_device: Option<Arm64BootVsockDevice>,
 }
 
 #[derive(Debug)]
@@ -99,6 +105,7 @@ pub struct Arm64BootRuntimeResources {
     pub serial_device: Option<Arm64BootSerialDevice>,
     pub block_devices: Vec<Arm64BootBlockDevice>,
     pub network_devices: Vec<Arm64BootNetworkDevice>,
+    pub vsock_device: Option<Arm64BootVsockDevice>,
 }
 
 #[derive(Debug)]
@@ -425,6 +432,12 @@ pub struct Arm64BootNetworkDevice {
     pub fdt_device: Arm64FdtVirtioMmioDevice,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Arm64BootVsockDevice {
+    pub registration: VsockMmioDeviceRegistration,
+    pub fdt_device: Arm64FdtVirtioMmioDevice,
+}
+
 #[derive(Debug, Clone)]
 pub struct Arm64BootSerialDevice {
     pub region: MmioRegion,
@@ -580,6 +593,9 @@ pub enum Arm64BootResourceError {
     RegisterNetworkMmio {
         source: Box<NetworkMmioRegistrationError>,
     },
+    RegisterVsockMmio {
+        source: Box<VsockMmioRegistrationError>,
+    },
     RegisterSerialMmio {
         source: Box<Arm64BootSerialMmioRegistrationError>,
     },
@@ -591,10 +607,17 @@ pub enum Arm64BootResourceError {
         devices: usize,
         lines: usize,
     },
+    VsockInterruptLineCount {
+        devices: usize,
+        lines: usize,
+    },
     BlockDeviceMetadataAllocation {
         source: TryReserveError,
     },
     NetworkDeviceMetadataAllocation {
+        source: TryReserveError,
+    },
+    VsockDeviceMetadataAllocation {
         source: TryReserveError,
     },
     Fdt {
@@ -637,6 +660,9 @@ impl fmt::Display for Arm64BootResourceError {
             Self::RegisterNetworkMmio { source } => {
                 write!(f, "failed to register network MMIO devices: {source}")
             }
+            Self::RegisterVsockMmio { source } => {
+                write!(f, "failed to register vsock MMIO device: {source}")
+            }
             Self::RegisterSerialMmio { source } => {
                 write!(f, "failed to register serial MMIO device: {source}")
             }
@@ -648,11 +674,18 @@ impl fmt::Display for Arm64BootResourceError {
                 f,
                 "network MMIO device count {devices} does not match interrupt line count {lines}"
             ),
+            Self::VsockInterruptLineCount { devices, lines } => write!(
+                f,
+                "vsock MMIO device count {devices} does not match interrupt line count {lines}"
+            ),
             Self::BlockDeviceMetadataAllocation { source } => {
                 write!(f, "failed to allocate block device metadata: {source}")
             }
             Self::NetworkDeviceMetadataAllocation { source } => {
                 write!(f, "failed to allocate network device metadata: {source}")
+            }
+            Self::VsockDeviceMetadataAllocation { source } => {
+                write!(f, "failed to allocate vsock device metadata: {source}")
             }
             Self::Fdt { source } => write!(f, "failed to write arm64 FDT: {source}"),
         }
@@ -669,15 +702,18 @@ impl std::error::Error for Arm64BootResourceError {
             Self::PrepareNetworkDevices { source } => Some(source),
             Self::RegisterBlockMmio { source } => Some(source.as_ref()),
             Self::RegisterNetworkMmio { source } => Some(source.as_ref()),
+            Self::RegisterVsockMmio { source } => Some(source.as_ref()),
             Self::RegisterSerialMmio { source } => Some(source.as_ref()),
             Self::BlockDeviceMetadataAllocation { source } => Some(source),
             Self::NetworkDeviceMetadataAllocation { source } => Some(source),
+            Self::VsockDeviceMetadataAllocation { source } => Some(source),
             Self::Fdt { source } => Some(source),
             Self::MissingBootSource
             | Self::MemorySizeOverflow { .. }
             | Self::MemorySizeExceedsArchitecturalMaximum { .. }
             | Self::BlockInterruptLineCount { .. }
-            | Self::NetworkInterruptLineCount { .. } => None,
+            | Self::NetworkInterruptLineCount { .. }
+            | Self::VsockInterruptLineCount { .. } => None,
         }
     }
 }
@@ -737,6 +773,8 @@ impl Arm64BootResources {
             block_interrupt_lines,
             network_mmio_layout,
             network_interrupt_lines,
+            vsock_mmio_layout,
+            vsock_interrupt_line,
         } = config;
         let boot_source_config = controller
             .boot_source_config()
@@ -748,6 +786,10 @@ impl Arm64BootResources {
         validate_network_interrupt_line_count(
             controller.network_interface_configs().len(),
             network_interrupt_lines.len(),
+        )?;
+        validate_vsock_interrupt_line_count(
+            controller.vsock_config().is_some(),
+            vsock_interrupt_line.is_some(),
         )?;
 
         let machine_config = controller.machine_config();
@@ -787,6 +829,32 @@ impl Arm64BootResources {
             .try_reserve_exact(network_fdt_devices.len())
             .map_err(|source| Arm64BootResourceError::NetworkDeviceMetadataAllocation { source })?;
         fdt_devices.extend(network_fdt_devices);
+        let vsock_device = match (controller.vsock_config(), vsock_interrupt_line) {
+            (Some(config), Some(interrupt_line)) => {
+                let prepared_vsock = PreparedVsockDevice::from_config(config);
+                let vsock_mmio = prepared_vsock
+                    .register_mmio_with_dispatcher(vsock_mmio_layout, mmio_dispatcher)
+                    .map_err(|source| Arm64BootResourceError::RegisterVsockMmio {
+                        source: Box::new(source),
+                    })?;
+                let (dispatcher, registration) = vsock_mmio.into_parts();
+                mmio_dispatcher = dispatcher;
+                let (device, fdt_device) =
+                    arm64_boot_vsock_device_metadata(registration, interrupt_line);
+                fdt_devices.try_reserve_exact(1).map_err(|source| {
+                    Arm64BootResourceError::VsockDeviceMetadataAllocation { source }
+                })?;
+                fdt_devices.push(fdt_device);
+                Some(device)
+            }
+            (None, None) => None,
+            (Some(_), None) | (None, Some(_)) => {
+                return Err(vsock_interrupt_line_count_error(
+                    controller.vsock_config().is_some(),
+                    vsock_interrupt_line.is_some(),
+                ));
+            }
+        };
         let serial_device = serial_device
             .map(|serial| register_serial_mmio(&mut mmio_dispatcher, serial))
             .transpose()?;
@@ -815,6 +883,7 @@ impl Arm64BootResources {
             serial_device,
             block_devices,
             network_devices,
+            vsock_device,
         })
     }
 
@@ -830,6 +899,7 @@ impl Arm64BootResources {
                 serial_device: self.serial_device,
                 block_devices: self.block_devices,
                 network_devices: self.network_devices,
+                vsock_device: self.vsock_device,
             },
         }
     }
@@ -882,6 +952,27 @@ fn validate_network_interrupt_line_count(
         Ok(())
     } else {
         Err(Arm64BootResourceError::NetworkInterruptLineCount { devices, lines })
+    }
+}
+
+fn validate_vsock_interrupt_line_count(
+    configured: bool,
+    line_present: bool,
+) -> Result<(), Arm64BootResourceError> {
+    if configured == line_present {
+        Ok(())
+    } else {
+        Err(vsock_interrupt_line_count_error(configured, line_present))
+    }
+}
+
+fn vsock_interrupt_line_count_error(
+    configured: bool,
+    line_present: bool,
+) -> Arm64BootResourceError {
+    Arm64BootResourceError::VsockInterruptLineCount {
+        devices: usize::from(configured),
+        lines: usize::from(line_present),
     }
 }
 
@@ -951,6 +1042,28 @@ pub fn arm64_boot_network_device_metadata(
     }
 
     Ok((network_devices, fdt_devices))
+}
+
+fn arm64_boot_vsock_device_metadata(
+    registration: VsockMmioDeviceRegistration,
+    interrupt_line: GuestInterruptLine,
+) -> (Arm64BootVsockDevice, Arm64FdtVirtioMmioDevice) {
+    let range = registration.region().range();
+    let fdt_device = Arm64FdtVirtioMmioDevice {
+        region: Arm64FdtRegion {
+            base: range.start().raw_value(),
+            size: range.size(),
+        },
+        interrupt_line,
+    };
+
+    (
+        Arm64BootVsockDevice {
+            registration,
+            fdt_device,
+        },
+        fdt_device,
+    )
 }
 
 fn register_serial_mmio(
@@ -1049,6 +1162,7 @@ mod tests {
     use crate::virtio_queue::{
         VIRTQUEUE_DESC_F_NEXT, VIRTQUEUE_DESC_F_WRITE, VIRTQUEUE_DESCRIPTOR_SIZE,
     };
+    use crate::vsock::{VirtioVsockMmioHandler, VsockConfigInput, VsockMmioLayout};
 
     static NEXT_TEST_FILE_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -1060,6 +1174,7 @@ mod tests {
     const ARM64_IMAGE_MAGIC: u32 = 0x644d_5241;
     const TEST_BLOCK_MMIO_BASE: GuestAddress = GuestAddress::new(0x4000_0000);
     const TEST_NETWORK_MMIO_BASE: GuestAddress = GuestAddress::new(0x4000_4000);
+    const TEST_VSOCK_MMIO_BASE: GuestAddress = GuestAddress::new(0x4000_6000);
     const TEST_SERIAL_MMIO_BASE: GuestAddress = GuestAddress::new(0x4000_2000);
     const TEST_QUEUE_SIZE: u16 = 4;
     const TEST_DESCRIPTOR_TABLE: GuestAddress = GuestAddress::new(0x8040_0000);
@@ -1191,6 +1306,15 @@ mod tests {
             .expect("network config should be stored");
     }
 
+    fn add_vsock(controller: &mut crate::VmmController, guest_cid: u32, uds_path: &Path) {
+        controller
+            .handle_action(VmmAction::PutVsock(VsockConfigInput::new(
+                guest_cid,
+                uds_path.to_string_lossy().into_owned(),
+            )))
+            .expect("vsock config should be stored");
+    }
+
     fn network_registrations(
         interfaces: &[(&str, &str)],
         layout: NetworkMmioLayout,
@@ -1230,6 +1354,8 @@ mod tests {
                 MmioRegionId::new(50),
             ),
             network_interrupt_lines: &[],
+            vsock_mmio_layout: VsockMmioLayout::new(TEST_VSOCK_MMIO_BASE, MmioRegionId::new(90)),
+            vsock_interrupt_line: None,
         }
     }
 
@@ -2095,9 +2221,11 @@ mod tests {
         );
         assert!(resources.block_devices.is_empty());
         assert!(resources.network_devices.is_empty());
+        assert!(resources.vsock_device.is_none());
         assert!(resources.serial_device.is_none());
         assert!(resources.mmio_dispatcher.regions().is_empty());
         assert!(read_fdt(&resources).find("/uart@40002000").is_none());
+        assert!(read_fdt(&resources).find("/virtio_mmio@40006000").is_none());
     }
 
     #[test]
@@ -2169,6 +2297,125 @@ mod tests {
             .find("/virtio_mmio@40004000")
             .expect("network virtio-mmio node should be in assembled FDT");
         assert_eq!(network_node.prop_str("compatible").unwrap(), "virtio,mmio");
+    }
+
+    #[test]
+    fn assembles_boot_resources_with_vsock_mmio_metadata() {
+        let kernel = temp_file("kernel-with-vsock", &arm64_image());
+        let socket_path = missing_path("vsock-startup.sock");
+        let mut controller = controller_with_kernel(kernel.path());
+        add_vsock(&mut controller, 42, &socket_path);
+        let config = Arm64BootResourceConfig {
+            vsock_interrupt_line: Some(line(35)),
+            ..valid_config(&[])
+        };
+
+        assert!(!socket_path.exists());
+
+        let mut resources = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect("boot resources should assemble with vsock device");
+
+        assert!(resources.block_devices.is_empty());
+        assert!(resources.network_devices.is_empty());
+        let vsock = resources
+            .vsock_device
+            .as_ref()
+            .expect("vsock metadata should be returned");
+        assert_eq!(vsock.registration.guest_cid(), 42);
+        assert_eq!(vsock.registration.uds_path(), socket_path.as_path());
+        assert_eq!(vsock.registration.region_id(), MmioRegionId::new(90));
+        assert_eq!(vsock.registration.address(), TEST_VSOCK_MMIO_BASE);
+        assert_eq!(
+            vsock.registration.region().range().size(),
+            VIRTIO_MMIO_DEVICE_WINDOW_SIZE
+        );
+        assert_eq!(
+            vsock.fdt_device.region.base,
+            TEST_VSOCK_MMIO_BASE.raw_value()
+        );
+        assert_eq!(vsock.fdt_device.region.size, VIRTIO_MMIO_DEVICE_WINDOW_SIZE);
+        assert_eq!(vsock.fdt_device.interrupt_line, line(35));
+        assert_eq!(resources.mmio_dispatcher.regions().len(), 1);
+        resources
+            .mmio_dispatcher
+            .handler_mut::<VirtioVsockMmioHandler>(vsock.registration.region_id())
+            .expect("vsock MMIO handler should be registered");
+        assert!(!socket_path.exists());
+
+        let tree = read_fdt(&resources);
+        let vsock_node = tree
+            .find("/virtio_mmio@40006000")
+            .expect("vsock virtio-mmio node should be in assembled FDT");
+        assert_eq!(vsock_node.prop_str("compatible").unwrap(), "virtio,mmio");
+    }
+
+    #[test]
+    fn configured_vsock_without_interrupt_line_fails_before_socket_access() {
+        let kernel = temp_file("kernel-vsock-missing-line", &arm64_image());
+        let socket_path = missing_path("vsock-missing-line.sock");
+        let mut controller = controller_with_kernel(kernel.path());
+        add_vsock(&mut controller, 43, &socket_path);
+
+        let err = Arm64BootResources::assemble_from_controller(&controller, valid_config(&[]))
+            .expect_err("configured vsock without interrupt line should fail");
+
+        assert!(matches!(
+            err,
+            Arm64BootResourceError::VsockInterruptLineCount {
+                devices: 1,
+                lines: 0
+            }
+        ));
+        assert!(std::error::Error::source(&err).is_none());
+        assert!(!socket_path.exists());
+    }
+
+    #[test]
+    fn extra_vsock_interrupt_line_without_config_fails() {
+        let kernel = temp_file("kernel-vsock-extra-line", &arm64_image());
+        let controller = controller_with_kernel(kernel.path());
+        let config = Arm64BootResourceConfig {
+            vsock_interrupt_line: Some(line(35)),
+            ..valid_config(&[])
+        };
+
+        let err = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect_err("extra vsock interrupt line should fail");
+
+        assert!(matches!(
+            err,
+            Arm64BootResourceError::VsockInterruptLineCount {
+                devices: 0,
+                lines: 1
+            }
+        ));
+        assert!(std::error::Error::source(&err).is_none());
+    }
+
+    #[test]
+    fn vsock_region_overlapping_block_mmio_fails_during_registration_without_path_leak() {
+        let kernel = temp_file("kernel-vsock-overlap-block", &arm64_image());
+        let block = temp_file("block-vsock-overlap", &[0x5a; 512]);
+        let socket_path = missing_path("vsock-overlap-secret.sock");
+        let mut controller = controller_with_kernel(kernel.path());
+        add_drive(&mut controller, "rootfs", block.path());
+        add_vsock(&mut controller, 44, &socket_path);
+        let block_interrupt_lines = [line(32)];
+        let config = Arm64BootResourceConfig {
+            vsock_mmio_layout: VsockMmioLayout::new(TEST_BLOCK_MMIO_BASE, MmioRegionId::new(90)),
+            vsock_interrupt_line: Some(line(35)),
+            ..valid_config(&block_interrupt_lines)
+        };
+
+        let err = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect_err("overlapping vsock MMIO should fail");
+
+        assert!(matches!(
+            err,
+            Arm64BootResourceError::RegisterVsockMmio { .. }
+        ));
+        assert!(!err.to_string().contains("vsock-overlap-secret"));
+        assert!(!socket_path.exists());
     }
 
     #[test]
@@ -2297,6 +2544,7 @@ mod tests {
         );
         assert_eq!(parts.runtime.fdt, fdt);
         assert_eq!(parts.runtime.block_devices.len(), 1);
+        assert!(parts.runtime.vsock_device.is_none());
         assert_eq!(
             parts.runtime.block_devices[0].registration,
             block_registration

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -8,7 +8,7 @@ The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /`, `GET /version`,
 `GET /vm/config`, `GET /machine-config`, pre-boot `PUT /machine-config`
 configuration storage, pre-boot `PUT /boot-source` configuration storage, pre-boot `PUT /drives/{drive_id}`
-configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, prepared device resource, MMIO registration helper, and inert MMIO handler skeleton, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
+configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, prepared device resource, MMIO registration helper, inert MMIO handler skeleton, and startup FDT attachment, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
 `InstanceStart` preflight, transactional startup executor, and successful-start state transition helpers, backend-neutral guest
 physical address and aarch64 DRAM layout/access primitives, arm64 boot
 placement helpers, internal boot-source validation and arm64 kernel/initrd
@@ -233,7 +233,7 @@ compatibility targets.
 | `PATCH` | `/machine-config` | deferred | Partial updates belong with later state and validation rules. |
 | `PUT` | `/cpu-config` | deferred | Needs HVF CPU feature design with VM and boot work in #8 and #10. |
 | `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores up to 16 initial virtio-net configurations before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the interface count before opening vmnet resources, then selects vmnet packet I/O only for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names; unsupported names fail startup before `Running` is committed. Internal network notification dispatch can route each configured interface through selected packet I/O, parse TX descriptors through a packet sink boundary, and copy injected RX packets into guest buffers through a packet source boundary. Public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
-| `PUT` | `/vsock` | supported target; configuration storage implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. An internal virtio-vsock prepared resource, MMIO registration helper, config-space, and inert MMIO handler skeleton exist, but startup attachment, queue data movement, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
+| `PUT` | `/vsock` | supported target; startup attachment implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Startup preparation attaches the configured device as one virtio-mmio FDT node backed by the inert MMIO handler. Queue data movement, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
 | `GET`, `PUT`, `PATCH` | `/mmds` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/mmds/config` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/snapshot/create`, `/snapshot/load` | deferred | Tied to snapshot and restore work in #19. |
@@ -352,8 +352,9 @@ pre-boot-only guest configuration section. Valid requests replace the stored
 vsock config and return `204 No Content`; invalid requests fail without
 mutating previous vsock state. The current response reports `guest_cid` and
 `uds_path` while omitting the accepted deprecated `vsock_id`, matching
-Firecracker's effective config output. It does not attach a guest-visible
-virtio-vsock device, open host socket resources, route CIDs, or move data.
+Firecracker's effective config output. Startup preparation attaches the
+configured virtio-vsock device as guest-visible FDT/MMIO metadata, but it still
+does not open host socket resources, route CIDs, or move data.
 `SendCtrlAltDel` is rejected at parse time for the first aarch64 target.
 
 Future implementation PRs should derive unit or golden tests from these tables.
@@ -560,16 +561,18 @@ and is returned from `GET /vm/config` as `vsock` with `guest_cid` and
 does not open, bind, connect, unlink, or create the configured `uds_path`.
 
 The runtime crate has an internal virtio-vsock prepared resource, MMIO
-registration helper, config-space, and inert MMIO handler skeleton. It uses the
+registration helper, config-space, inert MMIO handler skeleton, and startup
+FDT attachment. It uses the
 virtio device id `19`, three 256-entry RX, TX, and event queues, Firecracker's
 `VERSION_1`, `IN_ORDER`, and `EVENT_IDX` feature bits, and a guest-CID config
 field that supports Firecracker-shaped 8-byte and 4-byte-half reads. Config
 writes are rejected. The prepared resource preserves the validated guest CID,
 socket path, config-space, and inactive device state, and the registration
 helper can consume it into a caller-provided internal MMIO dispatcher without
-touching host socket resources. Startup FDT attachment, startup resource
-assembly, queue activation beyond inert state, packet formats, host Unix socket
-backend behavior, CID routing, and data movement remain deferred.
+touching host socket resources. Arm64 startup resource assembly can expose one
+configured vsock device in the guest FDT. Queue activation beyond inert state,
+packet formats, host Unix socket backend behavior, CID routing, and data
+movement remain deferred.
 
 The runtime crate also has the first backend-neutral virtio-net config-space,
 activation, TX frame parser, RX buffer parser, prepared device resources, and
@@ -1023,7 +1026,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | `PUT /boot-source` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; host paths are opened during startup preparation. Host path errors must avoid leaking sensitive path details. |
 | `PUT /drives/{drive_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; startup preparation opens backing files and registers initial block MMIO devices. Runtime hotplug remains deferred. |
 | `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records up to 16 validated pre-boot configs without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the count before opening vmnet packet I/O for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names and fails before `Running` for unsupported names. Internal network notification dispatch can route each interface through selected packet I/O, complete TX descriptor heads through a packet sink boundary, and write injected RX packets into guest buffers through a packet source boundary. Public packet movement, PATCH, and DELETE remain deferred. |
-| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Internal virtio-vsock prepared resource, MMIO registration helper, config-space, and inert MMIO handler skeleton exist, but startup attachment, host socket backend behavior, CID routing, data movement, PATCH, and DELETE remain deferred. |
+| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Startup preparation attaches one configured virtio-vsock device as guest-visible FDT/MMIO metadata backed by the inert MMIO handler. Host socket backend behavior, CID routing, data movement, PATCH, and DELETE remain deferred. |
 | `PUT /metrics` | implemented; `204` empty response on successful output initialization | unsupported after start; `400` `fault_message` | Metrics output is process observability state, not guest configuration. Duplicate initialization fails. |
 | `PUT /logger` | implemented; `204` empty response on successful pre-boot configuration | unsupported after start; `400` `fault_message` | Logger output is process observability state, not guest configuration. Repeated pre-boot requests update provided fields; full log routing remains deferred. |
 | `PUT /actions` with `InstanceStart` | process-routed; `204` after successful owned HVF startup with internal boot run-loop worker across bounded step windows or `400` preflight/preparation fault | unsupported after start; `400` `fault_message` | Commits `Running` only after the owned HVF boot-session worker with internal serial capture is retained. The worker keeps internal active, terminal-outcome, or error status; public run-loop control and public serial streaming remain deferred. |
@@ -1072,8 +1075,8 @@ Their eventual support level should follow the endpoint matrix:
   parser, prepared device resources, MMIO registration, startup FDT metadata,
   TX/RX notification dispatch metadata helpers, and startup-time vmnet packet
   I/O selection for supported `host_dev_name` forms
-- virtio-vsock startup attachment, host Unix socket backend behavior, CID
-  routing, and data movement beyond pre-boot `/vsock` configuration storage and
+- virtio-vsock host Unix socket backend behavior, CID routing, and data movement
+  beyond pre-boot `/vsock` configuration storage, startup FDT attachment, and
   the internal prepared resource/MMIO registration/config-space/MMIO handler
   skeleton
 - snapshots

--- a/docs/security.md
+++ b/docs/security.md
@@ -63,9 +63,10 @@ is resource-specific:
   Files are opened later during `InstanceStart`.
 - `/drives/{drive_id}` stores block backing paths during configuration. Backing
   files are opened later during `InstanceStart`.
-- `/vsock` stores the configured Unix socket path during configuration only.
-  The current implementation does not open, bind, connect, unlink, or create
-  that socket path.
+- `/vsock` stores the configured Unix socket path during configuration. Startup
+  can attach an inert guest-visible virtio-vsock device, but the current
+  implementation does not open, bind, connect, unlink, or create that socket
+  path.
 - `/metrics` opens the output path during pre-boot configuration and keeps a
   per-process metrics sink.
 - `/logger` opens `log_path` during pre-boot configuration when that field is
@@ -172,11 +173,11 @@ The current scaffold does not implement:
   broker, connectivity policy, and live vmnet integration proof. The current
   vsock API path validates and stores `guest_cid` plus `uds_path` before boot.
   The runtime crate has an internal virtio-vsock prepared resource, MMIO
-  registration helper, config-space, and inert MMIO handler skeleton that
-  preserve the configured socket path and expose only the configured guest CID
-  through bounded config reads. Preparation and MMIO registration do not open,
-  bind, connect, unlink, or create `uds_path`, do not attach a guest-visible
-  startup device, and do not implement host Unix socket backend behavior, CID
+  registration helper, config-space, inert MMIO handler skeleton, and startup
+  FDT attachment that preserve the configured socket path and expose only the
+  configured guest CID through bounded config reads. Preparation, MMIO
+  registration, and startup attachment do not open, bind, connect, unlink, or
+  create `uds_path`, and do not implement host Unix socket backend behavior, CID
   routing, or data movement
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy


### PR DESCRIPTION
## Summary

- attach a configured virtio-vsock device to arm64 boot resources as one inert virtio-mmio device
- allocate and expose the optional HVF vsock interrupt line and add a default non-overlapping vsock MMIO layout
- update compatibility and security docs to describe guest-visible startup/FDT metadata without host socket I/O

## Scope Exclusions

- no host Unix socket backend behavior
- no vsock queue dispatch, packet formats, CID routing, or data movement
- no public API request/response shape changes

Closes #327

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
