### PR TITLE
feat: recognize vm state updates as unsupported

### DIFF
--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -48,6 +48,7 @@ pub enum RequestError {
     SendCtrlAltDelUnsupported,
     SerialUnsupported,
     SnapshotUnsupported,
+    VmStateUpdateUnsupported,
 }
 
 impl RequestError {
@@ -64,6 +65,7 @@ impl RequestError {
             Self::SendCtrlAltDelUnsupported => "SendCtrlAltDel is not supported on aarch64.",
             Self::SerialUnsupported => "Serial device is not supported.",
             Self::SnapshotUnsupported => "Snapshot and restore are not supported.",
+            Self::VmStateUpdateUnsupported => "VM state updates are not supported.",
         }
     }
 }
@@ -1156,6 +1158,9 @@ pub fn parse_request_with_limit(
     }
     if method == "PATCH" && path == "/machine-config" {
         return parse_machine_config_patch_request(body);
+    }
+    if method == "PATCH" && path == "/vm" {
+        return Err(RequestError::VmStateUpdateUnsupported);
     }
     if method == "PUT" && path == "/metrics" {
         return parse_metrics_config_request(body);
@@ -3468,6 +3473,40 @@ mod tests {
     #[test]
     fn rejects_non_exact_serial_path_as_invalid_path_method() {
         let request = request_with_body("PUT", "/serial/extra", "{}");
+
+        assert_eq!(
+            parse_request(&request),
+            Err(RequestError::InvalidPathMethod)
+        );
+    }
+
+    #[test]
+    fn rejects_vm_state_update_as_unsupported() {
+        let request = request_with_body("PATCH", "/vm", r#"{"state":"Paused"}"#);
+
+        let err = parse_request(&request).expect_err("VM state updates should be unsupported");
+        assert_eq!(err, RequestError::VmStateUpdateUnsupported);
+        assert_eq!(err.fault_message(), "VM state updates are not supported.");
+    }
+
+    #[test]
+    fn rejects_vm_state_update_as_unsupported_without_parsing_body() {
+        let malformed_body = request_with_body("PATCH", "/vm", "not-json");
+        let empty_body = b"PATCH /vm HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n";
+
+        assert_eq!(
+            parse_request(&malformed_body),
+            Err(RequestError::VmStateUpdateUnsupported)
+        );
+        assert_eq!(
+            parse_request(empty_body),
+            Err(RequestError::VmStateUpdateUnsupported)
+        );
+    }
+
+    #[test]
+    fn rejects_non_exact_vm_state_update_path_as_invalid_path_method() {
+        let request = request_with_body("PATCH", "/vm/extra", r#"{"state":"Paused"}"#);
 
         assert_eq!(
             parse_request(&request),

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -2887,6 +2887,35 @@ mod tests {
     }
 
     #[test]
+    fn returns_fault_for_vm_state_update_endpoint() {
+        let path = unique_socket_path("vm-state-fault");
+        let server = ApiServer::bind(&path).expect("server should bind");
+        let mut client = UnixStream::connect(&path).expect("client should connect");
+
+        client
+            .write_all(
+                b"PATCH /vm HTTP/1.1\r\nHost: localhost\r\nContent-Length: 18\r\n\r\n{\"state\":\"Paused\"}",
+            )
+            .expect("client should write request");
+        let mut vmm = test_controller();
+        server
+            .serve_next(&mut vmm)
+            .expect("server should handle one request");
+
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("client should read response");
+
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        assert!(response.contains(r#"{"fault_message":"VM state updates are not supported."}"#));
+        assert_eq!(
+            vmm.instance_info().state,
+            bangbang_runtime::InstanceState::NotStarted
+        );
+    }
+
+    #[test]
     fn returns_fault_for_send_ctrl_alt_del_action() {
         let path = unique_socket_path("cad-fault");
         let server = ApiServer::bind(&path).expect("server should bind");

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -255,7 +255,7 @@ compatibility targets.
 | `PUT` | `/entropy` | recognized; rejected | Returns an entropy-specific unsupported fault. Real virtio-rng configuration storage, rate limiting, guest randomness wiring, and startup resource attachment need a dedicated device design. |
 | `PUT` | `/serial` | recognized; rejected | Returns a serial-specific unsupported fault. Public serial configuration storage, host output redirection, rate limiting, and integration with the existing internal serial capture path need a dedicated design. |
 | `GET`, `PUT`, `PATCH` | `/hotplug/memory` | deferred | Requires memory hotplug device and runtime update design. |
-| `PATCH` | `/vm` | deferred | Pause and resume state rules need future VMM action and run-loop control design. |
+| `PATCH` | `/vm` | recognized; rejected | Returns a VM-state-specific unsupported fault. Real pause/resume state rules, VMM actions, and public run-loop control need a dedicated design. |
 | `PATCH` | `/drives/{drive_id}`, `/network-interfaces/{iface_id}` | deferred | Hotplug and runtime update behavior belongs with the relevant device issues. |
 | `DELETE` | `/drives/{drive_id}`, `/pmem/{id}`, `/network-interfaces/{iface_id}` | deferred | Firecracker routes these hot-unplug requests in `parsed_request.rs`, but they are not in the `v1.16.0` swagger surface; support needs an explicit compatibility decision. |
 


### PR DESCRIPTION
## Summary

- Recognize exact `PATCH /vm` requests and return a VM-state-specific unsupported fault.
- Cover parser and API-server behavior, including malformed/empty body handling and unchanged VM state.
- Update the Firecracker compatibility matrix to mark `PATCH /vm` as recognized and rejected.

## Scope Exclusions

- Does not parse Firecracker `Vm` state request bodies.
- Does not add VMM pause/resume actions or public run-loop control.
- Does not change current `GET /vm/config` behavior.

Closes #512

## Validation

- `cargo test -p bangbang-api --lib --all-features --locked vm_state`
- `cargo test -p bangbang --bin bangbang --all-features --locked vm_state`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`
