### PR TITLE
test: cover executable balloon endpoint rejection

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -261,6 +261,46 @@ fn executable_rejects_remaining_device_requests_without_mutating() {
         }
     }
 
+    for path in ["/balloon", "/balloon/statistics", "/balloon/hinting/status"] {
+        let request_name = format!("GET {path}");
+        let response = http_get(&socket_path, path);
+
+        assert_bad_request_response(&response, &request_name);
+        assert_response_contains(
+            &response,
+            r#"{"fault_message":"Balloon device is not supported."}"#,
+            &request_name,
+        );
+    }
+
+    for (path, body) in [
+        ("/balloon", r#"{"amount_mib":32}"#),
+        ("/balloon/statistics", r#"{"stats_polling_interval_s":1}"#),
+        ("/balloon/hinting/start", r#"{"acknowledge_on_stop":false}"#),
+    ] {
+        let request_name = format!("PATCH {path}");
+        let response = http_json(&socket_path, "PATCH", path, body);
+
+        assert_bad_request_response(&response, &request_name);
+        assert_response_contains(
+            &response,
+            r#"{"fault_message":"Balloon device is not supported."}"#,
+            &request_name,
+        );
+    }
+
+    let balloon_hinting_stop_response =
+        http_no_body(&socket_path, "PATCH", "/balloon/hinting/stop");
+    assert_bad_request_response(
+        &balloon_hinting_stop_response,
+        "PATCH /balloon/hinting/stop",
+    );
+    assert_response_contains(
+        &balloon_hinting_stop_response,
+        r#"{"fault_message":"Balloon device is not supported."}"#,
+        "PATCH /balloon/hinting/stop",
+    );
+
     let pmem_delete_response = http_no_body(&socket_path, "DELETE", "/pmem/pmem0");
     assert_bad_request_response(&pmem_delete_response, "DELETE /pmem/pmem0");
     assert_response_contains(


### PR DESCRIPTION
## Summary

- Add process e2e coverage for balloon query endpoints through the real `bangbang` executable.
- Add process e2e coverage for representative balloon PATCH endpoints, including statistics and hinting paths.
- Assert each covered endpoint returns the documented balloon unsupported fault and reuses the existing `Not started` state check.

## Scope Exclusions

- Does not implement virtio-balloon support.
- Does not implement balloon statistics, hinting, or runtime mutation.
- Does not duplicate malformed parser cases already covered by API unit tests.

Closes #645

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test -p bangbang --test process_e2e --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`
