### PR TITLE
test: cover executable help and version exits

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -34,6 +34,83 @@ const SIGILL_EXIT_CODE: i32 = 157;
 const MULTI_VCPU_STARTUP_ERROR: &str = "HVF arm64 boot session supports exactly 1 vCPU, got 2";
 
 #[test]
+fn executable_prints_help_and_exits_before_socket_publication() {
+    let test_dir = TestDir::new();
+    let socket_path = test_dir.path().join("help.socket");
+    let instance_id = test_dir.instance_id();
+
+    let output = BangbangProcess::run_with_extra_args_expect_successful_exit(
+        &socket_path,
+        &instance_id,
+        &["--help"],
+    );
+
+    assert_eq!(output.stderr, "", "help should not write stderr");
+    assert!(
+        output.stdout.contains("Usage:\n  bangbang [OPTIONS]"),
+        "help should print usage; stdout:\n{}",
+        output.stdout
+    );
+    assert!(
+        output.stdout.contains("--api-sock <PATH>"),
+        "help should list API socket option; stdout:\n{}",
+        output.stdout
+    );
+    assert!(
+        output
+            .stdout
+            .contains("Logger level: Off, Trace, Debug, Info, Warn, Warning, or Error"),
+        "help should list accepted logger levels; stdout:\n{}",
+        output.stdout
+    );
+    assert!(
+        output.stdout.contains("Current scope:"),
+        "help should describe current public scope; stdout:\n{}",
+        output.stdout
+    );
+    assert!(
+        !output.stdout.contains("status: API server listening")
+            && !output.stdout.contains("status: VM running without API"),
+        "help must exit before startup readiness; stdout:\n{}",
+        output.stdout
+    );
+    assert!(
+        !socket_path.exists(),
+        "help must not publish the API socket"
+    );
+}
+
+#[test]
+fn executable_prints_version_and_exits_before_socket_publication() {
+    let test_dir = TestDir::new();
+    let socket_path = test_dir.path().join("version.socket");
+    let instance_id = test_dir.instance_id();
+
+    let output = BangbangProcess::run_with_extra_args_expect_successful_exit(
+        &socket_path,
+        &instance_id,
+        &["--version"],
+    );
+
+    assert_eq!(
+        output.stdout,
+        format!("bangbang {BANGBANG_VERSION}\n"),
+        "version should report the package version"
+    );
+    assert_eq!(output.stderr, "", "version should not write stderr");
+    assert!(
+        !output.stdout.contains("status: API server listening")
+            && !output.stdout.contains("status: VM running without API"),
+        "version must exit before startup readiness; stdout:\n{}",
+        output.stdout
+    );
+    assert!(
+        !socket_path.exists(),
+        "version must not publish the API socket"
+    );
+}
+
+#[test]
 fn executable_serves_api_and_shuts_down_cleanly() {
     let test_dir = TestDir::new();
     let socket_path = test_dir.path().join("api.socket");

--- a/crates/bangbang/tests/support/mod.rs
+++ b/crates/bangbang/tests/support/mod.rs
@@ -287,12 +287,38 @@ impl BangbangProcess {
         process.wait_for_startup_failure()
     }
 
+    #[allow(
+        dead_code,
+        reason = "shared integration-test support is compiled once per test target"
+    )]
+    pub(crate) fn run_with_extra_args_expect_successful_exit(
+        socket_path: &Path,
+        instance_id: &str,
+        extra_args: &[&str],
+    ) -> CompletedProcess {
+        let mut process = Self::spawn_with_extra_args(socket_path, instance_id, extra_args);
+        let output = process.wait_for_startup_exit("successful early exit");
+        assert!(
+            output.status.success(),
+            "bangbang should exit successfully before startup readiness; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            output.stdout,
+            output.stderr
+        );
+
+        output
+    }
+
     fn wait_for_startup_failure(&mut self) -> CompletedProcess {
+        self.wait_for_startup_exit("startup failure")
+    }
+
+    fn wait_for_startup_exit(&mut self, expected_exit: &str) -> CompletedProcess {
         match self.ready.recv_timeout(STARTUP_TIMEOUT) {
             Ok(()) => {
                 let output = self.force_stop_and_collect();
                 panic!(
-                    "bangbang reported startup readiness but startup failure was expected; binary: {}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                    "bangbang reported startup readiness but {expected_exit} was expected; binary: {}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
                     self.binary_path.display(),
                     output.status,
                     output.stdout,
@@ -307,7 +333,7 @@ impl BangbangProcess {
             Err(RecvTimeoutError::Timeout) => {
                 let output = self.force_stop_and_collect();
                 panic!(
-                    "bangbang did not fail before timeout; binary: {}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                    "bangbang did not exit for {expected_exit} before timeout; binary: {}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
                     self.binary_path.display(),
                     output.status,
                     output.stdout,


### PR DESCRIPTION
## Summary
- Add process e2e coverage for `bangbang --help` and `bangbang --version` successful early exits.
- Add a shared process-test helper for commands that exit before startup readiness.
- Assert help/version do not publish the configured API socket and do not report startup readiness.

## Scope
- Test-only change; executable behavior is unchanged.
- Documentation is unchanged because the documented behavior already matches the implementation.

Closes #1116

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p bangbang --test process_e2e --all-features --locked executable_prints_help_and_exits_before_socket_publication -- --exact`
- `cargo test -p bangbang --test process_e2e --all-features --locked executable_prints_version_and_exits_before_socket_publication -- --exact`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`
- `git diff --check`
