### PR TITLE
test: cover executable running state

### DIFF
--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -18,7 +18,8 @@ mod macos_arm64 {
 
     use crate::support::{
         BangbangProcess, TestDir, assert_clean_shutdown, assert_no_content_response,
-        assert_ok_response, http_get, http_put_json, json_string, path_text,
+        assert_ok_response, assert_response_contains, http_get, http_put_json, json_string,
+        path_text,
     };
 
     const BANGBANG_GUEST_KERNEL_PATH_ENV: &str = "BANGBANG_GUEST_KERNEL_PATH";
@@ -81,6 +82,26 @@ mod macos_arm64 {
             r#"{"action_type":"InstanceStart"}"#,
         );
         assert_no_content_response(&start_response, "PUT /actions InstanceStart");
+
+        let running_instance_info = http_get(&socket_path, "/");
+        assert_ok_response(&running_instance_info, "GET / after InstanceStart");
+        assert_response_contains(
+            &running_instance_info,
+            &format!(r#""id":"{instance_id}""#),
+            "GET / after InstanceStart",
+        );
+        assert_response_contains(
+            &running_instance_info,
+            r#""state":"Running""#,
+            "GET / after InstanceStart",
+        );
+
+        let flush_metrics_response = http_put_json(
+            &socket_path,
+            "/actions",
+            r#"{"action_type":"FlushMetrics"}"#,
+        );
+        assert_no_content_response(&flush_metrics_response, "PUT /actions FlushMetrics");
 
         if let Err(err) =
             wait_for_file_prefix_marker(&backing_path, BLOCK_WRITE_MARKER, GUEST_EXECUTION_TIMEOUT)


### PR DESCRIPTION
## Summary
- assert the signed executable reports the same instance as `Running` through `GET /` after `InstanceStart`
- exercise runtime `FlushMetrics` through the real executable API socket after startup
- keep the existing guest block-marker and clean shutdown coverage in the same signed HVF e2e path

Closes #561

## Verification
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test executable_hvf_e2e`
