### PR TITLE
test: cover executable malformed HTTP rejection

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -143,6 +143,35 @@ fn executable_rejects_api_payload_over_limit_without_stopping() {
 }
 
 #[test]
+fn executable_rejects_malformed_http_request_without_stopping() {
+    let test_dir = TestDir::new();
+    let socket_path = test_dir.path().join("api.socket");
+    let instance_id = test_dir.instance_id();
+    let bangbang = BangbangProcess::start(&socket_path, &instance_id);
+
+    let malformed_response = http_raw(
+        &socket_path,
+        b"GET /version HTTP/1.1\r\nHost: localhost\r\nContent-Length: +0\r\nConnection: close\r\n\r\n",
+    );
+    assert_bad_request_response(&malformed_response, "malformed GET /version");
+    assert_response_contains(
+        &malformed_response,
+        r#"{"fault_message":"Malformed HTTP request."}"#,
+        "malformed GET /version",
+    );
+
+    let instance_info = http_get(&socket_path, "/");
+    assert_ok_response(&instance_info, "GET / after malformed request");
+    assert_response_contains(
+        &instance_info,
+        r#""state":"Not started""#,
+        "GET / after malformed request",
+    );
+
+    assert_clean_shutdown(bangbang.terminate(), &socket_path, "bangbang");
+}
+
+#[test]
 fn executable_rejects_invalid_api_routes_without_stopping() {
     let test_dir = TestDir::new();
     let socket_path = test_dir.path().join("api.socket");


### PR DESCRIPTION
## Summary

- Add process e2e coverage for malformed HTTP framing at the real executable API socket.
- Verify an invalid `Content-Length` request returns the public malformed-request fault.
- Confirm the executable remains usable by serving instance info afterward.

Closes #659

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test -p bangbang --test process_e2e executable_rejects_malformed_http_request_without_stopping --all-features --locked`
- `cargo test -p bangbang --test process_e2e --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`
