### PR TITLE
test: cover config-file rejected drive socket

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -139,6 +139,48 @@ fn executable_no_api_config_file_failure_does_not_publish_socket() {
 }
 
 #[test]
+fn executable_config_file_rejected_drive_socket_does_not_publish_socket() {
+    let test_dir = TestDir::new();
+    let socket_path = test_dir.path().join("api.socket");
+    let (config_path, private_socket_path) = write_rejected_drive_socket_config(&test_dir);
+    let instance_id = test_dir.instance_id();
+
+    let output = BangbangProcess::start_with_extra_args_expect_failure(
+        &socket_path,
+        &instance_id,
+        &["--config-file", path_text(&config_path)],
+    );
+
+    assert_rejected_drive_socket_config_failure(
+        &output,
+        &socket_path,
+        &private_socket_path,
+        "config-file rejected drive socket",
+    );
+}
+
+#[test]
+fn executable_no_api_config_file_rejected_drive_socket_does_not_publish_socket() {
+    let test_dir = TestDir::new();
+    let socket_path = test_dir.path().join("api.socket");
+    let (config_path, private_socket_path) = write_rejected_drive_socket_config(&test_dir);
+    let instance_id = test_dir.instance_id();
+
+    let output = BangbangProcess::start_with_extra_args_expect_failure(
+        &socket_path,
+        &instance_id,
+        &["--config-file", path_text(&config_path), "--no-api"],
+    );
+
+    assert_rejected_drive_socket_config_failure(
+        &output,
+        &socket_path,
+        &private_socket_path,
+        "no-api config-file rejected drive socket",
+    );
+}
+
+#[test]
 fn executable_configures_vm_before_start() {
     let test_dir = TestDir::new();
     let socket_path = test_dir.path().join("api.socket");
@@ -800,6 +842,81 @@ fn concurrent_executables_keep_api_sockets_isolated() {
     let second_output = second_bangbang.terminate();
     assert_clean_shutdown(first_output, &first_socket_path, "first bangbang");
     assert_clean_shutdown(second_output, &second_socket_path, "second bangbang");
+}
+
+fn write_rejected_drive_socket_config(
+    test_dir: &TestDir,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let config_path = test_dir.path().join("vm-config.json");
+    let drive_path = test_dir.path().join("drive.img");
+    let private_socket_path = test_dir.path().join("private-vhost.sock");
+    let drive_path_json = json_string(path_text(&drive_path));
+    let private_socket_path_json = json_string(path_text(&private_socket_path));
+    let config = format!(
+        r#"{{
+            "boot-source": {{"kernel_image_path": "/tmp/vmlinux"}},
+            "drives": [{{
+                "drive_id": "rootfs",
+                "path_on_host": {drive_path_json},
+                "is_root_device": true,
+                "socket": {private_socket_path_json}
+            }}]
+        }}"#
+    );
+    fs::write(&config_path, config).expect("config file should be written");
+
+    (config_path, private_socket_path)
+}
+
+fn assert_rejected_drive_socket_config_failure(
+    output: &support::CompletedProcess,
+    socket_path: &std::path::Path,
+    private_socket_path: &std::path::Path,
+    case_name: &str,
+) {
+    assert!(
+        !output.status.success(),
+        "{case_name} should fail startup; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        output.stdout,
+        output.stderr
+    );
+    assert!(
+        !socket_path.exists(),
+        "{case_name} should fail before API socket publication"
+    );
+    assert!(
+        !output.stdout.contains("status: API server listening"),
+        "{case_name} must not report API readiness; stdout:\n{}",
+        output.stdout
+    );
+    assert!(
+        !output.stdout.contains("status: VM running without API"),
+        "{case_name} must not report no-api readiness; stdout:\n{}",
+        output.stdout
+    );
+    assert!(
+        output
+            .stderr
+            .contains("bangbang: config-file error: failed to apply config-file action: drive socket is not supported"),
+        "{case_name} stderr should describe config-file drive socket rejection; stderr:\n{}",
+        output.stderr
+    );
+    let private_socket_path_text = path_text(private_socket_path);
+    assert!(
+        !output.stdout.contains(private_socket_path_text),
+        "{case_name} stdout must not echo private drive socket path; stdout:\n{}",
+        output.stdout
+    );
+    assert!(
+        !output.stderr.contains(private_socket_path_text),
+        "{case_name} stderr must not echo private drive socket path; stderr:\n{}",
+        output.stderr
+    );
+    assert!(
+        !private_socket_path.exists(),
+        "{case_name} must not create rejected drive socket path"
+    );
 }
 
 fn assert_instance_info_matches(


### PR DESCRIPTION
## Summary
- Add process-level coverage for config files that reject unsupported drive socket configuration before API publication.
- Cover both API-enabled startup and `--no-api` startup paths.
- Assert the rejected private drive socket path is neither created nor echoed in process output.

Closes #601

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p bangbang --test process_e2e --all-features --locked`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`