### PR TITLE
feat: include origins in action logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,13 @@ Configure logger output before boot:
 curl --unix-socket /tmp/bangbang.socket \
   -X PUT http://localhost/logger \
   -H 'Content-Type: application/json' \
-  -d '{"log_path":"/tmp/bangbang.log","level":"Info","show_level":true}'
+  -d '{"log_path":"/tmp/bangbang.log","level":"Info","show_level":true,"show_log_origin":true}'
 ```
 
 Configured logger output records minimal successful `InstanceStart` and
-`FlushMetrics` action events. Full internal log routing remains deferred.
+`FlushMetrics` action events. `show_level` adds `level=Info`, and
+`show_log_origin` adds the runtime action callsite as `origin=<file>:<line>`.
+Full internal log routing remains deferred.
 
 Submit an `InstanceStart` action:
 

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -1959,7 +1959,8 @@ mod tests {
             r#"{{
                 "log_path": "{}",
                 "level": "Info",
-                "show_level": true
+                "show_level": true,
+                "show_log_origin": true
             }}"#,
             logger_path.to_string_lossy()
         );
@@ -1986,12 +1987,38 @@ mod tests {
         let flush_response = put_action_over_socket(&mut vmm, "flush-with-logger", "FlushMetrics");
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
 
-        assert_eq!(
-            fs::read_to_string(&logger_path).expect("logger output should be readable"),
-            "level=Info action=InstanceStart\nlevel=Info action=FlushMetrics\n"
-        );
+        let output = fs::read_to_string(&logger_path).expect("logger output should be readable");
+        let mut lines = output.lines();
+        assert_action_log_with_origin(lines.next(), "InstanceStart");
+        assert_action_log_with_origin(lines.next(), "FlushMetrics");
+        assert_eq!(lines.next(), None);
 
         fs::remove_file(logger_path).expect("fixture should clean up");
+    }
+
+    fn assert_action_log_with_origin(line: Option<&str>, action: &str) {
+        let line = line.expect("logger output should include action line");
+        assert!(line.starts_with("level=Info origin="));
+        assert!(line.ends_with(&format!(" action={action}")));
+
+        let suffix = format!(" action={action}");
+        let origin = line
+            .strip_prefix("level=Info origin=")
+            .expect("logger output should include origin prefix")
+            .strip_suffix(&suffix)
+            .expect("logger output should include action suffix");
+        let (file, line_number) = origin
+            .rsplit_once(':')
+            .expect("logger origin should include file and line");
+
+        assert!(
+            file.ends_with("crates/runtime/src/lib.rs"),
+            "unexpected origin file: {file}"
+        );
+        assert!(
+            line_number.parse::<u32>().is_ok(),
+            "unexpected origin line: {line_number}"
+        );
     }
 
     #[test]

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -467,7 +467,7 @@ fn help_text() -> String {
             "      --metrics-path <PATH>  Metrics output file or FIFO path\n",
             "      --module <MODULE>  Logger module filter stored for future log integration\n",
             "      --show-level       Include level in minimal logger action lines\n",
-            "      --show-log-origin  Store log-origin flag for future log integration\n",
+            "      --show-log-origin  Include callsite origin in minimal logger action lines\n",
             "  -V, --version          Print version\n",
             "  -h, --help             Print help\n\n",
             "Current scope:\n",

--- a/crates/runtime/src/logger.rs
+++ b/crates/runtime/src/logger.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::fs::OpenOptions;
 use std::io::{LineWriter, Write};
 use std::os::unix::fs::OpenOptionsExt;
+use std::panic::Location;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -239,6 +240,7 @@ impl LoggerState {
         Ok(())
     }
 
+    #[track_caller]
     pub(crate) fn log_action(&mut self, action: &str) -> Result<bool, LoggerWriteError> {
         const ACTION_LEVEL: LoggerLevel = LoggerLevel::Info;
 
@@ -250,7 +252,13 @@ impl LoggerState {
             return Ok(false);
         };
 
-        sink.write_action(self.show_level, ACTION_LEVEL, action)?;
+        sink.write_action(
+            self.show_level,
+            self.show_log_origin,
+            Location::caller(),
+            ACTION_LEVEL,
+            action,
+        )?;
         Ok(true)
     }
 
@@ -308,16 +316,29 @@ impl LoggerSink {
     fn write_action(
         &mut self,
         show_level: bool,
+        show_log_origin: bool,
+        origin: &Location<'_>,
         level: LoggerLevel,
         action: &str,
     ) -> Result<(), LoggerWriteError> {
-        if show_level {
-            writeln!(self.writer, "level={} action={action}", level.as_str())
-                .map_err(|err| LoggerWriteError::Write(err.kind()))?;
-        } else {
-            writeln!(self.writer, "action={action}")
-                .map_err(|err| LoggerWriteError::Write(err.kind()))?;
+        match (show_level, show_log_origin) {
+            (true, true) => writeln!(
+                self.writer,
+                "level={} origin={}:{} action={action}",
+                level.as_str(),
+                origin.file(),
+                origin.line()
+            ),
+            (true, false) => writeln!(self.writer, "level={} action={action}", level.as_str()),
+            (false, true) => writeln!(
+                self.writer,
+                "origin={}:{} action={action}",
+                origin.file(),
+                origin.line()
+            ),
+            (false, false) => writeln!(self.writer, "action={action}"),
         }
+        .map_err(|err| LoggerWriteError::Write(err.kind()))?;
         self.writer
             .flush()
             .map_err(|err| LoggerWriteError::Write(err.kind()))
@@ -362,6 +383,38 @@ mod tests {
         fn flush(&mut self) -> std::io::Result<()> {
             Ok(())
         }
+    }
+
+    fn assert_action_output_with_origin(output: &str, level: Option<LoggerLevel>, action: &str) {
+        let mut lines = output.lines();
+        let line = lines
+            .next()
+            .expect("logger output should include action line");
+        assert_eq!(lines.next(), None);
+
+        let prefix = level.map_or_else(
+            || "origin=".to_string(),
+            |level| format!("level={} origin=", level.as_str()),
+        );
+        assert!(line.starts_with(&prefix));
+
+        let suffix = format!(" action={action}");
+        assert!(line.ends_with(&suffix));
+
+        let origin = line
+            .strip_prefix(&prefix)
+            .expect("logger output should include origin prefix")
+            .strip_suffix(&suffix)
+            .expect("logger output should include action suffix");
+        let (file, line_number) = origin
+            .rsplit_once(':')
+            .expect("logger origin should include file and line");
+
+        assert!(file.ends_with(file!()), "unexpected origin file: {file}");
+        assert!(
+            line_number.parse::<u32>().is_ok(),
+            "unexpected origin line: {line_number}"
+        );
     }
 
     #[test]
@@ -488,6 +541,45 @@ mod tests {
 
         let output = fs::read_to_string(&path).expect("logger output should be readable");
         assert_eq!(output, "level=Info action=InstanceStart\n");
+        fs::remove_file(path).expect("fixture should clean up");
+    }
+
+    #[test]
+    fn log_action_includes_origin_when_configured() {
+        let path = unique_logger_path("actions-with-origin");
+        let mut state = LoggerState::default();
+        state
+            .configure(
+                LoggerConfigInput::new()
+                    .with_log_path(&path)
+                    .with_show_log_origin(true),
+            )
+            .expect("logger should configure");
+
+        assert_eq!(state.log_action("InstanceStart"), Ok(true));
+
+        let output = fs::read_to_string(&path).expect("logger output should be readable");
+        assert_action_output_with_origin(&output, None, "InstanceStart");
+        fs::remove_file(path).expect("fixture should clean up");
+    }
+
+    #[test]
+    fn log_action_includes_level_and_origin_when_configured() {
+        let path = unique_logger_path("actions-with-level-origin");
+        let mut state = LoggerState::default();
+        state
+            .configure(
+                LoggerConfigInput::new()
+                    .with_log_path(&path)
+                    .with_show_level(true)
+                    .with_show_log_origin(true),
+            )
+            .expect("logger should configure");
+
+        assert_eq!(state.log_action("FlushMetrics"), Ok(true));
+
+        let output = fs::read_to_string(&path).expect("logger output should be readable");
+        assert_action_output_with_origin(&output, Some(LoggerLevel::Info), "FlushMetrics");
         fs::remove_file(path).expect("fixture should clean up");
     }
 

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -120,7 +120,7 @@ public run-loop control.
 | `--level <LEVEL>` | configures logger level before API serving | Accepts the existing logger levels `Off`, `Trace`, `Debug`, `Info`, `Warn`, `Warning`, and `Error`; minimal action logs are emitted only when the configured level allows `Info`. |
 | `--module <MODULE>` | stored for future logger filtering | Matches the stored `PUT /logger` field but does not filter the current minimal action logs yet. |
 | `--show-level` | enables level prefix for minimal action logs | Writes `level=Info` before minimal `InstanceStart` and `FlushMetrics` action lines. |
-| `--show-log-origin` | stored for future logger formatting | Full Firecracker origin formatting remains deferred. |
+| `--show-log-origin` | enables origin field for minimal action logs | Writes `origin=<file>:<line>` before minimal `InstanceStart` and `FlushMetrics` action names. Full Firecracker logger integration remains deferred. |
 | `--help`, `-h` | prints help | Help describes the current API socket scope. |
 | `--version`, `-V` | prints version | `-V` is retained from the existing bangbang scaffold. |
 | `--config-file`, `--no-api` | rejected | Deferred until VM configuration models and no-API startup behavior exist. |
@@ -301,7 +301,7 @@ exist.
 | `PUT /logger` | `log_path` | optional | Host path to the logger output file or FIFO. When present, the runtime opens it as per-process observability state and redacts path details from API-facing open errors. When omitted, the existing sink is left unchanged. |
 | `PUT /logger` | `level` | optional | Case-insensitive values `Off`, `Trace`, `Debug`, `Info`, `Warn`, `Warning`, and `Error` are accepted. `Warning` is normalized to `Warn`. |
 | `PUT /logger` | `show_level` | optional | When true, minimal action log lines include a `level=Info` prefix. |
-| `PUT /logger` | `show_log_origin` | optional | Stored as logger formatting configuration for future log integration. |
+| `PUT /logger` | `show_log_origin` | optional | When true, minimal action log lines include an `origin=<file>:<line>` field for the runtime action callsite. |
 | `PUT /logger` | `module` | optional | Stored as logger filtering configuration for future log integration. |
 | `PUT /logger` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
 | `PUT /actions` | `action_type=InstanceStart` | process-routed; internal startup execution across bounded step windows implemented | Validates stored boot-source and state preflight first, then attempts owned HVF boot-session preparation with an internal serial MMIO console and starts the process-owned internal boot run-loop worker across bounded step windows. Success returns `204 No Content`, writes one minimal logger action line when configured and enabled, and commits `Running`; preparation, worker-start, or logger-output failures return a fault without mutating state. Public run-loop control and public serial streaming remain deferred. |
@@ -358,7 +358,9 @@ Repeated pre-boot `PUT /logger` requests update only the fields they provide,
 including after startup CLI configuration. Runtime requests fail without opening
 a new output path. The configured logger sink records minimal successful
 `InstanceStart` and `FlushMetrics` action lines when the logger level allows
-`Info`; it is not wired into the full process logging backend yet.
+`Info`. `show_level` adds `level=Info`, and `show_log_origin` adds the runtime
+action callsite as `origin=<file>:<line>`. It is not wired into the full process
+logging backend yet.
 The API and VMM state path implement the `PUT /vsock` field policy above as a
 pre-boot-only guest configuration section. Valid requests replace the stored
 vsock config and return `204 No Content`; invalid requests fail without
@@ -1188,7 +1190,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | `PATCH /mmds` | implemented after data initialization; `204` empty response | implemented after data initialization; `204` empty response | Applies RFC 7396 merge-patch semantics to the stored JSON object. Oversized patched results are rejected without mutating the previous value. |
 | `PUT /mmds/config` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Stores control-plane MMDS config before startup after validating that each listed interface ID already exists in the configured network interface set. At startup, the configured interfaces can enable the implemented guest-visible MMDS packet path; runtime MMDS config updates and public packet movement remain deferred. |
 | `PUT /metrics` | implemented; `204` empty response on successful output initialization | unsupported after start; `400` `fault_message` | Metrics output is process observability state, not guest configuration. Duplicate initialization fails. |
-| `PUT /logger` | implemented; `204` empty response on successful pre-boot configuration | unsupported after start; `400` `fault_message` | Logger output is process observability state, not guest configuration. Repeated pre-boot requests update provided fields; minimal successful action logging exists, but full log routing remains deferred. |
+| `PUT /logger` | implemented; `204` empty response on successful pre-boot configuration | unsupported after start; `400` `fault_message` | Logger output is process observability state, not guest configuration. Repeated pre-boot requests update provided fields; minimal successful action logging supports configured level and origin fields, but full log routing remains deferred. |
 | `PUT /actions` with `InstanceStart` | process-routed; `204` after successful owned HVF startup with internal boot run-loop worker across bounded step windows or `400` preflight/preparation/logger-output fault | unsupported after start; `400` `fault_message` | Commits `Running` only after the owned HVF boot-session worker with internal serial capture is retained and configured action logging succeeds. The worker keeps internal active, terminal-outcome, or error status; public run-loop control and public serial streaming remain deferred. |
 | `PUT /actions` with `FlushMetrics` | VMM-routed; `400` unsupported-state `fault_message` | implemented; `204` empty response or `400` logger/metrics output fault | Firecracker treats this as runtime-only. bangbang writes one minimal JSON line when metrics output was configured, including `boot_run_loop_status` as `running`, `exited`, or `failed` when a process-owned boot worker exists, writes one minimal action line when logger output is configured and enabled, and otherwise succeeds without writing. |
 | `PUT /actions` with `SendCtrlAltDel` | intentionally unsupported; parser returns `400` `fault_message` | intentionally unsupported; `400` `fault_message` | Firecracker rejects this on aarch64; bangbang's first target is Apple Silicon. |


### PR DESCRIPTION
## Summary

- include `origin=<file>:<line>` in minimal action logger output when `show_log_origin=true`
- preserve existing no-origin and `show_level` action log formats
- update API coverage, CLI help, README, and Firecracker compatibility docs for the implemented minimal behavior

## Scope

Full Firecracker logger routing, timestamps, instance-id prefixes, and `module` filtering remain out of scope.

Closes #482

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p bangbang-runtime --all-targets --all-features --locked logger::tests::`
- `cargo test -p bangbang --all-targets --all-features --locked logger`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`

Signed HVF integration tests were not run because this only changes runtime/process logger formatting and documentation.
