### PR TITLE
feat: honor virtqueue event-index interrupts

### DIFF
--- a/crates/runtime/src/network.rs
+++ b/crates/runtime/src/network.rs
@@ -20,7 +20,8 @@ use crate::virtio_mmio::{
 };
 use crate::virtio_queue::{
     VirtqueueAvailableRing, VirtqueueAvailableRingError, VirtqueueDescriptor,
-    VirtqueueDescriptorChain, VirtqueueUsedRing, VirtqueueUsedRingError,
+    VirtqueueDescriptorChain, VirtqueueNotificationSuppression, VirtqueueUsedRing,
+    VirtqueueUsedRingError, VirtqueueUsedRingPublication,
 };
 
 const MAC_ADDRESS_LEN: usize = 6;
@@ -972,23 +973,23 @@ impl VirtioNetworkDevice {
             return Err(VirtioNetworkDeviceActivationError::AlreadyActive);
         }
 
+        let event_idx_enabled =
+            virtio_feature_enabled(activation.driver_features(), VIRTIO_RING_FEATURE_EVENT_IDX);
         let active_rx_queue = active_network_queue_state(activation, VIRTIO_NET_RX_QUEUE_INDEX_U32)
             .and_then(|queue| {
-                VirtioNetworkRxQueue::from_mmio_queue_state(queue).map_err(|source| {
-                    VirtioNetworkDeviceActivationError::RxQueueBuild {
+                VirtioNetworkRxQueue::from_mmio_queue_state_with_event_idx(queue, event_idx_enabled)
+                    .map_err(|source| VirtioNetworkDeviceActivationError::RxQueueBuild {
                         queue_index: VIRTIO_NET_RX_QUEUE_INDEX_U32,
                         source,
-                    }
-                })
+                    })
             })?;
         let active_tx_queue = active_network_queue_state(activation, VIRTIO_NET_TX_QUEUE_INDEX_U32)
             .and_then(|queue| {
-                VirtioNetworkTxQueue::from_mmio_queue_state(queue).map_err(|source| {
-                    VirtioNetworkDeviceActivationError::TxQueueBuild {
+                VirtioNetworkTxQueue::from_mmio_queue_state_with_event_idx(queue, event_idx_enabled)
+                    .map_err(|source| VirtioNetworkDeviceActivationError::TxQueueBuild {
                         queue_index: VIRTIO_NET_TX_QUEUE_INDEX_U32,
                         source,
-                    }
-                })
+                    })
             })?;
 
         self.active_rx_queue = Some(active_rx_queue);
@@ -1136,11 +1137,19 @@ pub struct VirtioNetworkRxQueue {
     queue_state: VirtioMmioQueueState,
     available: VirtqueueAvailableRing,
     used: VirtqueueUsedRing,
+    event_idx_enabled: bool,
 }
 
 impl VirtioNetworkRxQueue {
     pub fn from_mmio_queue_state(
         queue: VirtioMmioQueueState,
+    ) -> Result<Self, VirtioNetworkRxQueueBuildError> {
+        Self::from_mmio_queue_state_with_event_idx(queue, false)
+    }
+
+    fn from_mmio_queue_state_with_event_idx(
+        queue: VirtioMmioQueueState,
+        event_idx_enabled: bool,
     ) -> Result<Self, VirtioNetworkRxQueueBuildError> {
         if !queue.ready() {
             return Err(VirtioNetworkRxQueueBuildError::QueueNotReady);
@@ -1159,6 +1168,7 @@ impl VirtioNetworkRxQueue {
             queue_state: queue,
             available,
             used,
+            event_idx_enabled,
         })
     }
 
@@ -1172,6 +1182,10 @@ impl VirtioNetworkRxQueue {
 
     pub const fn used_ring(&self) -> &VirtqueueUsedRing {
         &self.used
+    }
+
+    pub const fn event_idx_enabled(&self) -> bool {
+        self.event_idx_enabled
     }
 
     pub fn dispatch(
@@ -1266,16 +1280,34 @@ impl VirtioNetworkRxQueue {
                 match VirtioNetworkRxBuffer::parse(memory, &chain) {
                     Ok(buffer) => {
                         if u64::from(bytes_written_to_guest) > buffer.len() {
-                            if let Err(source) =
-                                self.used.publish_used_element(memory, descriptor_head, 0)
+                            let notification_suppression = match self
+                                .notification_suppression(memory)
                             {
-                                return Err(VirtioNetworkRxQueueDispatchError::UsedRing {
-                                    completed_dispatch: Box::new(dispatch),
+                                Ok(notification_suppression) => notification_suppression,
+                                Err(source) => {
+                                    return Err(VirtioNetworkRxQueueDispatchError::AvailableRing {
+                                        completed_dispatch: Box::new(dispatch),
+                                        source,
+                                    });
+                                }
+                            };
+                            let publication =
+                                match self.used.publish_used_element_with_notification(
+                                    memory,
                                     descriptor_head,
-                                    bytes_written_to_guest: 0,
-                                    source,
-                                });
-                            }
+                                    0,
+                                    notification_suppression,
+                                ) {
+                                    Ok(publication) => publication,
+                                    Err(source) => {
+                                        return Err(VirtioNetworkRxQueueDispatchError::UsedRing {
+                                            completed_dispatch: Box::new(dispatch),
+                                            descriptor_head,
+                                            bytes_written_to_guest: 0,
+                                            source,
+                                        });
+                                    }
+                                };
                             VirtioNetworkRxQueueDispatchAction::Record(
                                 VirtioNetworkRxQueueDispatchOutcome::BufferTooSmall(
                                     VirtioNetworkRxBufferTooSmall {
@@ -1284,6 +1316,7 @@ impl VirtioNetworkRxQueue {
                                         required_len: u64::from(bytes_written_to_guest),
                                     },
                                 ),
+                                publication,
                             )
                         } else {
                             if let Err(source) = write_rx_packet_to_buffer(memory, &buffer, packet)
@@ -1294,18 +1327,34 @@ impl VirtioNetworkRxQueue {
                                     source,
                                 });
                             }
-                            if let Err(source) = self.used.publish_used_element(
-                                memory,
-                                descriptor_head,
-                                bytes_written_to_guest,
-                            ) {
-                                return Err(VirtioNetworkRxQueueDispatchError::UsedRing {
-                                    completed_dispatch: Box::new(dispatch),
+                            let notification_suppression = match self
+                                .notification_suppression(memory)
+                            {
+                                Ok(notification_suppression) => notification_suppression,
+                                Err(source) => {
+                                    return Err(VirtioNetworkRxQueueDispatchError::AvailableRing {
+                                        completed_dispatch: Box::new(dispatch),
+                                        source,
+                                    });
+                                }
+                            };
+                            let publication =
+                                match self.used.publish_used_element_with_notification(
+                                    memory,
                                     descriptor_head,
                                     bytes_written_to_guest,
-                                    source,
-                                });
-                            }
+                                    notification_suppression,
+                                ) {
+                                    Ok(publication) => publication,
+                                    Err(source) => {
+                                        return Err(VirtioNetworkRxQueueDispatchError::UsedRing {
+                                            completed_dispatch: Box::new(dispatch),
+                                            descriptor_head,
+                                            bytes_written_to_guest,
+                                            source,
+                                        });
+                                    }
+                                };
                             VirtioNetworkRxQueueDispatchAction::Consume(
                                 VirtioNetworkRxQueueDispatchOutcome::Delivered(
                                     VirtioNetworkRxPacketDelivery {
@@ -1314,37 +1363,69 @@ impl VirtioNetworkRxQueue {
                                         bytes_written_to_guest,
                                     },
                                 ),
+                                publication,
                             )
                         }
                     }
                     Err(source) => {
-                        if let Err(used_source) =
-                            self.used.publish_used_element(memory, descriptor_head, 0)
-                        {
-                            return Err(VirtioNetworkRxQueueDispatchError::UsedRing {
-                                completed_dispatch: Box::new(dispatch),
-                                descriptor_head,
-                                bytes_written_to_guest: 0,
-                                source: used_source,
-                            });
-                        }
+                        let notification_suppression = match self.notification_suppression(memory) {
+                            Ok(notification_suppression) => notification_suppression,
+                            Err(source) => {
+                                return Err(VirtioNetworkRxQueueDispatchError::AvailableRing {
+                                    completed_dispatch: Box::new(dispatch),
+                                    source,
+                                });
+                            }
+                        };
+                        let publication = match self.used.publish_used_element_with_notification(
+                            memory,
+                            descriptor_head,
+                            0,
+                            notification_suppression,
+                        ) {
+                            Ok(publication) => publication,
+                            Err(used_source) => {
+                                return Err(VirtioNetworkRxQueueDispatchError::UsedRing {
+                                    completed_dispatch: Box::new(dispatch),
+                                    descriptor_head,
+                                    bytes_written_to_guest: 0,
+                                    source: used_source,
+                                });
+                            }
+                        };
                         VirtioNetworkRxQueueDispatchAction::Record(
                             VirtioNetworkRxQueueDispatchOutcome::BufferParseError(source),
+                            publication,
                         )
                     }
                 }
             };
 
             match action {
-                VirtioNetworkRxQueueDispatchAction::Record(outcome) => dispatch.record(outcome),
-                VirtioNetworkRxQueueDispatchAction::Consume(outcome) => {
+                VirtioNetworkRxQueueDispatchAction::Record(outcome, publication) => {
+                    dispatch.record(outcome, publication);
+                }
+                VirtioNetworkRxQueueDispatchAction::Consume(outcome, publication) => {
                     rx_source.consume_packet();
-                    dispatch.record(outcome);
+                    dispatch.record(outcome, publication);
                 }
             }
         }
 
         Ok(dispatch)
+    }
+
+    fn notification_suppression(
+        &self,
+        memory: &GuestMemory,
+    ) -> Result<VirtqueueNotificationSuppression, VirtqueueAvailableRingError> {
+        if self.event_idx_enabled {
+            Ok(VirtqueueNotificationSuppression::EventIdx {
+                used_event: self.available.used_event(memory)?,
+            })
+        } else {
+            Ok(VirtqueueNotificationSuppression::Disabled)
+        }
     }
 }
 
@@ -1436,6 +1517,7 @@ pub struct VirtioNetworkRxQueueDispatch {
     first_buffer_parse_failure: Option<VirtioNetworkRxBufferParseError>,
     first_buffer_too_small: Option<VirtioNetworkRxBufferTooSmall>,
     first_source_failure: Option<VirtioNetworkRxPacketSourceError>,
+    needs_queue_interrupt: bool,
 }
 
 impl VirtioNetworkRxQueueDispatch {
@@ -1457,6 +1539,7 @@ impl VirtioNetworkRxQueueDispatch {
             first_buffer_parse_failure: None,
             first_buffer_too_small: None,
             first_source_failure: None,
+            needs_queue_interrupt: false,
         })
     }
 
@@ -1497,11 +1580,16 @@ impl VirtioNetworkRxQueueDispatch {
     }
 
     pub const fn needs_queue_interrupt(&self) -> bool {
-        self.processed_buffers != 0
+        self.needs_queue_interrupt
     }
 
-    fn record(&mut self, outcome: VirtioNetworkRxQueueDispatchOutcome) {
+    fn record(
+        &mut self,
+        outcome: VirtioNetworkRxQueueDispatchOutcome,
+        publication: VirtqueueUsedRingPublication,
+    ) {
         self.processed_buffers += 1;
+        self.needs_queue_interrupt |= publication.needs_queue_interrupt();
         match outcome {
             VirtioNetworkRxQueueDispatchOutcome::Delivered(delivery) => {
                 self.delivered_packets += 1;
@@ -1539,8 +1627,14 @@ enum VirtioNetworkRxQueueDispatchOutcome {
 
 #[derive(Debug)]
 enum VirtioNetworkRxQueueDispatchAction {
-    Record(VirtioNetworkRxQueueDispatchOutcome),
-    Consume(VirtioNetworkRxQueueDispatchOutcome),
+    Record(
+        VirtioNetworkRxQueueDispatchOutcome,
+        VirtqueueUsedRingPublication,
+    ),
+    Consume(
+        VirtioNetworkRxQueueDispatchOutcome,
+        VirtqueueUsedRingPublication,
+    ),
 }
 
 #[derive(Debug)]
@@ -1850,11 +1944,19 @@ pub struct VirtioNetworkTxQueue {
     queue_state: VirtioMmioQueueState,
     available: VirtqueueAvailableRing,
     used: VirtqueueUsedRing,
+    event_idx_enabled: bool,
 }
 
 impl VirtioNetworkTxQueue {
     pub fn from_mmio_queue_state(
         queue: VirtioMmioQueueState,
+    ) -> Result<Self, VirtioNetworkTxQueueBuildError> {
+        Self::from_mmio_queue_state_with_event_idx(queue, false)
+    }
+
+    fn from_mmio_queue_state_with_event_idx(
+        queue: VirtioMmioQueueState,
+        event_idx_enabled: bool,
     ) -> Result<Self, VirtioNetworkTxQueueBuildError> {
         if !queue.ready() {
             return Err(VirtioNetworkTxQueueBuildError::QueueNotReady);
@@ -1873,6 +1975,7 @@ impl VirtioNetworkTxQueue {
             queue_state: queue,
             available,
             used,
+            event_idx_enabled,
         })
     }
 
@@ -1886,6 +1989,10 @@ impl VirtioNetworkTxQueue {
 
     pub const fn used_ring(&self) -> &VirtqueueUsedRing {
         &self.used
+    }
+
+    pub const fn event_idx_enabled(&self) -> bool {
+        self.event_idx_enabled
     }
 
     pub fn dispatch(
@@ -1921,14 +2028,31 @@ impl VirtioNetworkTxQueue {
                 }
             };
             let frame = VirtioNetworkTxFrame::parse(memory, &chain);
-            if let Err(source) = self.used.publish_used_element(memory, descriptor_head, 0) {
-                return Err(VirtioNetworkTxQueueDispatchError::UsedRing {
-                    completed_dispatch: Box::new(dispatch),
-                    descriptor_head,
-                    bytes_written_to_guest: 0,
-                    source,
-                });
-            }
+            let notification_suppression = match self.notification_suppression(memory) {
+                Ok(notification_suppression) => notification_suppression,
+                Err(source) => {
+                    return Err(VirtioNetworkTxQueueDispatchError::AvailableRing {
+                        completed_dispatch: Box::new(dispatch),
+                        source,
+                    });
+                }
+            };
+            let publication = match self.used.publish_used_element_with_notification(
+                memory,
+                descriptor_head,
+                0,
+                notification_suppression,
+            ) {
+                Ok(publication) => publication,
+                Err(source) => {
+                    return Err(VirtioNetworkTxQueueDispatchError::UsedRing {
+                        completed_dispatch: Box::new(dispatch),
+                        descriptor_head,
+                        bytes_written_to_guest: 0,
+                        source,
+                    });
+                }
+            };
             let outcome = match frame {
                 Ok(frame) => {
                     let sink_error = tx_sink.transmit_frame(memory, &frame).err();
@@ -1936,10 +2060,23 @@ impl VirtioNetworkTxQueue {
                 }
                 Err(source) => VirtioNetworkTxQueueDispatchOutcome::ParseError(source),
             };
-            dispatch.record(outcome);
+            dispatch.record(outcome, publication);
         }
 
         Ok(dispatch)
+    }
+
+    fn notification_suppression(
+        &self,
+        memory: &GuestMemory,
+    ) -> Result<VirtqueueNotificationSuppression, VirtqueueAvailableRingError> {
+        if self.event_idx_enabled {
+            Ok(VirtqueueNotificationSuppression::EventIdx {
+                used_event: self.available.used_event(memory)?,
+            })
+        } else {
+            Ok(VirtqueueNotificationSuppression::Disabled)
+        }
     }
 }
 
@@ -1984,6 +2121,7 @@ pub struct VirtioNetworkTxQueueDispatch {
     frames: Vec<VirtioNetworkTxFrame>,
     first_parse_failure: Option<VirtioNetworkTxFrameParseError>,
     first_sink_failure: Option<VirtioNetworkTxPacketSinkError>,
+    needs_queue_interrupt: bool,
 }
 
 impl VirtioNetworkTxQueueDispatch {
@@ -2004,6 +2142,7 @@ impl VirtioNetworkTxQueueDispatch {
             frames,
             first_parse_failure: None,
             first_sink_failure: None,
+            needs_queue_interrupt: false,
         })
     }
 
@@ -2040,11 +2179,16 @@ impl VirtioNetworkTxQueueDispatch {
     }
 
     pub const fn needs_queue_interrupt(&self) -> bool {
-        self.processed_frames != 0
+        self.needs_queue_interrupt
     }
 
-    fn record(&mut self, outcome: VirtioNetworkTxQueueDispatchOutcome) {
+    fn record(
+        &mut self,
+        outcome: VirtioNetworkTxQueueDispatchOutcome,
+        publication: VirtqueueUsedRingPublication,
+    ) {
         self.processed_frames += 1;
+        self.needs_queue_interrupt |= publication.needs_queue_interrupt();
         match outcome {
             VirtioNetworkTxQueueDispatchOutcome::Ok { frame, sink_error } => {
                 self.successful_frames += 1;
@@ -3408,6 +3552,10 @@ fn active_network_queue_state(
     Ok(queue)
 }
 
+fn virtio_feature_enabled(features: u64, feature: u32) -> bool {
+    features & (1_u64 << feature) != 0
+}
+
 impl FromStr for GuestMacAddress {
     type Err = NetworkInterfaceConfigError;
 
@@ -3854,6 +4002,29 @@ mod tests {
             .expect("status should accept FEATURES_OK");
     }
 
+    fn put_network_handler_in_queue_config_state_with_event_idx(
+        handler: &mut VirtioNetworkMmioHandler,
+    ) {
+        handler
+            .write_register(VirtioMmioRegister::Status, VIRTIO_DEVICE_STATUS_ACKNOWLEDGE)
+            .expect("status should accept ACKNOWLEDGE");
+        handler
+            .write_register(
+                VirtioMmioRegister::Status,
+                VIRTIO_DEVICE_STATUS_ACKNOWLEDGE | VIRTIO_DEVICE_STATUS_DRIVER,
+            )
+            .expect("status should accept DRIVER");
+        handler
+            .write_register(
+                VirtioMmioRegister::DriverFeatures,
+                1_u32 << VIRTIO_RING_FEATURE_EVENT_IDX,
+            )
+            .expect("event index feature should write");
+        handler
+            .write_register(VirtioMmioRegister::Status, QUEUE_CONFIG_STATUS)
+            .expect("status should accept FEATURES_OK");
+    }
+
     fn configure_network_handler_queue(
         handler: &mut VirtioNetworkMmioHandler,
         queue_index: u32,
@@ -3891,6 +4062,24 @@ mod tests {
 
     fn configure_network_handler_queues(handler: &mut VirtioNetworkMmioHandler) {
         put_network_handler_in_queue_config_state(handler);
+        configure_network_handler_queue(
+            handler,
+            VIRTIO_NET_RX_QUEUE_INDEX
+                .try_into()
+                .expect("RX queue index should fit"),
+            TEST_QUEUE_SIZE,
+        );
+        configure_network_handler_queue(
+            handler,
+            VIRTIO_NET_TX_QUEUE_INDEX
+                .try_into()
+                .expect("TX queue index should fit"),
+            TEST_QUEUE_SIZE,
+        );
+    }
+
+    fn configure_network_handler_queues_with_event_idx(handler: &mut VirtioNetworkMmioHandler) {
+        put_network_handler_in_queue_config_state_with_event_idx(handler);
         configure_network_handler_queue(
             handler,
             VIRTIO_NET_RX_QUEUE_INDEX
@@ -4270,6 +4459,12 @@ mod tests {
             .expect("RX available ring entry address should not overflow")
     }
 
+    fn rx_available_ring_used_event_address() -> GuestAddress {
+        TEST_RX_AVAILABLE_RING
+            .checked_add(4 + u64::from(TEST_QUEUE_SIZE) * 2)
+            .expect("RX available ring used_event address should not overflow")
+    }
+
     fn write_rx_available_heads(memory: &mut GuestMemory, heads: &[u16]) {
         for (index, head) in heads.iter().copied().enumerate() {
             write_guest_u16(memory, rx_available_ring_entry_address(index), head);
@@ -4279,6 +4474,10 @@ mod tests {
             rx_available_ring_idx_address(),
             u16::try_from(heads.len()).expect("test RX available head count should fit"),
         );
+    }
+
+    fn write_rx_available_used_event(memory: &mut GuestMemory, used_event: u16) {
+        write_guest_u16(memory, rx_available_ring_used_event_address(), used_event);
     }
 
     fn rx_used_ring_idx_address() -> GuestAddress {
@@ -4331,6 +4530,12 @@ mod tests {
             .expect("available ring entry address should not overflow")
     }
 
+    fn tx_available_ring_used_event_address() -> GuestAddress {
+        TEST_TX_AVAILABLE_RING
+            .checked_add(4 + u64::from(TEST_QUEUE_SIZE) * 2)
+            .expect("TX available ring used_event address should not overflow")
+    }
+
     fn write_tx_available_heads(memory: &mut GuestMemory, heads: &[u16]) {
         for (index, head) in heads.iter().copied().enumerate() {
             write_guest_u16(memory, tx_available_ring_entry_address(index), head);
@@ -4340,6 +4545,10 @@ mod tests {
             tx_available_ring_idx_address(),
             u16::try_from(heads.len()).expect("test available head count should fit"),
         );
+    }
+
+    fn write_tx_available_used_event(memory: &mut GuestMemory, used_event: u16) {
+        write_guest_u16(memory, tx_available_ring_used_event_address(), used_event);
     }
 
     fn tx_used_ring_idx_address() -> GuestAddress {
@@ -7354,6 +7563,162 @@ mod tests {
         assert_eq!(active_tx_queue.available_ring().next_avail(), 0);
         assert_eq!(active_tx_queue.used_ring().next_used(), 0);
         assert_eq!(read_tx_used_index(&memory), 0);
+    }
+
+    #[test]
+    fn virtio_network_notifications_suppress_rx_interrupt_with_event_idx() {
+        let mut memory = tx_frame_memory();
+        let mut handler = network_activation_handler();
+        let mut sink = RecordingTxPacketSink::default();
+        let mut source = RecordingRxPacketSource::with_packets(vec![vec![0x41]]);
+
+        configure_network_handler_queues_with_event_idx(&mut handler);
+        activate_network_handler(&mut handler);
+        write_rx_descriptors(
+            &mut memory,
+            &[TestDescriptor::writable(
+                TEST_RX_BUFFER,
+                u32::try_from(VIRTIO_NET_RX_MIN_BUFFER_SIZE).expect("RX minimum should fit u32"),
+                None,
+            )],
+        );
+        write_rx_available_heads(&mut memory, &[0]);
+        write_rx_available_used_event(&mut memory, 1);
+        handler
+            .write_register(
+                VirtioMmioRegister::QueueNotify,
+                VIRTIO_NET_RX_QUEUE_INDEX
+                    .try_into()
+                    .expect("RX queue index should fit"),
+            )
+            .expect("RX notification should write");
+
+        let notification = handler
+            .dispatch_network_queue_notifications_with_packet_io(
+                &mut memory,
+                &mut sink,
+                &mut source,
+            )
+            .expect("event-index RX notification should dispatch");
+
+        let active_rx_queue = handler
+            .activation_handler()
+            .active_rx_dispatch_queue()
+            .expect("RX dispatch queue should be active");
+        assert!(active_rx_queue.event_idx_enabled());
+        let rx_dispatch = notification
+            .rx_queue_dispatch()
+            .expect("RX dispatch summary should be present");
+        assert_eq!(rx_dispatch.processed_buffers(), 1);
+        assert_eq!(rx_dispatch.delivered_packets(), 1);
+        assert!(!rx_dispatch.needs_queue_interrupt());
+        assert!(!notification.needs_queue_interrupt());
+        assert_eq!(read_interrupt_status(&handler), 0);
+        assert_eq!(read_rx_used_index(&memory), 1);
+        assert_eq!(read_rx_used_element(&memory, 0), (0, rx_used_len(1)));
+        assert_eq!(source.consume_calls, 1);
+        assert_eq!(sink.calls, 0);
+    }
+
+    #[test]
+    fn virtio_network_notifications_suppress_tx_interrupt_with_event_idx() {
+        let mut memory = tx_frame_memory();
+        let mut handler = network_activation_handler();
+        let mut sink = RecordingTxPacketSink::default();
+
+        configure_network_handler_queues_with_event_idx(&mut handler);
+        activate_network_handler(&mut handler);
+        write_tx_header(&mut memory, TEST_TX_HEADER);
+        write_tx_payload(&mut memory, TEST_TX_PAYLOAD, &[0x20]);
+        tx_descriptor_chain(
+            &mut memory,
+            &[
+                TestDescriptor::readable(TEST_TX_HEADER, VIRTIO_NET_TX_HEADER_SIZE, Some(1)),
+                TestDescriptor::readable(TEST_TX_PAYLOAD, 1, None),
+            ],
+        );
+        write_tx_available_heads(&mut memory, &[0]);
+        write_tx_available_used_event(&mut memory, 1);
+        handler
+            .write_register(
+                VirtioMmioRegister::QueueNotify,
+                VIRTIO_NET_TX_QUEUE_INDEX
+                    .try_into()
+                    .expect("TX queue index should fit"),
+            )
+            .expect("TX notification should write");
+
+        let notification = handler
+            .dispatch_network_queue_notifications_with_tx_sink(&mut memory, &mut sink)
+            .expect("event-index TX notification should dispatch");
+
+        let active_tx_queue = handler
+            .activation_handler()
+            .active_tx_dispatch_queue()
+            .expect("TX dispatch queue should be active");
+        assert!(active_tx_queue.event_idx_enabled());
+        let tx_dispatch = notification
+            .tx_queue_dispatch()
+            .expect("TX dispatch summary should be present");
+        assert_eq!(tx_dispatch.processed_frames(), 1);
+        assert_eq!(tx_dispatch.successful_frames(), 1);
+        assert!(!tx_dispatch.needs_queue_interrupt());
+        assert!(!notification.needs_queue_interrupt());
+        assert_eq!(read_interrupt_status(&handler), 0);
+        assert_eq!(read_tx_used_index(&memory), 1);
+        assert_eq!(read_tx_used_element(&memory, 0), (0, 0));
+        assert_eq!(sink.calls, 1);
+    }
+
+    #[test]
+    fn virtio_network_notifications_preserve_suppressed_partial_tx_error_with_event_idx() {
+        let mut memory = tx_frame_memory();
+        let mut handler = network_activation_handler();
+        let mut sink = RecordingTxPacketSink::default();
+
+        configure_network_handler_queues_with_event_idx(&mut handler);
+        activate_network_handler(&mut handler);
+        write_tx_header(&mut memory, TEST_TX_HEADER);
+        write_tx_payload(&mut memory, TEST_TX_PAYLOAD, &[0x30]);
+        tx_descriptor_chain(
+            &mut memory,
+            &[
+                TestDescriptor::readable(TEST_TX_HEADER, VIRTIO_NET_TX_HEADER_SIZE, Some(1)),
+                TestDescriptor::readable(TEST_TX_PAYLOAD, 1, None),
+            ],
+        );
+        write_tx_available_heads(&mut memory, &[0, TEST_QUEUE_SIZE]);
+        write_tx_available_used_event(&mut memory, 1);
+        handler
+            .write_register(
+                VirtioMmioRegister::QueueNotify,
+                VIRTIO_NET_TX_QUEUE_INDEX
+                    .try_into()
+                    .expect("TX queue index should fit"),
+            )
+            .expect("TX notification should write");
+
+        let error = handler
+            .dispatch_network_queue_notifications_with_tx_sink(&mut memory, &mut sink)
+            .expect_err("invalid second TX descriptor head should fail");
+
+        assert!(matches!(
+            error,
+            VirtioNetworkDeviceNotificationError::TxQueueDispatch {
+                source: VirtioNetworkTxQueueDispatchError::AvailableRing { .. },
+                ..
+            }
+        ));
+        let completed = error
+            .completed_tx_dispatch()
+            .expect("completed TX dispatch metadata should be preserved");
+        assert_eq!(completed.processed_frames(), 1);
+        assert_eq!(completed.successful_frames(), 1);
+        assert!(!completed.needs_queue_interrupt());
+        assert_eq!(read_interrupt_status(&handler), 0);
+        assert_eq!(read_tx_used_index(&memory), 1);
+        assert_eq!(read_tx_used_element(&memory, 0), (0, 0));
+        assert_eq!(sink.calls, 1);
     }
 
     #[test]

--- a/crates/runtime/src/virtio_queue.rs
+++ b/crates/runtime/src/virtio_queue.rs
@@ -235,6 +235,19 @@ impl VirtqueueAvailableRing {
         self.next_avail
     }
 
+    pub fn used_event(&self, memory: &GuestMemory) -> Result<u16, VirtqueueAvailableRingError> {
+        validate_available_ring_range(memory, self.available_ring, self.queue_size)?;
+
+        let used_event_address =
+            available_ring_used_event_address(self.available_ring, self.queue_size)?;
+        read_available_ring_u16(
+            memory,
+            self.available_ring,
+            self.queue_size,
+            used_event_address,
+        )
+    }
+
     pub fn pop_descriptor_chain(
         &mut self,
         memory: &GuestMemory,
@@ -289,6 +302,31 @@ impl VirtqueueAvailableRing {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VirtqueueNotificationSuppression {
+    Disabled,
+    EventIdx { used_event: u16 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VirtqueueUsedRingPublication {
+    needs_queue_interrupt: bool,
+}
+
+impl VirtqueueUsedRingPublication {
+    pub const fn needs_queue_interrupt(self) -> bool {
+        self.needs_queue_interrupt
+    }
+}
+
+pub const fn virtqueue_event_idx_needs_notification(
+    old_used: u16,
+    new_used: u16,
+    used_event: u16,
+) -> bool {
+    new_used.wrapping_sub(used_event).wrapping_sub(1) < new_used.wrapping_sub(old_used)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VirtqueueUsedRing {
     used_ring: GuestAddress,
@@ -335,9 +373,26 @@ impl VirtqueueUsedRing {
         descriptor_head: u16,
         len: u32,
     ) -> Result<(), VirtqueueUsedRingError> {
+        self.publish_used_element_with_notification(
+            memory,
+            descriptor_head,
+            len,
+            VirtqueueNotificationSuppression::Disabled,
+        )
+        .map(|_| ())
+    }
+
+    pub fn publish_used_element_with_notification(
+        &mut self,
+        memory: &mut GuestMemory,
+        descriptor_head: u16,
+        len: u32,
+        notification_suppression: VirtqueueNotificationSuppression,
+    ) -> Result<VirtqueueUsedRingPublication, VirtqueueUsedRingError> {
         validate_used_ring_descriptor_head(descriptor_head, self.queue_size)?;
         validate_used_ring_range(memory, self.used_ring, self.queue_size)?;
 
+        let old_used = self.next_used;
         let ring_index = self.next_used % self.queue_size;
         let entry_address = used_ring_entry_address(self.used_ring, self.queue_size, ring_index)?;
         let next_used = self.next_used.wrapping_add(1);
@@ -370,7 +425,14 @@ impl VirtqueueUsedRing {
 
         self.next_used = next_used;
 
-        Ok(())
+        Ok(VirtqueueUsedRingPublication {
+            needs_queue_interrupt: match notification_suppression {
+                VirtqueueNotificationSuppression::Disabled => true,
+                VirtqueueNotificationSuppression::EventIdx { used_event } => {
+                    virtqueue_event_idx_needs_notification(old_used, next_used, used_event)
+                }
+            },
+        })
     }
 }
 
@@ -1000,6 +1062,21 @@ fn available_ring_entry_address(
     available_ring_offset_address(available_ring, queue_size, entry_offset)
 }
 
+fn available_ring_used_event_address(
+    available_ring: GuestAddress,
+    queue_size: u16,
+) -> Result<GuestAddress, VirtqueueAvailableRingError> {
+    let used_event_offset = u64::from(queue_size)
+        .checked_mul(VIRTQUEUE_AVAILABLE_RING_ENTRY_SIZE_U64)
+        .and_then(|offset| offset.checked_add(VIRTQUEUE_AVAILABLE_RING_RING_OFFSET))
+        .ok_or(VirtqueueAvailableRingError::AvailableRingRangeOverflow {
+            available_ring,
+            queue_size,
+        })?;
+
+    available_ring_offset_address(available_ring, queue_size, used_event_offset)
+}
+
 fn used_ring_offset_address(
     used_ring: GuestAddress,
     queue_size: u16,
@@ -1180,7 +1257,8 @@ mod tests {
         VIRTQUEUE_USED_RING_ALIGNMENT, VIRTQUEUE_USED_RING_ELEMENT_SIZE_U64,
         VIRTQUEUE_USED_RING_IDX_OFFSET, VIRTQUEUE_USED_RING_RING_OFFSET, VirtqueueAvailableRing,
         VirtqueueAvailableRingError, VirtqueueDescriptorChainError, VirtqueueDescriptorFlags,
-        VirtqueueUsedRing, VirtqueueUsedRingError, read_descriptor_chain,
+        VirtqueueNotificationSuppression, VirtqueueUsedRing, VirtqueueUsedRingError,
+        read_descriptor_chain, virtqueue_event_idx_needs_notification,
     };
     use crate::memory::{
         GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryLayout, GuestMemoryRange,
@@ -1287,6 +1365,31 @@ mod tests {
         write_u16(memory, entry, head_index);
     }
 
+    fn available_ring_used_event_address(
+        available_ring: GuestAddress,
+        queue_size: u16,
+    ) -> GuestAddress {
+        available_ring
+            .checked_add(
+                VIRTQUEUE_AVAILABLE_RING_RING_OFFSET
+                    + u64::from(queue_size) * VIRTQUEUE_AVAILABLE_RING_ENTRY_SIZE_U64,
+            )
+            .expect("available ring used_event address should not overflow")
+    }
+
+    fn write_available_used_event(
+        memory: &mut GuestMemory,
+        available_ring: GuestAddress,
+        queue_size: u16,
+        value: u16,
+    ) {
+        write_u16(
+            memory,
+            available_ring_used_event_address(available_ring, queue_size),
+            value,
+        );
+    }
+
     fn used_ring_entry_address(used_ring: GuestAddress, ring_index: u16) -> GuestAddress {
         used_ring
             .checked_add(
@@ -1339,6 +1442,84 @@ mod tests {
         assert_eq!(queue.used_ring(), USED);
         assert_eq!(queue.queue_size(), 8);
         assert_eq!(queue.next_used(), 3);
+    }
+
+    #[test]
+    fn reads_available_ring_used_event_trailer() {
+        let mut memory = guest_memory(0x4000);
+        write_available_used_event(&mut memory, AVAIL, 8, 3);
+        let queue =
+            VirtqueueAvailableRing::new(TABLE, AVAIL, 8).expect("available ring should be valid");
+
+        let used_event = queue
+            .used_event(&memory)
+            .expect("used_event trailer should read");
+
+        assert_eq!(used_event, 3);
+    }
+
+    #[test]
+    fn rejects_unmapped_available_ring_used_event_trailer() {
+        let memory = guest_memory(0x4000);
+        let available_ring = GuestAddress::new(0x3fec);
+        let queue = VirtqueueAvailableRing::new(TABLE, available_ring, 8)
+            .expect("available ring should be valid");
+
+        let err = queue
+            .used_event(&memory)
+            .expect_err("partially unmapped used_event trailer should fail");
+
+        assert!(matches!(
+            err,
+            VirtqueueAvailableRingError::AvailableRingAccess { .. }
+        ));
+    }
+
+    #[test]
+    fn event_idx_notification_formula_handles_boundaries() {
+        assert!(!virtqueue_event_idx_needs_notification(0, 0, 0));
+        assert!(virtqueue_event_idx_needs_notification(0, 1, 0));
+        assert!(!virtqueue_event_idx_needs_notification(0, 1, 1));
+        assert!(!virtqueue_event_idx_needs_notification(10, 11, 9));
+        assert!(virtqueue_event_idx_needs_notification(10, 11, 10));
+        assert!(virtqueue_event_idx_needs_notification(
+            u16::MAX,
+            0,
+            u16::MAX
+        ));
+        assert!(!virtqueue_event_idx_needs_notification(u16::MAX, 0, 0));
+    }
+
+    #[test]
+    fn publish_used_element_reports_event_idx_interrupt_need() {
+        let mut memory = guest_memory(0x4000);
+        let mut queue =
+            VirtqueueUsedRing::new(USED, 8).expect("used ring should be valid for publishing");
+
+        let first = queue
+            .publish_used_element_with_notification(
+                &mut memory,
+                0,
+                0,
+                VirtqueueNotificationSuppression::EventIdx { used_event: 1 },
+            )
+            .expect("first used element should publish");
+        let second = queue
+            .publish_used_element_with_notification(
+                &mut memory,
+                1,
+                0,
+                VirtqueueNotificationSuppression::EventIdx { used_event: 1 },
+            )
+            .expect("second used element should publish");
+
+        assert!(!first.needs_queue_interrupt());
+        assert!(second.needs_queue_interrupt());
+        assert_eq!(queue.next_used(), 2);
+        assert_eq!(
+            read_u16_field(&memory, USED.checked_add(2).expect("idx should fit")),
+            2
+        );
     }
 
     #[test]

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -27,7 +27,8 @@ use crate::virtio_mmio::{
 };
 use crate::virtio_queue::{
     VirtqueueAvailableRing, VirtqueueAvailableRingError, VirtqueueDescriptor,
-    VirtqueueDescriptorChain, VirtqueueUsedRing, VirtqueueUsedRingError,
+    VirtqueueDescriptorChain, VirtqueueNotificationSuppression, VirtqueueUsedRing,
+    VirtqueueUsedRingError, VirtqueueUsedRingPublication,
 };
 
 pub const MIN_GUEST_CID: u32 = 3;
@@ -3776,6 +3777,7 @@ pub struct VirtioVsockRxQueueDispatch {
     deliveries: Vec<VirtioVsockRxPacketDelivery>,
     first_buffer_parse_failure: Option<VirtioVsockRxBufferParseError>,
     first_buffer_too_small: Option<VirtioVsockRxBufferTooSmall>,
+    needs_queue_interrupt: bool,
 }
 
 impl VirtioVsockRxQueueDispatch {
@@ -3793,6 +3795,7 @@ impl VirtioVsockRxQueueDispatch {
             deliveries: Vec::new(),
             first_buffer_parse_failure: None,
             first_buffer_too_small: None,
+            needs_queue_interrupt: false,
         }
     }
 
@@ -3819,6 +3822,7 @@ impl VirtioVsockRxQueueDispatch {
             deliveries,
             first_buffer_parse_failure: None,
             first_buffer_too_small: None,
+            needs_queue_interrupt: false,
         })
     }
 
@@ -3881,11 +3885,16 @@ impl VirtioVsockRxQueueDispatch {
     }
 
     pub const fn needs_queue_interrupt(&self) -> bool {
-        self.processed_buffers != 0
+        self.needs_queue_interrupt
     }
 
-    fn record(&mut self, outcome: VirtioVsockRxQueueDispatchOutcome) {
+    fn record(
+        &mut self,
+        outcome: VirtioVsockRxQueueDispatchOutcome,
+        publication: VirtqueueUsedRingPublication,
+    ) {
         self.processed_buffers += 1;
+        self.needs_queue_interrupt |= publication.needs_queue_interrupt();
         match outcome {
             VirtioVsockRxQueueDispatchOutcome::Delivered(delivery) => {
                 match delivery.packet_kind() {
@@ -4167,11 +4176,19 @@ pub struct VirtioVsockRxQueue {
     queue_state: VirtioMmioQueueState,
     available: VirtqueueAvailableRing,
     used: VirtqueueUsedRing,
+    event_idx_enabled: bool,
 }
 
 impl VirtioVsockRxQueue {
     pub fn from_mmio_queue_state(
         queue: VirtioMmioQueueState,
+    ) -> Result<Self, VirtioVsockQueueBuildError> {
+        Self::from_mmio_queue_state_with_event_idx(queue, false)
+    }
+
+    fn from_mmio_queue_state_with_event_idx(
+        queue: VirtioMmioQueueState,
+        event_idx_enabled: bool,
     ) -> Result<Self, VirtioVsockQueueBuildError> {
         validate_active_vsock_queue(queue)?;
         let available = VirtqueueAvailableRing::new(
@@ -4187,6 +4204,7 @@ impl VirtioVsockRxQueue {
             queue_state: queue,
             available,
             used,
+            event_idx_enabled,
         })
     }
 
@@ -4200,6 +4218,10 @@ impl VirtioVsockRxQueue {
 
     pub const fn used_ring(&self) -> &VirtqueueUsedRing {
         &self.used
+    }
+
+    pub const fn event_idx_enabled(&self) -> bool {
+        self.event_idx_enabled
     }
 
     pub fn dispatch_host_request(
@@ -4255,22 +4277,41 @@ impl VirtioVsockRxQueue {
             Ok(buffer) => {
                 let required_len = packet.required_len();
                 if required_len > buffer.len() {
-                    if let Err(source) = self.used.publish_used_element(memory, descriptor_head, 0)
-                    {
-                        return Err(VirtioVsockRxQueueDispatchError::UsedRing {
-                            completed_dispatch: Box::new(dispatch),
-                            descriptor_head,
-                            bytes_written_to_guest: 0,
-                            source,
-                        });
-                    }
-                    dispatch.record(VirtioVsockRxQueueDispatchOutcome::BufferTooSmall(
-                        VirtioVsockRxBufferTooSmall {
-                            descriptor_head,
-                            len: buffer.len(),
-                            required_len,
-                        },
-                    ));
+                    let notification_suppression = match self.notification_suppression(memory) {
+                        Ok(notification_suppression) => notification_suppression,
+                        Err(source) => {
+                            return Err(VirtioVsockRxQueueDispatchError::AvailableRing {
+                                completed_dispatch: Box::new(dispatch),
+                                source,
+                            });
+                        }
+                    };
+                    let publication = match self.used.publish_used_element_with_notification(
+                        memory,
+                        descriptor_head,
+                        0,
+                        notification_suppression,
+                    ) {
+                        Ok(publication) => publication,
+                        Err(source) => {
+                            return Err(VirtioVsockRxQueueDispatchError::UsedRing {
+                                completed_dispatch: Box::new(dispatch),
+                                descriptor_head,
+                                bytes_written_to_guest: 0,
+                                source,
+                            });
+                        }
+                    };
+                    dispatch.record(
+                        VirtioVsockRxQueueDispatchOutcome::BufferTooSmall(
+                            VirtioVsockRxBufferTooSmall {
+                                descriptor_head,
+                                len: buffer.len(),
+                                required_len,
+                            },
+                        ),
+                        publication,
+                    );
                     return Ok(dispatch);
                 }
 
@@ -4282,41 +4323,88 @@ impl VirtioVsockRxQueue {
                     });
                 }
                 let bytes_written_to_guest = packet.bytes_written_to_guest();
-                if let Err(source) =
-                    self.used
-                        .publish_used_element(memory, descriptor_head, bytes_written_to_guest)
-                {
-                    return Err(VirtioVsockRxQueueDispatchError::UsedRing {
-                        completed_dispatch: Box::new(dispatch),
-                        descriptor_head,
-                        bytes_written_to_guest,
-                        source,
-                    });
-                }
-                dispatch.record(VirtioVsockRxQueueDispatchOutcome::Delivered(
-                    VirtioVsockRxPacketDelivery {
+                let notification_suppression = match self.notification_suppression(memory) {
+                    Ok(notification_suppression) => notification_suppression,
+                    Err(source) => {
+                        return Err(VirtioVsockRxQueueDispatchError::AvailableRing {
+                            completed_dispatch: Box::new(dispatch),
+                            source,
+                        });
+                    }
+                };
+                let publication = match self.used.publish_used_element_with_notification(
+                    memory,
+                    descriptor_head,
+                    bytes_written_to_guest,
+                    notification_suppression,
+                ) {
+                    Ok(publication) => publication,
+                    Err(source) => {
+                        return Err(VirtioVsockRxQueueDispatchError::UsedRing {
+                            completed_dispatch: Box::new(dispatch),
+                            descriptor_head,
+                            bytes_written_to_guest,
+                            source,
+                        });
+                    }
+                };
+                dispatch.record(
+                    VirtioVsockRxQueueDispatchOutcome::Delivered(VirtioVsockRxPacketDelivery {
                         packet_kind: packet.packet_kind(),
                         descriptor_head,
                         bytes_written_to_guest,
                         payload_bytes_written_to_guest: packet.payload_bytes_written_to_guest(),
-                    },
-                ));
+                    }),
+                    publication,
+                );
             }
             Err(source) => {
-                if let Err(used_source) = self.used.publish_used_element(memory, descriptor_head, 0)
-                {
-                    return Err(VirtioVsockRxQueueDispatchError::UsedRing {
-                        completed_dispatch: Box::new(dispatch),
-                        descriptor_head,
-                        bytes_written_to_guest: 0,
-                        source: used_source,
-                    });
-                }
-                dispatch.record(VirtioVsockRxQueueDispatchOutcome::BufferParseError(source));
+                let notification_suppression = match self.notification_suppression(memory) {
+                    Ok(notification_suppression) => notification_suppression,
+                    Err(source) => {
+                        return Err(VirtioVsockRxQueueDispatchError::AvailableRing {
+                            completed_dispatch: Box::new(dispatch),
+                            source,
+                        });
+                    }
+                };
+                let publication = match self.used.publish_used_element_with_notification(
+                    memory,
+                    descriptor_head,
+                    0,
+                    notification_suppression,
+                ) {
+                    Ok(publication) => publication,
+                    Err(used_source) => {
+                        return Err(VirtioVsockRxQueueDispatchError::UsedRing {
+                            completed_dispatch: Box::new(dispatch),
+                            descriptor_head,
+                            bytes_written_to_guest: 0,
+                            source: used_source,
+                        });
+                    }
+                };
+                dispatch.record(
+                    VirtioVsockRxQueueDispatchOutcome::BufferParseError(source),
+                    publication,
+                );
             }
         }
 
         Ok(dispatch)
+    }
+
+    fn notification_suppression(
+        &self,
+        memory: &GuestMemory,
+    ) -> Result<VirtqueueNotificationSuppression, VirtqueueAvailableRingError> {
+        if self.event_idx_enabled {
+            Ok(VirtqueueNotificationSuppression::EventIdx {
+                used_event: self.available.used_event(memory)?,
+            })
+        } else {
+            Ok(VirtqueueNotificationSuppression::Disabled)
+        }
     }
 }
 
@@ -4483,11 +4571,19 @@ pub struct VirtioVsockTxQueue {
     queue_state: VirtioMmioQueueState,
     available: VirtqueueAvailableRing,
     used: VirtqueueUsedRing,
+    event_idx_enabled: bool,
 }
 
 impl VirtioVsockTxQueue {
     pub fn from_mmio_queue_state(
         queue: VirtioMmioQueueState,
+    ) -> Result<Self, VirtioVsockQueueBuildError> {
+        Self::from_mmio_queue_state_with_event_idx(queue, false)
+    }
+
+    fn from_mmio_queue_state_with_event_idx(
+        queue: VirtioMmioQueueState,
+        event_idx_enabled: bool,
     ) -> Result<Self, VirtioVsockQueueBuildError> {
         validate_active_vsock_queue(queue)?;
         let available = VirtqueueAvailableRing::new(
@@ -4503,6 +4599,7 @@ impl VirtioVsockTxQueue {
             queue_state: queue,
             available,
             used,
+            event_idx_enabled,
         })
     }
 
@@ -4516,6 +4613,10 @@ impl VirtioVsockTxQueue {
 
     pub const fn used_ring(&self) -> &VirtqueueUsedRing {
         &self.used
+    }
+
+    pub const fn event_idx_enabled(&self) -> bool {
+        self.event_idx_enabled
     }
 
     pub fn dispatch(
@@ -4542,24 +4643,59 @@ impl VirtioVsockTxQueue {
             };
 
             let packet = VirtioVsockTxPacket::parse(memory, &chain);
-            if let Err(source) = self.used.publish_used_element(memory, descriptor_head, 0) {
-                return Err(VirtioVsockTxQueueDispatchError::UsedRing {
-                    completed_dispatch: Box::new(dispatch),
-                    descriptor_head,
-                    bytes_written_to_guest: 0,
-                    source,
-                });
-            }
+            let notification_suppression = match self.notification_suppression(memory) {
+                Ok(notification_suppression) => notification_suppression,
+                Err(source) => {
+                    return Err(VirtioVsockTxQueueDispatchError::AvailableRing {
+                        completed_dispatch: Box::new(dispatch),
+                        source,
+                    });
+                }
+            };
+            let publication = match self.used.publish_used_element_with_notification(
+                memory,
+                descriptor_head,
+                0,
+                notification_suppression,
+            ) {
+                Ok(publication) => publication,
+                Err(source) => {
+                    return Err(VirtioVsockTxQueueDispatchError::UsedRing {
+                        completed_dispatch: Box::new(dispatch),
+                        descriptor_head,
+                        bytes_written_to_guest: 0,
+                        source,
+                    });
+                }
+            };
 
             match packet {
-                Ok(packet) => dispatch.record(VirtioVsockTxQueueDispatchOutcome::Ok(packet)),
+                Ok(packet) => {
+                    dispatch.record(VirtioVsockTxQueueDispatchOutcome::Ok(packet), publication);
+                }
                 Err(source) => {
-                    dispatch.record(VirtioVsockTxQueueDispatchOutcome::ParseError(source));
+                    dispatch.record(
+                        VirtioVsockTxQueueDispatchOutcome::ParseError(source),
+                        publication,
+                    );
                 }
             }
         }
 
         Ok(dispatch)
+    }
+
+    fn notification_suppression(
+        &self,
+        memory: &GuestMemory,
+    ) -> Result<VirtqueueNotificationSuppression, VirtqueueAvailableRingError> {
+        if self.event_idx_enabled {
+            Ok(VirtqueueNotificationSuppression::EventIdx {
+                used_event: self.available.used_event(memory)?,
+            })
+        } else {
+            Ok(VirtqueueNotificationSuppression::Disabled)
+        }
     }
 }
 
@@ -4570,6 +4706,7 @@ pub struct VirtioVsockTxQueueDispatch {
     parse_failures: usize,
     packets: Vec<VirtioVsockTxPacket>,
     first_parse_failure: Option<VirtioVsockTxPacketParseError>,
+    needs_queue_interrupt: bool,
 }
 
 impl VirtioVsockTxQueueDispatch {
@@ -4587,6 +4724,7 @@ impl VirtioVsockTxQueueDispatch {
             parse_failures: 0,
             packets,
             first_parse_failure: None,
+            needs_queue_interrupt: false,
         })
     }
 
@@ -4611,11 +4749,16 @@ impl VirtioVsockTxQueueDispatch {
     }
 
     pub const fn needs_queue_interrupt(&self) -> bool {
-        self.processed_packets != 0
+        self.needs_queue_interrupt
     }
 
-    fn record(&mut self, outcome: VirtioVsockTxQueueDispatchOutcome) {
+    fn record(
+        &mut self,
+        outcome: VirtioVsockTxQueueDispatchOutcome,
+        publication: VirtqueueUsedRingPublication,
+    ) {
         self.processed_packets += 1;
+        self.needs_queue_interrupt |= publication.needs_queue_interrupt();
         match outcome {
             VirtioVsockTxQueueDispatchOutcome::Ok(packet) => {
                 self.successful_packets += 1;
@@ -5067,23 +5210,23 @@ impl VirtioVsockDevice {
             });
         }
 
+        let event_idx_enabled =
+            virtio_feature_enabled(activation.driver_features(), VIRTIO_RING_FEATURE_EVENT_IDX);
         let active_rx_queue = active_vsock_queue_state(activation, VIRTIO_VSOCK_RX_QUEUE_INDEX_U32)
             .and_then(|queue| {
-                VirtioVsockRxQueue::from_mmio_queue_state(queue).map_err(|source| {
-                    VirtioVsockDeviceActivationError::RxQueueBuild {
+                VirtioVsockRxQueue::from_mmio_queue_state_with_event_idx(queue, event_idx_enabled)
+                    .map_err(|source| VirtioVsockDeviceActivationError::RxQueueBuild {
                         queue_index: VIRTIO_VSOCK_RX_QUEUE_INDEX_U32,
                         source,
-                    }
-                })
+                    })
             })?;
         let active_tx_queue = active_vsock_queue_state(activation, VIRTIO_VSOCK_TX_QUEUE_INDEX_U32)
             .and_then(|queue| {
-                VirtioVsockTxQueue::from_mmio_queue_state(queue).map_err(|source| {
-                    VirtioVsockDeviceActivationError::TxQueueBuild {
+                VirtioVsockTxQueue::from_mmio_queue_state_with_event_idx(queue, event_idx_enabled)
+                    .map_err(|source| VirtioVsockDeviceActivationError::TxQueueBuild {
                         queue_index: VIRTIO_VSOCK_TX_QUEUE_INDEX_U32,
                         source,
-                    }
-                })
+                    })
             })?;
         let active_event_queue =
             active_vsock_queue_state(activation, VIRTIO_VSOCK_EVENT_QUEUE_INDEX_U32).and_then(
@@ -6620,6 +6763,10 @@ fn active_vsock_queue_state(
     })
 }
 
+fn virtio_feature_enabled(features: u64, feature: u32) -> bool {
+    features & (1_u64 << feature) != 0
+}
+
 impl VirtioMmioDeviceActivationHandler for VirtioVsockDevice {
     fn activate(
         &mut self,
@@ -7830,6 +7977,27 @@ mod tests {
             .expect("status should accept FEATURES_OK");
     }
 
+    fn advance_handler_to_features_ok_with_event_idx(handler: &mut VirtioVsockMmioHandler) {
+        handler
+            .write_register(VirtioMmioRegister::Status, VIRTIO_DEVICE_STATUS_ACKNOWLEDGE)
+            .expect("status should accept ACKNOWLEDGE");
+        handler
+            .write_register(
+                VirtioMmioRegister::Status,
+                VIRTIO_DEVICE_STATUS_ACKNOWLEDGE | VIRTIO_DEVICE_STATUS_DRIVER,
+            )
+            .expect("status should accept DRIVER");
+        handler
+            .write_register(
+                VirtioMmioRegister::DriverFeatures,
+                1_u32 << VIRTIO_RING_FEATURE_EVENT_IDX,
+            )
+            .expect("event index feature should write");
+        handler
+            .write_register(VirtioMmioRegister::Status, QUEUE_CONFIG_STATUS)
+            .expect("status should accept FEATURES_OK");
+    }
+
     fn guest_address_low(address: GuestAddress) -> u32 {
         u32::try_from(address.raw_value()).expect("test guest address should fit in low half")
     }
@@ -7878,6 +8046,14 @@ mod tests {
 
     fn activate_vsock_handler(handler: &mut VirtioVsockMmioHandler) {
         advance_handler_to_features_ok(handler);
+        configure_vsock_queues(handler);
+        handler
+            .write_register(VirtioMmioRegister::Status, DRIVER_OK_STATUS)
+            .expect("DRIVER_OK should activate vsock device");
+    }
+
+    fn activate_vsock_handler_with_event_idx(handler: &mut VirtioVsockMmioHandler) {
+        advance_handler_to_features_ok_with_event_idx(handler);
         configure_vsock_queues(handler);
         handler
             .write_register(VirtioMmioRegister::Status, DRIVER_OK_STATUS)
@@ -8102,6 +8278,12 @@ mod tests {
             .expect("vsock TX available entry should write");
     }
 
+    fn vsock_tx_available_used_event_address() -> GuestAddress {
+        TEST_VSOCK_TX_AVAILABLE_RING
+            .checked_add(4 + u64::from(TEST_VSOCK_QUEUE_SIZE) * 2)
+            .expect("vsock TX available used_event address should not overflow")
+    }
+
     fn write_vsock_tx_available_heads(memory: &mut GuestMemory, heads: &[u16]) {
         for (slot, head) in heads.iter().copied().enumerate() {
             write_vsock_tx_available_entry(memory, slot, head);
@@ -8110,6 +8292,10 @@ mod tests {
             memory,
             u16::try_from(heads.len()).expect("available head count should fit"),
         );
+    }
+
+    fn write_vsock_tx_available_used_event(memory: &mut GuestMemory, used_event: u16) {
+        write_guest_u16(memory, vsock_tx_available_used_event_address(), used_event);
     }
 
     fn append_vsock_tx_available_head(
@@ -8221,6 +8407,12 @@ mod tests {
         bytes
     }
 
+    fn write_guest_u16(memory: &mut GuestMemory, address: GuestAddress, value: u16) {
+        memory
+            .write_slice(&value.to_le_bytes(), address)
+            .expect("test guest u16 should write");
+    }
+
     fn read_guest_u16(memory: &GuestMemory, address: GuestAddress) -> u16 {
         let mut bytes = [0; 2];
         memory
@@ -8255,6 +8447,17 @@ mod tests {
     }
 
     fn vsock_tx_queue_with_used_ring(device_ring: GuestAddress) -> VirtioVsockTxQueue {
+        vsock_tx_queue_with_used_ring_and_event_idx(device_ring, false)
+    }
+
+    fn vsock_tx_queue_with_event_idx() -> VirtioVsockTxQueue {
+        vsock_tx_queue_with_used_ring_and_event_idx(TEST_VSOCK_TX_USED_RING, true)
+    }
+
+    fn vsock_tx_queue_with_used_ring_and_event_idx(
+        device_ring: GuestAddress,
+        event_idx_enabled: bool,
+    ) -> VirtioVsockTxQueue {
         let mut queues = VirtioMmioQueueRegisters::new(&VIRTIO_VSOCK_QUEUE_SIZES)
             .expect("queue table should build");
         let queue_index =
@@ -8300,7 +8503,8 @@ mod tests {
         let queue_state = *queues
             .queue(queue_index)
             .expect("TX queue state should be configured");
-        VirtioVsockTxQueue::from_mmio_queue_state(queue_state).expect("TX queue should build")
+        VirtioVsockTxQueue::from_mmio_queue_state_with_event_idx(queue_state, event_idx_enabled)
+            .expect("TX queue should build")
     }
 
     fn write_vsock_rx_descriptor(memory: &mut GuestMemory, index: u16, descriptor: TestDescriptor) {
@@ -8343,6 +8547,12 @@ mod tests {
             .expect("vsock RX available entry should write");
     }
 
+    fn vsock_rx_available_used_event_address() -> GuestAddress {
+        TEST_VSOCK_RX_AVAILABLE_RING
+            .checked_add(4 + u64::from(TEST_VSOCK_QUEUE_SIZE) * 2)
+            .expect("vsock RX available used_event address should not overflow")
+    }
+
     fn write_vsock_rx_available_heads(memory: &mut GuestMemory, heads: &[u16]) {
         for (slot, head) in heads.iter().copied().enumerate() {
             write_vsock_rx_available_entry(memory, slot, head);
@@ -8351,6 +8561,10 @@ mod tests {
             memory,
             u16::try_from(heads.len()).expect("available head count should fit"),
         );
+    }
+
+    fn write_vsock_rx_available_used_event(memory: &mut GuestMemory, used_event: u16) {
+        write_guest_u16(memory, vsock_rx_available_used_event_address(), used_event);
     }
 
     fn append_vsock_rx_available_head(
@@ -8407,6 +8621,17 @@ mod tests {
     }
 
     fn vsock_rx_queue_with_used_ring(device_ring: GuestAddress) -> VirtioVsockRxQueue {
+        vsock_rx_queue_with_used_ring_and_event_idx(device_ring, false)
+    }
+
+    fn vsock_rx_queue_with_event_idx() -> VirtioVsockRxQueue {
+        vsock_rx_queue_with_used_ring_and_event_idx(TEST_VSOCK_RX_USED_RING, true)
+    }
+
+    fn vsock_rx_queue_with_used_ring_and_event_idx(
+        device_ring: GuestAddress,
+        event_idx_enabled: bool,
+    ) -> VirtioVsockRxQueue {
         let mut queues = VirtioMmioQueueRegisters::new(&VIRTIO_VSOCK_QUEUE_SIZES)
             .expect("queue table should build");
         let queue_index =
@@ -8452,7 +8677,8 @@ mod tests {
         let queue_state = *queues
             .queue(queue_index)
             .expect("RX queue state should be configured");
-        VirtioVsockRxQueue::from_mmio_queue_state(queue_state).expect("RX queue should build")
+        VirtioVsockRxQueue::from_mmio_queue_state_with_event_idx(queue_state, event_idx_enabled)
+            .expect("RX queue should build")
     }
 
     #[test]
@@ -10668,6 +10894,43 @@ mod tests {
     }
 
     #[test]
+    fn virtio_vsock_rx_queue_dispatch_suppresses_interrupt_with_event_idx() {
+        let mut memory = vsock_tx_memory();
+        let mut queue = vsock_rx_queue_with_event_idx();
+        let mut table = VsockHostConnectionTable::new();
+        let (key, _client) =
+            insert_accepted_host_connection_for_test(&mut table, "rx-event-idx", 4000);
+        write_vsock_rx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::writable(
+                TEST_VSOCK_RX_BUFFER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            ),
+        );
+        write_vsock_rx_available_heads(&mut memory, &[0]);
+        write_vsock_rx_available_used_event(&mut memory, 1);
+
+        let dispatch = queue
+            .dispatch_host_request(&mut memory, &mut table, key, 42)
+            .expect("event-index host request should dispatch");
+
+        assert!(queue.event_idx_enabled());
+        assert_eq!(dispatch.processed_buffers(), 1);
+        assert_eq!(dispatch.delivered_requests(), 1);
+        assert!(!dispatch.needs_queue_interrupt());
+        assert_eq!(queue.available_ring().next_avail(), 1);
+        assert_eq!(queue.used_ring().next_used(), 1);
+        assert_eq!(read_vsock_rx_used_index(&memory), 1);
+        assert_eq!(
+            read_vsock_rx_used_element(&memory, 0),
+            (0, VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32)
+        );
+        assert!(!table.has_pending_request_packet(key));
+    }
+
+    #[test]
     fn virtio_vsock_rx_queue_dispatch_without_pending_request_is_noop() {
         let mut memory = vsock_tx_memory();
         let mut queue = vsock_rx_queue();
@@ -11465,6 +11728,38 @@ mod tests {
     }
 
     #[test]
+    fn virtio_vsock_tx_queue_dispatch_suppresses_interrupt_with_event_idx() {
+        let mut memory = vsock_tx_memory();
+        let mut queue = vsock_tx_queue_with_event_idx();
+        let header = test_vsock_packet_header().with_payload_len(0);
+        write_vsock_packet_header(&mut memory, TEST_VSOCK_HEADER, header);
+        write_vsock_tx_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::readable(
+                TEST_VSOCK_HEADER,
+                VIRTIO_VSOCK_PACKET_HEADER_SIZE as u32,
+                None,
+            ),
+        );
+        write_vsock_tx_available_heads(&mut memory, &[0]);
+        write_vsock_tx_available_used_event(&mut memory, 1);
+
+        let dispatch = queue
+            .dispatch(&mut memory)
+            .expect("event-index TX packet should dispatch");
+
+        assert!(queue.event_idx_enabled());
+        assert_eq!(dispatch.processed_packets(), 1);
+        assert_eq!(dispatch.successful_packets(), 1);
+        assert!(!dispatch.needs_queue_interrupt());
+        assert_eq!(queue.available_ring().next_avail(), 1);
+        assert_eq!(queue.used_ring().next_used(), 1);
+        assert_eq!(read_vsock_tx_used_index(&memory), 1);
+        assert_eq!(read_vsock_tx_used_element(&memory, 0), (0, 0));
+    }
+
+    #[test]
     fn virtio_vsock_tx_queue_dispatch_preserves_next_avail_across_calls() {
         let mut memory = vsock_tx_memory();
         let mut queue = vsock_tx_queue();
@@ -11839,6 +12134,28 @@ mod tests {
                 .queue_state(),
             event_queue
         );
+    }
+
+    #[test]
+    fn virtio_vsock_handler_activation_enables_event_idx_for_rx_tx_queues() {
+        let mut handler = virtio_vsock_mmio_handler(42).expect("vsock handler should build");
+
+        activate_vsock_handler_with_event_idx(&mut handler);
+
+        let device = handler.activation_handler();
+        assert!(
+            device
+                .active_rx_dispatch_queue()
+                .expect("RX queue should be active")
+                .event_idx_enabled()
+        );
+        assert!(
+            device
+                .active_tx_dispatch_queue()
+                .expect("TX queue should be active")
+                .event_idx_enabled()
+        );
+        assert!(device.active_event_dispatch_queue().is_some());
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -726,14 +726,15 @@ configured and builds vmnet packet I/O for configured interfaces during
 chains into `VirtioNetworkTxFrame` metadata, publishes used-ring
 completions with length 0, delivers parsed frames to an injected internal packet
 sink, preserves parse, sink, and partial-dispatch errors, and marks queue
-interrupt status when descriptor heads complete and the negotiated used-event
-threshold requires notification. RX dispatch uses an injected
+interrupt status when descriptor heads complete unless negotiated `EVENT_IDX`
+suppresses the notification. RX dispatch uses an injected
 internal packet source, can perform one bounded post-TX RX retry when that
 source reports already-ready packets, copies a zeroed 12-byte virtio-net header
 plus packet payload into validated guest-writable RX buffers, publishes
 used-ring completions with the written length, preserves malformed-buffer and
 partial-dispatch metadata, and marks queue interrupt status when RX buffers
-complete and the negotiated used-event threshold requires notification. On macOS, the process crate also defines internal vmnet descriptor,
+complete unless negotiated `EVENT_IDX` suppresses the notification. On macOS,
+the process crate also defines internal vmnet descriptor,
 lifecycle, start owner, packet descriptor, and concrete system start/stop
 backend boundaries with vmnet mode, status, operation error, XPC descriptor
 configuration, retained dispatch queue ownership, completion-status mapping,

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -644,7 +644,10 @@ headers across descriptor boundaries, validates readable descriptor ranges, and
 returns payload segment metadata trimmed to the advertised payload length. The
 TX drain helper consumes available TX descriptor chains from the active queue
 into parsed packet metadata while preserving queue progress and publishes
-zero-length used-ring completions for consumed descriptor heads. The handler can
+zero-length used-ring completions for consumed descriptor heads. When
+`EVENT_IDX` is negotiated, RX and TX dispatch use the available-ring
+`used_event` value to decide whether completed descriptors require a queue
+interrupt. The handler can
 drain RX, TX, and no-op event queue notifications, dispatch the active RX queue
 for pending host request headers, dispatch the active TX queue, preserve
 completed RX/TX dispatch metadata on errors, and mark the virtio queue
@@ -723,13 +726,14 @@ configured and builds vmnet packet I/O for configured interfaces during
 chains into `VirtioNetworkTxFrame` metadata, publishes used-ring
 completions with length 0, delivers parsed frames to an injected internal packet
 sink, preserves parse, sink, and partial-dispatch errors, and marks queue
-interrupt status when descriptor heads complete. RX dispatch uses an injected
+interrupt status when descriptor heads complete and the negotiated used-event
+threshold requires notification. RX dispatch uses an injected
 internal packet source, can perform one bounded post-TX RX retry when that
 source reports already-ready packets, copies a zeroed 12-byte virtio-net header
 plus packet payload into validated guest-writable RX buffers, publishes
 used-ring completions with the written length, preserves malformed-buffer and
 partial-dispatch metadata, and marks queue interrupt status when RX buffers
-complete. On macOS, the process crate also defines internal vmnet descriptor,
+complete and the negotiated used-event threshold requires notification. On macOS, the process crate also defines internal vmnet descriptor,
 lifecycle, start owner, packet descriptor, and concrete system start/stop
 backend boundaries with vmnet mode, status, operation error, XPC descriptor
 configuration, retained dispatch queue ownership, completion-status mapping,
@@ -981,8 +985,10 @@ against caller-supplied guest memory. Internal HVF boot sessions can signal
 needed block, network, and vsock SPI interrupts from those dispatch summaries, but
 future public scheduler and device policy remain deferred. The
 virtqueue model can publish one used-ring completion element with validated
-layout, mapped-memory checks, wrapping, and release ordering, but batching,
-event-index notification suppression, and device-backed completion loops are
+layout, mapped-memory checks, wrapping, and release ordering. Network and vsock
+RX/TX dispatch honor negotiated used-event interrupt suppression for each
+published completion, while batching, avail-event kick suppression,
+virtio-block `EVENT_IDX` advertisement, and device-backed completion loops are
 still deferred.
 
 The runtime crate also contains backend-neutral interrupt signaling groundwork.


### PR DESCRIPTION
## Summary

- Add backend-neutral virtqueue used-event notification helpers and publish summaries.
- Honor negotiated `VIRTIO_RING_F_EVENT_IDX` for virtio-net and virtio-vsock RX/TX queue interrupt decisions.
- Preserve no-event-index interrupt behavior and document the implemented scope.

## Scope Exclusions

- Does not advertise `EVENT_IDX` for virtio-block.
- Does not implement virtqueue batching, avail-event kick suppression, or device-backed completion loops.

Closes #476

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test -p bangbang-runtime --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`
