### PR TITLE
test: cover executable machine config patch rejection

### DIFF
--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -502,6 +502,36 @@ mod macos_arm64 {
             r#"{"fault_message":"The requested operation is not supported in Running state: PutMachineConfig"}"#,
             "PUT /machine-config after InstanceStart",
         );
+        let post_start_machine_patch_response = http_json(
+            &socket_path,
+            "PATCH",
+            "/machine-config",
+            r#"{"mem_size_mib":512}"#,
+        );
+        assert_bad_request_response(
+            &post_start_machine_patch_response,
+            "PATCH /machine-config after InstanceStart",
+        );
+        assert_response_contains(
+            &post_start_machine_patch_response,
+            r#"{"fault_message":"The requested operation is not supported in Running state: PatchMachineConfig"}"#,
+            "PATCH /machine-config after InstanceStart",
+        );
+        let machine_config_after_patch = http_get(&socket_path, "/machine-config");
+        assert_ok_response(
+            &machine_config_after_patch,
+            "GET /machine-config after rejected PATCH /machine-config",
+        );
+        assert_response_contains(
+            &machine_config_after_patch,
+            r#""vcpu_count":1"#,
+            "GET /machine-config after rejected PATCH /machine-config",
+        );
+        assert_response_contains(
+            &machine_config_after_patch,
+            r#""mem_size_mib":256"#,
+            "GET /machine-config after rejected PATCH /machine-config",
+        );
 
         if let Err(err) =
             wait_for_file_prefix_marker(&backing_path, BLOCK_WRITE_MARKER, GUEST_EXECUTION_TIMEOUT)


### PR DESCRIPTION
## Summary
- extend the signed executable HVF e2e running-state scenario with PATCH /machine-config after InstanceStart
- assert the Firecracker-style PatchMachineConfig unsupported-state fault
- verify the rejected partial machine-config update does not mutate vCPU count or memory size

Closes #697

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo check --workspace --all-targets --all-features --locked
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings
- cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings
- cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings
- scripts/run-signed-process-tests.sh
- scripts/run-integration-tests.sh --test executable_hvf_e2e
- scripts/run-integration-tests.sh