### PR TITLE
test: cover config-file vsock startup listener

### DIFF
--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -222,6 +222,7 @@ mod macos_arm64 {
         let backing_path = test_dir.path().join("data.img");
         let metrics_path = test_dir.path().join("metrics.out");
         let logger_path = test_dir.path().join("logger.out");
+        let uds_path = test_dir.path().join("config-file-vsock.sock");
         let kernel_path = env_path(BANGBANG_GUEST_KERNEL_PATH_ENV);
         let initrd_path = env_path(BANGBANG_GUEST_INITRD_PATH_ENV);
         let instance_id = test_dir.instance_id();
@@ -234,6 +235,7 @@ mod macos_arm64 {
         let backing_path_json = json_string(path_text(&backing_path));
         let metrics_path_json = json_string(path_text(&metrics_path));
         let logger_path_json = json_string(path_text(&logger_path));
+        let uds_path_json = json_string(path_text(&uds_path));
         let config = format!(
             r#"{{
                 "machine-config": {{"vcpu_count": 1, "mem_size_mib": 256}},
@@ -248,6 +250,7 @@ mod macos_arm64 {
                     "is_root_device": false,
                     "is_read_only": false
                 }}],
+                "vsock": {{"guest_cid": 3, "uds_path": {uds_path_json}}},
                 "metrics": {{"metrics_path": {metrics_path_json}}},
                 "logger": {{"log_path": {logger_path_json}}}
             }}"#
@@ -310,6 +313,22 @@ mod macos_arm64 {
             &format!(r#""path_on_host":{backing_path_json}"#),
             "GET /vm/config after config-file startup",
         );
+        assert_response_contains(
+            &vm_config,
+            r#""guest_cid":3"#,
+            "GET /vm/config after config-file startup",
+        );
+        assert_response_contains(
+            &vm_config,
+            &format!(r#""uds_path":{uds_path_json}"#),
+            "GET /vm/config after config-file startup",
+        );
+        UnixStream::connect(&uds_path).unwrap_or_else(|err| {
+            panic!(
+                "config-file startup should bind the configured vsock listener at {}: {err}",
+                uds_path.display()
+            )
+        });
 
         let second_start_response = http_put_json(
             &socket_path,
@@ -361,6 +380,10 @@ mod macos_arm64 {
         }
 
         assert_clean_shutdown(bangbang.terminate(), &socket_path, "bangbang config file");
+        assert!(
+            !uds_path.exists(),
+            "bangbang config-file shutdown should remove its owned vsock listener path"
+        );
     }
 
     #[test]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -175,14 +175,14 @@ starts `bangbang` as a child process, configures the VM through the Unix-socket
 API or a Firecracker-shaped config file depending on the scenario, and waits for
 the guest to write deterministic markers to host-observable outputs. The
 tiny-initrd scenarios write `BANGBANG_BLOCK_WRITE_OK` to scratch block backing
-files. The API-request scenario also verifies the configured serial output file,
-vsock listener binding during `InstanceStart`, and owned vsock listener cleanup
-on shutdown. The API-request plus API-enabled config-file scenarios verify
-metrics and logger outputs after runtime `FlushMetrics`. The direct-rootfs
-scenarios boot the generated ext4 rootfs without an initrd and write
-`BANGBANG_DIRECT_ROOTFS_BLOCK_OK` through a second writable drive. This verifies
-the public process/API/config-file/HVF path, including public serial output
-redirection and minimal observability output.
+files. The API-request scenario also verifies the configured serial output file.
+The API-request and API-enabled config-file scenarios verify vsock listener
+binding during startup and owned vsock listener cleanup on shutdown. The same
+scenarios verify metrics and logger outputs after runtime `FlushMetrics`. The
+direct-rootfs scenarios boot the generated ext4 rootfs without an initrd and
+write `BANGBANG_DIRECT_ROOTFS_BLOCK_OK` through a second writable drive. This
+verifies the public process/API/config-file/HVF path, including public serial
+output redirection and minimal observability output.
 
 Hosted macOS CI may use:
 


### PR DESCRIPTION
## Summary

- Extend the signed executable config-file HVF e2e scenario with a Firecracker-shaped `vsock` section.
- Verify config-file startup exposes `guest_cid` and `uds_path` through `GET /vm/config`, binds a connectable Unix socket listener, and removes the owned listener on shutdown.
- Update the testing guide so executable HVF e2e coverage documents the API-enabled config-file vsock listener path.

## Scope

- No no-api config-file vsock coverage.
- No guest-visible vsock traffic, host `CONNECT` handshake, RW forwarding, reset/shutdown, credit accounting, CID routing, PATCH, DELETE, or hotplug coverage.

Closes #593

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test executable_hvf_e2e`
- `scripts/run-integration-tests.sh`
- `cargo run -p bangbang -- --help`
- `git diff --check`
