### PR TITLE
test: cover executable network hot-unplug rejection

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -997,24 +997,32 @@ fn executable_configures_network_and_mmds() {
         "malformed PATCH /network-interfaces/eth0",
     );
 
-    let vm_config_after_network_patch = http_get(&socket_path, "/vm/config");
+    let network_delete_response = http_no_body(&socket_path, "DELETE", "/network-interfaces/eth0");
+    assert_bad_request_response(&network_delete_response, "DELETE /network-interfaces/eth0");
+    assert_response_contains(
+        &network_delete_response,
+        r#"{"fault_message":"Network interface updates are not supported."}"#,
+        "DELETE /network-interfaces/eth0",
+    );
+
+    let vm_config_after_network_updates = http_get(&socket_path, "/vm/config");
     assert_ok_response(
-        &vm_config_after_network_patch,
-        "GET /vm/config after rejected network PATCH",
+        &vm_config_after_network_updates,
+        "GET /vm/config after rejected network updates",
     );
     assert_response_contains(
-        &vm_config_after_network_patch,
+        &vm_config_after_network_updates,
         r#""iface_id":"eth0""#,
-        "GET /vm/config after rejected network PATCH",
+        "GET /vm/config after rejected network updates",
     );
     assert_response_contains(
-        &vm_config_after_network_patch,
+        &vm_config_after_network_updates,
         r#""host_dev_name":"vmnet:shared""#,
-        "GET /vm/config after rejected network PATCH",
+        "GET /vm/config after rejected network updates",
     );
     assert!(
-        !vm_config_after_network_patch.contains(r#""iface_id":"eth1""#),
-        "rejected network PATCH must not add a new interface; response:\n{vm_config_after_network_patch}"
+        !vm_config_after_network_updates.contains(r#""iface_id":"eth1""#),
+        "rejected network updates must not add a new interface; response:\n{vm_config_after_network_updates}"
     );
 
     let put_mmds_response = http_put_json(

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -1020,6 +1020,16 @@ fn executable_configures_network_and_mmds() {
         r#""host_dev_name":"vmnet:shared""#,
         "GET /vm/config after rejected network updates",
     );
+    assert_response_contains(
+        &vm_config_after_network_updates,
+        r#""guest_mac":"12:34:56:78:9a:bc""#,
+        "GET /vm/config after rejected network updates",
+    );
+    assert_response_contains(
+        &vm_config_after_network_updates,
+        r#""mtu":1500"#,
+        "GET /vm/config after rejected network updates",
+    );
     assert!(
         !vm_config_after_network_updates.contains(r#""iface_id":"eth1""#),
         "rejected network updates must not add a new interface; response:\n{vm_config_after_network_updates}"


### PR DESCRIPTION
## Summary

- Add process e2e coverage for bodyless `DELETE /network-interfaces/eth0` through the real `bangbang` executable.
- Assert the existing network-interface-update unsupported fault is returned.
- Reuse the network vm_config check to verify the configured interface remains after rejected updates.

## Scope Exclusions

- Does not implement network hot-unplug.
- Does not implement runtime network-interface updates.
- Does not change vmnet packet behavior.

Closes #643

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test -p bangbang --test process_e2e --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`
