### PR TITLE
test: cover empty cpu config arrays

### DIFF
--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -4929,6 +4929,30 @@ mod tests {
     }
 
     #[test]
+    fn config_file_empty_array_cpu_config_starts_instance() {
+        let config_path = unique_config_path("empty-array-cpu-config");
+        fs::write(
+            &config_path,
+            r#"{"boot-source":{"kernel_image_path":"/tmp/vmlinux"},"cpu-config":{"kvm_capabilities":[],"reg_modifiers":[],"vcpu_features":[]}}"#,
+        )
+        .expect("config file should be written");
+        let mut vmm = ProcessVmm::with_starter(
+            "demo-1",
+            env!("CARGO_PKG_VERSION"),
+            "bangbang",
+            TestInstanceStarter,
+        );
+
+        super::apply_startup_config_file(&mut vmm, Some(config_path.to_str().expect("UTF-8 path")))
+            .expect("empty array cpu-config should not block config-file startup");
+
+        assert_eq!(vmm.instance_info().state, InstanceState::Running);
+        assert!(vmm.has_started_session());
+
+        fs::remove_file(config_path).expect("fixture config should clean up");
+    }
+
+    #[test]
     fn config_file_serial_rate_limiter_starts_instance() {
         let config_path = unique_config_path("serial-rate-limiter");
         fs::write(

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -1821,6 +1821,22 @@ fn executable_configures_vm_before_start() {
     let cpu_config_response = http_put_json(&socket_path, "/cpu-config", "{}");
     assert_no_content_response(&cpu_config_response, "PUT /cpu-config empty");
 
+    let empty_array_cpu_config_response = http_put_json(
+        &socket_path,
+        "/cpu-config",
+        r#"{"kvm_capabilities":[],"reg_modifiers":[],"vcpu_features":[]}"#,
+    );
+    assert_no_content_response(
+        &empty_array_cpu_config_response,
+        "PUT /cpu-config empty arrays",
+    );
+    let instance_info_after_empty_array_cpu_config = http_get(&socket_path, "/");
+    assert_response_contains(
+        &instance_info_after_empty_array_cpu_config,
+        r#""state":"Not started""#,
+        "GET / after empty array PUT /cpu-config",
+    );
+
     let custom_cpu_config_response =
         http_put_json(&socket_path, "/cpu-config", r#"{"kvm_capabilities":["1"]}"#);
     assert_bad_request_response(&custom_cpu_config_response, "PUT /cpu-config custom");


### PR DESCRIPTION
## Summary

- Add executable API coverage for empty-array `PUT /cpu-config` no-op requests.
- Assert the VM remains `Not started` after the no-op CPU config request.
- Add config-file startup coverage for the same empty-array CPU config shape.

## Scope

- Test-only change.
- No production or documentation changes.

Closes #1134

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p bangbang --all-features --locked config_file_empty_array_cpu_config_starts_instance`
- `cargo test -p bangbang --test process_e2e --all-features --locked`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh`
- `git diff --check`