### PR TITLE
fix: list Warning logger level in help

### DIFF
--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -1807,7 +1807,7 @@ fn help_text() -> String {
             "      --id <ID>          MicroVM unique identifier [default: {}]\n",
             "                         Accepts 1-64 bytes, ASCII alphanumeric or '-'\n",
             "      --log-path <PATH>  Logger output file or FIFO path\n",
-            "      --level <LEVEL>    Logger level: Off, Trace, Debug, Info, Warn, or Error\n",
+            "      --level <LEVEL>    Logger level: Off, Trace, Debug, Info, Warn, Warning, or Error\n",
             "      --metrics-path <PATH>  Metrics output file or FIFO path\n",
             "      --mmds-size-limit <BYTES>\n",
             "                         MMDS data store size; defaults to HTTP API limit\n",
@@ -2732,6 +2732,7 @@ mod tests {
         assert!(help.contains("PATCH /vm supports Paused and Resumed"));
         assert!(help.contains("PUT /cpu-config accepts empty CPU config as no-op"));
         assert!(help.contains("--log-path <PATH>"));
+        assert!(help.contains("Logger level: Off, Trace, Debug, Info, Warn, Warning, or Error"));
         assert!(help.contains("--metrics-path <PATH>"));
         assert!(help.contains("--http-api-max-payload-size <BYTES>"));
         assert!(help.contains("Maximum HTTP API request body size"));


### PR DESCRIPTION
## Summary
- List the accepted `Warning` logger level alias in `bangbang --help`.
- Extend the help text test to assert the complete logger level list.

## Scope
- Parser behavior is unchanged; `Warn` and `Warning` were already accepted.
- Documentation is unchanged because `docs/firecracker-compatibility.md` already listed `Warning`.

Closes #1114

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p bangbang --bin bangbang --all-features --locked tests::help_text_lists_current_api_scope -- --exact`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
