### PR TITLE
feat: parse vm state patch requests

### DIFF
--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -25,6 +25,7 @@ pub enum ApiRequest {
     PutBootSource(Box<BootSourceRequest>),
     PutDrive(Box<DriveConfigRequest>),
     PatchDrive(Box<DrivePatchRequest>),
+    PatchVmState(Box<VmStateUpdateRequest>),
     PutLogger(Box<LoggerConfigRequest>),
     PutMachineConfig(Box<MachineConfigRequest>),
     PatchMachineConfig(Box<MachineConfigPatchRequest>),
@@ -54,7 +55,6 @@ pub enum RequestError {
     SendCtrlAltDelUnsupported,
     SerialUnsupported,
     SnapshotUnsupported,
-    VmStateUpdateUnsupported,
 }
 
 impl RequestError {
@@ -78,7 +78,6 @@ impl RequestError {
             Self::SendCtrlAltDelUnsupported => "SendCtrlAltDel is not supported on aarch64.",
             Self::SerialUnsupported => "Serial device is not supported.",
             Self::SnapshotUnsupported => "Snapshot and restore are not supported.",
-            Self::VmStateUpdateUnsupported => "VM state updates are not supported.",
         }
     }
 }
@@ -119,6 +118,35 @@ enum ActionTypeBody {
     FlushMetrics,
     InstanceStart,
     SendCtrlAltDel,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VmStateUpdateRequest {
+    state: VmStateUpdate,
+}
+
+impl VmStateUpdateRequest {
+    pub const fn state(&self) -> VmStateUpdate {
+        self.state
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VmStateUpdate {
+    Paused,
+    Resumed,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VmStateUpdateRequestBody {
+    state: VmStateUpdateBody,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+enum VmStateUpdateBody {
+    Paused,
+    Resumed,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1234,7 +1262,7 @@ pub fn parse_request_with_limit(
         return parse_machine_config_patch_request(body);
     }
     if method == "PATCH" && path == "/vm" {
-        return Err(RequestError::VmStateUpdateUnsupported);
+        return parse_vm_state_update_request(body);
     }
     if method == "PUT" && path == "/metrics" {
         return parse_metrics_config_request(body);
@@ -1316,6 +1344,20 @@ fn parse_action_request(body: &[u8]) -> Result<ApiRequest, RequestError> {
 
     Ok(ApiRequest::PutAction(Box::new(ActionRequest {
         action_type,
+    })))
+}
+
+fn parse_vm_state_update_request(body: &[u8]) -> Result<ApiRequest, RequestError> {
+    let body = serde_json::from_slice::<VmStateUpdateRequestBody>(body)
+        .map_err(|_| RequestError::MalformedRequest)?;
+
+    let state = match body.state {
+        VmStateUpdateBody::Paused => VmStateUpdate::Paused,
+        VmStateUpdateBody::Resumed => VmStateUpdate::Resumed,
+    };
+
+    Ok(ApiRequest::PatchVmState(Box::new(VmStateUpdateRequest {
+        state,
     })))
 }
 
@@ -1791,6 +1833,7 @@ impl From<ApiRequest> for Endpoint {
             ApiRequest::GetMmds => Self::Mmds,
             ApiRequest::GetVmConfig => Self::VmConfig,
             ApiRequest::GetVersion => Self::Version,
+            ApiRequest::PatchVmState(_) => Self::VmState,
             ApiRequest::PutAction(_) => Self::Actions,
             ApiRequest::PutBootSource(_) => Self::BootSource,
             ApiRequest::PutDrive(_) | ApiRequest::PatchDrive(_) => Self::Drive,
@@ -4268,27 +4311,43 @@ mod tests {
     }
 
     #[test]
-    fn rejects_vm_state_update_as_unsupported() {
+    fn parses_vm_state_update_pause() {
         let request = request_with_body("PATCH", "/vm", r#"{"state":"Paused"}"#);
 
-        let err = parse_request(&request).expect_err("VM state updates should be unsupported");
-        assert_eq!(err, RequestError::VmStateUpdateUnsupported);
-        assert_eq!(err.fault_message(), "VM state updates are not supported.");
+        let parsed = parse_request(&request).expect("VM state update should parse");
+
+        let ApiRequest::PatchVmState(update) = parsed else {
+            panic!("expected VM state update request");
+        };
+        assert_eq!(update.state(), VmStateUpdate::Paused);
     }
 
     #[test]
-    fn rejects_vm_state_update_as_unsupported_without_parsing_body() {
-        let malformed_body = request_with_body("PATCH", "/vm", "not-json");
-        let empty_body = b"PATCH /vm HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n";
+    fn parses_vm_state_update_resume() {
+        let request = request_with_body("PATCH", "/vm", r#"{"state":"Resumed"}"#);
 
-        assert_eq!(
-            parse_request(&malformed_body),
-            Err(RequestError::VmStateUpdateUnsupported)
-        );
-        assert_eq!(
-            parse_request(empty_body),
-            Err(RequestError::VmStateUpdateUnsupported)
-        );
+        let parsed = parse_request(&request).expect("VM state update should parse");
+
+        let ApiRequest::PatchVmState(update) = parsed else {
+            panic!("expected VM state update request");
+        };
+        assert_eq!(update.state(), VmStateUpdate::Resumed);
+    }
+
+    #[test]
+    fn rejects_malformed_vm_state_update_bodies() {
+        for body in [
+            "not-json",
+            "",
+            "{}",
+            r#"{"state":null}"#,
+            r#"{"state":"Running"}"#,
+            r#"{"state":"Paused","unknown":true}"#,
+        ] {
+            let request = request_with_body("PATCH", "/vm", body);
+
+            assert_eq!(parse_request(&request), Err(RequestError::MalformedRequest));
+        }
     }
 
     #[test]
@@ -4709,6 +4768,11 @@ mod tests {
             Endpoint::MachineConfig
         );
         assert_eq!(Endpoint::from(ApiRequest::GetVmConfig), Endpoint::VmConfig);
+        let request = parse_request(&request_with_body("PATCH", "/vm", r#"{"state":"Paused"}"#))
+            .expect("VM state update request should parse");
+
+        assert_eq!(Endpoint::from(request), Endpoint::VmState);
+
         let request = parse_request(&request_with_body(
             "PUT",
             "/actions",

--- a/crates/api/src/route.rs
+++ b/crates/api/src/route.rs
@@ -2,6 +2,7 @@
 pub enum Endpoint {
     DescribeInstance,
     Version,
+    VmState,
     VmConfig,
     Actions,
     BootSource,

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -18,8 +18,9 @@ use bangbang_api::http::{
     LoggerLevel as ApiLoggerLevel, MachineConfigPatchRequest, MachineConfigRequest,
     MachineConfigResponse, MetricsConfigRequest, MmdsConfigRequest, MmdsConfigResponse,
     MmdsContentRequest, MmdsVersion as ApiMmdsVersion, NetworkInterfaceConfigRequest,
-    NetworkInterfaceConfigResponse, RequestError, VmConfigResponse, VsockConfigRequest,
-    VsockConfigResponse, parse_request_with_limit, request_total_len_with_limit,
+    NetworkInterfaceConfigResponse, RequestError, VmConfigResponse, VmStateUpdate,
+    VmStateUpdateRequest, VsockConfigRequest, VsockConfigResponse, parse_request_with_limit,
+    request_total_len_with_limit,
 };
 use bangbang_runtime::block::{
     DriveCacheType, DriveConfig, DriveConfigInput, DriveIoEngine, DriveUpdateInput,
@@ -477,6 +478,9 @@ fn handle_api_request(request: ApiRequest, vmm: &mut impl VmmRequestHandler) -> 
         ApiRequest::PatchDrive(config) => handle_empty(vmm.handle_action(
             VmmAction::UpdateBlockDevice(drive_update_input_from_request(config.as_ref())),
         )),
+        ApiRequest::PatchVmState(update) => {
+            handle_empty(vmm.handle_action(vm_state_action_from_request(update.as_ref())))
+        }
         ApiRequest::PutNetworkInterface(config) => {
             handle_empty(vmm.handle_action(VmmAction::PutNetworkInterface(
                 network_interface_config_input_from_request(config.as_ref()),
@@ -492,6 +496,13 @@ fn action_from_request(action: &ActionRequest) -> VmmAction {
     match action.action_type() {
         ActionType::InstanceStart => VmmAction::InstanceStart,
         ActionType::FlushMetrics => VmmAction::FlushMetrics,
+    }
+}
+
+fn vm_state_action_from_request(update: &VmStateUpdateRequest) -> VmmAction {
+    match update.state() {
+        VmStateUpdate::Paused => VmmAction::Pause,
+        VmStateUpdate::Resumed => VmmAction::Resume,
     }
 }
 
@@ -3115,31 +3126,64 @@ mod tests {
     }
 
     #[test]
-    fn returns_fault_for_vm_state_update_endpoint() {
-        let path = unique_socket_path("vm-state-fault");
-        let server = ApiServer::bind(&path).expect("server should bind");
-        let mut client = UnixStream::connect(&path).expect("client should connect");
-
-        client
-            .write_all(
-                b"PATCH /vm HTTP/1.1\r\nHost: localhost\r\nContent-Length: 18\r\n\r\n{\"state\":\"Paused\"}",
-            )
-            .expect("client should write request");
+    fn not_started_state_rejects_vm_state_update_without_mutating() {
         let mut vmm = test_controller();
-        server
-            .serve_next(&mut vmm)
-            .expect("server should handle one request");
+        let request = "PATCH /vm HTTP/1.1\r\nHost: localhost\r\nContent-Length: 18\r\n\r\n{\"state\":\"Paused\"}";
 
-        let mut response = String::new();
-        client
-            .read_to_string(&mut response)
-            .expect("client should read response");
+        let response = request_over_socket(&mut vmm, "vm-state-not-started", request);
 
         assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
-        assert!(response.contains(r#"{"fault_message":"VM state updates are not supported."}"#));
+        assert!(response.contains(
+            r#"{"fault_message":"The requested operation is not supported in Not started state: Pause"}"#
+        ));
         assert_eq!(
             vmm.instance_info().state,
             bangbang_runtime::InstanceState::NotStarted
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_vm_state_update_without_mutating() {
+        let mut vmm = test_controller();
+        let request = "PATCH /vm HTTP/1.1\r\nHost: localhost\r\nContent-Length: 19\r\n\r\n{\"state\":\"Running\"}";
+
+        let response = request_over_socket(&mut vmm, "vm-state-malformed", request);
+
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        assert!(response.contains(r#"{"fault_message":"Malformed HTTP request."}"#));
+        assert_eq!(
+            vmm.instance_info().state,
+            bangbang_runtime::InstanceState::NotStarted
+        );
+    }
+
+    #[test]
+    fn running_state_rejects_vm_state_update_without_mutating() {
+        let mut vmm = test_controller_with_starter(TestInstanceStarter::success());
+        let boot_body = r#"{"kernel_image_path":"/tmp/original-vmlinux"}"#;
+        let boot_request = format!(
+            "PUT /boot-source HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{boot_body}",
+            boot_body.len()
+        );
+        assert_eq!(
+            handle_request_bytes(boot_request.as_bytes(), &mut vmm).status(),
+            bangbang_api::http::StatusCode::NoContent
+        );
+        let start_response = put_action_over_socket(&mut vmm, "vm-state-start", "InstanceStart");
+        assert!(start_response.starts_with("HTTP/1.1 204 No Content\r\n"));
+        let request = "PATCH /vm HTTP/1.1\r\nHost: localhost\r\nContent-Length: 19\r\n\r\n{\"state\":\"Resumed\"}";
+
+        let response = request_over_socket(&mut vmm, "vm-state-running", request);
+
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        assert!(
+            response.contains(
+                r#"{"fault_message":"The requested operation is not supported: Resume"}"#
+            )
+        );
+        assert_eq!(
+            vmm.instance_info().state,
+            bangbang_runtime::InstanceState::Running
         );
     }
 

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -521,9 +521,10 @@ fn help_text() -> String {
             "PUT /network-interfaces/{{iface_id}}, pre-boot PUT /vsock, ",
             "pre-boot PUT /metrics and startup metrics output configuration, ",
             "and pre-boot PUT /logger and startup logger configuration with ",
-            "minimal action logs; PUT /actions starts a process-owned HVF boot run-loop ",
-            "worker across bounded step windows for InstanceStart, but public ",
-            "run-loop control is not implemented yet."
+            "minimal action logs; PATCH /vm parses Paused and Resumed state requests ",
+            "as unsupported lifecycle actions; PUT /actions starts a process-owned ",
+            "HVF boot run-loop worker across bounded step windows for InstanceStart, ",
+            "but public run-loop control is not implemented yet."
         ),
         env!("CARGO_PKG_VERSION"),
         DEFAULT_API_SOCK_PATH,
@@ -802,6 +803,7 @@ mod tests {
         assert!(help.contains("startup metrics output configuration"));
         assert!(help.contains("pre-boot PUT /logger and startup logger configuration"));
         assert!(help.contains("minimal action logs"));
+        assert!(help.contains("PATCH /vm parses Paused and Resumed state requests"));
         assert!(help.contains("--log-path <PATH>"));
         assert!(help.contains("--metrics-path <PATH>"));
         assert!(help.contains("--http-api-max-payload-size <BYTES>"));

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -141,6 +141,21 @@ fn executable_configures_vm_before_start() {
         !vm_config.contains(&format!(r#""path_on_host":{replaced_rootfs_path_json}"#)),
         "failed PATCH /drives/rootfs must not mutate drive path; response:\n{vm_config}"
     );
+
+    let vm_state_response = http_json(&socket_path, "PATCH", "/vm", r#"{"state":"Paused"}"#);
+    assert_bad_request_response(&vm_state_response, "PATCH /vm");
+    assert_response_contains(
+        &vm_state_response,
+        r#"{"fault_message":"The requested operation is not supported in Not started state: Pause"}"#,
+        "PATCH /vm",
+    );
+    let instance_info_after_vm_state_patch = http_get(&socket_path, "/");
+    assert_response_contains(
+        &instance_info_after_vm_state_patch,
+        r#""state":"Not started""#,
+        "GET / after failed PATCH /vm",
+    );
+
     assert_response_contains(&vm_config, r#""is_root_device":true"#, "GET /vm/config");
     assert_response_contains(&vm_config, r#""is_read_only":true"#, "GET /vm/config");
     assert_response_contains(&vm_config, r#""partuuid":"0eaa91a0-01""#, "GET /vm/config");

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -69,6 +69,8 @@ pub enum VmmAction {
     GetMmds,
     GetVmConfig,
     InstanceStart,
+    Pause,
+    Resume,
     FlushMetrics,
     PutBootSource(boot::BootSourceConfigInput),
     PutLogger(logger::LoggerConfigInput),
@@ -93,6 +95,8 @@ impl VmmAction {
             Self::GetMmds => "GetMmds",
             Self::GetVmConfig => "GetVmConfig",
             Self::InstanceStart => "InstanceStart",
+            Self::Pause => "Pause",
+            Self::Resume => "Resume",
             Self::FlushMetrics => "FlushMetrics",
             Self::PutBootSource(_) => "PutBootSource",
             Self::PutLogger(_) => "PutLogger",
@@ -402,6 +406,16 @@ impl VmmController {
                 .map_err(VmmActionError::MmdsState),
             VmmAction::InstanceStart => {
                 self.preflight_instance_start()?;
+                Err(VmmActionError::UnsupportedAction(action_name))
+            }
+            VmmAction::Pause | VmmAction::Resume => {
+                if self.instance_info.state == InstanceState::NotStarted {
+                    return Err(VmmActionError::UnsupportedState {
+                        action: action_name,
+                        state: self.instance_info.state,
+                    });
+                }
+
                 Err(VmmActionError::UnsupportedAction(action_name))
             }
             VmmAction::FlushMetrics => {
@@ -919,6 +933,8 @@ mod tests {
     fn action_names_include_start_metrics_and_logger() {
         assert_eq!(VmmAction::GetVmConfig.name(), "GetVmConfig");
         assert_eq!(VmmAction::InstanceStart.name(), "InstanceStart");
+        assert_eq!(VmmAction::Pause.name(), "Pause");
+        assert_eq!(VmmAction::Resume.name(), "Resume");
         assert_eq!(VmmAction::FlushMetrics.name(), "FlushMetrics");
         assert_eq!(VmmAction::GetMmds.name(), "GetMmds");
         assert_eq!(
@@ -975,6 +991,51 @@ mod tests {
         assert_eq!(controller.machine_config().vcpu_count(), 2);
         assert!(controller.boot_source_config().is_some());
         assert_eq!(controller.drive_configs().len(), 1);
+    }
+
+    #[test]
+    fn pause_and_resume_reject_not_started_without_mutating() {
+        for action in [VmmAction::Pause, VmmAction::Resume] {
+            let mut controller = VmmController::new("demo-1", "0.1.0", "bangbang");
+            controller
+                .handle_action(VmmAction::PutBootSource(boot_source_input("/tmp/vmlinux")))
+                .expect("boot source config should be stored");
+
+            let err = controller
+                .handle_action(action.clone())
+                .expect_err("VM state update should be unsupported before start");
+
+            assert_eq!(
+                err,
+                VmmActionError::UnsupportedState {
+                    action: action.name(),
+                    state: InstanceState::NotStarted,
+                }
+            );
+            assert_eq!(controller.instance_info().state, InstanceState::NotStarted);
+            assert!(controller.boot_source_config().is_some());
+        }
+    }
+
+    #[test]
+    fn pause_and_resume_reject_running_or_paused_without_mutating() {
+        for state in [InstanceState::Running, InstanceState::Paused] {
+            for action in [VmmAction::Pause, VmmAction::Resume] {
+                let mut controller = VmmController::new("demo-1", "0.1.0", "bangbang");
+                controller
+                    .handle_action(VmmAction::PutBootSource(boot_source_input("/tmp/vmlinux")))
+                    .expect("boot source config should be stored");
+                controller.instance_info.state = state;
+
+                let err = controller
+                    .handle_action(action.clone())
+                    .expect_err("VM state update should remain unsupported");
+
+                assert_eq!(err, VmmActionError::UnsupportedAction(action.name()));
+                assert_eq!(controller.instance_info().state, state);
+                assert!(controller.boot_source_config().is_some());
+            }
+        }
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -92,10 +92,10 @@ socket. The implemented `GET /`, `GET /version`, `GET /vm/config`,
 `GET /machine-config`, pre-boot `PUT /machine-config`, pre-boot
 `PUT /boot-source`, pre-boot `PUT /drives/{drive_id}`, pre-boot
 `PUT /network-interfaces/{iface_id}`, pre-boot `PUT /vsock`, pre-boot
-`PUT /metrics`, pre-boot `PUT /logger`, parsed `PUT /actions`, and recognized
-`PATCH /drives/{drive_id}` requests already map through a minimal internal VMM
+`PUT /metrics`, pre-boot `PUT /logger`, parsed `PUT /actions`, parsed
+`PATCH /vm`, and recognized `PATCH /drives/{drive_id}` requests already map through a minimal internal VMM
 action/data boundary. Validation rejects malformed boot-source, drive update,
-and actions requests before VMM state mutation.
+VM state update, and actions requests before VMM state mutation.
 Successful `InstanceStart` startup, the `Running` transition, and an internal boot run-loop worker across bounded step windows are implemented with an internal serial MMIO
 console capture path and retained internal active, terminal-outcome, or error worker status. `FlushMetrics` is implemented as a runtime-only minimal JSON-line flush through per-process metrics state, and includes a terse `boot_run_loop_status` summary when a process-owned boot worker exists. `PUT /logger` is implemented as pre-boot per-process observability configuration with minimal successful `InstanceStart` and `FlushMetrics` action-event output; public run-loop control, public serial
 streaming, full Firecracker metrics counters, periodic flush, and full logger integration remain deferred.
@@ -257,7 +257,7 @@ compatibility targets.
 | `PUT` | `/entropy` | recognized; rejected | Returns an entropy-specific unsupported fault. Real virtio-rng configuration storage, rate limiting, guest randomness wiring, and startup resource attachment need a dedicated device design. |
 | `PUT` | `/serial` | recognized; rejected | Returns a serial-specific unsupported fault. Public serial configuration storage, host output redirection, rate limiting, and integration with the existing internal serial capture path need a dedicated design. |
 | `GET`, `PUT`, `PATCH` | `/hotplug/memory` | recognized; rejected | Returns a memory-hotplug-specific unsupported fault. Real virtio-mem device support, guest memory accounting, and runtime memory update behavior need a dedicated design. |
-| `PATCH` | `/vm` | recognized; rejected | Returns a VM-state-specific unsupported fault. Real pause/resume state rules, VMM actions, and public run-loop control need a dedicated design. |
+| `PATCH` | `/vm` | recognized; rejected | Parses the Firecracker-shaped VM state request with required `state` values `Paused` and `Resumed`, then routes valid requests through `Pause` or `Resume` VMM actions. Requests before startup fail as unsupported in `Not started` state, and runtime requests fail as unsupported actions without mutating VM state. Real pause/resume state transitions and public run-loop control remain deferred. |
 | `PATCH` | `/drives/{drive_id}` | recognized; rejected | Parses the Firecracker-shaped block-device update request with required `drive_id`, optional `path_on_host`, and optional `rate_limiter`, then routes valid updates through `UpdateBlockDevice`. Pre-boot requests fail as post-boot-only operations and runtime requests fail as unsupported actions without mutating stored drive configuration. Configured rate limiters remain unsupported until block update behavior exists. |
 | `PATCH` | `/network-interfaces/{iface_id}` | recognized; rejected | Returns device-update-specific unsupported faults. Real network-interface updates, runtime mutation, and hotplug behavior need dedicated device designs. |
 | `DELETE` | `/drives/{drive_id}`, `/pmem/{id}`, `/network-interfaces/{iface_id}` | recognized; rejected | Firecracker routes these hot-unplug requests in `parsed_request.rs`, but they are not in the `v1.16.0` swagger surface. bangbang returns existing device-update or pmem unsupported faults; real hot-unplug behavior remains deferred. |
@@ -1202,8 +1202,8 @@ The first API implementation should model the same broad stages as Firecracker:
   capture, and transitions the process out of pre-boot state on success
 - runtime: the microVM is running; pre-boot-only configuration requests should
   fail with a Firecracker-shaped unsupported-state error
-- paused/resumed: deferred until `/vm` state update work defines pause and
-  resume behavior
+- paused/resumed: `PATCH /vm` parses `Paused` and `Resumed` requests, but real
+  pause and resume behavior remains deferred
 
 ### Initial Operation State Matrix
 
@@ -1366,7 +1366,7 @@ Their eventual support level should follow the endpoint matrix:
 - full logger integration, full Firecracker metrics counters, and periodic
   metrics flush
 - memory hotplug
-- pause and resume VM state updates
+- real pause and resume VM state transitions
 - PATCH and DELETE hotplug/update behavior
 
 Non-initial features should be introduced through narrower capability work that


### PR DESCRIPTION
## Summary

- Parse Firecracker-shaped `PATCH /vm` bodies with `Paused` and `Resumed` states.
- Route valid VM state updates to explicit `Pause` and `Resume` runtime actions that still return unsupported faults without mutating VM state.
- Cover malformed bodies, pre-start/runtime no-mutation behavior, process-level behavior, CLI help text, and compatibility docs.

## Scope Exclusions

- Does not implement real pause/resume.
- Does not change HVF run-loop control, snapshot paused-state behavior, `GET /`, or `GET /vm/config` semantics.

Closes #569

## Verification

```sh
cargo fmt --all -- --check
cargo check --workspace --all-targets --all-features --locked
cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
cargo test -p bangbang-hvf --lib --all-features --locked
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings
cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings
cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
```
