### PR TITLE
test: run process e2e against signed executable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Run HVF unit tests
         run: cargo test -p bangbang-hvf --lib --all-features --locked
 
-      - name: Build and sign bangbang executable
-        run: scripts/build-signed-bangbang.sh --output .tmp/signed-bangbang/bangbang
+      - name: Run signed process e2e tests
+        run: scripts/run-signed-process-tests.sh
 
       - name: Build and sign integration tests
         run: scripts/run-integration-tests.sh --allow-unsupported

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -18,7 +18,8 @@ use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-const BANGBANG_BIN: &str = env!("CARGO_BIN_EXE_bangbang");
+const DEFAULT_BANGBANG_BIN: &str = env!("CARGO_BIN_EXE_bangbang");
+const BANGBANG_PROCESS_E2E_BIN_ENV: &str = "BANGBANG_PROCESS_E2E_BIN";
 const BANGBANG_VERSION: &str = env!("CARGO_PKG_VERSION");
 const STARTUP_READY_LINE: &str = "status: API server listening";
 const HTTP_IO_TIMEOUT: Duration = Duration::from_secs(5);
@@ -326,6 +327,7 @@ impl Drop for TestDir {
 
 #[derive(Debug)]
 struct BangbangProcess {
+    binary_path: PathBuf,
     child: Option<Child>,
     stdout: Option<OutputReader>,
     stderr: Option<OutputReader>,
@@ -334,7 +336,8 @@ struct BangbangProcess {
 
 impl BangbangProcess {
     fn start(socket_path: &Path, instance_id: &str) -> Self {
-        let mut child = Command::new(BANGBANG_BIN)
+        let binary_path = bangbang_bin();
+        let mut child = Command::new(&binary_path)
             .arg("--api-sock")
             .arg(socket_path)
             .arg("--id")
@@ -342,13 +345,19 @@ impl BangbangProcess {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
-            .expect("bangbang process should start");
+            .unwrap_or_else(|err| {
+                panic!(
+                    "bangbang process should start from {}: {err}",
+                    binary_path.display()
+                )
+            });
 
         let stdout = child.stdout.take().expect("stdout should be piped");
         let stderr = child.stderr.take().expect("stderr should be piped");
         let (stdout, ready) = OutputReader::stdout(stdout);
         let stderr = OutputReader::stderr(stderr);
         let mut process = Self {
+            binary_path,
             child: Some(child),
             stdout: Some(stdout),
             stderr: Some(stderr),
@@ -365,8 +374,11 @@ impl BangbangProcess {
             Err(err) => {
                 let output = self.force_stop_and_collect();
                 panic!(
-                    "bangbang did not report API readiness before timeout: {err:?}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
-                    output.status, output.stdout, output.stderr
+                    "bangbang did not report API readiness before timeout: {err:?}; binary: {}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                    self.binary_path.display(),
+                    output.status,
+                    output.stdout,
+                    output.stderr
                 );
             }
         }
@@ -422,6 +434,16 @@ impl Drop for BangbangProcess {
         if let Some(stderr) = self.stderr.take() {
             let _ = stderr.try_join();
         }
+    }
+}
+
+fn bangbang_bin() -> PathBuf {
+    match std::env::var_os(BANGBANG_PROCESS_E2E_BIN_ENV) {
+        Some(path) if path.is_empty() => {
+            panic!("{BANGBANG_PROCESS_E2E_BIN_ENV} must not be empty")
+        }
+        Some(path) => PathBuf::from(path),
+        None => PathBuf::from(DEFAULT_BANGBANG_BIN),
     }
 }
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -130,7 +130,8 @@ This builds and signs a temporary `bangbang` executable, then sets
 `BANGBANG_PROCESS_E2E_BIN` so `process_e2e` launches that signed binary instead
 of Cargo's default test binary. The script verifies process startup, API socket
 serving, configuration requests, multi-process socket isolation, and clean
-shutdown. It does not start HVF or send `InstanceStart`.
+shutdown. It requires macOS Apple Silicon because the signed executable target
+is `aarch64-apple-darwin`, but it does not start HVF or send `InstanceStart`.
 
 Build a signed `bangbang` executable artifact for future HVF-backed process e2e
 tests without running it:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -120,6 +120,18 @@ the `bangbang` process boundary:
 cargo test -p bangbang --test process_e2e --all-features --locked
 ```
 
+Run the same process-level e2e test against a signed `bangbang` executable:
+
+```sh
+scripts/run-signed-process-tests.sh
+```
+
+This builds and signs a temporary `bangbang` executable, then sets
+`BANGBANG_PROCESS_E2E_BIN` so `process_e2e` launches that signed binary instead
+of Cargo's default test binary. The script verifies process startup, API socket
+serving, configuration requests, multi-process socket isolation, and clean
+shutdown. It does not start HVF or send `InstanceStart`.
+
 Build a signed `bangbang` executable artifact for future HVF-backed process e2e
 tests without running it:
 

--- a/scripts/run-signed-process-tests.sh
+++ b/scripts/run-signed-process-tests.sh
@@ -5,9 +5,9 @@ usage() {
   cat <<'EOF'
 Usage: scripts/run-signed-process-tests.sh
 
-Build and sign the bangbang executable, then run process-level e2e tests
-against that signed executable. This script does not start HVF or send
-InstanceStart.
+Build and sign the bangbang executable for aarch64-apple-darwin, then run
+process-level e2e tests against that signed executable. This script requires
+macOS Apple Silicon but does not start HVF or send InstanceStart.
 
 Options:
   -h, --help  Show this help.
@@ -30,6 +30,13 @@ fi
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
+
+host_os="$(uname -s)"
+host_arch="$(uname -m)"
+if [[ "$host_os" != "Darwin" || "$host_arch" != "arm64" ]]; then
+  echo "signed process e2e tests require macOS Apple Silicon; found $host_os $host_arch" >&2
+  exit 1
+fi
 
 tmp_root="$repo_root/.tmp"
 mkdir -p -- "$tmp_root"

--- a/scripts/run-signed-process-tests.sh
+++ b/scripts/run-signed-process-tests.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/run-signed-process-tests.sh
+
+Build and sign the bangbang executable, then run process-level e2e tests
+against that signed executable. This script does not start HVF or send
+InstanceStart.
+
+Options:
+  -h, --help  Show this help.
+EOF
+}
+
+if [[ "$#" -eq 1 ]]; then
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+  esac
+fi
+
+if [[ "$#" -ne 0 ]]; then
+  usage >&2
+  exit 2
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+tmp_root="$repo_root/.tmp"
+mkdir -p -- "$tmp_root"
+signed_dir="$(mktemp -d "$tmp_root/signed-process-e2e.XXXXXX")"
+trap 'rm -rf -- "$signed_dir"' EXIT
+
+signed_bangbang="$signed_dir/bangbang"
+scripts/build-signed-bangbang.sh --output "$signed_bangbang"
+
+BANGBANG_PROCESS_E2E_BIN="$signed_bangbang" \
+  cargo test -p bangbang --test process_e2e --all-features --locked


### PR DESCRIPTION
## Summary

- let `process_e2e` launch a caller-provided `bangbang` executable through `BANGBANG_PROCESS_E2E_BIN`
- add `scripts/run-signed-process-tests.sh` to build/sign `bangbang` and run the existing process e2e tests against the signed binary
- run the signed process e2e script in CI and document the command

## Scope Exclusions

- does not send `InstanceStart`
- does not require HVF execution or guest boot markers
- does require macOS Apple Silicon because the signed executable target is `aarch64-apple-darwin`
- does not change runtime VM behavior

Closes #553

## Verification

- `bash -n scripts/run-signed-process-tests.sh scripts/build-signed-bangbang.sh scripts/sign-hvf-binary.sh scripts/run-integration-tests.sh`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test -p bangbang --test process_e2e --all-features --locked`
- `scripts/run-signed-process-tests.sh`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --allow-unsupported`
