### PR TITLE
test: cover executable drive hot-unplug rejection

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -598,7 +598,7 @@ fn executable_configures_vm_before_start() {
     );
     assert!(
         !vm_config.contains(&format!(r#""path_on_host":{replaced_rootfs_path_json}"#)),
-        "failed PATCH /drives/rootfs must not mutate drive path; response:\n{vm_config}"
+        "failed PATCH or DELETE /drives/rootfs must not mutate drive path; response:\n{vm_config}"
     );
 
     let cpu_config_response = http_put_json(&socket_path, "/cpu-config", "{}");

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -15,7 +15,7 @@ use std::os::unix::fs::MetadataExt;
 use support::{
     BangbangProcess, TestDir, assert_bad_request_response, assert_clean_shutdown,
     assert_no_content_response, assert_ok_response, assert_response_contains, http_get, http_json,
-    http_put_json, json_string, path_text,
+    http_no_body, http_put_json, json_string, path_text,
 };
 
 use bangbang_runtime::machine::MAX_MEM_SIZE_MIB;
@@ -563,6 +563,14 @@ fn executable_configures_vm_before_start() {
         &drive_patch_response,
         r#"{"fault_message":"The requested operation is not supported in Not started state: UpdateBlockDevice"}"#,
         "PATCH /drives/rootfs",
+    );
+
+    let drive_delete_response = http_no_body(&socket_path, "DELETE", "/drives/rootfs");
+    assert_bad_request_response(&drive_delete_response, "DELETE /drives/rootfs");
+    assert_response_contains(
+        &drive_delete_response,
+        r#"{"fault_message":"Drive updates are not supported."}"#,
+        "DELETE /drives/rootfs",
     );
 
     let vm_config = http_get(&socket_path, "/vm/config");

--- a/crates/bangbang/tests/support/mod.rs
+++ b/crates/bangbang/tests/support/mod.rs
@@ -27,7 +27,11 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(0);
 
 pub(crate) fn http_get(socket_path: &Path, path: &str) -> String {
-    http_request(socket_path, "GET", path, None)
+    http_no_body(socket_path, "GET", path)
+}
+
+pub(crate) fn http_no_body(socket_path: &Path, method: &str, path: &str) -> String {
+    http_request(socket_path, method, path, None)
 }
 
 pub(crate) fn http_put_json(socket_path: &Path, path: &str, body: &str) -> String {


### PR DESCRIPTION
## Summary
- add a no-body HTTP helper for executable process tests
- cover `DELETE /drives/rootfs` through the real `bangbang` API socket
- assert the Firecracker-compatible drive update rejection and keep the existing `GET /vm/config` no-mutation assertions

## Scope
- Does not implement runtime block hot-unplug.

Closes #637

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p bangbang --test process_e2e --all-features --locked executable_configures_vm_before_start -- --exact`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`