### PR TITLE
feat: recognize entropy as unsupported

### DIFF
--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -38,6 +38,7 @@ pub enum ApiRequest {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RequestError {
     CpuConfigUnsupported,
+    EntropyUnsupported,
     GetRequestBody,
     InvalidPathMethod,
     MismatchedDriveId,
@@ -52,6 +53,7 @@ impl RequestError {
     pub fn fault_message(&self) -> &'static str {
         match self {
             Self::CpuConfigUnsupported => "CPU config is not supported.",
+            Self::EntropyUnsupported => "Entropy device is not supported.",
             Self::GetRequestBody => "GET request cannot have a body.",
             Self::InvalidPathMethod => "Invalid request method and/or path.",
             Self::MismatchedDriveId => "path drive_id must match body drive_id.",
@@ -1137,6 +1139,9 @@ pub fn parse_request_with_limit(
     }
     if method == "PUT" && path == "/cpu-config" {
         return Err(RequestError::CpuConfigUnsupported);
+    }
+    if method == "PUT" && path == "/entropy" {
+        return Err(RequestError::EntropyUnsupported);
     }
     if method == "PUT" && path == "/logger" {
         return parse_logger_config_request(body);
@@ -3390,6 +3395,40 @@ mod tests {
     #[test]
     fn rejects_non_exact_cpu_config_path_as_invalid_path_method() {
         let request = request_with_body("PUT", "/cpu-config/extra", "{}");
+
+        assert_eq!(
+            parse_request(&request),
+            Err(RequestError::InvalidPathMethod)
+        );
+    }
+
+    #[test]
+    fn rejects_entropy_as_unsupported() {
+        let request = request_with_body("PUT", "/entropy", "{}");
+
+        let err = parse_request(&request).expect_err("entropy should be unsupported");
+        assert_eq!(err, RequestError::EntropyUnsupported);
+        assert_eq!(err.fault_message(), "Entropy device is not supported.");
+    }
+
+    #[test]
+    fn rejects_entropy_as_unsupported_without_parsing_body() {
+        let malformed_body = request_with_body("PUT", "/entropy", "not-json");
+        let empty_body = b"PUT /entropy HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n";
+
+        assert_eq!(
+            parse_request(&malformed_body),
+            Err(RequestError::EntropyUnsupported)
+        );
+        assert_eq!(
+            parse_request(empty_body),
+            Err(RequestError::EntropyUnsupported)
+        );
+    }
+
+    #[test]
+    fn rejects_non_exact_entropy_path_as_invalid_path_method() {
+        let request = request_with_body("PUT", "/entropy/extra", "{}");
 
         assert_eq!(
             parse_request(&request),

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -2833,6 +2833,33 @@ mod tests {
     }
 
     #[test]
+    fn returns_fault_for_entropy_endpoint() {
+        let path = unique_socket_path("entropy-fault");
+        let server = ApiServer::bind(&path).expect("server should bind");
+        let mut client = UnixStream::connect(&path).expect("client should connect");
+
+        client
+            .write_all(b"PUT /entropy HTTP/1.1\r\nHost: localhost\r\nContent-Length: 2\r\n\r\n{}")
+            .expect("client should write request");
+        let mut vmm = test_controller();
+        server
+            .serve_next(&mut vmm)
+            .expect("server should handle one request");
+
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("client should read response");
+
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        assert!(response.contains(r#"{"fault_message":"Entropy device is not supported."}"#));
+        assert_eq!(
+            vmm.instance_info().state,
+            bangbang_runtime::InstanceState::NotStarted
+        );
+    }
+
+    #[test]
     fn returns_fault_for_send_ctrl_alt_del_action() {
         let path = unique_socket_path("cad-fault");
         let server = ApiServer::bind(&path).expect("server should bind");

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -252,7 +252,8 @@ compatibility targets.
 | `PATCH` | `/balloon/hinting/start`, `/balloon/hinting/stop` | deferred | Requires balloon free-page hinting design. |
 | `GET` | `/balloon/hinting/status` | deferred | Requires balloon free-page hinting design. |
 | `PUT`, `PATCH` | `/pmem/{id}` | deferred | Requires a separate pmem device design. |
-| `PUT` | `/entropy`, `/serial` | deferred | Requires separate device and macOS/HVF design work. |
+| `PUT` | `/entropy` | recognized; rejected | Returns an entropy-specific unsupported fault. Real virtio-rng configuration storage, rate limiting, guest randomness wiring, and startup resource attachment need a dedicated device design. |
+| `PUT` | `/serial` | deferred | Requires separate serial customization and macOS/HVF design work. |
 | `GET`, `PUT`, `PATCH` | `/hotplug/memory` | deferred | Requires memory hotplug device and runtime update design. |
 | `PATCH` | `/vm` | deferred | Pause and resume state rules need future VMM action and run-loop control design. |
 | `PATCH` | `/drives/{drive_id}`, `/network-interfaces/{iface_id}` | deferred | Hotplug and runtime update behavior belongs with the relevant device issues. |


### PR DESCRIPTION
## Summary

- Recognize exact `PUT /entropy` requests and return an entropy-specific unsupported fault.
- Cover parser and API-server behavior, including malformed/empty body handling and unchanged VM state.
- Update the Firecracker compatibility matrix to mark `/entropy` as recognized and rejected.

## Scope Exclusions

- Does not add virtio-rng configuration storage, device emulation, rate limiting, or guest randomness wiring.
- Leaves `/serial` deferred.

Closes #508

## Validation

- `cargo test -p bangbang-api --lib --all-features --locked entropy`
- `cargo test -p bangbang --bin bangbang --all-features --locked entropy`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`
