### PR TITLE
test: cover config-file direct rootfs startup

### DIFF
--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -483,6 +483,129 @@ mod macos_arm64 {
         assert_clean_shutdown(bangbang.terminate(), &socket_path, "bangbang direct rootfs");
     }
 
+    #[test]
+    fn signed_executable_starts_from_config_file_with_direct_rootfs() {
+        let test_dir = TestDir::new();
+        let socket_path = test_dir.path().join("api.socket");
+        let config_path = test_dir.path().join("vm-config.json");
+        let data_backing_path = test_dir.path().join("data.img");
+        let kernel_path = env_path(BANGBANG_GUEST_KERNEL_PATH_ENV);
+        let rootfs_path = env_path(BANGBANG_GUEST_EXT4_ROOTFS_PATH_ENV);
+        let instance_id = test_dir.instance_id();
+
+        create_zeroed_block_backing(&data_backing_path);
+
+        let kernel_path_json = json_string(path_text(&kernel_path));
+        let boot_args_json = json_string(DIRECT_ROOTFS_BOOT_ARGS);
+        let rootfs_path_json = json_string(path_text(&rootfs_path));
+        let data_backing_path_json = json_string(path_text(&data_backing_path));
+        let config = format!(
+            r#"{{
+                "machine-config": {{"vcpu_count": 1, "mem_size_mib": 256}},
+                "boot-source": {{
+                    "kernel_image_path": {kernel_path_json},
+                    "boot_args": {boot_args_json}
+                }},
+                "drives": [
+                    {{
+                        "drive_id": "rootfs",
+                        "path_on_host": {rootfs_path_json},
+                        "is_root_device": true,
+                        "is_read_only": true
+                    }},
+                    {{
+                        "drive_id": "data",
+                        "path_on_host": {data_backing_path_json},
+                        "is_root_device": false,
+                        "is_read_only": false
+                    }}
+                ]
+            }}"#
+        );
+        fs::write(&config_path, config).expect("direct rootfs config file should be written");
+
+        let mut bangbang = BangbangProcess::start_with_extra_args(
+            &socket_path,
+            &instance_id,
+            &["--config-file", path_text(&config_path)],
+        );
+
+        assert!(
+            socket_path.exists(),
+            "API-enabled config-file startup should publish an API socket"
+        );
+
+        let running_instance_info = http_get(&socket_path, "/");
+        assert_ok_response(
+            &running_instance_info,
+            "GET / after config-file direct rootfs startup",
+        );
+        assert_response_contains(
+            &running_instance_info,
+            &format!(r#""id":"{instance_id}""#),
+            "GET / after config-file direct rootfs startup",
+        );
+        assert_response_contains(
+            &running_instance_info,
+            r#""state":"Running""#,
+            "GET / after config-file direct rootfs startup",
+        );
+
+        let vm_config = http_get(&socket_path, "/vm/config");
+        assert_ok_response(
+            &vm_config,
+            "GET /vm/config after config-file direct rootfs startup",
+        );
+        assert_response_contains(
+            &vm_config,
+            r#""drive_id":"rootfs""#,
+            "GET /vm/config after config-file direct rootfs startup",
+        );
+        assert_response_contains(
+            &vm_config,
+            &format!(r#""path_on_host":{rootfs_path_json}"#),
+            "GET /vm/config after config-file direct rootfs startup",
+        );
+        assert_response_contains(
+            &vm_config,
+            r#""is_root_device":true"#,
+            "GET /vm/config after config-file direct rootfs startup",
+        );
+        assert_response_contains(
+            &vm_config,
+            r#""is_read_only":true"#,
+            "GET /vm/config after config-file direct rootfs startup",
+        );
+        assert_response_contains(
+            &vm_config,
+            r#""drive_id":"data""#,
+            "GET /vm/config after config-file direct rootfs startup",
+        );
+        assert_response_contains(
+            &vm_config,
+            &format!(r#""path_on_host":{data_backing_path_json}"#),
+            "GET /vm/config after config-file direct rootfs startup",
+        );
+
+        if let Err(err) = wait_for_file_prefix_marker(
+            &data_backing_path,
+            DIRECT_ROOTFS_BLOCK_MARKER,
+            GUEST_EXECUTION_TIMEOUT,
+        ) {
+            let output = bangbang.force_stop_and_collect();
+            panic!(
+                "config-file direct rootfs guest did not write block marker through signed bangbang executable: {err}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                output.status, output.stdout, output.stderr
+            );
+        }
+
+        assert_clean_shutdown(
+            bangbang.terminate(),
+            &socket_path,
+            "bangbang config-file direct rootfs",
+        );
+    }
+
     fn env_path(name: &str) -> PathBuf {
         match std::env::var_os(name) {
             Some(value) if value.is_empty() => panic!("{name} must not be empty"),

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -852,8 +852,9 @@ mounts the virtio-block root drive as `/`, and reads `/etc/os-release`; the
 signed `guest_boot` target validates guest-visible `root=/dev/vda ro`
 command-line arguments through captured serial output, and the signed
 executable HVF e2e target validates the same direct-rootfs path through public
-API configuration plus a host-observed scratch block marker. This does not yet
-claim arbitrary distro rootfs boot or default Ubuntu systemd startup.
+API configuration and config-file startup plus a host-observed scratch block
+marker. This does not yet claim arbitrary distro rootfs boot or default Ubuntu
+systemd startup.
 Block hotplug, remaining cache-mode semantics, and rate limiting remain
 deferred.
 It does not provide a public runner control, implement rate limiting, support

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -175,12 +175,13 @@ starts `bangbang` as a child process, configures the VM through the Unix-socket
 API or a Firecracker-shaped config file depending on the scenario, and waits for
 the guest to write deterministic markers to host-observable outputs. The
 tiny-initrd scenarios write `BANGBANG_BLOCK_WRITE_OK` to scratch block backing
-files, and the API-configured case also verifies the configured serial output
-file plus metrics and logger outputs after runtime `FlushMetrics`; the
-direct-rootfs scenarios boot the generated ext4 rootfs without an initrd and
-write `BANGBANG_DIRECT_ROOTFS_BLOCK_OK` through a second writable drive. This
-verifies the public process/API/config-file/HVF path, including public serial
-output redirection and minimal observability output.
+files. The API-request scenario also verifies the configured serial output file,
+and the API-request plus API-enabled config-file scenarios verify metrics and
+logger outputs after runtime `FlushMetrics`; the direct-rootfs scenarios boot
+the generated ext4 rootfs without an initrd and write
+`BANGBANG_DIRECT_ROOTFS_BLOCK_OK` through a second writable drive. This verifies
+the public process/API/config-file/HVF path, including public serial output
+redirection and minimal observability output.
 
 Hosted macOS CI may use:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -172,14 +172,15 @@ This target runs the dedicated `executable_hvf_e2e` Cargo test target. It builds
 and signs a temporary `bangbang` executable, prepares the pinned Firecracker
 kernel, deterministic tiny initrd, and generated direct-boot ext4 rootfs,
 starts `bangbang` as a child process, configures the VM through the Unix-socket
-API, sends `InstanceStart`, and waits for the guest to write deterministic
-markers to host-observable outputs. The tiny-initrd scenario writes
-`BANGBANG_BLOCK_WRITE_OK` to both a scratch block backing file and the configured
-serial output file, and it verifies configured metrics and logger outputs after
-runtime `FlushMetrics`; the direct-rootfs scenario boots the generated ext4
-rootfs without an initrd and writes `BANGBANG_DIRECT_ROOTFS_BLOCK_OK` through a
-second writable drive. This verifies the public process/API/HVF path, including
-public serial output redirection and minimal observability output.
+API or a Firecracker-shaped config file depending on the scenario, and waits for
+the guest to write deterministic markers to host-observable outputs. The
+tiny-initrd scenarios write `BANGBANG_BLOCK_WRITE_OK` to scratch block backing
+files, and the API-configured case also verifies the configured serial output
+file plus metrics and logger outputs after runtime `FlushMetrics`; the
+direct-rootfs scenarios boot the generated ext4 rootfs without an initrd and
+write `BANGBANG_DIRECT_ROOTFS_BLOCK_OK` through a second writable drive. This
+verifies the public process/API/config-file/HVF path, including public serial
+output redirection and minimal observability output.
 
 Hosted macOS CI may use:
 


### PR DESCRIPTION
## Summary

- Add signed executable HVF e2e coverage for `bangbang --config-file` direct-rootfs startup.
- Verify API-enabled config-file startup publishes the socket, reports `Running`, exposes the configured root and data drives, and reaches guest execution through the direct-rootfs block marker.
- Update compatibility and testing docs to describe direct-rootfs executable validation through both API configuration and config-file startup.

## Scope

- Does not change guest artifact download or rootfs generation behavior.
- Does not add drive hotplug, PATCH, DELETE, cache, or rate-limiter behavior.
- Does not claim general distro rootfs boot support.

Closes #585

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
- `git diff --check`
