### PR TITLE
test: cover executable drive update rejection

### DIFF
--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -163,8 +163,49 @@ mod macos_arm64 {
             );
         }
 
+        let replacement_backing_path = test_dir.path().join("replacement-data.img");
+        let replacement_backing_path_json = json_string(path_text(&replacement_backing_path));
+        let drive_update_body = format!(
+            r#"{{
+                "drive_id":"data",
+                "path_on_host":{replacement_backing_path_json}
+            }}"#
+        );
+        let drive_update_response =
+            http_json(&socket_path, "PATCH", "/drives/data", &drive_update_body);
+        assert_bad_request_response(
+            &drive_update_response,
+            "PATCH /drives/data after InstanceStart",
+        );
+        assert_response_contains(
+            &drive_update_response,
+            r#"{"fault_message":"The requested operation is not supported: UpdateBlockDevice"}"#,
+            "PATCH /drives/data after InstanceStart",
+        );
+
         let vm_config = http_get(&socket_path, "/vm/config");
         assert_ok_response(&vm_config, "GET /vm/config after InstanceStart");
+        assert_response_contains(
+            &vm_config,
+            r#""drive_id":"data""#,
+            "GET /vm/config after InstanceStart",
+        );
+        assert_response_contains(
+            &vm_config,
+            &format!(r#""path_on_host":{backing_path_json}"#),
+            "GET /vm/config after InstanceStart",
+        );
+        assert_eq!(
+            vm_config.matches(r#""drive_id":"#).count(),
+            1,
+            "rejected drive update must not add another drive; response:\n{vm_config}"
+        );
+        assert!(
+            !vm_config.contains(&format!(
+                r#""path_on_host":{replacement_backing_path_json}"#
+            )),
+            "rejected drive update must not mutate the configured drive path; response:\n{vm_config}"
+        );
         assert_response_contains(
             &vm_config,
             r#""guest_cid":3"#,


### PR DESCRIPTION
Summary:
- Extend the signed executable HVF e2e running-state scenario with `PATCH /drives/data`.
- Assert the public `UpdateBlockDevice` unsupported-action fault after `InstanceStart`.
- Verify `GET /vm/config` still reports the original drive path and does not add or replace the drive.

Closes #677

Verification:
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh --test executable_hvf_e2e`
- `scripts/run-integration-tests.sh`
