### PR TITLE
test: cover malformed cpu config

### DIFF
--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -1836,6 +1836,20 @@ fn executable_configures_vm_before_start() {
         "GET / after custom PUT /cpu-config",
     );
 
+    let malformed_cpu_config_response = http_put_json(&socket_path, "/cpu-config", "not-json");
+    assert_bad_request_response(&malformed_cpu_config_response, "PUT /cpu-config malformed");
+    assert_response_contains(
+        &malformed_cpu_config_response,
+        r#"{"fault_message":"Malformed HTTP request."}"#,
+        "PUT /cpu-config malformed",
+    );
+    let instance_info_after_malformed_cpu_config = http_get(&socket_path, "/");
+    assert_response_contains(
+        &instance_info_after_malformed_cpu_config,
+        r#""state":"Not started""#,
+        "GET / after malformed PUT /cpu-config",
+    );
+
     let vm_state_response = http_json(&socket_path, "PATCH", "/vm", r#"{"state":"Paused"}"#);
     assert_bad_request_response(&vm_state_response, "PATCH /vm");
     assert_response_contains(


### PR DESCRIPTION
## Summary

- Add process e2e coverage for malformed `PUT /cpu-config` through the real bangbang executable API.
- Assert the Firecracker-shaped malformed request fault.
- Verify the VM remains `Not started` after the rejected request.

## Scope

- Test-only change.
- No production or documentation changes.

Closes #1132

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p bangbang --test process_e2e --all-features --locked`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`
- `git diff --check`