### PR TITLE
feat: recognize hot-unplug endpoints as unsupported

### DIFF
--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -4061,27 +4061,20 @@ mod tests {
 
     #[test]
     fn rejects_non_exact_pmem_paths_as_invalid_path_method() {
-        for (route, request) in [
-            ("PUT /pmem", request_with_body("PUT", "/pmem", "{}")),
-            ("PUT /pmem/", request_with_body("PUT", "/pmem/", "{}")),
-            (
-                "PUT /pmem/pmem0/extra",
-                request_with_body("PUT", "/pmem/pmem0/extra", "{}"),
-            ),
-            (
-                "PATCH /pmem/pmem-0",
-                request_with_body("PATCH", "/pmem/pmem-0", "{}"),
-            ),
-            (
-                "DELETE /pmem/pmem-0",
-                request_with_body("DELETE", "/pmem/pmem-0", "{}"),
-            ),
-        ] {
-            assert_eq!(
-                parse_request(&request),
-                Err(RequestError::InvalidPathMethod),
-                "{route}"
-            );
+        for method in ["PUT", "PATCH", "DELETE"] {
+            for path in [
+                "/pmem",
+                "/pmem/",
+                "/pmem/pmem0/extra",
+                "/pmem/pmem-0",
+                "/pmem/pmem0?debug=true",
+            ] {
+                assert_eq!(
+                    parse_request(&request_with_body(method, path, "{}")),
+                    Err(RequestError::InvalidPathMethod),
+                    "{method} {path}"
+                );
+            }
         }
     }
 

--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -1151,14 +1151,14 @@ pub fn parse_request_with_limit(
         return Err(RequestError::MemoryHotplugUnsupported);
     }
 
-    if matches!(method, "PUT" | "PATCH") && pmem_path_id(path).is_some() {
+    if matches!(method, "PUT" | "PATCH" | "DELETE") && pmem_path_id(path).is_some() {
         return Err(RequestError::PmemUnsupported);
     }
 
-    if method == "PATCH" && drive_path_id(path).is_some() {
+    if matches!(method, "PATCH" | "DELETE") && drive_path_id(path).is_some() {
         return Err(RequestError::DriveUpdateUnsupported);
     }
-    if method == "PATCH" && network_interface_path_id(path).is_some() {
+    if matches!(method, "PATCH" | "DELETE") && network_interface_path_id(path).is_some() {
         return Err(RequestError::NetworkInterfaceUpdateUnsupported);
     }
 
@@ -3302,56 +3302,60 @@ mod tests {
     }
 
     #[test]
-    fn rejects_drive_update_as_unsupported() {
-        let request = request_with_body("PATCH", "/drives/rootfs", r#"{"drive_id":"rootfs"}"#);
-
-        let err = parse_request(&request).expect_err("drive update should be unsupported");
-        assert_eq!(err, RequestError::DriveUpdateUnsupported);
-        assert_eq!(err.fault_message(), "Drive updates are not supported.");
+    fn rejects_drive_update_and_hot_unplug_as_unsupported() {
+        for (route, request) in [
+            (
+                "PATCH /drives/rootfs",
+                request_with_body("PATCH", "/drives/rootfs", r#"{"drive_id":"rootfs"}"#),
+            ),
+            (
+                "DELETE /drives/rootfs",
+                b"DELETE /drives/rootfs HTTP/1.1\r\nHost: localhost\r\n\r\n".to_vec(),
+            ),
+        ] {
+            let err = parse_request(&request).expect_err("drive update should be unsupported");
+            assert_eq!(err, RequestError::DriveUpdateUnsupported, "{route}");
+            assert_eq!(err.fault_message(), "Drive updates are not supported.");
+        }
     }
 
     #[test]
     fn rejects_drive_update_without_parsing_body() {
-        let malformed_body = request_with_body("PATCH", "/drives/rootfs", "not-json");
-        let empty_body =
-            b"PATCH /drives/rootfs HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n";
+        for method in ["PATCH", "DELETE"] {
+            let malformed_body = request_with_body(method, "/drives/rootfs", "not-json");
+            let empty_body = format!(
+                "{method} /drives/rootfs HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n"
+            );
 
-        assert_eq!(
-            parse_request(&malformed_body),
-            Err(RequestError::DriveUpdateUnsupported)
-        );
-        assert_eq!(
-            parse_request(empty_body),
-            Err(RequestError::DriveUpdateUnsupported)
-        );
+            assert_eq!(
+                parse_request(&malformed_body),
+                Err(RequestError::DriveUpdateUnsupported),
+                "{method}"
+            );
+            assert_eq!(
+                parse_request(empty_body.as_bytes()),
+                Err(RequestError::DriveUpdateUnsupported),
+                "{method}"
+            );
+        }
     }
 
     #[test]
     fn rejects_non_exact_drive_update_paths_as_invalid_path_method() {
-        for (route, request) in [
-            ("PATCH /drives", request_with_body("PATCH", "/drives", "{}")),
-            (
-                "PATCH /drives/",
-                request_with_body("PATCH", "/drives/", "{}"),
-            ),
-            (
-                "PATCH /drives/rootfs/extra",
-                request_with_body("PATCH", "/drives/rootfs/extra", "{}"),
-            ),
-            (
-                "PATCH /drives/root-fs",
-                request_with_body("PATCH", "/drives/root-fs", "{}"),
-            ),
-            (
-                "PATCH /drives/rootfs?debug=true",
-                request_with_body("PATCH", "/drives/rootfs?debug=true", "{}"),
-            ),
-        ] {
-            assert_eq!(
-                parse_request(&request),
-                Err(RequestError::InvalidPathMethod),
-                "{route}"
-            );
+        for method in ["PATCH", "DELETE"] {
+            for path in [
+                "/drives",
+                "/drives/",
+                "/drives/rootfs/extra",
+                "/drives/root-fs",
+                "/drives/rootfs?debug=true",
+            ] {
+                assert_eq!(
+                    parse_request(&request_with_body(method, path, "{}")),
+                    Err(RequestError::InvalidPathMethod),
+                    "{method} {path}"
+                );
+            }
         }
     }
 
@@ -3361,10 +3365,6 @@ mod tests {
             (
                 "GET /drives/rootfs",
                 b"GET /drives/rootfs HTTP/1.1\r\nHost: localhost\r\n\r\n".to_vec(),
-            ),
-            (
-                "DELETE /drives/rootfs",
-                b"DELETE /drives/rootfs HTTP/1.1\r\nHost: localhost\r\n\r\n".to_vec(),
             ),
             (
                 "POST /drives/rootfs",
@@ -3601,66 +3601,72 @@ mod tests {
     }
 
     #[test]
-    fn rejects_network_interface_update_as_unsupported() {
-        let request = request_with_body(
-            "PATCH",
-            "/network-interfaces/eth0",
-            r#"{"iface_id":"eth0"}"#,
-        );
-
-        let err =
-            parse_request(&request).expect_err("network interface update should be unsupported");
-        assert_eq!(err, RequestError::NetworkInterfaceUpdateUnsupported);
-        assert_eq!(
-            err.fault_message(),
-            "Network interface updates are not supported."
-        );
+    fn rejects_network_interface_update_and_hot_unplug_as_unsupported() {
+        for (route, request) in [
+            (
+                "PATCH /network-interfaces/eth0",
+                request_with_body(
+                    "PATCH",
+                    "/network-interfaces/eth0",
+                    r#"{"iface_id":"eth0"}"#,
+                ),
+            ),
+            (
+                "DELETE /network-interfaces/eth0",
+                b"DELETE /network-interfaces/eth0 HTTP/1.1\r\nHost: localhost\r\n\r\n".to_vec(),
+            ),
+        ] {
+            let err = parse_request(&request)
+                .expect_err("network interface update should be unsupported");
+            assert_eq!(
+                err,
+                RequestError::NetworkInterfaceUpdateUnsupported,
+                "{route}"
+            );
+            assert_eq!(
+                err.fault_message(),
+                "Network interface updates are not supported."
+            );
+        }
     }
 
     #[test]
     fn rejects_network_interface_update_without_parsing_body() {
-        let malformed_body = request_with_body("PATCH", "/network-interfaces/eth0", "not-json");
-        let empty_body = b"PATCH /network-interfaces/eth0 HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n";
+        for method in ["PATCH", "DELETE"] {
+            let malformed_body = request_with_body(method, "/network-interfaces/eth0", "not-json");
+            let empty_body = format!(
+                "{method} /network-interfaces/eth0 HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n"
+            );
 
-        assert_eq!(
-            parse_request(&malformed_body),
-            Err(RequestError::NetworkInterfaceUpdateUnsupported)
-        );
-        assert_eq!(
-            parse_request(empty_body),
-            Err(RequestError::NetworkInterfaceUpdateUnsupported)
-        );
+            assert_eq!(
+                parse_request(&malformed_body),
+                Err(RequestError::NetworkInterfaceUpdateUnsupported),
+                "{method}"
+            );
+            assert_eq!(
+                parse_request(empty_body.as_bytes()),
+                Err(RequestError::NetworkInterfaceUpdateUnsupported),
+                "{method}"
+            );
+        }
     }
 
     #[test]
     fn rejects_non_exact_network_interface_update_paths_as_invalid_path_method() {
-        for (route, request) in [
-            (
-                "PATCH /network-interfaces",
-                request_with_body("PATCH", "/network-interfaces", "{}"),
-            ),
-            (
-                "PATCH /network-interfaces/",
-                request_with_body("PATCH", "/network-interfaces/", "{}"),
-            ),
-            (
-                "PATCH /network-interfaces/eth0/extra",
-                request_with_body("PATCH", "/network-interfaces/eth0/extra", "{}"),
-            ),
-            (
-                "PATCH /network-interfaces/eth-0",
-                request_with_body("PATCH", "/network-interfaces/eth-0", "{}"),
-            ),
-            (
-                "PATCH /network-interfaces/eth0?debug=true",
-                request_with_body("PATCH", "/network-interfaces/eth0?debug=true", "{}"),
-            ),
-        ] {
-            assert_eq!(
-                parse_request(&request),
-                Err(RequestError::InvalidPathMethod),
-                "{route}"
-            );
+        for method in ["PATCH", "DELETE"] {
+            for path in [
+                "/network-interfaces",
+                "/network-interfaces/",
+                "/network-interfaces/eth0/extra",
+                "/network-interfaces/eth-0",
+                "/network-interfaces/eth0?debug=true",
+            ] {
+                assert_eq!(
+                    parse_request(&request_with_body(method, path, "{}")),
+                    Err(RequestError::InvalidPathMethod),
+                    "{method} {path}"
+                );
+            }
         }
     }
 
@@ -3670,10 +3676,6 @@ mod tests {
             (
                 "GET /network-interfaces/eth0",
                 b"GET /network-interfaces/eth0 HTTP/1.1\r\nHost: localhost\r\n\r\n".to_vec(),
-            ),
-            (
-                "DELETE /network-interfaces/eth0",
-                b"DELETE /network-interfaces/eth0 HTTP/1.1\r\nHost: localhost\r\n\r\n".to_vec(),
             ),
             (
                 "POST /network-interfaces/eth0",
@@ -4022,6 +4024,10 @@ mod tests {
                 request_with_body("PATCH", "/pmem/pmem0", r#"{"id":"pmem0"}"#),
             ),
             (
+                "DELETE /pmem/pmem0",
+                b"DELETE /pmem/pmem0 HTTP/1.1\r\nHost: localhost\r\n\r\n".to_vec(),
+            ),
+            (
                 "PUT /pmem/pmem_0",
                 request_with_body("PUT", "/pmem/pmem_0", r#"{"id":"pmem_0"}"#),
             ),
@@ -4034,7 +4040,7 @@ mod tests {
 
     #[test]
     fn rejects_pmem_body_methods_without_parsing_body() {
-        for method in ["PUT", "PATCH"] {
+        for method in ["PUT", "PATCH", "DELETE"] {
             let malformed_body = request_with_body(method, "/pmem/pmem0", "not-json");
             let empty_body = format!(
                 "{method} /pmem/pmem0 HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n"
@@ -4066,6 +4072,10 @@ mod tests {
                 "PATCH /pmem/pmem-0",
                 request_with_body("PATCH", "/pmem/pmem-0", "{}"),
             ),
+            (
+                "DELETE /pmem/pmem-0",
+                request_with_body("DELETE", "/pmem/pmem-0", "{}"),
+            ),
         ] {
             assert_eq!(
                 parse_request(&request),
@@ -4081,10 +4091,6 @@ mod tests {
             (
                 "GET /pmem/pmem0",
                 b"GET /pmem/pmem0 HTTP/1.1\r\nHost: localhost\r\n\r\n".to_vec(),
-            ),
-            (
-                "DELETE /pmem/pmem0",
-                b"DELETE /pmem/pmem0 HTTP/1.1\r\nHost: localhost\r\n\r\n".to_vec(),
             ),
             (
                 "POST /pmem/pmem0",

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -3188,6 +3188,10 @@ mod tests {
                 b"PATCH /pmem/pmem0 HTTP/1.1\r\nHost: localhost\r\nContent-Length: 14\r\n\r\n{\"id\":\"pmem0\"}"
                     .as_slice(),
             ),
+            (
+                "delete",
+                b"DELETE /pmem/pmem0 HTTP/1.1\r\nHost: localhost\r\n\r\n".as_slice(),
+            ),
         ] {
             let socket_name = format!("p{method}");
             let path = unique_socket_path(&socket_name);
@@ -3218,17 +3222,33 @@ mod tests {
 
     #[test]
     fn returns_fault_for_device_update_endpoints() {
-        for (name, path, body, fault_message) in [
+        for (name, method, path, body, fault_message) in [
             (
                 "drive",
+                "PATCH",
                 "/drives/rootfs",
                 r#"{"drive_id":"rootfs"}"#,
                 r#"{"fault_message":"Drive updates are not supported."}"#,
             ),
             (
+                "drive-delete",
+                "DELETE",
+                "/drives/rootfs",
+                "",
+                r#"{"fault_message":"Drive updates are not supported."}"#,
+            ),
+            (
                 "net",
+                "PATCH",
                 "/network-interfaces/eth0",
                 r#"{"iface_id":"eth0"}"#,
+                r#"{"fault_message":"Network interface updates are not supported."}"#,
+            ),
+            (
+                "net-delete",
+                "DELETE",
+                "/network-interfaces/eth0",
+                "",
                 r#"{"fault_message":"Network interface updates are not supported."}"#,
             ),
         ] {
@@ -3237,7 +3257,7 @@ mod tests {
             let server = ApiServer::bind(&socket_path).expect("server should bind");
             let mut client = UnixStream::connect(&socket_path).expect("client should connect");
             let request = format!(
-                "PATCH {path} HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n{body}",
+                "{method} {path} HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n{body}",
                 body.len()
             );
 

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -257,7 +257,7 @@ compatibility targets.
 | `GET`, `PUT`, `PATCH` | `/hotplug/memory` | recognized; rejected | Returns a memory-hotplug-specific unsupported fault. Real virtio-mem device support, guest memory accounting, and runtime memory update behavior need a dedicated design. |
 | `PATCH` | `/vm` | recognized; rejected | Returns a VM-state-specific unsupported fault. Real pause/resume state rules, VMM actions, and public run-loop control need a dedicated design. |
 | `PATCH` | `/drives/{drive_id}`, `/network-interfaces/{iface_id}` | recognized; rejected | Returns device-update-specific unsupported faults. Real block-device updates, network-interface updates, runtime mutation, and hotplug behavior need dedicated device designs. |
-| `DELETE` | `/drives/{drive_id}`, `/pmem/{id}`, `/network-interfaces/{iface_id}` | deferred | Firecracker routes these hot-unplug requests in `parsed_request.rs`, but they are not in the `v1.16.0` swagger surface; support needs an explicit compatibility decision. |
+| `DELETE` | `/drives/{drive_id}`, `/pmem/{id}`, `/network-interfaces/{iface_id}` | recognized; rejected | Firecracker routes these hot-unplug requests in `parsed_request.rs`, but they are not in the `v1.16.0` swagger surface. bangbang returns existing device-update or pmem unsupported faults; real hot-unplug behavior remains deferred. |
 
 ## Initial Field Handling Policy
 


### PR DESCRIPTION
Summary:
- Recognize Firecracker-routed DELETE hot-unplug paths for drives, pmem, and network interfaces.
- Return existing unsupported faults without parsing request bodies or mutating VMM state.
- Update the Firecracker compatibility matrix from deferred to recognized and rejected.

Scope exclusions:
- No runtime device removal or hot-unplug implementation.
- No new public fault strings for hot-unplug.
- No changes to configured device startup behavior.

Closes #532

Validation:
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`
