### PR TITLE
test: cover executable pmem hot-unplug rejection

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -261,6 +261,14 @@ fn executable_rejects_remaining_device_requests_without_mutating() {
         }
     }
 
+    let pmem_delete_response = http_no_body(&socket_path, "DELETE", "/pmem/pmem0");
+    assert_bad_request_response(&pmem_delete_response, "DELETE /pmem/pmem0");
+    assert_response_contains(
+        &pmem_delete_response,
+        r#"{"fault_message":"Pmem device is not supported."}"#,
+        "DELETE /pmem/pmem0",
+    );
+
     let instance_info = http_get(&socket_path, "/");
     assert_ok_response(&instance_info, "GET / after rejected remaining devices");
     assert_response_contains(


### PR DESCRIPTION
## Summary

- Add process e2e coverage for bodyless `DELETE /pmem/pmem0` through the real `bangbang` executable.
- Assert the existing Firecracker-shaped pmem unsupported fault is returned.
- Reuse the existing remaining-device state check to verify the instance stays `Not started`.

## Scope Exclusions

- Does not implement pmem devices.
- Does not implement hot-unplug behavior.
- Does not cover network-interface hot-unplug.

Closes #641

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test -p bangbang --test process_e2e --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`
