### PR TITLE
test: cover executable drive writeback cache type

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -256,6 +256,48 @@ fn executable_configures_vm_before_start() {
 }
 
 #[test]
+fn executable_configures_writeback_drive_cache_type() {
+    let test_dir = TestDir::new();
+    let socket_path = test_dir.path().join("api.socket");
+    let drive_path = test_dir.path().join("writeback.img");
+    let instance_id = test_dir.instance_id();
+    let bangbang = BangbangProcess::start(&socket_path, &instance_id);
+
+    let drive_path_json = json_string(path_text(&drive_path));
+    let drive_body = format!(
+        r#"{{
+            "drive_id":"cache",
+            "path_on_host":{drive_path_json},
+            "is_root_device":false,
+            "is_read_only":false,
+            "cache_type":"Writeback"
+        }}"#
+    );
+    let drive_response = http_put_json(&socket_path, "/drives/cache", &drive_body);
+    assert_no_content_response(&drive_response, "PUT /drives/cache");
+
+    let vm_config = http_get(&socket_path, "/vm/config");
+    assert_ok_response(&vm_config, "GET /vm/config after writeback drive");
+    assert_response_contains(
+        &vm_config,
+        r#""drive_id":"cache""#,
+        "GET /vm/config after writeback drive",
+    );
+    assert_response_contains(
+        &vm_config,
+        &format!(r#""path_on_host":{drive_path_json}"#),
+        "GET /vm/config after writeback drive",
+    );
+    assert_response_contains(
+        &vm_config,
+        r#""cache_type":"Writeback""#,
+        "GET /vm/config after writeback drive",
+    );
+
+    assert_clean_shutdown(bangbang.terminate(), &socket_path, "bangbang");
+}
+
+#[test]
 fn executable_configures_network_and_mmds() {
     let test_dir = TestDir::new();
     let socket_path = test_dir.path().join("api.socket");


### PR DESCRIPTION
## Summary

- Add a focused process-level executable e2e test for `PUT /drives/cache` with `cache_type=Writeback`.
- Verify the real Unix-socket API stores and returns the writeback cache type through `GET /vm/config`.
- Keep guest-visible flush, drive update, rate limiter, async I/O, and vhost-user-block behavior out of scope.

Closes #597

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p bangbang --test process_e2e --all-features --locked`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`
