### PR TITLE
test: cover executable help precedence

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -111,6 +111,86 @@ fn executable_prints_version_and_exits_before_socket_publication() {
 }
 
 #[test]
+fn executable_help_precedence_ignores_later_unknown_args() {
+    let test_dir = TestDir::new();
+    let socket_path = test_dir.path().join("help-precedence.socket");
+    let instance_id = test_dir.instance_id();
+
+    let output = BangbangProcess::run_with_extra_args_expect_successful_exit(
+        &socket_path,
+        &instance_id,
+        &["--help", "--unknown"],
+    );
+
+    assert_eq!(output.stderr, "", "help precedence should not write stderr");
+    assert!(
+        output.stdout.contains("Usage:\n  bangbang [OPTIONS]"),
+        "help precedence should print usage; stdout:\n{}",
+        output.stdout
+    );
+    assert!(
+        output.stdout.contains("Current scope:"),
+        "help precedence should still print help scope; stdout:\n{}",
+        output.stdout
+    );
+    assert!(
+        !output.stdout.contains("--unknown") && !output.stderr.contains("--unknown"),
+        "help precedence must not report the later unknown argument; stdout:\n{}\nstderr:\n{}",
+        output.stdout,
+        output.stderr
+    );
+    assert!(
+        !output.stdout.contains("status: API server listening")
+            && !output.stdout.contains("status: VM running without API"),
+        "help precedence must exit before startup readiness; stdout:\n{}",
+        output.stdout
+    );
+    assert!(
+        !socket_path.exists(),
+        "help precedence must not publish the API socket"
+    );
+}
+
+#[test]
+fn executable_version_precedence_ignores_later_unknown_args() {
+    let test_dir = TestDir::new();
+    let socket_path = test_dir.path().join("version-precedence.socket");
+    let instance_id = test_dir.instance_id();
+
+    let output = BangbangProcess::run_with_extra_args_expect_successful_exit(
+        &socket_path,
+        &instance_id,
+        &["--version", "--unknown"],
+    );
+
+    assert_eq!(
+        output.stdout,
+        format!("bangbang {BANGBANG_VERSION}\n"),
+        "version precedence should report the package version"
+    );
+    assert_eq!(
+        output.stderr, "",
+        "version precedence should not write stderr"
+    );
+    assert!(
+        !output.stdout.contains("--unknown") && !output.stderr.contains("--unknown"),
+        "version precedence must not report the later unknown argument; stdout:\n{}\nstderr:\n{}",
+        output.stdout,
+        output.stderr
+    );
+    assert!(
+        !output.stdout.contains("status: API server listening")
+            && !output.stdout.contains("status: VM running without API"),
+        "version precedence must exit before startup readiness; stdout:\n{}",
+        output.stdout
+    );
+    assert!(
+        !socket_path.exists(),
+        "version precedence must not publish the API socket"
+    );
+}
+
+#[test]
 fn executable_serves_api_and_shuts_down_cleanly() {
     let test_dir = TestDir::new();
     let socket_path = test_dir.path().join("api.socket");


### PR DESCRIPTION
## Summary
- Add process e2e coverage for `bangbang --help --unknown` and `bangbang --version --unknown`.
- Assert help/version precedence still exits successfully before startup readiness and API socket publication.
- Assert the later unknown argument is not reported as an error.

## Scope
- Test-only change; executable behavior is unchanged.
- Documentation is unchanged because the documented Firecracker-style early-command behavior already matches the implementation.

Closes #1118

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p bangbang --test process_e2e --all-features --locked executable_help_precedence_ignores_later_unknown_args -- --exact`
- `cargo test -p bangbang --test process_e2e --all-features --locked executable_version_precedence_ignores_later_unknown_args -- --exact`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`
- `git diff --check`
