### PR TITLE
test: cover executable machine-config PUT validation errors

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -1584,6 +1584,69 @@ fn executable_serves_and_patches_machine_config() {
 }
 
 #[test]
+fn executable_rejects_invalid_machine_config_put_without_mutating() {
+    let test_dir = TestDir::new();
+    let socket_path = test_dir.path().join("api.socket");
+    let instance_id = test_dir.instance_id();
+    let bangbang = BangbangProcess::start(&socket_path, &instance_id);
+
+    let put_response = http_put_json(
+        &socket_path,
+        "/machine-config",
+        r#"{"vcpu_count":2,"mem_size_mib":256}"#,
+    );
+    assert_no_content_response(&put_response, "PUT /machine-config original");
+
+    let invalid_put_response = http_put_json(
+        &socket_path,
+        "/machine-config",
+        r#"{"vcpu_count":4,"mem_size_mib":512,"track_dirty_pages":true}"#,
+    );
+    assert_bad_request_response(&invalid_put_response, "PUT /machine-config invalid");
+    assert_response_contains(
+        &invalid_put_response,
+        r#"{"fault_message":"machine track_dirty_pages is not supported"}"#,
+        "PUT /machine-config invalid",
+    );
+
+    let machine_config = http_get(&socket_path, "/machine-config");
+    assert_ok_response(&machine_config, "GET /machine-config after invalid PUT");
+    assert_response_contains(
+        &machine_config,
+        r#""vcpu_count":2"#,
+        "GET /machine-config after invalid PUT",
+    );
+    assert_response_contains(
+        &machine_config,
+        r#""mem_size_mib":256"#,
+        "GET /machine-config after invalid PUT",
+    );
+    assert_response_contains(
+        &machine_config,
+        r#""smt":false"#,
+        "GET /machine-config after invalid PUT",
+    );
+    assert_response_contains(
+        &machine_config,
+        r#""track_dirty_pages":false"#,
+        "GET /machine-config after invalid PUT",
+    );
+    assert_response_contains(
+        &machine_config,
+        r#""huge_pages":"None""#,
+        "GET /machine-config after invalid PUT",
+    );
+    assert!(
+        !machine_config.contains(r#""vcpu_count":4"#)
+            && !machine_config.contains(r#""mem_size_mib":512"#)
+            && !machine_config.contains(r#""track_dirty_pages":true"#),
+        "invalid PUT /machine-config must not mutate stored machine config; response:\n{machine_config}"
+    );
+
+    assert_clean_shutdown(bangbang.terminate(), &socket_path, "bangbang");
+}
+
+#[test]
 fn executable_fails_when_api_socket_path_exists_without_removing_it() {
     let test_dir = TestDir::new();
     let socket_path = test_dir.path().join("api.socket");


### PR DESCRIPTION
## Summary
- add a process e2e test for invalid full `PUT /machine-config` payloads
- verify unsupported `track_dirty_pages` returns a public validation fault
- verify the previously stored machine config remains unchanged after rejection

Closes #663

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p bangbang --test process_e2e executable_rejects_invalid_machine_config_put_without_mutating --all-features --locked`
- `cargo test -p bangbang --test process_e2e --all-features --locked`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`
