### PR TITLE
test: cover executable logger config rejection

### DIFF
--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -266,6 +266,11 @@ mod macos_arm64 {
         assert_metrics_output(&metrics_path);
         assert_startup_time_metrics_output(&metrics_path);
         assert_logger_output(&logger_path);
+        assert!(
+            !replacement_logger_path.exists(),
+            "rejected logger update must not write later action records to replacement output path {}",
+            replacement_logger_path.display()
+        );
 
         let second_start_response = http_put_json(
             &socket_path,

--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -201,6 +201,22 @@ mod macos_arm64 {
             replacement_serial_output_path.display()
         );
 
+        let replacement_logger_path = test_dir.path().join("replacement-logger.out");
+        let replacement_logger_path_json = json_string(path_text(&replacement_logger_path));
+        let logger_update_body = format!(r#"{{"log_path":{replacement_logger_path_json}}}"#);
+        let logger_update_response = http_put_json(&socket_path, "/logger", &logger_update_body);
+        assert_bad_request_response(&logger_update_response, "PUT /logger after InstanceStart");
+        assert_response_contains(
+            &logger_update_response,
+            r#"{"fault_message":"The requested operation is not supported in Running state: PutLogger"}"#,
+            "PUT /logger after InstanceStart",
+        );
+        assert!(
+            !replacement_logger_path.exists(),
+            "rejected logger update must not create or use replacement output path {}",
+            replacement_logger_path.display()
+        );
+
         let vm_config = http_get(&socket_path, "/vm/config");
         assert_ok_response(&vm_config, "GET /vm/config after InstanceStart");
         assert_response_contains(


### PR DESCRIPTION
## Summary

- Extend the signed executable HVF running-state scenario with `PUT /logger` after `InstanceStart`.
- Assert the public `PutLogger` unsupported-state fault.
- Verify the rejected replacement logger output path is not created while the existing logger output assertion proves output stays on the configured path.

Closes #681

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh --test executable_hvf_e2e`
- `scripts/run-integration-tests.sh`
