### PR TITLE
feat: support logger startup CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,25 @@ cargo run -p bangbang -- --api-sock /tmp/bangbang.socket --id demo-1
   `/tmp/bangbang.socket`.
 - `--id <ID>` records the microVM identifier. The default is
   `anonymous-instance`.
+- `--log-path <PATH>`, `--level <LEVEL>`, `--module <MODULE>`,
+  `--show-level`, and `--show-log-origin` configure the same per-process
+  logger state as `PUT /logger` before the API socket is served.
 - `--help`, `-h`, `--version`, and `-V` are supported.
 
 The API socket is an unauthenticated local control interface. Filesystem
 permissions on the socket path and parent directory are the access-control
 boundary, so use a private directory or restrictive umask on multi-user hosts.
+
+Start with logger output configured:
+
+```sh
+cargo run -p bangbang -- \
+  --api-sock /tmp/bangbang.socket \
+  --id demo-1 \
+  --log-path /tmp/bangbang.log \
+  --level Info \
+  --show-level
+```
 
 ## API Examples
 

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -898,7 +898,7 @@ mod tests {
     use std::thread;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-    use bangbang_runtime::logger::LoggerWriteError;
+    use bangbang_runtime::logger::{LoggerConfigInput, LoggerWriteError};
     use bangbang_runtime::{BackendError, VmmActionError};
 
     use crate::vmm::{InstanceStartExecutor, ProcessVmm};
@@ -1951,6 +1951,61 @@ mod tests {
         );
 
         fs::remove_file(logger_path).expect("fixture should clean up");
+    }
+
+    #[test]
+    fn api_logger_update_replaces_startup_logger_before_actions() {
+        let mut vmm = test_controller_with_starter(TestInstanceStarter::success());
+        let startup_logger_path = unique_socket_path("startup-logger").with_extension("log");
+        let api_logger_path = unique_socket_path("api-logger").with_extension("log");
+        vmm.handle_action(VmmAction::PutLogger(
+            LoggerConfigInput::new()
+                .with_log_path(&startup_logger_path)
+                .with_show_level(true),
+        ))
+        .expect("startup logger config should apply");
+        let logger_body = format!(
+            r#"{{
+                "log_path": "{}",
+                "level": "Info",
+                "show_level": false
+            }}"#,
+            api_logger_path.to_string_lossy()
+        );
+        let logger_request = format!(
+            "PUT /logger HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{logger_body}",
+            logger_body.len()
+        );
+        assert_eq!(
+            handle_request_bytes(logger_request.as_bytes(), &mut vmm).status(),
+            bangbang_api::http::StatusCode::NoContent
+        );
+        let boot_body = r#"{"kernel_image_path":"/tmp/original-vmlinux"}"#;
+        let boot_request = format!(
+            "PUT /boot-source HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{boot_body}",
+            boot_body.len()
+        );
+        assert_eq!(
+            handle_request_bytes(boot_request.as_bytes(), &mut vmm).status(),
+            bangbang_api::http::StatusCode::NoContent
+        );
+
+        let start_response =
+            put_action_over_socket(&mut vmm, "start-with-api-logger", "InstanceStart");
+        assert!(start_response.starts_with("HTTP/1.1 204 No Content\r\n"));
+
+        assert_eq!(
+            fs::read_to_string(&startup_logger_path)
+                .expect("startup logger output should be readable"),
+            ""
+        );
+        assert_eq!(
+            fs::read_to_string(&api_logger_path).expect("api logger output should be readable"),
+            "action=InstanceStart\n"
+        );
+
+        fs::remove_file(startup_logger_path).expect("startup fixture should clean up");
+        fs::remove_file(api_logger_path).expect("api fixture should clean up");
     }
 
     #[test]

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -1990,8 +1990,7 @@ mod tests {
             bangbang_api::http::StatusCode::NoContent
         );
 
-        let start_response =
-            put_action_over_socket(&mut vmm, "start-with-api-logger", "InstanceStart");
+        let start_response = put_action_over_socket(&mut vmm, "api-log", "InstanceStart");
         assert!(start_response.starts_with("HTTP/1.1 204 No Content\r\n"));
 
         assert_eq!(

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -17,6 +17,9 @@ use signal_hook::consts::signal::{SIGINT, SIGTERM};
 use signal_hook::{SigId, low_level};
 use vmm::ProcessVmm;
 
+use bangbang_runtime::logger::{LoggerConfigInput, LoggerLevel};
+use bangbang_runtime::{VmmAction, VmmActionError};
+
 const DEFAULT_API_SOCK_PATH: &str = "/tmp/bangbang.socket";
 const DEFAULT_INSTANCE_ID: &str = "anonymous-instance";
 const APP_NAME: &str = "bangbang";
@@ -28,18 +31,13 @@ const UNSUPPORTED_FIRECRACKER_ARGS: &[&str] = &[
     "describe-snapshot",
     "enable-pci",
     "http-api-max-payload-size",
-    "level",
-    "log-path",
     "metadata",
     "metrics-path",
     "mmds-size-limit",
-    "module",
     "no-api",
     "no-seccomp",
     "parent-cpu-time-us",
     "seccomp-filter",
-    "show-level",
-    "show-log-origin",
     "snapshot-version",
     "start-time-cpu-us",
     "start-time-us",
@@ -69,21 +67,44 @@ fn run() -> Result<(), ProcessError> {
             return Ok(());
         }
         Command::Run(config) => {
+            let StartupConfig {
+                api_sock,
+                id,
+                logger_config,
+            } = config;
+
             println!("bangbang {}", env!("CARGO_PKG_VERSION"));
             println!(
                 "hvf target supported: {}",
                 HvfBackend::is_supported_target()
             );
 
+            let mut vmm = ProcessVmm::new(id, env!("CARGO_PKG_VERSION"), APP_NAME);
+            apply_startup_logger_config(&mut vmm, logger_config)?;
             let mut shutdown_signal = ShutdownSignal::install()?;
-            let server = ApiServer::bind(&config.api_sock).map_err(ProcessError::ApiServer)?;
-            let mut vmm = ProcessVmm::new(config.id, env!("CARGO_PKG_VERSION"), APP_NAME);
+            let server = ApiServer::bind(&api_sock).map_err(ProcessError::ApiServer)?;
             println!("status: API server listening; VM execution loop is not implemented yet");
             let shutdown_wakeup = shutdown_signal.wakeup_reader();
             server
                 .run_until(&mut vmm, shutdown_wakeup)
                 .map_err(ProcessError::ApiServer)?;
         }
+    }
+
+    Ok(())
+}
+
+fn apply_startup_logger_config<S>(
+    vmm: &mut ProcessVmm<S>,
+    logger_config: Option<LoggerConfigInput>,
+) -> Result<(), ProcessError>
+where
+    S: vmm::InstanceStartExecutor,
+{
+    if let Some(logger_config) = logger_config {
+        vmm.handle_action(VmmAction::PutLogger(logger_config))
+            .map(|_| ())
+            .map_err(ProcessError::StartupConfiguration)?;
     }
 
     Ok(())
@@ -117,6 +138,7 @@ enum ProcessError {
     ApiServer(ApiServerError),
     ArgumentParsing(String),
     SignalHandler(std::io::ErrorKind),
+    StartupConfiguration(VmmActionError),
 }
 
 impl ProcessError {
@@ -125,6 +147,7 @@ impl ProcessError {
             Self::ApiServer(_) => ProcessExitCode::ProcessFailure,
             Self::ArgumentParsing(_) => ProcessExitCode::ArgumentParsing,
             Self::SignalHandler(_) => ProcessExitCode::ProcessFailure,
+            Self::StartupConfiguration(_) => ProcessExitCode::ProcessFailure,
         }
     }
 }
@@ -136,6 +159,9 @@ impl fmt::Display for ProcessError {
             Self::ArgumentParsing(message) => f.write_str(message),
             Self::SignalHandler(kind) => {
                 write!(f, "failed to register shutdown signal handler: {kind:?}")
+            }
+            Self::StartupConfiguration(err) => {
+                write!(f, "startup configuration error: {err}")
             }
         }
     }
@@ -214,6 +240,7 @@ enum Command {
 struct StartupConfig {
     api_sock: String,
     id: String,
+    logger_config: Option<LoggerConfigInput>,
 }
 
 impl Default for StartupConfig {
@@ -221,6 +248,7 @@ impl Default for StartupConfig {
         Self {
             api_sock: DEFAULT_API_SOCK_PATH.to_string(),
             id: DEFAULT_INSTANCE_ID.to_string(),
+            logger_config: None,
         }
     }
 }
@@ -273,6 +301,13 @@ impl Args {
         let mut config = StartupConfig::default();
         let mut api_sock_seen = false;
         let mut id_seen = false;
+        let mut logger_config = LoggerConfigInput::new();
+        let mut logger_config_seen = false;
+        let mut log_path_seen = false;
+        let mut level_seen = false;
+        let mut module_seen = false;
+        let mut show_level_seen = false;
+        let mut show_log_origin_seen = false;
         let mut index = 0;
 
         while let Some(arg) = args.get(index) {
@@ -297,6 +332,57 @@ impl Args {
                     id_seen = true;
                     index += 2;
                 }
+                "--log-path" => {
+                    if log_path_seen {
+                        return Err("duplicate argument: --log-path".to_string());
+                    }
+                    let value = take_value(&args, index, "--log-path")?;
+                    logger_config = logger_config.with_log_path(value);
+                    logger_config_seen = true;
+                    log_path_seen = true;
+                    index += 2;
+                }
+                "--level" => {
+                    if level_seen {
+                        return Err("duplicate argument: --level".to_string());
+                    }
+                    let value = take_value(&args, index, "--level")?;
+                    let level = value
+                        .parse::<LoggerLevel>()
+                        .map_err(|err| format!("invalid --level: {err}"))?;
+                    logger_config = logger_config.with_level(level);
+                    logger_config_seen = true;
+                    level_seen = true;
+                    index += 2;
+                }
+                "--module" => {
+                    if module_seen {
+                        return Err("duplicate argument: --module".to_string());
+                    }
+                    let value = take_value(&args, index, "--module")?;
+                    logger_config = logger_config.with_module(value);
+                    logger_config_seen = true;
+                    module_seen = true;
+                    index += 2;
+                }
+                "--show-level" => {
+                    if show_level_seen {
+                        return Err("duplicate argument: --show-level".to_string());
+                    }
+                    logger_config = logger_config.with_show_level(true);
+                    logger_config_seen = true;
+                    show_level_seen = true;
+                    index += 1;
+                }
+                "--show-log-origin" => {
+                    if show_log_origin_seen {
+                        return Err("duplicate argument: --show-log-origin".to_string());
+                    }
+                    logger_config = logger_config.with_show_log_origin(true);
+                    logger_config_seen = true;
+                    show_log_origin_seen = true;
+                    index += 1;
+                }
                 other => {
                     if let Some(name) = unsupported_firecracker_arg(other) {
                         return Err(format!("unsupported Firecracker argument: --{name}"));
@@ -315,6 +401,10 @@ impl Args {
                     return Err("unexpected positional argument".to_string());
                 }
             }
+        }
+
+        if logger_config_seen {
+            config.logger_config = Some(logger_config);
         }
 
         Ok(Self {
@@ -342,6 +432,11 @@ fn help_text() -> String {
             "      --api-sock <PATH>  Unix domain socket path for the API server [default: {}]\n",
             "      --id <ID>          MicroVM unique identifier [default: {}]\n",
             "                         Accepts 1-64 bytes, ASCII alphanumeric or '-'\n",
+            "      --log-path <PATH>  Logger output file or FIFO path\n",
+            "      --level <LEVEL>    Logger level: Off, Trace, Debug, Info, Warn, or Error\n",
+            "      --module <MODULE>  Logger module filter stored for future log integration\n",
+            "      --show-level       Include level in minimal logger action lines\n",
+            "      --show-log-origin  Store log-origin flag for future log integration\n",
             "  -V, --version          Print version\n",
             "  -h, --help             Print help\n\n",
             "Current scope:\n",
@@ -350,7 +445,7 @@ fn help_text() -> String {
             "pre-boot PUT /drives/{{drive_id}}, pre-boot ",
             "PUT /network-interfaces/{{iface_id}}, pre-boot PUT /vsock, ",
             "pre-boot PUT /metrics, and pre-boot PUT /logger configuration ",
-            "with minimal action logs over the API ",
+            "with minimal action logs over the API or logger startup CLI ",
             "socket; PUT /actions starts a process-owned HVF boot run-loop ",
             "worker across bounded step windows for InstanceStart, but public ",
             "run-loop control is not implemented yet."
@@ -417,20 +512,49 @@ fn display_arg_name(arg: &str) -> &str {
 }
 
 fn unsupported_equals_syntax(arg: &str) -> Option<&'static str> {
-    [("--api-sock=", "api-sock"), ("--id=", "id")]
-        .into_iter()
-        .find_map(|(prefix, name)| arg.starts_with(prefix).then_some(name))
+    [
+        ("--api-sock=", "api-sock"),
+        ("--id=", "id"),
+        ("--log-path=", "log-path"),
+        ("--level=", "level"),
+        ("--module=", "module"),
+    ]
+    .into_iter()
+    .find_map(|(prefix, name)| arg.starts_with(prefix).then_some(name))
 }
 
 #[cfg(test)]
 mod tests {
     use std::ffi::OsString;
+    use std::fs;
     use std::os::unix::ffi::OsStringExt;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use bangbang_runtime::boot::BootSourceConfigInput;
+    use bangbang_runtime::logger::{LoggerConfigError, LoggerConfigInput, LoggerLevel};
+    use bangbang_runtime::{BackendError, VmmAction};
+
+    use crate::vmm::{InstanceStartExecutor, ProcessVmm};
 
     use super::{
         ApiServerError, Args, Command, DEFAULT_API_SOCK_PATH, DEFAULT_INSTANCE_ID,
         MAX_INSTANCE_ID_LEN, ProcessError, ProcessExitCode, StartupConfig, parse_process_args,
     };
+
+    #[derive(Debug, Clone)]
+    struct TestInstanceStarter;
+
+    impl InstanceStartExecutor for TestInstanceStarter {
+        type Session = ();
+
+        fn start(
+            &mut self,
+            _controller: &bangbang_runtime::VmmController,
+        ) -> Result<Self::Session, BackendError> {
+            Ok(())
+        }
+    }
 
     fn parse(args: &[&str]) -> Result<Args, String> {
         Args::parse(args.iter().map(|arg| arg.to_string()))
@@ -441,6 +565,17 @@ mod tests {
             Command::Run(config) => Ok(config),
             command => Err(format!("expected run command, got {command:?}")),
         }
+    }
+
+    fn unique_logger_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "bangbang-main-test-{}-{nanos}-{name}.log",
+            std::process::id()
+        ))
     }
 
     #[test]
@@ -454,6 +589,19 @@ mod tests {
         let err = ProcessError::ApiServer(ApiServerError::SocketPathExists);
 
         assert_eq!(err.exit_code(), ProcessExitCode::ProcessFailure);
+    }
+
+    #[test]
+    fn startup_configuration_error_maps_to_process_failure_exit_code() {
+        let err = ProcessError::StartupConfiguration(
+            bangbang_runtime::VmmActionError::LoggerConfig(LoggerConfigError::EmptyPath),
+        );
+
+        assert_eq!(err.exit_code(), ProcessExitCode::ProcessFailure);
+        assert_eq!(
+            err.to_string(),
+            "startup configuration error: logger path must not be empty"
+        );
     }
 
     #[test]
@@ -504,6 +652,7 @@ mod tests {
 
         assert_eq!(config.api_sock, DEFAULT_API_SOCK_PATH);
         assert_eq!(config.id, DEFAULT_INSTANCE_ID);
+        assert_eq!(config.logger_config, None);
     }
 
     #[test]
@@ -525,6 +674,8 @@ mod tests {
         assert!(help.contains("pre-boot PUT /drives/{drive_id}"));
         assert!(help.contains("pre-boot PUT /metrics"));
         assert!(help.contains("pre-boot PUT /logger configuration with minimal action logs"));
+        assert!(help.contains("--log-path <PATH>"));
+        assert!(help.contains("--show-level"));
         assert!(help.contains("PUT /actions starts a process-owned HVF boot run-loop worker"));
         assert!(help.contains("across bounded step windows for InstanceStart"));
         assert!(help.contains("public run-loop control is not implemented yet"));
@@ -572,6 +723,7 @@ mod tests {
 
         assert_eq!(config.api_sock, "/tmp/custom.socket");
         assert_eq!(config.id, DEFAULT_INSTANCE_ID);
+        assert_eq!(config.logger_config, None);
     }
 
     #[test]
@@ -580,6 +732,34 @@ mod tests {
 
         assert_eq!(config.api_sock, DEFAULT_API_SOCK_PATH);
         assert_eq!(config.id, "demo-1");
+        assert_eq!(config.logger_config, None);
+    }
+
+    #[test]
+    fn parse_logger_startup_args() {
+        let config = parse_run(&[
+            "--log-path",
+            "/tmp/bangbang.log",
+            "--level",
+            "Warning",
+            "--module",
+            "api_server",
+            "--show-level",
+            "--show-log-origin",
+        ])
+        .expect("logger startup args should parse");
+
+        assert_eq!(
+            config.logger_config,
+            Some(
+                LoggerConfigInput::new()
+                    .with_log_path("/tmp/bangbang.log")
+                    .with_level(LoggerLevel::Warn)
+                    .with_module("api_server")
+                    .with_show_level(true)
+                    .with_show_log_origin(true)
+            )
+        );
     }
 
     #[test]
@@ -589,6 +769,7 @@ mod tests {
 
         assert_eq!(config.api_sock, "/tmp/custom.socket");
         assert_eq!(config.id, "demo-1");
+        assert_eq!(config.logger_config, None);
     }
 
     #[test]
@@ -603,6 +784,13 @@ mod tests {
         let err = parse(&["--id", "--api-sock"]).expect_err("missing id value should fail");
 
         assert_eq!(err, "missing value for --id");
+    }
+
+    #[test]
+    fn rejects_missing_log_path_value() {
+        let err = parse(&["--log-path", "--id"]).expect_err("missing log path value should fail");
+
+        assert_eq!(err, "missing value for --log-path");
     }
 
     #[test]
@@ -623,6 +811,19 @@ mod tests {
         let err = parse(&["--id", "one", "--id", "two"]).expect_err("duplicate id should fail");
 
         assert_eq!(err, "duplicate argument: --id");
+    }
+
+    #[test]
+    fn rejects_duplicate_logger_args() {
+        let err = parse(&["--show-level", "--show-level"])
+            .expect_err("duplicate show-level flag should fail");
+
+        assert_eq!(err, "duplicate argument: --show-level");
+
+        let err = parse(&["--level", "Info", "--level", "Debug"])
+            .expect_err("duplicate level arg should fail");
+
+        assert_eq!(err, "duplicate argument: --level");
     }
 
     #[test]
@@ -739,6 +940,81 @@ mod tests {
             err,
             "unsupported argument syntax for --api-sock; use --api-sock <VALUE>"
         );
+
+        let err = parse(&["--log-path=/tmp/secret.log"]).expect_err("equals syntax should fail");
+
+        assert_eq!(
+            err,
+            "unsupported argument syntax for --log-path; use --log-path <VALUE>"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_logger_level() {
+        let err = parse(&["--level", "verbose"]).expect_err("invalid level should fail");
+
+        assert_eq!(err, "invalid --level: logger level is invalid");
+    }
+
+    #[test]
+    fn applies_startup_logger_config_before_actions() {
+        let path = unique_logger_path("actions");
+        let mut vmm = ProcessVmm::with_starter(
+            "demo-1",
+            env!("CARGO_PKG_VERSION"),
+            "bangbang",
+            TestInstanceStarter,
+        );
+
+        super::apply_startup_logger_config(
+            &mut vmm,
+            Some(
+                LoggerConfigInput::new()
+                    .with_log_path(&path)
+                    .with_show_level(true),
+            ),
+        )
+        .expect("startup logger config should apply");
+        vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            "/tmp/vmlinux",
+        )))
+        .expect("boot source should configure");
+        vmm.handle_action(VmmAction::InstanceStart)
+            .expect("instance start should succeed");
+        vmm.handle_action(VmmAction::FlushMetrics)
+            .expect("flush metrics should succeed");
+
+        assert_eq!(
+            fs::read_to_string(&path).expect("logger output should be readable"),
+            "level=Info action=InstanceStart\nlevel=Info action=FlushMetrics\n"
+        );
+
+        fs::remove_file(path).expect("fixture should clean up");
+    }
+
+    #[test]
+    fn startup_logger_config_errors_do_not_echo_path() {
+        let path = unique_logger_path("missing-parent").join("logger");
+        let mut vmm = ProcessVmm::with_starter(
+            "demo-1",
+            env!("CARGO_PKG_VERSION"),
+            "bangbang",
+            TestInstanceStarter,
+        );
+
+        let err = super::apply_startup_logger_config(
+            &mut vmm,
+            Some(LoggerConfigInput::new().with_log_path(&path)),
+        )
+        .expect_err("missing parent should fail startup logger config");
+
+        assert!(!err.to_string().contains(path.to_string_lossy().as_ref()));
+        assert!(matches!(
+            err,
+            ProcessError::StartupConfiguration(bangbang_runtime::VmmActionError::LoggerConfig(
+                LoggerConfigError::OpenFile(_)
+            ))
+        ));
     }
 
     #[test]

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -791,6 +791,14 @@ mod tests {
         let err = parse(&["--log-path", "--id"]).expect_err("missing log path value should fail");
 
         assert_eq!(err, "missing value for --log-path");
+
+        let err = parse(&["--level", "--id"]).expect_err("missing level value should fail");
+
+        assert_eq!(err, "missing value for --level");
+
+        let err = parse(&["--module", "--id"]).expect_err("missing module value should fail");
+
+        assert_eq!(err, "missing value for --module");
     }
 
     #[test]
@@ -824,6 +832,21 @@ mod tests {
             .expect_err("duplicate level arg should fail");
 
         assert_eq!(err, "duplicate argument: --level");
+
+        let err = parse(&["--log-path", "/tmp/one.log", "--log-path", "/tmp/two.log"])
+            .expect_err("duplicate log-path arg should fail");
+
+        assert_eq!(err, "duplicate argument: --log-path");
+
+        let err = parse(&["--module", "api_server", "--module", "runtime"])
+            .expect_err("duplicate module arg should fail");
+
+        assert_eq!(err, "duplicate argument: --module");
+
+        let err = parse(&["--show-log-origin", "--show-log-origin"])
+            .expect_err("duplicate show-log-origin flag should fail");
+
+        assert_eq!(err, "duplicate argument: --show-log-origin");
     }
 
     #[test]
@@ -946,6 +969,20 @@ mod tests {
         assert_eq!(
             err,
             "unsupported argument syntax for --log-path; use --log-path <VALUE>"
+        );
+
+        let err = parse(&["--level=Info"]).expect_err("equals syntax should fail");
+
+        assert_eq!(
+            err,
+            "unsupported argument syntax for --level; use --level <VALUE>"
+        );
+
+        let err = parse(&["--module=api_server"]).expect_err("equals syntax should fail");
+
+        assert_eq!(
+            err,
+            "unsupported argument syntax for --module; use --module <VALUE>"
         );
     }
 

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -787,7 +787,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_missing_log_path_value() {
+    fn rejects_missing_logger_arg_values() {
         let err = parse(&["--log-path", "--id"]).expect_err("missing log path value should fail");
 
         assert_eq!(err, "missing value for --log-path");

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -106,7 +106,7 @@ serves `GET /`, `GET /version`, `GET /vm/config`, `GET /machine-config`,
 pre-boot `PUT /machine-config`, pre-boot `PUT /boot-source` configuration storage, and
 pre-boot `PUT /drives/{drive_id}` configuration storage, pre-boot
 `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage, pre-boot `PUT /metrics`
-output configuration, pre-boot `PUT /logger` output configuration, plus process-routed `PUT /actions` startup and metrics
+output configuration, pre-boot `PUT /logger` output configuration, logger startup CLI configuration, plus process-routed `PUT /actions` startup and metrics
 flush with an internal boot run-loop worker across bounded step windows or
 state/configuration faults, but does not load a configuration file or provide
 public run-loop control.
@@ -115,10 +115,15 @@ public run-loop control.
 | --- | --- | --- |
 | `--api-sock <PATH>` | binds the API Unix socket | Firecracker defaults to `/run/firecracker.socket`; bangbang defaults to `/tmp/bangbang.socket` because macOS does not normally provide `/run`. This is an intentional host-platform difference. |
 | `--id <ID>` | parsed and stored | Defaults to Firecracker's `anonymous-instance`. IDs must be 1 to 64 bytes and contain only ASCII alphanumeric characters or `-`. |
+| `--log-path <PATH>` | configures logger output before API serving | Uses the same per-process logger sink and redacted host-path error policy as `PUT /logger`. |
+| `--level <LEVEL>` | configures logger level before API serving | Accepts the existing logger levels `Off`, `Trace`, `Debug`, `Info`, `Warn`, `Warning`, and `Error`; minimal action logs are emitted only when the configured level allows `Info`. |
+| `--module <MODULE>` | stored for future logger filtering | Matches the stored `PUT /logger` field but does not filter the current minimal action logs yet. |
+| `--show-level` | enables level prefix for minimal action logs | Writes `level=Info` before minimal `InstanceStart` and `FlushMetrics` action lines. |
+| `--show-log-origin` | stored for future logger formatting | Full Firecracker origin formatting remains deferred. |
 | `--help`, `-h` | prints help | Help describes the current API socket scope. |
 | `--version`, `-V` | prints version | `-V` is retained from the existing bangbang scaffold. |
 | `--config-file`, `--no-api` | rejected | Deferred until VM configuration models and no-API startup behavior exist. |
-| seccomp, logger and metrics CLI, snapshot, MMDS, boot timer, payload-size, and PCI process flags | rejected | These Firecracker options are Linux-specific, observability-related, or tied to later capability work. The API-level `PUT /metrics` and `PUT /logger` subsets are supported separately; CLI observability flags remain deferred. |
+| seccomp, metrics CLI, snapshot, MMDS, boot timer, payload-size, and PCI process flags | rejected | These Firecracker options are Linux-specific, observability-related, or tied to later capability work. The API-level `PUT /metrics` subset is supported separately; metrics CLI flags remain deferred. |
 
 bangbang intentionally treats `--id` alphanumeric characters as ASCII only.
 This is stricter than Firecracker `v1.16.0`'s Rust validator, which accepts
@@ -342,12 +347,14 @@ replacing the original sink. `FlushMetrics` is runtime-only: it fails before
 startup, succeeds without writing when the sink is unconfigured, and writes one
 minimal JSON line when `/metrics` configured an output path. Public run-loop
 control, guest boot output, public runner loop scheduling, full Firecracker
-metrics counters, periodic metrics flush, full logger integration, and CLI
-observability flags remain deferred.
-The API and VMM state path implement the `PUT /logger` field policy above as a
-pre-boot-only per-process observability configuration. Repeated pre-boot
-requests update only the fields they provide. Runtime requests fail without
-opening a new output path. The configured logger sink records minimal successful
+metrics counters, periodic metrics flush, full logger integration, and metrics
+CLI flags remain deferred.
+The process startup path and API/VMM state path implement the logger field
+policy above as pre-boot-only per-process observability configuration. Startup
+CLI flags can configure the initial logger before the API socket is served.
+Repeated pre-boot `PUT /logger` requests update only the fields they provide,
+including after startup CLI configuration. Runtime requests fail without opening
+a new output path. The configured logger sink records minimal successful
 `InstanceStart` and `FlushMetrics` action lines when the logger level allows
 `Info`; it is not wired into the full process logging backend yet.
 The API and VMM state path implement the `PUT /vsock` field policy above as a
@@ -1265,7 +1272,7 @@ Their eventual support level should follow the endpoint matrix:
 - entropy device configuration
 - serial customization
 - full logger integration, full Firecracker metrics counters, periodic metrics
-  flush, and CLI observability configuration
+  flush, and metrics CLI configuration
 - memory hotplug
 - pause and resume VM state updates
 - PATCH and DELETE hotplug/update behavior

--- a/docs/security.md
+++ b/docs/security.md
@@ -120,7 +120,8 @@ is resource-specific:
 - `/logger` opens `log_path` during pre-boot configuration when that field is
   present and keeps a per-process logger sink. Successful `InstanceStart` and
   `FlushMetrics` can append minimal action-event lines to that sink when the
-  configured level allows `Info`.
+  configured level allows `Info`. Logger startup CLI flags use the same sink and
+  host-path error redaction rules before the API socket is served.
 - `scripts/run-integration-tests.sh` creates temporary files for signed
   integration tests and removes them when the wrapper exits normally. Its
   generated guest initrd is cached under `.tmp/guest-artifacts` by default.


### PR DESCRIPTION
## Summary

- Accept Firecracker-style logger startup flags: `--log-path`, `--level`, `--module`, `--show-level`, and `--show-log-origin`.
- Apply startup logger configuration through the existing `PutLogger` runtime action before the API socket is bound.
- Document startup logger CLI behavior and API replacement semantics.

## Scope Exclusions

- Does not add a global Rust logging backend, full Firecracker log formatting, or logger module filtering.
- Does not add metrics CLI flags, `--config-file`, or `--no-api` startup behavior.

Closes #436

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test -p bangbang logger --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`
