### PR TITLE
test: cover executable direct rootfs boot

### DIFF
--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -24,8 +24,12 @@ mod macos_arm64 {
 
     const BANGBANG_GUEST_KERNEL_PATH_ENV: &str = "BANGBANG_GUEST_KERNEL_PATH";
     const BANGBANG_GUEST_INITRD_PATH_ENV: &str = "BANGBANG_GUEST_INITRD_PATH";
+    const BANGBANG_GUEST_EXT4_ROOTFS_PATH_ENV: &str = "BANGBANG_GUEST_EXT4_ROOTFS_PATH";
     const BLOCK_WRITE_MARKER: &[u8] = b"BANGBANG_BLOCK_WRITE_OK";
+    const DIRECT_ROOTFS_BLOCK_MARKER: &[u8] = b"BANGBANG_DIRECT_ROOTFS_BLOCK_OK";
     const GUEST_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 rdinit=/init";
+    const DIRECT_ROOTFS_BOOT_ARGS: &str =
+        "console=ttyS0 reboot=k panic=1 quiet loglevel=1 init=/bangbang-direct-rootfs-init";
     const GUEST_EXECUTION_TIMEOUT: Duration = Duration::from_secs(30);
 
     #[test]
@@ -141,6 +145,94 @@ mod macos_arm64 {
         }
 
         assert_clean_shutdown(bangbang.terminate(), &socket_path, "bangbang");
+    }
+
+    #[test]
+    fn signed_executable_boots_direct_rootfs_and_writes_block_marker() {
+        let test_dir = TestDir::new();
+        let socket_path = test_dir.path().join("api.socket");
+        let data_backing_path = test_dir.path().join("data.img");
+        let kernel_path = env_path(BANGBANG_GUEST_KERNEL_PATH_ENV);
+        let rootfs_path = env_path(BANGBANG_GUEST_EXT4_ROOTFS_PATH_ENV);
+        let instance_id = test_dir.instance_id();
+
+        create_zeroed_block_backing(&data_backing_path);
+
+        let mut bangbang = BangbangProcess::start(&socket_path, &instance_id);
+
+        let machine_response = http_put_json(
+            &socket_path,
+            "/machine-config",
+            r#"{"vcpu_count":1,"mem_size_mib":256}"#,
+        );
+        assert_no_content_response(&machine_response, "PUT /machine-config direct rootfs");
+
+        let kernel_path_json = json_string(path_text(&kernel_path));
+        let boot_args_json = json_string(DIRECT_ROOTFS_BOOT_ARGS);
+        let boot_body = format!(
+            r#"{{
+                "kernel_image_path":{kernel_path_json},
+                "boot_args":{boot_args_json}
+            }}"#
+        );
+        let boot_response = http_put_json(&socket_path, "/boot-source", &boot_body);
+        assert_no_content_response(&boot_response, "PUT /boot-source direct rootfs");
+
+        let rootfs_path_json = json_string(path_text(&rootfs_path));
+        let rootfs_body = format!(
+            r#"{{
+                "drive_id":"rootfs",
+                "path_on_host":{rootfs_path_json},
+                "is_root_device":true,
+                "is_read_only":true
+            }}"#
+        );
+        let rootfs_response = http_put_json(&socket_path, "/drives/rootfs", &rootfs_body);
+        assert_no_content_response(&rootfs_response, "PUT /drives/rootfs direct rootfs");
+
+        let data_backing_path_json = json_string(path_text(&data_backing_path));
+        let data_drive_body = format!(
+            r#"{{
+                "drive_id":"data",
+                "path_on_host":{data_backing_path_json},
+                "is_root_device":false,
+                "is_read_only":false
+            }}"#
+        );
+        let data_drive_response = http_put_json(&socket_path, "/drives/data", &data_drive_body);
+        assert_no_content_response(&data_drive_response, "PUT /drives/data direct rootfs");
+
+        let start_response = http_put_json(
+            &socket_path,
+            "/actions",
+            r#"{"action_type":"InstanceStart"}"#,
+        );
+        assert_no_content_response(&start_response, "PUT /actions InstanceStart direct rootfs");
+
+        let running_instance_info = http_get(&socket_path, "/");
+        assert_ok_response(
+            &running_instance_info,
+            "GET / after direct rootfs InstanceStart",
+        );
+        assert_response_contains(
+            &running_instance_info,
+            r#""state":"Running""#,
+            "GET / after direct rootfs InstanceStart",
+        );
+
+        if let Err(err) = wait_for_file_prefix_marker(
+            &data_backing_path,
+            DIRECT_ROOTFS_BLOCK_MARKER,
+            GUEST_EXECUTION_TIMEOUT,
+        ) {
+            let output = bangbang.force_stop_and_collect();
+            panic!(
+                "direct rootfs guest did not write block marker through signed bangbang executable: {err}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                output.status, output.stdout, output.stderr
+            );
+        }
+
+        assert_clean_shutdown(bangbang.terminate(), &socket_path, "bangbang direct rootfs");
     }
 
     fn env_path(name: &str) -> PathBuf {

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -819,9 +819,12 @@ pinned Firecracker squashfs rootfs as a read-only root drive, mounts it from the
 deterministic initrd, and reads `/mnt/etc/os-release` from the guest. Direct
 root-drive boot validation is covered by a generated ext4 variant of the same
 Firecracker rootfs that adds a deterministic test init, boots without an initrd,
-mounts the virtio-block root drive as `/`, reads `/etc/os-release`, and
-validates guest-visible `root=/dev/vda ro` command-line arguments. This does
-not yet claim arbitrary distro rootfs boot or default Ubuntu systemd startup.
+mounts the virtio-block root drive as `/`, and reads `/etc/os-release`; the
+signed `guest_boot` target validates guest-visible `root=/dev/vda ro`
+command-line arguments through captured serial output, and the signed
+executable HVF e2e target validates the same direct-rootfs path through public
+API configuration plus a host-observed scratch block marker. This does not yet
+claim arbitrary distro rootfs boot or default Ubuntu systemd startup.
 Block hotplug, remaining cache-mode semantics, and rate limiting remain
 deferred.
 It does not provide a public runner control, implement rate limiting, support

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -167,11 +167,14 @@ scripts/run-integration-tests.sh --test executable_hvf_e2e
 
 This target runs the dedicated `executable_hvf_e2e` Cargo test target. It builds
 and signs a temporary `bangbang` executable, prepares the pinned Firecracker
-kernel plus the deterministic tiny initrd, starts `bangbang` as a child process,
-configures the VM through the Unix-socket API, sends `InstanceStart`, and waits
-for the guest to write `BANGBANG_BLOCK_WRITE_OK` to a scratch block backing
-file. It verifies the public process/API/HVF path without requiring public
-serial output. It does not cover direct rootfs boot through the executable path.
+kernel, deterministic tiny initrd, and generated direct-boot ext4 rootfs,
+starts `bangbang` as a child process, configures the VM through the Unix-socket
+API, sends `InstanceStart`, and waits for the guest to write deterministic
+markers to scratch block backing files. The tiny-initrd scenario writes
+`BANGBANG_BLOCK_WRITE_OK`; the direct-rootfs scenario boots the generated ext4
+rootfs without an initrd and writes `BANGBANG_DIRECT_ROOTFS_BLOCK_OK` through a
+second writable drive. This verifies the public process/API/HVF path without
+requiring public serial output.
 
 Hosted macOS CI may use:
 
@@ -185,11 +188,10 @@ misconfigured hosts fail.
 
 ## Guest Boot Artifacts
 
-Guest boot and executable HVF e2e tests use the pinned Firecracker arm64 kernel
-and a deterministic tiny initrd. Guest boot tests also use the pinned
-Firecracker rootfs artifact. The integration runner prepares the relevant
-artifacts when `guest_boot` or `executable_hvf_e2e` is selected. To prepare only
-the kernel cache, run:
+Guest boot and executable HVF e2e tests use the pinned Firecracker arm64 kernel,
+a deterministic tiny initrd, and rootfs artifacts where their scenarios require
+them. The integration runner prepares the relevant artifacts when `guest_boot`
+or `executable_hvf_e2e` is selected. To prepare only the kernel cache, run:
 
 ```sh
 scripts/fetch-firecracker-kernel.sh
@@ -255,17 +257,21 @@ into the generated ext4 image keep the local extraction ownership rather than
 Firecracker's root-owned demo ownership. This is suitable for local development
 artifacts and is not a substitute for a production rootfs build process.
 
-The signed `guest_boot` target also validates a deterministic direct-rootfs
-boot. For that scenario, `scripts/run-integration-tests.sh` prepares
-`.tmp/guest-artifacts/bangbang/rootfs/ubuntu-24.04-512M-direct-boot-v4.ext4`
+The signed `guest_boot` and executable HVF e2e targets also validate a
+deterministic direct-rootfs boot. For those scenarios,
+`scripts/run-integration-tests.sh` prepares
+`.tmp/guest-artifacts/bangbang/rootfs/ubuntu-24.04-512M-direct-boot-v6.ext4`
 after confirming the host can execute HVF. The generated image is an ext4 copy
 of the pinned Firecracker rootfs with a test-specific
 `/bangbang-direct-rootfs-init` script added before image creation. The test
 boots without the tiny initrd, attaches that ext4 image as a read-only root
-drive, passes `init=/bangbang-direct-rootfs-init`, and expects deterministic
-serial markers plus Ubuntu os-release content from `/etc/os-release`. This
-proves the kernel mounted the virtio-block root drive as `/`; it does not claim
-that bangbang can boot an arbitrary distro image through its default init.
+drive, and passes `init=/bangbang-direct-rootfs-init`. The `guest_boot` target
+expects deterministic serial markers plus Ubuntu os-release content from
+`/etc/os-release`; the executable HVF e2e target observes
+`BANGBANG_DIRECT_ROOTFS_BLOCK_OK` in a second writable scratch drive because it
+does not expose public serial output. This proves the kernel mounted the
+virtio-block root drive as `/`; it does not claim that bangbang can boot an
+arbitrary distro image through its default init.
 
 bangbang appends Firecracker-style root-drive command-line arguments during
 startup resource assembly when a configured drive has `is_root_device=true`.

--- a/scripts/fetch-firecracker-rootfs.sh
+++ b/scripts/fetch-firecracker-rootfs.sh
@@ -14,7 +14,9 @@ Options:
                    Only valid with --format ext4.
   --direct-boot-init
                    Add a deterministic bangbang direct-rootfs boot init script
-                   to the generated ext4 image. Only valid with --format ext4.
+                   to the generated ext4 image. The init emits serial markers
+                   and writes an optional /dev/vdb marker when that drive
+                   exists. Only valid with --format ext4.
   -h, --help       Show this help.
 
 Environment:
@@ -111,7 +113,7 @@ rootfs_arch="aarch64"
 rootfs_name="ubuntu-24.04"
 rootfs_sha256="0efb6a3ff2982baa6ca7e3d940966516ba7ddd2df5deb3e6c2161d369a15d608"
 rootfs_url="https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/${firecracker_minor}/${rootfs_arch}/${rootfs_name}.squashfs"
-direct_boot_variant="direct-boot-v4"
+direct_boot_variant="direct-boot-v6"
 
 cache_root="${BANGBANG_GUEST_ARTIFACTS_DIR:-$repo_root/.tmp/guest-artifacts}"
 upstream_dir="${cache_root}/firecracker-ci/${firecracker_minor}/${rootfs_arch}"
@@ -339,6 +341,15 @@ emit_line() {
   printf '\n'
 }
 
+mount_if_directory() {
+  fs_type=$1
+  source=$2
+  target=$3
+  if [ -d "$target" ]; then
+    mount -t "$fs_type" "$source" "$target" 2>/dev/null || true
+  fi
+}
+
 emit_line BANGBANG_DIRECT_ROOTFS_BOOT_BEGIN
 if [ -r /etc/os-release ]; then
   id_line=$(grep -m 1 '^ID=' /etc/os-release 2>/dev/null || true)
@@ -350,14 +361,16 @@ if [ -r /etc/os-release ]; then
     emit_line "$codename_line"
   fi
 fi
-if [ -d /proc ]; then
-  mount -t proc proc /proc 2>/dev/null || true
-fi
+mount_if_directory proc proc /proc
+mount_if_directory devtmpfs devtmpfs /dev
 if [ -r /proc/cmdline ]; then
   emit_line BANGBANG_CMDLINE_BEGIN
   cmdline=$(cat /proc/cmdline 2>/dev/null || true)
   emit_line "$cmdline"
   emit_line BANGBANG_CMDLINE_END
+fi
+if [ -b /dev/vdb ]; then
+  printf '%-512s' BANGBANG_DIRECT_ROOTFS_BLOCK_OK >/dev/vdb 2>/dev/null || true
 fi
 emit_line BANGBANG_DIRECT_ROOTFS_BOOT_OK
 exec sleep 3600

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -267,7 +267,7 @@ if [[ "$hv_disable" == "1" ]]; then
   finish_unsupported "Hypervisor.framework is disabled on this host"
 fi
 
-if contains guest_boot "${selected_tests[@]}"; then
+if contains guest_boot "${selected_tests[@]}" || contains executable_hvf_e2e "${selected_tests[@]}"; then
   guest_ext4_rootfs_path="$(scripts/fetch-firecracker-rootfs.sh \
     --format ext4 \
     --ext4-size 512M \
@@ -313,6 +313,7 @@ if contains executable_hvf_e2e "${selected_tests[@]}"; then
     BANGBANG_PROCESS_E2E_BIN="$executable_hvf_e2e_bangbang" \
       BANGBANG_GUEST_KERNEL_PATH="$guest_kernel_path" \
       BANGBANG_GUEST_INITRD_PATH="$guest_initrd_path" \
+      BANGBANG_GUEST_EXT4_ROOTFS_PATH="$guest_ext4_rootfs_path" \
       cargo test \
         -p bangbang \
         --test executable_hvf_e2e \
@@ -325,6 +326,7 @@ if contains executable_hvf_e2e "${selected_tests[@]}"; then
     BANGBANG_PROCESS_E2E_BIN="$executable_hvf_e2e_bangbang" \
       BANGBANG_GUEST_KERNEL_PATH="$guest_kernel_path" \
       BANGBANG_GUEST_INITRD_PATH="$guest_initrd_path" \
+      BANGBANG_GUEST_EXT4_ROOTFS_PATH="$guest_ext4_rootfs_path" \
       cargo test \
         -p bangbang \
         --test executable_hvf_e2e \


### PR DESCRIPTION
## Summary
- add a signed executable HVF e2e scenario that boots the generated Firecracker ext4 rootfs directly through the public API
- teach the direct-rootfs test init to emit a host-observable `/dev/vdb` block marker and bump the generated rootfs cache variant to `direct-boot-v6`
- prepare/pass the direct-boot ext4 rootfs for `executable_hvf_e2e` and update testing/compatibility docs

## Scope
- does not add public serial streaming
- does not claim arbitrary distro boot or default Ubuntu systemd startup
- does not change production API behavior, block hotplug, cache modes, rate limiters, or vhost-user-block support

Closes #565

## Verification
- `bash -n scripts/fetch-firecracker-rootfs.sh scripts/run-integration-tests.sh`
- `cargo fmt --all -- --check`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `scripts/run-integration-tests.sh --test executable_hvf_e2e`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test guest_boot`
