### PR TITLE
test: cover executable running-state rejections

### DIFF
--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -17,9 +17,9 @@ mod macos_arm64 {
     use std::time::{Duration, Instant};
 
     use crate::support::{
-        BangbangProcess, TestDir, assert_clean_shutdown, assert_no_content_response,
-        assert_ok_response, assert_response_contains, http_get, http_put_json, json_string,
-        path_text,
+        BangbangProcess, TestDir, assert_bad_request_response, assert_clean_shutdown,
+        assert_no_content_response, assert_ok_response, assert_response_contains, http_get,
+        http_put_json, json_string, path_text,
     };
 
     const BANGBANG_GUEST_KERNEL_PATH_ENV: &str = "BANGBANG_GUEST_KERNEL_PATH";
@@ -102,6 +102,33 @@ mod macos_arm64 {
             r#"{"action_type":"FlushMetrics"}"#,
         );
         assert_no_content_response(&flush_metrics_response, "PUT /actions FlushMetrics");
+
+        let second_start_response = http_put_json(
+            &socket_path,
+            "/actions",
+            r#"{"action_type":"InstanceStart"}"#,
+        );
+        assert_bad_request_response(&second_start_response, "PUT /actions second InstanceStart");
+        assert_response_contains(
+            &second_start_response,
+            r#"{"fault_message":"The requested operation is not supported in Running state: InstanceStart"}"#,
+            "PUT /actions second InstanceStart",
+        );
+
+        let post_start_machine_response = http_put_json(
+            &socket_path,
+            "/machine-config",
+            r#"{"vcpu_count":1,"mem_size_mib":256}"#,
+        );
+        assert_bad_request_response(
+            &post_start_machine_response,
+            "PUT /machine-config after InstanceStart",
+        );
+        assert_response_contains(
+            &post_start_machine_response,
+            r#"{"fault_message":"The requested operation is not supported in Running state: PutMachineConfig"}"#,
+            "PUT /machine-config after InstanceStart",
+        );
 
         if let Err(err) =
             wait_for_file_prefix_marker(&backing_path, BLOCK_WRITE_MARKER, GUEST_EXECUTION_TIMEOUT)

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -13,9 +13,9 @@ use std::fs;
 use std::os::unix::fs::MetadataExt;
 
 use support::{
-    BangbangProcess, TestDir, assert_clean_shutdown, assert_no_content_response,
-    assert_ok_response, assert_response_contains, http_get, http_json, http_put_json, json_string,
-    path_text,
+    BangbangProcess, TestDir, assert_bad_request_response, assert_clean_shutdown,
+    assert_no_content_response, assert_ok_response, assert_response_contains, http_get, http_json,
+    http_put_json, json_string, path_text,
 };
 
 const BANGBANG_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -305,13 +305,6 @@ fn concurrent_executables_keep_api_sockets_isolated() {
     let second_output = second_bangbang.terminate();
     assert_clean_shutdown(first_output, &first_socket_path, "first bangbang");
     assert_clean_shutdown(second_output, &second_socket_path, "second bangbang");
-}
-
-fn assert_bad_request_response(response: &str, request_name: &str) {
-    assert!(
-        response.starts_with("HTTP/1.1 400 Bad Request\r\n"),
-        "{request_name} should return 400 Bad Request; response:\n{response}"
-    );
 }
 
 fn assert_instance_info_matches(

--- a/crates/bangbang/tests/support/mod.rs
+++ b/crates/bangbang/tests/support/mod.rs
@@ -130,6 +130,13 @@ pub(crate) fn assert_no_content_response(response: &str, request_name: &str) {
     );
 }
 
+pub(crate) fn assert_bad_request_response(response: &str, request_name: &str) {
+    assert!(
+        response.starts_with("HTTP/1.1 400 Bad Request\r\n"),
+        "{request_name} should return 400 Bad Request; response:\n{response}"
+    );
+}
+
 pub(crate) fn assert_response_contains(response: &str, expected: &str, request_name: &str) {
     assert!(
         response.contains(expected),


### PR DESCRIPTION
## Summary
- extend the signed executable HVF e2e test to reject a second `InstanceStart` after the VM reaches `Running`
- cover `PUT /machine-config` returning a Firecracker-style state fault after startup
- move the shared 400 response assertion into the process e2e support module

## Scope
- does not add pause, resume, guest shutdown, or additional VM controls
- does not change API behavior; this only adds submitted executable coverage

Closes #563

## Verification
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test -p bangbang --test process_e2e --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test executable_hvf_e2e`
