### PR TITLE
feat: add virtio-vsock packet header model

### DIFF
--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -25,6 +25,19 @@ pub const VIRTIO_VSOCK_QUEUE_SIZE: u16 = 256;
 pub const VIRTIO_VSOCK_QUEUE_SIZES: [u16; VIRTIO_VSOCK_QUEUE_COUNT] =
     [VIRTIO_VSOCK_QUEUE_SIZE; VIRTIO_VSOCK_QUEUE_COUNT];
 pub const VIRTIO_VSOCK_CONFIG_GUEST_CID_SIZE: usize = 8;
+pub const VIRTIO_VSOCK_PACKET_HEADER_SIZE: usize = 44;
+pub const VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE: u32 = 64 * 1024;
+pub const VIRTIO_VSOCK_HOST_CID: u64 = 2;
+pub const VIRTIO_VSOCK_PACKET_TYPE_STREAM: u16 = 1;
+pub const VIRTIO_VSOCK_OP_REQUEST: u16 = 1;
+pub const VIRTIO_VSOCK_OP_RESPONSE: u16 = 2;
+pub const VIRTIO_VSOCK_OP_RST: u16 = 3;
+pub const VIRTIO_VSOCK_OP_SHUTDOWN: u16 = 4;
+pub const VIRTIO_VSOCK_OP_RW: u16 = 5;
+pub const VIRTIO_VSOCK_OP_CREDIT_UPDATE: u16 = 6;
+pub const VIRTIO_VSOCK_OP_CREDIT_REQUEST: u16 = 7;
+pub const VIRTIO_VSOCK_FLAGS_SHUTDOWN_RCV: u32 = 1;
+pub const VIRTIO_VSOCK_FLAGS_SHUTDOWN_SEND: u32 = 2;
 pub const VIRTIO_RING_FEATURE_EVENT_IDX: u32 = 29;
 pub const VIRTIO_FEATURE_VERSION_1: u32 = 32;
 pub const VIRTIO_FEATURE_IN_ORDER: u32 = 35;
@@ -160,6 +173,346 @@ impl fmt::Display for VsockConfigError {
 }
 
 impl std::error::Error for VsockConfigError {}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct VirtioVsockPacketHeader {
+    src_cid: u64,
+    dst_cid: u64,
+    src_port: u32,
+    dst_port: u32,
+    payload_len: u32,
+    packet_type: u16,
+    operation: u16,
+    flags: u32,
+    buffer_allocation: u32,
+    forwarded_count: u32,
+}
+
+impl VirtioVsockPacketHeader {
+    pub const fn new() -> Self {
+        Self {
+            src_cid: 0,
+            dst_cid: 0,
+            src_port: 0,
+            dst_port: 0,
+            payload_len: 0,
+            packet_type: 0,
+            operation: 0,
+            flags: 0,
+            buffer_allocation: 0,
+            forwarded_count: 0,
+        }
+    }
+
+    pub const fn src_cid(self) -> u64 {
+        self.src_cid
+    }
+
+    pub const fn dst_cid(self) -> u64 {
+        self.dst_cid
+    }
+
+    pub const fn src_port(self) -> u32 {
+        self.src_port
+    }
+
+    pub const fn dst_port(self) -> u32 {
+        self.dst_port
+    }
+
+    pub const fn payload_len(self) -> u32 {
+        self.payload_len
+    }
+
+    pub const fn packet_type(self) -> u16 {
+        self.packet_type
+    }
+
+    pub const fn operation(self) -> u16 {
+        self.operation
+    }
+
+    pub const fn flags(self) -> u32 {
+        self.flags
+    }
+
+    pub const fn buffer_allocation(self) -> u32 {
+        self.buffer_allocation
+    }
+
+    pub const fn forwarded_count(self) -> u32 {
+        self.forwarded_count
+    }
+
+    pub const fn with_src_cid(mut self, src_cid: u64) -> Self {
+        self.src_cid = src_cid;
+        self
+    }
+
+    pub const fn with_dst_cid(mut self, dst_cid: u64) -> Self {
+        self.dst_cid = dst_cid;
+        self
+    }
+
+    pub const fn with_src_port(mut self, src_port: u32) -> Self {
+        self.src_port = src_port;
+        self
+    }
+
+    pub const fn with_dst_port(mut self, dst_port: u32) -> Self {
+        self.dst_port = dst_port;
+        self
+    }
+
+    pub const fn with_payload_len(mut self, payload_len: u32) -> Self {
+        self.payload_len = payload_len;
+        self
+    }
+
+    pub const fn with_packet_type(mut self, packet_type: u16) -> Self {
+        self.packet_type = packet_type;
+        self
+    }
+
+    pub const fn with_operation(mut self, operation: u16) -> Self {
+        self.operation = operation;
+        self
+    }
+
+    pub const fn with_flags(mut self, flags: u32) -> Self {
+        self.flags = flags;
+        self
+    }
+
+    pub const fn with_buffer_allocation(mut self, buffer_allocation: u32) -> Self {
+        self.buffer_allocation = buffer_allocation;
+        self
+    }
+
+    pub const fn with_forwarded_count(mut self, forwarded_count: u32) -> Self {
+        self.forwarded_count = forwarded_count;
+        self
+    }
+
+    pub fn validate_payload_len(self) -> Result<(), VirtioVsockPacketLengthError> {
+        if self.payload_len > VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE {
+            return Err(VirtioVsockPacketLengthError {
+                payload_len: self.payload_len,
+                max_payload_len: VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE,
+            });
+        }
+
+        Ok(())
+    }
+
+    pub fn to_bytes(self) -> [u8; VIRTIO_VSOCK_PACKET_HEADER_SIZE] {
+        let [
+            src_cid_0,
+            src_cid_1,
+            src_cid_2,
+            src_cid_3,
+            src_cid_4,
+            src_cid_5,
+            src_cid_6,
+            src_cid_7,
+        ] = self.src_cid.to_le_bytes();
+        let [
+            dst_cid_0,
+            dst_cid_1,
+            dst_cid_2,
+            dst_cid_3,
+            dst_cid_4,
+            dst_cid_5,
+            dst_cid_6,
+            dst_cid_7,
+        ] = self.dst_cid.to_le_bytes();
+        let [src_port_0, src_port_1, src_port_2, src_port_3] = self.src_port.to_le_bytes();
+        let [dst_port_0, dst_port_1, dst_port_2, dst_port_3] = self.dst_port.to_le_bytes();
+        let [payload_len_0, payload_len_1, payload_len_2, payload_len_3] =
+            self.payload_len.to_le_bytes();
+        let [packet_type_0, packet_type_1] = self.packet_type.to_le_bytes();
+        let [operation_0, operation_1] = self.operation.to_le_bytes();
+        let [flags_0, flags_1, flags_2, flags_3] = self.flags.to_le_bytes();
+        let [
+            buffer_allocation_0,
+            buffer_allocation_1,
+            buffer_allocation_2,
+            buffer_allocation_3,
+        ] = self.buffer_allocation.to_le_bytes();
+        let [
+            forwarded_count_0,
+            forwarded_count_1,
+            forwarded_count_2,
+            forwarded_count_3,
+        ] = self.forwarded_count.to_le_bytes();
+
+        [
+            src_cid_0,
+            src_cid_1,
+            src_cid_2,
+            src_cid_3,
+            src_cid_4,
+            src_cid_5,
+            src_cid_6,
+            src_cid_7,
+            dst_cid_0,
+            dst_cid_1,
+            dst_cid_2,
+            dst_cid_3,
+            dst_cid_4,
+            dst_cid_5,
+            dst_cid_6,
+            dst_cid_7,
+            src_port_0,
+            src_port_1,
+            src_port_2,
+            src_port_3,
+            dst_port_0,
+            dst_port_1,
+            dst_port_2,
+            dst_port_3,
+            payload_len_0,
+            payload_len_1,
+            payload_len_2,
+            payload_len_3,
+            packet_type_0,
+            packet_type_1,
+            operation_0,
+            operation_1,
+            flags_0,
+            flags_1,
+            flags_2,
+            flags_3,
+            buffer_allocation_0,
+            buffer_allocation_1,
+            buffer_allocation_2,
+            buffer_allocation_3,
+            forwarded_count_0,
+            forwarded_count_1,
+            forwarded_count_2,
+            forwarded_count_3,
+        ]
+    }
+
+    pub fn try_from_bytes(
+        bytes: [u8; VIRTIO_VSOCK_PACKET_HEADER_SIZE],
+    ) -> Result<Self, VirtioVsockPacketLengthError> {
+        let header = Self::decode_bytes(bytes);
+        header.validate_payload_len()?;
+        Ok(header)
+    }
+
+    const fn decode_bytes(bytes: [u8; VIRTIO_VSOCK_PACKET_HEADER_SIZE]) -> Self {
+        let [
+            src_cid_0,
+            src_cid_1,
+            src_cid_2,
+            src_cid_3,
+            src_cid_4,
+            src_cid_5,
+            src_cid_6,
+            src_cid_7,
+            dst_cid_0,
+            dst_cid_1,
+            dst_cid_2,
+            dst_cid_3,
+            dst_cid_4,
+            dst_cid_5,
+            dst_cid_6,
+            dst_cid_7,
+            src_port_0,
+            src_port_1,
+            src_port_2,
+            src_port_3,
+            dst_port_0,
+            dst_port_1,
+            dst_port_2,
+            dst_port_3,
+            payload_len_0,
+            payload_len_1,
+            payload_len_2,
+            payload_len_3,
+            packet_type_0,
+            packet_type_1,
+            operation_0,
+            operation_1,
+            flags_0,
+            flags_1,
+            flags_2,
+            flags_3,
+            buffer_allocation_0,
+            buffer_allocation_1,
+            buffer_allocation_2,
+            buffer_allocation_3,
+            forwarded_count_0,
+            forwarded_count_1,
+            forwarded_count_2,
+            forwarded_count_3,
+        ] = bytes;
+
+        Self {
+            src_cid: u64::from_le_bytes([
+                src_cid_0, src_cid_1, src_cid_2, src_cid_3, src_cid_4, src_cid_5, src_cid_6,
+                src_cid_7,
+            ]),
+            dst_cid: u64::from_le_bytes([
+                dst_cid_0, dst_cid_1, dst_cid_2, dst_cid_3, dst_cid_4, dst_cid_5, dst_cid_6,
+                dst_cid_7,
+            ]),
+            src_port: u32::from_le_bytes([src_port_0, src_port_1, src_port_2, src_port_3]),
+            dst_port: u32::from_le_bytes([dst_port_0, dst_port_1, dst_port_2, dst_port_3]),
+            payload_len: u32::from_le_bytes([
+                payload_len_0,
+                payload_len_1,
+                payload_len_2,
+                payload_len_3,
+            ]),
+            packet_type: u16::from_le_bytes([packet_type_0, packet_type_1]),
+            operation: u16::from_le_bytes([operation_0, operation_1]),
+            flags: u32::from_le_bytes([flags_0, flags_1, flags_2, flags_3]),
+            buffer_allocation: u32::from_le_bytes([
+                buffer_allocation_0,
+                buffer_allocation_1,
+                buffer_allocation_2,
+                buffer_allocation_3,
+            ]),
+            forwarded_count: u32::from_le_bytes([
+                forwarded_count_0,
+                forwarded_count_1,
+                forwarded_count_2,
+                forwarded_count_3,
+            ]),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VirtioVsockPacketLengthError {
+    payload_len: u32,
+    max_payload_len: u32,
+}
+
+impl VirtioVsockPacketLengthError {
+    pub const fn payload_len(self) -> u32 {
+        self.payload_len
+    }
+
+    pub const fn max_payload_len(self) -> u32 {
+        self.max_payload_len
+    }
+}
+
+impl fmt::Display for VirtioVsockPacketLengthError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "virtio-vsock packet payload length {} exceeds maximum {}",
+            self.payload_len, self.max_payload_len
+        )
+    }
+}
+
+impl std::error::Error for VirtioVsockPacketLengthError {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VirtioVsockConfigSpace {
@@ -855,11 +1208,18 @@ mod tests {
     use super::{
         MIN_GUEST_CID, PreparedVsockDevice, VIRTIO_FEATURE_IN_ORDER, VIRTIO_FEATURE_VERSION_1,
         VIRTIO_RING_FEATURE_EVENT_IDX, VIRTIO_VSOCK_CONFIG_GUEST_CID_SIZE, VIRTIO_VSOCK_DEVICE_ID,
-        VIRTIO_VSOCK_EVENT_QUEUE_INDEX, VIRTIO_VSOCK_QUEUE_COUNT, VIRTIO_VSOCK_QUEUE_SIZE,
-        VIRTIO_VSOCK_QUEUE_SIZES, VIRTIO_VSOCK_RX_QUEUE_INDEX, VIRTIO_VSOCK_TX_QUEUE_INDEX,
-        VirtioVsockConfigSpace, VirtioVsockDevice, VirtioVsockDeviceActivationError,
-        VirtioVsockMmioHandler, VirtioVsockQueueBuildError, VsockConfigError, VsockConfigInput,
-        VsockMmioDevice, VsockMmioLayout, VsockMmioRegistrationError, virtio_vsock_mmio_handler,
+        VIRTIO_VSOCK_EVENT_QUEUE_INDEX, VIRTIO_VSOCK_FLAGS_SHUTDOWN_RCV,
+        VIRTIO_VSOCK_FLAGS_SHUTDOWN_SEND, VIRTIO_VSOCK_HOST_CID,
+        VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE, VIRTIO_VSOCK_OP_CREDIT_REQUEST,
+        VIRTIO_VSOCK_OP_CREDIT_UPDATE, VIRTIO_VSOCK_OP_REQUEST, VIRTIO_VSOCK_OP_RESPONSE,
+        VIRTIO_VSOCK_OP_RST, VIRTIO_VSOCK_OP_RW, VIRTIO_VSOCK_OP_SHUTDOWN,
+        VIRTIO_VSOCK_PACKET_HEADER_SIZE, VIRTIO_VSOCK_PACKET_TYPE_STREAM, VIRTIO_VSOCK_QUEUE_COUNT,
+        VIRTIO_VSOCK_QUEUE_SIZE, VIRTIO_VSOCK_QUEUE_SIZES, VIRTIO_VSOCK_RX_QUEUE_INDEX,
+        VIRTIO_VSOCK_TX_QUEUE_INDEX, VirtioVsockConfigSpace, VirtioVsockDevice,
+        VirtioVsockDeviceActivationError, VirtioVsockMmioHandler, VirtioVsockPacketHeader,
+        VirtioVsockPacketLengthError, VirtioVsockQueueBuildError, VsockConfigError,
+        VsockConfigInput, VsockMmioDevice, VsockMmioLayout, VsockMmioRegistrationError,
+        virtio_vsock_mmio_handler,
     };
 
     const TEST_MMIO_BASE: u64 = 0x1000_0000;
@@ -1084,6 +1444,20 @@ mod tests {
             VirtioVsockDevice::new(),
         )
         .expect("vsock handler should build")
+    }
+
+    fn test_vsock_packet_header() -> VirtioVsockPacketHeader {
+        VirtioVsockPacketHeader::new()
+            .with_src_cid(0x0102_0304_0506_0708)
+            .with_dst_cid(0x1112_1314_1516_1718)
+            .with_src_port(0x2122_2324)
+            .with_dst_port(0x3132_3334)
+            .with_payload_len(0x1000)
+            .with_packet_type(VIRTIO_VSOCK_PACKET_TYPE_STREAM)
+            .with_operation(VIRTIO_VSOCK_OP_RW)
+            .with_flags(VIRTIO_VSOCK_FLAGS_SHUTDOWN_RCV | VIRTIO_VSOCK_FLAGS_SHUTDOWN_SEND)
+            .with_buffer_allocation(0x4142_4344)
+            .with_forwarded_count(0x5152_5354)
     }
 
     #[test]
@@ -1400,6 +1774,108 @@ mod tests {
         assert_eq!(VIRTIO_VSOCK_QUEUE_SIZE, 256);
         assert_eq!(VIRTIO_VSOCK_QUEUE_SIZES, [256, 256, 256]);
         assert_eq!(VIRTIO_VSOCK_CONFIG_GUEST_CID_SIZE, 8);
+    }
+
+    #[test]
+    fn virtio_vsock_packet_constants_match_firecracker_shape() {
+        assert_eq!(VIRTIO_VSOCK_PACKET_HEADER_SIZE, 44);
+        assert_eq!(VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE, 64 * 1024);
+        assert_eq!(VIRTIO_VSOCK_HOST_CID, 2);
+        assert_eq!(VIRTIO_VSOCK_PACKET_TYPE_STREAM, 1);
+        assert_eq!(VIRTIO_VSOCK_OP_REQUEST, 1);
+        assert_eq!(VIRTIO_VSOCK_OP_RESPONSE, 2);
+        assert_eq!(VIRTIO_VSOCK_OP_RST, 3);
+        assert_eq!(VIRTIO_VSOCK_OP_SHUTDOWN, 4);
+        assert_eq!(VIRTIO_VSOCK_OP_RW, 5);
+        assert_eq!(VIRTIO_VSOCK_OP_CREDIT_UPDATE, 6);
+        assert_eq!(VIRTIO_VSOCK_OP_CREDIT_REQUEST, 7);
+        assert_eq!(VIRTIO_VSOCK_FLAGS_SHUTDOWN_RCV, 1);
+        assert_eq!(VIRTIO_VSOCK_FLAGS_SHUTDOWN_SEND, 2);
+    }
+
+    #[test]
+    fn virtio_vsock_packet_header_serializes_little_endian_layout() {
+        let header = test_vsock_packet_header();
+
+        assert_eq!(
+            header.to_bytes(),
+            [
+                0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x18, 0x17, 0x16, 0x15, 0x14, 0x13,
+                0x12, 0x11, 0x24, 0x23, 0x22, 0x21, 0x34, 0x33, 0x32, 0x31, 0x00, 0x10, 0x00, 0x00,
+                0x01, 0x00, 0x05, 0x00, 0x03, 0x00, 0x00, 0x00, 0x44, 0x43, 0x42, 0x41, 0x54, 0x53,
+                0x52, 0x51,
+            ]
+        );
+    }
+
+    #[test]
+    fn virtio_vsock_packet_header_parses_little_endian_layout() {
+        let header = VirtioVsockPacketHeader::try_from_bytes([
+            0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x18, 0x17, 0x16, 0x15, 0x14, 0x13,
+            0x12, 0x11, 0x24, 0x23, 0x22, 0x21, 0x34, 0x33, 0x32, 0x31, 0x00, 0x10, 0x00, 0x00,
+            0x01, 0x00, 0x05, 0x00, 0x03, 0x00, 0x00, 0x00, 0x44, 0x43, 0x42, 0x41, 0x54, 0x53,
+            0x52, 0x51,
+        ])
+        .expect("valid header bytes should parse");
+
+        assert_eq!(header, test_vsock_packet_header());
+        assert_eq!(header.src_cid(), 0x0102_0304_0506_0708);
+        assert_eq!(header.dst_cid(), 0x1112_1314_1516_1718);
+        assert_eq!(header.src_port(), 0x2122_2324);
+        assert_eq!(header.dst_port(), 0x3132_3334);
+        assert_eq!(header.payload_len(), 0x1000);
+        assert_eq!(header.packet_type(), VIRTIO_VSOCK_PACKET_TYPE_STREAM);
+        assert_eq!(header.operation(), VIRTIO_VSOCK_OP_RW);
+        assert_eq!(
+            header.flags(),
+            VIRTIO_VSOCK_FLAGS_SHUTDOWN_RCV | VIRTIO_VSOCK_FLAGS_SHUTDOWN_SEND
+        );
+        assert_eq!(header.buffer_allocation(), 0x4142_4344);
+        assert_eq!(header.forwarded_count(), 0x5152_5354);
+    }
+
+    #[test]
+    fn virtio_vsock_packet_header_accepts_zero_and_max_payload_len() {
+        VirtioVsockPacketHeader::new()
+            .with_payload_len(0)
+            .validate_payload_len()
+            .expect("zero payload length should be accepted");
+        VirtioVsockPacketHeader::new()
+            .with_payload_len(VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE)
+            .validate_payload_len()
+            .expect("maximum payload length should be accepted");
+    }
+
+    #[test]
+    fn virtio_vsock_packet_header_rejects_payload_len_over_maximum() {
+        let err = VirtioVsockPacketHeader::new()
+            .with_payload_len(VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE + 1)
+            .validate_payload_len()
+            .expect_err("payload length above maximum should fail");
+
+        assert_eq!(
+            err,
+            VirtioVsockPacketLengthError {
+                payload_len: VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE + 1,
+                max_payload_len: VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE,
+            }
+        );
+        assert_eq!(
+            err.to_string(),
+            "virtio-vsock packet payload length 65537 exceeds maximum 65536"
+        );
+    }
+
+    #[test]
+    fn virtio_vsock_packet_header_rejects_payload_len_over_maximum_from_bytes() {
+        let err = VirtioVsockPacketHeader::try_from_bytes([
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ])
+        .expect_err("oversized payload length should fail");
+
+        assert_eq!(err.payload_len(), VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE + 1);
+        assert_eq!(err.max_payload_len(), VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE);
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -8,7 +8,7 @@ The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /`, `GET /version`,
 `GET /vm/config`, `GET /machine-config`, pre-boot `PUT /machine-config`
 configuration storage, pre-boot `PUT /boot-source` configuration storage, pre-boot `PUT /drives/{drive_id}`
-configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, prepared device resource, MMIO registration helper, MMIO handler skeleton with active queue metadata retention, and startup FDT attachment, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
+configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, packet header model, prepared device resource, MMIO registration helper, MMIO handler skeleton with active queue metadata retention, and startup FDT attachment, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
 `InstanceStart` preflight, transactional startup executor, and successful-start state transition helpers, backend-neutral guest
 physical address and aarch64 DRAM layout/access primitives, arm64 boot
 placement helpers, internal boot-source validation and arm64 kernel/initrd
@@ -233,7 +233,7 @@ compatibility targets.
 | `PATCH` | `/machine-config` | deferred | Partial updates belong with later state and validation rules. |
 | `PUT` | `/cpu-config` | deferred | Needs HVF CPU feature design with VM and boot work in #8 and #10. |
 | `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores up to 16 initial virtio-net configurations before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the interface count before opening vmnet resources, then selects vmnet packet I/O only for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names; unsupported names fail startup before `Running` is committed. Internal network notification dispatch can route each configured interface through selected packet I/O, parse TX descriptors through a packet sink boundary, and copy injected RX packets into guest buffers through a packet source boundary. Public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
-| `PUT` | `/vsock` | supported target; startup attachment implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Startup preparation attaches the configured device as one virtio-mmio FDT node backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. Queue notification dispatch, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
+| `PUT` | `/vsock` | supported target; startup attachment implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Startup preparation attaches the configured device as one virtio-mmio FDT node backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has a Firecracker-shaped packet header model for later queue parsing. Queue notification dispatch, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
 | `GET`, `PUT`, `PATCH` | `/mmds` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/mmds/config` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/snapshot/create`, `/snapshot/load` | deferred | Tied to snapshot and restore work in #19. |
@@ -353,8 +353,11 @@ vsock config and return `204 No Content`; invalid requests fail without
 mutating previous vsock state. The current response reports `guest_cid` and
 `uds_path` while omitting the accepted deprecated `vsock_id`, matching
 Firecracker's effective config output. Startup preparation attaches the
-configured virtio-vsock device as guest-visible FDT/MMIO metadata, but it still
-does not open host socket resources, route CIDs, or move data.
+configured virtio-vsock device as guest-visible FDT/MMIO metadata. The runtime
+also models Firecracker's 44-byte little-endian virtio-vsock packet header and
+rejects header byte parsing when payload length exceeds the 64 KiB maximum
+packet buffer length, but it still does not parse descriptor chains, open host
+socket resources, route CIDs, or move data.
 `SendCtrlAltDel` is rejected at parse time for the first aarch64 target.
 
 Future implementation PRs should derive unit or golden tests from these tables.
@@ -561,19 +564,23 @@ and is returned from `GET /vm/config` as `vsock` with `guest_cid` and
 does not open, bind, connect, unlink, or create the configured `uds_path`.
 
 The runtime crate has an internal virtio-vsock prepared resource, MMIO
-registration helper, config-space, MMIO handler skeleton with active queue
-metadata retention, and startup FDT attachment. It uses the
+registration helper, config-space, 44-byte little-endian packet header model,
+MMIO handler skeleton with active queue metadata retention, and startup FDT
+attachment. It uses the
 virtio device id `19`, three 256-entry RX, TX, and event queues, Firecracker's
 `VERSION_1`, `IN_ORDER`, and `EVENT_IDX` feature bits, and a guest-CID config
 field that supports Firecracker-shaped 8-byte and 4-byte-half reads. Config
-writes are rejected. The prepared resource preserves the validated guest CID,
-socket path, config-space, and inactive device state, and the registration
-helper can consume it into a caller-provided internal MMIO dispatcher without
-touching host socket resources. Arm64 startup resource assembly can expose one
+writes are rejected. The packet header model preserves Firecracker's header
+field order and rejects header byte parsing when payload length exceeds
+Firecracker's 64 KiB maximum packet buffer length without reading descriptor
+chains yet. The prepared resource preserves the validated guest CID, socket
+path, config-space, and inactive device state, and the registration helper can
+consume it into a caller-provided internal MMIO dispatcher without touching
+host socket resources. Arm64 startup resource assembly can expose one
 configured vsock device in the guest FDT. After `DRIVER_OK`, the internal
 device retains active RX, TX, and event queue metadata for later notification
-dispatch work. Packet formats, host Unix socket backend behavior, CID routing,
-queue notification dispatch, and data movement remain deferred.
+dispatch work. Host Unix socket backend behavior, CID routing, queue
+notification dispatch, descriptor parsing, and data movement remain deferred.
 
 The runtime crate also has the first backend-neutral virtio-net config-space,
 activation, TX frame parser, RX buffer parser, prepared device resources, and
@@ -1079,7 +1086,7 @@ Their eventual support level should follow the endpoint matrix:
 - virtio-vsock host Unix socket backend behavior, CID routing, and data movement
   beyond pre-boot `/vsock` configuration storage, startup FDT attachment, and
   the internal prepared resource/MMIO registration/config-space/MMIO handler
-  skeleton with active queue metadata retention
+  skeleton with active queue metadata retention plus packet header model
 - snapshots
 - MMDS
 - balloon devices and balloon statistics

--- a/docs/security.md
+++ b/docs/security.md
@@ -65,9 +65,10 @@ is resource-specific:
   files are opened later during `InstanceStart`.
 - `/vsock` stores the configured Unix socket path during configuration. Startup
   can attach a guest-visible virtio-vsock device whose internal MMIO handler
-  retains active RX, TX, and event queue metadata after `DRIVER_OK`, but the
-  current implementation does not open, bind, connect, unlink, or create that
-  socket path.
+  retains active RX, TX, and event queue metadata after `DRIVER_OK`, and the
+  runtime has an internal Firecracker-shaped packet header model. The current
+  implementation does not open, bind, connect, unlink, or create that socket
+  path.
 - `/metrics` opens the output path during pre-boot configuration and keeps a
   per-process metrics sink.
 - `/logger` opens `log_path` during pre-boot configuration when that field is
@@ -102,8 +103,9 @@ HVF; local HVF verification should fail when HVF is unavailable.
 
 The guest is untrusted. vCPU execution, guest memory contents, virtqueue
 descriptor chains, MMIO accesses, block requests, virtio-net TX descriptor
-metadata and payload bytes, virtio-net RX buffer descriptors, and future device
-inputs must be validated before they affect host resources.
+metadata and payload bytes, virtio-net RX buffer descriptors, virtio-vsock
+packet headers, and future device inputs must be validated before they affect
+host resources.
 Trapped system-register exits are guest-visible CPU behavior and must stay
 explicit. The current HVF runner emulates only the early-boot `OSDLR_EL1` and
 `OSLAR_EL1` OS lock RAZ/WI behavior needed by the pinned Firecracker kernel;
@@ -174,13 +176,13 @@ The current scaffold does not implement:
   broker, connectivity policy, and live vmnet integration proof. The current
   vsock API path validates and stores `guest_cid` plus `uds_path` before boot.
   The runtime crate has an internal virtio-vsock prepared resource, MMIO
-  registration helper, config-space, MMIO handler skeleton with active queue
-  metadata retention, and startup FDT attachment that preserve the configured
-  socket path and expose only the configured guest CID through bounded config
-  reads. Preparation, MMIO registration, and startup attachment do not open,
-  bind, connect, unlink, or create `uds_path`, and do not implement host Unix
-  socket backend behavior, CID routing, queue notification dispatch, or data
-  movement
+  registration helper, config-space, packet header model, MMIO handler skeleton
+  with active queue metadata retention, and startup FDT attachment that
+  preserve the configured socket path and expose only the configured guest CID
+  through bounded config reads. Preparation, MMIO registration, and startup
+  attachment do not open, bind, connect, unlink, or create `uds_path`, and do
+  not implement host Unix socket backend behavior, CID routing, queue
+  notification dispatch, descriptor parsing, or data movement
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy
 


### PR DESCRIPTION
## Summary
- Add Firecracker-shaped virtio-vsock packet constants and a 44-byte little-endian packet header model.
- Make header byte parsing validate the 64 KiB maximum packet buffer length.
- Update compatibility and security docs for the new internal packet boundary.

## Scope
- Does not parse virtqueue descriptor chains.
- Does not add queue notification dispatch, CID routing, data movement, or host Unix socket backend behavior.

## Verification
- cargo fmt --all -- --check
- cargo check --workspace --all-targets --all-features --locked
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- scripts/run-integration-tests.sh

Closes #331