### PR TITLE
test: stabilize guest reset executable e2e waits

### DIFF
--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -3946,7 +3946,8 @@ mod macos_arm64 {
             &instance_id,
             &["--config-file", path_text(&config_path)],
         );
-        let output = bangbang.wait_for_exit();
+        let output = bangbang
+            .wait_for_exit_with_timeout(GUEST_EXECUTION_TIMEOUT, "API-enabled guest SYSTEM_OFF");
 
         assert!(
             output.status.success(),
@@ -3987,7 +3988,8 @@ mod macos_arm64 {
             "guest shutdown no-api startup must not publish an API socket"
         );
 
-        let output = bangbang.wait_for_exit();
+        let output =
+            bangbang.wait_for_exit_with_timeout(GUEST_EXECUTION_TIMEOUT, "no-api guest SYSTEM_OFF");
 
         assert!(
             output.status.success(),
@@ -4023,7 +4025,8 @@ mod macos_arm64 {
             &instance_id,
             &["--config-file", path_text(&config_path)],
         );
-        let output = bangbang.wait_for_exit();
+        let output = bangbang
+            .wait_for_exit_with_timeout(GUEST_EXECUTION_TIMEOUT, "API-enabled guest SYSTEM_RESET");
 
         assert!(
             output.status.success(),
@@ -4064,7 +4067,8 @@ mod macos_arm64 {
             "guest reset no-api startup must not publish an API socket"
         );
 
-        let output = bangbang.wait_for_exit();
+        let output = bangbang
+            .wait_for_exit_with_timeout(GUEST_EXECUTION_TIMEOUT, "no-api guest SYSTEM_RESET");
 
         assert!(
             output.status.success(),

--- a/crates/bangbang/tests/support/mod.rs
+++ b/crates/bangbang/tests/support/mod.rs
@@ -402,11 +402,26 @@ impl BangbangProcess {
         dead_code,
         reason = "shared integration-test support is compiled once per test target"
     )]
-    pub(crate) fn wait_for_exit(mut self) -> CompletedProcess {
-        let child = self.child.take().expect("child should still be owned");
-        let status = wait_for_child_exit(child, SHUTDOWN_TIMEOUT);
+    pub(crate) fn wait_for_exit(self) -> CompletedProcess {
+        self.wait_for_exit_with_timeout(SHUTDOWN_TIMEOUT, "process exit")
+    }
 
-        self.collect_output(status)
+    pub(crate) fn wait_for_exit_with_timeout(
+        mut self,
+        timeout: Duration,
+        context: &str,
+    ) -> CompletedProcess {
+        let child = self.child.take().expect("child should still be owned");
+        let exit = wait_for_child_exit_result(child, timeout);
+        let timed_out = exit.timed_out;
+        let output = self.collect_output(exit.status);
+        assert!(
+            !timed_out,
+            "bangbang did not exit for {context} within {timeout:?}; status after SIGKILL: {:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status, output.stdout, output.stderr
+        );
+
+        output
     }
 
     #[allow(
@@ -560,6 +575,18 @@ impl OutputReader {
 }
 
 fn wait_for_child_exit(child: Child, timeout: Duration) -> ExitStatus {
+    let exit = wait_for_child_exit_result(child, timeout);
+    let _timed_out = exit.timed_out;
+    exit.status
+}
+
+#[derive(Debug)]
+struct ChildExitResult {
+    status: ExitStatus,
+    timed_out: bool,
+}
+
+fn wait_for_child_exit_result(child: Child, timeout: Duration) -> ChildExitResult {
     let pid = child.id();
     let (status_sender, status_receiver) = mpsc::channel();
     let waiter = thread::spawn(move || {
@@ -568,20 +595,26 @@ fn wait_for_child_exit(child: Child, timeout: Duration) -> ExitStatus {
         let _ = status_sender.send(status);
     });
 
-    let status = match status_receiver.recv_timeout(timeout) {
-        Ok(status) => status.expect("child wait should succeed"),
+    let exit = match status_receiver.recv_timeout(timeout) {
+        Ok(status) => ChildExitResult {
+            status: status.expect("child wait should succeed"),
+            timed_out: false,
+        },
         Err(RecvTimeoutError::Timeout) => {
             force_kill(pid);
-            status_receiver
-                .recv_timeout(timeout)
-                .expect("child should exit after SIGKILL")
-                .expect("child wait after SIGKILL should succeed")
+            ChildExitResult {
+                status: status_receiver
+                    .recv_timeout(SHUTDOWN_TIMEOUT)
+                    .expect("child should exit after SIGKILL")
+                    .expect("child wait after SIGKILL should succeed"),
+                timed_out: true,
+            }
         }
         Err(RecvTimeoutError::Disconnected) => panic!("child wait thread disconnected"),
     };
     waiter.join().expect("child wait thread should join");
 
-    status
+    exit
 }
 
 fn send_signal(pid: u32, signal: i32) -> std::io::Result<()> {


### PR DESCRIPTION
## Summary

- Add a test support wait path that accepts an explicit timeout and reports guest-exit timeouts before returning a SIGKILL-looking status.
- Use the existing `GUEST_EXECUTION_TIMEOUT` for config-file guest shutdown/reset executable e2e tests.
- Keep the regular host signal shutdown timeout unchanged.

Closes #1151

## Scope Exclusions

- No production VM lifecycle or run-loop behavior changes.
- No global timeout increase for host-triggered shutdown cleanup.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test executable_hvf_e2e -- signed_executable_exits_after_guest_reset`
- `scripts/run-integration-tests.sh --test executable_hvf_e2e -- signed_executable_exits_after_guest_shutdown`
- `scripts/run-integration-tests.sh`
