### PR TITLE
test: cover unsupported Firecracker process flags

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -108,19 +108,21 @@ fn executable_accepts_firecracker_startup_time_args() {
 
 #[test]
 fn executable_rejects_unsupported_firecracker_process_flags_before_socket_publication() {
-    for (name, args) in [
-        ("boot-timer", &["--boot-timer"][..]),
+    for (name, args, private_value) in [
+        ("boot-timer", &["--boot-timer"][..], None),
         (
             "describe-snapshot",
             &["--describe-snapshot", "secret-snapshot.vmstate"],
+            Some("secret-snapshot.vmstate"),
         ),
-        ("enable-pci", &["--enable-pci"]),
-        ("no-seccomp", &["--no-seccomp"]),
+        ("enable-pci", &["--enable-pci"], None),
+        ("no-seccomp", &["--no-seccomp"], None),
         (
             "seccomp-filter",
             &["--seccomp-filter", "secret-seccomp.bpf"],
+            Some("secret-seccomp.bpf"),
         ),
-        ("snapshot-version", &["--snapshot-version"]),
+        ("snapshot-version", &["--snapshot-version"], None),
     ] {
         let test_dir = TestDir::new();
         let socket_path = test_dir.path().join(format!("{name}.socket"));
@@ -149,6 +151,14 @@ fn executable_rejects_unsupported_firecracker_process_flags_before_socket_public
             "unsupported --{name} must not report API readiness; stdout:\n{}",
             output.stdout
         );
+        if let Some(private_value) = private_value {
+            assert!(
+                !output.stdout.contains(private_value) && !output.stderr.contains(private_value),
+                "unsupported --{name} failure must not echo private argument value {private_value:?}; stdout:\n{}\nstderr:\n{}",
+                output.stdout,
+                output.stderr
+            );
+        }
         assert!(
             !socket_path.exists(),
             "unsupported --{name} must fail before publishing the API socket"

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -21,6 +21,7 @@ use support::{
 use bangbang_runtime::machine::MAX_MEM_SIZE_MIB;
 
 const BANGBANG_VERSION: &str = env!("CARGO_PKG_VERSION");
+const ARGUMENT_PARSING_EXIT_CODE: i32 = 153;
 
 #[test]
 fn executable_serves_api_and_shuts_down_cleanly() {
@@ -103,6 +104,56 @@ fn executable_accepts_firecracker_startup_time_args() {
     );
 
     assert_clean_shutdown(bangbang.terminate(), &socket_path, "bangbang");
+}
+
+#[test]
+fn executable_rejects_unsupported_firecracker_process_flags_before_socket_publication() {
+    for (name, args) in [
+        ("boot-timer", &["--boot-timer"][..]),
+        (
+            "describe-snapshot",
+            &["--describe-snapshot", "secret-snapshot.vmstate"],
+        ),
+        ("enable-pci", &["--enable-pci"]),
+        ("no-seccomp", &["--no-seccomp"]),
+        (
+            "seccomp-filter",
+            &["--seccomp-filter", "secret-seccomp.bpf"],
+        ),
+        ("snapshot-version", &["--snapshot-version"]),
+    ] {
+        let test_dir = TestDir::new();
+        let socket_path = test_dir.path().join(format!("{name}.socket"));
+        let instance_id = test_dir.instance_id();
+
+        let output =
+            BangbangProcess::start_with_extra_args_expect_failure(&socket_path, &instance_id, args);
+
+        assert_eq!(
+            output.status.code(),
+            Some(ARGUMENT_PARSING_EXIT_CODE),
+            "unsupported --{name} should fail with the argument parsing exit code; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            output.stdout,
+            output.stderr
+        );
+        assert!(
+            output.stderr.contains(&format!(
+                "bangbang: unsupported Firecracker argument: --{name}"
+            )),
+            "unsupported --{name} should report a Firecracker argument rejection; stderr:\n{}",
+            output.stderr
+        );
+        assert!(
+            !output.stdout.contains("status: API server listening"),
+            "unsupported --{name} must not report API readiness; stdout:\n{}",
+            output.stdout
+        );
+        assert!(
+            !socket_path.exists(),
+            "unsupported --{name} must fail before publishing the API socket"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add executable e2e coverage for recognized unsupported Firecracker process flags
- assert unsupported flags return the argument-parsing exit code before API socket publication
- cover seccomp, snapshot, boot timer, and PCI process flags without changing behavior

Closes #631.

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo test -p bangbang --test process_e2e --all-features --locked unsupported_firecracker
- cargo check --workspace --all-targets --all-features --locked
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings
- cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings
- cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- scripts/run-signed-process-tests.sh
- scripts/run-integration-tests.sh