### PR TITLE
test: verify guest virtio-block writes during boot

### DIFF
--- a/crates/hvf/tests/guest_boot.rs
+++ b/crates/hvf/tests/guest_boot.rs
@@ -47,6 +47,11 @@ fn boots_firecracker_kernel_to_guest_marker() {
         "guest boot test without a drive should not observe block-read marker\nserial output:\n{}",
         String::from_utf8_lossy(&observation.serial_bytes)
     );
+    assert!(
+        !bytes_contain_marker(&observation.serial_bytes, BLOCK_WRITE_MARKER),
+        "guest boot test without a drive should not observe block-write marker\nserial output:\n{}",
+        String::from_utf8_lossy(&observation.serial_bytes)
+    );
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/crates/hvf/tests/guest_boot.rs
+++ b/crates/hvf/tests/guest_boot.rs
@@ -15,6 +15,8 @@ const BOOT_MARKER: &[u8] = b"BANGBANG_BOOT_OK";
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const BLOCK_READ_MARKER: &[u8] = b"BANGBANG_BLOCK_READ_OK";
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const BLOCK_WRITE_MARKER: &[u8] = b"BANGBANG_BLOCK_WRITE_OK";
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const CMDLINE_BEGIN_MARKER: &[u8] = b"BANGBANG_CMDLINE_BEGIN";
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const CMDLINE_END_MARKER: &[u8] = b"BANGBANG_CMDLINE_END";
@@ -73,6 +75,48 @@ fn boots_firecracker_kernel_and_reads_virtio_block_marker() {
         "guest block read test should still observe boot marker\nserial output:\n{}",
         String::from_utf8_lossy(&observation.serial_bytes)
     );
+    assert!(
+        !bytes_contain_marker(&observation.serial_bytes, BLOCK_WRITE_MARKER),
+        "guest block read test with a read-only drive should not observe block-write marker\nserial output:\n{}",
+        String::from_utf8_lossy(&observation.serial_bytes)
+    );
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn boots_firecracker_kernel_and_writes_virtio_block_marker() {
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::block::DriveConfigInput;
+
+    let _test_lock = GUEST_BOOT_TEST_LOCK
+        .lock()
+        .expect("guest boot integration test lock should not be poisoned");
+    let backing = GuestBlockBacking::zeroed();
+    let observation =
+        run_guest_boot_until_marker("guest-block-write", BLOCK_WRITE_MARKER, |controller| {
+            controller
+                .handle_action(VmmAction::PutDrive(DriveConfigInput::new(
+                    "data",
+                    "data",
+                    backing.path(),
+                    false,
+                )))
+                .expect("guest block write drive should configure");
+        });
+
+    assert_guest_boot_observed_marker(&observation, BLOCK_WRITE_MARKER, "block-write marker");
+    assert!(
+        bytes_contain_marker(&observation.serial_bytes, BOOT_MARKER),
+        "guest block write test should still observe boot marker\nserial output:\n{}",
+        String::from_utf8_lossy(&observation.serial_bytes)
+    );
+    let backing_bytes = backing.bytes();
+    assert!(
+        backing_bytes.starts_with(BLOCK_WRITE_MARKER),
+        "guest block write test should mutate backing with marker {:?}; backing bytes: {:?}",
+        String::from_utf8_lossy(BLOCK_WRITE_MARKER),
+        backing_bytes
+    );
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -103,6 +147,11 @@ fn boots_firecracker_kernel_with_root_drive_boot_args() {
     assert_guest_cmdline_contains_arg(cmdline, b"root=/dev/vda");
     assert_guest_cmdline_contains_arg(cmdline, b"ro");
     assert_guest_cmdline_contains_arg(cmdline, b"rdinit=/init");
+    assert!(
+        !bytes_contain_marker(&observation.serial_bytes, BLOCK_WRITE_MARKER),
+        "guest root-drive cmdline test with a read-only drive should not observe block-write marker\nserial output:\n{}",
+        String::from_utf8_lossy(&observation.serial_bytes)
+    );
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -283,8 +332,16 @@ impl GuestBlockBacking {
         backing
     }
 
+    fn zeroed() -> Self {
+        Self::new(&[])
+    }
+
     fn path(&self) -> &std::path::Path {
         &self.path
+    }
+
+    fn bytes(&self) -> Vec<u8> {
+        std::fs::read(&self.path).expect("guest block backing should read")
     }
 }
 

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -769,8 +769,10 @@ The internal boot run loop across bounded step windows can dispatch active
 block queue notifications and signal interrupts. The signed `guest_boot`
 integration target now validates that the pinned Firecracker arm64 kernel can
 discover the first virtio-block device as `/dev/vda` and read a marker from a
-temporary host backing file through the raw block device. Guest writes, rootfs
-boot, block hotplug, cache-mode expansion, and rate limiting remain deferred.
+temporary host backing file through the raw block device. The same target also
+validates a basic writable-drive path by writing a marker from the guest to
+`/dev/vda` and checking the scratch host backing file. Rootfs boot, block
+hotplug, cache-mode expansion, and rate limiting remain deferred.
 It does not provide a public runner control, implement rate limiting, support
 vhost-user-block sockets, or use an async I/O engine. Internal HVF boot sessions
 can signal block SPI interrupts after boot-runtime block notification dispatch.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -143,7 +143,10 @@ sector contains `BANGBANG_BLOCK_READ_OK`, mounts `devtmpfs` from the tiny
 `/init`, reads `/dev/vda`, and expects the marker to appear on serial. It also
 mounts procfs and writes `/proc/cmdline` to serial between deterministic markers
 so a root-drive scenario can verify guest-visible `root=/dev/vda ro` arguments.
-Rootfs boot and guest writes are separate follow-up coverage.
+The signed target also includes a writable virtio-block scenario: the guest
+writes `BANGBANG_BLOCK_WRITE_OK` to `/dev/vda`, and the host-side test verifies
+the marker in a scratch backing file. Rootfs boot remains separate follow-up
+coverage.
 
 The pinned Firecracker CI rootfs artifact can be prepared separately:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -143,10 +143,9 @@ sector contains `BANGBANG_BLOCK_READ_OK`, mounts `devtmpfs` from the tiny
 `/init`, reads `/dev/vda`, and expects the marker to appear on serial. It also
 mounts procfs and writes `/proc/cmdline` to serial between deterministic markers
 so a root-drive scenario can verify guest-visible `root=/dev/vda ro` arguments.
-The signed target also includes a writable virtio-block scenario: the guest
-writes `BANGBANG_BLOCK_WRITE_OK` to `/dev/vda`, and the host-side test verifies
-the marker in a scratch backing file. Rootfs boot remains separate follow-up
-coverage.
+A writable virtio-block scenario writes `BANGBANG_BLOCK_WRITE_OK` from the
+guest to `/dev/vda`, and the host-side test verifies the marker in a scratch
+backing file. Rootfs boot remains separate follow-up coverage.
 
 The pinned Firecracker CI rootfs artifact can be prepared separately:
 

--- a/scripts/build-guest-boot-initrd.py
+++ b/scripts/build-guest-boot-initrd.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 BOOT_MARKER = b"BANGBANG_BOOT_OK\n"
 BLOCK_READ_MARKER = b"BANGBANG_BLOCK_READ_OK"
+BLOCK_WRITE_MARKER = b"BANGBANG_BLOCK_WRITE_OK"
+BLOCK_WRITE_SECTOR_SIZE = 512
 CMDLINE_BEGIN_MARKER = b"BANGBANG_CMDLINE_BEGIN\n"
 CMDLINE_END_MARKER = b"BANGBANG_CMDLINE_END\n"
 DEV_TMPFS_NAME = b"devtmpfs\0"
@@ -32,10 +34,12 @@ ELF_PROGRAM_HEADER_SIZE = 0x38
 
 AT_FDCWD_U64 = (1 << 64) - 100
 AARCH64_COND_NE = 1
+LINUX_OPEN_FLAG_RDWR = 2
 LINUX_AARCH64_SYSCALL_MOUNT = 40
 LINUX_AARCH64_SYSCALL_OPENAT = 56
 LINUX_AARCH64_SYSCALL_READ = 63
 LINUX_AARCH64_SYSCALL_WRITE = 64
+LINUX_AARCH64_SYSCALL_FSYNC = 82
 LINUX_AARCH64_SYSCALL_EXIT = 93
 # The tiny init has no UART drain loop, so keep serial writes within the FIFO depth.
 GUEST_SERIAL_WRITE_CHUNK_SIZE = 16
@@ -70,6 +74,11 @@ def mov_imm_64(register: int, value: int) -> bytes:
             movk_64(register, (value >> 48) & 0xFFFF, 48),
         )
     )
+
+
+def mov_reg_64(destination: int, source: int) -> bytes:
+    instruction = 0xAA0003E0 | (source << 16) | destination
+    return struct.pack("<I", instruction)
 
 
 def svc_0() -> bytes:
@@ -150,6 +159,23 @@ def write_syscalls(fd: int, buffer_vaddr: int, size: int) -> bytes:
     return b"".join(chunks)
 
 
+def write_from_open_fd(buffer_vaddr: int, size: int) -> bytes:
+    return b"".join(
+        (
+            mov_imm_64(1, buffer_vaddr),
+            movz_64(2, size),
+            movz_64(8, LINUX_AARCH64_SYSCALL_WRITE),
+            svc_0(),
+        )
+    )
+
+
+def block_write_sector() -> bytes:
+    if len(BLOCK_WRITE_MARKER) > BLOCK_WRITE_SECTOR_SIZE:
+        raise RuntimeError("guest block write marker does not fit in one sector")
+    return BLOCK_WRITE_MARKER + bytes(BLOCK_WRITE_SECTOR_SIZE - len(BLOCK_WRITE_MARKER))
+
+
 def build_guest_init_code(addresses: dict[str, int]) -> bytes:
     code = Aarch64CodeBuilder()
     code.emit(write_syscalls(1, addresses["boot_marker"], len(BOOT_MARKER)))
@@ -219,6 +245,36 @@ def build_guest_init_code(addresses: dict[str, int]) -> bytes:
     )
     code.branch_cond("exit", AARCH64_COND_NE)
     code.emit(write_syscalls(1, addresses["block_read_buffer"], len(BLOCK_READ_MARKER)))
+    code.emit(
+        b"".join(
+            (
+                mov_imm_64(0, AT_FDCWD_U64),
+                mov_imm_64(1, addresses["vda"]),
+                movz_64(2, LINUX_OPEN_FLAG_RDWR),
+                movz_64(3, 0),
+                movz_64(8, LINUX_AARCH64_SYSCALL_OPENAT),
+                svc_0(),
+                mov_reg_64(19, 0),
+                write_from_open_fd(
+                    addresses["block_write_sector"], BLOCK_WRITE_SECTOR_SIZE
+                ),
+                cmp_imm_64(0, BLOCK_WRITE_SECTOR_SIZE),
+            )
+        )
+    )
+    code.branch_cond("exit", AARCH64_COND_NE)
+    code.emit(
+        b"".join(
+            (
+                mov_reg_64(0, 19),
+                movz_64(8, LINUX_AARCH64_SYSCALL_FSYNC),
+                svc_0(),
+                cmp_imm_64(0, 0),
+            )
+        )
+    )
+    code.branch_cond("exit", AARCH64_COND_NE)
+    code.emit(write_syscalls(1, addresses["block_write_marker"], len(BLOCK_WRITE_MARKER)))
     code.label("exit")
     code.emit(
         b"".join(
@@ -246,6 +302,8 @@ def guest_init_data() -> list[tuple[str, bytes]]:
         ("vda", VDA_PATH),
         ("cmdline_buffer", bytes(GUEST_CMDLINE_BUFFER_SIZE)),
         ("block_read_buffer", bytes(len(BLOCK_READ_MARKER))),
+        ("block_write_marker", BLOCK_WRITE_MARKER),
+        ("block_write_sector", block_write_sector()),
     ]
 
 
@@ -506,11 +564,13 @@ def validate_initrd(data: bytes) -> None:
         raise RuntimeError("guest initrd init payload is not an ELF file")
     if BOOT_MARKER not in payload:
         raise RuntimeError("guest initrd init payload does not contain the boot marker")
-    for marker in (CMDLINE_BEGIN_MARKER, CMDLINE_END_MARKER):
+    for marker in (CMDLINE_BEGIN_MARKER, CMDLINE_END_MARKER, BLOCK_WRITE_MARKER):
         if marker not in payload:
             raise RuntimeError(
                 f"guest initrd init payload does not contain {marker!r}"
             )
+    if block_write_sector() not in payload:
+        raise RuntimeError("guest initrd init payload does not contain the write sector")
     for guest_path in (
         DEV_TMPFS_NAME,
         DEV_PATH,


### PR DESCRIPTION
## Summary

- Extend the deterministic guest boot initrd with an optional writable `/dev/vda` path that writes and `fsync`s a full sector before emitting `BANGBANG_BLOCK_WRITE_OK`.
- Add a signed `guest_boot` integration test that attaches a writable scratch backing and verifies the host file contains the guest-written marker.
- Update testing and Firecracker compatibility docs to describe basic guest write coverage while keeping rootfs boot deferred.

Closes #430

## Validation

- `python3 scripts/build-guest-boot-initrd.py --check`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test guest_boot`
