### PR TITLE
chore: ignore codex work directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 /codereviews/
+/codex-work/
 /.tmp/


### PR DESCRIPTION
## Summary

- ignore the repository-local `codex-work` directory used for Codex workflow artifacts

## Scope exclusions

- no source, build, or runtime behavior changes

## Verification

- `git diff --cached --check`
- `git check-ignore -v codex-work/probe`
