### PR TITLE
feat: add boot run loop command queue

### DIFF
--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -81,6 +81,7 @@ const DEFAULT_SERIAL_MMIO_REGION_ID: MmioRegionId = MmioRegionId::new(0);
 const DEFAULT_ENTROPY_MMIO_BASE: GuestAddress = GuestAddress::new(0x4000_7000);
 const DEFAULT_ENTROPY_MMIO_REGION_ID: MmioRegionId = MmioRegionId::new(3000);
 const DEFAULT_HVF_BOOT_RUN_LOOP_STEP_LIMIT: usize = 1024;
+const BOOT_RUN_LOOP_COMMAND_QUEUE_CAPACITY: usize = 32;
 const HVF_BOOT_RUN_LOOP_THREAD_NAME: &str = "bangbang-hvf-boot-loop";
 
 pub(crate) trait InstanceStartExecutor {
@@ -1389,6 +1390,8 @@ pub(crate) trait BootRunLoopControl: Clone + fmt::Debug + Send + Sync + 'static 
     fn stop_token(&self) -> Self::StopToken;
 
     fn request_stop(&self) -> Result<(), Self::Error>;
+
+    fn request_wakeup(&self) -> Result<(), Self::Error>;
 }
 
 impl BootRunLoopControl for HvfArm64BootRunLoopControl {
@@ -1401,6 +1404,10 @@ impl BootRunLoopControl for HvfArm64BootRunLoopControl {
 
     fn request_stop(&self) -> Result<(), Self::Error> {
         HvfArm64BootRunLoopControl::request_stop(self)
+    }
+
+    fn request_wakeup(&self) -> Result<(), Self::Error> {
+        HvfArm64BootRunLoopControl::request_wakeup(self)
     }
 }
 
@@ -1574,12 +1581,155 @@ impl<O> Default for BootRunLoopWorkerStatusCell<O> {
     }
 }
 
+type BootRunLoopCommand<S> = Box<dyn FnOnce(&mut S) + Send + 'static>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum BootRunLoopCommandError<C, E> {
+    WorkerNotRunning,
+    QueueFull,
+    QueueClosed,
+    Wakeup { source: C },
+    ResponseClosed,
+    Command { source: E },
+}
+
+impl<C, E> fmt::Display for BootRunLoopCommandError<C, E>
+where
+    C: fmt::Display,
+    E: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::WorkerNotRunning => f.write_str("boot run loop worker is not running"),
+            Self::QueueFull => f.write_str("boot run loop command queue is full"),
+            Self::QueueClosed => f.write_str("boot run loop command queue is closed"),
+            Self::Wakeup { source } => {
+                write!(f, "failed to wake boot run loop for command: {source}")
+            }
+            Self::ResponseClosed => f.write_str("boot run loop command response closed"),
+            Self::Command { source } => write!(f, "boot run loop command failed: {source}"),
+        }
+    }
+}
+
+pub(crate) struct BootRunLoopCommandHandle<S>
+where
+    S: BootRunLoopSession,
+{
+    sender: mpsc::SyncSender<BootRunLoopCommand<S>>,
+    control: S::Control,
+    status: Arc<BootRunLoopWorkerStatusCell<S::Outcome>>,
+}
+
+impl<S> Clone for BootRunLoopCommandHandle<S>
+where
+    S: BootRunLoopSession,
+{
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+            control: self.control.clone(),
+            status: Arc::clone(&self.status),
+        }
+    }
+}
+
+impl<S> fmt::Debug for BootRunLoopCommandHandle<S>
+where
+    S: BootRunLoopSession,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BootRunLoopCommandHandle")
+            .field("control", &self.control)
+            .field("status", &self.status.snapshot())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<S> BootRunLoopCommandHandle<S>
+where
+    S: BootRunLoopSession,
+{
+    fn new(
+        sender: mpsc::SyncSender<BootRunLoopCommand<S>>,
+        control: S::Control,
+        status: Arc<BootRunLoopWorkerStatusCell<S::Outcome>>,
+    ) -> Self {
+        Self {
+            sender,
+            control,
+            status,
+        }
+    }
+
+    fn run<R, E>(
+        &self,
+        command: impl FnOnce(&mut S) -> Result<R, E> + Send + 'static,
+    ) -> Result<R, BootRunLoopCommandError<<S::Control as BootRunLoopControl>::Error, E>>
+    where
+        R: Send + 'static,
+        E: Send + 'static,
+    {
+        if !matches!(self.status.snapshot(), BootRunLoopWorkerStatus::Running) {
+            return Err(BootRunLoopCommandError::WorkerNotRunning);
+        }
+
+        let (response_sender, response_receiver) = mpsc::sync_channel(1);
+        let queued_command: BootRunLoopCommand<S> = Box::new(move |session| {
+            let _ = response_sender.send(command(session));
+        });
+
+        match self.sender.try_send(queued_command) {
+            Ok(()) => {}
+            Err(mpsc::TrySendError::Full(_)) => return Err(BootRunLoopCommandError::QueueFull),
+            Err(mpsc::TrySendError::Disconnected(_)) => {
+                return Err(BootRunLoopCommandError::QueueClosed);
+            }
+        }
+
+        match response_receiver.try_recv() {
+            Ok(Ok(result)) => return Ok(result),
+            Ok(Err(source)) => return Err(BootRunLoopCommandError::Command { source }),
+            Err(mpsc::TryRecvError::Disconnected) => {
+                return Err(BootRunLoopCommandError::ResponseClosed);
+            }
+            Err(mpsc::TryRecvError::Empty) => {}
+        }
+
+        let wakeup_result = self.control.request_wakeup();
+        match response_receiver.recv() {
+            Ok(Ok(result)) => Ok(result),
+            Ok(Err(source)) => Err(BootRunLoopCommandError::Command { source }),
+            Err(_) => match wakeup_result {
+                Ok(()) => Err(BootRunLoopCommandError::ResponseClosed),
+                Err(source) => Err(BootRunLoopCommandError::Wakeup { source }),
+            },
+        }
+    }
+}
+
+fn drain_boot_run_loop_commands<S>(
+    session: &mut S,
+    command_receiver: &mpsc::Receiver<BootRunLoopCommand<S>>,
+    command_limit: usize,
+) where
+    S: BootRunLoopSession,
+{
+    for _ in 0..command_limit {
+        let Ok(command) = command_receiver.try_recv() else {
+            break;
+        };
+        command(session);
+    }
+}
+
 pub(crate) struct BootRunLoopSupervisor<S>
 where
     S: BootRunLoopSession,
 {
     control: S::Control,
     block_device_updater: Option<BootRunLoopBlockDeviceUpdater>,
+    command_handle: BootRunLoopCommandHandle<S>,
     status: Arc<BootRunLoopWorkerStatusCell<S::Outcome>>,
     terminal_wakeup_reader: UnixStream,
     session_release_sender: Option<mpsc::Sender<()>>,
@@ -1590,12 +1740,27 @@ impl<S> BootRunLoopSupervisor<S>
 where
     S: BootRunLoopSession,
 {
-    fn start(mut session: S, max_steps: NonZeroUsize) -> Result<Self, BackendError> {
+    fn start(session: S, max_steps: NonZeroUsize) -> Result<Self, BackendError> {
+        Self::start_with_command_queue_capacity(
+            session,
+            max_steps,
+            BOOT_RUN_LOOP_COMMAND_QUEUE_CAPACITY,
+        )
+    }
+
+    fn start_with_command_queue_capacity(
+        mut session: S,
+        max_steps: NonZeroUsize,
+        command_queue_capacity: usize,
+    ) -> Result<Self, BackendError> {
         let control = session.run_loop_control();
         let block_device_updater = session.block_device_updater();
         let stop_token = control.stop_token();
         let status = Arc::new(BootRunLoopWorkerStatusCell::new());
         let worker_status = Arc::clone(&status);
+        let (command_sender, command_receiver) = mpsc::sync_channel(command_queue_capacity);
+        let command_handle =
+            BootRunLoopCommandHandle::new(command_sender, control.clone(), Arc::clone(&status));
         let (terminal_wakeup_reader, mut terminal_wakeup_writer) =
             UnixStream::pair().map_err(|err| {
                 BackendError::Hypervisor(format!(
@@ -1614,6 +1779,11 @@ where
             .name(HVF_BOOT_RUN_LOOP_THREAD_NAME.to_owned())
             .spawn(move || {
                 let result = loop {
+                    drain_boot_run_loop_commands(
+                        &mut session,
+                        &command_receiver,
+                        command_queue_capacity,
+                    );
                     match session.run_loop(&stop_token, max_steps) {
                         Ok(outcome) if S::should_continue_after_outcome(&outcome) => continue,
                         Ok(outcome) => {
@@ -1628,6 +1798,7 @@ where
                         }
                     }
                 };
+                drop(command_receiver);
                 let _ = session_release_receiver.recv();
                 result
             })
@@ -1638,11 +1809,35 @@ where
         Ok(Self {
             control,
             block_device_updater,
+            command_handle,
             status,
             terminal_wakeup_reader,
             session_release_sender: Some(session_release_sender),
             worker: Some(worker),
         })
+    }
+
+    #[cfg(test)]
+    fn command_handle(&self) -> BootRunLoopCommandHandle<S> {
+        self.command_handle.clone()
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "boot run-loop commands are introduced before #828 drive update migration"
+        )
+    )]
+    pub(crate) fn run_command<R, E>(
+        &self,
+        command: impl FnOnce(&mut S) -> Result<R, E> + Send + 'static,
+    ) -> Result<R, BootRunLoopCommandError<<S::Control as BootRunLoopControl>::Error, E>>
+    where
+        R: Send + 'static,
+        E: Send + 'static,
+    {
+        self.command_handle.run(command)
     }
 
     fn status(&self) -> BootRunLoopWorkerStatus<S::Outcome> {
@@ -1740,6 +1935,7 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BootRunLoopSupervisor")
             .field("control", &self.control)
+            .field("command_handle", &self.command_handle)
             .field("status", &self.status())
             .field("worker_active", &self.worker.is_some())
             .finish()
@@ -2075,6 +2271,15 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct FakeRunLoopCommandError;
+
+    impl fmt::Display for FakeRunLoopCommandError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("fake run loop command failed")
+        }
+    }
+
     #[derive(Clone, Debug, Default)]
     struct FakeRunLoopStopToken {
         stopped: Arc<(Mutex<bool>, Condvar)>,
@@ -2103,11 +2308,38 @@ mod tests {
     struct FakeRunLoopControl {
         stop_token: FakeRunLoopStopToken,
         request_stop_count: Arc<AtomicU64>,
+        wakeup: Arc<(Mutex<u64>, Condvar)>,
+        request_wakeup_count: Arc<AtomicU64>,
     }
 
     impl FakeRunLoopControl {
         fn request_stop_count(&self) -> u64 {
             self.request_stop_count.load(Ordering::SeqCst)
+        }
+
+        fn request_wakeup_count(&self) -> u64 {
+            self.request_wakeup_count.load(Ordering::SeqCst)
+        }
+
+        fn wait_for_wakeup(&self) {
+            let (lock, condition) = &*self.wakeup;
+            let mut wakeup_count = lock.lock().expect("wakeup count should lock");
+            while *wakeup_count == 0 {
+                wakeup_count = condition
+                    .wait(wakeup_count)
+                    .expect("wakeup count should wait without poisoning");
+            }
+            *wakeup_count -= 1;
+        }
+
+        fn wait_for_request_wakeup_count(&self, expected_count: u64) {
+            let (lock, condition) = &*self.wakeup;
+            let mut wakeup_count = lock.lock().expect("wakeup count should lock");
+            while self.request_wakeup_count() < expected_count {
+                wakeup_count = condition
+                    .wait(wakeup_count)
+                    .expect("wakeup count should wait without poisoning");
+            }
         }
     }
 
@@ -2122,6 +2354,19 @@ mod tests {
         fn request_stop(&self) -> Result<(), Self::Error> {
             self.request_stop_count.fetch_add(1, Ordering::SeqCst);
             self.stop_token.request_stop();
+            let (lock, condition) = &*self.wakeup;
+            let mut wakeup_count = lock.lock().expect("wakeup count should lock");
+            *wakeup_count += 1;
+            condition.notify_one();
+            Ok(())
+        }
+
+        fn request_wakeup(&self) -> Result<(), Self::Error> {
+            self.request_wakeup_count.fetch_add(1, Ordering::SeqCst);
+            let (lock, condition) = &*self.wakeup;
+            let mut wakeup_count = lock.lock().expect("wakeup count should lock");
+            *wakeup_count += 1;
+            condition.notify_one();
             Ok(())
         }
     }
@@ -2133,6 +2378,7 @@ mod tests {
         max_steps_sender: mpsc::Sender<usize>,
         outcomes: Arc<Mutex<VecDeque<Result<FakeRunLoopOutcome, FakeRunLoopError>>>>,
         wait_for_stop: bool,
+        wait_for_wakeup: bool,
         wait_for_stop_sequence: Arc<Mutex<VecDeque<bool>>>,
     }
 
@@ -2151,6 +2397,7 @@ mod tests {
                     FakeRunLoopOutcome::Terminal,
                 )]))),
                 wait_for_stop: true,
+                wait_for_wakeup: false,
                 wait_for_stop_sequence: Arc::default(),
             }
         }
@@ -2169,6 +2416,11 @@ mod tests {
 
         const fn with_wait_for_stop(mut self, wait_for_stop: bool) -> Self {
             self.wait_for_stop = wait_for_stop;
+            self
+        }
+
+        const fn with_wait_for_wakeup(mut self, wait_for_wakeup: bool) -> Self {
+            self.wait_for_wakeup = wait_for_wakeup;
             self
         }
 
@@ -2211,6 +2463,9 @@ mod tests {
                 .unwrap_or(self.wait_for_stop);
             if wait_for_stop {
                 stop_token.wait_for_stop();
+            }
+            if self.wait_for_wakeup {
+                self.control.wait_for_wakeup();
             }
             self.outcomes
                 .lock()
@@ -3292,6 +3547,286 @@ mod tests {
         drop(supervisor);
 
         assert_eq!(control.request_stop_count(), 1);
+        assert_eq!(drop_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn boot_run_loop_supervisor_runs_command_on_worker_after_wakeup() {
+        let control = FakeRunLoopControl::default();
+        let drop_count = Arc::new(AtomicU64::new(0));
+        let (max_steps_sender, max_steps_receiver) = mpsc::channel();
+        let session =
+            FakeRunLoopSession::new(control.clone(), Arc::clone(&drop_count), max_steps_sender)
+                .with_wait_for_stop(false)
+                .with_wait_for_wakeup(true)
+                .with_outcomes([
+                    Ok(FakeRunLoopOutcome::Wakeup),
+                    Ok(FakeRunLoopOutcome::Terminal),
+                ]);
+
+        let supervisor =
+            BootRunLoopSupervisor::start(session, NonZeroUsize::new(23).expect("non-zero limit"))
+                .expect("supervisor should start");
+
+        assert_eq!(
+            max_steps_receiver
+                .recv()
+                .expect("worker should enter run loop"),
+            23
+        );
+
+        let result = supervisor
+            .run_command(|session| {
+                Ok::<_, FakeRunLoopCommandError>((
+                    session.run_count.load(Ordering::SeqCst),
+                    std::thread::current()
+                        .name()
+                        .unwrap_or_default()
+                        .to_string(),
+                ))
+            })
+            .expect("command should run");
+
+        assert_eq!(result.0, 1);
+        assert_eq!(result.1, super::HVF_BOOT_RUN_LOOP_THREAD_NAME);
+        assert_eq!(control.request_wakeup_count(), 1);
+
+        drop(supervisor);
+
+        assert_eq!(control.request_stop_count(), 1);
+        assert_eq!(drop_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn boot_run_loop_supervisor_returns_command_failure_without_terminal_status() {
+        let control = FakeRunLoopControl::default();
+        let drop_count = Arc::new(AtomicU64::new(0));
+        let (max_steps_sender, max_steps_receiver) = mpsc::channel();
+        let session =
+            FakeRunLoopSession::new(control.clone(), Arc::clone(&drop_count), max_steps_sender)
+                .with_wait_for_stop(false)
+                .with_wait_for_wakeup(true)
+                .with_outcomes([
+                    Ok(FakeRunLoopOutcome::Wakeup),
+                    Ok(FakeRunLoopOutcome::Terminal),
+                ]);
+
+        let supervisor =
+            BootRunLoopSupervisor::start(session, NonZeroUsize::new(29).expect("non-zero limit"))
+                .expect("supervisor should start");
+
+        assert_eq!(
+            max_steps_receiver
+                .recv()
+                .expect("worker should enter run loop"),
+            29
+        );
+
+        let error = supervisor
+            .run_command(|_| Err::<(), _>(FakeRunLoopCommandError))
+            .expect_err("command failure should be returned");
+
+        assert_eq!(
+            error,
+            super::BootRunLoopCommandError::Command {
+                source: FakeRunLoopCommandError
+            }
+        );
+        assert_eq!(supervisor.status(), BootRunLoopWorkerStatus::Running);
+        assert_eq!(control.request_wakeup_count(), 1);
+
+        drop(supervisor);
+
+        assert_eq!(control.request_stop_count(), 1);
+        assert_eq!(drop_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn boot_run_loop_supervisor_rejects_command_after_terminal_outcome() {
+        let control = FakeRunLoopControl::default();
+        let drop_count = Arc::new(AtomicU64::new(0));
+        let (max_steps_sender, max_steps_receiver) = mpsc::channel();
+        let session =
+            FakeRunLoopSession::new(control.clone(), Arc::clone(&drop_count), max_steps_sender)
+                .with_wait_for_stop(false);
+
+        let supervisor =
+            BootRunLoopSupervisor::start(session, NonZeroUsize::new(31).expect("non-zero limit"))
+                .expect("supervisor should start");
+
+        assert_eq!(
+            max_steps_receiver
+                .recv()
+                .expect("worker should enter run loop"),
+            31
+        );
+        assert_eq!(
+            supervisor.wait_for_terminal_status(),
+            BootRunLoopWorkerStatus::Exited(FakeRunLoopOutcome::Terminal)
+        );
+
+        let error = supervisor
+            .run_command(|_| Ok::<_, FakeRunLoopCommandError>(()))
+            .expect_err("terminal worker should reject commands");
+
+        assert_eq!(error, super::BootRunLoopCommandError::WorkerNotRunning);
+        assert_eq!(control.request_wakeup_count(), 0);
+
+        drop(supervisor);
+
+        assert_eq!(control.request_stop_count(), 1);
+        assert_eq!(drop_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn boot_run_loop_supervisor_closes_pending_command_after_run_loop_error() {
+        let control = FakeRunLoopControl::default();
+        let drop_count = Arc::new(AtomicU64::new(0));
+        let (max_steps_sender, max_steps_receiver) = mpsc::channel();
+        let session =
+            FakeRunLoopSession::new(control.clone(), Arc::clone(&drop_count), max_steps_sender)
+                .with_outcomes([Err(FakeRunLoopError)]);
+
+        let mut supervisor =
+            BootRunLoopSupervisor::start(session, NonZeroUsize::new(33).expect("non-zero limit"))
+                .expect("supervisor should start");
+        let command_handle = supervisor.command_handle();
+
+        assert_eq!(
+            max_steps_receiver
+                .recv()
+                .expect("worker should enter run loop"),
+            33
+        );
+
+        let command_caller = std::thread::spawn(move || {
+            command_handle.run(|_| Ok::<_, FakeRunLoopCommandError>(()))
+        });
+        control.wait_for_request_wakeup_count(1);
+        control
+            .request_stop()
+            .expect("fake stop should release fake run loop");
+
+        let error = command_caller
+            .join()
+            .expect("command caller should not panic")
+            .expect_err("pending command response should close");
+
+        assert_eq!(error, super::BootRunLoopCommandError::ResponseClosed);
+        assert_eq!(
+            supervisor.wait_for_terminal_status(),
+            BootRunLoopWorkerStatus::Failed("fake run loop failed".to_string())
+        );
+        supervisor
+            .drain_process_exit_wakeup()
+            .expect("error wakeup should drain");
+
+        drop(supervisor);
+
+        assert_eq!(control.request_stop_count(), 2);
+        assert_eq!(drop_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn boot_run_loop_supervisor_command_queue_full_does_not_block() {
+        let control = FakeRunLoopControl::default();
+        let drop_count = Arc::new(AtomicU64::new(0));
+        let (max_steps_sender, max_steps_receiver) = mpsc::channel();
+        let session =
+            FakeRunLoopSession::new(control.clone(), Arc::clone(&drop_count), max_steps_sender);
+
+        let supervisor = BootRunLoopSupervisor::start_with_command_queue_capacity(
+            session,
+            NonZeroUsize::new(37).expect("non-zero limit"),
+            0,
+        )
+        .expect("supervisor should start");
+
+        assert_eq!(
+            max_steps_receiver
+                .recv()
+                .expect("worker should enter run loop"),
+            37
+        );
+
+        let error = supervisor
+            .run_command(|_| Ok::<_, FakeRunLoopCommandError>(()))
+            .expect_err("zero-capacity queue should reject command");
+
+        assert_eq!(error, super::BootRunLoopCommandError::QueueFull);
+        assert_eq!(control.request_wakeup_count(), 0);
+
+        drop(supervisor);
+
+        assert_eq!(control.request_stop_count(), 1);
+        assert_eq!(drop_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn boot_run_loop_supervisor_handles_concurrent_command_callers() {
+        let control = FakeRunLoopControl::default();
+        let drop_count = Arc::new(AtomicU64::new(0));
+        let (max_steps_sender, max_steps_receiver) = mpsc::channel();
+        let session =
+            FakeRunLoopSession::new(control.clone(), Arc::clone(&drop_count), max_steps_sender)
+                .with_outcomes([
+                    Ok(FakeRunLoopOutcome::StepLimitReached),
+                    Ok(FakeRunLoopOutcome::Terminal),
+                ]);
+
+        let supervisor =
+            BootRunLoopSupervisor::start(session, NonZeroUsize::new(41).expect("non-zero limit"))
+                .expect("supervisor should start");
+        let command_handle = supervisor.command_handle();
+
+        assert_eq!(
+            max_steps_receiver
+                .recv()
+                .expect("worker should enter run loop"),
+            41
+        );
+
+        let mut results = std::thread::scope(|scope| {
+            let mut handles = Vec::new();
+            for index in 0..4 {
+                let handle = command_handle.clone();
+                handles.push(scope.spawn(move || {
+                    handle.run(move |session| {
+                        Ok::<_, FakeRunLoopCommandError>((
+                            index,
+                            session.run_count.load(Ordering::SeqCst),
+                        ))
+                    })
+                }));
+            }
+
+            control.wait_for_request_wakeup_count(4);
+            control
+                .request_stop()
+                .expect("fake stop should release fake run loop");
+
+            handles
+                .into_iter()
+                .map(|handle| {
+                    handle
+                        .join()
+                        .expect("command caller should not panic")
+                        .expect("command should succeed")
+                })
+                .collect::<Vec<_>>()
+        });
+        results.sort_unstable();
+
+        assert_eq!(
+            results.iter().map(|(index, _)| *index).collect::<Vec<_>>(),
+            [0, 1, 2, 3]
+        );
+        assert!(results.iter().all(|(_, run_count)| *run_count > 0));
+        assert_eq!(control.request_wakeup_count(), 4);
+
+        drop(supervisor);
+
+        assert_eq!(control.request_stop_count(), 2);
         assert_eq!(drop_count.load(Ordering::SeqCst), 1);
     }
 


### PR DESCRIPTION
## Summary

- add a bounded boot run-loop command queue owned by `BootRunLoopSupervisor`
- wake the HVF boot run loop without requesting stop so queued commands execute on the worker thread
- cover command success, command failure, terminal/error ordering, queue-full behavior, and concurrent callers

## Scope

This PR only introduces the device-neutral command path needed by #828. Moving drive backing refresh onto the command path remains out of scope for this PR.

Closes #831

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `scripts/run-integration-tests.sh`
