### PR TITLE
feat: dispatch virtio-vsock TX notifications

### DIFF
--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -4294,6 +4294,41 @@ mod tests {
     }
 
     #[test]
+    fn virtio_vsock_notifications_dispatch_empty_tx_queue_without_interrupt() {
+        let mut memory = vsock_tx_memory();
+        let mut handler = virtio_vsock_mmio_handler(3).expect("vsock handler should build");
+
+        activate_vsock_handler(&mut handler);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_TX_QUEUE_INDEX);
+
+        let notification = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect("empty TX queue notification should dispatch");
+
+        assert_eq!(
+            notification.drained_notifications(),
+            &[VIRTIO_VSOCK_TX_QUEUE_INDEX]
+        );
+        assert!(!notification.needs_queue_interrupt());
+        let dispatch = notification
+            .tx_queue_dispatch()
+            .expect("TX dispatch summary should be present");
+        assert_eq!(dispatch.processed_packets(), 0);
+        assert_eq!(dispatch.successful_packets(), 0);
+        assert_eq!(dispatch.parse_failures(), 0);
+        assert!(!dispatch.needs_queue_interrupt());
+        assert_eq!(read_interrupt_status(&handler), 0);
+        assert!(handler.pending_queue_notifications().is_empty());
+        let active_tx_queue = handler
+            .activation_handler()
+            .active_tx_dispatch_queue()
+            .expect("TX dispatch queue should remain active");
+        assert_eq!(active_tx_queue.available_ring().next_avail(), 0);
+        assert_eq!(active_tx_queue.used_ring().next_used(), 0);
+        assert_eq!(read_vsock_tx_used_index(&memory), 0);
+    }
+
+    #[test]
     fn virtio_vsock_notifications_complete_malformed_tx_packet_and_mark_interrupt() {
         let mut memory = vsock_tx_memory();
         let mut handler = virtio_vsock_mmio_handler(3).expect("vsock handler should build");

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -4240,6 +4240,54 @@ mod tests {
     }
 
     #[test]
+    fn virtio_vsock_notifications_reject_mixed_unsupported_queue_without_tx_dispatch() {
+        let mut memory = vsock_tx_memory();
+        let mut handler = virtio_vsock_mmio_handler(3).expect("vsock handler should build");
+        let header = test_vsock_packet_header().with_payload_len(0);
+
+        activate_vsock_handler(&mut handler);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, header);
+        write_vsock_tx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            ),
+        );
+        write_vsock_tx_available_heads(&mut memory, &[0]);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_TX_QUEUE_INDEX);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_RX_QUEUE_INDEX);
+
+        let error = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect_err("mixed unsupported notification should reject before TX dispatch");
+
+        assert!(matches!(
+            error,
+            super::VirtioVsockDeviceNotificationError::UnsupportedQueue {
+                queue_index: VIRTIO_VSOCK_RX_QUEUE_INDEX,
+                ..
+            }
+        ));
+        assert_eq!(
+            error.drained_notifications(),
+            &[VIRTIO_VSOCK_RX_QUEUE_INDEX, VIRTIO_VSOCK_TX_QUEUE_INDEX]
+        );
+        assert!(error.completed_tx_dispatch().is_none());
+        assert_eq!(read_interrupt_status(&handler), 0);
+        assert!(handler.pending_queue_notifications().is_empty());
+        let active_tx_queue = handler
+            .activation_handler()
+            .active_tx_dispatch_queue()
+            .expect("TX dispatch queue should remain active");
+        assert_eq!(active_tx_queue.available_ring().next_avail(), 0);
+        assert_eq!(active_tx_queue.used_ring().next_used(), 0);
+        assert_eq!(read_vsock_tx_used_index(&memory), 0);
+    }
+
+    #[test]
     fn virtio_vsock_notifications_dispatch_tx_queue_and_mark_interrupt() {
         let mut memory = vsock_tx_memory();
         let mut handler = virtio_vsock_mmio_handler(3).expect("vsock handler should build");

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 use std::path::{Path, PathBuf};
 
+use crate::interrupt::DeviceInterruptKind;
 use crate::memory::{
     GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryError, GuestMemoryRange,
 };
@@ -1467,6 +1468,66 @@ impl VirtioVsockDevice {
         self.active_tx_queue = None;
         self.active_event_queue = None;
     }
+
+    fn dispatch_drained_queue_notifications(
+        &mut self,
+        memory: &mut GuestMemory,
+        drained_notifications: Vec<usize>,
+    ) -> Result<VirtioVsockDeviceNotificationDispatch, VirtioVsockDeviceNotificationError> {
+        if drained_notifications.is_empty() {
+            return Ok(VirtioVsockDeviceNotificationDispatch::new(
+                drained_notifications,
+                None,
+            ));
+        }
+
+        if !self.is_activated() {
+            return Err(VirtioVsockDeviceNotificationError::Inactive {
+                drained_notifications,
+            });
+        }
+
+        if let Some(queue_index) = drained_notifications
+            .iter()
+            .copied()
+            .find(|queue_index| *queue_index != VIRTIO_VSOCK_TX_QUEUE_INDEX)
+        {
+            return Err(VirtioVsockDeviceNotificationError::UnsupportedQueue {
+                drained_notifications,
+                queue_index,
+            });
+        }
+
+        let dispatch_tx = drained_notifications
+            .iter()
+            .copied()
+            .any(|queue_index| queue_index == VIRTIO_VSOCK_TX_QUEUE_INDEX);
+
+        let tx_queue_dispatch = if dispatch_tx {
+            let Some(queue) = self.active_tx_queue.as_mut() else {
+                return Err(VirtioVsockDeviceNotificationError::Inactive {
+                    drained_notifications,
+                });
+            };
+
+            match queue.dispatch(memory) {
+                Ok(dispatch) => Some(dispatch),
+                Err(source) => {
+                    return Err(VirtioVsockDeviceNotificationError::TxQueueDispatch {
+                        drained_notifications,
+                        source,
+                    });
+                }
+            }
+        } else {
+            None
+        };
+
+        Ok(VirtioVsockDeviceNotificationDispatch::new(
+            drained_notifications,
+            tx_queue_dispatch,
+        ))
+    }
 }
 
 #[derive(Debug)]
@@ -1556,6 +1617,129 @@ impl std::error::Error for VirtioVsockDeviceActivationError {
 impl From<VirtioVsockDeviceActivationError> for VirtioMmioDeviceActivationError {
     fn from(source: VirtioVsockDeviceActivationError) -> Self {
         MmioHandlerError::new(source.to_string()).into()
+    }
+}
+
+#[derive(Debug)]
+pub struct VirtioVsockDeviceNotificationDispatch {
+    drained_notifications: Vec<usize>,
+    tx_queue_dispatch: Option<VirtioVsockTxQueueDispatch>,
+}
+
+impl VirtioVsockDeviceNotificationDispatch {
+    const fn new(
+        drained_notifications: Vec<usize>,
+        tx_queue_dispatch: Option<VirtioVsockTxQueueDispatch>,
+    ) -> Self {
+        Self {
+            drained_notifications,
+            tx_queue_dispatch,
+        }
+    }
+
+    pub fn drained_notifications(&self) -> &[usize] {
+        &self.drained_notifications
+    }
+
+    pub const fn tx_queue_dispatch(&self) -> Option<&VirtioVsockTxQueueDispatch> {
+        self.tx_queue_dispatch.as_ref()
+    }
+
+    pub fn needs_queue_interrupt(&self) -> bool {
+        self.tx_queue_dispatch
+            .as_ref()
+            .is_some_and(VirtioVsockTxQueueDispatch::needs_queue_interrupt)
+    }
+}
+
+#[derive(Debug)]
+pub enum VirtioVsockDeviceNotificationError {
+    Inactive {
+        drained_notifications: Vec<usize>,
+    },
+    UnsupportedQueue {
+        drained_notifications: Vec<usize>,
+        queue_index: usize,
+    },
+    TxQueueDispatch {
+        drained_notifications: Vec<usize>,
+        source: VirtioVsockTxQueueDispatchError,
+    },
+}
+
+impl VirtioVsockDeviceNotificationError {
+    pub fn drained_notifications(&self) -> &[usize] {
+        match self {
+            Self::Inactive {
+                drained_notifications,
+            }
+            | Self::UnsupportedQueue {
+                drained_notifications,
+                ..
+            }
+            | Self::TxQueueDispatch {
+                drained_notifications,
+                ..
+            } => drained_notifications,
+        }
+    }
+
+    pub const fn completed_tx_dispatch(&self) -> Option<&VirtioVsockTxQueueDispatch> {
+        match self {
+            Self::TxQueueDispatch { source, .. } => source.completed_dispatch(),
+            Self::Inactive { .. } | Self::UnsupportedQueue { .. } => None,
+        }
+    }
+}
+
+impl fmt::Display for VirtioVsockDeviceNotificationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Inactive { .. } => f.write_str(
+                "virtio-vsock queue notification cannot be dispatched before activation",
+            ),
+            Self::UnsupportedQueue { queue_index, .. } => {
+                write!(
+                    f,
+                    "virtio-vsock queue notification for unsupported queue {queue_index}"
+                )
+            }
+            Self::TxQueueDispatch { source, .. } => {
+                write!(f, "failed to dispatch virtio-vsock TX queue: {source}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VirtioVsockDeviceNotificationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::TxQueueDispatch { source, .. } => Some(source),
+            Self::Inactive { .. } | Self::UnsupportedQueue { .. } => None,
+        }
+    }
+}
+
+impl<C: VirtioMmioDeviceConfigHandler> VirtioMmioRegisterHandler<C, VirtioVsockDevice> {
+    pub fn dispatch_vsock_queue_notifications(
+        &mut self,
+        memory: &mut GuestMemory,
+    ) -> Result<VirtioVsockDeviceNotificationDispatch, VirtioVsockDeviceNotificationError> {
+        let drained_notifications = self.take_pending_queue_notifications();
+        let dispatch = self
+            .activation_handler_mut()
+            .dispatch_drained_queue_notifications(memory, drained_notifications);
+        let needs_queue_interrupt = match &dispatch {
+            Ok(dispatch) => dispatch.needs_queue_interrupt(),
+            Err(error) => error
+                .completed_tx_dispatch()
+                .is_some_and(VirtioVsockTxQueueDispatch::needs_queue_interrupt),
+        };
+        if needs_queue_interrupt {
+            self.mark_interrupt_pending(DeviceInterruptKind::Queue);
+        }
+
+        dispatch
     }
 }
 
@@ -1900,6 +2084,7 @@ mod tests {
     use std::error::Error as _;
     use std::path::Path;
 
+    use crate::interrupt::DeviceInterruptKind;
     use crate::memory::{GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange};
     use crate::mmio::{
         MmioAccess, MmioAccessBytes, MmioBus, MmioDispatchOutcome, MmioDispatcher, MmioOperation,
@@ -2028,6 +2213,12 @@ mod tests {
             .to_vec()
     }
 
+    fn read_interrupt_status(handler: &VirtioVsockMmioHandler) -> u32 {
+        handler
+            .read_register(VirtioMmioRegister::InterruptStatus)
+            .expect("interrupt status should read")
+    }
+
     fn advance_handler_to_features_ok(handler: &mut VirtioVsockMmioHandler) {
         handler
             .write_register(VirtioMmioRegister::Status, VIRTIO_DEVICE_STATUS_ACKNOWLEDGE)
@@ -2087,6 +2278,23 @@ mod tests {
                 .write_register(VirtioMmioRegister::QueueReady, 1)
                 .expect("queue ready should write");
         }
+    }
+
+    fn activate_vsock_handler(handler: &mut VirtioVsockMmioHandler) {
+        advance_handler_to_features_ok(handler);
+        configure_vsock_queues(handler);
+        handler
+            .write_register(VirtioMmioRegister::Status, DRIVER_OK_STATUS)
+            .expect("DRIVER_OK should activate vsock device");
+    }
+
+    fn notify_vsock_queue(handler: &mut VirtioVsockMmioHandler, queue_index: usize) {
+        handler
+            .write_register(
+                VirtioMmioRegister::QueueNotify,
+                u32::try_from(queue_index).expect("queue index should fit"),
+            )
+            .expect("queue notification should write");
     }
 
     fn configured_vsock_queue_registers(
@@ -3920,6 +4128,267 @@ mod tests {
         assert!(handler.activation_handler().active_rx_queue().is_none());
         assert!(handler.activation_handler().active_tx_queue().is_none());
         assert!(handler.activation_handler().active_event_queue().is_none());
+    }
+
+    #[test]
+    fn virtio_vsock_notifications_without_pending_work_are_noop() {
+        let mut memory = vsock_tx_memory();
+        let mut device = VirtioVsockDevice::new();
+
+        let dispatch = device
+            .dispatch_drained_queue_notifications(&mut memory, Vec::new())
+            .expect("empty notification drain should be a no-op");
+
+        assert_eq!(dispatch.drained_notifications(), &[]);
+        assert!(dispatch.tx_queue_dispatch().is_none());
+        assert!(!dispatch.needs_queue_interrupt());
+    }
+
+    #[test]
+    fn virtio_vsock_notifications_reject_inactive_device_with_drained_metadata() {
+        let mut memory = vsock_tx_memory();
+        let mut device = VirtioVsockDevice::new();
+
+        let error = device
+            .dispatch_drained_queue_notifications(&mut memory, vec![VIRTIO_VSOCK_TX_QUEUE_INDEX])
+            .expect_err("notification before activation should fail");
+
+        assert!(matches!(
+            error,
+            super::VirtioVsockDeviceNotificationError::Inactive { .. }
+        ));
+        assert_eq!(
+            error.drained_notifications(),
+            &[VIRTIO_VSOCK_TX_QUEUE_INDEX]
+        );
+        assert_eq!(
+            error.to_string(),
+            "virtio-vsock queue notification cannot be dispatched before activation"
+        );
+        assert!(error.completed_tx_dispatch().is_none());
+        assert!(error.source().is_none());
+    }
+
+    #[test]
+    fn virtio_vsock_notifications_reject_rx_queue_without_dispatch() {
+        let mut memory = vsock_tx_memory();
+        let mut handler = virtio_vsock_mmio_handler(3).expect("vsock handler should build");
+
+        activate_vsock_handler(&mut handler);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_RX_QUEUE_INDEX);
+
+        let error = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect_err("RX notification should be unsupported");
+
+        assert!(matches!(
+            error,
+            super::VirtioVsockDeviceNotificationError::UnsupportedQueue {
+                queue_index: VIRTIO_VSOCK_RX_QUEUE_INDEX,
+                ..
+            }
+        ));
+        assert_eq!(
+            error.drained_notifications(),
+            &[VIRTIO_VSOCK_RX_QUEUE_INDEX]
+        );
+        assert_eq!(
+            error.to_string(),
+            "virtio-vsock queue notification for unsupported queue 0"
+        );
+        assert!(error.completed_tx_dispatch().is_none());
+        assert_eq!(read_interrupt_status(&handler), 0);
+        assert!(handler.pending_queue_notifications().is_empty());
+        let active_tx_queue = handler
+            .activation_handler()
+            .active_tx_dispatch_queue()
+            .expect("TX dispatch queue should remain active");
+        assert_eq!(active_tx_queue.available_ring().next_avail(), 0);
+        assert_eq!(active_tx_queue.used_ring().next_used(), 0);
+    }
+
+    #[test]
+    fn virtio_vsock_notifications_reject_event_queue_without_dispatch() {
+        let mut memory = vsock_tx_memory();
+        let mut handler = virtio_vsock_mmio_handler(3).expect("vsock handler should build");
+
+        activate_vsock_handler(&mut handler);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_EVENT_QUEUE_INDEX);
+
+        let error = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect_err("event notification should be unsupported");
+
+        assert!(matches!(
+            error,
+            super::VirtioVsockDeviceNotificationError::UnsupportedQueue {
+                queue_index: VIRTIO_VSOCK_EVENT_QUEUE_INDEX,
+                ..
+            }
+        ));
+        assert_eq!(
+            error.drained_notifications(),
+            &[VIRTIO_VSOCK_EVENT_QUEUE_INDEX]
+        );
+        assert_eq!(
+            error.to_string(),
+            "virtio-vsock queue notification for unsupported queue 2"
+        );
+        assert!(error.completed_tx_dispatch().is_none());
+        assert_eq!(read_interrupt_status(&handler), 0);
+        assert!(handler.pending_queue_notifications().is_empty());
+    }
+
+    #[test]
+    fn virtio_vsock_notifications_dispatch_tx_queue_and_mark_interrupt() {
+        let mut memory = vsock_tx_memory();
+        let mut handler = virtio_vsock_mmio_handler(3).expect("vsock handler should build");
+        let header = test_vsock_packet_header().with_payload_len(4);
+        let payload_address = vsock_payload_address_after_header(TEST_VSOCK_HEADER);
+
+        activate_vsock_handler(&mut handler);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, header);
+        write_guest_bytes(&mut memory, payload_address, &[0xa0, 0xa1, 0xa2, 0xa3]);
+        write_vsock_tx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32 + 4,
+                None,
+            ),
+        );
+        write_vsock_tx_available_heads(&mut memory, &[0]);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_TX_QUEUE_INDEX);
+
+        let notification = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect("TX queue notification should dispatch");
+
+        assert_eq!(
+            notification.drained_notifications(),
+            &[VIRTIO_VSOCK_TX_QUEUE_INDEX]
+        );
+        assert!(notification.needs_queue_interrupt());
+        let dispatch = notification
+            .tx_queue_dispatch()
+            .expect("TX dispatch summary should be present");
+        assert_eq!(dispatch.processed_packets(), 1);
+        assert_eq!(dispatch.successful_packets(), 1);
+        assert_eq!(dispatch.parse_failures(), 0);
+        assert!(dispatch.needs_queue_interrupt());
+        assert_eq!(dispatch.packets()[0].descriptor_head(), 0);
+        assert_eq!(
+            read_interrupt_status(&handler),
+            DeviceInterruptKind::Queue.status().bits()
+        );
+        assert!(handler.pending_queue_notifications().is_empty());
+        let active_tx_queue = handler
+            .activation_handler()
+            .active_tx_dispatch_queue()
+            .expect("TX dispatch queue should remain active");
+        assert_eq!(active_tx_queue.available_ring().next_avail(), 1);
+        assert_eq!(active_tx_queue.used_ring().next_used(), 1);
+        assert_eq!(read_vsock_tx_used_index(&memory), 1);
+        assert_eq!(read_vsock_tx_used_element(&memory, 0), (0, 0));
+    }
+
+    #[test]
+    fn virtio_vsock_notifications_complete_malformed_tx_packet_and_mark_interrupt() {
+        let mut memory = vsock_tx_memory();
+        let mut handler = virtio_vsock_mmio_handler(3).expect("vsock handler should build");
+
+        activate_vsock_handler(&mut handler);
+        write_vsock_tx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32 - 1,
+                None,
+            ),
+        );
+        write_vsock_tx_available_heads(&mut memory, &[0]);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_TX_QUEUE_INDEX);
+
+        let notification = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect("malformed TX packet notification should dispatch");
+
+        assert!(notification.needs_queue_interrupt());
+        let dispatch = notification
+            .tx_queue_dispatch()
+            .expect("TX dispatch summary should be present");
+        assert_eq!(dispatch.processed_packets(), 1);
+        assert_eq!(dispatch.successful_packets(), 0);
+        assert_eq!(dispatch.parse_failures(), 1);
+        assert!(matches!(
+            dispatch.first_parse_failure(),
+            Some(VirtioVsockTxPacketParseError::HeaderTooShort {
+                descriptor_head: 0,
+                actual: 43,
+                min: VIRTIO_VSOCK_PACKET_HEADER_SIZE_U64,
+            })
+        ));
+        assert_eq!(
+            read_interrupt_status(&handler),
+            DeviceInterruptKind::Queue.status().bits()
+        );
+        assert_eq!(read_vsock_tx_used_index(&memory), 1);
+        assert_eq!(read_vsock_tx_used_element(&memory, 0), (0, 0));
+    }
+
+    #[test]
+    fn virtio_vsock_notifications_preserve_partial_tx_error_and_mark_interrupt() {
+        let mut memory = vsock_tx_memory();
+        let mut handler = virtio_vsock_mmio_handler(3).expect("vsock handler should build");
+        let header = test_vsock_packet_header().with_payload_len(0);
+
+        activate_vsock_handler(&mut handler);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, header);
+        write_vsock_tx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            ),
+        );
+        write_vsock_tx_available_heads(&mut memory, &[0, VIRTIO_VSOCK_QUEUE_SIZE]);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_TX_QUEUE_INDEX);
+
+        let error = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect_err("invalid second TX head should fail after partial dispatch");
+
+        assert!(matches!(
+            error,
+            super::VirtioVsockDeviceNotificationError::TxQueueDispatch { .. }
+        ));
+        assert_eq!(
+            error.drained_notifications(),
+            &[VIRTIO_VSOCK_TX_QUEUE_INDEX]
+        );
+        let completed = error
+            .completed_tx_dispatch()
+            .expect("partial TX dispatch metadata should be preserved");
+        assert_eq!(completed.processed_packets(), 1);
+        assert_eq!(completed.successful_packets(), 1);
+        assert!(completed.needs_queue_interrupt());
+        assert_eq!(
+            read_interrupt_status(&handler),
+            DeviceInterruptKind::Queue.status().bits()
+        );
+        assert!(handler.pending_queue_notifications().is_empty());
+        let active_tx_queue = handler
+            .activation_handler()
+            .active_tx_dispatch_queue()
+            .expect("TX dispatch queue should remain active");
+        assert_eq!(active_tx_queue.available_ring().next_avail(), 1);
+        assert_eq!(active_tx_queue.used_ring().next_used(), 1);
+        assert_eq!(read_vsock_tx_used_index(&memory), 1);
+        assert_eq!(read_vsock_tx_used_element(&memory, 0), (0, 0));
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -358,9 +358,10 @@ also models Firecracker's 44-byte little-endian virtio-vsock packet header and
 can parse guest-readable TX descriptor chains into validated packet metadata and
 payload segments. Header byte parsing rejects payload lengths above the 64 KiB
 maximum packet buffer length, and TX parsing rejects payload lengths larger
-than readable descriptor bytes after the header. The implementation still does
-not dispatch vsock queue notifications, parse RX buffers, open host socket
-resources, route CIDs, or move data.
+than readable descriptor bytes after the header. The handler can dispatch TX
+queue notifications into descriptor completions, but startup run-loop
+notification dispatch, RX buffers, host socket resources, CID routing, and data
+movement remain deferred.
 `SendCtrlAltDel` is rejected at parse time for the first aarch64 target.
 
 Future implementation PRs should derive unit or golden tests from these tables.

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -8,7 +8,7 @@ The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /`, `GET /version`,
 `GET /vm/config`, `GET /machine-config`, pre-boot `PUT /machine-config`
 configuration storage, pre-boot `PUT /boot-source` configuration storage, pre-boot `PUT /drives/{drive_id}`
-configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, packet header model, TX descriptor packet parser, TX available-ring drain helper with used-ring descriptor completion, prepared device resource, MMIO registration helper, MMIO handler skeleton with active queue metadata retention, and startup FDT attachment, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
+configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, packet header model, TX descriptor packet parser, TX available-ring drain helper with used-ring descriptor completion, prepared device resource, MMIO registration helper, MMIO handler skeleton with active queue metadata retention and TX notification dispatch, and startup FDT attachment, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
 `InstanceStart` preflight, transactional startup executor, and successful-start state transition helpers, backend-neutral guest
 physical address and aarch64 DRAM layout/access primitives, arm64 boot
 placement helpers, internal boot-source validation and arm64 kernel/initrd
@@ -233,7 +233,7 @@ compatibility targets.
 | `PATCH` | `/machine-config` | deferred | Partial updates belong with later state and validation rules. |
 | `PUT` | `/cpu-config` | deferred | Needs HVF CPU feature design with VM and boot work in #8 and #10. |
 | `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores up to 16 initial virtio-net configurations before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the interface count before opening vmnet resources, then selects vmnet packet I/O only for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names; unsupported names fail startup before `Running` is committed. Internal network notification dispatch can route each configured interface through selected packet I/O, parse TX descriptors through a packet sink boundary, and copy injected RX packets into guest buffers through a packet source boundary. Public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
-| `PUT` | `/vsock` | supported target; startup attachment implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Startup preparation attaches the configured device as one virtio-mmio FDT node backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has a Firecracker-shaped packet header model, internal TX descriptor packet parser, and TX available-ring drain helper that publishes zero-length TX used-ring completions and reports queue-interrupt need for later device dispatch. MMIO notification-handler wiring, interrupt delivery, RX buffers, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
+| `PUT` | `/vsock` | supported target; startup attachment implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Startup preparation attaches the configured device as one virtio-mmio FDT node backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has a Firecracker-shaped packet header model, internal TX descriptor packet parser, and TX available-ring drain helper that publishes zero-length TX used-ring completions. The handler can drain TX queue notifications, complete queued TX descriptors, and mark the virtio queue interrupt status pending. Startup run-loop wiring, interrupt-line signaling, RX buffers, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
 | `GET`, `PUT`, `PATCH` | `/mmds` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/mmds/config` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/snapshot/create`, `/snapshot/load` | deferred | Tied to snapshot and restore work in #19. |
@@ -570,8 +570,8 @@ The runtime crate has an internal virtio-vsock prepared resource, MMIO
 registration helper, config-space, 44-byte little-endian packet header model,
 guest-readable TX descriptor packet parser, TX available-ring drain helper with
 used-ring descriptor completion,
-MMIO handler skeleton with active queue metadata retention, and startup FDT
-attachment. It uses the
+MMIO handler skeleton with active queue metadata retention and TX notification
+dispatch, and startup FDT attachment. It uses the
 virtio device id `19`, three 256-entry RX, TX, and event queues, Firecracker's
 `VERSION_1`, `IN_ORDER`, and `EVENT_IDX` feature bits, and a guest-CID config
 field that supports Firecracker-shaped 8-byte and 4-byte-half reads. Config
@@ -581,16 +581,18 @@ Firecracker's 64 KiB maximum packet buffer length. The TX packet parser reads
 headers across descriptor boundaries, validates readable descriptor ranges, and
 returns payload segment metadata trimmed to the advertised payload length. The
 TX drain helper consumes available TX descriptor chains from the active queue
-into parsed packet metadata while preserving queue progress, publishes
-zero-length used-ring completions for consumed descriptor heads, and reports
-whether a queue interrupt will be needed once notification dispatch is wired. The
+into parsed packet metadata while preserving queue progress and publishes
+zero-length used-ring completions for consumed descriptor heads. The handler can
+drain TX queue notifications, dispatch the active TX queue, preserve completed
+TX dispatch metadata on errors, and mark the virtio queue interrupt status when
+completed descriptors require guest notification. The
 prepared resource preserves the validated guest CID, socket path, config-space,
 and inactive device state, and the registration helper can consume it into a
 caller-provided internal MMIO dispatcher without touching host socket
 resources. Arm64 startup resource assembly can expose one
 configured vsock device in the guest FDT. Host Unix socket backend behavior,
-CID routing, MMIO notification-handler wiring, interrupt delivery, RX buffer
-parsing, and data movement remain deferred.
+CID routing, startup run-loop notification dispatch, interrupt-line signaling,
+RX buffer parsing, and data movement remain deferred.
 
 The runtime crate also has the first backend-neutral virtio-net config-space,
 activation, TX frame parser, RX buffer parser, prepared device resources, and
@@ -1044,7 +1046,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | `PUT /boot-source` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; host paths are opened during startup preparation. Host path errors must avoid leaking sensitive path details. |
 | `PUT /drives/{drive_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; startup preparation opens backing files and registers initial block MMIO devices. Runtime hotplug remains deferred. |
 | `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records up to 16 validated pre-boot configs without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the count before opening vmnet packet I/O for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names and fails before `Running` for unsupported names. Internal network notification dispatch can route each interface through selected packet I/O, complete TX descriptor heads through a packet sink boundary, and write injected RX packets into guest buffers through a packet source boundary. Public packet movement, PATCH, and DELETE remain deferred. |
-| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Startup preparation attaches one configured virtio-vsock device as guest-visible FDT/MMIO metadata backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has an internal TX descriptor packet parser and TX available-ring drain helper that completes consumed TX descriptor heads through the used ring, but host socket backend behavior, CID routing, MMIO notification-handler wiring, interrupts, RX buffers, data movement, PATCH, and DELETE remain deferred. |
+| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Startup preparation attaches one configured virtio-vsock device as guest-visible FDT/MMIO metadata backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has an internal TX descriptor packet parser, TX available-ring drain helper, used-ring TX descriptor completion, and handler-level TX notification dispatch, but host socket backend behavior, CID routing, startup run-loop notification dispatch, interrupt-line signaling, RX buffers, data movement, PATCH, and DELETE remain deferred. |
 | `PUT /metrics` | implemented; `204` empty response on successful output initialization | unsupported after start; `400` `fault_message` | Metrics output is process observability state, not guest configuration. Duplicate initialization fails. |
 | `PUT /logger` | implemented; `204` empty response on successful pre-boot configuration | unsupported after start; `400` `fault_message` | Logger output is process observability state, not guest configuration. Repeated pre-boot requests update provided fields; full log routing remains deferred. |
 | `PUT /actions` with `InstanceStart` | process-routed; `204` after successful owned HVF startup with internal boot run-loop worker across bounded step windows or `400` preflight/preparation fault | unsupported after start; `400` `fault_message` | Commits `Running` only after the owned HVF boot-session worker with internal serial capture is retained. The worker keeps internal active, terminal-outcome, or error status; public run-loop control and public serial streaming remain deferred. |
@@ -1098,7 +1100,7 @@ Their eventual support level should follow the endpoint matrix:
   the internal prepared resource/MMIO registration/config-space/MMIO handler
   skeleton with active queue metadata retention plus packet header model, TX
   descriptor packet parser, and TX available-ring drain helper with used-ring
-  descriptor completion
+  descriptor completion and handler-level TX notification dispatch
 - snapshots
 - MMDS
 - balloon devices and balloon statistics

--- a/docs/security.md
+++ b/docs/security.md
@@ -105,8 +105,9 @@ The guest is untrusted. vCPU execution, guest memory contents, virtqueue
 descriptor chains, MMIO accesses, block requests, virtio-net TX descriptor
 metadata and payload bytes, virtio-net RX buffer descriptors, virtio-vsock
 packet headers, virtio-vsock TX available-ring heads, virtio-vsock TX payload
-descriptor ranges, virtio-vsock TX used-ring completion writes, and future
-device inputs must be validated before they affect host resources.
+descriptor ranges, virtio-vsock TX used-ring completion writes, virtio-vsock
+queue notifications, and future device inputs must be validated before they
+affect host resources.
 Trapped system-register exits are guest-visible CPU behavior and must stay
 explicit. The current HVF runner emulates only the early-boot `OSDLR_EL1` and
 `OSLAR_EL1` OS lock RAZ/WI behavior needed by the pinned Firecracker kernel;
@@ -179,13 +180,14 @@ The current scaffold does not implement:
   The runtime crate has an internal virtio-vsock prepared resource, MMIO
   registration helper, config-space, packet header model, TX descriptor packet
   parser, TX available-ring drain helper with used-ring descriptor completion,
-  MMIO handler skeleton with active queue metadata retention, and startup FDT
-  attachment that preserve the configured socket path and expose only the
-  configured guest CID through bounded config reads. Preparation, MMIO
+  MMIO handler skeleton with active queue metadata retention and TX notification
+  dispatch, and startup FDT attachment that preserve the configured socket path
+  and expose only the configured guest CID through bounded config reads.
+  Preparation, MMIO
   registration, and startup attachment do not open, bind, connect, unlink, or
   create `uds_path`, and do not implement host Unix socket backend behavior,
-  CID routing, MMIO notification-handler wiring, interrupts, RX buffer parsing,
-  or data movement
+  CID routing, startup run-loop notification dispatch, interrupt-line signaling,
+  RX buffer parsing, or data movement
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy
 


### PR DESCRIPTION
## Summary
- add handler-level virtio-vsock TX queue notification dispatch
- complete queued TX descriptors through the existing TX drain helper and mark virtio queue interrupt status when completions need guest notification
- document the new vsock dispatch scope and remaining deferred startup/socket work

## Scope Exclusions
- no host Unix socket backend, CID routing, RX/event queue dispatch, startup run-loop notification wiring, or interrupt-line signaling

Closes #339

## Verification
- cargo fmt --all -- --check
- cargo check --workspace --all-targets --all-features --locked
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- scripts/run-integration-tests.sh
