### PR TITLE
feat: support virtqueue indirect descriptors

### DIFF
--- a/crates/runtime/src/block.rs
+++ b/crates/runtime/src/block.rs
@@ -24,8 +24,8 @@ use crate::virtio_mmio::{
 };
 use crate::virtio_queue::{
     VirtqueueAvailableRing, VirtqueueAvailableRingError, VirtqueueDescriptor,
-    VirtqueueDescriptorChain, VirtqueueNotificationSuppression, VirtqueueUsedRing,
-    VirtqueueUsedRingError, VirtqueueUsedRingPublication,
+    VirtqueueDescriptorChain, VirtqueueDescriptorChainOptions, VirtqueueNotificationSuppression,
+    VirtqueueUsedRing, VirtqueueUsedRingError, VirtqueueUsedRingPublication,
 };
 
 pub const VIRTIO_BLOCK_DEVICE_ID: u32 = 2;
@@ -37,6 +37,7 @@ pub const VIRTIO_BLOCK_SECTOR_SIZE: u64 = 1 << VIRTIO_BLOCK_SECTOR_SHIFT;
 pub const VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE: usize = 8;
 pub const VIRTIO_BLOCK_FEATURE_READ_ONLY: u32 = 5;
 pub const VIRTIO_BLOCK_FEATURE_FLUSH: u32 = 9;
+pub const VIRTIO_RING_FEATURE_INDIRECT_DESC: u32 = 28;
 pub const VIRTIO_RING_FEATURE_EVENT_IDX: u32 = 29;
 pub const VIRTIO_FEATURE_VERSION_1: u32 = 32;
 pub const VIRTIO_BLOCK_REQUEST_HEADER_SIZE: u32 = 16;
@@ -416,6 +417,7 @@ impl VirtioBlockConfigSpace {
 
     pub const fn available_features(self) -> u64 {
         let mut features = virtio_feature_bit(VIRTIO_FEATURE_VERSION_1)
+            | virtio_feature_bit(VIRTIO_RING_FEATURE_INDIRECT_DESC)
             | virtio_feature_bit(VIRTIO_RING_FEATURE_EVENT_IDX);
         if matches!(self.cache_type, DriveCacheType::Writeback) {
             features |= virtio_feature_bit(VIRTIO_BLOCK_FEATURE_FLUSH);
@@ -1127,12 +1129,13 @@ impl VirtioBlockQueue {
     pub fn from_mmio_queue_state(
         queue: &VirtioMmioQueueState,
     ) -> Result<Self, VirtioBlockQueueBuildError> {
-        Self::from_mmio_queue_state_with_event_idx(queue, false)
+        Self::from_mmio_queue_state_with_event_idx(queue, false, false)
     }
 
     fn from_mmio_queue_state_with_event_idx(
         queue: &VirtioMmioQueueState,
         event_idx_enabled: bool,
+        indirect_descriptors_enabled: bool,
     ) -> Result<Self, VirtioBlockQueueBuildError> {
         if !queue.ready() {
             return Err(VirtioBlockQueueBuildError::QueueNotReady);
@@ -1144,6 +1147,10 @@ impl VirtioBlockQueue {
             queue.size(),
         )
         .map_err(|source| VirtioBlockQueueBuildError::AvailableRing { source })?;
+        let available = available.with_descriptor_chain_options(
+            VirtqueueDescriptorChainOptions::new()
+                .with_indirect_descriptors(indirect_descriptors_enabled),
+        );
         let used = VirtqueueUsedRing::new(queue.device_ring(), queue.size())
             .map_err(|source| VirtioBlockQueueBuildError::UsedRing { source })?;
 
@@ -1409,10 +1416,11 @@ impl VirtioBlockQueueDispatchError {
 }
 
 fn descriptor_chain_head(chain: &VirtqueueDescriptorChain) -> Option<u16> {
-    chain
-        .descriptors()
-        .first()
-        .map(|descriptor| descriptor.index())
+    if chain.is_empty() {
+        None
+    } else {
+        Some(chain.head_index())
+    }
 }
 
 fn normalize_completion_status(
@@ -2116,6 +2124,10 @@ impl VirtioBlockDevice {
 
         let event_idx_enabled =
             virtio_feature_enabled(activation.driver_features(), VIRTIO_RING_FEATURE_EVENT_IDX);
+        let indirect_descriptors_enabled = virtio_feature_enabled(
+            activation.driver_features(),
+            VIRTIO_RING_FEATURE_INDIRECT_DESC,
+        );
         let queue_index = 0;
         let queue = activation
             .queue(queue_index)
@@ -2124,11 +2136,15 @@ impl VirtioBlockDevice {
                 source,
             })
             .and_then(|queue| {
-                VirtioBlockQueue::from_mmio_queue_state_with_event_idx(queue, event_idx_enabled)
-                    .map_err(|source| VirtioBlockDeviceActivationError::QueueBuild {
-                        queue_index,
-                        source,
-                    })
+                VirtioBlockQueue::from_mmio_queue_state_with_event_idx(
+                    queue,
+                    event_idx_enabled,
+                    indirect_descriptors_enabled,
+                )
+                .map_err(|source| VirtioBlockDeviceActivationError::QueueBuild {
+                    queue_index,
+                    source,
+                })
             })?;
         self.active_queue = Some(queue);
 
@@ -2954,11 +2970,12 @@ mod tests {
         VIRTIO_BLOCK_REQUEST_TYPE_OUT, VIRTIO_BLOCK_SECTOR_SHIFT, VIRTIO_BLOCK_SECTOR_SIZE,
         VIRTIO_BLOCK_STATUS_IOERR, VIRTIO_BLOCK_STATUS_OK, VIRTIO_BLOCK_STATUS_SIZE,
         VIRTIO_BLOCK_STATUS_UNSUPPORTED, VIRTIO_FEATURE_VERSION_1, VIRTIO_RING_FEATURE_EVENT_IDX,
-        VirtioBlockConfigSpace, VirtioBlockDevice, VirtioBlockDeviceActivationError,
-        VirtioBlockDeviceId, VirtioBlockDeviceNotificationError, VirtioBlockQueue,
-        VirtioBlockQueueBuildError, VirtioBlockQueueDispatchError, VirtioBlockRequest,
-        VirtioBlockRequestCompletion, VirtioBlockRequestError, VirtioBlockRequestExecutionError,
-        VirtioBlockRequestExecutionOutcome, VirtioBlockRequestType, normalize_completion_status,
+        VIRTIO_RING_FEATURE_INDIRECT_DESC, VirtioBlockConfigSpace, VirtioBlockDevice,
+        VirtioBlockDeviceActivationError, VirtioBlockDeviceId, VirtioBlockDeviceNotificationError,
+        VirtioBlockQueue, VirtioBlockQueueBuildError, VirtioBlockQueueDispatchError,
+        VirtioBlockRequest, VirtioBlockRequestCompletion, VirtioBlockRequestError,
+        VirtioBlockRequestExecutionError, VirtioBlockRequestExecutionOutcome,
+        VirtioBlockRequestType, normalize_completion_status,
     };
 
     static NEXT_TEMP_PATH_ID: AtomicUsize = AtomicUsize::new(0);
@@ -2975,6 +2992,7 @@ mod tests {
     const TEST_USED_RING_RING_OFFSET: u64 = 4;
     const TEST_USED_RING_ELEMENT_SIZE: u64 = 8;
     const EVENT_IDX_DRIVER_FEATURE: u32 = 1_u32 << VIRTIO_RING_FEATURE_EVENT_IDX;
+    const INDIRECT_DESC_DRIVER_FEATURE: u32 = 1_u32 << VIRTIO_RING_FEATURE_INDIRECT_DESC;
     const HEADER_ADDR: GuestAddress = GuestAddress::new(0x2000);
     const DATA_ADDR: GuestAddress = GuestAddress::new(0x3000);
     const STATUS_ADDR: GuestAddress = GuestAddress::new(0x4000);
@@ -4607,6 +4625,7 @@ mod tests {
         assert_eq!(VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE, 8);
         assert_eq!(VIRTIO_BLOCK_FEATURE_READ_ONLY, 5);
         assert_eq!(VIRTIO_BLOCK_FEATURE_FLUSH, 9);
+        assert_eq!(VIRTIO_RING_FEATURE_INDIRECT_DESC, 28);
         assert_eq!(VIRTIO_RING_FEATURE_EVENT_IDX, 29);
         assert_eq!(VIRTIO_FEATURE_VERSION_1, 32);
         assert_eq!(VIRTIO_BLOCK_REQUEST_HEADER_SIZE, 16);
@@ -4648,14 +4667,21 @@ mod tests {
 
     #[test]
     fn config_space_tracks_cache_and_read_only_features() {
+        let indirect_feature = 1_u64 << VIRTIO_RING_FEATURE_INDIRECT_DESC;
         let event_idx_feature = 1_u64 << VIRTIO_RING_FEATURE_EVENT_IDX;
-        let base_features = (1_u64 << VIRTIO_FEATURE_VERSION_1) | event_idx_feature;
+        let base_features =
+            (1_u64 << VIRTIO_FEATURE_VERSION_1) | indirect_feature | event_idx_feature;
         let flush_feature = 1_u64 << VIRTIO_BLOCK_FEATURE_FLUSH;
         let read_only_feature = 1_u64 << VIRTIO_BLOCK_FEATURE_READ_ONLY;
 
         assert_eq!(
             VirtioBlockConfigSpace::new(512, false, DriveCacheType::Unsafe).available_features(),
             base_features
+        );
+        assert_ne!(
+            VirtioBlockConfigSpace::new(512, false, DriveCacheType::Unsafe).available_features()
+                & indirect_feature,
+            0
         );
         assert_ne!(
             VirtioBlockConfigSpace::new(512, false, DriveCacheType::Unsafe).available_features()
@@ -5709,6 +5735,32 @@ mod tests {
         assert_eq!(queue.available_ring().queue_size(), 4);
         assert_eq!(queue.used_ring().used_ring(), TEST_USED_RING);
         assert_eq!(queue.used_ring().queue_size(), 4);
+    }
+
+    #[test]
+    fn block_device_activation_enables_indirect_descriptors_when_negotiated() {
+        let file = temp_file("block-device-activate-indirect.img", &sector_payload(0x11));
+        let backing = open_backing(file.as_path(), false).expect("backing should open");
+        let mut handler = block_notification_handler(backing, &VIRTIO_BLOCK_QUEUE_SIZES);
+        configure_block_notification_handler_queue_with_features(
+            &mut handler,
+            4,
+            TEST_USED_RING,
+            INDIRECT_DESC_DRIVER_FEATURE,
+        );
+
+        activate_block_notification_handler(&mut handler);
+
+        let active_queue = handler
+            .activation_handler()
+            .active_queue()
+            .expect("active queue should be stored");
+        assert!(
+            active_queue
+                .available_ring()
+                .descriptor_chain_options()
+                .indirect_descriptors()
+        );
     }
 
     #[test]

--- a/crates/runtime/src/network.rs
+++ b/crates/runtime/src/network.rs
@@ -20,8 +20,8 @@ use crate::virtio_mmio::{
 };
 use crate::virtio_queue::{
     VirtqueueAvailableRing, VirtqueueAvailableRingError, VirtqueueDescriptor,
-    VirtqueueDescriptorChain, VirtqueueNotificationSuppression, VirtqueueUsedRing,
-    VirtqueueUsedRingError, VirtqueueUsedRingPublication,
+    VirtqueueDescriptorChain, VirtqueueDescriptorChainOptions, VirtqueueNotificationSuppression,
+    VirtqueueUsedRing, VirtqueueUsedRingError, VirtqueueUsedRingPublication,
 };
 
 const MAC_ADDRESS_LEN: usize = 6;
@@ -39,6 +39,7 @@ pub const VIRTIO_NET_MIN_MTU: u16 = 68;
 pub const VIRTIO_NET_MAX_MTU: u16 = u16::MAX;
 pub const VIRTIO_NET_F_MTU: u32 = 3;
 pub const VIRTIO_NET_F_MAC: u32 = 5;
+pub const VIRTIO_RING_FEATURE_INDIRECT_DESC: u32 = 28;
 pub const VIRTIO_RING_FEATURE_EVENT_IDX: u32 = 29;
 pub const VIRTIO_FEATURE_VERSION_1: u32 = 32;
 pub const VIRTIO_NET_TX_HEADER_SIZE: u32 = 12;
@@ -269,6 +270,7 @@ impl VirtioNetworkConfigSpace {
 
     pub const fn available_features(self) -> u64 {
         let mut features = virtio_feature_bit(VIRTIO_FEATURE_VERSION_1)
+            | virtio_feature_bit(VIRTIO_RING_FEATURE_INDIRECT_DESC)
             | virtio_feature_bit(VIRTIO_RING_FEATURE_EVENT_IDX);
         if self.guest_mac.is_some() {
             features |= virtio_feature_bit(VIRTIO_NET_F_MAC);
@@ -989,21 +991,37 @@ impl VirtioNetworkDevice {
 
         let event_idx_enabled =
             virtio_feature_enabled(activation.driver_features(), VIRTIO_RING_FEATURE_EVENT_IDX);
+        let indirect_descriptors_enabled = virtio_feature_enabled(
+            activation.driver_features(),
+            VIRTIO_RING_FEATURE_INDIRECT_DESC,
+        );
         let active_rx_queue = active_network_queue_state(activation, VIRTIO_NET_RX_QUEUE_INDEX_U32)
             .and_then(|queue| {
-                VirtioNetworkRxQueue::from_mmio_queue_state_with_event_idx(queue, event_idx_enabled)
-                    .map_err(|source| VirtioNetworkDeviceActivationError::RxQueueBuild {
+                VirtioNetworkRxQueue::from_mmio_queue_state_with_event_idx(
+                    queue,
+                    event_idx_enabled,
+                    indirect_descriptors_enabled,
+                )
+                .map_err(|source| {
+                    VirtioNetworkDeviceActivationError::RxQueueBuild {
                         queue_index: VIRTIO_NET_RX_QUEUE_INDEX_U32,
                         source,
-                    })
+                    }
+                })
             })?;
         let active_tx_queue = active_network_queue_state(activation, VIRTIO_NET_TX_QUEUE_INDEX_U32)
             .and_then(|queue| {
-                VirtioNetworkTxQueue::from_mmio_queue_state_with_event_idx(queue, event_idx_enabled)
-                    .map_err(|source| VirtioNetworkDeviceActivationError::TxQueueBuild {
+                VirtioNetworkTxQueue::from_mmio_queue_state_with_event_idx(
+                    queue,
+                    event_idx_enabled,
+                    indirect_descriptors_enabled,
+                )
+                .map_err(|source| {
+                    VirtioNetworkDeviceActivationError::TxQueueBuild {
                         queue_index: VIRTIO_NET_TX_QUEUE_INDEX_U32,
                         source,
-                    })
+                    }
+                })
             })?;
 
         self.active_rx_queue = Some(active_rx_queue);
@@ -1158,12 +1176,13 @@ impl VirtioNetworkRxQueue {
     pub fn from_mmio_queue_state(
         queue: VirtioMmioQueueState,
     ) -> Result<Self, VirtioNetworkRxQueueBuildError> {
-        Self::from_mmio_queue_state_with_event_idx(queue, false)
+        Self::from_mmio_queue_state_with_event_idx(queue, false, false)
     }
 
     fn from_mmio_queue_state_with_event_idx(
         queue: VirtioMmioQueueState,
         event_idx_enabled: bool,
+        indirect_descriptors_enabled: bool,
     ) -> Result<Self, VirtioNetworkRxQueueBuildError> {
         if !queue.ready() {
             return Err(VirtioNetworkRxQueueBuildError::QueueNotReady);
@@ -1175,6 +1194,10 @@ impl VirtioNetworkRxQueue {
             queue.size(),
         )
         .map_err(|source| VirtioNetworkRxQueueBuildError::AvailableRing { source })?;
+        let available = available.with_descriptor_chain_options(
+            VirtqueueDescriptorChainOptions::new()
+                .with_indirect_descriptors(indirect_descriptors_enabled),
+        );
         let used = VirtqueueUsedRing::new(queue.device_ring(), queue.size())
             .map_err(|source| VirtioNetworkRxQueueBuildError::UsedRing { source })?;
 
@@ -1965,12 +1988,13 @@ impl VirtioNetworkTxQueue {
     pub fn from_mmio_queue_state(
         queue: VirtioMmioQueueState,
     ) -> Result<Self, VirtioNetworkTxQueueBuildError> {
-        Self::from_mmio_queue_state_with_event_idx(queue, false)
+        Self::from_mmio_queue_state_with_event_idx(queue, false, false)
     }
 
     fn from_mmio_queue_state_with_event_idx(
         queue: VirtioMmioQueueState,
         event_idx_enabled: bool,
+        indirect_descriptors_enabled: bool,
     ) -> Result<Self, VirtioNetworkTxQueueBuildError> {
         if !queue.ready() {
             return Err(VirtioNetworkTxQueueBuildError::QueueNotReady);
@@ -1982,6 +2006,10 @@ impl VirtioNetworkTxQueue {
             queue.size(),
         )
         .map_err(|source| VirtioNetworkTxQueueBuildError::AvailableRing { source })?;
+        let available = available.with_descriptor_chain_options(
+            VirtqueueDescriptorChainOptions::new()
+                .with_indirect_descriptors(indirect_descriptors_enabled),
+        );
         let used = VirtqueueUsedRing::new(queue.device_ring(), queue.size())
             .map_err(|source| VirtioNetworkTxQueueBuildError::UsedRing { source })?;
 
@@ -2320,10 +2348,11 @@ impl std::error::Error for VirtioNetworkTxQueueDispatchError {
 }
 
 fn descriptor_chain_head(chain: &VirtqueueDescriptorChain) -> Option<u16> {
-    chain
-        .descriptors()
-        .first()
-        .map(|descriptor| descriptor.index())
+    if chain.is_empty() {
+        None
+    } else {
+        Some(chain.head_index())
+    }
 }
 
 impl<C: VirtioMmioDeviceConfigHandler> VirtioMmioRegisterHandler<C, VirtioNetworkDevice> {
@@ -3788,12 +3817,13 @@ mod tests {
         VIRTIO_NET_F_MAC, VIRTIO_NET_F_MTU, VIRTIO_NET_MAX_BUFFER_SIZE, VIRTIO_NET_MAX_MTU,
         VIRTIO_NET_MIN_MTU, VIRTIO_NET_QUEUE_COUNT, VIRTIO_NET_QUEUE_SIZE, VIRTIO_NET_QUEUE_SIZES,
         VIRTIO_NET_RX_MIN_BUFFER_SIZE, VIRTIO_NET_RX_QUEUE_INDEX, VIRTIO_NET_TX_HEADER_SIZE,
-        VIRTIO_NET_TX_QUEUE_INDEX, VIRTIO_RING_FEATURE_EVENT_IDX, VirtioNetworkConfigSpace,
-        VirtioNetworkDevice, VirtioNetworkDeviceActivationError,
-        VirtioNetworkDeviceNotificationError, VirtioNetworkMmioHandler, VirtioNetworkRxBuffer,
-        VirtioNetworkRxBufferParseError, VirtioNetworkRxPacket, VirtioNetworkRxPacketSource,
-        VirtioNetworkRxPacketSourceError, VirtioNetworkRxQueueDispatchError, VirtioNetworkTxFrame,
-        VirtioNetworkTxFrameParseError, VirtioNetworkTxPacketSink, VirtioNetworkTxPacketSinkError,
+        VIRTIO_NET_TX_QUEUE_INDEX, VIRTIO_RING_FEATURE_EVENT_IDX,
+        VIRTIO_RING_FEATURE_INDIRECT_DESC, VirtioNetworkConfigSpace, VirtioNetworkDevice,
+        VirtioNetworkDeviceActivationError, VirtioNetworkDeviceNotificationError,
+        VirtioNetworkMmioHandler, VirtioNetworkRxBuffer, VirtioNetworkRxBufferParseError,
+        VirtioNetworkRxPacket, VirtioNetworkRxPacketSource, VirtioNetworkRxPacketSourceError,
+        VirtioNetworkRxQueueDispatchError, VirtioNetworkTxFrame, VirtioNetworkTxFrameParseError,
+        VirtioNetworkTxPacketSink, VirtioNetworkTxPacketSinkError,
         VirtioNetworkTxQueueDispatchError,
     };
 
@@ -5060,6 +5090,7 @@ mod tests {
             .first()
             .expect("prepared network device should exist");
         let base_features = virtio_feature_bit(VIRTIO_FEATURE_VERSION_1)
+            | virtio_feature_bit(VIRTIO_RING_FEATURE_INDIRECT_DESC)
             | virtio_feature_bit(VIRTIO_RING_FEATURE_EVENT_IDX);
 
         assert_eq!(devices.len(), 1);
@@ -5089,6 +5120,7 @@ mod tests {
         assert_eq!(
             device.config_space().available_features(),
             virtio_feature_bit(VIRTIO_FEATURE_VERSION_1)
+                | virtio_feature_bit(VIRTIO_RING_FEATURE_INDIRECT_DESC)
                 | virtio_feature_bit(VIRTIO_RING_FEATURE_EVENT_IDX)
                 | virtio_feature_bit(VIRTIO_NET_F_MAC)
         );
@@ -5114,6 +5146,7 @@ mod tests {
         assert_eq!(
             device.config_space().available_features(),
             virtio_feature_bit(VIRTIO_FEATURE_VERSION_1)
+                | virtio_feature_bit(VIRTIO_RING_FEATURE_INDIRECT_DESC)
                 | virtio_feature_bit(VIRTIO_RING_FEATURE_EVENT_IDX)
                 | virtio_feature_bit(VIRTIO_NET_F_MTU)
         );
@@ -5459,6 +5492,7 @@ mod tests {
         assert_eq!(VIRTIO_NET_QUEUE_SIZES, [256, 256]);
         assert_eq!(VIRTIO_NET_CONFIG_MAC_SIZE, 6);
         assert_eq!(VIRTIO_NET_F_MAC, 5);
+        assert_eq!(VIRTIO_RING_FEATURE_INDIRECT_DESC, 28);
         assert_eq!(VIRTIO_RING_FEATURE_EVENT_IDX, 29);
         assert_eq!(VIRTIO_FEATURE_VERSION_1, 32);
         assert_eq!(VIRTIO_NET_TX_HEADER_SIZE, 12);
@@ -5944,6 +5978,7 @@ mod tests {
     #[test]
     fn virtio_network_config_space_tracks_configured_features() {
         let base_features = virtio_feature_bit(VIRTIO_FEATURE_VERSION_1)
+            | virtio_feature_bit(VIRTIO_RING_FEATURE_INDIRECT_DESC)
             | virtio_feature_bit(VIRTIO_RING_FEATURE_EVENT_IDX);
         let without_mac = VirtioNetworkConfigSpace::new(None, None);
         let with_mac = VirtioNetworkConfigSpace::new(Some(test_guest_mac()), None);

--- a/crates/runtime/src/virtio_queue.rs
+++ b/crates/runtime/src/virtio_queue.rs
@@ -14,7 +14,7 @@ pub const VIRTQUEUE_DESC_F_NEXT: u16 = 0x1;
 pub const VIRTQUEUE_DESC_F_WRITE: u16 = 0x2;
 pub const VIRTQUEUE_DESC_F_INDIRECT: u16 = 0x4;
 
-const VIRTQUEUE_DESCRIPTOR_SIZE_U64: u64 = 16;
+const VIRTQUEUE_DESCRIPTOR_SIZE_U64: u64 = VIRTQUEUE_DESCRIPTOR_SIZE as u64;
 const VIRTQUEUE_AVAILABLE_RING_HEADER_SIZE_U64: u64 = 4;
 const VIRTQUEUE_AVAILABLE_RING_ENTRY_SIZE_U64: u64 = 2;
 const VIRTQUEUE_AVAILABLE_RING_USED_EVENT_SIZE_U64: u64 = 2;
@@ -30,6 +30,7 @@ const DESCRIPTOR_LEN_SIZE: usize = 4;
 const DESCRIPTOR_FLAGS_SIZE: usize = 2;
 const U16_FIELD_SIZE: usize = 2;
 const U32_FIELD_SIZE: usize = 4;
+const VIRTQUEUE_DESCRIPTOR_SIZE_U32: u32 = VIRTQUEUE_DESCRIPTOR_SIZE as u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VirtqueueDescriptorFlags(u16);
@@ -105,10 +106,15 @@ impl VirtqueueDescriptor {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VirtqueueDescriptorChain {
+    head_index: u16,
     descriptors: Vec<VirtqueueDescriptor>,
 }
 
 impl VirtqueueDescriptorChain {
+    pub const fn head_index(&self) -> u16 {
+        self.head_index
+    }
+
     pub fn descriptors(&self) -> &[VirtqueueDescriptor] {
         &self.descriptors
     }
@@ -122,11 +128,49 @@ impl VirtqueueDescriptorChain {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct VirtqueueDescriptorChainOptions {
+    indirect_descriptors: bool,
+}
+
+impl VirtqueueDescriptorChainOptions {
+    pub const fn new() -> Self {
+        Self {
+            indirect_descriptors: false,
+        }
+    }
+
+    pub const fn with_indirect_descriptors(mut self, enabled: bool) -> Self {
+        self.indirect_descriptors = enabled;
+        self
+    }
+
+    pub const fn indirect_descriptors(self) -> bool {
+        self.indirect_descriptors
+    }
+}
+
 pub fn read_descriptor_chain(
     memory: &GuestMemory,
     descriptor_table: GuestAddress,
     queue_size: u16,
     head_index: u16,
+) -> Result<VirtqueueDescriptorChain, VirtqueueDescriptorChainError> {
+    read_descriptor_chain_with_options(
+        memory,
+        descriptor_table,
+        queue_size,
+        head_index,
+        VirtqueueDescriptorChainOptions::new(),
+    )
+}
+
+pub fn read_descriptor_chain_with_options(
+    memory: &GuestMemory,
+    descriptor_table: GuestAddress,
+    queue_size: u16,
+    head_index: u16,
+    options: VirtqueueDescriptorChainOptions,
 ) -> Result<VirtqueueDescriptorChain, VirtqueueDescriptorChainError> {
     validate_queue_size(queue_size)?;
     validate_descriptor_table_alignment(descriptor_table)?;
@@ -152,10 +196,13 @@ pub fn read_descriptor_chain(
     for _ in 0..queue_size {
         let descriptor = read_descriptor(memory, descriptor_table, queue_size, current_index)?;
         if descriptor.is_indirect() {
-            return Err(
-                VirtqueueDescriptorChainError::UnsupportedIndirectDescriptor {
-                    index: descriptor.index(),
-                },
+            return read_indirect_descriptor_chain(
+                memory,
+                head_index,
+                queue_size,
+                descriptor,
+                options,
+                descriptors,
             );
         }
 
@@ -173,7 +220,12 @@ pub fn read_descriptor_chain(
                 })?;
                 current_index = index;
             }
-            None => return Ok(VirtqueueDescriptorChain { descriptors }),
+            None => {
+                return Ok(VirtqueueDescriptorChain {
+                    head_index,
+                    descriptors,
+                });
+            }
         }
     }
 
@@ -183,12 +235,148 @@ pub fn read_descriptor_chain(
     })
 }
 
+fn read_indirect_descriptor_chain(
+    memory: &GuestMemory,
+    head_index: u16,
+    queue_size: u16,
+    descriptor: VirtqueueDescriptor,
+    options: VirtqueueDescriptorChainOptions,
+    mut descriptors: Vec<VirtqueueDescriptor>,
+) -> Result<VirtqueueDescriptorChain, VirtqueueDescriptorChainError> {
+    if !options.indirect_descriptors() {
+        return Err(
+            VirtqueueDescriptorChainError::UnsupportedIndirectDescriptor {
+                index: descriptor.index(),
+            },
+        );
+    }
+    if descriptor.has_next() {
+        return Err(
+            VirtqueueDescriptorChainError::InvalidIndirectDescriptorWithNext {
+                index: descriptor.index(),
+            },
+        );
+    }
+
+    let indirect_queue_size =
+        validate_indirect_descriptor_table(memory, head_index, descriptor, queue_size)?;
+    let resolved_count = descriptors
+        .len()
+        .checked_add(usize::from(indirect_queue_size))
+        .ok_or(VirtqueueDescriptorChainError::DescriptorChainTooLong {
+            head_index,
+            queue_size,
+        })?;
+    if resolved_count > usize::from(queue_size) {
+        return Err(VirtqueueDescriptorChainError::DescriptorChainTooLong {
+            head_index,
+            queue_size,
+        });
+    }
+
+    let mut current_index = 0;
+    for _ in 0..indirect_queue_size {
+        let indirect_descriptor = read_descriptor(
+            memory,
+            descriptor.address(),
+            indirect_queue_size,
+            current_index,
+        )?;
+        if indirect_descriptor.is_indirect() {
+            return Err(VirtqueueDescriptorChainError::NestedIndirectDescriptor {
+                index: indirect_descriptor.index(),
+            });
+        }
+
+        let next_index = indirect_descriptor.next_index();
+        descriptors.push(indirect_descriptor);
+
+        match next_index {
+            Some(index) => {
+                validate_descriptor_index(index, indirect_queue_size).map_err(|_| {
+                    VirtqueueDescriptorChainError::InvalidNextIndex {
+                        index: current_index,
+                        next_index: index,
+                        queue_size: indirect_queue_size,
+                    }
+                })?;
+                current_index = index;
+            }
+            None => {
+                return Ok(VirtqueueDescriptorChain {
+                    head_index,
+                    descriptors,
+                });
+            }
+        }
+    }
+
+    Err(VirtqueueDescriptorChainError::DescriptorChainTooLong {
+        head_index,
+        queue_size,
+    })
+}
+
+fn validate_indirect_descriptor_table(
+    memory: &GuestMemory,
+    head_index: u16,
+    descriptor: VirtqueueDescriptor,
+    queue_size: u16,
+) -> Result<u16, VirtqueueDescriptorChainError> {
+    let table_len = descriptor.len();
+    if table_len == 0 || !table_len.is_multiple_of(VIRTQUEUE_DESCRIPTOR_SIZE_U32) {
+        return Err(
+            VirtqueueDescriptorChainError::InvalidIndirectDescriptorLength {
+                index: descriptor.index(),
+                len: table_len,
+            },
+        );
+    }
+
+    let table_descriptor_count = table_len / VIRTQUEUE_DESCRIPTOR_SIZE_U32;
+    if table_descriptor_count > u32::from(queue_size) {
+        return Err(VirtqueueDescriptorChainError::DescriptorChainTooLong {
+            head_index,
+            queue_size,
+        });
+    }
+    let table_queue_size = u16::try_from(table_descriptor_count).map_err(|_| {
+        VirtqueueDescriptorChainError::DescriptorChainTooLong {
+            head_index,
+            queue_size,
+        }
+    })?;
+
+    validate_descriptor_table_alignment(descriptor.address())?;
+    let table_range =
+        GuestMemoryRange::new(descriptor.address(), u64::from(table_len)).map_err(|_| {
+            VirtqueueDescriptorChainError::IndirectDescriptorTableRangeOverflow {
+                index: descriptor.index(),
+                descriptor_table: descriptor.address(),
+                len: table_len,
+            }
+        })?;
+    memory
+        .validate_mapped_range(table_range)
+        .map_err(
+            |source| VirtqueueDescriptorChainError::IndirectDescriptorTableAccess {
+                index: descriptor.index(),
+                descriptor_table: descriptor.address(),
+                len: table_len,
+                source,
+            },
+        )?;
+
+    Ok(table_queue_size)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VirtqueueAvailableRing {
     descriptor_table: GuestAddress,
     available_ring: GuestAddress,
     queue_size: u16,
     next_avail: u16,
+    descriptor_chain_options: VirtqueueDescriptorChainOptions,
 }
 
 impl VirtqueueAvailableRing {
@@ -216,6 +404,7 @@ impl VirtqueueAvailableRing {
             available_ring,
             queue_size,
             next_avail,
+            descriptor_chain_options: VirtqueueDescriptorChainOptions::new(),
         })
     }
 
@@ -233,6 +422,18 @@ impl VirtqueueAvailableRing {
 
     pub const fn next_avail(&self) -> u16 {
         self.next_avail
+    }
+
+    pub const fn descriptor_chain_options(&self) -> VirtqueueDescriptorChainOptions {
+        self.descriptor_chain_options
+    }
+
+    pub const fn with_descriptor_chain_options(
+        mut self,
+        options: VirtqueueDescriptorChainOptions,
+    ) -> Self {
+        self.descriptor_chain_options = options;
+        self
     }
 
     pub fn used_event(&self, memory: &GuestMemory) -> Result<u16, VirtqueueAvailableRingError> {
@@ -289,12 +490,14 @@ impl VirtqueueAvailableRing {
             available_ring_entry_address(self.available_ring, self.queue_size, ring_index)?;
         let head_index =
             read_available_ring_u16(memory, self.available_ring, self.queue_size, head_address)?;
-        let chain =
-            read_descriptor_chain(memory, self.descriptor_table, self.queue_size, head_index)
-                .map_err(|source| VirtqueueAvailableRingError::DescriptorChain {
-                    head_index,
-                    source,
-                })?;
+        let chain = read_descriptor_chain_with_options(
+            memory,
+            self.descriptor_table,
+            self.queue_size,
+            head_index,
+            self.descriptor_chain_options,
+        )
+        .map_err(|source| VirtqueueAvailableRingError::DescriptorChain { head_index, source })?;
 
         self.next_avail = self.next_avail.wrapping_add(1);
 
@@ -676,6 +879,27 @@ pub enum VirtqueueDescriptorChainError {
     UnsupportedIndirectDescriptor {
         index: u16,
     },
+    InvalidIndirectDescriptorWithNext {
+        index: u16,
+    },
+    InvalidIndirectDescriptorLength {
+        index: u16,
+        len: u32,
+    },
+    IndirectDescriptorTableRangeOverflow {
+        index: u16,
+        descriptor_table: GuestAddress,
+        len: u32,
+    },
+    IndirectDescriptorTableAccess {
+        index: u16,
+        descriptor_table: GuestAddress,
+        len: u32,
+        source: GuestMemoryAccessError,
+    },
+    NestedIndirectDescriptor {
+        index: u16,
+    },
     DescriptorChainTooLong {
         head_index: u16,
         queue_size: u16,
@@ -748,7 +972,46 @@ impl fmt::Display for VirtqueueDescriptorChainError {
             Self::UnsupportedIndirectDescriptor { index } => {
                 write!(
                     f,
-                    "virtqueue descriptor {index} uses unsupported indirect descriptors"
+                    "virtqueue descriptor {index} uses indirect descriptors without negotiated support"
+                )
+            }
+            Self::InvalidIndirectDescriptorWithNext { index } => {
+                write!(
+                    f,
+                    "virtqueue descriptor {index} cannot set both indirect and next flags"
+                )
+            }
+            Self::InvalidIndirectDescriptorLength { index, len } => {
+                write!(
+                    f,
+                    "virtqueue descriptor {index} has invalid indirect table length {len}"
+                )
+            }
+            Self::IndirectDescriptorTableRangeOverflow {
+                index,
+                descriptor_table,
+                len,
+            } => {
+                write!(
+                    f,
+                    "virtqueue descriptor {index} indirect table at {descriptor_table} with length {len} overflows address space"
+                )
+            }
+            Self::IndirectDescriptorTableAccess {
+                index,
+                descriptor_table,
+                len,
+                source,
+            } => {
+                write!(
+                    f,
+                    "virtqueue descriptor {index} indirect table at {descriptor_table} with length {len} is not fully mapped: {source}"
+                )
+            }
+            Self::NestedIndirectDescriptor { index } => {
+                write!(
+                    f,
+                    "virtqueue indirect descriptor {index} cannot point to another indirect table"
                 )
             }
             Self::DescriptorChainTooLong {
@@ -774,6 +1037,7 @@ impl std::error::Error for VirtqueueDescriptorChainError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::DescriptorTableAccess { source, .. } => Some(source),
+            Self::IndirectDescriptorTableAccess { source, .. } => Some(source),
             Self::DescriptorRead { source, .. } => Some(source),
             Self::DescriptorChainAllocationFailed { source, .. } => Some(source),
             Self::InvalidQueueSize { .. }
@@ -782,6 +1046,10 @@ impl std::error::Error for VirtqueueDescriptorChainError {
             | Self::DescriptorTableRangeOverflow { .. }
             | Self::InvalidNextIndex { .. }
             | Self::UnsupportedIndirectDescriptor { .. }
+            | Self::InvalidIndirectDescriptorWithNext { .. }
+            | Self::InvalidIndirectDescriptorLength { .. }
+            | Self::IndirectDescriptorTableRangeOverflow { .. }
+            | Self::NestedIndirectDescriptor { .. }
             | Self::DescriptorChainTooLong { .. } => None,
         }
     }
@@ -1256,9 +1524,11 @@ mod tests {
         VIRTQUEUE_DESCRIPTOR_ALIGNMENT, VIRTQUEUE_DESCRIPTOR_SIZE, VIRTQUEUE_DESCRIPTOR_SIZE_U64,
         VIRTQUEUE_USED_RING_ALIGNMENT, VIRTQUEUE_USED_RING_ELEMENT_SIZE_U64,
         VIRTQUEUE_USED_RING_IDX_OFFSET, VIRTQUEUE_USED_RING_RING_OFFSET, VirtqueueAvailableRing,
-        VirtqueueAvailableRingError, VirtqueueDescriptorChainError, VirtqueueDescriptorFlags,
+        VirtqueueAvailableRingError, VirtqueueDescriptorChainError,
+        VirtqueueDescriptorChainOptions, VirtqueueDescriptorFlags,
         VirtqueueNotificationSuppression, VirtqueueUsedRing, VirtqueueUsedRingError,
-        read_descriptor_chain, virtqueue_event_idx_needs_notification,
+        read_descriptor_chain, read_descriptor_chain_with_options,
+        virtqueue_event_idx_needs_notification,
     };
     use crate::memory::{
         GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryLayout, GuestMemoryRange,
@@ -1267,6 +1537,7 @@ mod tests {
     const TABLE: GuestAddress = GuestAddress::new(0x1000);
     const AVAIL: GuestAddress = GuestAddress::new(0x2000);
     const USED: GuestAddress = GuestAddress::new(0x2800);
+    const INDIRECT_TABLE: GuestAddress = GuestAddress::new(0x3000);
 
     fn guest_memory(size: u64) -> GuestMemory {
         let range = GuestMemoryRange::new(GuestAddress::new(0), size)
@@ -1399,6 +1670,10 @@ mod tests {
             .expect("used ring entry address should not overflow")
     }
 
+    fn indirect_descriptor_options() -> VirtqueueDescriptorChainOptions {
+        VirtqueueDescriptorChainOptions::new().with_indirect_descriptors(true)
+    }
+
     #[test]
     fn exposes_virtqueue_descriptor_constants() {
         assert_eq!(VIRTQUEUE_DESCRIPTOR_SIZE, 16);
@@ -1432,6 +1707,10 @@ mod tests {
         assert_eq!(queue.available_ring(), AVAIL);
         assert_eq!(queue.queue_size(), 8);
         assert_eq!(queue.next_avail(), 3);
+        assert!(!queue.descriptor_chain_options().indirect_descriptors());
+
+        let queue = queue.with_descriptor_chain_options(indirect_descriptor_options());
+        assert!(queue.descriptor_chain_options().indirect_descriptors());
     }
 
     #[test]
@@ -1558,6 +1837,46 @@ mod tests {
     }
 
     #[test]
+    fn pops_available_indirect_descriptor_chain_when_negotiated() {
+        let mut memory = guest_memory(0x8000);
+        write_descriptor(
+            &mut memory,
+            TABLE,
+            2,
+            INDIRECT_TABLE.raw_value(),
+            16,
+            VIRTQUEUE_DESC_F_INDIRECT,
+            0,
+        );
+        write_descriptor(
+            &mut memory,
+            INDIRECT_TABLE,
+            0,
+            0x5000,
+            0x40,
+            VIRTQUEUE_DESC_F_WRITE,
+            0,
+        );
+        write_available_index(&mut memory, AVAIL, 1);
+        write_available_head(&mut memory, AVAIL, 0, 2);
+        let mut queue = VirtqueueAvailableRing::new(TABLE, AVAIL, 8)
+            .expect("available ring should be valid")
+            .with_descriptor_chain_options(indirect_descriptor_options());
+
+        let chain = queue
+            .pop_descriptor_chain(&memory)
+            .expect("available indirect descriptor chain should pop")
+            .expect("available ring should contain one head");
+
+        assert_eq!(chain.head_index(), 2);
+        assert_eq!(chain.len(), 1);
+        assert_eq!(chain.descriptors()[0].index(), 0);
+        assert_eq!(chain.descriptors()[0].address(), GuestAddress::new(0x5000));
+        assert!(chain.descriptors()[0].is_write_only());
+        assert_eq!(queue.next_avail(), 1);
+    }
+
+    #[test]
     fn does_not_advance_next_avail_when_available_head_is_malformed() {
         let mut memory = guest_memory(0x4000);
         write_available_index(&mut memory, AVAIL, 1);
@@ -1577,6 +1896,44 @@ mod tests {
                     VirtqueueDescriptorChainError::InvalidHeadIndex {
                         head_index: 8,
                         queue_size: 8
+                    }
+                ));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+        assert_eq!(queue.next_avail(), 0);
+    }
+
+    #[test]
+    fn does_not_advance_next_avail_when_indirect_chain_is_malformed() {
+        let mut memory = guest_memory(0x8000);
+        write_descriptor(
+            &mut memory,
+            TABLE,
+            2,
+            INDIRECT_TABLE.raw_value(),
+            15,
+            VIRTQUEUE_DESC_F_INDIRECT,
+            0,
+        );
+        write_available_index(&mut memory, AVAIL, 1);
+        write_available_head(&mut memory, AVAIL, 0, 2);
+        let mut queue = VirtqueueAvailableRing::new(TABLE, AVAIL, 8)
+            .expect("available ring should be valid")
+            .with_descriptor_chain_options(indirect_descriptor_options());
+
+        let err = queue
+            .pop_descriptor_chain(&memory)
+            .expect_err("malformed indirect chain should fail");
+
+        match err {
+            VirtqueueAvailableRingError::DescriptorChain { head_index, source } => {
+                assert_eq!(head_index, 2);
+                assert!(matches!(
+                    source,
+                    VirtqueueDescriptorChainError::InvalidIndirectDescriptorLength {
+                        index: 2,
+                        len: 15
                     }
                 ));
             }
@@ -2086,6 +2443,94 @@ mod tests {
     }
 
     #[test]
+    fn reads_indirect_descriptor_chain_when_negotiated() {
+        let mut memory = guest_memory(0x8000);
+        write_descriptor(
+            &mut memory,
+            TABLE,
+            2,
+            INDIRECT_TABLE.raw_value(),
+            32,
+            VIRTQUEUE_DESC_F_INDIRECT,
+            0,
+        );
+        write_descriptor(
+            &mut memory,
+            INDIRECT_TABLE,
+            0,
+            0x4000,
+            0x20,
+            VIRTQUEUE_DESC_F_NEXT,
+            1,
+        );
+        write_descriptor(
+            &mut memory,
+            INDIRECT_TABLE,
+            1,
+            0x5000,
+            0x30,
+            VIRTQUEUE_DESC_F_WRITE,
+            0,
+        );
+
+        let chain =
+            read_descriptor_chain_with_options(&memory, TABLE, 8, 2, indirect_descriptor_options())
+                .expect("negotiated indirect descriptor chain should read");
+
+        assert_eq!(chain.head_index(), 2);
+        assert_eq!(chain.len(), 2);
+        assert_eq!(chain.descriptors()[0].index(), 0);
+        assert_eq!(chain.descriptors()[0].address(), GuestAddress::new(0x4000));
+        assert_eq!(chain.descriptors()[0].next_index(), Some(1));
+        assert_eq!(chain.descriptors()[1].index(), 1);
+        assert_eq!(chain.descriptors()[1].address(), GuestAddress::new(0x5000));
+        assert!(chain.descriptors()[1].is_write_only());
+    }
+
+    #[test]
+    fn reads_direct_prefix_before_indirect_descriptor_when_negotiated() {
+        let mut memory = guest_memory(0x8000);
+        write_descriptor(
+            &mut memory,
+            TABLE,
+            0,
+            0x4000,
+            0x20,
+            VIRTQUEUE_DESC_F_NEXT,
+            1,
+        );
+        write_descriptor(
+            &mut memory,
+            TABLE,
+            1,
+            INDIRECT_TABLE.raw_value(),
+            16,
+            VIRTQUEUE_DESC_F_INDIRECT,
+            0,
+        );
+        write_descriptor(
+            &mut memory,
+            INDIRECT_TABLE,
+            0,
+            0x5000,
+            0x30,
+            VIRTQUEUE_DESC_F_WRITE,
+            0,
+        );
+
+        let chain =
+            read_descriptor_chain_with_options(&memory, TABLE, 8, 0, indirect_descriptor_options())
+                .expect("direct prefix followed by indirect table should read");
+
+        assert_eq!(chain.head_index(), 0);
+        assert_eq!(chain.len(), 2);
+        assert_eq!(chain.descriptors()[0].index(), 0);
+        assert_eq!(chain.descriptors()[0].address(), GuestAddress::new(0x4000));
+        assert_eq!(chain.descriptors()[1].index(), 0);
+        assert_eq!(chain.descriptors()[1].address(), GuestAddress::new(0x5000));
+    }
+
+    #[test]
     fn ignores_next_index_without_next_flag() {
         let mut memory = guest_memory(0x4000);
         write_descriptor(&mut memory, TABLE, 0, 0x2000, 0x20, 0, 8);
@@ -2306,6 +2751,300 @@ mod tests {
         assert!(matches!(
             err,
             VirtqueueDescriptorChainError::UnsupportedIndirectDescriptor { index: 0 }
+        ));
+    }
+
+    #[test]
+    fn rejects_indirect_descriptor_with_next_when_negotiated() {
+        let mut memory = guest_memory(0x8000);
+        write_descriptor(
+            &mut memory,
+            TABLE,
+            2,
+            INDIRECT_TABLE.raw_value(),
+            16,
+            VIRTQUEUE_DESC_F_INDIRECT | VIRTQUEUE_DESC_F_NEXT,
+            3,
+        );
+
+        let err =
+            read_descriptor_chain_with_options(&memory, TABLE, 8, 2, indirect_descriptor_options())
+                .expect_err("indirect descriptor with next should fail");
+
+        assert!(matches!(
+            err,
+            VirtqueueDescriptorChainError::InvalidIndirectDescriptorWithNext { index: 2 }
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_indirect_descriptor_table_lengths() {
+        let mut memory = guest_memory(0x8000);
+        write_descriptor(
+            &mut memory,
+            TABLE,
+            0,
+            INDIRECT_TABLE.raw_value(),
+            0,
+            VIRTQUEUE_DESC_F_INDIRECT,
+            0,
+        );
+
+        let err =
+            read_descriptor_chain_with_options(&memory, TABLE, 8, 0, indirect_descriptor_options())
+                .expect_err("empty indirect table should fail");
+        assert!(matches!(
+            err,
+            VirtqueueDescriptorChainError::InvalidIndirectDescriptorLength { index: 0, len: 0 }
+        ));
+
+        write_descriptor(
+            &mut memory,
+            TABLE,
+            0,
+            INDIRECT_TABLE.raw_value(),
+            15,
+            VIRTQUEUE_DESC_F_INDIRECT,
+            0,
+        );
+
+        let err =
+            read_descriptor_chain_with_options(&memory, TABLE, 8, 0, indirect_descriptor_options())
+                .expect_err("partial descriptor indirect table should fail");
+        assert!(matches!(
+            err,
+            VirtqueueDescriptorChainError::InvalidIndirectDescriptorLength { index: 0, len: 15 }
+        ));
+    }
+
+    #[test]
+    fn rejects_unaligned_indirect_descriptor_table() {
+        let mut memory = guest_memory(0x8000);
+        let table = GuestAddress::new(0x3001);
+        write_descriptor(
+            &mut memory,
+            TABLE,
+            0,
+            table.raw_value(),
+            16,
+            VIRTQUEUE_DESC_F_INDIRECT,
+            0,
+        );
+
+        let err =
+            read_descriptor_chain_with_options(&memory, TABLE, 8, 0, indirect_descriptor_options())
+                .expect_err("unaligned indirect table should fail");
+
+        assert!(matches!(
+            err,
+            VirtqueueDescriptorChainError::UnalignedDescriptorTable {
+                descriptor_table,
+                alignment: VIRTQUEUE_DESCRIPTOR_ALIGNMENT
+            } if descriptor_table == table
+        ));
+    }
+
+    #[test]
+    fn rejects_indirect_descriptor_table_range_overflow() {
+        let mut memory = guest_memory(0x8000);
+        let table = GuestAddress::new(u64::MAX - 15);
+        write_descriptor(
+            &mut memory,
+            TABLE,
+            0,
+            table.raw_value(),
+            32,
+            VIRTQUEUE_DESC_F_INDIRECT,
+            0,
+        );
+
+        let err =
+            read_descriptor_chain_with_options(&memory, TABLE, 8, 0, indirect_descriptor_options())
+                .expect_err("overflowing indirect table range should fail");
+
+        assert!(matches!(
+            err,
+            VirtqueueDescriptorChainError::IndirectDescriptorTableRangeOverflow {
+                index: 0,
+                descriptor_table,
+                len: 32
+            } if descriptor_table == table
+        ));
+    }
+
+    #[test]
+    fn rejects_unmapped_indirect_descriptor_table() {
+        let mut memory = guest_memory(0x4000);
+        let table = GuestAddress::new(0x4000);
+        write_descriptor(
+            &mut memory,
+            TABLE,
+            0,
+            table.raw_value(),
+            16,
+            VIRTQUEUE_DESC_F_INDIRECT,
+            0,
+        );
+
+        let err =
+            read_descriptor_chain_with_options(&memory, TABLE, 8, 0, indirect_descriptor_options())
+                .expect_err("unmapped indirect table should fail");
+
+        assert!(matches!(
+            err,
+            VirtqueueDescriptorChainError::IndirectDescriptorTableAccess {
+                index: 0,
+                descriptor_table,
+                len: 16,
+                source: GuestMemoryAccessError::UnmappedRange { .. }
+            } if descriptor_table == table
+        ));
+    }
+
+    #[test]
+    fn rejects_nested_indirect_descriptor() {
+        let mut memory = guest_memory(0x8000);
+        write_descriptor(
+            &mut memory,
+            TABLE,
+            0,
+            INDIRECT_TABLE.raw_value(),
+            16,
+            VIRTQUEUE_DESC_F_INDIRECT,
+            0,
+        );
+        write_descriptor(
+            &mut memory,
+            INDIRECT_TABLE,
+            0,
+            0x4000,
+            16,
+            VIRTQUEUE_DESC_F_INDIRECT,
+            0,
+        );
+
+        let err =
+            read_descriptor_chain_with_options(&memory, TABLE, 8, 0, indirect_descriptor_options())
+                .expect_err("nested indirect descriptor should fail");
+
+        assert!(matches!(
+            err,
+            VirtqueueDescriptorChainError::NestedIndirectDescriptor { index: 0 }
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_indirect_next_index() {
+        let mut memory = guest_memory(0x8000);
+        write_descriptor(
+            &mut memory,
+            TABLE,
+            0,
+            INDIRECT_TABLE.raw_value(),
+            32,
+            VIRTQUEUE_DESC_F_INDIRECT,
+            0,
+        );
+        write_descriptor(
+            &mut memory,
+            INDIRECT_TABLE,
+            0,
+            0x4000,
+            0x20,
+            VIRTQUEUE_DESC_F_NEXT,
+            2,
+        );
+
+        let err =
+            read_descriptor_chain_with_options(&memory, TABLE, 8, 0, indirect_descriptor_options())
+                .expect_err("invalid indirect next index should fail");
+
+        assert!(matches!(
+            err,
+            VirtqueueDescriptorChainError::InvalidNextIndex {
+                index: 0,
+                next_index: 2,
+                queue_size: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_cyclic_indirect_descriptor_chain() {
+        let mut memory = guest_memory(0x8000);
+        write_descriptor(
+            &mut memory,
+            TABLE,
+            2,
+            INDIRECT_TABLE.raw_value(),
+            32,
+            VIRTQUEUE_DESC_F_INDIRECT,
+            0,
+        );
+        write_descriptor(
+            &mut memory,
+            INDIRECT_TABLE,
+            0,
+            0x4000,
+            0x20,
+            VIRTQUEUE_DESC_F_NEXT,
+            1,
+        );
+        write_descriptor(
+            &mut memory,
+            INDIRECT_TABLE,
+            1,
+            0x5000,
+            0x20,
+            VIRTQUEUE_DESC_F_NEXT,
+            0,
+        );
+
+        let err =
+            read_descriptor_chain_with_options(&memory, TABLE, 4, 2, indirect_descriptor_options())
+                .expect_err("cyclic indirect descriptor chain should fail");
+
+        assert!(matches!(
+            err,
+            VirtqueueDescriptorChainError::DescriptorChainTooLong {
+                head_index: 2,
+                queue_size: 4
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_resolved_indirect_chain_longer_than_queue() {
+        let mut memory = guest_memory(0x8000);
+        write_descriptor(
+            &mut memory,
+            TABLE,
+            0,
+            0x4000,
+            0x20,
+            VIRTQUEUE_DESC_F_NEXT,
+            1,
+        );
+        write_descriptor(
+            &mut memory,
+            TABLE,
+            1,
+            INDIRECT_TABLE.raw_value(),
+            32,
+            VIRTQUEUE_DESC_F_INDIRECT,
+            0,
+        );
+
+        let err =
+            read_descriptor_chain_with_options(&memory, TABLE, 2, 0, indirect_descriptor_options())
+                .expect_err("resolved descriptor chain should not exceed queue size");
+
+        assert!(matches!(
+            err,
+            VirtqueueDescriptorChainError::DescriptorChainTooLong {
+                head_index: 0,
+                queue_size: 2
+            }
         ));
     }
 

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -27,8 +27,8 @@ use crate::virtio_mmio::{
 };
 use crate::virtio_queue::{
     VirtqueueAvailableRing, VirtqueueAvailableRingError, VirtqueueDescriptor,
-    VirtqueueDescriptorChain, VirtqueueNotificationSuppression, VirtqueueUsedRing,
-    VirtqueueUsedRingError, VirtqueueUsedRingPublication,
+    VirtqueueDescriptorChain, VirtqueueDescriptorChainOptions, VirtqueueNotificationSuppression,
+    VirtqueueUsedRing, VirtqueueUsedRingError, VirtqueueUsedRingPublication,
 };
 
 pub const MIN_GUEST_CID: u32 = 3;
@@ -55,6 +55,7 @@ pub const VIRTIO_VSOCK_OP_CREDIT_UPDATE: u16 = 6;
 pub const VIRTIO_VSOCK_OP_CREDIT_REQUEST: u16 = 7;
 pub const VIRTIO_VSOCK_FLAGS_SHUTDOWN_RCV: u32 = 1;
 pub const VIRTIO_VSOCK_FLAGS_SHUTDOWN_SEND: u32 = 2;
+pub const VIRTIO_RING_FEATURE_INDIRECT_DESC: u32 = 28;
 pub const VIRTIO_RING_FEATURE_EVENT_IDX: u32 = 29;
 pub const VIRTIO_FEATURE_VERSION_1: u32 = 32;
 pub const VIRTIO_FEATURE_IN_ORDER: u32 = 35;
@@ -3497,6 +3498,7 @@ impl VirtioVsockConfigSpace {
     pub const fn available_features(self) -> u64 {
         virtio_feature_bit(VIRTIO_FEATURE_VERSION_1)
             | virtio_feature_bit(VIRTIO_FEATURE_IN_ORDER)
+            | virtio_feature_bit(VIRTIO_RING_FEATURE_INDIRECT_DESC)
             | virtio_feature_bit(VIRTIO_RING_FEATURE_EVENT_IDX)
     }
 
@@ -4183,12 +4185,13 @@ impl VirtioVsockRxQueue {
     pub fn from_mmio_queue_state(
         queue: VirtioMmioQueueState,
     ) -> Result<Self, VirtioVsockQueueBuildError> {
-        Self::from_mmio_queue_state_with_event_idx(queue, false)
+        Self::from_mmio_queue_state_with_event_idx(queue, false, false)
     }
 
     fn from_mmio_queue_state_with_event_idx(
         queue: VirtioMmioQueueState,
         event_idx_enabled: bool,
+        indirect_descriptors_enabled: bool,
     ) -> Result<Self, VirtioVsockQueueBuildError> {
         validate_active_vsock_queue(queue)?;
         let available = VirtqueueAvailableRing::new(
@@ -4197,6 +4200,10 @@ impl VirtioVsockRxQueue {
             queue.size(),
         )
         .map_err(|source| VirtioVsockQueueBuildError::AvailableRing { source })?;
+        let available = available.with_descriptor_chain_options(
+            VirtqueueDescriptorChainOptions::new()
+                .with_indirect_descriptors(indirect_descriptors_enabled),
+        );
         let used = VirtqueueUsedRing::new(queue.device_ring(), queue.size())
             .map_err(|source| VirtioVsockQueueBuildError::UsedRing { source })?;
 
@@ -4578,12 +4585,13 @@ impl VirtioVsockTxQueue {
     pub fn from_mmio_queue_state(
         queue: VirtioMmioQueueState,
     ) -> Result<Self, VirtioVsockQueueBuildError> {
-        Self::from_mmio_queue_state_with_event_idx(queue, false)
+        Self::from_mmio_queue_state_with_event_idx(queue, false, false)
     }
 
     fn from_mmio_queue_state_with_event_idx(
         queue: VirtioMmioQueueState,
         event_idx_enabled: bool,
+        indirect_descriptors_enabled: bool,
     ) -> Result<Self, VirtioVsockQueueBuildError> {
         validate_active_vsock_queue(queue)?;
         let available = VirtqueueAvailableRing::new(
@@ -4592,6 +4600,10 @@ impl VirtioVsockTxQueue {
             queue.size(),
         )
         .map_err(|source| VirtioVsockQueueBuildError::AvailableRing { source })?;
+        let available = available.with_descriptor_chain_options(
+            VirtqueueDescriptorChainOptions::new()
+                .with_indirect_descriptors(indirect_descriptors_enabled),
+        );
         let used = VirtqueueUsedRing::new(queue.device_ring(), queue.size())
             .map_err(|source| VirtioVsockQueueBuildError::UsedRing { source })?;
 
@@ -4915,10 +4927,11 @@ impl std::error::Error for VirtioVsockQueueBuildError {
 }
 
 fn descriptor_chain_head(chain: &VirtqueueDescriptorChain) -> Option<u16> {
-    chain
-        .descriptors()
-        .first()
-        .map(|descriptor| descriptor.index())
+    if chain.is_empty() {
+        None
+    } else {
+        Some(chain.head_index())
+    }
 }
 
 fn validate_active_vsock_queue(
@@ -5212,21 +5225,33 @@ impl VirtioVsockDevice {
 
         let event_idx_enabled =
             virtio_feature_enabled(activation.driver_features(), VIRTIO_RING_FEATURE_EVENT_IDX);
+        let indirect_descriptors_enabled = virtio_feature_enabled(
+            activation.driver_features(),
+            VIRTIO_RING_FEATURE_INDIRECT_DESC,
+        );
         let active_rx_queue = active_vsock_queue_state(activation, VIRTIO_VSOCK_RX_QUEUE_INDEX_U32)
             .and_then(|queue| {
-                VirtioVsockRxQueue::from_mmio_queue_state_with_event_idx(queue, event_idx_enabled)
-                    .map_err(|source| VirtioVsockDeviceActivationError::RxQueueBuild {
-                        queue_index: VIRTIO_VSOCK_RX_QUEUE_INDEX_U32,
-                        source,
-                    })
+                VirtioVsockRxQueue::from_mmio_queue_state_with_event_idx(
+                    queue,
+                    event_idx_enabled,
+                    indirect_descriptors_enabled,
+                )
+                .map_err(|source| VirtioVsockDeviceActivationError::RxQueueBuild {
+                    queue_index: VIRTIO_VSOCK_RX_QUEUE_INDEX_U32,
+                    source,
+                })
             })?;
         let active_tx_queue = active_vsock_queue_state(activation, VIRTIO_VSOCK_TX_QUEUE_INDEX_U32)
             .and_then(|queue| {
-                VirtioVsockTxQueue::from_mmio_queue_state_with_event_idx(queue, event_idx_enabled)
-                    .map_err(|source| VirtioVsockDeviceActivationError::TxQueueBuild {
-                        queue_index: VIRTIO_VSOCK_TX_QUEUE_INDEX_U32,
-                        source,
-                    })
+                VirtioVsockTxQueue::from_mmio_queue_state_with_event_idx(
+                    queue,
+                    event_idx_enabled,
+                    indirect_descriptors_enabled,
+                )
+                .map_err(|source| VirtioVsockDeviceActivationError::TxQueueBuild {
+                    queue_index: VIRTIO_VSOCK_TX_QUEUE_INDEX_U32,
+                    source,
+                })
             })?;
         let active_event_queue =
             active_vsock_queue_state(activation, VIRTIO_VSOCK_EVENT_QUEUE_INDEX_U32).and_then(
@@ -7180,9 +7205,9 @@ mod tests {
 
     use super::{
         MIN_GUEST_CID, PreparedVsockDevice, VIRTIO_FEATURE_IN_ORDER, VIRTIO_FEATURE_VERSION_1,
-        VIRTIO_RING_FEATURE_EVENT_IDX, VIRTIO_VSOCK_CONFIG_GUEST_CID_SIZE,
-        VIRTIO_VSOCK_CONNECTION_BUFFER_SIZE, VIRTIO_VSOCK_DEVICE_ID,
-        VIRTIO_VSOCK_EVENT_QUEUE_INDEX, VIRTIO_VSOCK_FLAGS_SHUTDOWN_RCV,
+        VIRTIO_RING_FEATURE_EVENT_IDX, VIRTIO_RING_FEATURE_INDIRECT_DESC,
+        VIRTIO_VSOCK_CONFIG_GUEST_CID_SIZE, VIRTIO_VSOCK_CONNECTION_BUFFER_SIZE,
+        VIRTIO_VSOCK_DEVICE_ID, VIRTIO_VSOCK_EVENT_QUEUE_INDEX, VIRTIO_VSOCK_FLAGS_SHUTDOWN_RCV,
         VIRTIO_VSOCK_FLAGS_SHUTDOWN_SEND, VIRTIO_VSOCK_HOST_CID,
         VIRTIO_VSOCK_MAX_PACKET_BUFFER_SIZE, VIRTIO_VSOCK_OP_CREDIT_REQUEST,
         VIRTIO_VSOCK_OP_CREDIT_UPDATE, VIRTIO_VSOCK_OP_REQUEST, VIRTIO_VSOCK_OP_RESPONSE,
@@ -8503,8 +8528,12 @@ mod tests {
         let queue_state = *queues
             .queue(queue_index)
             .expect("TX queue state should be configured");
-        VirtioVsockTxQueue::from_mmio_queue_state_with_event_idx(queue_state, event_idx_enabled)
-            .expect("TX queue should build")
+        VirtioVsockTxQueue::from_mmio_queue_state_with_event_idx(
+            queue_state,
+            event_idx_enabled,
+            false,
+        )
+        .expect("TX queue should build")
     }
 
     fn write_vsock_rx_descriptor(memory: &mut GuestMemory, index: u16, descriptor: TestDescriptor) {
@@ -8677,8 +8706,12 @@ mod tests {
         let queue_state = *queues
             .queue(queue_index)
             .expect("RX queue state should be configured");
-        VirtioVsockRxQueue::from_mmio_queue_state_with_event_idx(queue_state, event_idx_enabled)
-            .expect("RX queue should build")
+        VirtioVsockRxQueue::from_mmio_queue_state_with_event_idx(
+            queue_state,
+            event_idx_enabled,
+            false,
+        )
+        .expect("RX queue should build")
     }
 
     #[test]
@@ -10681,6 +10714,10 @@ mod tests {
         assert_eq!(VIRTIO_VSOCK_QUEUE_SIZE, 256);
         assert_eq!(VIRTIO_VSOCK_QUEUE_SIZES, [256, 256, 256]);
         assert_eq!(VIRTIO_VSOCK_CONFIG_GUEST_CID_SIZE, 8);
+        assert_eq!(VIRTIO_RING_FEATURE_INDIRECT_DESC, 28);
+        assert_eq!(VIRTIO_RING_FEATURE_EVENT_IDX, 29);
+        assert_eq!(VIRTIO_FEATURE_VERSION_1, 32);
+        assert_eq!(VIRTIO_FEATURE_IN_ORDER, 35);
     }
 
     #[test]
@@ -11955,6 +11992,7 @@ mod tests {
         let features = config.available_features();
         let expected_features = (1_u64 << VIRTIO_FEATURE_VERSION_1)
             | (1_u64 << VIRTIO_FEATURE_IN_ORDER)
+            | (1_u64 << VIRTIO_RING_FEATURE_INDIRECT_DESC)
             | (1_u64 << VIRTIO_RING_FEATURE_EVENT_IDX);
 
         assert_eq!(config.guest_cid(), 3);

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -36,7 +36,8 @@ status/acknowledgement register state, a composed runtime handler that routes
 common register accesses through those state models and exposes drained queue
 notifications, delegated device-configuration accesses, and a `DRIVER_OK`
 activation hook with reset callback, plus virtqueue descriptor-chain validator,
-available-ring read model, used-ring write model, and internal virtio-block
+available-ring read model with negotiated indirect descriptor support,
+used-ring write model, and internal virtio-block
 queue construction, drain, resettable active queue ownership, and active queue
 notification dispatch helper with virtio-mmio queue interrupt-status updates
 for future device handlers, internal boot-resource assembly from stored VM
@@ -63,7 +64,7 @@ delivery, including timer EOI/deactivation-driven unmasking,
 general HVF runner-loop notification scheduling, public serial output streaming,
 serial/backend interrupt wiring beyond the internal boot block and network notification
 and retained serial capture paths,
-device-backed feature negotiation, indirect descriptor support,
+broader device-backed feature negotiation,
 device-backed runner-loop MMIO scheduling, complete device emulation,
 full Firecracker metrics counters, periodic metrics flushing, full logger integration,
 multi-vCPU setup, full PSCI behavior, or successful actions beyond owned `InstanceStart`
@@ -992,10 +993,14 @@ can dispatch registered block-device, virtio-net, and virtio-vsock queue notific
 against caller-supplied guest memory. Internal HVF boot sessions can signal
 needed block, network, and vsock SPI interrupts from those dispatch summaries, but
 future public scheduler and device policy remain deferred. The
-virtqueue model can publish one used-ring completion element with validated
-layout, mapped-memory checks, wrapping, and release ordering. Virtio-block
-queue dispatch, network RX/TX dispatch, and vsock RX/TX dispatch honor
-negotiated used-event interrupt suppression for each published completion,
+shared virtqueue descriptor-chain reader supports direct chains by default and
+negotiated `VIRTIO_RING_F_INDIRECT_DESC` indirect descriptor tables for
+virtio-block, virtio-net, and virtio-vsock RX/TX queues, while preserving the
+main descriptor head for used-ring completions. The virtqueue model can publish
+one used-ring completion element with validated layout, mapped-memory checks,
+wrapping, and release ordering. Virtio-block queue dispatch, network RX/TX
+dispatch, and vsock RX/TX dispatch honor negotiated used-event interrupt
+suppression for each published completion,
 while batching, avail-event kick suppression, and device-backed completion loops
 are still deferred.
 


### PR DESCRIPTION
## Summary

- Add negotiated split-virtqueue indirect descriptor parsing to the shared descriptor-chain reader.
- Wire block, net, and vsock active queues to enable indirect descriptors only after driver feature bit 28 is negotiated.
- Advertise the indirect descriptor feature bit from existing virtio devices and update compatibility documentation.

## Scope

- Supports split-ring indirect descriptor tables for the existing shared block/net/vsock descriptor path.
- Leaves packed virtqueues, `VIRTIO_F_IN_ORDER` semantics, rate limiting, and broader device emulation out of scope.

Closes #484

## Validation

- `cargo test -p bangbang-runtime --all-targets --all-features --locked virtio_queue`
- `cargo test -p bangbang-runtime --all-targets --all-features --locked block::tests::`
- `cargo test -p bangbang-runtime --all-targets --all-features --locked network::tests::`
- `cargo test -p bangbang-runtime --all-targets --all-features --locked vsock::tests::`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`
