### PR TITLE
test: cover executable vsock startup listener

### DIFF
--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -13,6 +13,7 @@ mod support;
 mod macos_arm64 {
     use std::fs;
     use std::io::Read;
+    use std::os::unix::net::UnixStream;
     use std::path::{Path, PathBuf};
     use std::time::{Duration, Instant};
 
@@ -40,6 +41,7 @@ mod macos_arm64 {
         let serial_output_path = test_dir.path().join("serial.out");
         let metrics_path = test_dir.path().join("metrics.out");
         let logger_path = test_dir.path().join("logger.out");
+        let uds_path = test_dir.path().join("vsock.sock");
         let kernel_path = env_path(BANGBANG_GUEST_KERNEL_PATH_ENV);
         let initrd_path = env_path(BANGBANG_GUEST_INITRD_PATH_ENV);
         let instance_id = test_dir.instance_id();
@@ -99,6 +101,15 @@ mod macos_arm64 {
         let logger_response = http_put_json(&socket_path, "/logger", &logger_body);
         assert_no_content_response(&logger_response, "PUT /logger");
 
+        let uds_path_json = json_string(path_text(&uds_path));
+        let vsock_body = format!(r#"{{"guest_cid":3,"uds_path":{uds_path_json}}}"#);
+        let vsock_response = http_put_json(&socket_path, "/vsock", &vsock_body);
+        assert_no_content_response(&vsock_response, "PUT /vsock");
+        assert!(
+            !uds_path.exists(),
+            "PUT /vsock should store config without binding the host socket path"
+        );
+
         let start_response = http_put_json(
             &socket_path,
             "/actions",
@@ -118,6 +129,25 @@ mod macos_arm64 {
             r#""state":"Running""#,
             "GET / after InstanceStart",
         );
+
+        let vm_config = http_get(&socket_path, "/vm/config");
+        assert_ok_response(&vm_config, "GET /vm/config after InstanceStart");
+        assert_response_contains(
+            &vm_config,
+            r#""guest_cid":3"#,
+            "GET /vm/config after InstanceStart",
+        );
+        assert_response_contains(
+            &vm_config,
+            &format!(r#""uds_path":{uds_path_json}"#),
+            "GET /vm/config after InstanceStart",
+        );
+        UnixStream::connect(&uds_path).unwrap_or_else(|err| {
+            panic!(
+                "InstanceStart should bind the configured vsock listener at {}: {err}",
+                uds_path.display()
+            )
+        });
 
         let flush_metrics_response = http_put_json(
             &socket_path,
@@ -178,6 +208,10 @@ mod macos_arm64 {
         }
 
         assert_clean_shutdown(bangbang.terminate(), &socket_path, "bangbang");
+        assert!(
+            !uds_path.exists(),
+            "bangbang shutdown should remove its owned vsock listener path"
+        );
     }
 
     #[test]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -176,10 +176,10 @@ API or a Firecracker-shaped config file depending on the scenario, and waits for
 the guest to write deterministic markers to host-observable outputs. The
 tiny-initrd scenarios write `BANGBANG_BLOCK_WRITE_OK` to scratch block backing
 files. The API-request scenario also verifies the configured serial output file,
-and the API-request plus API-enabled config-file scenarios verify metrics and
-logger outputs after runtime `FlushMetrics`; it also verifies that configured
-vsock paths bind during `InstanceStart` and are removed on shutdown. The
-direct-rootfs scenarios boot the generated ext4 rootfs without an initrd and write
+vsock listener binding during `InstanceStart`, and owned vsock listener cleanup
+on shutdown. The API-request plus API-enabled config-file scenarios verify
+metrics and logger outputs after runtime `FlushMetrics`. The direct-rootfs
+scenarios boot the generated ext4 rootfs without an initrd and write
 `BANGBANG_DIRECT_ROOTFS_BLOCK_OK` through a second writable drive. This verifies
 the public process/API/config-file/HVF path, including public serial output
 redirection and minimal observability output.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -177,8 +177,9 @@ the guest to write deterministic markers to host-observable outputs. The
 tiny-initrd scenarios write `BANGBANG_BLOCK_WRITE_OK` to scratch block backing
 files. The API-request scenario also verifies the configured serial output file,
 and the API-request plus API-enabled config-file scenarios verify metrics and
-logger outputs after runtime `FlushMetrics`; the direct-rootfs scenarios boot
-the generated ext4 rootfs without an initrd and write
+logger outputs after runtime `FlushMetrics`; it also verifies that configured
+vsock paths bind during `InstanceStart` and are removed on shutdown. The
+direct-rootfs scenarios boot the generated ext4 rootfs without an initrd and write
 `BANGBANG_DIRECT_ROOTFS_BLOCK_OK` through a second writable drive. This verifies
 the public process/API/config-file/HVF path, including public serial output
 redirection and minimal observability output.


### PR DESCRIPTION
## Summary

- Extend the signed executable HVF e2e startup scenario to configure `/vsock` before `InstanceStart`.
- Verify `/vsock` API config does not bind early, `InstanceStart` binds the configured host listener, `/vm/config` preserves the config after startup, and shutdown removes the owned listener path.
- Update the testing guide to include the executable HVF vsock listener coverage.

## Scope

- Does not test host-initiated `CONNECT` handshakes, guest-visible vsock traffic, RW forwarding, reset/shutdown semantics, credit accounting, CID routing, PATCH, DELETE, or hotplug.

Closes #591

## Validation

- `cargo fmt --all -- --check`
- `scripts/run-integration-tests.sh --test executable_hvf_e2e`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
- `cargo run -p bangbang -- --help`
- `git diff --check`
