### PR TITLE
feat: accept startup time cli arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ cargo run -p bangbang -- --api-sock /tmp/bangbang.socket --id demo-1
   request size. The default is `51200` bytes.
 - `--id <ID>` records the microVM identifier. The default is
   `anonymous-instance`.
+- `--start-time-us <MICROS>`, `--start-time-cpu-us <MICROS>`, and
+  `--parent-cpu-time-us <MICROS>` accept Firecracker launcher timing values for
+  future metrics integration; the current minimal metrics output does not report
+  them yet.
 - `--metrics-path <PATH>` configures the same per-process metrics sink as
   `PUT /metrics` before the API socket is served.
 - `--mmds-size-limit <BYTES>` sets the maximum serialized MMDS data-store size.

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -1619,6 +1619,29 @@ mod tests {
     }
 
     #[test]
+    fn parse_max_startup_time_args() {
+        let max_value = u64::MAX.to_string();
+        let config = parse_run(&[
+            "--start-time-us",
+            &max_value,
+            "--start-time-cpu-us",
+            &max_value,
+            "--parent-cpu-time-us",
+            &max_value,
+        ])
+        .expect("maximum startup timing args should parse");
+
+        assert_eq!(
+            config.startup_time,
+            StartupTimeConfig {
+                start_time_us: Some(u64::MAX),
+                start_time_cpu_us: Some(u64::MAX),
+                parent_cpu_time_us: Some(u64::MAX),
+            }
+        );
+    }
+
+    #[test]
     fn parse_startup_args_together() {
         let config = parse_run(&[
             "--api-sock",

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -39,11 +39,8 @@ const UNSUPPORTED_FIRECRACKER_ARGS: &[&str] = &[
     "describe-snapshot",
     "enable-pci",
     "no-seccomp",
-    "parent-cpu-time-us",
     "seccomp-filter",
     "snapshot-version",
-    "start-time-cpu-us",
-    "start-time-us",
 ];
 
 fn main() -> ExitCode {
@@ -82,7 +79,15 @@ fn run() -> Result<(), ProcessError> {
                 metadata,
                 metrics_config,
                 no_api,
+                startup_time,
             } = config;
+            // Accepted for Firecracker-compatible launchers; reporting is deferred
+            // until full process startup metrics are implemented.
+            let StartupTimeConfig {
+                start_time_us: _,
+                start_time_cpu_us: _,
+                parent_cpu_time_us: _,
+            } = startup_time;
 
             println!("bangbang {}", env!("CARGO_PKG_VERSION"));
             println!(
@@ -679,6 +684,14 @@ struct StartupConfig {
     metadata: Option<String>,
     metrics_config: Option<MetricsConfigInput>,
     no_api: bool,
+    startup_time: StartupTimeConfig,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct StartupTimeConfig {
+    start_time_us: Option<u64>,
+    start_time_cpu_us: Option<u64>,
+    parent_cpu_time_us: Option<u64>,
 }
 
 impl Default for StartupConfig {
@@ -693,6 +706,7 @@ impl Default for StartupConfig {
             metadata: None,
             metrics_config: None,
             no_api: false,
+            startup_time: StartupTimeConfig::default(),
         }
     }
 }
@@ -763,8 +777,11 @@ impl Args {
         let mut metrics_path_seen = false;
         let mut module_seen = false;
         let mut no_api_seen = false;
+        let mut parent_cpu_time_us_seen = false;
         let mut show_level_seen = false;
         let mut show_log_origin_seen = false;
+        let mut start_time_cpu_us_seen = false;
+        let mut start_time_us_seen = false;
         let mut index = 0;
 
         while let Some(arg) = args.get(index) {
@@ -858,6 +875,16 @@ impl Args {
                     no_api_seen = true;
                     index += 1;
                 }
+                "--parent-cpu-time-us" => {
+                    if parent_cpu_time_us_seen {
+                        return Err("duplicate argument: --parent-cpu-time-us".to_string());
+                    }
+                    let value = take_value(&args, index, "--parent-cpu-time-us")?;
+                    config.startup_time.parent_cpu_time_us =
+                        Some(parse_startup_time_us(&value, "parent-cpu-time-us")?);
+                    parent_cpu_time_us_seen = true;
+                    index += 2;
+                }
                 "--metrics-path" => {
                     if metrics_path_seen {
                         return Err("duplicate argument: --metrics-path".to_string());
@@ -894,6 +921,26 @@ impl Args {
                     logger_config_seen = true;
                     show_log_origin_seen = true;
                     index += 1;
+                }
+                "--start-time-cpu-us" => {
+                    if start_time_cpu_us_seen {
+                        return Err("duplicate argument: --start-time-cpu-us".to_string());
+                    }
+                    let value = take_value(&args, index, "--start-time-cpu-us")?;
+                    config.startup_time.start_time_cpu_us =
+                        Some(parse_startup_time_us(&value, "start-time-cpu-us")?);
+                    start_time_cpu_us_seen = true;
+                    index += 2;
+                }
+                "--start-time-us" => {
+                    if start_time_us_seen {
+                        return Err("duplicate argument: --start-time-us".to_string());
+                    }
+                    let value = take_value(&args, index, "--start-time-us")?;
+                    config.startup_time.start_time_us =
+                        Some(parse_startup_time_us(&value, "start-time-us")?);
+                    start_time_us_seen = true;
+                    index += 2;
                 }
                 other => {
                     if let Some(name) = unsupported_flag_equals_syntax(other) {
@@ -968,6 +1015,12 @@ fn help_text() -> String {
             "      --no-api          Start from --config-file without publishing an API socket\n",
             "      --show-level       Include level in minimal logger action lines\n",
             "      --show-log-origin  Include callsite origin in minimal logger action lines\n",
+            "      --start-time-us <MICROS>\n",
+            "                         Process start wall-clock time for future metrics\n",
+            "      --start-time-cpu-us <MICROS>\n",
+            "                         Process start CPU time for future metrics\n",
+            "      --parent-cpu-time-us <MICROS>\n",
+            "                         Parent process CPU time for future metrics\n",
             "  -V, --version          Print version\n",
             "  -h, --help             Print help\n\n",
             "Current scope:\n",
@@ -1043,6 +1096,12 @@ fn parse_mmds_size_limit(value: &str) -> Result<usize, String> {
     parse_positive_usize_arg(value, "mmds-size-limit")
 }
 
+fn parse_startup_time_us(value: &str, name: &str) -> Result<u64, String> {
+    value
+        .parse::<u64>()
+        .map_err(|_| format!("invalid --{name}: value must be a non-negative integer"))
+}
+
 fn parse_positive_usize_arg(value: &str, name: &str) -> Result<usize, String> {
     let parsed = value
         .parse::<usize>()
@@ -1103,6 +1162,9 @@ fn unsupported_equals_syntax(arg: &str) -> Option<&'static str> {
         ("--metrics-path=", "metrics-path"),
         ("--mmds-size-limit=", "mmds-size-limit"),
         ("--module=", "module"),
+        ("--parent-cpu-time-us=", "parent-cpu-time-us"),
+        ("--start-time-cpu-us=", "start-time-cpu-us"),
+        ("--start-time-us=", "start-time-us"),
     ]
     .into_iter()
     .find_map(|(prefix, name)| arg.starts_with(prefix).then_some(name))
@@ -1134,7 +1196,7 @@ mod tests {
     use super::{
         ApiServerError, Args, Command, DEFAULT_API_SOCK_PATH, DEFAULT_INSTANCE_ID,
         HTTP_MAX_PAYLOAD_SIZE, MAX_INSTANCE_ID_LEN, ProcessError, ProcessExitCode, StartupConfig,
-        parse_process_args,
+        StartupTimeConfig, parse_process_args,
     };
 
     #[derive(Debug, Clone)]
@@ -1298,6 +1360,7 @@ mod tests {
         assert_eq!(config.metrics_config, None);
         assert_eq!(config.metadata, None);
         assert!(!config.no_api);
+        assert_eq!(config.startup_time, StartupTimeConfig::default());
     }
 
     #[test]
@@ -1333,6 +1396,9 @@ mod tests {
         assert!(help.contains("--no-api"));
         assert!(help.contains("without publishing an API socket"));
         assert!(help.contains("--show-level"));
+        assert!(help.contains("--start-time-us <MICROS>"));
+        assert!(help.contains("--start-time-cpu-us <MICROS>"));
+        assert!(help.contains("--parent-cpu-time-us <MICROS>"));
         assert!(help.contains("PUT /actions starts a process-owned HVF boot run-loop worker"));
         assert!(help.contains("across bounded step windows for InstanceStart"));
         assert!(help.contains("public run-loop control is not implemented yet"));
@@ -1509,6 +1575,50 @@ mod tests {
     }
 
     #[test]
+    fn parse_startup_time_args() {
+        let config = parse_run(&[
+            "--start-time-us",
+            "1000",
+            "--start-time-cpu-us",
+            "2000",
+            "--parent-cpu-time-us",
+            "3000",
+        ])
+        .expect("startup timing args should parse");
+
+        assert_eq!(
+            config.startup_time,
+            StartupTimeConfig {
+                start_time_us: Some(1000),
+                start_time_cpu_us: Some(2000),
+                parent_cpu_time_us: Some(3000),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_zero_startup_time_args() {
+        let config = parse_run(&[
+            "--start-time-us",
+            "0",
+            "--start-time-cpu-us",
+            "0",
+            "--parent-cpu-time-us",
+            "0",
+        ])
+        .expect("zero startup timing args should parse");
+
+        assert_eq!(
+            config.startup_time,
+            StartupTimeConfig {
+                start_time_us: Some(0),
+                start_time_cpu_us: Some(0),
+                parent_cpu_time_us: Some(0),
+            }
+        );
+    }
+
+    #[test]
     fn parse_startup_args_together() {
         let config = parse_run(&[
             "--api-sock",
@@ -1525,6 +1635,12 @@ mod tests {
             "/tmp/mmds.json",
             "--metrics-path",
             "/tmp/bangbang.metrics",
+            "--start-time-us",
+            "1000",
+            "--start-time-cpu-us",
+            "2000",
+            "--parent-cpu-time-us",
+            "3000",
         ])
         .expect("startup args should parse");
 
@@ -1541,6 +1657,14 @@ mod tests {
         assert_eq!(
             config.metrics_config,
             Some(MetricsConfigInput::new("/tmp/bangbang.metrics"))
+        );
+        assert_eq!(
+            config.startup_time,
+            StartupTimeConfig {
+                start_time_us: Some(1000),
+                start_time_cpu_us: Some(2000),
+                parent_cpu_time_us: Some(3000),
+            }
         );
     }
 
@@ -1612,6 +1736,23 @@ mod tests {
             parse(&["--metrics-path", "--id"]).expect_err("missing metrics path value should fail");
 
         assert_eq!(err, "missing value for --metrics-path");
+    }
+
+    #[test]
+    fn rejects_missing_startup_time_values() {
+        let err = parse(&["--start-time-us", "--id"]).expect_err("missing start time should fail");
+
+        assert_eq!(err, "missing value for --start-time-us");
+
+        let err = parse(&["--start-time-cpu-us", "--id"])
+            .expect_err("missing start CPU time should fail");
+
+        assert_eq!(err, "missing value for --start-time-cpu-us");
+
+        let err = parse(&["--parent-cpu-time-us", "--id"])
+            .expect_err("missing parent CPU time should fail");
+
+        assert_eq!(err, "missing value for --parent-cpu-time-us");
     }
 
     #[test]
@@ -1781,6 +1922,50 @@ mod tests {
         .expect_err("duplicate metrics-path arg should fail");
 
         assert_eq!(err, "duplicate argument: --metrics-path");
+    }
+
+    #[test]
+    fn rejects_duplicate_startup_time_args() {
+        let err = parse(&["--start-time-us", "1", "--start-time-us", "2"])
+            .expect_err("duplicate start time should fail");
+
+        assert_eq!(err, "duplicate argument: --start-time-us");
+
+        let err = parse(&["--start-time-cpu-us", "1", "--start-time-cpu-us", "2"])
+            .expect_err("duplicate start CPU time should fail");
+
+        assert_eq!(err, "duplicate argument: --start-time-cpu-us");
+
+        let err = parse(&["--parent-cpu-time-us", "1", "--parent-cpu-time-us", "2"])
+            .expect_err("duplicate parent CPU time should fail");
+
+        assert_eq!(err, "duplicate argument: --parent-cpu-time-us");
+    }
+
+    #[test]
+    fn rejects_invalid_startup_time_args() {
+        let err = parse(&["--start-time-us", "-1"]).expect_err("negative start time should fail");
+
+        assert_eq!(
+            err,
+            "invalid --start-time-us: value must be a non-negative integer"
+        );
+
+        let err = parse(&["--start-time-cpu-us", "abc"])
+            .expect_err("non-numeric start CPU time should fail");
+
+        assert_eq!(
+            err,
+            "invalid --start-time-cpu-us: value must be a non-negative integer"
+        );
+
+        let err = parse(&["--parent-cpu-time-us", "999999999999999999999999999999"])
+            .expect_err("overflowing parent CPU time should fail");
+
+        assert_eq!(
+            err,
+            "invalid --parent-cpu-time-us: value must be a non-negative integer"
+        );
     }
 
     #[test]
@@ -1977,6 +2162,27 @@ mod tests {
         assert_eq!(
             err,
             "unsupported argument syntax for --metadata; use --metadata <VALUE>"
+        );
+
+        let err = parse(&["--start-time-us=1000"]).expect_err("equals syntax should fail");
+
+        assert_eq!(
+            err,
+            "unsupported argument syntax for --start-time-us; use --start-time-us <VALUE>"
+        );
+
+        let err = parse(&["--start-time-cpu-us=2000"]).expect_err("equals syntax should fail");
+
+        assert_eq!(
+            err,
+            "unsupported argument syntax for --start-time-cpu-us; use --start-time-cpu-us <VALUE>"
+        );
+
+        let err = parse(&["--parent-cpu-time-us=3000"]).expect_err("equals syntax should fail");
+
+        assert_eq!(
+            err,
+            "unsupported argument syntax for --parent-cpu-time-us; use --parent-cpu-time-us <VALUE>"
         );
     }
 

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -61,6 +61,40 @@ fn executable_serves_api_and_shuts_down_cleanly() {
 }
 
 #[test]
+fn executable_accepts_firecracker_startup_time_args() {
+    let test_dir = TestDir::new();
+    let socket_path = test_dir.path().join("api.socket");
+    let instance_id = test_dir.instance_id();
+    let bangbang = BangbangProcess::start_with_extra_args(
+        &socket_path,
+        &instance_id,
+        &[
+            "--start-time-us",
+            "1000",
+            "--start-time-cpu-us",
+            "2000",
+            "--parent-cpu-time-us",
+            "3000",
+        ],
+    );
+
+    let instance_info = http_get(&socket_path, "/");
+    assert_ok_response(&instance_info, "GET / with startup time args");
+    assert_response_contains(
+        &instance_info,
+        &format!(r#""id":"{instance_id}""#),
+        "GET / with startup time args",
+    );
+    assert_response_contains(
+        &instance_info,
+        r#""state":"Not started""#,
+        "GET / with startup time args",
+    );
+
+    assert_clean_shutdown(bangbang.terminate(), &socket_path, "bangbang");
+}
+
+#[test]
 fn executable_config_file_failure_does_not_publish_socket() {
     let test_dir = TestDir::new();
     let socket_path = test_dir.path().join("api.socket");

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -124,6 +124,9 @@ control yet.
 | `--api-sock <PATH>` | binds the API Unix socket | Firecracker defaults to `/run/firecracker.socket`; bangbang defaults to `/tmp/bangbang.socket` because macOS does not normally provide `/run`. This is an intentional host-platform difference. |
 | `--http-api-max-payload-size <BYTES>` | configures the maximum accepted HTTP API request size | Defaults to Firecracker's `51200` byte limit. The configured value applies to API socket reads and final request parsing. Zero, malformed, duplicate, and equals-syntax values are rejected during argument parsing. |
 | `--id <ID>` | parsed and stored | Defaults to Firecracker's `anonymous-instance`. IDs must be 1 to 64 bytes and contain only ASCII alphanumeric characters or `-`. |
+| `--start-time-us <MICROS>` | parsed and stored for future metrics | Accepts non-negative `u64` microsecond values passed by Firecracker-style launchers. Full `ProcessTimeReporter` integration and metrics output remain deferred. |
+| `--start-time-cpu-us <MICROS>` | parsed and stored for future metrics | Accepts non-negative `u64` microsecond values passed by Firecracker-style launchers. Full `ProcessTimeReporter` integration and metrics output remain deferred. |
+| `--parent-cpu-time-us <MICROS>` | parsed and stored for future metrics | Accepts non-negative `u64` microsecond values passed by Firecracker-style launchers. Full `ProcessTimeReporter` integration and metrics output remain deferred. |
 | `--metrics-path <PATH>` | configures metrics output before API serving | Uses the same per-process metrics sink and redacted host-path error policy as `PUT /metrics`. A later duplicate `PUT /metrics` request fails without replacing this sink. |
 | `--log-path <PATH>` | configures logger output before API serving | Uses the same per-process logger sink and redacted host-path error policy as `PUT /logger`. |
 | `--level <LEVEL>` | configures logger level before API serving | Accepts the existing logger levels `Off`, `Trace`, `Debug`, `Info`, `Warn`, `Warning`, and `Error`; minimal action logs are emitted only when the configured level allows `Info`. |
@@ -137,6 +140,10 @@ control yet.
 | `--version`, `-V` | prints version | `-V` is retained from the existing bangbang scaffold. |
 | `--no-api` | config-file startup without API socket | Requires `--config-file`. Starts the supported config-file subset without binding or publishing the configured API socket, then waits for handled `SIGINT` or `SIGTERM`. Runtime control, guest-initiated shutdown, and no-api exit-code parity remain deferred. |
 | seccomp, snapshot, boot timer, and PCI process flags | rejected | These Firecracker options are Linux-specific or tied to later capability work. |
+
+Startup timing arguments are intentionally retained without being exposed in
+`GET /vm/config`, logs, or the current minimal metrics output. They reserve the
+Firecracker-compatible process input shape for a later metrics parity change.
 
 bangbang intentionally treats `--id` alphanumeric characters as ASCII only.
 This is stricter than Firecracker `v1.16.0`'s Rust validator, which accepts


### PR DESCRIPTION
## Summary

- Accept Firecracker startup timing arguments: `--start-time-us`, `--start-time-cpu-us`, and `--parent-cpu-time-us`.
- Store the parsed `u64` microsecond values in startup configuration for future metrics integration without changing runtime metrics output.
- Cover valid, zero, duplicate, missing, malformed, overflow, equals-syntax, and executable startup behavior.
- Document the accepted-but-not-yet-reported compatibility boundary.

Closes #607

## Scope Exclusions

- Does not implement Firecracker `ProcessTimeReporter` parity.
- Does not add new metrics fields or logger output.
- Does not implement a jailer.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test -p bangbang --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `git diff --check`
