### PR TITLE
test: validate guest-visible network MTU

### DIFF
--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -48,6 +48,7 @@ mod macos_arm64 {
     const PMEM_GUEST_FLUSH_MARKER: &[u8] = b"BANGBANG_PMEM_GUEST_FLUSH_OK";
     const PMEM_GUEST_FLUSH_OFFSET: u64 = 4096;
     const DIRECT_ROOTFS_MMDS_MARKER: &[u8] = b"BANGBANG_MMDS_GUEST_FETCH_OK";
+    const DIRECT_ROOTFS_MMDS_MTU_MARKER: &[u8] = b"BANGBANG_MMDS_MTU_GUEST_FETCH_OK";
     const DIRECT_ROOTFS_MMDS_V2_MARKER: &[u8] = b"BANGBANG_MMDS_V2_GUEST_FETCH_OK";
     const DIRECT_ROOTFS_VSOCK_MARKER: &[u8] = b"BANGBANG_VSOCK_GUEST_CONNECT_OK";
     const DIRECT_ROOTFS_VSOCK_EXCHANGES: &[(&[u8], &[u8])] = &[
@@ -2824,7 +2825,7 @@ mod macos_arm64 {
             request_context: "MMDS guest fetch with configured MTU",
             mmds_config_body: r#"{"network_interfaces":["eth0"],"version":"V1","ipv4_address":"169.254.169.254"}"#,
             boot_args: DIRECT_ROOTFS_MMDS_MTU_BOOT_ARGS,
-            success_marker: DIRECT_ROOTFS_MMDS_MARKER,
+            success_marker: DIRECT_ROOTFS_MMDS_MTU_MARKER,
             network_mtu: Some(1280),
             content_source: DirectRootfsMmdsContentSource::ApiRequest,
         });

--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -121,6 +121,7 @@ mod macos_arm64 {
         "console=ttyS0 reboot=k panic=1 nomodule swiotlb=noforce init=/usr/local/bin/init";
     const DIRECT_ROOTFS_ENTROPY_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 quiet loglevel=1 init=/bangbang-direct-rootfs-init bangbang.entropy-read=1";
     const DIRECT_ROOTFS_MMDS_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 quiet loglevel=1 init=/bangbang-direct-rootfs-init bangbang.mmds-fetch=1";
+    const DIRECT_ROOTFS_MMDS_MTU_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 quiet loglevel=1 init=/bangbang-direct-rootfs-init bangbang.mmds-fetch=1 bangbang.mmds-mtu=1280";
     const DIRECT_ROOTFS_MMDS_V2_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 quiet loglevel=1 init=/bangbang-direct-rootfs-init bangbang.mmds-v2-fetch=1";
     const DIRECT_ROOTFS_MMDS_CONTENT: &str =
         r#"{"meta-data":{"bangbang-marker":"BANGBANG_MMDS_GUEST_VALUE"}}"#;
@@ -149,6 +150,7 @@ mod macos_arm64 {
         mmds_config_body: &'a str,
         boot_args: &'a str,
         success_marker: &'a [u8],
+        network_mtu: Option<u16>,
         content_source: DirectRootfsMmdsContentSource,
     }
 
@@ -2817,12 +2819,13 @@ mod macos_arm64 {
     }
 
     #[test]
-    fn signed_executable_serves_mmds_to_direct_rootfs_guest() {
+    fn signed_executable_serves_mmds_with_configured_mtu_to_direct_rootfs_guest() {
         run_direct_rootfs_mmds_guest_fetch_test(DirectRootfsMmdsFetchCase {
-            request_context: "MMDS guest fetch",
+            request_context: "MMDS guest fetch with configured MTU",
             mmds_config_body: r#"{"network_interfaces":["eth0"],"version":"V1","ipv4_address":"169.254.169.254"}"#,
-            boot_args: DIRECT_ROOTFS_MMDS_BOOT_ARGS,
+            boot_args: DIRECT_ROOTFS_MMDS_MTU_BOOT_ARGS,
             success_marker: DIRECT_ROOTFS_MMDS_MARKER,
+            network_mtu: Some(1280),
             content_source: DirectRootfsMmdsContentSource::ApiRequest,
         });
     }
@@ -2834,6 +2837,7 @@ mod macos_arm64 {
             mmds_config_body: r#"{"network_interfaces":["eth0"],"version":"V1","ipv4_address":"169.254.169.254"}"#,
             boot_args: DIRECT_ROOTFS_MMDS_BOOT_ARGS,
             success_marker: DIRECT_ROOTFS_MMDS_MARKER,
+            network_mtu: None,
             content_source: DirectRootfsMmdsContentSource::MetadataFile,
         });
     }
@@ -2845,6 +2849,7 @@ mod macos_arm64 {
             mmds_config_body: r#"{"network_interfaces":["eth0"],"version":"V2","ipv4_address":"169.254.169.254","imds_compat":true}"#,
             boot_args: DIRECT_ROOTFS_MMDS_V2_BOOT_ARGS,
             success_marker: DIRECT_ROOTFS_MMDS_V2_MARKER,
+            network_mtu: None,
             content_source: DirectRootfsMmdsContentSource::MetadataFile,
         });
     }
@@ -2866,6 +2871,7 @@ mod macos_arm64 {
             mmds_config_body: r#"{"network_interfaces":["eth0"],"version":"V2","ipv4_address":"169.254.169.254","imds_compat":true}"#,
             boot_args: DIRECT_ROOTFS_MMDS_V2_BOOT_ARGS,
             success_marker: DIRECT_ROOTFS_MMDS_V2_MARKER,
+            network_mtu: None,
             content_source: DirectRootfsMmdsContentSource::ApiRequest,
         });
     }
@@ -3788,11 +3794,14 @@ mod macos_arm64 {
         let machine_context = format!("PUT /machine-config {}", case.request_context);
         assert_no_content_response(&machine_response, &machine_context);
 
-        let network_response = http_put_json(
-            &socket_path,
-            "/network-interfaces/eth0",
-            r#"{"iface_id":"eth0","host_dev_name":"vmnet:shared","guest_mac":"06:00:00:00:00:01"}"#,
-        );
+        let network_body = match case.network_mtu {
+            Some(mtu) => format!(
+                r#"{{"iface_id":"eth0","host_dev_name":"vmnet:shared","guest_mac":"06:00:00:00:00:01","mtu":{mtu}}}"#
+            ),
+            None => r#"{"iface_id":"eth0","host_dev_name":"vmnet:shared","guest_mac":"06:00:00:00:00:01"}"#.to_string(),
+        };
+        let network_response =
+            http_put_json(&socket_path, "/network-interfaces/eth0", &network_body);
         let network_context = format!("PUT /network-interfaces/eth0 {}", case.request_context);
         assert_no_content_response(&network_response, &network_context);
 
@@ -3930,6 +3939,9 @@ mod macos_arm64 {
             r#""host_dev_name":"vmnet:shared""#,
             &vm_config_context,
         );
+        if let Some(mtu) = case.network_mtu {
+            assert_response_contains(&vm_config, &format!(r#""mtu":{mtu}"#), &vm_config_context);
+        }
         assert!(
             !vm_config.contains(r#""iface_id":"eth9""#),
             "{vm_config_context} must not add the rejected interface; response:\n{vm_config}"

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -1176,9 +1176,12 @@ host device names, and MAC strings.
 
 The internal model accepts configured `mtu` values in the Firecracker-compatible
 `68..=65535` range, preserves them in stored configs and `GET /vm/config`,
-and exposes them to the guest through `VIRTIO_NET_F_MTU`. The internal model
-still rejects configured `rx_rate_limiter` and `tx_rate_limiter` fields as
-unsupported. bangbang currently limits stored network interfaces to 16.
+and exposes them to the guest through `VIRTIO_NET_F_MTU`. A signed executable
+MMDS-only case configures `1280`, requires the Linux interface to report that
+value, and then completes the guest MMDS fetch through the same device. The
+internal model still rejects configured `rx_rate_limiter` and
+`tx_rate_limiter` fields as unsupported. bangbang currently limits stored
+network interfaces to 16.
 Firecracker `v1.16.0` does not publish a separate network-interface count
 limit; this is a macOS/HVF host-resource boundary for the current scaffold.
 Configuration storage does not open host networking resources or change host

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -861,7 +861,7 @@ artifacts and is not a substitute for a production rootfs build process.
 The signed `guest_boot` and executable HVF e2e targets also validate a
 deterministic direct-rootfs boot. For those scenarios,
 `scripts/run-integration-tests.sh` prepares
-`.tmp/guest-artifacts/bangbang/rootfs/ubuntu-24.04-512M-direct-boot-v29.ext4`
+`.tmp/guest-artifacts/bangbang/rootfs/ubuntu-24.04-512M-direct-boot-v30.ext4`
 after confirming the host can execute HVF. The generated image is an ext4 copy
 of the pinned Firecracker rootfs with a test-specific
 `/bangbang-direct-rootfs-init` script added before image creation. The test

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -736,6 +736,9 @@ e2e target also includes direct-rootfs MMDS v1 and v2 token-flow scenarios that
 configure a `vmnet:shared` network interface, configure MMDS for that
 interface, fetch a deterministic MMDS value from the guest through
 `169.254.169.254`, and write host-observable markers to unique scratch drives.
+The API-driven v1 case also configures a nondefault `1280` MTU and requires the
+guest's selected Linux interface to report that value before the MMDS fetch can
+write its success marker.
 It also includes a direct-rootfs entropy scenario that configures `/entropy`,
 checks that the guest selected `virtio_rng` as the current hardware RNG, reads
 from `/dev/hwrng`, and writes a host-observable marker only after a non-empty
@@ -858,7 +861,7 @@ artifacts and is not a substitute for a production rootfs build process.
 The signed `guest_boot` and executable HVF e2e targets also validate a
 deterministic direct-rootfs boot. For those scenarios,
 `scripts/run-integration-tests.sh` prepares
-`.tmp/guest-artifacts/bangbang/rootfs/ubuntu-24.04-512M-direct-boot-v28.ext4`
+`.tmp/guest-artifacts/bangbang/rootfs/ubuntu-24.04-512M-direct-boot-v29.ext4`
 after confirming the host can execute HVF. The generated image is an ext4 copy
 of the pinned Firecracker rootfs with a test-specific
 `/bangbang-direct-rootfs-init` script added before image creation. The test

--- a/scripts/fetch-firecracker-rootfs.sh
+++ b/scripts/fetch-firecracker-rootfs.sh
@@ -114,7 +114,7 @@ rootfs_arch="aarch64"
 rootfs_name="ubuntu-24.04"
 rootfs_sha256="0efb6a3ff2982baa6ca7e3d940966516ba7ddd2df5deb3e6c2161d369a15d608"
 rootfs_url="https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/${firecracker_minor}/${rootfs_arch}/${rootfs_name}.squashfs"
-direct_boot_variant="direct-boot-v29"
+direct_boot_variant="direct-boot-v30"
 
 cache_root="${BANGBANG_GUEST_ARTIFACTS_DIR:-$repo_root/.tmp/guest-artifacts}"
 upstream_dir="${cache_root}/firecracker-ci/${firecracker_minor}/${rootfs_arch}"
@@ -447,7 +447,11 @@ fetch_mmds_marker() {
 
   if [ "$mmds_value" = BANGBANG_MMDS_GUEST_VALUE ]; then
     emit_line BANGBANG_MMDS_FETCH_OK
-    write_vdb_marker BANGBANG_MMDS_GUEST_FETCH_OK
+    if cmdline_has bangbang.mmds-mtu=1280; then
+      write_vdb_marker BANGBANG_MMDS_MTU_GUEST_FETCH_OK
+    else
+      write_vdb_marker BANGBANG_MMDS_GUEST_FETCH_OK
+    fi
   else
     emit_line BANGBANG_MMDS_FETCH_FAIL_RESPONSE
     write_vdb_marker BANGBANG_MMDS_FETCH_FAIL

--- a/scripts/fetch-firecracker-rootfs.sh
+++ b/scripts/fetch-firecracker-rootfs.sh
@@ -114,7 +114,7 @@ rootfs_arch="aarch64"
 rootfs_name="ubuntu-24.04"
 rootfs_sha256="0efb6a3ff2982baa6ca7e3d940966516ba7ddd2df5deb3e6c2161d369a15d608"
 rootfs_url="https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/${firecracker_minor}/${rootfs_arch}/${rootfs_name}.squashfs"
-direct_boot_variant="direct-boot-v28"
+direct_boot_variant="direct-boot-v29"
 
 cache_root="${BANGBANG_GUEST_ARTIFACTS_DIR:-$repo_root/.tmp/guest-artifacts}"
 upstream_dir="${cache_root}/firecracker-ci/${firecracker_minor}/${rootfs_arch}"
@@ -399,6 +399,23 @@ prepare_mmds_network() {
     emit_line "${1}_NO_IFACE"
     write_vdb_marker "$2"
     return 1
+  fi
+
+  if cmdline_has bangbang.mmds-mtu=1280; then
+    mmds_mtu_path="/sys/class/net/$mmds_iface/mtu"
+    if [ ! -r "$mmds_mtu_path" ]; then
+      emit_line "${1}_MTU_UNREADABLE"
+      write_vdb_marker "$2"
+      return 1
+    fi
+
+    mmds_actual_mtu=$(cat "$mmds_mtu_path" 2>/dev/null || true)
+    if [ "$mmds_actual_mtu" != 1280 ]; then
+      emit_line "${1}_MTU_MISMATCH"
+      write_vdb_marker "$2"
+      return 1
+    fi
+    emit_line BANGBANG_MMDS_MTU_OK
   fi
 
   if ! ip link set dev "$mmds_iface" up 2>/dev/null; then


### PR DESCRIPTION
## Summary

- configure a nondefault MTU in the signed API-driven MMDS guest scenario
- require the Linux guest to observe MTU 1280 before completing its MMDS fetch
- advance the direct-rootfs fixture and document the signed compatibility proof

## Scope exclusions

- no runtime network semantics or host vmnet behavior changes
- rate limiting and broader network/MMDS follow-ups remain tracked under #540

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `bash -n scripts/fetch-firecracker-rootfs.sh`
- focused API/runtime/VMM/process network and MMDS tests
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all three documented Apple-target integration-test Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- focused signed executable MTU/MMDS guest test
- `scripts/run-integration-tests.sh`

Closes #1306
Parent: #540