### PR TITLE
feat: drain virtio-vsock TX queue packets

### DIFF
--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -16,7 +16,10 @@ use crate::virtio_mmio::{
     VirtioMmioDeviceConfigHandler, VirtioMmioQueueRegisterError, VirtioMmioQueueState,
     VirtioMmioRegisterHandler, VirtioMmioRegisterHandlerError,
 };
-use crate::virtio_queue::{VirtqueueDescriptor, VirtqueueDescriptorChain};
+use crate::virtio_queue::{
+    VirtqueueAvailableRing, VirtqueueAvailableRingError, VirtqueueDescriptor,
+    VirtqueueDescriptorChain,
+};
 
 pub const MIN_GUEST_CID: u32 = 3;
 pub const VIRTIO_VSOCK_DEVICE_ID: u32 = 19;
@@ -1050,9 +1053,10 @@ impl VirtioVsockRxQueue {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VirtioVsockTxQueue {
     queue_state: VirtioMmioQueueState,
+    available: VirtqueueAvailableRing,
 }
 
 impl VirtioVsockTxQueue {
@@ -1060,11 +1064,190 @@ impl VirtioVsockTxQueue {
         queue: VirtioMmioQueueState,
     ) -> Result<Self, VirtioVsockQueueBuildError> {
         validate_active_vsock_queue(queue)?;
-        Ok(Self { queue_state: queue })
+        let available = VirtqueueAvailableRing::new(
+            queue.descriptor_table(),
+            queue.driver_ring(),
+            queue.size(),
+        )
+        .map_err(|source| VirtioVsockQueueBuildError::AvailableRing { source })?;
+
+        Ok(Self {
+            queue_state: queue,
+            available,
+        })
     }
 
-    pub const fn queue_state(self) -> VirtioMmioQueueState {
+    pub const fn queue_state(&self) -> VirtioMmioQueueState {
         self.queue_state
+    }
+
+    pub const fn available_ring(&self) -> &VirtqueueAvailableRing {
+        &self.available
+    }
+
+    pub fn dispatch(
+        &mut self,
+        memory: &GuestMemory,
+    ) -> Result<VirtioVsockTxQueueDispatch, VirtioVsockTxQueueDispatchError> {
+        let mut dispatch = VirtioVsockTxQueueDispatch::with_capacity(self.available.queue_size())?;
+        while let Some(chain) = match self.available.pop_descriptor_chain(memory) {
+            Ok(chain) => chain,
+            Err(source) => {
+                return Err(VirtioVsockTxQueueDispatchError::AvailableRing {
+                    completed_dispatch: Box::new(dispatch),
+                    source,
+                });
+            }
+        } {
+            if chain.is_empty() {
+                return Err(VirtioVsockTxQueueDispatchError::EmptyDescriptorChain {
+                    completed_dispatch: Box::new(dispatch),
+                });
+            }
+
+            match VirtioVsockTxPacket::parse(memory, &chain) {
+                Ok(packet) => dispatch.record(VirtioVsockTxQueueDispatchOutcome::Ok(packet)),
+                Err(source) => {
+                    dispatch.record(VirtioVsockTxQueueDispatchOutcome::ParseError(source));
+                }
+            }
+        }
+
+        Ok(dispatch)
+    }
+}
+
+#[derive(Debug)]
+pub struct VirtioVsockTxQueueDispatch {
+    processed_packets: usize,
+    successful_packets: usize,
+    parse_failures: usize,
+    packets: Vec<VirtioVsockTxPacket>,
+    first_parse_failure: Option<VirtioVsockTxPacketParseError>,
+}
+
+impl VirtioVsockTxQueueDispatch {
+    fn with_capacity(queue_size: u16) -> Result<Self, VirtioVsockTxQueueDispatchError> {
+        let mut packets = Vec::new();
+        packets
+            .try_reserve_exact(usize::from(queue_size))
+            .map_err(
+                |source| VirtioVsockTxQueueDispatchError::PacketMetadataAllocation { source },
+            )?;
+
+        Ok(Self {
+            processed_packets: 0,
+            successful_packets: 0,
+            parse_failures: 0,
+            packets,
+            first_parse_failure: None,
+        })
+    }
+
+    pub const fn processed_packets(&self) -> usize {
+        self.processed_packets
+    }
+
+    pub const fn successful_packets(&self) -> usize {
+        self.successful_packets
+    }
+
+    pub const fn parse_failures(&self) -> usize {
+        self.parse_failures
+    }
+
+    pub fn packets(&self) -> &[VirtioVsockTxPacket] {
+        &self.packets
+    }
+
+    pub const fn first_parse_failure(&self) -> Option<&VirtioVsockTxPacketParseError> {
+        self.first_parse_failure.as_ref()
+    }
+
+    pub const fn needs_queue_interrupt(&self) -> bool {
+        false
+    }
+
+    fn record(&mut self, outcome: VirtioVsockTxQueueDispatchOutcome) {
+        self.processed_packets += 1;
+        match outcome {
+            VirtioVsockTxQueueDispatchOutcome::Ok(packet) => {
+                self.successful_packets += 1;
+                self.packets.push(packet);
+            }
+            VirtioVsockTxQueueDispatchOutcome::ParseError(source) => {
+                self.parse_failures += 1;
+                if self.first_parse_failure.is_none() {
+                    self.first_parse_failure = Some(source);
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum VirtioVsockTxQueueDispatchOutcome {
+    Ok(VirtioVsockTxPacket),
+    ParseError(VirtioVsockTxPacketParseError),
+}
+
+#[derive(Debug)]
+pub enum VirtioVsockTxQueueDispatchError {
+    PacketMetadataAllocation {
+        source: std::collections::TryReserveError,
+    },
+    AvailableRing {
+        completed_dispatch: Box<VirtioVsockTxQueueDispatch>,
+        source: VirtqueueAvailableRingError,
+    },
+    EmptyDescriptorChain {
+        completed_dispatch: Box<VirtioVsockTxQueueDispatch>,
+    },
+}
+
+impl VirtioVsockTxQueueDispatchError {
+    pub const fn completed_dispatch(&self) -> Option<&VirtioVsockTxQueueDispatch> {
+        match self {
+            Self::AvailableRing {
+                completed_dispatch, ..
+            }
+            | Self::EmptyDescriptorChain {
+                completed_dispatch, ..
+            } => Some(completed_dispatch),
+            Self::PacketMetadataAllocation { .. } => None,
+        }
+    }
+}
+
+impl fmt::Display for VirtioVsockTxQueueDispatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PacketMetadataAllocation { source } => {
+                write!(
+                    f,
+                    "failed to reserve virtio-vsock TX packet metadata: {source}"
+                )
+            }
+            Self::AvailableRing { source, .. } => {
+                write!(
+                    f,
+                    "failed to pop virtio-vsock TX available descriptor chain: {source}"
+                )
+            }
+            Self::EmptyDescriptorChain { .. } => {
+                f.write_str("virtio-vsock TX queue produced an empty descriptor chain")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VirtioVsockTxQueueDispatchError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::PacketMetadataAllocation { source } => Some(source),
+            Self::AvailableRing { source, .. } => Some(source),
+            Self::EmptyDescriptorChain { .. } => None,
+        }
     }
 }
 
@@ -1086,10 +1269,11 @@ impl VirtioVsockEventQueue {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum VirtioVsockQueueBuildError {
     QueueNotReady,
     QueueSizeNotConfigured,
+    AvailableRing { source: VirtqueueAvailableRingError },
 }
 
 impl fmt::Display for VirtioVsockQueueBuildError {
@@ -1099,11 +1283,21 @@ impl fmt::Display for VirtioVsockQueueBuildError {
             Self::QueueSizeNotConfigured => {
                 f.write_str("virtio-vsock queue size is not configured")
             }
+            Self::AvailableRing { source } => {
+                write!(f, "failed to build virtio-vsock available ring: {source}")
+            }
         }
     }
 }
 
-impl std::error::Error for VirtioVsockQueueBuildError {}
+impl std::error::Error for VirtioVsockQueueBuildError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::AvailableRing { source } => Some(source),
+            Self::QueueNotReady | Self::QueueSizeNotConfigured => None,
+        }
+    }
+}
 
 fn validate_active_vsock_queue(
     queue: VirtioMmioQueueState,
@@ -1145,7 +1339,9 @@ impl VirtioVsockDevice {
     }
 
     pub fn active_tx_queue(&self) -> Option<VirtioMmioQueueState> {
-        self.active_tx_queue.map(VirtioVsockTxQueue::queue_state)
+        self.active_tx_queue
+            .as_ref()
+            .map(VirtioVsockTxQueue::queue_state)
     }
 
     pub const fn active_tx_dispatch_queue(&self) -> Option<&VirtioVsockTxQueue> {
@@ -1683,8 +1879,8 @@ mod tests {
         VirtioVsockConfigSpace, VirtioVsockDevice, VirtioVsockDeviceActivationError,
         VirtioVsockMmioHandler, VirtioVsockPacketHeader, VirtioVsockPacketLengthError,
         VirtioVsockQueueBuildError, VirtioVsockTxPacket, VirtioVsockTxPacketParseError,
-        VsockConfigError, VsockConfigInput, VsockMmioDevice, VsockMmioLayout,
-        VsockMmioRegistrationError, virtio_vsock_mmio_handler,
+        VirtioVsockTxQueue, VirtioVsockTxQueueDispatchError, VsockConfigError, VsockConfigInput,
+        VsockMmioDevice, VsockMmioLayout, VsockMmioRegistrationError, virtio_vsock_mmio_handler,
     };
 
     const TEST_MMIO_BASE: u64 = 0x1000_0000;
@@ -1695,7 +1891,8 @@ mod tests {
     const TEST_QUEUE_ADDRESS_BASE: u64 = 0x1000;
     const TEST_QUEUE_ADDRESS_STRIDE: u64 = 0x1000;
     const TEST_VSOCK_TX_MEMORY_SIZE: u64 = 0x20_000;
-    const TEST_VSOCK_TX_DESCRIPTOR_TABLE: GuestAddress = GuestAddress::new(0x1000);
+    const TEST_VSOCK_TX_DESCRIPTOR_TABLE: GuestAddress = GuestAddress::new(0x2000);
+    const TEST_VSOCK_TX_AVAILABLE_RING: GuestAddress = GuestAddress::new(0x2200);
     const TEST_VSOCK_HEADER: GuestAddress = GuestAddress::new(0x4000);
     const TEST_VSOCK_SECOND_HEADER: GuestAddress = GuestAddress::new(0x5000);
     const TEST_VSOCK_PAYLOAD: GuestAddress = GuestAddress::new(0x6000);
@@ -2005,6 +2202,35 @@ mod tests {
             .expect("vsock TX descriptor should write");
     }
 
+    fn write_vsock_tx_available_index(memory: &mut GuestMemory, index: u16) {
+        let index_address = TEST_VSOCK_TX_AVAILABLE_RING
+            .checked_add(2)
+            .expect("available index address should not overflow");
+        memory
+            .write_slice(&index.to_le_bytes(), index_address)
+            .expect("vsock TX available index should write");
+    }
+
+    fn write_vsock_tx_available_entry(memory: &mut GuestMemory, slot: usize, head: u16) {
+        let slot_offset = u64::try_from(slot).expect("available slot should fit") * 2;
+        let entry_address = TEST_VSOCK_TX_AVAILABLE_RING
+            .checked_add(4 + slot_offset)
+            .expect("available entry address should not overflow");
+        memory
+            .write_slice(&head.to_le_bytes(), entry_address)
+            .expect("vsock TX available entry should write");
+    }
+
+    fn write_vsock_tx_available_heads(memory: &mut GuestMemory, heads: &[u16]) {
+        for (slot, head) in heads.iter().copied().enumerate() {
+            write_vsock_tx_available_entry(memory, slot, head);
+        }
+        write_vsock_tx_available_index(
+            memory,
+            u16::try_from(heads.len()).expect("available head count should fit"),
+        );
+    }
+
     fn vsock_tx_descriptor_chain(
         memory: &mut GuestMemory,
         descriptors: &[TestDescriptor],
@@ -2061,6 +2287,16 @@ mod tests {
         chain: &VirtqueueDescriptorChain,
     ) -> Result<VirtioVsockTxPacket, VirtioVsockTxPacketParseError> {
         VirtioVsockTxPacket::parse(memory, chain)
+    }
+
+    fn vsock_tx_queue() -> VirtioVsockTxQueue {
+        let queues = configured_vsock_queue_registers(Some(TEST_VSOCK_QUEUE_SIZE), true);
+        let queue_index =
+            u32::try_from(VIRTIO_VSOCK_TX_QUEUE_INDEX).expect("TX queue index should fit");
+        let queue_state = *queues
+            .queue(queue_index)
+            .expect("TX queue state should be configured");
+        VirtioVsockTxQueue::from_mmio_queue_state(queue_state).expect("TX queue should build")
     }
 
     #[test]
@@ -2871,6 +3107,205 @@ mod tests {
             }
             other => panic!("expected descriptor access error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn virtio_vsock_tx_queue_dispatch_empty_available_ring_is_noop() {
+        let memory = vsock_tx_memory();
+        let mut queue = vsock_tx_queue();
+
+        let dispatch = queue
+            .dispatch(&memory)
+            .expect("empty TX queue should dispatch");
+
+        assert_eq!(dispatch.processed_packets(), 0);
+        assert_eq!(dispatch.successful_packets(), 0);
+        assert_eq!(dispatch.parse_failures(), 0);
+        assert!(dispatch.packets().is_empty());
+        assert!(dispatch.first_parse_failure().is_none());
+        assert!(!dispatch.needs_queue_interrupt());
+        assert_eq!(queue.available_ring().next_avail(), 0);
+    }
+
+    #[test]
+    fn virtio_vsock_tx_queue_dispatch_parses_single_packet() {
+        let mut memory = vsock_tx_memory();
+        let mut queue = vsock_tx_queue();
+        let header = test_vsock_packet_header().with_payload_len(4);
+        let payload_address = vsock_payload_address_after_header(TEST_VSOCK_HEADER);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, header);
+        write_guest_bytes(&mut memory, payload_address, &[0xa0, 0xa1, 0xa2, 0xa3]);
+        write_vsock_tx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32 + 4,
+                None,
+            ),
+        );
+        write_vsock_tx_available_heads(&mut memory, &[0]);
+
+        let dispatch = queue
+            .dispatch(&memory)
+            .expect("single TX packet should dispatch");
+
+        assert_eq!(dispatch.processed_packets(), 1);
+        assert_eq!(dispatch.successful_packets(), 1);
+        assert_eq!(dispatch.parse_failures(), 0);
+        assert!(dispatch.first_parse_failure().is_none());
+        assert!(!dispatch.needs_queue_interrupt());
+        let packet = dispatch
+            .packets()
+            .first()
+            .expect("parsed packet should be recorded");
+        assert_eq!(packet.descriptor_head(), 0);
+        assert_eq!(packet.header(), header);
+        assert_eq!(packet.payload_len(), 4);
+        assert_eq!(packet.payload_segments().len(), 1);
+        assert_eq!(
+            packet
+                .payload_segments()
+                .first()
+                .expect("payload segment should exist")
+                .address(),
+            payload_address
+        );
+        assert_eq!(queue.available_ring().next_avail(), 1);
+    }
+
+    #[test]
+    fn virtio_vsock_tx_queue_dispatch_preserves_next_avail_across_calls() {
+        let mut memory = vsock_tx_memory();
+        let mut queue = vsock_tx_queue();
+        let first_header = test_vsock_packet_header().with_payload_len(1);
+        let second_header = test_vsock_packet_header().with_payload_len(2);
+        let third_header = test_vsock_packet_header().with_payload_len(3);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, first_header);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_SECOND_HEADER, second_header);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_PAYLOAD, third_header);
+        write_vsock_tx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32 + 1,
+                None,
+            ),
+        );
+        write_vsock_tx_descriptor(
+            &mut memory,
+            1,
+            TestDescriptor::readable(
+                TEST_VSOCK_SECOND_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32 + 2,
+                None,
+            ),
+        );
+        write_vsock_tx_available_heads(&mut memory, &[0, 1]);
+
+        let first_dispatch = queue
+            .dispatch(&memory)
+            .expect("first TX dispatch should drain two packets");
+
+        assert_eq!(first_dispatch.processed_packets(), 2);
+        assert_eq!(first_dispatch.successful_packets(), 2);
+        assert_eq!(queue.available_ring().next_avail(), 2);
+        assert_eq!(first_dispatch.packets()[0].descriptor_head(), 0);
+        assert_eq!(first_dispatch.packets()[1].descriptor_head(), 1);
+
+        write_vsock_tx_descriptor(
+            &mut memory,
+            2,
+            TestDescriptor::readable(
+                TEST_VSOCK_PAYLOAD,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32 + 3,
+                None,
+            ),
+        );
+        write_vsock_tx_available_entry(&mut memory, 2, 2);
+        write_vsock_tx_available_index(&mut memory, 3);
+
+        let second_dispatch = queue
+            .dispatch(&memory)
+            .expect("second TX dispatch should drain only the new packet");
+
+        assert_eq!(second_dispatch.processed_packets(), 1);
+        assert_eq!(second_dispatch.successful_packets(), 1);
+        assert_eq!(second_dispatch.packets()[0].descriptor_head(), 2);
+        assert_eq!(queue.available_ring().next_avail(), 3);
+    }
+
+    #[test]
+    fn virtio_vsock_tx_queue_dispatch_records_parse_failure() {
+        let mut memory = vsock_tx_memory();
+        let mut queue = vsock_tx_queue();
+        write_vsock_tx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32 - 1,
+                None,
+            ),
+        );
+        write_vsock_tx_available_heads(&mut memory, &[0]);
+
+        let dispatch = queue
+            .dispatch(&memory)
+            .expect("malformed TX packet should be recorded");
+
+        assert_eq!(dispatch.processed_packets(), 1);
+        assert_eq!(dispatch.successful_packets(), 0);
+        assert_eq!(dispatch.parse_failures(), 1);
+        assert!(dispatch.packets().is_empty());
+        assert!(matches!(
+            dispatch.first_parse_failure(),
+            Some(VirtioVsockTxPacketParseError::HeaderTooShort {
+                descriptor_head: 0,
+                actual: 43,
+                min: VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64,
+            })
+        ));
+        assert!(!dispatch.needs_queue_interrupt());
+        assert_eq!(queue.available_ring().next_avail(), 1);
+    }
+
+    #[test]
+    fn virtio_vsock_tx_queue_dispatch_preserves_partial_available_ring_failure() {
+        let mut memory = vsock_tx_memory();
+        let mut queue = vsock_tx_queue();
+        let header = test_vsock_packet_header().with_payload_len(0);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, header);
+        write_vsock_tx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            ),
+        );
+        write_vsock_tx_available_heads(&mut memory, &[0, TEST_VSOCK_QUEUE_SIZE]);
+
+        let error = queue
+            .dispatch(&memory)
+            .expect_err("invalid second TX head should fail after partial dispatch");
+
+        assert!(matches!(
+            error,
+            VirtioVsockTxQueueDispatchError::AvailableRing { .. }
+        ));
+        let completed = error
+            .completed_dispatch()
+            .expect("partial dispatch metadata should be preserved");
+        assert_eq!(completed.processed_packets(), 1);
+        assert_eq!(completed.successful_packets(), 1);
+        assert_eq!(completed.parse_failures(), 0);
+        assert_eq!(completed.packets().len(), 1);
+        assert_eq!(completed.packets()[0].descriptor_head(), 0);
+        assert!(!completed.needs_queue_interrupt());
+        assert_eq!(queue.available_ring().next_avail(), 1);
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -8,7 +8,7 @@ The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /`, `GET /version`,
 `GET /vm/config`, `GET /machine-config`, pre-boot `PUT /machine-config`
 configuration storage, pre-boot `PUT /boot-source` configuration storage, pre-boot `PUT /drives/{drive_id}`
-configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, packet header model, TX descriptor packet parser, prepared device resource, MMIO registration helper, MMIO handler skeleton with active queue metadata retention, and startup FDT attachment, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
+configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, packet header model, TX descriptor packet parser, TX available-ring drain helper, prepared device resource, MMIO registration helper, MMIO handler skeleton with active queue metadata retention, and startup FDT attachment, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
 `InstanceStart` preflight, transactional startup executor, and successful-start state transition helpers, backend-neutral guest
 physical address and aarch64 DRAM layout/access primitives, arm64 boot
 placement helpers, internal boot-source validation and arm64 kernel/initrd
@@ -233,7 +233,7 @@ compatibility targets.
 | `PATCH` | `/machine-config` | deferred | Partial updates belong with later state and validation rules. |
 | `PUT` | `/cpu-config` | deferred | Needs HVF CPU feature design with VM and boot work in #8 and #10. |
 | `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores up to 16 initial virtio-net configurations before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the interface count before opening vmnet resources, then selects vmnet packet I/O only for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names; unsupported names fail startup before `Running` is committed. Internal network notification dispatch can route each configured interface through selected packet I/O, parse TX descriptors through a packet sink boundary, and copy injected RX packets into guest buffers through a packet source boundary. Public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
-| `PUT` | `/vsock` | supported target; startup attachment implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Startup preparation attaches the configured device as one virtio-mmio FDT node backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has a Firecracker-shaped packet header model and internal TX descriptor packet parser for later queue dispatch. Queue notification dispatch, RX buffers, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
+| `PUT` | `/vsock` | supported target; startup attachment implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Startup preparation attaches the configured device as one virtio-mmio FDT node backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has a Firecracker-shaped packet header model, internal TX descriptor packet parser, and TX available-ring drain helper for later device dispatch. MMIO notification-handler wiring, used-ring completion, interrupts, RX buffers, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
 | `GET`, `PUT`, `PATCH` | `/mmds` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/mmds/config` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/snapshot/create`, `/snapshot/load` | deferred | Tied to snapshot and restore work in #19. |
@@ -568,8 +568,9 @@ does not open, bind, connect, unlink, or create the configured `uds_path`.
 
 The runtime crate has an internal virtio-vsock prepared resource, MMIO
 registration helper, config-space, 44-byte little-endian packet header model,
-guest-readable TX descriptor packet parser, MMIO handler skeleton with active
-queue metadata retention, and startup FDT attachment. It uses the
+guest-readable TX descriptor packet parser, TX available-ring drain helper,
+MMIO handler skeleton with active queue metadata retention, and startup FDT
+attachment. It uses the
 virtio device id `19`, three 256-entry RX, TX, and event queues, Firecracker's
 `VERSION_1`, `IN_ORDER`, and `EVENT_IDX` feature bits, and a guest-CID config
 field that supports Firecracker-shaped 8-byte and 4-byte-half reads. Config
@@ -578,14 +579,16 @@ field order and rejects header byte parsing when payload length exceeds
 Firecracker's 64 KiB maximum packet buffer length. The TX packet parser reads
 headers across descriptor boundaries, validates readable descriptor ranges, and
 returns payload segment metadata trimmed to the advertised payload length. The
+TX drain helper consumes available TX descriptor chains from the active queue
+into parsed packet metadata while preserving queue progress, without writing the
+used ring or raising queue interrupts. The
 prepared resource preserves the validated guest CID, socket path, config-space,
 and inactive device state, and the registration helper can consume it into a
 caller-provided internal MMIO dispatcher without touching host socket
 resources. Arm64 startup resource assembly can expose one
-configured vsock device in the guest FDT. After `DRIVER_OK`, the internal
-device retains active RX, TX, and event queue metadata for later notification
-dispatch work. Host Unix socket backend behavior, CID routing, queue
-notification dispatch, RX buffer parsing, and data movement remain deferred.
+configured vsock device in the guest FDT. Host Unix socket backend behavior,
+CID routing, MMIO notification-handler wiring, used-ring completion, interrupt
+delivery, RX buffer parsing, and data movement remain deferred.
 
 The runtime crate also has the first backend-neutral virtio-net config-space,
 activation, TX frame parser, RX buffer parser, prepared device resources, and
@@ -1039,7 +1042,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | `PUT /boot-source` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; host paths are opened during startup preparation. Host path errors must avoid leaking sensitive path details. |
 | `PUT /drives/{drive_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; startup preparation opens backing files and registers initial block MMIO devices. Runtime hotplug remains deferred. |
 | `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records up to 16 validated pre-boot configs without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the count before opening vmnet packet I/O for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names and fails before `Running` for unsupported names. Internal network notification dispatch can route each interface through selected packet I/O, complete TX descriptor heads through a packet sink boundary, and write injected RX packets into guest buffers through a packet source boundary. Public packet movement, PATCH, and DELETE remain deferred. |
-| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Startup preparation attaches one configured virtio-vsock device as guest-visible FDT/MMIO metadata backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has an internal TX descriptor packet parser, but host socket backend behavior, CID routing, queue notification dispatch, RX buffers, data movement, PATCH, and DELETE remain deferred. |
+| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Startup preparation attaches one configured virtio-vsock device as guest-visible FDT/MMIO metadata backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has an internal TX descriptor packet parser and TX available-ring drain helper, but host socket backend behavior, CID routing, MMIO notification-handler wiring, used-ring completion, interrupts, RX buffers, data movement, PATCH, and DELETE remain deferred. |
 | `PUT /metrics` | implemented; `204` empty response on successful output initialization | unsupported after start; `400` `fault_message` | Metrics output is process observability state, not guest configuration. Duplicate initialization fails. |
 | `PUT /logger` | implemented; `204` empty response on successful pre-boot configuration | unsupported after start; `400` `fault_message` | Logger output is process observability state, not guest configuration. Repeated pre-boot requests update provided fields; full log routing remains deferred. |
 | `PUT /actions` with `InstanceStart` | process-routed; `204` after successful owned HVF startup with internal boot run-loop worker across bounded step windows or `400` preflight/preparation fault | unsupported after start; `400` `fault_message` | Commits `Running` only after the owned HVF boot-session worker with internal serial capture is retained. The worker keeps internal active, terminal-outcome, or error status; public run-loop control and public serial streaming remain deferred. |
@@ -1091,8 +1094,8 @@ Their eventual support level should follow the endpoint matrix:
 - virtio-vsock host Unix socket backend behavior, CID routing, and data movement
   beyond pre-boot `/vsock` configuration storage, startup FDT attachment, and
   the internal prepared resource/MMIO registration/config-space/MMIO handler
-  skeleton with active queue metadata retention plus packet header model and TX
-  descriptor packet parser
+  skeleton with active queue metadata retention plus packet header model, TX
+  descriptor packet parser, and TX available-ring drain helper
 - snapshots
 - MMDS
 - balloon devices and balloon statistics

--- a/docs/security.md
+++ b/docs/security.md
@@ -104,8 +104,9 @@ HVF; local HVF verification should fail when HVF is unavailable.
 The guest is untrusted. vCPU execution, guest memory contents, virtqueue
 descriptor chains, MMIO accesses, block requests, virtio-net TX descriptor
 metadata and payload bytes, virtio-net RX buffer descriptors, virtio-vsock
-packet headers, virtio-vsock TX payload descriptor ranges, and future device
-inputs must be validated before they affect host resources.
+packet headers, virtio-vsock TX available-ring heads, virtio-vsock TX payload
+descriptor ranges, and future device inputs must be validated before they
+affect host resources.
 Trapped system-register exits are guest-visible CPU behavior and must stay
 explicit. The current HVF runner emulates only the early-boot `OSDLR_EL1` and
 `OSLAR_EL1` OS lock RAZ/WI behavior needed by the pinned Firecracker kernel;
@@ -177,12 +178,14 @@ The current scaffold does not implement:
   vsock API path validates and stores `guest_cid` plus `uds_path` before boot.
   The runtime crate has an internal virtio-vsock prepared resource, MMIO
   registration helper, config-space, packet header model, TX descriptor packet
-  parser, MMIO handler skeleton with active queue metadata retention, and
-  startup FDT attachment that preserve the configured socket path and expose
-  only the configured guest CID through bounded config reads. Preparation, MMIO
+  parser, TX available-ring drain helper, MMIO handler skeleton with active
+  queue metadata retention, and startup FDT attachment that preserve the
+  configured socket path and expose only the configured guest CID through
+  bounded config reads. Preparation, MMIO
   registration, and startup attachment do not open, bind, connect, unlink, or
   create `uds_path`, and do not implement host Unix socket backend behavior,
-  CID routing, queue notification dispatch, RX buffer parsing, or data movement
+  CID routing, MMIO notification-handler wiring, used-ring completion,
+  interrupts, RX buffer parsing, or data movement
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy
 


### PR DESCRIPTION
## Summary

- Add an internal virtio-vsock TX queue dispatch path that drains available-ring descriptor chains into parsed `VirtioVsockTxPacket` metadata.
- Preserve TX available-ring progress across dispatch calls and expose dispatch summaries for successful packets, parse failures, and partial available-ring errors.
- Document the narrower vsock TX drain capability and the remaining deferred host socket, RX, completion, interrupt, and data-movement work.

## Scope Exclusions

- No host Unix socket backend behavior.
- No guest CID routing or connection lifecycle.
- No RX queue buffer parsing or packet injection.
- No used-ring completion, interrupt signaling, or MMIO notification-handler wiring.
- No public API changes.

Closes #335

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
