### PR TITLE
feat: verify guest block read during boot

### DIFF
--- a/crates/hvf/src/mmio.rs
+++ b/crates/hvf/src/mmio.rs
@@ -16,6 +16,8 @@ use crate::exit::{
 };
 use crate::vcpu::HvfRegister;
 
+const AARCH64_ZERO_REGISTER: u8 = 31;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HvfMmioCompletionError {
     UnsupportedRegister {
@@ -156,17 +158,17 @@ pub(crate) fn build_mmio_operation(
     mut read_register: impl FnMut(HvfRegister) -> Result<u64, BackendError>,
 ) -> Result<MmioOperation, HvfMmioCompletionError> {
     match access.direction() {
-        HvfMmioDirection::Read => {
-            let _register = mmio_gpr(access.register())?;
-
-            MmioOperation::read(access.runtime_access())
-                .map_err(|source| HvfMmioCompletionError::Operation { source })
-        }
+        HvfMmioDirection::Read => MmioOperation::read(access.runtime_access())
+            .map_err(|source| HvfMmioCompletionError::Operation { source }),
         HvfMmioDirection::Write => {
-            let register = mmio_gpr(access.register())?;
-            let value = read_register(register).map_err(|source| {
-                HvfMmioCompletionError::RegisterReadFailed { register, source }
-            })?;
+            let value = if is_zero_register(access.register()) {
+                0
+            } else {
+                let register = mmio_gpr(access.register())?;
+                read_register(register).map_err(|source| {
+                    HvfMmioCompletionError::RegisterReadFailed { register, source }
+                })?
+            };
             let data = register_value_to_access_bytes(value, access.size())?;
 
             MmioOperation::write(access.runtime_access(), data)
@@ -196,6 +198,10 @@ pub(crate) fn complete_mmio_read(
         });
     }
 
+    if is_zero_register(access.register()) {
+        return Ok(());
+    }
+
     let register = mmio_gpr(access.register())?;
     let value = read_data_register_value(data, access.sign_extend(), access.register_width());
     set_register(register, value)
@@ -221,6 +227,10 @@ pub(crate) fn dispatch_mmio_access(
     }
 
     Ok(outcome)
+}
+
+const fn is_zero_register(register: HvfMmioRegister) -> bool {
+    register.raw_value() == AARCH64_ZERO_REGISTER
 }
 
 fn mmio_gpr(register: HvfMmioRegister) -> Result<HvfRegister, HvfMmioCompletionError> {
@@ -558,32 +568,30 @@ mod tests {
     }
 
     #[test]
-    fn write_access_rejects_guest_register_thirty_one() {
+    fn write_access_uses_zero_for_guest_register_thirty_one() {
         let access = resolved_access(
-            HvfMmioAccessSize::Byte,
+            HvfMmioAccessSize::Word,
             HvfMmioDirection::Write,
             31,
             false,
             HvfMmioRegisterWidth::Bits64,
         );
         let mut register_read = false;
-        let err = build_mmio_operation(access, |_| {
+        let operation = build_mmio_operation(access, |_| {
             register_read = true;
             Ok(0)
         })
-        .expect_err("register thirty-one should be rejected");
+        .expect("register thirty-one write should use zero");
 
-        assert_eq!(
-            err,
-            HvfMmioCompletionError::UnsupportedRegister {
-                register: HvfMmioRegister::new(31).expect("register should exist")
-            }
-        );
+        let MmioOperation::Write { data, .. } = operation else {
+            panic!("expected write operation");
+        };
+        assert_eq!(data.as_slice(), [0, 0, 0, 0]);
         assert!(!register_read);
     }
 
     #[test]
-    fn read_access_rejects_guest_register_thirty_one_before_operation_build() {
+    fn read_access_allows_guest_register_thirty_one_without_register_read() {
         let access = resolved_access(
             HvfMmioAccessSize::Byte,
             HvfMmioDirection::Read,
@@ -591,16 +599,14 @@ mod tests {
             false,
             HvfMmioRegisterWidth::Bits64,
         );
-        let err = build_mmio_operation(access, |_| {
+        let operation = build_mmio_operation(access, |_| {
             Err(BackendError::InvalidState("read register should not run"))
         })
-        .expect_err("register thirty-one should be rejected");
+        .expect("register thirty-one read operation should build");
 
         assert_eq!(
-            err,
-            HvfMmioCompletionError::UnsupportedRegister {
-                register: HvfMmioRegister::new(31).expect("register should exist")
-            }
+            operation,
+            MmioOperation::read(access.runtime_access()).expect("runtime read should build")
         );
     }
 
@@ -765,7 +771,7 @@ mod tests {
     }
 
     #[test]
-    fn read_completion_rejects_guest_register_thirty_one() {
+    fn read_completion_discards_guest_register_thirty_one() {
         let access = resolved_access(
             HvfMmioAccessSize::Byte,
             HvfMmioDirection::Read,
@@ -774,18 +780,12 @@ mod tests {
             HvfMmioRegisterWidth::Bits64,
         );
         let mut register_write = false;
-        let err = complete_mmio_read(access, bytes(&[0]), |_, _| {
+        complete_mmio_read(access, bytes(&[0]), |_, _| {
             register_write = true;
             Ok(())
         })
-        .expect_err("register thirty-one should be rejected");
+        .expect("register thirty-one read completion should be discarded");
 
-        assert_eq!(
-            err,
-            HvfMmioCompletionError::UnsupportedRegister {
-                register: HvfMmioRegister::new(31).expect("register should exist")
-            }
-        );
         assert!(!register_write);
     }
 
@@ -884,7 +884,7 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_rejects_unsupported_read_register_before_handler() {
+    fn dispatch_read_to_guest_register_thirty_one_calls_handler_without_completion_write() {
         let access = resolved_access(
             HvfMmioAccessSize::Byte,
             HvfMmioDirection::Read,
@@ -898,17 +898,39 @@ mod tests {
             Ok(()),
         );
 
-        let err = dispatch_mmio_access(access, &mut dispatcher, &mut registers)
-            .expect_err("unsupported read register should fail before dispatch");
+        let outcome = dispatch_mmio_access(access, &mut dispatcher, &mut registers)
+            .expect("zero register read should dispatch without completion write");
 
-        assert_eq!(
-            err,
-            HvfMmioDispatchError::Operation {
-                source: HvfMmioCompletionError::UnsupportedRegister {
-                    register: HvfMmioRegister::new(31).expect("register should exist")
-                }
-            }
+        assert_eq!(outcome, MmioDispatchOutcome::Read { data: bytes(&[0]) });
+        assert!(registers.reads.is_empty());
+        assert!(registers.writes.is_empty());
+
+        let state = state
+            .lock()
+            .expect("handler state lock should not be poisoned");
+        assert_eq!(state.reads, vec![access.runtime_access()]);
+        assert!(state.writes.is_empty());
+    }
+
+    #[test]
+    fn dispatch_write_from_guest_register_thirty_one_writes_zero_bytes_without_register_read() {
+        let access = resolved_access(
+            HvfMmioAccessSize::Halfword,
+            HvfMmioDirection::Write,
+            31,
+            false,
+            HvfMmioRegisterWidth::Bits64,
         );
+        let (mut dispatcher, state) = dispatcher_with_handler(Ok(bytes(&[0, 0])), Ok(()));
+        let mut registers = FakeRegisters::new(
+            Err(BackendError::InvalidState("read register should not run")),
+            Ok(()),
+        );
+
+        let outcome = dispatch_mmio_access(access, &mut dispatcher, &mut registers)
+            .expect("zero register write should dispatch");
+
+        assert_eq!(outcome, MmioDispatchOutcome::Write);
         assert!(registers.reads.is_empty());
         assert!(registers.writes.is_empty());
 
@@ -916,7 +938,10 @@ mod tests {
             .lock()
             .expect("handler state lock should not be poisoned");
         assert!(state.reads.is_empty());
-        assert!(state.writes.is_empty());
+        assert_eq!(
+            state.writes,
+            vec![(access.runtime_access(), bytes(&[0, 0]))]
+        );
     }
 
     #[test]

--- a/crates/hvf/tests/guest_boot.rs
+++ b/crates/hvf/tests/guest_boot.rs
@@ -13,6 +13,8 @@ static GUEST_BOOT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const BOOT_MARKER: &[u8] = b"BANGBANG_BOOT_OK";
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const BLOCK_READ_MARKER: &[u8] = b"BANGBANG_BLOCK_READ_OK";
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 rdinit=/init";
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const GUEST_BOOT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
@@ -28,6 +30,53 @@ const VSOCK_MMIO_BASE: u64 = 0x7000_0000;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 #[test]
 fn boots_firecracker_kernel_to_guest_marker() {
+    let _test_lock = GUEST_BOOT_TEST_LOCK
+        .lock()
+        .expect("guest boot integration test lock should not be poisoned");
+    let observation = run_guest_boot_until_marker("guest-boot", BOOT_MARKER, |_| {});
+
+    assert_guest_boot_observed_marker(&observation, BOOT_MARKER, "boot marker");
+    assert!(
+        !bytes_contain_marker(&observation.serial_bytes, BLOCK_READ_MARKER),
+        "guest boot test without a drive should not observe block-read marker\nserial output:\n{}",
+        String::from_utf8_lossy(&observation.serial_bytes)
+    );
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn boots_firecracker_kernel_and_reads_virtio_block_marker() {
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::block::DriveConfigInput;
+
+    let _test_lock = GUEST_BOOT_TEST_LOCK
+        .lock()
+        .expect("guest boot integration test lock should not be poisoned");
+    let backing = GuestBlockBacking::new(BLOCK_READ_MARKER);
+    let observation =
+        run_guest_boot_until_marker("guest-block-read", BLOCK_READ_MARKER, |controller| {
+            controller
+                .handle_action(VmmAction::PutDrive(
+                    DriveConfigInput::new("data", "data", backing.path(), false)
+                        .with_is_read_only(true),
+                ))
+                .expect("guest block read drive should configure");
+        });
+
+    assert_guest_boot_observed_marker(&observation, BLOCK_READ_MARKER, "block-read marker");
+    assert!(
+        bytes_contain_marker(&observation.serial_bytes, BOOT_MARKER),
+        "guest block read test should still observe boot marker\nserial output:\n{}",
+        String::from_utf8_lossy(&observation.serial_bytes)
+    );
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn run_guest_boot_until_marker(
+    instance_id: &str,
+    marker: &[u8],
+    configure_controller: impl FnOnce(&mut bangbang_runtime::VmmController),
+) -> GuestBootObservation {
     use std::num::NonZeroUsize;
     use std::time::Instant;
 
@@ -43,13 +92,10 @@ fn boots_firecracker_kernel_to_guest_marker() {
     use bangbang_runtime::vsock::VsockMmioLayout;
     use bangbang_runtime::{VmmAction, VmmController};
 
-    let _test_lock = GUEST_BOOT_TEST_LOCK
-        .lock()
-        .expect("guest boot integration test lock should not be poisoned");
     let kernel_path = env_path("BANGBANG_GUEST_KERNEL_PATH");
     let initrd_path = env_path("BANGBANG_GUEST_INITRD_PATH");
     let serial_output = SharedSerialOutputBuffer::default();
-    let mut controller = VmmController::new("guest-boot", "0.1.0", "bangbang");
+    let mut controller = VmmController::new(instance_id, "0.1.0", "bangbang");
     controller
         .handle_action(VmmAction::PutBootSource(
             BootSourceConfigInput::new(kernel_path.clone())
@@ -57,6 +103,7 @@ fn boots_firecracker_kernel_to_guest_marker() {
                 .with_boot_args(BOOT_ARGS),
         ))
         .expect("guest boot test boot source should configure");
+    configure_controller(&mut controller);
     let serial_address = GuestAddress::new(SERIAL_MMIO_BASE);
     let config = HvfArm64BootSessionConfig::new(
         BlockMmioLayout::new(GuestAddress::new(BLOCK_MMIO_BASE), MmioRegionId::new(1)),
@@ -85,7 +132,7 @@ fn boots_firecracker_kernel_to_guest_marker() {
     let mut terminal_outcome = None;
 
     while started_at.elapsed() < GUEST_BOOT_TIMEOUT {
-        if serial_contains_marker(&serial_output) {
+        if serial_contains_marker(&serial_output, marker) {
             break;
         }
 
@@ -96,7 +143,7 @@ fn boots_firecracker_kernel_to_guest_marker() {
             .expect("guest boot test run-loop should not fail before marker");
         run_diagnostics.record_loop_outcome(&outcome);
 
-        if serial_contains_marker(&serial_output) {
+        if serial_contains_marker(&serial_output, marker) {
             break;
         }
 
@@ -106,7 +153,7 @@ fn boots_firecracker_kernel_to_guest_marker() {
         }
     }
 
-    let marker_observed = serial_contains_marker(&serial_output);
+    let marker_observed = serial_contains_marker(&serial_output, marker);
     let stop_requested_after_loop = if marker_observed {
         false
     } else {
@@ -123,26 +170,94 @@ fn boots_firecracker_kernel_to_guest_marker() {
         marker_observed,
         stop_requested_after_loop,
         watchdog_timed_out,
-        serial_bytes.len(),
+        &serial_bytes,
         terminal_outcome.as_ref(),
     );
     session
         .shutdown()
         .expect("guest boot test session should shut down");
 
+    GuestBootObservation {
+        boot_diagnostics,
+        run_diagnostics,
+        serial_bytes,
+    }
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn assert_guest_boot_observed_marker(
+    observation: &GuestBootObservation,
+    marker: &[u8],
+    marker_name: &str,
+) {
     assert!(
-        !watchdog_timed_out,
+        !observation.run_diagnostics.watchdog_timed_out,
         "guest boot test watchdog canceled the vCPU run\n{}\nserial output:\n{}",
-        GuestBootFailureReport::new(&boot_diagnostics, &run_diagnostics),
-        String::from_utf8_lossy(&serial_bytes)
+        GuestBootFailureReport::new(&observation.boot_diagnostics, &observation.run_diagnostics),
+        String::from_utf8_lossy(&observation.serial_bytes)
     );
     assert!(
-        bytes_contain_marker(&serial_bytes),
-        "guest boot test did not observe marker {:?}\n{}\nserial output:\n{}",
-        String::from_utf8_lossy(BOOT_MARKER),
-        GuestBootFailureReport::new(&boot_diagnostics, &run_diagnostics),
-        String::from_utf8_lossy(&serial_bytes)
+        bytes_contain_marker(&observation.serial_bytes, marker),
+        "guest boot test did not observe {marker_name} {:?}\n{}\nserial output:\n{}",
+        String::from_utf8_lossy(marker),
+        GuestBootFailureReport::new(&observation.boot_diagnostics, &observation.run_diagnostics),
+        String::from_utf8_lossy(&observation.serial_bytes)
     );
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+struct GuestBootObservation {
+    boot_diagnostics: GuestBootDiagnostics,
+    run_diagnostics: GuestBootRunDiagnostics,
+    serial_bytes: Vec<u8>,
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+struct GuestBlockBacking {
+    path: std::path::PathBuf,
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+impl GuestBlockBacking {
+    fn new(marker: &[u8]) -> Self {
+        use std::io::Write;
+
+        let mut path = std::env::temp_dir();
+        let unique = format!(
+            "bangbang-guest-block-read-{}-{}.img",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("guest block backing timestamp should be after epoch")
+                .as_nanos()
+        );
+        path.push(unique);
+        let mut sector = vec![0; bangbang_runtime::block::VIRTIO_BLOCK_SECTOR_SIZE as usize];
+        assert!(
+            marker.len() <= sector.len(),
+            "guest block marker should fit in one sector"
+        );
+        sector[..marker.len()].copy_from_slice(marker);
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .expect("guest block backing should create");
+        file.write_all(&sector)
+            .expect("guest block backing sector should write");
+        Self { path }
+    }
+
+    fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+impl Drop for GuestBlockBacking {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -273,11 +388,13 @@ struct GuestBootRunDiagnostics {
     unknown_steps: usize,
     terminal_outcome: Option<String>,
     last_step: Option<String>,
+    last_mmio_step: Option<String>,
     elapsed: Option<std::time::Duration>,
     marker_observed: bool,
     stop_requested_after_loop: bool,
     watchdog_timed_out: bool,
     serial_byte_count: usize,
+    serial_tail_hex: Option<String>,
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -297,6 +414,7 @@ impl GuestBootRunDiagnostics {
             }
             bangbang_hvf::HvfVcpuRunStepOutcome::Mmio { .. } => {
                 self.mmio_steps += 1;
+                self.last_mmio_step = Some(format!("{step:?}"));
             }
             bangbang_hvf::HvfVcpuRunStepOutcome::VtimerActivated => {
                 self.virtual_timer_steps += 1;
@@ -333,14 +451,15 @@ impl GuestBootRunDiagnostics {
         marker_observed: bool,
         stop_requested_after_loop: bool,
         watchdog_timed_out: bool,
-        serial_byte_count: usize,
+        serial_bytes: &[u8],
         terminal_outcome: Option<&bangbang_hvf::HvfArm64BootRunLoopOutcome>,
     ) {
         self.elapsed = Some(elapsed);
         self.marker_observed = marker_observed;
         self.stop_requested_after_loop = stop_requested_after_loop;
         self.watchdog_timed_out = watchdog_timed_out;
-        self.serial_byte_count = serial_byte_count;
+        self.serial_byte_count = serial_bytes.len();
+        self.serial_tail_hex = Some(serial_tail_hex(serial_bytes));
         if let Some(outcome) = terminal_outcome {
             self.terminal_outcome = Some(format!("{outcome:?}"));
         }
@@ -385,6 +504,8 @@ impl std::fmt::Display for GuestBootFailureReport<'_> {
             .unwrap_or_else(|| "unknown".to_string());
         let terminal = self.run.terminal_outcome.as_deref().unwrap_or("none");
         let last_step = self.run.last_step.as_deref().unwrap_or("none");
+        let last_mmio_step = self.run.last_mmio_step.as_deref().unwrap_or("none");
+        let serial_tail_hex = self.run.serial_tail_hex.as_deref().unwrap_or("none");
 
         writeln!(f, "guest boot diagnostics:")?;
         writeln!(f, "  classification: {}", self.run.timeout_classification())?;
@@ -417,6 +538,8 @@ impl std::fmt::Display for GuestBootFailureReport<'_> {
         )?;
         writeln!(f, "  terminal outcome: {terminal}")?;
         writeln!(f, "  last raw step: {last_step}")?;
+        writeln!(f, "  last MMIO step: {last_mmio_step}")?;
+        writeln!(f, "  serial tail hex: {serial_tail_hex}")?;
         writeln!(f, "  kernel path: {}", self.boot.kernel_path.display())?;
         writeln!(f, "  initrd path: {}", self.boot.initrd_path.display())?;
         writeln!(f, "  boot args: {}", self.boot.boot_args)?;
@@ -540,19 +663,35 @@ fn env_path(name: &str) -> std::path::PathBuf {
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-fn serial_contains_marker(output: &bangbang_runtime::serial::SharedSerialOutputBuffer) -> bool {
+fn serial_contains_marker(
+    output: &bangbang_runtime::serial::SharedSerialOutputBuffer,
+    marker: &[u8],
+) -> bool {
     output
         .bytes()
         .expect("guest boot test serial output should read")
-        .windows(BOOT_MARKER.len())
-        .any(|window| window == BOOT_MARKER)
+        .windows(marker.len())
+        .any(|window| window == marker)
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-fn bytes_contain_marker(bytes: &[u8]) -> bool {
-    bytes
-        .windows(BOOT_MARKER.len())
-        .any(|window| window == BOOT_MARKER)
+fn bytes_contain_marker(bytes: &[u8], marker: &[u8]) -> bool {
+    bytes.windows(marker.len()).any(|window| window == marker)
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn serial_tail_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    let mut tail = String::new();
+    let start = bytes.len().saturating_sub(64);
+    for (index, byte) in bytes[start..].iter().copied().enumerate() {
+        if index > 0 {
+            tail.push(' ');
+        }
+        write!(&mut tail, "{byte:02x}").expect("hex tail write should not fail");
+    }
+    tail
 }
 
 #[cfg(all(test, target_os = "macos", target_arch = "aarch64"))]
@@ -573,7 +712,7 @@ mod tests {
             false,
             true,
             false,
-            0,
+            &[],
             None,
         );
 
@@ -584,6 +723,7 @@ mod tests {
         assert_eq!(diagnostics.run_loop_calls, 1);
         assert_eq!(diagnostics.step_limit_outcomes, 1);
         assert_eq!(diagnostics.virtual_timer_steps, 1);
+        assert_eq!(diagnostics.last_mmio_step, None);
     }
 
     #[test]
@@ -597,7 +737,7 @@ mod tests {
             false,
             true,
             true,
-            0,
+            &[],
             Some(&outcome),
         );
 
@@ -632,7 +772,7 @@ mod tests {
             false,
             true,
             false,
-            0,
+            &[],
             None,
         );
 
@@ -675,6 +815,9 @@ mod tests {
 
     #[test]
     fn marker_match_accepts_tty_crlf_translation() {
-        assert!(bytes_contain_marker(b"BANGBANG_BOOT_OK\r\n"));
+        assert!(bytes_contain_marker(
+            b"BANGBANG_BOOT_OK\r\n",
+            super::BOOT_MARKER
+        ));
     }
 }

--- a/crates/hvf/tests/guest_boot.rs
+++ b/crates/hvf/tests/guest_boot.rs
@@ -232,6 +232,7 @@ impl GuestBlockBacking {
                 .as_nanos()
         );
         path.push(unique);
+        let backing = Self { path };
         let mut sector = vec![0; bangbang_runtime::block::VIRTIO_BLOCK_SECTOR_SIZE as usize];
         assert!(
             marker.len() <= sector.len(),
@@ -241,11 +242,11 @@ impl GuestBlockBacking {
         let mut file = std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
-            .open(&path)
+            .open(&backing.path)
             .expect("guest block backing should create");
         file.write_all(&sector)
             .expect("guest block backing sector should write");
-        Self { path }
+        backing
     }
 
     fn path(&self) -> &std::path::Path {

--- a/crates/hvf/tests/guest_boot.rs
+++ b/crates/hvf/tests/guest_boot.rs
@@ -232,7 +232,6 @@ impl GuestBlockBacking {
                 .as_nanos()
         );
         path.push(unique);
-        let backing = Self { path };
         let mut sector = vec![0; bangbang_runtime::block::VIRTIO_BLOCK_SECTOR_SIZE as usize];
         assert!(
             marker.len() <= sector.len(),
@@ -242,8 +241,9 @@ impl GuestBlockBacking {
         let mut file = std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
-            .open(&backing.path)
+            .open(&path)
             .expect("guest block backing should create");
+        let backing = Self { path };
         file.write_all(&sector)
             .expect("guest block backing sector should write");
         backing

--- a/crates/runtime/src/block.rs
+++ b/crates/runtime/src/block.rs
@@ -417,8 +417,7 @@ impl VirtioBlockConfigSpace {
     }
 
     pub const fn available_features(self) -> u64 {
-        let features = virtio_feature_bit(VIRTIO_FEATURE_VERSION_1)
-            | virtio_feature_bit(VIRTIO_RING_FEATURE_EVENT_IDX);
+        let features = virtio_feature_bit(VIRTIO_FEATURE_VERSION_1);
         if self.is_read_only {
             features | virtio_feature_bit(VIRTIO_BLOCK_FEATURE_READ_ONLY)
         } else {
@@ -4526,12 +4525,16 @@ mod tests {
 
     #[test]
     fn config_space_tracks_read_only_feature() {
-        let base_features =
-            (1_u64 << VIRTIO_FEATURE_VERSION_1) | (1_u64 << VIRTIO_RING_FEATURE_EVENT_IDX);
+        let base_features = 1_u64 << VIRTIO_FEATURE_VERSION_1;
 
         assert_eq!(
             VirtioBlockConfigSpace::new(512, false).available_features(),
             base_features
+        );
+        assert_eq!(
+            VirtioBlockConfigSpace::new(512, false).available_features()
+                & (1_u64 << VIRTIO_RING_FEATURE_EVENT_IDX),
+            0
         );
         assert_eq!(
             VirtioBlockConfigSpace::new(512, true).available_features(),

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -18,7 +18,8 @@ validation model, internal virtio-net config-space, activation, TX frame parser,
 preparation and MMIO registration helpers, an internal virtio-block
 config-space capacity model, an internal virtio-block request parser, single-request
 executor, queue dispatcher, MMIO queue-state bridge, resettable activation
-state, notification/interrupt-status dispatch helper, an internal TX-only
+state, notification/interrupt-status dispatch helper, guest-visible raw block
+read validation through the signed HVF boot test, an internal TX-only
 serial MMIO output device model with shared bounded capture support, and a minimal
 Hypervisor.framework VM create/destroy wrapper, a current-thread HVF vCPU
 create/destroy wrapper, typed HVF exit surface with MMIO data-abort decoding,
@@ -749,16 +750,22 @@ The runtime crate can derive an internal virtio-block configuration space from
 the backing length. It reports capacity as full 512-byte sectors, matching
 Firecracker's truncation of non-sector-aligned tails, exposes the virtio block
 device id and one 256-entry queue shape, always advertises
-`VIRTIO_F_VERSION_1` and `VIRTIO_RING_F_EVENT_IDX`, and advertises
-`VIRTIO_BLK_F_RO` only for read-only drives.
+`VIRTIO_F_VERSION_1`, and advertises `VIRTIO_BLK_F_RO` only for read-only
+drives. It does not advertise `VIRTIO_RING_F_EVENT_IDX` until event-index
+notification semantics are implemented.
 The config handler supports bounded read-only capacity reads through the
 existing virtio-mmio device-configuration path and rejects config writes.
 
 The runtime model is wired to successful pre-boot `PUT /drives/{drive_id}` VMM
 configuration storage. Public `InstanceStart` startup can call block-device
 preparation, MMIO registration, and FDT device description for initial
-configured drives, and the internal boot run loop across bounded step windows can dispatch active
-block notifications. It does not select a root block device for boot, provide an
+configured drives, and the internal boot run loop across bounded step windows
+can dispatch active block queue notifications and signal interrupts. The signed
+`guest_boot` integration target now validates that the pinned Firecracker arm64
+kernel can discover the first virtio-block device as `/dev/vda` and read a
+marker from a temporary host backing file through the raw block device. Guest
+writes, rootfs boot, block hotplug, cache-mode expansion, and rate limiting
+remain deferred. It does not select a root block device for boot, provide a
 public runner control, implement rate limiting, support
 vhost-user-block sockets, or use an async I/O engine. Internal HVF boot sessions
 can signal block SPI interrupts after boot-runtime block notification dispatch.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -137,7 +137,11 @@ The `guest_boot` runner also generates a deterministic tiny initrd under
 `.tmp/guest-artifacts/bangbang/guest-boot/` by default. That initrd contains its
 own `/init`, so a rootfs drive is not required for the minimal guest boot
 integration test. The test succeeds when the guest emits `BANGBANG_BOOT_OK` on
-the internal serial console.
+the internal serial console. The same signed target also includes a raw
+virtio-block read scenario: the test configures one temporary drive whose first
+sector contains `BANGBANG_BLOCK_READ_OK`, mounts `devtmpfs` from the tiny
+`/init`, reads `/dev/vda`, and expects the marker to appear on serial. Rootfs
+boot and guest writes are separate follow-up coverage.
 
 ## PR Expectations
 

--- a/scripts/build-guest-boot-initrd.py
+++ b/scripts/build-guest-boot-initrd.py
@@ -11,6 +11,10 @@ import tempfile
 from pathlib import Path
 
 BOOT_MARKER = b"BANGBANG_BOOT_OK\n"
+BLOCK_READ_MARKER = b"BANGBANG_BLOCK_READ_OK"
+DEV_TMPFS_NAME = b"devtmpfs\0"
+DEV_PATH = b"/dev\0"
+VDA_PATH = b"/dev/vda\0"
 DEFAULT_RELATIVE_OUTPUT = Path("bangbang/guest-boot/initrd.cpio")
 CPIO_NEWC_HEADER_SIZE = 110
 CPIO_TRAILER = "TRAILER!!!"
@@ -20,6 +24,16 @@ ELF_CODE_OFFSET = 0x100
 ELF_PHDR_OFFSET = 0x40
 ELF_HEADER_SIZE = 0x40
 ELF_PROGRAM_HEADER_SIZE = 0x38
+
+AT_FDCWD_U64 = (1 << 64) - 100
+AARCH64_COND_NE = 1
+LINUX_AARCH64_SYSCALL_MOUNT = 40
+LINUX_AARCH64_SYSCALL_OPENAT = 56
+LINUX_AARCH64_SYSCALL_READ = 63
+LINUX_AARCH64_SYSCALL_WRITE = 64
+LINUX_AARCH64_SYSCALL_EXIT = 93
+# The tiny init has no UART drain loop, so keep serial writes within the FIFO depth.
+GUEST_SERIAL_WRITE_CHUNK_SIZE = 16
 
 S_IFDIR = 0o040000
 S_IFCHR = 0o020000
@@ -54,31 +68,158 @@ def svc_0() -> bytes:
     return struct.pack("<I", 0xD4000001)
 
 
+def cmp_imm_64(register: int, immediate: int) -> bytes:
+    if not 0 <= immediate <= 0xFFF:
+        raise RuntimeError(f"unsupported CMP immediate: {immediate}")
+    instruction = 0xF100001F | ((immediate & 0xFFF) << 10) | (register << 5)
+    return struct.pack("<I", instruction)
+
+
 def branch_to_self() -> bytes:
     return struct.pack("<I", 0x14000000)
 
 
-def build_guest_init_elf() -> bytes:
-    marker_vaddr = ELF_BASE_VADDR + ELF_CODE_OFFSET + 48
-    code = b"".join(
+class Aarch64CodeBuilder:
+    def __init__(self) -> None:
+        self._data = bytearray()
+        self._labels: dict[str, int] = {}
+        self._conditional_branches: list[tuple[int, str, int]] = []
+
+    def emit(self, data: bytes) -> None:
+        if len(data) % 4 != 0:
+            raise RuntimeError("AArch64 code emission must stay instruction-aligned")
+        self._data.extend(data)
+
+    def label(self, name: str) -> None:
+        if name in self._labels:
+            raise RuntimeError(f"duplicate AArch64 label: {name}")
+        self._labels[name] = len(self._data)
+
+    def branch_cond(self, label: str, condition: int) -> None:
+        if not 0 <= condition <= 0xF:
+            raise RuntimeError(f"invalid AArch64 branch condition: {condition}")
+        offset = len(self._data)
+        self._conditional_branches.append((offset, label, condition))
+        self.emit(bytes(4))
+
+    def build(self) -> bytes:
+        data = bytearray(self._data)
+        for offset, label, condition in self._conditional_branches:
+            try:
+                target = self._labels[label]
+            except KeyError as err:
+                raise RuntimeError(f"unknown AArch64 label: {label}") from err
+            delta = target - offset
+            if delta % 4 != 0:
+                raise RuntimeError("AArch64 conditional branch target is not aligned")
+            immediate = delta // 4
+            if not -(1 << 18) <= immediate < (1 << 18):
+                raise RuntimeError("AArch64 conditional branch target is out of range")
+            instruction = 0x54000000 | ((immediate & 0x7FFFF) << 5) | condition
+            data[offset : offset + 4] = struct.pack("<I", instruction)
+        return bytes(data)
+
+
+def write_syscall(fd: int, buffer_vaddr: int, size: int) -> bytes:
+    return b"".join(
         (
-            movz_64(0, 1),
-            mov_imm_64(1, marker_vaddr),
-            movz_64(2, len(BOOT_MARKER)),
-            movz_64(8, 64),
+            movz_64(0, fd),
+            mov_imm_64(1, buffer_vaddr),
+            movz_64(2, size),
+            movz_64(8, LINUX_AARCH64_SYSCALL_WRITE),
             svc_0(),
-            movz_64(0, 0),
-            movz_64(8, 93),
-            svc_0(),
-            branch_to_self(),
         )
     )
 
-    if len(code) != 48:
-        raise RuntimeError(f"unexpected guest init code size: {len(code)}")
 
-    marker_offset = ELF_CODE_OFFSET + len(code)
-    file_size = marker_offset + len(BOOT_MARKER)
+def write_syscalls(fd: int, buffer_vaddr: int, size: int) -> bytes:
+    chunks = []
+    offset = 0
+    while offset < size:
+        chunk_size = min(GUEST_SERIAL_WRITE_CHUNK_SIZE, size - offset)
+        chunks.append(write_syscall(fd, buffer_vaddr + offset, chunk_size))
+        offset += chunk_size
+    return b"".join(chunks)
+
+
+def build_guest_init_code(addresses: dict[str, int]) -> bytes:
+    code = Aarch64CodeBuilder()
+    code.emit(write_syscalls(1, addresses["boot_marker"], len(BOOT_MARKER)))
+    code.emit(
+        b"".join(
+            (
+                mov_imm_64(0, addresses["devtmpfs"]),
+                mov_imm_64(1, addresses["dev"]),
+                mov_imm_64(2, addresses["devtmpfs"]),
+                movz_64(3, 0),
+                movz_64(4, 0),
+                movz_64(8, LINUX_AARCH64_SYSCALL_MOUNT),
+                svc_0(),
+            )
+        )
+    )
+    code.emit(
+        b"".join(
+            (
+                mov_imm_64(0, AT_FDCWD_U64),
+                mov_imm_64(1, addresses["vda"]),
+                movz_64(2, 0),
+                movz_64(3, 0),
+                movz_64(8, LINUX_AARCH64_SYSCALL_OPENAT),
+                svc_0(),
+                mov_imm_64(1, addresses["block_read_buffer"]),
+                movz_64(2, len(BLOCK_READ_MARKER)),
+                movz_64(8, LINUX_AARCH64_SYSCALL_READ),
+                svc_0(),
+                cmp_imm_64(0, len(BLOCK_READ_MARKER)),
+            )
+        )
+    )
+    code.branch_cond("exit", AARCH64_COND_NE)
+    code.emit(write_syscalls(1, addresses["block_read_buffer"], len(BLOCK_READ_MARKER)))
+    code.label("exit")
+    code.emit(
+        b"".join(
+            (
+                movz_64(0, 0),
+                movz_64(8, LINUX_AARCH64_SYSCALL_EXIT),
+                svc_0(),
+                branch_to_self(),
+            )
+        )
+    )
+    return code.build()
+
+
+def guest_init_data() -> list[tuple[str, bytes]]:
+    return [
+        ("boot_marker", BOOT_MARKER),
+        ("devtmpfs", DEV_TMPFS_NAME),
+        ("dev", DEV_PATH),
+        ("vda", VDA_PATH),
+        ("block_read_buffer", bytes(len(BLOCK_READ_MARKER))),
+    ]
+
+
+def guest_init_addresses(code_size: int) -> dict[str, int]:
+    addresses: dict[str, int] = {}
+    data_offset = ELF_CODE_OFFSET + code_size
+    for name, data in guest_init_data():
+        addresses[name] = ELF_BASE_VADDR + data_offset
+        data_offset += len(data)
+    return addresses
+
+
+def build_guest_init_elf() -> bytes:
+    placeholder_addresses = {name: ELF_BASE_VADDR for name, _data in guest_init_data()}
+    code_size = len(build_guest_init_code(placeholder_addresses))
+    addresses = guest_init_addresses(code_size)
+    code = build_guest_init_code(addresses)
+    if len(code) != code_size:
+        raise RuntimeError("guest init code size changed after address assignment")
+
+    data = b"".join(data for _name, data in guest_init_data())
+    file_size = ELF_CODE_OFFSET + len(code) + len(data)
     entry_vaddr = ELF_BASE_VADDR + ELF_CODE_OFFSET
 
     elf_ident = b"\x7fELF" + bytes([2, 1, 1, 0]) + bytes(8)
@@ -102,7 +243,7 @@ def build_guest_init_elf() -> bytes:
     program_header = struct.pack(
         "<IIQQQQQQ",
         1,
-        5,
+        7,
         0,
         ELF_BASE_VADDR,
         ELF_BASE_VADDR,
@@ -115,7 +256,7 @@ def build_guest_init_elf() -> bytes:
     if len(headers) > ELF_CODE_OFFSET:
         raise RuntimeError("ELF headers do not fit before code offset")
 
-    return headers + bytes(ELF_CODE_OFFSET - len(headers)) + code + BOOT_MARKER
+    return headers + bytes(ELF_CODE_OFFSET - len(headers)) + code + data
 
 
 def pad4(data: bytes) -> bytes:
@@ -312,6 +453,11 @@ def validate_initrd(data: bytes) -> None:
         raise RuntimeError("guest initrd init payload is not an ELF file")
     if BOOT_MARKER not in payload:
         raise RuntimeError("guest initrd init payload does not contain the boot marker")
+    for guest_path in (DEV_TMPFS_NAME, DEV_PATH, VDA_PATH):
+        if guest_path not in payload:
+            raise RuntimeError(
+                f"guest initrd init payload does not contain {guest_path!r}"
+            )
 
 
 def default_output_path() -> Path:


### PR DESCRIPTION
## Summary

- extend the deterministic guest boot initrd so `/init` mounts `devtmpfs`, reads `/dev/vda`, and writes the bytes read from the raw block device to serial
- add a signed `guest_boot` scenario that configures a temporary read-only virtio-block backing file containing `BANGBANG_BLOCK_READ_OK`
- fix HVF MMIO Rt=31 handling and stop advertising `VIRTIO_RING_F_EVENT_IDX` for virtio-block until event-index notification semantics are implemented
- update testing and Firecracker compatibility docs for the new guest-visible block-read validation

Closes #419

## Scope Exclusions

- no guest write validation
- no rootfs or root-device boot validation
- no block hotplug, cache-mode expansion, rate limiting, or async I/O support

## Validation

- `scripts/build-guest-boot-initrd.py --check`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test guest_boot`
- `scripts/run-integration-tests.sh --test guest_boot --allow-unsupported`
