### PR TITLE
feat: publish PSCI 1.0 guest discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,14 @@ and later `CPU_ON` re-entry reuse the fixed owner topology. PSCI
 guest-unmasked EL1 virtual timer: affinity remains `ON`, all three call
 arguments are ignored, the timer PPI is made pending before `SUCCESS`, and
 lifecycle cancellation rearms the same transaction without fabricating a
-wake. FDT idle-state discovery and SGI/SPI/direct IRQ/FIQ wake are not exposed.
-Dynamic CPU topology, SMT, non-`None` CPU templates, and cross-host CPU
-portability remain unsupported. The native-v1 snapshot profile below remains
-restricted to exactly one vCPU.
+wake. Runtime discovery reports PSCI 1.0 and a minimal safe SMCCC 1.1 surface:
+`PSCI_FEATURES` advertises only delivered calls, `SMCCC_ARCH_FEATURES` reports
+only its mandatory VERSION/self results, and optional firmware services remain
+unsupported. The FDT deliberately keeps Firecracker v1.15.1's
+`arm,psci-0.2`/HVC binding. FDT idle-state discovery and SGI/SPI/direct IRQ/FIQ
+wake are not exposed. Dynamic CPU topology, SMT, non-`None` CPU templates, and
+cross-host CPU portability remain unsupported. The native-v1 snapshot profile
+below remains restricted to exactly one vCPU.
 
 Firecracker-shaped `PUT /cpu-config` input is fully syntax-validated. Empty
 custom templates remain successful no-ops; non-empty KVM capability,

--- a/crates/hvf/src/psci.rs
+++ b/crates/hvf/src/psci.rs
@@ -14,7 +14,10 @@ const PSCI_FEATURES: u64 = 0x8400_000a;
 const PSCI_CPU_SUSPEND_64: u64 = 0xc400_0001;
 const PSCI_CPU_ON_64: u64 = 0xc400_0003;
 const PSCI_AFFINITY_INFO_64: u64 = 0xc400_0004;
-const PSCI_VERSION_0_2: u64 = 0x0000_0002;
+const ARM_SMCCC_VERSION: u64 = 0x8000_0000;
+const ARM_SMCCC_ARCH_FEATURES: u64 = 0x8000_0001;
+const PSCI_VERSION_1_0: u64 = 0x0001_0000;
+const ARM_SMCCC_VERSION_1_1: u64 = 0x0001_0001;
 const PSCI_MIGRATE_INFO_TYPE_TRUSTED_OS_NOT_REQUIRED: u64 = 2;
 const PSCI_MPIDR_AFFINITY_MASK: u64 = 0x0000_00ff_00ff_ffff;
 const PSCI_MPIDR_32_RESERVED_MASK: u64 = 0xff00_0000;
@@ -44,16 +47,82 @@ impl PsciCall {
 }
 
 pub(crate) const fn call_uses_arg0(function_id: u64) -> bool {
-    matches!(function_id, PSCI_FEATURES)
+    matches!(function_id, PSCI_FEATURES | ARM_SMCCC_ARCH_FEATURES)
 }
 
 pub(crate) const fn coordinated_call_argument_count(function_id: u64) -> usize {
     match function_id {
         PSCI_CPU_SUSPEND_32 | PSCI_CPU_SUSPEND_64 | PSCI_CPU_ON_32 | PSCI_CPU_ON_64 => 3,
         PSCI_AFFINITY_INFO_32 | PSCI_AFFINITY_INFO_64 => 2,
-        PSCI_FEATURES => 1,
+        PSCI_FEATURES | ARM_SMCCC_ARCH_FEATURES => 1,
         _ => 0,
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PsciFeatureAvailability {
+    Immediate,
+    Coordinated,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PsciFunctionFeatures {
+    flags: u64,
+    availability: PsciFeatureAvailability,
+}
+
+impl PsciFunctionFeatures {
+    const fn immediate(flags: u64) -> Self {
+        Self {
+            flags,
+            availability: PsciFeatureAvailability::Immediate,
+        }
+    }
+
+    const fn coordinated(flags: u64) -> Self {
+        Self {
+            flags,
+            availability: PsciFeatureAvailability::Coordinated,
+        }
+    }
+
+    const fn requires_coordination(self) -> bool {
+        matches!(self.availability, PsciFeatureAvailability::Coordinated)
+    }
+
+    const fn available(self, coordinated: bool) -> bool {
+        !self.requires_coordination() || coordinated
+    }
+}
+
+const fn psci_function_features(function_id: u64) -> Option<PsciFunctionFeatures> {
+    match function_id {
+        PSCI_VERSION
+        | PSCI_MIGRATE_INFO_TYPE
+        | PSCI_SYSTEM_OFF
+        | PSCI_SYSTEM_RESET
+        | PSCI_FEATURES
+        | ARM_SMCCC_VERSION => Some(PsciFunctionFeatures::immediate(0)),
+        PSCI_CPU_SUSPEND_32
+        | PSCI_CPU_SUSPEND_64
+        | PSCI_CPU_OFF
+        | PSCI_CPU_ON_32
+        | PSCI_CPU_ON_64
+        | PSCI_AFFINITY_INFO_32
+        | PSCI_AFFINITY_INFO_64 => Some(PsciFunctionFeatures::coordinated(0)),
+        _ => None,
+    }
+}
+
+const fn advertised_psci_features(function_id: u64, coordinated: bool) -> Option<u64> {
+    match psci_function_features(function_id) {
+        Some(features) if features.available(coordinated) => Some(features.flags),
+        Some(_) | None => None,
+    }
+}
+
+const fn narrow_u32(value: u64) -> u64 {
+    (value as u32) as u64
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -125,8 +194,29 @@ impl PsciCallResult {
 }
 
 pub(crate) const fn handle_call(call: PsciCall) -> PsciCallResult {
+    if call.function_id != ARM_SMCCC_ARCH_FEATURES {
+        let Some(features) = psci_function_features(call.function_id) else {
+            return not_supported_result();
+        };
+        if features.requires_coordination() {
+            return not_supported_result();
+        }
+    }
+
     match call.function_id {
-        PSCI_VERSION => PsciCallResult::returned(PSCI_VERSION_0_2),
+        PSCI_VERSION => PsciCallResult::returned(PSCI_VERSION_1_0),
+        ARM_SMCCC_VERSION => PsciCallResult::returned(ARM_SMCCC_VERSION_1_1),
+        ARM_SMCCC_ARCH_FEATURES => {
+            let status = if matches!(
+                narrow_u32(call.arg0),
+                ARM_SMCCC_VERSION | ARM_SMCCC_ARCH_FEATURES
+            ) {
+                PsciStatus::Success
+            } else {
+                PsciStatus::NotSupported
+            };
+            PsciCallResult::returned(status.return_value())
+        }
         PSCI_MIGRATE_INFO_TYPE => {
             PsciCallResult::returned(PSCI_MIGRATE_INFO_TYPE_TRUSTED_OS_NOT_REQUIRED)
         }
@@ -139,37 +229,14 @@ pub(crate) const fn handle_call(call: PsciCall) -> PsciCallResult {
             PsciCallAction::SystemReset,
         ),
         PSCI_FEATURES => {
-            let status = if supports_legacy_function(call.arg0) {
-                PsciStatus::Success
-            } else {
-                PsciStatus::NotSupported
+            let return_value = match advertised_psci_features(narrow_u32(call.arg0), false) {
+                Some(flags) => flags,
+                None => PsciStatus::NotSupported.return_value(),
             };
-            PsciCallResult::returned(status.return_value())
+            PsciCallResult::returned(return_value)
         }
-        PSCI_CPU_OFF => not_supported_result(),
         _ => not_supported_result(),
     }
-}
-
-const fn supports_legacy_function(function_id: u64) -> bool {
-    matches!(
-        function_id,
-        PSCI_VERSION | PSCI_MIGRATE_INFO_TYPE | PSCI_SYSTEM_OFF | PSCI_SYSTEM_RESET | PSCI_FEATURES
-    )
-}
-
-const fn supports_coordinated_function(function_id: u64) -> bool {
-    supports_legacy_function(function_id)
-        || matches!(
-            function_id,
-            PSCI_CPU_SUSPEND_32
-                | PSCI_CPU_SUSPEND_64
-                | PSCI_CPU_OFF
-                | PSCI_CPU_ON_32
-                | PSCI_CPU_ON_64
-                | PSCI_AFFINITY_INFO_32
-                | PSCI_AFFINITY_INFO_64
-        )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -308,12 +375,22 @@ pub(crate) enum PsciCoordinatedDispatch {
 
 pub(crate) const fn handle_coordinated_call(call: PsciCall) -> PsciCoordinatedDispatch {
     if call.function_id == PSCI_FEATURES {
-        let status = if supports_coordinated_function(call.arg0) {
-            PsciStatus::Success
-        } else {
-            PsciStatus::NotSupported
+        let return_value = match advertised_psci_features(narrow_u32(call.arg0), true) {
+            Some(flags) => flags,
+            None => PsciStatus::NotSupported.return_value(),
         };
-        return PsciCoordinatedDispatch::Immediate(PsciCallResult::returned(status.return_value()));
+        return PsciCoordinatedDispatch::Immediate(PsciCallResult::returned(return_value));
+    }
+
+    if call.function_id == ARM_SMCCC_ARCH_FEATURES {
+        return PsciCoordinatedDispatch::Immediate(handle_call(call));
+    }
+
+    let Some(features) = psci_function_features(call.function_id) else {
+        return PsciCoordinatedDispatch::Immediate(not_supported_result());
+    };
+    if !features.requires_coordination() {
+        return PsciCoordinatedDispatch::Immediate(handle_call(call));
     }
 
     if call.function_id == PSCI_CPU_OFF {
@@ -367,7 +444,7 @@ pub(crate) const fn handle_coordinated_call(call: PsciCall) -> PsciCoordinatedDi
                 },
             ))
         }
-        _ => PsciCoordinatedDispatch::Immediate(handle_call(call)),
+        _ => PsciCoordinatedDispatch::Immediate(not_supported_result()),
     }
 }
 
@@ -1052,10 +1129,11 @@ impl PsciCpuPowerCoordinator {
 #[cfg(test)]
 mod tests {
     use super::{
-        PSCI_AFFINITY_INFO_32, PSCI_AFFINITY_INFO_64, PSCI_CPU_OFF, PSCI_CPU_ON_32, PSCI_CPU_ON_64,
-        PSCI_CPU_SUSPEND_32, PSCI_CPU_SUSPEND_64, PSCI_FEATURES, PSCI_MIGRATE_INFO_TYPE,
+        ARM_SMCCC_ARCH_FEATURES, ARM_SMCCC_VERSION, ARM_SMCCC_VERSION_1_1, PSCI_AFFINITY_INFO_32,
+        PSCI_AFFINITY_INFO_64, PSCI_CPU_OFF, PSCI_CPU_ON_32, PSCI_CPU_ON_64, PSCI_CPU_SUSPEND_32,
+        PSCI_CPU_SUSPEND_64, PSCI_FEATURES, PSCI_MIGRATE_INFO_TYPE,
         PSCI_MIGRATE_INFO_TYPE_TRUSTED_OS_NOT_REQUIRED, PSCI_SYSTEM_OFF, PSCI_SYSTEM_RESET,
-        PSCI_VERSION, PSCI_VERSION_0_2, PsciAffinityInfoRequest, PsciAffinityInfoResponse,
+        PSCI_VERSION, PSCI_VERSION_1_0, PsciAffinityInfoRequest, PsciAffinityInfoResponse,
         PsciCall, PsciCallAction, PsciCoordinatedDispatch, PsciCoordinatorRequest, PsciCpuOffBegin,
         PsciCpuOffResponse, PsciCpuOnBegin, PsciCpuOnRequest, PsciCpuOnResponse,
         PsciCpuPowerCoordinator, PsciCpuPowerError, PsciCpuPowerState, PsciCpuSuspendToken,
@@ -1111,10 +1189,14 @@ mod tests {
     }
 
     #[test]
-    fn preserves_legacy_psci_version_migration_and_terminal_actions() {
+    fn reports_psci_1_0_smccc_1_1_and_preserves_existing_immediate_actions() {
         assert_eq!(
             handle_call(PsciCall::new(PSCI_VERSION, 0)).return_value(),
-            PSCI_VERSION_0_2
+            PSCI_VERSION_1_0
+        );
+        assert_eq!(
+            handle_call(PsciCall::new(ARM_SMCCC_VERSION, 0)).return_value(),
+            ARM_SMCCC_VERSION_1_1
         );
         assert_eq!(
             handle_call(PsciCall::new(PSCI_MIGRATE_INFO_TYPE, 0)).return_value(),
@@ -1130,7 +1212,50 @@ mod tests {
     }
 
     #[test]
-    fn legacy_features_and_cpu_power_calls_stay_unsupported() {
+    fn smccc_arch_features_exposes_only_the_mandatory_minimum() {
+        for function_id in [ARM_SMCCC_VERSION, ARM_SMCCC_ARCH_FEATURES] {
+            assert_eq!(
+                handle_call(PsciCall::new(ARM_SMCCC_ARCH_FEATURES, function_id)).return_value(),
+                PsciStatus::Success.return_value()
+            );
+            assert_eq!(
+                handle_call(PsciCall::new(
+                    ARM_SMCCC_ARCH_FEATURES,
+                    0xfeed_face_0000_0000 | function_id,
+                ))
+                .return_value(),
+                PsciStatus::Success.return_value()
+            );
+        }
+
+        for function_id in [0x8000_0002, 0x8000_7fff, 0x8000_8000, 0xc000_0000] {
+            assert_eq!(
+                handle_call(PsciCall::new(ARM_SMCCC_ARCH_FEATURES, function_id)).return_value(),
+                PsciStatus::NotSupported.return_value()
+            );
+            assert_eq!(
+                handle_call(PsciCall::new(function_id, 0)).return_value(),
+                PsciStatus::NotSupported.return_value()
+            );
+        }
+    }
+
+    #[test]
+    fn immediate_features_advertise_only_immediate_calls() {
+        for function_id in [
+            PSCI_VERSION,
+            PSCI_MIGRATE_INFO_TYPE,
+            PSCI_SYSTEM_OFF,
+            PSCI_SYSTEM_RESET,
+            PSCI_FEATURES,
+            ARM_SMCCC_VERSION,
+        ] {
+            assert_eq!(
+                handle_call(PsciCall::new(PSCI_FEATURES, function_id)).return_value(),
+                0
+            );
+        }
+
         for function_id in [
             PSCI_CPU_SUSPEND_32,
             PSCI_CPU_SUSPEND_64,
@@ -1147,11 +1272,25 @@ mod tests {
                 PsciStatus::NotSupported.return_value()
             );
         }
+
+        assert_eq!(
+            handle_call(PsciCall::new(PSCI_FEATURES, ARM_SMCCC_ARCH_FEATURES)).return_value(),
+            PsciStatus::NotSupported.return_value()
+        );
+        assert_eq!(
+            handle_call(PsciCall::new(
+                PSCI_FEATURES,
+                0xfeed_face_0000_0000 | ARM_SMCCC_VERSION,
+            ))
+            .return_value(),
+            0
+        );
     }
 
     #[test]
-    fn coordinated_features_advertise_cpu_off_cpu_on_and_affinity_info() {
+    fn coordinated_features_match_the_complete_delivered_psci_1_0_matrix() {
         for function_id in [
+            PSCI_VERSION,
             PSCI_CPU_SUSPEND_32,
             PSCI_CPU_SUSPEND_64,
             PSCI_CPU_OFF,
@@ -1159,21 +1298,65 @@ mod tests {
             PSCI_CPU_ON_64,
             PSCI_AFFINITY_INFO_32,
             PSCI_AFFINITY_INFO_64,
+            PSCI_MIGRATE_INFO_TYPE,
+            PSCI_SYSTEM_OFF,
+            PSCI_SYSTEM_RESET,
+            PSCI_FEATURES,
+            ARM_SMCCC_VERSION,
         ] {
             let PsciCoordinatedDispatch::Immediate(result) =
                 handle_coordinated_call(PsciCall::new(PSCI_FEATURES, function_id))
             else {
                 panic!("PSCI_FEATURES should complete immediately");
             };
-            assert_eq!(result.return_value(), PsciStatus::Success.return_value());
+            assert_eq!(result.return_value(), 0);
+        }
+
+        for function_id in [
+            ARM_SMCCC_ARCH_FEATURES,
+            0x8400_0005, // MIGRATE32
+            0xc400_0005, // MIGRATE64
+            0x8400_0007, // MIGRATE_INFO_UP_CPU32
+            0xc400_0007, // MIGRATE_INFO_UP_CPU64
+            0x8400_000b, // CPU_FREEZE
+            0x8400_000c, // CPU_DEFAULT_SUSPEND32
+            0xc400_000c, // CPU_DEFAULT_SUSPEND64
+            0x8400_000d, // NODE_HW_STATE32
+            0xc400_000d, // NODE_HW_STATE64
+            0x8400_000e, // SYSTEM_SUSPEND32
+            0xc400_000e, // SYSTEM_SUSPEND64
+            0x8400_000f, // PSCI_SET_SUSPEND_MODE
+            0x8400_0010, // PSCI_STAT_RESIDENCY32
+            0xc400_0010, // PSCI_STAT_RESIDENCY64
+            0x8400_0011, // PSCI_STAT_COUNT32
+            0xc400_0011, // PSCI_STAT_COUNT64
+            0x8400_0012, // SYSTEM_RESET2_32
+            0xc400_0012, // SYSTEM_RESET2_64
+            0x8400_0013, // MEM_PROTECT
+            0x8400_0014, // MEM_PROTECT_CHECK_RANGE32
+            0xc400_0014, // MEM_PROTECT_CHECK_RANGE64
+            0xdead_beef,
+        ] {
+            let PsciCoordinatedDispatch::Immediate(result) =
+                handle_coordinated_call(PsciCall::new(PSCI_FEATURES, function_id))
+            else {
+                panic!("PSCI_FEATURES should complete immediately");
+            };
+            assert_eq!(
+                result.return_value(),
+                PsciStatus::NotSupported.return_value()
+            );
         }
     }
 
     #[test]
-    fn identifies_legacy_and_coordinated_argument_counts() {
+    fn identifies_immediate_and_coordinated_argument_counts() {
         assert!(call_uses_arg0(PSCI_FEATURES));
+        assert!(call_uses_arg0(ARM_SMCCC_ARCH_FEATURES));
         assert!(!call_uses_arg0(PSCI_CPU_ON_32));
         assert_eq!(coordinated_call_argument_count(PSCI_VERSION), 0);
+        assert_eq!(coordinated_call_argument_count(ARM_SMCCC_VERSION), 0);
+        assert_eq!(coordinated_call_argument_count(ARM_SMCCC_ARCH_FEATURES), 1);
         assert_eq!(coordinated_call_argument_count(PSCI_CPU_OFF), 0);
         assert_eq!(coordinated_call_argument_count(PSCI_CPU_SUSPEND_32), 3);
         assert_eq!(coordinated_call_argument_count(PSCI_CPU_SUSPEND_64), 3);

--- a/crates/hvf/src/runner.rs
+++ b/crates/hvf/src/runner.rs
@@ -8188,7 +8188,10 @@ pub(crate) mod tests {
     const PSCI_SYSTEM_OFF: u64 = 0x8400_0008;
     const PSCI_SYSTEM_RESET: u64 = 0x8400_0009;
     const PSCI_FEATURES: u64 = 0x8400_000a;
-    const PSCI_VERSION_0_2: u64 = 0x0000_0002;
+    const ARM_SMCCC_VERSION: u64 = 0x8000_0000;
+    const ARM_SMCCC_ARCH_FEATURES: u64 = 0x8000_0001;
+    const PSCI_VERSION_1_0: u64 = 0x0001_0000;
+    const ARM_SMCCC_VERSION_1_1: u64 = 0x0001_0001;
     const PSCI_RET_SUCCESS: u64 = 0;
     const PSCI_RET_NOT_SUPPORTED: u64 = 0xffff_ffff;
     const GIC_DEVICE_STATE_TEST_BYTES: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
@@ -33699,6 +33702,49 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn coordinated_smccc_arch_features_reads_one_argument_without_deferred_work() {
+        for queried_function in [ARM_SMCCC_VERSION, ARM_SMCCC_ARCH_FEATURES, 0x8000_8000] {
+            let expected = if matches!(
+                queried_function,
+                ARM_SMCCC_VERSION | ARM_SMCCC_ARCH_FEATURES
+            ) {
+                PSCI_RET_SUCCESS
+            } else {
+                PSCI_RET_NOT_SUPPORTED
+            };
+            let (runner, register_read_receiver, register_write_receiver) =
+                start_coordinated_psci_run_step_recording_runner(
+                    ARM_SMCCC_ARCH_FEATURES,
+                    [queried_function, 0xfeed_face, 0xcafe_beef],
+                    0,
+                    false,
+                );
+
+            assert_eq!(
+                runner.run_once_and_handle_mmio_coordinated(shared_dispatcher()),
+                Ok(HvfVcpuCoordinatedRunStepOutcome::Handled(
+                    HvfVcpuRunStepOutcome::Hvc {
+                        exit: hvc_exit(0),
+                        function_id: ARM_SMCCC_ARCH_FEATURES,
+                        return_value: expected,
+                    }
+                ))
+            );
+            assert_eq!(
+                register_read_receiver.try_iter().collect::<Vec<_>>(),
+                vec![HvfRegister::X0, HvfRegister::X1]
+            );
+            assert_eq!(
+                register_write_receiver
+                    .recv()
+                    .expect("SMCCC_ARCH_FEATURES should write X0"),
+                (HvfRegister::X0, expected)
+            );
+            runner.shutdown().expect("runner should shut down");
+        }
+    }
+
+    #[test]
     fn deferred_psci_completion_retries_x0_write_without_repeating_run() {
         let (runner, _, register_write_receiver) = start_coordinated_psci_run_step_recording_runner(
             PSCI_CPU_ON,
@@ -33817,7 +33863,8 @@ pub(crate) mod tests {
     #[test]
     fn coordinated_immediate_and_nonzero_hvc_calls_do_not_read_extra_arguments() {
         for (function_id, immediate, return_value) in [
-            (PSCI_VERSION, 0, PSCI_VERSION_0_2),
+            (PSCI_VERSION, 0, PSCI_VERSION_1_0),
+            (ARM_SMCCC_VERSION, 0, ARM_SMCCC_VERSION_1_1),
             (PSCI_CPU_ON, 1, PSCI_RET_NOT_SUPPORTED),
         ] {
             let (runner, register_read_receiver, register_write_receiver) =
@@ -33999,7 +34046,7 @@ pub(crate) mod tests {
             Ok(HvfVcpuRunStepOutcome::Hvc {
                 exit: hvc_exit(0),
                 function_id: PSCI_VERSION,
-                return_value: PSCI_VERSION_0_2,
+                return_value: PSCI_VERSION_1_0,
             })
         );
         drop(dispatcher_guard);
@@ -34007,7 +34054,7 @@ pub(crate) mod tests {
             register_write_receiver
                 .recv()
                 .expect("PSCI HVC should write X0"),
-            (HvfRegister::X0, PSCI_VERSION_0_2)
+            (HvfRegister::X0, PSCI_VERSION_1_0)
         );
         assert_eq!(
             register_write_receiver.try_recv(),
@@ -34020,7 +34067,7 @@ pub(crate) mod tests {
     #[test]
     fn run_once_and_handle_mmio_reads_psci_features_argument() {
         let (runner, register_write_receiver) =
-            start_psci_run_step_recording_runner(PSCI_FEATURES, PSCI_VERSION);
+            start_psci_run_step_recording_runner(PSCI_FEATURES, ARM_SMCCC_VERSION);
 
         assert_eq!(
             runner.run_once_and_handle_mmio(shared_dispatcher()),
@@ -34035,6 +34082,75 @@ pub(crate) mod tests {
                 .recv()
                 .expect("PSCI_FEATURES should write X0"),
             (HvfRegister::X0, PSCI_RET_SUCCESS)
+        );
+
+        runner.shutdown().expect("runner should shut down");
+    }
+
+    #[test]
+    fn run_once_and_handle_mmio_reports_smccc_1_1_without_reading_x1() {
+        let (runner, register_write_receiver) = start_psci_run_step_recording_runner_with_x1(
+            ARM_SMCCC_VERSION,
+            Err(BackendError::InvalidState("X1 should not be read")),
+        );
+
+        assert_eq!(
+            runner.run_once_and_handle_mmio(shared_dispatcher()),
+            Ok(HvfVcpuRunStepOutcome::Hvc {
+                exit: hvc_exit(0),
+                function_id: ARM_SMCCC_VERSION,
+                return_value: ARM_SMCCC_VERSION_1_1,
+            })
+        );
+        assert_eq!(
+            register_write_receiver
+                .recv()
+                .expect("SMCCC_VERSION should write X0"),
+            (HvfRegister::X0, ARM_SMCCC_VERSION_1_1)
+        );
+
+        runner.shutdown().expect("runner should shut down");
+    }
+
+    #[test]
+    fn run_once_and_handle_mmio_reads_smccc_arch_features_argument() {
+        let (runner, register_write_receiver) =
+            start_psci_run_step_recording_runner(ARM_SMCCC_ARCH_FEATURES, ARM_SMCCC_VERSION);
+
+        assert_eq!(
+            runner.run_once_and_handle_mmio(shared_dispatcher()),
+            Ok(HvfVcpuRunStepOutcome::Hvc {
+                exit: hvc_exit(0),
+                function_id: ARM_SMCCC_ARCH_FEATURES,
+                return_value: PSCI_RET_SUCCESS,
+            })
+        );
+        assert_eq!(
+            register_write_receiver
+                .recv()
+                .expect("SMCCC_ARCH_FEATURES should write X0"),
+            (HvfRegister::X0, PSCI_RET_SUCCESS)
+        );
+
+        runner.shutdown().expect("runner should shut down");
+    }
+
+    #[test]
+    fn run_once_and_handle_mmio_propagates_smccc_arch_features_x1_read_failure() {
+        let (runner, register_write_receiver) = start_psci_run_step_recording_runner_with_x1(
+            ARM_SMCCC_ARCH_FEATURES,
+            Err(BackendError::InvalidState("fake SMCCC X1 read failed")),
+        );
+
+        assert_eq!(
+            runner.run_once_and_handle_mmio(shared_dispatcher()),
+            Err(HvfVcpuRunnerError::Backend(BackendError::InvalidState(
+                "fake SMCCC X1 read failed"
+            )))
+        );
+        assert_eq!(
+            register_write_receiver.try_recv(),
+            Err(mpsc::TryRecvError::Empty)
         );
 
         runner.shutdown().expect("runner should shut down");

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -8462,7 +8462,7 @@ mod tests {
     const PSCI_VERSION: u64 = 0x8400_0000;
     const PSCI_SYSTEM_OFF: u64 = 0x8400_0008;
     const PSCI_SYSTEM_RESET: u64 = 0x8400_0009;
-    const PSCI_VERSION_0_2: u64 = 0x0000_0002;
+    const PSCI_VERSION_1_0: u64 = 0x0001_0000;
     const PSCI_RET_SUCCESS: u64 = 0;
     const TEST_NETWORK_MMIO_BASE: GuestAddress = GuestAddress::new(0x4000_4000);
     const TEST_RTC_MMIO_BASE: GuestAddress = GuestAddress::new(0x4000_1000);
@@ -9283,7 +9283,7 @@ mod tests {
         HvfVcpuRunStepOutcome::Hvc {
             exit: hvc_exit(0),
             function_id: PSCI_VERSION,
-            return_value: PSCI_VERSION_0_2,
+            return_value: PSCI_VERSION_1_0,
         }
     }
 

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -4073,7 +4073,7 @@ fn psci_cpu_suspend_retains_context_until_two_virtual_timer_wakeups() {
             } => suspend_completions += 1,
             HvfVcpuRunStepOutcome::Hvc {
                 function_id: PSCI_VERSION,
-                return_value: 2,
+                return_value: 0x0001_0000,
                 ..
             } => {
                 peer_checkpoint_seen = true;
@@ -4112,6 +4112,283 @@ fn psci_cpu_suspend_retains_context_until_two_virtual_timer_wakeups() {
     session
         .shutdown()
         .expect("CPU_SUSPEND session should shut down");
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn psci_1_0_and_smccc_1_1_discovery_match_the_advertised_guest_contract() {
+    use std::num::NonZeroUsize;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::{Duration, Instant};
+
+    use bangbang_hvf::{
+        HvfArm64BootRunLoopOutcome, HvfArm64BootSessionConfig, HvfVcpuRunStepOutcome,
+        OwnedHvfArm64BootSession,
+    };
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::block::BlockMmioLayout;
+    use bangbang_runtime::boot::BootSourceConfigInput;
+    use bangbang_runtime::machine::MachineConfigInput;
+    use bangbang_runtime::memory::GuestAddress;
+    use bangbang_runtime::mmio::MmioRegionId;
+    use bangbang_runtime::network::NetworkMmioLayout;
+    use bangbang_runtime::pmem::PmemMmioLayout;
+    use bangbang_runtime::vsock::VsockMmioLayout;
+
+    const RESULTS_OFFSET: u64 = 0x1000;
+    const QUERIES_OFFSET: u64 = 0x2000;
+    const NOT_SUPPORTED: u64 = 0x0000_0000_ffff_ffff;
+    const FEATURE_QUERIES: [(u32, u64); 36] = [
+        (0x8400_0000, 0),             // PSCI_VERSION
+        (0x8400_0001, 0),             // CPU_SUSPEND32
+        (0xc400_0001, 0),             // CPU_SUSPEND64
+        (0x8400_0002, 0),             // CPU_OFF
+        (0x8400_0003, 0),             // CPU_ON32
+        (0xc400_0003, 0),             // CPU_ON64
+        (0x8400_0004, 0),             // AFFINITY_INFO32
+        (0xc400_0004, 0),             // AFFINITY_INFO64
+        (0x8400_0006, 0),             // MIGRATE_INFO_TYPE
+        (0x8400_0008, 0),             // SYSTEM_OFF
+        (0x8400_0009, 0),             // SYSTEM_RESET
+        (0x8400_000a, 0),             // PSCI_FEATURES
+        (0x8000_0000, 0),             // SMCCC_VERSION
+        (0x8000_0001, NOT_SUPPORTED), // SMCCC_ARCH_FEATURES is not a PSCI query
+        (0x8400_0005, NOT_SUPPORTED), // MIGRATE32
+        (0xc400_0005, NOT_SUPPORTED), // MIGRATE64
+        (0x8400_0007, NOT_SUPPORTED), // MIGRATE_INFO_UP_CPU32
+        (0xc400_0007, NOT_SUPPORTED), // MIGRATE_INFO_UP_CPU64
+        (0x8400_000b, NOT_SUPPORTED), // CPU_FREEZE
+        (0x8400_000c, NOT_SUPPORTED), // CPU_DEFAULT_SUSPEND32
+        (0xc400_000c, NOT_SUPPORTED), // CPU_DEFAULT_SUSPEND64
+        (0x8400_000d, NOT_SUPPORTED), // NODE_HW_STATE32
+        (0xc400_000d, NOT_SUPPORTED), // NODE_HW_STATE64
+        (0x8400_000e, NOT_SUPPORTED), // SYSTEM_SUSPEND32
+        (0xc400_000e, NOT_SUPPORTED), // SYSTEM_SUSPEND64
+        (0x8400_000f, NOT_SUPPORTED), // PSCI_SET_SUSPEND_MODE
+        (0x8400_0010, NOT_SUPPORTED), // PSCI_STAT_RESIDENCY32
+        (0xc400_0010, NOT_SUPPORTED), // PSCI_STAT_RESIDENCY64
+        (0x8400_0011, NOT_SUPPORTED), // PSCI_STAT_COUNT32
+        (0xc400_0011, NOT_SUPPORTED), // PSCI_STAT_COUNT64
+        (0x8400_0012, NOT_SUPPORTED), // SYSTEM_RESET2_32
+        (0xc400_0012, NOT_SUPPORTED), // SYSTEM_RESET2_64
+        (0x8400_0013, NOT_SUPPORTED), // MEM_PROTECT
+        (0x8400_0014, NOT_SUPPORTED), // MEM_PROTECT_CHECK_RANGE32
+        (0xc400_0014, NOT_SUPPORTED), // MEM_PROTECT_CHECK_RANGE64
+        (0xdead_beef, NOT_SUPPORTED), // unknown
+    ];
+    const EXTRA_RESULT_COUNT: usize = 5;
+    const RESULT_COUNT: usize = FEATURE_QUERIES.len() + EXTRA_RESULT_COUNT;
+    const RESULTS_SIZE: usize = RESULT_COUNT * size_of::<u64>();
+    const PSCI_VERSION: u64 = 0x8400_0000;
+    const PSCI_FEATURES: u64 = 0x8400_000a;
+    const PSCI_SYSTEM_OFF: u64 = 0x8400_0008;
+    const ARM_SMCCC_VERSION: u64 = 0x8000_0000;
+    const ARM_SMCCC_ARCH_FEATURES: u64 = 0x8000_0001;
+
+    // Loop over the host-supplied PSCI_FEATURES table, then query PSCI and
+    // SMCCC versions plus the mandatory minimum SMCCC_ARCH_FEATURES boundary.
+    let guest_code = [
+        0x1000_8013, // adr x19, results (+0x1000)
+        0x1000_fff4, // adr x20, queries (+0x2000)
+        0x5280_0495, // mov w21, #36
+        0xb840_4681, // ldr w1, [x20], #4
+        0xd280_0140, // mov x0, #0xa
+        0xf2b0_8000, // movk x0, #0x8400, lsl #16 (PSCI_FEATURES)
+        0xd400_0002, // hvc #0
+        0xf800_8660, // str x0, [x19], #8
+        0x7100_06b5, // subs w21, w21, #1
+        0x54ff_ff41, // b.ne feature loop
+        0xd280_0000, // mov x0, #0
+        0xf2b0_8000, // movk x0, #0x8400, lsl #16 (PSCI_VERSION)
+        0xd400_0002, // hvc #0
+        0xf800_8660, // str x0, [x19], #8
+        0xd280_0000, // mov x0, #0
+        0xf2b0_0000, // movk x0, #0x8000, lsl #16 (SMCCC_VERSION)
+        0xd400_0002, // hvc #0
+        0xf800_8660, // str x0, [x19], #8
+        0xd280_0001, // mov x1, #0
+        0xf2b0_0001, // movk x1, #0x8000, lsl #16 (SMCCC_VERSION query)
+        0xd280_0020, // mov x0, #1
+        0xf2b0_0000, // movk x0, #0x8000, lsl #16 (SMCCC_ARCH_FEATURES)
+        0xd400_0002, // hvc #0
+        0xf800_8660, // str x0, [x19], #8
+        0xd280_0021, // mov x1, #1
+        0xf2b0_0001, // movk x1, #0x8000, lsl #16 (self query)
+        0xd280_0020, // mov x0, #1
+        0xf2b0_0000, // movk x0, #0x8000, lsl #16 (SMCCC_ARCH_FEATURES)
+        0xd400_0002, // hvc #0
+        0xf800_8660, // str x0, [x19], #8
+        0xd290_0001, // mov x1, #0x8000
+        0xf2b0_0001, // movk x1, #0x8000, lsl #16 (WORKAROUND_1 query)
+        0xd280_0020, // mov x0, #1
+        0xf2b0_0000, // movk x0, #0x8000, lsl #16 (SMCCC_ARCH_FEATURES)
+        0xd400_0002, // hvc #0
+        0xf800_8660, // str x0, [x19], #8
+        0xd280_0100, // mov x0, #8
+        0xf2b0_8000, // movk x0, #0x8400, lsl #16 (SYSTEM_OFF)
+        0xd400_0002, // hvc #0
+        0x1400_0000, // b .
+    ]
+    .into_iter()
+    .flat_map(u32::to_le_bytes)
+    .collect::<Vec<_>>();
+    let query_bytes = FEATURE_QUERIES
+        .into_iter()
+        .flat_map(|(function_id, _)| function_id.to_le_bytes())
+        .collect::<Vec<_>>();
+
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let image = arm64_image().expect("test arm64 image should build");
+    let kernel = TempFile::new("psci-discovery-kernel", &image)
+        .expect("temporary PSCI discovery kernel should be created");
+    let mut controller = bangbang_runtime::VmmController::new("test", "0.1.0", "bangbang");
+    controller
+        .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            kernel.path(),
+        )))
+        .expect("boot source config should be stored");
+    controller
+        .handle_action(VmmAction::PutMachineConfig(MachineConfigInput::new(1, 16)))
+        .expect("one-vCPU discovery machine should configure");
+    let config = HvfArm64BootSessionConfig::new(
+        BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1)),
+        PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500)),
+        NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000)),
+        VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
+        test_rtc_mmio_layout(),
+    );
+    let mut session = OwnedHvfArm64BootSession::new(&controller, config)
+        .expect("PSCI discovery session should prepare");
+    let entry = GuestAddress::new(
+        session
+            .capture_arm64_general_register_state()
+            .expect("discovery entry registers should capture")
+            .pc(),
+    );
+    let results = entry
+        .checked_add(RESULTS_OFFSET)
+        .expect("discovery results should fit");
+    let queries = entry
+        .checked_add(QUERIES_OFFSET)
+        .expect("discovery queries should fit");
+    {
+        let memory = session
+            .guest_memory_mut()
+            .expect("discovery guest memory should be mutable before execution");
+        memory
+            .write_slice(&guest_code, entry)
+            .expect("discovery guest code should fit");
+        memory
+            .write_slice(&query_bytes, queries)
+            .expect("discovery query table should fit");
+        memory
+            .write_slice(&[0; RESULTS_SIZE], results)
+            .expect("discovery result table should fit");
+    }
+
+    let control = session.run_loop_control();
+    let stop_token = control.stop_token();
+    let watchdog_done = Arc::new(AtomicBool::new(false));
+    let watchdog_done_for_thread = Arc::clone(&watchdog_done);
+    let watchdog = std::thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !watchdog_done_for_thread.load(Ordering::Acquire) && Instant::now() < deadline {
+            std::thread::yield_now();
+        }
+        if !watchdog_done_for_thread.load(Ordering::Acquire) {
+            let _ = control.request_stop();
+        }
+    });
+
+    let mut observed = Vec::new();
+    let outcome = session
+        .run_loop_with_observer(
+            &stop_token,
+            NonZeroUsize::new(64).expect("step limit should be nonzero"),
+            |step| observed.push(*step),
+        )
+        .expect("bounded PSCI discovery guest should run");
+    watchdog_done.store(true, Ordering::Release);
+    watchdog
+        .join()
+        .expect("PSCI discovery watchdog should join");
+    assert!(matches!(
+        outcome,
+        HvfArm64BootRunLoopOutcome::GuestShutdown { .. }
+    ));
+    assert_eq!(
+        observed
+            .iter()
+            .filter(|step| matches!(
+                step,
+                HvfVcpuRunStepOutcome::Hvc {
+                    function_id: PSCI_FEATURES,
+                    ..
+                }
+            ))
+            .count(),
+        FEATURE_QUERIES.len()
+    );
+    assert!(observed.iter().any(|step| matches!(
+        step,
+        HvfVcpuRunStepOutcome::Hvc {
+            function_id: PSCI_VERSION,
+            return_value: 0x0001_0000,
+            ..
+        }
+    )));
+    assert!(observed.iter().any(|step| matches!(
+        step,
+        HvfVcpuRunStepOutcome::Hvc {
+            function_id: ARM_SMCCC_VERSION,
+            return_value: 0x0001_0001,
+            ..
+        }
+    )));
+    assert_eq!(
+        observed
+            .iter()
+            .filter(|step| matches!(
+                step,
+                HvfVcpuRunStepOutcome::Hvc {
+                    function_id: ARM_SMCCC_ARCH_FEATURES,
+                    ..
+                }
+            ))
+            .count(),
+        3
+    );
+    assert!(matches!(
+        observed.last(),
+        Some(HvfVcpuRunStepOutcome::GuestShutdown {
+            function_id: PSCI_SYSTEM_OFF,
+            ..
+        })
+    ));
+
+    let mut result_bytes = [0; RESULTS_SIZE];
+    session
+        .guest_memory()
+        .expect("discovery guest memory should remain mapped")
+        .read_slice(&mut result_bytes, results)
+        .expect("discovery results should read after terminal exit");
+    let actual = result_bytes
+        .chunks_exact(size_of::<u64>())
+        .map(|bytes| u64::from_le_bytes(bytes.try_into().expect("result chunk should be u64")))
+        .collect::<Vec<_>>();
+    let mut expected = FEATURE_QUERIES
+        .iter()
+        .map(|(_, result)| *result)
+        .collect::<Vec<_>>();
+    expected.extend([0x0001_0000, 0x0001_0001, 0, 0, NOT_SUPPORTED]);
+    assert_eq!(actual, expected);
+
+    session
+        .shutdown()
+        .expect("PSCI discovery session should shut down");
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -4223,7 +4500,7 @@ fn captures_native_v1_composite_and_keeps_source_session_usable() {
         session.run_once_and_handle_mmio(),
         Ok(HvfVcpuRunStepOutcome::Hvc {
             function_id: 0x8400_0000,
-            return_value: 2,
+            return_value: 0x0001_0000,
             ..
         })
     ));
@@ -4334,7 +4611,7 @@ fn captures_native_v1_composite_and_keeps_source_session_usable() {
         session.run_once_and_handle_mmio(),
         Ok(HvfVcpuRunStepOutcome::Hvc {
             function_id: 0x8400_0000,
-            return_value: 2,
+            return_value: 0x0001_0000,
             ..
         })
     ));
@@ -4416,7 +4693,7 @@ fn captures_native_v1_composite_and_keeps_source_session_usable() {
         restored_session.run_once_and_handle_mmio(),
         Ok(HvfVcpuRunStepOutcome::Hvc {
             function_id: 0x8400_0000,
-            return_value: 2,
+            return_value: 0x0001_0000,
             ..
         })
     ));

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -131,8 +131,10 @@ Public process startup now uses this capability for the host-limited range
 profile. Guest CPU off/re-entry does not change public topology; `CPU_SUSPEND`
 is limited to retained EL1 virtual-timer wake without FDT idle-state discovery;
 dynamic CPU add/remove and writable CPU-template feature configuration remain
-deferred. Firecracker delegates equivalent PSCI 0.2 behavior to KVM; bangbang
-coordinates it explicitly above Hypervisor.framework's per-vCPU owner threads.
+deferred. Firecracker v1.15.1 enables KVM's PSCI 0.2 vCPU feature while KVM
+exposes its latest compatible PSCI 1.0 revision; bangbang matches that runtime
+contract and coordinates it explicitly above Hypervisor.framework's per-vCPU
+owner threads.
 
 ## Internal Concurrent vCPU Run Coordination
 
@@ -1410,27 +1412,34 @@ descriptors. The optional RTC node uses Firecracker's aarch64 PL031 shape with
 `clock-names = "apb_pclk"`, and intentionally omits `interrupts` because the
 minimal RTC device does not implement alarm interrupts. PCI and other device
 nodes remain deferred until the corresponding emulation paths exist.
-Because the FDT advertises PSCI with `method = "hvc"`, the HVF backend decodes
-arm64 HVC exception exits and handles `HVC #0` through its PSCI 0.2 responder.
-The aggregate boot-session path coordinates `CPU_SUSPEND32/64`, `CPU_ON32/64`,
-`CPU_OFF`, and `AFFINITY_INFO32/64` against the ordered topology; the immediate responder
-returns `PSCI_VERSION`, reports feature support for implemented calls, returns
-`MIGRATE_INFO_TYPE` as the PSCI value for a trusted OS that is MP-capable or
-not present, where migration is not required, and translates `SYSTEM_OFF` and
-`SYSTEM_RESET` into guest-requested terminal boot run-loop outcomes. Successful
+The FDT deliberately retains Firecracker v1.15.1's `arm,psci-0.2` compatible
+string and `method = "hvc"`. As in that Firecracker/KVM baseline, the runtime
+`PSCI_VERSION` call reports PSCI 1.0. The HVF backend decodes arm64 HVC
+exception exits and handles `HVC #0` through one PSCI/SMCCC responder. The
+aggregate boot-session path coordinates `CPU_SUSPEND32/64`, `CPU_ON32/64`,
+`CPU_OFF`, and `AFFINITY_INFO32/64` against the ordered topology. The immediate
+path returns `MIGRATE_INFO_TYPE` as the PSCI value for a trusted OS that is
+MP-capable or not present, where migration is not required, and translates
+`SYSTEM_OFF` and `SYSTEM_RESET` into guest-requested terminal boot run-loop
+outcomes. `PSCI_FEATURES` returns zero only for the delivered PSCI functions
+and `SMCCC_VERSION`; both CPU_SUSPEND IDs therefore declare original
+power-state format and platform-coordinated mode. `SMCCC_VERSION` reports 1.1,
+and its mandatory `SMCCC_ARCH_FEATURES` query returns success only for VERSION
+and itself. Optional architecture workarounds, SoC ID, KVM paravirtual time,
+vendor calls, and TRNG remain safely unsupported. Successful
 `CPU_OFF` does not return to the caller or write X0; the last committed online
 CPU receives `DENIED`. `CPU_SUSPEND` retains the caller's context and power
 affinity, deliberately ignores all three ABI arguments like KVM's retained
 standby path, and defers X0 `SUCCESS` until the caller's enabled,
 guest-unmasked EL1 virtual timer becomes due and its PPI is pending. Wakeup and
 pause cancellation keep the exact call pending for rearm; stop, shutdown, and
-terminal drains do not synthesize success. PSCI remains version 0.2, the FDT
-does not publish CPU idle states, and SGI/SPI/direct IRQ/FIQ wake is outside
-this timer-only subset. Other unsupported PSCI calls and HVC immediates write
-`NOT_SUPPORTED` to X0.
+terminal drains do not synthesize success. The FDT does not publish CPU idle
+states, and SGI/SPI/direct IRQ/FIQ wake is outside this timer-only subset.
+Optional PSCI 1.0 power/statistics calls, PSCI 1.1+, other unsupported firmware
+calls, and nonzero HVC immediates write `NOT_SUPPORTED` to X0.
 Early boot also traps the guest's `OSDLR_EL1` and `OSLAR_EL1` OS lock
 system-register accesses through the AArch64 SYS64 exception class (`0x18`),
-not through SMC/SMCCC. The HVF runner handles only those observed
+not through SMCCC. The HVF runner handles only those observed
 debug-register accesses with KVM-like RAZ/WI semantics: reads return zero,
 writes are ignored, and other trapped system registers still fail closed.
 

--- a/docs/firecracker-validation-matrix.md
+++ b/docs/firecracker-validation-matrix.md
@@ -499,7 +499,21 @@ suspended scheduling, cancellation debt, and session teardown. The signed
 two-vCPU bare guest proves CPU0 can observe CPU1 as `ON` while CPU1 makes no
 post-call progress, then proves two real timer wakes preserve non-result
 context and return success without fixed sleeps. FDT idle-state discovery,
-SGI/SPI/direct IRQ/FIQ wake, PSCI 1.0, and powerdown resume remain deferred.
+SGI/SPI/direct IRQ/FIQ wake and powerdown resume remain deferred.
+
+#1300 completes the dependency-ordered PSCI discovery layer after the power
+calls are real. `PSCI_VERSION` reports 1.0, and one metadata table defines the
+exact `PSCI_FEATURES` matrix plus immediate/coordinated availability; both
+CPU_SUSPEND IDs return zero feature bits for original power-state format and
+platform-coordinated mode. The retained
+Firecracker v1.15.1 `arm,psci-0.2`/HVC FDT binding discovers that runtime
+revision just as its KVM baseline does. `SMCCC_VERSION` reports 1.1 with the
+mandatory minimum `SMCCC_ARCH_FEATURES` VERSION/self results; optional
+architecture workarounds, SoC ID, KVM PV/vendor calls, and TRNG remain
+unsupported. Unit coverage exhausts supported and excluded IDs, runner reads
+and writes, unknown calls, and nonzero HVC immediates. A signed one-vCPU bare
+guest stores 36 feature-query results plus both version and architecture
+discovery results before terminating through SYSTEM_OFF without fixed sleeps.
 
 ## Update Rule
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -862,6 +862,16 @@ and any pending raw HVF cancellation is absorbed by a later identified run
 before guest execution resumes. Diagnostics retain only index, MPIDR, and
 transaction stage, not ignored guest arguments or timer values.
 
+PSCI/SMCCC discovery is a fixed guest ABI, not a probe of Apple host firmware
+or vulnerability state. PSCI 1.0 feature results come from one reviewed static
+table and expose only delivered function IDs plus zero CPU_SUSPEND mode/format
+flags. SMCCC 1.1 architecture discovery returns success only for VERSION and
+the discovery function itself; workaround, SoC ID, KVM PV/vendor, and TRNG
+queries return `NOT_SUPPORTED`. No call reads host mitigation policy, logs a
+guest query, mutates vCPU power state, or creates deferred coordinator work.
+Unknown IDs and nonzero HVC immediates retain the same zero-extended,
+fail-closed `NOT_SUPPORTED` result.
+
 Public `InstanceStart` now exposes the same topology for counts through
 `min(32, host_max)`; it does not add another owner or capacity authority. A
 capacity or later construction failure publishes no partial session and cannot

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -99,7 +99,21 @@ AFFINITY_INFO checkpoint while CPU1 has made no post-call progress, then CPU1
 must complete two real virtual-timer suspend cycles with preserved non-result
 register sentinels. Use guest publications, observed run-loop steps, and a
 bounded watchdog rather than fixed sleeps. Do not claim FDT idle discovery,
-SGI/SPI/direct IRQ/FIQ wake, PSCI 1.0, or powerdown resume from this gate.
+SGI/SPI/direct IRQ/FIQ wake, discovery revision changes, or powerdown resume
+from this gate.
+
+PSCI 1.0 discovery validation is a separate gate after CPU_OFF/re-entry and
+CPU_SUSPEND retention pass. Table tests must cover every advertised PSCI ID,
+both CPU_SUSPEND feature values, optional PSCI 1.0 and PSCI 1.1+ exclusions,
+SMCCC_VERSION, mandatory SMCCC_ARCH_FEATURES VERSION/self queries, optional
+architecture IDs, unknown calls, 32-bit zero extension, and direct versus
+coordinated availability. Runner tests must prove exact X1 reads and X0 writes
+without deferred PSCI work while preserving nonzero-HVC rejection. The signed
+one-vCPU guest stores the complete supported/unsupported query table and both
+revision results in guest memory before SYSTEM_OFF; drive it with observed
+steps and a bounded watchdog, never fixed sleeps. Retain the Firecracker
+`arm,psci-0.2` FDT binding and do not infer host mitigation, KVM PV/vendor,
+TRNG, PSCI 1.1+, or optional power-service support from this gate.
 
 Validation for internal PSCI secondary-power changes must cover both CPU_ON calling
 conventions, exact X1-X3 reads and 32-bit truncation, MPIDR reserved-bit


### PR DESCRIPTION
Closes #1300

## Summary

- report PSCI 1.0 from one metadata-gated immediate/coordinated capability matrix while retaining the Firecracker v1.15.1 `arm,psci-0.2` / HVC FDT binding
- expose a minimal coherent SMCCC 1.1 surface: VERSION plus mandatory ARCH_FEATURES VERSION/self discovery, with optional architecture, KVM PV/vendor, and TRNG calls unsupported
- add exhaustive unit/runner matrices, a signed one-vCPU 36-query guest proof, and aligned compatibility, validation, testing, and security documentation

## Scope exclusions

- optional PSCI 1.0 power/statistics functions and PSCI 1.1+
- SMCCC architecture workarounds, SoC ID, KVM paravirtual time/vendor calls, and TRNG
- FDT idle states, general interrupt wake, topology mutation, and broader snapshots

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf` (1998 passed, 1 ignored)
- `cargo test -p bangbang-hvf --lib --all-features --locked` (1045 passed)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh` twice after final behavior review (HVF 50/50, guest boot 17/17, executable e2e 42/42)