### PR TITLE
test: cover executable pre-start action rejections

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -698,6 +698,42 @@ fn executable_configures_vm_before_start() {
         "GET / after failed PATCH /vm",
     );
 
+    let flush_metrics_response = http_put_json(
+        &socket_path,
+        "/actions",
+        r#"{"action_type":"FlushMetrics"}"#,
+    );
+    assert_bad_request_response(&flush_metrics_response, "PUT /actions FlushMetrics");
+    assert_response_contains(
+        &flush_metrics_response,
+        r#"{"fault_message":"The requested operation is not supported in Not started state: FlushMetrics"}"#,
+        "PUT /actions FlushMetrics",
+    );
+    let instance_info_after_flush_metrics = http_get(&socket_path, "/");
+    assert_response_contains(
+        &instance_info_after_flush_metrics,
+        r#""state":"Not started""#,
+        "GET / after failed PUT /actions FlushMetrics",
+    );
+
+    let send_ctrl_alt_del_response = http_put_json(
+        &socket_path,
+        "/actions",
+        r#"{"action_type":"SendCtrlAltDel"}"#,
+    );
+    assert_bad_request_response(&send_ctrl_alt_del_response, "PUT /actions SendCtrlAltDel");
+    assert_response_contains(
+        &send_ctrl_alt_del_response,
+        r#"{"fault_message":"SendCtrlAltDel is not supported on aarch64."}"#,
+        "PUT /actions SendCtrlAltDel",
+    );
+    let instance_info_after_send_ctrl_alt_del = http_get(&socket_path, "/");
+    assert_response_contains(
+        &instance_info_after_send_ctrl_alt_del,
+        r#""state":"Not started""#,
+        "GET / after failed PUT /actions SendCtrlAltDel",
+    );
+
     assert_response_contains(&vm_config, r#""is_root_device":true"#, "GET /vm/config");
     assert_response_contains(&vm_config, r#""is_read_only":true"#, "GET /vm/config");
     assert_response_contains(&vm_config, r#""partuuid":"0eaa91a0-01""#, "GET /vm/config");


### PR DESCRIPTION
## Summary

- Add executable process e2e coverage for pre-start `PUT /actions` with `FlushMetrics`.
- Add executable process e2e coverage for `PUT /actions` with `SendCtrlAltDel`.
- Assert both requests return documented faults and leave the instance in `Not started` state.

## Scope Exclusions

- Does not change `/actions` API behavior or lifecycle runtime logic.
- Does not cover successful `InstanceStart`, runtime `FlushMetrics`, pause/resume, guest shutdown, or HVF boot behavior.
- Does not duplicate malformed action parser cases already covered by API unit tests.

Closes #651

## Validation

- `cargo test -p bangbang --test process_e2e --all-features --locked`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`
