### PR TITLE
feat: recognize memory hotplug as unsupported

### DIFF
--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -3497,12 +3497,28 @@ mod tests {
 
     #[test]
     fn rejects_non_exact_memory_hotplug_path_as_invalid_path_method() {
-        let request = request_with_body("PUT", "/hotplug/memory/extra", "{}");
+        let requests = [
+            (
+                "GET",
+                b"GET /hotplug/memory/extra HTTP/1.1\r\nHost: localhost\r\n\r\n".to_vec(),
+            ),
+            (
+                "PUT",
+                request_with_body("PUT", "/hotplug/memory/extra", "{}"),
+            ),
+            (
+                "PATCH",
+                request_with_body("PATCH", "/hotplug/memory/extra", "{}"),
+            ),
+        ];
 
-        assert_eq!(
-            parse_request(&request),
-            Err(RequestError::InvalidPathMethod)
-        );
+        for (method, request) in requests {
+            assert_eq!(
+                parse_request(&request),
+                Err(RequestError::InvalidPathMethod),
+                "{method}"
+            );
+        }
     }
 
     #[test]

--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -44,6 +44,7 @@ pub enum RequestError {
     MismatchedDriveId,
     MismatchedInterfaceId,
     MalformedRequest,
+    MemoryHotplugUnsupported,
     PayloadTooLarge,
     SendCtrlAltDelUnsupported,
     SerialUnsupported,
@@ -61,6 +62,7 @@ impl RequestError {
             Self::MismatchedDriveId => "path drive_id must match body drive_id.",
             Self::MismatchedInterfaceId => "path iface_id must match body iface_id.",
             Self::MalformedRequest => "Malformed HTTP request.",
+            Self::MemoryHotplugUnsupported => "Memory hotplug is not supported.",
             Self::PayloadTooLarge => "HTTP request payload exceeds the configured limit.",
             Self::SendCtrlAltDelUnsupported => "SendCtrlAltDel is not supported on aarch64.",
             Self::SerialUnsupported => "Serial device is not supported.",
@@ -1123,6 +1125,10 @@ pub fn parse_request_with_limit(
 
     if method == "GET" && request_body.has_content() {
         return Err(RequestError::GetRequestBody);
+    }
+
+    if matches!(method, "GET" | "PUT" | "PATCH") && path == "/hotplug/memory" {
+        return Err(RequestError::MemoryHotplugUnsupported);
     }
 
     if method == "PUT"
@@ -3439,6 +3445,59 @@ mod tests {
     #[test]
     fn rejects_non_exact_entropy_path_as_invalid_path_method() {
         let request = request_with_body("PUT", "/entropy/extra", "{}");
+
+        assert_eq!(
+            parse_request(&request),
+            Err(RequestError::InvalidPathMethod)
+        );
+    }
+
+    #[test]
+    fn rejects_memory_hotplug_methods_as_unsupported() {
+        let get_request = b"GET /hotplug/memory HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        let err = parse_request(get_request).expect_err("memory hotplug should be unsupported");
+        assert_eq!(err, RequestError::MemoryHotplugUnsupported, "GET");
+        assert_eq!(err.fault_message(), "Memory hotplug is not supported.");
+
+        for method in ["PUT", "PATCH"] {
+            let request = request_with_body(method, "/hotplug/memory", r#"{"size_mib":128}"#);
+            let err = parse_request(&request).expect_err("memory hotplug should be unsupported");
+            assert_eq!(err, RequestError::MemoryHotplugUnsupported, "{method}");
+            assert_eq!(err.fault_message(), "Memory hotplug is not supported.");
+        }
+    }
+
+    #[test]
+    fn rejects_memory_hotplug_body_methods_without_parsing_body() {
+        for method in ["PUT", "PATCH"] {
+            let malformed_body = request_with_body(method, "/hotplug/memory", "not-json");
+            let empty_body = format!(
+                "{method} /hotplug/memory HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n"
+            );
+
+            assert_eq!(
+                parse_request(&malformed_body),
+                Err(RequestError::MemoryHotplugUnsupported),
+                "{method}"
+            );
+            assert_eq!(
+                parse_request(empty_body.as_bytes()),
+                Err(RequestError::MemoryHotplugUnsupported),
+                "{method}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_memory_hotplug_get_with_body_before_endpoint_handling() {
+        let request = request_with_body("GET", "/hotplug/memory", "{}");
+
+        assert_eq!(parse_request(&request), Err(RequestError::GetRequestBody));
+    }
+
+    #[test]
+    fn rejects_non_exact_memory_hotplug_path_as_invalid_path_method() {
+        let request = request_with_body("PUT", "/hotplug/memory/extra", "{}");
 
         assert_eq!(
             parse_request(&request),

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -2916,6 +2916,51 @@ mod tests {
     }
 
     #[test]
+    fn returns_fault_for_memory_hotplug_endpoints() {
+        for (method, request) in [
+            (
+                "get",
+                b"GET /hotplug/memory HTTP/1.1\r\nHost: localhost\r\n\r\n".as_slice(),
+            ),
+            (
+                "put",
+                b"PUT /hotplug/memory HTTP/1.1\r\nHost: localhost\r\nContent-Length: 16\r\n\r\n{\"size_mib\":128}"
+                    .as_slice(),
+            ),
+            (
+                "patch",
+                b"PATCH /hotplug/memory HTTP/1.1\r\nHost: localhost\r\nContent-Length: 16\r\n\r\n{\"size_mib\":256}"
+                    .as_slice(),
+            ),
+        ] {
+            let socket_name = format!("mh-{method}");
+            let path = unique_socket_path(&socket_name);
+            let server = ApiServer::bind(&path).expect("server should bind");
+            let mut client = UnixStream::connect(&path).expect("client should connect");
+
+            client
+                .write_all(request)
+                .expect("client should write request");
+            let mut vmm = test_controller();
+            server
+                .serve_next(&mut vmm)
+                .expect("server should handle one request");
+
+            let mut response = String::new();
+            client
+                .read_to_string(&mut response)
+                .expect("client should read response");
+
+            assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+            assert!(response.contains(r#"{"fault_message":"Memory hotplug is not supported."}"#));
+            assert_eq!(
+                vmm.instance_info().state,
+                bangbang_runtime::InstanceState::NotStarted
+            );
+        }
+    }
+
+    #[test]
     fn returns_fault_for_send_ctrl_alt_del_action() {
         let path = unique_socket_path("cad-fault");
         let server = ApiServer::bind(&path).expect("server should bind");

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -254,7 +254,7 @@ compatibility targets.
 | `PUT`, `PATCH` | `/pmem/{id}` | deferred | Requires a separate pmem device design. |
 | `PUT` | `/entropy` | recognized; rejected | Returns an entropy-specific unsupported fault. Real virtio-rng configuration storage, rate limiting, guest randomness wiring, and startup resource attachment need a dedicated device design. |
 | `PUT` | `/serial` | recognized; rejected | Returns a serial-specific unsupported fault. Public serial configuration storage, host output redirection, rate limiting, and integration with the existing internal serial capture path need a dedicated design. |
-| `GET`, `PUT`, `PATCH` | `/hotplug/memory` | deferred | Requires memory hotplug device and runtime update design. |
+| `GET`, `PUT`, `PATCH` | `/hotplug/memory` | recognized; rejected | Returns a memory-hotplug-specific unsupported fault. Real virtio-mem device support, guest memory accounting, and runtime memory update behavior need a dedicated design. |
 | `PATCH` | `/vm` | recognized; rejected | Returns a VM-state-specific unsupported fault. Real pause/resume state rules, VMM actions, and public run-loop control need a dedicated design. |
 | `PATCH` | `/drives/{drive_id}`, `/network-interfaces/{iface_id}` | deferred | Hotplug and runtime update behavior belongs with the relevant device issues. |
 | `DELETE` | `/drives/{drive_id}`, `/pmem/{id}`, `/network-interfaces/{iface_id}` | deferred | Firecracker routes these hot-unplug requests in `parsed_request.rs`, but they are not in the `v1.16.0` swagger surface; support needs an explicit compatibility decision. |


### PR DESCRIPTION
## Summary

- Recognize exact `GET`, `PUT`, and `PATCH /hotplug/memory` requests with a memory-hotplug-specific unsupported fault.
- Add parser and API server coverage for the unsupported response and unchanged VM state.
- Update the Firecracker compatibility matrix to mark memory hotplug as recognized and rejected.

## Scope Exclusions

- No memory hotplug request/status schema parsing.
- No virtio-mem device support.
- No guest memory resize, mapping, accounting, or runtime update behavior.

Closes #514

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p bangbang-api --lib --all-features --locked memory_hotplug`
- `cargo test -p bangbang --bin bangbang --all-features --locked memory_hotplug`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`
