### PR TITLE
test: cover executable boot-source rejection

### DIFF
--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -163,6 +163,25 @@ mod macos_arm64 {
             );
         }
 
+        let replacement_kernel_path = test_dir.path().join("replacement-vmlinux");
+        let replacement_kernel_path_json = json_string(path_text(&replacement_kernel_path));
+        let boot_update_body = format!(r#"{{"kernel_image_path":{replacement_kernel_path_json}}}"#);
+        let boot_update_response = http_put_json(&socket_path, "/boot-source", &boot_update_body);
+        assert_bad_request_response(
+            &boot_update_response,
+            "PUT /boot-source after InstanceStart",
+        );
+        assert_response_contains(
+            &boot_update_response,
+            r#"{"fault_message":"The requested operation is not supported in Running state: PutBootSource"}"#,
+            "PUT /boot-source after InstanceStart",
+        );
+        assert!(
+            !replacement_kernel_path.exists(),
+            "rejected boot-source update must not create or use replacement kernel path {}",
+            replacement_kernel_path.display()
+        );
+
         let replacement_backing_path = test_dir.path().join("replacement-data.img");
         let replacement_backing_path_json = json_string(path_text(&replacement_backing_path));
         let drive_update_body = format!(
@@ -273,6 +292,27 @@ mod macos_arm64 {
 
         let vm_config = http_get(&socket_path, "/vm/config");
         assert_ok_response(&vm_config, "GET /vm/config after InstanceStart");
+        assert_response_contains(
+            &vm_config,
+            &format!(r#""kernel_image_path":{kernel_path_json}"#),
+            "GET /vm/config after InstanceStart",
+        );
+        assert_response_contains(
+            &vm_config,
+            &format!(r#""initrd_path":{initrd_path_json}"#),
+            "GET /vm/config after InstanceStart",
+        );
+        assert_response_contains(
+            &vm_config,
+            &format!(r#""boot_args":{boot_args_json}"#),
+            "GET /vm/config after InstanceStart",
+        );
+        assert!(
+            !vm_config.contains(&format!(
+                r#""kernel_image_path":{replacement_kernel_path_json}"#
+            )),
+            "rejected boot-source update must not mutate the configured kernel path; response:\n{vm_config}"
+        );
         assert_response_contains(
             &vm_config,
             r#""drive_id":"data""#,


### PR DESCRIPTION
## Summary
- extend the signed executable HVF e2e running-state scenario with `PUT /boot-source` after `InstanceStart`
- assert the Firecracker-style `PutBootSource` unsupported-state fault
- verify `GET /vm/config` keeps the original boot source and omits the rejected replacement kernel path

Closes #689

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `scripts/run-integration-tests.sh --test executable_hvf_e2e`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`
