### PR TITLE
feat: prepare Firecracker rootfs artifacts

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -143,6 +143,49 @@ sector contains `BANGBANG_BLOCK_READ_OK`, mounts `devtmpfs` from the tiny
 `/init`, reads `/dev/vda`, and expects the marker to appear on serial. Rootfs
 boot and guest writes are separate follow-up coverage.
 
+The pinned Firecracker CI rootfs artifact can be prepared separately:
+
+```sh
+scripts/fetch-firecracker-rootfs.sh
+```
+
+By default this stores and verifies
+`.tmp/guest-artifacts/firecracker-ci/v1.15/aarch64/ubuntu-24.04.squashfs` and
+prints its path. The script verifies the pinned SHA-256 before reusing or
+installing the cached squashfs. The upstream Firecracker artifact is a
+read-only squashfs; do not mutate it in tests.
+
+To prepare a local ext4 image from that squashfs, install the local tools and
+request ext4 output:
+
+```sh
+brew install squashfs e2fsprogs
+scripts/fetch-firecracker-rootfs.sh --format ext4
+```
+
+Homebrew's `e2fsprogs` package is keg-only, so `mkfs.ext4` is not normally on
+`PATH`. The script first looks for `mkfs.ext4` on `PATH`, then checks
+`$(brew --prefix e2fsprogs)/sbin/mkfs.ext4`. Set `BANGBANG_MKFS_EXT4` to
+override the tool path. The generated ext4 image is stored under
+`.tmp/guest-artifacts/bangbang/rootfs/`; tests that need writable rootfs state
+should use a scratch copy of that image.
+
+The ext4 preparation path intentionally does not require `sudo`. Files copied
+into the generated ext4 image keep the local extraction ownership rather than
+Firecracker's root-owned demo ownership. This is suitable for local development
+artifacts and is not a substitute for a production rootfs build process.
+
+bangbang currently does not append Firecracker-style root-drive command-line
+arguments automatically. Until that behavior is implemented, rootfs boot tests
+must pass explicit boot args such as:
+
+```sh
+console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda ro
+```
+
+Use `ro` when attaching the cached squashfs rootfs as a read-only drive. Use
+`rw` only with a writable scratch copy of the generated ext4 image.
+
 ## PR Expectations
 
 Bug fixes should include a regression test unless the behavior cannot be tested

--- a/scripts/fetch-firecracker-rootfs.sh
+++ b/scripts/fetch-firecracker-rootfs.sh
@@ -81,7 +81,12 @@ if [[ "$format" != "ext4" && "$ext4_size_set" == true ]]; then
   exit 2
 fi
 
-if [[ ! "$ext4_size" =~ ^[0-9]+[KkMmGgTt]?$ ]]; then
+if [[ ! "$ext4_size" =~ ^([0-9]+)[KkMmGgTt]?$ ]]; then
+  echo "invalid ext4 size: $ext4_size" >&2
+  usage >&2
+  exit 2
+fi
+if [[ "${BASH_REMATCH[1]}" =~ ^0+$ ]]; then
   echo "invalid ext4 size: $ext4_size" >&2
   usage >&2
   exit 2

--- a/scripts/fetch-firecracker-rootfs.sh
+++ b/scripts/fetch-firecracker-rootfs.sh
@@ -108,6 +108,7 @@ ext4_path="${prepared_dir}/${rootfs_name}-${ext4_size}.ext4"
 tmp_file=""
 tmp_ext4=""
 extract_dir=""
+mkfs_ext4=""
 
 cleanup() {
   if [[ -n "$tmp_file" && -e "$tmp_file" ]]; then
@@ -204,12 +205,12 @@ find_mkfs_ext4() {
   local prefix
 
   if [[ -n "${BANGBANG_MKFS_EXT4:-}" ]]; then
-    if [[ -x "$BANGBANG_MKFS_EXT4" ]]; then
+    if [[ -f "$BANGBANG_MKFS_EXT4" && -x "$BANGBANG_MKFS_EXT4" ]]; then
       printf '%s\n' "$BANGBANG_MKFS_EXT4"
       return
     fi
 
-    echo "BANGBANG_MKFS_EXT4 does not point to an executable: $BANGBANG_MKFS_EXT4" >&2
+    echo "BANGBANG_MKFS_EXT4 does not point to a regular executable file: $BANGBANG_MKFS_EXT4" >&2
     exit 1
   fi
 
@@ -222,7 +223,7 @@ find_mkfs_ext4() {
     prefix="$(brew --prefix e2fsprogs 2>/dev/null || true)"
     if [[ -n "$prefix" ]]; then
       candidate="${prefix}/sbin/mkfs.ext4"
-      if [[ -x "$candidate" ]]; then
+      if [[ -f "$candidate" && -x "$candidate" ]]; then
         printf '%s\n' "$candidate"
         return
       fi
@@ -233,9 +234,7 @@ find_mkfs_ext4() {
   exit 1
 }
 
-prepare_ext4() {
-  local mkfs_ext4
-
+check_ext4_output_path() {
   if [[ -L "$ext4_path" ]]; then
     echo "prepared ext4 rootfs path must not be a symlink: $ext4_path" >&2
     exit 1
@@ -245,18 +244,38 @@ prepare_ext4() {
     echo "prepared ext4 rootfs path exists but is not a regular file: $ext4_path" >&2
     exit 1
   fi
+}
+
+ensure_ext4_tools() {
+  if ! command -v unsquashfs >/dev/null 2>&1; then
+    echo "unsquashfs is required to prepare an ext4 rootfs; install squashfs" >&2
+    exit 1
+  fi
+
+  if [[ -z "$mkfs_ext4" ]]; then
+    mkfs_ext4="$(find_mkfs_ext4)"
+  fi
+}
+
+preflight_ext4_preparation() {
+  check_ext4_output_path
+
+  if [[ -f "$ext4_path" ]]; then
+    return
+  fi
+
+  ensure_ext4_tools
+}
+
+prepare_ext4() {
+  check_ext4_output_path
 
   if [[ -f "$ext4_path" ]]; then
     echo "using prepared ext4 rootfs artifact: $ext4_path" >&2
     return
   fi
 
-  if ! command -v unsquashfs >/dev/null 2>&1; then
-    echo "unsquashfs is required to prepare an ext4 rootfs; install squashfs" >&2
-    exit 1
-  fi
-
-  mkfs_ext4="$(find_mkfs_ext4)"
+  ensure_ext4_tools
 
   mkdir -p "$prepared_dir"
   extract_dir="$(mktemp -d "${prepared_dir}/${rootfs_name}.extract.XXXXXX")"
@@ -274,6 +293,10 @@ prepare_ext4() {
   rm -rf "$extract_dir"
   extract_dir=""
 }
+
+if [[ "$format" == "ext4" ]]; then
+  preflight_ext4_preparation
+fi
 
 fetch_squashfs
 

--- a/scripts/fetch-firecracker-rootfs.sh
+++ b/scripts/fetch-firecracker-rootfs.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/fetch-firecracker-rootfs.sh [--format squashfs|ext4] [--ext4-size SIZE]
+
+Fetch and verify the pinned Firecracker arm64 Ubuntu rootfs artifact.
+
+Options:
+  --format FORMAT  Output format to prepare. Supported values: squashfs, ext4.
+                   Defaults to squashfs.
+  --ext4-size SIZE Size for the generated ext4 image. Defaults to 1G.
+                   Only valid with --format ext4.
+  -h, --help       Show this help.
+
+Environment:
+  BANGBANG_GUEST_ARTIFACTS_DIR  Override the guest artifact cache root.
+  BANGBANG_MKFS_EXT4            Override the mkfs.ext4 executable path.
+EOF
+}
+
+format="squashfs"
+ext4_size="1G"
+ext4_size_set=false
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --format)
+      shift
+      if [[ "$#" -eq 0 ]]; then
+        echo "--format requires a value" >&2
+        usage >&2
+        exit 2
+      fi
+      format="$1"
+      ;;
+    --format=*)
+      format="${1#--format=}"
+      ;;
+    --ext4-size)
+      shift
+      if [[ "$#" -eq 0 ]]; then
+        echo "--ext4-size requires a value" >&2
+        usage >&2
+        exit 2
+      fi
+      ext4_size="$1"
+      ext4_size_set=true
+      ;;
+    --ext4-size=*)
+      ext4_size="${1#--ext4-size=}"
+      ext4_size_set=true
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+case "$format" in
+  squashfs | ext4)
+    ;;
+  *)
+    echo "unsupported rootfs format: $format" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if [[ "$format" != "ext4" && "$ext4_size_set" == true ]]; then
+  echo "--ext4-size is only valid with --format ext4" >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ ! "$ext4_size" =~ ^[0-9]+[KkMmGgTt]?$ ]]; then
+  echo "invalid ext4 size: $ext4_size" >&2
+  usage >&2
+  exit 2
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+firecracker_minor="v1.15"
+rootfs_arch="aarch64"
+rootfs_name="ubuntu-24.04"
+rootfs_sha256="0efb6a3ff2982baa6ca7e3d940966516ba7ddd2df5deb3e6c2161d369a15d608"
+rootfs_url="https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/${firecracker_minor}/${rootfs_arch}/${rootfs_name}.squashfs"
+
+cache_root="${BANGBANG_GUEST_ARTIFACTS_DIR:-$repo_root/.tmp/guest-artifacts}"
+upstream_dir="${cache_root}/firecracker-ci/${firecracker_minor}/${rootfs_arch}"
+upstream_path="${upstream_dir}/${rootfs_name}.squashfs"
+prepared_dir="${cache_root}/bangbang/rootfs"
+ext4_path="${prepared_dir}/${rootfs_name}-${ext4_size}.ext4"
+tmp_file=""
+tmp_ext4=""
+extract_dir=""
+
+cleanup() {
+  if [[ -n "$tmp_file" && -e "$tmp_file" ]]; then
+    rm -f "$tmp_file"
+  fi
+  if [[ -n "$tmp_ext4" && -e "$tmp_ext4" ]]; then
+    rm -f "$tmp_ext4"
+  fi
+  if [[ -n "$extract_dir" && -e "$extract_dir" ]]; then
+    rm -rf "$extract_dir"
+  fi
+}
+trap cleanup EXIT
+
+hash_file() {
+  local path="$1"
+  local output
+
+  if command -v shasum >/dev/null 2>&1; then
+    output="$(shasum -a 256 "$path")"
+    printf '%s\n' "${output%% *}"
+    return
+  fi
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    output="$(sha256sum "$path")"
+    printf '%s\n' "${output%% *}"
+    return
+  fi
+
+  echo "shasum or sha256sum is required to verify guest artifacts" >&2
+  exit 1
+}
+
+verify_sha256() {
+  local path="$1"
+  local actual
+
+  actual="$(hash_file "$path")"
+  [[ "$actual" == "$rootfs_sha256" ]]
+}
+
+fetch_squashfs() {
+  if [[ -L "$upstream_path" ]]; then
+    echo "cached Firecracker rootfs artifact path must not be a symlink: $upstream_path" >&2
+    exit 1
+  fi
+
+  if [[ -e "$upstream_path" && ! -f "$upstream_path" ]]; then
+    echo "cached Firecracker rootfs artifact path exists but is not a regular file: $upstream_path" >&2
+    exit 1
+  fi
+
+  if [[ -f "$upstream_path" ]]; then
+    if verify_sha256 "$upstream_path"; then
+      echo "using cached Firecracker rootfs artifact: $upstream_path" >&2
+      return
+    fi
+
+    echo "cached Firecracker rootfs artifact failed SHA-256 verification; redownloading" >&2
+  fi
+
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "curl is required to fetch guest artifacts" >&2
+    exit 1
+  fi
+
+  mkdir -p "$upstream_dir"
+  tmp_file="$(mktemp "${upstream_path}.download.XXXXXX")"
+
+  echo "fetching Firecracker rootfs artifact: $rootfs_url" >&2
+  curl \
+    --fail \
+    --location \
+    --show-error \
+    --silent \
+    --retry 3 \
+    --connect-timeout 10 \
+    --output "$tmp_file" \
+    "$rootfs_url"
+
+  if ! verify_sha256 "$tmp_file"; then
+    echo "downloaded Firecracker rootfs artifact failed SHA-256 verification" >&2
+    exit 1
+  fi
+
+  chmod 0644 "$tmp_file"
+  mv "$tmp_file" "$upstream_path"
+  tmp_file=""
+}
+
+find_mkfs_ext4() {
+  local candidate
+  local prefix
+
+  if [[ -n "${BANGBANG_MKFS_EXT4:-}" ]]; then
+    if [[ -x "$BANGBANG_MKFS_EXT4" ]]; then
+      printf '%s\n' "$BANGBANG_MKFS_EXT4"
+      return
+    fi
+
+    echo "BANGBANG_MKFS_EXT4 does not point to an executable: $BANGBANG_MKFS_EXT4" >&2
+    exit 1
+  fi
+
+  if command -v mkfs.ext4 >/dev/null 2>&1; then
+    command -v mkfs.ext4
+    return
+  fi
+
+  if command -v brew >/dev/null 2>&1; then
+    prefix="$(brew --prefix e2fsprogs 2>/dev/null || true)"
+    if [[ -n "$prefix" ]]; then
+      candidate="${prefix}/sbin/mkfs.ext4"
+      if [[ -x "$candidate" ]]; then
+        printf '%s\n' "$candidate"
+        return
+      fi
+    fi
+  fi
+
+  echo "mkfs.ext4 is required to prepare an ext4 rootfs; install e2fsprogs" >&2
+  exit 1
+}
+
+prepare_ext4() {
+  local mkfs_ext4
+
+  if [[ -L "$ext4_path" ]]; then
+    echo "prepared ext4 rootfs path must not be a symlink: $ext4_path" >&2
+    exit 1
+  fi
+
+  if [[ -e "$ext4_path" && ! -f "$ext4_path" ]]; then
+    echo "prepared ext4 rootfs path exists but is not a regular file: $ext4_path" >&2
+    exit 1
+  fi
+
+  if [[ -f "$ext4_path" ]]; then
+    echo "using prepared ext4 rootfs artifact: $ext4_path" >&2
+    return
+  fi
+
+  if ! command -v unsquashfs >/dev/null 2>&1; then
+    echo "unsquashfs is required to prepare an ext4 rootfs; install squashfs" >&2
+    exit 1
+  fi
+
+  mkfs_ext4="$(find_mkfs_ext4)"
+
+  mkdir -p "$prepared_dir"
+  extract_dir="$(mktemp -d "${prepared_dir}/${rootfs_name}.extract.XXXXXX")"
+  tmp_ext4="$(mktemp "${ext4_path}.build.XXXXXX")"
+
+  echo "extracting Firecracker rootfs artifact: $upstream_path" >&2
+  unsquashfs -q -no-progress -no-xattrs -d "$extract_dir" "$upstream_path"
+
+  echo "preparing ext4 rootfs artifact: $ext4_path" >&2
+  truncate -s "$ext4_size" "$tmp_ext4"
+  "$mkfs_ext4" -q -d "$extract_dir" -F "$tmp_ext4"
+  chmod 0644 "$tmp_ext4"
+  mv "$tmp_ext4" "$ext4_path"
+  tmp_ext4=""
+  rm -rf "$extract_dir"
+  extract_dir=""
+}
+
+fetch_squashfs
+
+case "$format" in
+  squashfs)
+    printf '%s\n' "$upstream_path"
+    ;;
+  ext4)
+    prepare_ext4
+    printf '%s\n' "$ext4_path"
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Add `scripts/fetch-firecracker-rootfs.sh` to fetch and verify the pinned Firecracker Ubuntu 24.04 arm64 squashfs rootfs artifact.
- Support optional no-sudo ext4 preparation with `unsquashfs` and `mkfs.ext4`, including Homebrew's keg-only `e2fsprogs` path.
- Document rootfs cache paths, local tool setup, scratch-copy expectations, and explicit `root=/dev/vda ro/rw` boot args required until bangbang appends Firecracker-style root drive cmdline entries.

## Scope Exclusions

- Does not add a rootfs boot integration test.
- Does not implement automatic root-drive kernel command-line insertion.
- Does not create a production root-owned rootfs build process.

Closes #421

## Validation

- `bash -n scripts/fetch-firecracker-rootfs.sh`
- `scripts/fetch-firecracker-rootfs.sh --help`
- `scripts/fetch-firecracker-rootfs.sh`
- `scripts/fetch-firecracker-rootfs.sh --format ext4`
- custom-cache symlink rejection check for `scripts/fetch-firecracker-rootfs.sh`
- `$(brew --prefix e2fsprogs)/sbin/e2fsck -fn .tmp/guest-artifacts/bangbang/rootfs/ubuntu-24.04-1G.ext4`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test guest_boot`
