### PR TITLE
test: verify Firecracker rootfs access during boot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .tmp/guest-artifacts
-          key: guest-artifacts-firecracker-v1.15-aarch64-vmlinux-6.1.155-e3544b10603acbf3db492cb52e000d22ba202cb4b63b9add027565683e11c591
+          key: guest-artifacts-firecracker-v1.15-aarch64-vmlinux-6.1.155-e3544b10603acbf3db492cb52e000d22ba202cb4b63b9add027565683e11c591-rootfs-ubuntu-24.04-0efb6a3ff2982baa6ca7e3d940966516ba7ddd2df5deb3e6c2161d369a15d608
 
       - name: Fetch Firecracker guest kernel
         run: scripts/fetch-firecracker-kernel.sh

--- a/crates/hvf/tests/guest_boot.rs
+++ b/crates/hvf/tests/guest_boot.rs
@@ -17,6 +17,12 @@ const BLOCK_READ_MARKER: &[u8] = b"BANGBANG_BLOCK_READ_OK";
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const BLOCK_WRITE_MARKER: &[u8] = b"BANGBANG_BLOCK_WRITE_OK";
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const ROOTFS_READ_MARKER: &[u8] = b"BANGBANG_ROOTFS_READ_OK";
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const ROOTFS_OS_RELEASE_ID: &[u8] = b"ID=ubuntu";
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const ROOTFS_OS_RELEASE_CODENAME: &[u8] = b"VERSION_CODENAME=noble";
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const CMDLINE_BEGIN_MARKER: &[u8] = b"BANGBANG_CMDLINE_BEGIN";
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const CMDLINE_END_MARKER: &[u8] = b"BANGBANG_CMDLINE_END";
@@ -52,6 +58,11 @@ fn boots_firecracker_kernel_to_guest_marker() {
         "guest boot test without a drive should not observe block-write marker\nserial output:\n{}",
         String::from_utf8_lossy(&observation.serial_bytes)
     );
+    assert!(
+        !bytes_contain_marker(&observation.serial_bytes, ROOTFS_READ_MARKER),
+        "guest boot test without a drive should not observe rootfs-read marker\nserial output:\n{}",
+        String::from_utf8_lossy(&observation.serial_bytes)
+    );
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -83,6 +94,11 @@ fn boots_firecracker_kernel_and_reads_virtio_block_marker() {
     assert!(
         !bytes_contain_marker(&observation.serial_bytes, BLOCK_WRITE_MARKER),
         "guest block read test with a read-only drive should not observe block-write marker\nserial output:\n{}",
+        String::from_utf8_lossy(&observation.serial_bytes)
+    );
+    assert!(
+        !bytes_contain_marker(&observation.serial_bytes, ROOTFS_READ_MARKER),
+        "guest block read test with a raw marker drive should not observe rootfs-read marker\nserial output:\n{}",
         String::from_utf8_lossy(&observation.serial_bytes)
     );
 }
@@ -122,6 +138,11 @@ fn boots_firecracker_kernel_and_writes_virtio_block_marker() {
         String::from_utf8_lossy(BLOCK_WRITE_MARKER),
         backing_bytes
     );
+    assert!(
+        !bytes_contain_marker(&observation.serial_bytes, ROOTFS_READ_MARKER),
+        "guest block write test with a raw writable drive should not observe rootfs-read marker\nserial output:\n{}",
+        String::from_utf8_lossy(&observation.serial_bytes)
+    );
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -155,6 +176,58 @@ fn boots_firecracker_kernel_with_root_drive_boot_args() {
     assert!(
         !bytes_contain_marker(&observation.serial_bytes, BLOCK_WRITE_MARKER),
         "guest root-drive cmdline test with a read-only drive should not observe block-write marker\nserial output:\n{}",
+        String::from_utf8_lossy(&observation.serial_bytes)
+    );
+    assert!(
+        !bytes_contain_marker(&observation.serial_bytes, ROOTFS_READ_MARKER),
+        "guest root-drive cmdline test with a raw marker drive should not observe rootfs-read marker\nserial output:\n{}",
+        String::from_utf8_lossy(&observation.serial_bytes)
+    );
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn boots_firecracker_kernel_and_reads_firecracker_rootfs() {
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::block::DriveConfigInput;
+
+    let _test_lock = GUEST_BOOT_TEST_LOCK
+        .lock()
+        .expect("guest boot integration test lock should not be poisoned");
+    let rootfs_path = env_path("BANGBANG_GUEST_ROOTFS_PATH");
+    let observation =
+        run_guest_boot_until_marker("guest-rootfs-read", ROOTFS_READ_MARKER, |controller| {
+            controller
+                .handle_action(VmmAction::PutDrive(
+                    DriveConfigInput::new("rootfs", "rootfs", rootfs_path.as_path(), true)
+                        .with_is_read_only(true),
+                ))
+                .expect("guest rootfs drive should configure");
+        });
+
+    assert_guest_boot_observed_marker(&observation, ROOTFS_READ_MARKER, "rootfs-read marker");
+    assert!(
+        bytes_contain_marker(&observation.serial_bytes, BOOT_MARKER),
+        "guest rootfs read test should still observe boot marker\nserial output:\n{}",
+        String::from_utf8_lossy(&observation.serial_bytes)
+    );
+    assert!(
+        bytes_contain_marker(&observation.serial_bytes, ROOTFS_OS_RELEASE_ID),
+        "guest rootfs read test should observe os-release ID\nserial output:\n{}",
+        String::from_utf8_lossy(&observation.serial_bytes)
+    );
+    assert!(
+        bytes_contain_marker(&observation.serial_bytes, ROOTFS_OS_RELEASE_CODENAME),
+        "guest rootfs read test should observe os-release codename\nserial output:\n{}",
+        String::from_utf8_lossy(&observation.serial_bytes)
+    );
+    let cmdline = guest_cmdline_capture(&observation);
+    assert_guest_cmdline_contains_arg(cmdline, b"root=/dev/vda");
+    assert_guest_cmdline_contains_arg(cmdline, b"ro");
+    assert_guest_cmdline_contains_arg(cmdline, b"rdinit=/init");
+    assert!(
+        !bytes_contain_marker(&observation.serial_bytes, BLOCK_WRITE_MARKER),
+        "guest rootfs read test with a read-only rootfs should not observe block-write marker\nserial output:\n{}",
         String::from_utf8_lossy(&observation.serial_bytes)
     );
 }

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -771,8 +771,11 @@ integration target now validates that the pinned Firecracker arm64 kernel can
 discover the first virtio-block device as `/dev/vda` and read a marker from a
 temporary host backing file through the raw block device. The same target also
 validates a basic writable-drive path by writing a marker from the guest to
-`/dev/vda` and checking the scratch host backing file. Rootfs boot, block
-hotplug, cache-mode expansion, and rate limiting remain deferred.
+`/dev/vda` and checking the scratch host backing file. It also attaches the
+pinned Firecracker squashfs rootfs as a read-only root drive, mounts it from the
+deterministic initrd, and reads `/mnt/etc/os-release` from the guest. Full
+rootfs boot, block hotplug, cache-mode expansion, and rate limiting remain
+deferred.
 It does not provide a public runner control, implement rate limiting, support
 vhost-user-block sockets, or use an async I/O engine. Internal HVF boot sessions
 can signal block SPI interrupts after boot-runtime block notification dispatch.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -117,9 +117,10 @@ misconfigured hosts fail.
 
 ## Guest Boot Artifacts
 
-Guest boot tests use the pinned Firecracker arm64 kernel and a deterministic
-tiny initrd. The integration runner prepares both when `guest_boot` is selected.
-To prepare only the kernel cache, run:
+Guest boot tests use the pinned Firecracker arm64 kernel, a deterministic tiny
+initrd, and the pinned Firecracker rootfs artifact. The integration runner
+prepares them when `guest_boot` is selected. To prepare only the kernel cache,
+run:
 
 ```sh
 scripts/fetch-firecracker-kernel.sh
@@ -145,7 +146,12 @@ mounts procfs and writes `/proc/cmdline` to serial between deterministic markers
 so a root-drive scenario can verify guest-visible `root=/dev/vda ro` arguments.
 A writable virtio-block scenario writes `BANGBANG_BLOCK_WRITE_OK` from the
 guest to `/dev/vda`, and the host-side test verifies the marker in a scratch
-backing file. Rootfs boot remains separate follow-up coverage.
+backing file. A rootfs artifact scenario attaches the cached Firecracker
+squashfs as a read-only root drive, mounts it from the tiny initrd, reads
+`/mnt/etc/os-release`, and expects `BANGBANG_ROOTFS_READ_OK` plus stable Ubuntu
+os-release content on serial. This verifies guest-visible rootfs access through
+virtio-block; full rootfs boot with an init process from that rootfs remains
+separate follow-up coverage.
 
 The pinned Firecracker CI rootfs artifact can be prepared separately:
 
@@ -157,7 +163,9 @@ By default this stores and verifies
 `.tmp/guest-artifacts/firecracker-ci/v1.15/aarch64/ubuntu-24.04.squashfs` and
 prints its path. The script verifies the pinned SHA-256 before reusing or
 installing the cached squashfs. The upstream Firecracker artifact is a
-read-only squashfs; do not mutate it in tests.
+read-only squashfs; do not mutate it in tests. The signed `guest_boot`
+integration target uses this cached squashfs directly for its read-only rootfs
+access scenario.
 
 To prepare a local ext4 image from that squashfs, install the local tools and
 request ext4 output:

--- a/scripts/build-guest-boot-initrd.py
+++ b/scripts/build-guest-boot-initrd.py
@@ -14,14 +14,19 @@ BOOT_MARKER = b"BANGBANG_BOOT_OK\n"
 BLOCK_READ_MARKER = b"BANGBANG_BLOCK_READ_OK"
 BLOCK_WRITE_MARKER = b"BANGBANG_BLOCK_WRITE_OK"
 BLOCK_WRITE_SECTOR_SIZE = 512
+ROOTFS_READ_MARKER = b"BANGBANG_ROOTFS_READ_OK"
+ROOTFS_OS_RELEASE_READ_SIZE = 256
 CMDLINE_BEGIN_MARKER = b"BANGBANG_CMDLINE_BEGIN\n"
 CMDLINE_END_MARKER = b"BANGBANG_CMDLINE_END\n"
 DEV_TMPFS_NAME = b"devtmpfs\0"
 DEV_PATH = b"/dev\0"
+MNT_PATH = b"/mnt\0"
 PROC_FS_NAME = b"proc\0"
 PROC_PATH = b"/proc\0"
 PROC_CMDLINE_PATH = b"/proc/cmdline\0"
+SQUASHFS_NAME = b"squashfs\0"
 VDA_PATH = b"/dev/vda\0"
+ROOTFS_OS_RELEASE_PATH = b"/mnt/etc/os-release\0"
 DEFAULT_RELATIVE_OUTPUT = Path("bangbang/guest-boot/initrd.cpio")
 CPIO_NEWC_HEADER_SIZE = 110
 CPIO_TRAILER = "TRAILER!!!"
@@ -34,6 +39,7 @@ ELF_PROGRAM_HEADER_SIZE = 0x38
 
 AT_FDCWD_U64 = (1 << 64) - 100
 AARCH64_COND_NE = 1
+LINUX_MOUNT_FLAG_RDONLY = 1
 LINUX_OPEN_FLAG_RDWR = 2
 LINUX_AARCH64_SYSCALL_MOUNT = 40
 LINUX_AARCH64_SYSCALL_OPENAT = 56
@@ -229,6 +235,48 @@ def build_guest_init_code(addresses: dict[str, int]) -> bytes:
     code.emit(
         b"".join(
             (
+                mov_imm_64(0, addresses["vda"]),
+                mov_imm_64(1, addresses["mnt"]),
+                mov_imm_64(2, addresses["squashfs"]),
+                movz_64(3, LINUX_MOUNT_FLAG_RDONLY),
+                movz_64(4, 0),
+                movz_64(8, LINUX_AARCH64_SYSCALL_MOUNT),
+                svc_0(),
+                cmp_imm_64(0, 0),
+            )
+        )
+    )
+    code.branch_cond("after_rootfs_attempt", AARCH64_COND_NE)
+    code.emit(
+        b"".join(
+            (
+                mov_imm_64(0, AT_FDCWD_U64),
+                mov_imm_64(1, addresses["rootfs_os_release"]),
+                movz_64(2, 0),
+                movz_64(3, 0),
+                movz_64(8, LINUX_AARCH64_SYSCALL_OPENAT),
+                svc_0(),
+                mov_imm_64(1, addresses["rootfs_os_release_buffer"]),
+                movz_64(2, ROOTFS_OS_RELEASE_READ_SIZE),
+                movz_64(8, LINUX_AARCH64_SYSCALL_READ),
+                svc_0(),
+                cmp_imm_64(0, ROOTFS_OS_RELEASE_READ_SIZE),
+            )
+        )
+    )
+    code.branch_cond("after_rootfs_attempt", AARCH64_COND_NE)
+    code.emit(
+        write_syscalls(
+            1,
+            addresses["rootfs_os_release_buffer"],
+            ROOTFS_OS_RELEASE_READ_SIZE,
+        )
+    )
+    code.emit(write_syscalls(1, addresses["rootfs_read_marker"], len(ROOTFS_READ_MARKER)))
+    code.label("after_rootfs_attempt")
+    code.emit(
+        b"".join(
+            (
                 mov_imm_64(0, AT_FDCWD_U64),
                 mov_imm_64(1, addresses["vda"]),
                 movz_64(2, 0),
@@ -296,14 +344,19 @@ def guest_init_data() -> list[tuple[str, bytes]]:
         ("cmdline_end_marker", CMDLINE_END_MARKER),
         ("devtmpfs", DEV_TMPFS_NAME),
         ("dev", DEV_PATH),
+        ("mnt", MNT_PATH),
         ("procfs", PROC_FS_NAME),
         ("proc", PROC_PATH),
         ("proc_cmdline", PROC_CMDLINE_PATH),
+        ("squashfs", SQUASHFS_NAME),
         ("vda", VDA_PATH),
+        ("rootfs_os_release", ROOTFS_OS_RELEASE_PATH),
         ("cmdline_buffer", bytes(GUEST_CMDLINE_BUFFER_SIZE)),
+        ("rootfs_os_release_buffer", bytes(ROOTFS_OS_RELEASE_READ_SIZE)),
         ("block_read_buffer", bytes(len(BLOCK_READ_MARKER))),
         ("block_write_marker", BLOCK_WRITE_MARKER),
         ("block_write_sector", block_write_sector()),
+        ("rootfs_read_marker", ROOTFS_READ_MARKER),
     ]
 
 
@@ -436,15 +489,16 @@ def build_initrd() -> bytes:
         (
             cpio_entry(name="dev", ino=1, mode=S_IFDIR | 0o755, nlink=2),
             cpio_entry(name="proc", ino=2, mode=S_IFDIR | 0o755, nlink=2),
+            cpio_entry(name="mnt", ino=3, mode=S_IFDIR | 0o755, nlink=2),
             cpio_entry(
                 name="dev/console",
-                ino=3,
+                ino=4,
                 mode=S_IFCHR | 0o600,
                 rdevmajor=5,
                 rdevminor=1,
             ),
-            cpio_entry(name="init", ino=4, mode=S_IFREG | 0o755, data=guest_init),
-            cpio_entry(name="TRAILER!!!", ino=5, mode=0, nlink=1),
+            cpio_entry(name="init", ino=5, mode=S_IFREG | 0o755, data=guest_init),
+            cpio_entry(name="TRAILER!!!", ino=6, mode=0, nlink=1),
         )
     )
     return pad512(archive)
@@ -538,7 +592,7 @@ def validate_initrd(data: bytes) -> None:
     parsed = parse_newc_entries(data)
     entries = {str(entry["name"]): entry for entry in parsed}
     names = [str(entry["name"]) for entry in parsed]
-    expected_names = ["dev", "proc", "dev/console", "init", CPIO_TRAILER]
+    expected_names = ["dev", "proc", "mnt", "dev/console", "init", CPIO_TRAILER]
     if names != expected_names:
         raise RuntimeError(f"guest initrd entries {names!r} do not match {expected_names!r}")
 
@@ -549,6 +603,10 @@ def validate_initrd(data: bytes) -> None:
     proc = required_entry(entries, "proc")
     if file_type(proc["mode"]) != S_IFDIR:
         raise RuntimeError("guest initrd proc entry is not a directory")
+
+    mnt = required_entry(entries, "mnt")
+    if file_type(mnt["mode"]) != S_IFDIR:
+        raise RuntimeError("guest initrd mnt entry is not a directory")
 
     console = required_entry(entries, "dev/console")
     if file_type(console["mode"]) != S_IFCHR:
@@ -564,7 +622,12 @@ def validate_initrd(data: bytes) -> None:
         raise RuntimeError("guest initrd init payload is not an ELF file")
     if BOOT_MARKER not in payload:
         raise RuntimeError("guest initrd init payload does not contain the boot marker")
-    for marker in (CMDLINE_BEGIN_MARKER, CMDLINE_END_MARKER, BLOCK_WRITE_MARKER):
+    for marker in (
+        CMDLINE_BEGIN_MARKER,
+        CMDLINE_END_MARKER,
+        BLOCK_WRITE_MARKER,
+        ROOTFS_READ_MARKER,
+    ):
         if marker not in payload:
             raise RuntimeError(
                 f"guest initrd init payload does not contain {marker!r}"
@@ -574,10 +637,13 @@ def validate_initrd(data: bytes) -> None:
     for guest_path in (
         DEV_TMPFS_NAME,
         DEV_PATH,
+        MNT_PATH,
         PROC_FS_NAME,
         PROC_PATH,
         PROC_CMDLINE_PATH,
+        SQUASHFS_NAME,
         VDA_PATH,
+        ROOTFS_OS_RELEASE_PATH,
     ):
         if guest_path not in payload:
             raise RuntimeError(

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -208,9 +208,11 @@ fi
 
 guest_kernel_path=""
 guest_initrd_path=""
+guest_rootfs_path=""
 if contains guest_boot "${selected_tests[@]}"; then
   guest_kernel_path="$(scripts/fetch-firecracker-kernel.sh)"
   guest_initrd_path="$(scripts/build-guest-boot-initrd.py --check)"
+  guest_rootfs_path="$(scripts/fetch-firecracker-rootfs.sh)"
 fi
 
 target_triple="aarch64-apple-darwin"
@@ -257,10 +259,12 @@ for index in "${!signed_test_bins[@]}"; do
       if [[ "${#test_args[@]}" -eq 0 ]]; then
         BANGBANG_GUEST_KERNEL_PATH="$guest_kernel_path" \
           BANGBANG_GUEST_INITRD_PATH="$guest_initrd_path" \
+          BANGBANG_GUEST_ROOTFS_PATH="$guest_rootfs_path" \
           "$test_bin" --test-threads=1
       else
         BANGBANG_GUEST_KERNEL_PATH="$guest_kernel_path" \
           BANGBANG_GUEST_INITRD_PATH="$guest_initrd_path" \
+          BANGBANG_GUEST_ROOTFS_PATH="$guest_rootfs_path" \
           "$test_bin" --test-threads=1 "${test_args[@]}"
       fi
       ;;


### PR DESCRIPTION
## Summary

- prepare the pinned Firecracker rootfs artifact for signed `guest_boot` runs and pass it to the test binary
- extend the deterministic initrd to mount `/dev/vda` as read-only squashfs and read `/mnt/etc/os-release`
- add signed guest-level coverage for rootfs access while documenting that full rootfs boot remains deferred

Closes #432

## Scope

This does not boot `/sbin/init` or another program from the rootfs as PID 1, does not prepare writable ext4 rootfs state, and does not change public drive API behavior.

## Verification

- `python3 scripts/build-guest-boot-initrd.py --check`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test guest_boot`
