### PR TITLE
test: cover malformed vm state update

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -1864,6 +1864,21 @@ fn executable_configures_vm_before_start() {
         "GET / after failed PATCH /vm resumed",
     );
 
+    let malformed_vm_state_response =
+        http_json(&socket_path, "PATCH", "/vm", r#"{"state":"Running"}"#);
+    assert_bad_request_response(&malformed_vm_state_response, "PATCH /vm running");
+    assert_response_contains(
+        &malformed_vm_state_response,
+        r#"{"fault_message":"Malformed HTTP request."}"#,
+        "PATCH /vm running",
+    );
+    let instance_info_after_malformed_vm_state = http_get(&socket_path, "/");
+    assert_response_contains(
+        &instance_info_after_malformed_vm_state,
+        r#""state":"Not started""#,
+        "GET / after malformed PATCH /vm running",
+    );
+
     let flush_metrics_response = http_put_json(
         &socket_path,
         "/actions",


### PR DESCRIPTION
## Summary

- Add process e2e coverage for malformed VM state updates through the real bangbang executable API.
- Assert PATCH /vm with {"state":"Running"} returns the Firecracker-shaped malformed request fault.
- Verify the executable still reports the VM as Not started after the rejected request.

## Scope

- Test-only change.
- No production or documentation changes.

Closes #1130

## Verification

- cargo fmt --all -- --check
- cargo test -p bangbang --test process_e2e --all-features --locked
- cargo check --workspace --all-targets --all-features --locked
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings
- cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings
- cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- scripts/run-signed-process-tests.sh
- scripts/run-integration-tests.sh
- git diff --check