### PR TITLE
feat: dispatch vsock boot notifications

### DIFF
--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -36,7 +36,8 @@ pub use startup::{
     HvfArm64BootRunLoopControl, HvfArm64BootRunLoopError, HvfArm64BootRunLoopOutcome,
     HvfArm64BootRunLoopStopToken, HvfArm64BootSerialDeviceConfig, HvfArm64BootSession,
     HvfArm64BootSessionConfig, HvfArm64BootSessionError, HvfArm64BootSessionShutdownError,
-    OwnedHvfArm64BootSession,
+    HvfArm64BootVsockNotificationDispatch, HvfArm64BootVsockNotificationDispatchError,
+    HvfArm64BootVsockNotificationDispatches, OwnedHvfArm64BootSession,
 };
 pub use vcpu::{
     ARM64_LINUX_BOOT_CPSR, HvfArm64BootRegisters, HvfRegister, HvfSystemRegister, HvfVcpu,

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -22,6 +22,8 @@ use bangbang_runtime::startup::{
     Arm64BootNetworkPacketIoProvider, Arm64BootResourceConfig, Arm64BootResourceError,
     Arm64BootResources, Arm64BootRuntimeResources,
     Arm64BootSerialDeviceConfig as RuntimeArm64BootSerialDeviceConfig,
+    Arm64BootVsockNotificationDispatch, Arm64BootVsockNotificationDispatchError,
+    Arm64BootVsockNotificationDispatches,
 };
 use bangbang_runtime::vsock::VsockMmioLayout;
 use bangbang_runtime::{BackendError, VmBackend, VmmController};
@@ -195,6 +197,10 @@ pub enum HvfArm64BootRunLoopError {
         steps_completed: usize,
         source: Box<HvfArm64BootNetworkNotificationDispatchError>,
     },
+    DispatchVsockNotifications {
+        steps_completed: usize,
+        source: Box<HvfArm64BootVsockNotificationDispatchError>,
+    },
     HandleVirtualTimer {
         steps_completed: usize,
         source: Box<HvfVcpuRunnerError>,
@@ -225,6 +231,13 @@ impl fmt::Display for HvfArm64BootRunLoopError {
                 f,
                 "failed to dispatch HVF boot-session network notifications after {steps_completed} completed steps: {source}"
             ),
+            Self::DispatchVsockNotifications {
+                steps_completed,
+                source,
+            } => write!(
+                f,
+                "failed to dispatch HVF boot-session vsock notifications after {steps_completed} completed steps: {source}"
+            ),
             Self::HandleVirtualTimer {
                 steps_completed,
                 source,
@@ -242,6 +255,7 @@ impl std::error::Error for HvfArm64BootRunLoopError {
             Self::RunStep { source, .. } => Some(source.as_ref()),
             Self::DispatchBlockNotifications { source, .. } => Some(source.as_ref()),
             Self::DispatchNetworkNotifications { source, .. } => Some(source.as_ref()),
+            Self::DispatchVsockNotifications { source, .. } => Some(source.as_ref()),
             Self::HandleVirtualTimer { source, .. } => Some(source.as_ref()),
         }
     }
@@ -342,7 +356,7 @@ impl HvfArm64BootSession<'_> {
     }
 
     /// Run bounded vCPU steps and dispatch boot block and virtio-net TX
-    /// notifications between steps.
+    /// notifications plus virtio-vsock TX notifications between steps.
     ///
     /// The step limit keeps this scaffold deterministic until a later scheduler
     /// owns the continuous guest loop and timer/device policy.
@@ -449,6 +463,29 @@ impl HvfArm64BootSession<'_> {
         };
 
         collect_or_signal_network_queue_interrupts(dispatches, &self.gic)
+    }
+
+    pub fn dispatch_vsock_queue_notifications_and_signal_interrupts(
+        &mut self,
+    ) -> Result<HvfArm64BootVsockNotificationDispatches, HvfArm64BootVsockNotificationDispatchError>
+    {
+        let dispatches = {
+            let memory = self.backend.mapped_guest_memory_mut().map_err(|source| {
+                HvfArm64BootVsockNotificationDispatchError::MapGuestMemory { source }
+            })?;
+            let mut mmio_dispatcher =
+                lock_boot_mmio_dispatcher(&self.mmio_dispatcher).map_err(|source| {
+                    HvfArm64BootVsockNotificationDispatchError::MmioDispatcher { source }
+                })?;
+
+            dispatch_vsock_runtime_notifications(
+                memory,
+                &mut self.runtime_resources,
+                &mut mmio_dispatcher,
+            )?
+        };
+
+        collect_or_signal_vsock_queue_interrupts(dispatches, &self.gic)
     }
 }
 
@@ -678,6 +715,29 @@ impl OwnedHvfArm64BootSession {
 
         collect_or_signal_network_queue_interrupts(dispatches, &self.gic)
     }
+
+    pub fn dispatch_vsock_queue_notifications_and_signal_interrupts(
+        &mut self,
+    ) -> Result<HvfArm64BootVsockNotificationDispatches, HvfArm64BootVsockNotificationDispatchError>
+    {
+        let dispatches = {
+            let memory = self.backend.mapped_guest_memory_mut().map_err(|source| {
+                HvfArm64BootVsockNotificationDispatchError::MapGuestMemory { source }
+            })?;
+            let mut mmio_dispatcher =
+                lock_boot_mmio_dispatcher(&self.mmio_dispatcher).map_err(|source| {
+                    HvfArm64BootVsockNotificationDispatchError::MmioDispatcher { source }
+                })?;
+
+            dispatch_vsock_runtime_notifications(
+                memory,
+                &mut self.runtime_resources,
+                &mut mmio_dispatcher,
+            )?
+        };
+
+        collect_or_signal_vsock_queue_interrupts(dispatches, &self.gic)
+    }
 }
 
 impl BootSessionRunLoopSession for OwnedHvfArm64BootSession {
@@ -704,6 +764,13 @@ impl BootSessionRunLoopSession for OwnedHvfArm64BootSession {
         HvfArm64BootNetworkNotificationDispatchError,
     > {
         self.dispatch_network_queue_notifications_and_signal_interrupts()
+    }
+
+    fn dispatch_run_loop_vsock_notifications(
+        &mut self,
+    ) -> Result<HvfArm64BootVsockNotificationDispatches, HvfArm64BootVsockNotificationDispatchError>
+    {
+        self.dispatch_vsock_queue_notifications_and_signal_interrupts()
     }
 }
 
@@ -758,6 +825,14 @@ where
             .dispatch_network_queue_notifications_with_packet_io_and_signal_interrupts(
                 self.packet_io,
             )
+    }
+
+    fn dispatch_run_loop_vsock_notifications(
+        &mut self,
+    ) -> Result<HvfArm64BootVsockNotificationDispatches, HvfArm64BootVsockNotificationDispatchError>
+    {
+        self.session
+            .dispatch_vsock_queue_notifications_and_signal_interrupts()
     }
 }
 
@@ -886,6 +961,65 @@ impl HvfArm64BootNetworkNotificationDispatch {
 }
 
 #[derive(Debug)]
+pub struct HvfArm64BootVsockNotificationDispatches {
+    devices: Vec<HvfArm64BootVsockNotificationDispatch>,
+}
+
+impl HvfArm64BootVsockNotificationDispatches {
+    fn new(devices: Vec<HvfArm64BootVsockNotificationDispatch>) -> Self {
+        Self { devices }
+    }
+
+    pub fn as_slice(&self) -> &[HvfArm64BootVsockNotificationDispatch] {
+        &self.devices
+    }
+
+    pub fn len(&self) -> usize {
+        self.devices.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.devices.is_empty()
+    }
+
+    pub fn has_signal_failure(&self) -> bool {
+        self.devices
+            .iter()
+            .any(|device| device.signal_error().is_some())
+    }
+}
+
+#[derive(Debug)]
+pub struct HvfArm64BootVsockNotificationDispatch {
+    dispatch: Arm64BootVsockNotificationDispatch,
+    signal_error: Option<DeviceInterruptTriggerError>,
+}
+
+impl HvfArm64BootVsockNotificationDispatch {
+    fn new(
+        dispatch: Arm64BootVsockNotificationDispatch,
+        signal_error: Option<DeviceInterruptTriggerError>,
+    ) -> Self {
+        Self {
+            dispatch,
+            signal_error,
+        }
+    }
+
+    pub const fn dispatch(&self) -> &Arm64BootVsockNotificationDispatch {
+        &self.dispatch
+    }
+
+    pub const fn signal_error(&self) -> Option<&DeviceInterruptTriggerError> {
+        self.signal_error.as_ref()
+    }
+
+    pub fn queue_interrupt_signaled(&self) -> bool {
+        self.dispatch.needs_queue_interrupt() && self.signal_error.is_none()
+    }
+}
+
+#[derive(Debug)]
 pub enum HvfArm64BootBlockNotificationDispatchError {
     MapGuestMemory {
         source: HvfGuestMemoryMappingError,
@@ -914,6 +1048,25 @@ pub enum HvfArm64BootNetworkNotificationDispatchError {
     },
     DispatchNotifications {
         source: Arm64BootNetworkNotificationDispatchError,
+    },
+    CreateSignalSink {
+        source: HvfGicSpiSignalError,
+    },
+    ResultAllocation {
+        source: TryReserveError,
+    },
+}
+
+#[derive(Debug)]
+pub enum HvfArm64BootVsockNotificationDispatchError {
+    MapGuestMemory {
+        source: HvfGuestMemoryMappingError,
+    },
+    MmioDispatcher {
+        source: HvfArm64BootMmioDispatcherError,
+    },
+    DispatchNotifications {
+        source: Arm64BootVsockNotificationDispatchError,
     },
     CreateSignalSink {
         source: HvfGicSpiSignalError,
@@ -956,6 +1109,55 @@ impl fmt::Display for HvfArm64BootNetworkNotificationDispatchError {
                     "failed to allocate HVF boot network notification results: {source}"
                 )
             }
+        }
+    }
+}
+
+impl fmt::Display for HvfArm64BootVsockNotificationDispatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MapGuestMemory { source } => {
+                write!(
+                    f,
+                    "failed to borrow HVF boot-session guest memory for vsock notifications: {source}"
+                )
+            }
+            Self::MmioDispatcher { source } => {
+                write!(
+                    f,
+                    "failed to lock HVF boot-session MMIO dispatcher: {source}"
+                )
+            }
+            Self::DispatchNotifications { source } => {
+                write!(
+                    f,
+                    "failed to dispatch boot vsock queue notifications: {source}"
+                )
+            }
+            Self::CreateSignalSink { source } => {
+                write!(
+                    f,
+                    "failed to create HVF boot vsock interrupt signaler: {source}"
+                )
+            }
+            Self::ResultAllocation { source } => {
+                write!(
+                    f,
+                    "failed to allocate HVF boot vsock notification results: {source}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for HvfArm64BootVsockNotificationDispatchError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::MapGuestMemory { source } => Some(source),
+            Self::MmioDispatcher { source } => Some(source),
+            Self::DispatchNotifications { source } => Some(source),
+            Self::CreateSignalSink { source } => Some(source),
+            Self::ResultAllocation { source } => Some(source),
         }
     }
 }
@@ -1076,6 +1278,10 @@ trait BootSessionRunLoopSession {
         HvfArm64BootNetworkNotificationDispatches,
         HvfArm64BootNetworkNotificationDispatchError,
     >;
+
+    fn dispatch_run_loop_vsock_notifications(
+        &mut self,
+    ) -> Result<HvfArm64BootVsockNotificationDispatches, HvfArm64BootVsockNotificationDispatchError>;
 }
 
 impl BootSessionRunLoopSession for HvfArm64BootSession<'_> {
@@ -1102,6 +1308,13 @@ impl BootSessionRunLoopSession for HvfArm64BootSession<'_> {
         HvfArm64BootNetworkNotificationDispatchError,
     > {
         self.dispatch_network_queue_notifications_and_signal_interrupts()
+    }
+
+    fn dispatch_run_loop_vsock_notifications(
+        &mut self,
+    ) -> Result<HvfArm64BootVsockNotificationDispatches, HvfArm64BootVsockNotificationDispatchError>
+    {
+        self.dispatch_vsock_queue_notifications_and_signal_interrupts()
     }
 }
 
@@ -1192,6 +1405,17 @@ fn run_boot_session_loop_with_observer(
                 if stop_token.is_stop_requested() {
                     return Ok(HvfArm64BootRunLoopOutcome::Stopped { steps });
                 }
+                session
+                    .dispatch_run_loop_vsock_notifications()
+                    .map_err(
+                        |source| HvfArm64BootRunLoopError::DispatchVsockNotifications {
+                            steps_completed: steps,
+                            source: Box::new(source),
+                        },
+                    )?;
+                if stop_token.is_stop_requested() {
+                    return Ok(HvfArm64BootRunLoopOutcome::Stopped { steps });
+                }
                 if steps == max_steps {
                     return Ok(HvfArm64BootRunLoopOutcome::StepLimitReached { steps });
                 }
@@ -1273,6 +1497,24 @@ fn collect_network_notification_dispatches(
     Ok(HvfArm64BootNetworkNotificationDispatches::new(devices))
 }
 
+fn collect_vsock_notification_dispatches(
+    dispatches: Arm64BootVsockNotificationDispatches,
+) -> Result<HvfArm64BootVsockNotificationDispatches, HvfArm64BootVsockNotificationDispatchError> {
+    let runtime_dispatches = dispatches.into_vec();
+    let mut devices = Vec::new();
+    devices
+        .try_reserve_exact(runtime_dispatches.len())
+        .map_err(
+            |source| HvfArm64BootVsockNotificationDispatchError::ResultAllocation { source },
+        )?;
+
+    for dispatch in runtime_dispatches {
+        devices.push(HvfArm64BootVsockNotificationDispatch::new(dispatch, None));
+    }
+
+    Ok(HvfArm64BootVsockNotificationDispatches::new(devices))
+}
+
 fn dispatch_network_runtime_notifications(
     memory: &mut GuestMemory,
     runtime_resources: &mut Arm64BootRuntimeResources,
@@ -1298,6 +1540,18 @@ fn dispatch_network_runtime_notifications_with_packet_io(
         )
 }
 
+fn dispatch_vsock_runtime_notifications(
+    memory: &mut GuestMemory,
+    runtime_resources: &mut Arm64BootRuntimeResources,
+    mmio_dispatcher: &mut MmioDispatcher,
+) -> Result<Arm64BootVsockNotificationDispatches, HvfArm64BootVsockNotificationDispatchError> {
+    runtime_resources
+        .dispatch_vsock_queue_notifications(memory, mmio_dispatcher)
+        .map_err(
+            |source| HvfArm64BootVsockNotificationDispatchError::DispatchNotifications { source },
+        )
+}
+
 fn collect_or_signal_network_queue_interrupts(
     dispatches: Arm64BootNetworkNotificationDispatches,
     gic: &HvfGicMetadata,
@@ -1312,6 +1566,21 @@ fn collect_or_signal_network_queue_interrupts(
     })?;
 
     signal_network_queue_interrupts(dispatches, &signaler)
+}
+
+fn collect_or_signal_vsock_queue_interrupts(
+    dispatches: Arm64BootVsockNotificationDispatches,
+    gic: &HvfGicMetadata,
+) -> Result<HvfArm64BootVsockNotificationDispatches, HvfArm64BootVsockNotificationDispatchError> {
+    if !dispatches.needs_queue_interrupt() {
+        return collect_vsock_notification_dispatches(dispatches);
+    }
+
+    let signaler = HvfGicSpiSignaler::from_metadata(gic).map_err(|source| {
+        HvfArm64BootVsockNotificationDispatchError::CreateSignalSink { source }
+    })?;
+
+    signal_vsock_queue_interrupts(dispatches, &signaler)
 }
 
 fn signal_network_queue_interrupts(
@@ -1340,6 +1609,33 @@ fn signal_network_queue_interrupts(
     }
 
     Ok(HvfArm64BootNetworkNotificationDispatches::new(devices))
+}
+
+fn signal_vsock_queue_interrupts(
+    dispatches: Arm64BootVsockNotificationDispatches,
+    signaler: &dyn InterruptSink,
+) -> Result<HvfArm64BootVsockNotificationDispatches, HvfArm64BootVsockNotificationDispatchError> {
+    let runtime_dispatches = dispatches.into_vec();
+    let mut devices = Vec::new();
+    devices
+        .try_reserve_exact(runtime_dispatches.len())
+        .map_err(
+            |source| HvfArm64BootVsockNotificationDispatchError::ResultAllocation { source },
+        )?;
+
+    for dispatch in runtime_dispatches {
+        let signal_error = if dispatch.needs_queue_interrupt() {
+            signal_queue_interrupt(dispatch.device().fdt_device.interrupt_line, signaler).err()
+        } else {
+            None
+        };
+        devices.push(HvfArm64BootVsockNotificationDispatch::new(
+            dispatch,
+            signal_error,
+        ));
+    }
+
+    Ok(HvfArm64BootVsockNotificationDispatches::new(devices))
 }
 
 fn signal_queue_interrupt(
@@ -1766,7 +2062,7 @@ mod tests {
         Arm64BootBlockNotificationDispatches, Arm64BootNetworkNotificationDispatches,
         Arm64BootNetworkNotificationOutcome, Arm64BootNetworkPacketIo,
         Arm64BootNetworkPacketIoError, Arm64BootNetworkPacketIoProvider, Arm64BootResourceConfig,
-        Arm64BootResources, Arm64BootRuntimeResources,
+        Arm64BootResources, Arm64BootRuntimeResources, Arm64BootVsockNotificationDispatches,
     };
     use bangbang_runtime::virtio_mmio::{
         VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DRIVER,
@@ -1775,17 +2071,23 @@ mod tests {
     use bangbang_runtime::virtio_queue::{
         VIRTQUEUE_DESC_F_NEXT, VIRTQUEUE_DESC_F_WRITE, VIRTQUEUE_DESCRIPTOR_SIZE,
     };
-    use bangbang_runtime::vsock::VsockMmioLayout;
+    use bangbang_runtime::vsock::{
+        VIRTIO_VSOCK_EVENT_QUEUE_INDEX, VIRTIO_VSOCK_PACKET_HEADER_SIZE,
+        VIRTIO_VSOCK_RX_QUEUE_INDEX, VIRTIO_VSOCK_TX_QUEUE_INDEX, VirtioVsockPacketHeader,
+        VsockConfigInput, VsockMmioLayout,
+    };
 
     use super::{
         HvfArm64BootBlockNotificationDispatchError, HvfArm64BootInterruptLinePurpose,
         HvfArm64BootMmioDispatcherError, HvfArm64BootNetworkNotificationDispatchError,
         HvfArm64BootRunLoopOutcome, HvfArm64BootRunLoopStopToken, HvfArm64BootSerialDeviceConfig,
-        HvfArm64BootSessionConfig, HvfArm64BootSessionError, allocate_interrupt_lines,
+        HvfArm64BootSessionConfig, HvfArm64BootSessionError,
+        HvfArm64BootVsockNotificationDispatchError, allocate_interrupt_lines,
         collect_block_notification_dispatches, collect_network_notification_dispatches,
+        collect_vsock_notification_dispatches,
         dispatch_network_runtime_notifications_with_packet_io, lock_boot_mmio_dispatcher,
         run_boot_session_loop, run_boot_session_vcpu_step, signal_block_queue_interrupts,
-        signal_network_queue_interrupts, validate_single_vcpu,
+        signal_network_queue_interrupts, signal_vsock_queue_interrupts, validate_single_vcpu,
     };
     use crate::exit::{
         HvfExceptionExit, HvfHvcExit, HvfMmioAccessSize, HvfMmioDirection, HvfMmioRegister,
@@ -1828,6 +2130,16 @@ mod tests {
     const TEST_NETWORK_TX_USED_RING: GuestAddress = GuestAddress::new(0x8062_0000);
     const TEST_NETWORK_TX_HEADER: GuestAddress = GuestAddress::new(0x8063_0000);
     const TEST_NETWORK_TX_PAYLOAD: GuestAddress = GuestAddress::new(0x8064_0000);
+    const TEST_VSOCK_RX_DESCRIPTOR_TABLE: GuestAddress = GuestAddress::new(0x8070_0000);
+    const TEST_VSOCK_RX_AVAILABLE_RING: GuestAddress = GuestAddress::new(0x8071_0000);
+    const TEST_VSOCK_RX_USED_RING: GuestAddress = GuestAddress::new(0x8072_0000);
+    const TEST_VSOCK_TX_DESCRIPTOR_TABLE: GuestAddress = GuestAddress::new(0x8073_0000);
+    const TEST_VSOCK_TX_AVAILABLE_RING: GuestAddress = GuestAddress::new(0x8074_0000);
+    const TEST_VSOCK_TX_USED_RING: GuestAddress = GuestAddress::new(0x8075_0000);
+    const TEST_VSOCK_EVENT_DESCRIPTOR_TABLE: GuestAddress = GuestAddress::new(0x8076_0000);
+    const TEST_VSOCK_EVENT_AVAILABLE_RING: GuestAddress = GuestAddress::new(0x8077_0000);
+    const TEST_VSOCK_EVENT_USED_RING: GuestAddress = GuestAddress::new(0x8078_0000);
+    const TEST_VSOCK_HEADER: GuestAddress = GuestAddress::new(0x8079_0000);
     const TEST_AVAILABLE_RING_IDX_OFFSET: u64 = 2;
     const TEST_AVAILABLE_RING_RING_OFFSET: u64 = 4;
     const TEST_AVAILABLE_RING_ENTRY_SIZE: u64 = 2;
@@ -2092,11 +2404,18 @@ mod tests {
                 HvfArm64BootNetworkNotificationDispatchError,
             >,
         >,
+        vsock_dispatch_results: VecDeque<
+            Result<
+                super::HvfArm64BootVsockNotificationDispatches,
+                HvfArm64BootVsockNotificationDispatchError,
+            >,
+        >,
         timer_results: VecDeque<Result<(), HvfVcpuRunnerError>>,
         events: Vec<&'static str>,
         request_stop_on_run: Option<HvfArm64BootRunLoopStopToken>,
         request_stop_on_dispatch: Option<HvfArm64BootRunLoopStopToken>,
         request_stop_on_network_dispatch: Option<HvfArm64BootRunLoopStopToken>,
+        request_stop_on_vsock_dispatch: Option<HvfArm64BootRunLoopStopToken>,
         request_stop_on_timer: Option<HvfArm64BootRunLoopStopToken>,
     }
 
@@ -2106,11 +2425,13 @@ mod tests {
                 run_results: run_results.into_iter().map(Ok).collect(),
                 dispatch_results: VecDeque::new(),
                 network_dispatch_results: VecDeque::new(),
+                vsock_dispatch_results: VecDeque::new(),
                 timer_results: VecDeque::new(),
                 events: Vec::new(),
                 request_stop_on_run: None,
                 request_stop_on_dispatch: None,
                 request_stop_on_network_dispatch: None,
+                request_stop_on_vsock_dispatch: None,
                 request_stop_on_timer: None,
             }
         }
@@ -2120,11 +2441,13 @@ mod tests {
                 run_results: VecDeque::from([Err(source)]),
                 dispatch_results: VecDeque::new(),
                 network_dispatch_results: VecDeque::new(),
+                vsock_dispatch_results: VecDeque::new(),
                 timer_results: VecDeque::new(),
                 events: Vec::new(),
                 request_stop_on_run: None,
                 request_stop_on_dispatch: None,
                 request_stop_on_network_dispatch: None,
+                request_stop_on_vsock_dispatch: None,
                 request_stop_on_timer: None,
             }
         }
@@ -2138,6 +2461,13 @@ mod tests {
             source: HvfArm64BootNetworkNotificationDispatchError,
         ) {
             self.network_dispatch_results.push_back(Err(source));
+        }
+
+        fn push_vsock_dispatch_error(
+            &mut self,
+            source: HvfArm64BootVsockNotificationDispatchError,
+        ) {
+            self.vsock_dispatch_results.push_back(Err(source));
         }
 
         fn push_timer_error(&mut self, source: HvfVcpuRunnerError) {
@@ -2154,6 +2484,10 @@ mod tests {
 
         fn request_stop_on_network_dispatch(&mut self, stop_token: HvfArm64BootRunLoopStopToken) {
             self.request_stop_on_network_dispatch = Some(stop_token);
+        }
+
+        fn request_stop_on_vsock_dispatch(&mut self, stop_token: HvfArm64BootRunLoopStopToken) {
+            self.request_stop_on_vsock_dispatch = Some(stop_token);
         }
 
         fn request_stop_on_timer(&mut self, stop_token: HvfArm64BootRunLoopStopToken) {
@@ -2218,6 +2552,24 @@ mod tests {
                         Vec::new(),
                     ))
                 })
+        }
+
+        fn dispatch_run_loop_vsock_notifications(
+            &mut self,
+        ) -> Result<
+            super::HvfArm64BootVsockNotificationDispatches,
+            HvfArm64BootVsockNotificationDispatchError,
+        > {
+            self.events.push("vsock-dispatch");
+            if let Some(stop_token) = self.request_stop_on_vsock_dispatch.take() {
+                stop_token.request_stop();
+            }
+
+            self.vsock_dispatch_results.pop_front().unwrap_or_else(|| {
+                Ok(super::HvfArm64BootVsockNotificationDispatches::new(
+                    Vec::new(),
+                ))
+            })
         }
     }
 
@@ -2455,6 +2807,19 @@ mod tests {
             .expect("network interface config should be stored");
     }
 
+    fn add_vsock(
+        controller: &mut bangbang_runtime::VmmController,
+        guest_cid: u32,
+        uds_path: &Path,
+    ) {
+        controller
+            .handle_action(VmmAction::PutVsock(VsockConfigInput::new(
+                guest_cid,
+                uds_path.to_string_lossy().into_owned(),
+            )))
+            .expect("vsock config should be stored");
+    }
+
     fn valid_boot_resource_config(lines: &[GuestInterruptLine]) -> Arm64BootResourceConfig<'_> {
         valid_boot_resource_config_with_network_lines(lines, &[])
     }
@@ -2462,6 +2827,14 @@ mod tests {
     fn valid_boot_resource_config_with_network_lines<'a>(
         block_lines: &'a [GuestInterruptLine],
         network_lines: &'a [GuestInterruptLine],
+    ) -> Arm64BootResourceConfig<'a> {
+        valid_boot_resource_config_with_network_and_vsock_lines(block_lines, network_lines, None)
+    }
+
+    fn valid_boot_resource_config_with_network_and_vsock_lines<'a>(
+        block_lines: &'a [GuestInterruptLine],
+        network_lines: &'a [GuestInterruptLine],
+        vsock_line: Option<GuestInterruptLine>,
     ) -> Arm64BootResourceConfig<'a> {
         Arm64BootResourceConfig {
             vcpu_mpidrs: &[0],
@@ -2479,7 +2852,7 @@ mod tests {
                 GuestAddress::new(0x4000_6000),
                 MmioRegionId::new(90),
             ),
-            vsock_interrupt_line: None,
+            vsock_interrupt_line: vsock_line,
         }
     }
 
@@ -2572,6 +2945,21 @@ mod tests {
         (parts.memory, parts.runtime, parts.mmio_dispatcher)
     }
 
+    fn boot_runtime_with_vsock() -> (GuestMemory, Arm64BootRuntimeResources, MmioDispatcher) {
+        let kernel = temp_file("kernel-with-vsock", &arm64_image());
+        let uds_path = temp_path("vsock-test.sock");
+        let mut controller = controller_with_kernel(kernel.path());
+        add_vsock(&mut controller, 42, &uds_path);
+        let resources = Arm64BootResources::assemble_from_controller(
+            &controller,
+            valid_boot_resource_config_with_network_and_vsock_lines(&[], &[], Some(line(32))),
+        )
+        .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+
+        (parts.memory, parts.runtime, parts.mmio_dispatcher)
+    }
+
     fn dispatch_boot_block_notifications(
         memory: &mut GuestMemory,
         runtime: &mut Arm64BootRuntimeResources,
@@ -2605,6 +2993,16 @@ mod tests {
             provider,
         )
         .expect("network packet I/O notification dispatch result should allocate")
+    }
+
+    fn dispatch_boot_vsock_notifications(
+        memory: &mut GuestMemory,
+        runtime: &mut Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+    ) -> Arm64BootVsockNotificationDispatches {
+        runtime
+            .dispatch_vsock_queue_notifications(memory, mmio_dispatcher)
+            .expect("vsock notification dispatch result should allocate")
     }
 
     fn write_boot_block_mmio_u32(
@@ -2698,6 +3096,61 @@ mod tests {
         let outcome = mmio_dispatcher
             .dispatch(MmioOperation::read(access).expect("u32 read should be valid"))
             .expect("network MMIO read should dispatch");
+
+        match outcome {
+            MmioDispatchOutcome::Read { data } => u32::from_le_bytes(
+                data.as_slice()
+                    .try_into()
+                    .expect("u32 read should return four bytes"),
+            ),
+            MmioDispatchOutcome::Write => panic!("read operation should not return write outcome"),
+        }
+    }
+
+    fn write_boot_vsock_mmio_u32(
+        runtime: &mut Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+        register: VirtioMmioRegister,
+        value: u32,
+    ) {
+        let address = runtime
+            .vsock_device
+            .as_ref()
+            .expect("vsock device should exist")
+            .registration
+            .address()
+            .checked_add(register.offset())
+            .expect("test MMIO address should not overflow");
+        let access = mmio_dispatcher
+            .lookup(address, 4)
+            .expect("vsock MMIO access should resolve");
+        let data = MmioAccessBytes::new(&value.to_le_bytes()).expect("u32 bytes should be valid");
+        let outcome = mmio_dispatcher
+            .dispatch(MmioOperation::write(access, data).expect("u32 write should be valid"))
+            .expect("vsock MMIO write should dispatch");
+
+        assert_eq!(outcome, MmioDispatchOutcome::Write);
+    }
+
+    fn read_boot_vsock_mmio_u32(
+        runtime: &mut Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+        register: VirtioMmioRegister,
+    ) -> u32 {
+        let address = runtime
+            .vsock_device
+            .as_ref()
+            .expect("vsock device should exist")
+            .registration
+            .address()
+            .checked_add(register.offset())
+            .expect("test MMIO address should not overflow");
+        let access = mmio_dispatcher
+            .lookup(address, 4)
+            .expect("vsock MMIO access should resolve");
+        let outcome = mmio_dispatcher
+            .dispatch(MmioOperation::read(access).expect("u32 read should be valid"))
+            .expect("vsock MMIO read should dispatch");
 
         match outcome {
             MmioDispatchOutcome::Read { data } => u32::from_le_bytes(
@@ -2909,6 +3362,92 @@ mod tests {
         );
     }
 
+    fn configure_boot_vsock_queues(
+        runtime: &mut Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+    ) {
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::Status,
+            VIRTIO_DEVICE_STATUS_ACKNOWLEDGE,
+        );
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::Status,
+            VIRTIO_DEVICE_STATUS_ACKNOWLEDGE | VIRTIO_DEVICE_STATUS_DRIVER,
+        );
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::Status,
+            QUEUE_CONFIG_STATUS,
+        );
+        configure_boot_vsock_queue(runtime, mmio_dispatcher, VIRTIO_VSOCK_RX_QUEUE_INDEX);
+        configure_boot_vsock_queue(runtime, mmio_dispatcher, VIRTIO_VSOCK_TX_QUEUE_INDEX);
+        configure_boot_vsock_queue(runtime, mmio_dispatcher, VIRTIO_VSOCK_EVENT_QUEUE_INDEX);
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::Status,
+            DRIVER_OK_STATUS,
+        );
+    }
+
+    fn configure_boot_vsock_queue(
+        runtime: &mut Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+        queue_index: usize,
+    ) {
+        let queue_index_u32 = u32::try_from(queue_index).expect("test queue index should fit");
+        let (descriptor_table, driver_ring, device_ring) = vsock_queue_addresses(queue_index_u32);
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::QueueSel,
+            queue_index_u32,
+        );
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::QueueNum,
+            u32::from(TEST_QUEUE_SIZE),
+        );
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::QueueDescLow,
+            guest_address_low(descriptor_table),
+        );
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::QueueDriverLow,
+            guest_address_low(driver_ring),
+        );
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::QueueDeviceLow,
+            guest_address_low(device_ring),
+        );
+        write_boot_vsock_mmio_u32(runtime, mmio_dispatcher, VirtioMmioRegister::QueueReady, 1);
+    }
+
+    fn notify_boot_vsock_queue(
+        runtime: &mut Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+        queue_index: usize,
+    ) {
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::QueueNotify,
+            queue_index.try_into().expect("queue index should fit"),
+        );
+    }
+
     fn network_queue_addresses(queue_index: u32) -> (GuestAddress, GuestAddress, GuestAddress) {
         match queue_index {
             0 => (
@@ -2922,6 +3461,27 @@ mod tests {
                 TEST_NETWORK_TX_USED_RING,
             ),
             other => panic!("unsupported test network queue index {other}"),
+        }
+    }
+
+    fn vsock_queue_addresses(queue_index: u32) -> (GuestAddress, GuestAddress, GuestAddress) {
+        match usize::try_from(queue_index).expect("queue index should fit") {
+            VIRTIO_VSOCK_RX_QUEUE_INDEX => (
+                TEST_VSOCK_RX_DESCRIPTOR_TABLE,
+                TEST_VSOCK_RX_AVAILABLE_RING,
+                TEST_VSOCK_RX_USED_RING,
+            ),
+            VIRTIO_VSOCK_TX_QUEUE_INDEX => (
+                TEST_VSOCK_TX_DESCRIPTOR_TABLE,
+                TEST_VSOCK_TX_AVAILABLE_RING,
+                TEST_VSOCK_TX_USED_RING,
+            ),
+            VIRTIO_VSOCK_EVENT_QUEUE_INDEX => (
+                TEST_VSOCK_EVENT_DESCRIPTOR_TABLE,
+                TEST_VSOCK_EVENT_AVAILABLE_RING,
+                TEST_VSOCK_EVENT_USED_RING,
+            ),
+            other => panic!("unsupported test vsock queue index {other}"),
         }
     }
 
@@ -3090,6 +3650,46 @@ mod tests {
         }
     }
 
+    fn write_vsock_tx_packet_header(memory: &mut GuestMemory) {
+        memory
+            .write_slice(
+                &VirtioVsockPacketHeader::new().to_bytes(),
+                TEST_VSOCK_HEADER,
+            )
+            .expect("virtio-vsock TX header should write");
+    }
+
+    fn write_vsock_tx_descriptor(memory: &mut GuestMemory, index: u16, descriptor: TestDescriptor) {
+        let mut bytes = [0; VIRTQUEUE_DESCRIPTOR_SIZE];
+        let (address_bytes, tail) = bytes.split_at_mut(8);
+        let (len_bytes, tail) = tail.split_at_mut(4);
+        let (flags_bytes, next_bytes) = tail.split_at_mut(2);
+        address_bytes.copy_from_slice(&descriptor.address.raw_value().to_le_bytes());
+        len_bytes.copy_from_slice(&descriptor.len.to_le_bytes());
+        flags_bytes.copy_from_slice(&descriptor.flags.to_le_bytes());
+        next_bytes.copy_from_slice(&descriptor.next.to_le_bytes());
+
+        let descriptor_address = TEST_VSOCK_TX_DESCRIPTOR_TABLE
+            .checked_add(
+                u64::from(index)
+                    * u64::try_from(VIRTQUEUE_DESCRIPTOR_SIZE).expect("descriptor size should fit"),
+            )
+            .expect("descriptor address should not overflow");
+        memory
+            .write_slice(&bytes, descriptor_address)
+            .expect("vsock TX descriptor should write");
+    }
+
+    fn write_vsock_tx_descriptors(memory: &mut GuestMemory, descriptors: &[TestDescriptor]) {
+        for (index, descriptor) in descriptors.iter().copied().enumerate() {
+            write_vsock_tx_descriptor(
+                memory,
+                u16::try_from(index).expect("test descriptor index should fit"),
+                descriptor,
+            );
+        }
+    }
+
     fn write_guest_u16(memory: &mut GuestMemory, address: GuestAddress, value: u16) {
         memory
             .write_slice(&value.to_le_bytes(), address)
@@ -3210,6 +3810,48 @@ mod tests {
                 .expect("network TX used-ring len address should not overflow"),
         );
         (descriptor_head, len)
+    }
+
+    fn vsock_tx_available_ring_idx_address() -> GuestAddress {
+        TEST_VSOCK_TX_AVAILABLE_RING
+            .checked_add(TEST_AVAILABLE_RING_IDX_OFFSET)
+            .expect("vsock TX available idx address should not overflow")
+    }
+
+    fn vsock_tx_available_ring_entry_address(ring_index: u16) -> GuestAddress {
+        TEST_VSOCK_TX_AVAILABLE_RING
+            .checked_add(
+                TEST_AVAILABLE_RING_RING_OFFSET
+                    + u64::from(ring_index) * TEST_AVAILABLE_RING_ENTRY_SIZE,
+            )
+            .expect("vsock TX available entry address should not overflow")
+    }
+
+    fn write_vsock_tx_available_heads(memory: &mut GuestMemory, heads: &[u16]) {
+        for (ring_index, head) in heads.iter().copied().enumerate() {
+            write_guest_u16(
+                memory,
+                vsock_tx_available_ring_entry_address(
+                    u16::try_from(ring_index).expect("test ring index should fit in u16"),
+                ),
+                head,
+            );
+        }
+        write_guest_u16(
+            memory,
+            vsock_tx_available_ring_idx_address(),
+            u16::try_from(heads.len()).expect("test available length should fit in u16"),
+        );
+    }
+
+    fn vsock_tx_used_ring_idx_address() -> GuestAddress {
+        TEST_VSOCK_TX_USED_RING
+            .checked_add(2)
+            .expect("vsock TX used idx address should not overflow")
+    }
+
+    fn read_vsock_tx_used_index(memory: &GuestMemory) -> u16 {
+        read_guest_u16(memory, vsock_tx_used_ring_idx_address())
     }
 
     #[test]
@@ -3871,6 +4513,252 @@ mod tests {
     }
 
     #[test]
+    fn vsock_notification_signal_dispatch_accepts_empty_device() {
+        let (mut memory, mut runtime, mut mmio_dispatcher) = boot_runtime_without_drives();
+        let dispatches =
+            dispatch_boot_vsock_notifications(&mut memory, &mut runtime, &mut mmio_dispatcher);
+        let result = collect_vsock_notification_dispatches(dispatches)
+            .expect("empty vsock dispatch result should collect");
+
+        assert!(result.is_empty());
+        assert_eq!(result.len(), 0);
+        assert!(!result.has_signal_failure());
+    }
+
+    #[test]
+    fn vsock_notification_signal_dispatch_skips_noop_device() {
+        let (mut memory, mut runtime, mut mmio_dispatcher) = boot_runtime_with_vsock();
+        let dispatches =
+            dispatch_boot_vsock_notifications(&mut memory, &mut runtime, &mut mmio_dispatcher);
+        let (lines, sink) = RecordingSink::successful();
+
+        let result = signal_vsock_queue_interrupts(dispatches, sink.as_ref())
+            .expect("noop vsock dispatch should collect");
+
+        assert_eq!(result.len(), 1);
+        let device = &result.as_slice()[0];
+        assert_eq!(device.dispatch().device().registration.guest_cid(), 42);
+        assert!(!device.dispatch().needs_queue_interrupt());
+        assert!(!device.queue_interrupt_signaled());
+        assert!(device.signal_error().is_none());
+        assert!(recorded_lines(&lines).is_empty());
+        assert_eq!(
+            read_boot_vsock_mmio_u32(
+                &mut runtime,
+                &mut mmio_dispatcher,
+                VirtioMmioRegister::InterruptStatus
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn vsock_notification_signal_dispatch_signals_queued_tx_packet() {
+        let (mut memory, mut runtime, mut mmio_dispatcher) = boot_runtime_with_vsock();
+        configure_boot_vsock_queues(&mut runtime, &mut mmio_dispatcher);
+        write_vsock_tx_packet_header(&mut memory);
+        write_vsock_tx_descriptors(
+            &mut memory,
+            &[TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            )],
+        );
+        write_vsock_tx_available_heads(&mut memory, &[0]);
+        notify_boot_vsock_queue(
+            &mut runtime,
+            &mut mmio_dispatcher,
+            VIRTIO_VSOCK_TX_QUEUE_INDEX,
+        );
+        let dispatches =
+            dispatch_boot_vsock_notifications(&mut memory, &mut runtime, &mut mmio_dispatcher);
+        let (lines, sink) = RecordingSink::successful();
+
+        let result = signal_vsock_queue_interrupts(dispatches, sink.as_ref())
+            .expect("queued vsock dispatch should collect");
+
+        assert_eq!(result.len(), 1);
+        let device = &result.as_slice()[0];
+        assert!(device.dispatch().needs_queue_interrupt());
+        assert!(device.queue_interrupt_signaled());
+        assert!(device.signal_error().is_none());
+        assert_eq!(recorded_lines(&lines), vec![32]);
+        let dispatch = device
+            .dispatch()
+            .outcome()
+            .dispatched()
+            .expect("vsock notification should dispatch");
+        let tx = dispatch
+            .tx_queue_dispatch()
+            .expect("TX queue dispatch should be present");
+        assert_eq!(tx.processed_packets(), 1);
+        assert_eq!(tx.successful_packets(), 1);
+        assert_eq!(tx.parse_failures(), 0);
+        assert_eq!(
+            read_boot_vsock_mmio_u32(
+                &mut runtime,
+                &mut mmio_dispatcher,
+                VirtioMmioRegister::InterruptStatus
+            ),
+            DeviceInterruptKind::Queue.status().bits()
+        );
+        assert_eq!(read_vsock_tx_used_index(&memory), 1);
+    }
+
+    #[test]
+    fn vsock_notification_signal_dispatch_preserves_unsupported_queue_without_signal() {
+        let (mut memory, mut runtime, mut mmio_dispatcher) = boot_runtime_with_vsock();
+        configure_boot_vsock_queues(&mut runtime, &mut mmio_dispatcher);
+        notify_boot_vsock_queue(
+            &mut runtime,
+            &mut mmio_dispatcher,
+            VIRTIO_VSOCK_RX_QUEUE_INDEX,
+        );
+        let dispatches =
+            dispatch_boot_vsock_notifications(&mut memory, &mut runtime, &mut mmio_dispatcher);
+        let (lines, sink) = RecordingSink::successful();
+
+        let result = signal_vsock_queue_interrupts(dispatches, sink.as_ref())
+            .expect("unsupported vsock dispatch should collect");
+
+        let device = &result.as_slice()[0];
+        assert!(!device.dispatch().needs_queue_interrupt());
+        assert!(!device.queue_interrupt_signaled());
+        assert!(device.signal_error().is_none());
+        assert!(recorded_lines(&lines).is_empty());
+        let err = device
+            .dispatch()
+            .outcome()
+            .dispatch_error()
+            .expect("unsupported queue error should be preserved");
+        assert!(matches!(
+            err,
+            bangbang_runtime::vsock::VirtioVsockDeviceNotificationError::UnsupportedQueue {
+                queue_index: VIRTIO_VSOCK_RX_QUEUE_INDEX,
+                ..
+            }
+        ));
+        assert_eq!(err.drained_notifications(), [VIRTIO_VSOCK_RX_QUEUE_INDEX]);
+        assert_eq!(
+            read_boot_vsock_mmio_u32(
+                &mut runtime,
+                &mut mmio_dispatcher,
+                VirtioMmioRegister::InterruptStatus
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn vsock_notification_signal_dispatch_preserves_partial_error_interrupt_intent() {
+        let (mut memory, mut runtime, mut mmio_dispatcher) = boot_runtime_with_vsock();
+        configure_boot_vsock_queues(&mut runtime, &mut mmio_dispatcher);
+        write_vsock_tx_packet_header(&mut memory);
+        write_vsock_tx_descriptors(
+            &mut memory,
+            &[TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            )],
+        );
+        write_vsock_tx_available_heads(&mut memory, &[0, TEST_QUEUE_SIZE]);
+        notify_boot_vsock_queue(
+            &mut runtime,
+            &mut mmio_dispatcher,
+            VIRTIO_VSOCK_TX_QUEUE_INDEX,
+        );
+        let dispatches =
+            dispatch_boot_vsock_notifications(&mut memory, &mut runtime, &mut mmio_dispatcher);
+        let (lines, sink) = RecordingSink::successful();
+
+        let result = signal_vsock_queue_interrupts(dispatches, sink.as_ref())
+            .expect("partial vsock dispatch result should collect");
+
+        let device = &result.as_slice()[0];
+        assert!(device.dispatch().needs_queue_interrupt());
+        assert!(device.queue_interrupt_signaled());
+        let err = device
+            .dispatch()
+            .outcome()
+            .dispatch_error()
+            .expect("partial TX dispatch error should be preserved");
+        let completed = err
+            .completed_tx_dispatch()
+            .expect("completed TX metadata should be preserved");
+        assert_eq!(completed.processed_packets(), 1);
+        assert!(completed.needs_queue_interrupt());
+        assert_eq!(recorded_lines(&lines), vec![32]);
+        assert_eq!(read_vsock_tx_used_index(&memory), 1);
+    }
+
+    #[test]
+    fn vsock_notification_signal_dispatch_preserves_signal_failure_per_device() {
+        let (mut memory, mut runtime, mut mmio_dispatcher) = boot_runtime_with_vsock();
+        configure_boot_vsock_queues(&mut runtime, &mut mmio_dispatcher);
+        write_vsock_tx_packet_header(&mut memory);
+        write_vsock_tx_descriptors(
+            &mut memory,
+            &[TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            )],
+        );
+        write_vsock_tx_available_heads(&mut memory, &[0]);
+        notify_boot_vsock_queue(
+            &mut runtime,
+            &mut mmio_dispatcher,
+            VIRTIO_VSOCK_TX_QUEUE_INDEX,
+        );
+        let dispatches =
+            dispatch_boot_vsock_notifications(&mut memory, &mut runtime, &mut mmio_dispatcher);
+        let (lines, sink) = RecordingSink::failing("injected vsock signal failure");
+
+        let result = signal_vsock_queue_interrupts(dispatches, sink.as_ref())
+            .expect("vsock signal failure should stay per-device");
+
+        let device = &result.as_slice()[0];
+        assert!(result.has_signal_failure());
+        assert!(!device.queue_interrupt_signaled());
+        let err = device
+            .signal_error()
+            .expect("vsock signal failure should be preserved");
+        assert_eq!(
+            err.to_string(),
+            "failed to signal guest interrupt line 32 for queue interrupt: injected vsock signal failure"
+        );
+        assert_eq!(recorded_lines(&lines), vec![32]);
+        assert_eq!(
+            read_boot_vsock_mmio_u32(
+                &mut runtime,
+                &mut mmio_dispatcher,
+                VirtioMmioRegister::InterruptStatus
+            ),
+            DeviceInterruptKind::Queue.status().bits()
+        );
+    }
+
+    #[test]
+    fn vsock_notification_signal_dispatch_preserves_missing_handler_without_signal() {
+        let (mut memory, mut runtime, _) = boot_runtime_with_vsock();
+        let mut mmio_dispatcher = MmioDispatcher::new();
+        let dispatches =
+            dispatch_boot_vsock_notifications(&mut memory, &mut runtime, &mut mmio_dispatcher);
+        let (lines, sink) = RecordingSink::successful();
+
+        let result = signal_vsock_queue_interrupts(dispatches, sink.as_ref())
+            .expect("missing vsock handler dispatch should collect");
+
+        let device = &result.as_slice()[0];
+        assert!(device.dispatch().outcome().handler_lookup_error().is_some());
+        assert!(!device.queue_interrupt_signaled());
+        assert!(device.signal_error().is_none());
+        assert!(recorded_lines(&lines).is_empty());
+    }
+
+    #[test]
     fn boot_session_run_step_delegates_with_session_dispatcher() {
         let dispatcher = Arc::new(Mutex::new(MmioDispatcher::new()));
         let (runner, recorded_dispatchers) =
@@ -3951,9 +4839,11 @@ mod tests {
                 "run",
                 "dispatch",
                 "network-dispatch",
+                "vsock-dispatch",
                 "run",
                 "dispatch",
                 "network-dispatch",
+                "vsock-dispatch",
             ]
         );
     }
@@ -4036,6 +4926,7 @@ mod tests {
                 "run",
                 "dispatch",
                 "network-dispatch",
+                "vsock-dispatch",
             ]
         );
     }
@@ -4064,6 +4955,22 @@ mod tests {
 
         assert_eq!(outcome, HvfArm64BootRunLoopOutcome::Stopped { steps: 1 });
         assert_eq!(session.events, ["run", "dispatch", "network-dispatch"]);
+    }
+
+    #[test]
+    fn boot_session_run_loop_reports_stop_after_vsock_dispatch_before_step_limit() {
+        let stop_token = HvfArm64BootRunLoopStopToken::new();
+        let mut session = RecordingBootSessionRunLoopSession::new([mmio_run_step_outcome()]);
+        session.request_stop_on_vsock_dispatch(stop_token.clone());
+
+        let outcome = run_boot_session_loop(&mut session, &stop_token, max_steps(1))
+            .expect("stop after vsock dispatch should succeed");
+
+        assert_eq!(outcome, HvfArm64BootRunLoopOutcome::Stopped { steps: 1 });
+        assert_eq!(
+            session.events,
+            ["run", "dispatch", "network-dispatch", "vsock-dispatch"]
+        );
     }
 
     #[test]
@@ -4182,6 +5089,38 @@ mod tests {
             other => panic!("expected network notification error, got {other:?}"),
         }
         assert_eq!(session.events, ["run", "dispatch", "network-dispatch"]);
+    }
+
+    #[test]
+    fn boot_session_run_loop_preserves_vsock_notification_error_after_mmio_step() {
+        let stop_token = HvfArm64BootRunLoopStopToken::new();
+        let mut session = RecordingBootSessionRunLoopSession::new([mmio_run_step_outcome()]);
+        session.push_vsock_dispatch_error(
+            HvfArm64BootVsockNotificationDispatchError::MmioDispatcher {
+                source: HvfArm64BootMmioDispatcherError::Busy,
+            },
+        );
+
+        let err = run_boot_session_loop(&mut session, &stop_token, max_steps(1))
+            .expect_err("vsock notification error should stop loop");
+
+        match err {
+            super::HvfArm64BootRunLoopError::DispatchVsockNotifications {
+                steps_completed,
+                source,
+            } => {
+                assert_eq!(steps_completed, 1);
+                assert_eq!(
+                    source.to_string(),
+                    "failed to lock HVF boot-session MMIO dispatcher: HVF boot-session MMIO dispatcher lock is busy"
+                );
+            }
+            other => panic!("expected vsock notification error, got {other:?}"),
+        }
+        assert_eq!(
+            session.events,
+            ["run", "dispatch", "network-dispatch", "vsock-dispatch"]
+        );
     }
 
     #[test]
@@ -4346,6 +5285,34 @@ mod tests {
         );
 
         let err = HvfArm64BootNetworkNotificationDispatchError::MmioDispatcher {
+            source: HvfArm64BootMmioDispatcherError::Busy,
+        };
+        assert_eq!(
+            err.to_string(),
+            "failed to lock HVF boot-session MMIO dispatcher: HVF boot-session MMIO dispatcher lock is busy"
+        );
+        assert_eq!(
+            err.source().map(ToString::to_string),
+            Some("HVF boot-session MMIO dispatcher lock is busy".to_string())
+        );
+    }
+
+    #[test]
+    fn displays_vsock_notification_dispatch_errors() {
+        let err = HvfArm64BootVsockNotificationDispatchError::MapGuestMemory {
+            source: crate::memory::HvfGuestMemoryMappingError::InvalidState("mapping missing"),
+        };
+
+        assert_eq!(
+            err.to_string(),
+            "failed to borrow HVF boot-session guest memory for vsock notifications: invalid guest memory mapping state: mapping missing"
+        );
+        assert_eq!(
+            err.source().map(ToString::to_string),
+            Some("invalid guest memory mapping state: mapping missing".to_string())
+        );
+
+        let err = HvfArm64BootVsockNotificationDispatchError::MmioDispatcher {
             source: HvfArm64BootMmioDispatcherError::Busy,
         };
         assert_eq!(

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -32,7 +32,9 @@ use crate::network::{
 };
 use crate::serial::{SERIAL_MMIO_DEVICE_WINDOW_SIZE, SerialMmioDevice, SharedSerialOutputBuffer};
 use crate::vsock::{
-    PreparedVsockDevice, VsockMmioDeviceRegistration, VsockMmioLayout, VsockMmioRegistrationError,
+    PreparedVsockDevice, VirtioVsockDeviceNotificationDispatch, VirtioVsockDeviceNotificationError,
+    VirtioVsockMmioHandler, VsockMmioDeviceRegistration, VsockMmioLayout,
+    VsockMmioRegistrationError,
 };
 
 const MIB: u64 = 1024 * 1024;
@@ -420,6 +422,126 @@ impl std::error::Error for Arm64BootNetworkNotificationDispatchError {
     }
 }
 
+#[derive(Debug)]
+pub struct Arm64BootVsockNotificationDispatches {
+    devices: Vec<Arm64BootVsockNotificationDispatch>,
+}
+
+impl Arm64BootVsockNotificationDispatches {
+    fn new(devices: Vec<Arm64BootVsockNotificationDispatch>) -> Self {
+        Self { devices }
+    }
+
+    pub fn as_slice(&self) -> &[Arm64BootVsockNotificationDispatch] {
+        &self.devices
+    }
+
+    pub fn into_vec(self) -> Vec<Arm64BootVsockNotificationDispatch> {
+        self.devices
+    }
+
+    pub fn len(&self) -> usize {
+        self.devices.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.devices.is_empty()
+    }
+
+    pub fn needs_queue_interrupt(&self) -> bool {
+        self.devices
+            .iter()
+            .any(Arm64BootVsockNotificationDispatch::needs_queue_interrupt)
+    }
+}
+
+#[derive(Debug)]
+pub struct Arm64BootVsockNotificationDispatch {
+    device: Arm64BootVsockDevice,
+    outcome: Arm64BootVsockNotificationOutcome,
+}
+
+impl Arm64BootVsockNotificationDispatch {
+    fn new(device: Arm64BootVsockDevice, outcome: Arm64BootVsockNotificationOutcome) -> Self {
+        Self { device, outcome }
+    }
+
+    pub const fn device(&self) -> &Arm64BootVsockDevice {
+        &self.device
+    }
+
+    pub const fn outcome(&self) -> &Arm64BootVsockNotificationOutcome {
+        &self.outcome
+    }
+
+    pub fn needs_queue_interrupt(&self) -> bool {
+        self.outcome.needs_queue_interrupt()
+    }
+}
+
+#[derive(Debug)]
+pub enum Arm64BootVsockNotificationOutcome {
+    Dispatched(VirtioVsockDeviceNotificationDispatch),
+    DispatchFailed(VirtioVsockDeviceNotificationError),
+    HandlerLookupFailed(MmioHandlerLookupError),
+}
+
+impl Arm64BootVsockNotificationOutcome {
+    pub fn needs_queue_interrupt(&self) -> bool {
+        match self {
+            Self::Dispatched(dispatch) => dispatch.needs_queue_interrupt(),
+            Self::DispatchFailed(source) => source
+                .completed_tx_dispatch()
+                .is_some_and(crate::vsock::VirtioVsockTxQueueDispatch::needs_queue_interrupt),
+            Self::HandlerLookupFailed(_) => false,
+        }
+    }
+
+    pub const fn dispatched(&self) -> Option<&VirtioVsockDeviceNotificationDispatch> {
+        match self {
+            Self::Dispatched(dispatch) => Some(dispatch),
+            Self::DispatchFailed(_) | Self::HandlerLookupFailed(_) => None,
+        }
+    }
+
+    pub const fn dispatch_error(&self) -> Option<&VirtioVsockDeviceNotificationError> {
+        match self {
+            Self::DispatchFailed(source) => Some(source),
+            Self::Dispatched(_) | Self::HandlerLookupFailed(_) => None,
+        }
+    }
+
+    pub const fn handler_lookup_error(&self) -> Option<&MmioHandlerLookupError> {
+        match self {
+            Self::HandlerLookupFailed(source) => Some(source),
+            Self::Dispatched(_) | Self::DispatchFailed(_) => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Arm64BootVsockNotificationDispatchError {
+    ResultAllocation { source: TryReserveError },
+}
+
+impl fmt::Display for Arm64BootVsockNotificationDispatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ResultAllocation { source } => {
+                write!(f, "failed to allocate vsock notification results: {source}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for Arm64BootVsockNotificationDispatchError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::ResultAllocation { source } => Some(source),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Arm64BootBlockDevice {
     pub registration: BlockMmioDeviceRegistration,
@@ -559,6 +681,32 @@ impl Arm64BootRuntimeResources {
         }
 
         Ok(Arm64BootNetworkNotificationDispatches::new(devices))
+    }
+
+    pub fn dispatch_vsock_queue_notifications(
+        &mut self,
+        memory: &mut GuestMemory,
+        mmio_dispatcher: &mut MmioDispatcher,
+    ) -> Result<Arm64BootVsockNotificationDispatches, Arm64BootVsockNotificationDispatchError> {
+        let mut devices = Vec::new();
+        let device_count = if self.vsock_device.is_some() { 1 } else { 0 };
+        devices.try_reserve_exact(device_count).map_err(|source| {
+            Arm64BootVsockNotificationDispatchError::ResultAllocation { source }
+        })?;
+
+        if let Some(device) = self.vsock_device.clone() {
+            let region_id = device.registration.region_id();
+            let outcome = match mmio_dispatcher.handler_mut::<VirtioVsockMmioHandler>(region_id) {
+                Ok(handler) => match handler.dispatch_vsock_queue_notifications(memory) {
+                    Ok(dispatch) => Arm64BootVsockNotificationOutcome::Dispatched(dispatch),
+                    Err(source) => Arm64BootVsockNotificationOutcome::DispatchFailed(source),
+                },
+                Err(source) => Arm64BootVsockNotificationOutcome::HandlerLookupFailed(source),
+            };
+            devices.push(Arm64BootVsockNotificationDispatch::new(device, outcome));
+        }
+
+        Ok(Arm64BootVsockNotificationDispatches::new(devices))
     }
 }
 
@@ -1162,7 +1310,11 @@ mod tests {
     use crate::virtio_queue::{
         VIRTQUEUE_DESC_F_NEXT, VIRTQUEUE_DESC_F_WRITE, VIRTQUEUE_DESCRIPTOR_SIZE,
     };
-    use crate::vsock::{VirtioVsockMmioHandler, VsockConfigInput, VsockMmioLayout};
+    use crate::vsock::{
+        VIRTIO_VSOCK_EVENT_QUEUE_INDEX, VIRTIO_VSOCK_PACKET_HEADER_SIZE,
+        VIRTIO_VSOCK_RX_QUEUE_INDEX, VIRTIO_VSOCK_TX_QUEUE_INDEX, VirtioVsockMmioHandler,
+        VirtioVsockPacketHeader, VsockConfigInput, VsockMmioLayout,
+    };
 
     static NEXT_TEST_FILE_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -1187,6 +1339,16 @@ mod tests {
     const TEST_RX_AVAILABLE_RING: GuestAddress = GuestAddress::new(0x8047_0000);
     const TEST_RX_USED_RING: GuestAddress = GuestAddress::new(0x8048_0000);
     const TEST_RX_BUFFER: GuestAddress = GuestAddress::new(0x8049_0000);
+    const TEST_VSOCK_RX_DESCRIPTOR_TABLE: GuestAddress = GuestAddress::new(0x8050_0000);
+    const TEST_VSOCK_RX_AVAILABLE_RING: GuestAddress = GuestAddress::new(0x8051_0000);
+    const TEST_VSOCK_RX_USED_RING: GuestAddress = GuestAddress::new(0x8052_0000);
+    const TEST_VSOCK_TX_DESCRIPTOR_TABLE: GuestAddress = GuestAddress::new(0x8053_0000);
+    const TEST_VSOCK_TX_AVAILABLE_RING: GuestAddress = GuestAddress::new(0x8054_0000);
+    const TEST_VSOCK_TX_USED_RING: GuestAddress = GuestAddress::new(0x8055_0000);
+    const TEST_VSOCK_EVENT_DESCRIPTOR_TABLE: GuestAddress = GuestAddress::new(0x8056_0000);
+    const TEST_VSOCK_EVENT_AVAILABLE_RING: GuestAddress = GuestAddress::new(0x8057_0000);
+    const TEST_VSOCK_EVENT_USED_RING: GuestAddress = GuestAddress::new(0x8058_0000);
+    const TEST_VSOCK_HEADER: GuestAddress = GuestAddress::new(0x8059_0000);
     const TEST_NETWORK_QUEUE_DEVICE_STRIDE: u64 = 0x0010_0000;
     const TEST_AVAILABLE_RING_IDX_OFFSET: u64 = 2;
     const TEST_AVAILABLE_RING_RING_OFFSET: u64 = 4;
@@ -1526,6 +1688,60 @@ mod tests {
         }
     }
 
+    fn write_boot_vsock_mmio_u32(
+        runtime: &mut super::Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+        register: VirtioMmioRegister,
+        value: u32,
+    ) {
+        let address = runtime
+            .vsock_device
+            .as_ref()
+            .expect("vsock device should be configured")
+            .registration
+            .address()
+            .checked_add(register.offset())
+            .expect("test MMIO address should not overflow");
+        let access = mmio_dispatcher
+            .lookup(address, 4)
+            .expect("vsock MMIO access should resolve");
+        let data = MmioAccessBytes::new(&value.to_le_bytes()).expect("u32 bytes should be valid");
+        mmio_dispatcher
+            .dispatch(
+                MmioOperation::write(access, data).expect("u32 write operation should be valid"),
+            )
+            .expect("vsock MMIO write should dispatch");
+    }
+
+    fn read_boot_vsock_mmio_u32(
+        runtime: &mut super::Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+        register: VirtioMmioRegister,
+    ) -> u32 {
+        let address = runtime
+            .vsock_device
+            .as_ref()
+            .expect("vsock device should be configured")
+            .registration
+            .address()
+            .checked_add(register.offset())
+            .expect("test MMIO address should not overflow");
+        let access = mmio_dispatcher
+            .lookup(address, 4)
+            .expect("vsock MMIO access should resolve");
+        let outcome = mmio_dispatcher
+            .dispatch(MmioOperation::read(access).expect("u32 read operation should be valid"))
+            .expect("vsock MMIO read should dispatch");
+        match outcome {
+            MmioDispatchOutcome::Read { data } => u32::from_le_bytes(
+                data.as_slice()
+                    .try_into()
+                    .expect("u32 read should return four bytes"),
+            ),
+            MmioDispatchOutcome::Write => panic!("read operation should not produce write outcome"),
+        }
+    }
+
     fn configure_boot_block_queue(
         runtime: &mut super::Arm64BootRuntimeResources,
         mmio_dispatcher: &mut MmioDispatcher,
@@ -1757,6 +1973,144 @@ mod tests {
             VirtioMmioRegister::QueueNotify,
             u32::try_from(VIRTIO_NET_RX_QUEUE_INDEX).expect("RX queue index should fit"),
         );
+    }
+
+    fn configure_boot_vsock_queue(
+        runtime: &mut super::Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+        queue_index: usize,
+        descriptor_table: GuestAddress,
+        driver_ring: GuestAddress,
+        device_ring: GuestAddress,
+    ) {
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::QueueSel,
+            u32::try_from(queue_index).expect("queue index should fit"),
+        );
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::QueueNum,
+            u32::from(TEST_QUEUE_SIZE),
+        );
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::QueueDescLow,
+            guest_address_low(descriptor_table),
+        );
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::QueueDriverLow,
+            guest_address_low(driver_ring),
+        );
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::QueueDeviceLow,
+            guest_address_low(device_ring),
+        );
+        write_boot_vsock_mmio_u32(runtime, mmio_dispatcher, VirtioMmioRegister::QueueReady, 1);
+    }
+
+    fn configure_boot_vsock_queues(
+        runtime: &mut super::Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+    ) {
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::Status,
+            VIRTIO_DEVICE_STATUS_ACKNOWLEDGE,
+        );
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::Status,
+            VIRTIO_DEVICE_STATUS_ACKNOWLEDGE | VIRTIO_DEVICE_STATUS_DRIVER,
+        );
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::Status,
+            QUEUE_CONFIG_STATUS,
+        );
+        configure_boot_vsock_queue(
+            runtime,
+            mmio_dispatcher,
+            VIRTIO_VSOCK_RX_QUEUE_INDEX,
+            TEST_VSOCK_RX_DESCRIPTOR_TABLE,
+            TEST_VSOCK_RX_AVAILABLE_RING,
+            TEST_VSOCK_RX_USED_RING,
+        );
+        configure_boot_vsock_queue(
+            runtime,
+            mmio_dispatcher,
+            VIRTIO_VSOCK_TX_QUEUE_INDEX,
+            TEST_VSOCK_TX_DESCRIPTOR_TABLE,
+            TEST_VSOCK_TX_AVAILABLE_RING,
+            TEST_VSOCK_TX_USED_RING,
+        );
+        configure_boot_vsock_queue(
+            runtime,
+            mmio_dispatcher,
+            VIRTIO_VSOCK_EVENT_QUEUE_INDEX,
+            TEST_VSOCK_EVENT_DESCRIPTOR_TABLE,
+            TEST_VSOCK_EVENT_AVAILABLE_RING,
+            TEST_VSOCK_EVENT_USED_RING,
+        );
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::Status,
+            DRIVER_OK_STATUS,
+        );
+    }
+
+    fn notify_boot_vsock_queue(
+        runtime: &mut super::Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+        queue_index: usize,
+    ) {
+        write_boot_vsock_mmio_u32(
+            runtime,
+            mmio_dispatcher,
+            VirtioMmioRegister::QueueNotify,
+            u32::try_from(queue_index).expect("queue index should fit"),
+        );
+    }
+
+    fn write_boot_vsock_tx_packet_header(
+        memory: &mut crate::memory::GuestMemory,
+        header: VirtioVsockPacketHeader,
+    ) {
+        memory
+            .write_slice(&header.to_bytes(), TEST_VSOCK_HEADER)
+            .expect("vsock packet header should write");
+    }
+
+    fn write_boot_vsock_tx_descriptor(
+        memory: &mut crate::memory::GuestMemory,
+        index: u16,
+        descriptor: TestDescriptor,
+    ) {
+        write_descriptor_at(memory, TEST_VSOCK_TX_DESCRIPTOR_TABLE, index, descriptor);
+    }
+
+    fn write_boot_vsock_tx_available_heads(memory: &mut crate::memory::GuestMemory, heads: &[u16]) {
+        write_available_heads_at(memory, TEST_VSOCK_TX_AVAILABLE_RING, heads);
+    }
+
+    fn read_boot_vsock_tx_used_index(memory: &crate::memory::GuestMemory) -> u16 {
+        read_guest_u16(
+            memory,
+            TEST_VSOCK_TX_USED_RING
+                .checked_add(2)
+                .expect("vsock TX used idx address should not overflow"),
+        )
     }
 
     fn guest_address_low(address: GuestAddress) -> u32 {
@@ -2094,6 +2448,14 @@ mod tests {
             .read_slice(&mut bytes, address)
             .expect("guest bytes should read");
         bytes
+    }
+
+    fn read_guest_u16(memory: &crate::memory::GuestMemory, address: GuestAddress) -> u16 {
+        let mut bytes = [0; 2];
+        memory
+            .read_slice(&mut bytes, address)
+            .expect("guest u16 should read");
+        u16::from_le_bytes(bytes)
     }
 
     fn available_ring_idx_address_at(available_ring: GuestAddress) -> GuestAddress {
@@ -2627,6 +2989,344 @@ mod tests {
         assert_eq!(dispatches.len(), 0);
         assert!(!dispatches.needs_queue_interrupt());
         assert!(provider.requested_ifaces.is_empty());
+    }
+
+    #[test]
+    fn boot_runtime_vsock_notification_dispatch_accepts_empty_vsock_device() {
+        let kernel = temp_file("kernel-empty-vsock-dispatch", &arm64_image());
+        let controller = controller_with_kernel(kernel.path());
+        let resources =
+            Arm64BootResources::assemble_from_controller(&controller, valid_config(&[]))
+                .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+        let mut memory = parts.memory;
+        let mut mmio_dispatcher = parts.mmio_dispatcher;
+        let mut runtime = parts.runtime;
+
+        let dispatches = runtime
+            .dispatch_vsock_queue_notifications(&mut memory, &mut mmio_dispatcher)
+            .expect("empty vsock dispatch result should allocate");
+
+        assert!(dispatches.is_empty());
+        assert_eq!(dispatches.len(), 0);
+        assert!(!dispatches.needs_queue_interrupt());
+    }
+
+    #[test]
+    fn boot_runtime_vsock_notification_dispatch_without_pending_notification_is_noop() {
+        let kernel = temp_file("kernel-vsock-noop-dispatch", &arm64_image());
+        let socket_path = missing_path("vsock-noop.sock");
+        let mut controller = controller_with_kernel(kernel.path());
+        add_vsock(&mut controller, 42, &socket_path);
+        let config = Arm64BootResourceConfig {
+            vsock_interrupt_line: Some(line(35)),
+            ..valid_config(&[])
+        };
+        let resources = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+        let mut memory = parts.memory;
+        let mut mmio_dispatcher = parts.mmio_dispatcher;
+        let mut runtime = parts.runtime;
+
+        let dispatches = runtime
+            .dispatch_vsock_queue_notifications(&mut memory, &mut mmio_dispatcher)
+            .expect("vsock dispatch result should allocate");
+
+        assert_eq!(dispatches.len(), 1);
+        assert!(!dispatches.needs_queue_interrupt());
+        let device_dispatch = &dispatches.as_slice()[0];
+        assert_eq!(device_dispatch.device().registration.guest_cid(), 42);
+        assert_eq!(device_dispatch.device().fdt_device.interrupt_line, line(35));
+        let dispatch = device_dispatch
+            .outcome()
+            .dispatched()
+            .expect("no pending notification should dispatch as no-op");
+        assert_eq!(dispatch.drained_notifications(), []);
+        assert!(dispatch.tx_queue_dispatch().is_none());
+        assert!(!device_dispatch.needs_queue_interrupt());
+        assert_eq!(
+            read_boot_vsock_mmio_u32(
+                &mut runtime,
+                &mut mmio_dispatcher,
+                VirtioMmioRegister::InterruptStatus
+            ),
+            0
+        );
+        assert!(!socket_path.exists());
+    }
+
+    #[test]
+    fn boot_runtime_vsock_notification_dispatch_executes_tx_queue() {
+        let kernel = temp_file("kernel-vsock-tx-dispatch", &arm64_image());
+        let socket_path = missing_path("vsock-tx.sock");
+        let mut controller = controller_with_kernel(kernel.path());
+        add_vsock(&mut controller, 43, &socket_path);
+        let config = Arm64BootResourceConfig {
+            vsock_interrupt_line: Some(line(35)),
+            ..valid_config(&[])
+        };
+        let resources = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+        let mut memory = parts.memory;
+        let mut mmio_dispatcher = parts.mmio_dispatcher;
+        let mut runtime = parts.runtime;
+        configure_boot_vsock_queues(&mut runtime, &mut mmio_dispatcher);
+        write_boot_vsock_tx_packet_header(&mut memory, VirtioVsockPacketHeader::new());
+        write_boot_vsock_tx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            ),
+        );
+        write_boot_vsock_tx_available_heads(&mut memory, &[0]);
+        notify_boot_vsock_queue(
+            &mut runtime,
+            &mut mmio_dispatcher,
+            VIRTIO_VSOCK_TX_QUEUE_INDEX,
+        );
+
+        let dispatches = runtime
+            .dispatch_vsock_queue_notifications(&mut memory, &mut mmio_dispatcher)
+            .expect("vsock dispatch result should allocate");
+
+        assert_eq!(dispatches.len(), 1);
+        assert!(dispatches.needs_queue_interrupt());
+        let device_dispatch = &dispatches.as_slice()[0];
+        assert_eq!(device_dispatch.device().registration.guest_cid(), 43);
+        assert_eq!(device_dispatch.device().fdt_device.interrupt_line, line(35));
+        let dispatch = device_dispatch
+            .outcome()
+            .dispatched()
+            .expect("queued TX notification should dispatch");
+        assert_eq!(
+            dispatch.drained_notifications(),
+            [VIRTIO_VSOCK_TX_QUEUE_INDEX]
+        );
+        let tx_dispatch = dispatch
+            .tx_queue_dispatch()
+            .expect("TX dispatch summary should be present");
+        assert_eq!(tx_dispatch.processed_packets(), 1);
+        assert_eq!(tx_dispatch.successful_packets(), 1);
+        assert_eq!(tx_dispatch.parse_failures(), 0);
+        assert!(device_dispatch.needs_queue_interrupt());
+        assert_eq!(read_boot_vsock_tx_used_index(&memory), 1);
+        assert_eq!(
+            read_boot_vsock_mmio_u32(
+                &mut runtime,
+                &mut mmio_dispatcher,
+                VirtioMmioRegister::InterruptStatus
+            ),
+            DeviceInterruptKind::Queue.status().bits()
+        );
+        assert!(!socket_path.exists());
+    }
+
+    #[test]
+    fn boot_runtime_vsock_notification_dispatch_reports_unsupported_queue() {
+        let kernel = temp_file("kernel-vsock-unsupported-dispatch", &arm64_image());
+        let socket_path = missing_path("vsock-unsupported.sock");
+        let mut controller = controller_with_kernel(kernel.path());
+        add_vsock(&mut controller, 44, &socket_path);
+        let config = Arm64BootResourceConfig {
+            vsock_interrupt_line: Some(line(35)),
+            ..valid_config(&[])
+        };
+        let resources = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+        let mut memory = parts.memory;
+        let mut mmio_dispatcher = parts.mmio_dispatcher;
+        let mut runtime = parts.runtime;
+        configure_boot_vsock_queues(&mut runtime, &mut mmio_dispatcher);
+        notify_boot_vsock_queue(
+            &mut runtime,
+            &mut mmio_dispatcher,
+            VIRTIO_VSOCK_RX_QUEUE_INDEX,
+        );
+
+        let dispatches = runtime
+            .dispatch_vsock_queue_notifications(&mut memory, &mut mmio_dispatcher)
+            .expect("vsock dispatch result should allocate");
+
+        assert_eq!(dispatches.len(), 1);
+        assert!(!dispatches.needs_queue_interrupt());
+        let error = dispatches.as_slice()[0]
+            .outcome()
+            .dispatch_error()
+            .expect("unsupported queue should be preserved as a device error");
+        assert_eq!(error.drained_notifications(), [VIRTIO_VSOCK_RX_QUEUE_INDEX]);
+        assert!(matches!(
+            error,
+            crate::vsock::VirtioVsockDeviceNotificationError::UnsupportedQueue {
+                queue_index: VIRTIO_VSOCK_RX_QUEUE_INDEX,
+                ..
+            }
+        ));
+        assert!(error.completed_tx_dispatch().is_none());
+        assert_eq!(
+            read_boot_vsock_mmio_u32(
+                &mut runtime,
+                &mut mmio_dispatcher,
+                VirtioMmioRegister::InterruptStatus
+            ),
+            0
+        );
+        assert!(!socket_path.exists());
+    }
+
+    #[test]
+    fn boot_runtime_vsock_notification_dispatch_preserves_partial_error_interrupt_intent() {
+        let kernel = temp_file("kernel-vsock-partial-error-dispatch", &arm64_image());
+        let socket_path = missing_path("vsock-partial-error.sock");
+        let mut controller = controller_with_kernel(kernel.path());
+        add_vsock(&mut controller, 45, &socket_path);
+        let config = Arm64BootResourceConfig {
+            vsock_interrupt_line: Some(line(35)),
+            ..valid_config(&[])
+        };
+        let resources = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+        let mut memory = parts.memory;
+        let mut mmio_dispatcher = parts.mmio_dispatcher;
+        let mut runtime = parts.runtime;
+        configure_boot_vsock_queues(&mut runtime, &mut mmio_dispatcher);
+        write_boot_vsock_tx_packet_header(&mut memory, VirtioVsockPacketHeader::new());
+        write_boot_vsock_tx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            ),
+        );
+        write_boot_vsock_tx_available_heads(&mut memory, &[0, TEST_QUEUE_SIZE]);
+        notify_boot_vsock_queue(
+            &mut runtime,
+            &mut mmio_dispatcher,
+            VIRTIO_VSOCK_TX_QUEUE_INDEX,
+        );
+
+        let dispatches = runtime
+            .dispatch_vsock_queue_notifications(&mut memory, &mut mmio_dispatcher)
+            .expect("vsock dispatch result should allocate");
+
+        assert!(dispatches.needs_queue_interrupt());
+        let device_dispatch = &dispatches.as_slice()[0];
+        assert!(device_dispatch.needs_queue_interrupt());
+        let error = device_dispatch
+            .outcome()
+            .dispatch_error()
+            .expect("partial TX failure should be preserved as a device error");
+        assert_eq!(error.drained_notifications(), [VIRTIO_VSOCK_TX_QUEUE_INDEX]);
+        let completed = error
+            .completed_tx_dispatch()
+            .expect("partial TX failure should preserve completed dispatch metadata");
+        assert_eq!(completed.processed_packets(), 1);
+        assert_eq!(completed.successful_packets(), 1);
+        assert!(completed.needs_queue_interrupt());
+        assert_eq!(read_boot_vsock_tx_used_index(&memory), 1);
+        assert_eq!(
+            read_boot_vsock_mmio_u32(
+                &mut runtime,
+                &mut mmio_dispatcher,
+                VirtioMmioRegister::InterruptStatus
+            ),
+            DeviceInterruptKind::Queue.status().bits()
+        );
+        assert!(!socket_path.exists());
+    }
+
+    #[test]
+    fn boot_runtime_vsock_notification_dispatch_reports_missing_handler() {
+        let kernel = temp_file("kernel-vsock-missing-handler", &arm64_image());
+        let socket_path = missing_path("vsock-missing-handler.sock");
+        let mut controller = controller_with_kernel(kernel.path());
+        add_vsock(&mut controller, 46, &socket_path);
+        let config = Arm64BootResourceConfig {
+            vsock_interrupt_line: Some(line(35)),
+            ..valid_config(&[])
+        };
+        let resources = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+        let mut memory = parts.memory;
+        let mut mmio_dispatcher = MmioDispatcher::new();
+        let mut runtime = parts.runtime;
+
+        let dispatches = runtime
+            .dispatch_vsock_queue_notifications(&mut memory, &mut mmio_dispatcher)
+            .expect("vsock dispatch result should allocate");
+
+        assert_eq!(dispatches.len(), 1);
+        assert!(!dispatches.needs_queue_interrupt());
+        let error = dispatches.as_slice()[0]
+            .outcome()
+            .handler_lookup_error()
+            .expect("missing vsock handler should be reported");
+        assert!(matches!(
+            error,
+            crate::mmio::MmioHandlerLookupError::MissingHandler {
+                region_id
+            } if *region_id == MmioRegionId::new(90)
+        ));
+        assert!(!socket_path.exists());
+    }
+
+    #[test]
+    fn boot_runtime_vsock_notification_dispatch_reports_wrong_handler_type() {
+        let kernel = temp_file("kernel-vsock-wrong-handler", &arm64_image());
+        let socket_path = missing_path("vsock-wrong-handler.sock");
+        let mut controller = controller_with_kernel(kernel.path());
+        add_vsock(&mut controller, 47, &socket_path);
+        let config = Arm64BootResourceConfig {
+            vsock_interrupt_line: Some(line(35)),
+            ..valid_config(&[])
+        };
+        let resources = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+        let mut memory = parts.memory;
+        let mut runtime = parts.runtime;
+        let region = runtime
+            .vsock_device
+            .as_ref()
+            .expect("vsock device should exist")
+            .registration
+            .region();
+        let mut mmio_dispatcher = MmioDispatcher::new();
+        mmio_dispatcher
+            .insert_region(region.id(), region.range().start(), region.range().size())
+            .expect("replacement region should insert");
+        mmio_dispatcher
+            .register_handler(
+                region.id(),
+                SerialMmioDevice::new(SharedSerialOutputBuffer::default()),
+            )
+            .expect("serial handler should register under vsock region id for test");
+
+        let dispatches = runtime
+            .dispatch_vsock_queue_notifications(&mut memory, &mut mmio_dispatcher)
+            .expect("vsock dispatch result should allocate");
+
+        let error = dispatches.as_slice()[0]
+            .outcome()
+            .handler_lookup_error()
+            .expect("wrong vsock handler type should be reported");
+        assert!(matches!(
+            error,
+            crate::mmio::MmioHandlerLookupError::UnexpectedHandlerType {
+                region_id,
+                ..
+            } if *region_id == MmioRegionId::new(90)
+        ));
+        assert!(!socket_path.exists());
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -8,7 +8,7 @@ The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /`, `GET /version`,
 `GET /vm/config`, `GET /machine-config`, pre-boot `PUT /machine-config`
 configuration storage, pre-boot `PUT /boot-source` configuration storage, pre-boot `PUT /drives/{drive_id}`
-configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, packet header model, TX descriptor packet parser, TX available-ring drain helper with used-ring descriptor completion, prepared device resource, MMIO registration helper, MMIO handler skeleton with active queue metadata retention and TX notification dispatch, and startup FDT attachment, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
+configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, packet header model, TX descriptor packet parser, TX available-ring drain helper with used-ring descriptor completion, prepared device resource, MMIO registration helper, MMIO handler skeleton with active queue metadata retention and handler-level TX notification dispatch, startup FDT attachment, and boot-runtime/HVF TX notification dispatch with queue interrupt signaling, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
 `InstanceStart` preflight, transactional startup executor, and successful-start state transition helpers, backend-neutral guest
 physical address and aarch64 DRAM layout/access primitives, arm64 boot
 placement helpers, internal boot-source validation and arm64 kernel/initrd
@@ -52,7 +52,7 @@ wiring with optional serial capture and boot run-loop supervision across bounded
 step windows with retained internal worker status, process-owned virtio-net
 packet-I/O provider selection with no-op fallback and vmnet-backed startup for
 configured interfaces, an internal vmnet virtio-net packet I/O provider keyed by
-configured interface ID, boot block and virtio-net queue
+configured interface ID, boot block, virtio-net, and virtio-vsock queue
 interrupt signaling,
 virtual timer PPI assertion, per-controller metrics and logger output state, and an initial process startup argument model.
 There is no broader API request body model beyond the initial boot-source,
@@ -233,7 +233,7 @@ compatibility targets.
 | `PATCH` | `/machine-config` | deferred | Partial updates belong with later state and validation rules. |
 | `PUT` | `/cpu-config` | deferred | Needs HVF CPU feature design with VM and boot work in #8 and #10. |
 | `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores up to 16 initial virtio-net configurations before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the interface count before opening vmnet resources, then selects vmnet packet I/O only for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names; unsupported names fail startup before `Running` is committed. Internal network notification dispatch can route each configured interface through selected packet I/O, parse TX descriptors through a packet sink boundary, and copy injected RX packets into guest buffers through a packet source boundary. Public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
-| `PUT` | `/vsock` | supported target; startup attachment implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Startup preparation attaches the configured device as one virtio-mmio FDT node backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has a Firecracker-shaped packet header model, internal TX descriptor packet parser, and TX available-ring drain helper that publishes zero-length TX used-ring completions. The handler can drain TX queue notifications, complete queued TX descriptors, and mark the virtio queue interrupt status pending. Startup run-loop wiring, interrupt-line signaling, RX buffers, host socket backend behavior, guest CID routing, runtime updates, PATCH, and DELETE remain tied to #15. |
+| `PUT` | `/vsock` | supported target; startup attachment and TX notification dispatch implemented | Stores one initial virtio-vsock configuration before boot without opening, binding, connecting, unlinking, or creating host Unix socket resources. Startup preparation attaches the configured device as one virtio-mmio FDT node backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has a Firecracker-shaped packet header model, internal TX descriptor packet parser, and TX available-ring drain helper that publishes zero-length TX used-ring completions. The handler and startup notification path can drain TX queue notifications, complete queued TX descriptors, mark the virtio queue interrupt status pending, and signal the allocated vsock interrupt line from the HVF boot loop. RX buffers, host socket backend behavior, guest CID routing, data movement, runtime updates, PATCH, and DELETE remain tied to #15. |
 | `GET`, `PUT`, `PATCH` | `/mmds` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/mmds/config` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/snapshot/create`, `/snapshot/load` | deferred | Tied to snapshot and restore work in #19. |
@@ -586,14 +586,17 @@ into parsed packet metadata while preserving queue progress and publishes
 zero-length used-ring completions for consumed descriptor heads. The handler can
 drain TX queue notifications, dispatch the active TX queue, preserve completed
 TX dispatch metadata on errors, and mark the virtio queue interrupt status when
-completed descriptors require guest notification. The
+completed descriptors require guest notification. Boot runtime resources can
+dispatch the registered vsock MMIO handler's TX notifications, and internal HVF
+boot sessions can signal the allocated vsock SPI line from those dispatch
+summaries. The
 prepared resource preserves the validated guest CID, socket path, config-space,
 and inactive device state, and the registration helper can consume it into a
 caller-provided internal MMIO dispatcher without touching host socket
 resources. Arm64 startup resource assembly can expose one
 configured vsock device in the guest FDT. Host Unix socket backend behavior,
-CID routing, startup run-loop notification dispatch, interrupt-line signaling,
-RX buffer parsing, and data movement remain deferred.
+CID routing, RX buffer parsing, event queue dispatch, and data movement remain
+deferred.
 
 The runtime crate also has the first backend-neutral virtio-net config-space,
 activation, TX frame parser, RX buffer parser, prepared device resources, and
@@ -851,12 +854,12 @@ reset hook when the virtio-mmio status is reset to zero or the handler is
 explicitly reset. Activation failure marks the device as needing reset, but
 concrete device activation effects, device config layouts, config generation
 policy, and general runner-loop device-backed notification dispatch are still
-deferred. Activated queue metadata can now feed the internal virtio-block queue
-builder and the internal virtio-net queue dispatchers. Boot runtime resources
-can dispatch registered block-device and virtio-net queue notifications
+deferred. Activated queue metadata can now feed the internal virtio-block,
+virtio-net, and virtio-vsock queue dispatchers. Boot runtime resources
+can dispatch registered block-device, virtio-net, and virtio-vsock queue notifications
 against caller-supplied guest memory. Internal HVF boot sessions can signal
-needed block and network SPI interrupts from those dispatch summaries, but
-general HVF runner-loop calls remain deferred. The
+needed block, network, and vsock SPI interrupts from those dispatch summaries, but
+future public scheduler and device policy remain deferred. The
 virtqueue model can publish one used-ring completion element with validated
 layout, mapped-memory checks, wrapping, and release ordering, but batching,
 event-index notification suppression, and device-backed completion loops are
@@ -956,17 +959,17 @@ in-flight run step without exposing the full runner. Public `InstanceStart`
 now starts a process-owned internal boot run-loop worker across bounded step windows with retained internal worker status and an owned
 HVF boot session and internal serial MMIO console after successful startup. A
 bounded internal
-boot-session run-loop pump now composes that one-step path with boot block and
-virtio-net notification dispatch between successful MMIO steps and virtual
+boot-session run-loop pump now composes that one-step path with boot block,
+virtio-net, and virtio-vsock notification dispatch between successful MMIO steps and virtual
 timer PPI assertion after virtual timer exits. It stops explicitly on a step limit,
 stop-token request, canceled run exit, unknown run exit, dispatch error, or
 timer handler error. This remains internal runner-loop plumbing, not the future
 public guest scheduler. An owned internal session handle preserves the same
 session operations while avoiding a self-referential backend/session owner in
 process-level state.
-The boot session can also dispatch pending boot block and virtio-net queue
-notifications against mapped guest memory and signal the corresponding block or
-network SPI line when the runtime dispatch summary reports queue-interrupt
+The boot session can also dispatch pending boot block, virtio-net, and
+virtio-vsock queue notifications against mapped guest memory and signal the
+corresponding block, network, or vsock SPI line when the runtime dispatch summary reports queue-interrupt
 intent; per-device results preserve dispatch, lookup, and signal failures for
 later runner-loop policy.
 Boot notification dispatch locks the shared dispatcher only while draining
@@ -1047,7 +1050,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | `PUT /boot-source` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; host paths are opened during startup preparation. Host path errors must avoid leaking sensitive path details. |
 | `PUT /drives/{drive_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; startup preparation opens backing files and registers initial block MMIO devices. Runtime hotplug remains deferred. |
 | `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records up to 16 validated pre-boot configs without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the count before opening vmnet packet I/O for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names and fails before `Running` for unsupported names. Internal network notification dispatch can route each interface through selected packet I/O, complete TX descriptor heads through a packet sink boundary, and write injected RX packets into guest buffers through a packet source boundary. Public packet movement, PATCH, and DELETE remain deferred. |
-| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Startup preparation attaches one configured virtio-vsock device as guest-visible FDT/MMIO metadata backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has an internal TX descriptor packet parser, TX available-ring drain helper, used-ring TX descriptor completion, and handler-level TX notification dispatch, but host socket backend behavior, CID routing, startup run-loop notification dispatch, interrupt-line signaling, RX buffers, data movement, PATCH, and DELETE remain deferred. |
+| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening or creating host Unix socket resources. Startup preparation attaches one configured virtio-vsock device as guest-visible FDT/MMIO metadata backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has an internal TX descriptor packet parser, TX available-ring drain helper, used-ring TX descriptor completion, handler-level and startup-level TX notification dispatch, and HVF boot-loop vsock queue interrupt signaling, but host socket backend behavior, CID routing, RX buffers, event queue dispatch, data movement, PATCH, and DELETE remain deferred. |
 | `PUT /metrics` | implemented; `204` empty response on successful output initialization | unsupported after start; `400` `fault_message` | Metrics output is process observability state, not guest configuration. Duplicate initialization fails. |
 | `PUT /logger` | implemented; `204` empty response on successful pre-boot configuration | unsupported after start; `400` `fault_message` | Logger output is process observability state, not guest configuration. Repeated pre-boot requests update provided fields; full log routing remains deferred. |
 | `PUT /actions` with `InstanceStart` | process-routed; `204` after successful owned HVF startup with internal boot run-loop worker across bounded step windows or `400` preflight/preparation fault | unsupported after start; `400` `fault_message` | Commits `Running` only after the owned HVF boot-session worker with internal serial capture is retained. The worker keeps internal active, terminal-outcome, or error status; public run-loop control and public serial streaming remain deferred. |
@@ -1096,12 +1099,14 @@ Their eventual support level should follow the endpoint matrix:
   parser, prepared device resources, MMIO registration, startup FDT metadata,
   TX/RX notification dispatch metadata helpers, and startup-time vmnet packet
   I/O selection for supported `host_dev_name` forms
-- virtio-vsock host Unix socket backend behavior, CID routing, and data movement
+- virtio-vsock host Unix socket backend behavior, CID routing, RX/event queue
+  dispatch, and data movement
   beyond pre-boot `/vsock` configuration storage, startup FDT attachment, and
   the internal prepared resource/MMIO registration/config-space/MMIO handler
   skeleton with active queue metadata retention plus packet header model, TX
   descriptor packet parser, and TX available-ring drain helper with used-ring
-  descriptor completion and handler-level TX notification dispatch
+  descriptor completion, handler-level and startup-level TX notification
+  dispatch, and boot-loop queue interrupt signaling
 - snapshots
 - MMDS
 - balloon devices and balloon statistics

--- a/docs/security.md
+++ b/docs/security.md
@@ -67,7 +67,9 @@ is resource-specific:
   can attach a guest-visible virtio-vsock device whose internal MMIO handler
   retains active RX, TX, and event queue metadata after `DRIVER_OK`, and the
   runtime has an internal Firecracker-shaped packet header model plus TX
-  descriptor packet parser. The current implementation does not open, bind,
+  descriptor packet parser. Startup-level dispatch can drain TX queue
+  notifications, complete TX descriptor heads, and signal the allocated vsock
+  queue interrupt line. The current implementation does not open, bind,
   connect, unlink, or create that socket path.
 - `/metrics` opens the output path during pre-boot configuration and keeps a
   per-process metrics sink.
@@ -181,13 +183,13 @@ The current scaffold does not implement:
   registration helper, config-space, packet header model, TX descriptor packet
   parser, TX available-ring drain helper with used-ring descriptor completion,
   MMIO handler skeleton with active queue metadata retention and TX notification
-  dispatch, and startup FDT attachment that preserve the configured socket path
-  and expose only the configured guest CID through bounded config reads.
+  dispatch, startup FDT attachment, startup-level TX notification dispatch, and
+  HVF queue interrupt signaling that preserve the configured socket path and
+  expose only the configured guest CID through bounded config reads.
   Preparation, MMIO
   registration, and startup attachment do not open, bind, connect, unlink, or
   create `uds_path`, and do not implement host Unix socket backend behavior,
-  CID routing, startup run-loop notification dispatch, interrupt-line signaling,
-  RX buffer parsing, or data movement
+  CID routing, RX buffer parsing, event queue dispatch, or data movement
 - complete production logging or metrics policy
 - public run-loop control or public serial streaming policy
 


### PR DESCRIPTION
## Summary

- Add startup-level virtio-vsock notification dispatch in runtime resources, including per-device outcomes and partial TX interrupt-intent preservation.
- Wire HVF boot sessions and the bounded MMIO run loop to dispatch vsock notifications and signal the allocated vsock interrupt line.
- Update Firecracker compatibility and security docs for implemented startup-level vsock TX dispatch and remaining gaps.

## Scope Exclusions

- Host Unix socket backend behavior, CID routing, RX/event queue dispatch, data movement, runtime updates, PATCH, and DELETE remain out of scope.

Closes #341

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
