### PR TITLE
feat: handle PSCI system shutdown exits

### DIFF
--- a/crates/hvf/src/psci.rs
+++ b/crates/hvf/src/psci.rs
@@ -2,6 +2,8 @@
 
 const PSCI_VERSION: u64 = 0x8400_0000;
 const PSCI_MIGRATE_INFO_TYPE: u64 = 0x8400_0006;
+const PSCI_SYSTEM_OFF: u64 = 0x8400_0008;
+const PSCI_SYSTEM_RESET: u64 = 0x8400_0009;
 const PSCI_FEATURES: u64 = 0x8400_000a;
 const PSCI_VERSION_0_2: u64 = 0x0000_0002;
 const PSCI_RET_SUCCESS: u64 = 0;
@@ -27,41 +29,62 @@ pub(crate) const fn call_uses_arg0(function_id: u64) -> bool {
 pub(crate) const fn not_supported_result() -> PsciCallResult {
     PsciCallResult {
         return_value: PSCI_RET_NOT_SUPPORTED,
+        action: PsciCallAction::Return,
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PsciCallAction {
+    Return,
+    SystemOff,
+    SystemReset,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PsciCallResult {
     return_value: u64,
+    action: PsciCallAction,
 }
 
 impl PsciCallResult {
     pub(crate) const fn return_value(self) -> u64 {
         self.return_value
     }
+
+    pub(crate) const fn action(self) -> PsciCallAction {
+        self.action
+    }
 }
 
 pub(crate) const fn handle_call(call: PsciCall) -> PsciCallResult {
-    let return_value = match call.function_id {
-        PSCI_VERSION => PSCI_VERSION_0_2,
-        PSCI_MIGRATE_INFO_TYPE => PSCI_MIGRATE_INFO_TYPE_TRUSTED_OS_NOT_REQUIRED,
+    let (return_value, action) = match call.function_id {
+        PSCI_VERSION => (PSCI_VERSION_0_2, PsciCallAction::Return),
+        PSCI_MIGRATE_INFO_TYPE => (
+            PSCI_MIGRATE_INFO_TYPE_TRUSTED_OS_NOT_REQUIRED,
+            PsciCallAction::Return,
+        ),
+        PSCI_SYSTEM_OFF => (PSCI_RET_SUCCESS, PsciCallAction::SystemOff),
+        PSCI_SYSTEM_RESET => (PSCI_RET_SUCCESS, PsciCallAction::SystemReset),
         PSCI_FEATURES => {
             if supports_function(call.arg0) {
-                PSCI_RET_SUCCESS
+                (PSCI_RET_SUCCESS, PsciCallAction::Return)
             } else {
-                PSCI_RET_NOT_SUPPORTED
+                (PSCI_RET_NOT_SUPPORTED, PsciCallAction::Return)
             }
         }
-        _ => PSCI_RET_NOT_SUPPORTED,
+        _ => (PSCI_RET_NOT_SUPPORTED, PsciCallAction::Return),
     };
 
-    PsciCallResult { return_value }
+    PsciCallResult {
+        return_value,
+        action,
+    }
 }
 
 const fn supports_function(function_id: u64) -> bool {
     matches!(
         function_id,
-        PSCI_VERSION | PSCI_MIGRATE_INFO_TYPE | PSCI_FEATURES
+        PSCI_VERSION | PSCI_MIGRATE_INFO_TYPE | PSCI_SYSTEM_OFF | PSCI_SYSTEM_RESET | PSCI_FEATURES
     )
 }
 
@@ -69,8 +92,9 @@ const fn supports_function(function_id: u64) -> bool {
 mod tests {
     use super::{
         PSCI_FEATURES, PSCI_MIGRATE_INFO_TYPE, PSCI_MIGRATE_INFO_TYPE_TRUSTED_OS_NOT_REQUIRED,
-        PSCI_RET_NOT_SUPPORTED, PSCI_RET_SUCCESS, PSCI_VERSION, PSCI_VERSION_0_2, PsciCall,
-        call_uses_arg0, handle_call, not_supported_result,
+        PSCI_RET_NOT_SUPPORTED, PSCI_RET_SUCCESS, PSCI_SYSTEM_OFF, PSCI_SYSTEM_RESET, PSCI_VERSION,
+        PSCI_VERSION_0_2, PsciCall, PsciCallAction, call_uses_arg0, handle_call,
+        not_supported_result,
     };
 
     #[test]
@@ -91,7 +115,13 @@ mod tests {
 
     #[test]
     fn reports_features_for_supported_functions() {
-        for function_id in [PSCI_VERSION, PSCI_MIGRATE_INFO_TYPE, PSCI_FEATURES] {
+        for function_id in [
+            PSCI_VERSION,
+            PSCI_MIGRATE_INFO_TYPE,
+            PSCI_SYSTEM_OFF,
+            PSCI_SYSTEM_RESET,
+            PSCI_FEATURES,
+        ] {
             assert_eq!(
                 handle_call(PsciCall::new(PSCI_FEATURES, function_id)).return_value(),
                 PSCI_RET_SUCCESS
@@ -104,15 +134,33 @@ mod tests {
         assert!(call_uses_arg0(PSCI_FEATURES));
         assert!(!call_uses_arg0(PSCI_VERSION));
         assert!(!call_uses_arg0(PSCI_MIGRATE_INFO_TYPE));
+        assert!(!call_uses_arg0(PSCI_SYSTEM_OFF));
+        assert!(!call_uses_arg0(PSCI_SYSTEM_RESET));
         assert!(!call_uses_arg0(0x8400_0003));
     }
 
     #[test]
     fn builds_not_supported_result() {
-        assert_eq!(
-            not_supported_result().return_value(),
-            PSCI_RET_NOT_SUPPORTED
-        );
+        let result = not_supported_result();
+
+        assert_eq!(result.return_value(), PSCI_RET_NOT_SUPPORTED);
+        assert_eq!(result.action(), PsciCallAction::Return);
+    }
+
+    #[test]
+    fn classifies_system_off_as_terminal_action() {
+        let result = handle_call(PsciCall::new(PSCI_SYSTEM_OFF, 0));
+
+        assert_eq!(result.return_value(), PSCI_RET_SUCCESS);
+        assert_eq!(result.action(), PsciCallAction::SystemOff);
+    }
+
+    #[test]
+    fn classifies_system_reset_as_terminal_action() {
+        let result = handle_call(PsciCall::new(PSCI_SYSTEM_RESET, 0));
+
+        assert_eq!(result.return_value(), PSCI_RET_SUCCESS);
+        assert_eq!(result.action(), PsciCallAction::SystemReset);
     }
 
     #[test]
@@ -127,7 +175,7 @@ mod tests {
 
     #[test]
     fn returns_not_supported_for_unsupported_calls() {
-        for function_id in [0x8400_0001, 0x8400_0008, 0x8400_0009, 0xc400_0003] {
+        for function_id in [0x8400_0001, 0x8400_0002, 0x8400_0003, 0xc400_0003] {
             assert_eq!(
                 handle_call(PsciCall::new(function_id, 0)).return_value(),
                 PSCI_RET_NOT_SUPPORTED

--- a/crates/hvf/src/runner.rs
+++ b/crates/hvf/src/runner.rs
@@ -4599,6 +4599,32 @@ mod tests {
     }
 
     #[test]
+    fn run_once_and_handle_mmio_rejects_nonzero_hvc_immediate_without_guest_shutdown() {
+        let (runner, register_write_receiver) = start_psci_run_step_recording_runner_with_exit(
+            PSCI_SYSTEM_OFF,
+            Err(BackendError::InvalidState("X1 should not be read")),
+            1,
+        );
+
+        assert_eq!(
+            runner.run_once_and_handle_mmio(shared_dispatcher()),
+            Ok(HvfVcpuRunStepOutcome::Hvc {
+                exit: hvc_exit(1),
+                function_id: PSCI_SYSTEM_OFF,
+                return_value: PSCI_RET_NOT_SUPPORTED,
+            })
+        );
+        assert_eq!(
+            register_write_receiver
+                .recv()
+                .expect("nonzero HVC immediate should still write X0"),
+            (HvfRegister::X0, PSCI_RET_NOT_SUPPORTED)
+        );
+
+        runner.shutdown().expect("runner should shut down");
+    }
+
+    #[test]
     fn run_once_and_handle_mmio_returns_not_supported_for_unsupported_psci_hvc() {
         let (runner, register_write_receiver) = start_psci_run_step_recording_runner_with_x1(
             PSCI_CPU_ON,

--- a/crates/hvf/src/runner.rs
+++ b/crates/hvf/src/runner.rs
@@ -15,7 +15,7 @@ use crate::exit::{
 use crate::gic::{HvfGicError, HvfGicPpiPendingWriter, validate_gic_ppi_pending_intid};
 use crate::mmio::HvfMmioDispatchError;
 use crate::psci::{
-    PsciCall, call_uses_arg0, handle_call as handle_psci_call, not_supported_result,
+    PsciCall, PsciCallAction, call_uses_arg0, handle_call as handle_psci_call, not_supported_result,
 };
 use crate::vcpu::{HvfArm64BootRegisters, HvfRegister, HvfSystemRegister, HvfVcpuOwner};
 
@@ -64,6 +64,16 @@ pub enum HvfVcpuRunnerError {
 pub enum HvfVcpuRunStepOutcome {
     Canceled,
     Hvc {
+        exit: HvfHvcExit,
+        function_id: u64,
+        return_value: u64,
+    },
+    GuestShutdown {
+        exit: HvfHvcExit,
+        function_id: u64,
+        return_value: u64,
+    },
+    GuestReset {
         exit: HvfHvcExit,
         function_id: u64,
         return_value: u64,
@@ -1564,11 +1574,23 @@ fn handle_hvc_on_runner_thread(
     vcpu.write_register(HvfRegister::X0, return_value)
         .map_err(HvfVcpuRunnerError::Backend)?;
 
-    Ok(HvfVcpuRunStepOutcome::Hvc {
-        exit,
-        function_id,
-        return_value,
-    })
+    match result.action() {
+        PsciCallAction::Return => Ok(HvfVcpuRunStepOutcome::Hvc {
+            exit,
+            function_id,
+            return_value,
+        }),
+        PsciCallAction::SystemOff => Ok(HvfVcpuRunStepOutcome::GuestShutdown {
+            exit,
+            function_id,
+            return_value,
+        }),
+        PsciCallAction::SystemReset => Ok(HvfVcpuRunStepOutcome::GuestReset {
+            exit,
+            function_id,
+            return_value,
+        }),
+    }
 }
 
 fn dispatch_mmio_access_on_runner_thread(
@@ -1657,6 +1679,8 @@ mod tests {
     const ESR_ISS_SF: u64 = 1 << 15;
     const PSCI_VERSION: u64 = 0x8400_0000;
     const PSCI_CPU_ON: u64 = 0x8400_0003;
+    const PSCI_SYSTEM_OFF: u64 = 0x8400_0008;
+    const PSCI_SYSTEM_RESET: u64 = 0x8400_0009;
     const PSCI_FEATURES: u64 = 0x8400_000a;
     const PSCI_VERSION_0_2: u64 = 0x0000_0002;
     const PSCI_RET_SUCCESS: u64 = 0;
@@ -4492,6 +4516,56 @@ mod tests {
             register_write_receiver
                 .recv()
                 .expect("PSCI_FEATURES should write X0"),
+            (HvfRegister::X0, PSCI_RET_SUCCESS)
+        );
+
+        runner.shutdown().expect("runner should shut down");
+    }
+
+    #[test]
+    fn run_once_and_handle_mmio_returns_guest_shutdown_for_psci_system_off() {
+        let (runner, register_write_receiver) = start_psci_run_step_recording_runner_with_x1(
+            PSCI_SYSTEM_OFF,
+            Err(BackendError::InvalidState("X1 should not be read")),
+        );
+
+        assert_eq!(
+            runner.run_once_and_handle_mmio(shared_dispatcher()),
+            Ok(HvfVcpuRunStepOutcome::GuestShutdown {
+                exit: hvc_exit(0),
+                function_id: PSCI_SYSTEM_OFF,
+                return_value: PSCI_RET_SUCCESS,
+            })
+        );
+        assert_eq!(
+            register_write_receiver
+                .recv()
+                .expect("PSCI_SYSTEM_OFF should write X0"),
+            (HvfRegister::X0, PSCI_RET_SUCCESS)
+        );
+
+        runner.shutdown().expect("runner should shut down");
+    }
+
+    #[test]
+    fn run_once_and_handle_mmio_returns_guest_reset_for_psci_system_reset() {
+        let (runner, register_write_receiver) = start_psci_run_step_recording_runner_with_x1(
+            PSCI_SYSTEM_RESET,
+            Err(BackendError::InvalidState("X1 should not be read")),
+        );
+
+        assert_eq!(
+            runner.run_once_and_handle_mmio(shared_dispatcher()),
+            Ok(HvfVcpuRunStepOutcome::GuestReset {
+                exit: hvc_exit(0),
+                function_id: PSCI_SYSTEM_RESET,
+                return_value: PSCI_RET_SUCCESS,
+            })
+        );
+        assert_eq!(
+            register_write_receiver
+                .recv()
+                .expect("PSCI_SYSTEM_RESET should write X0"),
             (HvfRegister::X0, PSCI_RET_SUCCESS)
         );
 

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -176,6 +176,8 @@ pub enum HvfArm64BootRunLoopOutcome {
     StepLimitReached { steps: usize },
     Stopped { steps: usize },
     Canceled { steps: usize },
+    GuestShutdown { steps: usize },
+    GuestReset { steps: usize },
     Unknown { steps: usize, reason: u32 },
 }
 
@@ -1370,6 +1372,12 @@ fn run_boot_session_loop_with_observer(
             HvfVcpuRunStepOutcome::Unknown { reason } => {
                 return Ok(HvfArm64BootRunLoopOutcome::Unknown { steps, reason });
             }
+            HvfVcpuRunStepOutcome::GuestShutdown { .. } => {
+                return Ok(HvfArm64BootRunLoopOutcome::GuestShutdown { steps });
+            }
+            HvfVcpuRunStepOutcome::GuestReset { .. } => {
+                return Ok(HvfArm64BootRunLoopOutcome::GuestReset { steps });
+            }
             HvfVcpuRunStepOutcome::Hvc { .. } | HvfVcpuRunStepOutcome::Sys64 { .. } => {
                 if stop_token.is_stop_requested() {
                     return Ok(HvfArm64BootRunLoopOutcome::Stopped { steps });
@@ -2144,7 +2152,10 @@ mod tests {
         | VIRTIO_DEVICE_STATUS_FEATURES_OK;
     const DRIVER_OK_STATUS: u32 = QUEUE_CONFIG_STATUS | VIRTIO_DEVICE_STATUS_DRIVER_OK;
     const PSCI_VERSION: u64 = 0x8400_0000;
+    const PSCI_SYSTEM_OFF: u64 = 0x8400_0008;
+    const PSCI_SYSTEM_RESET: u64 = 0x8400_0009;
     const PSCI_VERSION_0_2: u64 = 0x0000_0002;
+    const PSCI_RET_SUCCESS: u64 = 0;
     const TEST_NETWORK_MMIO_BASE: GuestAddress = GuestAddress::new(0x4000_4000);
 
     struct TempFile {
@@ -2604,6 +2615,22 @@ mod tests {
             exit: hvc_exit(0),
             function_id: PSCI_VERSION,
             return_value: PSCI_VERSION_0_2,
+        }
+    }
+
+    fn guest_shutdown_run_step_outcome() -> HvfVcpuRunStepOutcome {
+        HvfVcpuRunStepOutcome::GuestShutdown {
+            exit: hvc_exit(0),
+            function_id: PSCI_SYSTEM_OFF,
+            return_value: PSCI_RET_SUCCESS,
+        }
+    }
+
+    fn guest_reset_run_step_outcome() -> HvfVcpuRunStepOutcome {
+        HvfVcpuRunStepOutcome::GuestReset {
+            exit: hvc_exit(0),
+            function_id: PSCI_SYSTEM_RESET,
+            return_value: PSCI_RET_SUCCESS,
         }
     }
 
@@ -4902,6 +4929,34 @@ mod tests {
             HvfArm64BootRunLoopOutcome::StepLimitReached { steps: 2 }
         );
         assert_eq!(session.events, ["run", "run"]);
+    }
+
+    #[test]
+    fn boot_session_run_loop_returns_guest_shutdown_as_terminal_outcome() {
+        let stop_token = HvfArm64BootRunLoopStopToken::new();
+        let mut session =
+            RecordingBootSessionRunLoopSession::new([guest_shutdown_run_step_outcome()]);
+
+        let outcome = run_boot_session_loop(&mut session, &stop_token, max_steps(2))
+            .expect("guest shutdown loop should succeed");
+
+        assert_eq!(
+            outcome,
+            HvfArm64BootRunLoopOutcome::GuestShutdown { steps: 1 }
+        );
+        assert_eq!(session.events, ["run"]);
+    }
+
+    #[test]
+    fn boot_session_run_loop_returns_guest_reset_as_terminal_outcome() {
+        let stop_token = HvfArm64BootRunLoopStopToken::new();
+        let mut session = RecordingBootSessionRunLoopSession::new([guest_reset_run_step_outcome()]);
+
+        let outcome = run_boot_session_loop(&mut session, &stop_token, max_steps(2))
+            .expect("guest reset loop should succeed");
+
+        assert_eq!(outcome, HvfArm64BootRunLoopOutcome::GuestReset { steps: 1 });
+        assert_eq!(session.events, ["run"]);
     }
 
     #[test]

--- a/crates/hvf/tests/guest_boot.rs
+++ b/crates/hvf/tests/guest_boot.rs
@@ -667,6 +667,8 @@ impl GuestBootRunDiagnostics {
             bangbang_hvf::HvfVcpuRunStepOutcome::Hvc { .. } => {
                 self.hvc_steps += 1;
             }
+            bangbang_hvf::HvfVcpuRunStepOutcome::GuestShutdown { .. }
+            | bangbang_hvf::HvfVcpuRunStepOutcome::GuestReset { .. } => {}
             bangbang_hvf::HvfVcpuRunStepOutcome::Sys64 { .. } => {
                 self.sys64_steps += 1;
             }
@@ -891,6 +893,8 @@ fn run_loop_completed_steps(outcome: &bangbang_hvf::HvfArm64BootRunLoopOutcome) 
         bangbang_hvf::HvfArm64BootRunLoopOutcome::StepLimitReached { steps }
         | bangbang_hvf::HvfArm64BootRunLoopOutcome::Stopped { steps }
         | bangbang_hvf::HvfArm64BootRunLoopOutcome::Canceled { steps }
+        | bangbang_hvf::HvfArm64BootRunLoopOutcome::GuestShutdown { steps }
+        | bangbang_hvf::HvfArm64BootRunLoopOutcome::GuestReset { steps }
         | bangbang_hvf::HvfArm64BootRunLoopOutcome::Unknown { steps, .. } => *steps,
     }
 }
@@ -1116,11 +1120,23 @@ mod tests {
             3
         );
         assert_eq!(
-            run_loop_completed_steps(&bangbang_hvf::HvfArm64BootRunLoopOutcome::Unknown {
-                steps: 4,
-                reason: 99
+            run_loop_completed_steps(&bangbang_hvf::HvfArm64BootRunLoopOutcome::GuestShutdown {
+                steps: 4
             }),
             4
+        );
+        assert_eq!(
+            run_loop_completed_steps(&bangbang_hvf::HvfArm64BootRunLoopOutcome::GuestReset {
+                steps: 5
+            }),
+            5
+        );
+        assert_eq!(
+            run_loop_completed_steps(&bangbang_hvf::HvfArm64BootRunLoopOutcome::Unknown {
+                steps: 6,
+                reason: 99
+            }),
+            6
         );
     }
 

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -974,8 +974,9 @@ arm64 HVC exception exits and handles `HVC #0` as a minimal PSCI 0.2 responder
 for early single-vCPU boot probing. The responder returns `PSCI_VERSION`,
 reports feature support only for the implemented minimal calls, returns
 `MIGRATE_INFO_TYPE` as the PSCI value for a trusted OS that is MP-capable or
-not present, where migration is not required, and writes `NOT_SUPPORTED` to X0
-for other PSCI calls or HVC immediates.
+not present, where migration is not required, and translates `SYSTEM_OFF` and
+`SYSTEM_RESET` into guest-requested terminal boot run-loop outcomes. It writes
+`NOT_SUPPORTED` to X0 for other PSCI calls or HVC immediates.
 Early boot also traps the guest's `OSDLR_EL1` and `OSLAR_EL1` OS lock
 system-register accesses through the AArch64 SYS64 exception class (`0x18`),
 not through SMC/SMCCC. The HVF runner handles only those observed
@@ -1247,9 +1248,10 @@ bounded internal
 boot-session run-loop pump now composes that one-step path with boot block,
 virtio-net, and virtio-vsock notification dispatch between successful MMIO steps and virtual
 timer PPI assertion after virtual timer exits. It stops explicitly on a step limit,
-stop-token request, canceled run exit, unknown run exit, dispatch error, or
-timer handler error. This remains internal runner-loop plumbing, not the future
-public guest scheduler. An owned internal session handle preserves the same
+stop-token request, canceled run exit, PSCI `SYSTEM_OFF` or `SYSTEM_RESET`
+guest request, unknown run exit, dispatch error, or timer handler error. This
+remains internal runner-loop plumbing, not the future public guest scheduler.
+An owned internal session handle preserves the same
 session operations while avoiding a self-referential backend/session owner in
 process-level state.
 The boot session can also dispatch pending boot block, virtio-net, and
@@ -1263,10 +1265,11 @@ runtime notifications and releases it before HVF GIC signaling.
 bangbang now wires `mem_size_mib` into startup preparation, but still does not
 wire device interrupts into public guest execution, emulate devices, provide
 public run-loop control, power on secondary vCPUs, or implement full PSCI CPU
-and system power actions. Public machine configuration rejects `mem_size_mib`
-above the current 1022 GiB Apple Silicon/aarch64 DRAM maximum before storage;
-startup keeps its architectural maximum check as a defensive guard. Dynamic
-host-memory availability policy remains deferred.
+control and process exit-code parity for guest system power actions. Public
+machine configuration rejects `mem_size_mib` above the current 1022 GiB Apple
+Silicon/aarch64 DRAM maximum before storage; startup keeps its architectural
+maximum check as a defensive guard. Dynamic host-memory availability policy
+remains deferred.
 
 ## API State and Response Policy
 


### PR DESCRIPTION
## Summary

- Recognize PSCI `SYSTEM_OFF` and `SYSTEM_RESET` on the HVF single-vCPU HVC path.
- Propagate guest shutdown/reset as dedicated vCPU step and boot run-loop terminal outcomes.
- Document the new PSCI shutdown/reset boundary while leaving full PSCI CPU control and process exit-code parity out of scope.

Closes #718

## Out Of Scope

- Full process exit-code parity for API/no-api modes.
- Multi-vCPU PSCI calls such as `CPU_ON`.
- Public pause/resume lifecycle control.
- New guest e2e poweroff/reboot artifacts.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`
- `git diff --check`
