### PR TITLE
test: verify guest root-drive boot args

### DIFF
--- a/crates/hvf/tests/guest_boot.rs
+++ b/crates/hvf/tests/guest_boot.rs
@@ -15,6 +15,10 @@ const BOOT_MARKER: &[u8] = b"BANGBANG_BOOT_OK";
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const BLOCK_READ_MARKER: &[u8] = b"BANGBANG_BLOCK_READ_OK";
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const CMDLINE_BEGIN_MARKER: &[u8] = b"BANGBANG_CMDLINE_BEGIN";
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const CMDLINE_END_MARKER: &[u8] = b"BANGBANG_CMDLINE_END";
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 rdinit=/init";
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const GUEST_BOOT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
@@ -69,6 +73,36 @@ fn boots_firecracker_kernel_and_reads_virtio_block_marker() {
         "guest block read test should still observe boot marker\nserial output:\n{}",
         String::from_utf8_lossy(&observation.serial_bytes)
     );
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn boots_firecracker_kernel_with_root_drive_boot_args() {
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::block::DriveConfigInput;
+
+    let _test_lock = GUEST_BOOT_TEST_LOCK
+        .lock()
+        .expect("guest boot integration test lock should not be poisoned");
+    let backing = GuestBlockBacking::new(BLOCK_READ_MARKER);
+    let observation = run_guest_boot_until_marker(
+        "guest-root-drive-cmdline",
+        CMDLINE_END_MARKER,
+        |controller| {
+            controller
+                .handle_action(VmmAction::PutDrive(
+                    DriveConfigInput::new("rootfs", "rootfs", backing.path(), true)
+                        .with_is_read_only(true),
+                ))
+                .expect("guest root drive should configure");
+        },
+    );
+
+    assert_guest_boot_observed_marker(&observation, CMDLINE_END_MARKER, "cmdline end marker");
+    let cmdline = guest_cmdline_capture(&observation);
+    assert_guest_cmdline_contains_arg(cmdline, b"root=/dev/vda");
+    assert_guest_cmdline_contains_arg(cmdline, b"ro");
+    assert_guest_cmdline_contains_arg(cmdline, b"rdinit=/init");
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -319,7 +353,7 @@ impl Drop for GuestBootWatchdog {
 struct GuestBootDiagnostics {
     kernel_path: std::path::PathBuf,
     initrd_path: std::path::PathBuf,
-    boot_args: &'static str,
+    boot_args: String,
     boot_pc: u64,
     fdt_address: u64,
     fdt_size: usize,
@@ -357,11 +391,16 @@ impl GuestBootDiagnostics {
             session.serial_interrupt_line(),
             "guest boot test runtime and HVF serial interrupt metadata should match"
         );
+        let boot_args = resources
+            .loaded_boot_source
+            .command_line
+            .as_str()
+            .to_string();
 
         Self {
             kernel_path,
             initrd_path,
-            boot_args: BOOT_ARGS,
+            boot_args,
             boot_pc: session.boot_registers().kernel_entry.raw_value(),
             fdt_address: resources.fdt.address.raw_value(),
             fdt_size: resources.fdt.size,
@@ -573,7 +612,7 @@ fn validate_pre_run_boot_metadata(
     let resources = session.runtime_resources();
     assert_eq!(
         resources.loaded_boot_source.command_line.as_str(),
-        BOOT_ARGS,
+        diagnostics.boot_args,
         "guest boot test boot args should match diagnostics"
     );
     assert_eq!(
@@ -597,7 +636,7 @@ fn validate_pre_run_boot_metadata(
     let chosen = tree
         .find("/chosen")
         .expect("guest boot test FDT should contain /chosen");
-    assert_eq!(chosen.prop_str("bootargs").unwrap(), BOOT_ARGS);
+    assert_eq!(chosen.prop_str("bootargs").unwrap(), diagnostics.boot_args);
     assert_eq!(
         chosen.prop_u64("linux,initrd-start").unwrap(),
         diagnostics.initrd_address
@@ -681,6 +720,52 @@ fn bytes_contain_marker(bytes: &[u8], marker: &[u8]) -> bool {
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn guest_cmdline_capture(observation: &GuestBootObservation) -> &[u8] {
+    bytes_between_markers(
+        &observation.serial_bytes,
+        CMDLINE_BEGIN_MARKER,
+        CMDLINE_END_MARKER,
+    )
+    .unwrap_or_else(|| {
+        panic!(
+            "guest serial output did not contain marker-bounded /proc/cmdline\nserial output:\n{}",
+            String::from_utf8_lossy(&observation.serial_bytes)
+        )
+    })
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn bytes_between_markers<'a>(bytes: &'a [u8], begin: &[u8], end: &[u8]) -> Option<&'a [u8]> {
+    let begin_start = bytes
+        .windows(begin.len())
+        .position(|window| window == begin)?;
+    let content_start = begin_start + begin.len();
+    let content = &bytes[content_start..];
+    let end_start = content
+        .windows(end.len())
+        .position(|window| window == end)?;
+
+    Some(&content[..end_start])
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn assert_guest_cmdline_contains_arg(cmdline: &[u8], expected: &[u8]) {
+    assert!(
+        guest_cmdline_contains_arg(cmdline, expected),
+        "guest /proc/cmdline did not contain argument {:?}\ncmdline bytes:\n{}",
+        String::from_utf8_lossy(expected),
+        String::from_utf8_lossy(cmdline)
+    );
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn guest_cmdline_contains_arg(cmdline: &[u8], expected: &[u8]) -> bool {
+    cmdline
+        .split(|byte| byte.is_ascii_whitespace() || *byte == 0)
+        .any(|arg| arg == expected)
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 fn serial_tail_hex(bytes: &[u8]) -> String {
     use std::fmt::Write as _;
 
@@ -699,7 +784,8 @@ fn serial_tail_hex(bytes: &[u8]) -> String {
 mod tests {
     use super::{
         GuestBootDiagnostics, GuestBootFailureReport, GuestBootRunDiagnostics,
-        bytes_contain_marker, run_loop_completed_steps,
+        bytes_between_markers, bytes_contain_marker, guest_cmdline_contains_arg,
+        run_loop_completed_steps,
     };
 
     #[test]
@@ -757,7 +843,7 @@ mod tests {
         let boot = GuestBootDiagnostics {
             kernel_path: "/tmp/vmlinux".into(),
             initrd_path: "/tmp/initrd.cpio".into(),
-            boot_args: super::BOOT_ARGS,
+            boot_args: super::BOOT_ARGS.to_string(),
             boot_pc: 0x8020_0000,
             fdt_address: 0x87e0_0000,
             fdt_size: 4096,
@@ -820,5 +906,27 @@ mod tests {
             b"BANGBANG_BOOT_OK\r\n",
             super::BOOT_MARKER
         ));
+    }
+
+    #[test]
+    fn bytes_between_markers_extracts_payload() {
+        assert_eq!(
+            bytes_between_markers(b"prefix BEGINpayloadEND suffix", b"BEGIN", b"END"),
+            Some(&b"payload"[..])
+        );
+        assert_eq!(
+            bytes_between_markers(b"prefix BEGINpayload suffix", b"BEGIN", b"END"),
+            None
+        );
+    }
+
+    #[test]
+    fn guest_cmdline_arg_match_requires_exact_token() {
+        let cmdline = b"console=ttyS0 root=/dev/vda ro\0";
+
+        assert!(guest_cmdline_contains_arg(cmdline, b"root=/dev/vda"));
+        assert!(guest_cmdline_contains_arg(cmdline, b"ro"));
+        assert!(!guest_cmdline_contains_arg(cmdline, b"root=/dev"));
+        assert!(!guest_cmdline_contains_arg(cmdline, b"r"));
     }
 }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -140,8 +140,10 @@ integration test. The test succeeds when the guest emits `BANGBANG_BOOT_OK` on
 the internal serial console. The same signed target also includes a raw
 virtio-block read scenario: the test configures one temporary drive whose first
 sector contains `BANGBANG_BLOCK_READ_OK`, mounts `devtmpfs` from the tiny
-`/init`, reads `/dev/vda`, and expects the marker to appear on serial. Rootfs
-boot and guest writes are separate follow-up coverage.
+`/init`, reads `/dev/vda`, and expects the marker to appear on serial. It also
+mounts procfs and writes `/proc/cmdline` to serial between deterministic markers
+so a root-drive scenario can verify guest-visible `root=/dev/vda ro` arguments.
+Rootfs boot and guest writes are separate follow-up coverage.
 
 The pinned Firecracker CI rootfs artifact can be prepared separately:
 

--- a/scripts/build-guest-boot-initrd.py
+++ b/scripts/build-guest-boot-initrd.py
@@ -12,8 +12,13 @@ from pathlib import Path
 
 BOOT_MARKER = b"BANGBANG_BOOT_OK\n"
 BLOCK_READ_MARKER = b"BANGBANG_BLOCK_READ_OK"
+CMDLINE_BEGIN_MARKER = b"BANGBANG_CMDLINE_BEGIN\n"
+CMDLINE_END_MARKER = b"BANGBANG_CMDLINE_END\n"
 DEV_TMPFS_NAME = b"devtmpfs\0"
 DEV_PATH = b"/dev\0"
+PROC_FS_NAME = b"proc\0"
+PROC_PATH = b"/proc\0"
+PROC_CMDLINE_PATH = b"/proc/cmdline\0"
 VDA_PATH = b"/dev/vda\0"
 DEFAULT_RELATIVE_OUTPUT = Path("bangbang/guest-boot/initrd.cpio")
 CPIO_NEWC_HEADER_SIZE = 110
@@ -34,6 +39,7 @@ LINUX_AARCH64_SYSCALL_WRITE = 64
 LINUX_AARCH64_SYSCALL_EXIT = 93
 # The tiny init has no UART drain loop, so keep serial writes within the FIFO depth.
 GUEST_SERIAL_WRITE_CHUNK_SIZE = 16
+GUEST_CMDLINE_BUFFER_SIZE = 512
 
 S_IFDIR = 0o040000
 S_IFCHR = 0o020000
@@ -161,6 +167,40 @@ def build_guest_init_code(addresses: dict[str, int]) -> bytes:
     code.emit(
         b"".join(
             (
+                mov_imm_64(0, addresses["procfs"]),
+                mov_imm_64(1, addresses["proc"]),
+                mov_imm_64(2, addresses["procfs"]),
+                movz_64(3, 0),
+                movz_64(4, 0),
+                movz_64(8, LINUX_AARCH64_SYSCALL_MOUNT),
+                svc_0(),
+            )
+        )
+    )
+    code.emit(
+        b"".join(
+            (
+                mov_imm_64(0, AT_FDCWD_U64),
+                mov_imm_64(1, addresses["proc_cmdline"]),
+                movz_64(2, 0),
+                movz_64(3, 0),
+                movz_64(8, LINUX_AARCH64_SYSCALL_OPENAT),
+                svc_0(),
+                mov_imm_64(1, addresses["cmdline_buffer"]),
+                movz_64(2, GUEST_CMDLINE_BUFFER_SIZE),
+                movz_64(8, LINUX_AARCH64_SYSCALL_READ),
+                svc_0(),
+            )
+        )
+    )
+    code.emit(
+        write_syscalls(1, addresses["cmdline_begin_marker"], len(CMDLINE_BEGIN_MARKER))
+    )
+    code.emit(write_syscalls(1, addresses["cmdline_buffer"], GUEST_CMDLINE_BUFFER_SIZE))
+    code.emit(write_syscalls(1, addresses["cmdline_end_marker"], len(CMDLINE_END_MARKER)))
+    code.emit(
+        b"".join(
+            (
                 mov_imm_64(0, AT_FDCWD_U64),
                 mov_imm_64(1, addresses["vda"]),
                 movz_64(2, 0),
@@ -194,9 +234,15 @@ def build_guest_init_code(addresses: dict[str, int]) -> bytes:
 def guest_init_data() -> list[tuple[str, bytes]]:
     return [
         ("boot_marker", BOOT_MARKER),
+        ("cmdline_begin_marker", CMDLINE_BEGIN_MARKER),
+        ("cmdline_end_marker", CMDLINE_END_MARKER),
         ("devtmpfs", DEV_TMPFS_NAME),
         ("dev", DEV_PATH),
+        ("procfs", PROC_FS_NAME),
+        ("proc", PROC_PATH),
+        ("proc_cmdline", PROC_CMDLINE_PATH),
         ("vda", VDA_PATH),
+        ("cmdline_buffer", bytes(GUEST_CMDLINE_BUFFER_SIZE)),
         ("block_read_buffer", bytes(len(BLOCK_READ_MARKER))),
     ]
 
@@ -329,15 +375,16 @@ def build_initrd() -> bytes:
     archive = b"".join(
         (
             cpio_entry(name="dev", ino=1, mode=S_IFDIR | 0o755, nlink=2),
+            cpio_entry(name="proc", ino=2, mode=S_IFDIR | 0o755, nlink=2),
             cpio_entry(
                 name="dev/console",
-                ino=2,
+                ino=3,
                 mode=S_IFCHR | 0o600,
                 rdevmajor=5,
                 rdevminor=1,
             ),
-            cpio_entry(name="init", ino=3, mode=S_IFREG | 0o755, data=guest_init),
-            cpio_entry(name="TRAILER!!!", ino=4, mode=0, nlink=1),
+            cpio_entry(name="init", ino=4, mode=S_IFREG | 0o755, data=guest_init),
+            cpio_entry(name="TRAILER!!!", ino=5, mode=0, nlink=1),
         )
     )
     return pad512(archive)
@@ -431,13 +478,17 @@ def validate_initrd(data: bytes) -> None:
     parsed = parse_newc_entries(data)
     entries = {str(entry["name"]): entry for entry in parsed}
     names = [str(entry["name"]) for entry in parsed]
-    expected_names = ["dev", "dev/console", "init", CPIO_TRAILER]
+    expected_names = ["dev", "proc", "dev/console", "init", CPIO_TRAILER]
     if names != expected_names:
         raise RuntimeError(f"guest initrd entries {names!r} do not match {expected_names!r}")
 
     dev = required_entry(entries, "dev")
     if file_type(dev["mode"]) != S_IFDIR:
         raise RuntimeError("guest initrd dev entry is not a directory")
+
+    proc = required_entry(entries, "proc")
+    if file_type(proc["mode"]) != S_IFDIR:
+        raise RuntimeError("guest initrd proc entry is not a directory")
 
     console = required_entry(entries, "dev/console")
     if file_type(console["mode"]) != S_IFCHR:
@@ -453,7 +504,19 @@ def validate_initrd(data: bytes) -> None:
         raise RuntimeError("guest initrd init payload is not an ELF file")
     if BOOT_MARKER not in payload:
         raise RuntimeError("guest initrd init payload does not contain the boot marker")
-    for guest_path in (DEV_TMPFS_NAME, DEV_PATH, VDA_PATH):
+    for marker in (CMDLINE_BEGIN_MARKER, CMDLINE_END_MARKER):
+        if marker not in payload:
+            raise RuntimeError(
+                f"guest initrd init payload does not contain {marker!r}"
+            )
+    for guest_path in (
+        DEV_TMPFS_NAME,
+        DEV_PATH,
+        PROC_FS_NAME,
+        PROC_PATH,
+        PROC_CMDLINE_PATH,
+        VDA_PATH,
+    ):
         if guest_path not in payload:
             raise RuntimeError(
                 f"guest initrd init payload does not contain {guest_path!r}"

--- a/scripts/build-guest-boot-initrd.py
+++ b/scripts/build-guest-boot-initrd.py
@@ -39,7 +39,9 @@ LINUX_AARCH64_SYSCALL_WRITE = 64
 LINUX_AARCH64_SYSCALL_EXIT = 93
 # The tiny init has no UART drain loop, so keep serial writes within the FIFO depth.
 GUEST_SERIAL_WRITE_CHUNK_SIZE = 16
-GUEST_CMDLINE_BUFFER_SIZE = 512
+# Match bangbang's arm64 command-line capacity so the serial capture can include
+# any valid guest command line plus the zero-filled tail after a shorter read.
+GUEST_CMDLINE_BUFFER_SIZE = 2048
 
 S_IFDIR = 0o040000
 S_IFCHR = 0o020000


### PR DESCRIPTION
## Summary

- capture guest `/proc/cmdline` from the deterministic `guest_boot` initrd
- add a signed guest integration scenario for read-only root-drive `root=/dev/vda ro` args
- document the new guest_boot command-line verification coverage

Closes #426

## Scope exclusions

- no full rootfs boot or rootfs mount validation
- no PARTUUID guest-level scenario in this PR
- no public drive API behavior changes

## Verification

- `scripts/build-guest-boot-initrd.py --check`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test guest_boot`
