### PR TITLE
test: cover executable memory hotplug endpoint rejection

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -261,6 +261,27 @@ fn executable_rejects_remaining_device_requests_without_mutating() {
         }
     }
 
+    let memory_hotplug_get_response = http_get(&socket_path, "/hotplug/memory");
+    assert_bad_request_response(&memory_hotplug_get_response, "GET /hotplug/memory");
+    assert_response_contains(
+        &memory_hotplug_get_response,
+        r#"{"fault_message":"Memory hotplug is not supported."}"#,
+        "GET /hotplug/memory",
+    );
+
+    let memory_hotplug_patch_response = http_json(
+        &socket_path,
+        "PATCH",
+        "/hotplug/memory",
+        r#"{"requested_size_mib":256}"#,
+    );
+    assert_bad_request_response(&memory_hotplug_patch_response, "PATCH /hotplug/memory");
+    assert_response_contains(
+        &memory_hotplug_patch_response,
+        r#"{"fault_message":"Memory hotplug is not supported."}"#,
+        "PATCH /hotplug/memory",
+    );
+
     for path in ["/balloon", "/balloon/statistics", "/balloon/hinting/status"] {
         let request_name = format!("GET {path}");
         let response = http_get(&socket_path, path);


### PR DESCRIPTION
## Summary

- Add executable process e2e coverage for `GET /hotplug/memory`.
- Add executable process e2e coverage for schema-valid `PATCH /hotplug/memory`.
- Assert both paths return the documented unsupported memory-hotplug fault without changing instance state.

## Scope Exclusions

- Does not add real virtio-mem or memory hotplug support.
- Does not change API routing, runtime state, or compatibility documentation.
- Does not duplicate malformed parser cases already covered by API unit tests.

Closes #647

## Validation

- `cargo test -p bangbang --test process_e2e --all-features --locked`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`
