### PR TITLE
feat: reject machine cpu templates via runtime fault

### DIFF
--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -297,6 +297,12 @@ impl MachineConfigPatchRequest {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 pub enum MachineConfigCpuTemplate {
+    C3,
+    T2,
+    T2S,
+    T2CL,
+    T2A,
+    V1N1,
     None,
 }
 
@@ -2285,6 +2291,29 @@ mod tests {
     }
 
     #[test]
+    fn parses_put_machine_config_with_firecracker_cpu_templates() {
+        for (template, expected) in [
+            ("C3", MachineConfigCpuTemplate::C3),
+            ("T2", MachineConfigCpuTemplate::T2),
+            ("T2S", MachineConfigCpuTemplate::T2S),
+            ("T2CL", MachineConfigCpuTemplate::T2CL),
+            ("T2A", MachineConfigCpuTemplate::T2A),
+            ("V1N1", MachineConfigCpuTemplate::V1N1),
+        ] {
+            let body =
+                format!(r#"{{"vcpu_count":1,"mem_size_mib":128,"cpu_template":"{template}"}}"#);
+            let request = request_with_body("PUT", "/machine-config", &body);
+
+            let parsed = parse_request(&request).expect("CPU template should parse");
+
+            let ApiRequest::PutMachineConfig(config) = parsed else {
+                panic!("expected machine-config request");
+            };
+            assert_eq!(config.cpu_template(), Some(expected), "{template}");
+        }
+    }
+
+    #[test]
     fn rejects_put_machine_config_missing_required_fields() {
         assert_eq!(
             parse_request(&request_with_body(
@@ -2345,7 +2374,6 @@ mod tests {
     fn rejects_put_machine_config_unsupported_values() {
         for body in [
             r#"{"vcpu_count":1,"mem_size_mib":128,"smt":true}"#,
-            r#"{"vcpu_count":1,"mem_size_mib":128,"cpu_template":"V1N1"}"#,
             r#"{"vcpu_count":1,"mem_size_mib":128,"huge_pages":"2M"}"#,
         ] {
             assert_eq!(
@@ -2406,6 +2434,28 @@ mod tests {
         assert_eq!(config.track_dirty_pages(), None);
         assert_eq!(config.huge_pages(), None);
         assert_eq!(request_total_len(&request), Ok(Some(request.len())));
+    }
+
+    #[test]
+    fn parses_patch_machine_config_with_firecracker_cpu_templates() {
+        for (template, expected) in [
+            ("C3", MachineConfigCpuTemplate::C3),
+            ("T2", MachineConfigCpuTemplate::T2),
+            ("T2S", MachineConfigCpuTemplate::T2S),
+            ("T2CL", MachineConfigCpuTemplate::T2CL),
+            ("T2A", MachineConfigCpuTemplate::T2A),
+            ("V1N1", MachineConfigCpuTemplate::V1N1),
+        ] {
+            let body = format!(r#"{{"cpu_template":"{template}"}}"#);
+            let request = request_with_body("PATCH", "/machine-config", &body);
+
+            let parsed = parse_request(&request).expect("CPU template patch should parse");
+
+            let ApiRequest::PatchMachineConfig(config) = parsed else {
+                panic!("expected machine-config patch request");
+            };
+            assert_eq!(config.cpu_template(), Some(expected), "{template}");
+        }
     }
 
     #[test]
@@ -2483,14 +2533,28 @@ mod tests {
 
     #[test]
     fn rejects_patch_machine_config_unsupported_values() {
-        for body in [
-            r#"{"smt":true}"#,
-            r#"{"cpu_template":"V1N1"}"#,
-            r#"{"huge_pages":"2M"}"#,
-        ] {
+        for body in [r#"{"smt":true}"#, r#"{"huge_pages":"2M"}"#] {
             assert_eq!(
                 parse_request(&request_with_body("PATCH", "/machine-config", body)),
                 Err(RequestError::MalformedRequest)
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_machine_config_unknown_cpu_template() {
+        for (method, path, body) in [
+            (
+                "PUT",
+                "/machine-config",
+                r#"{"vcpu_count":1,"mem_size_mib":128,"cpu_template":"M7G"}"#,
+            ),
+            ("PATCH", "/machine-config", r#"{"cpu_template":"M7G"}"#),
+        ] {
+            assert_eq!(
+                parse_request(&request_with_body(method, path, body)),
+                Err(RequestError::MalformedRequest),
+                "{method} {path}"
             );
         }
     }

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -697,6 +697,20 @@ fn path_text(path: &Path) -> String {
     path.to_string_lossy().into_owned()
 }
 
+fn machine_cpu_template_from_request(
+    cpu_template: bangbang_api::http::MachineConfigCpuTemplate,
+) -> RuntimeMachineConfigCpuTemplate {
+    match cpu_template {
+        bangbang_api::http::MachineConfigCpuTemplate::C3 => RuntimeMachineConfigCpuTemplate::C3,
+        bangbang_api::http::MachineConfigCpuTemplate::T2 => RuntimeMachineConfigCpuTemplate::T2,
+        bangbang_api::http::MachineConfigCpuTemplate::T2S => RuntimeMachineConfigCpuTemplate::T2S,
+        bangbang_api::http::MachineConfigCpuTemplate::T2CL => RuntimeMachineConfigCpuTemplate::T2CL,
+        bangbang_api::http::MachineConfigCpuTemplate::T2A => RuntimeMachineConfigCpuTemplate::T2A,
+        bangbang_api::http::MachineConfigCpuTemplate::V1N1 => RuntimeMachineConfigCpuTemplate::V1N1,
+        bangbang_api::http::MachineConfigCpuTemplate::None => RuntimeMachineConfigCpuTemplate::None,
+    }
+}
+
 fn machine_config_input_from_request(config: &MachineConfigRequest) -> MachineConfigInput {
     let mut input = MachineConfigInput::new(config.vcpu_count(), config.mem_size_mib())
         .with_smt(config.smt())
@@ -707,11 +721,7 @@ fn machine_config_input_from_request(config: &MachineConfigRequest) -> MachineCo
         });
 
     if let Some(cpu_template) = config.cpu_template() {
-        input = input.with_cpu_template(match cpu_template {
-            bangbang_api::http::MachineConfigCpuTemplate::None => {
-                RuntimeMachineConfigCpuTemplate::None
-            }
-        });
+        input = input.with_cpu_template(machine_cpu_template_from_request(cpu_template));
     }
 
     input
@@ -732,11 +742,7 @@ fn machine_config_patch_input_from_request(
         input = input.with_smt(smt);
     }
     if let Some(cpu_template) = config.cpu_template() {
-        input = input.with_cpu_template(match cpu_template {
-            bangbang_api::http::MachineConfigCpuTemplate::None => {
-                RuntimeMachineConfigCpuTemplate::None
-            }
-        });
+        input = input.with_cpu_template(machine_cpu_template_from_request(cpu_template));
     }
     if let Some(track_dirty_pages) = config.track_dirty_pages() {
         input = input.with_track_dirty_pages(track_dirty_pages);
@@ -1752,6 +1758,52 @@ mod tests {
         assert_eq!(vmm.machine_config().vcpu_count(), 2);
         assert_eq!(vmm.machine_config().mem_size_mib(), 256);
         assert!(!vmm.machine_config().track_dirty_pages());
+    }
+
+    #[test]
+    fn machine_cpu_template_faults_do_not_mutate_vmm_state_over_socket() {
+        let mut vmm = test_controller();
+        let body = r#"{"vcpu_count":2,"mem_size_mib":256}"#;
+        let request = format!(
+            "PUT /machine-config HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        assert_eq!(
+            handle_request_bytes(request.as_bytes(), &mut vmm).status(),
+            bangbang_api::http::StatusCode::NoContent
+        );
+
+        let unsupported_put_body = r#"{"vcpu_count":4,"mem_size_mib":512,"cpu_template":"V1N1"}"#;
+        let unsupported_put_request = format!(
+            "PUT /machine-config HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{unsupported_put_body}",
+            unsupported_put_body.len()
+        );
+
+        let response = request_over_socket(&mut vmm, "mct-put", &unsupported_put_request);
+
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        assert!(
+            response.contains(r#"{"fault_message":"machine cpu_template V1N1 is not supported"}"#)
+        );
+        assert_eq!(vmm.machine_config().vcpu_count(), 2);
+        assert_eq!(vmm.machine_config().mem_size_mib(), 256);
+        assert_eq!(vmm.machine_config().cpu_template(), None);
+
+        let unsupported_patch_body = r#"{"mem_size_mib":512,"cpu_template":"T2A"}"#;
+        let unsupported_patch_request = format!(
+            "PATCH /machine-config HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{unsupported_patch_body}",
+            unsupported_patch_body.len()
+        );
+
+        let response = request_over_socket(&mut vmm, "mct-patch", &unsupported_patch_request);
+
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        assert!(
+            response.contains(r#"{"fault_message":"machine cpu_template T2A is not supported"}"#)
+        );
+        assert_eq!(vmm.machine_config().vcpu_count(), 2);
+        assert_eq!(vmm.machine_config().mem_size_mib(), 256);
+        assert_eq!(vmm.machine_config().cpu_template(), None);
     }
 
     #[test]

--- a/crates/runtime/src/machine.rs
+++ b/crates/runtime/src/machine.rs
@@ -200,6 +200,11 @@ impl TryFrom<MachineConfigInput> for MachineConfig {
         if input.smt {
             return Err(MachineConfigError::SmtNotSupported);
         }
+        if let Some(cpu_template) = input.cpu_template
+            && cpu_template != MachineConfigCpuTemplate::None
+        {
+            return Err(MachineConfigError::UnsupportedCpuTemplate { cpu_template });
+        }
         if input.track_dirty_pages {
             return Err(MachineConfigError::DirtyPageTrackingNotSupported);
         }
@@ -211,9 +216,7 @@ impl TryFrom<MachineConfigInput> for MachineConfig {
             vcpu_count: input.vcpu_count,
             mem_size_mib: input.mem_size_mib,
             smt: input.smt,
-            cpu_template: match input.cpu_template {
-                Some(MachineConfigCpuTemplate::None) | None => None,
-            },
+            cpu_template: None,
             track_dirty_pages: input.track_dirty_pages,
             huge_pages: input.huge_pages,
         })
@@ -222,7 +225,27 @@ impl TryFrom<MachineConfigInput> for MachineConfig {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MachineConfigCpuTemplate {
+    C3,
+    T2,
+    T2S,
+    T2CL,
+    T2A,
+    V1N1,
     None,
+}
+
+impl fmt::Display for MachineConfigCpuTemplate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::C3 => f.write_str("C3"),
+            Self::T2 => f.write_str("T2"),
+            Self::T2S => f.write_str("T2S"),
+            Self::T2CL => f.write_str("T2CL"),
+            Self::T2A => f.write_str("T2A"),
+            Self::V1N1 => f.write_str("V1N1"),
+            Self::None => f.write_str("None"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -238,6 +261,9 @@ pub enum MachineConfigError {
     InvalidVcpuCount,
     InvalidMemorySize,
     SmtNotSupported,
+    UnsupportedCpuTemplate {
+        cpu_template: MachineConfigCpuTemplate,
+    },
     DirtyPageTrackingNotSupported,
     HugePagesNotSupported,
 }
@@ -251,6 +277,9 @@ impl fmt::Display for MachineConfigError {
             }
             Self::InvalidMemorySize => f.write_str("machine mem_size_mib must not be zero"),
             Self::SmtNotSupported => f.write_str("machine smt is not supported"),
+            Self::UnsupportedCpuTemplate { cpu_template } => {
+                write!(f, "machine cpu_template {cpu_template} is not supported")
+            }
             Self::DirtyPageTrackingNotSupported => {
                 f.write_str("machine track_dirty_pages is not supported")
             }
@@ -309,6 +338,12 @@ mod tests {
             (
                 MachineConfigInput::new(1, 128).with_smt(true),
                 MachineConfigError::SmtNotSupported,
+            ),
+            (
+                MachineConfigInput::new(1, 128).with_cpu_template(MachineConfigCpuTemplate::V1N1),
+                MachineConfigError::UnsupportedCpuTemplate {
+                    cpu_template: MachineConfigCpuTemplate::V1N1,
+                },
             ),
             (
                 MachineConfigInput::new(1, 128).with_track_dirty_pages(true),
@@ -370,6 +405,12 @@ mod tests {
                 MachineConfigError::SmtNotSupported,
             ),
             (
+                MachineConfigPatchInput::new().with_cpu_template(MachineConfigCpuTemplate::T2A),
+                MachineConfigError::UnsupportedCpuTemplate {
+                    cpu_template: MachineConfigCpuTemplate::T2A,
+                },
+            ),
+            (
                 MachineConfigPatchInput::new().with_track_dirty_pages(true),
                 MachineConfigError::DirtyPageTrackingNotSupported,
             ),
@@ -388,7 +429,7 @@ mod tests {
     }
 
     #[test]
-    fn displays_machine_config_errors_without_user_values() {
+    fn displays_machine_config_errors() {
         assert_eq!(
             MachineConfigError::EmptyPatch.to_string(),
             "machine config patch must update at least one field"
@@ -404,6 +445,13 @@ mod tests {
         assert_eq!(
             MachineConfigError::SmtNotSupported.to_string(),
             "machine smt is not supported"
+        );
+        assert_eq!(
+            MachineConfigError::UnsupportedCpuTemplate {
+                cpu_template: MachineConfigCpuTemplate::V1N1,
+            }
+            .to_string(),
+            "machine cpu_template V1N1 is not supported"
         );
         assert_eq!(
             MachineConfigError::DirtyPageTrackingNotSupported.to_string(),

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -274,14 +274,14 @@ exist.
 | `PUT /machine-config` | `vcpu_count` | required | Firecracker bounds this to `1..=32`; HVF work must also account for host CPU and thread limits. |
 | `PUT /machine-config` | `mem_size_mib` | required | Drives guest memory allocation and mapping; later work must cover bounds and startup performance. |
 | `PUT /machine-config` | `smt` | optional when `false`; rejected when `true` | Firecracker defaults this to `false` and rejects `true` on aarch64; the initial HVF target should accept explicit no-SMT config without exposing SMT control. |
-| `PUT /machine-config` | `cpu_template` | optional when omitted, `null`, or `None`; deferred for non-`None` templates | Explicit `None` matches Firecracker's deprecated default; non-default CPU templates need a separate HVF compatibility design. |
+| `PUT /machine-config` | `cpu_template` | optional when omitted, `null`, or `None`; rejected for known non-`None` templates | Explicit `None` matches Firecracker's deprecated default; known non-default CPU templates currently return `machine cpu_template <template> is not supported` and need a separate HVF compatibility design. |
 | `PUT /machine-config` | `track_dirty_pages` | optional when `false`; rejected when `true` | Explicit `false` matches Firecracker's default; enabling dirty tracking belongs with snapshot support and currently returns `machine track_dirty_pages is not supported`. |
 | `PUT /machine-config` | `huge_pages` | optional when `None`; rejected for `2M` | Explicit `None` matches Firecracker's default; Linux hugetlbfs does not directly apply to the macOS target. |
 | `PUT /machine-config` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
 | `PATCH /machine-config` | `vcpu_count` | optional | When present, updates the stored vCPU count with the same `1..=32` bounds as `PUT`; omitted fields keep their current values. |
 | `PATCH /machine-config` | `mem_size_mib` | optional | When present, updates the stored memory size and rejects zero; omitted fields keep their current values. |
 | `PATCH /machine-config` | `smt` | optional when `false`; rejected when `true` | Matches the current `PUT` policy for the Apple Silicon target. |
-| `PATCH /machine-config` | `cpu_template` | optional when omitted or `null`; accepted when `None`; deferred for non-`None` templates | `null` is treated as omitted. Explicit `None` is accepted; non-default CPU templates remain deferred. |
+| `PATCH /machine-config` | `cpu_template` | optional when omitted or `null`; accepted when `None`; rejected for known non-`None` templates | `null` is treated as omitted. Explicit `None` is accepted; known non-default CPU templates currently return `machine cpu_template <template> is not supported`. |
 | `PATCH /machine-config` | `track_dirty_pages` | optional when `false`; rejected when `true` | Matches the current `PUT` dirty-tracking policy. |
 | `PATCH /machine-config` | `huge_pages` | optional when `None`; rejected for `2M` | Matches the current `PUT` huge-pages policy. |
 | `PATCH /machine-config` | unknown fields or empty patch | rejected | Matches Firecracker's strict request model behavior and avoids silent no-op updates. |


### PR DESCRIPTION
## Summary
- recognize Firecracker static machine `cpu_template` names in PUT/PATCH `/machine-config` parsing
- reject known non-`None` templates through the runtime fault path without mutating stored machine config
- update the Firecracker compatibility notes for the current unsupported CPU template policy

## Scope Exclusions
- does not apply CPU templates or mask host CPU features
- does not add `/cpu-config` custom template support
- does not change HVF vCPU creation behavior

Closes #528

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p bangbang-api machine_config --all-features --locked`
- `cargo test -p bangbang-runtime machine --all-features --locked`
- `cargo test -p bangbang --bin bangbang cpu_template --all-features --locked`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`
