### PR TITLE
feat: complete virtio-vsock TX descriptors

### DIFF
--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -18,7 +18,7 @@ use crate::virtio_mmio::{
 };
 use crate::virtio_queue::{
     VirtqueueAvailableRing, VirtqueueAvailableRingError, VirtqueueDescriptor,
-    VirtqueueDescriptorChain,
+    VirtqueueDescriptorChain, VirtqueueUsedRing, VirtqueueUsedRingError,
 };
 
 pub const MIN_GUEST_CID: u32 = 3;
@@ -1057,6 +1057,7 @@ impl VirtioVsockRxQueue {
 pub struct VirtioVsockTxQueue {
     queue_state: VirtioMmioQueueState,
     available: VirtqueueAvailableRing,
+    used: VirtqueueUsedRing,
 }
 
 impl VirtioVsockTxQueue {
@@ -1070,10 +1071,13 @@ impl VirtioVsockTxQueue {
             queue.size(),
         )
         .map_err(|source| VirtioVsockQueueBuildError::AvailableRing { source })?;
+        let used = VirtqueueUsedRing::new(queue.device_ring(), queue.size())
+            .map_err(|source| VirtioVsockQueueBuildError::UsedRing { source })?;
 
         Ok(Self {
             queue_state: queue,
             available,
+            used,
         })
     }
 
@@ -1085,9 +1089,13 @@ impl VirtioVsockTxQueue {
         &self.available
     }
 
+    pub const fn used_ring(&self) -> &VirtqueueUsedRing {
+        &self.used
+    }
+
     pub fn dispatch(
         &mut self,
-        memory: &GuestMemory,
+        memory: &mut GuestMemory,
     ) -> Result<VirtioVsockTxQueueDispatch, VirtioVsockTxQueueDispatchError> {
         let mut dispatch = VirtioVsockTxQueueDispatch::with_capacity(self.available.queue_size())?;
         while let Some(chain) = match self.available.pop_descriptor_chain(memory) {
@@ -1099,13 +1107,26 @@ impl VirtioVsockTxQueue {
                 });
             }
         } {
-            if chain.is_empty() {
-                return Err(VirtioVsockTxQueueDispatchError::EmptyDescriptorChain {
+            let descriptor_head = match descriptor_chain_head(&chain) {
+                Some(descriptor_head) => descriptor_head,
+                None => {
+                    return Err(VirtioVsockTxQueueDispatchError::EmptyDescriptorChain {
+                        completed_dispatch: Box::new(dispatch),
+                    });
+                }
+            };
+
+            let packet = VirtioVsockTxPacket::parse(memory, &chain);
+            if let Err(source) = self.used.publish_used_element(memory, descriptor_head, 0) {
+                return Err(VirtioVsockTxQueueDispatchError::UsedRing {
                     completed_dispatch: Box::new(dispatch),
+                    descriptor_head,
+                    bytes_written_to_guest: 0,
+                    source,
                 });
             }
 
-            match VirtioVsockTxPacket::parse(memory, &chain) {
+            match packet {
                 Ok(packet) => dispatch.record(VirtioVsockTxQueueDispatchOutcome::Ok(packet)),
                 Err(source) => {
                     dispatch.record(VirtioVsockTxQueueDispatchOutcome::ParseError(source));
@@ -1165,7 +1186,7 @@ impl VirtioVsockTxQueueDispatch {
     }
 
     pub const fn needs_queue_interrupt(&self) -> bool {
-        false
+        self.processed_packets != 0
     }
 
     fn record(&mut self, outcome: VirtioVsockTxQueueDispatchOutcome) {
@@ -1203,6 +1224,12 @@ pub enum VirtioVsockTxQueueDispatchError {
     EmptyDescriptorChain {
         completed_dispatch: Box<VirtioVsockTxQueueDispatch>,
     },
+    UsedRing {
+        completed_dispatch: Box<VirtioVsockTxQueueDispatch>,
+        descriptor_head: u16,
+        bytes_written_to_guest: u32,
+        source: VirtqueueUsedRingError,
+    },
 }
 
 impl VirtioVsockTxQueueDispatchError {
@@ -1212,6 +1239,9 @@ impl VirtioVsockTxQueueDispatchError {
                 completed_dispatch, ..
             }
             | Self::EmptyDescriptorChain {
+                completed_dispatch, ..
+            }
+            | Self::UsedRing {
                 completed_dispatch, ..
             } => Some(completed_dispatch),
             Self::PacketMetadataAllocation { .. } => None,
@@ -1237,6 +1267,17 @@ impl fmt::Display for VirtioVsockTxQueueDispatchError {
             Self::EmptyDescriptorChain { .. } => {
                 f.write_str("virtio-vsock TX queue produced an empty descriptor chain")
             }
+            Self::UsedRing {
+                descriptor_head,
+                bytes_written_to_guest,
+                source,
+                ..
+            } => {
+                write!(
+                    f,
+                    "failed to publish virtio-vsock TX used descriptor head {descriptor_head} with length {bytes_written_to_guest}: {source}"
+                )
+            }
         }
     }
 }
@@ -1246,6 +1287,7 @@ impl std::error::Error for VirtioVsockTxQueueDispatchError {
         match self {
             Self::PacketMetadataAllocation { source } => Some(source),
             Self::AvailableRing { source, .. } => Some(source),
+            Self::UsedRing { source, .. } => Some(source),
             Self::EmptyDescriptorChain { .. } => None,
         }
     }
@@ -1274,6 +1316,7 @@ pub enum VirtioVsockQueueBuildError {
     QueueNotReady,
     QueueSizeNotConfigured,
     AvailableRing { source: VirtqueueAvailableRingError },
+    UsedRing { source: VirtqueueUsedRingError },
 }
 
 impl fmt::Display for VirtioVsockQueueBuildError {
@@ -1286,6 +1329,9 @@ impl fmt::Display for VirtioVsockQueueBuildError {
             Self::AvailableRing { source } => {
                 write!(f, "failed to build virtio-vsock available ring: {source}")
             }
+            Self::UsedRing { source } => {
+                write!(f, "failed to build virtio-vsock used ring: {source}")
+            }
         }
     }
 }
@@ -1294,9 +1340,17 @@ impl std::error::Error for VirtioVsockQueueBuildError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::AvailableRing { source } => Some(source),
+            Self::UsedRing { source } => Some(source),
             Self::QueueNotReady | Self::QueueSizeNotConfigured => None,
         }
     }
+}
+
+fn descriptor_chain_head(chain: &VirtqueueDescriptorChain) -> Option<u16> {
+    chain
+        .descriptors()
+        .first()
+        .map(|descriptor| descriptor.index())
 }
 
 fn validate_active_vsock_queue(
@@ -1893,6 +1947,8 @@ mod tests {
     const TEST_VSOCK_TX_MEMORY_SIZE: u64 = 0x20_000;
     const TEST_VSOCK_TX_DESCRIPTOR_TABLE: GuestAddress = GuestAddress::new(0x2000);
     const TEST_VSOCK_TX_AVAILABLE_RING: GuestAddress = GuestAddress::new(0x2200);
+    const TEST_VSOCK_TX_USED_RING: GuestAddress = GuestAddress::new(0x2400);
+    const TEST_VSOCK_TX_UNMAPPED_USED_RING: GuestAddress = GuestAddress::new(0x30_000);
     const TEST_VSOCK_HEADER: GuestAddress = GuestAddress::new(0x4000);
     const TEST_VSOCK_SECOND_HEADER: GuestAddress = GuestAddress::new(0x5000);
     const TEST_VSOCK_PAYLOAD: GuestAddress = GuestAddress::new(0x6000);
@@ -2231,6 +2287,34 @@ mod tests {
         );
     }
 
+    fn vsock_tx_used_ring_idx_address() -> GuestAddress {
+        TEST_VSOCK_TX_USED_RING
+            .checked_add(2)
+            .expect("vsock TX used ring idx address should not overflow")
+    }
+
+    fn vsock_tx_used_ring_entry_address(index: usize) -> GuestAddress {
+        TEST_VSOCK_TX_USED_RING
+            .checked_add(4 + u64::try_from(index).expect("used ring index should fit") * 8)
+            .expect("vsock TX used ring entry address should not overflow")
+    }
+
+    fn read_vsock_tx_used_index(memory: &GuestMemory) -> u16 {
+        read_guest_u16(memory, vsock_tx_used_ring_idx_address())
+    }
+
+    fn read_vsock_tx_used_element(memory: &GuestMemory, index: usize) -> (u32, u32) {
+        let address = vsock_tx_used_ring_entry_address(index);
+        let descriptor_head = read_guest_u32(memory, address);
+        let len = read_guest_u32(
+            memory,
+            address
+                .checked_add(4)
+                .expect("vsock TX used ring len address should not overflow"),
+        );
+        (descriptor_head, len)
+    }
+
     fn vsock_tx_descriptor_chain(
         memory: &mut GuestMemory,
         descriptors: &[TestDescriptor],
@@ -2276,6 +2360,22 @@ mod tests {
         bytes
     }
 
+    fn read_guest_u16(memory: &GuestMemory, address: GuestAddress) -> u16 {
+        let mut bytes = [0; 2];
+        memory
+            .read_slice(&mut bytes, address)
+            .expect("test guest u16 should read");
+        u16::from_le_bytes(bytes)
+    }
+
+    fn read_guest_u32(memory: &GuestMemory, address: GuestAddress) -> u32 {
+        let mut bytes = [0; 4];
+        memory
+            .read_slice(&mut bytes, address)
+            .expect("test guest u32 should read");
+        u32::from_le_bytes(bytes)
+    }
+
     fn vsock_payload_address_after_header(header_address: GuestAddress) -> GuestAddress {
         header_address
             .checked_add(VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64)
@@ -2290,9 +2390,52 @@ mod tests {
     }
 
     fn vsock_tx_queue() -> VirtioVsockTxQueue {
-        let queues = configured_vsock_queue_registers(Some(TEST_VSOCK_QUEUE_SIZE), true);
+        vsock_tx_queue_with_used_ring(TEST_VSOCK_TX_USED_RING)
+    }
+
+    fn vsock_tx_queue_with_used_ring(device_ring: GuestAddress) -> VirtioVsockTxQueue {
+        let mut queues = VirtioMmioQueueRegisters::new(&VIRTIO_VSOCK_QUEUE_SIZES)
+            .expect("queue table should build");
         let queue_index =
             u32::try_from(VIRTIO_VSOCK_TX_QUEUE_INDEX).expect("TX queue index should fit");
+        queues
+            .write_register(
+                VirtioMmioRegister::QueueSel,
+                queue_index,
+                QUEUE_CONFIG_STATUS,
+            )
+            .expect("TX queue select should write");
+        queues
+            .write_register(
+                VirtioMmioRegister::QueueNum,
+                u32::from(TEST_VSOCK_QUEUE_SIZE),
+                QUEUE_CONFIG_STATUS,
+            )
+            .expect("TX queue size should write");
+        queues
+            .write_register(
+                VirtioMmioRegister::QueueDescLow,
+                guest_address_low(TEST_VSOCK_TX_DESCRIPTOR_TABLE),
+                QUEUE_CONFIG_STATUS,
+            )
+            .expect("TX descriptor table should write");
+        queues
+            .write_register(
+                VirtioMmioRegister::QueueDriverLow,
+                guest_address_low(TEST_VSOCK_TX_AVAILABLE_RING),
+                QUEUE_CONFIG_STATUS,
+            )
+            .expect("TX available ring should write");
+        queues
+            .write_register(
+                VirtioMmioRegister::QueueDeviceLow,
+                guest_address_low(device_ring),
+                QUEUE_CONFIG_STATUS,
+            )
+            .expect("TX used ring should write");
+        queues
+            .write_register(VirtioMmioRegister::QueueReady, 1, QUEUE_CONFIG_STATUS)
+            .expect("TX queue ready should write");
         let queue_state = *queues
             .queue(queue_index)
             .expect("TX queue state should be configured");
@@ -3111,11 +3254,11 @@ mod tests {
 
     #[test]
     fn virtio_vsock_tx_queue_dispatch_empty_available_ring_is_noop() {
-        let memory = vsock_tx_memory();
+        let mut memory = vsock_tx_memory();
         let mut queue = vsock_tx_queue();
 
         let dispatch = queue
-            .dispatch(&memory)
+            .dispatch(&mut memory)
             .expect("empty TX queue should dispatch");
 
         assert_eq!(dispatch.processed_packets(), 0);
@@ -3125,6 +3268,8 @@ mod tests {
         assert!(dispatch.first_parse_failure().is_none());
         assert!(!dispatch.needs_queue_interrupt());
         assert_eq!(queue.available_ring().next_avail(), 0);
+        assert_eq!(queue.used_ring().next_used(), 0);
+        assert_eq!(read_vsock_tx_used_index(&memory), 0);
     }
 
     #[test]
@@ -3147,14 +3292,14 @@ mod tests {
         write_vsock_tx_available_heads(&mut memory, &[0]);
 
         let dispatch = queue
-            .dispatch(&memory)
+            .dispatch(&mut memory)
             .expect("single TX packet should dispatch");
 
         assert_eq!(dispatch.processed_packets(), 1);
         assert_eq!(dispatch.successful_packets(), 1);
         assert_eq!(dispatch.parse_failures(), 0);
         assert!(dispatch.first_parse_failure().is_none());
-        assert!(!dispatch.needs_queue_interrupt());
+        assert!(dispatch.needs_queue_interrupt());
         let packet = dispatch
             .packets()
             .first()
@@ -3172,6 +3317,9 @@ mod tests {
             payload_address
         );
         assert_eq!(queue.available_ring().next_avail(), 1);
+        assert_eq!(queue.used_ring().next_used(), 1);
+        assert_eq!(read_vsock_tx_used_index(&memory), 1);
+        assert_eq!(read_vsock_tx_used_element(&memory, 0), (0, 0));
     }
 
     #[test]
@@ -3205,14 +3353,19 @@ mod tests {
         write_vsock_tx_available_heads(&mut memory, &[0, 1]);
 
         let first_dispatch = queue
-            .dispatch(&memory)
+            .dispatch(&mut memory)
             .expect("first TX dispatch should drain two packets");
 
         assert_eq!(first_dispatch.processed_packets(), 2);
         assert_eq!(first_dispatch.successful_packets(), 2);
+        assert!(first_dispatch.needs_queue_interrupt());
         assert_eq!(queue.available_ring().next_avail(), 2);
+        assert_eq!(queue.used_ring().next_used(), 2);
         assert_eq!(first_dispatch.packets()[0].descriptor_head(), 0);
         assert_eq!(first_dispatch.packets()[1].descriptor_head(), 1);
+        assert_eq!(read_vsock_tx_used_index(&memory), 2);
+        assert_eq!(read_vsock_tx_used_element(&memory, 0), (0, 0));
+        assert_eq!(read_vsock_tx_used_element(&memory, 1), (1, 0));
 
         write_vsock_tx_descriptor(
             &mut memory,
@@ -3227,13 +3380,17 @@ mod tests {
         write_vsock_tx_available_index(&mut memory, 3);
 
         let second_dispatch = queue
-            .dispatch(&memory)
+            .dispatch(&mut memory)
             .expect("second TX dispatch should drain only the new packet");
 
         assert_eq!(second_dispatch.processed_packets(), 1);
         assert_eq!(second_dispatch.successful_packets(), 1);
+        assert!(second_dispatch.needs_queue_interrupt());
         assert_eq!(second_dispatch.packets()[0].descriptor_head(), 2);
         assert_eq!(queue.available_ring().next_avail(), 3);
+        assert_eq!(queue.used_ring().next_used(), 3);
+        assert_eq!(read_vsock_tx_used_index(&memory), 3);
+        assert_eq!(read_vsock_tx_used_element(&memory, 2), (2, 0));
     }
 
     #[test]
@@ -3252,7 +3409,7 @@ mod tests {
         write_vsock_tx_available_heads(&mut memory, &[0]);
 
         let dispatch = queue
-            .dispatch(&memory)
+            .dispatch(&mut memory)
             .expect("malformed TX packet should be recorded");
 
         assert_eq!(dispatch.processed_packets(), 1);
@@ -3267,8 +3424,11 @@ mod tests {
                 min: VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64,
             })
         ));
-        assert!(!dispatch.needs_queue_interrupt());
+        assert!(dispatch.needs_queue_interrupt());
         assert_eq!(queue.available_ring().next_avail(), 1);
+        assert_eq!(queue.used_ring().next_used(), 1);
+        assert_eq!(read_vsock_tx_used_index(&memory), 1);
+        assert_eq!(read_vsock_tx_used_element(&memory, 0), (0, 0));
     }
 
     #[test]
@@ -3289,7 +3449,7 @@ mod tests {
         write_vsock_tx_available_heads(&mut memory, &[0, TEST_VSOCK_QUEUE_SIZE]);
 
         let error = queue
-            .dispatch(&memory)
+            .dispatch(&mut memory)
             .expect_err("invalid second TX head should fail after partial dispatch");
 
         assert!(matches!(
@@ -3304,8 +3464,52 @@ mod tests {
         assert_eq!(completed.parse_failures(), 0);
         assert_eq!(completed.packets().len(), 1);
         assert_eq!(completed.packets()[0].descriptor_head(), 0);
+        assert!(completed.needs_queue_interrupt());
+        assert_eq!(queue.available_ring().next_avail(), 1);
+        assert_eq!(queue.used_ring().next_used(), 1);
+        assert_eq!(read_vsock_tx_used_index(&memory), 1);
+        assert_eq!(read_vsock_tx_used_element(&memory, 0), (0, 0));
+    }
+
+    #[test]
+    fn virtio_vsock_tx_queue_dispatch_preserves_used_ring_failure() {
+        let mut memory = vsock_tx_memory();
+        let mut queue = vsock_tx_queue_with_used_ring(TEST_VSOCK_TX_UNMAPPED_USED_RING);
+        let header = test_vsock_packet_header().with_payload_len(0);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, header);
+        write_vsock_tx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            ),
+        );
+        write_vsock_tx_available_heads(&mut memory, &[0]);
+
+        let error = queue
+            .dispatch(&mut memory)
+            .expect_err("unmapped TX used ring should fail");
+
+        assert!(matches!(
+            error,
+            VirtioVsockTxQueueDispatchError::UsedRing {
+                descriptor_head: 0,
+                bytes_written_to_guest: 0,
+                ..
+            }
+        ));
+        let completed = error
+            .completed_dispatch()
+            .expect("completed dispatch metadata should be preserved");
+        assert_eq!(completed.processed_packets(), 0);
+        assert_eq!(completed.successful_packets(), 0);
+        assert_eq!(completed.parse_failures(), 0);
         assert!(!completed.needs_queue_interrupt());
         assert_eq!(queue.available_ring().next_avail(), 1);
+        assert_eq!(queue.used_ring().next_used(), 0);
+        assert_eq!(read_vsock_tx_used_index(&memory), 0);
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -8,7 +8,7 @@ The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /`, `GET /version`,
 `GET /vm/config`, `GET /machine-config`, pre-boot `PUT /machine-config`
 configuration storage, pre-boot `PUT /boot-source` configuration storage, pre-boot `PUT /drives/{drive_id}`
-configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, packet header model, TX descriptor packet parser, TX available-ring drain helper, prepared device resource, MMIO registration helper, MMIO handler skeleton with active queue metadata retention, and startup FDT attachment, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
+configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, packet header model, TX descriptor packet parser, TX available-ring drain helper with used-ring descriptor completion, prepared device resource, MMIO registration helper, MMIO handler skeleton with active queue metadata retention, and startup FDT attachment, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
 `InstanceStart` preflight, transactional startup executor, and successful-start state transition helpers, backend-neutral guest
 physical address and aarch64 DRAM layout/access primitives, arm64 boot
 placement helpers, internal boot-source validation and arm64 kernel/initrd
@@ -233,7 +233,7 @@ compatibility targets.
 | `PATCH` | `/machine-config` | deferred | Partial updates belong with later state and validation rules. |
 | `PUT` | `/cpu-config` | deferred | Needs HVF CPU feature design with VM and boot work in #8 and #10. |
 | `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores up to 16 initial virtio-net configurations before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the interface count before opening vmnet resources, then selects vmnet packet I/O only for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names; unsupported names fail startup before `Running` is committed. Internal network notification dispatch can route each configured interface through selected packet I/O, parse TX descriptors through a packet sink boundary, and copy injected RX packets into guest buffers through a packet source boundary. Public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
-| `PUT` | `/vsock` | supported target; startup attachment implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Startup preparation attaches the configured device as one virtio-mmio FDT node backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has a Firecracker-shaped packet header model, internal TX descriptor packet parser, and TX available-ring drain helper for later device dispatch. MMIO notification-handler wiring, used-ring completion, interrupts, RX buffers, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
+| `PUT` | `/vsock` | supported target; startup attachment implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Startup preparation attaches the configured device as one virtio-mmio FDT node backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has a Firecracker-shaped packet header model, internal TX descriptor packet parser, and TX available-ring drain helper that publishes zero-length TX used-ring completions and reports queue-interrupt need for later device dispatch. MMIO notification-handler wiring, interrupt delivery, RX buffers, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
 | `GET`, `PUT`, `PATCH` | `/mmds` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/mmds/config` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/snapshot/create`, `/snapshot/load` | deferred | Tied to snapshot and restore work in #19. |
@@ -568,7 +568,8 @@ does not open, bind, connect, unlink, or create the configured `uds_path`.
 
 The runtime crate has an internal virtio-vsock prepared resource, MMIO
 registration helper, config-space, 44-byte little-endian packet header model,
-guest-readable TX descriptor packet parser, TX available-ring drain helper,
+guest-readable TX descriptor packet parser, TX available-ring drain helper with
+used-ring descriptor completion,
 MMIO handler skeleton with active queue metadata retention, and startup FDT
 attachment. It uses the
 virtio device id `19`, three 256-entry RX, TX, and event queues, Firecracker's
@@ -580,15 +581,16 @@ Firecracker's 64 KiB maximum packet buffer length. The TX packet parser reads
 headers across descriptor boundaries, validates readable descriptor ranges, and
 returns payload segment metadata trimmed to the advertised payload length. The
 TX drain helper consumes available TX descriptor chains from the active queue
-into parsed packet metadata while preserving queue progress, without writing the
-used ring or raising queue interrupts. The
+into parsed packet metadata while preserving queue progress, publishes
+zero-length used-ring completions for consumed descriptor heads, and reports
+whether a queue interrupt will be needed once notification dispatch is wired. The
 prepared resource preserves the validated guest CID, socket path, config-space,
 and inactive device state, and the registration helper can consume it into a
 caller-provided internal MMIO dispatcher without touching host socket
 resources. Arm64 startup resource assembly can expose one
 configured vsock device in the guest FDT. Host Unix socket backend behavior,
-CID routing, MMIO notification-handler wiring, used-ring completion, interrupt
-delivery, RX buffer parsing, and data movement remain deferred.
+CID routing, MMIO notification-handler wiring, interrupt delivery, RX buffer
+parsing, and data movement remain deferred.
 
 The runtime crate also has the first backend-neutral virtio-net config-space,
 activation, TX frame parser, RX buffer parser, prepared device resources, and
@@ -1042,7 +1044,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | `PUT /boot-source` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; host paths are opened during startup preparation. Host path errors must avoid leaking sensitive path details. |
 | `PUT /drives/{drive_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; startup preparation opens backing files and registers initial block MMIO devices. Runtime hotplug remains deferred. |
 | `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records up to 16 validated pre-boot configs without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the count before opening vmnet packet I/O for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names and fails before `Running` for unsupported names. Internal network notification dispatch can route each interface through selected packet I/O, complete TX descriptor heads through a packet sink boundary, and write injected RX packets into guest buffers through a packet source boundary. Public packet movement, PATCH, and DELETE remain deferred. |
-| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Startup preparation attaches one configured virtio-vsock device as guest-visible FDT/MMIO metadata backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has an internal TX descriptor packet parser and TX available-ring drain helper, but host socket backend behavior, CID routing, MMIO notification-handler wiring, used-ring completion, interrupts, RX buffers, data movement, PATCH, and DELETE remain deferred. |
+| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Startup preparation attaches one configured virtio-vsock device as guest-visible FDT/MMIO metadata backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has an internal TX descriptor packet parser and TX available-ring drain helper that completes consumed TX descriptor heads through the used ring, but host socket backend behavior, CID routing, MMIO notification-handler wiring, interrupts, RX buffers, data movement, PATCH, and DELETE remain deferred. |
 | `PUT /metrics` | implemented; `204` empty response on successful output initialization | unsupported after start; `400` `fault_message` | Metrics output is process observability state, not guest configuration. Duplicate initialization fails. |
 | `PUT /logger` | implemented; `204` empty response on successful pre-boot configuration | unsupported after start; `400` `fault_message` | Logger output is process observability state, not guest configuration. Repeated pre-boot requests update provided fields; full log routing remains deferred. |
 | `PUT /actions` with `InstanceStart` | process-routed; `204` after successful owned HVF startup with internal boot run-loop worker across bounded step windows or `400` preflight/preparation fault | unsupported after start; `400` `fault_message` | Commits `Running` only after the owned HVF boot-session worker with internal serial capture is retained. The worker keeps internal active, terminal-outcome, or error status; public run-loop control and public serial streaming remain deferred. |
@@ -1095,7 +1097,8 @@ Their eventual support level should follow the endpoint matrix:
   beyond pre-boot `/vsock` configuration storage, startup FDT attachment, and
   the internal prepared resource/MMIO registration/config-space/MMIO handler
   skeleton with active queue metadata retention plus packet header model, TX
-  descriptor packet parser, and TX available-ring drain helper
+  descriptor packet parser, and TX available-ring drain helper with used-ring
+  descriptor completion
 - snapshots
 - MMDS
 - balloon devices and balloon statistics

--- a/docs/security.md
+++ b/docs/security.md
@@ -105,8 +105,8 @@ The guest is untrusted. vCPU execution, guest memory contents, virtqueue
 descriptor chains, MMIO accesses, block requests, virtio-net TX descriptor
 metadata and payload bytes, virtio-net RX buffer descriptors, virtio-vsock
 packet headers, virtio-vsock TX available-ring heads, virtio-vsock TX payload
-descriptor ranges, and future device inputs must be validated before they
-affect host resources.
+descriptor ranges, virtio-vsock TX used-ring completion writes, and future
+device inputs must be validated before they affect host resources.
 Trapped system-register exits are guest-visible CPU behavior and must stay
 explicit. The current HVF runner emulates only the early-boot `OSDLR_EL1` and
 `OSLAR_EL1` OS lock RAZ/WI behavior needed by the pinned Firecracker kernel;
@@ -178,14 +178,14 @@ The current scaffold does not implement:
   vsock API path validates and stores `guest_cid` plus `uds_path` before boot.
   The runtime crate has an internal virtio-vsock prepared resource, MMIO
   registration helper, config-space, packet header model, TX descriptor packet
-  parser, TX available-ring drain helper, MMIO handler skeleton with active
-  queue metadata retention, and startup FDT attachment that preserve the
-  configured socket path and expose only the configured guest CID through
-  bounded config reads. Preparation, MMIO
+  parser, TX available-ring drain helper with used-ring descriptor completion,
+  MMIO handler skeleton with active queue metadata retention, and startup FDT
+  attachment that preserve the configured socket path and expose only the
+  configured guest CID through bounded config reads. Preparation, MMIO
   registration, and startup attachment do not open, bind, connect, unlink, or
   create `uds_path`, and do not implement host Unix socket backend behavior,
-  CID routing, MMIO notification-handler wiring, used-ring completion,
-  interrupts, RX buffer parsing, or data movement
+  CID routing, MMIO notification-handler wiring, interrupts, RX buffer parsing,
+  or data movement
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy
 


### PR DESCRIPTION
## Summary

- add used-ring ownership to the virtio-vsock TX queue
- publish zero-length used-ring completions for consumed TX descriptor heads, including parse failures
- update vsock compatibility and security docs for the new guest-memory write surface

## Scope Exclusions

- no MMIO queue notification dispatch wiring
- no interrupt-status delivery beyond reporting queue-interrupt need from dispatch summaries
- no host Unix socket backend, RX/event queue handling, CID routing, or vsock data movement

Closes #337

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
