### PR TITLE
feat: recognize serial as unsupported

### DIFF
--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -46,6 +46,7 @@ pub enum RequestError {
     MalformedRequest,
     PayloadTooLarge,
     SendCtrlAltDelUnsupported,
+    SerialUnsupported,
     SnapshotUnsupported,
 }
 
@@ -61,6 +62,7 @@ impl RequestError {
             Self::MalformedRequest => "Malformed HTTP request.",
             Self::PayloadTooLarge => "HTTP request payload exceeds the configured limit.",
             Self::SendCtrlAltDelUnsupported => "SendCtrlAltDel is not supported on aarch64.",
+            Self::SerialUnsupported => "Serial device is not supported.",
             Self::SnapshotUnsupported => "Snapshot and restore are not supported.",
         }
     }
@@ -1142,6 +1144,9 @@ pub fn parse_request_with_limit(
     }
     if method == "PUT" && path == "/entropy" {
         return Err(RequestError::EntropyUnsupported);
+    }
+    if method == "PUT" && path == "/serial" {
+        return Err(RequestError::SerialUnsupported);
     }
     if method == "PUT" && path == "/logger" {
         return parse_logger_config_request(body);
@@ -3429,6 +3434,40 @@ mod tests {
     #[test]
     fn rejects_non_exact_entropy_path_as_invalid_path_method() {
         let request = request_with_body("PUT", "/entropy/extra", "{}");
+
+        assert_eq!(
+            parse_request(&request),
+            Err(RequestError::InvalidPathMethod)
+        );
+    }
+
+    #[test]
+    fn rejects_serial_as_unsupported() {
+        let request = request_with_body("PUT", "/serial", "{}");
+
+        let err = parse_request(&request).expect_err("serial should be unsupported");
+        assert_eq!(err, RequestError::SerialUnsupported);
+        assert_eq!(err.fault_message(), "Serial device is not supported.");
+    }
+
+    #[test]
+    fn rejects_serial_as_unsupported_without_parsing_body() {
+        let malformed_body = request_with_body("PUT", "/serial", "not-json");
+        let empty_body = b"PUT /serial HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n";
+
+        assert_eq!(
+            parse_request(&malformed_body),
+            Err(RequestError::SerialUnsupported)
+        );
+        assert_eq!(
+            parse_request(empty_body),
+            Err(RequestError::SerialUnsupported)
+        );
+    }
+
+    #[test]
+    fn rejects_non_exact_serial_path_as_invalid_path_method() {
+        let request = request_with_body("PUT", "/serial/extra", "{}");
 
         assert_eq!(
             parse_request(&request),

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -2860,6 +2860,33 @@ mod tests {
     }
 
     #[test]
+    fn returns_fault_for_serial_endpoint() {
+        let path = unique_socket_path("serial-fault");
+        let server = ApiServer::bind(&path).expect("server should bind");
+        let mut client = UnixStream::connect(&path).expect("client should connect");
+
+        client
+            .write_all(b"PUT /serial HTTP/1.1\r\nHost: localhost\r\nContent-Length: 2\r\n\r\n{}")
+            .expect("client should write request");
+        let mut vmm = test_controller();
+        server
+            .serve_next(&mut vmm)
+            .expect("server should handle one request");
+
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("client should read response");
+
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        assert!(response.contains(r#"{"fault_message":"Serial device is not supported."}"#));
+        assert_eq!(
+            vmm.instance_info().state,
+            bangbang_runtime::InstanceState::NotStarted
+        );
+    }
+
+    #[test]
     fn returns_fault_for_send_ctrl_alt_del_action() {
         let path = unique_socket_path("cad-fault");
         let server = ApiServer::bind(&path).expect("server should bind");

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -253,7 +253,7 @@ compatibility targets.
 | `GET` | `/balloon/hinting/status` | deferred | Requires balloon free-page hinting design. |
 | `PUT`, `PATCH` | `/pmem/{id}` | deferred | Requires a separate pmem device design. |
 | `PUT` | `/entropy` | recognized; rejected | Returns an entropy-specific unsupported fault. Real virtio-rng configuration storage, rate limiting, guest randomness wiring, and startup resource attachment need a dedicated device design. |
-| `PUT` | `/serial` | deferred | Requires separate serial customization and macOS/HVF design work. |
+| `PUT` | `/serial` | recognized; rejected | Returns a serial-specific unsupported fault. Public serial configuration storage, host output redirection, rate limiting, and integration with the existing internal serial capture path need a dedicated design. |
 | `GET`, `PUT`, `PATCH` | `/hotplug/memory` | deferred | Requires memory hotplug device and runtime update design. |
 | `PATCH` | `/vm` | deferred | Pause and resume state rules need future VMM action and run-loop control design. |
 | `PATCH` | `/drives/{drive_id}`, `/network-interfaces/{iface_id}` | deferred | Hotplug and runtime update behavior belongs with the relevant device issues. |


### PR DESCRIPTION
## Summary

- Recognize exact `PUT /serial` requests and return a serial-specific unsupported fault.
- Cover parser and API-server behavior, including malformed/empty body handling and unchanged VM state.
- Update the Firecracker compatibility matrix to mark `/serial` as recognized and rejected.

## Scope Exclusions

- Does not add public serial configuration parsing or storage.
- Does not redirect serial output to host files/FIFOs or add serial rate limiting.
- Does not change the existing internal startup serial capture path.

Closes #510

## Validation

- `cargo test -p bangbang-api --lib --all-features --locked serial`
- `cargo test -p bangbang --bin bangbang --all-features --locked serial`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`
