### PR TITLE
feat: reject dirty page tracking via runtime fault

### DIFF
--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -1467,7 +1467,7 @@ fn validate_machine_config_request(body: &MachineConfigRequestBody) -> Result<()
     if body.mem_size_mib == 0 {
         return Err(RequestError::MalformedRequest);
     }
-    if body.smt || body.track_dirty_pages || body.huge_pages != MachineConfigHugePages::None {
+    if body.smt || body.huge_pages != MachineConfigHugePages::None {
         return Err(RequestError::MalformedRequest);
     }
 
@@ -1488,10 +1488,7 @@ fn validate_machine_config_patch_request(
     if body.mem_size_mib == Some(0) {
         return Err(RequestError::MalformedRequest);
     }
-    if body.smt == Some(true)
-        || body.track_dirty_pages == Some(true)
-        || body.huge_pages == Some(MachineConfigHugePages::TwoM)
-    {
+    if body.smt == Some(true) || body.huge_pages == Some(MachineConfigHugePages::TwoM) {
         return Err(RequestError::MalformedRequest);
     }
 
@@ -2348,7 +2345,6 @@ mod tests {
     fn rejects_put_machine_config_unsupported_values() {
         for body in [
             r#"{"vcpu_count":1,"mem_size_mib":128,"smt":true}"#,
-            r#"{"vcpu_count":1,"mem_size_mib":128,"track_dirty_pages":true}"#,
             r#"{"vcpu_count":1,"mem_size_mib":128,"cpu_template":"V1N1"}"#,
             r#"{"vcpu_count":1,"mem_size_mib":128,"huge_pages":"2M"}"#,
         ] {
@@ -2357,6 +2353,23 @@ mod tests {
                 Err(RequestError::MalformedRequest)
             );
         }
+    }
+
+    #[test]
+    fn parses_put_machine_config_with_dirty_page_tracking_enabled() {
+        let body = r#"{
+            "vcpu_count": 1,
+            "mem_size_mib": 128,
+            "track_dirty_pages": true
+        }"#;
+        let request = request_with_body("PUT", "/machine-config", body);
+
+        let parsed = parse_request(&request).expect("machine-config request should parse");
+
+        let ApiRequest::PutMachineConfig(config) = parsed else {
+            panic!("expected machine-config request");
+        };
+        assert!(config.track_dirty_pages());
     }
 
     #[test]
@@ -2472,7 +2485,6 @@ mod tests {
     fn rejects_patch_machine_config_unsupported_values() {
         for body in [
             r#"{"smt":true}"#,
-            r#"{"track_dirty_pages":true}"#,
             r#"{"cpu_template":"V1N1"}"#,
             r#"{"huge_pages":"2M"}"#,
         ] {
@@ -2481,6 +2493,19 @@ mod tests {
                 Err(RequestError::MalformedRequest)
             );
         }
+    }
+
+    #[test]
+    fn parses_patch_machine_config_with_dirty_page_tracking_enabled() {
+        let body = r#"{"track_dirty_pages":true}"#;
+        let request = request_with_body("PATCH", "/machine-config", body);
+
+        let parsed = parse_request(&request).expect("machine-config patch should parse");
+
+        let ApiRequest::PatchMachineConfig(config) = parsed else {
+            panic!("expected machine-config patch request");
+        };
+        assert_eq!(config.track_dirty_pages(), Some(true));
     }
 
     #[test]

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -1672,7 +1672,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_machine_config_request_does_not_mutate_vmm_state() {
+    fn machine_config_faults_do_not_mutate_vmm_state() {
         let mut vmm = test_controller();
         let body = r#"{"vcpu_count":2,"mem_size_mib":256}"#;
         let request = format!(
@@ -1698,10 +1698,11 @@ mod tests {
         );
         assert_eq!(
             response.body(),
-            r#"{"fault_message":"Malformed HTTP request."}"#
+            r#"{"fault_message":"machine track_dirty_pages is not supported"}"#
         );
         assert_eq!(vmm.machine_config().vcpu_count(), 2);
         assert_eq!(vmm.machine_config().mem_size_mib(), 256);
+        assert!(!vmm.machine_config().track_dirty_pages());
 
         let invalid_patch_body = r#"{"mem_size_mib":0}"#;
         let invalid_patch_request = format!(
@@ -1721,6 +1722,27 @@ mod tests {
         );
         assert_eq!(vmm.machine_config().vcpu_count(), 2);
         assert_eq!(vmm.machine_config().mem_size_mib(), 256);
+        assert!(!vmm.machine_config().track_dirty_pages());
+
+        let unsupported_patch_body = r#"{"track_dirty_pages":true}"#;
+        let unsupported_patch_request = format!(
+            "PATCH /machine-config HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{unsupported_patch_body}",
+            unsupported_patch_body.len()
+        );
+
+        let response = handle_request_bytes(unsupported_patch_request.as_bytes(), &mut vmm);
+
+        assert_eq!(
+            response.status(),
+            bangbang_api::http::StatusCode::BadRequest
+        );
+        assert_eq!(
+            response.body(),
+            r#"{"fault_message":"machine track_dirty_pages is not supported"}"#
+        );
+        assert_eq!(vmm.machine_config().vcpu_count(), 2);
+        assert_eq!(vmm.machine_config().mem_size_mib(), 256);
+        assert!(!vmm.machine_config().track_dirty_pages());
     }
 
     #[test]

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -3233,6 +3233,34 @@ mod tests {
         assert!(response.ends_with("\r\n\r\n"));
         assert_eq!(vmm.machine_config().vcpu_count(), 2);
         assert_eq!(vmm.machine_config().mem_size_mib(), 512);
+
+        let mut client =
+            UnixStream::connect(&path).expect("client should connect for unsupported patch");
+        let patch_body = r#"{"track_dirty_pages":true}"#;
+        let patch_request = format!(
+            "PATCH /machine-config HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{patch_body}",
+            patch_body.len()
+        );
+
+        client
+            .write_all(patch_request.as_bytes())
+            .expect("client should write unsupported patch request");
+        server
+            .serve_next(&mut vmm)
+            .expect("server should handle unsupported patch request");
+
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("client should read unsupported patch response");
+
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        assert!(
+            response.contains(r#"{"fault_message":"machine track_dirty_pages is not supported"}"#)
+        );
+        assert_eq!(vmm.machine_config().vcpu_count(), 2);
+        assert_eq!(vmm.machine_config().mem_size_mib(), 512);
+        assert!(!vmm.machine_config().track_dirty_pages());
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -275,14 +275,14 @@ exist.
 | `PUT /machine-config` | `mem_size_mib` | required | Drives guest memory allocation and mapping; later work must cover bounds and startup performance. |
 | `PUT /machine-config` | `smt` | optional when `false`; rejected when `true` | Firecracker defaults this to `false` and rejects `true` on aarch64; the initial HVF target should accept explicit no-SMT config without exposing SMT control. |
 | `PUT /machine-config` | `cpu_template` | optional when omitted, `null`, or `None`; deferred for non-`None` templates | Explicit `None` matches Firecracker's deprecated default; non-default CPU templates need a separate HVF compatibility design. |
-| `PUT /machine-config` | `track_dirty_pages` | optional when `false`; deferred when `true` | Explicit `false` matches Firecracker's default; enabling dirty tracking belongs with snapshot support. |
+| `PUT /machine-config` | `track_dirty_pages` | optional when `false`; rejected when `true` | Explicit `false` matches Firecracker's default; enabling dirty tracking belongs with snapshot support and currently returns `machine track_dirty_pages is not supported`. |
 | `PUT /machine-config` | `huge_pages` | optional when `None`; rejected for `2M` | Explicit `None` matches Firecracker's default; Linux hugetlbfs does not directly apply to the macOS target. |
 | `PUT /machine-config` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
 | `PATCH /machine-config` | `vcpu_count` | optional | When present, updates the stored vCPU count with the same `1..=32` bounds as `PUT`; omitted fields keep their current values. |
 | `PATCH /machine-config` | `mem_size_mib` | optional | When present, updates the stored memory size and rejects zero; omitted fields keep their current values. |
 | `PATCH /machine-config` | `smt` | optional when `false`; rejected when `true` | Matches the current `PUT` policy for the Apple Silicon target. |
 | `PATCH /machine-config` | `cpu_template` | optional when omitted or `null`; accepted when `None`; deferred for non-`None` templates | `null` is treated as omitted. Explicit `None` is accepted; non-default CPU templates remain deferred. |
-| `PATCH /machine-config` | `track_dirty_pages` | optional when `false`; deferred when `true` | Matches the current `PUT` dirty-tracking policy. |
+| `PATCH /machine-config` | `track_dirty_pages` | optional when `false`; rejected when `true` | Matches the current `PUT` dirty-tracking policy. |
 | `PATCH /machine-config` | `huge_pages` | optional when `None`; rejected for `2M` | Matches the current `PUT` huge-pages policy. |
 | `PATCH /machine-config` | unknown fields or empty patch | rejected | Matches Firecracker's strict request model behavior and avoids silent no-op updates. |
 | `PUT /drives/{drive_id}` | path `drive_id` | required | The API parser captures this value, and the internal model validates it as nonempty alphanumeric or `_`, matching Firecracker's `checked_id` rule. |


### PR DESCRIPTION
## Summary

- allow `track_dirty_pages: true` to parse for `PUT` and `PATCH /machine-config`
- route dirty-page tracking through the VMM/runtime unsupported fault path
- update compatibility docs from deferred to rejected for dirty-page tracking

## Scope Exclusions

- Does not implement dirty-page tracking or snapshot support.
- Does not change CPU template, SMT, or huge-pages behavior.

Closes #522

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p bangbang-api --lib machine_config --all-features --locked`
- `cargo test -p bangbang --bin bangbang machine_config --all-features --locked`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `git diff --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
