### PR TITLE
feat: reject oversized machine memory config

### DIFF
--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -1072,6 +1072,7 @@ mod tests {
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     use bangbang_runtime::logger::{LoggerConfigInput, LoggerWriteError};
+    use bangbang_runtime::machine::MAX_MEM_SIZE_MIB;
     use bangbang_runtime::metrics::{
         BootRunLoopMetricStatus, MetricsConfigInput, MetricsDiagnostics,
     };
@@ -1805,6 +1806,30 @@ mod tests {
         assert_eq!(vmm.machine_config().mem_size_mib(), 256);
         assert!(!vmm.machine_config().track_dirty_pages());
 
+        let oversized_mem_size_mib = MAX_MEM_SIZE_MIB + 1;
+        let oversized_body =
+            format!(r#"{{"vcpu_count":4,"mem_size_mib":{oversized_mem_size_mib}}}"#);
+        let oversized_request = format!(
+            "PUT /machine-config HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{oversized_body}",
+            oversized_body.len()
+        );
+
+        let response = handle_request_bytes(oversized_request.as_bytes(), &mut vmm);
+
+        assert_eq!(
+            response.status(),
+            bangbang_api::http::StatusCode::BadRequest
+        );
+        assert_eq!(
+            response.body(),
+            format!(
+                r#"{{"fault_message":"machine mem_size_mib must be in 1..={MAX_MEM_SIZE_MIB}"}}"#
+            )
+        );
+        assert_eq!(vmm.machine_config().vcpu_count(), 2);
+        assert_eq!(vmm.machine_config().mem_size_mib(), 256);
+        assert!(!vmm.machine_config().track_dirty_pages());
+
         let invalid_patch_body = r#"{"mem_size_mib":0}"#;
         let invalid_patch_request = format!(
             "PATCH /machine-config HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{invalid_patch_body}",
@@ -1820,6 +1845,28 @@ mod tests {
         assert_eq!(
             response.body(),
             r#"{"fault_message":"Malformed HTTP request."}"#
+        );
+        assert_eq!(vmm.machine_config().vcpu_count(), 2);
+        assert_eq!(vmm.machine_config().mem_size_mib(), 256);
+        assert!(!vmm.machine_config().track_dirty_pages());
+
+        let oversized_patch_body = format!(r#"{{"mem_size_mib":{oversized_mem_size_mib}}}"#);
+        let oversized_patch_request = format!(
+            "PATCH /machine-config HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{oversized_patch_body}",
+            oversized_patch_body.len()
+        );
+
+        let response = handle_request_bytes(oversized_patch_request.as_bytes(), &mut vmm);
+
+        assert_eq!(
+            response.status(),
+            bangbang_api::http::StatusCode::BadRequest
+        );
+        assert_eq!(
+            response.body(),
+            format!(
+                r#"{{"fault_message":"machine mem_size_mib must be in 1..={MAX_MEM_SIZE_MIB}"}}"#
+            )
         );
         assert_eq!(vmm.machine_config().vcpu_count(), 2);
         assert_eq!(vmm.machine_config().mem_size_mib(), 256);

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -1198,6 +1198,7 @@ mod tests {
 
     use bangbang_runtime::boot::BootSourceConfigInput;
     use bangbang_runtime::logger::{LoggerConfigError, LoggerConfigInput, LoggerLevel};
+    use bangbang_runtime::machine::{MAX_MEM_SIZE_MIB, MachineConfigError};
     use bangbang_runtime::metrics::{MetricsConfigError, MetricsConfigInput};
     use bangbang_runtime::mmds::MmdsDataStoreError;
     use bangbang_runtime::serial::SerialConfigError;
@@ -2321,6 +2322,45 @@ mod tests {
         .expect_err("missing boot-source should fail");
 
         assert_eq!(err, super::ConfigFileError::MissingSection("boot-source"));
+    }
+
+    #[test]
+    fn config_file_rejects_oversized_machine_config_before_starting() {
+        let config_path = unique_config_path("oversized-machine-config");
+        let oversized_mem_size_mib = MAX_MEM_SIZE_MIB + 1;
+        let config = format!(
+            r#"{{
+                "machine-config":{{"vcpu_count":1,"mem_size_mib":{oversized_mem_size_mib}}},
+                "boot-source":{{"kernel_image_path":"/tmp/vmlinux"}}
+            }}"#
+        );
+        fs::write(&config_path, config).expect("config file should be written");
+        let mut vmm = ProcessVmm::with_starter(
+            "demo-1",
+            env!("CARGO_PKG_VERSION"),
+            "bangbang",
+            TestInstanceStarter,
+        );
+
+        let err = super::apply_startup_config_file(
+            &mut vmm,
+            Some(config_path.to_str().expect("UTF-8 path")),
+        )
+        .expect_err("oversized machine config should fail");
+
+        assert!(matches!(
+            err,
+            ProcessError::ConfigFile(super::ConfigFileError::Apply(
+                bangbang_runtime::VmmActionError::MachineConfig(
+                    MachineConfigError::InvalidMemorySize
+                )
+            ))
+        ));
+        assert_eq!(vmm.instance_info().state, InstanceState::NotStarted);
+        assert!(!vmm.has_started_session());
+        assert_eq!(vmm.machine_config().mem_size_mib(), 128);
+
+        fs::remove_file(config_path).expect("fixture config should clean up");
     }
 
     #[test]

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -18,6 +18,8 @@ use support::{
     http_put_json, json_string, path_text,
 };
 
+use bangbang_runtime::machine::MAX_MEM_SIZE_MIB;
+
 const BANGBANG_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[test]
@@ -893,6 +895,32 @@ fn executable_serves_and_patches_machine_config() {
         &patched_config,
         r#""track_dirty_pages":false"#,
         "GET /machine-config patched",
+    );
+
+    let oversized_mem_size_mib = MAX_MEM_SIZE_MIB + 1;
+    let oversized_put_response = http_put_json(
+        &socket_path,
+        "/machine-config",
+        &format!(r#"{{"vcpu_count":4,"mem_size_mib":{oversized_mem_size_mib}}}"#),
+    );
+    assert_bad_request_response(&oversized_put_response, "PUT /machine-config oversized");
+    assert_response_contains(
+        &oversized_put_response,
+        &format!(r#"{{"fault_message":"machine mem_size_mib must be in 1..={MAX_MEM_SIZE_MIB}"}}"#),
+        "PUT /machine-config oversized",
+    );
+
+    let oversized_patch_response = http_json(
+        &socket_path,
+        "PATCH",
+        "/machine-config",
+        &format!(r#"{{"mem_size_mib":{oversized_mem_size_mib}}}"#),
+    );
+    assert_bad_request_response(&oversized_patch_response, "PATCH /machine-config oversized");
+    assert_response_contains(
+        &oversized_patch_response,
+        &format!(r#"{{"fault_message":"machine mem_size_mib must be in 1..={MAX_MEM_SIZE_MIB}"}}"#),
+        "PATCH /machine-config oversized",
     );
 
     let invalid_patch_response = http_json(

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -674,8 +674,8 @@ mod tests {
         },
         logger::{LoggerConfigError, LoggerConfigInput, LoggerLevel, LoggerWriteError},
         machine::{
-            DEFAULT_MEM_SIZE_MIB, DEFAULT_VCPU_COUNT, MachineConfigError, MachineConfigInput,
-            MachineConfigPatchInput,
+            DEFAULT_MEM_SIZE_MIB, DEFAULT_VCPU_COUNT, MAX_MEM_SIZE_MIB, MachineConfigError,
+            MachineConfigInput, MachineConfigPatchInput,
         },
         metrics::{MetricsConfigError, MetricsConfigInput},
         mmds::{
@@ -2268,6 +2268,20 @@ mod tests {
         assert_eq!(err.to_string(), "machine vcpu_count must be in 1..=32");
         assert_eq!(controller.machine_config().vcpu_count(), 2);
         assert_eq!(controller.machine_config().mem_size_mib(), 256);
+
+        let err = controller
+            .handle_action(VmmAction::PutMachineConfig(MachineConfigInput::new(
+                4,
+                MAX_MEM_SIZE_MIB + 1,
+            )))
+            .expect_err("oversized machine config should fail");
+
+        assert_eq!(
+            err.to_string(),
+            format!("machine mem_size_mib must be in 1..={MAX_MEM_SIZE_MIB}")
+        );
+        assert_eq!(controller.machine_config().vcpu_count(), 2);
+        assert_eq!(controller.machine_config().mem_size_mib(), 256);
     }
 
     #[test]
@@ -2344,6 +2358,19 @@ mod tests {
             .expect_err("invalid machine config patch should fail");
 
         assert_eq!(err.to_string(), "machine vcpu_count must be in 1..=32");
+        assert_eq!(controller.machine_config().vcpu_count(), 2);
+        assert_eq!(controller.machine_config().mem_size_mib(), 256);
+
+        let err = controller
+            .handle_action(VmmAction::PatchMachineConfig(
+                MachineConfigPatchInput::new().with_mem_size_mib(MAX_MEM_SIZE_MIB + 1),
+            ))
+            .expect_err("oversized machine config patch should fail");
+
+        assert_eq!(
+            err.to_string(),
+            format!("machine mem_size_mib must be in 1..={MAX_MEM_SIZE_MIB}")
+        );
         assert_eq!(controller.machine_config().vcpu_count(), 2);
         assert_eq!(controller.machine_config().mem_size_mib(), 256);
     }
@@ -3153,7 +3180,13 @@ mod tests {
         let err =
             VmmActionError::MachineConfig(super::machine::MachineConfigError::InvalidMemorySize);
 
-        assert_eq!(err.to_string(), "machine mem_size_mib must not be zero");
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "machine mem_size_mib must be in 1..={}",
+                super::machine::MAX_MEM_SIZE_MIB
+            )
+        );
         assert!(err.source().is_some());
     }
 

--- a/crates/runtime/src/machine.rs
+++ b/crates/runtime/src/machine.rs
@@ -1,10 +1,15 @@
 //! Backend-neutral machine configuration model.
 
+use crate::memory::aarch64;
+
 use std::fmt;
+
+const MIB: u64 = 1024 * 1024;
 
 pub const DEFAULT_VCPU_COUNT: u8 = 1;
 pub const DEFAULT_MEM_SIZE_MIB: u64 = 128;
 pub const MAX_SUPPORTED_VCPUS: u8 = 32;
+pub const MAX_MEM_SIZE_MIB: u64 = aarch64::DRAM_MEM_MAX_SIZE / MIB;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MachineConfigInput {
@@ -172,6 +177,18 @@ impl MachineConfig {
     pub const fn huge_pages(self) -> MachineConfigHugePages {
         self.huge_pages
     }
+
+    #[cfg(test)]
+    pub(crate) const fn new_unchecked_for_tests(vcpu_count: u8, mem_size_mib: u64) -> Self {
+        Self {
+            vcpu_count,
+            mem_size_mib,
+            smt: false,
+            cpu_template: None,
+            track_dirty_pages: false,
+            huge_pages: MachineConfigHugePages::None,
+        }
+    }
 }
 
 impl Default for MachineConfig {
@@ -194,7 +211,7 @@ impl TryFrom<MachineConfigInput> for MachineConfig {
         if input.vcpu_count == 0 || input.vcpu_count > MAX_SUPPORTED_VCPUS {
             return Err(MachineConfigError::InvalidVcpuCount);
         }
-        if input.mem_size_mib == 0 {
+        if input.mem_size_mib == 0 || input.mem_size_mib > MAX_MEM_SIZE_MIB {
             return Err(MachineConfigError::InvalidMemorySize);
         }
         if input.smt {
@@ -275,7 +292,9 @@ impl fmt::Display for MachineConfigError {
             Self::InvalidVcpuCount => {
                 write!(f, "machine vcpu_count must be in 1..={MAX_SUPPORTED_VCPUS}")
             }
-            Self::InvalidMemorySize => f.write_str("machine mem_size_mib must not be zero"),
+            Self::InvalidMemorySize => {
+                write!(f, "machine mem_size_mib must be in 1..={MAX_MEM_SIZE_MIB}")
+            }
             Self::SmtNotSupported => f.write_str("machine smt is not supported"),
             Self::UnsupportedCpuTemplate { cpu_template } => {
                 write!(f, "machine cpu_template {cpu_template} is not supported")
@@ -321,6 +340,15 @@ mod tests {
     }
 
     #[test]
+    fn accepts_maximum_machine_memory_size() {
+        let config = MachineConfigInput::new(1, MAX_MEM_SIZE_MIB)
+            .validate()
+            .expect("maximum memory size should validate");
+
+        assert_eq!(config.mem_size_mib(), MAX_MEM_SIZE_MIB);
+    }
+
+    #[test]
     fn rejects_invalid_machine_config_input() {
         for (input, expected) in [
             (
@@ -333,6 +361,14 @@ mod tests {
             ),
             (
                 MachineConfigInput::new(1, 0),
+                MachineConfigError::InvalidMemorySize,
+            ),
+            (
+                MachineConfigInput::new(1, MAX_MEM_SIZE_MIB + 1),
+                MachineConfigError::InvalidMemorySize,
+            ),
+            (
+                MachineConfigInput::new(1, u64::MAX),
                 MachineConfigError::InvalidMemorySize,
             ),
             (
@@ -401,6 +437,10 @@ mod tests {
                 MachineConfigError::InvalidMemorySize,
             ),
             (
+                MachineConfigPatchInput::new().with_mem_size_mib(MAX_MEM_SIZE_MIB + 1),
+                MachineConfigError::InvalidMemorySize,
+            ),
+            (
                 MachineConfigPatchInput::new().with_smt(true),
                 MachineConfigError::SmtNotSupported,
             ),
@@ -440,7 +480,7 @@ mod tests {
         );
         assert_eq!(
             MachineConfigError::InvalidMemorySize.to_string(),
-            "machine mem_size_mib must not be zero"
+            format!("machine mem_size_mib must be in 1..={MAX_MEM_SIZE_MIB}")
         );
         assert_eq!(
             MachineConfigError::SmtNotSupported.to_string(),

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -1340,7 +1340,7 @@ mod tests {
     };
     use crate::fdt::{Arm64FdtError, Arm64FdtGic, Arm64FdtRegion, Arm64FdtTimerInterrupts};
     use crate::interrupt::{DeviceInterruptKind, GuestInterruptLine};
-    use crate::machine::MachineConfigInput;
+    use crate::machine::{MachineConfig, MachineConfigInput};
     use crate::memory::{GuestAddress, aarch64};
     use crate::mmio::{
         MmioAccessBytes, MmioBusError, MmioDispatchOutcome, MmioDispatcher, MmioOperation,
@@ -4785,15 +4785,11 @@ mod tests {
     }
 
     #[test]
-    fn oversized_memory_fails_before_boot_source_load() {
+    fn memory_size_bytes_rejects_oversized_unchecked_config() {
         let mem_size_mib = aarch64::DRAM_MEM_MAX_SIZE / MIB + 1;
-        let controller = controller_with_kernel_and_memory(
-            &missing_path("oversized-memory-kernel"),
-            mem_size_mib,
-        );
+        let config = MachineConfig::new_unchecked_for_tests(1, mem_size_mib);
 
-        let err = Arm64BootResources::assemble_from_controller(&controller, valid_config(&[]))
-            .expect_err("oversized memory should fail");
+        let err = super::memory_size_bytes(config).expect_err("oversized memory should fail");
 
         assert!(matches!(
             err,

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -301,14 +301,14 @@ exist.
 | `PUT /boot-source` | `boot_args` | optional | Firecracker uses its default kernel command line when omitted. The API/VMM storage path validates the 2048-byte aarch64 limit including the trailing NUL byte and rejects embedded NUL bytes. |
 | `PUT /boot-source` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
 | `PUT /machine-config` | `vcpu_count` | required | Firecracker bounds this to `1..=32`; HVF work must also account for host CPU and thread limits. |
-| `PUT /machine-config` | `mem_size_mib` | required | Drives guest memory allocation and mapping; later work must cover bounds and startup performance. |
+| `PUT /machine-config` | `mem_size_mib` | required | Drives guest memory allocation and mapping; accepted range is `1..=1046528` MiB for the current Apple Silicon/aarch64 target. Host free-memory preflight remains deferred. |
 | `PUT /machine-config` | `smt` | optional when `false`; rejected when `true` | Firecracker defaults this to `false`; the initial HVF target accepts explicit no-SMT config and currently returns `machine smt is not supported` when SMT is enabled. |
 | `PUT /machine-config` | `cpu_template` | optional when omitted, `null`, or `None`; rejected for known non-`None` templates | Explicit `None` matches Firecracker's deprecated default; known non-default CPU templates currently return `machine cpu_template <template> is not supported` and need a separate HVF compatibility design. |
 | `PUT /machine-config` | `track_dirty_pages` | optional when `false`; rejected when `true` | Explicit `false` matches Firecracker's default; enabling dirty tracking belongs with snapshot support and currently returns `machine track_dirty_pages is not supported`. |
 | `PUT /machine-config` | `huge_pages` | optional when `None`; rejected for `2M` | Explicit `None` matches Firecracker's default; Linux hugetlbfs does not directly apply to the macOS target and `2M` currently returns `machine huge_pages is not supported`. |
 | `PUT /machine-config` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
 | `PATCH /machine-config` | `vcpu_count` | optional | When present, updates the stored vCPU count with the same `1..=32` bounds as `PUT`; omitted fields keep their current values. |
-| `PATCH /machine-config` | `mem_size_mib` | optional | When present, updates the stored memory size and rejects zero; omitted fields keep their current values. |
+| `PATCH /machine-config` | `mem_size_mib` | optional | When present, updates the stored memory size with the same `1..=1046528` MiB target bound as `PUT`; omitted fields keep their current values. |
 | `PATCH /machine-config` | `smt` | optional when `false`; rejected when `true` | Matches the current `PUT` policy for the Apple Silicon target and currently returns `machine smt is not supported` when SMT is enabled. |
 | `PATCH /machine-config` | `cpu_template` | optional when omitted or `null`; accepted when `None`; rejected for known non-`None` templates | `null` is treated as omitted. Explicit `None` is accepted; known non-default CPU templates currently return `machine cpu_template <template> is not supported`. |
 | `PATCH /machine-config` | `track_dirty_pages` | optional when `false`; rejected when `true` | Matches the current `PUT` dirty-tracking policy. |
@@ -543,7 +543,8 @@ The aarch64 layout helper follows Firecracker's `v1.16.0` ARM layout shape:
 - the architectural DRAM maximum is 1022 GiB
 - RAM crossing the 256-512 GiB MMIO64 gap is split around that gap
 - zero requested memory is rejected by the layout helper
-- requests above the architectural maximum are capped inside the layout model
+- requests above the architectural maximum are capped inside the layout model,
+  while public machine configuration rejects them before storage
 
 The allocation model creates one anonymous read/write private host memory
 mapping for each validated guest RAM range and releases the mappings with
@@ -1174,10 +1175,10 @@ runtime notifications and releases it before HVF GIC signaling.
 bangbang now wires `mem_size_mib` into startup preparation, but still does not
 wire device interrupts into public guest execution, emulate devices, provide
 public run-loop control, power on secondary vCPUs, or implement full PSCI CPU
-and system power actions. Later API and startup work still needs to decide
-whether an oversized `mem_size_mib` request should be rejected before layout
-construction or should preserve Firecracker's architecture-helper truncation
-behavior.
+and system power actions. Public machine configuration rejects `mem_size_mib`
+above the current 1022 GiB Apple Silicon/aarch64 DRAM maximum before storage;
+startup keeps its architectural maximum check as a defensive guard. Dynamic
+host-memory availability policy remains deferred.
 
 ## API State and Response Policy
 


### PR DESCRIPTION
## Summary

- reject machine `mem_size_mib` outside the current Apple Silicon/aarch64 supported range before storing config
- cover runtime, HTTP API, and config-file oversized memory rejection without mutating existing state
- update compatibility docs to document the `1..=1046528` MiB public policy and deferred host free-memory checks

## Scope Exclusions

- does not add dynamic host-memory availability preflight
- does not change low-level aarch64 DRAM layout truncation behavior
- does not add memory hotplug, balloon, huge pages, or dirty-page tracking support

Closes #611

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test -p bangbang-runtime --all-targets --all-features --locked`
- `cargo test -p bangbang --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`
