### PR TITLE
feat: count balloon api metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,13 @@ while the VM is running. After `InstanceStart`, the line also includes a
 process-owned boot worker exists. When startup timing CLI values are provided,
 the same metrics output includes `start_time_us`, `start_time_cpu_us`, and
 `parent_cpu_time_us`. The current Firecracker-shaped API request metrics subset
-also reports selected GET counters under `get_api_requests`, parsed core
+also reports selected GET counters under `get_api_requests`; parsed core
 configuration, MMDS, observability, memory hotplug, pmem, and `/actions`
-counters under `put_api_requests`, and selected PATCH counters including
-memory hotplug and pmem under `patch_api_requests`. Parsed deprecated HTTP API
+counters under `put_api_requests`; and selected PATCH counters including memory
+hotplug and pmem under `patch_api_requests`. bangbang also records
+bangbang-specific `balloon_count` and `balloon_fails` API request counters for
+parsed balloon routes because Firecracker does not expose matching balloon API
+request metric fields. Parsed deprecated HTTP API
 usage is counted under `deprecated_api.deprecated_http_api_calls` for supported
 deprecated machine `cpu_template`, MMDS V1 config, `vsock_id`, and snapshot-load
 field forms.

--- a/README.md
+++ b/README.md
@@ -169,9 +169,10 @@ also reports selected GET counters under `get_api_requests`; parsed core
 configuration, MMDS, observability, memory hotplug, pmem, and `/actions`
 counters under `put_api_requests`; and selected PATCH counters including memory
 hotplug and pmem under `patch_api_requests`. bangbang also records
-bangbang-specific `balloon_count` and `balloon_fails` API request counters for
-parsed balloon routes because Firecracker does not expose matching balloon API
-request metric fields. Parsed deprecated HTTP API
+bangbang-specific `balloon_count` API request counters for parsed balloon GET,
+PUT, and PATCH routes, plus `balloon_fails` counters for parsed balloon PUT and
+PATCH failures, because Firecracker does not expose matching balloon API request
+metric fields. Parsed deprecated HTTP API
 usage is counted under `deprecated_api.deprecated_http_api_calls` for supported
 deprecated machine `cpu_template`, MMDS V1 config, `vsock_id`, and snapshot-load
 field forms.

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -588,21 +588,25 @@ fn handle_api_request(request: ApiRequest, vmm: &mut impl VmmRequestHandler) -> 
         ApiRequest::PutSerial(config) => handle_empty(vmm.handle_put_request(
             PutApiRequest::serial(serial_config_input_from_request(config.as_ref())),
         )),
-        ApiRequest::GetBalloon => handle_empty(vmm.handle_action(VmmAction::GetBalloon)),
-        ApiRequest::GetBalloonStats => handle_empty(vmm.handle_action(VmmAction::GetBalloonStats)),
-        ApiRequest::GetBalloonHintingStatus => {
-            handle_empty(vmm.handle_action(VmmAction::GetBalloonHintingStatus))
+        ApiRequest::GetBalloon => handle_empty(vmm.handle_get_request(GetApiRequest::Balloon)),
+        ApiRequest::GetBalloonStats => {
+            handle_empty(vmm.handle_get_request(GetApiRequest::BalloonStats))
         }
-        ApiRequest::PutBalloon => handle_empty(vmm.handle_action(VmmAction::PutBalloon)),
-        ApiRequest::PatchBalloon => handle_empty(vmm.handle_action(VmmAction::PatchBalloon)),
+        ApiRequest::GetBalloonHintingStatus => {
+            handle_empty(vmm.handle_get_request(GetApiRequest::BalloonHintingStatus))
+        }
+        ApiRequest::PutBalloon => handle_empty(vmm.handle_put_request(PutApiRequest::balloon())),
+        ApiRequest::PatchBalloon => {
+            handle_empty(vmm.handle_patch_request(PatchApiRequest::balloon()))
+        }
         ApiRequest::PatchBalloonStats => {
-            handle_empty(vmm.handle_action(VmmAction::PatchBalloonStats))
+            handle_empty(vmm.handle_patch_request(PatchApiRequest::balloon_stats()))
         }
         ApiRequest::PatchBalloonHintingStart => {
-            handle_empty(vmm.handle_action(VmmAction::PatchBalloonHintingStart))
+            handle_empty(vmm.handle_patch_request(PatchApiRequest::balloon_hinting_start()))
         }
         ApiRequest::PatchBalloonHintingStop => {
-            handle_empty(vmm.handle_action(VmmAction::PatchBalloonHintingStop))
+            handle_empty(vmm.handle_patch_request(PatchApiRequest::balloon_hinting_stop()))
         }
         ApiRequest::GetMemoryHotplug => {
             handle_empty(vmm.handle_get_request(GetApiRequest::HotplugMemory))
@@ -3154,7 +3158,7 @@ mod tests {
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
         assert_eq!(
             fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
 
         fs::remove_file(metrics_path).expect("fixture should clean up");
@@ -3195,7 +3199,7 @@ mod tests {
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
         assert_eq!(
             fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"put_api_requests\":{\"actions_count\":3,\"actions_fails\":1,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"put_api_requests\":{\"actions_count\":3,\"actions_fails\":1,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
 
         fs::remove_file(metrics_path).expect("fixture should clean up");
@@ -3259,7 +3263,100 @@ mod tests {
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
         assert_eq!(
             fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"get_api_requests\":{\"hotplug_memory_count\":0,\"instance_info_count\":1,\"machine_cfg_count\":1,\"mmds_count\":1,\"vmm_version_count\":1},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"get_api_requests\":{\"balloon_count\":0,\"hotplug_memory_count\":0,\"instance_info_count\":1,\"machine_cfg_count\":1,\"mmds_count\":1,\"vmm_version_count\":1},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+        );
+
+        fs::remove_file(metrics_path).expect("fixture should clean up");
+    }
+
+    #[test]
+    fn configured_metrics_counts_balloon_api_requests() {
+        let mut vmm = test_controller_with_starter(TestInstanceStarter::success());
+        let metrics_path = unique_socket_path("metrics-balloon").with_extension("metrics");
+        let metrics_body = format!(r#"{{"metrics_path":"{}"}}"#, metrics_path.to_string_lossy());
+        let metrics_request = request_with_body("PUT", "/metrics", &metrics_body);
+        assert_eq!(
+            handle_request_bytes(metrics_request.as_bytes(), &mut vmm).status(),
+            bangbang_api::http::StatusCode::NoContent
+        );
+
+        for (socket_name, request) in [
+            (
+                "bg",
+                "GET /balloon HTTP/1.1\r\nHost: localhost\r\n\r\n".to_string(),
+            ),
+            (
+                "bgs",
+                "GET /balloon/statistics HTTP/1.1\r\nHost: localhost\r\n\r\n".to_string(),
+            ),
+            (
+                "bgh",
+                "GET /balloon/hinting/status HTTP/1.1\r\nHost: localhost\r\n\r\n".to_string(),
+            ),
+        ] {
+            let response = request_over_socket(&mut vmm, socket_name, &request);
+            assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        }
+
+        let valid_put_response = request_over_socket(
+            &mut vmm,
+            "bp",
+            &request_with_body(
+                "PUT",
+                "/balloon",
+                r#"{"amount_mib":64,"deflate_on_oom":true}"#,
+            ),
+        );
+        assert!(valid_put_response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+
+        let malformed_put_response =
+            request_over_socket(&mut vmm, "bpm", &request_with_body("PUT", "/balloon", "{}"));
+        assert!(malformed_put_response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+
+        for (socket_name, request) in [
+            (
+                "bpa",
+                request_with_body("PATCH", "/balloon", r#"{"amount_mib":32}"#),
+            ),
+            (
+                "bps",
+                request_with_body(
+                    "PATCH",
+                    "/balloon/statistics",
+                    r#"{"stats_polling_interval_s":1}"#,
+                ),
+            ),
+            (
+                "bphs",
+                request_with_body(
+                    "PATCH",
+                    "/balloon/hinting/start",
+                    r#"{"acknowledge_on_stop":false}"#,
+                ),
+            ),
+            (
+                "bphx",
+                "PATCH /balloon/hinting/stop HTTP/1.1\r\nHost: localhost\r\n\r\n".to_string(),
+            ),
+        ] {
+            let response = request_over_socket(&mut vmm, socket_name, &request);
+            assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        }
+
+        let boot_body = r#"{"kernel_image_path":"/tmp/original-vmlinux"}"#;
+        let boot_request = request_with_body("PUT", "/boot-source", boot_body);
+        assert_eq!(
+            handle_request_bytes(boot_request.as_bytes(), &mut vmm).status(),
+            bangbang_api::http::StatusCode::NoContent
+        );
+        let start_response = put_action_over_socket(&mut vmm, "bs", "InstanceStart");
+        assert!(start_response.starts_with("HTTP/1.1 204 No Content\r\n"));
+        let flush_response = put_action_over_socket(&mut vmm, "bf", "FlushMetrics");
+
+        assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
+        assert_eq!(
+            fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
+            "{\"get_api_requests\":{\"balloon_count\":3,\"hotplug_memory_count\":0,\"instance_info_count\":0,\"machine_cfg_count\":0,\"mmds_count\":0,\"vmm_version_count\":0},\"patch_api_requests\":{\"balloon_count\":4,\"balloon_fails\":4,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":1,\"balloon_fails\":1,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
 
         fs::remove_file(metrics_path).expect("fixture should clean up");
@@ -3362,7 +3459,7 @@ mod tests {
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
         assert_eq!(
             fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":2,\"logger_fails\":1,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":2,\"metrics_fails\":1,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":2,\"serial_fails\":1,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":2,\"logger_fails\":1,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":2,\"metrics_fails\":1,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":2,\"serial_fails\":1,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
 
         fs::remove_file(metrics_path).expect("metrics fixture should clean up");
@@ -3527,7 +3624,7 @@ mod tests {
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
         assert_eq!(
             fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"boot_source_count\":2,\"boot_source_fails\":1,\"cpu_cfg_count\":2,\"cpu_cfg_fails\":1,\"drive_count\":2,\"drive_fails\":1,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":1,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":2,\"network_fails\":1,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":2,\"vsock_fails\":1},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":2,\"boot_source_fails\":1,\"cpu_cfg_count\":2,\"cpu_cfg_fails\":1,\"drive_count\":2,\"drive_fails\":1,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":1,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":2,\"network_fails\":1,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":2,\"vsock_fails\":1},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
 
         assert!(!drive_path.exists());
@@ -3615,7 +3712,7 @@ mod tests {
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
         assert_eq!(
             fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"patch_api_requests\":{\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":1,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":4,\"mmds_fails\":2,\"network_count\":1,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":1,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":4,\"mmds_fails\":2,\"network_count\":1,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
 
         fs::remove_file(metrics_path).expect("metrics fixture should clean up");
@@ -3691,7 +3788,7 @@ mod tests {
             fs::read_to_string(&metrics_path).expect("metrics output should be readable");
         assert_eq!(
             metrics_output,
-            "{\"patch_api_requests\":{\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":1,\"pmem_fails\":1},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":1,\"pmem_fails\":1,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":1,\"pmem_fails\":1},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":1,\"pmem_fails\":1,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
         assert!(!metrics_output.contains("pmem0"));
         assert!(!metrics_output.contains("/private/tmp/pmem.img"));
@@ -3791,7 +3888,7 @@ mod tests {
             fs::read_to_string(&metrics_path).expect("metrics output should be readable");
         assert_eq!(
             metrics_output,
-            "{\"get_api_requests\":{\"hotplug_memory_count\":1,\"instance_info_count\":0,\"machine_cfg_count\":0,\"mmds_count\":0,\"vmm_version_count\":0},\"patch_api_requests\":{\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":1,\"hotplug_memory_fails\":1,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":1,\"hotplug_memory_fails\":1,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"get_api_requests\":{\"balloon_count\":0,\"hotplug_memory_count\":1,\"instance_info_count\":0,\"machine_cfg_count\":0,\"mmds_count\":0,\"vmm_version_count\":0},\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":1,\"hotplug_memory_fails\":1,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":1,\"hotplug_memory_fails\":1,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
         assert!(!metrics_output.contains("222222222"));
         assert!(!metrics_output.contains("333333333"));
@@ -3912,7 +4009,7 @@ mod tests {
             fs::read_to_string(&metrics_path).expect("metrics output should be readable");
         assert_eq!(
             metrics_output,
-            "{\"deprecated_api\":{\"deprecated_http_api_calls\":6},\"patch_api_requests\":{\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":1,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":1,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":1,\"mmds_fails\":1,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":1,\"vsock_fails\":1},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"deprecated_api\":{\"deprecated_http_api_calls\":6},\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":1,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":1,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":1,\"mmds_fails\":1,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":1,\"vsock_fails\":1},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
         assert!(!metrics_output.contains("vsock-secret"));
         assert!(!metrics_output.contains("deprecated-vsock-secret"));
@@ -4099,7 +4196,7 @@ mod tests {
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
         assert_eq!(
             fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"patch_api_requests\":{\"drive_count\":1,\"drive_fails\":1,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":1,\"mmds_count\":2,\"mmds_fails\":1,\"network_count\":2,\"network_fails\":2,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":1,\"drive_fails\":1,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":1,\"mmds_count\":2,\"mmds_fails\":1,\"network_count\":2,\"network_fails\":2,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
 
         fs::remove_file(metrics_path).expect("metrics fixture should clean up");
@@ -4140,7 +4237,7 @@ mod tests {
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
         assert_eq!(
             fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"boot_run_loop_status\":\"running\",\"metrics_flush_count\":1}}\n"
+            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"boot_run_loop_status\":\"running\",\"metrics_flush_count\":1}}\n"
         );
 
         fs::remove_file(metrics_path).expect("fixture should clean up");
@@ -4190,7 +4287,7 @@ mod tests {
         assert_eq!(
             fs::read_to_string(&startup_metrics_path)
                 .expect("startup metrics output should be readable"),
-            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":1,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":1,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
         assert!(!api_metrics_path.exists());
 

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -131,6 +131,9 @@ impl ProcessSessionExitStatus {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum GetApiRequest {
+    Balloon,
+    BalloonHintingStatus,
+    BalloonStats,
     HotplugMemory,
     InstanceInfo,
     VmmVersion,
@@ -141,6 +144,9 @@ pub(crate) enum GetApiRequest {
 impl GetApiRequest {
     const fn action(self) -> VmmAction {
         match self {
+            Self::Balloon => VmmAction::GetBalloon,
+            Self::BalloonHintingStatus => VmmAction::GetBalloonHintingStatus,
+            Self::BalloonStats => VmmAction::GetBalloonStats,
             Self::HotplugMemory => VmmAction::GetMemoryHotplug,
             Self::InstanceInfo => VmmAction::GetVmInstanceInfo,
             Self::VmmVersion => VmmAction::GetVmmVersion,
@@ -151,6 +157,9 @@ impl GetApiRequest {
 
     fn record(self, controller: &mut VmmController) {
         match self {
+            Self::Balloon | Self::BalloonHintingStatus | Self::BalloonStats => {
+                controller.record_get_balloon_request();
+            }
             Self::HotplugMemory => controller.record_get_hotplug_memory_request(),
             Self::InstanceInfo => controller.record_get_instance_info_request(),
             Self::VmmVersion => controller.record_get_vmm_version_request(),
@@ -167,6 +176,13 @@ pub(crate) struct PutApiRequest {
 }
 
 impl PutApiRequest {
+    pub(crate) const fn balloon() -> Self {
+        Self {
+            kind: PutApiRequestKind::Balloon,
+            action: VmmAction::PutBalloon,
+        }
+    }
+
     pub(crate) fn boot_source(input: BootSourceConfigInput) -> Self {
         Self {
             kind: PutApiRequestKind::BootSource,
@@ -269,6 +285,7 @@ impl PutApiRequest {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PutApiRequestKind {
+    Balloon,
     BootSource,
     CpuConfig,
     Drive,
@@ -286,6 +303,7 @@ enum PutApiRequestKind {
 impl PutApiRequestKind {
     fn record_request(self, controller: &mut VmmController) {
         match self {
+            Self::Balloon => controller.record_put_balloon_request(),
             Self::BootSource => controller.record_put_boot_source_request(),
             Self::CpuConfig => controller.record_put_cpu_config_request(),
             Self::Drive => controller.record_put_drive_request(),
@@ -303,6 +321,7 @@ impl PutApiRequestKind {
 
     fn record_failure(self, controller: &mut VmmController) {
         match self {
+            Self::Balloon => controller.record_put_balloon_failure(),
             Self::BootSource => controller.record_put_boot_source_failure(),
             Self::CpuConfig => controller.record_put_cpu_config_failure(),
             Self::Drive => controller.record_put_drive_failure(),
@@ -326,6 +345,34 @@ pub(crate) struct PatchApiRequest {
 }
 
 impl PatchApiRequest {
+    pub(crate) const fn balloon() -> Self {
+        Self {
+            kind: PatchApiRequestKind::Balloon,
+            action: VmmAction::PatchBalloon,
+        }
+    }
+
+    pub(crate) const fn balloon_hinting_start() -> Self {
+        Self {
+            kind: PatchApiRequestKind::Balloon,
+            action: VmmAction::PatchBalloonHintingStart,
+        }
+    }
+
+    pub(crate) const fn balloon_hinting_stop() -> Self {
+        Self {
+            kind: PatchApiRequestKind::Balloon,
+            action: VmmAction::PatchBalloonHintingStop,
+        }
+    }
+
+    pub(crate) const fn balloon_stats() -> Self {
+        Self {
+            kind: PatchApiRequestKind::Balloon,
+            action: VmmAction::PatchBalloonStats,
+        }
+    }
+
     pub(crate) fn drive(input: DriveUpdateInput) -> Self {
         Self {
             kind: PatchApiRequestKind::Drive,
@@ -379,6 +426,7 @@ impl PatchApiRequest {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PatchApiRequestKind {
+    Balloon,
     Drive,
     HotplugMemory,
     MachineConfig,
@@ -390,6 +438,7 @@ enum PatchApiRequestKind {
 impl PatchApiRequestKind {
     fn record_request(self, controller: &mut VmmController) {
         match self {
+            Self::Balloon => controller.record_patch_balloon_request(),
             Self::Drive => controller.record_patch_drive_request(),
             Self::HotplugMemory => controller.record_patch_hotplug_memory_request(),
             Self::MachineConfig => controller.record_patch_machine_config_request(),
@@ -401,6 +450,7 @@ impl PatchApiRequestKind {
 
     fn record_failure(self, controller: &mut VmmController) {
         match self {
+            Self::Balloon => controller.record_patch_balloon_failure(),
             Self::Drive => controller.record_patch_drive_failure(),
             Self::HotplugMemory => controller.record_patch_hotplug_memory_failure(),
             Self::MachineConfig => controller.record_patch_machine_config_failure(),

--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -20,7 +20,7 @@ mod macos_arm64 {
     use crate::support::{
         BangbangProcess, TestDir, assert_bad_request_response, assert_clean_shutdown,
         assert_no_content_response, assert_ok_response, assert_response_contains, http_get,
-        http_json, http_put_json, json_string, path_text,
+        http_json, http_no_body, http_put_json, json_string, path_text,
     };
 
     const BANGBANG_GUEST_KERNEL_PATH_ENV: &str = "BANGBANG_GUEST_KERNEL_PATH";
@@ -461,6 +461,70 @@ mod macos_arm64 {
             "PATCH /mmds should remove null-valued fields; response:\n{mmds_data}"
         );
 
+        for (request_name, response, fault_message) in [
+            (
+                "GET /balloon",
+                http_get(&socket_path, "/balloon"),
+                "Balloon device is not supported.",
+            ),
+            (
+                "GET /balloon/statistics",
+                http_get(&socket_path, "/balloon/statistics"),
+                "Balloon device is not supported.",
+            ),
+            (
+                "GET /balloon/hinting/status",
+                http_get(&socket_path, "/balloon/hinting/status"),
+                "Balloon device is not supported.",
+            ),
+            (
+                "PUT /balloon",
+                http_put_json(
+                    &socket_path,
+                    "/balloon",
+                    r#"{"amount_mib":64,"deflate_on_oom":true}"#,
+                ),
+                "The requested operation is not supported in Running state: PutBalloon",
+            ),
+            (
+                "PATCH /balloon",
+                http_json(&socket_path, "PATCH", "/balloon", r#"{"amount_mib":32}"#),
+                "Balloon device is not supported.",
+            ),
+            (
+                "PATCH /balloon/statistics",
+                http_json(
+                    &socket_path,
+                    "PATCH",
+                    "/balloon/statistics",
+                    r#"{"stats_polling_interval_s":1}"#,
+                ),
+                "Balloon device is not supported.",
+            ),
+            (
+                "PATCH /balloon/hinting/start",
+                http_json(
+                    &socket_path,
+                    "PATCH",
+                    "/balloon/hinting/start",
+                    r#"{"acknowledge_on_stop":false}"#,
+                ),
+                "Balloon device is not supported.",
+            ),
+            (
+                "PATCH /balloon/hinting/stop",
+                http_no_body(&socket_path, "PATCH", "/balloon/hinting/stop"),
+                "Balloon device is not supported.",
+            ),
+        ] {
+            assert_bad_request_response(&response, request_name);
+            assert_response_contains(
+                &response,
+                &format!(r#"{{"fault_message":"{fault_message}"}}"#),
+                request_name,
+            );
+        }
+
         let vm_config = http_get(&socket_path, "/vm/config");
         assert_ok_response(&vm_config, "GET /vm/config after InstanceStart");
         assert_response_contains(
@@ -571,9 +635,12 @@ mod macos_arm64 {
         assert_no_content_response(&flush_metrics_response, "PUT /actions FlushMetrics");
         assert_metrics_output(
             &metrics_path,
-            r#"{"actions_count":2,"actions_fails":0,"boot_source_count":2,"boot_source_fails":1,"cpu_cfg_count":1,"cpu_cfg_fails":1,"drive_count":2,"drive_fails":1,"logger_count":2,"logger_fails":1,"machine_cfg_count":1,"machine_cfg_fails":0,"metrics_count":2,"metrics_fails":1,"mmds_count":2,"mmds_fails":1,"network_count":1,"network_fails":1,"pmem_count":0,"pmem_fails":0,"serial_count":2,"serial_fails":1,"vsock_count":2,"vsock_fails":1}"#,
             Some(
-                r#"{"drive_count":1,"drive_fails":1,"machine_cfg_count":0,"machine_cfg_fails":0,"mmds_count":1,"mmds_fails":0,"network_count":0,"network_fails":0,"pmem_count":0,"pmem_fails":0}"#,
+                r#"{"balloon_count":3,"hotplug_memory_count":0,"instance_info_count":5,"machine_cfg_count":0,"mmds_count":1,"vmm_version_count":0}"#,
+            ),
+            r#"{"actions_count":2,"actions_fails":0,"balloon_count":1,"balloon_fails":1,"boot_source_count":2,"boot_source_fails":1,"cpu_cfg_count":1,"cpu_cfg_fails":1,"drive_count":2,"drive_fails":1,"hotplug_memory_count":0,"hotplug_memory_fails":0,"logger_count":2,"logger_fails":1,"machine_cfg_count":1,"machine_cfg_fails":0,"metrics_count":2,"metrics_fails":1,"mmds_count":2,"mmds_fails":1,"network_count":1,"network_fails":1,"pmem_count":0,"pmem_fails":0,"serial_count":2,"serial_fails":1,"vsock_count":2,"vsock_fails":1}"#,
+            Some(
+                r#"{"balloon_count":4,"balloon_fails":4,"drive_count":1,"drive_fails":1,"hotplug_memory_count":0,"hotplug_memory_fails":0,"machine_cfg_count":0,"machine_cfg_fails":0,"mmds_count":1,"mmds_fails":0,"network_count":0,"network_fails":0,"pmem_count":0,"pmem_fails":0}"#,
             ),
         );
         assert_startup_time_metrics_output(&metrics_path);
@@ -838,7 +905,8 @@ mod macos_arm64 {
         assert_no_content_response(&flush_metrics_response, "PUT /actions FlushMetrics");
         assert_metrics_output(
             &metrics_path,
-            r#"{"actions_count":2,"actions_fails":1,"boot_source_count":0,"boot_source_fails":0,"cpu_cfg_count":0,"cpu_cfg_fails":0,"drive_count":0,"drive_fails":0,"logger_count":0,"logger_fails":0,"machine_cfg_count":1,"machine_cfg_fails":1,"metrics_count":0,"metrics_fails":0,"mmds_count":0,"mmds_fails":0,"network_count":0,"network_fails":0,"pmem_count":0,"pmem_fails":0,"serial_count":0,"serial_fails":0,"vsock_count":0,"vsock_fails":0}"#,
+            None,
+            r#"{"actions_count":2,"actions_fails":1,"balloon_count":0,"balloon_fails":0,"boot_source_count":0,"boot_source_fails":0,"cpu_cfg_count":0,"cpu_cfg_fails":0,"drive_count":0,"drive_fails":0,"hotplug_memory_count":0,"hotplug_memory_fails":0,"logger_count":0,"logger_fails":0,"machine_cfg_count":1,"machine_cfg_fails":1,"metrics_count":0,"metrics_fails":0,"mmds_count":0,"mmds_fails":0,"network_count":0,"network_fails":0,"pmem_count":0,"pmem_fails":0,"serial_count":0,"serial_fails":0,"vsock_count":0,"vsock_fails":0}"#,
             None,
         );
         assert_logger_output(&logger_path);
@@ -2389,6 +2457,7 @@ mod macos_arm64 {
 
     fn assert_metrics_output(
         path: &Path,
+        expected_get_api_requests: Option<&str>,
         expected_put_api_requests: &str,
         expected_patch_api_requests: Option<&str>,
     ) {
@@ -2403,6 +2472,13 @@ mod macos_arm64 {
             output.contains(r#""metrics_flush_count":1"#),
             "metrics output should include first flush count; output:\n{output}"
         );
+        if let Some(expected_get_api_requests) = expected_get_api_requests {
+            let expected_get_metrics = format!(r#""get_api_requests":{expected_get_api_requests}"#);
+            assert!(
+                output.contains(&expected_get_metrics),
+                "metrics output should include expected GET API request counters; output:\n{output}"
+            );
+        }
         let expected_put_metrics = format!(r#""put_api_requests":{expected_put_api_requests}"#);
         assert!(
             output.contains(&expected_put_metrics),

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -503,6 +503,14 @@ impl VmmController {
         self.metrics_state.record_put_actions_failure();
     }
 
+    pub fn record_put_balloon_request(&mut self) {
+        self.metrics_state.record_put_balloon_request();
+    }
+
+    pub fn record_put_balloon_failure(&mut self) {
+        self.metrics_state.record_put_balloon_failure();
+    }
+
     pub fn record_put_boot_source_request(&mut self) {
         self.metrics_state.record_put_boot_source_request();
     }
@@ -611,6 +619,14 @@ impl VmmController {
         self.metrics_state.record_patch_drive_failure();
     }
 
+    pub fn record_patch_balloon_request(&mut self) {
+        self.metrics_state.record_patch_balloon_request();
+    }
+
+    pub fn record_patch_balloon_failure(&mut self) {
+        self.metrics_state.record_patch_balloon_failure();
+    }
+
     pub fn record_patch_network_request(&mut self) {
         self.metrics_state.record_patch_network_request();
     }
@@ -649,6 +665,10 @@ impl VmmController {
 
     pub fn record_patch_pmem_failure(&mut self) {
         self.metrics_state.record_patch_pmem_failure();
+    }
+
+    pub fn record_get_balloon_request(&mut self) {
+        self.metrics_state.record_get_balloon_request();
     }
 
     pub fn record_get_instance_info_request(&mut self) {

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -111,6 +111,14 @@ impl MetricsState {
         self.put_api_requests.record_actions_failure();
     }
 
+    pub(crate) fn record_put_balloon_request(&mut self) {
+        self.put_api_requests.record_balloon_request();
+    }
+
+    pub(crate) fn record_put_balloon_failure(&mut self) {
+        self.put_api_requests.record_balloon_failure();
+    }
+
     pub(crate) fn record_put_boot_source_request(&mut self) {
         self.put_api_requests.record_boot_source_request();
     }
@@ -215,6 +223,14 @@ impl MetricsState {
         self.patch_api_requests.record_drive_failure();
     }
 
+    pub(crate) fn record_patch_balloon_request(&mut self) {
+        self.patch_api_requests.record_balloon_request();
+    }
+
+    pub(crate) fn record_patch_balloon_failure(&mut self) {
+        self.patch_api_requests.record_balloon_failure();
+    }
+
     pub(crate) fn record_patch_network_request(&mut self) {
         self.patch_api_requests.record_network_request();
     }
@@ -253,6 +269,10 @@ impl MetricsState {
 
     pub(crate) fn record_patch_pmem_failure(&mut self) {
         self.patch_api_requests.record_pmem_failure();
+    }
+
+    pub(crate) fn record_get_balloon_request(&mut self) {
+        self.get_api_requests.record_balloon_request();
     }
 
     pub(crate) fn record_get_instance_info_request(&mut self) {
@@ -340,6 +360,7 @@ impl DeprecatedApiMetrics {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct GetApiRequestMetrics {
+    balloon_count: u64,
     hotplug_memory_count: u64,
     instance_info_count: u64,
     vmm_version_count: u64,
@@ -377,11 +398,16 @@ impl LoggerMetrics {
 
 impl GetApiRequestMetrics {
     const fn is_empty(self) -> bool {
-        self.hotplug_memory_count == 0
+        self.balloon_count == 0
+            && self.hotplug_memory_count == 0
             && self.instance_info_count == 0
             && self.vmm_version_count == 0
             && self.machine_cfg_count == 0
             && self.mmds_count == 0
+    }
+
+    fn record_balloon_request(&mut self) {
+        self.balloon_count = self.balloon_count.saturating_add(1);
     }
 
     fn record_hotplug_memory_request(&mut self) {
@@ -402,6 +428,10 @@ impl GetApiRequestMetrics {
 
     fn record_mmds_request(&mut self) {
         self.mmds_count = self.mmds_count.saturating_add(1);
+    }
+
+    const fn balloon_count(self) -> u64 {
+        self.balloon_count
     }
 
     const fn hotplug_memory_count(self) -> u64 {
@@ -427,6 +457,8 @@ impl GetApiRequestMetrics {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct PatchApiRequestMetrics {
+    balloon_count: u64,
+    balloon_fails: u64,
     drive_count: u64,
     drive_fails: u64,
     network_count: u64,
@@ -443,7 +475,9 @@ struct PatchApiRequestMetrics {
 
 impl PatchApiRequestMetrics {
     const fn is_empty(self) -> bool {
-        self.drive_count == 0
+        self.balloon_count == 0
+            && self.balloon_fails == 0
+            && self.drive_count == 0
             && self.drive_fails == 0
             && self.network_count == 0
             && self.network_fails == 0
@@ -463,6 +497,14 @@ impl PatchApiRequestMetrics {
 
     fn record_drive_failure(&mut self) {
         self.drive_fails = self.drive_fails.saturating_add(1);
+    }
+
+    fn record_balloon_request(&mut self) {
+        self.balloon_count = self.balloon_count.saturating_add(1);
+    }
+
+    fn record_balloon_failure(&mut self) {
+        self.balloon_fails = self.balloon_fails.saturating_add(1);
     }
 
     fn record_network_request(&mut self) {
@@ -513,6 +555,14 @@ impl PatchApiRequestMetrics {
         self.drive_fails
     }
 
+    const fn balloon_count(self) -> u64 {
+        self.balloon_count
+    }
+
+    const fn balloon_fails(self) -> u64 {
+        self.balloon_fails
+    }
+
     const fn network_count(self) -> u64 {
         self.network_count
     }
@@ -558,6 +608,8 @@ impl PatchApiRequestMetrics {
 struct PutApiRequestMetrics {
     actions_count: u64,
     actions_fails: u64,
+    balloon_count: u64,
+    balloon_fails: u64,
     boot_source_count: u64,
     boot_source_fails: u64,
     cpu_cfg_count: u64,
@@ -588,6 +640,8 @@ impl PutApiRequestMetrics {
     const fn is_empty(self) -> bool {
         self.actions_count == 0
             && self.actions_fails == 0
+            && self.balloon_count == 0
+            && self.balloon_fails == 0
             && self.boot_source_count == 0
             && self.boot_source_fails == 0
             && self.cpu_cfg_count == 0
@@ -620,6 +674,14 @@ impl PutApiRequestMetrics {
 
     fn record_actions_failure(&mut self) {
         self.actions_fails = self.actions_fails.saturating_add(1);
+    }
+
+    fn record_balloon_request(&mut self) {
+        self.balloon_count = self.balloon_count.saturating_add(1);
+    }
+
+    fn record_balloon_failure(&mut self) {
+        self.balloon_fails = self.balloon_fails.saturating_add(1);
     }
 
     fn record_boot_source_request(&mut self) {
@@ -724,6 +786,14 @@ impl PutApiRequestMetrics {
 
     const fn actions_fails(self) -> u64 {
         self.actions_fails
+    }
+
+    const fn balloon_count(self) -> u64 {
+        self.balloon_count
+    }
+
+    const fn balloon_fails(self) -> u64 {
+        self.balloon_fails
     }
 
     const fn boot_source_count(self) -> u64 {
@@ -1023,6 +1093,10 @@ impl MetricsSink {
         if !get_api_requests.is_empty() {
             let mut get_requests = serde_json::Map::new();
             get_requests.insert(
+                "balloon_count".to_string(),
+                serde_json::Value::Number(get_api_requests.balloon_count().into()),
+            );
+            get_requests.insert(
                 "hotplug_memory_count".to_string(),
                 serde_json::Value::Number(get_api_requests.hotplug_memory_count().into()),
             );
@@ -1065,6 +1139,14 @@ impl MetricsSink {
         }
         if !patch_api_requests.is_empty() {
             let mut patch_requests = serde_json::Map::new();
+            patch_requests.insert(
+                "balloon_count".to_string(),
+                serde_json::Value::Number(patch_api_requests.balloon_count().into()),
+            );
+            patch_requests.insert(
+                "balloon_fails".to_string(),
+                serde_json::Value::Number(patch_api_requests.balloon_fails().into()),
+            );
             patch_requests.insert(
                 "drive_count".to_string(),
                 serde_json::Value::Number(patch_api_requests.drive_count().into()),
@@ -1127,6 +1209,14 @@ impl MetricsSink {
             put_requests.insert(
                 "actions_fails".to_string(),
                 serde_json::Value::Number(put_api_requests.actions_fails().into()),
+            );
+            put_requests.insert(
+                "balloon_count".to_string(),
+                serde_json::Value::Number(put_api_requests.balloon_count().into()),
+            );
+            put_requests.insert(
+                "balloon_fails".to_string(),
+                serde_json::Value::Number(put_api_requests.balloon_fails().into()),
             );
             put_requests.insert(
                 "boot_source_count".to_string(),
@@ -1476,7 +1566,7 @@ mod tests {
         let output = fs::read_to_string(&path).expect("metrics output should be readable");
         assert_eq!(
             output,
-            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":1,\"boot_source_count\":0,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":0,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":1,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":0,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":0,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
 
         fs::remove_file(path).expect("fixture should clean up");
@@ -1504,7 +1594,7 @@ mod tests {
         let output = fs::read_to_string(&path).expect("metrics output should be readable");
         assert_eq!(
             output,
-            "{\"patch_api_requests\":{\"drive_count\":1,\"drive_fails\":1,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":1,\"mmds_count\":1,\"mmds_fails\":1,\"network_count\":1,\"network_fails\":1,\"pmem_count\":0,\"pmem_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":1,\"drive_fails\":1,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":1,\"mmds_count\":1,\"mmds_fails\":1,\"network_count\":1,\"network_fails\":1,\"pmem_count\":0,\"pmem_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
 
         fs::remove_file(path).expect("fixture should clean up");
@@ -1537,7 +1627,7 @@ mod tests {
         let output = fs::read_to_string(&path).expect("metrics output should be readable");
         assert_eq!(
             output,
-            "{\"put_api_requests\":{\"actions_count\":0,\"actions_fails\":0,\"boot_source_count\":2,\"boot_source_fails\":1,\"cpu_cfg_count\":1,\"cpu_cfg_fails\":1,\"drive_count\":1,\"drive_fails\":1,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":1,\"metrics_count\":0,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":1,\"network_fails\":1,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":1,\"vsock_fails\":1},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"put_api_requests\":{\"actions_count\":0,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":2,\"boot_source_fails\":1,\"cpu_cfg_count\":1,\"cpu_cfg_fails\":1,\"drive_count\":1,\"drive_fails\":1,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":1,\"metrics_count\":0,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":1,\"network_fails\":1,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":1,\"vsock_fails\":1},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
 
         fs::remove_file(path).expect("fixture should clean up");
@@ -1559,7 +1649,7 @@ mod tests {
         let output = fs::read_to_string(&path).expect("metrics output should be readable");
         assert_eq!(
             output,
-            "{\"put_api_requests\":{\"actions_count\":0,\"actions_fails\":0,\"boot_source_count\":0,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":0,\"metrics_fails\":0,\"mmds_count\":2,\"mmds_fails\":1,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"put_api_requests\":{\"actions_count\":0,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":0,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":0,\"metrics_fails\":0,\"mmds_count\":2,\"mmds_fails\":1,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
 
         fs::remove_file(path).expect("fixture should clean up");
@@ -1583,7 +1673,7 @@ mod tests {
         let output = fs::read_to_string(&path).expect("metrics output should be readable");
         assert_eq!(
             output,
-            "{\"patch_api_requests\":{\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":1,\"pmem_fails\":1},\"put_api_requests\":{\"actions_count\":0,\"actions_fails\":0,\"boot_source_count\":0,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":0,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":2,\"pmem_fails\":1,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":1,\"pmem_fails\":1},\"put_api_requests\":{\"actions_count\":0,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":0,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":0,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":2,\"pmem_fails\":1,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
 
         fs::remove_file(path).expect("fixture should clean up");
@@ -1608,7 +1698,34 @@ mod tests {
         let output = fs::read_to_string(&path).expect("metrics output should be readable");
         assert_eq!(
             output,
-            "{\"get_api_requests\":{\"hotplug_memory_count\":1,\"instance_info_count\":0,\"machine_cfg_count\":0,\"mmds_count\":0,\"vmm_version_count\":0},\"patch_api_requests\":{\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":1,\"hotplug_memory_fails\":1,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":0,\"actions_fails\":0,\"boot_source_count\":0,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":2,\"hotplug_memory_fails\":1,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":0,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"get_api_requests\":{\"balloon_count\":0,\"hotplug_memory_count\":1,\"instance_info_count\":0,\"machine_cfg_count\":0,\"mmds_count\":0,\"vmm_version_count\":0},\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":1,\"hotplug_memory_fails\":1,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":0,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":0,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":2,\"hotplug_memory_fails\":1,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":0,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+        );
+
+        fs::remove_file(path).expect("fixture should clean up");
+    }
+
+    #[test]
+    fn writes_balloon_api_request_metrics_when_recorded() {
+        let path = unique_metrics_path("api-request-balloon");
+        let mut state = MetricsState::default();
+
+        state.record_get_balloon_request();
+        state.record_get_balloon_request();
+        state.record_put_balloon_request();
+        state.record_put_balloon_request();
+        state.record_put_balloon_failure();
+        state.record_patch_balloon_request();
+        state.record_patch_balloon_request();
+        state.record_patch_balloon_failure();
+        state
+            .configure(MetricsConfigInput::new(&path))
+            .expect("metrics should configure");
+        assert_eq!(state.flush(), Ok(true));
+
+        let output = fs::read_to_string(&path).expect("metrics output should be readable");
+        assert_eq!(
+            output,
+            "{\"get_api_requests\":{\"balloon_count\":2,\"hotplug_memory_count\":0,\"instance_info_count\":0,\"machine_cfg_count\":0,\"mmds_count\":0,\"vmm_version_count\":0},\"patch_api_requests\":{\"balloon_count\":2,\"balloon_fails\":1,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":0,\"actions_fails\":0,\"balloon_count\":2,\"balloon_fails\":1,\"boot_source_count\":0,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":0,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
 
         fs::remove_file(path).expect("fixture should clean up");
@@ -1655,7 +1772,7 @@ mod tests {
         let output = fs::read_to_string(&path).expect("metrics output should be readable");
         assert_eq!(
             output,
-            "{\"put_api_requests\":{\"actions_count\":0,\"actions_fails\":0,\"boot_source_count\":0,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":1,\"logger_fails\":1,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":2,\"metrics_fails\":1,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":1,\"serial_fails\":1,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"put_api_requests\":{\"actions_count\":0,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":0,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":1,\"logger_fails\":1,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":2,\"metrics_fails\":1,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":1,\"serial_fails\":1,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
 
         fs::remove_file(path).expect("fixture should clean up");
@@ -1679,7 +1796,7 @@ mod tests {
         let output = fs::read_to_string(&path).expect("metrics output should be readable");
         assert_eq!(
             output,
-            "{\"get_api_requests\":{\"hotplug_memory_count\":0,\"instance_info_count\":1,\"machine_cfg_count\":1,\"mmds_count\":2,\"vmm_version_count\":1},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"get_api_requests\":{\"balloon_count\":0,\"hotplug_memory_count\":0,\"instance_info_count\":1,\"machine_cfg_count\":1,\"mmds_count\":2,\"vmm_version_count\":1},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
 
         fs::remove_file(path).expect("fixture should clean up");

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -178,8 +178,10 @@ Direct config-file and startup initialization paths are not API requests and
 are not included in these counters. `PATCH /vm` remains outside
 `patch_api_requests` because Firecracker does not expose a matching
 `PatchRequestsMetrics` field for VM state changes. The balloon API request
-fields are bangbang-specific extension counters; Firecracker exposes balloon
-device metrics but no matching balloon API request metric fields. Full Firecracker
+fields are bangbang-specific extension counters: GET, PUT, and PATCH balloon
+routes report `balloon_count`, and PUT/PATCH failures also report
+`balloon_fails`. Firecracker exposes balloon device metrics but no matching
+balloon API request metric fields. Full Firecracker
 `ProcessTimeReporter` parity remains deferred.
 
 bangbang intentionally treats `--id` alphanumeric characters as ASCII only.
@@ -510,9 +512,9 @@ through VMM control, plus selected `patch_api_requests` counters for parsed
 `PATCH /machine-config`, `PATCH /mmds`, `PATCH /drives/{drive_id}`,
 `PATCH /network-interfaces/{iface_id}`, `PATCH /hotplug/memory`, and
 `PATCH /pmem/{pmem_id}` requests routed through VMM control. bangbang also
-records `balloon_count` and `balloon_fails` extension fields for parsed balloon
-GET, PUT, and PATCH routes because Firecracker does not expose matching request
-metrics.
+records `balloon_count` extension fields for parsed balloon GET, PUT, and PATCH
+routes, plus `balloon_fails` extension fields for parsed balloon PUT and PATCH
+failures, because Firecracker does not expose matching request metrics.
 Parsed deprecated HTTP API usage is counted under
 `deprecated_api.deprecated_http_api_calls` for the supported deprecated fields
 above; malformed parser failures remain outside the counter.

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -156,17 +156,19 @@ Startup timing arguments are intentionally not exposed in `GET /vm/config` or
 logs because they are process observability data, not guest configuration. When
 metrics are configured, startup, explicit `FlushMetrics`, and periodic runtime
 metrics flushes write provided values under the minimal `vmm` metrics object;
-omitted timing arguments remain omitted. Parsed `GET /`,
-`GET /version`, `GET /machine-config`, `GET /mmds`, and
+omitted timing arguments remain omitted. Parsed `GET /`, `GET /version`,
+`GET /machine-config`, `GET /mmds`, `GET /balloon`,
+`GET /balloon/statistics`, `GET /balloon/hinting/status`, and
 `GET /hotplug/memory` API requests are counted under `get_api_requests`; parsed
 core configuration PUTs, `PUT /mmds`, `PUT /mmds/config`, `PUT /metrics`,
-`PUT /logger`, `PUT /serial`, `PUT /hotplug/memory`,
-`PUT /pmem/{pmem_id}`, and `/actions` API
-requests are counted under `put_api_requests`; parsed `PATCH /machine-config`,
-`PATCH /mmds`, `PATCH /drives/{drive_id}`,
-`PATCH /network-interfaces/{iface_id}`, `PATCH /hotplug/memory`, and
-`PATCH /pmem/{pmem_id}` requests
-routed through VMM control are counted under `patch_api_requests`.
+`PUT /logger`, `PUT /serial`, `PUT /balloon`, `PUT /hotplug/memory`,
+`PUT /pmem/{pmem_id}`, and `/actions` API requests are counted under
+`put_api_requests`; parsed `PATCH /machine-config`, `PATCH /mmds`,
+`PATCH /drives/{drive_id}`, `PATCH /network-interfaces/{iface_id}`,
+`PATCH /balloon`, `PATCH /balloon/statistics`,
+`PATCH /balloon/hinting/start`, `PATCH /balloon/hinting/stop`,
+`PATCH /hotplug/memory`, and `PATCH /pmem/{pmem_id}` requests routed through
+VMM control are counted under `patch_api_requests`.
 Parsed deprecated HTTP API usage is counted under
 `deprecated_api.deprecated_http_api_calls` for supported machine
 `cpu_template`, MMDS V1 config, deprecated `vsock_id`, and snapshot-load
@@ -175,7 +177,9 @@ failures are not counted.
 Direct config-file and startup initialization paths are not API requests and
 are not included in these counters. `PATCH /vm` remains outside
 `patch_api_requests` because Firecracker does not expose a matching
-`PatchRequestsMetrics` field for VM state changes. Full Firecracker
+`PatchRequestsMetrics` field for VM state changes. The balloon API request
+fields are bangbang-specific extension counters; Firecracker exposes balloon
+device metrics but no matching balloon API request metric fields. Full Firecracker
 `ProcessTimeReporter` parity remains deferred.
 
 bangbang intentionally treats `--id` alphanumeric characters as ASCII only.
@@ -496,17 +500,19 @@ unconfigured, and writes one minimal JSON line when `--metrics-path` or
 paths also write one initial minimal metrics line when the sink is configured.
 API-enabled and no-api runtime loops flush the same metrics line every 60
 seconds while the VM is running; those periodic flushes do not log `/actions`
-events. The line includes initial
-Firecracker-shaped `get_api_requests.instance_info_count`,
-`vmm_version_count`, `machine_cfg_count`, `mmds_count`, and
-`hotplug_memory_count` counters for parsed GET API requests, plus selected
+events. The line includes initial Firecracker-shaped GET API counters for
+`get_api_requests.instance_info_count`, `vmm_version_count`,
+`machine_cfg_count`, `mmds_count`, and `hotplug_memory_count`, plus selected
 `put_api_requests` counters for parsed core configuration PUTs, `PUT /mmds`,
 `PUT /mmds/config`, `PUT /metrics`, `PUT /logger`, `PUT /serial`,
 `PUT /hotplug/memory`, `PUT /pmem/{pmem_id}`, and `/actions` requests routed
 through VMM control, plus selected `patch_api_requests` counters for parsed
 `PATCH /machine-config`, `PATCH /mmds`, `PATCH /drives/{drive_id}`,
 `PATCH /network-interfaces/{iface_id}`, `PATCH /hotplug/memory`, and
-`PATCH /pmem/{pmem_id}` requests routed through VMM control.
+`PATCH /pmem/{pmem_id}` requests routed through VMM control. bangbang also
+records `balloon_count` and `balloon_fails` extension fields for parsed balloon
+GET, PUT, and PATCH routes because Firecracker does not expose matching request
+metrics.
 Parsed deprecated HTTP API usage is counted under
 `deprecated_api.deprecated_http_api_calls` for the supported deprecated fields
 above; malformed parser failures remain outside the counter.


### PR DESCRIPTION
## Summary

- Count parsed balloon GET, PUT, and PATCH API requests in minimal metrics output.
- Route balloon API handlers through the existing GET/PUT/PATCH VMM request wrappers so all valid balloon routes increment request counters and valid PUT/PATCH VMM errors increment failure counters.
- Cover balloon metrics in runtime, API server, and signed executable HVF e2e tests.
- Document that balloon API request counters are bangbang-specific extension fields because Firecracker does not expose matching request metrics.

## Scope

- Does not implement virtio-balloon device behavior, guest memory accounting, or runtime balloon updates.
- Malformed parser failures remain outside API request counters.

Closes #787

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test -p bangbang-runtime metrics --locked`
- `cargo test -p bangbang balloon --locked`
- `cargo test -p bangbang api_server --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh --test executable_hvf_e2e`
- `git diff --check`
