### PR TITLE
fix: restrict api socket permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ Value-less flags, such as `--no-api`, do not accept an attached value.
   without publishing an API socket, and exits cleanly on `SIGINT` or `SIGTERM`.
 - `--help`, `-h`, `--version`, and `-V` are supported.
 
-The API socket is an unauthenticated local control interface. Filesystem
-permissions on the socket path and parent directory are the access-control
-boundary, so use a private directory or restrictive umask on multi-user hosts.
+The API socket is an unauthenticated local control interface. bangbang restricts
+the published socket inode to owner-only permissions; the parent directory is
+still part of the access-control boundary, so use a private directory on
+multi-user hosts.
 
 Start with metrics and logger output configured:
 

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -2,7 +2,7 @@ use std::ffi::{CString, OsString};
 use std::fs;
 use std::io::{Read, Write};
 use std::os::unix::ffi::OsStrExt;
-use std::os::unix::fs::{FileTypeExt, MetadataExt};
+use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
@@ -58,6 +58,7 @@ use crate::vmm::{
 
 const READ_CHUNK_SIZE: usize = 4096;
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
+const API_SOCKET_MODE: u32 = 0o600;
 static NEXT_TEMP_SOCKET_ID: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, PartialEq, Eq)]
@@ -68,6 +69,7 @@ pub(crate) enum ApiServerError {
     PeriodicMetricsFlush(VmmActionError),
     ProcessSessionTerminal,
     SocketMetadata(std::io::ErrorKind),
+    SocketPermissions(std::io::ErrorKind),
     SocketPathCheck(std::io::ErrorKind),
     SocketPathChanged,
     SocketPathExists,
@@ -88,6 +90,9 @@ impl std::fmt::Display for ApiServerError {
             }
             Self::SocketMetadata(kind) => {
                 write!(f, "failed to inspect bound API socket: {kind:?}")
+            }
+            Self::SocketPermissions(kind) => {
+                write!(f, "failed to restrict API socket permissions: {kind:?}")
             }
             Self::SocketPathCheck(kind) => write!(f, "failed to check API socket path: {kind:?}"),
             Self::SocketPathChanged => f.write_str("API socket path changed during bind"),
@@ -370,15 +375,25 @@ fn bind_unpublished_socket(
             Err(err) => return Err(ApiServerError::Bind(err.kind())),
         };
         let metadata = socket_path_metadata(&temp_path)?;
+        let bound_metadata = BoundSocketMetadata {
+            path: temp_path,
+            dev: metadata.dev(),
+            ino: metadata.ino(),
+        };
+        if let Err(err) = restrict_socket_path_permissions(
+            &bound_metadata.path,
+            bound_metadata.dev,
+            bound_metadata.ino,
+        ) {
+            remove_socket_path_if_owned(
+                &bound_metadata.path,
+                bound_metadata.dev,
+                bound_metadata.ino,
+            );
+            return Err(err);
+        }
 
-        return Ok((
-            listener,
-            BoundSocketMetadata {
-                path: temp_path,
-                dev: metadata.dev(),
-                ino: metadata.ino(),
-            },
-        ));
+        return Ok((listener, bound_metadata));
     }
 
     Err(ApiServerError::Bind(std::io::ErrorKind::AlreadyExists))
@@ -411,6 +426,13 @@ fn ensure_socket_path_owner(path: &Path, dev: u64, ino: u64) -> Result<(), ApiSe
     } else {
         Err(ApiServerError::SocketPathChanged)
     }
+}
+
+fn restrict_socket_path_permissions(path: &Path, dev: u64, ino: u64) -> Result<(), ApiServerError> {
+    ensure_socket_path_owner(path, dev, ino)?;
+    fs::set_permissions(path, fs::Permissions::from_mode(API_SOCKET_MODE))
+        .map_err(|err| ApiServerError::SocketPermissions(err.kind()))?;
+    ensure_socket_path_owner(path, dev, ino)
 }
 
 fn remove_socket_path_if_owned(path: &Path, dev: u64, ino: u64) {
@@ -4332,6 +4354,15 @@ mod tests {
         drop(listener);
         drop(replacement);
         fs::remove_file(path).expect("fixture should clean up");
+    }
+
+    #[test]
+    fn bind_restricts_socket_path_permissions() {
+        let path = unique_socket_path("mode");
+        let _server = ApiServer::bind(&path).expect("server should bind");
+        let metadata = socket_path_metadata(&path).expect("API socket path should exist");
+
+        assert_eq!(metadata.mode() & 0o777, API_SOCKET_MODE);
     }
 
     #[test]

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -36,6 +36,14 @@ fn executable_serves_api_and_shuts_down_cleanly() {
         socket_path.exists(),
         "bangbang should publish the configured API socket"
     );
+    let socket_mode = fs::symlink_metadata(&socket_path)
+        .expect("published API socket metadata should be readable")
+        .mode()
+        & 0o777;
+    assert_eq!(
+        socket_mode, 0o600,
+        "bangbang should restrict the published API socket to owner-only access"
+    );
 
     let instance_info = http_get(&socket_path, "/");
     assert_ok_response(&instance_info, "GET /");

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -210,11 +210,11 @@ fails if the configured socket path already exists. Socket cleanup removes the
 socket inode created by the current process during normal shutdown and handled
 `SIGINT`/`SIGTERM` shutdown; uncatchable forced termination such as `SIGKILL`
 can still leave a stale socket path behind. The API socket is unauthenticated;
-filesystem permissions on the socket path and parent directory are the current
-access-control boundary. Operators should use a private socket directory or a
-restrictive umask on multi-user hosts. Process CLI parsing stays outside the
-future VM/vCPU fast path and should add only trivial startup overhead. Error and
-status output avoid echoing path-like CLI values.
+bangbang restricts the published socket inode to owner-only permissions, and
+the parent directory remains part of the access-control boundary. Operators
+should use a private socket directory on multi-user hosts. Process CLI parsing
+stays outside the future VM/vCPU fast path and should add only trivial startup
+overhead. Error and status output avoid echoing path-like CLI values.
 
 ### Process Exit Status
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,10 +15,10 @@ permissions around configured host paths. API clients, API request bodies,
 guest-provided MMIO data, guest memory, and configured host paths must be treated
 as untrusted input.
 
-There is no authentication on the HTTP-over-Unix-socket API. Access control is
-provided by the socket path and parent-directory permissions. Operators should
-place the socket in a private directory and use restrictive permissions or
-umask settings on multi-user hosts.
+There is no authentication on the HTTP-over-Unix-socket API. bangbang restricts
+the published socket inode to owner-only permissions, and access control still
+depends on the socket path and parent-directory permissions. Operators should
+place the socket in a private directory on multi-user hosts.
 
 ## Firecracker Differences
 
@@ -63,7 +63,7 @@ changes Firecracker-facing behavior or security posture:
   that intentionally return a Firecracker-shaped fault without mutating state
   are `recognized unsupported`. Add parser/state tests and process e2e coverage
   when the public process boundary is affected.
-- Operator-owned policy: socket-directory permissions, restrictive umask,
+- Operator-owned policy: socket-directory permissions,
   host-path ownership, and current resource-sharing rules are deployment
   assumptions until a launcher or resource broker exists. Document the
   assumption and test that one `bangbang` process does not clean up resources it
@@ -79,11 +79,12 @@ authentication. Any process that can connect to the socket can send supported
 API requests.
 
 When binding the socket, bangbang refuses to overwrite an existing final socket
-path. It first binds a temporary sibling socket, publishes it to the requested
-path, records the socket device and inode, and removes the path on shutdown only
-when it still refers to the socket created by this process. Forced termination,
-such as `SIGKILL`, can still leave a stale socket path that the operator must
-remove.
+path. It first binds a temporary sibling socket, records the socket device and
+inode, restricts that socket inode to owner-only permissions, publishes it to
+the requested path, and verifies that the published path still refers to that
+socket. It removes the path on shutdown only when it still refers to the socket
+created by this process. Forced termination, such as `SIGKILL`, can still leave
+a stale socket path that the operator must remove.
 
 For multiple bangbang processes, use separate socket paths in directories whose
 ownership and permissions match the intended control boundary. Do not share a


### PR DESCRIPTION
Closes #791.

## Summary
- Restrict the API socket inode to owner-only permissions before publishing the final socket path.
- Keep the existing owned-path verification and cleanup guard around socket publication and shutdown.
- Cover the mode at both the API server unit level and executable process e2e level, and update security/compatibility docs.

## Scope
- Does not add protocol-level authentication or redesign the parent-directory trust boundary.
- Does not change the Firecracker-style Unix socket API shape.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test -p bangbang --bin bangbang --all-features --locked`
- `cargo test -p bangbang --test process_e2e --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy -p bangbang --all-targets --all-features --locked -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`