### PR TITLE
feat: recognize pmem endpoints as unsupported

### DIFF
--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -47,6 +47,7 @@ pub enum RequestError {
     MalformedRequest,
     MemoryHotplugUnsupported,
     PayloadTooLarge,
+    PmemUnsupported,
     SendCtrlAltDelUnsupported,
     SerialUnsupported,
     SnapshotUnsupported,
@@ -66,6 +67,7 @@ impl RequestError {
             Self::MalformedRequest => "Malformed HTTP request.",
             Self::MemoryHotplugUnsupported => "Memory hotplug is not supported.",
             Self::PayloadTooLarge => "HTTP request payload exceeds the configured limit.",
+            Self::PmemUnsupported => "Pmem device is not supported.",
             Self::SendCtrlAltDelUnsupported => "SendCtrlAltDel is not supported on aarch64.",
             Self::SerialUnsupported => "Serial device is not supported.",
             Self::SnapshotUnsupported => "Snapshot and restore are not supported.",
@@ -1137,6 +1139,10 @@ pub fn parse_request_with_limit(
         return Err(RequestError::MemoryHotplugUnsupported);
     }
 
+    if matches!(method, "PUT" | "PATCH") && pmem_path_id(path).is_some() {
+        return Err(RequestError::PmemUnsupported);
+    }
+
     if method == "PUT"
         && let Some(path_drive_id) = drive_path_id(path)
     {
@@ -1218,21 +1224,18 @@ fn is_balloon_endpoint(method: &str, path: &str) -> bool {
 }
 
 fn drive_path_id(path: &str) -> Option<&str> {
-    let rest = path.strip_prefix("/drives/")?;
-    if rest.is_empty()
-        || rest.contains('/')
-        || !rest
-            .chars()
-            .all(|character| character == '_' || character.is_alphanumeric())
-    {
-        return None;
-    }
-
-    Some(rest)
+    single_segment_id(path.strip_prefix("/drives/")?)
 }
 
 fn network_interface_path_id(path: &str) -> Option<&str> {
-    let rest = path.strip_prefix("/network-interfaces/")?;
+    single_segment_id(path.strip_prefix("/network-interfaces/")?)
+}
+
+fn pmem_path_id(path: &str) -> Option<&str> {
+    single_segment_id(path.strip_prefix("/pmem/")?)
+}
+
+fn single_segment_id(rest: &str) -> Option<&str> {
     if rest.is_empty()
         || rest.contains('/')
         || !rest
@@ -3690,6 +3693,95 @@ mod tests {
                 parse_request(&request),
                 Err(RequestError::InvalidPathMethod),
                 "{method}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_pmem_methods_as_unsupported() {
+        for (route, request) in [
+            (
+                "PUT /pmem/pmem0",
+                request_with_body("PUT", "/pmem/pmem0", r#"{"id":"pmem0"}"#),
+            ),
+            (
+                "PATCH /pmem/pmem0",
+                request_with_body("PATCH", "/pmem/pmem0", r#"{"id":"pmem0"}"#),
+            ),
+            (
+                "PUT /pmem/pmem_0",
+                request_with_body("PUT", "/pmem/pmem_0", r#"{"id":"pmem_0"}"#),
+            ),
+        ] {
+            let err = parse_request(&request).expect_err("pmem should be unsupported");
+            assert_eq!(err, RequestError::PmemUnsupported, "{route}");
+            assert_eq!(err.fault_message(), "Pmem device is not supported.");
+        }
+    }
+
+    #[test]
+    fn rejects_pmem_body_methods_without_parsing_body() {
+        for method in ["PUT", "PATCH"] {
+            let malformed_body = request_with_body(method, "/pmem/pmem0", "not-json");
+            let empty_body = format!(
+                "{method} /pmem/pmem0 HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n"
+            );
+
+            assert_eq!(
+                parse_request(&malformed_body),
+                Err(RequestError::PmemUnsupported),
+                "{method}"
+            );
+            assert_eq!(
+                parse_request(empty_body.as_bytes()),
+                Err(RequestError::PmemUnsupported),
+                "{method}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_non_exact_pmem_paths_as_invalid_path_method() {
+        for (route, request) in [
+            ("PUT /pmem", request_with_body("PUT", "/pmem", "{}")),
+            ("PUT /pmem/", request_with_body("PUT", "/pmem/", "{}")),
+            (
+                "PUT /pmem/pmem0/extra",
+                request_with_body("PUT", "/pmem/pmem0/extra", "{}"),
+            ),
+            (
+                "PATCH /pmem/pmem-0",
+                request_with_body("PATCH", "/pmem/pmem-0", "{}"),
+            ),
+        ] {
+            assert_eq!(
+                parse_request(&request),
+                Err(RequestError::InvalidPathMethod),
+                "{route}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_unsupported_pmem_methods_as_invalid_path_method() {
+        for (route, request) in [
+            (
+                "GET /pmem/pmem0",
+                b"GET /pmem/pmem0 HTTP/1.1\r\nHost: localhost\r\n\r\n".to_vec(),
+            ),
+            (
+                "DELETE /pmem/pmem0",
+                b"DELETE /pmem/pmem0 HTTP/1.1\r\nHost: localhost\r\n\r\n".to_vec(),
+            ),
+            (
+                "POST /pmem/pmem0",
+                request_with_body("POST", "/pmem/pmem0", "{}"),
+            ),
+        ] {
+            assert_eq!(
+                parse_request(&request),
+                Err(RequestError::InvalidPathMethod),
+                "{route}"
             );
         }
     }

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -3035,6 +3035,47 @@ mod tests {
     }
 
     #[test]
+    fn returns_fault_for_pmem_endpoints() {
+        for (method, request) in [
+            (
+                "put",
+                b"PUT /pmem/pmem0 HTTP/1.1\r\nHost: localhost\r\nContent-Length: 14\r\n\r\n{\"id\":\"pmem0\"}"
+                    .as_slice(),
+            ),
+            (
+                "patch",
+                b"PATCH /pmem/pmem0 HTTP/1.1\r\nHost: localhost\r\nContent-Length: 14\r\n\r\n{\"id\":\"pmem0\"}"
+                    .as_slice(),
+            ),
+        ] {
+            let socket_name = format!("p{method}");
+            let path = unique_socket_path(&socket_name);
+            let server = ApiServer::bind(&path).expect("server should bind");
+            let mut client = UnixStream::connect(&path).expect("client should connect");
+
+            client
+                .write_all(request)
+                .expect("client should write request");
+            let mut vmm = test_controller();
+            server
+                .serve_next(&mut vmm)
+                .expect("server should handle one request");
+
+            let mut response = String::new();
+            client
+                .read_to_string(&mut response)
+                .expect("client should read response");
+
+            assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+            assert!(response.contains(r#"{"fault_message":"Pmem device is not supported."}"#));
+            assert_eq!(
+                vmm.instance_info().state,
+                bangbang_runtime::InstanceState::NotStarted
+            );
+        }
+    }
+
+    #[test]
     fn returns_fault_for_send_ctrl_alt_del_action() {
         let path = unique_socket_path("cad-fault");
         let server = ApiServer::bind(&path).expect("server should bind");

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -251,7 +251,7 @@ compatibility targets.
 | `GET`, `PATCH` | `/balloon/statistics` | recognized; rejected | Returns a balloon-specific unsupported fault. Real statistics polling and guest-reported memory accounting need a dedicated design. |
 | `PATCH` | `/balloon/hinting/start`, `/balloon/hinting/stop` | recognized; rejected | Returns a balloon-specific unsupported fault. Real free-page hinting and reporting need a dedicated design. |
 | `GET` | `/balloon/hinting/status` | recognized; rejected | Returns a balloon-specific unsupported fault. Real free-page hinting state tracking needs a dedicated design. |
-| `PUT`, `PATCH` | `/pmem/{id}` | deferred | Requires a separate pmem device design. |
+| `PUT`, `PATCH` | `/pmem/{id}` | recognized; rejected | Returns a pmem-specific unsupported fault. Real pmem device configuration, guest attachment, rate limiting, and runtime update behavior need a dedicated device design. |
 | `PUT` | `/entropy` | recognized; rejected | Returns an entropy-specific unsupported fault. Real virtio-rng configuration storage, rate limiting, guest randomness wiring, and startup resource attachment need a dedicated device design. |
 | `PUT` | `/serial` | recognized; rejected | Returns a serial-specific unsupported fault. Public serial configuration storage, host output redirection, rate limiting, and integration with the existing internal serial capture path need a dedicated design. |
 | `GET`, `PUT`, `PATCH` | `/hotplug/memory` | recognized; rejected | Returns a memory-hotplug-specific unsupported fault. Real virtio-mem device support, guest memory accounting, and runtime memory update behavior need a dedicated design. |


### PR DESCRIPTION
## Summary

- Recognize `PUT /pmem/{id}` and `PATCH /pmem/{id}` as Firecracker-shaped but currently unsupported endpoints.
- Return a deterministic pmem-specific fault before parsing request bodies.
- Cover parser behavior, real Unix socket API server behavior, and the compatibility matrix.

## Scope Exclusions

- Does not implement real pmem device configuration, guest attachment, rate limiting, or runtime updates.
- Does not change `DELETE /pmem/{id}`; DELETE hot-unplug compatibility remains a separate documented decision.

Closes #518

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`
