### PR TITLE
feat: support virtio-block writeback flush

### DIFF
--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -2714,7 +2714,7 @@ mod tests {
     }
 
     #[test]
-    fn returns_fault_for_unsupported_drive_cache_without_storing() {
+    fn configures_writeback_drive_over_unix_socket() {
         let path = unique_socket_path("drive-cache");
         let server = ApiServer::bind(&path).expect("server should bind");
         let mut client = UnixStream::connect(&path).expect("client should connect");
@@ -2742,11 +2742,15 @@ mod tests {
             .read_to_string(&mut response)
             .expect("client should read response");
 
-        assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
-        assert!(
-            response.contains(r#"{"fault_message":"drive cache_type Writeback is not supported"}"#)
-        );
-        assert!(vmm.drive_configs().is_empty());
+        assert!(response.starts_with("HTTP/1.1 204 No Content\r\n"));
+        assert!(response.contains("Content-Length: 0\r\n"));
+        assert!(response.ends_with("\r\n\r\n"));
+        assert_eq!(vmm.drive_configs().len(), 1);
+        let config = &vmm.drive_configs()[0];
+        assert_eq!(config.drive_id(), "rootfs");
+        assert_eq!(config.path_on_host(), PathBuf::from("/tmp/rootfs.ext4"));
+        assert!(config.is_root_device());
+        assert_eq!(config.cache_type(), DriveCacheType::Writeback);
     }
 
     #[test]

--- a/crates/runtime/src/block.rs
+++ b/crates/runtime/src/block.rs
@@ -35,6 +35,7 @@ pub const VIRTIO_BLOCK_SECTOR_SHIFT: u32 = 9;
 pub const VIRTIO_BLOCK_SECTOR_SIZE: u64 = 1 << VIRTIO_BLOCK_SECTOR_SHIFT;
 pub const VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE: usize = 8;
 pub const VIRTIO_BLOCK_FEATURE_READ_ONLY: u32 = 5;
+pub const VIRTIO_BLOCK_FEATURE_FLUSH: u32 = 9;
 pub const VIRTIO_RING_FEATURE_EVENT_IDX: u32 = 29;
 pub const VIRTIO_FEATURE_VERSION_1: u32 = 32;
 pub const VIRTIO_BLOCK_REQUEST_HEADER_SIZE: u32 = 16;
@@ -262,10 +263,6 @@ impl TryFrom<DriveConfigInput> for DriveConfig {
         }
 
         let cache_type = input.cache_type.unwrap_or_default();
-        if cache_type != DriveCacheType::Unsafe {
-            return Err(DriveConfigError::UnsupportedCacheType { cache_type });
-        }
-
         let io_engine = input.io_engine.unwrap_or_default();
         if io_engine != DriveIoEngine::Sync {
             return Err(DriveConfigError::UnsupportedIoEngine { io_engine });
@@ -352,9 +349,6 @@ pub enum DriveConfigError {
         body_drive_id: String,
     },
     EmptyPathOnHost,
-    UnsupportedCacheType {
-        cache_type: DriveCacheType,
-    },
     UnsupportedIoEngine {
         io_engine: DriveIoEngine,
     },
@@ -375,9 +369,6 @@ impl fmt::Display for DriveConfigError {
             }
             Self::MismatchedDriveId { .. } => f.write_str("path drive_id must match body drive_id"),
             Self::EmptyPathOnHost => f.write_str("drive path_on_host must not be empty"),
-            Self::UnsupportedCacheType { cache_type } => {
-                write!(f, "drive cache_type {cache_type} is not supported")
-            }
             Self::UnsupportedIoEngine { io_engine } => {
                 write!(f, "drive io_engine {io_engine} is not supported")
             }
@@ -394,18 +385,20 @@ impl std::error::Error for DriveConfigError {}
 pub struct VirtioBlockConfigSpace {
     capacity_sectors: u64,
     is_read_only: bool,
+    cache_type: DriveCacheType,
 }
 
 impl VirtioBlockConfigSpace {
-    pub const fn new(backing_len: u64, is_read_only: bool) -> Self {
+    pub const fn new(backing_len: u64, is_read_only: bool, cache_type: DriveCacheType) -> Self {
         Self {
             capacity_sectors: backing_len >> VIRTIO_BLOCK_SECTOR_SHIFT,
             is_read_only,
+            cache_type,
         }
     }
 
-    pub fn from_backing(backing: &BlockFileBacking) -> Self {
-        Self::new(backing.len(), backing.is_read_only())
+    pub fn from_backing(backing: &BlockFileBacking, cache_type: DriveCacheType) -> Self {
+        Self::new(backing.len(), backing.is_read_only(), cache_type)
     }
 
     pub const fn capacity_sectors(self) -> u64 {
@@ -416,13 +409,19 @@ impl VirtioBlockConfigSpace {
         self.is_read_only
     }
 
+    pub const fn cache_type(self) -> DriveCacheType {
+        self.cache_type
+    }
+
     pub const fn available_features(self) -> u64 {
-        let features = virtio_feature_bit(VIRTIO_FEATURE_VERSION_1);
-        if self.is_read_only {
-            features | virtio_feature_bit(VIRTIO_BLOCK_FEATURE_READ_ONLY)
-        } else {
-            features
+        let mut features = virtio_feature_bit(VIRTIO_FEATURE_VERSION_1);
+        if matches!(self.cache_type, DriveCacheType::Writeback) {
+            features |= virtio_feature_bit(VIRTIO_BLOCK_FEATURE_FLUSH);
         }
+        if self.is_read_only {
+            features |= virtio_feature_bit(VIRTIO_BLOCK_FEATURE_READ_ONLY);
+        }
+        features
     }
 
     const fn capacity_bytes(self) -> [u8; VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE] {
@@ -2101,7 +2100,7 @@ impl PreparedBlockDevice {
                 source,
             }
         })?;
-        let config_space = VirtioBlockConfigSpace::from_backing(&backing);
+        let config_space = VirtioBlockConfigSpace::from_backing(&backing, config.cache_type());
         let device_id = VirtioBlockDeviceId::from_bytes(config.drive_id().as_bytes());
         let device = VirtioBlockDevice::new(backing, device_id);
 
@@ -2893,18 +2892,18 @@ mod tests {
         BlockMmioRegistrationError, DriveCacheType, DriveConfig, DriveConfigError,
         DriveConfigInput, DriveConfigs, DriveIdSource, DriveIoEngine, PreparedBlockDeviceError,
         PreparedBlockDevices, VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE, VIRTIO_BLOCK_DEVICE_ID,
-        VIRTIO_BLOCK_FEATURE_READ_ONLY, VIRTIO_BLOCK_ID_BYTES, VIRTIO_BLOCK_QUEUE_COUNT,
-        VIRTIO_BLOCK_QUEUE_SIZE, VIRTIO_BLOCK_QUEUE_SIZES, VIRTIO_BLOCK_REQUEST_HEADER_SIZE,
-        VIRTIO_BLOCK_REQUEST_TYPE_FLUSH, VIRTIO_BLOCK_REQUEST_TYPE_GET_ID,
-        VIRTIO_BLOCK_REQUEST_TYPE_IN, VIRTIO_BLOCK_REQUEST_TYPE_OUT, VIRTIO_BLOCK_SECTOR_SHIFT,
-        VIRTIO_BLOCK_SECTOR_SIZE, VIRTIO_BLOCK_STATUS_IOERR, VIRTIO_BLOCK_STATUS_OK,
-        VIRTIO_BLOCK_STATUS_SIZE, VIRTIO_BLOCK_STATUS_UNSUPPORTED, VIRTIO_FEATURE_VERSION_1,
-        VIRTIO_RING_FEATURE_EVENT_IDX, VirtioBlockConfigSpace, VirtioBlockDevice,
-        VirtioBlockDeviceActivationError, VirtioBlockDeviceId, VirtioBlockDeviceNotificationError,
-        VirtioBlockQueue, VirtioBlockQueueBuildError, VirtioBlockQueueDispatchError,
-        VirtioBlockRequest, VirtioBlockRequestCompletion, VirtioBlockRequestError,
-        VirtioBlockRequestExecutionError, VirtioBlockRequestExecutionOutcome,
-        VirtioBlockRequestType, normalize_completion_status,
+        VIRTIO_BLOCK_FEATURE_FLUSH, VIRTIO_BLOCK_FEATURE_READ_ONLY, VIRTIO_BLOCK_ID_BYTES,
+        VIRTIO_BLOCK_QUEUE_COUNT, VIRTIO_BLOCK_QUEUE_SIZE, VIRTIO_BLOCK_QUEUE_SIZES,
+        VIRTIO_BLOCK_REQUEST_HEADER_SIZE, VIRTIO_BLOCK_REQUEST_TYPE_FLUSH,
+        VIRTIO_BLOCK_REQUEST_TYPE_GET_ID, VIRTIO_BLOCK_REQUEST_TYPE_IN,
+        VIRTIO_BLOCK_REQUEST_TYPE_OUT, VIRTIO_BLOCK_SECTOR_SHIFT, VIRTIO_BLOCK_SECTOR_SIZE,
+        VIRTIO_BLOCK_STATUS_IOERR, VIRTIO_BLOCK_STATUS_OK, VIRTIO_BLOCK_STATUS_SIZE,
+        VIRTIO_BLOCK_STATUS_UNSUPPORTED, VIRTIO_FEATURE_VERSION_1, VIRTIO_RING_FEATURE_EVENT_IDX,
+        VirtioBlockConfigSpace, VirtioBlockDevice, VirtioBlockDeviceActivationError,
+        VirtioBlockDeviceId, VirtioBlockDeviceNotificationError, VirtioBlockQueue,
+        VirtioBlockQueueBuildError, VirtioBlockQueueDispatchError, VirtioBlockRequest,
+        VirtioBlockRequestCompletion, VirtioBlockRequestError, VirtioBlockRequestExecutionError,
+        VirtioBlockRequestExecutionOutcome, VirtioBlockRequestType, normalize_completion_status,
     };
 
     static NEXT_TEMP_PATH_ID: AtomicUsize = AtomicUsize::new(0);
@@ -3089,7 +3088,7 @@ mod tests {
         backing: BlockFileBacking,
         queue_max_sizes: &[u16],
     ) -> VirtioMmioRegisterHandler<VirtioBlockConfigSpace, VirtioBlockDevice> {
-        let config = VirtioBlockConfigSpace::from_backing(&backing);
+        let config = VirtioBlockConfigSpace::from_backing(&backing, DriveCacheType::Unsafe);
         let device = VirtioBlockDevice::new(backing, TEST_DEVICE_ID);
         VirtioMmioRegisterHandler::with_device_config_and_activation(
             VIRTIO_BLOCK_DEVICE_ID,
@@ -3484,7 +3483,8 @@ mod tests {
     fn block_device_registers() -> VirtioMmioDeviceRegisters {
         VirtioMmioDeviceRegisters::new(
             VIRTIO_BLOCK_DEVICE_ID,
-            VirtioBlockConfigSpace::new(VIRTIO_BLOCK_SECTOR_SIZE, false).available_features(),
+            VirtioBlockConfigSpace::new(VIRTIO_BLOCK_SECTOR_SIZE, false, DriveCacheType::Unsafe)
+                .available_features(),
         )
     }
 
@@ -3730,20 +3730,11 @@ mod tests {
     }
 
     #[test]
-    fn rejects_unsupported_cache_type() {
-        let err = validate(input().with_cache_type(DriveCacheType::Writeback))
-            .expect_err("Writeback cache should be unsupported");
+    fn accepts_writeback_cache_type() {
+        let config = validate(input().with_cache_type(DriveCacheType::Writeback))
+            .expect("Writeback cache should be supported");
 
-        assert_eq!(
-            err,
-            DriveConfigError::UnsupportedCacheType {
-                cache_type: DriveCacheType::Writeback,
-            }
-        );
-        assert_eq!(
-            err.to_string(),
-            "drive cache_type Writeback is not supported"
-        );
+        assert_eq!(config.cache_type(), DriveCacheType::Writeback);
     }
 
     #[test]
@@ -3968,6 +3959,28 @@ mod tests {
             .write_at(1, b"Z")
             .expect("read-write prepared backing should write");
         assert_eq!(fs::read(file.as_path()).expect("file should read"), b"aZc");
+    }
+
+    #[test]
+    fn prepared_block_devices_preserve_writeback_cache_type() {
+        let file = temp_file("prepared-writeback.img", &[0; 512]);
+        let mut configs = DriveConfigs::new();
+        configs
+            .insert(
+                DriveConfigInput::new("data", "data", file.as_path(), false)
+                    .with_cache_type(DriveCacheType::Writeback),
+            )
+            .expect("writeback drive config should insert");
+
+        let prepared = PreparedBlockDevices::from_configs(&configs)
+            .expect("writeback block device should prepare");
+
+        let config_space = prepared.as_slice()[0].config_space();
+        assert_eq!(config_space.cache_type(), DriveCacheType::Writeback);
+        assert_ne!(
+            config_space.available_features() & (1_u64 << VIRTIO_BLOCK_FEATURE_FLUSH),
+            0
+        );
     }
 
     #[test]
@@ -4485,6 +4498,7 @@ mod tests {
         assert_eq!(VIRTIO_BLOCK_SECTOR_SIZE, 512);
         assert_eq!(VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE, 8);
         assert_eq!(VIRTIO_BLOCK_FEATURE_READ_ONLY, 5);
+        assert_eq!(VIRTIO_BLOCK_FEATURE_FLUSH, 9);
         assert_eq!(VIRTIO_RING_FEATURE_EVENT_IDX, 29);
         assert_eq!(VIRTIO_FEATURE_VERSION_1, 32);
         assert_eq!(VIRTIO_BLOCK_REQUEST_HEADER_SIZE, 16);
@@ -4501,44 +4515,55 @@ mod tests {
 
     #[test]
     fn config_space_reports_sector_capacity() {
-        let config = VirtioBlockConfigSpace::new(4096, false);
+        let config = VirtioBlockConfigSpace::new(4096, false, DriveCacheType::Unsafe);
 
         assert_eq!(config.capacity_sectors(), 8);
         assert!(!config.is_read_only());
+        assert_eq!(config.cache_type(), DriveCacheType::Unsafe);
     }
 
     #[test]
     fn config_space_truncates_unaligned_tail() {
         assert_eq!(
-            VirtioBlockConfigSpace::new(511, false).capacity_sectors(),
+            VirtioBlockConfigSpace::new(511, false, DriveCacheType::Unsafe).capacity_sectors(),
             0
         );
         assert_eq!(
-            VirtioBlockConfigSpace::new(512, false).capacity_sectors(),
+            VirtioBlockConfigSpace::new(512, false, DriveCacheType::Unsafe).capacity_sectors(),
             1
         );
         assert_eq!(
-            VirtioBlockConfigSpace::new(4097, false).capacity_sectors(),
+            VirtioBlockConfigSpace::new(4097, false, DriveCacheType::Unsafe).capacity_sectors(),
             8
         );
     }
 
     #[test]
-    fn config_space_tracks_read_only_feature() {
+    fn config_space_tracks_cache_and_read_only_features() {
         let base_features = 1_u64 << VIRTIO_FEATURE_VERSION_1;
+        let flush_feature = 1_u64 << VIRTIO_BLOCK_FEATURE_FLUSH;
+        let read_only_feature = 1_u64 << VIRTIO_BLOCK_FEATURE_READ_ONLY;
 
         assert_eq!(
-            VirtioBlockConfigSpace::new(512, false).available_features(),
+            VirtioBlockConfigSpace::new(512, false, DriveCacheType::Unsafe).available_features(),
             base_features
         );
         assert_eq!(
-            VirtioBlockConfigSpace::new(512, false).available_features()
+            VirtioBlockConfigSpace::new(512, false, DriveCacheType::Unsafe).available_features()
                 & (1_u64 << VIRTIO_RING_FEATURE_EVENT_IDX),
             0
         );
         assert_eq!(
-            VirtioBlockConfigSpace::new(512, true).available_features(),
-            base_features | (1_u64 << VIRTIO_BLOCK_FEATURE_READ_ONLY)
+            VirtioBlockConfigSpace::new(512, false, DriveCacheType::Writeback).available_features(),
+            base_features | flush_feature
+        );
+        assert_eq!(
+            VirtioBlockConfigSpace::new(512, true, DriveCacheType::Unsafe).available_features(),
+            base_features | read_only_feature
+        );
+        assert_eq!(
+            VirtioBlockConfigSpace::new(512, true, DriveCacheType::Writeback).available_features(),
+            base_features | read_only_feature | flush_feature
         );
     }
 
@@ -4546,16 +4571,21 @@ mod tests {
     fn config_space_can_be_derived_from_backing() {
         let file = temp_file("config-space.img", &[0; 1024]);
         let backing = open_backing(file.as_path(), true).expect("backing should open");
-        let config = VirtioBlockConfigSpace::from_backing(&backing);
+        let config = VirtioBlockConfigSpace::from_backing(&backing, DriveCacheType::Writeback);
 
         assert_eq!(config.capacity_sectors(), 2);
         assert!(config.is_read_only());
+        assert_eq!(config.cache_type(), DriveCacheType::Writeback);
     }
 
     #[test]
     fn config_space_reads_full_and_partial_capacity() {
         let sectors = 0x0102_0304_u64;
-        let config = VirtioBlockConfigSpace::new(sectors << VIRTIO_BLOCK_SECTOR_SHIFT, false);
+        let config = VirtioBlockConfigSpace::new(
+            sectors << VIRTIO_BLOCK_SECTOR_SHIFT,
+            false,
+            DriveCacheType::Unsafe,
+        );
         let expected = sectors.to_le_bytes();
 
         assert_eq!(
@@ -4580,7 +4610,7 @@ mod tests {
 
     #[test]
     fn config_space_reads_ending_at_capacity_boundary() {
-        let config = VirtioBlockConfigSpace::new(u64::MAX, false);
+        let config = VirtioBlockConfigSpace::new(u64::MAX, false, DriveCacheType::Unsafe);
         let expected = config.capacity_sectors().to_le_bytes();
 
         assert_eq!(
@@ -4599,7 +4629,7 @@ mod tests {
 
     #[test]
     fn config_space_rejects_out_of_bounds_reads() {
-        let config = VirtioBlockConfigSpace::new(512, false);
+        let config = VirtioBlockConfigSpace::new(512, false, DriveCacheType::Unsafe);
 
         assert!(matches!(
             read_block_config(config, 8, 1),
@@ -4613,7 +4643,7 @@ mod tests {
 
     #[test]
     fn config_space_rejects_writes_after_driver_status() {
-        let config = VirtioBlockConfigSpace::new(512, false);
+        let config = VirtioBlockConfigSpace::new(512, false, DriveCacheType::Unsafe);
 
         assert!(matches!(
             write_block_config_after_driver(config, 0, &[1, 2, 3, 4]),
@@ -5575,7 +5605,7 @@ mod tests {
     fn block_device_activation_runs_through_mmio_register_handler_and_reset() {
         let file = temp_file("block-device-mmio-handler.img", &sector_payload(0x12));
         let backing = open_backing(file.as_path(), false).expect("backing should open");
-        let config = VirtioBlockConfigSpace::from_backing(&backing);
+        let config = VirtioBlockConfigSpace::from_backing(&backing, DriveCacheType::Unsafe);
         let device = VirtioBlockDevice::new(backing, TEST_DEVICE_ID);
         let mut handler = VirtioMmioRegisterHandler::with_device_config_and_activation(
             VIRTIO_BLOCK_DEVICE_ID,

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -280,7 +280,7 @@ exist.
 | `PUT /drives/{drive_id}` | `path_on_host` | required | The API/VMM path records this value only after rejecting empty paths; it does not open or stat the path yet. Future validation must cover access, file type, and path redaction in errors. |
 | `PUT /drives/{drive_id}` | `is_read_only` | optional | The internal model defaults omitted virtio-block drives to read-write. |
 | `PUT /drives/{drive_id}` | `partuuid` | optional | Only meaningful for root-device boot selection. |
-| `PUT /drives/{drive_id}` | `cache_type` | optional when `Unsafe`; deferred when `Writeback` | The internal model accepts omitted/default `Unsafe` and rejects `Writeback` as unsupported. |
+| `PUT /drives/{drive_id}` | `cache_type` | optional when `Unsafe`; supported when `Writeback` | The internal model accepts omitted/default `Unsafe` and explicit `Writeback`. `Unsafe` does not advertise `VIRTIO_BLK_F_FLUSH`; `Writeback` advertises it and routes guest flush requests through the backing flush path. |
 | `PUT /drives/{drive_id}` | `rate_limiter` | optional when absent or `null`; deferred when configured | The internal model rejects configured rate limiters; non-null rate limiting is tied to future block I/O performance work in #13. |
 | `PUT /drives/{drive_id}` | `io_engine` | optional when `Sync`; rejected when `Async` | The internal model accepts omitted/default `Sync` and rejects `Async`; `Async` is tied to Linux io_uring and does not directly map to the first macOS target. |
 | `PUT /drives/{drive_id}` | `socket` | optional when absent or `null`; deferred when set | The internal model rejects configured sockets; vhost-user-block is outside the first tier. |
@@ -566,10 +566,11 @@ values as nonempty alphanumeric strings with `_`, requires the two IDs to
 match, rejects an empty `path_on_host` without opening or statting host files,
 and normalizes omitted `is_read_only` to read-write.
 
-The internal model accepts omitted/default `cache_type=Unsafe` and
-`io_engine=Sync`, and rejects `Writeback`, `Async`, configured rate limiters,
-and configured sockets as unsupported. Displayed errors avoid echoing
-`path_on_host` so future API code can preserve host path redaction.
+The internal model accepts omitted/default `cache_type=Unsafe`, explicit
+`cache_type=Writeback`, and omitted/default `io_engine=Sync`, and rejects
+`Async`, configured rate limiters, and configured sockets as unsupported.
+Displayed errors avoid echoing `path_on_host` so future API code can preserve
+host path redaction.
 
 The runtime crate can also open the normalized `path_on_host` as a regular
 host file, preserve the configured read-only mode, report byte length, and
@@ -578,6 +579,11 @@ request execution. It rejects non-regular backing paths before data I/O and
 rejects read-only writes before mutating the file. Backing errors also avoid
 echoing `path_on_host`. This host-file opening path is internal and not invoked
 by public drive configuration yet.
+
+Virtio-block feature negotiation follows the selected cache mode:
+`cache_type=Unsafe` keeps the flush feature hidden, while
+`cache_type=Writeback` advertises `VIRTIO_BLK_F_FLUSH` and uses the existing
+backing-file flush path for guest flush requests.
 
 ## Internal Network Interface Configuration
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -173,7 +173,10 @@ to observe it and how it is bounded.
 Block devices can expose host file contents to the guest and can write to the
 backing file when configured read-write. Operators should use dedicated disk
 images per microVM and avoid sharing writable backing files between multiple
-bangbang processes.
+bangbang processes. The default `cache_type=Unsafe` mode does not advertise
+guest flush support. When `cache_type=Writeback` is configured, the block device
+advertises guest flush support and handles flush requests through the backing
+file `sync_all()` path.
 
 Metrics and logger outputs are host observability state, not guest
 configuration, and are intentionally omitted from `GET /vm/config`. Current


### PR DESCRIPTION
## Summary
- Support Firecracker-style `cache_type=Writeback` for virtio-block drive config.
- Advertise `VIRTIO_BLK_F_FLUSH` only for Writeback block devices while keeping Unsafe as the default without the flush feature.
- Update API/runtime tests and compatibility/security docs for the new cache-mode boundary.

## Scope Exclusions
- No async I/O engine, rate limiting, hotplug, or broader block cache-policy changes.

Closes #470

## Validation
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
- `git diff --check`
