### PR TITLE
docs: align serial security notes

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -206,10 +206,12 @@ explicit. The current HVF runner emulates only the early-boot `OSDLR_EL1` and
 unsupported trapped system registers fail closed instead of being treated as
 generic no-ops.
 
-The current serial device is an internal TX-only MMIO output path with bounded
-capture. Public serial output streaming is not implemented. Treat serial output
-as guest data; future public exposure must document whether the host is expected
-to observe it and how it is bounded.
+The current serial device is a TX-only MMIO output path. By default, guest
+serial bytes go to a bounded internal capture buffer; when `/serial` configures
+`serial_out_path`, startup opens that host path and routes guest TX bytes there.
+Treat serial output as untrusted guest data. Reviews for serial-output changes
+must preserve explicit host-observation behavior, bounded buffering or writes,
+path redaction, and per-process ownership.
 
 Block devices can expose host file contents to the guest and can write to the
 backing file when configured read-write. Operators should use dedicated disk
@@ -410,7 +412,7 @@ The current scaffold does not implement:
   checks, dispatch real event payloads, track graceful half-close state, or
   implement full virtio-vsock credit accounting.
 - complete production logging or metrics policy
-- public run-loop control or public serial streaming policy
+- public run-loop control or serial input, rate-limiting, and streaming policy
 
 These are future security design and implementation topics. PRs that add new
 host-facing resources should update this document and include resource-specific

--- a/docs/security.md
+++ b/docs/security.md
@@ -208,10 +208,11 @@ generic no-ops.
 
 The current serial device is a TX-only MMIO output path. By default, guest
 serial bytes go to a bounded internal capture buffer; when `/serial` configures
-`serial_out_path`, startup opens that host path and routes guest TX bytes there.
-Treat serial output as untrusted guest data. Reviews for serial-output changes
-must preserve explicit host-observation behavior, bounded buffering or writes,
-path redaction, and per-process ownership.
+`serial_out_path`, startup opens that host path with nonblocking output
+semantics and routes guest TX bytes there. Treat serial output as untrusted
+guest data. Reviews for serial-output changes must preserve explicit
+host-observation behavior, bounded internal buffering where used, path
+redaction, and per-process ownership.
 
 Block devices can expose host file contents to the guest and can write to the
 backing file when configured read-write. Operators should use dedicated disk

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -291,13 +291,14 @@ of the pinned Firecracker rootfs with a test-specific
 boots without the tiny initrd, attaches that ext4 image as a read-only root
 drive, and passes `init=/bangbang-direct-rootfs-init`. The `guest_boot` target
 expects deterministic serial markers plus Ubuntu os-release content from
-`/etc/os-release`; the executable HVF e2e target observes
-`BANGBANG_DIRECT_ROOTFS_BLOCK_OK` in a second writable scratch drive because it
-does not expose public serial output. When the boot args also include
-`bangbang.mmds-fetch=1`, the same init script configures the first non-loopback
-guest interface with a link-local address, runs a bounded `curl` request for
-`/meta-data/bangbang-marker`, and writes `BANGBANG_MMDS_GUEST_FETCH_OK` to the
-scratch drive only after the expected MMDS value is returned. With
+`/etc/os-release`; the direct-rootfs executable HVF e2e scenarios observe
+`BANGBANG_DIRECT_ROOTFS_BLOCK_OK` in a second writable scratch drive because
+those scenarios do not configure a public serial output path. When the boot
+args also include `bangbang.mmds-fetch=1`, the same init script configures the
+first non-loopback guest interface with a link-local address, runs a bounded
+`curl` request for `/meta-data/bangbang-marker`, and writes
+`BANGBANG_MMDS_GUEST_FETCH_OK` to the scratch drive only after the expected
+MMDS value is returned. With
 `bangbang.mmds-v2-fetch=1`, it first requests a v2 token from
 `/latest/api/token`, then fetches the same marker with the token header and
 writes `BANGBANG_MMDS_V2_GUEST_FETCH_OK`. The init script emits only static


### PR DESCRIPTION
## Summary

- Align `docs/security.md` with the implemented TX-only `/serial` output-path support.
- Clarify that direct-rootfs executable HVF e2e scenarios use block markers because those scenarios do not configure a public serial output path.
- Preserve the remaining serial limitations: no input/RX, rate limiting, public streaming API, or full logging/metrics routing of serial bytes.

## Scope

No runtime behavior or tests changed; this PR corrects stale serial documentation only.

Closes #761

## Validation

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`
