### PR TITLE
feat: count balloon parser failures in metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,9 @@ memory hotplug and pmem under `patch_api_requests`, including parser failures
 for those PATCH endpoints. bangbang also records
 bangbang-specific `balloon_count` API request counters for parsed balloon GET,
 PUT, and PATCH routes, plus `balloon_fails` counters for parsed balloon PUT and
-PATCH failures, because Firecracker does not expose matching balloon API request
-metric fields. Parsed deprecated HTTP API
+PATCH failures and identifiable malformed balloon PUT/PATCH parser failures,
+because Firecracker does not expose matching balloon API request metric fields.
+Parsed deprecated HTTP API
 usage is counted under `deprecated_api.deprecated_http_api_calls` for supported
 deprecated machine `cpu_template`, MMDS V1 config, `vsock_id`, and snapshot-load
 field forms.

--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -112,6 +112,7 @@ pub enum ApiRequestMetricEndpoint {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApiRequestMetricPutEndpoint {
     Actions,
+    Balloon,
     BootSource,
     CpuConfig,
     Drive,
@@ -128,6 +129,7 @@ pub enum ApiRequestMetricPutEndpoint {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApiRequestMetricPatchEndpoint {
+    Balloon,
     Drive,
     HotplugMemory,
     MachineConfig,
@@ -159,6 +161,7 @@ fn put_api_request_metric_endpoint(path: &str) -> Option<ApiRequestMetricPutEndp
 
     match path {
         "/actions" => Some(ApiRequestMetricPutEndpoint::Actions),
+        "/balloon" => Some(ApiRequestMetricPutEndpoint::Balloon),
         "/boot-source" => Some(ApiRequestMetricPutEndpoint::BootSource),
         "/cpu-config" => Some(ApiRequestMetricPutEndpoint::CpuConfig),
         "/hotplug/memory" => Some(ApiRequestMetricPutEndpoint::HotplugMemory),
@@ -184,6 +187,9 @@ fn patch_api_request_metric_endpoint(path: &str) -> Option<ApiRequestMetricPatch
     }
 
     match path {
+        "/balloon" | "/balloon/statistics" | "/balloon/hinting/start" | "/balloon/hinting/stop" => {
+            Some(ApiRequestMetricPatchEndpoint::Balloon)
+        }
         "/hotplug/memory" => Some(ApiRequestMetricPatchEndpoint::HotplugMemory),
         "/machine-config" => Some(ApiRequestMetricPatchEndpoint::MachineConfig),
         "/mmds" => Some(ApiRequestMetricPatchEndpoint::Mmds),
@@ -2914,6 +2920,7 @@ mod tests {
     fn identifies_put_api_request_metric_endpoints_from_request_head() {
         for (path, endpoint) in [
             ("/actions", ApiRequestMetricPutEndpoint::Actions),
+            ("/balloon", ApiRequestMetricPutEndpoint::Balloon),
             ("/boot-source", ApiRequestMetricPutEndpoint::BootSource),
             ("/cpu-config", ApiRequestMetricPutEndpoint::CpuConfig),
             ("/drives/rootfs", ApiRequestMetricPutEndpoint::Drive),
@@ -2948,6 +2955,19 @@ mod tests {
     #[test]
     fn identifies_patch_api_request_metric_endpoints_from_request_head() {
         for (path, endpoint) in [
+            ("/balloon", ApiRequestMetricPatchEndpoint::Balloon),
+            (
+                "/balloon/statistics",
+                ApiRequestMetricPatchEndpoint::Balloon,
+            ),
+            (
+                "/balloon/hinting/start",
+                ApiRequestMetricPatchEndpoint::Balloon,
+            ),
+            (
+                "/balloon/hinting/stop",
+                ApiRequestMetricPatchEndpoint::Balloon,
+            ),
             ("/drives/rootfs", ApiRequestMetricPatchEndpoint::Drive),
             (
                 "/hotplug/memory",
@@ -2976,11 +2996,13 @@ mod tests {
     fn ignores_requests_without_matching_api_request_metric_endpoint() {
         for request in [
             request_with_body("GET", "/metrics", "{}"),
+            request_with_body("GET", "/balloon", "{}"),
             request_with_body("DELETE", "/drives/rootfs", "{}"),
             request_with_body("PUT", "/entropy", "{}"),
-            request_with_body("PUT", "/balloon", "{}"),
             request_with_body("PATCH", "/vm", "{}"),
-            request_with_body("PATCH", "/balloon", "{}"),
+            request_with_body("PUT", "/balloon/extra", "{}"),
+            request_with_body("PATCH", "/balloon/hinting/status", "{}"),
+            request_with_body("PATCH", "/balloon/hinting/start/extra", "{}"),
             request_with_body("PUT", "/metrics/extra", "{}"),
             request_with_body("PUT", "/drives/rootfs/extra", "{}"),
             request_with_body("PUT", "/drives/rootfs?debug=true", "{}"),

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -600,6 +600,7 @@ const fn api_request_metric_put_parse_failure(
 ) -> ApiRequestMetricPutParseFailure {
     match endpoint {
         ApiRequestMetricPutEndpoint::Actions => ApiRequestMetricPutParseFailure::Actions,
+        ApiRequestMetricPutEndpoint::Balloon => ApiRequestMetricPutParseFailure::Balloon,
         ApiRequestMetricPutEndpoint::BootSource => ApiRequestMetricPutParseFailure::BootSource,
         ApiRequestMetricPutEndpoint::CpuConfig => ApiRequestMetricPutParseFailure::CpuConfig,
         ApiRequestMetricPutEndpoint::Drive => ApiRequestMetricPutParseFailure::Drive,
@@ -623,6 +624,7 @@ const fn api_request_metric_patch_parse_failure(
     endpoint: ApiRequestMetricPatchEndpoint,
 ) -> ApiRequestMetricPatchParseFailure {
     match endpoint {
+        ApiRequestMetricPatchEndpoint::Balloon => ApiRequestMetricPatchParseFailure::Balloon,
         ApiRequestMetricPatchEndpoint::Drive => ApiRequestMetricPatchParseFailure::Drive,
         ApiRequestMetricPatchEndpoint::HotplugMemory => {
             ApiRequestMetricPatchParseFailure::HotplugMemory
@@ -3542,7 +3544,7 @@ mod tests {
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
         assert_eq!(
             fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"get_api_requests\":{\"balloon_count\":3,\"hotplug_memory_count\":0,\"instance_info_count\":0,\"machine_cfg_count\":0,\"mmds_count\":0,\"vmm_version_count\":0},\"patch_api_requests\":{\"balloon_count\":4,\"balloon_fails\":4,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":1,\"balloon_fails\":1,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"get_api_requests\":{\"balloon_count\":3,\"hotplug_memory_count\":0,\"instance_info_count\":0,\"machine_cfg_count\":0,\"mmds_count\":0,\"vmm_version_count\":0},\"patch_api_requests\":{\"balloon_count\":4,\"balloon_fails\":4,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":2,\"balloon_fails\":2,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
 
         fs::remove_file(metrics_path).expect("fixture should clean up");
@@ -3756,6 +3758,7 @@ mod tests {
 
         for (method, path, body) in [
             ("PUT", "/actions", "not-json"),
+            ("PUT", "/balloon", "not-json"),
             ("PUT", "/boot-source", "{}"),
             ("PUT", "/cpu-config", "not-json"),
             ("PUT", "/drives/data", "not-json"),
@@ -3768,6 +3771,9 @@ mod tests {
             ("PUT", "/pmem/pmem0", "not-json"),
             ("PUT", "/serial", "not-json"),
             ("PUT", "/vsock", "not-json"),
+            ("PATCH", "/balloon", "not-json"),
+            ("PATCH", "/balloon/statistics", "not-json"),
+            ("PATCH", "/balloon/hinting/start", "not-json"),
             ("PATCH", "/drives/data", "not-json"),
             ("PATCH", "/hotplug/memory", "not-json"),
             ("PATCH", "/machine-config", "not-json"),
@@ -3843,9 +3849,7 @@ mod tests {
 
         for (method, path, body) in [
             ("DELETE", "/drives/data", "{}"),
-            ("PUT", "/balloon", "not-json"),
             ("PUT", "/entropy", "not-json"),
-            ("PATCH", "/balloon", "not-json"),
             ("PATCH", "/vm", "not-json"),
         ] {
             let response =
@@ -3889,7 +3893,7 @@ mod tests {
         let metrics = read_metrics_json(&metrics_path);
         for (field, count, fails) in [
             ("actions", 1, 1),
-            ("balloon", 0, 0),
+            ("balloon", 1, 1),
             ("boot_source", 2, 1),
             ("cpu_cfg", 1, 1),
             ("drive", 2, 2),
@@ -3926,7 +3930,7 @@ mod tests {
             "pmem",
         ] {
             let (count, fails) = match field {
-                "balloon" => (0, 0),
+                "balloon" => (3, 3),
                 "drive" | "network" | "pmem" => (2, 2),
                 _ => (1, 1),
             };

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -3742,7 +3742,7 @@ mod tests {
     }
 
     #[test]
-    fn configured_metrics_counts_core_parser_failures() {
+    fn configured_metrics_counts_identifiable_parser_failures() {
         let mut vmm = test_controller_with_starter(TestInstanceStarter::success());
         let metrics_path = unique_socket_path("metrics-core-parser").with_extension("metrics");
 

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -502,6 +502,7 @@ impl ApiRequestMetricParseFailure {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ApiRequestMetricPutParseFailure {
     Actions,
+    Balloon,
     BootSource,
     CpuConfig,
     Drive,
@@ -523,6 +524,7 @@ impl ApiRequestMetricPutParseFailure {
                 controller.record_put_actions_request();
                 controller.record_put_actions_failure();
             }
+            Self::Balloon => PutApiRequestKind::Balloon.record_parse_failure(controller),
             Self::BootSource => PutApiRequestKind::BootSource.record_parse_failure(controller),
             Self::CpuConfig => PutApiRequestKind::CpuConfig.record_parse_failure(controller),
             Self::Drive => PutApiRequestKind::Drive.record_parse_failure(controller),
@@ -545,6 +547,7 @@ impl ApiRequestMetricPutParseFailure {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ApiRequestMetricPatchParseFailure {
+    Balloon,
     Drive,
     HotplugMemory,
     MachineConfig,
@@ -556,6 +559,7 @@ pub(crate) enum ApiRequestMetricPatchParseFailure {
 impl ApiRequestMetricPatchParseFailure {
     fn record(self, controller: &mut VmmController) {
         match self {
+            Self::Balloon => PatchApiRequestKind::Balloon.record_parse_failure(controller),
             Self::Drive => PatchApiRequestKind::Drive.record_parse_failure(controller),
             Self::HotplugMemory => {
                 PatchApiRequestKind::HotplugMemory.record_parse_failure(controller)

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -564,9 +564,9 @@ through VMM control, parser failures for those endpoints in the matching
 for those PATCH endpoints. bangbang also records
 `balloon_count` extension fields for parsed balloon GET, PUT, and PATCH routes,
 plus `balloon_fails` extension fields for parsed balloon PUT and PATCH
-failures, because Firecracker does not expose matching request metrics. It does
-not count malformed balloon parser failures in those extension fields. It also
-does not emit entropy request-counter fields; Firecracker does not define
+failures and identifiable malformed balloon PUT/PATCH parser failures, because
+Firecracker does not expose matching request metrics. It also does not emit
+entropy request-counter fields; Firecracker does not define
 `put_api_requests.entropy_count` or `entropy_fails`. Entropy device runtime
 metrics remain deferred until their producers exist.
 Parsed deprecated HTTP API usage is counted under


### PR DESCRIPTION
## Summary

- Count identifiable malformed balloon PUT/PATCH requests in existing balloon API request metrics.
- Keep unsupported methods, unsupported balloon subpaths, `PATCH /vm`, and entropy request metrics uncounted.
- Update compatibility docs to remove the malformed-balloon exclusion.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p bangbang-api --lib --all-features --locked api_request_metric_endpoint -- --quiet`
- `cargo test -p bangbang --bin bangbang --all-features --locked configured_metrics_counts_balloon_api_requests -- --quiet`
- `cargo test -p bangbang --bin bangbang --all-features --locked configured_metrics_counts_identifiable_parser_failures -- --quiet`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf -- --quiet`
- `cargo test -p bangbang-hvf --lib --all-features --locked -- --quiet`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `scripts/run-integration-tests.sh`

Closes #865

