### PR TITLE
feat: support no-api config-file startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cargo run -p bangbang -- --api-sock /tmp/bangbang.socket --id demo-1
   `/tmp/bangbang.socket`.
 - `--config-file <PATH>` reads a Firecracker-shaped JSON configuration for the
   supported startup subset from a readable regular file up to 1 MiB, starts the
-  VM, then serves the API socket. `--no-api` is not supported yet.
+  VM, then serves the API socket unless `--no-api` is set.
 - `--http-api-max-payload-size <BYTES>` sets the maximum accepted HTTP API
   request size. The default is `51200` bytes.
 - `--id <ID>` records the microVM identifier. The default is
@@ -47,6 +47,8 @@ cargo run -p bangbang -- --api-sock /tmp/bangbang.socket --id demo-1
 - `--log-path <PATH>`, `--level <LEVEL>`, `--module <MODULE>`,
   `--show-level`, and `--show-log-origin` configure the same per-process
   logger state as `PUT /logger` before the API socket is served.
+- `--no-api` requires `--config-file <PATH>`, starts from that configuration
+  without publishing an API socket, and exits cleanly on `SIGINT` or `SIGTERM`.
 - `--help`, `-h`, `--version`, and `-V` are supported.
 
 The API socket is an unauthenticated local control interface. Filesystem
@@ -71,6 +73,14 @@ Start from a configuration file while keeping the API socket enabled:
 cargo run -p bangbang -- \
   --api-sock /tmp/bangbang.socket \
   --config-file /tmp/bangbang-vm.json
+```
+
+Start from a configuration file without publishing an API socket:
+
+```sh
+cargo run -p bangbang -- \
+  --config-file /tmp/bangbang-vm.json \
+  --no-api
 ```
 
 ## API Examples
@@ -213,9 +223,10 @@ rules, guest boot artifact caching, and local verification expectations.
 
 ## Exit Status
 
-- `0`: help or version completed successfully, or the API server exited without
-  error.
+- `0`: help or version completed successfully, the API server exited without
+  error, or no-api mode handled `SIGINT`/`SIGTERM`.
 - `153`: startup argument parsing failed before process configuration began.
   This matches Firecracker's argument-parsing exit code.
 - `1`: process failure, including config-file startup, startup metrics/logger
-  configuration, API socket bind, or API accept failures.
+  configuration, API socket bind, shutdown signal handling, or API accept
+  failures.

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -39,7 +39,6 @@ const UNSUPPORTED_FIRECRACKER_ARGS: &[&str] = &[
     "describe-snapshot",
     "enable-pci",
     "metadata",
-    "no-api",
     "no-seccomp",
     "parent-cpu-time-us",
     "seccomp-filter",
@@ -81,6 +80,7 @@ fn run() -> Result<(), ProcessError> {
                 logger_config,
                 mmds_size_limit: _,
                 metrics_config,
+                no_api,
             } = config;
 
             println!("bangbang {}", env!("CARGO_PKG_VERSION"));
@@ -99,6 +99,12 @@ fn run() -> Result<(), ProcessError> {
             apply_startup_logger_config(&mut vmm, logger_config)?;
             apply_startup_config_file(&mut vmm, config_file.as_deref())?;
             let mut shutdown_signal = ShutdownSignal::install()?;
+            if no_api {
+                println!("status: VM running without API");
+                shutdown_signal.wait()?;
+                return Ok(());
+            }
+
             let server =
                 ApiServer::bind_with_max_payload_size(&api_sock, http_api_max_payload_size)
                     .map_err(ProcessError::ApiServer)?;
@@ -415,7 +421,7 @@ impl fmt::Display for ProcessError {
             Self::ArgumentParsing(message) => f.write_str(message),
             Self::ConfigFile(err) => write!(f, "config-file error: {err}"),
             Self::SignalHandler(kind) => {
-                write!(f, "failed to register shutdown signal handler: {kind:?}")
+                write!(f, "shutdown signal handling failed: {kind:?}")
             }
             Self::StartupConfiguration(err) => {
                 write!(f, "startup configuration error: {err}")
@@ -511,6 +517,22 @@ impl ShutdownSignal {
     fn wakeup_reader(&mut self) -> &mut UnixStream {
         &mut self.wakeup_reader
     }
+
+    fn wait(&mut self) -> Result<(), ProcessError> {
+        let mut buffer = [0; 64];
+        loop {
+            match self.wakeup_reader.read(&mut buffer) {
+                Ok(0) => {
+                    return Err(ProcessError::SignalHandler(
+                        std::io::ErrorKind::UnexpectedEof,
+                    ));
+                }
+                Ok(_) => return Ok(()),
+                Err(err) if err.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(err) => return Err(ProcessError::SignalHandler(err.kind())),
+            }
+        }
+    }
 }
 
 fn register_signal_wakeup(signal: i32, wakeup_writer: &UnixStream) -> Result<SigId, ProcessError> {
@@ -559,6 +581,7 @@ struct StartupConfig {
     logger_config: Option<LoggerConfigInput>,
     mmds_size_limit: Option<usize>,
     metrics_config: Option<MetricsConfigInput>,
+    no_api: bool,
 }
 
 impl Default for StartupConfig {
@@ -571,6 +594,7 @@ impl Default for StartupConfig {
             logger_config: None,
             mmds_size_limit: None,
             metrics_config: None,
+            no_api: false,
         }
     }
 }
@@ -639,6 +663,7 @@ impl Args {
         let mut mmds_size_limit_seen = false;
         let mut metrics_path_seen = false;
         let mut module_seen = false;
+        let mut no_api_seen = false;
         let mut show_level_seen = false;
         let mut show_log_origin_seen = false;
         let mut index = 0;
@@ -716,6 +741,14 @@ impl Args {
                     mmds_size_limit_seen = true;
                     index += 2;
                 }
+                "--no-api" => {
+                    if no_api_seen {
+                        return Err("duplicate argument: --no-api".to_string());
+                    }
+                    config.no_api = true;
+                    no_api_seen = true;
+                    index += 1;
+                }
                 "--metrics-path" => {
                     if metrics_path_seen {
                         return Err("duplicate argument: --metrics-path".to_string());
@@ -754,6 +787,12 @@ impl Args {
                     index += 1;
                 }
                 other => {
+                    if let Some(name) = unsupported_flag_equals_syntax(other) {
+                        return Err(format!(
+                            "unsupported argument syntax for --{name}; use --{name}"
+                        ));
+                    }
+
                     if let Some(name) = unsupported_firecracker_arg(other) {
                         return Err(format!("unsupported Firecracker argument: --{name}"));
                     }
@@ -775,6 +814,10 @@ impl Args {
 
         if logger_config_seen {
             config.logger_config = Some(logger_config);
+        }
+
+        if config.no_api && config.config_file.is_none() {
+            return Err("--no-api requires --config-file".to_string());
         }
 
         Ok(Self {
@@ -812,6 +855,7 @@ fn help_text() -> String {
             "      --mmds-size-limit <BYTES>\n",
             "                         MMDS data store size; defaults to HTTP API limit\n",
             "      --module <MODULE>  Logger module filter stored for future log integration\n",
+            "      --no-api          Start from --config-file without publishing an API socket\n",
             "      --show-level       Include level in minimal logger action lines\n",
             "      --show-log-origin  Include callsite origin in minimal logger action lines\n",
             "  -V, --version          Print version\n",
@@ -824,7 +868,8 @@ fn help_text() -> String {
             "pre-boot PUT /metrics and startup metrics output configuration, ",
             "and pre-boot PUT /logger and startup logger configuration with ",
             "minimal action logs; --config-file can apply the same supported ",
-            "pre-boot configuration and start the VM before API serving; ",
+            "pre-boot configuration and start the VM before API serving, ",
+            "or with --no-api can start without publishing an API socket; ",
             "PATCH /vm parses Paused and Resumed state requests ",
             "as unsupported lifecycle actions; PUT /cpu-config parses custom CPU ",
             "template requests as unsupported CPU configuration actions; ",
@@ -940,6 +985,12 @@ fn unsupported_equals_syntax(arg: &str) -> Option<&'static str> {
     ]
     .into_iter()
     .find_map(|(prefix, name)| arg.starts_with(prefix).then_some(name))
+}
+
+fn unsupported_flag_equals_syntax(arg: &str) -> Option<&'static str> {
+    [("--no-api=", "no-api")]
+        .into_iter()
+        .find_map(|(prefix, name)| arg.starts_with(prefix).then_some(name))
 }
 
 #[cfg(test)]
@@ -1111,6 +1162,7 @@ mod tests {
         assert_eq!(config.id, DEFAULT_INSTANCE_ID);
         assert_eq!(config.logger_config, None);
         assert_eq!(config.metrics_config, None);
+        assert!(!config.no_api);
     }
 
     #[test]
@@ -1142,6 +1194,8 @@ mod tests {
         assert!(help.contains("--metrics-path <PATH>"));
         assert!(help.contains("--http-api-max-payload-size <BYTES>"));
         assert!(help.contains("--mmds-size-limit <BYTES>"));
+        assert!(help.contains("--no-api"));
+        assert!(help.contains("without publishing an API socket"));
         assert!(help.contains("--show-level"));
         assert!(help.contains("PUT /actions starts a process-owned HVF boot run-loop worker"));
         assert!(help.contains("across bounded step windows for InstanceStart"));
@@ -1205,6 +1259,19 @@ mod tests {
             config.config_file,
             Some("/tmp/bangbang-config.json".to_string())
         );
+        assert!(!config.no_api);
+    }
+
+    #[test]
+    fn parse_no_api_config_file_arg() {
+        let config = parse_run(&["--config-file", "/tmp/bangbang-config.json", "--no-api"])
+            .expect("no-api config-file startup should parse");
+
+        assert_eq!(
+            config.config_file,
+            Some("/tmp/bangbang-config.json".to_string())
+        );
+        assert!(config.no_api);
     }
 
     #[test]
@@ -1345,6 +1412,13 @@ mod tests {
     }
 
     #[test]
+    fn rejects_no_api_without_config_file() {
+        let err = parse(&["--no-api"]).expect_err("no-api should require config file");
+
+        assert_eq!(err, "--no-api requires --config-file");
+    }
+
+    #[test]
     fn rejects_missing_id_value() {
         let err = parse(&["--id", "--api-sock"]).expect_err("missing id value should fail");
 
@@ -1410,6 +1484,19 @@ mod tests {
         .expect_err("duplicate config-file should fail");
 
         assert_eq!(err, "duplicate argument: --config-file");
+    }
+
+    #[test]
+    fn rejects_duplicate_no_api() {
+        let err = parse(&[
+            "--config-file",
+            "/tmp/bangbang-config.json",
+            "--no-api",
+            "--no-api",
+        ])
+        .expect_err("duplicate no-api should fail");
+
+        assert_eq!(err, "duplicate argument: --no-api");
     }
 
     #[test]
@@ -1630,13 +1717,6 @@ mod tests {
     }
 
     #[test]
-    fn rejects_unsupported_firecracker_no_api_arg() {
-        let err = parse(&["--no-api"]).expect_err("unsupported flag should fail");
-
-        assert_eq!(err, "unsupported Firecracker argument: --no-api");
-    }
-
-    #[test]
     fn rejects_unsupported_firecracker_linux_arg() {
         let err = parse(&["--no-seccomp"]).expect_err("unsupported Linux flag should fail");
 
@@ -1659,6 +1739,13 @@ mod tests {
         assert_eq!(
             err,
             "unsupported argument syntax for --config-file; use --config-file <VALUE>"
+        );
+
+        let err = parse(&["--no-api=true"]).expect_err("equals syntax should fail");
+
+        assert_eq!(
+            err,
+            "unsupported argument syntax for --no-api; use --no-api"
         );
 
         let err =

--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -330,6 +330,72 @@ mod macos_arm64 {
     }
 
     #[test]
+    fn signed_executable_starts_no_api_from_config_file() {
+        let test_dir = TestDir::new();
+        let socket_path = test_dir.path().join("api.socket");
+        let config_path = test_dir.path().join("vm-config.json");
+        let backing_path = test_dir.path().join("data.img");
+        let logger_path = test_dir.path().join("logger.out");
+        let kernel_path = env_path(BANGBANG_GUEST_KERNEL_PATH_ENV);
+        let initrd_path = env_path(BANGBANG_GUEST_INITRD_PATH_ENV);
+        let instance_id = test_dir.instance_id();
+
+        create_zeroed_block_backing(&backing_path);
+
+        let kernel_path_json = json_string(path_text(&kernel_path));
+        let initrd_path_json = json_string(path_text(&initrd_path));
+        let boot_args_json = json_string(GUEST_BOOT_ARGS);
+        let backing_path_json = json_string(path_text(&backing_path));
+        let logger_path_json = json_string(path_text(&logger_path));
+        let config = format!(
+            r#"{{
+                "machine-config": {{"vcpu_count": 1, "mem_size_mib": 256}},
+                "boot-source": {{
+                    "kernel_image_path": {kernel_path_json},
+                    "initrd_path": {initrd_path_json},
+                    "boot_args": {boot_args_json}
+                }},
+                "drives": [{{
+                    "drive_id": "data",
+                    "path_on_host": {backing_path_json},
+                    "is_root_device": false,
+                    "is_read_only": false
+                }}],
+                "logger": {{"log_path": {logger_path_json}}}
+            }}"#
+        );
+        fs::write(&config_path, config).expect("config file should be written");
+
+        let mut bangbang = BangbangProcess::start_with_extra_args(
+            &socket_path,
+            &instance_id,
+            &["--config-file", path_text(&config_path), "--no-api"],
+        );
+
+        assert!(
+            !socket_path.exists(),
+            "no-api config-file startup must not publish an API socket"
+        );
+
+        if let Err(err) =
+            wait_for_file_prefix_marker(&backing_path, BLOCK_WRITE_MARKER, GUEST_EXECUTION_TIMEOUT)
+        {
+            let output = bangbang.force_stop_and_collect();
+            panic!(
+                "no-api config-file guest did not write block marker through signed bangbang executable: {err}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                output.status, output.stdout, output.stderr
+            );
+        }
+
+        assert_no_api_logger_output(&logger_path);
+        assert_clean_shutdown(
+            bangbang.terminate(),
+            &socket_path,
+            "bangbang no-api config file",
+        );
+    }
+
+    #[test]
     fn signed_executable_boots_direct_rootfs_and_writes_block_marker() {
         let test_dir = TestDir::new();
         let socket_path = test_dir.path().join("api.socket");
@@ -474,6 +540,17 @@ mod macos_arm64 {
         assert_eq!(
             output, "action=InstanceStart\naction=FlushMetrics\n",
             "logger output should include the expected action records"
+        );
+    }
+
+    fn assert_no_api_logger_output(path: &Path) {
+        let output = fs::read_to_string(path).unwrap_or_else(|err| {
+            panic!("logger output {} should be readable: {err}", path.display())
+        });
+
+        assert_eq!(
+            output, "action=InstanceStart\n",
+            "no-api logger output should include only the startup action record"
         );
     }
 

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -95,6 +95,50 @@ fn executable_config_file_failure_does_not_publish_socket() {
 }
 
 #[test]
+fn executable_no_api_config_file_failure_does_not_publish_socket() {
+    let test_dir = TestDir::new();
+    let socket_path = test_dir.path().join("api.socket");
+    let config_path = test_dir.path().join("vm-config.json");
+    let instance_id = test_dir.instance_id();
+    fs::write(&config_path, "{").expect("malformed config file should be written");
+
+    let output = BangbangProcess::start_with_extra_args_expect_failure(
+        &socket_path,
+        &instance_id,
+        &["--config-file", path_text(&config_path), "--no-api"],
+    );
+
+    assert!(
+        !output.status.success(),
+        "malformed no-api config file should fail startup; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        output.stdout,
+        output.stderr
+    );
+    assert!(
+        !socket_path.exists(),
+        "malformed no-api config file should not publish an API socket"
+    );
+    assert!(
+        !output.stdout.contains("status: API server listening"),
+        "no-api failure must not report API readiness; stdout:\n{}",
+        output.stdout
+    );
+    assert!(
+        !output.stdout.contains("status: VM running without API"),
+        "malformed no-api config must not report no-api readiness; stdout:\n{}",
+        output.stdout
+    );
+    assert!(
+        output
+            .stderr
+            .contains("bangbang: config-file error: malformed config file"),
+        "stderr should describe config-file parse failure without JSON contents; stderr:\n{}",
+        output.stderr
+    );
+}
+
+#[test]
 fn executable_configures_vm_before_start() {
     let test_dir = TestDir::new();
     let socket_path = test_dir.path().join("api.socket");

--- a/crates/bangbang/tests/support/mod.rs
+++ b/crates/bangbang/tests/support/mod.rs
@@ -18,7 +18,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const DEFAULT_BANGBANG_BIN: &str = env!("CARGO_BIN_EXE_bangbang");
 const BANGBANG_PROCESS_E2E_BIN_ENV: &str = "BANGBANG_PROCESS_E2E_BIN";
-const STARTUP_READY_LINE: &str = "status: API server listening";
+const API_STARTUP_READY_LINE: &str = "status: API server listening";
+const NO_API_STARTUP_READY_LINE: &str = "status: VM running without API";
+const STARTUP_READY_LINES: &[&str] = &[API_STARTUP_READY_LINE, NO_API_STARTUP_READY_LINE];
 const HTTP_IO_TIMEOUT: Duration = Duration::from_secs(5);
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
@@ -232,7 +234,7 @@ impl BangbangProcess {
             Ok(()) => {
                 let output = self.force_stop_and_collect();
                 panic!(
-                    "bangbang reported API readiness but startup failure was expected; binary: {}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                    "bangbang reported startup readiness but startup failure was expected; binary: {}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
                     self.binary_path.display(),
                     output.status,
                     output.stdout,
@@ -298,7 +300,7 @@ impl BangbangProcess {
             Err(err) => {
                 let output = self.force_stop_and_collect();
                 panic!(
-                    "bangbang did not report API readiness before timeout: {err:?}; binary: {}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                    "bangbang did not report startup readiness before timeout: {err:?}; binary: {}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
                     self.binary_path.display(),
                     output.status,
                     output.stdout,
@@ -395,7 +397,10 @@ impl OutputReader {
                 match reader.read_line(&mut line) {
                     Ok(0) => break,
                     Ok(_) => {
-                        if line.contains(STARTUP_READY_LINE) {
+                        if STARTUP_READY_LINES
+                            .iter()
+                            .any(|ready_line| line.contains(ready_line))
+                        {
                             let _ = ready_sender.send(());
                         }
                         output.push_str(&line);

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -111,10 +111,12 @@ pre-boot `PUT /drives/{drive_id}` configuration storage, recognized
 `PUT /network-interfaces/{iface_id}` configuration storage, pre-boot `PUT /vsock` configuration storage, pre-boot `PUT /metrics`
 output configuration, pre-boot `PUT /logger` output configuration, metrics and logger startup CLI configuration, plus process-routed `PUT /actions` startup and metrics
 flush with an internal boot run-loop worker across bounded step windows or
-state/configuration faults. The process can also read an API-enabled
-`--config-file` for the supported startup subset, start the VM before serving
-the API socket, and then keep the API socket available for runtime requests.
-It does not provide `--no-api` or public run-loop control yet.
+state/configuration faults. The process can also read `--config-file` for the
+supported startup subset, start the VM before serving the API socket, and then
+keep the API socket available for runtime requests. With `--no-api`, the same
+supported config-file startup path runs without publishing an API socket and
+exits on handled `SIGINT` or `SIGTERM`. It does not provide public run-loop
+control yet.
 
 | Argument | Current behavior | Compatibility notes |
 | --- | --- | --- |
@@ -128,10 +130,10 @@ It does not provide `--no-api` or public run-loop control yet.
 | `--show-level` | enables level prefix for minimal action logs | Writes `level=Info` before minimal `InstanceStart` and `FlushMetrics` action lines. |
 | `--show-log-origin` | enables origin field for minimal action logs | Writes `origin=<file>:<line>` before minimal `InstanceStart` and `FlushMetrics` action names. Full Firecracker logger integration remains deferred. |
 | `--mmds-size-limit <BYTES>` | configures the maximum serialized MMDS data-store size | When omitted, follows the effective HTTP API payload limit like Firecracker; with default HTTP settings this is `51200` bytes. Zero, malformed, duplicate, and equals-syntax values are rejected during argument parsing. |
-| `--config-file <PATH>` | API-enabled startup implemented for supported subset | Reads a Firecracker-shaped JSON configuration from a readable regular file up to 1 MiB before binding the API socket, applies supported sections through the same validation path as matching API requests, starts the VM with `InstanceStart`, then serves the API socket. Malformed, oversized, unknown, unsupported, or invalid sections fail before socket publication. |
+| `--config-file <PATH>` | startup implemented for supported subset | Reads a Firecracker-shaped JSON configuration from a readable regular file up to 1 MiB, applies supported sections through the same validation path as matching API requests, and starts the VM with `InstanceStart`. In API-enabled mode, the API socket is published only after successful startup. Malformed, oversized, unknown, unsupported, or invalid sections fail before socket publication or no-api readiness. |
 | `--help`, `-h` | prints help | Help describes the current API socket scope. |
 | `--version`, `-V` | prints version | `-V` is retained from the existing bangbang scaffold. |
-| `--no-api` | rejected | Deferred until a separate no-API process mode can start and drive the VM without an API socket. |
+| `--no-api` | config-file startup without API socket | Requires `--config-file`. Starts the supported config-file subset without binding or publishing the configured API socket, then waits for handled `SIGINT` or `SIGTERM`. Runtime control, guest-initiated shutdown, and no-api exit-code parity remain deferred. |
 | seccomp, snapshot, metadata, boot timer, and PCI process flags | rejected | These Firecracker options are Linux-specific or tied to later capability work. |
 
 bangbang intentionally treats `--id` alphanumeric characters as ASCII only.
@@ -148,9 +150,9 @@ compatibility decision expands the CLI parser.
 `cpu-config` section is parsed through the same request model as
 `PUT /cpu-config` and still fails as an unsupported CPU configuration action.
 Known unsupported sections such as `balloon`, `entropy`, `memory-hotplug`, and
-`pmem` fail before the API socket is published. The config-file path does not
-load MMDS data; Firecracker's separate metadata startup argument remains
-unsupported.
+`pmem` fail before the API socket is published or before no-api readiness is
+reported. The config-file path does not load MMDS data; Firecracker's separate
+metadata startup argument remains unsupported.
 
 CLI values are untrusted input. Current validation rejects invalid IDs, empty
 socket paths, and socket paths containing control characters. API startup also
@@ -170,9 +172,9 @@ The current executable uses a small process exit status contract:
 
 | Exit status | Current meaning | Compatibility notes |
 | --- | --- | --- |
-| `0` | Help or version completed successfully, or the API server exited without error, including handled `SIGINT`/`SIGTERM` shutdown. | Matches Firecracker's success status. |
+| `0` | Help or version completed successfully, the API server exited without error, or no-api mode handled `SIGINT`/`SIGTERM` shutdown. | Matches Firecracker's success status. |
 | `153` | Startup argument parsing failed before process configuration began. | Matches Firecracker's `ArgParsing` exit code. |
-| `1` | Process failure, including config-file startup, startup metrics/logger configuration, API socket bind, signal handler registration, or API accept failure. | Used for non-argument process failures before more specific Firecracker-compatible process errors exist. Per-connection read/write errors do not terminate the API server. |
+| `1` | Process failure, including config-file startup, startup metrics/logger configuration, API socket bind, signal handler registration, no-api signal wait failure, or API accept failure. | Used for non-argument process failures before more specific Firecracker-compatible process errors exist. Per-connection read/write errors do not terminate the API server. |
 
 Firecracker also defines bad-configuration and signal-specific exit codes.
 bangbang does not expose those until the corresponding configuration loading,


### PR DESCRIPTION
## Summary

- support `--no-api` with `--config-file` startup
- start the supported config-file VM path without binding or publishing the API socket
- keep the no-api process alive until handled `SIGINT` or `SIGTERM`
- cover parser, failure, and signed executable HVF no-api config-file behavior
- update README and Firecracker compatibility docs

## Scope Exclusions

- no runtime API control in no-api mode
- no guest-initiated shutdown or Firecracker exit-code parity beyond handled host signals

Closes #583

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
- `git diff --check`
