### PR TITLE
feat: verify direct ext4 rootfs boot

### DIFF
--- a/crates/hvf/tests/guest_boot.rs
+++ b/crates/hvf/tests/guest_boot.rs
@@ -19,6 +19,8 @@ const BLOCK_WRITE_MARKER: &[u8] = b"BANGBANG_BLOCK_WRITE_OK";
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const ROOTFS_READ_MARKER: &[u8] = b"BANGBANG_ROOTFS_READ_OK";
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const DIRECT_ROOTFS_BOOT_MARKER: &[u8] = b"BANGBANG_DIRECT_ROOTFS_BOOT_OK";
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const ROOTFS_OS_RELEASE_ID: &[u8] = b"ID=ubuntu";
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const ROOTFS_OS_RELEASE_CODENAME: &[u8] = b"VERSION_CODENAME=noble";
@@ -27,7 +29,10 @@ const CMDLINE_BEGIN_MARKER: &[u8] = b"BANGBANG_CMDLINE_BEGIN";
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const CMDLINE_END_MARKER: &[u8] = b"BANGBANG_CMDLINE_END";
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-const BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 rdinit=/init";
+const INITRD_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 rdinit=/init";
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const DIRECT_ROOTFS_BOOT_ARGS: &str =
+    "console=ttyS0 reboot=k panic=1 quiet loglevel=1 init=/bangbang-direct-rootfs-init";
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const GUEST_BOOT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -233,9 +238,87 @@ fn boots_firecracker_kernel_and_reads_firecracker_rootfs() {
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn boots_firecracker_kernel_from_ext4_rootfs() {
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::block::DriveConfigInput;
+
+    let _test_lock = GUEST_BOOT_TEST_LOCK
+        .lock()
+        .expect("guest boot integration test lock should not be poisoned");
+    let rootfs_path = env_path("BANGBANG_GUEST_EXT4_ROOTFS_PATH");
+    let observation = run_guest_boot_without_initrd_until_marker(
+        "guest-ext4-rootfs-boot",
+        DIRECT_ROOTFS_BOOT_MARKER,
+        DIRECT_ROOTFS_BOOT_ARGS,
+        |controller| {
+            controller
+                .handle_action(VmmAction::PutDrive(
+                    DriveConfigInput::new("rootfs", "rootfs", rootfs_path.as_path(), true)
+                        .with_is_read_only(true),
+                ))
+                .expect("guest ext4 rootfs drive should configure");
+        },
+    );
+
+    assert_guest_boot_observed_marker(
+        &observation,
+        DIRECT_ROOTFS_BOOT_MARKER,
+        "direct rootfs boot marker",
+    );
+    assert!(
+        bytes_contain_marker(&observation.serial_bytes, ROOTFS_OS_RELEASE_ID),
+        "direct rootfs boot should read os-release ID from /\nserial output:\n{}",
+        String::from_utf8_lossy(&observation.serial_bytes)
+    );
+    assert!(
+        bytes_contain_marker(&observation.serial_bytes, ROOTFS_OS_RELEASE_CODENAME),
+        "direct rootfs boot should read os-release codename from /\nserial output:\n{}",
+        String::from_utf8_lossy(&observation.serial_bytes)
+    );
+    let cmdline = guest_cmdline_capture(&observation);
+    assert_guest_cmdline_contains_arg(cmdline, b"root=/dev/vda");
+    assert_guest_cmdline_contains_arg(cmdline, b"ro");
+    assert_guest_cmdline_contains_arg(cmdline, b"init=/bangbang-direct-rootfs-init");
+    assert!(
+        !guest_cmdline_contains_arg(cmdline, b"rdinit=/init"),
+        "direct rootfs boot should not rely on the tiny initrd: {}",
+        String::from_utf8_lossy(cmdline)
+    );
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 fn run_guest_boot_until_marker(
     instance_id: &str,
     marker: &[u8],
+    configure_controller: impl FnOnce(&mut bangbang_runtime::VmmController),
+) -> GuestBootObservation {
+    let initrd_path = env_path("BANGBANG_GUEST_INITRD_PATH");
+    run_guest_boot_with_boot_source(
+        instance_id,
+        marker,
+        Some(initrd_path),
+        INITRD_BOOT_ARGS,
+        configure_controller,
+    )
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn run_guest_boot_without_initrd_until_marker(
+    instance_id: &str,
+    marker: &[u8],
+    boot_args: &str,
+    configure_controller: impl FnOnce(&mut bangbang_runtime::VmmController),
+) -> GuestBootObservation {
+    run_guest_boot_with_boot_source(instance_id, marker, None, boot_args, configure_controller)
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn run_guest_boot_with_boot_source(
+    instance_id: &str,
+    marker: &[u8],
+    initrd_path: Option<std::path::PathBuf>,
+    boot_args: &str,
     configure_controller: impl FnOnce(&mut bangbang_runtime::VmmController),
 ) -> GuestBootObservation {
     use std::num::NonZeroUsize;
@@ -254,15 +337,14 @@ fn run_guest_boot_until_marker(
     use bangbang_runtime::{VmmAction, VmmController};
 
     let kernel_path = env_path("BANGBANG_GUEST_KERNEL_PATH");
-    let initrd_path = env_path("BANGBANG_GUEST_INITRD_PATH");
     let serial_output = SharedSerialOutputBuffer::default();
     let mut controller = VmmController::new(instance_id, "0.1.0", "bangbang");
+    let mut boot_source = BootSourceConfigInput::new(kernel_path.clone()).with_boot_args(boot_args);
+    if let Some(path) = initrd_path.as_ref() {
+        boot_source = boot_source.with_initrd_path(path.clone());
+    }
     controller
-        .handle_action(VmmAction::PutBootSource(
-            BootSourceConfigInput::new(kernel_path.clone())
-                .with_initrd_path(initrd_path.clone())
-                .with_boot_args(BOOT_ARGS),
-        ))
+        .handle_action(VmmAction::PutBootSource(boot_source))
         .expect("guest boot test boot source should configure");
     configure_controller(&mut controller);
     let serial_address = GuestAddress::new(SERIAL_MMIO_BASE);
@@ -487,13 +569,13 @@ impl Drop for GuestBootWatchdog {
 #[derive(Debug, Clone)]
 struct GuestBootDiagnostics {
     kernel_path: std::path::PathBuf,
-    initrd_path: std::path::PathBuf,
+    initrd_path: Option<std::path::PathBuf>,
     boot_args: String,
     boot_pc: u64,
     fdt_address: u64,
     fdt_size: usize,
-    initrd_address: u64,
-    initrd_size: u64,
+    initrd_address: Option<u64>,
+    initrd_size: Option<u64>,
     serial_mmio_base: u64,
     serial_mmio_size: u64,
     serial_interrupt_line: u32,
@@ -504,14 +586,15 @@ impl GuestBootDiagnostics {
     fn from_session(
         session: &bangbang_hvf::OwnedHvfArm64BootSession,
         kernel_path: std::path::PathBuf,
-        initrd_path: std::path::PathBuf,
+        initrd_path: Option<std::path::PathBuf>,
         expected_serial_address: bangbang_runtime::memory::GuestAddress,
     ) -> Self {
         let resources = session.runtime_resources();
-        let initrd = resources
-            .loaded_boot_source
-            .initrd
-            .expect("guest boot test initrd should be loaded");
+        let initrd = resources.loaded_boot_source.initrd;
+        let (initrd_address, initrd_size) = match initrd {
+            Some(loaded) => (Some(loaded.address.raw_value()), Some(loaded.size)),
+            None => (None, None),
+        };
         let serial = resources
             .serial_device
             .as_ref()
@@ -539,8 +622,8 @@ impl GuestBootDiagnostics {
             boot_pc: session.boot_registers().kernel_entry.raw_value(),
             fdt_address: resources.fdt.address.raw_value(),
             fdt_size: resources.fdt.size,
-            initrd_address: initrd.address.raw_value(),
-            initrd_size: initrd.size,
+            initrd_address,
+            initrd_size,
             serial_mmio_base: serial.region.range().start().raw_value(),
             serial_mmio_size: serial.region.range().size(),
             serial_interrupt_line: serial.fdt_device.interrupt_line.raw_value(),
@@ -716,7 +799,10 @@ impl std::fmt::Display for GuestBootFailureReport<'_> {
         writeln!(f, "  last MMIO step: {last_mmio_step}")?;
         writeln!(f, "  serial tail hex: {serial_tail_hex}")?;
         writeln!(f, "  kernel path: {}", self.boot.kernel_path.display())?;
-        writeln!(f, "  initrd path: {}", self.boot.initrd_path.display())?;
+        match self.boot.initrd_path.as_ref() {
+            Some(path) => writeln!(f, "  initrd path: {}", path.display())?,
+            None => writeln!(f, "  initrd path: none")?,
+        }
         writeln!(f, "  boot args: {}", self.boot.boot_args)?;
         writeln!(f, "  boot PC: 0x{:x}", self.boot.boot_pc)?;
         writeln!(
@@ -724,11 +810,13 @@ impl std::fmt::Display for GuestBootFailureReport<'_> {
             "  FDT: address=0x{:x}, size={}",
             self.boot.fdt_address, self.boot.fdt_size
         )?;
-        writeln!(
-            f,
-            "  initrd: address=0x{:x}, size={}",
-            self.boot.initrd_address, self.boot.initrd_size
-        )?;
+        match (self.boot.initrd_address, self.boot.initrd_size) {
+            (Some(address), Some(size)) => {
+                writeln!(f, "  initrd: address=0x{address:x}, size={size}")?;
+            }
+            (None, None) => writeln!(f, "  initrd: none")?,
+            _ => writeln!(f, "  initrd: inconsistent metadata")?,
+        }
         writeln!(
             f,
             "  serial: base=0x{:x}, size={}, interrupt_line={}",
@@ -754,11 +842,9 @@ fn validate_pre_run_boot_metadata(
         resources
             .loaded_boot_source
             .initrd
-            .expect("guest boot test initrd should be loaded")
-            .address
-            .raw_value(),
+            .map(|loaded| loaded.address.raw_value()),
         diagnostics.initrd_address,
-        "guest boot test initrd address should match diagnostics"
+        "guest boot test loaded initrd address should match diagnostics"
     );
 
     let mut fdt_bytes = vec![0; resources.fdt.size];
@@ -772,14 +858,17 @@ fn validate_pre_run_boot_metadata(
         .find("/chosen")
         .expect("guest boot test FDT should contain /chosen");
     assert_eq!(chosen.prop_str("bootargs").unwrap(), diagnostics.boot_args);
-    assert_eq!(
-        chosen.prop_u64("linux,initrd-start").unwrap(),
-        diagnostics.initrd_address
-    );
-    assert_eq!(
-        chosen.prop_u64("linux,initrd-end").unwrap(),
-        diagnostics.initrd_address + diagnostics.initrd_size
-    );
+    match (diagnostics.initrd_address, diagnostics.initrd_size) {
+        (Some(address), Some(size)) => {
+            assert_eq!(chosen.prop_u64("linux,initrd-start").unwrap(), address);
+            assert_eq!(chosen.prop_u64("linux,initrd-end").unwrap(), address + size);
+        }
+        (None, None) => {
+            assert!(!chosen.has_prop("linux,initrd-start"));
+            assert!(!chosen.has_prop("linux,initrd-end"));
+        }
+        _ => panic!("guest boot test initrd diagnostics should be internally consistent"),
+    }
 
     let serial_node_path = format!("/uart@{:x}", diagnostics.serial_mmio_base);
     let serial = tree
@@ -977,13 +1066,13 @@ mod tests {
     fn guest_boot_failure_report_includes_boot_and_run_context() {
         let boot = GuestBootDiagnostics {
             kernel_path: "/tmp/vmlinux".into(),
-            initrd_path: "/tmp/initrd.cpio".into(),
-            boot_args: super::BOOT_ARGS.to_string(),
+            initrd_path: Some("/tmp/initrd.cpio".into()),
+            boot_args: super::INITRD_BOOT_ARGS.to_string(),
             boot_pc: 0x8020_0000,
             fdt_address: 0x87e0_0000,
             fdt_size: 4096,
-            initrd_address: 0x87df_f000,
-            initrd_size: 512,
+            initrd_address: Some(0x87df_f000),
+            initrd_size: Some(512),
             serial_mmio_base: 0x4000_0000,
             serial_mmio_size: 4096,
             serial_interrupt_line: 32,

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -790,8 +790,13 @@ temporary host backing file through the raw block device. The same target also
 validates a basic writable-drive path by writing a marker from the guest to
 `/dev/vda` and checking the scratch host backing file. It also attaches the
 pinned Firecracker squashfs rootfs as a read-only root drive, mounts it from the
-deterministic initrd, and reads `/mnt/etc/os-release` from the guest. Full
-rootfs boot, block hotplug, cache-mode expansion, and rate limiting remain
+deterministic initrd, and reads `/mnt/etc/os-release` from the guest. Direct
+root-drive boot validation is covered by a generated ext4 variant of the same
+Firecracker rootfs that adds a deterministic test init, boots without an initrd,
+mounts the virtio-block root drive as `/`, reads `/etc/os-release`, and
+validates guest-visible `root=/dev/vda ro` command-line arguments. This does
+not yet claim arbitrary distro rootfs boot or default Ubuntu systemd startup.
+Block hotplug, remaining cache-mode semantics, and rate limiting remain
 deferred.
 It does not provide a public runner control, implement rate limiting, support
 vhost-user-block sockets, or use an async I/O engine. Internal HVF boot sessions

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -188,7 +188,7 @@ artifacts and is not a substitute for a production rootfs build process.
 
 The signed `guest_boot` target also validates a deterministic direct-rootfs
 boot. For that scenario, `scripts/run-integration-tests.sh` prepares
-`.tmp/guest-artifacts/bangbang/rootfs/ubuntu-24.04-512M-direct-boot-v3.ext4`
+`.tmp/guest-artifacts/bangbang/rootfs/ubuntu-24.04-512M-direct-boot-v4.ext4`
 after confirming the host can execute HVF. The generated image is an ext4 copy
 of the pinned Firecracker rootfs with a test-specific
 `/bangbang-direct-rootfs-init` script added before image creation. The test

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -150,8 +150,7 @@ backing file. A rootfs artifact scenario attaches the cached Firecracker
 squashfs as a read-only root drive, mounts it from the tiny initrd, reads
 `/mnt/etc/os-release`, and expects `BANGBANG_ROOTFS_READ_OK` plus stable Ubuntu
 os-release content on serial. This verifies guest-visible rootfs access through
-virtio-block; full rootfs boot with an init process from that rootfs remains
-separate follow-up coverage.
+virtio-block.
 
 The pinned Firecracker CI rootfs artifact can be prepared separately:
 
@@ -186,6 +185,18 @@ The ext4 preparation path intentionally does not require `sudo`. Files copied
 into the generated ext4 image keep the local extraction ownership rather than
 Firecracker's root-owned demo ownership. This is suitable for local development
 artifacts and is not a substitute for a production rootfs build process.
+
+The signed `guest_boot` target also validates a deterministic direct-rootfs
+boot. For that scenario, `scripts/run-integration-tests.sh` prepares
+`.tmp/guest-artifacts/bangbang/rootfs/ubuntu-24.04-512M-direct-boot-v3.ext4`
+after confirming the host can execute HVF. The generated image is an ext4 copy
+of the pinned Firecracker rootfs with a test-specific
+`/bangbang-direct-rootfs-init` script added before image creation. The test
+boots without the tiny initrd, attaches that ext4 image as a read-only root
+drive, passes `init=/bangbang-direct-rootfs-init`, and expects deterministic
+serial markers plus Ubuntu os-release content from `/etc/os-release`. This
+proves the kernel mounted the virtio-block root drive as `/`; it does not claim
+that bangbang can boot an arbitrary distro image through its default init.
 
 bangbang appends Firecracker-style root-drive command-line arguments during
 startup resource assembly when a configured drive has `is_root_device=true`.

--- a/scripts/fetch-firecracker-rootfs.sh
+++ b/scripts/fetch-firecracker-rootfs.sh
@@ -12,6 +12,9 @@ Options:
                    Defaults to squashfs.
   --ext4-size SIZE Size for the generated ext4 image. Defaults to 1G.
                    Only valid with --format ext4.
+  --direct-boot-init
+                   Add a deterministic bangbang direct-rootfs boot init script
+                   to the generated ext4 image. Only valid with --format ext4.
   -h, --help       Show this help.
 
 Environment:
@@ -23,6 +26,7 @@ EOF
 format="squashfs"
 ext4_size="1G"
 ext4_size_set=false
+direct_boot_init=false
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
@@ -52,6 +56,9 @@ while [[ "$#" -gt 0 ]]; do
       ext4_size="${1#--ext4-size=}"
       ext4_size_set=true
       ;;
+    --direct-boot-init)
+      direct_boot_init=true
+      ;;
     -h | --help)
       usage
       exit 0
@@ -80,6 +87,11 @@ if [[ "$format" != "ext4" && "$ext4_size_set" == true ]]; then
   usage >&2
   exit 2
 fi
+if [[ "$format" != "ext4" && "$direct_boot_init" == true ]]; then
+  echo "--direct-boot-init is only valid with --format ext4" >&2
+  usage >&2
+  exit 2
+fi
 
 if [[ ! "$ext4_size" =~ ^([0-9]+)[KkMmGgTt]?$ ]]; then
   echo "invalid ext4 size: $ext4_size" >&2
@@ -99,12 +111,17 @@ rootfs_arch="aarch64"
 rootfs_name="ubuntu-24.04"
 rootfs_sha256="0efb6a3ff2982baa6ca7e3d940966516ba7ddd2df5deb3e6c2161d369a15d608"
 rootfs_url="https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/${firecracker_minor}/${rootfs_arch}/${rootfs_name}.squashfs"
+direct_boot_variant="direct-boot-v3"
 
 cache_root="${BANGBANG_GUEST_ARTIFACTS_DIR:-$repo_root/.tmp/guest-artifacts}"
 upstream_dir="${cache_root}/firecracker-ci/${firecracker_minor}/${rootfs_arch}"
 upstream_path="${upstream_dir}/${rootfs_name}.squashfs"
 prepared_dir="${cache_root}/bangbang/rootfs"
-ext4_path="${prepared_dir}/${rootfs_name}-${ext4_size}.ext4"
+if [[ "$direct_boot_init" == true ]]; then
+  ext4_path="${prepared_dir}/${rootfs_name}-${ext4_size}-${direct_boot_variant}.ext4"
+else
+  ext4_path="${prepared_dir}/${rootfs_name}-${ext4_size}.ext4"
+fi
 tmp_file=""
 tmp_ext4=""
 extract_dir=""
@@ -283,6 +300,9 @@ prepare_ext4() {
 
   echo "extracting Firecracker rootfs artifact: $upstream_path" >&2
   unsquashfs -q -no-progress -no-xattrs -d "$extract_dir" "$upstream_path"
+  if [[ "$direct_boot_init" == true ]]; then
+    install_direct_boot_init
+  fi
 
   echo "preparing ext4 rootfs artifact: $ext4_path" >&2
   truncate -s "$ext4_size" "$tmp_ext4"
@@ -292,6 +312,57 @@ prepare_ext4() {
   tmp_ext4=""
   rm -rf "$extract_dir"
   extract_dir=""
+}
+
+install_direct_boot_init() {
+  local init_path="${extract_dir}/bangbang-direct-rootfs-init"
+
+  cat > "$init_path" <<'EOF'
+#!/bin/sh
+emit_text() {
+  text=$1
+  while [ -n "$text" ]; do
+    rest=${text#????????????????}
+    if [ "$rest" = "$text" ]; then
+      printf '%s' "$text"
+      text=
+    else
+      chunk=${text%"$rest"}
+      printf '%s' "$chunk"
+      text=$rest
+    fi
+  done
+}
+
+emit_line() {
+  emit_text "$1"
+  printf '\n'
+}
+
+emit_line BANGBANG_DIRECT_ROOTFS_BOOT_BEGIN
+if [ -r /etc/os-release ]; then
+  id_line=$(grep -m 1 '^ID=' /etc/os-release 2>/dev/null || true)
+  codename_line=$(grep -m 1 '^VERSION_CODENAME=' /etc/os-release 2>/dev/null || true)
+  if [ -n "$id_line" ]; then
+    emit_line "$id_line"
+  fi
+  if [ -n "$codename_line" ]; then
+    emit_line "$codename_line"
+  fi
+fi
+if [ -d /proc ]; then
+  mount -t proc proc /proc 2>/dev/null || true
+fi
+if [ -r /proc/cmdline ]; then
+  emit_line BANGBANG_CMDLINE_BEGIN
+  cmdline=$(cat /proc/cmdline 2>/dev/null || true)
+  emit_line "$cmdline"
+  emit_line BANGBANG_CMDLINE_END
+fi
+emit_line BANGBANG_DIRECT_ROOTFS_BOOT_OK
+while :; do :; done
+EOF
+  chmod 0755 "$init_path"
 }
 
 if [[ "$format" == "ext4" ]]; then

--- a/scripts/fetch-firecracker-rootfs.sh
+++ b/scripts/fetch-firecracker-rootfs.sh
@@ -111,7 +111,7 @@ rootfs_arch="aarch64"
 rootfs_name="ubuntu-24.04"
 rootfs_sha256="0efb6a3ff2982baa6ca7e3d940966516ba7ddd2df5deb3e6c2161d369a15d608"
 rootfs_url="https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/${firecracker_minor}/${rootfs_arch}/${rootfs_name}.squashfs"
-direct_boot_variant="direct-boot-v3"
+direct_boot_variant="direct-boot-v4"
 
 cache_root="${BANGBANG_GUEST_ARTIFACTS_DIR:-$repo_root/.tmp/guest-artifacts}"
 upstream_dir="${cache_root}/firecracker-ci/${firecracker_minor}/${rootfs_arch}"
@@ -360,7 +360,7 @@ if [ -r /proc/cmdline ]; then
   emit_line BANGBANG_CMDLINE_END
 fi
 emit_line BANGBANG_DIRECT_ROOTFS_BOOT_OK
-while :; do :; done
+exec sleep 3600
 EOF
   chmod 0755 "$init_path"
 }

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -209,6 +209,7 @@ fi
 guest_kernel_path=""
 guest_initrd_path=""
 guest_rootfs_path=""
+guest_ext4_rootfs_path=""
 if contains guest_boot "${selected_tests[@]}"; then
   guest_kernel_path="$(scripts/fetch-firecracker-kernel.sh)"
   guest_initrd_path="$(scripts/build-guest-boot-initrd.py --check)"
@@ -250,6 +251,13 @@ if [[ "$hv_disable" == "1" ]]; then
   finish_unsupported "Hypervisor.framework is disabled on this host"
 fi
 
+if contains guest_boot "${selected_tests[@]}"; then
+  guest_ext4_rootfs_path="$(scripts/fetch-firecracker-rootfs.sh \
+    --format ext4 \
+    --ext4-size 512M \
+    --direct-boot-init)"
+fi
+
 for index in "${!signed_test_bins[@]}"; do
   test_name="${signed_test_names[$index]}"
   test_bin="${signed_test_bins[$index]}"
@@ -260,11 +268,13 @@ for index in "${!signed_test_bins[@]}"; do
         BANGBANG_GUEST_KERNEL_PATH="$guest_kernel_path" \
           BANGBANG_GUEST_INITRD_PATH="$guest_initrd_path" \
           BANGBANG_GUEST_ROOTFS_PATH="$guest_rootfs_path" \
+          BANGBANG_GUEST_EXT4_ROOTFS_PATH="$guest_ext4_rootfs_path" \
           "$test_bin" --test-threads=1
       else
         BANGBANG_GUEST_KERNEL_PATH="$guest_kernel_path" \
           BANGBANG_GUEST_INITRD_PATH="$guest_initrd_path" \
           BANGBANG_GUEST_ROOTFS_PATH="$guest_rootfs_path" \
+          BANGBANG_GUEST_EXT4_ROOTFS_PATH="$guest_ext4_rootfs_path" \
           "$test_bin" --test-threads=1 "${test_args[@]}"
       fi
       ;;


### PR DESCRIPTION
## Summary

- add a direct-rootfs ext4 guest boot artifact variant with a deterministic test init
- prepare the direct-boot ext4 rootfs only on the HVF-capable execution path and pass it to `guest_boot`
- add a signed `guest_boot` scenario that boots without initrd, mounts the ext4 root drive as `/`, and validates os-release plus root-drive kernel args
- update testing and Firecracker compatibility docs for the new validation boundary

## Scope Notes

- This validates direct root-drive mounting with a test-specific init.
- This does not claim arbitrary distro rootfs boot, default Ubuntu systemd startup, writable shared rootfs policy, block hotplug, async I/O, or rate limiting.

Closes #472

## Validation

- `bash -n scripts/fetch-firecracker-rootfs.sh scripts/run-integration-tests.sh`
- `scripts/fetch-firecracker-rootfs.sh --direct-boot-init` returned exit 2 as expected
- `scripts/fetch-firecracker-rootfs.sh --format ext4 --ext4-size 512M --direct-boot-init`
- `scripts/run-integration-tests.sh --test guest_boot -- boots_firecracker_kernel_from_ext4_rootfs --exact`
- `scripts/run-integration-tests.sh`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`
