### PR TITLE
docs: document macOS isolation boundaries

### DIFF
--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -1984,7 +1984,9 @@ macOS design work instead of direct implementation:
 - Snapshot and device behavior may differ when backed by HVF.
 
 The initial compatibility scope should document these differences without
-pretending they are solved.
+pretending they are solved. See [macOS Host Security Model](security.md) for the
+current host isolation boundary and the deferred macOS sandbox, launcher, and
+resource-broker design options.
 
 ## Validation Expectations
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -91,6 +91,29 @@ Use this checklist when reviewing Firecracker-facing host isolation changes:
 | macOS sandboxing | Deferred feasible macOS work | Do not claim production containment until a sandbox profile and resource policy are designed and tested. |
 | Launcher or resource broker | Deferred feasible macOS work | Keep host-path and shared-resource isolation as operator responsibility until a separate broker owns privileged preparation and cleanup. |
 
+## macOS Isolation Design Boundaries
+
+The current isolation boundary is one macOS process running as the invoking host
+user. bangbang does not yet split privilege between a launcher, broker, and VMM
+worker, and it does not install a sandbox profile. The host user account,
+filesystem permissions, API socket directory, and per-resource validation are
+therefore the only deployed host isolation controls.
+
+Use the following boundaries when designing or reviewing macOS isolation work:
+
+| Boundary or option | Current behavior | Future direction |
+| --- | --- | --- |
+| Operator-owned private directories | Required for API sockets, vsock sockets, observability sinks, and other configured paths that should not be shared. | A launcher or broker could create and own these directories before starting a VM process. |
+| HVF entitlement and code signing | Required to execute Hypervisor.framework code paths; signed integration wrappers cover the validation path. | A production launcher may control which executable receives the entitlement, but the entitlement itself is not guest containment. |
+| macOS sandbox profile | Not implemented. | A future profile must be resource-specific and tested against configured host paths, HVF access, vmnet use, logging, metrics, and guest artifacts before it is a claimed security boundary. |
+| Launcher or resource broker | Not implemented. | A future process could prepare privileged or shared host resources, pass owned descriptors to the VMM, and centralize cleanup policy. |
+| Firecracker Linux jailer model | Platform-limited unsupported as a direct port. | Keep Linux jailer, seccomp, namespaces, cgroups, chroot, and privilege-drop flags rejected or documented until macOS replacements exist. |
+
+This document intentionally does not define a sandbox profile, broker protocol,
+privilege-dropping flow, or new public API. PRs that add host resource types
+should state which current boundary protects the resource and whether a future
+launcher, broker, or sandbox profile would need to own it.
+
 ## API Socket Handling
 
 The API socket is a local control interface with no protocol-level


### PR DESCRIPTION
## Summary

- Document the current macOS host isolation boundary in `docs/security.md`.
- Compare deferred macOS isolation options, including sandboxing, a launcher/resource broker, entitlement-controlled execution, and operator-owned private directories.
- Link the compatibility guide's macOS/HVF differences section back to the security model.

## Scope Exclusions

- No sandbox profile implementation.
- No launcher, resource broker, privilege separation, or public API behavior changes.
- No runtime behavior changes.

Closes #1098

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
