### PR TITLE
feat: build signed bangbang executable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Run HVF unit tests
         run: cargo test -p bangbang-hvf --lib --all-features --locked
 
+      - name: Build and sign bangbang executable
+        run: scripts/build-signed-bangbang.sh --output .tmp/signed-bangbang/bangbang
+
       - name: Build and sign integration tests
         run: scripts/run-integration-tests.sh --allow-unsupported
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -120,6 +120,17 @@ the `bangbang` process boundary:
 cargo test -p bangbang --test process_e2e --all-features --locked
 ```
 
+Build a signed `bangbang` executable artifact for future HVF-backed process e2e
+tests without running it:
+
+```sh
+scripts/build-signed-bangbang.sh --output .tmp/signed-bangbang/bangbang
+```
+
+This requires macOS `codesign` and the `aarch64-apple-darwin` Rust target. The
+command only builds and signs the executable; HVF execution remains the job of
+the signed integration runner.
+
 Hosted macOS CI may use:
 
 ```sh

--- a/scripts/build-signed-bangbang.sh
+++ b/scripts/build-signed-bangbang.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build-signed-bangbang.sh --output PATH
+
+Build the bangbang executable for aarch64-apple-darwin, copy it to PATH, and
+sign PATH with the Hypervisor.framework entitlement. This script does not run
+the signed executable.
+
+Options:
+  --output PATH  Destination path for the signed bangbang executable.
+  -h, --help     Show this help.
+EOF
+}
+
+output_path=""
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --output)
+      shift
+      if [[ "$#" -eq 0 ]]; then
+        echo "--output requires a path" >&2
+        usage >&2
+        exit 2
+      fi
+      output_path="$1"
+      ;;
+    --output=*)
+      output_path="${1#--output=}"
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ -z "$output_path" ]]; then
+  echo "--output is required" >&2
+  usage >&2
+  exit 2
+fi
+
+if ! command -v codesign >/dev/null 2>&1; then
+  echo "codesign is required to sign the bangbang executable" >&2
+  exit 1
+fi
+
+initial_dir="$(pwd)"
+case "$output_path" in
+  /*)
+    signed_output="$output_path"
+    ;;
+  *)
+    signed_output="$initial_dir/$output_path"
+    ;;
+esac
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+target_triple="aarch64-apple-darwin"
+cargo build \
+  -p bangbang \
+  --all-features \
+  --locked \
+  --target "$target_triple"
+
+unsigned_bangbang="$repo_root/target/$target_triple/debug/bangbang"
+scripts/sign-hvf-binary.sh "$unsigned_bangbang" "$signed_output"
+
+printf '%s\n' "$signed_output"

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -182,8 +182,7 @@ PY
   for index in "${!test_bins[@]}"; do
     test_bin="${test_bins[$index]}"
     signed_test_bin="$tmp_dir/$(basename "$test_bin").$index"
-    cp "$test_bin" "$signed_test_bin"
-    codesign --force --sign - --entitlements "$entitlements" "$signed_test_bin"
+    scripts/sign-hvf-binary.sh "$test_bin" "$signed_test_bin"
     signed_test_names+=("$test_name")
     signed_test_bins+=("$signed_test_bin")
   done
@@ -217,18 +216,6 @@ if contains guest_boot "${selected_tests[@]}"; then
 fi
 
 target_triple="aarch64-apple-darwin"
-
-entitlements="$tmp_dir/hvf-entitlements.plist"
-cat > "$entitlements" <<'EOF'
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>com.apple.security.hypervisor</key>
-  <true/>
-</dict>
-</plist>
-EOF
 
 signed_test_names=()
 signed_test_bins=()

--- a/scripts/sign-hvf-binary.sh
+++ b/scripts/sign-hvf-binary.sh
@@ -50,9 +50,9 @@ signed_tmp=""
 
 cleanup() {
   if [[ -n "$signed_tmp" ]]; then
-    rm -f "$signed_tmp"
+    rm -f -- "$signed_tmp"
   fi
-  rm -rf "$tmp_dir"
+  rm -rf -- "$tmp_dir"
 }
 trap cleanup EXIT
 
@@ -68,17 +68,25 @@ cat > "$entitlements" <<'EOF'
 </plist>
 EOF
 
-output_dir="$(dirname "$output")"
-output_name="$(basename "$output")"
+output_dir="$(dirname -- "$output")"
+output_name="$(basename -- "$output")"
 
 if [[ "$output_name" == "." || "$output_name" == "/" ]]; then
   echo "output path must name a file: $output" >&2
   exit 2
 fi
 
-mkdir -p "$output_dir"
-signed_tmp="$(mktemp "$output_dir/.$output_name.signed.XXXXXX")"
-cp -p "$input" "$signed_tmp"
+mkdir -p -- "$output_dir"
+case "$output_dir" in
+  /*)
+    output_tmp_dir="$output_dir"
+    ;;
+  *)
+    output_tmp_dir="./$output_dir"
+    ;;
+esac
+signed_tmp="$(mktemp "$output_tmp_dir/.$output_name.signed.XXXXXX")"
+cp -p -- "$input" "$signed_tmp"
 codesign --force --sign - --entitlements "$entitlements" "$signed_tmp"
-mv -f "$signed_tmp" "$output"
+mv -f -- "$signed_tmp" "$output"
 signed_tmp=""

--- a/scripts/sign-hvf-binary.sh
+++ b/scripts/sign-hvf-binary.sh
@@ -46,7 +46,15 @@ if ! command -v codesign >/dev/null 2>&1; then
 fi
 
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/bangbang-hvf-sign.XXXXXX")"
-trap 'rm -rf "$tmp_dir"' EXIT
+signed_tmp=""
+
+cleanup() {
+  if [[ -n "$signed_tmp" ]]; then
+    rm -f "$signed_tmp"
+  fi
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
 
 entitlements="$tmp_dir/hvf-entitlements.plist"
 cat > "$entitlements" <<'EOF'
@@ -60,6 +68,17 @@ cat > "$entitlements" <<'EOF'
 </plist>
 EOF
 
-mkdir -p "$(dirname "$output")"
-cp "$input" "$output"
-codesign --force --sign - --entitlements "$entitlements" "$output"
+output_dir="$(dirname "$output")"
+output_name="$(basename "$output")"
+
+if [[ "$output_name" == "." || "$output_name" == "/" ]]; then
+  echo "output path must name a file: $output" >&2
+  exit 2
+fi
+
+mkdir -p "$output_dir"
+signed_tmp="$(mktemp "$output_dir/.$output_name.signed.XXXXXX")"
+cp -p "$input" "$signed_tmp"
+codesign --force --sign - --entitlements "$entitlements" "$signed_tmp"
+mv -f "$signed_tmp" "$output"
+signed_tmp=""

--- a/scripts/sign-hvf-binary.sh
+++ b/scripts/sign-hvf-binary.sh
@@ -40,6 +40,18 @@ if [[ -z "$output" ]]; then
   exit 2
 fi
 
+case "$output" in
+  */)
+    echo "output path must name a file: $output" >&2
+    exit 2
+    ;;
+esac
+
+if [[ -d "$output" ]]; then
+  echo "output path must not be an existing directory: $output" >&2
+  exit 2
+fi
+
 if ! command -v codesign >/dev/null 2>&1; then
   echo "codesign is required to sign HVF binaries" >&2
   exit 1

--- a/scripts/sign-hvf-binary.sh
+++ b/scripts/sign-hvf-binary.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/sign-hvf-binary.sh INPUT OUTPUT
+
+Copy INPUT to OUTPUT and sign OUTPUT with the Hypervisor.framework entitlement.
+
+Arguments:
+  INPUT   Existing binary to copy and sign.
+  OUTPUT  Destination path for the signed binary.
+EOF
+}
+
+if [[ "$#" -eq 1 ]]; then
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+  esac
+fi
+
+if [[ "$#" -ne 2 ]]; then
+  usage >&2
+  exit 2
+fi
+
+input="$1"
+output="$2"
+
+if [[ ! -f "$input" ]]; then
+  echo "input binary does not exist or is not a regular file: $input" >&2
+  exit 1
+fi
+
+if [[ -z "$output" ]]; then
+  echo "output path must not be empty" >&2
+  exit 2
+fi
+
+if ! command -v codesign >/dev/null 2>&1; then
+  echo "codesign is required to sign HVF binaries" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/bangbang-hvf-sign.XXXXXX")"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+entitlements="$tmp_dir/hvf-entitlements.plist"
+cat > "$entitlements" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.hypervisor</key>
+  <true/>
+</dict>
+</plist>
+EOF
+
+mkdir -p "$(dirname "$output")"
+cp "$input" "$output"
+codesign --force --sign - --entitlements "$entitlements" "$output"


### PR DESCRIPTION
## Summary

- add a reusable HVF signing helper for copied binaries
- add a script that builds the `bangbang` executable for `aarch64-apple-darwin` and signs it with the Hypervisor.framework entitlement
- make CI build and sign the `bangbang` executable artifact without executing it
- refactor the signed integration test runner to reuse the same signing helper
- document the signed executable build command

## Scope Exclusions

- does not start the signed `bangbang` executable
- does not add `InstanceStart` process e2e coverage
- does not change guest boot or HVF runtime behavior

Closes #551

## Verification

- `bash -n scripts/sign-hvf-binary.sh scripts/build-signed-bangbang.sh scripts/run-integration-tests.sh`
- helper failure-atomicity, executable-mode, option-like path, and directory-output checks with a temporary fake `codesign`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/build-signed-bangbang.sh --output .tmp/signed-bangbang/bangbang`
- `scripts/run-integration-tests.sh --allow-unsupported`
