### PR TITLE
feat: publish virtqueue avail-event hints

### DIFF
--- a/crates/runtime/src/block.rs
+++ b/crates/runtime/src/block.rs
@@ -1243,6 +1243,7 @@ impl VirtioBlockQueue {
         if self.event_idx_enabled {
             Ok(VirtqueueNotificationSuppression::EventIdx {
                 used_event: self.available.used_event(memory)?,
+                avail_event: self.available.next_avail(),
             })
         } else {
             Ok(VirtqueueNotificationSuppression::Disabled)
@@ -3493,6 +3494,14 @@ mod tests {
             .expect("used entry address should not overflow")
     }
 
+    fn used_ring_avail_event_address(queue_size: u16) -> GuestAddress {
+        TEST_USED_RING
+            .checked_add(
+                TEST_USED_RING_RING_OFFSET + u64::from(queue_size) * TEST_USED_RING_ELEMENT_SIZE,
+            )
+            .expect("used avail-event address should not overflow")
+    }
+
     fn write_available_heads(memory: &mut GuestMemory, heads: &[u16]) {
         for (ring_index, head) in heads.iter().copied().enumerate() {
             write_guest_u16(
@@ -3520,6 +3529,10 @@ mod tests {
 
     fn read_used_index(memory: &GuestMemory) -> u16 {
         read_guest_u16(memory, used_ring_idx_address())
+    }
+
+    fn read_used_avail_event(memory: &GuestMemory, queue_size: u16) -> u16 {
+        read_guest_u16(memory, used_ring_avail_event_address(queue_size))
     }
 
     fn read_used_element(memory: &GuestMemory, ring_index: u16) -> (u32, u32) {
@@ -6196,6 +6209,7 @@ mod tests {
                 VIRTIO_BLOCK_SECTOR_SIZE as u32 + VIRTIO_BLOCK_STATUS_SIZE,
             )
         );
+        assert_eq!(read_used_avail_event(&memory, queue_size), 1);
     }
 
     #[test]

--- a/crates/runtime/src/network.rs
+++ b/crates/runtime/src/network.rs
@@ -1459,6 +1459,7 @@ impl VirtioNetworkRxQueue {
         if self.event_idx_enabled {
             Ok(VirtqueueNotificationSuppression::EventIdx {
                 used_event: self.available.used_event(memory)?,
+                avail_event: self.available.next_avail(),
             })
         } else {
             Ok(VirtqueueNotificationSuppression::Disabled)
@@ -2115,6 +2116,7 @@ impl VirtioNetworkTxQueue {
         if self.event_idx_enabled {
             Ok(VirtqueueNotificationSuppression::EventIdx {
                 used_event: self.available.used_event(memory)?,
+                avail_event: self.available.next_avail(),
             })
         } else {
             Ok(VirtqueueNotificationSuppression::Disabled)

--- a/crates/runtime/src/virtio_queue.rs
+++ b/crates/runtime/src/virtio_queue.rs
@@ -508,7 +508,7 @@ impl VirtqueueAvailableRing {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VirtqueueNotificationSuppression {
     Disabled,
-    EventIdx { used_event: u16 },
+    EventIdx { used_event: u16, avail_event: u16 },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -609,6 +609,25 @@ impl VirtqueueUsedRing {
             len,
         )?;
 
+        let needs_queue_interrupt = match notification_suppression {
+            VirtqueueNotificationSuppression::Disabled => true,
+            VirtqueueNotificationSuppression::EventIdx {
+                used_event,
+                avail_event,
+            } => {
+                let avail_event_address =
+                    used_ring_avail_event_address(self.used_ring, self.queue_size)?;
+                write_used_ring_u16(
+                    memory,
+                    self.used_ring,
+                    self.queue_size,
+                    avail_event_address,
+                    avail_event,
+                )?;
+                virtqueue_event_idx_needs_notification(old_used, next_used, used_event)
+            }
+        };
+
         // Match Firecracker's ordering point before making a used entry
         // visible by advancing UsedRing.idx.
         fence(Ordering::Release);
@@ -629,12 +648,7 @@ impl VirtqueueUsedRing {
         self.next_used = next_used;
 
         Ok(VirtqueueUsedRingPublication {
-            needs_queue_interrupt: match notification_suppression {
-                VirtqueueNotificationSuppression::Disabled => true,
-                VirtqueueNotificationSuppression::EventIdx { used_event } => {
-                    virtqueue_event_idx_needs_notification(old_used, next_used, used_event)
-                }
-            },
+            needs_queue_interrupt,
         })
     }
 }
@@ -1374,6 +1388,21 @@ fn used_ring_entry_address(
     used_ring_offset_address(used_ring, queue_size, entry_offset)
 }
 
+fn used_ring_avail_event_address(
+    used_ring: GuestAddress,
+    queue_size: u16,
+) -> Result<GuestAddress, VirtqueueUsedRingError> {
+    let avail_event_offset = u64::from(queue_size)
+        .checked_mul(VIRTQUEUE_USED_RING_ELEMENT_SIZE_U64)
+        .and_then(|offset| offset.checked_add(VIRTQUEUE_USED_RING_RING_OFFSET))
+        .ok_or(VirtqueueUsedRingError::UsedRingRangeOverflow {
+            used_ring,
+            queue_size,
+        })?;
+
+    used_ring_offset_address(used_ring, queue_size, avail_event_offset)
+}
+
 fn read_available_ring_u16(
     memory: &GuestMemory,
     available_ring: GuestAddress,
@@ -1670,6 +1699,28 @@ mod tests {
             .expect("used ring entry address should not overflow")
     }
 
+    fn used_ring_avail_event_address(used_ring: GuestAddress, queue_size: u16) -> GuestAddress {
+        used_ring
+            .checked_add(
+                VIRTQUEUE_USED_RING_RING_OFFSET
+                    + u64::from(queue_size) * VIRTQUEUE_USED_RING_ELEMENT_SIZE_U64,
+            )
+            .expect("used ring avail_event address should not overflow")
+    }
+
+    fn write_used_avail_event(
+        memory: &mut GuestMemory,
+        used_ring: GuestAddress,
+        queue_size: u16,
+        value: u16,
+    ) {
+        write_u16(
+            memory,
+            used_ring_avail_event_address(used_ring, queue_size),
+            value,
+        );
+    }
+
     fn indirect_descriptor_options() -> VirtqueueDescriptorChainOptions {
         VirtqueueDescriptorChainOptions::new().with_indirect_descriptors(true)
     }
@@ -1780,7 +1831,10 @@ mod tests {
                 &mut memory,
                 0,
                 0,
-                VirtqueueNotificationSuppression::EventIdx { used_event: 1 },
+                VirtqueueNotificationSuppression::EventIdx {
+                    used_event: 1,
+                    avail_event: 10,
+                },
             )
             .expect("first used element should publish");
         let second = queue
@@ -1788,7 +1842,10 @@ mod tests {
                 &mut memory,
                 1,
                 0,
-                VirtqueueNotificationSuppression::EventIdx { used_event: 1 },
+                VirtqueueNotificationSuppression::EventIdx {
+                    used_event: 1,
+                    avail_event: 11,
+                },
             )
             .expect("second used element should publish");
 
@@ -1798,6 +1855,117 @@ mod tests {
         assert_eq!(
             read_u16_field(&memory, USED.checked_add(2).expect("idx should fit")),
             2
+        );
+        assert_eq!(
+            read_u16_field(&memory, used_ring_avail_event_address(USED, 8)),
+            11
+        );
+    }
+
+    #[test]
+    fn publish_used_element_writes_avail_event_with_event_idx() {
+        let mut memory = guest_memory(0x4000);
+        let mut queue =
+            VirtqueueUsedRing::new(USED, 8).expect("used ring should be valid for publishing");
+
+        let publication = queue
+            .publish_used_element_with_notification(
+                &mut memory,
+                0,
+                16,
+                VirtqueueNotificationSuppression::EventIdx {
+                    used_event: 0,
+                    avail_event: 7,
+                },
+            )
+            .expect("used element with avail_event should publish");
+
+        assert!(publication.needs_queue_interrupt());
+        assert_eq!(queue.next_used(), 1);
+        assert_eq!(
+            read_u16_field(&memory, used_ring_avail_event_address(USED, 8)),
+            7
+        );
+        assert_eq!(
+            read_u16_field(&memory, USED.checked_add(2).expect("idx should fit")),
+            1
+        );
+    }
+
+    #[test]
+    fn publish_used_element_does_not_write_avail_event_when_event_idx_disabled() {
+        let mut memory = guest_memory(0x4000);
+        write_used_avail_event(&mut memory, USED, 8, 0x1234);
+        let mut queue =
+            VirtqueueUsedRing::new(USED, 8).expect("used ring should be valid for publishing");
+
+        let publication = queue
+            .publish_used_element_with_notification(
+                &mut memory,
+                0,
+                16,
+                VirtqueueNotificationSuppression::Disabled,
+            )
+            .expect("disabled event-index used element should publish");
+
+        assert!(publication.needs_queue_interrupt());
+        assert_eq!(queue.next_used(), 1);
+        assert_eq!(
+            read_u16_field(&memory, used_ring_avail_event_address(USED, 8)),
+            0x1234
+        );
+    }
+
+    #[test]
+    fn publish_used_element_rejects_unmapped_avail_event_trailer_without_advancing() {
+        let mut memory = guest_memory(0x4000);
+        let used_ring = GuestAddress::new(0x3fe0);
+        let mut queue = VirtqueueUsedRing::new(used_ring, 4)
+            .expect("used ring address should be valid without memory mapping");
+
+        let err = queue
+            .publish_used_element_with_notification(
+                &mut memory,
+                0,
+                16,
+                VirtqueueNotificationSuppression::EventIdx {
+                    used_event: 0,
+                    avail_event: 1,
+                },
+            )
+            .expect_err("partially unmapped used ring trailer should fail");
+
+        assert!(matches!(err, VirtqueueUsedRingError::UsedRingAccess { .. }));
+        assert_eq!(queue.next_used(), 0);
+    }
+
+    #[test]
+    fn publish_used_element_writes_wrapping_avail_event_with_event_idx() {
+        let mut memory = guest_memory(0x4000);
+        let mut queue = VirtqueueUsedRing::with_next_used(USED, 8, u16::MAX)
+            .expect("used ring should be valid for wrapping publication");
+
+        let publication = queue
+            .publish_used_element_with_notification(
+                &mut memory,
+                0,
+                16,
+                VirtqueueNotificationSuppression::EventIdx {
+                    used_event: u16::MAX,
+                    avail_event: u16::MAX,
+                },
+            )
+            .expect("wrapping used element should publish");
+
+        assert!(publication.needs_queue_interrupt());
+        assert_eq!(queue.next_used(), 0);
+        assert_eq!(
+            read_u16_field(&memory, USED.checked_add(2).expect("idx should fit")),
+            0
+        );
+        assert_eq!(
+            read_u16_field(&memory, used_ring_avail_event_address(USED, 8)),
+            u16::MAX
         );
     }
 

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -4408,6 +4408,7 @@ impl VirtioVsockRxQueue {
         if self.event_idx_enabled {
             Ok(VirtqueueNotificationSuppression::EventIdx {
                 used_event: self.available.used_event(memory)?,
+                avail_event: self.available.next_avail(),
             })
         } else {
             Ok(VirtqueueNotificationSuppression::Disabled)
@@ -4704,6 +4705,7 @@ impl VirtioVsockTxQueue {
         if self.event_idx_enabled {
             Ok(VirtqueueNotificationSuppression::EventIdx {
                 used_event: self.available.used_event(memory)?,
+                avail_event: self.available.next_avail(),
             })
         } else {
             Ok(VirtqueueNotificationSuppression::Disabled)

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -1000,9 +1000,9 @@ main descriptor head for used-ring completions. The virtqueue model can publish
 one used-ring completion element with validated layout, mapped-memory checks,
 wrapping, and release ordering. Virtio-block queue dispatch, network RX/TX
 dispatch, and vsock RX/TX dispatch honor negotiated used-event interrupt
-suppression for each published completion,
-while batching, avail-event kick suppression, and device-backed completion loops
-are still deferred.
+suppression for each published completion and publish a shared used-ring
+`avail_event` hint for available-buffer notification suppression, while
+batching and device-backed completion loops are still deferred.
 
 The runtime crate also contains backend-neutral interrupt signaling groundwork.
 It can validate nonzero guest interrupt lines, represent queue and


### PR DESCRIPTION
## Summary

- publish the used-ring `avail_event` trailer from the shared virtqueue event-index path
- pass the available-ring `next_avail` hint from block, network, and vsock queues when `EVENT_IDX` is negotiated
- cover trailer publication, disabled behavior, mapped-memory failure, wrapping values, and representative block integration
- update Firecracker compatibility docs to move shared avail-event hint publication out of deferred work

## Scope

Out of scope: descriptor batching, Firecracker-style drained-queue notification rearming, public scheduler/device loops, hotplug, and new virtio device types.

Closes #486

## Validation

- `cargo test -p bangbang-runtime --all-targets --all-features --locked virtio_queue`
- `cargo test -p bangbang-runtime --all-targets --all-features --locked block_device_notification_dispatch_suppresses_interrupt_with_event_idx`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`
