### PR TITLE
test: cover executable SIGINT shutdown cleanup

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -143,6 +143,21 @@ fn executable_rejects_api_payload_over_limit_without_stopping() {
 }
 
 #[test]
+fn executable_handles_sigint_shutdown_cleanly() {
+    let test_dir = TestDir::new();
+    let socket_path = test_dir.path().join("api.socket");
+    let instance_id = test_dir.instance_id();
+    let bangbang = BangbangProcess::start(&socket_path, &instance_id);
+
+    assert!(
+        socket_path.exists(),
+        "bangbang should publish the configured API socket before SIGINT"
+    );
+
+    assert_clean_shutdown(bangbang.interrupt(), &socket_path, "bangbang SIGINT");
+}
+
+#[test]
 fn executable_rejects_unsupported_firecracker_process_flags_before_socket_publication() {
     for (name, args, private_value) in [
         ("boot-timer", &["--boot-timer"][..], None),

--- a/crates/bangbang/tests/support/mod.rs
+++ b/crates/bangbang/tests/support/mod.rs
@@ -114,7 +114,7 @@ pub(crate) fn assert_clean_shutdown(
 ) {
     assert!(
         output.status.success(),
-        "{process_name} SIGTERM should make bangbang exit successfully; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        "{process_name} shutdown signal should make bangbang exit successfully; status: {:?}\nstdout:\n{}\nstderr:\n{}",
         output.status,
         output.stdout,
         output.stderr
@@ -323,8 +323,22 @@ impl BangbangProcess {
     }
 
     pub(crate) fn terminate(mut self) -> CompletedProcess {
+        self.stop_with_signal(libc::SIGTERM, "SIGTERM")
+    }
+
+    #[allow(
+        dead_code,
+        reason = "shared integration-test support is compiled once per test target"
+    )]
+    pub(crate) fn interrupt(mut self) -> CompletedProcess {
+        self.stop_with_signal(libc::SIGINT, "SIGINT")
+    }
+
+    fn stop_with_signal(&mut self, signal: i32, signal_name: &str) -> CompletedProcess {
         let child = self.child.as_ref().expect("child should still be running");
-        send_signal(child.id(), libc::SIGTERM).expect("SIGTERM should be delivered");
+        if let Err(err) = send_signal(child.id(), signal) {
+            panic!("{signal_name} should be delivered: {err}");
+        }
         let child = self.child.take().expect("child should still be owned");
         let status = wait_for_child_exit(child, SHUTDOWN_TIMEOUT);
 


### PR DESCRIPTION
## Summary

- add a SIGINT shutdown helper for process e2e tests
- cover the real `bangbang` executable exiting successfully on SIGINT
- keep the clean-shutdown assertion usable for both SIGTERM and SIGINT

Closes #655

## Verification

- `cargo test -p bangbang --test process_e2e executable_handles_sigint_shutdown_cleanly --all-features --locked`
- `cargo fmt --all -- --check`
- `cargo test -p bangbang --test process_e2e --all-features --locked`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`