### PR TITLE
test: cover executable serial configuration endpoint

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -712,6 +712,7 @@ fn executable_configures_observability_without_vm_config() {
     let metrics_path = test_dir.path().join("metrics.out");
     let second_metrics_path = test_dir.path().join("metrics-second.out");
     let logger_path = test_dir.path().join("logger.out");
+    let serial_output_path = test_dir.path().join("serial.out");
     let instance_id = test_dir.instance_id();
     let bangbang = BangbangProcess::start(&socket_path, &instance_id);
 
@@ -763,6 +764,15 @@ fn executable_configures_observability_without_vm_config() {
         "PUT /logger should create the configured output file"
     );
 
+    let serial_output_path_json = json_string(path_text(&serial_output_path));
+    let serial_body = format!(r#"{{"serial_out_path":{serial_output_path_json}}}"#);
+    let serial_response = http_put_json(&socket_path, "/serial", &serial_body);
+    assert_no_content_response(&serial_response, "PUT /serial");
+    assert!(
+        !serial_output_path.exists(),
+        "PUT /serial should store the output path without creating it before startup"
+    );
+
     let vm_config = http_get(&socket_path, "/vm/config");
     assert_ok_response(&vm_config, "GET /vm/config after observability config");
     assert_response_contains(
@@ -777,6 +787,10 @@ fn executable_configures_observability_without_vm_config() {
     assert!(
         !vm_config.contains("logger"),
         "GET /vm/config must not include logger observability state; response:\n{vm_config}"
+    );
+    assert!(
+        !vm_config.contains("serial"),
+        "GET /vm/config must not include serial observability state; response:\n{vm_config}"
     );
 
     assert_clean_shutdown(bangbang.terminate(), &socket_path, "bangbang");


### PR DESCRIPTION
## Summary

- Add executable process e2e coverage for valid pre-boot `PUT /serial`.
- Assert the endpoint returns `204 No Content` through the real `bangbang` process.
- Assert the configured serial output path is not created before startup and serial state is omitted from `GET /vm/config`.

## Scope Exclusions

- Does not change `/serial` API behavior or runtime serial configuration.
- Does not cover guest serial output, `InstanceStart`, serial input, rate limiter rejection, or public serial streaming.
- Does not duplicate invalid serial parser cases already covered by API unit tests.

Closes #649

## Validation

- `cargo test -p bangbang --test process_e2e --all-features --locked`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`
