### PR TITLE
fix: correct SendCtrlAltDel fault message

### DIFF
--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -56,7 +56,7 @@ impl RequestError {
             Self::MismatchedInterfaceId => "path iface_id must match body iface_id.",
             Self::MalformedRequest => "Malformed HTTP request.",
             Self::PayloadTooLarge => "HTTP request payload exceeds the configured limit.",
-            Self::SendCtrlAltDelUnsupported => "SendCtrlAltDel does not supported on aarch64.",
+            Self::SendCtrlAltDelUnsupported => "SendCtrlAltDel is not supported on aarch64.",
             Self::SnapshotUnsupported => "Snapshot and restore are not supported.",
         }
     }
@@ -1861,7 +1861,7 @@ mod tests {
         assert_eq!(err, RequestError::SendCtrlAltDelUnsupported);
         assert_eq!(
             err.fault_message(),
-            "SendCtrlAltDel does not supported on aarch64."
+            "SendCtrlAltDel is not supported on aarch64."
         );
     }
 

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -2804,6 +2804,40 @@ mod tests {
     }
 
     #[test]
+    fn returns_fault_for_send_ctrl_alt_del_action() {
+        let path = unique_socket_path("cad-fault");
+        let server = ApiServer::bind(&path).expect("server should bind");
+        let mut client = UnixStream::connect(&path).expect("client should connect");
+        let body = r#"{"action_type":"SendCtrlAltDel"}"#;
+        let request = format!(
+            "PUT /actions HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+
+        client
+            .write_all(request.as_bytes())
+            .expect("client should write request");
+        let mut vmm = test_controller();
+        server
+            .serve_next(&mut vmm)
+            .expect("server should handle one request");
+
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("client should read response");
+
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        assert!(
+            response.contains(r#"{"fault_message":"SendCtrlAltDel is not supported on aarch64."}"#)
+        );
+        assert_eq!(
+            vmm.instance_info().state,
+            bangbang_runtime::InstanceState::NotStarted
+        );
+    }
+
+    #[test]
     fn configures_machine_config_over_unix_socket() {
         let path = unique_socket_path("machine-config");
         let server = ApiServer::bind(&path).expect("server should bind");


### PR DESCRIPTION
## Summary
- Fix the user-visible `SendCtrlAltDel` unsupported fault grammar.
- Keep `SendCtrlAltDel` rejected at parse time for the Apple Silicon target.
- Add an API-server regression test for the HTTP fault response body.

Closes #503

## Validation
- `cargo test -p bangbang-api --lib --all-features --locked rejects_put_actions_send_ctrl_alt_del`
- `cargo test -p bangbang --bin bangbang --all-features --locked returns_fault_for_send_ctrl_alt_del_action`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
