### PR TITLE
feat: dispatch vsock rx host requests

### DIFF
--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -4607,13 +4607,56 @@ mod tests {
     }
 
     #[test]
-    fn vsock_notification_signal_dispatch_preserves_unsupported_queue_without_signal() {
+    fn vsock_notification_signal_dispatch_skips_rx_noop_device() {
         let (mut memory, mut runtime, mut mmio_dispatcher) = boot_runtime_with_vsock();
         configure_boot_vsock_queues(&mut runtime, &mut mmio_dispatcher);
         notify_boot_vsock_queue(
             &mut runtime,
             &mut mmio_dispatcher,
             VIRTIO_VSOCK_RX_QUEUE_INDEX,
+        );
+        let dispatches =
+            dispatch_boot_vsock_notifications(&mut memory, &mut runtime, &mut mmio_dispatcher);
+        let (lines, sink) = RecordingSink::successful();
+
+        let result = signal_vsock_queue_interrupts(dispatches, sink.as_ref())
+            .expect("unsupported vsock dispatch should collect");
+
+        let device = &result.as_slice()[0];
+        assert!(!device.dispatch().needs_queue_interrupt());
+        assert!(!device.queue_interrupt_signaled());
+        assert!(device.signal_error().is_none());
+        assert!(recorded_lines(&lines).is_empty());
+        let dispatch = device
+            .dispatch()
+            .outcome()
+            .dispatched()
+            .expect("RX noop should dispatch");
+        let rx = dispatch
+            .rx_queue_dispatch()
+            .expect("RX dispatch summary should be present");
+        assert_eq!(rx.processed_buffers(), 0);
+        assert_eq!(rx.delivered_requests(), 0);
+        assert!(!rx.needs_queue_interrupt());
+        assert!(dispatch.tx_queue_dispatch().is_none());
+        assert_eq!(
+            read_boot_vsock_mmio_u32(
+                &mut runtime,
+                &mut mmio_dispatcher,
+                VirtioMmioRegister::InterruptStatus
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn vsock_notification_signal_dispatch_preserves_unsupported_queue_without_signal() {
+        let (mut memory, mut runtime, mut mmio_dispatcher) = boot_runtime_with_vsock();
+        configure_boot_vsock_queues(&mut runtime, &mut mmio_dispatcher);
+        notify_boot_vsock_queue(
+            &mut runtime,
+            &mut mmio_dispatcher,
+            VIRTIO_VSOCK_EVENT_QUEUE_INDEX,
         );
         let dispatches =
             dispatch_boot_vsock_notifications(&mut memory, &mut runtime, &mut mmio_dispatcher);
@@ -4635,11 +4678,14 @@ mod tests {
         assert!(matches!(
             err,
             bangbang_runtime::vsock::VirtioVsockDeviceNotificationError::UnsupportedQueue {
-                queue_index: VIRTIO_VSOCK_RX_QUEUE_INDEX,
+                queue_index: VIRTIO_VSOCK_EVENT_QUEUE_INDEX,
                 ..
             }
         ));
-        assert_eq!(err.drained_notifications(), [VIRTIO_VSOCK_RX_QUEUE_INDEX]);
+        assert_eq!(
+            err.drained_notifications(),
+            [VIRTIO_VSOCK_EVENT_QUEUE_INDEX]
+        );
         assert_eq!(
             read_boot_vsock_mmio_u32(
                 &mut runtime,

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -490,9 +490,14 @@ impl Arm64BootVsockNotificationOutcome {
     pub fn needs_queue_interrupt(&self) -> bool {
         match self {
             Self::Dispatched(dispatch) => dispatch.needs_queue_interrupt(),
-            Self::DispatchFailed(source) => source
-                .completed_tx_dispatch()
-                .is_some_and(crate::vsock::VirtioVsockTxQueueDispatch::needs_queue_interrupt),
+            Self::DispatchFailed(source) => {
+                source
+                    .completed_tx_dispatch()
+                    .is_some_and(crate::vsock::VirtioVsockTxQueueDispatch::needs_queue_interrupt)
+                    || source.completed_rx_dispatch().is_some_and(
+                        crate::vsock::VirtioVsockRxQueueDispatch::needs_queue_interrupt,
+                    )
+            }
             Self::HandlerLookupFailed(_) => false,
         }
     }
@@ -3176,9 +3181,9 @@ mod tests {
     }
 
     #[test]
-    fn boot_runtime_vsock_notification_dispatch_reports_unsupported_queue() {
-        let kernel = temp_file("kernel-vsock-unsupported-dispatch", &arm64_image());
-        let socket_path = missing_path("vsock-unsupported.sock");
+    fn boot_runtime_vsock_notification_dispatch_reports_rx_noop() {
+        let kernel = temp_file("kernel-vsock-rx-noop-dispatch", &arm64_image());
+        let socket_path = missing_path("vsock-rx-noop.sock");
         let mut controller = controller_with_kernel(kernel.path());
         add_vsock(&mut controller, 44, &socket_path);
         let config = Arm64BootResourceConfig {
@@ -3204,18 +3209,79 @@ mod tests {
 
         assert_eq!(dispatches.len(), 1);
         assert!(!dispatches.needs_queue_interrupt());
+        let dispatch = dispatches.as_slice()[0]
+            .outcome()
+            .dispatched()
+            .expect("RX queue notification should dispatch as no-op");
+        assert_eq!(
+            dispatch.drained_notifications(),
+            [VIRTIO_VSOCK_RX_QUEUE_INDEX]
+        );
+        let rx = dispatch
+            .rx_queue_dispatch()
+            .expect("RX dispatch summary should be present");
+        assert_eq!(rx.processed_buffers(), 0);
+        assert_eq!(rx.delivered_requests(), 0);
+        assert!(!rx.needs_queue_interrupt());
+        assert!(dispatch.tx_queue_dispatch().is_none());
+        assert_eq!(
+            read_boot_vsock_mmio_u32(
+                &mut runtime,
+                &mut mmio_dispatcher,
+                VirtioMmioRegister::InterruptStatus
+            ),
+            0
+        );
+        assert!(socket_path.exists());
+        drop(mmio_dispatcher);
+        assert!(!socket_path.exists());
+    }
+
+    #[test]
+    fn boot_runtime_vsock_notification_dispatch_reports_unsupported_queue() {
+        let kernel = temp_file("kernel-vsock-unsupported-dispatch", &arm64_image());
+        let socket_path = missing_path("vsock-unsupported.sock");
+        let mut controller = controller_with_kernel(kernel.path());
+        add_vsock(&mut controller, 44, &socket_path);
+        let config = Arm64BootResourceConfig {
+            vsock_interrupt_line: Some(line(35)),
+            ..valid_config(&[])
+        };
+        let resources = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect("boot resources should assemble");
+        let parts = resources.into_parts();
+        let mut memory = parts.memory;
+        let mut mmio_dispatcher = parts.mmio_dispatcher;
+        let mut runtime = parts.runtime;
+        configure_boot_vsock_queues(&mut runtime, &mut mmio_dispatcher);
+        notify_boot_vsock_queue(
+            &mut runtime,
+            &mut mmio_dispatcher,
+            VIRTIO_VSOCK_EVENT_QUEUE_INDEX,
+        );
+
+        let dispatches = runtime
+            .dispatch_vsock_queue_notifications(&mut memory, &mut mmio_dispatcher)
+            .expect("vsock dispatch result should allocate");
+
+        assert_eq!(dispatches.len(), 1);
+        assert!(!dispatches.needs_queue_interrupt());
         let error = dispatches.as_slice()[0]
             .outcome()
             .dispatch_error()
             .expect("unsupported queue should be preserved as a device error");
-        assert_eq!(error.drained_notifications(), [VIRTIO_VSOCK_RX_QUEUE_INDEX]);
+        assert_eq!(
+            error.drained_notifications(),
+            [VIRTIO_VSOCK_EVENT_QUEUE_INDEX]
+        );
         assert!(matches!(
             error,
             crate::vsock::VirtioVsockDeviceNotificationError::UnsupportedQueue {
-                queue_index: VIRTIO_VSOCK_RX_QUEUE_INDEX,
+                queue_index: VIRTIO_VSOCK_EVENT_QUEUE_INDEX,
                 ..
             }
         ));
+        assert!(error.completed_rx_dispatch().is_none());
         assert!(error.completed_tx_dispatch().is_none());
         assert_eq!(
             read_boot_vsock_mmio_u32(

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -855,7 +855,7 @@ impl VsockHostConnectionTable {
             .take_pending_request_packet_header(key, guest_cid)
     }
 
-    pub fn first_pending_request_packet_key(&self) -> Option<VsockHostConnectionKey> {
+    fn first_pending_request_packet_key(&self) -> Option<VsockHostConnectionKey> {
         self.connections
             .iter()
             .filter_map(|(key, connection)| connection.has_pending_request_packet().then_some(*key))
@@ -2952,7 +2952,8 @@ impl VirtioVsockDevice {
             .accept_host_connection()
     }
 
-    pub fn insert_accepted_host_connection(
+    #[cfg(test)]
+    fn insert_accepted_host_connection(
         &mut self,
         accepted: VsockHostAcceptedConnection,
         request: VsockHostConnectRequest,
@@ -2961,7 +2962,8 @@ impl VirtioVsockDevice {
             .insert_accepted_host_connection(accepted, request)
     }
 
-    pub fn has_pending_host_request_packet(&self, key: VsockHostConnectionKey) -> bool {
+    #[cfg(test)]
+    fn has_pending_host_request_packet(&self, key: VsockHostConnectionKey) -> bool {
         self.host_connections.has_pending_request_packet(key)
     }
 

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -855,6 +855,13 @@ impl VsockHostConnectionTable {
             .take_pending_request_packet_header(key, guest_cid)
     }
 
+    pub fn first_pending_request_packet_key(&self) -> Option<VsockHostConnectionKey> {
+        self.connections
+            .iter()
+            .filter_map(|(key, connection)| connection.has_pending_request_packet().then_some(*key))
+            .min()
+    }
+
     pub fn contains(&self, key: VsockHostConnectionKey) -> bool {
         self.connections.contains_key(&key)
     }
@@ -2860,12 +2867,14 @@ fn validate_active_vsock_queue(
     Ok(())
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct VirtioVsockDevice {
+    guest_cid: u32,
     active_rx_queue: Option<VirtioVsockRxQueue>,
     active_tx_queue: Option<VirtioVsockTxQueue>,
     active_event_queue: Option<VirtioVsockEventQueue>,
     host_socket_owner: Option<VsockHostSocketOwner>,
+    host_connections: VsockHostConnectionTable,
 }
 
 impl VirtioVsockDevice {
@@ -2873,10 +2882,25 @@ impl VirtioVsockDevice {
         Self::default()
     }
 
-    pub(crate) fn with_host_socket_owner(host_socket_owner: VsockHostSocketOwner) -> Self {
+    fn with_guest_cid(guest_cid: u32) -> Self {
         Self {
+            guest_cid,
+            active_rx_queue: None,
+            active_tx_queue: None,
+            active_event_queue: None,
+            host_socket_owner: None,
+            host_connections: VsockHostConnectionTable::new(),
+        }
+    }
+
+    pub(crate) fn with_host_socket_owner(
+        guest_cid: u32,
+        host_socket_owner: VsockHostSocketOwner,
+    ) -> Self {
+        Self {
+            guest_cid,
             host_socket_owner: Some(host_socket_owner),
-            ..Self::default()
+            ..Self::with_guest_cid(guest_cid)
         }
     }
 
@@ -2926,6 +2950,19 @@ impl VirtioVsockDevice {
             .as_ref()
             .ok_or(VsockHostSocketAcceptError::HostSocketNotAttached)?
             .accept_host_connection()
+    }
+
+    pub fn insert_accepted_host_connection(
+        &mut self,
+        accepted: VsockHostAcceptedConnection,
+        request: VsockHostConnectRequest,
+    ) -> Result<VsockHostConnectionKey, VsockHostConnectionTableError> {
+        self.host_connections
+            .insert_accepted_host_connection(accepted, request)
+    }
+
+    pub fn has_pending_host_request_packet(&self, key: VsockHostConnectionKey) -> bool {
+        self.host_connections.has_pending_request_packet(key)
     }
 
     pub fn activate_vsock(
@@ -2983,6 +3020,7 @@ impl VirtioVsockDevice {
         self.active_rx_queue = None;
         self.active_tx_queue = None;
         self.active_event_queue = None;
+        self.host_connections = VsockHostConnectionTable::new();
     }
 
     fn dispatch_drained_queue_notifications(
@@ -2994,6 +3032,7 @@ impl VirtioVsockDevice {
             return Ok(VirtioVsockDeviceNotificationDispatch::new(
                 drained_notifications,
                 None,
+                None,
             ));
         }
 
@@ -3003,21 +3042,53 @@ impl VirtioVsockDevice {
             });
         }
 
-        if let Some(queue_index) = drained_notifications
-            .iter()
-            .copied()
-            .find(|queue_index| *queue_index != VIRTIO_VSOCK_TX_QUEUE_INDEX)
-        {
+        if let Some(queue_index) = drained_notifications.iter().copied().find(|queue_index| {
+            *queue_index != VIRTIO_VSOCK_RX_QUEUE_INDEX
+                && *queue_index != VIRTIO_VSOCK_TX_QUEUE_INDEX
+        }) {
             return Err(VirtioVsockDeviceNotificationError::UnsupportedQueue {
                 drained_notifications,
                 queue_index,
             });
         }
 
+        let dispatch_rx = drained_notifications
+            .iter()
+            .copied()
+            .any(|queue_index| queue_index == VIRTIO_VSOCK_RX_QUEUE_INDEX);
         let dispatch_tx = drained_notifications
             .iter()
             .copied()
             .any(|queue_index| queue_index == VIRTIO_VSOCK_TX_QUEUE_INDEX);
+
+        let rx_queue_dispatch = if dispatch_rx {
+            let Some(queue) = self.active_rx_queue.as_mut() else {
+                return Err(VirtioVsockDeviceNotificationError::Inactive {
+                    drained_notifications,
+                });
+            };
+
+            match self.host_connections.first_pending_request_packet_key() {
+                Some(key) => match queue.dispatch_host_request(
+                    memory,
+                    &mut self.host_connections,
+                    key,
+                    self.guest_cid,
+                ) {
+                    Ok(dispatch) => Some(dispatch),
+                    Err(source) => {
+                        return Err(VirtioVsockDeviceNotificationError::RxQueueDispatch {
+                            drained_notifications,
+                            completed_tx_dispatch: None,
+                            source,
+                        });
+                    }
+                },
+                None => Some(VirtioVsockRxQueueDispatch::new()),
+            }
+        } else {
+            None
+        };
 
         let tx_queue_dispatch = if dispatch_tx {
             let Some(queue) = self.active_tx_queue.as_mut() else {
@@ -3031,6 +3102,7 @@ impl VirtioVsockDevice {
                 Err(source) => {
                     return Err(VirtioVsockDeviceNotificationError::TxQueueDispatch {
                         drained_notifications,
+                        completed_rx_dispatch: rx_queue_dispatch.map(Box::new),
                         source,
                     });
                 }
@@ -3041,8 +3113,15 @@ impl VirtioVsockDevice {
 
         Ok(VirtioVsockDeviceNotificationDispatch::new(
             drained_notifications,
+            rx_queue_dispatch,
             tx_queue_dispatch,
         ))
+    }
+}
+
+impl Default for VirtioVsockDevice {
+    fn default() -> Self {
+        Self::with_guest_cid(MIN_GUEST_CID)
     }
 }
 
@@ -3139,16 +3218,19 @@ impl From<VirtioVsockDeviceActivationError> for VirtioMmioDeviceActivationError 
 #[derive(Debug)]
 pub struct VirtioVsockDeviceNotificationDispatch {
     drained_notifications: Vec<usize>,
+    rx_queue_dispatch: Option<VirtioVsockRxQueueDispatch>,
     tx_queue_dispatch: Option<VirtioVsockTxQueueDispatch>,
 }
 
 impl VirtioVsockDeviceNotificationDispatch {
     const fn new(
         drained_notifications: Vec<usize>,
+        rx_queue_dispatch: Option<VirtioVsockRxQueueDispatch>,
         tx_queue_dispatch: Option<VirtioVsockTxQueueDispatch>,
     ) -> Self {
         Self {
             drained_notifications,
+            rx_queue_dispatch,
             tx_queue_dispatch,
         }
     }
@@ -3161,10 +3243,18 @@ impl VirtioVsockDeviceNotificationDispatch {
         self.tx_queue_dispatch.as_ref()
     }
 
+    pub const fn rx_queue_dispatch(&self) -> Option<&VirtioVsockRxQueueDispatch> {
+        self.rx_queue_dispatch.as_ref()
+    }
+
     pub fn needs_queue_interrupt(&self) -> bool {
         self.tx_queue_dispatch
             .as_ref()
             .is_some_and(VirtioVsockTxQueueDispatch::needs_queue_interrupt)
+            || self
+                .rx_queue_dispatch
+                .as_ref()
+                .is_some_and(VirtioVsockRxQueueDispatch::needs_queue_interrupt)
     }
 }
 
@@ -3179,7 +3269,13 @@ pub enum VirtioVsockDeviceNotificationError {
     },
     TxQueueDispatch {
         drained_notifications: Vec<usize>,
+        completed_rx_dispatch: Option<Box<VirtioVsockRxQueueDispatch>>,
         source: VirtioVsockTxQueueDispatchError,
+    },
+    RxQueueDispatch {
+        drained_notifications: Vec<usize>,
+        completed_tx_dispatch: Option<Box<VirtioVsockTxQueueDispatch>>,
+        source: VirtioVsockRxQueueDispatchError,
     },
 }
 
@@ -3196,6 +3292,10 @@ impl VirtioVsockDeviceNotificationError {
             | Self::TxQueueDispatch {
                 drained_notifications,
                 ..
+            }
+            | Self::RxQueueDispatch {
+                drained_notifications,
+                ..
             } => drained_notifications,
         }
     }
@@ -3203,6 +3303,27 @@ impl VirtioVsockDeviceNotificationError {
     pub const fn completed_tx_dispatch(&self) -> Option<&VirtioVsockTxQueueDispatch> {
         match self {
             Self::TxQueueDispatch { source, .. } => source.completed_dispatch(),
+            Self::RxQueueDispatch {
+                completed_tx_dispatch,
+                ..
+            } => match completed_tx_dispatch {
+                Some(dispatch) => Some(dispatch),
+                None => None,
+            },
+            Self::Inactive { .. } | Self::UnsupportedQueue { .. } => None,
+        }
+    }
+
+    pub const fn completed_rx_dispatch(&self) -> Option<&VirtioVsockRxQueueDispatch> {
+        match self {
+            Self::RxQueueDispatch { source, .. } => source.completed_dispatch(),
+            Self::TxQueueDispatch {
+                completed_rx_dispatch,
+                ..
+            } => match completed_rx_dispatch {
+                Some(dispatch) => Some(dispatch),
+                None => None,
+            },
             Self::Inactive { .. } | Self::UnsupportedQueue { .. } => None,
         }
     }
@@ -3223,6 +3344,9 @@ impl fmt::Display for VirtioVsockDeviceNotificationError {
             Self::TxQueueDispatch { source, .. } => {
                 write!(f, "failed to dispatch virtio-vsock TX queue: {source}")
             }
+            Self::RxQueueDispatch { source, .. } => {
+                write!(f, "failed to dispatch virtio-vsock RX queue: {source}")
+            }
         }
     }
 }
@@ -3231,6 +3355,7 @@ impl std::error::Error for VirtioVsockDeviceNotificationError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::TxQueueDispatch { source, .. } => Some(source),
+            Self::RxQueueDispatch { source, .. } => Some(source),
             Self::Inactive { .. } | Self::UnsupportedQueue { .. } => None,
         }
     }
@@ -3247,9 +3372,14 @@ impl<C: VirtioMmioDeviceConfigHandler> VirtioMmioRegisterHandler<C, VirtioVsockD
             .dispatch_drained_queue_notifications(memory, drained_notifications);
         let needs_queue_interrupt = match &dispatch {
             Ok(dispatch) => dispatch.needs_queue_interrupt(),
-            Err(error) => error
-                .completed_tx_dispatch()
-                .is_some_and(VirtioVsockTxQueueDispatch::needs_queue_interrupt),
+            Err(error) => {
+                error
+                    .completed_tx_dispatch()
+                    .is_some_and(VirtioVsockTxQueueDispatch::needs_queue_interrupt)
+                    || error
+                        .completed_rx_dispatch()
+                        .is_some_and(VirtioVsockRxQueueDispatch::needs_queue_interrupt)
+            }
         };
         if needs_queue_interrupt {
             self.mark_interrupt_pending(DeviceInterruptKind::Queue);
@@ -3294,7 +3424,10 @@ pub struct PreparedVsockDevice {
 
 impl PreparedVsockDevice {
     pub fn from_config(config: &VsockConfig) -> Self {
-        Self::from_config_with_device(config, VirtioVsockDevice::new())
+        Self::from_config_with_device(
+            config,
+            VirtioVsockDevice::with_guest_cid(config.guest_cid()),
+        )
     }
 
     pub fn from_config_with_host_socket(
@@ -3309,7 +3442,7 @@ impl PreparedVsockDevice {
 
         Ok(Self::from_config_with_device(
             config,
-            VirtioVsockDevice::with_host_socket_owner(owner),
+            VirtioVsockDevice::with_host_socket_owner(config.guest_cid(), owner),
         ))
     }
 
@@ -3626,7 +3759,7 @@ pub fn virtio_vsock_mmio_handler(
         config.available_features(),
         &VIRTIO_VSOCK_QUEUE_SIZES,
         config,
-        VirtioVsockDevice::new(),
+        VirtioVsockDevice::with_guest_cid(guest_cid),
     )
 }
 
@@ -3716,9 +3849,9 @@ mod tests {
     const TEST_VSOCK_TX_AVAILABLE_RING: GuestAddress = GuestAddress::new(0x2200);
     const TEST_VSOCK_TX_USED_RING: GuestAddress = GuestAddress::new(0x2400);
     const TEST_VSOCK_TX_UNMAPPED_USED_RING: GuestAddress = GuestAddress::new(0x30_000);
-    const TEST_VSOCK_RX_DESCRIPTOR_TABLE: GuestAddress = GuestAddress::new(0x8000);
-    const TEST_VSOCK_RX_AVAILABLE_RING: GuestAddress = GuestAddress::new(0x8200);
-    const TEST_VSOCK_RX_USED_RING: GuestAddress = GuestAddress::new(0x8400);
+    const TEST_VSOCK_RX_DESCRIPTOR_TABLE: GuestAddress = GuestAddress::new(0x1000);
+    const TEST_VSOCK_RX_AVAILABLE_RING: GuestAddress = GuestAddress::new(0x1200);
+    const TEST_VSOCK_RX_USED_RING: GuestAddress = GuestAddress::new(0x1400);
     const TEST_VSOCK_RX_UNMAPPED_USED_RING: GuestAddress = GuestAddress::new(0x30_000);
     const TEST_VSOCK_RX_BUFFER: GuestAddress = GuestAddress::new(0x9000);
     const TEST_VSOCK_RX_SECOND_BUFFER: GuestAddress = GuestAddress::new(0xa000);
@@ -3980,6 +4113,27 @@ mod tests {
         ready: bool,
     ) -> VirtioMmioQueueRegisters {
         configured_vsock_queue_registers_from_specs([(queue_size, ready); VIRTIO_VSOCK_QUEUE_COUNT])
+    }
+
+    fn configured_vsock_queue_registers_with_rx_device_ring(
+        device_ring: GuestAddress,
+    ) -> VirtioMmioQueueRegisters {
+        let mut queues = configured_vsock_queue_registers(Some(VIRTIO_VSOCK_QUEUE_SIZE), true);
+        queues
+            .write_register(
+                VirtioMmioRegister::QueueSel,
+                u32::try_from(VIRTIO_VSOCK_RX_QUEUE_INDEX).expect("RX queue index should fit"),
+                QUEUE_CONFIG_STATUS,
+            )
+            .expect("RX queue select should write");
+        queues
+            .write_register(
+                VirtioMmioRegister::QueueDeviceLow,
+                guest_address_low(device_ring),
+                QUEUE_CONFIG_STATUS,
+            )
+            .expect("RX device ring should write");
+        queues
     }
 
     fn configured_vsock_queue_registers_from_specs(
@@ -5160,6 +5314,31 @@ mod tests {
         );
         assert!(table.take_pending_request_packet_header(key, 42).is_none());
         assert!(table.contains(key));
+    }
+
+    #[test]
+    fn vsock_host_connection_table_selects_smallest_pending_request_key() {
+        let mut table = VsockHostConnectionTable::new();
+        let (first_key, _first_client) =
+            insert_accepted_host_connection_for_test(&mut table, "table-pending-first", 4000);
+        let (second_key, _second_client) =
+            insert_accepted_host_connection_for_test(&mut table, "table-pending-second", 3000);
+
+        assert_eq!(table.first_pending_request_packet_key(), Some(first_key));
+
+        let first_header = table
+            .take_pending_request_packet_header(first_key, 42)
+            .expect("first pending request should exist");
+
+        assert_host_connection_request_header(first_header, 42, first_key.local_port(), 4000);
+        assert_eq!(table.first_pending_request_packet_key(), Some(second_key));
+
+        let second_header = table
+            .take_pending_request_packet_header(second_key, 42)
+            .expect("second pending request should exist");
+
+        assert_host_connection_request_header(second_header, 42, second_key.local_port(), 3000);
+        assert_eq!(table.first_pending_request_packet_key(), None);
     }
 
     #[test]
@@ -7366,6 +7545,23 @@ mod tests {
     }
 
     #[test]
+    fn virtio_vsock_device_reset_drops_retained_host_connections() {
+        let mut device = VirtioVsockDevice::new();
+        let (accepted, mut client, request) =
+            accepted_host_connection_with_request("device-reset-connection", 4000);
+        let key = device
+            .insert_accepted_host_connection(accepted, request)
+            .expect("host connection should insert");
+
+        assert!(device.has_pending_host_request_packet(key));
+
+        VirtioMmioDeviceActivationHandler::reset(&mut device);
+
+        assert!(!device.has_pending_host_request_packet(key));
+        assert_stream_closed(&mut client, "reset should close retained host stream");
+    }
+
+    #[test]
     fn virtio_vsock_device_rejects_not_ready_queue_without_partial_activation() {
         let registers = vsock_device_registers();
         let queues = configured_vsock_queue_registers(Some(4), false);
@@ -7536,6 +7732,7 @@ mod tests {
             .expect("empty notification drain should be a no-op");
 
         assert_eq!(dispatch.drained_notifications(), &[]);
+        assert!(dispatch.rx_queue_dispatch().is_none());
         assert!(dispatch.tx_queue_dispatch().is_none());
         assert!(!dispatch.needs_queue_interrupt());
     }
@@ -7562,45 +7759,247 @@ mod tests {
             "virtio-vsock queue notification cannot be dispatched before activation"
         );
         assert!(error.completed_tx_dispatch().is_none());
+        assert!(error.completed_rx_dispatch().is_none());
         assert!(error.source().is_none());
     }
 
     #[test]
-    fn virtio_vsock_notifications_reject_rx_queue_without_dispatch() {
+    fn virtio_vsock_notifications_dispatch_rx_queue_without_pending_request_as_noop() {
         let mut memory = vsock_tx_memory();
         let mut handler = virtio_vsock_mmio_handler(3).expect("vsock handler should build");
 
         activate_vsock_handler(&mut handler);
         notify_vsock_queue(&mut handler, VIRTIO_VSOCK_RX_QUEUE_INDEX);
 
-        let error = handler
+        let notification = handler
             .dispatch_vsock_queue_notifications(&mut memory)
-            .expect_err("RX notification should be unsupported");
+            .expect("RX notification without pending request should be a no-op");
+
+        assert_eq!(
+            notification.drained_notifications(),
+            &[VIRTIO_VSOCK_RX_QUEUE_INDEX]
+        );
+        assert!(!notification.needs_queue_interrupt());
+        assert!(notification.tx_queue_dispatch().is_none());
+        let rx = notification
+            .rx_queue_dispatch()
+            .expect("RX dispatch summary should be present");
+        assert_eq!(rx.processed_buffers(), 0);
+        assert_eq!(rx.delivered_requests(), 0);
+        assert!(!rx.needs_queue_interrupt());
+        assert_eq!(read_interrupt_status(&handler), 0);
+        assert!(handler.pending_queue_notifications().is_empty());
+        let active_rx_queue = handler
+            .activation_handler()
+            .active_rx_dispatch_queue()
+            .expect("RX dispatch queue should remain active");
+        assert_eq!(active_rx_queue.available_ring().next_avail(), 0);
+        assert_eq!(active_rx_queue.used_ring().next_used(), 0);
+        assert_eq!(read_vsock_rx_used_index(&memory), 0);
+    }
+
+    #[test]
+    fn virtio_vsock_notifications_dispatch_rx_host_request_and_mark_interrupt() {
+        let mut memory = vsock_tx_memory();
+        let mut handler = virtio_vsock_mmio_handler(42).expect("vsock handler should build");
+
+        activate_vsock_handler(&mut handler);
+        let (accepted, _client, request) =
+            accepted_host_connection_with_request("notify-rx-request", 4000);
+        let key = handler
+            .activation_handler_mut()
+            .insert_accepted_host_connection(accepted, request)
+            .expect("host connection should insert");
+        write_vsock_rx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::writable(
+                TEST_VSOCK_RX_BUFFER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            ),
+        );
+        write_vsock_rx_available_heads(&mut memory, &[0]);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_RX_QUEUE_INDEX);
+
+        let notification = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect("RX host request notification should dispatch");
+
+        assert_eq!(
+            notification.drained_notifications(),
+            &[VIRTIO_VSOCK_RX_QUEUE_INDEX]
+        );
+        assert!(notification.needs_queue_interrupt());
+        assert!(notification.tx_queue_dispatch().is_none());
+        let rx = notification
+            .rx_queue_dispatch()
+            .expect("RX dispatch summary should be present");
+        assert_eq!(rx.processed_buffers(), 1);
+        assert_eq!(rx.delivered_requests(), 1);
+        assert_eq!(rx.buffer_parse_failures(), 0);
+        assert!(rx.needs_queue_interrupt());
+        assert_eq!(rx.deliveries()[0].descriptor_head(), 0);
+        assert_eq!(
+            rx.deliveries()[0].bytes_written_to_guest(),
+            VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32
+        );
+        assert!(
+            !handler
+                .activation_handler()
+                .has_pending_host_request_packet(key)
+        );
+        assert_eq!(
+            read_interrupt_status(&handler),
+            DeviceInterruptKind::Queue.status().bits()
+        );
+        assert!(handler.pending_queue_notifications().is_empty());
+        assert_eq!(read_vsock_rx_used_index(&memory), 1);
+        assert_eq!(
+            read_vsock_rx_used_element(&memory, 0),
+            (0, VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32)
+        );
+        assert_host_connection_request_header(
+            read_vsock_packet_header(&memory, TEST_VSOCK_RX_BUFFER),
+            42,
+            key.local_port(),
+            4000,
+        );
+    }
+
+    #[test]
+    fn virtio_vsock_notifications_keep_pending_rx_request_without_available_buffer() {
+        let mut memory = vsock_tx_memory();
+        let mut handler = virtio_vsock_mmio_handler(42).expect("vsock handler should build");
+
+        activate_vsock_handler(&mut handler);
+        let (accepted, _client, request) =
+            accepted_host_connection_with_request("notify-rx-empty", 4001);
+        let key = handler
+            .activation_handler_mut()
+            .insert_accepted_host_connection(accepted, request)
+            .expect("host connection should insert");
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_RX_QUEUE_INDEX);
+
+        let notification = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect("RX notification without available buffer should be a no-op");
+
+        assert!(!notification.needs_queue_interrupt());
+        let rx = notification
+            .rx_queue_dispatch()
+            .expect("RX dispatch summary should be present");
+        assert_eq!(rx.processed_buffers(), 0);
+        assert_eq!(rx.delivered_requests(), 0);
+        assert!(
+            handler
+                .activation_handler()
+                .has_pending_host_request_packet(key)
+        );
+        assert_eq!(read_interrupt_status(&handler), 0);
+        assert_eq!(read_vsock_rx_used_index(&memory), 0);
+    }
+
+    #[test]
+    fn virtio_vsock_notifications_reject_malformed_rx_buffer_without_consuming_request() {
+        let mut memory = vsock_tx_memory();
+        let mut handler = virtio_vsock_mmio_handler(42).expect("vsock handler should build");
+
+        activate_vsock_handler(&mut handler);
+        let (accepted, _client, request) =
+            accepted_host_connection_with_request("notify-rx-bad", 4002);
+        let key = handler
+            .activation_handler_mut()
+            .insert_accepted_host_connection(accepted, request)
+            .expect("host connection should insert");
+        write_vsock_rx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::readable(
+                TEST_VSOCK_RX_BUFFER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            ),
+        );
+        write_vsock_rx_available_heads(&mut memory, &[0]);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_RX_QUEUE_INDEX);
+
+        let notification = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect("malformed RX buffer should be completed");
+
+        assert!(notification.needs_queue_interrupt());
+        let rx = notification
+            .rx_queue_dispatch()
+            .expect("RX dispatch summary should be present");
+        assert_eq!(rx.processed_buffers(), 1);
+        assert_eq!(rx.delivered_requests(), 0);
+        assert_eq!(rx.buffer_parse_failures(), 1);
+        assert!(matches!(
+            rx.first_buffer_parse_failure(),
+            Some(VirtioVsockRxBufferParseError::BufferDescriptorReadOnly { index: 0 })
+        ));
+        assert!(
+            handler
+                .activation_handler()
+                .has_pending_host_request_packet(key)
+        );
+        assert_eq!(
+            read_interrupt_status(&handler),
+            DeviceInterruptKind::Queue.status().bits()
+        );
+        assert_eq!(read_vsock_rx_used_index(&memory), 1);
+        assert_eq!(read_vsock_rx_used_element(&memory, 0), (0, 0));
+    }
+
+    #[test]
+    fn virtio_vsock_notifications_preserve_pending_request_on_rx_used_ring_error() {
+        let registers = vsock_device_registers();
+        let queues =
+            configured_vsock_queue_registers_with_rx_device_ring(TEST_VSOCK_RX_UNMAPPED_USED_RING);
+        let mut memory = vsock_tx_memory();
+        let mut device = VirtioVsockDevice::with_guest_cid(42);
+
+        device
+            .activate_vsock(VirtioMmioDeviceActivation::new(&registers, &queues))
+            .expect("vsock device should activate");
+        let (accepted, _client, request) =
+            accepted_host_connection_with_request("notify-rx-used", 4003);
+        let key = device
+            .insert_accepted_host_connection(accepted, request)
+            .expect("host connection should insert");
+        write_vsock_rx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::writable(
+                TEST_VSOCK_RX_BUFFER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            ),
+        );
+        write_vsock_rx_available_heads(&mut memory, &[0]);
+
+        let error = device
+            .dispatch_drained_queue_notifications(&mut memory, vec![VIRTIO_VSOCK_RX_QUEUE_INDEX])
+            .expect_err("unmapped RX used ring should fail notification dispatch");
 
         assert!(matches!(
             error,
-            super::VirtioVsockDeviceNotificationError::UnsupportedQueue {
-                queue_index: VIRTIO_VSOCK_RX_QUEUE_INDEX,
-                ..
-            }
+            super::VirtioVsockDeviceNotificationError::RxQueueDispatch { .. }
         ));
         assert_eq!(
             error.drained_notifications(),
             &[VIRTIO_VSOCK_RX_QUEUE_INDEX]
         );
-        assert_eq!(
-            error.to_string(),
-            "virtio-vsock queue notification for unsupported queue 0"
-        );
+        let completed = error
+            .completed_rx_dispatch()
+            .expect("completed RX metadata should be preserved");
+        assert_eq!(completed.processed_buffers(), 0);
+        assert_eq!(completed.delivered_requests(), 0);
+        assert!(!completed.needs_queue_interrupt());
         assert!(error.completed_tx_dispatch().is_none());
-        assert_eq!(read_interrupt_status(&handler), 0);
-        assert!(handler.pending_queue_notifications().is_empty());
-        let active_tx_queue = handler
-            .activation_handler()
-            .active_tx_dispatch_queue()
-            .expect("TX dispatch queue should remain active");
-        assert_eq!(active_tx_queue.available_ring().next_avail(), 0);
-        assert_eq!(active_tx_queue.used_ring().next_used(), 0);
+        assert!(device.has_pending_host_request_packet(key));
+        assert_eq!(read_vsock_rx_used_index(&memory), 0);
     }
 
     #[test]
@@ -7631,12 +8030,13 @@ mod tests {
             "virtio-vsock queue notification for unsupported queue 2"
         );
         assert!(error.completed_tx_dispatch().is_none());
+        assert!(error.completed_rx_dispatch().is_none());
         assert_eq!(read_interrupt_status(&handler), 0);
         assert!(handler.pending_queue_notifications().is_empty());
     }
 
     #[test]
-    fn virtio_vsock_notifications_reject_mixed_unsupported_queue_without_tx_dispatch() {
+    fn virtio_vsock_notifications_dispatch_mixed_rx_noop_and_tx_queue() {
         let mut memory = vsock_tx_memory();
         let mut handler = virtio_vsock_mmio_handler(3).expect("vsock handler should build");
         let header = test_vsock_packet_header().with_payload_len(0);
@@ -7656,31 +8056,38 @@ mod tests {
         notify_vsock_queue(&mut handler, VIRTIO_VSOCK_TX_QUEUE_INDEX);
         notify_vsock_queue(&mut handler, VIRTIO_VSOCK_RX_QUEUE_INDEX);
 
-        let error = handler
+        let notification = handler
             .dispatch_vsock_queue_notifications(&mut memory)
-            .expect_err("mixed unsupported notification should reject before TX dispatch");
+            .expect("mixed RX/TX notification should dispatch");
 
-        assert!(matches!(
-            error,
-            super::VirtioVsockDeviceNotificationError::UnsupportedQueue {
-                queue_index: VIRTIO_VSOCK_RX_QUEUE_INDEX,
-                ..
-            }
-        ));
         assert_eq!(
-            error.drained_notifications(),
+            notification.drained_notifications(),
             &[VIRTIO_VSOCK_RX_QUEUE_INDEX, VIRTIO_VSOCK_TX_QUEUE_INDEX]
         );
-        assert!(error.completed_tx_dispatch().is_none());
-        assert_eq!(read_interrupt_status(&handler), 0);
+        assert!(notification.needs_queue_interrupt());
+        let rx = notification
+            .rx_queue_dispatch()
+            .expect("RX dispatch summary should be present");
+        assert_eq!(rx.processed_buffers(), 0);
+        assert!(!rx.needs_queue_interrupt());
+        let tx = notification
+            .tx_queue_dispatch()
+            .expect("TX dispatch summary should be present");
+        assert_eq!(tx.processed_packets(), 1);
+        assert_eq!(tx.successful_packets(), 1);
+        assert!(tx.needs_queue_interrupt());
+        assert_eq!(
+            read_interrupt_status(&handler),
+            DeviceInterruptKind::Queue.status().bits()
+        );
         assert!(handler.pending_queue_notifications().is_empty());
         let active_tx_queue = handler
             .activation_handler()
             .active_tx_dispatch_queue()
             .expect("TX dispatch queue should remain active");
-        assert_eq!(active_tx_queue.available_ring().next_avail(), 0);
-        assert_eq!(active_tx_queue.used_ring().next_used(), 0);
-        assert_eq!(read_vsock_tx_used_index(&memory), 0);
+        assert_eq!(active_tx_queue.available_ring().next_avail(), 1);
+        assert_eq!(active_tx_queue.used_ring().next_used(), 1);
+        assert_eq!(read_vsock_tx_used_index(&memory), 1);
     }
 
     #[test]
@@ -7868,6 +8275,80 @@ mod tests {
         assert_eq!(active_tx_queue.used_ring().next_used(), 1);
         assert_eq!(read_vsock_tx_used_index(&memory), 1);
         assert_eq!(read_vsock_tx_used_element(&memory, 0), (0, 0));
+    }
+
+    #[test]
+    fn virtio_vsock_notifications_preserve_completed_rx_when_mixed_tx_fails() {
+        let mut memory = vsock_tx_memory();
+        let mut handler = virtio_vsock_mmio_handler(42).expect("vsock handler should build");
+        let header = test_vsock_packet_header().with_payload_len(0);
+
+        activate_vsock_handler(&mut handler);
+        let (accepted, _client, request) =
+            accepted_host_connection_with_request("notify-mixed-error", 4004);
+        let key = handler
+            .activation_handler_mut()
+            .insert_accepted_host_connection(accepted, request)
+            .expect("host connection should insert");
+        write_vsock_rx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::writable(
+                TEST_VSOCK_RX_BUFFER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            ),
+        );
+        write_vsock_rx_available_heads(&mut memory, &[0]);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, header);
+        write_vsock_tx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            ),
+        );
+        write_vsock_tx_available_heads(&mut memory, &[0, VIRTIO_VSOCK_QUEUE_SIZE]);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_RX_QUEUE_INDEX);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_TX_QUEUE_INDEX);
+
+        let error = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect_err("invalid second TX head should fail after RX dispatch");
+
+        assert!(matches!(
+            error,
+            super::VirtioVsockDeviceNotificationError::TxQueueDispatch { .. }
+        ));
+        assert_eq!(
+            error.drained_notifications(),
+            &[VIRTIO_VSOCK_RX_QUEUE_INDEX, VIRTIO_VSOCK_TX_QUEUE_INDEX]
+        );
+        let rx = error
+            .completed_rx_dispatch()
+            .expect("completed RX dispatch should be preserved");
+        assert_eq!(rx.processed_buffers(), 1);
+        assert_eq!(rx.delivered_requests(), 1);
+        assert!(rx.needs_queue_interrupt());
+        let tx = error
+            .completed_tx_dispatch()
+            .expect("completed TX dispatch should be preserved");
+        assert_eq!(tx.processed_packets(), 1);
+        assert_eq!(tx.successful_packets(), 1);
+        assert!(tx.needs_queue_interrupt());
+        assert!(
+            !handler
+                .activation_handler()
+                .has_pending_host_request_packet(key)
+        );
+        assert_eq!(
+            read_interrupt_status(&handler),
+            DeviceInterruptKind::Queue.status().bits()
+        );
+        assert_eq!(read_vsock_rx_used_index(&memory), 1);
+        assert_eq!(read_vsock_tx_used_index(&memory), 1);
     }
 
     #[test]

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -8038,6 +8038,58 @@ mod tests {
     }
 
     #[test]
+    fn virtio_vsock_notifications_reject_mixed_event_queue_without_rx_dispatch() {
+        let mut memory = vsock_tx_memory();
+        let mut handler = virtio_vsock_mmio_handler(42).expect("vsock handler should build");
+
+        activate_vsock_handler(&mut handler);
+        let (accepted, _client, request) =
+            accepted_host_connection_with_request("notify-event-rx", 4005);
+        let key = handler
+            .activation_handler_mut()
+            .insert_accepted_host_connection(accepted, request)
+            .expect("host connection should insert");
+        write_vsock_rx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::writable(
+                TEST_VSOCK_RX_BUFFER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            ),
+        );
+        write_vsock_rx_available_heads(&mut memory, &[0]);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_RX_QUEUE_INDEX);
+        notify_vsock_queue(&mut handler, VIRTIO_VSOCK_EVENT_QUEUE_INDEX);
+
+        let error = handler
+            .dispatch_vsock_queue_notifications(&mut memory)
+            .expect_err("mixed event notification should be unsupported before RX dispatch");
+
+        assert!(matches!(
+            error,
+            super::VirtioVsockDeviceNotificationError::UnsupportedQueue {
+                queue_index: VIRTIO_VSOCK_EVENT_QUEUE_INDEX,
+                ..
+            }
+        ));
+        assert_eq!(
+            error.drained_notifications(),
+            &[VIRTIO_VSOCK_RX_QUEUE_INDEX, VIRTIO_VSOCK_EVENT_QUEUE_INDEX]
+        );
+        assert!(
+            handler
+                .activation_handler()
+                .has_pending_host_request_packet(key)
+        );
+        assert!(error.completed_tx_dispatch().is_none());
+        assert!(error.completed_rx_dispatch().is_none());
+        assert_eq!(read_interrupt_status(&handler), 0);
+        assert_eq!(read_vsock_rx_used_index(&memory), 0);
+        assert!(handler.pending_queue_notifications().is_empty());
+    }
+
+    #[test]
     fn virtio_vsock_notifications_dispatch_mixed_rx_noop_and_tx_queue() {
         let mut memory = vsock_tx_memory();
         let mut handler = virtio_vsock_mmio_handler(3).expect("vsock handler should build");

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -8,7 +8,7 @@ The current repository defines crate boundaries, endpoint names, a minimal
 HTTP-over-Unix-socket API server for `GET /`, `GET /version`,
 `GET /vm/config`, `GET /machine-config`, pre-boot `PUT /machine-config`
 configuration storage, pre-boot `PUT /boot-source` configuration storage, pre-boot `PUT /drives/{drive_id}`
-configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, packet header model, TX descriptor packet parser, TX available-ring drain helper with used-ring descriptor completion, prepared device resource, host Unix socket listener owner, accepted host stream owner, accepted-stream `CONNECT <PORT>` handshake reader, host local port allocator, retained host connection table model with pending host-initiated request packet headers, RX queue delivery of host request packet headers, MMIO registration helper, MMIO handler skeleton with active queue metadata retention and handler-level TX notification dispatch, startup FDT attachment, and boot-runtime/HVF TX notification dispatch with queue interrupt signaling, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
+configuration storage, pre-boot `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage plus an internal virtio-vsock config-space, packet header model, TX descriptor packet parser, TX available-ring drain helper with used-ring descriptor completion, prepared device resource, host Unix socket listener owner, accepted host stream owner, accepted-stream `CONNECT <PORT>` handshake reader, host local port allocator, retained host connection table model with pending host-initiated request packet headers, RX queue notification delivery of host request packet headers, MMIO registration helper, MMIO handler skeleton with active queue metadata retention and handler-level RX/TX notification dispatch, startup FDT attachment, and boot-runtime/HVF RX/TX notification dispatch with queue interrupt signaling, pre-boot `PUT /metrics` output configuration, pre-boot `PUT /logger` output configuration, process-owned `PUT /actions` startup with an internal boot run-loop worker across bounded step windows, runtime `FlushMetrics` with a minimal per-process metrics sink, a macOS-gated internal vmnet descriptor, lifecycle, start owner, concrete system start/stop backend, and packet descriptor boundary model for future host networking, a backend-neutral VM trait, a minimal VMM action/data model with internal
 `InstanceStart` preflight, transactional startup executor, and successful-start state transition helpers, backend-neutral guest
 physical address and aarch64 DRAM layout/access primitives, arm64 boot
 placement helpers, internal boot-source validation and arm64 kernel/initrd
@@ -233,7 +233,7 @@ compatibility targets.
 | `PATCH` | `/machine-config` | deferred | Partial updates belong with later state and validation rules. |
 | `PUT` | `/cpu-config` | deferred | Needs HVF CPU feature design with VM and boot work in #8 and #10. |
 | `PUT` | `/network-interfaces/{iface_id}` | supported target; configuration storage implemented | Stores up to 16 initial virtio-net configurations before boot without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the interface count before opening vmnet resources, then selects vmnet packet I/O only for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names; unsupported names fail startup before `Running` is committed. Internal network notification dispatch can route each configured interface through selected packet I/O, parse TX descriptors through a packet sink boundary, and copy injected RX packets into guest buffers through a packet source boundary. Public packet movement, runtime updates, PATCH, and DELETE remain tied to #14. |
-| `PUT` | `/vsock` | supported target; startup listener attachment, host stream accept, accepted-stream `CONNECT` handshake read, host local port allocation/table ownership, pending host request packet modeling, RX request-header delivery, and TX notification dispatch implemented | Stores one initial virtio-vsock configuration before boot without opening host resources during the API request. Startup preparation binds a nonblocking host Unix listener at `uds_path`, keeps ownership in the internal vsock device resource, and removes the path on shutdown only when it still refers to the created socket. Startup also attaches the configured device as one virtio-mmio FDT node backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has a Firecracker-shaped packet header model, internal TX descriptor packet parser, TX available-ring drain helper that publishes zero-length TX used-ring completions, a host socket accept helper that returns one owned nonblocking stream per call, an accepted-stream `CONNECT <PORT>` handshake reader, host local port allocator, and host connection table model that retains accepted streams under Firecracker-shaped host-initiated connection keys and exposes a one-shot `VSOCK_OP_REQUEST` packet header for the guest-facing connection request. The RX queue helper can deliver that pending request header into writable guest RX descriptors and publish a used-ring completion while preserving the pending request on malformed buffers or used-ring failures. The handler and startup notification path can drain TX queue notifications, complete queued TX descriptors, mark the virtio queue interrupt status pending, and signal the allocated vsock interrupt line from the HVF boot loop. Guest `RESPONSE` handling, `OK`/`RST` host responses, guest-initiated `uds_path_<PORT>` connections, guest CID routing, data movement, runtime updates, PATCH, and DELETE remain tied to #15. |
+| `PUT` | `/vsock` | supported target; startup listener attachment, host stream accept, accepted-stream `CONNECT` handshake read, host local port allocation/table ownership, pending host request packet modeling, and RX/TX notification dispatch implemented | Stores one initial virtio-vsock configuration before boot without opening host resources during the API request. Startup preparation binds a nonblocking host Unix listener at `uds_path`, keeps ownership in the internal vsock device resource, and removes the path on shutdown only when it still refers to the created socket. Startup also attaches the configured device as one virtio-mmio FDT node backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has a Firecracker-shaped packet header model, internal TX descriptor packet parser, TX available-ring drain helper that publishes zero-length TX used-ring completions, a host socket accept helper that returns one owned nonblocking stream per call, an accepted-stream `CONNECT <PORT>` handshake reader, host local port allocator, and host connection table model that retains accepted streams under Firecracker-shaped host-initiated connection keys and exposes a one-shot `VSOCK_OP_REQUEST` packet header for the guest-facing connection request. The RX notification path can select the smallest pending host request, deliver that request header into writable guest RX descriptors, and publish a used-ring completion while preserving the pending request on malformed buffers or used-ring failures. The handler and startup notification path can drain RX and TX queue notifications, complete queued descriptors, mark the virtio queue interrupt status pending, and signal the allocated vsock interrupt line from the HVF boot loop. Guest `RESPONSE` handling, `OK`/`RST` host responses, guest-initiated `uds_path_<PORT>` connections, guest CID routing, data movement, runtime updates, PATCH, and DELETE remain tied to #15. |
 | `GET`, `PUT`, `PATCH` | `/mmds` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/mmds/config` | deferred | Tied to MMDS work in #16. |
 | `PUT` | `/snapshot/create`, `/snapshot/load` | deferred | Tied to snapshot and restore work in #19. |
@@ -359,16 +359,18 @@ can parse guest-readable TX descriptor chains into validated packet metadata and
 payload segments. Header byte parsing rejects payload lengths above the 64 KiB
 maximum packet buffer length, and TX parsing rejects payload lengths larger
 than readable descriptor bytes after the header. The handler can dispatch TX
-queue notifications into descriptor completions, and startup can dispatch those
+queue notifications into descriptor completions and RX queue notifications into
+pending host request-header delivery, and startup can dispatch those
 notifications through the boot loop while signaling the allocated vsock
-interrupt line. Startup can also bind and own a nonblocking host listener at
-`uds_path`. The runtime also parses Firecracker-shaped host `CONNECT <PORT>`
-requests, allocates Firecracker-shaped host local ports, retains
-host-initiated accepted streams in an internal table, can expose a one-shot
-guest-facing `VSOCK_OP_REQUEST` packet header for a retained host connection,
-can deliver that pending request header into writable guest RX descriptors with
-used-ring completion metadata, can accept one pending host connection per call
-into an owned nonblocking stream, and can read and parse bounded
+interrupt line when completed descriptors require it. Startup can also bind and
+own a nonblocking host listener at `uds_path`. The runtime also parses
+Firecracker-shaped host `CONNECT <PORT>` requests, allocates Firecracker-shaped
+host local ports, retains host-initiated accepted streams in an internal table,
+can expose a one-shot guest-facing `VSOCK_OP_REQUEST` packet header for a
+retained host connection, can dispatch that pending request header through RX
+queue notifications into writable guest RX descriptors with used-ring
+completion metadata, can accept one pending host connection per call into an
+owned nonblocking stream, and can read and parse bounded
 accepted-stream `CONNECT` handshakes. Guest-visible socket lifecycle,
 `OK`/`RST` host responses, guest-initiated `uds_path_<PORT>` connections, CID
 routing, event queue dispatch, and data movement remain deferred.
@@ -582,8 +584,8 @@ The runtime crate has an internal virtio-vsock prepared resource, MMIO
 registration helper, config-space, 44-byte little-endian packet header model,
 guest-readable TX descriptor packet parser, TX available-ring drain helper with
 used-ring descriptor completion,
-MMIO handler skeleton with active queue metadata retention and TX notification
-dispatch, and startup FDT attachment. It uses the
+MMIO handler skeleton with active queue metadata retention and RX/TX
+notification dispatch, and startup FDT attachment. It uses the
 virtio device id `19`, three 256-entry RX, TX, and event queues, Firecracker's
 `VERSION_1`, `IN_ORDER`, and `EVENT_IDX` feature bits, and a guest-CID config
 field that supports Firecracker-shaped 8-byte and 4-byte-half reads. Config
@@ -595,11 +597,12 @@ returns payload segment metadata trimmed to the advertised payload length. The
 TX drain helper consumes available TX descriptor chains from the active queue
 into parsed packet metadata while preserving queue progress and publishes
 zero-length used-ring completions for consumed descriptor heads. The handler can
-drain TX queue notifications, dispatch the active TX queue, preserve completed
-TX dispatch metadata on errors, and mark the virtio queue interrupt status when
+drain RX and TX queue notifications, dispatch the active RX queue for pending
+host request headers, dispatch the active TX queue, preserve completed RX/TX
+dispatch metadata on errors, and mark the virtio queue interrupt status when
 completed descriptors require guest notification. Boot runtime resources can
-dispatch the registered vsock MMIO handler's TX notifications, and internal HVF
-boot sessions can signal the allocated vsock SPI line from those dispatch
+dispatch the registered vsock MMIO handler's RX/TX notifications, and internal
+HVF boot sessions can signal the allocated vsock SPI line from those dispatch
 summaries. The prepared resource preserves the validated guest CID, socket path,
 config-space, and inactive device state. Arm64 startup resource assembly can
 bind and own the nonblocking host listener at `uds_path`, retain that owner in
@@ -608,8 +611,8 @@ the guest FDT. The runtime can parse Firecracker-shaped host `CONNECT <PORT>`
 requests into a guest port, allocate Firecracker-shaped host local ports,
 retain host-initiated accepted streams in an internal table, expose a one-shot
 guest-facing `VSOCK_OP_REQUEST` packet header for a retained host connection,
-deliver that pending request header into writable guest RX descriptors with
-used-ring completion metadata, accept one pending host connection per call into
+dispatch that pending request header through RX queue notifications into
+writable guest RX descriptors with used-ring completion metadata, accept one pending host connection per call into
 an owned nonblocking stream, then read and parse bounded accepted-stream
 `CONNECT` handshakes. Guest-visible socket lifecycle, `OK`/`RST` host
 responses, guest-initiated `uds_path_<PORT>` connections, CID routing, event
@@ -1067,7 +1070,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | `PUT /boot-source` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; host paths are opened during startup preparation. Host path errors must avoid leaking sensitive path details. |
 | `PUT /drives/{drive_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; startup preparation opens backing files and registers initial block MMIO devices. Runtime hotplug remains deferred. |
 | `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records up to 16 validated pre-boot configs without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the count before opening vmnet packet I/O for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names and fails before `Running` for unsupported names. Internal network notification dispatch can route each interface through selected packet I/O, complete TX descriptor heads through a packet sink boundary, and write injected RX packets into guest buffers through a packet source boundary. Public packet movement, PATCH, and DELETE remain deferred. |
-| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening host Unix socket resources during the request. Startup preparation binds the configured `uds_path` as a nonblocking host Unix listener and attaches one configured virtio-vsock device as guest-visible FDT/MMIO metadata backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has an internal TX descriptor packet parser, TX available-ring drain helper, used-ring TX descriptor completion, host socket accept helper for one owned nonblocking stream per call, accepted-stream `CONNECT <PORT>` handshake reader, host local port allocator, retained host connection table model with one-shot host request packet headers, RX request-header delivery into writable guest descriptors, handler-level and startup-level TX notification dispatch, and HVF boot-loop vsock queue interrupt signaling, but guest-visible socket lifecycle, `OK`/`RST` host responses, CID routing, event queue dispatch, data movement, PATCH, and DELETE remain deferred. |
+| `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening host Unix socket resources during the request. Startup preparation binds the configured `uds_path` as a nonblocking host Unix listener and attaches one configured virtio-vsock device as guest-visible FDT/MMIO metadata backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has an internal TX descriptor packet parser, TX available-ring drain helper, used-ring TX descriptor completion, host socket accept helper for one owned nonblocking stream per call, accepted-stream `CONNECT <PORT>` handshake reader, host local port allocator, retained host connection table model with one-shot host request packet headers, RX request-header delivery through queue notifications into writable guest descriptors, handler-level and startup-level RX/TX notification dispatch, and HVF boot-loop vsock queue interrupt signaling, but guest-visible socket lifecycle, `OK`/`RST` host responses, CID routing, event queue dispatch, data movement, PATCH, and DELETE remain deferred. |
 | `PUT /metrics` | implemented; `204` empty response on successful output initialization | unsupported after start; `400` `fault_message` | Metrics output is process observability state, not guest configuration. Duplicate initialization fails. |
 | `PUT /logger` | implemented; `204` empty response on successful pre-boot configuration | unsupported after start; `400` `fault_message` | Logger output is process observability state, not guest configuration. Repeated pre-boot requests update provided fields; full log routing remains deferred. |
 | `PUT /actions` with `InstanceStart` | process-routed; `204` after successful owned HVF startup with internal boot run-loop worker across bounded step windows or `400` preflight/preparation fault | unsupported after start; `400` `fault_message` | Commits `Running` only after the owned HVF boot-session worker with internal serial capture is retained. The worker keeps internal active, terminal-outcome, or error status; public run-loop control and public serial streaming remain deferred. |
@@ -1123,8 +1126,9 @@ Their eventual support level should follow the endpoint matrix:
   local port allocation, retained host connection table modeling with pending host request packet headers, and the internal prepared resource/MMIO
   registration/config-space/MMIO handler skeleton with active queue metadata retention plus packet header model, TX
   descriptor packet parser, TX available-ring drain helper with used-ring
-  descriptor completion, and RX request-header delivery helper, handler-level and startup-level TX notification
-  dispatch, and boot-loop queue interrupt signaling
+  descriptor completion, RX request-header delivery through queue notifications,
+  handler-level and startup-level RX/TX notification dispatch, and boot-loop
+  queue interrupt signaling
 - snapshots
 - MMDS
 - balloon devices and balloon statistics

--- a/docs/security.md
+++ b/docs/security.md
@@ -67,15 +67,16 @@ is resource-specific:
   can attach a guest-visible virtio-vsock device whose internal MMIO handler
   retains active RX, TX, and event queue metadata after `DRIVER_OK`, and the
   runtime has an internal Firecracker-shaped packet header model plus TX
-  descriptor packet parser. Startup-level dispatch can drain TX queue
-  notifications, complete TX descriptor heads, and signal the allocated vsock
-  queue interrupt line. The runtime can also parse host `CONNECT <PORT>`
-  requests, allocate Firecracker-shaped host local ports, retain
-  host-initiated accepted streams in an internal table, expose one-shot
-  guest-facing `VSOCK_OP_REQUEST` packet headers for retained host connections,
-  write those request headers into validated writable guest RX descriptors,
-  accept one pending host connection per call into an owned nonblocking stream,
-  then read and parse a bounded accepted-stream `CONNECT` handshake. Startup
+  descriptor packet parser. Startup-level dispatch can drain RX and TX queue
+  notifications, complete descriptor heads, and signal the allocated vsock
+  queue interrupt line when completed descriptors require it. The runtime can
+  also parse host `CONNECT <PORT>` requests, allocate Firecracker-shaped host
+  local ports, retain host-initiated accepted streams in an internal table,
+  expose one-shot guest-facing `VSOCK_OP_REQUEST` packet headers for retained
+  host connections, dispatch those request headers through RX queue
+  notifications into validated writable guest RX descriptors, accept one
+  pending host connection per call into an owned nonblocking stream, then read
+  and parse a bounded accepted-stream `CONNECT` handshake. Startup
   also binds a nonblocking host Unix listener at `uds_path`, records the
   listener socket device and inode, and removes the path on normal shutdown only
   when it still refers to the socket created by this process. It does not send
@@ -193,16 +194,17 @@ The current scaffold does not implement:
   The runtime crate has an internal virtio-vsock prepared resource, MMIO
   registration helper, config-space, packet header model, TX descriptor packet
   parser, TX available-ring drain helper with used-ring descriptor completion,
-  MMIO handler skeleton with active queue metadata retention and TX notification
-  dispatch, startup FDT attachment, startup-level TX notification dispatch, and
-  HVF queue interrupt signaling that expose only the configured guest CID
-  through bounded config reads. The runtime can also parse host `CONNECT <PORT>`
-  requests, allocate Firecracker-shaped host local ports, retain
-  host-initiated accepted streams in an internal table, expose one-shot
+  MMIO handler skeleton with active queue metadata retention and RX/TX
+  notification dispatch, startup FDT attachment, startup-level RX/TX
+  notification dispatch, and HVF queue interrupt signaling that expose only the
+  configured guest CID through bounded config reads. The runtime can also parse
+  host `CONNECT <PORT>` requests, allocate Firecracker-shaped host local ports,
+  retain host-initiated accepted streams in an internal table, expose one-shot
   guest-facing `VSOCK_OP_REQUEST` packet headers for retained host connections,
-  write those request headers into validated writable guest RX descriptors,
-  accept one pending host connection per call into an owned nonblocking stream,
-  and read and parse a bounded accepted-stream `CONNECT` handshake. Startup
+  dispatch those request headers through RX queue notifications into validated
+  writable guest RX descriptors, accept one pending host connection per call
+  into an owned nonblocking stream, and read and parse a bounded
+  accepted-stream `CONNECT` handshake. Startup
   preparation creates a nonblocking host Unix listener at `uds_path` and cleans
   it up only while the path still matches the created socket inode. It does not
   send `OK` or `RST` responses, connect guest-initiated `uds_path_<PORT>`


### PR DESCRIPTION
## Summary

- add device-owned vsock host connection state and dispatch pending host request headers from RX queue notifications
- propagate RX dispatch summaries and interrupt intent through runtime and HVF startup notification handling
- update vsock compatibility/security docs and tests for RX no-op, delivery, malformed buffers, partial errors, reset cleanup, and mixed RX/TX dispatch

Closes #363

## Verification

- cargo fmt --all -- --check
- cargo check --workspace --all-targets --all-features --locked
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- scripts/run-integration-tests.sh