### PR TITLE
test: cover executable API payload limit rejection

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -15,9 +15,10 @@ use std::os::unix::fs::MetadataExt;
 use support::{
     BangbangProcess, TestDir, assert_bad_request_response, assert_clean_shutdown,
     assert_no_content_response, assert_ok_response, assert_response_contains, http_get, http_json,
-    http_no_body, http_put_json, json_string, path_text,
+    http_no_body, http_put_json, http_raw, json_string, path_text,
 };
 
+use bangbang_api::HTTP_MAX_PAYLOAD_SIZE;
 use bangbang_runtime::machine::MAX_MEM_SIZE_MIB;
 
 const BANGBANG_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -101,6 +102,41 @@ fn executable_accepts_firecracker_startup_time_args() {
             && !vm_config.contains("start_time_cpu_us")
             && !vm_config.contains("parent_cpu_time_us"),
         "GET /vm/config should not expose process startup timing; response:\n{vm_config}"
+    );
+
+    assert_clean_shutdown(bangbang.terminate(), &socket_path, "bangbang");
+}
+
+#[test]
+fn executable_rejects_api_payload_over_limit_without_stopping() {
+    let test_dir = TestDir::new();
+    let socket_path = test_dir.path().join("api.socket");
+    let instance_id = test_dir.instance_id();
+    let bangbang = BangbangProcess::start(&socket_path, &instance_id);
+
+    let request = format!(
+        "PUT /mmds HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        HTTP_MAX_PAYLOAD_SIZE + 1
+    );
+    assert!(
+        request.len() <= HTTP_MAX_PAYLOAD_SIZE,
+        "fixture should exercise declared payload length rejection, not a large write"
+    );
+
+    let oversized_response = http_raw(&socket_path, request.as_bytes());
+    assert_bad_request_response(&oversized_response, "oversized PUT /mmds");
+    assert_response_contains(
+        &oversized_response,
+        r#"{"fault_message":"HTTP request payload exceeds the configured limit."}"#,
+        "oversized PUT /mmds",
+    );
+
+    let instance_info = http_get(&socket_path, "/");
+    assert_ok_response(&instance_info, "GET / after oversized request");
+    assert_response_contains(
+        &instance_info,
+        r#""state":"Not started""#,
+        "GET / after oversized request",
     );
 
     assert_clean_shutdown(bangbang.terminate(), &socket_path, "bangbang");

--- a/crates/bangbang/tests/support/mod.rs
+++ b/crates/bangbang/tests/support/mod.rs
@@ -42,7 +42,11 @@ pub(crate) fn http_json(socket_path: &Path, method: &str, path: &str, body: &str
     http_request(socket_path, method, path, Some(body))
 }
 
-fn http_request(socket_path: &Path, method: &str, path: &str, body: Option<&str>) -> String {
+#[allow(
+    dead_code,
+    reason = "shared integration-test support is compiled once per test target"
+)]
+pub(crate) fn http_raw(socket_path: &Path, request: &[u8]) -> String {
     let mut stream = UnixStream::connect(socket_path).expect("client should connect");
     stream
         .set_read_timeout(Some(HTTP_IO_TIMEOUT))
@@ -50,6 +54,18 @@ fn http_request(socket_path: &Path, method: &str, path: &str, body: Option<&str>
     stream
         .set_write_timeout(Some(HTTP_IO_TIMEOUT))
         .expect("client should set write timeout");
+    stream
+        .write_all(request)
+        .expect("client should write request");
+
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .expect("client should read response");
+    response
+}
+
+fn http_request(socket_path: &Path, method: &str, path: &str, body: Option<&str>) -> String {
     let mut request =
         format!("{method} {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n");
     if let Some(body) = body {
@@ -61,15 +77,7 @@ fn http_request(socket_path: &Path, method: &str, path: &str, body: Option<&str>
         request.push_str("\r\n");
     }
 
-    stream
-        .write_all(request.as_bytes())
-        .expect("client should write request");
-
-    let mut response = String::new();
-    stream
-        .read_to_string(&mut response)
-        .expect("client should read response");
-    response
+    http_raw(socket_path, request.as_bytes())
 }
 
 pub(crate) fn path_text(path: &Path) -> &str {


### PR DESCRIPTION
## Summary

- add raw HTTP support to the process e2e test helper
- cover the real `bangbang` executable rejecting an over-limit API payload declaration
- assert the process remains usable and `Not started` after the rejected request

Closes #653

## Verification

- `cargo test -p bangbang --test process_e2e executable_rejects_api_payload_over_limit_without_stopping --all-features --locked`
- `cargo fmt --all -- --check`
- `cargo test -p bangbang --test process_e2e --all-features --locked`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`