### PR TITLE
test: cover executable serial config rejection

### DIFF
--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -183,6 +183,24 @@ mod macos_arm64 {
             "PATCH /drives/data after InstanceStart",
         );
 
+        let replacement_serial_output_path = test_dir.path().join("replacement-serial.out");
+        let replacement_serial_output_path_json =
+            json_string(path_text(&replacement_serial_output_path));
+        let serial_update_body =
+            format!(r#"{{"serial_out_path":{replacement_serial_output_path_json}}}"#);
+        let serial_update_response = http_put_json(&socket_path, "/serial", &serial_update_body);
+        assert_bad_request_response(&serial_update_response, "PUT /serial after InstanceStart");
+        assert_response_contains(
+            &serial_update_response,
+            r#"{"fault_message":"The requested operation is not supported in Running state: PutSerial"}"#,
+            "PUT /serial after InstanceStart",
+        );
+        assert!(
+            !replacement_serial_output_path.exists(),
+            "rejected serial update must not create or use replacement output path {}",
+            replacement_serial_output_path.display()
+        );
+
         let vm_config = http_get(&socket_path, "/vm/config");
         assert_ok_response(&vm_config, "GET /vm/config after InstanceStart");
         assert_response_contains(


### PR DESCRIPTION
Summary:
- Extend the signed executable HVF running-state scenario with `PUT /serial` after `InstanceStart`.
- Assert the public `PutSerial` unsupported-state fault.
- Verify the rejected replacement serial output path is not created while the existing original serial marker check continues to prove output stays on the configured path.

Closes #679

Verification:
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh --test executable_hvf_e2e`
- `scripts/run-integration-tests.sh`
