### PR TITLE
test: cover executable resume before start

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -1850,6 +1850,20 @@ fn executable_configures_vm_before_start() {
         "GET / after failed PATCH /vm",
     );
 
+    let vm_resume_response = http_json(&socket_path, "PATCH", "/vm", r#"{"state":"Resumed"}"#);
+    assert_bad_request_response(&vm_resume_response, "PATCH /vm resumed");
+    assert_response_contains(
+        &vm_resume_response,
+        r#"{"fault_message":"The requested operation is not supported in Not started state: Resume"}"#,
+        "PATCH /vm resumed",
+    );
+    let instance_info_after_vm_resume_patch = http_get(&socket_path, "/");
+    assert_response_contains(
+        &instance_info_after_vm_resume_patch,
+        r#""state":"Not started""#,
+        "GET / after failed PATCH /vm resumed",
+    );
+
     let flush_metrics_response = http_put_json(
         &socket_path,
         "/actions",


### PR DESCRIPTION
## Summary

- Add process e2e coverage for `PATCH /vm {"state":"Resumed"}` before startup.
- Assert the request returns the expected Not-started `Resume` state fault.
- Assert the instance remains in `Not started` after the failed request.

## Scope

- Test-only change.
- No production behavior or documentation changes.

Closes #1122

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p bangbang --test process_e2e --all-features --locked executable_configures_vm_before_start -- --exact`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`
- `git diff --check`
