### PR TITLE
test: cover no-api config-file vsock startup listener

### DIFF
--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -393,6 +393,7 @@ mod macos_arm64 {
         let config_path = test_dir.path().join("vm-config.json");
         let backing_path = test_dir.path().join("data.img");
         let logger_path = test_dir.path().join("logger.out");
+        let uds_path = test_dir.path().join("no-api-config-file-vsock.sock");
         let kernel_path = env_path(BANGBANG_GUEST_KERNEL_PATH_ENV);
         let initrd_path = env_path(BANGBANG_GUEST_INITRD_PATH_ENV);
         let instance_id = test_dir.instance_id();
@@ -404,6 +405,7 @@ mod macos_arm64 {
         let boot_args_json = json_string(GUEST_BOOT_ARGS);
         let backing_path_json = json_string(path_text(&backing_path));
         let logger_path_json = json_string(path_text(&logger_path));
+        let uds_path_json = json_string(path_text(&uds_path));
         let config = format!(
             r#"{{
                 "machine-config": {{"vcpu_count": 1, "mem_size_mib": 256}},
@@ -418,6 +420,7 @@ mod macos_arm64 {
                     "is_root_device": false,
                     "is_read_only": false
                 }}],
+                "vsock": {{"guest_cid": 3, "uds_path": {uds_path_json}}},
                 "logger": {{"log_path": {logger_path_json}}}
             }}"#
         );
@@ -433,6 +436,12 @@ mod macos_arm64 {
             !socket_path.exists(),
             "no-api config-file startup must not publish an API socket"
         );
+        UnixStream::connect(&uds_path).unwrap_or_else(|err| {
+            panic!(
+                "no-api config-file startup should bind the configured vsock listener at {}: {err}",
+                uds_path.display()
+            )
+        });
 
         if let Err(err) =
             wait_for_file_prefix_marker(&backing_path, BLOCK_WRITE_MARKER, GUEST_EXECUTION_TIMEOUT)
@@ -449,6 +458,10 @@ mod macos_arm64 {
             bangbang.terminate(),
             &socket_path,
             "bangbang no-api config file",
+        );
+        assert!(
+            !uds_path.exists(),
+            "bangbang no-api config-file shutdown should remove its owned vsock listener path"
         );
     }
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -176,9 +176,10 @@ API or a Firecracker-shaped config file depending on the scenario, and waits for
 the guest to write deterministic markers to host-observable outputs. The
 tiny-initrd scenarios write `BANGBANG_BLOCK_WRITE_OK` to scratch block backing
 files. The API-request scenario also verifies the configured serial output file.
-The API-request and API-enabled config-file scenarios verify vsock listener
-binding during startup and owned vsock listener cleanup on shutdown. The same
-scenarios verify metrics and logger outputs after runtime `FlushMetrics`. The
+The API-request, API-enabled config-file, and no-api config-file scenarios
+verify vsock listener binding during startup and owned vsock listener cleanup
+on shutdown. The API-request and API-enabled config-file scenarios verify
+metrics and logger outputs after runtime `FlushMetrics`. The
 direct-rootfs scenarios boot the generated ext4 rootfs without an initrd and
 write `BANGBANG_DIRECT_ROOTFS_BLOCK_OK` through a second writable drive. This
 verifies the public process/API/config-file/HVF path, including public serial


### PR DESCRIPTION
## Summary

- Extend the signed executable no-api config-file HVF e2e scenario with a Firecracker-shaped `vsock` section.
- Verify no-api startup still keeps the API socket unpublished while binding a connectable `uds_path` listener.
- Verify normal shutdown removes the owned no-api vsock listener path and update testing docs to describe this coverage.

## Scope

- No API-enabled `GET /vm/config` changes.
- No guest-visible vsock traffic, host `CONNECT` handshake, RW forwarding, reset/shutdown semantics, credit accounting, CID routing, PATCH, DELETE, or hotplug coverage.

Closes #595

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test executable_hvf_e2e`
- `scripts/run-integration-tests.sh`
- `cargo run -p bangbang -- --help`
- `git diff --check`
