### PR TITLE
feat: support configurable HTTP API payload limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ cargo run -p bangbang -- --api-sock /tmp/bangbang.socket --id demo-1
 
 - `--api-sock <PATH>` sets the Unix socket path. The default is
   `/tmp/bangbang.socket`.
+- `--http-api-max-payload-size <BYTES>` sets the maximum accepted HTTP API
+  request size. The default is `51200` bytes.
 - `--id <ID>` records the microVM identifier. The default is
   `anonymous-instance`.
 - `--metrics-path <PATH>` configures the same per-process metrics sink as

--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -1087,7 +1087,14 @@ fn vsock_config_response_value(vsock: &VsockConfigResponse) -> serde_json::Value
 }
 
 pub fn parse_request(bytes: &[u8]) -> Result<ApiRequest, RequestError> {
-    if bytes.len() > HTTP_MAX_PAYLOAD_SIZE {
+    parse_request_with_limit(bytes, HTTP_MAX_PAYLOAD_SIZE)
+}
+
+pub fn parse_request_with_limit(
+    bytes: &[u8],
+    max_payload_size: usize,
+) -> Result<ApiRequest, RequestError> {
+    if bytes.len() > max_payload_size {
         return Err(RequestError::PayloadTooLarge);
     }
 
@@ -1100,7 +1107,7 @@ pub fn parse_request(bytes: &[u8]) -> Result<ApiRequest, RequestError> {
         return Err(RequestError::MalformedRequest);
     }
 
-    checked_request_len(header_len, request_body.content_length())?;
+    checked_request_len(header_len, request_body.content_length(), max_payload_size)?;
 
     if body.len() != request_body.content_length() {
         return Err(RequestError::MalformedRequest);
@@ -1509,7 +1516,14 @@ fn require_u64_field(
 }
 
 pub fn request_total_len(bytes: &[u8]) -> Result<Option<usize>, RequestError> {
-    if bytes.len() > HTTP_MAX_PAYLOAD_SIZE {
+    request_total_len_with_limit(bytes, HTTP_MAX_PAYLOAD_SIZE)
+}
+
+pub fn request_total_len_with_limit(
+    bytes: &[u8],
+    max_payload_size: usize,
+) -> Result<Option<usize>, RequestError> {
+    if bytes.len() > max_payload_size {
         return Err(RequestError::PayloadTooLarge);
     }
 
@@ -1531,6 +1545,7 @@ pub fn request_total_len(bytes: &[u8]) -> Result<Option<usize>, RequestError> {
     Ok(Some(checked_request_len(
         header_len,
         body.content_length(),
+        max_payload_size,
     )?))
 }
 
@@ -1640,12 +1655,16 @@ const fn is_http_optional_whitespace(byte: u8) -> bool {
     matches!(byte, b' ' | b'\t')
 }
 
-fn checked_request_len(header_len: usize, content_length: usize) -> Result<usize, RequestError> {
+fn checked_request_len(
+    header_len: usize,
+    content_length: usize,
+    max_payload_size: usize,
+) -> Result<usize, RequestError> {
     let total_len = header_len
         .checked_add(content_length)
         .ok_or(RequestError::PayloadTooLarge)?;
 
-    if total_len > HTTP_MAX_PAYLOAD_SIZE {
+    if total_len > max_payload_size {
         return Err(RequestError::PayloadTooLarge);
     }
 
@@ -1720,6 +1739,35 @@ mod tests {
 
         assert_eq!(parse_request(request), Ok(ApiRequest::GetVersion));
         assert_eq!(request_total_len(request), Ok(Some(request.len())));
+    }
+
+    #[test]
+    fn parses_request_at_custom_payload_limit() {
+        let request = b"GET /version HTTP/1.1\r\nHost: localhost\r\n\r\n";
+
+        assert_eq!(
+            parse_request_with_limit(request, request.len()),
+            Ok(ApiRequest::GetVersion)
+        );
+        assert_eq!(
+            request_total_len_with_limit(request, request.len()),
+            Ok(Some(request.len()))
+        );
+    }
+
+    #[test]
+    fn rejects_request_over_custom_payload_limit() {
+        let request = b"GET /version HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        let limit = request.len() - 1;
+
+        assert_eq!(
+            parse_request_with_limit(request, limit),
+            Err(RequestError::PayloadTooLarge)
+        );
+        assert_eq!(
+            request_total_len_with_limit(request, limit),
+            Err(RequestError::PayloadTooLarge)
+        );
     }
 
     #[test]
@@ -3385,6 +3433,20 @@ mod tests {
     }
 
     #[test]
+    fn rejects_declared_content_length_over_custom_payload_limit() {
+        let request = b"GET /version HTTP/1.1\r\nContent-Length: 10\r\n\r\n";
+
+        assert_eq!(
+            parse_request_with_limit(request, request.len()),
+            Err(RequestError::PayloadTooLarge)
+        );
+        assert_eq!(
+            request_total_len_with_limit(request, request.len()),
+            Err(RequestError::PayloadTooLarge)
+        );
+    }
+
+    #[test]
     fn rejects_declared_content_length_over_usize() {
         let request =
             b"GET /version HTTP/1.1\r\nContent-Length: 999999999999999999999999999999\r\n\r\n";
@@ -3401,6 +3463,27 @@ mod tests {
         let request = vec![b'a'; HTTP_MAX_PAYLOAD_SIZE + 1];
 
         assert_eq!(parse_request(&request), Err(RequestError::PayloadTooLarge));
+    }
+
+    #[test]
+    fn parses_request_above_default_with_custom_payload_limit() {
+        let module = "a".repeat(HTTP_MAX_PAYLOAD_SIZE);
+        let body = format!(r#"{{"module":"{module}"}}"#);
+        let request = request_with_body("PUT", "/logger", &body);
+
+        assert_eq!(parse_request(&request), Err(RequestError::PayloadTooLarge));
+        assert_eq!(
+            request_total_len_with_limit(&request, request.len()),
+            Ok(Some(request.len()))
+        );
+
+        let parsed = parse_request_with_limit(&request, request.len())
+            .expect("logger request above the default limit should parse");
+
+        let ApiRequest::PutLogger(config) = parsed else {
+            panic!("expected logger request");
+        };
+        assert_eq!(config.module(), Some(module.as_str()));
     }
 
     #[test]

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
+#[cfg(test)]
 use bangbang_api::HTTP_MAX_PAYLOAD_SIZE;
 use bangbang_api::http::{
     ActionRequest, ActionType, ApiRequest, BootSourceRequest, BootSourceResponse,
@@ -18,7 +19,7 @@ use bangbang_api::http::{
     MachineConfigResponse, MetricsConfigRequest, MmdsConfigRequest, MmdsConfigResponse,
     MmdsContentRequest, MmdsVersion as ApiMmdsVersion, NetworkInterfaceConfigRequest,
     NetworkInterfaceConfigResponse, RequestError, VmConfigResponse, VsockConfigRequest,
-    VsockConfigResponse, parse_request, request_total_len,
+    VsockConfigResponse, parse_request_with_limit, request_total_len_with_limit,
 };
 use bangbang_runtime::block::{DriveCacheType, DriveConfig, DriveConfigInput, DriveIoEngine};
 use bangbang_runtime::boot::{BootSourceConfig, BootSourceConfigInput};
@@ -78,11 +79,20 @@ impl std::error::Error for ApiServerError {}
 #[derive(Debug)]
 pub(crate) struct ApiServer {
     listener: UnixListener,
+    http_api_max_payload_size: usize,
     _socket_guard: SocketGuard,
 }
 
 impl ApiServer {
+    #[cfg(test)]
     pub(crate) fn bind(path: impl AsRef<Path>) -> Result<Self, ApiServerError> {
+        Self::bind_with_max_payload_size(path, HTTP_MAX_PAYLOAD_SIZE)
+    }
+
+    pub(crate) fn bind_with_max_payload_size(
+        path: impl AsRef<Path>,
+        http_api_max_payload_size: usize,
+    ) -> Result<Self, ApiServerError> {
         let path = path.as_ref();
 
         if path_exists_without_following_links(path)? {
@@ -98,6 +108,7 @@ impl ApiServer {
 
         Ok(Self {
             listener,
+            http_api_max_payload_size,
             _socket_guard: socket_guard,
         })
     }
@@ -137,7 +148,7 @@ impl ApiServer {
             .set_nonblocking(false)
             .map_err(|err| ApiServerError::Connection(err.kind()))?;
 
-        let _ = handle_connection(&mut stream, vmm);
+        let _ = handle_connection(&mut stream, vmm, self.http_api_max_payload_size);
 
         Ok(())
     }
@@ -383,23 +394,38 @@ enum RequestRead {
 fn handle_connection(
     stream: &mut UnixStream,
     vmm: &mut impl VmmRequestHandler,
+    http_api_max_payload_size: usize,
 ) -> Result<(), ApiServerError> {
     stream
         .set_write_timeout(Some(CONNECTION_TIMEOUT))
         .map_err(|err| ApiServerError::Connection(err.kind()))?;
 
-    let response = match read_request(stream, CONNECTION_TIMEOUT)? {
-        RequestRead::Complete(request) => handle_request_bytes(&request, vmm),
-        RequestRead::TooLarge => HttpResponse::fault(RequestError::PayloadTooLarge.fault_message()),
-    };
+    let response =
+        match read_request_with_limit(stream, CONNECTION_TIMEOUT, http_api_max_payload_size)? {
+            RequestRead::Complete(request) => {
+                handle_request_bytes_with_limit(&request, vmm, http_api_max_payload_size)
+            }
+            RequestRead::TooLarge => {
+                HttpResponse::fault(RequestError::PayloadTooLarge.fault_message())
+            }
+        };
 
     stream
         .write_all(&response.to_http_bytes())
         .map_err(|err| ApiServerError::Connection(err.kind()))
 }
 
+#[cfg(test)]
 fn handle_request_bytes(bytes: &[u8], vmm: &mut impl VmmRequestHandler) -> HttpResponse {
-    match parse_request(bytes) {
+    handle_request_bytes_with_limit(bytes, vmm, HTTP_MAX_PAYLOAD_SIZE)
+}
+
+fn handle_request_bytes_with_limit(
+    bytes: &[u8],
+    vmm: &mut impl VmmRequestHandler,
+    http_api_max_payload_size: usize,
+) -> HttpResponse {
+    match parse_request_with_limit(bytes, http_api_max_payload_size) {
         Ok(request) => handle_api_request(request, vmm),
         Err(err) => HttpResponse::fault(err.fault_message()),
     }
@@ -861,23 +887,37 @@ fn vsock_config_input_from_request(config: &VsockConfigRequest) -> VsockConfigIn
     input
 }
 
-fn read_request(stream: &mut UnixStream, timeout: Duration) -> Result<RequestRead, ApiServerError> {
+fn read_request_with_limit(
+    stream: &mut UnixStream,
+    timeout: Duration,
+    http_api_max_payload_size: usize,
+) -> Result<RequestRead, ApiServerError> {
     let deadline = Instant::now() + timeout;
     let mut now = Instant::now;
 
-    read_request_until(stream, deadline, &mut now)
+    read_request_until_with_limit(stream, deadline, &mut now, http_api_max_payload_size)
 }
 
+#[cfg(test)]
 fn read_request_until(
     stream: &mut UnixStream,
     deadline: Instant,
     now: &mut impl FnMut() -> Instant,
 ) -> Result<RequestRead, ApiServerError> {
+    read_request_until_with_limit(stream, deadline, now, HTTP_MAX_PAYLOAD_SIZE)
+}
+
+fn read_request_until_with_limit(
+    stream: &mut UnixStream,
+    deadline: Instant,
+    now: &mut impl FnMut() -> Instant,
+    http_api_max_payload_size: usize,
+) -> Result<RequestRead, ApiServerError> {
     let mut request = Vec::new();
     let mut chunk = [0; READ_CHUNK_SIZE];
 
     loop {
-        match request_total_len(&request) {
+        match request_total_len_with_limit(&request, http_api_max_payload_size) {
             Ok(Some(total_len)) if request.len() >= total_len => {
                 request.truncate(total_len);
                 return Ok(RequestRead::Complete(request));
@@ -887,7 +927,7 @@ fn read_request_until(
             Err(_) => return Ok(RequestRead::Complete(request)),
         }
 
-        let remaining = HTTP_MAX_PAYLOAD_SIZE.saturating_sub(request.len());
+        let remaining = http_api_max_payload_size.saturating_sub(request.len());
         if remaining == 0 {
             return Ok(RequestRead::TooLarge);
         }
@@ -3110,6 +3150,81 @@ mod tests {
                 r#"{"fault_message":"HTTP request payload exceeds the configured limit."}"#
             )
         );
+    }
+
+    #[test]
+    fn returns_fault_for_request_over_configured_payload_limit_without_mutation() {
+        let path = unique_socket_path("small-limit");
+        let logger_path = unique_socket_path("small-limit-output").with_extension("log");
+        let server = ApiServer::bind_with_max_payload_size(&path, 64).expect("server should bind");
+        let mut client = UnixStream::connect(&path).expect("client should connect");
+        let body = format!(
+            r#"{{"log_path":"{}","module":"{}"}}"#,
+            logger_path.to_string_lossy(),
+            "a".repeat(64)
+        );
+        let request = format!(
+            "PUT /logger HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+
+        client
+            .write_all(request.as_bytes())
+            .expect("client should write request");
+        let mut vmm = test_controller();
+        server
+            .serve_next(&mut vmm)
+            .expect("server should handle one request");
+
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("client should read response");
+
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        assert!(
+            response.contains(
+                r#"{"fault_message":"HTTP request payload exceeds the configured limit."}"#
+            )
+        );
+        assert!(!logger_path.exists());
+    }
+
+    #[test]
+    fn accepts_request_above_default_with_configured_payload_limit() {
+        let path = unique_socket_path("large-limit");
+        let module = "a".repeat(HTTP_MAX_PAYLOAD_SIZE);
+        let body = format!(r#"{{"module":"{module}"}}"#);
+        let request = format!(
+            "PUT /logger HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        assert!(request.len() > HTTP_MAX_PAYLOAD_SIZE);
+        let server = ApiServer::bind_with_max_payload_size(&path, request.len())
+            .expect("server should bind");
+        let mut client = UnixStream::connect(&path).expect("client should connect");
+        let client_handle = thread::spawn(move || {
+            client
+                .write_all(request.as_bytes())
+                .expect("client should write request");
+            let mut response = String::new();
+            client
+                .read_to_string(&mut response)
+                .expect("client should read response");
+            response
+        });
+        let mut vmm = test_controller();
+        server
+            .serve_next(&mut vmm)
+            .expect("server should handle one request");
+
+        let response = client_handle
+            .join()
+            .expect("client thread should not panic");
+
+        assert!(response.starts_with("HTTP/1.1 204 No Content\r\n"));
+        assert!(response.contains("Content-Length: 0\r\n"));
+        assert!(response.ends_with("\r\n\r\n"));
     }
 
     #[test]

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -12,6 +12,7 @@ pub mod host_network;
 mod vmm;
 
 use api_server::{ApiServer, ApiServerError};
+use bangbang_api::HTTP_MAX_PAYLOAD_SIZE;
 use bangbang_hvf::HvfBackend;
 use signal_hook::consts::signal::{SIGINT, SIGTERM};
 use signal_hook::{SigId, low_level};
@@ -31,7 +32,6 @@ const UNSUPPORTED_FIRECRACKER_ARGS: &[&str] = &[
     "config-file",
     "describe-snapshot",
     "enable-pci",
-    "http-api-max-payload-size",
     "metadata",
     "mmds-size-limit",
     "no-api",
@@ -69,6 +69,7 @@ fn run() -> Result<(), ProcessError> {
         Command::Run(config) => {
             let StartupConfig {
                 api_sock,
+                http_api_max_payload_size,
                 id,
                 logger_config,
                 metrics_config,
@@ -84,7 +85,9 @@ fn run() -> Result<(), ProcessError> {
             apply_startup_metrics_config(&mut vmm, metrics_config)?;
             apply_startup_logger_config(&mut vmm, logger_config)?;
             let mut shutdown_signal = ShutdownSignal::install()?;
-            let server = ApiServer::bind(&api_sock).map_err(ProcessError::ApiServer)?;
+            let server =
+                ApiServer::bind_with_max_payload_size(&api_sock, http_api_max_payload_size)
+                    .map_err(ProcessError::ApiServer)?;
             println!("status: API server listening; VM execution loop is not implemented yet");
             let shutdown_wakeup = shutdown_signal.wakeup_reader();
             server
@@ -257,6 +260,7 @@ enum Command {
 #[derive(Debug, PartialEq, Eq)]
 struct StartupConfig {
     api_sock: String,
+    http_api_max_payload_size: usize,
     id: String,
     logger_config: Option<LoggerConfigInput>,
     metrics_config: Option<MetricsConfigInput>,
@@ -266,6 +270,7 @@ impl Default for StartupConfig {
     fn default() -> Self {
         Self {
             api_sock: DEFAULT_API_SOCK_PATH.to_string(),
+            http_api_max_payload_size: HTTP_MAX_PAYLOAD_SIZE,
             id: DEFAULT_INSTANCE_ID.to_string(),
             logger_config: None,
             metrics_config: None,
@@ -320,6 +325,7 @@ impl Args {
 
         let mut config = StartupConfig::default();
         let mut api_sock_seen = false;
+        let mut http_api_max_payload_size_seen = false;
         let mut id_seen = false;
         let mut logger_config = LoggerConfigInput::new();
         let mut logger_config_seen = false;
@@ -341,6 +347,15 @@ impl Args {
                     validate_api_sock(&value)?;
                     config.api_sock = value;
                     api_sock_seen = true;
+                    index += 2;
+                }
+                "--http-api-max-payload-size" => {
+                    if http_api_max_payload_size_seen {
+                        return Err("duplicate argument: --http-api-max-payload-size".to_string());
+                    }
+                    let value = take_value(&args, index, "--http-api-max-payload-size")?;
+                    config.http_api_max_payload_size = parse_http_api_max_payload_size(&value)?;
+                    http_api_max_payload_size_seen = true;
                     index += 2;
                 }
                 "--id" => {
@@ -460,6 +475,8 @@ fn help_text() -> String {
             "  bangbang [OPTIONS]\n\n",
             "Options:\n",
             "      --api-sock <PATH>  Unix domain socket path for the API server [default: {}]\n",
+            "      --http-api-max-payload-size <BYTES>\n",
+            "                         Maximum HTTP API request size [default: {}]\n",
             "      --id <ID>          MicroVM unique identifier [default: {}]\n",
             "                         Accepts 1-64 bytes, ASCII alphanumeric or '-'\n",
             "      --log-path <PATH>  Logger output file or FIFO path\n",
@@ -483,6 +500,7 @@ fn help_text() -> String {
         ),
         env!("CARGO_PKG_VERSION"),
         DEFAULT_API_SOCK_PATH,
+        HTTP_MAX_PAYLOAD_SIZE,
         DEFAULT_INSTANCE_ID
     )
 }
@@ -504,6 +522,20 @@ fn validate_api_sock(api_sock: &str) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+fn parse_http_api_max_payload_size(value: &str) -> Result<usize, String> {
+    let max_payload_size = value.parse::<usize>().map_err(|_| {
+        "invalid --http-api-max-payload-size: value must be a positive integer".to_string()
+    })?;
+
+    if max_payload_size == 0 {
+        return Err(
+            "invalid --http-api-max-payload-size: value must be greater than 0".to_string(),
+        );
+    }
+
+    Ok(max_payload_size)
 }
 
 fn validate_instance_id(id: &str) -> Result<(), String> {
@@ -545,6 +577,7 @@ fn display_arg_name(arg: &str) -> &str {
 fn unsupported_equals_syntax(arg: &str) -> Option<&'static str> {
     [
         ("--api-sock=", "api-sock"),
+        ("--http-api-max-payload-size=", "http-api-max-payload-size"),
         ("--id=", "id"),
         ("--log-path=", "log-path"),
         ("--level=", "level"),
@@ -572,7 +605,8 @@ mod tests {
 
     use super::{
         ApiServerError, Args, Command, DEFAULT_API_SOCK_PATH, DEFAULT_INSTANCE_ID,
-        MAX_INSTANCE_ID_LEN, ProcessError, ProcessExitCode, StartupConfig, parse_process_args,
+        HTTP_MAX_PAYLOAD_SIZE, MAX_INSTANCE_ID_LEN, ProcessError, ProcessExitCode, StartupConfig,
+        parse_process_args,
     };
 
     #[derive(Debug, Clone)]
@@ -705,6 +739,7 @@ mod tests {
         let config = parse_run(&[]).expect("empty args should parse");
 
         assert_eq!(config.api_sock, DEFAULT_API_SOCK_PATH);
+        assert_eq!(config.http_api_max_payload_size, HTTP_MAX_PAYLOAD_SIZE);
         assert_eq!(config.id, DEFAULT_INSTANCE_ID);
         assert_eq!(config.logger_config, None);
         assert_eq!(config.metrics_config, None);
@@ -733,6 +768,7 @@ mod tests {
         assert!(help.contains("minimal action logs"));
         assert!(help.contains("--log-path <PATH>"));
         assert!(help.contains("--metrics-path <PATH>"));
+        assert!(help.contains("--http-api-max-payload-size <BYTES>"));
         assert!(help.contains("--show-level"));
         assert!(help.contains("PUT /actions starts a process-owned HVF boot run-loop worker"));
         assert!(help.contains("across bounded step windows for InstanceStart"));
@@ -780,9 +816,18 @@ mod tests {
             parse_run(&["--api-sock", "/tmp/custom.socket"]).expect("api socket arg should parse");
 
         assert_eq!(config.api_sock, "/tmp/custom.socket");
+        assert_eq!(config.http_api_max_payload_size, HTTP_MAX_PAYLOAD_SIZE);
         assert_eq!(config.id, DEFAULT_INSTANCE_ID);
         assert_eq!(config.logger_config, None);
         assert_eq!(config.metrics_config, None);
+    }
+
+    #[test]
+    fn parse_http_api_max_payload_size_arg() {
+        let config = parse_run(&["--http-api-max-payload-size", "65536"])
+            .expect("payload size arg should parse");
+
+        assert_eq!(config.http_api_max_payload_size, 65_536);
     }
 
     #[test]
@@ -790,6 +835,7 @@ mod tests {
         let config = parse_run(&["--id", "demo-1"]).expect("id arg should parse");
 
         assert_eq!(config.api_sock, DEFAULT_API_SOCK_PATH);
+        assert_eq!(config.http_api_max_payload_size, HTTP_MAX_PAYLOAD_SIZE);
         assert_eq!(config.id, "demo-1");
         assert_eq!(config.logger_config, None);
         assert_eq!(config.metrics_config, None);
@@ -840,12 +886,15 @@ mod tests {
             "/tmp/custom.socket",
             "--id",
             "demo-1",
+            "--http-api-max-payload-size",
+            "65536",
             "--metrics-path",
             "/tmp/bangbang.metrics",
         ])
         .expect("startup args should parse");
 
         assert_eq!(config.api_sock, "/tmp/custom.socket");
+        assert_eq!(config.http_api_max_payload_size, 65_536);
         assert_eq!(config.id, "demo-1");
         assert_eq!(config.logger_config, None);
         assert_eq!(
@@ -866,6 +915,14 @@ mod tests {
         let err = parse(&["--id", "--api-sock"]).expect_err("missing id value should fail");
 
         assert_eq!(err, "missing value for --id");
+    }
+
+    #[test]
+    fn rejects_missing_http_api_max_payload_size_value() {
+        let err = parse(&["--http-api-max-payload-size", "--id"])
+            .expect_err("missing payload size value should fail");
+
+        assert_eq!(err, "missing value for --http-api-max-payload-size");
     }
 
     #[test]
@@ -902,10 +959,53 @@ mod tests {
     }
 
     #[test]
+    fn rejects_duplicate_http_api_max_payload_size() {
+        let err = parse(&[
+            "--http-api-max-payload-size",
+            "65536",
+            "--http-api-max-payload-size",
+            "65537",
+        ])
+        .expect_err("duplicate payload size should fail");
+
+        assert_eq!(err, "duplicate argument: --http-api-max-payload-size");
+    }
+
+    #[test]
     fn rejects_duplicate_id() {
         let err = parse(&["--id", "one", "--id", "two"]).expect_err("duplicate id should fail");
 
         assert_eq!(err, "duplicate argument: --id");
+    }
+
+    #[test]
+    fn rejects_invalid_http_api_max_payload_size() {
+        let err = parse(&["--http-api-max-payload-size", "0"])
+            .expect_err("zero payload size should fail");
+
+        assert_eq!(
+            err,
+            "invalid --http-api-max-payload-size: value must be greater than 0"
+        );
+
+        let err = parse(&["--http-api-max-payload-size", "abc"])
+            .expect_err("non-numeric payload size should fail");
+
+        assert_eq!(
+            err,
+            "invalid --http-api-max-payload-size: value must be a positive integer"
+        );
+
+        let err = parse(&[
+            "--http-api-max-payload-size",
+            "999999999999999999999999999999",
+        ])
+        .expect_err("overflowing payload size should fail");
+
+        assert_eq!(
+            err,
+            "invalid --http-api-max-payload-size: value must be a positive integer"
+        );
     }
 
     #[test]
@@ -1059,6 +1159,14 @@ mod tests {
         assert_eq!(
             err,
             "unsupported argument syntax for --api-sock; use --api-sock <VALUE>"
+        );
+
+        let err =
+            parse(&["--http-api-max-payload-size=65536"]).expect_err("equals syntax should fail");
+
+        assert_eq!(
+            err,
+            "unsupported argument syntax for --http-api-max-payload-size; use --http-api-max-payload-size <VALUE>"
         );
 
         let err = parse(&["--log-path=/tmp/secret.log"]).expect_err("equals syntax should fail");

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -115,6 +115,7 @@ public run-loop control.
 | Argument | Current behavior | Compatibility notes |
 | --- | --- | --- |
 | `--api-sock <PATH>` | binds the API Unix socket | Firecracker defaults to `/run/firecracker.socket`; bangbang defaults to `/tmp/bangbang.socket` because macOS does not normally provide `/run`. This is an intentional host-platform difference. |
+| `--http-api-max-payload-size <BYTES>` | configures the maximum accepted HTTP API request size | Defaults to Firecracker's `51200` byte limit. The configured value applies to API socket reads and final request parsing. Zero, malformed, duplicate, and equals-syntax values are rejected during argument parsing. |
 | `--id <ID>` | parsed and stored | Defaults to Firecracker's `anonymous-instance`. IDs must be 1 to 64 bytes and contain only ASCII alphanumeric characters or `-`. |
 | `--metrics-path <PATH>` | configures metrics output before API serving | Uses the same per-process metrics sink and redacted host-path error policy as `PUT /metrics`. A later duplicate `PUT /metrics` request fails without replacing this sink. |
 | `--log-path <PATH>` | configures logger output before API serving | Uses the same per-process logger sink and redacted host-path error policy as `PUT /logger`. |
@@ -125,7 +126,7 @@ public run-loop control.
 | `--help`, `-h` | prints help | Help describes the current API socket scope. |
 | `--version`, `-V` | prints version | `-V` is retained from the existing bangbang scaffold. |
 | `--config-file`, `--no-api` | rejected | Deferred until VM configuration models and no-API startup behavior exist. |
-| seccomp, snapshot, MMDS, boot timer, payload-size, and PCI process flags | rejected | These Firecracker options are Linux-specific or tied to later capability work. |
+| seccomp, snapshot, MMDS, boot timer, and PCI process flags | rejected | These Firecracker options are Linux-specific or tied to later capability work. |
 
 bangbang intentionally treats `--id` alphanumeric characters as ASCII only.
 This is stricter than Firecracker `v1.16.0`'s Rust validator, which accepts
@@ -1229,8 +1230,8 @@ VMM action model exist, but this document only defines the initial status/body
 shape.
 
 The initial API implementation uses Firecracker's default `51200` byte HTTP
-request payload limit. The `--http-api-max-payload-size` process argument
-remains rejected until configurable payload limits are introduced explicitly.
+request payload limit unless `--http-api-max-payload-size <BYTES>` configures a
+different per-process API socket request limit.
 The MMDS data store also uses Firecracker's default fixed `51200` byte
 serialized JSON limit for now; `--mmds-size-limit` remains rejected until a
 separate configuration PR adds it.


### PR DESCRIPTION
## Summary

- Add Firecracker-style `--http-api-max-payload-size <BYTES>` process argument with the existing `51200` byte default.
- Add limit-aware HTTP parser helpers and thread the configured limit through API socket reads and final request parsing.
- Cover parser, CLI, and Unix-socket configured-limit behavior, including above-default acceptance and oversized rejection without logger mutation.
- Update README and Firecracker compatibility docs.

## Scope Exclusions

- Does not add `--config-file`, `--no-api`, `--mmds-size-limit`, or endpoint-specific MMDS payload limit changes.
- Does not change the current `fault_message` response shape or introduce async API serving.

Closes #490

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test -p bangbang-api --all-targets --all-features --locked payload`
- `cargo test -p bangbang --all-targets --all-features --locked payload`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
