### PR TITLE
test: cover executable API socket bind failures

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -10,6 +10,7 @@
 mod support;
 
 use std::fs;
+use std::os::unix::fs::MetadataExt;
 
 use support::{
     BangbangProcess, TestDir, assert_clean_shutdown, assert_no_content_response,
@@ -132,6 +133,8 @@ fn executable_fails_when_api_socket_path_exists_without_removing_it() {
     let socket_path = test_dir.path().join("api.socket");
     let instance_id = test_dir.instance_id();
     fs::write(&socket_path, "existing file").expect("fixture file should be written");
+    let original_metadata =
+        fs::symlink_metadata(&socket_path).expect("existing file metadata should be readable");
 
     let output = BangbangProcess::start_expect_failure(&socket_path, &instance_id);
 
@@ -157,6 +160,13 @@ fn executable_fails_when_api_socket_path_exists_without_removing_it() {
     assert_eq!(
         fs::read_to_string(&socket_path).expect("existing file should remain readable"),
         "existing file"
+    );
+    let current_metadata =
+        fs::symlink_metadata(&socket_path).expect("existing file metadata should remain readable");
+    assert_eq!(
+        (current_metadata.dev(), current_metadata.ino()),
+        (original_metadata.dev(), original_metadata.ino()),
+        "failed startup must not replace the existing API socket path"
     );
 }
 

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -9,6 +9,8 @@
 
 mod support;
 
+use std::fs;
+
 use support::{
     BangbangProcess, TestDir, assert_clean_shutdown, assert_no_content_response,
     assert_ok_response, assert_response_contains, http_get, http_put_json, json_string, path_text,
@@ -122,6 +124,40 @@ fn executable_configures_vm_before_start() {
     assert_response_contains(&vm_config, r#""partuuid":"0eaa91a0-01""#, "GET /vm/config");
 
     assert_clean_shutdown(bangbang.terminate(), &socket_path, "bangbang");
+}
+
+#[test]
+fn executable_fails_when_api_socket_path_exists_without_removing_it() {
+    let test_dir = TestDir::new();
+    let socket_path = test_dir.path().join("api.socket");
+    let instance_id = test_dir.instance_id();
+    fs::write(&socket_path, "existing file").expect("fixture file should be written");
+
+    let output = BangbangProcess::start_expect_failure(&socket_path, &instance_id);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "existing API socket path should fail with process failure; stdout:\n{}\nstderr:\n{}",
+        output.stdout,
+        output.stderr
+    );
+    assert!(
+        output
+            .stderr
+            .contains("API server error: API socket path already exists"),
+        "stderr should explain the API socket bind failure; stderr:\n{}",
+        output.stderr
+    );
+    assert!(
+        !output.stdout.contains("status: API server listening"),
+        "failed startup must not report API readiness; stdout:\n{}",
+        output.stdout
+    );
+    assert_eq!(
+        fs::read_to_string(&socket_path).expect("existing file should remain readable"),
+        "existing file"
+    );
 }
 
 #[test]

--- a/crates/bangbang/tests/support/mod.rs
+++ b/crates/bangbang/tests/support/mod.rs
@@ -179,6 +179,48 @@ pub(crate) struct BangbangProcess {
 
 impl BangbangProcess {
     pub(crate) fn start(socket_path: &Path, instance_id: &str) -> Self {
+        let mut process = Self::spawn(socket_path, instance_id);
+        process.wait_until_ready();
+        process
+    }
+
+    #[allow(
+        dead_code,
+        reason = "shared integration-test support is compiled once per test target"
+    )]
+    pub(crate) fn start_expect_failure(socket_path: &Path, instance_id: &str) -> CompletedProcess {
+        let mut process = Self::spawn(socket_path, instance_id);
+
+        match process.ready.recv_timeout(STARTUP_TIMEOUT) {
+            Ok(()) => {
+                let output = process.force_stop_and_collect();
+                panic!(
+                    "bangbang reported API readiness but startup failure was expected; binary: {}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                    process.binary_path.display(),
+                    output.status,
+                    output.stdout,
+                    output.stderr
+                );
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                let child = process.child.take().expect("child should still be owned");
+                let status = wait_for_child_exit(child, SHUTDOWN_TIMEOUT);
+                process.collect_output(status)
+            }
+            Err(RecvTimeoutError::Timeout) => {
+                let output = process.force_stop_and_collect();
+                panic!(
+                    "bangbang did not fail before timeout; binary: {}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                    process.binary_path.display(),
+                    output.status,
+                    output.stdout,
+                    output.stderr
+                );
+            }
+        }
+    }
+
+    fn spawn(socket_path: &Path, instance_id: &str) -> Self {
         let binary_path = bangbang_bin();
         let mut child = Command::new(&binary_path)
             .arg("--api-sock")
@@ -199,16 +241,13 @@ impl BangbangProcess {
         let stderr = child.stderr.take().expect("stderr should be piped");
         let (stdout, ready) = OutputReader::stdout(stdout);
         let stderr = OutputReader::stderr(stderr);
-        let mut process = Self {
+        Self {
             binary_path,
             child: Some(child),
             stdout: Some(stdout),
             stderr: Some(stderr),
             ready,
-        };
-
-        process.wait_until_ready();
-        process
+        }
     }
 
     fn wait_until_ready(&mut self) {


### PR DESCRIPTION
## Summary

- Add an executable-level process e2e failure path for pre-existing API socket paths.
- Add a bounded `BangbangProcess` helper for expected startup failures without using sleeps or polling loops.
- Assert the failed process exits with status `1`, reports the bind failure, does not report readiness, and preserves the existing file.

Closes #557

## Scope

This PR does not change production API socket bind semantics. Existing documentation already describes the failure and cleanup behavior, so no docs update is included.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p bangbang --test process_e2e --locked`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
