### PR TITLE
feat: compute startup timing metrics from clocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,12 @@ while the VM is running. After `InstanceStart`, the line also includes a
 process-owned boot worker exists. When startup timing CLI values are provided,
 the same metrics output includes Firecracker-style
 `api_server.process_startup_time_us` and
-`api_server.process_startup_time_cpu_us`; `--parent-cpu-time-us` contributes to
-the CPU value and is not serialized as a separate field. The current
+`api_server.process_startup_time_cpu_us` elapsed values. `--start-time-us` is
+subtracted from the sampled monotonic clock, `--start-time-cpu-us` is
+subtracted from the sampled process CPU clock, and `--parent-cpu-time-us`
+contributes to the CPU value without being serialized as a separate field. If a
+provided start timestamp is later than the sampled clock value, the elapsed
+component saturates at zero. The current
 Firecracker-shaped API request metrics subset also reports selected GET counters
 under `get_api_requests`; parsed core
 configuration, MMDS, observability, memory hotplug, pmem, and `/actions`

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -3,6 +3,7 @@ use std::ffi::OsString;
 use std::fmt;
 use std::fs;
 use std::io::Read;
+use std::mem::MaybeUninit;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 use std::os::unix::net::UnixStream;
@@ -84,7 +85,9 @@ fn run() -> Result<(), ProcessError> {
                 no_api,
                 startup_time,
             } = config;
-            let process_metrics_diagnostics = startup_time.metrics_diagnostics();
+            let process_metrics_diagnostics = startup_time
+                .metrics_diagnostics()
+                .map_err(ProcessError::StartupTime)?;
 
             println!("bangbang {}", env!("CARGO_PKG_VERSION"));
             println!(
@@ -534,6 +537,7 @@ enum ProcessError {
     ProcessSessionTerminal,
     SignalHandler(std::io::ErrorKind),
     StartupConfiguration(VmmActionError),
+    StartupTime(StartupTimeClockError),
 }
 
 impl ProcessError {
@@ -548,6 +552,7 @@ impl ProcessError {
             Self::ProcessSessionTerminal => ProcessExitCode::ProcessFailure,
             Self::SignalHandler(_) => ProcessExitCode::ProcessFailure,
             Self::StartupConfiguration(_) => ProcessExitCode::ProcessFailure,
+            Self::StartupTime(_) => ProcessExitCode::ProcessFailure,
         }
     }
 }
@@ -574,6 +579,7 @@ impl fmt::Display for ProcessError {
             Self::StartupConfiguration(err) => {
                 write!(f, "startup configuration error: {err}")
             }
+            Self::StartupTime(err) => write!(f, "startup time error: {err}"),
         }
     }
 }
@@ -850,20 +856,110 @@ struct StartupTimeConfig {
 }
 
 impl StartupTimeConfig {
-    fn metrics_diagnostics(self) -> MetricsDiagnostics {
+    fn metrics_diagnostics(self) -> Result<MetricsDiagnostics, StartupTimeClockError> {
+        if !self.needs_clock_sample() {
+            return Ok(MetricsDiagnostics::new());
+        }
+
+        let clock = StartupTimeClock::sample_for(&self)?;
+        Ok(self.metrics_diagnostics_at(clock))
+    }
+
+    fn metrics_diagnostics_at(self, clock: StartupTimeClock) -> MetricsDiagnostics {
         let mut diagnostics = MetricsDiagnostics::new();
         if let Some(start_time_us) = self.start_time_us {
-            diagnostics = diagnostics.with_start_time_us(start_time_us);
+            diagnostics = diagnostics
+                .with_start_time_us(clock.monotonic_time_us.saturating_sub(start_time_us));
         }
         if let Some(start_time_cpu_us) = self.start_time_cpu_us {
-            diagnostics = diagnostics.with_start_time_cpu_us(start_time_cpu_us);
-        }
-        if let Some(parent_cpu_time_us) = self.parent_cpu_time_us {
-            diagnostics = diagnostics.with_parent_cpu_time_us(parent_cpu_time_us);
+            let process_startup_time_cpu_us = clock
+                .process_cpu_time_us
+                .saturating_sub(start_time_cpu_us)
+                .saturating_add(self.parent_cpu_time_us.unwrap_or_default());
+            diagnostics = diagnostics.with_start_time_cpu_us(process_startup_time_cpu_us);
         }
 
         diagnostics
     }
+
+    fn needs_clock_sample(&self) -> bool {
+        self.start_time_us.is_some() || self.start_time_cpu_us.is_some()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct StartupTimeClock {
+    monotonic_time_us: u64,
+    process_cpu_time_us: u64,
+}
+
+impl StartupTimeClock {
+    #[cfg(test)]
+    const fn new(monotonic_time_us: u64, process_cpu_time_us: u64) -> Self {
+        Self {
+            monotonic_time_us,
+            process_cpu_time_us,
+        }
+    }
+
+    fn sample_for(config: &StartupTimeConfig) -> Result<Self, StartupTimeClockError> {
+        let monotonic_time_us = if config.start_time_us.is_some() {
+            clock_time_us(libc::CLOCK_MONOTONIC).map_err(StartupTimeClockError::Monotonic)?
+        } else {
+            0
+        };
+        let process_cpu_time_us = if config.start_time_cpu_us.is_some() {
+            clock_time_us(libc::CLOCK_PROCESS_CPUTIME_ID)
+                .map_err(StartupTimeClockError::ProcessCpu)?
+        } else {
+            0
+        };
+
+        Ok(Self {
+            monotonic_time_us,
+            process_cpu_time_us,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StartupTimeClockError {
+    Monotonic(std::io::ErrorKind),
+    ProcessCpu(std::io::ErrorKind),
+}
+
+impl fmt::Display for StartupTimeClockError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Monotonic(kind) => write!(f, "failed to read monotonic clock: {kind:?}"),
+            Self::ProcessCpu(kind) => write!(f, "failed to read process CPU clock: {kind:?}"),
+        }
+    }
+}
+
+impl std::error::Error for StartupTimeClockError {}
+
+fn clock_time_us(clock_id: libc::clockid_t) -> Result<u64, std::io::ErrorKind> {
+    let mut time = MaybeUninit::<libc::timespec>::uninit();
+    // SAFETY: `clock_gettime` writes a valid `timespec` to the provided pointer
+    // when it returns 0. The pointer is valid for writes and properly aligned.
+    let result = unsafe { libc::clock_gettime(clock_id, time.as_mut_ptr()) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().kind());
+    }
+    // SAFETY: `clock_gettime` returned success, so the `timespec` was initialized.
+    let time = unsafe { time.assume_init() };
+
+    timespec_time_us(time)
+}
+
+fn timespec_time_us(time: libc::timespec) -> Result<u64, std::io::ErrorKind> {
+    let seconds = u64::try_from(time.tv_sec).map_err(|_| std::io::ErrorKind::InvalidData)?;
+    let nanoseconds = u64::try_from(time.tv_nsec).map_err(|_| std::io::ErrorKind::InvalidData)?;
+
+    Ok(seconds
+        .saturating_mul(1_000_000)
+        .saturating_add(nanoseconds / 1_000))
 }
 
 impl Default for StartupConfig {
@@ -1378,7 +1474,7 @@ mod tests {
     use super::{
         ApiServerError, Args, Command, DEFAULT_API_SOCK_PATH, DEFAULT_INSTANCE_ID,
         HTTP_MAX_PAYLOAD_SIZE, MAX_INSTANCE_ID_LEN, ProcessError, ProcessExitCode, StartupConfig,
-        StartupTimeConfig, parse_process_args,
+        StartupTimeClock, StartupTimeConfig, parse_process_args,
     };
 
     #[derive(Debug, Clone)]
@@ -2016,17 +2112,57 @@ mod tests {
     }
 
     #[test]
-    fn startup_time_config_builds_metrics_diagnostics() {
+    fn startup_time_config_builds_elapsed_metrics_diagnostics() {
         let diagnostics = StartupTimeConfig {
             start_time_us: Some(1000),
+            start_time_cpu_us: Some(2000),
+            parent_cpu_time_us: Some(3000),
+        }
+        .metrics_diagnostics_at(StartupTimeClock::new(1500, 2500));
+
+        assert_eq!(diagnostics.start_time_us(), Some(500));
+        assert_eq!(diagnostics.start_time_cpu_us(), Some(3500));
+        assert_eq!(diagnostics.parent_cpu_time_us(), None);
+    }
+
+    #[test]
+    fn startup_time_config_omits_parent_only_diagnostics() {
+        let diagnostics = StartupTimeConfig {
+            start_time_us: None,
             start_time_cpu_us: None,
             parent_cpu_time_us: Some(3000),
         }
-        .metrics_diagnostics();
+        .metrics_diagnostics_at(StartupTimeClock::new(1500, 2500));
 
-        assert_eq!(diagnostics.start_time_us(), Some(1000));
-        assert_eq!(diagnostics.start_time_cpu_us(), None);
-        assert_eq!(diagnostics.parent_cpu_time_us(), Some(3000));
+        assert_eq!(diagnostics, MetricsDiagnostics::default());
+    }
+
+    #[test]
+    fn startup_time_config_saturates_future_start_times() {
+        let diagnostics = StartupTimeConfig {
+            start_time_us: Some(2000),
+            start_time_cpu_us: Some(3000),
+            parent_cpu_time_us: Some(4000),
+        }
+        .metrics_diagnostics_at(StartupTimeClock::new(1000, 2500));
+
+        assert_eq!(diagnostics.start_time_us(), Some(0));
+        assert_eq!(diagnostics.start_time_cpu_us(), Some(4000));
+        assert_eq!(diagnostics.parent_cpu_time_us(), None);
+    }
+
+    #[test]
+    fn startup_time_config_saturates_parent_cpu_overflow() {
+        let diagnostics = StartupTimeConfig {
+            start_time_us: None,
+            start_time_cpu_us: Some(0),
+            parent_cpu_time_us: Some(1),
+        }
+        .metrics_diagnostics_at(StartupTimeClock::new(0, u64::MAX));
+
+        assert_eq!(diagnostics.start_time_us(), None);
+        assert_eq!(diagnostics.start_time_cpu_us(), Some(u64::MAX));
+        assert_eq!(diagnostics.parent_cpu_time_us(), None);
     }
 
     #[test]

--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -119,6 +119,7 @@ mod macos_arm64 {
         let kernel_path = env_path(BANGBANG_GUEST_KERNEL_PATH_ENV);
         let initrd_path = env_path(BANGBANG_GUEST_INITRD_PATH_ENV);
         let instance_id = test_dir.instance_id();
+        let future_start_time = u64::MAX.to_string();
 
         create_zeroed_block_backing(&backing_path);
         create_empty_file(&serial_output_path);
@@ -128,9 +129,9 @@ mod macos_arm64 {
             &instance_id,
             &[
                 "--start-time-us",
-                "1000",
+                future_start_time.as_str(),
                 "--start-time-cpu-us",
-                "2000",
+                future_start_time.as_str(),
                 "--parent-cpu-time-us",
                 "3000",
             ],
@@ -2639,11 +2640,11 @@ mod macos_arm64 {
         });
 
         assert!(
-            output.contains(r#""process_startup_time_us":1000"#),
+            output.contains(r#""process_startup_time_us":0"#),
             "metrics output should include process_startup_time_us; output:\n{output}"
         );
         assert!(
-            output.contains(r#""process_startup_time_cpu_us":5000"#),
+            output.contains(r#""process_startup_time_cpu_us":3000"#),
             "metrics output should include process_startup_time_cpu_us; output:\n{output}"
         );
         assert!(

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -122,20 +122,23 @@ fn executable_startup_metrics_path_writes_initial_metrics() {
     let metrics_path = test_dir.path().join("startup.metrics");
     let instance_id = test_dir.instance_id();
     let metrics_arg = format!("--metrics-path={}", path_text(&metrics_path));
+    let future_start_time = u64::MAX.to_string();
     let bangbang = BangbangProcess::start_with_extra_args(
         &socket_path,
         &instance_id,
         &[
             metrics_arg.as_str(),
-            "--start-time-us=1000",
-            "--start-time-cpu-us=2000",
+            "--start-time-us",
+            future_start_time.as_str(),
+            "--start-time-cpu-us",
+            future_start_time.as_str(),
             "--parent-cpu-time-us=3000",
         ],
     );
 
     assert_eq!(
         fs::read_to_string(&metrics_path).expect("startup metrics should be readable"),
-        "{\"api_server\":{\"process_startup_time_cpu_us\":5000,\"process_startup_time_us\":1000},\"vmm\":{\"metrics_flush_count\":1}}\n"
+        "{\"api_server\":{\"process_startup_time_cpu_us\":3000,\"process_startup_time_us\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
     );
 
     let instance_info = http_get(&socket_path, "/");
@@ -2466,6 +2469,7 @@ fn concurrent_executables_keep_api_resources_isolated() {
     )
     .expect("second metadata file should be written");
 
+    let future_start_time = u64::MAX.to_string();
     let first_bangbang = BangbangProcess::start_with_extra_args(
         &first_socket_path,
         &first_instance_id,
@@ -2475,9 +2479,9 @@ fn concurrent_executables_keep_api_resources_isolated() {
             "--metrics-path",
             path_text(&first_metrics_path),
             "--start-time-us",
-            "1100",
+            future_start_time.as_str(),
             "--start-time-cpu-us",
-            "1200",
+            future_start_time.as_str(),
             "--parent-cpu-time-us",
             "1300",
         ],
@@ -2491,9 +2495,9 @@ fn concurrent_executables_keep_api_resources_isolated() {
             "--metrics-path",
             path_text(&second_metrics_path),
             "--start-time-us",
-            "2100",
+            future_start_time.as_str(),
             "--start-time-cpu-us",
-            "2200",
+            future_start_time.as_str(),
             "--parent-cpu-time-us",
             "2300",
         ],
@@ -2530,25 +2534,19 @@ fn concurrent_executables_keep_api_resources_isolated() {
     assert_startup_metrics_match(
         &first_metrics_path,
         &[
-            r#""process_startup_time_us":1100"#,
-            r#""process_startup_time_cpu_us":2500"#,
+            r#""process_startup_time_us":0"#,
+            r#""process_startup_time_cpu_us":1300"#,
         ],
-        &[
-            r#""process_startup_time_us":2100"#,
-            r#""process_startup_time_cpu_us":4500"#,
-        ],
+        &[r#""process_startup_time_cpu_us":2300"#],
         "first bangbang",
     );
     assert_startup_metrics_match(
         &second_metrics_path,
         &[
-            r#""process_startup_time_us":2100"#,
-            r#""process_startup_time_cpu_us":4500"#,
+            r#""process_startup_time_us":0"#,
+            r#""process_startup_time_cpu_us":2300"#,
         ],
-        &[
-            r#""process_startup_time_us":1100"#,
-            r#""process_startup_time_cpu_us":2500"#,
-        ],
+        &[r#""process_startup_time_cpu_us":1300"#],
         "second bangbang",
     );
 

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -135,9 +135,9 @@ exits on handled `SIGINT`, handled `SIGTERM`, or guest PSCI `SYSTEM_OFF` or
 | `--api-sock <PATH>` | binds the API Unix socket | Firecracker defaults to `/run/firecracker.socket`; bangbang defaults to `/tmp/bangbang.socket` because macOS does not normally provide `/run`. This is an intentional host-platform difference. |
 | `--http-api-max-payload-size <BYTES>` | configures the maximum accepted HTTP API request size | Defaults to Firecracker's `51200` byte limit. The configured value applies to API socket reads and final request parsing. Zero, malformed, and duplicate values are rejected during argument parsing. |
 | `--id <ID>` | parsed and stored | Defaults to Firecracker's `anonymous-instance`. IDs must be 1 to 64 bytes and contain only ASCII alphanumeric characters or `-`. |
-| `--start-time-us <MICROS>` | parsed and reported in minimal metrics | Accepts non-negative `u64` microsecond values passed by Firecracker-style launchers. When provided, startup, explicit runtime `FlushMetrics`, and periodic runtime metrics output include `api_server.process_startup_time_us`. Full `ProcessTimeReporter` parity remains deferred. |
-| `--start-time-cpu-us <MICROS>` | parsed and reported in minimal metrics | Accepts non-negative `u64` microsecond values passed by Firecracker-style launchers. When provided, startup, explicit runtime `FlushMetrics`, and periodic runtime metrics output include `api_server.process_startup_time_cpu_us`. Full `ProcessTimeReporter` parity remains deferred. |
-| `--parent-cpu-time-us <MICROS>` | parsed and reported in minimal metrics | Accepts non-negative `u64` microsecond values passed by Firecracker-style launchers. When `--start-time-cpu-us` is also provided, startup, explicit runtime `FlushMetrics`, and periodic runtime metrics output add this value into `api_server.process_startup_time_cpu_us`; it is not serialized separately. Full `ProcessTimeReporter` parity remains deferred. |
+| `--start-time-us <MICROS>` | parsed and reported in minimal metrics | Accepts non-negative `u64` microsecond values passed by Firecracker-style launchers. When provided, startup, explicit runtime `FlushMetrics`, and periodic runtime metrics output include `api_server.process_startup_time_us` as the sampled monotonic clock minus this value, saturating at zero for future timestamps. |
+| `--start-time-cpu-us <MICROS>` | parsed and reported in minimal metrics | Accepts non-negative `u64` microsecond values passed by Firecracker-style launchers. When provided, startup, explicit runtime `FlushMetrics`, and periodic runtime metrics output include `api_server.process_startup_time_cpu_us` as the sampled process CPU clock minus this value, saturating at zero for future timestamps before adding optional parent CPU time. |
+| `--parent-cpu-time-us <MICROS>` | parsed and reported in minimal metrics | Accepts non-negative `u64` microsecond values passed by Firecracker-style launchers. When `--start-time-cpu-us` is also provided, startup, explicit runtime `FlushMetrics`, and periodic runtime metrics output add this value into `api_server.process_startup_time_cpu_us`; it is not serialized separately. |
 | `--metrics-path <PATH>` | configures metrics output before API serving | Uses the same per-process metrics sink and redacted host-path error policy as `PUT /metrics`. A later duplicate `PUT /metrics` request fails without replacing this sink. |
 | `--log-path <PATH>` | configures logger output before API serving | Uses the same per-process logger sink and redacted host-path error policy as `PUT /logger`. |
 | `--level <LEVEL>` | configures logger level before API serving | Accepts the existing logger levels `Off`, `Trace`, `Debug`, `Info`, `Warn`, `Warning`, and `Error`; minimal action logs are emitted only when the configured level allows `Info`. |
@@ -181,8 +181,9 @@ are not included in these counters. `PATCH /vm` remains outside
 fields are bangbang-specific extension counters: GET, PUT, and PATCH balloon
 routes report `balloon_count`, and PUT/PATCH failures also report
 `balloon_fails`. Firecracker exposes balloon device metrics but no matching
-balloon API request metric fields. Full Firecracker
-`ProcessTimeReporter` parity remains deferred.
+balloon API request metric fields. The startup timing fields from
+Firecracker's `ProcessTimeReporter` are implemented; the broader full
+Firecracker metrics set remains deferred.
 
 bangbang intentionally treats `--id` alphanumeric characters as ASCII only.
 This is stricter than Firecracker `v1.16.0`'s Rust validator, which accepts


### PR DESCRIPTION
## Summary

- Compute Firecracker-style startup elapsed timing diagnostics from sampled monotonic and process CPU clocks before storing process metrics diagnostics.
- Saturate future timestamps and parent CPU overflow deterministically without panics.
- Update process and signed-target startup metrics assertions plus README and compatibility docs.

## Scope

This PR keeps additional device/API metrics and logger routing out of scope.

Closes #838

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p bangbang startup_time_config --locked`
- `cargo test -p bangbang --test process_e2e executable_startup_metrics_path_writes_initial_metrics --locked`
- `cargo test -p bangbang --test process_e2e concurrent_executables_keep_api_resources_isolated --locked`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
