### PR TITLE
test: cover executable invalid API route rejection

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -143,6 +143,39 @@ fn executable_rejects_api_payload_over_limit_without_stopping() {
 }
 
 #[test]
+fn executable_rejects_invalid_api_routes_without_stopping() {
+    let test_dir = TestDir::new();
+    let socket_path = test_dir.path().join("api.socket");
+    let instance_id = test_dir.instance_id();
+    let bangbang = BangbangProcess::start(&socket_path, &instance_id);
+
+    for (request_name, response) in [
+        ("GET /unknown", http_get(&socket_path, "/unknown")),
+        (
+            "POST /version",
+            http_no_body(&socket_path, "POST", "/version"),
+        ),
+    ] {
+        assert_bad_request_response(&response, request_name);
+        assert_response_contains(
+            &response,
+            r#"{"fault_message":"Invalid request method and/or path."}"#,
+            request_name,
+        );
+    }
+
+    let instance_info = http_get(&socket_path, "/");
+    assert_ok_response(&instance_info, "GET / after invalid API routes");
+    assert_response_contains(
+        &instance_info,
+        r#""state":"Not started""#,
+        "GET / after invalid API routes",
+    );
+
+    assert_clean_shutdown(bangbang.terminate(), &socket_path, "bangbang");
+}
+
+#[test]
 fn executable_handles_sigint_shutdown_cleanly() {
     let test_dir = TestDir::new();
     let socket_path = test_dir.path().join("api.socket");


### PR DESCRIPTION
## Summary
- Add process e2e coverage for invalid API route rejection.
- Verify GET /unknown and POST /version return the public Firecracker-style invalid path fault.
- Confirm the executable remains usable by serving instance info after invalid requests.

Closes #657

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo check --workspace --all-targets --all-features --locked
- cargo test -p bangbang --test process_e2e executable_rejects_invalid_api_routes_without_stopping --all-features --locked
- cargo test -p bangbang --test process_e2e --all-features --locked
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings
- cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings
- cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- scripts/run-signed-process-tests.sh
- scripts/run-integration-tests.sh