### PR TITLE
test: cover vm state latency metrics

### DIFF
--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -771,6 +771,7 @@ mod macos_arm64 {
                 r#"{"balloon_count":4,"balloon_fails":4,"drive_count":2,"drive_fails":0,"hotplug_memory_count":0,"hotplug_memory_fails":0,"machine_cfg_count":0,"machine_cfg_fails":0,"mmds_count":1,"mmds_fails":0,"network_count":0,"network_fails":0,"pmem_count":0,"pmem_fails":0}"#,
             ),
         );
+        assert_vm_state_latency_metrics_output(&metrics_path);
         assert_block_update_metrics_output(&metrics_path);
         assert_startup_time_metrics_output(&metrics_path);
         assert_sigpipe_signal_metrics_output(&metrics_path);
@@ -3892,6 +3893,41 @@ mod macos_arm64 {
         assert!(
             !output.contains(r#""boot_run_loop_status":"failed""#),
             "metrics output should not report failed boot run-loop status; output:\n{output}"
+        );
+    }
+
+    fn assert_vm_state_latency_metrics_output(path: &Path) {
+        let output = fs::read_to_string(path).unwrap_or_else(|err| {
+            panic!(
+                "metrics output {} should be readable for VM state latency metrics: {err}",
+                path.display()
+            )
+        });
+
+        let mut found_vm_state_latencies = false;
+        for line in output.lines() {
+            let value: serde_json::Value = serde_json::from_str(line).unwrap_or_else(|err| {
+                panic!("metrics output line should be valid JSON: {err}; line:\n{line}")
+            });
+            let Some(latencies) = value.get("latencies_us") else {
+                continue;
+            };
+            if latencies
+                .get("pause_vm")
+                .and_then(serde_json::Value::as_u64)
+                .is_some()
+                && latencies
+                    .get("resume_vm")
+                    .and_then(serde_json::Value::as_u64)
+                    .is_some()
+            {
+                found_vm_state_latencies = true;
+            }
+        }
+
+        assert!(
+            found_vm_state_latencies,
+            "metrics output should include numeric pause/resume VM state latencies; output:\n{output}"
         );
     }
 


### PR DESCRIPTION
## Summary
- add signed executable HVF e2e coverage for VM state latency metrics
- verify FlushMetrics output includes numeric latencies_us.pause_vm and latencies_us.resume_vm after successful runtime PATCH /vm transitions
- reuse the existing lifecycle scenario without adding another guest startup

## Scope
- test-only change; no production behavior or docs changes

Closes #1128

## Verification
- cargo fmt --all -- --check
- cargo check --workspace --all-targets --all-features --locked
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings
- cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings
- cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- scripts/run-signed-process-tests.sh
- scripts/run-integration-tests.sh
- scripts/run-integration-tests.sh --test executable_hvf_e2e
- git diff --check