### PR TITLE
feat: add ordered HVF vCPU topology

### DIFF
--- a/crates/hvf/src/backend.rs
+++ b/crates/hvf/src/backend.rs
@@ -12,6 +12,7 @@ use crate::memory::{
     HvfMemoryPermissions, HvfVirtioMemMutationExecutor, RealHvfMemoryMapper,
 };
 use crate::runner::{HvfVcpuRunner, HvfVcpuRunnerError};
+use crate::topology::{HvfVcpuTopology, HvfVcpuTopologyError};
 use crate::vcpu::HvfVcpu;
 
 const VM_NOT_CREATED_FOR_MEMORY_MESSAGE: &str = "VM must be created before mapping guest memory";
@@ -20,6 +21,9 @@ const GUEST_MEMORY_NOT_MAPPED_MESSAGE: &str = "guest memory is not mapped";
 const VM_NOT_CREATED_FOR_GIC_MESSAGE: &str = "VM must be created before creating a GIC";
 const GIC_ALREADY_CREATED_MESSAGE: &str = "GIC is already created";
 const VCPU_TOPOLOGY_ALREADY_STARTED_MESSAGE: &str = "GIC must be created before creating vCPUs";
+const GIC_NOT_CREATED_FOR_VCPU_TOPOLOGY_MESSAGE: &str =
+    "GIC must be created before starting a vCPU topology";
+const VCPU_TOPOLOGY_ALREADY_OWNED_MESSAGE: &str = "vCPU topology has already started";
 const PMEM_SHADOW_COPY_BUFFER_SIZE: usize = 64 * 1024;
 
 #[derive(Debug)]
@@ -251,6 +255,21 @@ impl HvfBackend {
         Ok(runner)
     }
 
+    /// Start an ordered set of permanent owner-thread vCPUs for this VM/GIC.
+    ///
+    /// This internal compatibility prerequisite does not activate multi-vCPU
+    /// boot. All runners remain idle until callers explicitly issue commands.
+    pub fn start_vcpu_topology(
+        &mut self,
+        vcpu_count: u8,
+    ) -> Result<HvfVcpuTopology<'_>, HvfVcpuTopologyError> {
+        self.validate_vcpu_topology_start()?;
+
+        let topology = HvfVcpuTopology::create(vcpu_count)?;
+        self.vcpu_topology_started = true;
+        Ok(topology)
+    }
+
     fn validate_vcpu_runner_start(&self) -> Result<(), HvfVcpuRunnerError> {
         if !Self::is_supported_target() {
             return Err(BackendError::Unsupported(crate::ffi::UNSUPPORTED_TARGET_MESSAGE).into());
@@ -261,6 +280,28 @@ impl HvfBackend {
                 "VM must be created before starting a vCPU runner",
             )
             .into());
+        }
+
+        Ok(())
+    }
+
+    fn validate_vcpu_topology_start(&self) -> Result<(), HvfVcpuTopologyError> {
+        if !Self::is_supported_target() {
+            return Err(BackendError::Unsupported(crate::ffi::UNSUPPORTED_TARGET_MESSAGE).into());
+        }
+        if !self.vm_created {
+            return Err(BackendError::InvalidState(
+                "VM must be created before starting a vCPU topology",
+            )
+            .into());
+        }
+        if self.gic.is_none() {
+            return Err(
+                BackendError::InvalidState(GIC_NOT_CREATED_FOR_VCPU_TOPOLOGY_MESSAGE).into(),
+            );
+        }
+        if self.vcpu_topology_started {
+            return Err(BackendError::InvalidState(VCPU_TOPOLOGY_ALREADY_OWNED_MESSAGE).into());
         }
 
         Ok(())
@@ -749,6 +790,94 @@ mod tests {
                 ))
             );
         }
+    }
+
+    #[test]
+    fn start_vcpu_topology_before_vm_reports_state_or_target_error() {
+        let mut backend = HvfBackend::new();
+        let err = backend
+            .start_vcpu_topology(2)
+            .expect_err("starting a topology before VM creation should fail");
+
+        if HvfBackend::is_supported_target() {
+            assert_eq!(
+                err,
+                crate::topology::HvfVcpuTopologyError::Backend(BackendError::InvalidState(
+                    "VM must be created before starting a vCPU topology"
+                ))
+            );
+        } else {
+            assert_eq!(
+                err,
+                crate::topology::HvfVcpuTopologyError::Backend(BackendError::Unsupported(
+                    crate::ffi::UNSUPPORTED_TARGET_MESSAGE
+                ))
+            );
+        }
+        assert!(!backend.vcpu_topology_started);
+    }
+
+    #[test]
+    fn start_vcpu_topology_requires_gic_before_count_validation() {
+        if !HvfBackend::is_supported_target() {
+            return;
+        }
+
+        let mut backend = HvfBackend::new();
+        backend.vm_created = true;
+
+        assert_eq!(
+            backend
+                .start_vcpu_topology(0)
+                .expect_err("missing GIC should fail first"),
+            crate::topology::HvfVcpuTopologyError::Backend(BackendError::InvalidState(
+                super::GIC_NOT_CREATED_FOR_VCPU_TOPOLOGY_MESSAGE
+            ))
+        );
+        assert!(!backend.vcpu_topology_started);
+    }
+
+    #[test]
+    fn failed_topology_validation_does_not_publish_backend_state() {
+        if !HvfBackend::is_supported_target() {
+            return;
+        }
+
+        let mut backend = HvfBackend::new();
+        backend.vm_created = true;
+        backend.gic = Some(gic_metadata());
+
+        assert_eq!(
+            backend
+                .start_vcpu_topology(0)
+                .expect_err("zero topology should fail"),
+            crate::topology::HvfVcpuTopologyError::InvalidVcpuCount {
+                requested: 0,
+                max: 32,
+            }
+        );
+        assert!(!backend.vcpu_topology_started);
+    }
+
+    #[test]
+    fn duplicate_topology_start_is_rejected_before_count_validation() {
+        if !HvfBackend::is_supported_target() {
+            return;
+        }
+
+        let mut backend = HvfBackend::new();
+        backend.vm_created = true;
+        backend.gic = Some(gic_metadata());
+        backend.vcpu_topology_started = true;
+
+        assert_eq!(
+            backend
+                .start_vcpu_topology(0)
+                .expect_err("duplicate topology should fail first"),
+            crate::topology::HvfVcpuTopologyError::Backend(BackendError::InvalidState(
+                super::VCPU_TOPOLOGY_ALREADY_OWNED_MESSAGE
+            ))
+        );
     }
 
     #[test]

--- a/crates/hvf/src/ffi.rs
+++ b/crates/hvf/src/ffi.rs
@@ -231,6 +231,7 @@ mod imp {
 
     type HvCacheType = u32;
     type HvFeatureReg = u32;
+    type HvVmGetMaxVcpuCount = unsafe extern "C" fn(max_vcpu_count: *mut u32) -> HvReturn;
     type HvVcpuConfigCreate = unsafe extern "C" fn() -> HvVcpuConfig;
     type HvVcpuConfigGetCcsidrEl1SysRegValues =
         unsafe extern "C" fn(HvVcpuConfig, HvCacheType, *mut u64) -> HvReturn;
@@ -270,6 +271,7 @@ mod imp {
         pub fn hv_vm_config_create() -> HvVmConfig;
         pub fn hv_vm_config_get_max_ipa_size(ipa_bit_length: *mut u32) -> HvReturn;
         pub fn hv_vm_config_set_ipa_size(config: HvVmConfig, ipa_bit_length: u32) -> HvReturn;
+        pub fn hv_vm_get_max_vcpu_count(max_vcpu_count: *mut u32) -> HvReturn;
         pub fn hv_vm_create(config: HvVmConfig) -> HvReturn;
         pub fn hv_vm_destroy() -> HvReturn;
         pub fn hv_vm_map(
@@ -771,6 +773,27 @@ mod imp {
         unsafe { check(hv_vm_create(config.as_ptr()), "hv_vm_create") }
     }
 
+    fn get_max_vcpu_count_with(
+        get_max_vcpu_count: HvVmGetMaxVcpuCount,
+    ) -> Result<u32, BackendError> {
+        let mut max_vcpu_count = 0;
+
+        // SAFETY: `max_vcpu_count` is a valid writable `u32` out-pointer for the
+        // duration of the call, and the injected function has the SDK's exact ABI.
+        unsafe {
+            check(
+                get_max_vcpu_count(&mut max_vcpu_count),
+                "hv_vm_get_max_vcpu_count",
+            )?;
+        }
+
+        Ok(max_vcpu_count)
+    }
+
+    pub fn get_max_vcpu_count() -> Result<u32, BackendError> {
+        get_max_vcpu_count_with(hv_vm_get_max_vcpu_count)
+    }
+
     pub fn destroy_vm() -> Result<(), BackendError> {
         // SAFETY: Destroys the process-local VM after vCPUs have been destroyed.
         unsafe { check(hv_vm_destroy(), "hv_vm_destroy") }
@@ -1181,11 +1204,12 @@ mod imp {
             HV_FEATURE_REG_CLIDR_EL1, HV_FEATURE_REG_CTR_EL0, HV_FEATURE_REG_DCZID_EL0, HV_SUCCESS,
             HV_UNSUPPORTED, HvVcpuConfig, HvVcpuConfigOwner, check,
             get_arm64_vcpu_cache_feature_registers_with, get_arm64_vcpu_cache_geometry_with,
-            get_arm64_vcpu_cache_manifest_with, get_sme_config_max_svl_bytes_with,
-            get_sme_p_reg_with, get_sme_z_reg_with, get_sme_za_reg_with, get_sme_zt0_reg_with,
-            sme_config_max_svl_bytes_getter_from_symbol, sme_p_reg_getter_from_symbol,
-            sme_state_getter_from_symbol, sme_z_reg_getter_from_symbol,
-            sme_za_reg_getter_from_symbol, sme_zt0_reg_getter_from_symbol,
+            get_arm64_vcpu_cache_manifest_with, get_max_vcpu_count_with,
+            get_sme_config_max_svl_bytes_with, get_sme_p_reg_with, get_sme_z_reg_with,
+            get_sme_za_reg_with, get_sme_zt0_reg_with, sme_config_max_svl_bytes_getter_from_symbol,
+            sme_p_reg_getter_from_symbol, sme_state_getter_from_symbol,
+            sme_z_reg_getter_from_symbol, sme_za_reg_getter_from_symbol,
+            sme_zt0_reg_getter_from_symbol,
         };
         use crate::ffi::{
             SME_CONFIGURATION_REQUIRES_MACOS_15_2_MESSAGE,
@@ -1543,6 +1567,53 @@ mod imp {
             _: *mut super::HvSmeZt0Value,
         ) -> super::HvReturn {
             HV_UNSUPPORTED
+        }
+
+        unsafe extern "C" fn test_get_max_vcpu_count_success(max_vcpu_count: *mut u32) -> i32 {
+            // SAFETY: The production helper supplies a live `u32` out-pointer.
+            unsafe { *max_vcpu_count = 17 };
+            HV_SUCCESS
+        }
+
+        unsafe extern "C" fn test_get_max_vcpu_count_failure(max_vcpu_count: *mut u32) -> i32 {
+            // Write a sentinel to prove a failed result is not returned as success.
+            // SAFETY: The production helper supplies a live `u32` out-pointer.
+            unsafe { *max_vcpu_count = u32::MAX };
+            HV_DENIED
+        }
+
+        unsafe extern "C" fn test_get_max_vcpu_count_unknown_failure(_: *mut u32) -> i32 {
+            0x1234_5678
+        }
+
+        #[test]
+        fn max_vcpu_count_returns_successful_value() {
+            assert_eq!(
+                get_max_vcpu_count_with(test_get_max_vcpu_count_success),
+                Ok(17)
+            );
+        }
+
+        #[test]
+        fn max_vcpu_count_preserves_exact_hvf_failure() {
+            let err = get_max_vcpu_count_with(test_get_max_vcpu_count_failure)
+                .expect_err("HV_DENIED should fail");
+
+            assert_eq!(
+                err.to_string(),
+                "hypervisor error: hv_vm_get_max_vcpu_count failed with HV_DENIED (hv_return_t=0xfae94007)"
+            );
+        }
+
+        #[test]
+        fn max_vcpu_count_preserves_unknown_raw_hvf_failure() {
+            let err = get_max_vcpu_count_with(test_get_max_vcpu_count_unknown_failure)
+                .expect_err("unknown status should fail");
+
+            assert_eq!(
+                err.to_string(),
+                "hypervisor error: hv_vm_get_max_vcpu_count failed with hv_return_t=0x12345678"
+            );
         }
 
         #[test]
@@ -2153,6 +2224,10 @@ mod imp {
     }
 
     pub fn create_vm() -> Result<(), BackendError> {
+        Err(BackendError::Unsupported(UNSUPPORTED_TARGET_MESSAGE))
+    }
+
+    pub fn get_max_vcpu_count() -> Result<u32, BackendError> {
         Err(BackendError::Unsupported(UNSUPPORTED_TARGET_MESSAGE))
     }
 

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -13,6 +13,7 @@ mod snapshot;
 mod snapshot_bundle;
 mod snapshot_restore;
 mod startup;
+mod topology;
 mod vcpu;
 mod vcpu_config;
 
@@ -35,8 +36,8 @@ pub use mmio::{HvfMmioCompletionError, HvfMmioDispatchError};
 pub use runner::{
     HvfArm64SnapshotV1Capture, HvfArm64SnapshotV1CaptureStage,
     HvfArm64SnapshotV1CompatibilityError, HvfArm64SnapshotV1Restore,
-    HvfArm64SnapshotV1RestoreStage, HvfVcpuRunCancelHandle, HvfVcpuRunStepOutcome, HvfVcpuRunner,
-    HvfVcpuRunnerError,
+    HvfArm64SnapshotV1RestoreStage, HvfVcpuMpidrAffinityStage, HvfVcpuRunCancelHandle,
+    HvfVcpuRunStepOutcome, HvfVcpuRunner, HvfVcpuRunnerError,
 };
 pub use sme::HvfArm64SmeConfiguration;
 pub use snapshot::{
@@ -72,6 +73,10 @@ pub use startup::{
     HvfArm64BootVmGenIdRestoreError, HvfArm64BootVsockNotificationDispatch,
     HvfArm64BootVsockNotificationDispatchError, HvfArm64BootVsockNotificationDispatches,
     OwnedHvfArm64BootSession, RestoredHvfArm64BootSession,
+};
+pub use topology::{
+    HvfVcpuTopology, HvfVcpuTopologyAllocation, HvfVcpuTopologyCreateStage, HvfVcpuTopologyError,
+    HvfVcpuTopologyMemberFailure, HvfVcpuTopologyOperation,
 };
 pub use vcpu::{
     ARM64_LINUX_BOOT_CPSR, HvfArm64BootRegisters, HvfArm64VcpuBreakpointRegisterState,

--- a/crates/hvf/src/runner.rs
+++ b/crates/hvf/src/runner.rs
@@ -94,6 +94,12 @@ const BOOT_REGISTERS_ALREADY_CONFIGURED_MESSAGE: &str =
     "vCPU runner boot registers are already configured";
 const RUN_ALREADY_STARTED_MESSAGE: &str = "vCPU runner has already started a run";
 const METADATA_READ_IN_FLIGHT_MESSAGE: &str = "vCPU runner already has metadata read in flight";
+const MPIDR_ALREADY_CONFIGURED_MESSAGE: &str = "vCPU runner MPIDR affinity is already configured";
+const MPIDR_CONFIGURATION_FAILED_MESSAGE: &str =
+    "vCPU runner MPIDR affinity configuration failed and runner must be discarded";
+const MPIDR_NOT_CONFIGURED_MESSAGE: &str = "vCPU runner MPIDR affinity is not configured";
+const MPIDR_CONFIGURATION_AFTER_RUN_MESSAGE: &str =
+    "vCPU runner MPIDR affinity cannot be configured after execution starts";
 const CORE_REGISTER_OPERATION_IN_FLIGHT_MESSAGE: &str =
     "vCPU runner already has core register operation in flight";
 const TIMER_OPERATION_IN_FLIGHT_MESSAGE: &str = "vCPU runner already has timer operation in flight";
@@ -138,6 +144,16 @@ pub enum HvfVcpuRunnerError {
     },
     VcpuExitResolve(HvfVcpuExitResolveError),
     MmioDispatch(HvfMmioDispatchError),
+    MpidrAffinity {
+        stage: HvfVcpuMpidrAffinityStage,
+        expected: u64,
+        actual: Option<u64>,
+        source: Option<BackendError>,
+    },
+    MpidrAffinityCleanup {
+        source: Box<HvfVcpuRunnerError>,
+        cleanup: Box<HvfVcpuRunnerError>,
+    },
     UnsupportedSys64 {
         exit: HvfSys64Exit,
     },
@@ -145,6 +161,24 @@ pub enum HvfVcpuRunnerError {
     ThreadSpawn(String),
     ChannelClosed(&'static str),
     ThreadPanicked,
+}
+
+/// Owner-thread stage that failed while assigning one vCPU's MPIDR affinity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfVcpuMpidrAffinityStage {
+    Write,
+    Read,
+    Verify,
+}
+
+impl fmt::Display for HvfVcpuMpidrAffinityStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Write => f.write_str("write"),
+            Self::Read => f.write_str("readback"),
+            Self::Verify => f.write_str("verification"),
+        }
+    }
 }
 
 /// Value-free reason why a fresh destination is incompatible with native-v1.
@@ -451,6 +485,28 @@ impl fmt::Display for HvfVcpuRunnerError {
             }
             Self::VcpuExitResolve(err) => write!(f, "{err}"),
             Self::MmioDispatch(err) => write!(f, "{err}"),
+            Self::MpidrAffinity {
+                stage,
+                expected,
+                actual,
+                source,
+            } => {
+                write!(
+                    f,
+                    "vCPU MPIDR affinity {stage} failed for expected 0x{expected:x}"
+                )?;
+                if let Some(actual) = actual {
+                    write!(f, ": read back 0x{actual:x}")?;
+                }
+                if let Some(source) = source {
+                    write!(f, ": {source}")?;
+                }
+                Ok(())
+            }
+            Self::MpidrAffinityCleanup { source, cleanup } => write!(
+                f,
+                "vCPU MPIDR affinity setup failed: {source}; runner cleanup also failed: {cleanup}"
+            ),
             Self::UnsupportedSys64 { exit } => write!(
                 f,
                 "unsupported HVF SYS64 {:?} access to {} using Rt {}",
@@ -491,7 +547,12 @@ impl std::error::Error for HvfVcpuRunnerError {
             Self::SnapshotRestore { source, .. } => Some(source.as_ref()),
             Self::VcpuExitResolve(err) => Some(err),
             Self::MmioDispatch(err) => Some(err),
+            Self::MpidrAffinity {
+                source: Some(err), ..
+            } => Some(err),
+            Self::MpidrAffinityCleanup { source, .. } => Some(source.as_ref()),
             Self::InvalidState(_)
+            | Self::MpidrAffinity { source: None, .. }
             | Self::UnsupportedSys64 { .. }
             | Self::ThreadSpawn(_)
             | Self::ChannelClosed(_)
@@ -639,6 +700,8 @@ impl fmt::Debug for HvfVcpuRunCancelHandle {
 struct RunnerHandleState {
     thread: Option<JoinHandle<()>>,
     shutting_down: bool,
+    mpidr_configured: bool,
+    mpidr_configuration_failed: bool,
     in_flight_runs: usize,
     mmio_dispatch_in_flight: bool,
     boot_register_setup_in_flight: bool,
@@ -652,6 +715,10 @@ struct RunnerHandleState {
 }
 
 enum RunnerCommand {
+    ConfigureMpidrEl1 {
+        expected: u64,
+        response_sender: mpsc::Sender<Result<u64, HvfVcpuRunnerError>>,
+    },
     ConfigureArm64BootRegisters {
         registers: HvfArm64BootRegisters,
         response_sender: mpsc::Sender<Result<(), HvfVcpuRunnerError>>,
@@ -1923,6 +1990,38 @@ fn restore_stage<T>(
     })
 }
 
+fn configure_mpidr_el1_on_runner_thread(
+    vcpu: &mut impl RunnerVcpu,
+    expected: u64,
+) -> Result<u64, HvfVcpuRunnerError> {
+    vcpu.write_system_register(HvfSystemRegister::MPIDR_EL1, expected)
+        .map_err(|source| HvfVcpuRunnerError::MpidrAffinity {
+            stage: HvfVcpuMpidrAffinityStage::Write,
+            expected,
+            actual: None,
+            source: Some(source),
+        })?;
+    let actual = vcpu
+        .mpidr_el1()
+        .map_err(|source| HvfVcpuRunnerError::MpidrAffinity {
+            stage: HvfVcpuMpidrAffinityStage::Read,
+            expected,
+            actual: None,
+            source: Some(source),
+        })?;
+
+    if actual != expected {
+        return Err(HvfVcpuRunnerError::MpidrAffinity {
+            stage: HvfVcpuMpidrAffinityStage::Verify,
+            expected,
+            actual: Some(actual),
+            source: None,
+        });
+    }
+
+    Ok(actual)
+}
+
 struct RealRunnerVcpu {
     owner: HvfVcpuOwner,
     gic_ppi_pending_writer: Option<HvfGicPpiPendingWriter>,
@@ -1934,11 +2033,7 @@ struct RealRunnerVcpu {
 
 impl RealRunnerVcpu {
     fn create() -> Result<Self, BackendError> {
-        let mut owner = HvfVcpuOwner::new()?;
-        // Hypervisor.framework GIC redistributor access requires vCPU
-        // affinity before the topology is finalized. The current runner owns a
-        // single primary vCPU, so affinity 0 is the deterministic topology.
-        owner.set_system_register(HvfSystemRegister::MPIDR_EL1, 0)?;
+        let owner = HvfVcpuOwner::new()?;
 
         Ok(Self {
             owner,
@@ -2222,10 +2317,48 @@ impl RunnerVcpu for RealRunnerVcpu {
 
 impl<'vm> HvfVcpuRunner<'vm> {
     pub(crate) fn new() -> Result<Self, HvfVcpuRunnerError> {
-        Self::from_started(
+        Self::new_with_mpidr(0)
+    }
+
+    pub(crate) fn new_with_mpidr(expected: u64) -> Result<Self, HvfVcpuRunnerError> {
+        let runner = Self::new_unconfigured()?;
+        match runner.configure_mpidr_el1(expected) {
+            Ok(_) => Ok(runner),
+            Err(source) => match runner.shutdown() {
+                Ok(()) => Err(source),
+                Err(cleanup) => Err(HvfVcpuRunnerError::MpidrAffinityCleanup {
+                    source: Box::new(source),
+                    cleanup: Box::new(cleanup),
+                }),
+            },
+        }
+    }
+
+    pub(crate) fn new_unconfigured() -> Result<Self, HvfVcpuRunnerError> {
+        Self::from_started_with_mpidr_state(
             spawn_runner_thread(RealRunnerVcpu::create)?,
             real_cancel_vcpu(),
+            false,
         )
+    }
+
+    pub(crate) fn configure_mpidr_el1(&self, expected: u64) -> Result<u64, HvfVcpuRunnerError> {
+        let (response_sender, response_receiver) = mpsc::channel();
+        let _in_flight_read = self.start_mpidr_el1_configuration(expected, response_sender)?;
+        let result = response_receiver
+            .recv()
+            .map_err(|_| HvfVcpuRunnerError::ChannelClosed(RESPONSE_CHANNEL_CLOSED_MESSAGE))
+            .and_then(|result| result);
+
+        let mut state = self.lock_state()?;
+        if result.is_ok() {
+            state.mpidr_configured = true;
+        } else {
+            state.mpidr_configuration_failed = true;
+        }
+        drop(state);
+
+        result
     }
 
     /// Verify that snapshot restore work may still mutate this unrun vCPU.
@@ -2330,6 +2463,8 @@ impl<'vm> HvfVcpuRunner<'vm> {
                 | HvfVcpuRunnerError::UnsupportedSys64 { .. }
                 | HvfVcpuRunnerError::VcpuExitResolve(_)
                 | HvfVcpuRunnerError::MmioDispatch(_)
+                | HvfVcpuRunnerError::MpidrAffinity { .. }
+                | HvfVcpuRunnerError::MpidrAffinityCleanup { .. }
                 | HvfVcpuRunnerError::ThreadSpawn(_)
                 | HvfVcpuRunnerError::ChannelClosed(_)
                 | HvfVcpuRunnerError::ThreadPanicked,
@@ -3389,9 +3524,18 @@ impl<'vm> HvfVcpuRunner<'vm> {
         shutdown_result(response_result, join_result)
     }
 
+    #[cfg(test)]
     fn from_started(
         started: StartedRunner,
         cancel_vcpu: CancelVcpu,
+    ) -> Result<Self, HvfVcpuRunnerError> {
+        Self::from_started_with_mpidr_state(started, cancel_vcpu, true)
+    }
+
+    fn from_started_with_mpidr_state(
+        started: StartedRunner,
+        cancel_vcpu: CancelVcpu,
+        mpidr_configured: bool,
     ) -> Result<Self, HvfVcpuRunnerError> {
         Ok(Self {
             command_sender: started.command_sender,
@@ -3400,6 +3544,8 @@ impl<'vm> HvfVcpuRunner<'vm> {
             state: Arc::new(Mutex::new(RunnerHandleState {
                 thread: Some(started.thread),
                 shutting_down: false,
+                mpidr_configured,
+                mpidr_configuration_failed: false,
                 in_flight_runs: 0,
                 mmio_dispatch_in_flight: false,
                 boot_register_setup_in_flight: false,
@@ -3499,6 +3645,11 @@ impl<'vm> HvfVcpuRunner<'vm> {
         if state.thread.is_none() || state.shutting_down {
             return Err(HvfVcpuRunnerError::InvalidState(RUNNER_SHUT_DOWN_MESSAGE));
         }
+        if !state.mpidr_configured {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                MPIDR_NOT_CONFIGURED_MESSAGE,
+            ));
+        }
         if state.in_flight_runs > 0 {
             return Err(HvfVcpuRunnerError::InvalidState(RUN_IN_FLIGHT_MESSAGE));
         }
@@ -3563,6 +3714,11 @@ impl<'vm> HvfVcpuRunner<'vm> {
         let mut state = self.lock_state()?;
         if state.thread.is_none() || state.shutting_down {
             return Err(HvfVcpuRunnerError::InvalidState(RUNNER_SHUT_DOWN_MESSAGE));
+        }
+        if !state.mpidr_configured {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                MPIDR_NOT_CONFIGURED_MESSAGE,
+            ));
         }
         if state.in_flight_runs > 0 {
             return Err(HvfVcpuRunnerError::InvalidState(RUN_IN_FLIGHT_MESSAGE));
@@ -3697,6 +3853,87 @@ impl<'vm> HvfVcpuRunner<'vm> {
         }
 
         Ok(InFlightMmioDispatch::new(&self.state))
+    }
+
+    fn start_mpidr_el1_configuration(
+        &self,
+        expected: u64,
+        response_sender: mpsc::Sender<Result<u64, HvfVcpuRunnerError>>,
+    ) -> Result<InFlightMetadataRead, HvfVcpuRunnerError> {
+        let mut state = self.lock_state()?;
+        if state.thread.is_none() {
+            return Err(HvfVcpuRunnerError::InvalidState(RUNNER_SHUT_DOWN_MESSAGE));
+        }
+        if state.shutting_down {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                RUNNER_SHUTTING_DOWN_MESSAGE,
+            ));
+        }
+        if state.mpidr_configured {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                MPIDR_ALREADY_CONFIGURED_MESSAGE,
+            ));
+        }
+        if state.mpidr_configuration_failed {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                MPIDR_CONFIGURATION_FAILED_MESSAGE,
+            ));
+        }
+        if state.run_started {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                MPIDR_CONFIGURATION_AFTER_RUN_MESSAGE,
+            ));
+        }
+        if state.in_flight_runs > 0 {
+            return Err(HvfVcpuRunnerError::InvalidState(RUN_IN_FLIGHT_MESSAGE));
+        }
+        if state.mmio_dispatch_in_flight {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                MMIO_DISPATCH_IN_FLIGHT_MESSAGE,
+            ));
+        }
+        if state.boot_register_setup_in_flight {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                BOOT_REGISTER_SETUP_IN_FLIGHT_MESSAGE,
+            ));
+        }
+        if state.metadata_read_in_flight {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                METADATA_READ_IN_FLIGHT_MESSAGE,
+            ));
+        }
+        if state.core_register_operation_in_flight {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                CORE_REGISTER_OPERATION_IN_FLIGHT_MESSAGE,
+            ));
+        }
+        if state.timer_operation_in_flight {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                TIMER_OPERATION_IN_FLIGHT_MESSAGE,
+            ));
+        }
+        if state.interrupt_operation_in_flight {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                INTERRUPT_OPERATION_IN_FLIGHT_MESSAGE,
+            ));
+        }
+
+        state.metadata_read_in_flight = true;
+        if self
+            .command_sender
+            .send(RunnerCommand::ConfigureMpidrEl1 {
+                expected,
+                response_sender,
+            })
+            .is_err()
+        {
+            state.metadata_read_in_flight = false;
+            return Err(HvfVcpuRunnerError::ChannelClosed(
+                COMMAND_CHANNEL_CLOSED_MESSAGE,
+            ));
+        }
+
+        Ok(InFlightMetadataRead::new(&self.state))
     }
 
     fn start_mpidr_el1_read(
@@ -5437,6 +5674,13 @@ fn run_runner_thread<C, V>(
 
     while let Ok(command) = command_receiver.recv() {
         match command {
+            RunnerCommand::ConfigureMpidrEl1 {
+                expected,
+                response_sender,
+            } => {
+                let result = configure_mpidr_el1_on_runner_thread(&mut vcpu, expected);
+                let _ = response_sender.send(result);
+            }
             RunnerCommand::ConfigureArm64BootRegisters {
                 registers,
                 response_sender,
@@ -6336,8 +6580,8 @@ mod tests {
 
     use super::{
         CancelVcpu, HvfArm64SnapshotV1CaptureStage, HvfArm64SnapshotV1Restore,
-        HvfArm64SnapshotV1RestoreStage, HvfVcpuRunStepOutcome, HvfVcpuRunner, HvfVcpuRunnerError,
-        RunnerVcpu, spawn_runner_thread,
+        HvfArm64SnapshotV1RestoreStage, HvfVcpuMpidrAffinityStage, HvfVcpuRunStepOutcome,
+        HvfVcpuRunner, HvfVcpuRunnerError, RunnerVcpu, spawn_runner_thread,
     };
     use crate::exit::{
         HvfExceptionExit, HvfHvcExit, HvfMmioAccessSize, HvfMmioDirection, HvfMmioRegister,
@@ -6884,6 +7128,9 @@ mod tests {
     struct MpidrRecordingVcpu {
         mpidr: u64,
         fail_next_read: bool,
+        fail_next_write: bool,
+        ignore_write: bool,
+        write_sender: Option<mpsc::Sender<(HvfSystemRegister, u64)>>,
     }
 
     struct BlockingMpidrVcpu {
@@ -8251,6 +8498,26 @@ mod tests {
             _dispatcher: &mut MmioDispatcher,
         ) -> Result<MmioDispatchOutcome, HvfVcpuRunnerError> {
             unsupported_mmio_dispatch()
+        }
+
+        fn write_system_register(
+            &mut self,
+            register: HvfSystemRegister,
+            value: u64,
+        ) -> Result<(), BackendError> {
+            if let Some(write_sender) = &self.write_sender {
+                write_sender
+                    .send((register, value))
+                    .map_err(|_| BackendError::InvalidState("fake MPIDR write receiver closed"))?;
+            }
+            if self.fail_next_write {
+                self.fail_next_write = false;
+                return Err(BackendError::InvalidState("fake MPIDR write failed"));
+            }
+            if !self.ignore_write {
+                self.mpidr = value;
+            }
+            Ok(())
         }
 
         fn mpidr_el1(&mut self) -> Result<u64, BackendError> {
@@ -16047,12 +16314,43 @@ mod tests {
             Ok(MpidrRecordingVcpu {
                 mpidr,
                 fail_next_read,
+                fail_next_write: false,
+                ignore_write: false,
+                write_sender: None,
             })
         })
         .expect("fake runner should start");
 
         HvfVcpuRunner::from_started(started, Arc::new(|_| Ok(())))
             .expect("runner should be created")
+    }
+
+    fn start_unconfigured_mpidr_runner(
+        mpidr: u64,
+        fail_next_read: bool,
+        fail_next_write: bool,
+        ignore_write: bool,
+    ) -> (
+        HvfVcpuRunner<'static>,
+        mpsc::Receiver<(HvfSystemRegister, u64)>,
+    ) {
+        let (write_sender, write_receiver) = mpsc::channel();
+        let started = spawn_runner_thread(move || {
+            Ok(MpidrRecordingVcpu {
+                mpidr,
+                fail_next_read,
+                fail_next_write,
+                ignore_write,
+                write_sender: Some(write_sender),
+            })
+        })
+        .expect("fake unconfigured runner should start");
+
+        (
+            HvfVcpuRunner::from_started_with_mpidr_state(started, Arc::new(|_| Ok(())), false)
+                .expect("fake unconfigured runner should initialize"),
+            write_receiver,
+        )
     }
 
     fn start_blocking_mpidr_runner() -> (
@@ -26690,6 +26988,115 @@ mod tests {
         destroyed_receiver
             .recv()
             .expect("fake vCPU should be destroyed");
+    }
+
+    #[test]
+    fn configures_and_verifies_mpidr_on_runner_thread_once() {
+        let (runner, write_receiver) = start_unconfigured_mpidr_runner(9, false, false, false);
+
+        assert_eq!(runner.configure_mpidr_el1(3), Ok(3));
+        assert_eq!(
+            write_receiver
+                .recv()
+                .expect("MPIDR write should be recorded"),
+            (HvfSystemRegister::MPIDR_EL1, 3)
+        );
+        assert_eq!(
+            runner.configure_mpidr_el1(4),
+            Err(HvfVcpuRunnerError::InvalidState(
+                super::MPIDR_ALREADY_CONFIGURED_MESSAGE
+            ))
+        );
+
+        runner.shutdown().expect("runner should shut down");
+    }
+
+    #[test]
+    fn mpidr_write_failure_is_typed_and_runner_becomes_fail_closed() {
+        let (runner, write_receiver) = start_unconfigured_mpidr_runner(9, false, true, false);
+
+        assert_eq!(
+            runner.configure_mpidr_el1(3),
+            Err(HvfVcpuRunnerError::MpidrAffinity {
+                stage: HvfVcpuMpidrAffinityStage::Write,
+                expected: 3,
+                actual: None,
+                source: Some(BackendError::InvalidState("fake MPIDR write failed")),
+            })
+        );
+        assert_eq!(
+            write_receiver
+                .recv()
+                .expect("failed MPIDR write should be recorded"),
+            (HvfSystemRegister::MPIDR_EL1, 3)
+        );
+        assert_eq!(
+            runner.configure_mpidr_el1(3),
+            Err(HvfVcpuRunnerError::InvalidState(
+                super::MPIDR_CONFIGURATION_FAILED_MESSAGE
+            ))
+        );
+
+        runner.shutdown().expect("runner should shut down");
+    }
+
+    #[test]
+    fn mpidr_readback_failure_and_mismatch_are_typed() {
+        let (read_failure_runner, _read_write_receiver) =
+            start_unconfigured_mpidr_runner(9, true, false, false);
+        assert_eq!(
+            read_failure_runner.configure_mpidr_el1(3),
+            Err(HvfVcpuRunnerError::MpidrAffinity {
+                stage: HvfVcpuMpidrAffinityStage::Read,
+                expected: 3,
+                actual: None,
+                source: Some(BackendError::InvalidState("fake MPIDR read failed")),
+            })
+        );
+        read_failure_runner
+            .shutdown()
+            .expect("read-failure runner should shut down");
+
+        let (mismatch_runner, _mismatch_write_receiver) =
+            start_unconfigured_mpidr_runner(9, false, false, true);
+        assert_eq!(
+            mismatch_runner.configure_mpidr_el1(3),
+            Err(HvfVcpuRunnerError::MpidrAffinity {
+                stage: HvfVcpuMpidrAffinityStage::Verify,
+                expected: 3,
+                actual: Some(9),
+                source: None,
+            })
+        );
+        mismatch_runner
+            .shutdown()
+            .expect("mismatch runner should shut down");
+    }
+
+    #[test]
+    fn mpidr_configuration_after_run_is_rejected_without_write() {
+        let (runner, write_receiver) = start_unconfigured_mpidr_runner(9, false, false, false);
+
+        assert_eq!(
+            runner.run_once(),
+            Err(HvfVcpuRunnerError::InvalidState(
+                super::MPIDR_NOT_CONFIGURED_MESSAGE
+            ))
+        );
+        runner
+            .state
+            .lock()
+            .expect("runner state should lock")
+            .run_started = true;
+        assert_eq!(
+            runner.configure_mpidr_el1(3),
+            Err(HvfVcpuRunnerError::InvalidState(
+                super::MPIDR_CONFIGURATION_AFTER_RUN_MESSAGE
+            ))
+        );
+        assert!(write_receiver.try_recv().is_err());
+
+        runner.shutdown().expect("runner should shut down");
     }
 
     #[test]

--- a/crates/hvf/src/topology.rs
+++ b/crates/hvf/src/topology.rs
@@ -1,0 +1,1182 @@
+use std::fmt;
+
+use bangbang_runtime::BackendError;
+use bangbang_runtime::machine::MAX_SUPPORTED_VCPUS;
+
+use crate::runner::{HvfVcpuMpidrAffinityStage, HvfVcpuRunner, HvfVcpuRunnerError};
+
+const MAX_ORDERED_MPIDR: u64 = MAX_SUPPORTED_VCPUS as u64 - 1;
+
+/// Allocation owned by an ordered vCPU topology constructor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfVcpuTopologyAllocation {
+    Mpidrs,
+    Runners,
+}
+
+impl fmt::Display for HvfVcpuTopologyAllocation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Mpidrs => f.write_str("MPIDR metadata"),
+            Self::Runners => f.write_str("vCPU runners"),
+        }
+    }
+}
+
+/// Topology construction stage associated with one vCPU member.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfVcpuTopologyCreateStage {
+    RunnerStart,
+    AffinityCommand,
+    AffinityWrite,
+    AffinityRead,
+    AffinityVerify,
+}
+
+impl fmt::Display for HvfVcpuTopologyCreateStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RunnerStart => f.write_str("runner start"),
+            Self::AffinityCommand => f.write_str("MPIDR affinity command"),
+            Self::AffinityWrite => f.write_str("MPIDR affinity write"),
+            Self::AffinityRead => f.write_str("MPIDR affinity readback"),
+            Self::AffinityVerify => f.write_str("MPIDR affinity verification"),
+        }
+    }
+}
+
+/// Aggregate control operation attempted across a complete vCPU topology.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfVcpuTopologyOperation {
+    Cancel,
+    Shutdown,
+}
+
+impl fmt::Display for HvfVcpuTopologyOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cancel => f.write_str("cancel"),
+            Self::Shutdown => f.write_str("shutdown"),
+        }
+    }
+}
+
+/// One indexed member failure retained after an aggregate control attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HvfVcpuTopologyMemberFailure {
+    index: usize,
+    mpidr: u64,
+    source: Box<HvfVcpuRunnerError>,
+}
+
+impl HvfVcpuTopologyMemberFailure {
+    /// Return the stable position of the failed runner.
+    pub const fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Return the expected MPIDR affinity of the failed runner.
+    pub const fn mpidr(&self) -> u64 {
+        self.mpidr
+    }
+
+    /// Return the underlying runner failure.
+    pub fn source_error(&self) -> &HvfVcpuRunnerError {
+        self.source.as_ref()
+    }
+}
+
+impl fmt::Display for HvfVcpuTopologyMemberFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "vCPU topology member {} (MPIDR 0x{:x}): {}",
+            self.index, self.mpidr, self.source
+        )
+    }
+}
+
+impl std::error::Error for HvfVcpuTopologyMemberFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
+/// Failure while validating, constructing, or controlling an ordered topology.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HvfVcpuTopologyError {
+    Backend(BackendError),
+    InvalidVcpuCount {
+        requested: usize,
+        max: usize,
+    },
+    HostCapacityExceeded {
+        requested: u8,
+        host_max: u32,
+    },
+    InvalidMpidr {
+        index: usize,
+        mpidr: u64,
+        max: u64,
+    },
+    DuplicateMpidr {
+        first_index: usize,
+        second_index: usize,
+        mpidr: u64,
+    },
+    Allocation {
+        allocation: HvfVcpuTopologyAllocation,
+        requested: usize,
+        source: String,
+    },
+    Construction {
+        stage: HvfVcpuTopologyCreateStage,
+        index: usize,
+        mpidr: u64,
+        source: Box<HvfVcpuRunnerError>,
+        cleanup_failures: Vec<HvfVcpuTopologyMemberFailure>,
+    },
+    Control {
+        operation: HvfVcpuTopologyOperation,
+        failures: Vec<HvfVcpuTopologyMemberFailure>,
+    },
+}
+
+impl fmt::Display for HvfVcpuTopologyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Backend(source) => write!(f, "{source}"),
+            Self::InvalidVcpuCount { requested, max } => write!(
+                f,
+                "HVF vCPU topology count {requested} is outside 1..={max}"
+            ),
+            Self::HostCapacityExceeded {
+                requested,
+                host_max,
+            } => write!(
+                f,
+                "HVF vCPU topology count {requested} exceeds host maximum {host_max}"
+            ),
+            Self::InvalidMpidr { index, mpidr, max } => write!(
+                f,
+                "HVF vCPU topology MPIDR 0x{mpidr:x} at index {index} exceeds supported maximum 0x{max:x}"
+            ),
+            Self::DuplicateMpidr {
+                first_index,
+                second_index,
+                mpidr,
+            } => write!(
+                f,
+                "HVF vCPU topology MPIDR 0x{mpidr:x} is duplicated at indexes {first_index} and {second_index}"
+            ),
+            Self::Allocation {
+                allocation,
+                requested,
+                source,
+            } => write!(
+                f,
+                "failed to reserve {requested} entries for HVF topology {allocation}: {source}"
+            ),
+            Self::Construction {
+                stage,
+                index,
+                mpidr,
+                source,
+                cleanup_failures,
+            } => {
+                write!(
+                    f,
+                    "HVF vCPU topology {stage} failed at index {index} (MPIDR 0x{mpidr:x}): {source}"
+                )?;
+                if !cleanup_failures.is_empty() {
+                    write!(
+                        f,
+                        "; {} runner cleanup operation(s) also failed",
+                        cleanup_failures.len()
+                    )?;
+                }
+                Ok(())
+            }
+            Self::Control {
+                operation,
+                failures,
+            } => write!(
+                f,
+                "HVF vCPU topology {operation} failed for {} member(s)",
+                failures.len()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for HvfVcpuTopologyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Backend(source) => Some(source),
+            Self::Construction { source, .. } => Some(source.as_ref()),
+            Self::Control { failures, .. } => failures
+                .first()
+                .map(|failure| failure as &(dyn std::error::Error + 'static)),
+            Self::InvalidVcpuCount { .. }
+            | Self::HostCapacityExceeded { .. }
+            | Self::InvalidMpidr { .. }
+            | Self::DuplicateMpidr { .. }
+            | Self::Allocation { .. } => None,
+        }
+    }
+}
+
+impl From<BackendError> for HvfVcpuTopologyError {
+    fn from(source: BackendError) -> Self {
+        Self::Backend(source)
+    }
+}
+
+trait TopologyMember {
+    fn configure_mpidr_el1(&self, expected: u64) -> Result<u64, HvfVcpuRunnerError>;
+    fn cancel(&self) -> Result<(), HvfVcpuRunnerError>;
+    fn shutdown(&self) -> Result<(), HvfVcpuRunnerError>;
+}
+
+impl TopologyMember for HvfVcpuRunner<'_> {
+    fn configure_mpidr_el1(&self, expected: u64) -> Result<u64, HvfVcpuRunnerError> {
+        HvfVcpuRunner::configure_mpidr_el1(self, expected)
+    }
+
+    fn cancel(&self) -> Result<(), HvfVcpuRunnerError> {
+        HvfVcpuRunner::cancel(self)
+    }
+
+    fn shutdown(&self) -> Result<(), HvfVcpuRunnerError> {
+        HvfVcpuRunner::shutdown(self)
+    }
+}
+
+struct CreatedTopology<M> {
+    members: Vec<M>,
+    mpidrs: Vec<u64>,
+}
+
+impl<M> fmt::Debug for CreatedTopology<M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CreatedTopology")
+            .field("member_count", &self.members.len())
+            .field("mpidrs", &self.mpidrs)
+            .finish()
+    }
+}
+
+/// Ordered permanent owner-thread vCPUs belonging to one HVF VM/GIC topology.
+pub struct HvfVcpuTopology<'vm> {
+    runners: Vec<HvfVcpuRunner<'vm>>,
+    mpidrs: Vec<u64>,
+}
+
+impl<'vm> HvfVcpuTopology<'vm> {
+    pub(crate) fn create(vcpu_count: u8) -> Result<Self, HvfVcpuTopologyError> {
+        let created = create_ordered_topology_with(
+            vcpu_count,
+            crate::ffi::get_max_vcpu_count,
+            |_, _| Ok(()),
+            |_| HvfVcpuRunner::new_unconfigured(),
+        )?;
+        Ok(Self {
+            runners: created.members,
+            mpidrs: created.mpidrs,
+        })
+    }
+
+    /// Return the number of vCPUs in the topology.
+    pub fn len(&self) -> usize {
+        self.runners.len()
+    }
+
+    /// Return whether the topology has no vCPUs.
+    pub fn is_empty(&self) -> bool {
+        self.runners.is_empty()
+    }
+
+    /// Return exact owner-thread-verified MPIDRs in topology order.
+    pub fn mpidrs(&self) -> &[u64] {
+        &self.mpidrs
+    }
+
+    /// Request cancellation from every topology member.
+    ///
+    /// This prerequisite primitive attempts each current singular cancel path.
+    /// It does not define the batch run-epoch behavior used by later concurrent
+    /// execution coordination.
+    pub fn cancel(&self) -> Result<(), HvfVcpuTopologyError> {
+        control_members(
+            &self.runners,
+            &self.mpidrs,
+            HvfVcpuTopologyOperation::Cancel,
+        )
+    }
+
+    /// Shut down every owner thread in reverse topology order.
+    pub fn shutdown(&self) -> Result<(), HvfVcpuTopologyError> {
+        shutdown_members(&self.runners, &self.mpidrs)
+    }
+}
+
+impl fmt::Debug for HvfVcpuTopology<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HvfVcpuTopology")
+            .field("mpidrs", &self.mpidrs)
+            .field("runner_count", &self.runners.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for HvfVcpuTopology<'_> {
+    fn drop(&mut self) {
+        let _ = self.shutdown();
+    }
+}
+
+fn validate_vcpu_count(vcpu_count: u8) -> Result<usize, HvfVcpuTopologyError> {
+    if vcpu_count == 0 || vcpu_count > MAX_SUPPORTED_VCPUS {
+        return Err(HvfVcpuTopologyError::InvalidVcpuCount {
+            requested: usize::from(vcpu_count),
+            max: usize::from(MAX_SUPPORTED_VCPUS),
+        });
+    }
+
+    Ok(usize::from(vcpu_count))
+}
+
+fn validate_host_capacity(vcpu_count: u8, host_max: u32) -> Result<(), HvfVcpuTopologyError> {
+    if u32::from(vcpu_count) > host_max {
+        return Err(HvfVcpuTopologyError::HostCapacityExceeded {
+            requested: vcpu_count,
+            host_max,
+        });
+    }
+
+    Ok(())
+}
+
+fn validate_mpidrs(mpidrs: &[u64]) -> Result<(), HvfVcpuTopologyError> {
+    if mpidrs.is_empty() || mpidrs.len() > usize::from(MAX_SUPPORTED_VCPUS) {
+        return Err(HvfVcpuTopologyError::InvalidVcpuCount {
+            requested: mpidrs.len(),
+            max: usize::from(MAX_SUPPORTED_VCPUS),
+        });
+    }
+
+    for (index, mpidr) in mpidrs.iter().copied().enumerate() {
+        if mpidr > MAX_ORDERED_MPIDR {
+            return Err(HvfVcpuTopologyError::InvalidMpidr {
+                index,
+                mpidr,
+                max: MAX_ORDERED_MPIDR,
+            });
+        }
+
+        if let Some(first_index) = mpidrs
+            .iter()
+            .take(index)
+            .position(|candidate| *candidate == mpidr)
+        {
+            return Err(HvfVcpuTopologyError::DuplicateMpidr {
+                first_index,
+                second_index: index,
+                mpidr,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn create_ordered_topology_with<M, Q, A, F>(
+    vcpu_count: u8,
+    query_host_max: Q,
+    mut before_allocation: A,
+    start_member: F,
+) -> Result<CreatedTopology<M>, HvfVcpuTopologyError>
+where
+    M: TopologyMember,
+    Q: FnOnce() -> Result<u32, BackendError>,
+    A: FnMut(HvfVcpuTopologyAllocation, usize) -> Result<(), String>,
+    F: FnMut(usize) -> Result<M, HvfVcpuRunnerError>,
+{
+    let requested = validate_vcpu_count(vcpu_count)?;
+    let host_max = query_host_max().map_err(HvfVcpuTopologyError::Backend)?;
+    validate_host_capacity(vcpu_count, host_max)?;
+
+    before_allocation(HvfVcpuTopologyAllocation::Mpidrs, requested).map_err(|source| {
+        HvfVcpuTopologyError::Allocation {
+            allocation: HvfVcpuTopologyAllocation::Mpidrs,
+            requested,
+            source,
+        }
+    })?;
+    let mut mpidrs = Vec::new();
+    mpidrs
+        .try_reserve_exact(requested)
+        .map_err(|source| HvfVcpuTopologyError::Allocation {
+            allocation: HvfVcpuTopologyAllocation::Mpidrs,
+            requested,
+            source: source.to_string(),
+        })?;
+    mpidrs.extend((0..vcpu_count).map(u64::from));
+    validate_mpidrs(&mpidrs)?;
+
+    create_topology_from_mpidrs_with(mpidrs, &mut before_allocation, start_member)
+}
+
+fn create_topology_from_mpidrs_with<M, A, F>(
+    mpidrs: Vec<u64>,
+    mut before_allocation: A,
+    mut start_member: F,
+) -> Result<CreatedTopology<M>, HvfVcpuTopologyError>
+where
+    M: TopologyMember,
+    A: FnMut(HvfVcpuTopologyAllocation, usize) -> Result<(), String>,
+    F: FnMut(usize) -> Result<M, HvfVcpuRunnerError>,
+{
+    validate_mpidrs(&mpidrs)?;
+    let requested = mpidrs.len();
+    before_allocation(HvfVcpuTopologyAllocation::Runners, requested).map_err(|source| {
+        HvfVcpuTopologyError::Allocation {
+            allocation: HvfVcpuTopologyAllocation::Runners,
+            requested,
+            source,
+        }
+    })?;
+    let mut members = Vec::new();
+    members
+        .try_reserve_exact(requested)
+        .map_err(|source| HvfVcpuTopologyError::Allocation {
+            allocation: HvfVcpuTopologyAllocation::Runners,
+            requested,
+            source: source.to_string(),
+        })?;
+
+    for (index, mpidr) in mpidrs.iter().copied().enumerate() {
+        let member = match start_member(index) {
+            Ok(member) => member,
+            Err(source) => {
+                let cleanup_failures = cleanup_members(&members, &mpidrs);
+                return Err(HvfVcpuTopologyError::Construction {
+                    stage: HvfVcpuTopologyCreateStage::RunnerStart,
+                    index,
+                    mpidr,
+                    source: Box::new(source),
+                    cleanup_failures,
+                });
+            }
+        };
+        members.push(member);
+
+        let Some(member) = members.last() else {
+            return Err(HvfVcpuTopologyError::Construction {
+                stage: HvfVcpuTopologyCreateStage::RunnerStart,
+                index,
+                mpidr,
+                source: Box::new(HvfVcpuRunnerError::InvalidState(
+                    "created vCPU topology member is missing",
+                )),
+                cleanup_failures: cleanup_members(&members, &mpidrs),
+            });
+        };
+        let actual = match member.configure_mpidr_el1(mpidr) {
+            Ok(actual) => actual,
+            Err(source) => {
+                let stage = topology_stage_for_runner_error(&source);
+                let cleanup_failures = cleanup_members(&members, &mpidrs);
+                return Err(HvfVcpuTopologyError::Construction {
+                    stage,
+                    index,
+                    mpidr,
+                    source: Box::new(source),
+                    cleanup_failures,
+                });
+            }
+        };
+        if actual != mpidr {
+            let source = HvfVcpuRunnerError::MpidrAffinity {
+                stage: HvfVcpuMpidrAffinityStage::Verify,
+                expected: mpidr,
+                actual: Some(actual),
+                source: None,
+            };
+            let cleanup_failures = cleanup_members(&members, &mpidrs);
+            return Err(HvfVcpuTopologyError::Construction {
+                stage: HvfVcpuTopologyCreateStage::AffinityVerify,
+                index,
+                mpidr,
+                source: Box::new(source),
+                cleanup_failures,
+            });
+        }
+    }
+
+    Ok(CreatedTopology { members, mpidrs })
+}
+
+fn topology_stage_for_runner_error(source: &HvfVcpuRunnerError) -> HvfVcpuTopologyCreateStage {
+    match source {
+        HvfVcpuRunnerError::MpidrAffinity { stage, .. } => match stage {
+            HvfVcpuMpidrAffinityStage::Write => HvfVcpuTopologyCreateStage::AffinityWrite,
+            HvfVcpuMpidrAffinityStage::Read => HvfVcpuTopologyCreateStage::AffinityRead,
+            HvfVcpuMpidrAffinityStage::Verify => HvfVcpuTopologyCreateStage::AffinityVerify,
+        },
+        _ => HvfVcpuTopologyCreateStage::AffinityCommand,
+    }
+}
+
+fn cleanup_members<M: TopologyMember>(
+    members: &[M],
+    mpidrs: &[u64],
+) -> Vec<HvfVcpuTopologyMemberFailure> {
+    let mut failures = Vec::new();
+    for (index, (member, mpidr)) in members.iter().zip(mpidrs).enumerate().rev() {
+        if let Err(source) = member.shutdown() {
+            failures.push(HvfVcpuTopologyMemberFailure {
+                index,
+                mpidr: *mpidr,
+                source: Box::new(source),
+            });
+        }
+    }
+    failures
+}
+
+fn control_members<M: TopologyMember>(
+    members: &[M],
+    mpidrs: &[u64],
+    operation: HvfVcpuTopologyOperation,
+) -> Result<(), HvfVcpuTopologyError> {
+    let mut failures = Vec::new();
+    for (index, (member, mpidr)) in members.iter().zip(mpidrs).enumerate() {
+        let result = match operation {
+            HvfVcpuTopologyOperation::Cancel => member.cancel(),
+            HvfVcpuTopologyOperation::Shutdown => member.shutdown(),
+        };
+        if let Err(source) = result {
+            failures.push(HvfVcpuTopologyMemberFailure {
+                index,
+                mpidr: *mpidr,
+                source: Box::new(source),
+            });
+        }
+    }
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(HvfVcpuTopologyError::Control {
+            operation,
+            failures,
+        })
+    }
+}
+
+fn shutdown_members<M: TopologyMember>(
+    members: &[M],
+    mpidrs: &[u64],
+) -> Result<(), HvfVcpuTopologyError> {
+    let failures = cleanup_members(members, mpidrs);
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(HvfVcpuTopologyError::Control {
+            operation: HvfVcpuTopologyOperation::Shutdown,
+            failures,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use bangbang_runtime::BackendError;
+
+    use super::{
+        CreatedTopology, HvfVcpuTopologyAllocation, HvfVcpuTopologyCreateStage,
+        HvfVcpuTopologyError, HvfVcpuTopologyOperation, TopologyMember,
+        create_ordered_topology_with, create_topology_from_mpidrs_with, shutdown_members,
+    };
+    use crate::runner::{HvfVcpuMpidrAffinityStage, HvfVcpuRunnerError};
+
+    type EventLog = Arc<Mutex<Vec<String>>>;
+
+    #[derive(Clone)]
+    enum ConfigureBehavior {
+        Echo,
+        Actual(u64),
+        Error(HvfVcpuRunnerError),
+    }
+
+    struct FakeMember {
+        index: usize,
+        log: EventLog,
+        configure: ConfigureBehavior,
+        cancel_result: Result<(), HvfVcpuRunnerError>,
+        shutdown_results: Mutex<VecDeque<Result<(), HvfVcpuRunnerError>>>,
+    }
+
+    impl FakeMember {
+        fn echo(index: usize, log: &EventLog) -> Self {
+            Self {
+                index,
+                log: Arc::clone(log),
+                configure: ConfigureBehavior::Echo,
+                cancel_result: Ok(()),
+                shutdown_results: Mutex::new(VecDeque::new()),
+            }
+        }
+
+        fn with_configure(index: usize, log: &EventLog, configure: ConfigureBehavior) -> Self {
+            Self {
+                index,
+                log: Arc::clone(log),
+                configure,
+                cancel_result: Ok(()),
+                shutdown_results: Mutex::new(VecDeque::new()),
+            }
+        }
+
+        fn with_control(
+            index: usize,
+            log: &EventLog,
+            cancel_result: Result<(), HvfVcpuRunnerError>,
+            shutdown_results: Vec<Result<(), HvfVcpuRunnerError>>,
+        ) -> Self {
+            Self {
+                index,
+                log: Arc::clone(log),
+                configure: ConfigureBehavior::Echo,
+                cancel_result,
+                shutdown_results: Mutex::new(shutdown_results.into()),
+            }
+        }
+
+        fn record(&self, event: impl Into<String>) {
+            self.log
+                .lock()
+                .expect("event log should lock")
+                .push(event.into());
+        }
+    }
+
+    impl TopologyMember for FakeMember {
+        fn configure_mpidr_el1(&self, expected: u64) -> Result<u64, HvfVcpuRunnerError> {
+            self.record(format!("configure:{}:{expected}", self.index));
+            match &self.configure {
+                ConfigureBehavior::Echo => Ok(expected),
+                ConfigureBehavior::Actual(actual) => Ok(*actual),
+                ConfigureBehavior::Error(source) => Err(source.clone()),
+            }
+        }
+
+        fn cancel(&self) -> Result<(), HvfVcpuRunnerError> {
+            self.record(format!("cancel:{}", self.index));
+            self.cancel_result.clone()
+        }
+
+        fn shutdown(&self) -> Result<(), HvfVcpuRunnerError> {
+            self.record(format!("shutdown:{}", self.index));
+            self.shutdown_results
+                .lock()
+                .expect("shutdown results should lock")
+                .pop_front()
+                .unwrap_or(Ok(()))
+        }
+    }
+
+    impl Drop for FakeMember {
+        fn drop(&mut self) {
+            self.record(format!("drop:{}", self.index));
+        }
+    }
+
+    fn log() -> EventLog {
+        Arc::new(Mutex::new(Vec::new()))
+    }
+
+    fn events(log: &EventLog) -> Vec<String> {
+        log.lock().expect("event log should lock").clone()
+    }
+
+    fn injected(message: &'static str) -> HvfVcpuRunnerError {
+        HvfVcpuRunnerError::Backend(BackendError::InvalidState(message))
+    }
+
+    fn affinity_error(
+        stage: HvfVcpuMpidrAffinityStage,
+        expected: u64,
+        message: &'static str,
+    ) -> HvfVcpuRunnerError {
+        HvfVcpuRunnerError::MpidrAffinity {
+            stage,
+            expected,
+            actual: None,
+            source: Some(BackendError::InvalidState(message)),
+        }
+    }
+
+    #[test]
+    fn invalid_counts_fail_before_query_allocation_or_member_start() {
+        for requested in [0, 33] {
+            let query_calls = AtomicUsize::new(0);
+            let allocation_calls = AtomicUsize::new(0);
+            let start_calls = AtomicUsize::new(0);
+            let result: Result<CreatedTopology<FakeMember>, _> = create_ordered_topology_with(
+                requested,
+                || {
+                    query_calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(64)
+                },
+                |_, _| {
+                    allocation_calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                },
+                |_| {
+                    start_calls.fetch_add(1, Ordering::SeqCst);
+                    Err(injected("unexpected member start after invalid count"))
+                },
+            );
+
+            assert_eq!(
+                result.expect_err("invalid count should fail"),
+                HvfVcpuTopologyError::InvalidVcpuCount {
+                    requested: usize::from(requested),
+                    max: 32,
+                }
+            );
+            assert_eq!(query_calls.load(Ordering::SeqCst), 0);
+            assert_eq!(allocation_calls.load(Ordering::SeqCst), 0);
+            assert_eq!(start_calls.load(Ordering::SeqCst), 0);
+        }
+    }
+
+    #[test]
+    fn capacity_query_failure_and_host_limit_precede_allocation() {
+        let allocation_calls = AtomicUsize::new(0);
+        let query_error: Result<CreatedTopology<FakeMember>, _> = create_ordered_topology_with(
+            2,
+            || {
+                Err(BackendError::Hypervisor(
+                    "injected capacity failure".to_string(),
+                ))
+            },
+            |_, _| {
+                allocation_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+            |_| Err(injected("unexpected member start after capacity failure")),
+        );
+        assert_eq!(
+            query_error.expect_err("query should fail"),
+            HvfVcpuTopologyError::Backend(BackendError::Hypervisor(
+                "injected capacity failure".to_string()
+            ))
+        );
+
+        let insufficient: Result<CreatedTopology<FakeMember>, _> = create_ordered_topology_with(
+            2,
+            || Ok(1),
+            |_, _| {
+                allocation_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+            |_| Err(injected("unexpected member start after host limit")),
+        );
+        assert_eq!(
+            insufficient.expect_err("host limit should fail"),
+            HvfVcpuTopologyError::HostCapacityExceeded {
+                requested: 2,
+                host_max: 1,
+            }
+        );
+        assert_eq!(allocation_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn portable_maximum_builds_exact_ordered_mpidrs() {
+        let log = log();
+        let created = create_ordered_topology_with(
+            32,
+            || Ok(64),
+            |_, _| Ok(()),
+            |index| {
+                log.lock()
+                    .expect("event log should lock")
+                    .push(format!("start:{index}"));
+                Ok(FakeMember::echo(index, &log))
+            },
+        )
+        .expect("portable maximum should build");
+
+        assert_eq!(
+            created.mpidrs,
+            (0_u8..32).map(u64::from).collect::<Vec<_>>()
+        );
+        assert_eq!(created.members.len(), 32);
+    }
+
+    #[test]
+    fn each_allocation_failure_precedes_member_start() {
+        for failed_allocation in [
+            HvfVcpuTopologyAllocation::Mpidrs,
+            HvfVcpuTopologyAllocation::Runners,
+        ] {
+            let start_calls = AtomicUsize::new(0);
+            let result: Result<CreatedTopology<FakeMember>, _> = create_ordered_topology_with(
+                2,
+                || Ok(2),
+                |allocation, _| {
+                    if allocation == failed_allocation {
+                        Err("injected allocation failure".to_string())
+                    } else {
+                        Ok(())
+                    }
+                },
+                |_| {
+                    start_calls.fetch_add(1, Ordering::SeqCst);
+                    Err(injected("unexpected member start after allocation failure"))
+                },
+            );
+
+            assert_eq!(
+                result.expect_err("allocation should fail"),
+                HvfVcpuTopologyError::Allocation {
+                    allocation: failed_allocation,
+                    requested: 2,
+                    source: "injected allocation failure".to_string(),
+                }
+            );
+            assert_eq!(start_calls.load(Ordering::SeqCst), 0);
+        }
+    }
+
+    #[test]
+    fn invalid_and_duplicate_affinities_precede_runner_allocation() {
+        for (mpidrs, expected) in [
+            (
+                Vec::new(),
+                HvfVcpuTopologyError::InvalidVcpuCount {
+                    requested: 0,
+                    max: 32,
+                },
+            ),
+            (
+                vec![32],
+                HvfVcpuTopologyError::InvalidMpidr {
+                    index: 0,
+                    mpidr: 32,
+                    max: 31,
+                },
+            ),
+            (
+                vec![0, 0],
+                HvfVcpuTopologyError::DuplicateMpidr {
+                    first_index: 0,
+                    second_index: 1,
+                    mpidr: 0,
+                },
+            ),
+        ] {
+            let allocation_calls = AtomicUsize::new(0);
+            let start_calls = AtomicUsize::new(0);
+            let result: Result<CreatedTopology<FakeMember>, _> = create_topology_from_mpidrs_with(
+                mpidrs,
+                |_, _| {
+                    allocation_calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                },
+                |_| {
+                    start_calls.fetch_add(1, Ordering::SeqCst);
+                    Err(injected("unexpected member start after invalid affinity"))
+                },
+            );
+
+            assert_eq!(result.expect_err("affinity should fail"), expected);
+            assert_eq!(allocation_calls.load(Ordering::SeqCst), 0);
+            assert_eq!(start_calls.load(Ordering::SeqCst), 0);
+        }
+    }
+
+    #[test]
+    fn runner_start_failure_cleans_successful_prefix_in_reverse_order() {
+        let log = log();
+        let result = create_ordered_topology_with(
+            3,
+            || Ok(3),
+            |_, _| Ok(()),
+            |index| {
+                log.lock()
+                    .expect("event log should lock")
+                    .push(format!("start:{index}"));
+                if index == 2 {
+                    Err(injected("injected runner start failure"))
+                } else {
+                    Ok(FakeMember::echo(index, &log))
+                }
+            },
+        );
+
+        let HvfVcpuTopologyError::Construction {
+            stage,
+            index,
+            mpidr,
+            source,
+            cleanup_failures,
+        } = result.expect_err("runner start should fail")
+        else {
+            panic!("unexpected topology error");
+        };
+        assert_eq!(stage, HvfVcpuTopologyCreateStage::RunnerStart);
+        assert_eq!((index, mpidr), (2, 2));
+        assert_eq!(*source, injected("injected runner start failure"));
+        assert!(cleanup_failures.is_empty());
+        let events = events(&log);
+        let shutdowns = events
+            .iter()
+            .filter(|event| event.starts_with("shutdown:"))
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(shutdowns, ["shutdown:1", "shutdown:0"]);
+    }
+
+    #[test]
+    fn affinity_failure_cleans_current_member_and_preserves_cleanup_failures() {
+        let log = log();
+        let source = affinity_error(
+            HvfVcpuMpidrAffinityStage::Write,
+            1,
+            "injected affinity write failure",
+        );
+        let cleanup = injected("injected cleanup failure");
+        let result = create_ordered_topology_with(
+            2,
+            || Ok(2),
+            |_, _| Ok(()),
+            |index| {
+                if index == 1 {
+                    Ok(FakeMember {
+                        index,
+                        log: Arc::clone(&log),
+                        configure: ConfigureBehavior::Error(source.clone()),
+                        cancel_result: Ok(()),
+                        shutdown_results: Mutex::new(VecDeque::from([Err(cleanup.clone())])),
+                    })
+                } else {
+                    Ok(FakeMember::echo(index, &log))
+                }
+            },
+        );
+
+        let HvfVcpuTopologyError::Construction {
+            stage,
+            index,
+            source: actual_source,
+            cleanup_failures,
+            ..
+        } = result.expect_err("affinity should fail")
+        else {
+            panic!("unexpected topology error");
+        };
+        assert_eq!(stage, HvfVcpuTopologyCreateStage::AffinityWrite);
+        assert_eq!(index, 1);
+        assert_eq!(*actual_source, source);
+        assert_eq!(cleanup_failures.len(), 1);
+        assert_eq!(cleanup_failures[0].index(), 1);
+        assert_eq!(cleanup_failures[0].source_error(), &cleanup);
+        let shutdowns = events(&log)
+            .into_iter()
+            .filter(|event| event.starts_with("shutdown:"))
+            .collect::<Vec<_>>();
+        assert_eq!(shutdowns, ["shutdown:1", "shutdown:0"]);
+    }
+
+    #[test]
+    fn affinity_mismatch_is_typed_and_cleans_current_member() {
+        let log = log();
+        let result = create_ordered_topology_with(
+            2,
+            || Ok(2),
+            |_, _| Ok(()),
+            |index| {
+                if index == 1 {
+                    Ok(FakeMember::with_configure(
+                        index,
+                        &log,
+                        ConfigureBehavior::Actual(9),
+                    ))
+                } else {
+                    Ok(FakeMember::echo(index, &log))
+                }
+            },
+        );
+
+        let HvfVcpuTopologyError::Construction {
+            stage,
+            index,
+            source,
+            cleanup_failures,
+            ..
+        } = result.expect_err("mismatch should fail")
+        else {
+            panic!("unexpected topology error");
+        };
+        assert_eq!(stage, HvfVcpuTopologyCreateStage::AffinityVerify);
+        assert_eq!(index, 1);
+        assert_eq!(
+            *source,
+            HvfVcpuRunnerError::MpidrAffinity {
+                stage: HvfVcpuMpidrAffinityStage::Verify,
+                expected: 1,
+                actual: Some(9),
+                source: None,
+            }
+        );
+        assert!(cleanup_failures.is_empty());
+        let shutdowns = events(&log)
+            .into_iter()
+            .filter(|event| event.starts_with("shutdown:"))
+            .collect::<Vec<_>>();
+        assert_eq!(shutdowns, ["shutdown:1", "shutdown:0"]);
+    }
+
+    #[test]
+    fn affinity_read_and_channel_failures_keep_stage_and_cleanup_order() {
+        for (source, expected_stage) in [
+            (
+                affinity_error(
+                    HvfVcpuMpidrAffinityStage::Read,
+                    1,
+                    "injected affinity read failure",
+                ),
+                HvfVcpuTopologyCreateStage::AffinityRead,
+            ),
+            (
+                HvfVcpuRunnerError::ChannelClosed("injected affinity channel failure"),
+                HvfVcpuTopologyCreateStage::AffinityCommand,
+            ),
+        ] {
+            let log = log();
+            let result = create_ordered_topology_with(
+                2,
+                || Ok(2),
+                |_, _| Ok(()),
+                |index| {
+                    if index == 1 {
+                        Ok(FakeMember::with_configure(
+                            index,
+                            &log,
+                            ConfigureBehavior::Error(source.clone()),
+                        ))
+                    } else {
+                        Ok(FakeMember::echo(index, &log))
+                    }
+                },
+            );
+
+            let HvfVcpuTopologyError::Construction {
+                stage,
+                index,
+                source: actual_source,
+                cleanup_failures,
+                ..
+            } = result.expect_err("affinity stage should fail")
+            else {
+                panic!("unexpected topology error");
+            };
+            assert_eq!(stage, expected_stage);
+            assert_eq!(index, 1);
+            assert_eq!(*actual_source, source);
+            assert!(cleanup_failures.is_empty());
+            let shutdowns = events(&log)
+                .into_iter()
+                .filter(|event| event.starts_with("shutdown:"))
+                .collect::<Vec<_>>();
+            assert_eq!(shutdowns, ["shutdown:1", "shutdown:0"]);
+        }
+    }
+
+    #[test]
+    fn aggregate_control_attempts_every_member_and_retains_indexes() {
+        let log = log();
+        let created = create_ordered_topology_with(
+            3,
+            || Ok(3),
+            |_, _| Ok(()),
+            |index| {
+                let cancel_result = if index == 0 || index == 2 {
+                    Err(injected("injected cancel failure"))
+                } else {
+                    Ok(())
+                };
+                let shutdown_results = if index == 1 {
+                    vec![Err(injected("injected shutdown failure"))]
+                } else {
+                    Vec::new()
+                };
+                Ok(FakeMember::with_control(
+                    index,
+                    &log,
+                    cancel_result,
+                    shutdown_results,
+                ))
+            },
+        )
+        .expect("topology should build");
+
+        let cancel = super::control_members(
+            &created.members,
+            &created.mpidrs,
+            HvfVcpuTopologyOperation::Cancel,
+        )
+        .expect_err("two cancels should fail");
+        let HvfVcpuTopologyError::Control {
+            operation,
+            failures,
+        } = cancel
+        else {
+            panic!("unexpected cancel error");
+        };
+        assert_eq!(operation, HvfVcpuTopologyOperation::Cancel);
+        assert_eq!(
+            failures
+                .iter()
+                .map(|failure| failure.index())
+                .collect::<Vec<_>>(),
+            [0, 2]
+        );
+
+        let shutdown = shutdown_members(&created.members, &created.mpidrs)
+            .expect_err("one shutdown should fail");
+        let HvfVcpuTopologyError::Control {
+            operation,
+            failures,
+        } = shutdown
+        else {
+            panic!("unexpected shutdown error");
+        };
+        assert_eq!(operation, HvfVcpuTopologyOperation::Shutdown);
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].index(), 1);
+
+        let events = events(&log);
+        let cancels = events
+            .iter()
+            .filter(|event| event.starts_with("cancel:"))
+            .cloned()
+            .collect::<Vec<_>>();
+        let shutdowns = events
+            .iter()
+            .filter(|event| event.starts_with("shutdown:"))
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(cancels, ["cancel:0", "cancel:1", "cancel:2"]);
+        assert_eq!(shutdowns, ["shutdown:2", "shutdown:1", "shutdown:0"]);
+    }
+}

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -2420,6 +2420,42 @@ fn cancels_runner_before_first_run() {
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 #[test]
+fn owns_and_cleans_ordered_two_vcpu_topology() {
+    use bangbang_hvf::HvfBackend;
+    use bangbang_runtime::VmBackend;
+
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let mut backend = HvfBackend::new();
+
+    backend.create_vm().expect("VM should be created");
+    backend
+        .create_gic()
+        .expect("GIC should be created before the vCPU topology");
+    {
+        let topology = backend
+            .start_vcpu_topology(2)
+            .expect("host should support a two-vCPU topology");
+        assert_eq!(topology.mpidrs(), [0, 1]);
+        assert_eq!(topology.len(), 2);
+
+        topology
+            .cancel()
+            .expect("every topology member should accept cancellation");
+
+        topology
+            .shutdown()
+            .expect("every topology member should shut down");
+        topology
+            .shutdown()
+            .expect("topology shutdown should be idempotent");
+    }
+    backend.destroy_vm().expect("VM should be destroyed");
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
 fn captures_arm64_physical_timer_tval_on_idle_runner_thread() {
     use bangbang_hvf::HvfBackend;
     use bangbang_runtime::VmBackend;

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -1638,6 +1638,18 @@ typed value in that same order. Those levels are not GIC state and HVF clears
 them after a vCPU run returns, so individual mutation and aggregate restore are
 pre-run injection primitives rather than durable delivery state.
 
+The HVF backend also has an internal ordered vCPU-topology prerequisite. It
+queries `hv_vm_get_max_vcpu_count`, rejects requests outside both the portable
+`1..=32` ceiling and the current host maximum before starting an owner, and can
+create affinities `0..vcpu_count` only after one VM and its GIC exist. Every
+idle vCPU stays on a permanent owner thread, writes and reads back its MPIDR
+there before publication, and participates in topology-wide cancellation and
+reverse-order shutdown. Construction returns no successful prefix; a later
+owner or affinity failure shuts down every retained owner and preserves both
+the primary failure and indexed cleanup failures. This primitive is not wired
+to FDT, PSCI, the boot session, or public `InstanceStart`, so the documented
+public startup limit remains exactly one vCPU and native-v1 remains one-vCPU.
+
 This still is not public guest startup. bangbang can now write an internal FDT
 payload, create an internal single-vCPU HVF arm64 boot session, read the primary
 runner-owned vCPU `MPIDR_EL1` for boot metadata, allocate deterministic block

--- a/docs/security.md
+++ b/docs/security.md
@@ -783,6 +783,23 @@ targets with one test thread. CI may use `--allow-unsupported` only to compile
 and sign on runners that cannot execute HVF; local HVF verification should fail
 when HVF is unavailable.
 
+An internal multi-vCPU topology does not relax HVF ownership rules. Each vCPU
+is created, configured, queried, run, and destroyed only on its permanent owner
+thread. The backend requires VM then GIC creation before topology allocation,
+checks both the portable count ceiling and the host-reported maximum before the
+first owner, reserves aggregate metadata first, and writes plus reads back every
+ordered MPIDR before returning the complete topology. A partial construction is
+never published: retained owners are shut down in reverse order, the original
+failure remains primary, and indexed cleanup failures remain observable. MPIDR
+values are topology metadata, but unrelated guest registers and memory are not
+included in these diagnostics.
+
+Topology-wide cancellation currently attempts each singular runner. Asking HVF
+to exit an idle vCPU can make that vCPU's next run return immediately, so this
+primitive is suitable for teardown and the signed pre-run cancellation proof;
+it is not a reusable concurrent run epoch. Batch in-flight snapshots and pause
+barriers remain deferred to the runner-coordination work.
+
 ## Guest Data Exposure
 
 The guest is untrusted. vCPU execution, guest memory contents, virtqueue

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -55,6 +55,17 @@ must run through
 `com.apple.security.hypervisor` entitlement. Do not add real HVF tests to the
 unsigned workspace test path.
 
+Ordered HVF vCPU-topology changes require a signed `hvf_lifecycle` scenario
+that creates one VM and GIC before two permanent owner-thread runners, proves
+their exact ordered MPIDRs are `[0, 1]`, cancels both before their first bounded
+run, shuts them down in full, and destroys the VM. The scenario proves capacity,
+affinity ownership, cancellation, and cleanup only; Linux SMP enumeration,
+PSCI secondary startup, concurrent execution, FDT activation, and public
+multi-vCPU startup require their later dedicated signed gates. Unit tests must
+inject count, host-capacity, allocation, owner-start, affinity write/readback,
+channel, cancel, and shutdown failures and assert reverse cleanup plus primary
+error precedence without entering unsigned HVF.
+
 For virtio-pmem changes, unit tests should cover MMIO registration, FDT
 metadata, config-space `start`/`size`, deterministic multi-device layout,
 queue parsing/completion, shadow writeback, and cleanup/error paths. Signed HVF


### PR DESCRIPTION
## Summary

- bind the exact HVF host vCPU-capacity query and validate requested topologies against both the Firecracker-compatible ceiling and the current host
- configure and verify explicit MPIDR affinities on each permanent owner thread, then publish an ordered topology only after the complete set succeeds
- preserve primary and indexed cleanup failures across construction, cancellation, and reverse shutdown, with focused injection tests and signed two-vCPU lifecycle proof
- document this as an internal prerequisite while public startup and native-v1 snapshots remain one-vCPU-only

## Scope exclusions

- no FDT or public multi-vCPU startup activation
- no PSCI secondary power transitions or concurrent runner scheduling
- no CPU-template or multi-vCPU snapshot support

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf` (1994 passed, 1 ignored)
- `cargo test -p bangbang-hvf --lib --all-features --locked` (948 passed)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh` (46 lifecycle, 15 guest boot, and 40 executable E2E tests passed)
- `git diff --check origin/main...HEAD`

Part of #538.

Closes #1280.
