### PR TITLE
test: cover boot-source startup path failures

### DIFF
--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -1898,8 +1898,10 @@ mod tests {
     use bangbang_runtime::metrics::{
         BootRunLoopMetricStatus, MetricsConfigInput, MetricsDiagnostics,
     };
+    use bangbang_runtime::startup::Arm64BootResources;
     use bangbang_runtime::{BackendError, VmmActionError};
 
+    use crate::test_support::minimal_arm64_boot_resource_config;
     use crate::vmm::{
         InstanceStartExecutor, ProcessSessionDiagnostics, ProcessSessionExitStatus, ProcessVmm,
     };
@@ -1911,6 +1913,7 @@ mod tests {
     #[derive(Debug, Clone)]
     struct TestInstanceStarter {
         result: Result<TestSession, BackendError>,
+        assemble_boot_resources: bool,
     }
 
     #[derive(Debug, Clone)]
@@ -2156,18 +2159,21 @@ mod tests {
         const fn success() -> Self {
             Self {
                 result: Ok(TestSession::without_boot_run_loop_status()),
+                assemble_boot_resources: false,
             }
         }
 
         const fn success_with_boot_run_loop_status(status: BootRunLoopMetricStatus) -> Self {
             Self {
                 result: Ok(TestSession::with_boot_run_loop_status(status)),
+                assemble_boot_resources: false,
             }
         }
 
         fn success_with_process_exit_signal(signal: TestProcessExitSignal) -> Self {
             Self {
                 result: Ok(TestSession::with_process_exit_signal(signal)),
+                assemble_boot_resources: false,
             }
         }
 
@@ -2178,12 +2184,21 @@ mod tests {
                 result: Ok(TestSession::with_memory_hotplug_status_plugged_size_mib(
                     plugged_size_mib,
                 )),
+                assemble_boot_resources: false,
             }
         }
 
         const fn failure() -> Self {
             Self {
                 result: Err(BackendError::InvalidState("test startup failed")),
+                assemble_boot_resources: false,
+            }
+        }
+
+        const fn boot_resource_assembler() -> Self {
+            Self {
+                result: Ok(TestSession::without_boot_run_loop_status()),
+                assemble_boot_resources: true,
             }
         }
     }
@@ -2193,8 +2208,21 @@ mod tests {
 
         fn start(
             &mut self,
-            _controller: &bangbang_runtime::VmmController,
+            controller: &bangbang_runtime::VmmController,
         ) -> Result<Self::Session, BackendError> {
+            if self.assemble_boot_resources {
+                return Arm64BootResources::assemble_from_controller(
+                    controller,
+                    minimal_arm64_boot_resource_config(),
+                )
+                .map(|_| TestSession::without_boot_run_loop_status())
+                .map_err(|source| {
+                    BackendError::Hypervisor(format!(
+                        "failed to assemble arm64 boot resources: {source}"
+                    ))
+                });
+            }
+
             self.result.clone()
         }
     }
@@ -3554,6 +3582,61 @@ mod tests {
             Path::new("/tmp/original-vmlinux")
         );
         assert!(vmm.drive_configs().is_empty());
+    }
+
+    #[test]
+    fn returns_redacted_fault_for_boot_source_payload_start_failure() {
+        let mut vmm = test_controller_with_starter(TestInstanceStarter::boot_resource_assembler());
+        let machine_response = request_over_socket(
+            &mut vmm,
+            "pfm",
+            &request_with_body(
+                "PUT",
+                "/machine-config",
+                r#"{"vcpu_count":1,"mem_size_mib":1}"#,
+            ),
+        );
+        assert!(machine_response.starts_with("HTTP/1.1 204 No Content\r\n"));
+        let kernel_path = unique_socket_path("pk").with_extension("vmlinux");
+        let kernel_path_text = kernel_path
+            .to_str()
+            .expect("test kernel path should be UTF-8");
+        let kernel_path_json =
+            serde_json::to_string(kernel_path_text).expect("kernel path should encode");
+        let boot_body = format!(r#"{{"kernel_image_path":{kernel_path_json}}}"#);
+        let boot_response = request_over_socket(
+            &mut vmm,
+            "pfb",
+            &request_with_body("PUT", "/boot-source", &boot_body),
+        );
+        assert!(boot_response.starts_with("HTTP/1.1 204 No Content\r\n"));
+
+        let response = put_action_over_socket(&mut vmm, "pfs", "InstanceStart");
+
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+        assert!(
+            response.contains(
+                r#"{"fault_message":"failed to start microVM: hypervisor error: failed to assemble arm64 boot resources: failed to load boot source: failed to open kernel image"#
+            ),
+            "InstanceStart response should describe redacted boot-source load failure; response:\n{response}"
+        );
+        assert!(
+            !response.contains(kernel_path_text),
+            "InstanceStart response must not echo private kernel path; response:\n{response}"
+        );
+        assert_eq!(
+            vmm.instance_info().state,
+            bangbang_runtime::InstanceState::NotStarted
+        );
+        assert!(!vmm.has_started_session());
+        let instance_info_response =
+            request_over_socket(&mut vmm, "pfi", "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        assert!(instance_info_response.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(instance_info_response.contains(r#""state":"Not started""#));
+        assert!(
+            !kernel_path.exists(),
+            "missing payload test fixture should remain absent"
+        );
     }
 
     #[test]

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -15,6 +15,8 @@ mod api_server;
 #[cfg(target_os = "macos")]
 pub mod host_network;
 mod periodic_metrics;
+#[cfg(test)]
+mod test_support;
 mod vmm;
 
 use api_server::{ApiServer, ApiServerError, config_vmm_action_from_api_request};
@@ -1908,8 +1910,10 @@ mod tests {
     use bangbang_runtime::network::{NetworkInterfaceConfigError, NetworkInterfaceConfigInput};
     use bangbang_runtime::pmem::{PmemConfigError, PmemConfigInput};
     use bangbang_runtime::serial::SerialRateLimiterConfig;
+    use bangbang_runtime::startup::Arm64BootResources;
     use bangbang_runtime::{BackendError, InstanceState, VmmAction, VmmActionError, VmmData};
 
+    use crate::test_support::minimal_arm64_boot_resource_config;
     use crate::vmm::{
         ApiRequestMetricParseFailure, GetApiRequest, InstanceStartExecutor, PatchApiRequest,
         ProcessSessionDiagnostics, ProcessSessionExitStatus, ProcessVmm, PutApiRequest,
@@ -1933,6 +1937,29 @@ mod tests {
             _controller: &bangbang_runtime::VmmController,
         ) -> Result<Self::Session, BackendError> {
             Ok(())
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct BootResourceAssemblingTestStarter;
+
+    impl InstanceStartExecutor for BootResourceAssemblingTestStarter {
+        type Session = ();
+
+        fn start(
+            &mut self,
+            controller: &bangbang_runtime::VmmController,
+        ) -> Result<Self::Session, BackendError> {
+            Arm64BootResources::assemble_from_controller(
+                controller,
+                minimal_arm64_boot_resource_config(),
+            )
+            .map(|_| ())
+            .map_err(|source| {
+                BackendError::Hypervisor(format!(
+                    "failed to assemble arm64 boot resources: {source}"
+                ))
+            })
         }
     }
 
@@ -4512,6 +4539,56 @@ mod tests {
         ));
         assert_eq!(vmm.instance_info().state, InstanceState::NotStarted);
         assert!(!vmm.has_started_session());
+
+        fs::remove_file(config_path).expect("fixture config should clean up");
+    }
+
+    #[test]
+    fn config_file_boot_source_payload_failure_does_not_start_or_leak_path() {
+        let config_path = unique_config_path("boot-source-payload");
+        let kernel_path = unique_config_path("private-kernel").with_extension("vmlinux");
+        let kernel_path_text = kernel_path
+            .to_str()
+            .expect("test kernel path should be UTF-8");
+        let kernel_path_json =
+            serde_json::to_string(kernel_path_text).expect("kernel path should encode");
+        let config = format!(
+            r#"{{
+                "machine-config": {{"vcpu_count": 1, "mem_size_mib": 1}},
+                "boot-source": {{"kernel_image_path": {kernel_path_json}}}
+            }}"#
+        );
+        fs::write(&config_path, config).expect("config file should be written");
+        let mut vmm = ProcessVmm::with_starter(
+            "demo-1",
+            env!("CARGO_PKG_VERSION"),
+            "bangbang",
+            BootResourceAssemblingTestStarter,
+        );
+
+        let err = super::apply_startup_config_file(
+            &mut vmm,
+            Some(config_path.to_str().expect("UTF-8 path")),
+        )
+        .expect_err("missing boot-source payload should fail startup");
+        let err = err.to_string();
+
+        assert!(
+            err.contains(
+                "config-file error: failed to apply config-file action: failed to start microVM: hypervisor error: failed to assemble arm64 boot resources: failed to load boot source: failed to open kernel image"
+            ),
+            "config-file startup error should describe redacted boot-source load failure; error: {err}"
+        );
+        assert!(
+            !err.contains(kernel_path_text),
+            "config-file startup error must not echo private kernel path; error: {err}"
+        );
+        assert_eq!(vmm.instance_info().state, InstanceState::NotStarted);
+        assert!(!vmm.has_started_session());
+        assert!(
+            !kernel_path.exists(),
+            "missing payload test fixture should remain absent"
+        );
 
         fs::remove_file(config_path).expect("fixture config should clean up");
     }

--- a/crates/bangbang/src/test_support.rs
+++ b/crates/bangbang/src/test_support.rs
@@ -1,0 +1,63 @@
+use bangbang_runtime::balloon::BalloonMmioLayout;
+use bangbang_runtime::block::BlockMmioLayout;
+use bangbang_runtime::fdt::{Arm64FdtGic, Arm64FdtRegion, Arm64FdtTimerInterrupts};
+use bangbang_runtime::interrupt::GuestInterruptLine;
+use bangbang_runtime::memory::GuestAddress;
+use bangbang_runtime::mmio::MmioRegionId;
+use bangbang_runtime::network::NetworkMmioLayout;
+use bangbang_runtime::pmem::PmemMmioLayout;
+use bangbang_runtime::startup::Arm64BootResourceConfig;
+use bangbang_runtime::vsock::VsockMmioLayout;
+
+pub(crate) fn minimal_arm64_boot_resource_config() -> Arm64BootResourceConfig<'static> {
+    const VCPU_MPIDRS: &[u64] = &[0x8000_0000];
+    const INTERRUPT_LINES: &[GuestInterruptLine] = &[];
+
+    Arm64BootResourceConfig {
+        vcpu_mpidrs: VCPU_MPIDRS,
+        gic: Arm64FdtGic {
+            distributor: Arm64FdtRegion {
+                base: 0x0800_0000,
+                size: 0x1_0000,
+            },
+            redistributor: Arm64FdtRegion {
+                base: 0x080a_0000,
+                size: 0xf6_0000,
+            },
+            compatibility: "arm,gic-v3",
+            interrupt_cells: 3,
+            maintenance_irq: 25,
+            msi: None,
+        },
+        timer: Arm64FdtTimerInterrupts::firecracker_default(),
+        rtc_device: None,
+        serial_device: None,
+        block_mmio_layout: BlockMmioLayout::new(
+            GuestAddress::new(0x1000_0000),
+            MmioRegionId::new(1000),
+        ),
+        block_interrupt_lines: INTERRUPT_LINES,
+        pmem_mmio_layout: PmemMmioLayout::new(
+            GuestAddress::new(0x2000_0000),
+            MmioRegionId::new(2000),
+        ),
+        pmem_interrupt_lines: INTERRUPT_LINES,
+        network_mmio_layout: NetworkMmioLayout::new(
+            GuestAddress::new(0x3000_0000),
+            MmioRegionId::new(3000),
+        ),
+        network_interrupt_lines: INTERRUPT_LINES,
+        vsock_mmio_layout: VsockMmioLayout::new(
+            GuestAddress::new(0x4000_0000),
+            MmioRegionId::new(4000),
+        ),
+        vsock_interrupt_line: None,
+        balloon_mmio_layout: BalloonMmioLayout::new(
+            GuestAddress::new(0x5000_0000),
+            MmioRegionId::new(5000),
+        ),
+        balloon_interrupt_line: None,
+        memory_hotplug_device: None,
+        entropy_device: None,
+    }
+}

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -455,8 +455,8 @@ fields and duplicate token bucket fields before VMM dispatch.
 
 | Endpoint | Field | Handling | Notes |
 | --- | --- | --- | --- |
-| `PUT /boot-source` | `kernel_image_path` | required | Host path to the kernel image. The API/VMM storage path rejects empty paths without file IO; future startup validation must check access without leaking sensitive path details. |
-| `PUT /boot-source` | `initrd_path` | optional | Host path to an initrd. The API/VMM storage path rejects explicitly empty initrd paths without file IO; future startup validation follows the kernel path policy. |
+| `PUT /boot-source` | `kernel_image_path` | required | Host path to the kernel image. The API/VMM storage path rejects empty paths without file IO; startup opens the payload read-only/nonblocking, rejects inaccessible, non-regular, or empty files, and redacts path details from API-facing load errors. |
+| `PUT /boot-source` | `initrd_path` | optional | Host path to an initrd. The API/VMM storage path rejects explicitly empty initrd paths without file IO; startup applies the same read-only/nonblocking payload loading and redacted error policy as the kernel path. |
 | `PUT /boot-source` | `boot_args` | optional | Firecracker uses its default kernel command line when omitted. The API/VMM storage path validates the 2048-byte aarch64 limit including the trailing NUL byte and rejects embedded NUL bytes. |
 | `PUT /boot-source` | unknown fields | rejected | Matches Firecracker's strict request model behavior. |
 | `PUT /machine-config` | `vcpu_count` | required | Firecracker bounds this to `1..=32`, and bangbang stores that range for API compatibility. Current HVF startup supports exactly one vCPU and rejects larger stored values during `InstanceStart` before creating an HVF VM. |
@@ -639,9 +639,11 @@ The API and VMM state path implement the `PUT /boot-source` field policy above.
 Valid pre-boot requests replace the stored boot-source configuration and return
 `204 No Content`; invalid requests fail without mutating existing state or
 echoing host path and boot-argument values. The public API path stores path
-values at configuration time; `InstanceStart` opens kernel and initrd host paths,
-loads payloads, builds an FDT, configures vCPU registers, and retains the owned
-HVF boot run-loop worker only after preparation succeeds.
+values at configuration time; `InstanceStart` opens kernel and initrd host paths
+read-only/nonblocking, rejects inaccessible, non-regular, or empty payloads
+without echoing the private path in API-facing load errors, loads accepted
+payloads, builds an FDT, configures vCPU registers, and retains the owned HVF
+boot run-loop worker only after preparation succeeds.
 
 The API and VMM state path implement the `PUT /actions` field policy above for
 `InstanceStart` and `FlushMetrics` and rejects malformed bodies before VMM state

--- a/docs/security.md
+++ b/docs/security.md
@@ -111,7 +111,9 @@ Host paths configured through the API are untrusted input. The current behavior
 is resource-specific:
 
 - `/boot-source` stores kernel and optional initrd paths during configuration.
-  Files are opened later during `InstanceStart`.
+  Files are opened later during `InstanceStart` with read-only nonblocking
+  access. Startup rejects inaccessible, non-regular, or empty payload files,
+  and API-facing startup errors must not echo the configured path.
 - `/drives/{drive_id}` stores block backing paths during configuration. Backing
   files are opened later during `InstanceStart`. Runtime
   `PATCH /drives/{drive_id}` opens a replacement backing for an existing active

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -75,6 +75,10 @@ memory, or host resources.
 For deferred-open paths such as serial output, also cover that parsing stores
 configuration without opening the path, and that startup wiring opens or writes
 through the selected sink with redacted errors.
+For boot-source payload failures, cover both request/API fault formatting and
+config-file startup failure paths. Use a test starter that invokes runtime boot
+resource assembly when the behavior does not need real HVF execution; keep real
+signed executable/HVF coverage in dedicated integration targets.
 
 For guest memory, address, and range logic, cover exact-fit success, one-past
 failure, overflow failure, overlapping ranges, and no-partial-mutation behavior.


### PR DESCRIPTION
## Summary

- add API and config-file startup tests for missing boot-source payload paths without requiring real HVF execution
- add a test-only minimal arm64 boot resource config helper for runtime assembly based startup failures
- update compatibility, security, and testing docs for current boot-source payload loading and path redaction behavior

## Scope

- Does not change runtime boot-source loading behavior or HVF startup order.
- Does not add signed executable/HVF execution coverage; this path is covered through a test starter that invokes runtime boot-resource assembly.

Closes #1054

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p bangbang returns_redacted_fault_for_boot_source_payload_start_failure --locked`
- `cargo test -p bangbang config_file_boot_source_payload_failure_does_not_start_or_leak_path --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
