### PR TITLE
feat: return machine field unsupported faults

### DIFF
--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -1473,10 +1473,6 @@ fn validate_machine_config_request(body: &MachineConfigRequestBody) -> Result<()
     if body.mem_size_mib == 0 {
         return Err(RequestError::MalformedRequest);
     }
-    if body.smt || body.huge_pages != MachineConfigHugePages::None {
-        return Err(RequestError::MalformedRequest);
-    }
-
     Ok(())
 }
 
@@ -1494,10 +1490,6 @@ fn validate_machine_config_patch_request(
     if body.mem_size_mib == Some(0) {
         return Err(RequestError::MalformedRequest);
     }
-    if body.smt == Some(true) || body.huge_pages == Some(MachineConfigHugePages::TwoM) {
-        return Err(RequestError::MalformedRequest);
-    }
-
     Ok(())
 }
 
@@ -2347,13 +2339,17 @@ mod tests {
 
     #[test]
     fn rejects_put_machine_config_invalid_field_type() {
-        let body = r#"{
-            "vcpu_count": "1",
-            "mem_size_mib": 128
-        }"#;
-        let request = request_with_body("PUT", "/machine-config", body);
-
-        assert_eq!(parse_request(&request), Err(RequestError::MalformedRequest));
+        for body in [
+            r#"{"vcpu_count":"1","mem_size_mib":128}"#,
+            r#"{"vcpu_count":1,"mem_size_mib":128,"smt":"true"}"#,
+            r#"{"vcpu_count":1,"mem_size_mib":128,"huge_pages":2}"#,
+        ] {
+            assert_eq!(
+                parse_request(&request_with_body("PUT", "/machine-config", body)),
+                Err(RequestError::MalformedRequest),
+                "{body}"
+            );
+        }
     }
 
     #[test]
@@ -2371,15 +2367,23 @@ mod tests {
     }
 
     #[test]
-    fn rejects_put_machine_config_unsupported_values() {
+    fn parses_put_machine_config_with_runtime_unsupported_values() {
         for body in [
             r#"{"vcpu_count":1,"mem_size_mib":128,"smt":true}"#,
             r#"{"vcpu_count":1,"mem_size_mib":128,"huge_pages":"2M"}"#,
         ] {
-            assert_eq!(
-                parse_request(&request_with_body("PUT", "/machine-config", body)),
-                Err(RequestError::MalformedRequest)
-            );
+            let parsed = parse_request(&request_with_body("PUT", "/machine-config", body))
+                .expect("known unsupported machine config value should parse");
+
+            let ApiRequest::PutMachineConfig(config) = parsed else {
+                panic!("expected machine-config request");
+            };
+            if body.contains(r#""smt":true"#) {
+                assert!(config.smt(), "{body}");
+            }
+            if body.contains(r#""huge_pages":"2M""#) {
+                assert_eq!(config.huge_pages(), MachineConfigHugePages::TwoM, "{body}");
+            }
         }
     }
 
@@ -2532,12 +2536,35 @@ mod tests {
     }
 
     #[test]
-    fn rejects_patch_machine_config_unsupported_values() {
-        for body in [r#"{"smt":true}"#, r#"{"huge_pages":"2M"}"#] {
+    fn rejects_patch_machine_config_invalid_field_type() {
+        for body in [r#"{"smt":"true"}"#, r#"{"huge_pages":2}"#] {
             assert_eq!(
                 parse_request(&request_with_body("PATCH", "/machine-config", body)),
-                Err(RequestError::MalformedRequest)
+                Err(RequestError::MalformedRequest),
+                "{body}"
             );
+        }
+    }
+
+    #[test]
+    fn parses_patch_machine_config_with_runtime_unsupported_values() {
+        for body in [r#"{"smt":true}"#, r#"{"huge_pages":"2M"}"#] {
+            let parsed = parse_request(&request_with_body("PATCH", "/machine-config", body))
+                .expect("known unsupported machine config patch value should parse");
+
+            let ApiRequest::PatchMachineConfig(config) = parsed else {
+                panic!("expected machine-config patch request");
+            };
+            if body.contains(r#""smt":true"#) {
+                assert_eq!(config.smt(), Some(true), "{body}");
+            }
+            if body.contains(r#""huge_pages":"2M""#) {
+                assert_eq!(
+                    config.huge_pages(),
+                    Some(MachineConfigHugePages::TwoM),
+                    "{body}"
+                );
+            }
         }
     }
 
@@ -2550,6 +2577,24 @@ mod tests {
                 r#"{"vcpu_count":1,"mem_size_mib":128,"cpu_template":"M7G"}"#,
             ),
             ("PATCH", "/machine-config", r#"{"cpu_template":"M7G"}"#),
+        ] {
+            assert_eq!(
+                parse_request(&request_with_body(method, path, body)),
+                Err(RequestError::MalformedRequest),
+                "{method} {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_machine_config_unknown_huge_pages() {
+        for (method, path, body) in [
+            (
+                "PUT",
+                "/machine-config",
+                r#"{"vcpu_count":1,"mem_size_mib":128,"huge_pages":"7M"}"#,
+            ),
+            ("PATCH", "/machine-config", r#"{"huge_pages":"7M"}"#),
         ] {
             assert_eq!(
                 parse_request(&request_with_body(method, path, body)),

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -1807,6 +1807,64 @@ mod tests {
     }
 
     #[test]
+    fn machine_smt_and_huge_pages_faults_do_not_mutate_vmm_state_over_socket() {
+        let mut vmm = test_controller();
+        let body = r#"{"vcpu_count":2,"mem_size_mib":256}"#;
+        let request = format!(
+            "PUT /machine-config HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        assert_eq!(
+            handle_request_bytes(request.as_bytes(), &mut vmm).status(),
+            bangbang_api::http::StatusCode::NoContent
+        );
+
+        for (method, socket_name, body, expected_fault) in [
+            (
+                "PUT",
+                "ms-put",
+                r#"{"vcpu_count":4,"mem_size_mib":512,"smt":true}"#,
+                r#"{"fault_message":"machine smt is not supported"}"#,
+            ),
+            (
+                "PATCH",
+                "ms-pat",
+                r#"{"mem_size_mib":512,"smt":true}"#,
+                r#"{"fault_message":"machine smt is not supported"}"#,
+            ),
+            (
+                "PUT",
+                "mh-put",
+                r#"{"vcpu_count":4,"mem_size_mib":512,"huge_pages":"2M"}"#,
+                r#"{"fault_message":"machine huge_pages is not supported"}"#,
+            ),
+            (
+                "PATCH",
+                "mh-pat",
+                r#"{"mem_size_mib":512,"huge_pages":"2M"}"#,
+                r#"{"fault_message":"machine huge_pages is not supported"}"#,
+            ),
+        ] {
+            let request = format!(
+                "{method} /machine-config HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                body.len()
+            );
+
+            let response = request_over_socket(&mut vmm, socket_name, &request);
+
+            assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+            assert!(response.contains(expected_fault), "{method} {body}");
+            assert_eq!(vmm.machine_config().vcpu_count(), 2);
+            assert_eq!(vmm.machine_config().mem_size_mib(), 256);
+            assert!(!vmm.machine_config().smt());
+            assert_eq!(
+                vmm.machine_config().huge_pages(),
+                RuntimeMachineConfigHugePages::None
+            );
+        }
+    }
+
+    #[test]
     fn running_state_rejects_machine_config_patch_without_mutating() {
         let mut vmm = test_controller_with_starter(TestInstanceStarter::success());
         let machine_body = r#"{"vcpu_count":2,"mem_size_mib":256}"#;

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -273,17 +273,17 @@ exist.
 | `PUT /boot-source` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
 | `PUT /machine-config` | `vcpu_count` | required | Firecracker bounds this to `1..=32`; HVF work must also account for host CPU and thread limits. |
 | `PUT /machine-config` | `mem_size_mib` | required | Drives guest memory allocation and mapping; later work must cover bounds and startup performance. |
-| `PUT /machine-config` | `smt` | optional when `false`; rejected when `true` | Firecracker defaults this to `false` and rejects `true` on aarch64; the initial HVF target should accept explicit no-SMT config without exposing SMT control. |
+| `PUT /machine-config` | `smt` | optional when `false`; rejected when `true` | Firecracker defaults this to `false`; the initial HVF target accepts explicit no-SMT config and currently returns `machine smt is not supported` when SMT is enabled. |
 | `PUT /machine-config` | `cpu_template` | optional when omitted, `null`, or `None`; rejected for known non-`None` templates | Explicit `None` matches Firecracker's deprecated default; known non-default CPU templates currently return `machine cpu_template <template> is not supported` and need a separate HVF compatibility design. |
 | `PUT /machine-config` | `track_dirty_pages` | optional when `false`; rejected when `true` | Explicit `false` matches Firecracker's default; enabling dirty tracking belongs with snapshot support and currently returns `machine track_dirty_pages is not supported`. |
-| `PUT /machine-config` | `huge_pages` | optional when `None`; rejected for `2M` | Explicit `None` matches Firecracker's default; Linux hugetlbfs does not directly apply to the macOS target. |
+| `PUT /machine-config` | `huge_pages` | optional when `None`; rejected for `2M` | Explicit `None` matches Firecracker's default; Linux hugetlbfs does not directly apply to the macOS target and `2M` currently returns `machine huge_pages is not supported`. |
 | `PUT /machine-config` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
 | `PATCH /machine-config` | `vcpu_count` | optional | When present, updates the stored vCPU count with the same `1..=32` bounds as `PUT`; omitted fields keep their current values. |
 | `PATCH /machine-config` | `mem_size_mib` | optional | When present, updates the stored memory size and rejects zero; omitted fields keep their current values. |
-| `PATCH /machine-config` | `smt` | optional when `false`; rejected when `true` | Matches the current `PUT` policy for the Apple Silicon target. |
+| `PATCH /machine-config` | `smt` | optional when `false`; rejected when `true` | Matches the current `PUT` policy for the Apple Silicon target and currently returns `machine smt is not supported` when SMT is enabled. |
 | `PATCH /machine-config` | `cpu_template` | optional when omitted or `null`; accepted when `None`; rejected for known non-`None` templates | `null` is treated as omitted. Explicit `None` is accepted; known non-default CPU templates currently return `machine cpu_template <template> is not supported`. |
 | `PATCH /machine-config` | `track_dirty_pages` | optional when `false`; rejected when `true` | Matches the current `PUT` dirty-tracking policy. |
-| `PATCH /machine-config` | `huge_pages` | optional when `None`; rejected for `2M` | Matches the current `PUT` huge-pages policy. |
+| `PATCH /machine-config` | `huge_pages` | optional when `None`; rejected for `2M` | Matches the current `PUT` huge-pages policy and currently returns `machine huge_pages is not supported` for `2M`. |
 | `PATCH /machine-config` | unknown fields or empty patch | rejected | Matches Firecracker's strict request model behavior and avoids silent no-op updates. |
 | `PUT /drives/{drive_id}` | path `drive_id` | required | The API parser captures this value, and the internal model validates it as nonempty alphanumeric or `_`, matching Firecracker's `checked_id` rule. |
 | `PUT /drives/{drive_id}` | body `drive_id` | required | The API parser rejects requests where this does not match the path `drive_id`. |


### PR DESCRIPTION
## Summary
- let Firecracker-known `smt: true` and `huge_pages: "2M"` machine-config values parse instead of failing as malformed JSON
- route those unsupported values through existing runtime/VMM faults without mutating stored machine config
- update compatibility notes with the concrete unsupported fault messages

## Scope Exclusions
- does not implement SMT support
- does not implement huge page backing
- does not change vCPU creation, guest memory allocation, or HVF startup behavior

Closes #530

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p bangbang-api machine_config --all-features --locked`
- `cargo test -p bangbang --bin bangbang machine_smt --all-features --locked`
- `cargo test -p bangbang --bin bangbang machine_config --all-features --locked`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`
