### PR TITLE
feat: parse virtio-vsock TX packets

### DIFF
--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -920,6 +920,10 @@ fn vsock_tx_payload_segments(
     chain: &VirtqueueDescriptorChain,
     payload_len: u32,
 ) -> Result<Vec<VirtioVsockTxPayloadSegment>, VirtioVsockTxPacketParseError> {
+    if payload_len == 0 {
+        return Ok(Vec::new());
+    }
+
     let mut segments = Vec::new();
     segments.try_reserve_exact(chain.len()).map_err(|source| {
         VirtioVsockTxPacketParseError::PayloadSegmentsAllocationFailed {

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -2637,6 +2637,41 @@ mod tests {
     }
 
     #[test]
+    fn virtio_vsock_tx_packet_parser_accepts_max_payload_len_packet() {
+        let mut memory = vsock_tx_memory();
+        let header =
+            test_vsock_packet_header().with_payload_len(VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE);
+        let payload_address = vsock_payload_address_after_header(TEST_VSOCK_HEADER);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, header);
+        let chain = vsock_tx_descriptor_chain(
+            &mut memory,
+            &[TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32 + VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE,
+                None,
+            )],
+        );
+
+        let packet =
+            parse_vsock_tx_packet(&memory, &chain).expect("max-payload packet should parse");
+
+        assert_eq!(packet.header(), header);
+        assert_eq!(packet.payload_len(), VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE);
+        assert_eq!(
+            packet.packet_len(),
+            VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64 + u64::from(VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE)
+        );
+        assert_eq!(packet.payload_segments().len(), 1);
+        let segment = packet
+            .payload_segments()
+            .first()
+            .expect("payload segment should be present");
+        assert_eq!(segment.descriptor_index(), 0);
+        assert_eq!(segment.address(), payload_address);
+        assert_eq!(segment.len(), VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE);
+    }
+
+    #[test]
     fn virtio_vsock_tx_packet_parser_accepts_zero_payload_header_only() {
         let mut memory = vsock_tx_memory();
         let header = test_vsock_packet_header().with_payload_len(0);

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -3,7 +3,9 @@
 use std::fmt;
 use std::path::{Path, PathBuf};
 
-use crate::memory::{GuestAddress, GuestMemoryError};
+use crate::memory::{
+    GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryError, GuestMemoryRange,
+};
 use crate::mmio::{
     MmioAccessBytes, MmioAccessBytesError, MmioBusError, MmioDispatchError, MmioDispatcher,
     MmioHandlerError, MmioRegion, MmioRegionId,
@@ -14,6 +16,7 @@ use crate::virtio_mmio::{
     VirtioMmioDeviceConfigHandler, VirtioMmioQueueRegisterError, VirtioMmioQueueState,
     VirtioMmioRegisterHandler, VirtioMmioRegisterHandlerError,
 };
+use crate::virtio_queue::{VirtqueueDescriptor, VirtqueueDescriptorChain};
 
 pub const MIN_GUEST_CID: u32 = 3;
 pub const VIRTIO_VSOCK_DEVICE_ID: u32 = 19;
@@ -45,6 +48,7 @@ pub const VIRTIO_FEATURE_IN_ORDER: u32 = 35;
 const VIRTIO_VSOCK_RX_QUEUE_INDEX_U32: u32 = 0;
 const VIRTIO_VSOCK_TX_QUEUE_INDEX_U32: u32 = 1;
 const VIRTIO_VSOCK_EVENT_QUEUE_INDEX_U32: u32 = 2;
+const VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64: u64 = VIRTIO_VSOCK_PACKET_HEADER_SIZE as u64;
 
 pub type VirtioVsockMmioHandler =
     VirtioMmioRegisterHandler<VirtioVsockConfigSpace, VirtioVsockDevice>;
@@ -513,6 +517,458 @@ impl fmt::Display for VirtioVsockPacketLengthError {
 }
 
 impl std::error::Error for VirtioVsockPacketLengthError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VirtioVsockTxPayloadSegment {
+    descriptor_index: u16,
+    address: GuestAddress,
+    len: u32,
+}
+
+impl VirtioVsockTxPayloadSegment {
+    const fn new(descriptor_index: u16, address: GuestAddress, len: u32) -> Self {
+        Self {
+            descriptor_index,
+            address,
+            len,
+        }
+    }
+
+    pub const fn descriptor_index(self) -> u16 {
+        self.descriptor_index
+    }
+
+    pub const fn address(self) -> GuestAddress {
+        self.address
+    }
+
+    pub const fn len(self) -> u32 {
+        self.len
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.len == 0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VirtioVsockTxPacket {
+    descriptor_head: u16,
+    header: VirtioVsockPacketHeader,
+    payload_segments: Vec<VirtioVsockTxPayloadSegment>,
+}
+
+impl VirtioVsockTxPacket {
+    pub fn parse(
+        memory: &GuestMemory,
+        chain: &VirtqueueDescriptorChain,
+    ) -> Result<Self, VirtioVsockTxPacketParseError> {
+        let (descriptor_head, total_readable_len) =
+            validate_vsock_tx_descriptor_chain(memory, chain)?;
+        validate_vsock_tx_header_available(descriptor_head, total_readable_len)?;
+
+        let header_bytes = read_vsock_tx_header_bytes(memory, chain, descriptor_head)?;
+        let header = VirtioVsockPacketHeader::try_from_bytes(header_bytes)
+            .map_err(|source| VirtioVsockTxPacketParseError::InvalidHeaderLength { source })?;
+        validate_vsock_tx_payload_len(descriptor_head, total_readable_len, header.payload_len())?;
+
+        let payload_segments = vsock_tx_payload_segments(chain, header.payload_len())?;
+
+        Ok(Self {
+            descriptor_head,
+            header,
+            payload_segments,
+        })
+    }
+
+    pub const fn descriptor_head(&self) -> u16 {
+        self.descriptor_head
+    }
+
+    pub const fn header(&self) -> VirtioVsockPacketHeader {
+        self.header
+    }
+
+    pub fn payload_segments(&self) -> &[VirtioVsockTxPayloadSegment] {
+        &self.payload_segments
+    }
+
+    pub const fn payload_len(&self) -> u32 {
+        self.header.payload_len()
+    }
+
+    pub fn packet_len(&self) -> u64 {
+        VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64 + u64::from(self.payload_len())
+    }
+}
+
+#[derive(Debug)]
+pub enum VirtioVsockTxPacketParseError {
+    DescriptorChainTooShort {
+        expected: usize,
+        actual: usize,
+    },
+    DescriptorWriteOnly {
+        index: u16,
+    },
+    DescriptorRangeOverflow {
+        index: u16,
+        address: GuestAddress,
+        len: u32,
+    },
+    DescriptorAccess {
+        index: u16,
+        address: GuestAddress,
+        len: u32,
+        source: GuestMemoryAccessError,
+    },
+    ReadableLengthOverflow {
+        descriptor_head: u16,
+    },
+    HeaderTooShort {
+        descriptor_head: u16,
+        actual: u64,
+        min: u64,
+    },
+    ReadHeader {
+        index: u16,
+        address: GuestAddress,
+        len: usize,
+        source: GuestMemoryAccessError,
+    },
+    InvalidHeaderLength {
+        source: VirtioVsockPacketLengthError,
+    },
+    PayloadTooShort {
+        descriptor_head: u16,
+        required: u32,
+        available: u64,
+    },
+    PayloadSegmentLengthOverflow {
+        index: u16,
+        available: u64,
+    },
+    PayloadSegmentsAllocationFailed {
+        descriptor_count: usize,
+        source: std::collections::TryReserveError,
+    },
+}
+
+impl fmt::Display for VirtioVsockTxPacketParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DescriptorChainTooShort { expected, actual } => {
+                write!(
+                    f,
+                    "virtio-vsock TX descriptor chain has {actual} descriptors; expected at least {expected}"
+                )
+            }
+            Self::DescriptorWriteOnly { index } => {
+                write!(f, "virtio-vsock TX descriptor {index} is write-only")
+            }
+            Self::DescriptorRangeOverflow {
+                index,
+                address,
+                len,
+            } => {
+                write!(
+                    f,
+                    "virtio-vsock TX descriptor {index} at {address} with length {len} overflows address space"
+                )
+            }
+            Self::DescriptorAccess {
+                index,
+                address,
+                len,
+                source,
+            } => {
+                write!(
+                    f,
+                    "virtio-vsock TX descriptor {index} at {address} with length {len} is not fully mapped: {source}"
+                )
+            }
+            Self::ReadableLengthOverflow { descriptor_head } => {
+                write!(
+                    f,
+                    "virtio-vsock TX descriptor chain headed by {descriptor_head} overflows readable length"
+                )
+            }
+            Self::HeaderTooShort {
+                descriptor_head,
+                actual,
+                min,
+            } => {
+                write!(
+                    f,
+                    "virtio-vsock TX descriptor chain headed by {descriptor_head} has {actual} readable bytes; expected at least {min} for the packet header"
+                )
+            }
+            Self::ReadHeader {
+                index,
+                address,
+                len,
+                source,
+            } => {
+                write!(
+                    f,
+                    "failed to read {len} virtio-vsock TX header bytes from descriptor {index} at {address}: {source}"
+                )
+            }
+            Self::InvalidHeaderLength { source } => {
+                write!(f, "invalid virtio-vsock TX packet header length: {source}")
+            }
+            Self::PayloadTooShort {
+                descriptor_head,
+                required,
+                available,
+            } => {
+                write!(
+                    f,
+                    "virtio-vsock TX descriptor chain headed by {descriptor_head} advertises {required} payload bytes but only {available} are readable after the header"
+                )
+            }
+            Self::PayloadSegmentLengthOverflow { index, available } => {
+                write!(
+                    f,
+                    "virtio-vsock TX payload segment in descriptor {index} has {available} readable bytes, which cannot fit in a segment length"
+                )
+            }
+            Self::PayloadSegmentsAllocationFailed {
+                descriptor_count,
+                source,
+            } => {
+                write!(
+                    f,
+                    "failed to reserve virtio-vsock TX payload segment storage for {descriptor_count} descriptors: {source}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for VirtioVsockTxPacketParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::DescriptorAccess { source, .. } => Some(source),
+            Self::ReadHeader { source, .. } => Some(source),
+            Self::InvalidHeaderLength { source } => Some(source),
+            Self::PayloadSegmentsAllocationFailed { source, .. } => Some(source),
+            Self::DescriptorChainTooShort { .. }
+            | Self::DescriptorWriteOnly { .. }
+            | Self::DescriptorRangeOverflow { .. }
+            | Self::ReadableLengthOverflow { .. }
+            | Self::HeaderTooShort { .. }
+            | Self::PayloadTooShort { .. }
+            | Self::PayloadSegmentLengthOverflow { .. } => None,
+        }
+    }
+}
+
+fn validate_vsock_tx_descriptor_chain(
+    memory: &GuestMemory,
+    chain: &VirtqueueDescriptorChain,
+) -> Result<(u16, u64), VirtioVsockTxPacketParseError> {
+    let descriptor_head = chain
+        .descriptors()
+        .first()
+        .copied()
+        .ok_or(VirtioVsockTxPacketParseError::DescriptorChainTooShort {
+            expected: 1,
+            actual: 0,
+        })?
+        .index();
+
+    let mut total_readable_len = 0_u64;
+    for descriptor in chain.descriptors().iter().copied() {
+        validate_vsock_tx_descriptor(memory, descriptor)?;
+        total_readable_len = total_readable_len
+            .checked_add(u64::from(descriptor.len()))
+            .ok_or(VirtioVsockTxPacketParseError::ReadableLengthOverflow { descriptor_head })?;
+    }
+
+    Ok((descriptor_head, total_readable_len))
+}
+
+fn validate_vsock_tx_descriptor(
+    memory: &GuestMemory,
+    descriptor: VirtqueueDescriptor,
+) -> Result<(), VirtioVsockTxPacketParseError> {
+    if descriptor.is_write_only() {
+        return Err(VirtioVsockTxPacketParseError::DescriptorWriteOnly {
+            index: descriptor.index(),
+        });
+    }
+
+    if descriptor.is_empty() {
+        return Ok(());
+    }
+
+    let range =
+        GuestMemoryRange::new(descriptor.address(), u64::from(descriptor.len())).map_err(|_| {
+            VirtioVsockTxPacketParseError::DescriptorRangeOverflow {
+                index: descriptor.index(),
+                address: descriptor.address(),
+                len: descriptor.len(),
+            }
+        })?;
+    memory.validate_mapped_range(range).map_err(|source| {
+        VirtioVsockTxPacketParseError::DescriptorAccess {
+            index: descriptor.index(),
+            address: descriptor.address(),
+            len: descriptor.len(),
+            source,
+        }
+    })
+}
+
+fn validate_vsock_tx_header_available(
+    descriptor_head: u16,
+    total_readable_len: u64,
+) -> Result<(), VirtioVsockTxPacketParseError> {
+    if total_readable_len < VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64 {
+        return Err(VirtioVsockTxPacketParseError::HeaderTooShort {
+            descriptor_head,
+            actual: total_readable_len,
+            min: VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64,
+        });
+    }
+
+    Ok(())
+}
+
+fn read_vsock_tx_header_bytes(
+    memory: &GuestMemory,
+    chain: &VirtqueueDescriptorChain,
+    descriptor_head: u16,
+) -> Result<[u8; VIRTIO_VSOCK_PACKET_HEADER_SIZE], VirtioVsockTxPacketParseError> {
+    let mut header = [0; VIRTIO_VSOCK_PACKET_HEADER_SIZE];
+    let unread_header_len = fill_vsock_tx_header_bytes(memory, chain, &mut header)?;
+    if unread_header_len != 0 {
+        let actual = VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64
+            - u64::try_from(unread_header_len).map_err(|_| {
+                VirtioVsockTxPacketParseError::HeaderTooShort {
+                    descriptor_head,
+                    actual: 0,
+                    min: VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64,
+                }
+            })?;
+        return Err(VirtioVsockTxPacketParseError::HeaderTooShort {
+            descriptor_head,
+            actual,
+            min: VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64,
+        });
+    }
+
+    Ok(header)
+}
+
+fn fill_vsock_tx_header_bytes(
+    memory: &GuestMemory,
+    chain: &VirtqueueDescriptorChain,
+    header: &mut [u8; VIRTIO_VSOCK_PACKET_HEADER_SIZE],
+) -> Result<usize, VirtioVsockTxPacketParseError> {
+    let mut remaining_header = header.as_mut_slice();
+    for descriptor in chain.descriptors().iter().copied() {
+        if remaining_header.is_empty() {
+            return Ok(0);
+        }
+
+        let descriptor_len = usize::try_from(descriptor.len()).map_err(|_| {
+            VirtioVsockTxPacketParseError::PayloadSegmentLengthOverflow {
+                index: descriptor.index(),
+                available: u64::from(descriptor.len()),
+            }
+        })?;
+        let read_len = remaining_header.len().min(descriptor_len);
+        if read_len == 0 {
+            continue;
+        }
+
+        let (destination, next_remaining) = remaining_header.split_at_mut(read_len);
+        memory
+            .read_slice(destination, descriptor.address())
+            .map_err(|source| VirtioVsockTxPacketParseError::ReadHeader {
+                index: descriptor.index(),
+                address: descriptor.address(),
+                len: read_len,
+                source,
+            })?;
+        remaining_header = next_remaining;
+    }
+
+    Ok(remaining_header.len())
+}
+
+fn validate_vsock_tx_payload_len(
+    descriptor_head: u16,
+    total_readable_len: u64,
+    payload_len: u32,
+) -> Result<(), VirtioVsockTxPacketParseError> {
+    let available = total_readable_len - VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64;
+    if u64::from(payload_len) > available {
+        return Err(VirtioVsockTxPacketParseError::PayloadTooShort {
+            descriptor_head,
+            required: payload_len,
+            available,
+        });
+    }
+
+    Ok(())
+}
+
+fn vsock_tx_payload_segments(
+    chain: &VirtqueueDescriptorChain,
+    payload_len: u32,
+) -> Result<Vec<VirtioVsockTxPayloadSegment>, VirtioVsockTxPacketParseError> {
+    let mut segments = Vec::new();
+    segments.try_reserve_exact(chain.len()).map_err(|source| {
+        VirtioVsockTxPacketParseError::PayloadSegmentsAllocationFailed {
+            descriptor_count: chain.len(),
+            source,
+        }
+    })?;
+
+    let mut header_remaining = VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64;
+    let mut payload_remaining = payload_len;
+    for descriptor in chain.descriptors().iter().copied() {
+        if payload_remaining == 0 {
+            break;
+        }
+
+        let descriptor_len = u64::from(descriptor.len());
+        if header_remaining >= descriptor_len {
+            header_remaining -= descriptor_len;
+            continue;
+        }
+
+        let payload_offset = header_remaining;
+        header_remaining = 0;
+        let available = descriptor_len - payload_offset;
+        let available = u32::try_from(available).map_err(|_| {
+            VirtioVsockTxPacketParseError::PayloadSegmentLengthOverflow {
+                index: descriptor.index(),
+                available,
+            }
+        })?;
+        let segment_len = payload_remaining.min(available);
+        let segment_address = descriptor.address().checked_add(payload_offset).ok_or(
+            VirtioVsockTxPacketParseError::DescriptorRangeOverflow {
+                index: descriptor.index(),
+                address: descriptor.address(),
+                len: descriptor.len(),
+            },
+        )?;
+
+        segments.push(VirtioVsockTxPayloadSegment::new(
+            descriptor.index(),
+            segment_address,
+            segment_len,
+        ));
+        payload_remaining -= segment_len;
+    }
+
+    Ok(segments)
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VirtioVsockConfigSpace {
@@ -1190,7 +1646,7 @@ mod tests {
     use std::error::Error as _;
     use std::path::Path;
 
-    use crate::memory::GuestAddress;
+    use crate::memory::{GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange};
     use crate::mmio::{
         MmioAccess, MmioAccessBytes, MmioBus, MmioDispatchOutcome, MmioDispatcher, MmioOperation,
         MmioRegionId,
@@ -1204,6 +1660,10 @@ mod tests {
         VirtioMmioDeviceRegisters, VirtioMmioQueueRegisters, VirtioMmioRegister,
         VirtioMmioRegisterHandlerError,
     };
+    use crate::virtio_queue::{
+        VIRTQUEUE_DESC_F_NEXT, VIRTQUEUE_DESC_F_WRITE, VIRTQUEUE_DESCRIPTOR_SIZE,
+        VirtqueueDescriptorChain, read_descriptor_chain,
+    };
 
     use super::{
         MIN_GUEST_CID, PreparedVsockDevice, VIRTIO_FEATURE_IN_ORDER, VIRTIO_FEATURE_VERSION_1,
@@ -1213,13 +1673,14 @@ mod tests {
         VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE, VIRTIO_VSOCK_OP_CREDIT_REQUEST,
         VIRTIO_VSOCK_OP_CREDIT_UPDATE, VIRTIO_VSOCK_OP_REQUEST, VIRTIO_VSOCK_OP_RESPONSE,
         VIRTIO_VSOCK_OP_RST, VIRTIO_VSOCK_OP_RW, VIRTIO_VSOCK_OP_SHUTDOWN,
-        VIRTIO_VSOCK_PACKET_HEADER_SIZE, VIRTIO_VSOCK_PACKET_TYPE_STREAM, VIRTIO_VSOCK_QUEUE_COUNT,
-        VIRTIO_VSOCK_QUEUE_SIZE, VIRTIO_VSOCK_QUEUE_SIZES, VIRTIO_VSOCK_RX_QUEUE_INDEX,
-        VIRTIO_VSOCK_TX_QUEUE_INDEX, VirtioVsockConfigSpace, VirtioVsockDevice,
-        VirtioVsockDeviceActivationError, VirtioVsockMmioHandler, VirtioVsockPacketHeader,
-        VirtioVsockPacketLengthError, VirtioVsockQueueBuildError, VsockConfigError,
-        VsockConfigInput, VsockMmioDevice, VsockMmioLayout, VsockMmioRegistrationError,
-        virtio_vsock_mmio_handler,
+        VIRTIO_VSOCK_PACKET_HEADER_SIZE, VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64,
+        VIRTIO_VSOCK_PACKET_TYPE_STREAM, VIRTIO_VSOCK_QUEUE_COUNT, VIRTIO_VSOCK_QUEUE_SIZE,
+        VIRTIO_VSOCK_QUEUE_SIZES, VIRTIO_VSOCK_RX_QUEUE_INDEX, VIRTIO_VSOCK_TX_QUEUE_INDEX,
+        VirtioVsockConfigSpace, VirtioVsockDevice, VirtioVsockDeviceActivationError,
+        VirtioVsockMmioHandler, VirtioVsockPacketHeader, VirtioVsockPacketLengthError,
+        VirtioVsockQueueBuildError, VirtioVsockTxPacket, VirtioVsockTxPacketParseError,
+        VsockConfigError, VsockConfigInput, VsockMmioDevice, VsockMmioLayout,
+        VsockMmioRegistrationError, virtio_vsock_mmio_handler,
     };
 
     const TEST_MMIO_BASE: u64 = 0x1000_0000;
@@ -1229,6 +1690,13 @@ mod tests {
     const DRIVER_OK_STATUS: u32 = QUEUE_CONFIG_STATUS | VIRTIO_DEVICE_STATUS_DRIVER_OK;
     const TEST_QUEUE_ADDRESS_BASE: u64 = 0x1000;
     const TEST_QUEUE_ADDRESS_STRIDE: u64 = 0x1000;
+    const TEST_VSOCK_TX_MEMORY_SIZE: u64 = 0x20_000;
+    const TEST_VSOCK_TX_DESCRIPTOR_TABLE: GuestAddress = GuestAddress::new(0x1000);
+    const TEST_VSOCK_HEADER: GuestAddress = GuestAddress::new(0x4000);
+    const TEST_VSOCK_SECOND_HEADER: GuestAddress = GuestAddress::new(0x5000);
+    const TEST_VSOCK_PAYLOAD: GuestAddress = GuestAddress::new(0x6000);
+    const TEST_VSOCK_SECOND_PAYLOAD: GuestAddress = GuestAddress::new(0x7000);
+    const TEST_VSOCK_QUEUE_SIZE: u16 = 8;
 
     fn validate(input: VsockConfigInput) -> Result<super::VsockConfig, VsockConfigError> {
         input.validate()
@@ -1458,6 +1926,137 @@ mod tests {
             .with_flags(VIRTIO_VSOCK_FLAGS_SHUTDOWN_RCV | VIRTIO_VSOCK_FLAGS_SHUTDOWN_SEND)
             .with_buffer_allocation(0x4142_4344)
             .with_forwarded_count(0x5152_5354)
+    }
+
+    #[derive(Clone, Copy)]
+    struct TestDescriptor {
+        address: GuestAddress,
+        len: u32,
+        flags: u16,
+        next: u16,
+    }
+
+    impl TestDescriptor {
+        const fn readable(address: GuestAddress, len: u32, next: Option<u16>) -> Self {
+            Self {
+                address,
+                len,
+                flags: descriptor_flags(next),
+                next: descriptor_next(next),
+            }
+        }
+
+        const fn writable(address: GuestAddress, len: u32, next: Option<u16>) -> Self {
+            Self {
+                address,
+                len,
+                flags: descriptor_flags(next) | VIRTQUEUE_DESC_F_WRITE,
+                next: descriptor_next(next),
+            }
+        }
+    }
+
+    const fn descriptor_flags(next: Option<u16>) -> u16 {
+        if next.is_some() {
+            VIRTQUEUE_DESC_F_NEXT
+        } else {
+            0
+        }
+    }
+
+    const fn descriptor_next(next: Option<u16>) -> u16 {
+        match next {
+            Some(next) => next,
+            None => 0,
+        }
+    }
+
+    fn vsock_tx_memory() -> GuestMemory {
+        let layout = GuestMemoryLayout::new(vec![
+            GuestMemoryRange::new(GuestAddress::new(0), TEST_VSOCK_TX_MEMORY_SIZE)
+                .expect("test range should be valid"),
+        ])
+        .expect("test memory layout should be valid");
+        GuestMemory::allocate(&layout).expect("test guest memory should allocate")
+    }
+
+    fn write_vsock_tx_descriptor(memory: &mut GuestMemory, index: u16, descriptor: TestDescriptor) {
+        let mut bytes = [0; VIRTQUEUE_DESCRIPTOR_SIZE];
+        let (address_bytes, tail) = bytes.split_at_mut(8);
+        let (len_bytes, tail) = tail.split_at_mut(4);
+        let (flags_bytes, next_bytes) = tail.split_at_mut(2);
+        address_bytes.copy_from_slice(&descriptor.address.raw_value().to_le_bytes());
+        len_bytes.copy_from_slice(&descriptor.len.to_le_bytes());
+        flags_bytes.copy_from_slice(&descriptor.flags.to_le_bytes());
+        next_bytes.copy_from_slice(&descriptor.next.to_le_bytes());
+
+        let descriptor_address = TEST_VSOCK_TX_DESCRIPTOR_TABLE
+            .checked_add(
+                u64::from(index)
+                    * u64::try_from(VIRTQUEUE_DESCRIPTOR_SIZE).expect("descriptor size should fit"),
+            )
+            .expect("descriptor address should not overflow");
+        memory
+            .write_slice(&bytes, descriptor_address)
+            .expect("vsock TX descriptor should write");
+    }
+
+    fn vsock_tx_descriptor_chain(
+        memory: &mut GuestMemory,
+        descriptors: &[TestDescriptor],
+    ) -> VirtqueueDescriptorChain {
+        for (index, descriptor) in descriptors.iter().copied().enumerate() {
+            write_vsock_tx_descriptor(
+                memory,
+                u16::try_from(index).expect("test descriptor index should fit"),
+                descriptor,
+            );
+        }
+
+        read_descriptor_chain(
+            memory,
+            TEST_VSOCK_TX_DESCRIPTOR_TABLE,
+            TEST_VSOCK_QUEUE_SIZE,
+            0,
+        )
+        .expect("vsock TX descriptor chain should read")
+    }
+
+    fn write_vsock_packet_header(
+        memory: &mut GuestMemory,
+        address: GuestAddress,
+        header: VirtioVsockPacketHeader,
+    ) {
+        memory
+            .write_slice(&header.to_bytes(), address)
+            .expect("vsock packet header should write");
+    }
+
+    fn write_guest_bytes(memory: &mut GuestMemory, address: GuestAddress, bytes: &[u8]) {
+        memory
+            .write_slice(bytes, address)
+            .expect("test guest bytes should write");
+    }
+
+    fn read_guest_bytes(memory: &GuestMemory, address: GuestAddress, len: usize) -> Vec<u8> {
+        let mut bytes = vec![0; len];
+        memory
+            .read_slice(&mut bytes, address)
+            .expect("test guest bytes should read");
+        bytes
+    }
+
+    fn vsock_payload_address_after_header(header_address: GuestAddress) -> GuestAddress {
+        header_address
+            .checked_add(VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64)
+            .expect("test vsock payload address should not overflow")
+    }
+
+    fn parse_vsock_tx_packet(
+        memory: &GuestMemory,
+        chain: &VirtqueueDescriptorChain,
+    ) -> Result<VirtioVsockTxPacket, VirtioVsockTxPacketParseError> {
+        VirtioVsockTxPacket::parse(memory, chain)
     }
 
     #[test]
@@ -1876,6 +2475,363 @@ mod tests {
 
         assert_eq!(err.payload_len(), VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE + 1);
         assert_eq!(err.max_payload_len(), VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE);
+    }
+
+    #[test]
+    fn virtio_vsock_tx_packet_parser_accepts_single_descriptor_packet() {
+        let mut memory = vsock_tx_memory();
+        let header = test_vsock_packet_header().with_payload_len(4);
+        let payload_address = vsock_payload_address_after_header(TEST_VSOCK_HEADER);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, header);
+        write_guest_bytes(&mut memory, payload_address, &[0xde, 0xad, 0xbe, 0xef]);
+        let chain = vsock_tx_descriptor_chain(
+            &mut memory,
+            &[TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32 + 4,
+                None,
+            )],
+        );
+
+        let packet =
+            parse_vsock_tx_packet(&memory, &chain).expect("single-descriptor packet should parse");
+
+        assert_eq!(packet.descriptor_head(), 0);
+        assert_eq!(packet.header(), header);
+        assert_eq!(packet.payload_len(), 4);
+        assert_eq!(packet.packet_len(), VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64 + 4);
+        assert_eq!(packet.payload_segments().len(), 1);
+        let segment = packet
+            .payload_segments()
+            .first()
+            .expect("payload segment should be present");
+        assert_eq!(segment.descriptor_index(), 0);
+        assert_eq!(segment.address(), payload_address);
+        assert_eq!(segment.len(), 4);
+        assert!(!segment.is_empty());
+        assert_eq!(
+            read_guest_bytes(
+                &memory,
+                segment.address(),
+                usize::try_from(segment.len()).expect("segment length should fit")
+            ),
+            [0xde, 0xad, 0xbe, 0xef]
+        );
+    }
+
+    #[test]
+    fn virtio_vsock_tx_packet_parser_accepts_split_header_packet() {
+        let mut memory = vsock_tx_memory();
+        let header = test_vsock_packet_header().with_payload_len(3);
+        let header_bytes = header.to_bytes();
+        let (first_header, second_header_and_payload) = header_bytes.split_at(16);
+        let payload_address = TEST_VSOCK_SECOND_HEADER
+            .checked_add(
+                u64::try_from(second_header_and_payload.len())
+                    .expect("second header length should fit"),
+            )
+            .expect("payload address should not overflow");
+        write_guest_bytes(&mut memory, TEST_VSOCK_HEADER, first_header);
+        write_guest_bytes(
+            &mut memory,
+            TEST_VSOCK_SECOND_HEADER,
+            second_header_and_payload,
+        );
+        write_guest_bytes(&mut memory, payload_address, &[0xaa, 0xbb, 0xcc]);
+        let chain = vsock_tx_descriptor_chain(
+            &mut memory,
+            &[
+                TestDescriptor::readable(TEST_VSOCK_HEADER, 16, Some(1)),
+                TestDescriptor::readable(
+                    TEST_VSOCK_SECOND_HEADER,
+                    u32::try_from(second_header_and_payload.len() + 3)
+                        .expect("descriptor length should fit"),
+                    None,
+                ),
+            ],
+        );
+
+        let packet =
+            parse_vsock_tx_packet(&memory, &chain).expect("split-header packet should parse");
+
+        assert_eq!(packet.header(), header);
+        assert_eq!(packet.payload_len(), 3);
+        assert_eq!(packet.payload_segments().len(), 1);
+        let segment = packet
+            .payload_segments()
+            .first()
+            .expect("payload segment should be present");
+        assert_eq!(segment.descriptor_index(), 1);
+        assert_eq!(segment.address(), payload_address);
+        assert_eq!(segment.len(), 3);
+        assert_eq!(
+            read_guest_bytes(
+                &memory,
+                segment.address(),
+                usize::try_from(segment.len()).expect("segment length should fit")
+            ),
+            [0xaa, 0xbb, 0xcc]
+        );
+    }
+
+    #[test]
+    fn virtio_vsock_tx_packet_parser_accepts_split_payload_packet() {
+        let mut memory = vsock_tx_memory();
+        let header = test_vsock_packet_header().with_payload_len(5);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, header);
+        write_guest_bytes(&mut memory, TEST_VSOCK_PAYLOAD, &[0x10, 0x11]);
+        write_guest_bytes(
+            &mut memory,
+            TEST_VSOCK_SECOND_PAYLOAD,
+            &[0x12, 0x13, 0x14, 0xff],
+        );
+        let chain = vsock_tx_descriptor_chain(
+            &mut memory,
+            &[
+                TestDescriptor::readable(
+                    TEST_VSOCK_HEADER,
+                    VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                    Some(1),
+                ),
+                TestDescriptor::readable(TEST_VSOCK_PAYLOAD, 2, Some(2)),
+                TestDescriptor::readable(TEST_VSOCK_SECOND_PAYLOAD, 4, None),
+            ],
+        );
+
+        let packet =
+            parse_vsock_tx_packet(&memory, &chain).expect("split-payload packet should parse");
+
+        assert_eq!(packet.header(), header);
+        assert_eq!(packet.payload_len(), 5);
+        assert_eq!(packet.payload_segments().len(), 2);
+        let first = packet
+            .payload_segments()
+            .first()
+            .expect("first payload segment should be present");
+        assert_eq!(first.descriptor_index(), 1);
+        assert_eq!(first.address(), TEST_VSOCK_PAYLOAD);
+        assert_eq!(first.len(), 2);
+        assert_eq!(
+            read_guest_bytes(
+                &memory,
+                first.address(),
+                usize::try_from(first.len()).expect("segment length should fit")
+            ),
+            [0x10, 0x11]
+        );
+        let second = packet
+            .payload_segments()
+            .get(1)
+            .expect("second payload segment should be present");
+        assert_eq!(second.descriptor_index(), 2);
+        assert_eq!(second.address(), TEST_VSOCK_SECOND_PAYLOAD);
+        assert_eq!(second.len(), 3);
+        assert_eq!(
+            read_guest_bytes(
+                &memory,
+                second.address(),
+                usize::try_from(second.len()).expect("segment length should fit")
+            ),
+            [0x12, 0x13, 0x14]
+        );
+    }
+
+    #[test]
+    fn virtio_vsock_tx_packet_parser_accepts_zero_payload_header_only() {
+        let mut memory = vsock_tx_memory();
+        let header = test_vsock_packet_header().with_payload_len(0);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, header);
+        let chain = vsock_tx_descriptor_chain(
+            &mut memory,
+            &[TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            )],
+        );
+
+        let packet =
+            parse_vsock_tx_packet(&memory, &chain).expect("zero-payload packet should parse");
+
+        assert_eq!(packet.header(), header);
+        assert_eq!(packet.payload_len(), 0);
+        assert_eq!(packet.packet_len(), VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64);
+        assert!(packet.payload_segments().is_empty());
+    }
+
+    #[test]
+    fn virtio_vsock_tx_packet_parser_rejects_write_only_descriptor() {
+        let mut memory = vsock_tx_memory();
+        let header = test_vsock_packet_header().with_payload_len(0);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, header);
+        let chain = vsock_tx_descriptor_chain(
+            &mut memory,
+            &[TestDescriptor::writable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            )],
+        );
+
+        let err =
+            parse_vsock_tx_packet(&memory, &chain).expect_err("write-only descriptor should fail");
+
+        assert!(matches!(
+            err,
+            VirtioVsockTxPacketParseError::DescriptorWriteOnly { index: 0 }
+        ));
+        assert_eq!(
+            err.to_string(),
+            "virtio-vsock TX descriptor 0 is write-only"
+        );
+    }
+
+    #[test]
+    fn virtio_vsock_tx_packet_parser_rejects_chain_shorter_than_header() {
+        let mut memory = vsock_tx_memory();
+        let chain = vsock_tx_descriptor_chain(
+            &mut memory,
+            &[TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32 - 1,
+                None,
+            )],
+        );
+
+        let err = parse_vsock_tx_packet(&memory, &chain).expect_err("short header should fail");
+
+        assert!(matches!(
+            err,
+            VirtioVsockTxPacketParseError::HeaderTooShort {
+                descriptor_head: 0,
+                actual: 43,
+                min: VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64,
+            }
+        ));
+    }
+
+    #[test]
+    fn virtio_vsock_tx_packet_parser_rejects_header_payload_len_over_maximum() {
+        let mut memory = vsock_tx_memory();
+        let header =
+            test_vsock_packet_header().with_payload_len(VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE + 1);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, header);
+        let chain = vsock_tx_descriptor_chain(
+            &mut memory,
+            &[TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            )],
+        );
+
+        let err =
+            parse_vsock_tx_packet(&memory, &chain).expect_err("oversized payload should fail");
+
+        let VirtioVsockTxPacketParseError::InvalidHeaderLength { source } = err else {
+            panic!("expected invalid header length, got {err:?}");
+        };
+        assert_eq!(
+            source.payload_len(),
+            VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE + 1
+        );
+        assert_eq!(
+            source.max_payload_len(),
+            VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE
+        );
+    }
+
+    #[test]
+    fn virtio_vsock_tx_packet_parser_rejects_payload_len_beyond_descriptor_bytes() {
+        let mut memory = vsock_tx_memory();
+        let header = test_vsock_packet_header().with_payload_len(8);
+        let payload_address = vsock_payload_address_after_header(TEST_VSOCK_HEADER);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, header);
+        write_guest_bytes(&mut memory, payload_address, &[0xde, 0xad, 0xbe, 0xef]);
+        let chain = vsock_tx_descriptor_chain(
+            &mut memory,
+            &[TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32 + 4,
+                None,
+            )],
+        );
+
+        let err = parse_vsock_tx_packet(&memory, &chain).expect_err("short payload should fail");
+
+        assert!(matches!(
+            err,
+            VirtioVsockTxPacketParseError::PayloadTooShort {
+                descriptor_head: 0,
+                required: 8,
+                available: 4,
+            }
+        ));
+    }
+
+    #[test]
+    fn virtio_vsock_tx_packet_parser_rejects_unmapped_header_descriptor() {
+        let mut memory = vsock_tx_memory();
+        let unmapped = GuestAddress::new(TEST_VSOCK_TX_MEMORY_SIZE + 0x1000);
+        let chain = vsock_tx_descriptor_chain(
+            &mut memory,
+            &[TestDescriptor::readable(
+                unmapped,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            )],
+        );
+
+        let err = parse_vsock_tx_packet(&memory, &chain).expect_err("unmapped header should fail");
+
+        match err {
+            VirtioVsockTxPacketParseError::DescriptorAccess {
+                index,
+                address,
+                len,
+                ..
+            } => {
+                assert_eq!(index, 0);
+                assert_eq!(address, unmapped);
+                assert_eq!(len, VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32);
+            }
+            other => panic!("expected descriptor access error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn virtio_vsock_tx_packet_parser_rejects_unmapped_payload_descriptor() {
+        let mut memory = vsock_tx_memory();
+        let header = test_vsock_packet_header().with_payload_len(4);
+        let unmapped = GuestAddress::new(TEST_VSOCK_TX_MEMORY_SIZE + 0x1000);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, header);
+        let chain = vsock_tx_descriptor_chain(
+            &mut memory,
+            &[
+                TestDescriptor::readable(
+                    TEST_VSOCK_HEADER,
+                    VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                    Some(1),
+                ),
+                TestDescriptor::readable(unmapped, 4, None),
+            ],
+        );
+
+        let err = parse_vsock_tx_packet(&memory, &chain).expect_err("unmapped payload should fail");
+
+        match err {
+            VirtioVsockTxPacketParseError::DescriptorAccess {
+                index,
+                address,
+                len,
+                ..
+            } => {
+                assert_eq!(index, 1);
+                assert_eq!(address, unmapped);
+                assert_eq!(len, 4);
+            }
+            other => panic!("expected descriptor access error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -8,7 +8,7 @@ The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /`, `GET /version`,
 `GET /vm/config`, `GET /machine-config`, pre-boot `PUT /machine-config`
 configuration storage, pre-boot `PUT /boot-source` configuration storage, pre-boot `PUT /drives/{drive_id}`
-configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, packet header model, prepared device resource, MMIO registration helper, MMIO handler skeleton with active queue metadata retention, and startup FDT attachment, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
+configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, packet header model, TX descriptor packet parser, prepared device resource, MMIO registration helper, MMIO handler skeleton with active queue metadata retention, and startup FDT attachment, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
 `InstanceStart` preflight, transactional startup executor, and successful-start state transition helpers, backend-neutral guest
 physical address and aarch64 DRAM layout/access primitives, arm64 boot
 placement helpers, internal boot-source validation and arm64 kernel/initrd
@@ -233,7 +233,7 @@ compatibility targets.
 | `PATCH` | `/machine-config` | deferred | Partial updates belong with later state and validation rules. |
 | `PUT` | `/cpu-config` | deferred | Needs HVF CPU feature design with VM and boot work in #8 and #10. |
 | `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores up to 16 initial virtio-net configurations before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the interface count before opening vmnet resources, then selects vmnet packet I/O only for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names; unsupported names fail startup before `Running` is committed. Internal network notification dispatch can route each configured interface through selected packet I/O, parse TX descriptors through a packet sink boundary, and copy injected RX packets into guest buffers through a packet source boundary. Public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
-| `PUT` | `/vsock` | supported target; startup attachment implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Startup preparation attaches the configured device as one virtio-mmio FDT node backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has a Firecracker-shaped packet header model for later queue parsing. Queue notification dispatch, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
+| `PUT` | `/vsock` | supported target; startup attachment implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Startup preparation attaches the configured device as one virtio-mmio FDT node backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has a Firecracker-shaped packet header model and internal TX descriptor packet parser for later queue dispatch. Queue notification dispatch, RX buffers, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
 | `GET`, `PUT`, `PATCH` | `/mmds` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/mmds/config` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/snapshot/create`, `/snapshot/load` | deferred | Tied to snapshot and restore work in #19. |
@@ -355,9 +355,12 @@ mutating previous vsock state. The current response reports `guest_cid` and
 Firecracker's effective config output. Startup preparation attaches the
 configured virtio-vsock device as guest-visible FDT/MMIO metadata. The runtime
 also models Firecracker's 44-byte little-endian virtio-vsock packet header and
-rejects header byte parsing when payload length exceeds the 64 KiB maximum
-packet buffer length, but it still does not parse descriptor chains, open host
-socket resources, route CIDs, or move data.
+can parse guest-readable TX descriptor chains into validated packet metadata and
+payload segments. Header byte parsing rejects payload lengths above the 64 KiB
+maximum packet buffer length, and TX parsing rejects payload lengths larger
+than readable descriptor bytes. The implementation still does not dispatch
+vsock queue notifications, parse RX buffers, open host socket resources, route
+CIDs, or move data.
 `SendCtrlAltDel` is rejected at parse time for the first aarch64 target.
 
 Future implementation PRs should derive unit or golden tests from these tables.
@@ -565,22 +568,24 @@ does not open, bind, connect, unlink, or create the configured `uds_path`.
 
 The runtime crate has an internal virtio-vsock prepared resource, MMIO
 registration helper, config-space, 44-byte little-endian packet header model,
-MMIO handler skeleton with active queue metadata retention, and startup FDT
-attachment. It uses the
+guest-readable TX descriptor packet parser, MMIO handler skeleton with active
+queue metadata retention, and startup FDT attachment. It uses the
 virtio device id `19`, three 256-entry RX, TX, and event queues, Firecracker's
 `VERSION_1`, `IN_ORDER`, and `EVENT_IDX` feature bits, and a guest-CID config
 field that supports Firecracker-shaped 8-byte and 4-byte-half reads. Config
 writes are rejected. The packet header model preserves Firecracker's header
 field order and rejects header byte parsing when payload length exceeds
-Firecracker's 64 KiB maximum packet buffer length without reading descriptor
-chains yet. The prepared resource preserves the validated guest CID, socket
-path, config-space, and inactive device state, and the registration helper can
-consume it into a caller-provided internal MMIO dispatcher without touching
-host socket resources. Arm64 startup resource assembly can expose one
+Firecracker's 64 KiB maximum packet buffer length. The TX packet parser reads
+headers across descriptor boundaries, validates readable descriptor ranges, and
+returns payload segment metadata trimmed to the advertised payload length. The
+prepared resource preserves the validated guest CID, socket path, config-space,
+and inactive device state, and the registration helper can consume it into a
+caller-provided internal MMIO dispatcher without touching host socket
+resources. Arm64 startup resource assembly can expose one
 configured vsock device in the guest FDT. After `DRIVER_OK`, the internal
 device retains active RX, TX, and event queue metadata for later notification
 dispatch work. Host Unix socket backend behavior, CID routing, queue
-notification dispatch, descriptor parsing, and data movement remain deferred.
+notification dispatch, RX buffer parsing, and data movement remain deferred.
 
 The runtime crate also has the first backend-neutral virtio-net config-space,
 activation, TX frame parser, RX buffer parser, prepared device resources, and
@@ -1034,7 +1039,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | `PUT /boot-source` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; host paths are opened during startup preparation. Host path errors must avoid leaking sensitive path details. |
 | `PUT /drives/{drive_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; startup preparation opens backing files and registers initial block MMIO devices. Runtime hotplug remains deferred. |
 | `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records up to 16 validated pre-boot configs without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the count before opening vmnet packet I/O for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names and fails before `Running` for unsupported names. Internal network notification dispatch can route each interface through selected packet I/O, complete TX descriptor heads through a packet sink boundary, and write injected RX packets into guest buffers through a packet source boundary. Public packet movement, PATCH, and DELETE remain deferred. |
-| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Startup preparation attaches one configured virtio-vsock device as guest-visible FDT/MMIO metadata backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. Host socket backend behavior, CID routing, queue notification dispatch, data movement, PATCH, and DELETE remain deferred. |
+| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Startup preparation attaches one configured virtio-vsock device as guest-visible FDT/MMIO metadata backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has an internal TX descriptor packet parser, but host socket backend behavior, CID routing, queue notification dispatch, RX buffers, data movement, PATCH, and DELETE remain deferred. |
 | `PUT /metrics` | implemented; `204` empty response on successful output initialization | unsupported after start; `400` `fault_message` | Metrics output is process observability state, not guest configuration. Duplicate initialization fails. |
 | `PUT /logger` | implemented; `204` empty response on successful pre-boot configuration | unsupported after start; `400` `fault_message` | Logger output is process observability state, not guest configuration. Repeated pre-boot requests update provided fields; full log routing remains deferred. |
 | `PUT /actions` with `InstanceStart` | process-routed; `204` after successful owned HVF startup with internal boot run-loop worker across bounded step windows or `400` preflight/preparation fault | unsupported after start; `400` `fault_message` | Commits `Running` only after the owned HVF boot-session worker with internal serial capture is retained. The worker keeps internal active, terminal-outcome, or error status; public run-loop control and public serial streaming remain deferred. |
@@ -1086,7 +1091,8 @@ Their eventual support level should follow the endpoint matrix:
 - virtio-vsock host Unix socket backend behavior, CID routing, and data movement
   beyond pre-boot `/vsock` configuration storage, startup FDT attachment, and
   the internal prepared resource/MMIO registration/config-space/MMIO handler
-  skeleton with active queue metadata retention plus packet header model
+  skeleton with active queue metadata retention plus packet header model and TX
+  descriptor packet parser
 - snapshots
 - MMDS
 - balloon devices and balloon statistics

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -358,9 +358,9 @@ also models Firecracker's 44-byte little-endian virtio-vsock packet header and
 can parse guest-readable TX descriptor chains into validated packet metadata and
 payload segments. Header byte parsing rejects payload lengths above the 64 KiB
 maximum packet buffer length, and TX parsing rejects payload lengths larger
-than readable descriptor bytes. The implementation still does not dispatch
-vsock queue notifications, parse RX buffers, open host socket resources, route
-CIDs, or move data.
+than readable descriptor bytes after the header. The implementation still does
+not dispatch vsock queue notifications, parse RX buffers, open host socket
+resources, route CIDs, or move data.
 `SendCtrlAltDel` is rejected at parse time for the first aarch64 target.
 
 Future implementation PRs should derive unit or golden tests from these tables.

--- a/docs/security.md
+++ b/docs/security.md
@@ -66,9 +66,9 @@ is resource-specific:
 - `/vsock` stores the configured Unix socket path during configuration. Startup
   can attach a guest-visible virtio-vsock device whose internal MMIO handler
   retains active RX, TX, and event queue metadata after `DRIVER_OK`, and the
-  runtime has an internal Firecracker-shaped packet header model. The current
-  implementation does not open, bind, connect, unlink, or create that socket
-  path.
+  runtime has an internal Firecracker-shaped packet header model plus TX
+  descriptor packet parser. The current implementation does not open, bind,
+  connect, unlink, or create that socket path.
 - `/metrics` opens the output path during pre-boot configuration and keeps a
   per-process metrics sink.
 - `/logger` opens `log_path` during pre-boot configuration when that field is
@@ -104,8 +104,8 @@ HVF; local HVF verification should fail when HVF is unavailable.
 The guest is untrusted. vCPU execution, guest memory contents, virtqueue
 descriptor chains, MMIO accesses, block requests, virtio-net TX descriptor
 metadata and payload bytes, virtio-net RX buffer descriptors, virtio-vsock
-packet headers, and future device inputs must be validated before they affect
-host resources.
+packet headers, virtio-vsock TX payload descriptor ranges, and future device
+inputs must be validated before they affect host resources.
 Trapped system-register exits are guest-visible CPU behavior and must stay
 explicit. The current HVF runner emulates only the early-boot `OSDLR_EL1` and
 `OSLAR_EL1` OS lock RAZ/WI behavior needed by the pinned Firecracker kernel;
@@ -176,13 +176,13 @@ The current scaffold does not implement:
   broker, connectivity policy, and live vmnet integration proof. The current
   vsock API path validates and stores `guest_cid` plus `uds_path` before boot.
   The runtime crate has an internal virtio-vsock prepared resource, MMIO
-  registration helper, config-space, packet header model, MMIO handler skeleton
-  with active queue metadata retention, and startup FDT attachment that
-  preserve the configured socket path and expose only the configured guest CID
-  through bounded config reads. Preparation, MMIO registration, and startup
-  attachment do not open, bind, connect, unlink, or create `uds_path`, and do
-  not implement host Unix socket backend behavior, CID routing, queue
-  notification dispatch, descriptor parsing, or data movement
+  registration helper, config-space, packet header model, TX descriptor packet
+  parser, MMIO handler skeleton with active queue metadata retention, and
+  startup FDT attachment that preserve the configured socket path and expose
+  only the configured guest CID through bounded config reads. Preparation, MMIO
+  registration, and startup attachment do not open, bind, connect, unlink, or
+  create `uds_path`, and do not implement host Unix socket backend behavior,
+  CID routing, queue notification dispatch, RX buffer parsing, or data movement
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy
 


### PR DESCRIPTION
Summary:
- add a runtime virtio-vsock TX packet parser for guest-readable descriptor chains
- read Firecracker-shaped packet headers across descriptor boundaries and return trimmed payload segment metadata
- reject write-only, unmapped, undersized, and oversized TX packet inputs before later queue dispatch uses them
- update compatibility and security docs for the new internal parser boundary

Scope exclusions:
- no vsock queue notification dispatch
- no RX buffer parser
- no CID routing
- no host Unix socket backend
- no guest/host data movement

Validation:
- cargo fmt --all -- --check
- cargo check --workspace --all-targets --all-features --locked
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- scripts/run-integration-tests.sh

Closes #333
