### PR TITLE
feat: support metrics startup CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ cargo run -p bangbang -- --api-sock /tmp/bangbang.socket --id demo-1
   `/tmp/bangbang.socket`.
 - `--id <ID>` records the microVM identifier. The default is
   `anonymous-instance`.
+- `--metrics-path <PATH>` configures the same per-process metrics sink as
+  `PUT /metrics` before the API socket is served.
 - `--log-path <PATH>`, `--level <LEVEL>`, `--module <MODULE>`,
   `--show-level`, and `--show-log-origin` configure the same per-process
   logger state as `PUT /logger` before the API socket is served.
@@ -43,12 +45,13 @@ The API socket is an unauthenticated local control interface. Filesystem
 permissions on the socket path and parent directory are the access-control
 boundary, so use a private directory or restrictive umask on multi-user hosts.
 
-Start with logger output configured:
+Start with metrics and logger output configured:
 
 ```sh
 cargo run -p bangbang -- \
   --api-sock /tmp/bangbang.socket \
   --id demo-1 \
+  --metrics-path /tmp/bangbang.metrics \
   --log-path /tmp/bangbang.log \
   --level Info \
   --show-level
@@ -109,6 +112,18 @@ curl --unix-socket /tmp/bangbang.socket \
   -H 'Content-Type: application/json' \
   -d '{"guest_cid":3,"uds_path":"./v.sock"}'
 ```
+
+Configure metrics output before boot:
+
+```sh
+curl --unix-socket /tmp/bangbang.socket \
+  -X PUT http://localhost/metrics \
+  -H 'Content-Type: application/json' \
+  -d '{"metrics_path":"/tmp/bangbang.metrics"}'
+```
+
+Configured metrics output records a minimal JSON line for successful runtime
+`FlushMetrics` actions.
 
 Configure logger output before boot:
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ rules, guest boot artifact caching, and local verification expectations.
 
 - `0`: help or version completed successfully, or the API server exited without
   error.
-- `153`: startup argument parsing or validation failed. This matches
-  Firecracker's argument-parsing exit code.
-- `1`: non-argument process failure, including API socket bind or accept
-  failures.
+- `153`: startup argument parsing failed before process configuration began.
+  This matches Firecracker's argument-parsing exit code.
+- `1`: process failure, including startup metrics/logger configuration, API
+  socket bind, or API accept failures.

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -899,6 +899,7 @@ mod tests {
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     use bangbang_runtime::logger::{LoggerConfigInput, LoggerWriteError};
+    use bangbang_runtime::metrics::MetricsConfigInput;
     use bangbang_runtime::{BackendError, VmmActionError};
 
     use crate::vmm::{InstanceStartExecutor, ProcessVmm};
@@ -2125,6 +2126,57 @@ mod tests {
         );
 
         fs::remove_file(metrics_path).expect("fixture should clean up");
+    }
+
+    #[test]
+    fn api_metrics_update_after_startup_metrics_preserves_startup_sink() {
+        let mut vmm = test_controller_with_starter(TestInstanceStarter::success());
+        let startup_metrics_path = unique_socket_path("startup-metrics").with_extension("metrics");
+        let api_metrics_path = unique_socket_path("api-metrics").with_extension("metrics");
+        vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+            &startup_metrics_path,
+        )))
+        .expect("startup metrics config should apply");
+        let metrics_body = format!(
+            r#"{{"metrics_path":"{}"}}"#,
+            api_metrics_path.to_string_lossy()
+        );
+        let metrics_request = format!(
+            "PUT /metrics HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{metrics_body}",
+            metrics_body.len()
+        );
+        let metrics_response = handle_request_bytes(metrics_request.as_bytes(), &mut vmm);
+        assert_eq!(
+            metrics_response.status(),
+            bangbang_api::http::StatusCode::BadRequest
+        );
+        assert_eq!(
+            metrics_response.body(),
+            r#"{"fault_message":"metrics system is already initialized"}"#
+        );
+
+        let boot_body = r#"{"kernel_image_path":"/tmp/original-vmlinux"}"#;
+        let boot_request = format!(
+            "PUT /boot-source HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{boot_body}",
+            boot_body.len()
+        );
+        assert_eq!(
+            handle_request_bytes(boot_request.as_bytes(), &mut vmm).status(),
+            bangbang_api::http::StatusCode::NoContent
+        );
+        let start_response = put_action_over_socket(&mut vmm, "met-start", "InstanceStart");
+        assert!(start_response.starts_with("HTTP/1.1 204 No Content\r\n"));
+        let flush_response = put_action_over_socket(&mut vmm, "met-flush", "FlushMetrics");
+        assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
+
+        assert_eq!(
+            fs::read_to_string(&startup_metrics_path)
+                .expect("startup metrics output should be readable"),
+            "{\"vmm\":{\"metrics_flush_count\":1}}\n"
+        );
+        assert!(!api_metrics_path.exists());
+
+        fs::remove_file(startup_metrics_path).expect("startup fixture should clean up");
     }
 
     #[test]

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -18,6 +18,7 @@ use signal_hook::{SigId, low_level};
 use vmm::ProcessVmm;
 
 use bangbang_runtime::logger::{LoggerConfigInput, LoggerLevel};
+use bangbang_runtime::metrics::MetricsConfigInput;
 use bangbang_runtime::{VmmAction, VmmActionError};
 
 const DEFAULT_API_SOCK_PATH: &str = "/tmp/bangbang.socket";
@@ -32,7 +33,6 @@ const UNSUPPORTED_FIRECRACKER_ARGS: &[&str] = &[
     "enable-pci",
     "http-api-max-payload-size",
     "metadata",
-    "metrics-path",
     "mmds-size-limit",
     "no-api",
     "no-seccomp",
@@ -71,6 +71,7 @@ fn run() -> Result<(), ProcessError> {
                 api_sock,
                 id,
                 logger_config,
+                metrics_config,
             } = config;
 
             println!("bangbang {}", env!("CARGO_PKG_VERSION"));
@@ -80,6 +81,7 @@ fn run() -> Result<(), ProcessError> {
             );
 
             let mut vmm = ProcessVmm::new(id, env!("CARGO_PKG_VERSION"), APP_NAME);
+            apply_startup_metrics_config(&mut vmm, metrics_config)?;
             apply_startup_logger_config(&mut vmm, logger_config)?;
             let mut shutdown_signal = ShutdownSignal::install()?;
             let server = ApiServer::bind(&api_sock).map_err(ProcessError::ApiServer)?;
@@ -89,6 +91,22 @@ fn run() -> Result<(), ProcessError> {
                 .run_until(&mut vmm, shutdown_wakeup)
                 .map_err(ProcessError::ApiServer)?;
         }
+    }
+
+    Ok(())
+}
+
+fn apply_startup_metrics_config<S>(
+    vmm: &mut ProcessVmm<S>,
+    metrics_config: Option<MetricsConfigInput>,
+) -> Result<(), ProcessError>
+where
+    S: vmm::InstanceStartExecutor,
+{
+    if let Some(metrics_config) = metrics_config {
+        vmm.handle_action(VmmAction::PutMetrics(metrics_config))
+            .map(|_| ())
+            .map_err(ProcessError::StartupConfiguration)?;
     }
 
     Ok(())
@@ -241,6 +259,7 @@ struct StartupConfig {
     api_sock: String,
     id: String,
     logger_config: Option<LoggerConfigInput>,
+    metrics_config: Option<MetricsConfigInput>,
 }
 
 impl Default for StartupConfig {
@@ -249,6 +268,7 @@ impl Default for StartupConfig {
             api_sock: DEFAULT_API_SOCK_PATH.to_string(),
             id: DEFAULT_INSTANCE_ID.to_string(),
             logger_config: None,
+            metrics_config: None,
         }
     }
 }
@@ -305,6 +325,7 @@ impl Args {
         let mut logger_config_seen = false;
         let mut log_path_seen = false;
         let mut level_seen = false;
+        let mut metrics_path_seen = false;
         let mut module_seen = false;
         let mut show_level_seen = false;
         let mut show_log_origin_seen = false;
@@ -353,6 +374,15 @@ impl Args {
                     logger_config = logger_config.with_level(level);
                     logger_config_seen = true;
                     level_seen = true;
+                    index += 2;
+                }
+                "--metrics-path" => {
+                    if metrics_path_seen {
+                        return Err("duplicate argument: --metrics-path".to_string());
+                    }
+                    let value = take_value(&args, index, "--metrics-path")?;
+                    config.metrics_config = Some(MetricsConfigInput::new(value));
+                    metrics_path_seen = true;
                     index += 2;
                 }
                 "--module" => {
@@ -434,6 +464,7 @@ fn help_text() -> String {
             "                         Accepts 1-64 bytes, ASCII alphanumeric or '-'\n",
             "      --log-path <PATH>  Logger output file or FIFO path\n",
             "      --level <LEVEL>    Logger level: Off, Trace, Debug, Info, Warn, or Error\n",
+            "      --metrics-path <PATH>  Metrics output file or FIFO path\n",
             "      --module <MODULE>  Logger module filter stored for future log integration\n",
             "      --show-level       Include level in minimal logger action lines\n",
             "      --show-log-origin  Store log-origin flag for future log integration\n",
@@ -444,9 +475,9 @@ fn help_text() -> String {
             "pre-boot PUT /machine-config, pre-boot PUT /boot-source, ",
             "pre-boot PUT /drives/{{drive_id}}, pre-boot ",
             "PUT /network-interfaces/{{iface_id}}, pre-boot PUT /vsock, ",
-            "pre-boot PUT /metrics, and pre-boot PUT /logger configuration ",
-            "with minimal action logs over the API or logger startup CLI ",
-            "socket; PUT /actions starts a process-owned HVF boot run-loop ",
+            "pre-boot PUT /metrics and startup metrics output configuration, ",
+            "and pre-boot PUT /logger and startup logger configuration with ",
+            "minimal action logs; PUT /actions starts a process-owned HVF boot run-loop ",
             "worker across bounded step windows for InstanceStart, but public ",
             "run-loop control is not implemented yet."
         ),
@@ -517,6 +548,7 @@ fn unsupported_equals_syntax(arg: &str) -> Option<&'static str> {
         ("--id=", "id"),
         ("--log-path=", "log-path"),
         ("--level=", "level"),
+        ("--metrics-path=", "metrics-path"),
         ("--module=", "module"),
     ]
     .into_iter()
@@ -533,6 +565,7 @@ mod tests {
 
     use bangbang_runtime::boot::BootSourceConfigInput;
     use bangbang_runtime::logger::{LoggerConfigError, LoggerConfigInput, LoggerLevel};
+    use bangbang_runtime::metrics::{MetricsConfigError, MetricsConfigInput};
     use bangbang_runtime::{BackendError, VmmAction};
 
     use crate::vmm::{InstanceStartExecutor, ProcessVmm};
@@ -578,6 +611,17 @@ mod tests {
         ))
     }
 
+    fn unique_metrics_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "bangbang-main-test-{}-{nanos}-{name}.metrics",
+            std::process::id()
+        ))
+    }
+
     #[test]
     fn process_exit_code_value_matches_argument_parsing_contract() {
         assert_eq!(ProcessExitCode::ProcessFailure.value(), 1);
@@ -601,6 +645,16 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "startup configuration error: logger path must not be empty"
+        );
+
+        let err = ProcessError::StartupConfiguration(
+            bangbang_runtime::VmmActionError::MetricsConfig(MetricsConfigError::EmptyPath),
+        );
+
+        assert_eq!(err.exit_code(), ProcessExitCode::ProcessFailure);
+        assert_eq!(
+            err.to_string(),
+            "startup configuration error: metrics path must not be empty"
         );
     }
 
@@ -653,6 +707,7 @@ mod tests {
         assert_eq!(config.api_sock, DEFAULT_API_SOCK_PATH);
         assert_eq!(config.id, DEFAULT_INSTANCE_ID);
         assert_eq!(config.logger_config, None);
+        assert_eq!(config.metrics_config, None);
     }
 
     #[test]
@@ -673,8 +728,11 @@ mod tests {
         assert!(help.contains("pre-boot PUT /boot-source"));
         assert!(help.contains("pre-boot PUT /drives/{drive_id}"));
         assert!(help.contains("pre-boot PUT /metrics"));
-        assert!(help.contains("pre-boot PUT /logger configuration with minimal action logs"));
+        assert!(help.contains("startup metrics output configuration"));
+        assert!(help.contains("pre-boot PUT /logger and startup logger configuration"));
+        assert!(help.contains("minimal action logs"));
         assert!(help.contains("--log-path <PATH>"));
+        assert!(help.contains("--metrics-path <PATH>"));
         assert!(help.contains("--show-level"));
         assert!(help.contains("PUT /actions starts a process-owned HVF boot run-loop worker"));
         assert!(help.contains("across bounded step windows for InstanceStart"));
@@ -724,6 +782,7 @@ mod tests {
         assert_eq!(config.api_sock, "/tmp/custom.socket");
         assert_eq!(config.id, DEFAULT_INSTANCE_ID);
         assert_eq!(config.logger_config, None);
+        assert_eq!(config.metrics_config, None);
     }
 
     #[test]
@@ -733,6 +792,7 @@ mod tests {
         assert_eq!(config.api_sock, DEFAULT_API_SOCK_PATH);
         assert_eq!(config.id, "demo-1");
         assert_eq!(config.logger_config, None);
+        assert_eq!(config.metrics_config, None);
     }
 
     #[test]
@@ -763,13 +823,35 @@ mod tests {
     }
 
     #[test]
+    fn parse_metrics_startup_args() {
+        let config = parse_run(&["--metrics-path", "/tmp/bangbang.metrics"])
+            .expect("metrics startup arg should parse");
+
+        assert_eq!(
+            config.metrics_config,
+            Some(MetricsConfigInput::new("/tmp/bangbang.metrics"))
+        );
+    }
+
+    #[test]
     fn parse_startup_args_together() {
-        let config = parse_run(&["--api-sock", "/tmp/custom.socket", "--id", "demo-1"])
-            .expect("startup args should parse");
+        let config = parse_run(&[
+            "--api-sock",
+            "/tmp/custom.socket",
+            "--id",
+            "demo-1",
+            "--metrics-path",
+            "/tmp/bangbang.metrics",
+        ])
+        .expect("startup args should parse");
 
         assert_eq!(config.api_sock, "/tmp/custom.socket");
         assert_eq!(config.id, "demo-1");
         assert_eq!(config.logger_config, None);
+        assert_eq!(
+            config.metrics_config,
+            Some(MetricsConfigInput::new("/tmp/bangbang.metrics"))
+        );
     }
 
     #[test]
@@ -787,7 +869,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_missing_logger_arg_values() {
+    fn rejects_missing_observability_arg_values() {
         let err = parse(&["--log-path", "--id"]).expect_err("missing log path value should fail");
 
         assert_eq!(err, "missing value for --log-path");
@@ -799,6 +881,11 @@ mod tests {
         let err = parse(&["--module", "--id"]).expect_err("missing module value should fail");
 
         assert_eq!(err, "missing value for --module");
+
+        let err =
+            parse(&["--metrics-path", "--id"]).expect_err("missing metrics path value should fail");
+
+        assert_eq!(err, "missing value for --metrics-path");
     }
 
     #[test]
@@ -822,7 +909,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_duplicate_logger_args() {
+    fn rejects_duplicate_observability_args() {
         let err = parse(&["--show-level", "--show-level"])
             .expect_err("duplicate show-level flag should fail");
 
@@ -847,6 +934,16 @@ mod tests {
             .expect_err("duplicate show-log-origin flag should fail");
 
         assert_eq!(err, "duplicate argument: --show-log-origin");
+
+        let err = parse(&[
+            "--metrics-path",
+            "/tmp/one.metrics",
+            "--metrics-path",
+            "/tmp/two.metrics",
+        ])
+        .expect_err("duplicate metrics-path arg should fail");
+
+        assert_eq!(err, "duplicate argument: --metrics-path");
     }
 
     #[test]
@@ -984,6 +1081,14 @@ mod tests {
             err,
             "unsupported argument syntax for --module; use --module <VALUE>"
         );
+
+        let err =
+            parse(&["--metrics-path=/tmp/secret.metrics"]).expect_err("equals syntax should fail");
+
+        assert_eq!(
+            err,
+            "unsupported argument syntax for --metrics-path; use --metrics-path <VALUE>"
+        );
     }
 
     #[test]
@@ -1030,6 +1135,35 @@ mod tests {
     }
 
     #[test]
+    fn applies_startup_metrics_config_before_actions() {
+        let path = unique_metrics_path("flush");
+        let mut vmm = ProcessVmm::with_starter(
+            "demo-1",
+            env!("CARGO_PKG_VERSION"),
+            "bangbang",
+            TestInstanceStarter,
+        );
+
+        super::apply_startup_metrics_config(&mut vmm, Some(MetricsConfigInput::new(&path)))
+            .expect("startup metrics config should apply");
+        vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            "/tmp/vmlinux",
+        )))
+        .expect("boot source should configure");
+        vmm.handle_action(VmmAction::InstanceStart)
+            .expect("instance start should succeed");
+        vmm.handle_action(VmmAction::FlushMetrics)
+            .expect("flush metrics should succeed");
+
+        assert_eq!(
+            fs::read_to_string(&path).expect("metrics output should be readable"),
+            "{\"vmm\":{\"metrics_flush_count\":1}}\n"
+        );
+
+        fs::remove_file(path).expect("fixture should clean up");
+    }
+
+    #[test]
     fn startup_logger_config_errors_do_not_echo_path() {
         let path = unique_logger_path("missing-parent").join("logger");
         let mut vmm = ProcessVmm::with_starter(
@@ -1050,6 +1184,29 @@ mod tests {
             err,
             ProcessError::StartupConfiguration(bangbang_runtime::VmmActionError::LoggerConfig(
                 LoggerConfigError::OpenFile(_)
+            ))
+        ));
+    }
+
+    #[test]
+    fn startup_metrics_config_errors_do_not_echo_path() {
+        let path = unique_metrics_path("missing-parent").join("metrics");
+        let mut vmm = ProcessVmm::with_starter(
+            "demo-1",
+            env!("CARGO_PKG_VERSION"),
+            "bangbang",
+            TestInstanceStarter,
+        );
+
+        let err =
+            super::apply_startup_metrics_config(&mut vmm, Some(MetricsConfigInput::new(&path)))
+                .expect_err("missing parent should fail startup metrics config");
+
+        assert!(!err.to_string().contains(path.to_string_lossy().as_ref()));
+        assert!(matches!(
+            err,
+            ProcessError::StartupConfiguration(bangbang_runtime::VmmActionError::MetricsConfig(
+                MetricsConfigError::OpenFile(_)
             ))
         ));
     }

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -153,8 +153,8 @@ The current executable uses a small process exit status contract:
 | Exit status | Current meaning | Compatibility notes |
 | --- | --- | --- |
 | `0` | Help or version completed successfully, or the API server exited without error, including handled `SIGINT`/`SIGTERM` shutdown. | Matches Firecracker's success status. |
-| `153` | Startup argument parsing or validation failed. | Matches Firecracker's `ArgParsing` exit code. |
-| `1` | API socket bind or accept failure. | Used for non-argument process failures before more specific Firecracker-compatible process errors exist. Per-connection read/write errors do not terminate the API server. |
+| `153` | Startup argument parsing failed before process configuration began. | Matches Firecracker's `ArgParsing` exit code. |
+| `1` | Process failure, including startup metrics/logger configuration, API socket bind, signal handler registration, or API accept failure. | Used for non-argument process failures before more specific Firecracker-compatible process errors exist. Per-connection read/write errors do not terminate the API server. |
 
 Firecracker also defines bad-configuration and signal-specific exit codes.
 bangbang does not expose those until the corresponding configuration loading,

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -106,7 +106,7 @@ serves `GET /`, `GET /version`, `GET /vm/config`, `GET /machine-config`,
 pre-boot `PUT /machine-config`, pre-boot `PUT /boot-source` configuration storage, and
 pre-boot `PUT /drives/{drive_id}` configuration storage, pre-boot
 `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage, pre-boot `PUT /metrics`
-output configuration, pre-boot `PUT /logger` output configuration, logger startup CLI configuration, plus process-routed `PUT /actions` startup and metrics
+output configuration, pre-boot `PUT /logger` output configuration, metrics and logger startup CLI configuration, plus process-routed `PUT /actions` startup and metrics
 flush with an internal boot run-loop worker across bounded step windows or
 state/configuration faults, but does not load a configuration file or provide
 public run-loop control.
@@ -115,6 +115,7 @@ public run-loop control.
 | --- | --- | --- |
 | `--api-sock <PATH>` | binds the API Unix socket | Firecracker defaults to `/run/firecracker.socket`; bangbang defaults to `/tmp/bangbang.socket` because macOS does not normally provide `/run`. This is an intentional host-platform difference. |
 | `--id <ID>` | parsed and stored | Defaults to Firecracker's `anonymous-instance`. IDs must be 1 to 64 bytes and contain only ASCII alphanumeric characters or `-`. |
+| `--metrics-path <PATH>` | configures metrics output before API serving | Uses the same per-process metrics sink and redacted host-path error policy as `PUT /metrics`. A later duplicate `PUT /metrics` request fails without replacing this sink. |
 | `--log-path <PATH>` | configures logger output before API serving | Uses the same per-process logger sink and redacted host-path error policy as `PUT /logger`. |
 | `--level <LEVEL>` | configures logger level before API serving | Accepts the existing logger levels `Off`, `Trace`, `Debug`, `Info`, `Warn`, `Warning`, and `Error`; minimal action logs are emitted only when the configured level allows `Info`. |
 | `--module <MODULE>` | stored for future logger filtering | Matches the stored `PUT /logger` field but does not filter the current minimal action logs yet. |
@@ -123,7 +124,7 @@ public run-loop control.
 | `--help`, `-h` | prints help | Help describes the current API socket scope. |
 | `--version`, `-V` | prints version | `-V` is retained from the existing bangbang scaffold. |
 | `--config-file`, `--no-api` | rejected | Deferred until VM configuration models and no-API startup behavior exist. |
-| seccomp, metrics CLI, snapshot, MMDS, boot timer, payload-size, and PCI process flags | rejected | These Firecracker options are Linux-specific, observability-related, or tied to later capability work. The API-level `PUT /metrics` subset is supported separately; metrics CLI flags remain deferred. |
+| seccomp, snapshot, MMDS, boot timer, payload-size, and PCI process flags | rejected | These Firecracker options are Linux-specific or tied to later capability work. |
 
 bangbang intentionally treats `--id` alphanumeric characters as ASCII only.
 This is stricter than Firecracker `v1.16.0`'s Rust validator, which accepts
@@ -304,7 +305,7 @@ exist.
 | `PUT /logger` | `module` | optional | Stored as logger filtering configuration for future log integration. |
 | `PUT /logger` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
 | `PUT /actions` | `action_type=InstanceStart` | process-routed; internal startup execution across bounded step windows implemented | Validates stored boot-source and state preflight first, then attempts owned HVF boot-session preparation with an internal serial MMIO console and starts the process-owned internal boot run-loop worker across bounded step windows. Success returns `204 No Content`, writes one minimal logger action line when configured and enabled, and commits `Running`; preparation, worker-start, or logger-output failures return a fault without mutating state. Public run-loop control and public serial streaming remain deferred. |
-| `PUT /actions` | `action_type=FlushMetrics` | runtime-only; minimal execution implemented | Rejected before startup. After startup, returns `204 No Content`; if `/metrics` was configured, appends one minimal JSON line, and if `/logger` was configured and enabled, appends one minimal action line. Full Firecracker counters, periodic flush, and full logger integration remain deferred. |
+| `PUT /actions` | `action_type=FlushMetrics` | runtime-only; minimal execution implemented | Rejected before startup. After startup, returns `204 No Content`; if metrics output was configured, appends one minimal JSON line, and if logger output was configured and enabled, appends one minimal action line. Full Firecracker counters, periodic flush, and full logger integration remain deferred. |
 | `PUT /actions` | `action_type=SendCtrlAltDel` | intentionally unsupported; parser rejected | Firecracker gates this on x86 keyboard behavior; the first target is Apple Silicon. |
 | `PUT /actions` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
 
@@ -341,14 +342,15 @@ startup preparation is attempted; when preflight succeeds, the process VMM owner
 prepares an owned HVF boot session, starts a process-owned internal boot
 run-loop worker across bounded step windows, and marks the instance `Running`
 only after that worker handle is retained.
-The API and VMM state path implement the `PUT /metrics` field policy above as a
-pre-boot-only per-process output sink. Duplicate initialization fails without
-replacing the original sink. `FlushMetrics` is runtime-only: it fails before
-startup, succeeds without writing when the sink is unconfigured, and writes one
-minimal JSON line when `/metrics` configured an output path. Public run-loop
-control, guest boot output, public runner loop scheduling, full Firecracker
-metrics counters, periodic metrics flush, full logger integration, and metrics
-CLI flags remain deferred.
+The process startup path and API/VMM state path implement the metrics field
+policy above as a pre-boot-only per-process output sink. Startup CLI can
+initialize the metrics sink before the API socket is served. Duplicate
+initialization fails without replacing the original sink. `FlushMetrics` is
+runtime-only: it fails before startup, succeeds without writing when the sink is
+unconfigured, and writes one minimal JSON line when `--metrics-path` or
+`PUT /metrics` configured an output path. Public run-loop control, guest boot
+output, public runner loop scheduling, full Firecracker metrics counters,
+periodic metrics flush, and full logger integration remain deferred.
 The process startup path and API/VMM state path implement the logger field
 policy above as pre-boot-only per-process observability configuration. Startup
 CLI flags can configure the initial logger before the API socket is served.
@@ -1271,8 +1273,8 @@ Their eventual support level should follow the endpoint matrix:
 - pmem
 - entropy device configuration
 - serial customization
-- full logger integration, full Firecracker metrics counters, periodic metrics
-  flush, and metrics CLI configuration
+- full logger integration, full Firecracker metrics counters, and periodic
+  metrics flush
 - memory hotplug
 - pause and resume VM state updates
 - PATCH and DELETE hotplug/update behavior

--- a/docs/security.md
+++ b/docs/security.md
@@ -116,7 +116,8 @@ is resource-specific:
   payloads, track graceful half-close state, or implement full virtio-vsock
   credit accounting yet.
 - `/metrics` opens the output path during pre-boot configuration and keeps a
-  per-process metrics sink.
+  per-process metrics sink. The `--metrics-path` startup CLI flag uses the same
+  sink and host-path error redaction rules before the API socket is served.
 - `/logger` opens `log_path` during pre-boot configuration when that field is
   present and keeps a per-process logger sink. Successful `InstanceStart` and
   `FlushMetrics` can append minimal action-event lines to that sink when the


### PR DESCRIPTION
## Summary
- Add Firecracker-style `--metrics-path <PATH>` startup parsing and apply it before serving the API socket.
- Preserve existing metrics sink semantics: duplicate `PUT /metrics` requests fail without replacing startup-configured output.
- Update README, compatibility scope, and security documentation for startup metrics configuration.

## Verification
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test -p bangbang metrics --all-features --locked`
- `cargo test -p bangbang startup --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`

Closes #438