### PR TITLE
feat: add virtio-vsock active queue metadata

### DIFF
--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -11,7 +11,8 @@ use crate::mmio::{
 use crate::virtio_mmio::{
     VIRTIO_MMIO_DEVICE_WINDOW_SIZE, VirtioMmioDeviceActivation, VirtioMmioDeviceActivationError,
     VirtioMmioDeviceActivationHandler, VirtioMmioDeviceConfigAccess, VirtioMmioDeviceConfigError,
-    VirtioMmioDeviceConfigHandler, VirtioMmioRegisterHandler, VirtioMmioRegisterHandlerError,
+    VirtioMmioDeviceConfigHandler, VirtioMmioQueueRegisterError, VirtioMmioQueueState,
+    VirtioMmioRegisterHandler, VirtioMmioRegisterHandlerError,
 };
 
 pub const MIN_GUEST_CID: u32 = 3;
@@ -28,7 +29,9 @@ pub const VIRTIO_RING_FEATURE_EVENT_IDX: u32 = 29;
 pub const VIRTIO_FEATURE_VERSION_1: u32 = 32;
 pub const VIRTIO_FEATURE_IN_ORDER: u32 = 35;
 
-const VIRTIO_VSOCK_QUEUE_INDEXES: [u32; VIRTIO_VSOCK_QUEUE_COUNT] = [0, 1, 2];
+const VIRTIO_VSOCK_RX_QUEUE_INDEX_U32: u32 = 0;
+const VIRTIO_VSOCK_TX_QUEUE_INDEX_U32: u32 = 1;
+const VIRTIO_VSOCK_EVENT_QUEUE_INDEX_U32: u32 = 2;
 
 pub type VirtioVsockMmioHandler =
     VirtioMmioRegisterHandler<VirtioVsockConfigSpace, VirtioVsockDevice>;
@@ -216,9 +219,97 @@ impl VirtioMmioDeviceConfigHandler for VirtioVsockConfigSpace {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VirtioVsockRxQueue {
+    queue_state: VirtioMmioQueueState,
+}
+
+impl VirtioVsockRxQueue {
+    pub fn from_mmio_queue_state(
+        queue: VirtioMmioQueueState,
+    ) -> Result<Self, VirtioVsockQueueBuildError> {
+        validate_active_vsock_queue(queue)?;
+        Ok(Self { queue_state: queue })
+    }
+
+    pub const fn queue_state(self) -> VirtioMmioQueueState {
+        self.queue_state
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VirtioVsockTxQueue {
+    queue_state: VirtioMmioQueueState,
+}
+
+impl VirtioVsockTxQueue {
+    pub fn from_mmio_queue_state(
+        queue: VirtioMmioQueueState,
+    ) -> Result<Self, VirtioVsockQueueBuildError> {
+        validate_active_vsock_queue(queue)?;
+        Ok(Self { queue_state: queue })
+    }
+
+    pub const fn queue_state(self) -> VirtioMmioQueueState {
+        self.queue_state
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VirtioVsockEventQueue {
+    queue_state: VirtioMmioQueueState,
+}
+
+impl VirtioVsockEventQueue {
+    pub fn from_mmio_queue_state(
+        queue: VirtioMmioQueueState,
+    ) -> Result<Self, VirtioVsockQueueBuildError> {
+        validate_active_vsock_queue(queue)?;
+        Ok(Self { queue_state: queue })
+    }
+
+    pub const fn queue_state(self) -> VirtioMmioQueueState {
+        self.queue_state
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VirtioVsockQueueBuildError {
+    QueueNotReady,
+    QueueSizeNotConfigured,
+}
+
+impl fmt::Display for VirtioVsockQueueBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::QueueNotReady => f.write_str("virtio-vsock queue is not ready"),
+            Self::QueueSizeNotConfigured => {
+                f.write_str("virtio-vsock queue size is not configured")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VirtioVsockQueueBuildError {}
+
+fn validate_active_vsock_queue(
+    queue: VirtioMmioQueueState,
+) -> Result<(), VirtioVsockQueueBuildError> {
+    if !queue.ready() {
+        return Err(VirtioVsockQueueBuildError::QueueNotReady);
+    }
+    if queue.size() == 0 {
+        return Err(VirtioVsockQueueBuildError::QueueSizeNotConfigured);
+    }
+
+    Ok(())
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct VirtioVsockDevice {
-    activated: bool,
+    active_rx_queue: Option<VirtioVsockRxQueue>,
+    active_tx_queue: Option<VirtioVsockTxQueue>,
+    active_event_queue: Option<VirtioVsockEventQueue>,
 }
 
 impl VirtioVsockDevice {
@@ -226,43 +317,195 @@ impl VirtioVsockDevice {
         Self::default()
     }
 
-    pub const fn is_activated(&self) -> bool {
-        self.activated
+    pub fn is_activated(&self) -> bool {
+        self.active_rx_queue.is_some()
+            && self.active_tx_queue.is_some()
+            && self.active_event_queue.is_some()
+    }
+
+    pub fn active_rx_queue(&self) -> Option<VirtioMmioQueueState> {
+        self.active_rx_queue.map(VirtioVsockRxQueue::queue_state)
+    }
+
+    pub const fn active_rx_dispatch_queue(&self) -> Option<&VirtioVsockRxQueue> {
+        self.active_rx_queue.as_ref()
+    }
+
+    pub fn active_tx_queue(&self) -> Option<VirtioMmioQueueState> {
+        self.active_tx_queue.map(VirtioVsockTxQueue::queue_state)
+    }
+
+    pub const fn active_tx_dispatch_queue(&self) -> Option<&VirtioVsockTxQueue> {
+        self.active_tx_queue.as_ref()
+    }
+
+    pub fn active_event_queue(&self) -> Option<VirtioMmioQueueState> {
+        self.active_event_queue
+            .map(VirtioVsockEventQueue::queue_state)
+    }
+
+    pub const fn active_event_dispatch_queue(&self) -> Option<&VirtioVsockEventQueue> {
+        self.active_event_queue.as_ref()
     }
 
     pub fn activate_vsock(
         &mut self,
         activation: VirtioMmioDeviceActivation<'_>,
-    ) -> Result<(), VirtioMmioDeviceActivationError> {
+    ) -> Result<(), VirtioVsockDeviceActivationError> {
+        if self.is_activated() {
+            return Err(VirtioVsockDeviceActivationError::AlreadyActive);
+        }
+
         if activation.queue_count() != VIRTIO_VSOCK_QUEUE_COUNT {
-            return Err(MmioHandlerError::new(format!(
-                "virtio-vsock expected {VIRTIO_VSOCK_QUEUE_COUNT} queues, got {}",
-                activation.queue_count()
-            ))
-            .into());
+            return Err(VirtioVsockDeviceActivationError::QueueCountMismatch {
+                expected: VIRTIO_VSOCK_QUEUE_COUNT,
+                got: activation.queue_count(),
+            });
         }
 
-        for queue_index in VIRTIO_VSOCK_QUEUE_INDEXES {
-            let queue = activation.queue(queue_index).map_err(|source| {
-                MmioHandlerError::new(format!(
-                    "failed to read virtio-vsock queue {queue_index}: {source}"
-                ))
+        let active_rx_queue = active_vsock_queue_state(activation, VIRTIO_VSOCK_RX_QUEUE_INDEX_U32)
+            .and_then(|queue| {
+                VirtioVsockRxQueue::from_mmio_queue_state(queue).map_err(|source| {
+                    VirtioVsockDeviceActivationError::RxQueueBuild {
+                        queue_index: VIRTIO_VSOCK_RX_QUEUE_INDEX_U32,
+                        source,
+                    }
+                })
             })?;
-            if !queue.ready() || queue.size() == 0 {
-                return Err(MmioHandlerError::new(format!(
-                    "virtio-vsock queue {queue_index} must be configured and ready before activation"
-                ))
-                .into());
-            }
-        }
+        let active_tx_queue = active_vsock_queue_state(activation, VIRTIO_VSOCK_TX_QUEUE_INDEX_U32)
+            .and_then(|queue| {
+                VirtioVsockTxQueue::from_mmio_queue_state(queue).map_err(|source| {
+                    VirtioVsockDeviceActivationError::TxQueueBuild {
+                        queue_index: VIRTIO_VSOCK_TX_QUEUE_INDEX_U32,
+                        source,
+                    }
+                })
+            })?;
+        let active_event_queue =
+            active_vsock_queue_state(activation, VIRTIO_VSOCK_EVENT_QUEUE_INDEX_U32).and_then(
+                |queue| {
+                    VirtioVsockEventQueue::from_mmio_queue_state(queue).map_err(|source| {
+                        VirtioVsockDeviceActivationError::EventQueueBuild {
+                            queue_index: VIRTIO_VSOCK_EVENT_QUEUE_INDEX_U32,
+                            source,
+                        }
+                    })
+                },
+            )?;
 
-        self.activated = true;
+        self.active_rx_queue = Some(active_rx_queue);
+        self.active_tx_queue = Some(active_tx_queue);
+        self.active_event_queue = Some(active_event_queue);
         Ok(())
     }
 
     pub fn reset(&mut self) {
-        self.activated = false;
+        self.active_rx_queue = None;
+        self.active_tx_queue = None;
+        self.active_event_queue = None;
     }
+}
+
+#[derive(Debug)]
+pub enum VirtioVsockDeviceActivationError {
+    AlreadyActive,
+    QueueCountMismatch {
+        expected: usize,
+        got: usize,
+    },
+    QueueMetadata {
+        queue_index: u32,
+        source: VirtioMmioQueueRegisterError,
+    },
+    RxQueueBuild {
+        queue_index: u32,
+        source: VirtioVsockQueueBuildError,
+    },
+    TxQueueBuild {
+        queue_index: u32,
+        source: VirtioVsockQueueBuildError,
+    },
+    EventQueueBuild {
+        queue_index: u32,
+        source: VirtioVsockQueueBuildError,
+    },
+}
+
+impl fmt::Display for VirtioVsockDeviceActivationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AlreadyActive => f.write_str("virtio-vsock device is already active"),
+            Self::QueueCountMismatch { expected, got } => {
+                write!(f, "virtio-vsock expected {expected} queues, got {got}")
+            }
+            Self::QueueMetadata {
+                queue_index,
+                source,
+            } => {
+                write!(
+                    f,
+                    "failed to read virtio-vsock queue {queue_index} activation metadata: {source}"
+                )
+            }
+            Self::RxQueueBuild {
+                queue_index,
+                source,
+            } => {
+                write!(
+                    f,
+                    "failed to activate virtio-vsock RX queue {queue_index}: {source}"
+                )
+            }
+            Self::TxQueueBuild {
+                queue_index,
+                source,
+            } => {
+                write!(
+                    f,
+                    "failed to activate virtio-vsock TX queue {queue_index}: {source}"
+                )
+            }
+            Self::EventQueueBuild {
+                queue_index,
+                source,
+            } => {
+                write!(
+                    f,
+                    "failed to activate virtio-vsock event queue {queue_index}: {source}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for VirtioVsockDeviceActivationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::QueueMetadata { source, .. } => Some(source),
+            Self::RxQueueBuild { source, .. }
+            | Self::TxQueueBuild { source, .. }
+            | Self::EventQueueBuild { source, .. } => Some(source),
+            Self::AlreadyActive | Self::QueueCountMismatch { .. } => None,
+        }
+    }
+}
+
+impl From<VirtioVsockDeviceActivationError> for VirtioMmioDeviceActivationError {
+    fn from(source: VirtioVsockDeviceActivationError) -> Self {
+        MmioHandlerError::new(source.to_string()).into()
+    }
+}
+
+fn active_vsock_queue_state(
+    activation: VirtioMmioDeviceActivation<'_>,
+    queue_index: u32,
+) -> Result<VirtioMmioQueueState, VirtioVsockDeviceActivationError> {
+    activation.queue(queue_index).copied().map_err(|source| {
+        VirtioVsockDeviceActivationError::QueueMetadata {
+            queue_index,
+            source,
+        }
+    })
 }
 
 impl VirtioMmioDeviceActivationHandler for VirtioVsockDevice {
@@ -270,7 +513,7 @@ impl VirtioMmioDeviceActivationHandler for VirtioVsockDevice {
         &mut self,
         activation: VirtioMmioDeviceActivation<'_>,
     ) -> Result<(), VirtioMmioDeviceActivationError> {
-        self.activate_vsock(activation)
+        self.activate_vsock(activation).map_err(Into::into)
     }
 
     fn reset(&mut self) {
@@ -603,8 +846,10 @@ mod tests {
         VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DRIVER,
         VIRTIO_DEVICE_STATUS_DRIVER_OK, VIRTIO_DEVICE_STATUS_FEATURES_OK,
         VIRTIO_DEVICE_STATUS_INIT, VIRTIO_MMIO_DEVICE_CONFIG_OFFSET,
-        VIRTIO_MMIO_DEVICE_WINDOW_SIZE, VirtioMmioDeviceActivation, VirtioMmioDeviceRegisters,
-        VirtioMmioQueueRegisters, VirtioMmioRegister, VirtioMmioRegisterHandlerError,
+        VIRTIO_MMIO_DEVICE_WINDOW_SIZE, VirtioMmioDeviceActivation,
+        VirtioMmioDeviceActivationError, VirtioMmioDeviceActivationHandler,
+        VirtioMmioDeviceRegisters, VirtioMmioQueueRegisters, VirtioMmioRegister,
+        VirtioMmioRegisterHandlerError,
     };
 
     use super::{
@@ -612,9 +857,9 @@ mod tests {
         VIRTIO_RING_FEATURE_EVENT_IDX, VIRTIO_VSOCK_CONFIG_GUEST_CID_SIZE, VIRTIO_VSOCK_DEVICE_ID,
         VIRTIO_VSOCK_EVENT_QUEUE_INDEX, VIRTIO_VSOCK_QUEUE_COUNT, VIRTIO_VSOCK_QUEUE_SIZE,
         VIRTIO_VSOCK_QUEUE_SIZES, VIRTIO_VSOCK_RX_QUEUE_INDEX, VIRTIO_VSOCK_TX_QUEUE_INDEX,
-        VirtioVsockConfigSpace, VirtioVsockDevice, VirtioVsockMmioHandler, VsockConfigError,
-        VsockConfigInput, VsockMmioDevice, VsockMmioLayout, VsockMmioRegistrationError,
-        virtio_vsock_mmio_handler,
+        VirtioVsockConfigSpace, VirtioVsockDevice, VirtioVsockDeviceActivationError,
+        VirtioVsockMmioHandler, VirtioVsockQueueBuildError, VsockConfigError, VsockConfigInput,
+        VsockMmioDevice, VsockMmioLayout, VsockMmioRegistrationError, virtio_vsock_mmio_handler,
     };
 
     const TEST_MMIO_BASE: u64 = 0x1000_0000;
@@ -717,42 +962,112 @@ mod tests {
         u32::try_from(address.raw_value()).expect("test guest address should fit in low half")
     }
 
+    fn queue_base(queue_index: u32) -> u64 {
+        TEST_QUEUE_ADDRESS_BASE + u64::from(queue_index) * TEST_QUEUE_ADDRESS_STRIDE
+    }
+
     fn configure_vsock_queues(handler: &mut VirtioVsockMmioHandler) {
+        configure_vsock_queues_with_size(handler, VIRTIO_VSOCK_QUEUE_SIZE);
+    }
+
+    fn configure_vsock_queues_with_size(handler: &mut VirtioVsockMmioHandler, queue_size: u16) {
         for queue_index in 0..VIRTIO_VSOCK_QUEUE_COUNT {
             let queue_index_u32 = u32::try_from(queue_index).expect("queue index should fit");
-            let queue_base =
-                TEST_QUEUE_ADDRESS_BASE + u64::from(queue_index_u32) * TEST_QUEUE_ADDRESS_STRIDE;
+            let base = queue_base(queue_index_u32);
             handler
                 .write_register(VirtioMmioRegister::QueueSel, queue_index_u32)
                 .expect("queue select should write");
             handler
-                .write_register(
-                    VirtioMmioRegister::QueueNum,
-                    u32::from(VIRTIO_VSOCK_QUEUE_SIZE),
-                )
+                .write_register(VirtioMmioRegister::QueueNum, u32::from(queue_size))
                 .expect("queue size should write");
             handler
                 .write_register(
                     VirtioMmioRegister::QueueDescLow,
-                    guest_address_low(GuestAddress::new(queue_base)),
+                    guest_address_low(GuestAddress::new(base)),
                 )
                 .expect("queue descriptor table should write");
             handler
                 .write_register(
                     VirtioMmioRegister::QueueDriverLow,
-                    guest_address_low(GuestAddress::new(queue_base + 0x200)),
+                    guest_address_low(GuestAddress::new(base + 0x200)),
                 )
                 .expect("queue driver ring should write");
             handler
                 .write_register(
                     VirtioMmioRegister::QueueDeviceLow,
-                    guest_address_low(GuestAddress::new(queue_base + 0x400)),
+                    guest_address_low(GuestAddress::new(base + 0x400)),
                 )
                 .expect("queue device ring should write");
             handler
                 .write_register(VirtioMmioRegister::QueueReady, 1)
                 .expect("queue ready should write");
         }
+    }
+
+    fn configured_vsock_queue_registers(
+        queue_size: Option<u16>,
+        ready: bool,
+    ) -> VirtioMmioQueueRegisters {
+        configured_vsock_queue_registers_from_specs([(queue_size, ready); VIRTIO_VSOCK_QUEUE_COUNT])
+    }
+
+    fn configured_vsock_queue_registers_from_specs(
+        specs: [(Option<u16>, bool); VIRTIO_VSOCK_QUEUE_COUNT],
+    ) -> VirtioMmioQueueRegisters {
+        let mut queues = VirtioMmioQueueRegisters::new(&VIRTIO_VSOCK_QUEUE_SIZES)
+            .expect("queue table should build");
+        for (queue_index, (queue_size, ready)) in specs.into_iter().enumerate() {
+            let queue_index_u32 = u32::try_from(queue_index).expect("queue index should fit");
+            let base = queue_base(queue_index_u32);
+            queues
+                .write_register(
+                    VirtioMmioRegister::QueueSel,
+                    queue_index_u32,
+                    QUEUE_CONFIG_STATUS,
+                )
+                .expect("queue select should write");
+            if let Some(queue_size) = queue_size {
+                queues
+                    .write_register(
+                        VirtioMmioRegister::QueueNum,
+                        u32::from(queue_size),
+                        QUEUE_CONFIG_STATUS,
+                    )
+                    .expect("queue size should write");
+            }
+            queues
+                .write_register(
+                    VirtioMmioRegister::QueueDescLow,
+                    guest_address_low(GuestAddress::new(base)),
+                    QUEUE_CONFIG_STATUS,
+                )
+                .expect("queue descriptor table should write");
+            queues
+                .write_register(
+                    VirtioMmioRegister::QueueDriverLow,
+                    guest_address_low(GuestAddress::new(base + 0x200)),
+                    QUEUE_CONFIG_STATUS,
+                )
+                .expect("queue driver ring should write");
+            queues
+                .write_register(
+                    VirtioMmioRegister::QueueDeviceLow,
+                    guest_address_low(GuestAddress::new(base + 0x400)),
+                    QUEUE_CONFIG_STATUS,
+                )
+                .expect("queue device ring should write");
+            if ready {
+                queues
+                    .write_register(VirtioMmioRegister::QueueReady, 1, QUEUE_CONFIG_STATUS)
+                    .expect("queue ready should write");
+            }
+        }
+
+        queues
+    }
+
+    fn vsock_device_registers() -> VirtioMmioDeviceRegisters {
+        VirtioMmioDeviceRegisters::new(VIRTIO_VSOCK_DEVICE_ID, 0)
     }
 
     fn vsock_handler_for_config(config: VirtioVsockConfigSpace) -> VirtioVsockMmioHandler {
@@ -1211,6 +1526,258 @@ mod tests {
     }
 
     #[test]
+    fn virtio_vsock_device_activation_retains_active_queue_metadata() {
+        let registers = vsock_device_registers();
+        let queues = configured_vsock_queue_registers(Some(4), true);
+        let mut device = VirtioVsockDevice::new();
+
+        device
+            .activate_vsock(VirtioMmioDeviceActivation::new(&registers, &queues))
+            .expect("vsock device should activate");
+
+        assert!(device.is_activated());
+        let rx_queue = device
+            .active_rx_queue()
+            .expect("active RX queue should be present");
+        let tx_queue = device
+            .active_tx_queue()
+            .expect("active TX queue should be present");
+        let event_queue = device
+            .active_event_queue()
+            .expect("active event queue should be present");
+
+        assert_eq!(rx_queue.size(), 4);
+        assert_eq!(tx_queue.size(), 4);
+        assert_eq!(event_queue.size(), 4);
+        assert_eq!(
+            rx_queue.descriptor_table(),
+            GuestAddress::new(queue_base(0))
+        );
+        assert_eq!(
+            tx_queue.descriptor_table(),
+            GuestAddress::new(queue_base(1))
+        );
+        assert_eq!(
+            event_queue.descriptor_table(),
+            GuestAddress::new(queue_base(2))
+        );
+        assert_eq!(
+            device
+                .active_rx_dispatch_queue()
+                .expect("active RX dispatch queue should be present")
+                .queue_state(),
+            rx_queue
+        );
+        assert_eq!(
+            device
+                .active_tx_dispatch_queue()
+                .expect("active TX dispatch queue should be present")
+                .queue_state(),
+            tx_queue
+        );
+        assert_eq!(
+            device
+                .active_event_dispatch_queue()
+                .expect("active event dispatch queue should be present")
+                .queue_state(),
+            event_queue
+        );
+    }
+
+    #[test]
+    fn virtio_vsock_device_rejects_duplicate_activation_without_replacing_queues() {
+        let registers = vsock_device_registers();
+        let first_queues = configured_vsock_queue_registers(Some(4), true);
+        let second_queues = configured_vsock_queue_registers(Some(8), true);
+        let mut device = VirtioVsockDevice::new();
+
+        device
+            .activate_vsock(VirtioMmioDeviceActivation::new(&registers, &first_queues))
+            .expect("first activation should succeed");
+
+        let error = device
+            .activate_vsock(VirtioMmioDeviceActivation::new(&registers, &second_queues))
+            .expect_err("duplicate activation should fail");
+
+        assert!(matches!(
+            &error,
+            VirtioVsockDeviceActivationError::AlreadyActive
+        ));
+        assert!(error.source().is_none());
+        assert_eq!(error.to_string(), "virtio-vsock device is already active");
+        assert_eq!(
+            device
+                .active_rx_queue()
+                .expect("original RX queue should remain active")
+                .size(),
+            4
+        );
+    }
+
+    #[test]
+    fn virtio_vsock_device_activation_reset_clears_queues_and_allows_retry() {
+        let registers = vsock_device_registers();
+        let first_queues = configured_vsock_queue_registers(Some(4), true);
+        let second_queues = configured_vsock_queue_registers(Some(8), true);
+        let mut device = VirtioVsockDevice::new();
+
+        device
+            .activate_vsock(VirtioMmioDeviceActivation::new(&registers, &first_queues))
+            .expect("first activation should succeed");
+        assert!(device.is_activated());
+
+        VirtioMmioDeviceActivationHandler::reset(&mut device);
+
+        assert!(!device.is_activated());
+        assert!(device.active_rx_queue().is_none());
+        assert!(device.active_tx_queue().is_none());
+        assert!(device.active_event_queue().is_none());
+
+        device
+            .activate_vsock(VirtioMmioDeviceActivation::new(&registers, &second_queues))
+            .expect("second activation should succeed after reset");
+
+        assert_eq!(
+            device
+                .active_event_queue()
+                .expect("new event queue should be active")
+                .size(),
+            8
+        );
+    }
+
+    #[test]
+    fn virtio_vsock_device_rejects_not_ready_queue_without_partial_activation() {
+        let registers = vsock_device_registers();
+        let queues = configured_vsock_queue_registers(Some(4), false);
+        let mut device = VirtioVsockDevice::new();
+
+        let error = device
+            .activate_vsock(VirtioMmioDeviceActivation::new(&registers, &queues))
+            .expect_err("not-ready queue should fail activation");
+
+        assert!(matches!(
+            &error,
+            VirtioVsockDeviceActivationError::RxQueueBuild {
+                queue_index: 0,
+                source: VirtioVsockQueueBuildError::QueueNotReady
+            }
+        ));
+        assert!(error.source().is_some());
+        assert_eq!(
+            error.to_string(),
+            "failed to activate virtio-vsock RX queue 0: virtio-vsock queue is not ready"
+        );
+        assert!(!device.is_activated());
+        assert!(device.active_rx_queue().is_none());
+        assert!(device.active_tx_queue().is_none());
+        assert!(device.active_event_queue().is_none());
+    }
+
+    #[test]
+    fn virtio_vsock_device_rejects_not_ready_tx_queue_without_partial_activation() {
+        let registers = vsock_device_registers();
+        let queues = configured_vsock_queue_registers_from_specs([
+            (Some(4), true),
+            (Some(4), false),
+            (Some(4), true),
+        ]);
+        let mut device = VirtioVsockDevice::new();
+
+        let error = device
+            .activate_vsock(VirtioMmioDeviceActivation::new(&registers, &queues))
+            .expect_err("not-ready TX queue should fail activation");
+
+        assert!(matches!(
+            &error,
+            VirtioVsockDeviceActivationError::TxQueueBuild {
+                queue_index: 1,
+                source: VirtioVsockQueueBuildError::QueueNotReady
+            }
+        ));
+        assert_eq!(
+            error.to_string(),
+            "failed to activate virtio-vsock TX queue 1: virtio-vsock queue is not ready"
+        );
+        assert!(!device.is_activated());
+    }
+
+    #[test]
+    fn virtio_vsock_device_rejects_ready_queue_without_size() {
+        let registers = vsock_device_registers();
+        let queues = configured_vsock_queue_registers(None, true);
+        let mut device = VirtioVsockDevice::new();
+
+        let error = device
+            .activate_vsock(VirtioMmioDeviceActivation::new(&registers, &queues))
+            .expect_err("missing queue size should fail activation");
+
+        assert!(matches!(
+            &error,
+            VirtioVsockDeviceActivationError::RxQueueBuild {
+                queue_index: 0,
+                source: VirtioVsockQueueBuildError::QueueSizeNotConfigured
+            }
+        ));
+        assert_eq!(
+            error.to_string(),
+            "failed to activate virtio-vsock RX queue 0: virtio-vsock queue size is not configured"
+        );
+        assert!(!device.is_activated());
+    }
+
+    #[test]
+    fn virtio_vsock_device_rejects_ready_event_queue_without_size() {
+        let registers = vsock_device_registers();
+        let queues = configured_vsock_queue_registers_from_specs([
+            (Some(4), true),
+            (Some(4), true),
+            (None, true),
+        ]);
+        let mut device = VirtioVsockDevice::new();
+
+        let error = device
+            .activate_vsock(VirtioMmioDeviceActivation::new(&registers, &queues))
+            .expect_err("missing event queue size should fail activation");
+
+        assert!(matches!(
+            &error,
+            VirtioVsockDeviceActivationError::EventQueueBuild {
+                queue_index: 2,
+                source: VirtioVsockQueueBuildError::QueueSizeNotConfigured
+            }
+        ));
+        assert_eq!(
+            error.to_string(),
+            "failed to activate virtio-vsock event queue 2: virtio-vsock queue size is not configured"
+        );
+        assert!(!device.is_activated());
+    }
+
+    #[test]
+    fn virtio_vsock_device_activation_trait_error_is_generic_handler_error() {
+        let registers = vsock_device_registers();
+        let queues = configured_vsock_queue_registers(Some(4), false);
+        let mut device = VirtioVsockDevice::new();
+
+        let error = VirtioMmioDeviceActivationHandler::activate(
+            &mut device,
+            VirtioMmioDeviceActivation::new(&registers, &queues),
+        )
+        .expect_err("trait activation should fail with generic handler error");
+
+        match error {
+            VirtioMmioDeviceActivationError::Handler { source } => {
+                assert_eq!(
+                    source.to_string(),
+                    "failed to activate virtio-vsock RX queue 0: virtio-vsock queue is not ready"
+                );
+            }
+        }
+        assert!(!device.is_activated());
+    }
+
+    #[test]
     fn virtio_vsock_device_activates_and_resets_through_handler() {
         let mut handler = virtio_vsock_mmio_handler(3).expect("vsock handler should build");
 
@@ -1225,6 +1792,9 @@ mod tests {
 
         assert!(handler.is_device_activated());
         assert!(handler.activation_handler().is_activated());
+        assert!(handler.activation_handler().active_rx_queue().is_some());
+        assert!(handler.activation_handler().active_tx_queue().is_some());
+        assert!(handler.activation_handler().active_event_queue().is_some());
 
         handler
             .write_register(VirtioMmioRegister::Status, VIRTIO_DEVICE_STATUS_INIT)
@@ -1232,6 +1802,9 @@ mod tests {
 
         assert!(!handler.is_device_activated());
         assert!(!handler.activation_handler().is_activated());
+        assert!(handler.activation_handler().active_rx_queue().is_none());
+        assert!(handler.activation_handler().active_tx_queue().is_none());
+        assert!(handler.activation_handler().active_event_queue().is_none());
     }
 
     #[test]
@@ -1264,10 +1837,14 @@ mod tests {
             .activate_vsock(activation)
             .expect_err("unexpected queue count should fail activation");
 
-        assert_eq!(
-            err.to_string(),
-            "virtio-mmio device activation handler failed: virtio-vsock expected 3 queues, got 2"
-        );
+        assert_eq!(err.to_string(), "virtio-vsock expected 3 queues, got 2");
+        assert!(matches!(
+            err,
+            VirtioVsockDeviceActivationError::QueueCountMismatch {
+                expected: 3,
+                got: 2
+            }
+        ));
         assert!(!device.is_activated());
     }
 }

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -1066,6 +1066,11 @@ mod tests {
         queues
     }
 
+    fn vsock_queue_registers_with_count(queue_count: usize) -> VirtioMmioQueueRegisters {
+        let queue_sizes = vec![VIRTIO_VSOCK_QUEUE_SIZE; queue_count];
+        VirtioMmioQueueRegisters::new(&queue_sizes).expect("queue table should build")
+    }
+
     fn vsock_device_registers() -> VirtioMmioDeviceRegisters {
         VirtioMmioDeviceRegisters::new(VIRTIO_VSOCK_DEVICE_ID, 0)
     }
@@ -1826,25 +1831,29 @@ mod tests {
 
     #[test]
     fn virtio_vsock_device_rejects_unexpected_queue_count() {
-        let registers = VirtioMmioDeviceRegisters::new(VIRTIO_VSOCK_DEVICE_ID, 0);
-        let queues =
-            VirtioMmioQueueRegisters::new(&[VIRTIO_VSOCK_QUEUE_SIZE, VIRTIO_VSOCK_QUEUE_SIZE])
-                .expect("short queue table should build");
-        let activation = VirtioMmioDeviceActivation::new(&registers, &queues);
-        let mut device = VirtioVsockDevice::new();
+        let registers = vsock_device_registers();
 
-        let err = device
-            .activate_vsock(activation)
-            .expect_err("unexpected queue count should fail activation");
+        for queue_count in [2, 4] {
+            let queues = vsock_queue_registers_with_count(queue_count);
+            let activation = VirtioMmioDeviceActivation::new(&registers, &queues);
+            let mut device = VirtioVsockDevice::new();
 
-        assert_eq!(err.to_string(), "virtio-vsock expected 3 queues, got 2");
-        assert!(matches!(
-            err,
-            VirtioVsockDeviceActivationError::QueueCountMismatch {
-                expected: 3,
-                got: 2
-            }
-        ));
-        assert!(!device.is_activated());
+            let err = device
+                .activate_vsock(activation)
+                .expect_err("unexpected queue count should fail activation");
+
+            assert_eq!(
+                err.to_string(),
+                format!("virtio-vsock expected 3 queues, got {queue_count}")
+            );
+            assert!(matches!(
+                err,
+                VirtioVsockDeviceActivationError::QueueCountMismatch {
+                    expected: 3,
+                    got
+                } if got == queue_count
+            ));
+            assert!(!device.is_activated());
+        }
     }
 }

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -8,7 +8,7 @@ The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /`, `GET /version`,
 `GET /vm/config`, `GET /machine-config`, pre-boot `PUT /machine-config`
 configuration storage, pre-boot `PUT /boot-source` configuration storage, pre-boot `PUT /drives/{drive_id}`
-configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, prepared device resource, MMIO registration helper, inert MMIO handler skeleton, and startup FDT attachment, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
+configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, prepared device resource, MMIO registration helper, MMIO handler skeleton with active queue metadata retention, and startup FDT attachment, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
 `InstanceStart` preflight, transactional startup executor, and successful-start state transition helpers, backend-neutral guest
 physical address and aarch64 DRAM layout/access primitives, arm64 boot
 placement helpers, internal boot-source validation and arm64 kernel/initrd
@@ -233,7 +233,7 @@ compatibility targets.
 | `PATCH` | `/machine-config` | deferred | Partial updates belong with later state and validation rules. |
 | `PUT` | `/cpu-config` | deferred | Needs HVF CPU feature design with VM and boot work in #8 and #10. |
 | `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores up to 16 initial virtio-net configurations before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the interface count before opening vmnet resources, then selects vmnet packet I/O only for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names; unsupported names fail startup before `Running` is committed. Internal network notification dispatch can route each configured interface through selected packet I/O, parse TX descriptors through a packet sink boundary, and copy injected RX packets into guest buffers through a packet source boundary. Public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
-| `PUT` | `/vsock` | supported target; startup attachment implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Startup preparation attaches the configured device as one virtio-mmio FDT node backed by the inert MMIO handler. Queue data movement, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
+| `PUT` | `/vsock` | supported target; startup attachment implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Startup preparation attaches the configured device as one virtio-mmio FDT node backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. Queue notification dispatch, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
 | `GET`, `PUT`, `PATCH` | `/mmds` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/mmds/config` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/snapshot/create`, `/snapshot/load` | deferred | Tied to snapshot and restore work in #19. |
@@ -561,8 +561,8 @@ and is returned from `GET /vm/config` as `vsock` with `guest_cid` and
 does not open, bind, connect, unlink, or create the configured `uds_path`.
 
 The runtime crate has an internal virtio-vsock prepared resource, MMIO
-registration helper, config-space, inert MMIO handler skeleton, and startup
-FDT attachment. It uses the
+registration helper, config-space, MMIO handler skeleton with active queue
+metadata retention, and startup FDT attachment. It uses the
 virtio device id `19`, three 256-entry RX, TX, and event queues, Firecracker's
 `VERSION_1`, `IN_ORDER`, and `EVENT_IDX` feature bits, and a guest-CID config
 field that supports Firecracker-shaped 8-byte and 4-byte-half reads. Config
@@ -570,9 +570,10 @@ writes are rejected. The prepared resource preserves the validated guest CID,
 socket path, config-space, and inactive device state, and the registration
 helper can consume it into a caller-provided internal MMIO dispatcher without
 touching host socket resources. Arm64 startup resource assembly can expose one
-configured vsock device in the guest FDT. Queue activation beyond inert state,
-packet formats, host Unix socket backend behavior, CID routing, and data
-movement remain deferred.
+configured vsock device in the guest FDT. After `DRIVER_OK`, the internal
+device retains active RX, TX, and event queue metadata for later notification
+dispatch work. Packet formats, host Unix socket backend behavior, CID routing,
+queue notification dispatch, and data movement remain deferred.
 
 The runtime crate also has the first backend-neutral virtio-net config-space,
 activation, TX frame parser, RX buffer parser, prepared device resources, and
@@ -1026,7 +1027,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | `PUT /boot-source` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; host paths are opened during startup preparation. Host path errors must avoid leaking sensitive path details. |
 | `PUT /drives/{drive_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; startup preparation opens backing files and registers initial block MMIO devices. Runtime hotplug remains deferred. |
 | `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records up to 16 validated pre-boot configs without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the count before opening vmnet packet I/O for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names and fails before `Running` for unsupported names. Internal network notification dispatch can route each interface through selected packet I/O, complete TX descriptor heads through a packet sink boundary, and write injected RX packets into guest buffers through a packet source boundary. Public packet movement, PATCH, and DELETE remain deferred. |
-| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Startup preparation attaches one configured virtio-vsock device as guest-visible FDT/MMIO metadata backed by the inert MMIO handler. Host socket backend behavior, CID routing, data movement, PATCH, and DELETE remain deferred. |
+| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Startup preparation attaches one configured virtio-vsock device as guest-visible FDT/MMIO metadata backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. Host socket backend behavior, CID routing, queue notification dispatch, data movement, PATCH, and DELETE remain deferred. |
 | `PUT /metrics` | implemented; `204` empty response on successful output initialization | unsupported after start; `400` `fault_message` | Metrics output is process observability state, not guest configuration. Duplicate initialization fails. |
 | `PUT /logger` | implemented; `204` empty response on successful pre-boot configuration | unsupported after start; `400` `fault_message` | Logger output is process observability state, not guest configuration. Repeated pre-boot requests update provided fields; full log routing remains deferred. |
 | `PUT /actions` with `InstanceStart` | process-routed; `204` after successful owned HVF startup with internal boot run-loop worker across bounded step windows or `400` preflight/preparation fault | unsupported after start; `400` `fault_message` | Commits `Running` only after the owned HVF boot-session worker with internal serial capture is retained. The worker keeps internal active, terminal-outcome, or error status; public run-loop control and public serial streaming remain deferred. |
@@ -1078,7 +1079,7 @@ Their eventual support level should follow the endpoint matrix:
 - virtio-vsock host Unix socket backend behavior, CID routing, and data movement
   beyond pre-boot `/vsock` configuration storage, startup FDT attachment, and
   the internal prepared resource/MMIO registration/config-space/MMIO handler
-  skeleton
+  skeleton with active queue metadata retention
 - snapshots
 - MMDS
 - balloon devices and balloon statistics

--- a/docs/security.md
+++ b/docs/security.md
@@ -64,9 +64,10 @@ is resource-specific:
 - `/drives/{drive_id}` stores block backing paths during configuration. Backing
   files are opened later during `InstanceStart`.
 - `/vsock` stores the configured Unix socket path during configuration. Startup
-  can attach an inert guest-visible virtio-vsock device, but the current
-  implementation does not open, bind, connect, unlink, or create that socket
-  path.
+  can attach a guest-visible virtio-vsock device whose internal MMIO handler
+  retains active RX, TX, and event queue metadata after `DRIVER_OK`, but the
+  current implementation does not open, bind, connect, unlink, or create that
+  socket path.
 - `/metrics` opens the output path during pre-boot configuration and keeps a
   per-process metrics sink.
 - `/logger` opens `log_path` during pre-boot configuration when that field is
@@ -173,12 +174,13 @@ The current scaffold does not implement:
   broker, connectivity policy, and live vmnet integration proof. The current
   vsock API path validates and stores `guest_cid` plus `uds_path` before boot.
   The runtime crate has an internal virtio-vsock prepared resource, MMIO
-  registration helper, config-space, inert MMIO handler skeleton, and startup
-  FDT attachment that preserve the configured socket path and expose only the
-  configured guest CID through bounded config reads. Preparation, MMIO
-  registration, and startup attachment do not open, bind, connect, unlink, or
-  create `uds_path`, and do not implement host Unix socket backend behavior, CID
-  routing, or data movement
+  registration helper, config-space, MMIO handler skeleton with active queue
+  metadata retention, and startup FDT attachment that preserve the configured
+  socket path and expose only the configured guest CID through bounded config
+  reads. Preparation, MMIO registration, and startup attachment do not open,
+  bind, connect, unlink, or create `uds_path`, and do not implement host Unix
+  socket backend behavior, CID routing, queue notification dispatch, or data
+  movement
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy
 


### PR DESCRIPTION
## Summary

- Add typed virtio-vsock RX, TX, and event active queue metadata wrappers in `bangbang-runtime`.
- Retain all three active queue states after successful `DRIVER_OK`, reject duplicate activation without replacing queues, and clear active queues on reset.
- Update Firecracker compatibility and security docs to describe active queue metadata retention while leaving vsock data path work deferred.

## Out Of Scope

- Virtio-vsock packet parsing.
- Queue notification dispatch.
- Host Unix socket backend behavior.
- CID routing and host/guest data movement.

Closes #329

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`