### PR TITLE
feat: recognize drive patch requests

### DIFF
--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -24,6 +24,7 @@ pub enum ApiRequest {
     PutAction(Box<ActionRequest>),
     PutBootSource(Box<BootSourceRequest>),
     PutDrive(Box<DriveConfigRequest>),
+    PatchDrive(Box<DrivePatchRequest>),
     PutLogger(Box<LoggerConfigRequest>),
     PutMachineConfig(Box<MachineConfigRequest>),
     PatchMachineConfig(Box<MachineConfigPatchRequest>),
@@ -739,6 +740,27 @@ impl MmdsConfigResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DrivePatchRequest {
+    path_drive_id: String,
+    body_drive_id: String,
+    path_on_host: Option<String>,
+}
+
+impl DrivePatchRequest {
+    pub fn path_drive_id(&self) -> &str {
+        &self.path_drive_id
+    }
+
+    pub fn body_drive_id(&self) -> &str {
+        &self.body_drive_id
+    }
+
+    pub fn path_on_host(&self) -> Option<&str> {
+        self.path_on_host.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VsockConfigResponse {
     guest_cid: u32,
     uds_path: String,
@@ -771,6 +793,16 @@ struct DriveConfigRequestBody {
     rate_limiter: Option<serde_json::Value>,
     #[serde(default)]
     socket: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DrivePatchRequestBody {
+    drive_id: String,
+    #[serde(default)]
+    path_on_host: Option<String>,
+    #[serde(default)]
+    rate_limiter: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1155,7 +1187,12 @@ pub fn parse_request_with_limit(
         return Err(RequestError::PmemUnsupported);
     }
 
-    if matches!(method, "PATCH" | "DELETE") && drive_path_id(path).is_some() {
+    if method == "PATCH"
+        && let Some(path_drive_id) = drive_path_id(path)
+    {
+        return parse_drive_patch_request(path_drive_id, body);
+    }
+    if method == "DELETE" && drive_path_id(path).is_some() {
         return Err(RequestError::DriveUpdateUnsupported);
     }
     if matches!(method, "PATCH" | "DELETE") && network_interface_path_id(path).is_some() {
@@ -1334,6 +1371,24 @@ fn parse_drive_config_request(
         io_engine: body.io_engine,
         rate_limiter_configured,
         socket: body.socket,
+    })))
+}
+
+fn parse_drive_patch_request(path_drive_id: &str, body: &[u8]) -> Result<ApiRequest, RequestError> {
+    let body = serde_json::from_slice::<DrivePatchRequestBody>(body)
+        .map_err(|_| RequestError::MalformedRequest)?;
+    if path_drive_id != body.drive_id {
+        return Err(RequestError::MismatchedDriveId);
+    }
+    if let Some(rate_limiter) = &body.rate_limiter {
+        validate_rate_limiter_config(rate_limiter)?;
+        return Err(RequestError::DriveUpdateUnsupported);
+    }
+
+    Ok(ApiRequest::PatchDrive(Box::new(DrivePatchRequest {
+        path_drive_id: path_drive_id.to_string(),
+        body_drive_id: body.drive_id,
+        path_on_host: body.path_on_host,
     })))
 }
 
@@ -1738,7 +1793,7 @@ impl From<ApiRequest> for Endpoint {
             ApiRequest::GetVersion => Self::Version,
             ApiRequest::PutAction(_) => Self::Actions,
             ApiRequest::PutBootSource(_) => Self::BootSource,
-            ApiRequest::PutDrive(_) => Self::Drive,
+            ApiRequest::PutDrive(_) | ApiRequest::PatchDrive(_) => Self::Drive,
             ApiRequest::PutLogger(_) => Self::Logger,
             ApiRequest::PutMachineConfig(_) => Self::MachineConfig,
             ApiRequest::PatchMachineConfig(_) => Self::MachineConfig,
@@ -3302,42 +3357,122 @@ mod tests {
     }
 
     #[test]
-    fn rejects_drive_update_and_hot_unplug_as_unsupported() {
-        for (route, request) in [
-            (
-                "PATCH /drives/rootfs",
-                request_with_body("PATCH", "/drives/rootfs", r#"{"drive_id":"rootfs"}"#),
-            ),
-            (
-                "DELETE /drives/rootfs",
-                b"DELETE /drives/rootfs HTTP/1.1\r\nHost: localhost\r\n\r\n".to_vec(),
-            ),
-        ] {
-            let err = parse_request(&request).expect_err("drive update should be unsupported");
-            assert_eq!(err, RequestError::DriveUpdateUnsupported, "{route}");
-            assert_eq!(err.fault_message(), "Drive updates are not supported.");
-        }
+    fn parses_patch_drive_with_path_update() {
+        let request = request_with_body(
+            "PATCH",
+            "/drives/rootfs",
+            r#"{"drive_id":"rootfs","path_on_host":"/tmp/replaced.ext4"}"#,
+        );
+
+        let parsed = parse_request(&request).expect("drive patch should parse");
+
+        let ApiRequest::PatchDrive(config) = parsed else {
+            panic!("expected drive patch request");
+        };
+        assert_eq!(config.path_drive_id(), "rootfs");
+        assert_eq!(config.body_drive_id(), "rootfs");
+        assert_eq!(config.path_on_host(), Some("/tmp/replaced.ext4"));
     }
 
     #[test]
-    fn rejects_drive_update_without_parsing_body() {
-        for method in ["PATCH", "DELETE"] {
-            let malformed_body = request_with_body(method, "/drives/rootfs", "not-json");
-            let empty_body = format!(
-                "{method} /drives/rootfs HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n"
-            );
+    fn parses_patch_drive_with_only_drive_id() {
+        let request = request_with_body("PATCH", "/drives/rootfs", r#"{"drive_id":"rootfs"}"#);
 
-            assert_eq!(
-                parse_request(&malformed_body),
-                Err(RequestError::DriveUpdateUnsupported),
-                "{method}"
-            );
-            assert_eq!(
-                parse_request(empty_body.as_bytes()),
-                Err(RequestError::DriveUpdateUnsupported),
-                "{method}"
-            );
-        }
+        let parsed = parse_request(&request).expect("drive patch should parse");
+
+        let ApiRequest::PatchDrive(config) = parsed else {
+            panic!("expected drive patch request");
+        };
+        assert_eq!(config.path_drive_id(), "rootfs");
+        assert_eq!(config.body_drive_id(), "rootfs");
+        assert_eq!(config.path_on_host(), None);
+    }
+
+    #[test]
+    fn parses_patch_drive_with_null_optional_fields() {
+        let request = request_with_body(
+            "PATCH",
+            "/drives/rootfs",
+            r#"{"drive_id":"rootfs","path_on_host":null,"rate_limiter":null}"#,
+        );
+
+        let parsed = parse_request(&request).expect("drive patch should parse");
+
+        let ApiRequest::PatchDrive(config) = parsed else {
+            panic!("expected drive patch request");
+        };
+        assert_eq!(config.path_drive_id(), "rootfs");
+        assert_eq!(config.body_drive_id(), "rootfs");
+        assert_eq!(config.path_on_host(), None);
+    }
+
+    #[test]
+    fn rejects_patch_drive_malformed_body() {
+        let request = request_with_body("PATCH", "/drives/rootfs", "not-json");
+
+        assert_eq!(parse_request(&request), Err(RequestError::MalformedRequest));
+    }
+
+    #[test]
+    fn rejects_patch_drive_missing_drive_id() {
+        let request = request_with_body("PATCH", "/drives/rootfs", r#"{"path_on_host":"x"}"#);
+
+        assert_eq!(parse_request(&request), Err(RequestError::MalformedRequest));
+    }
+
+    #[test]
+    fn rejects_patch_drive_mismatched_drive_id() {
+        let request = request_with_body("PATCH", "/drives/rootfs", r#"{"drive_id":"data"}"#);
+
+        assert_eq!(
+            parse_request(&request),
+            Err(RequestError::MismatchedDriveId)
+        );
+    }
+
+    #[test]
+    fn rejects_patch_drive_unknown_field() {
+        let request = request_with_body(
+            "PATCH",
+            "/drives/rootfs",
+            r#"{"drive_id":"rootfs","is_read_only":true}"#,
+        );
+
+        assert_eq!(parse_request(&request), Err(RequestError::MalformedRequest));
+    }
+
+    #[test]
+    fn rejects_patch_drive_invalid_rate_limiter_shape() {
+        let request = request_with_body(
+            "PATCH",
+            "/drives/rootfs",
+            r#"{"drive_id":"rootfs","rate_limiter":"unsupported"}"#,
+        );
+
+        assert_eq!(parse_request(&request), Err(RequestError::MalformedRequest));
+    }
+
+    #[test]
+    fn rejects_patch_drive_configured_rate_limiter_as_unsupported_update() {
+        let request = request_with_body(
+            "PATCH",
+            "/drives/rootfs",
+            r#"{"drive_id":"rootfs","rate_limiter":{"ops":{"size":100,"one_time_burst":null,"refill_time":1000}}}"#,
+        );
+
+        assert_eq!(
+            parse_request(&request),
+            Err(RequestError::DriveUpdateUnsupported)
+        );
+    }
+
+    #[test]
+    fn rejects_drive_hot_unplug_as_unsupported_without_parsing_body() {
+        let request = b"DELETE /drives/rootfs HTTP/1.1\r\nHost: localhost\r\n\r\n".to_vec();
+
+        let err = parse_request(&request).expect_err("drive hot-unplug should be unsupported");
+        assert_eq!(err, RequestError::DriveUpdateUnsupported);
+        assert_eq!(err.fault_message(), "Drive updates are not supported.");
     }
 
     #[test]
@@ -4607,6 +4742,15 @@ mod tests {
             }"#,
         ))
         .expect("drive request should parse");
+
+        assert_eq!(Endpoint::from(request), Endpoint::Drive);
+
+        let request = parse_request(&request_with_body(
+            "PATCH",
+            "/drives/rootfs",
+            r#"{"drive_id":"rootfs"}"#,
+        ))
+        .expect("drive patch request should parse");
 
         assert_eq!(Endpoint::from(request), Endpoint::Drive);
 

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -14,14 +14,16 @@ use bangbang_api::HTTP_MAX_PAYLOAD_SIZE;
 use bangbang_api::http::{
     ActionRequest, ActionType, ApiRequest, BootSourceRequest, BootSourceResponse,
     DriveCacheType as ApiDriveCacheType, DriveConfigRequest, DriveConfigResponse,
-    DriveIoEngine as ApiDriveIoEngine, HttpResponse, LoggerConfigRequest,
+    DriveIoEngine as ApiDriveIoEngine, DrivePatchRequest, HttpResponse, LoggerConfigRequest,
     LoggerLevel as ApiLoggerLevel, MachineConfigPatchRequest, MachineConfigRequest,
     MachineConfigResponse, MetricsConfigRequest, MmdsConfigRequest, MmdsConfigResponse,
     MmdsContentRequest, MmdsVersion as ApiMmdsVersion, NetworkInterfaceConfigRequest,
     NetworkInterfaceConfigResponse, RequestError, VmConfigResponse, VsockConfigRequest,
     VsockConfigResponse, parse_request_with_limit, request_total_len_with_limit,
 };
-use bangbang_runtime::block::{DriveCacheType, DriveConfig, DriveConfigInput, DriveIoEngine};
+use bangbang_runtime::block::{
+    DriveCacheType, DriveConfig, DriveConfigInput, DriveIoEngine, DriveUpdateInput,
+};
 use bangbang_runtime::boot::{BootSourceConfig, BootSourceConfigInput};
 use bangbang_runtime::logger::{LoggerConfigInput, LoggerLevel};
 use bangbang_runtime::machine::{
@@ -472,6 +474,9 @@ fn handle_api_request(request: ApiRequest, vmm: &mut impl VmmRequestHandler) -> 
         ApiRequest::PutDrive(config) => handle_empty(vmm.handle_action(VmmAction::PutDrive(
             drive_config_input_from_request(config.as_ref()),
         ))),
+        ApiRequest::PatchDrive(config) => handle_empty(vmm.handle_action(
+            VmmAction::UpdateBlockDevice(drive_update_input_from_request(config.as_ref())),
+        )),
         ApiRequest::PutNetworkInterface(config) => {
             handle_empty(vmm.handle_action(VmmAction::PutNetworkInterface(
                 network_interface_config_input_from_request(config.as_ref()),
@@ -857,6 +862,14 @@ fn drive_config_input_from_request(config: &DriveConfigRequest) -> DriveConfigIn
     }
 
     input
+}
+
+fn drive_update_input_from_request(config: &DrivePatchRequest) -> DriveUpdateInput {
+    DriveUpdateInput::new(
+        config.path_drive_id(),
+        config.body_drive_id(),
+        config.path_on_host().map(std::path::PathBuf::from),
+    )
 }
 
 fn network_interface_config_input_from_request(
@@ -3224,13 +3237,6 @@ mod tests {
     fn returns_fault_for_device_update_endpoints() {
         for (name, method, path, body, fault_message) in [
             (
-                "drive",
-                "PATCH",
-                "/drives/rootfs",
-                r#"{"drive_id":"rootfs"}"#,
-                r#"{"fault_message":"Drive updates are not supported."}"#,
-            ),
-            (
                 "drive-delete",
                 "DELETE",
                 "/drives/rootfs",
@@ -3609,6 +3615,85 @@ mod tests {
         assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
         assert!(response.contains(r#"{"fault_message":"drive rate_limiter is not supported"}"#));
         assert!(vmm.drive_configs().is_empty());
+    }
+
+    #[test]
+    fn returns_state_fault_for_preboot_drive_patch_without_mutating() {
+        let mut vmm = test_controller();
+        vmm.handle_action(VmmAction::PutDrive(
+            DriveConfigInput::new("rootfs", "rootfs", "/tmp/rootfs.ext4", true)
+                .with_is_read_only(true),
+        ))
+        .expect("initial drive should configure");
+        let body = r#"{
+            "drive_id": "rootfs",
+            "path_on_host": "/tmp/replaced.ext4"
+        }"#;
+        let request = format!(
+            "PATCH /drives/rootfs HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+
+        let response = request_over_socket(&mut vmm, "drive-patch-preboot", &request);
+
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        assert!(response.contains(
+            r#"{"fault_message":"The requested operation is not supported in Not started state: UpdateBlockDevice"}"#
+        ));
+        assert_eq!(vmm.drive_configs().len(), 1);
+        let config = &vmm.drive_configs()[0];
+        assert_eq!(
+            config.path_on_host(),
+            std::path::Path::new("/tmp/rootfs.ext4")
+        );
+        assert!(config.is_read_only());
+    }
+
+    #[test]
+    fn running_state_rejects_drive_patch_without_mutating() {
+        let mut vmm = test_controller_with_starter(TestInstanceStarter::success());
+        vmm.handle_action(VmmAction::PutDrive(
+            DriveConfigInput::new("rootfs", "rootfs", "/tmp/rootfs.ext4", true)
+                .with_is_read_only(true),
+        ))
+        .expect("initial drive should configure");
+        let boot_body = r#"{"kernel_image_path":"/tmp/original-vmlinux"}"#;
+        let boot_request = format!(
+            "PUT /boot-source HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{boot_body}",
+            boot_body.len()
+        );
+        assert_eq!(
+            handle_request_bytes(boot_request.as_bytes(), &mut vmm).status(),
+            bangbang_api::http::StatusCode::NoContent
+        );
+        let start_response = put_action_over_socket(&mut vmm, "drive-patch-start", "InstanceStart");
+        assert!(start_response.starts_with("HTTP/1.1 204 No Content\r\n"));
+        let body = r#"{
+            "drive_id": "rootfs",
+            "path_on_host": "/tmp/replaced.ext4"
+        }"#;
+        let request = format!(
+            "PATCH /drives/rootfs HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+
+        let response = request_over_socket(&mut vmm, "drive-patch-running", &request);
+
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        assert!(response.contains(
+            r#"{"fault_message":"The requested operation is not supported: UpdateBlockDevice"}"#
+        ));
+        assert_eq!(
+            vmm.instance_info().state,
+            bangbang_runtime::InstanceState::Running
+        );
+        assert_eq!(vmm.drive_configs().len(), 1);
+        let config = &vmm.drive_configs()[0];
+        assert_eq!(
+            config.path_on_host(),
+            std::path::Path::new("/tmp/rootfs.ext4")
+        );
+        assert!(config.is_read_only());
     }
 
     #[test]

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -98,6 +98,22 @@ fn executable_configures_vm_before_start() {
     let drive_response = http_put_json(&socket_path, "/drives/rootfs", &drive_body);
     assert_no_content_response(&drive_response, "PUT /drives/rootfs");
 
+    let replaced_rootfs_path_json = json_string(path_text(&test_dir.path().join("replaced.ext4")));
+    let drive_patch_body = format!(
+        r#"{{
+            "drive_id":"rootfs",
+            "path_on_host":{replaced_rootfs_path_json}
+        }}"#
+    );
+    let drive_patch_response =
+        http_json(&socket_path, "PATCH", "/drives/rootfs", &drive_patch_body);
+    assert_bad_request_response(&drive_patch_response, "PATCH /drives/rootfs");
+    assert_response_contains(
+        &drive_patch_response,
+        r#"{"fault_message":"The requested operation is not supported in Not started state: UpdateBlockDevice"}"#,
+        "PATCH /drives/rootfs",
+    );
+
     let vm_config = http_get(&socket_path, "/vm/config");
     assert_ok_response(&vm_config, "GET /vm/config");
     assert_response_contains(&vm_config, r#""machine-config":"#, "GET /vm/config");
@@ -120,6 +136,10 @@ fn executable_configures_vm_before_start() {
         &vm_config,
         &format!(r#""path_on_host":{rootfs_path_json}"#),
         "GET /vm/config",
+    );
+    assert!(
+        !vm_config.contains(&format!(r#""path_on_host":{replaced_rootfs_path_json}"#)),
+        "failed PATCH /drives/rootfs must not mutate drive path; response:\n{vm_config}"
     );
     assert_response_contains(&vm_config, r#""is_root_device":true"#, "GET /vm/config");
     assert_response_contains(&vm_config, r#""is_read_only":true"#, "GET /vm/config");

--- a/crates/runtime/src/block.rs
+++ b/crates/runtime/src/block.rs
@@ -68,6 +68,39 @@ pub struct DriveConfigInput {
     socket: Option<PathBuf>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DriveUpdateInput {
+    path_drive_id: String,
+    body_drive_id: String,
+    path_on_host: Option<PathBuf>,
+}
+
+impl DriveUpdateInput {
+    pub fn new(
+        path_drive_id: impl Into<String>,
+        body_drive_id: impl Into<String>,
+        path_on_host: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            path_drive_id: path_drive_id.into(),
+            body_drive_id: body_drive_id.into(),
+            path_on_host,
+        }
+    }
+
+    pub fn path_drive_id(&self) -> &str {
+        &self.path_drive_id
+    }
+
+    pub fn body_drive_id(&self) -> &str {
+        &self.body_drive_id
+    }
+
+    pub fn path_on_host(&self) -> Option<&Path> {
+        self.path_on_host.as_deref()
+    }
+}
+
 impl DriveConfigInput {
     pub fn new(
         path_drive_id: impl Into<String>,

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -79,6 +79,7 @@ pub enum VmmAction {
     PatchMmds(mmds::MmdsContentInput),
     PutMmdsConfig(mmds::MmdsConfigInput),
     PutDrive(block::DriveConfigInput),
+    UpdateBlockDevice(block::DriveUpdateInput),
     PutNetworkInterface(network::NetworkInterfaceConfigInput),
     PutVsock(vsock::VsockConfigInput),
 }
@@ -102,6 +103,7 @@ impl VmmAction {
             Self::PatchMmds(_) => "PatchMmds",
             Self::PutMmdsConfig(_) => "PutMmdsConfig",
             Self::PutDrive(_) => "PutDrive",
+            Self::UpdateBlockDevice(_) => "UpdateBlockDevice",
             Self::PutNetworkInterface(_) => "PutNetworkInterface",
             Self::PutVsock(_) => "PutVsock",
         }
@@ -522,6 +524,16 @@ impl VmmController {
 
                 Ok(VmmData::Empty)
             }
+            VmmAction::UpdateBlockDevice(_) => {
+                if self.instance_info.state == InstanceState::NotStarted {
+                    return Err(VmmActionError::UnsupportedState {
+                        action: action_name,
+                        state: self.instance_info.state,
+                    });
+                }
+
+                Err(VmmActionError::UnsupportedAction(action_name))
+            }
             VmmAction::PutNetworkInterface(config) => {
                 if self.instance_info.state != InstanceState::NotStarted {
                     return Err(VmmActionError::UnsupportedState {
@@ -607,7 +619,7 @@ mod tests {
 
     use super::{
         BackendError, InstanceState, VmmAction, VmmActionError, VmmController, VmmData,
-        block::{DriveConfigError, DriveConfigInput},
+        block::{DriveConfigError, DriveConfigInput, DriveUpdateInput},
         boot::{
             BootCommandLineError, BootPayloadKind, BootSourceConfigError, BootSourceConfigInput,
         },
@@ -2489,6 +2501,67 @@ mod tests {
             }
         );
         assert!(controller.drive_configs().is_empty());
+    }
+
+    #[test]
+    fn update_block_device_rejects_not_started_state_without_mutating() {
+        let mut controller = VmmController::new("demo-1", "0.1.0", "bangbang");
+        controller
+            .handle_action(VmmAction::PutDrive(drive_input(
+                "rootfs",
+                "/tmp/rootfs.ext4",
+                true,
+            )))
+            .expect("initial drive config should be stored");
+
+        let err = controller
+            .handle_action(VmmAction::UpdateBlockDevice(DriveUpdateInput::new(
+                "rootfs",
+                "rootfs",
+                Some(PathBuf::from("/tmp/replaced.ext4")),
+            )))
+            .expect_err("pre-boot drive update should fail");
+
+        assert_eq!(
+            err,
+            VmmActionError::UnsupportedState {
+                action: "UpdateBlockDevice",
+                state: InstanceState::NotStarted,
+            }
+        );
+        assert_eq!(controller.drive_configs().len(), 1);
+        assert_eq!(
+            controller.drive_configs()[0].path_on_host(),
+            Path::new("/tmp/rootfs.ext4")
+        );
+    }
+
+    #[test]
+    fn update_block_device_running_is_unsupported_without_mutating() {
+        let mut controller = VmmController::new("demo-1", "0.1.0", "bangbang");
+        controller
+            .handle_action(VmmAction::PutDrive(drive_input(
+                "rootfs",
+                "/tmp/rootfs.ext4",
+                true,
+            )))
+            .expect("initial drive config should be stored");
+        controller.instance_info.state = InstanceState::Running;
+
+        let err = controller
+            .handle_action(VmmAction::UpdateBlockDevice(DriveUpdateInput::new(
+                "rootfs",
+                "rootfs",
+                Some(PathBuf::from("/tmp/replaced.ext4")),
+            )))
+            .expect_err("runtime drive update should remain unsupported");
+
+        assert_eq!(err, VmmActionError::UnsupportedAction("UpdateBlockDevice"));
+        assert_eq!(controller.drive_configs().len(), 1);
+        assert_eq!(
+            controller.drive_configs()[0].path_on_host(),
+            Path::new("/tmp/rootfs.ext4")
+        );
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -58,7 +58,7 @@ configured interface ID, boot block, virtio-net, and virtio-vsock queue
 interrupt signaling,
 virtual timer PPI assertion, per-controller metrics and logger output state, and an initial process startup argument model.
 There is no broader API request body model beyond the initial boot-source,
-drive configuration, network-interface configuration, vsock configuration, machine-configuration, metrics, logger, and actions bodies, public guest
+drive configuration, drive update, network-interface configuration, vsock configuration, machine-configuration, metrics, logger, and actions bodies, public guest
 execution beyond internal startup execution across bounded step windows, public run-loop control, complete interrupt
 delivery, including timer EOI/deactivation-driven unmasking,
 general HVF runner-loop notification scheduling, public serial output streaming,
@@ -92,9 +92,10 @@ socket. The implemented `GET /`, `GET /version`, `GET /vm/config`,
 `GET /machine-config`, pre-boot `PUT /machine-config`, pre-boot
 `PUT /boot-source`, pre-boot `PUT /drives/{drive_id}`, pre-boot
 `PUT /network-interfaces/{iface_id}`, pre-boot `PUT /vsock`, pre-boot
-`PUT /metrics`, pre-boot `PUT /logger`, and parsed `PUT /actions` requests
-already map through a minimal internal VMM action/data boundary. Validation
-rejects malformed boot-source and actions requests before VMM state mutation.
+`PUT /metrics`, pre-boot `PUT /logger`, parsed `PUT /actions`, and recognized
+`PATCH /drives/{drive_id}` requests already map through a minimal internal VMM
+action/data boundary. Validation rejects malformed boot-source, drive update,
+and actions requests before VMM state mutation.
 Successful `InstanceStart` startup, the `Running` transition, and an internal boot run-loop worker across bounded step windows are implemented with an internal serial MMIO
 console capture path and retained internal active, terminal-outcome, or error worker status. `FlushMetrics` is implemented as a runtime-only minimal JSON-line flush through per-process metrics state, and includes a terse `boot_run_loop_status` summary when a process-owned boot worker exists. `PUT /logger` is implemented as pre-boot per-process observability configuration with minimal successful `InstanceStart` and `FlushMetrics` action-event output; public run-loop control, public serial
 streaming, full Firecracker metrics counters, periodic flush, and full logger integration remain deferred.
@@ -105,7 +106,8 @@ The current `bangbang` executable parses only the first process-lifecycle
 arguments and starts the first API socket surface. It binds a Unix socket and
 serves `GET /`, `GET /version`, `GET /vm/config`, `GET /machine-config`,
 pre-boot `PUT /machine-config`, pre-boot `PUT /boot-source` configuration storage, and
-pre-boot `PUT /drives/{drive_id}` configuration storage, pre-boot
+pre-boot `PUT /drives/{drive_id}` configuration storage, recognized
+`PATCH /drives/{drive_id}` update rejection, pre-boot
 `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage, pre-boot `PUT /metrics`
 output configuration, pre-boot `PUT /logger` output configuration, metrics and logger startup CLI configuration, plus process-routed `PUT /actions` startup and metrics
 flush with an internal boot run-loop worker across bounded step windows or
@@ -256,7 +258,8 @@ compatibility targets.
 | `PUT` | `/serial` | recognized; rejected | Returns a serial-specific unsupported fault. Public serial configuration storage, host output redirection, rate limiting, and integration with the existing internal serial capture path need a dedicated design. |
 | `GET`, `PUT`, `PATCH` | `/hotplug/memory` | recognized; rejected | Returns a memory-hotplug-specific unsupported fault. Real virtio-mem device support, guest memory accounting, and runtime memory update behavior need a dedicated design. |
 | `PATCH` | `/vm` | recognized; rejected | Returns a VM-state-specific unsupported fault. Real pause/resume state rules, VMM actions, and public run-loop control need a dedicated design. |
-| `PATCH` | `/drives/{drive_id}`, `/network-interfaces/{iface_id}` | recognized; rejected | Returns device-update-specific unsupported faults. Real block-device updates, network-interface updates, runtime mutation, and hotplug behavior need dedicated device designs. |
+| `PATCH` | `/drives/{drive_id}` | recognized; rejected | Parses the Firecracker-shaped block-device update request with required `drive_id`, optional `path_on_host`, and optional `rate_limiter`, then routes valid updates through `UpdateBlockDevice`. Pre-boot requests fail as post-boot-only operations and runtime requests fail as unsupported actions without mutating stored drive configuration. Configured rate limiters remain unsupported until block update behavior exists. |
+| `PATCH` | `/network-interfaces/{iface_id}` | recognized; rejected | Returns device-update-specific unsupported faults. Real network-interface updates, runtime mutation, and hotplug behavior need dedicated device designs. |
 | `DELETE` | `/drives/{drive_id}`, `/pmem/{id}`, `/network-interfaces/{iface_id}` | recognized; rejected | Firecracker routes these hot-unplug requests in `parsed_request.rs`, but they are not in the `v1.16.0` swagger surface. bangbang returns existing device-update or pmem unsupported faults; real hot-unplug behavior remains deferred. |
 
 ## Initial Field Handling Policy
@@ -296,6 +299,11 @@ exist.
 | `PUT /drives/{drive_id}` | `io_engine` | optional when `Sync`; rejected when `Async` | The internal model accepts omitted/default `Sync` and rejects `Async`; `Async` is tied to Linux io_uring and does not directly map to the first macOS target. |
 | `PUT /drives/{drive_id}` | `socket` | optional when absent or `null`; rejected when configured | The internal model rejects configured sockets with `drive socket is not supported`; vhost-user-block is outside the first tier. |
 | `PUT /drives/{drive_id}` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
+| `PATCH /drives/{drive_id}` | path `drive_id` | required | The API parser captures this value before building the runtime update action. |
+| `PATCH /drives/{drive_id}` | body `drive_id` | required | The API parser rejects requests where this does not match the path `drive_id`. |
+| `PATCH /drives/{drive_id}` | `path_on_host` | optional | Valid request parsing preserves this value for the future block update action, but the current runtime rejects the operation without opening the path or mutating stored configuration. |
+| `PATCH /drives/{drive_id}` | `rate_limiter` | optional when absent or `null`; rejected when configured | The parser accepts the Firecracker-shaped field name and returns the existing drive-update unsupported fault for configured rate limiters; real rate limiting belongs with future block update work. |
+| `PATCH /drives/{drive_id}` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
 | `PUT /network-interfaces/{iface_id}` | path `iface_id` | required | The API parser captures this value, and the internal model validates it as nonempty alphanumeric or `_`, matching Firecracker's `checked_id` rule. |
 | `PUT /network-interfaces/{iface_id}` | body `iface_id` | required | The API parser rejects requests where this does not match the path `iface_id`. |
 | `PUT /network-interfaces/{iface_id}` | `host_dev_name` | required | The API/VMM path records this value only after rejecting empty values and enforcing the current 16-interface bangbang limit; it does not open, stat, or otherwise touch host networking resources during configuration. `InstanceStart` later accepts only `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` for vmnet packet I/O startup. |
@@ -568,13 +576,16 @@ adapter or adopt `vm-memory` more broadly.
 
 ## Internal Drive Configuration
 
-The API crate has a strict Firecracker-shaped `PUT /drives/{drive_id}` request
-parser and body model. It accepts the documented drive fields, rejects unknown
-fields, rejects malformed or incomplete JSON bodies, rejects extra path
-segments, and rejects path/body `drive_id` mismatches without echoing host paths.
-The running API server converts parsed drive requests into a VMM action; valid
-pre-boot requests are recorded as VM configuration state and return `204 No
-Content`.
+The API crate has strict Firecracker-shaped `PUT /drives/{drive_id}` and
+`PATCH /drives/{drive_id}` request parser and body models. Initial drive
+configuration accepts the documented drive fields, rejects unknown fields,
+rejects malformed or incomplete JSON bodies, rejects extra path segments, and
+rejects path/body `drive_id` mismatches without echoing host paths. Drive update
+requests parse the Firecracker-shaped `drive_id`, `path_on_host`, and
+`rate_limiter` fields, reject invalid or mismatched bodies, and route valid
+updates to the runtime as unsupported update operations. The running API server
+converts parsed initial drive requests into a VMM action; valid pre-boot
+requests are recorded as VM configuration state and return `204 No Content`.
 
 The runtime crate has an internal, Firecracker-shaped drive configuration model
 for the initial virtio-block subset. It validates path and body `drive_id`
@@ -1206,6 +1217,7 @@ The first API implementation should model the same broad stages as Firecracker:
 | `PATCH /machine-config` | implemented; `204` empty response on successful partial config update | unsupported after start; `400` `fault_message` | Pre-boot-only partial configuration. Omitted fields preserve current stored values; invalid updates leave stored values unchanged. |
 | `PUT /boot-source` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; host paths are opened during startup preparation. Host path errors must avoid leaking sensitive path details. |
 | `PUT /drives/{drive_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config; startup preparation opens backing files and registers initial block MMIO devices. Runtime hotplug remains deferred. |
+| `PATCH /drives/{drive_id}` | recognized post-boot-only operation; `400` `fault_message` | recognized but unsupported; `400` `fault_message` | Parses Firecracker-shaped update requests and routes valid bodies through `UpdateBlockDevice`, but does not open new backing files or mutate stored drive configuration yet. Configured rate limiters remain parser-level unsupported until real update support exists. |
 | `PUT /network-interfaces/{iface_id}` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records up to 16 validated pre-boot configs without opening host networking resources. Startup preparation attaches configured interfaces as virtio-mmio devices in the MMIO dispatcher and guest FDT. `InstanceStart` revalidates the count before opening vmnet packet I/O for `vmnet:host`, `vmnet:shared`, and `vmnet:bridged:<interface>` host device names and fails before `Running` for unsupported names. Internal network notification dispatch can route each interface through selected packet I/O, complete TX descriptor heads through a packet sink boundary, and write injected RX packets into guest buffers through a packet source boundary. Public packet movement, PATCH, and DELETE remain deferred. |
 | `PUT /vsock` | implemented; `204` empty response on successful config storage | unsupported after start; `400` `fault_message` | Records validated pre-boot config without opening host Unix socket resources during the request. Startup preparation binds the configured `uds_path` as a nonblocking host Unix listener and attaches one configured virtio-vsock device as guest-visible FDT/MMIO metadata backed by the internal MMIO handler, which retains active RX, TX, and event queue metadata after `DRIVER_OK`. The runtime has an internal TX descriptor packet parser, TX available-ring drain helper, used-ring TX descriptor completion, host socket accept helper for one owned nonblocking stream per dispatch pass, bounded accepted-stream retention across partial handshakes and retained connection records, accepted-stream `CONNECT <PORT>` handshake reader, host local port allocator, retained host connection table model with one-shot host request packet headers, RX packet-header delivery into writable guest descriptors with late retry for pending host requests, guest responses, reset packets, credit updates, or host-to-guest `RW` payloads, guest `RESPONSE` acknowledgement to retained host streams, guest `RST` and full guest `SHUTDOWN` cleanup for retained host-initiated and guest-initiated connections, minimal guest `CREDIT_UPDATE` consumption and `CREDIT_REQUEST` responses with guest-visible `CREDIT_UPDATE` headers for established retained streams, bounded zero-payload `VSOCK_OP_RST` queueing for unsupported or orphan host-destined guest TX packets, guest `REQUEST` connection to Firecracker-shaped `${uds_path}_${PORT}` sockets with guest-visible `RESPONSE` or `RST` header delivery, bounded guest `RW` payload forwarding from established guest-initiated connections to retained host streams with bounded four-packet per-connection guest-to-host retry buffering, bounded four-packet per-connection host `RW` backlog delivery from established host-initiated or guest-initiated streams into guest RX buffers, handler-level and startup-level RX/TX notification dispatch, no-op event notification handling, and HVF boot-loop vsock queue interrupt signaling, but guest-visible socket lifecycle beyond connection setup and forceful guest reset/full-shutdown cleanup, full graceful half-close state tracking, full virtio-vsock credit accounting, CID routing beyond current host/guest checks, full event payload dispatch, PATCH, and DELETE remain deferred. |
 | `GET /mmds` | implemented after data initialization; `200` JSON | implemented after data initialization; `200` JSON | Returns the current process-local MMDS JSON object. Requests fail with `400` `fault_message` until `PUT /mmds` initializes the data store. The same initialized data is also used by the implemented guest-visible MMDS path when MMDS config selects startup network interfaces; packet handling remains limited to the documented internal vmnet detour boundary. |


### PR DESCRIPTION
## Summary
- Add a Firecracker-shaped `PATCH /drives/{drive_id}` request model with strict JSON parsing for `drive_id`, optional `path_on_host`, and optional `rate_limiter`.
- Route valid drive PATCH requests through a new `UpdateBlockDevice` VMM action and return explicit unsupported-state/action faults without mutating stored drive configuration.
- Cover parser, API-over-socket, process e2e, runtime state behavior, and compatibility documentation.

## Scope
- Does not implement actual block-device update, host file opening, hotplug, or rate limiting.
- Keeps drive DELETE and network device PATCH/DELETE on existing parser-level unsupported faults.

Closes #567

## Verification
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
