### PR TITLE
fix: preserve virtio-mem block ownership

### DIFF
--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -36,6 +36,7 @@ mod macos_arm64 {
     const DIRECT_ROOTFS_BALLOON_MARKER: &[u8] = b"BANGBANG_BALLOON_GUEST_CHECK_OK";
     const DIRECT_ROOTFS_MEMORY_HOTPLUG_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 quiet loglevel=1 memhp_default_state=online_movable init=/bangbang-direct-rootfs-init bangbang.memory-hotplug-check=1";
     const DIRECT_ROOTFS_MEMORY_HOTPLUG_READY_MARKER: &[u8] = b"BANGBANG_MEMORY_HOTPLUG_GUEST_READY";
+    const DIRECT_ROOTFS_MEMORY_HOTPLUG_GROWN_MARKER: &[u8] = b"BANGBANG_MEMORY_HOTPLUG_GUEST_GROWN";
     const DIRECT_ROOTFS_MEMORY_HOTPLUG_MARKER: &[u8] = b"BANGBANG_MEMORY_HOTPLUG_GUEST_CHECK_OK";
     const DIRECT_ROOTFS_RTC_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 quiet loglevel=1 init=/bangbang-direct-rootfs-init bangbang.rtc-check=1";
     const DIRECT_ROOTFS_RTC_MARKER: &[u8] = b"BANGBANG_RTC_GUEST_CHECK_OK";
@@ -2231,16 +2232,93 @@ mod macos_arm64 {
 
         if let Err(err) = wait_for_file_prefix_marker(
             &data_backing_path,
+            DIRECT_ROOTFS_MEMORY_HOTPLUG_GROWN_MARKER,
+            GUEST_EXECUTION_TIMEOUT,
+        ) {
+            let backing_prefix = file_prefix_lossy(&data_backing_path, 128);
+            let output = bangbang.force_stop_and_collect();
+            panic!(
+                "direct rootfs guest did not observe runtime virtio-mem grow request through signed bangbang executable: {err}; backing prefix: {backing_prefix:?}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                output.status, output.stdout, output.stderr
+            );
+        }
+
+        let plugged_memory_hotplug = match wait_for_http_response_fragment(
+            &socket_path,
+            "/hotplug/memory",
+            r#""plugged_size_mib":128"#,
+            GUEST_EXECUTION_TIMEOUT,
+        ) {
+            Ok(response) => response,
+            Err(err) => {
+                let backing_prefix = file_prefix_lossy(&data_backing_path, 128);
+                let output = bangbang.force_stop_and_collect();
+                panic!(
+                    "public API did not report the guest-completed virtio-mem grow: {err}; backing prefix: {backing_prefix:?}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                    output.status, output.stdout, output.stderr
+                );
+            }
+        };
+        assert_ok_response(
+            &plugged_memory_hotplug,
+            "GET /hotplug/memory after guest-completed grow",
+        );
+        assert_response_contains(
+            &plugged_memory_hotplug,
+            r#""requested_size_mib":128"#,
+            "GET /hotplug/memory after guest-completed grow",
+        );
+
+        let memory_hotplug_shrink = http_json_with_io_timeout(
+            &socket_path,
+            "PATCH",
+            "/hotplug/memory",
+            r#"{"requested_size_mib":0}"#,
+            GUEST_EXECUTION_TIMEOUT,
+        );
+        assert_no_content_response(
+            &memory_hotplug_shrink,
+            "PATCH /hotplug/memory shrink direct rootfs",
+        );
+
+        if let Err(err) = wait_for_file_prefix_marker(
+            &data_backing_path,
             DIRECT_ROOTFS_MEMORY_HOTPLUG_MARKER,
             GUEST_EXECUTION_TIMEOUT,
         ) {
             let backing_prefix = file_prefix_lossy(&data_backing_path, 128);
             let output = bangbang.force_stop_and_collect();
             panic!(
-                "direct rootfs guest did not observe runtime virtio-mem requested-size update through signed bangbang executable: {err}; backing prefix: {backing_prefix:?}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                "direct rootfs guest did not observe runtime virtio-mem shrink request through signed bangbang executable: {err}; backing prefix: {backing_prefix:?}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
                 output.status, output.stdout, output.stderr
             );
         }
+
+        let unplugged_memory_hotplug = match wait_for_http_response_fragment(
+            &socket_path,
+            "/hotplug/memory",
+            r#""plugged_size_mib":0"#,
+            GUEST_EXECUTION_TIMEOUT,
+        ) {
+            Ok(response) => response,
+            Err(err) => {
+                let backing_prefix = file_prefix_lossy(&data_backing_path, 128);
+                let output = bangbang.force_stop_and_collect();
+                panic!(
+                    "public API did not report the guest-completed virtio-mem shrink: {err}; backing prefix: {backing_prefix:?}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                    output.status, output.stdout, output.stderr
+                );
+            }
+        };
+        assert_ok_response(
+            &unplugged_memory_hotplug,
+            "GET /hotplug/memory after guest-completed shrink",
+        );
+        assert_response_contains(
+            &unplugged_memory_hotplug,
+            r#""requested_size_mib":0"#,
+            "GET /hotplug/memory after guest-completed shrink",
+        );
 
         assert_clean_shutdown(
             bangbang.terminate(),
@@ -6350,6 +6428,29 @@ mod macos_arm64 {
             };
 
             kqueue.wait_for_write(remaining)?;
+        }
+    }
+
+    fn wait_for_http_response_fragment(
+        socket_path: &Path,
+        path: &str,
+        expected: &str,
+        timeout: Duration,
+    ) -> Result<String, String> {
+        let started_at = Instant::now();
+
+        loop {
+            let response = http_get(socket_path, path);
+            if response.starts_with("HTTP/1.1 200 OK\r\n") && response.contains(expected) {
+                return Ok(response);
+            }
+            if started_at.elapsed() >= timeout {
+                return Err(format!(
+                    "timed out after {timeout:?} waiting for {path} response to contain {expected:?}; latest response:\n{response}"
+                ));
+            }
+
+            std::thread::sleep(Duration::from_millis(10));
         }
     }
 

--- a/crates/hvf/src/memory.rs
+++ b/crates/hvf/src/memory.rs
@@ -833,34 +833,80 @@ impl<'a> HvfVirtioMemMutationExecutor<'a> {
             .map_err(hvf_mutation_rollback_error)
     }
 
-    fn apply_unplug_all(
+    fn apply_plug(
         &mut self,
         memory: &mut GuestMemory,
         ranges: &[GuestMemoryRange],
     ) -> Result<(), VirtioMemMutationError> {
-        let mut applied = Vec::new();
-        applied
-            .try_reserve_exact(ranges.len())
-            .map_err(|source| VirtioMemMutationError::new(source.to_string()))?;
-
-        for range in ranges {
-            if let Err(source) = self.unmap_dynamic_region(memory, *range) {
-                if let Err(rollback_source) = self.rollback_unplug_all(memory, &applied) {
+        for (index, range) in ranges.iter().copied().enumerate() {
+            if let Err(source) = self.map_dynamic_region(memory, range) {
+                let Some(applied_ranges) = ranges.get(..index) else {
                     return Err(VirtioMemMutationError::new(format!(
-                        "{source}; also failed to roll back partially applied unplug-all: {rollback_source}"
+                        "{source}; completed plug prefix {index} exceeds {} ranges",
+                        ranges.len()
+                    )));
+                };
+                if let Err(rollback_source) = self.rollback_plug(memory, applied_ranges) {
+                    return Err(VirtioMemMutationError::new(format!(
+                        "{source}; also failed to roll back partially applied plug: {rollback_source}"
                     )));
                 }
 
                 return Err(source);
             }
-
-            applied.push(*range);
         }
 
         Ok(())
     }
 
-    fn rollback_unplug_all(
+    fn rollback_plug(
+        &mut self,
+        memory: &mut GuestMemory,
+        ranges: &[GuestMemoryRange],
+    ) -> Result<(), VirtioMemMutationRollbackError> {
+        let mut first_error = None;
+        for range in ranges.iter().rev().copied() {
+            if let Err(source) = self.rollback_mapped_region(memory, range)
+                && first_error.is_none()
+            {
+                first_error = Some(source);
+            }
+        }
+
+        match first_error {
+            Some(source) => Err(source),
+            None => Ok(()),
+        }
+    }
+
+    fn apply_unplug(
+        &mut self,
+        memory: &mut GuestMemory,
+        ranges: &[GuestMemoryRange],
+        operation: &str,
+    ) -> Result<(), VirtioMemMutationError> {
+        for (index, range) in ranges.iter().copied().enumerate() {
+            if let Err(source) = self.unmap_dynamic_region(memory, range) {
+                let Some(applied_ranges) = ranges.get(..index) else {
+                    return Err(VirtioMemMutationError::new(format!(
+                        "{source}; completed {operation} prefix {index} exceeds {} ranges",
+                        ranges.len()
+                    )));
+                };
+                if let Err(rollback_source) = self.rollback_unplug(memory, applied_ranges) {
+                    return Err(VirtioMemMutationError::new(format!(
+                        "{source}; also failed to roll back partially applied {operation}: {rollback_source}"
+                    )));
+                }
+
+                return Err(source);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn rollback_unplug(
         &mut self,
         memory: &mut GuestMemory,
         ranges: &[GuestMemoryRange],
@@ -888,9 +934,11 @@ impl VirtioMemMutationExecutor for HvfVirtioMemMutationExecutor<'_> {
         mutation: VirtioMemMutation,
     ) -> Result<VirtioMemAppliedMutation, VirtioMemMutationError> {
         match mutation.kind() {
-            VirtioMemMutationKind::Plug(range) => self.map_dynamic_region(memory, *range)?,
-            VirtioMemMutationKind::Unplug(range) => self.unmap_dynamic_region(memory, *range)?,
-            VirtioMemMutationKind::UnplugAll(ranges) => self.apply_unplug_all(memory, ranges)?,
+            VirtioMemMutationKind::Plug(ranges) => self.apply_plug(memory, ranges)?,
+            VirtioMemMutationKind::Unplug(ranges) => self.apply_unplug(memory, ranges, "unplug")?,
+            VirtioMemMutationKind::UnplugAll(ranges) => {
+                self.apply_unplug(memory, ranges, "unplug-all")?
+            }
         }
 
         Ok(VirtioMemAppliedMutation::new(mutation))
@@ -902,9 +950,10 @@ impl VirtioMemMutationExecutor for HvfVirtioMemMutationExecutor<'_> {
         applied: VirtioMemAppliedMutation,
     ) -> Result<(), VirtioMemMutationRollbackError> {
         match applied.mutation().kind() {
-            VirtioMemMutationKind::Plug(range) => self.rollback_mapped_region(memory, *range),
-            VirtioMemMutationKind::Unplug(range) => self.rollback_unmapped_region(memory, *range),
-            VirtioMemMutationKind::UnplugAll(ranges) => self.rollback_unplug_all(memory, ranges),
+            VirtioMemMutationKind::Plug(ranges) => self.rollback_plug(memory, ranges),
+            VirtioMemMutationKind::Unplug(ranges) | VirtioMemMutationKind::UnplugAll(ranges) => {
+                self.rollback_unplug(memory, ranges)
+            }
         }
     }
 }
@@ -2284,10 +2333,11 @@ mod tests {
     }
 
     #[test]
-    fn virtio_mem_executor_plug_maps_dynamic_range_and_rollback_unmaps() {
+    fn virtio_mem_executor_plug_maps_block_ranges_and_rollback_unmaps_in_reverse() {
         let page_size = page_size();
         let base_range = range(0, page_size);
-        let dynamic_range = range(page_size, page_size);
+        let first_dynamic = range(page_size, page_size);
+        let second_dynamic = range(page_size * 2, page_size);
         let memory = memory_for_ranges(vec![base_range]);
         let mapper = Arc::new(RecordingMapper::default());
         let mut mapping = HvfGuestMemoryMapping::map_with_mapper(
@@ -2304,16 +2354,23 @@ mod tests {
             executor
                 .apply(
                     memory,
-                    VirtioMemMutation::new(VirtioMemMutationKind::Plug(dynamic_range)),
+                    VirtioMemMutation::new(VirtioMemMutationKind::Plug(vec![
+                        first_dynamic,
+                        second_dynamic,
+                    ])),
                 )
                 .expect("plug mutation should map dynamic memory")
         };
 
         assert_eq!(
             memory_ranges(mapping.memory().expect("guest memory owner should exist")),
-            vec![base_range, dynamic_range]
+            vec![base_range, first_dynamic, second_dynamic]
         );
-        assert_eq!(mapper.map_count(), 2);
+        assert_eq!(
+            mapping.state.dynamic_regions,
+            vec![first_dynamic, second_dynamic]
+        );
+        assert_eq!(mapper.map_count(), 3);
 
         {
             let (memory, mut executor) = mapping
@@ -2329,14 +2386,22 @@ mod tests {
             vec![base_range]
         );
         assert!(!mapping.has_dynamic_regions());
-        assert_eq!(mapper.unmap_count(), 1);
+        assert_eq!(
+            mapper
+                .unmaps()
+                .iter()
+                .map(|mapped| mapped.range)
+                .collect::<Vec<_>>(),
+            vec![second_dynamic, first_dynamic]
+        );
     }
 
     #[test]
-    fn virtio_mem_executor_unplug_removes_dynamic_range_and_rollback_remaps() {
+    fn virtio_mem_executor_partially_unplugs_multi_block_plug_and_rollback_remaps() {
         let page_size = page_size();
         let base_range = range(0, page_size);
-        let dynamic_range = range(page_size, page_size);
+        let first_dynamic = range(page_size, page_size);
+        let second_dynamic = range(page_size * 2, page_size);
         let memory = memory_for_ranges(vec![base_range]);
         let mapper = Arc::new(RecordingMapper::default());
         let mut mapping = HvfGuestMemoryMapping::map_with_mapper(
@@ -2345,9 +2410,20 @@ mod tests {
             mapper.clone(),
         )
         .expect("initial guest memory should map");
-        mapping
-            .map_dynamic_region(dynamic_range, HvfMemoryPermissions::GUEST_RAM)
-            .expect("dynamic range should map");
+        {
+            let (memory, mut executor) = mapping
+                .memory_and_virtio_mem_executor_mut(HvfMemoryPermissions::GUEST_RAM)
+                .expect("virtio-mem executor should borrow mapped memory");
+            executor
+                .apply(
+                    memory,
+                    VirtioMemMutation::new(VirtioMemMutationKind::Plug(vec![
+                        first_dynamic,
+                        second_dynamic,
+                    ])),
+                )
+                .expect("multi-block plug should create exact block owners");
+        }
 
         let applied = {
             let (memory, mut executor) = mapping
@@ -2356,16 +2432,16 @@ mod tests {
             executor
                 .apply(
                     memory,
-                    VirtioMemMutation::new(VirtioMemMutationKind::Unplug(dynamic_range)),
+                    VirtioMemMutation::new(VirtioMemMutationKind::Unplug(vec![second_dynamic])),
                 )
-                .expect("unplug mutation should remove dynamic memory")
+                .expect("partial unplug should remove one block owner")
         };
 
         assert_eq!(
             memory_ranges(mapping.memory().expect("guest memory owner should exist")),
-            vec![base_range]
+            vec![base_range, first_dynamic]
         );
-        assert!(!mapping.has_dynamic_regions());
+        assert_eq!(mapping.state.dynamic_regions, vec![first_dynamic]);
 
         {
             let (memory, mut executor) = mapping
@@ -2378,10 +2454,83 @@ mod tests {
 
         assert_eq!(
             memory_ranges(mapping.memory().expect("guest memory owner should exist")),
-            vec![base_range, dynamic_range]
+            vec![base_range, first_dynamic, second_dynamic]
         );
-        assert_eq!(mapper.map_count(), 3);
+        assert_eq!(
+            mapping.state.dynamic_regions,
+            vec![first_dynamic, second_dynamic]
+        );
+        assert_eq!(mapper.map_count(), 4);
         assert_eq!(mapper.unmap_count(), 1);
+    }
+
+    #[test]
+    fn virtio_mem_executor_combines_adjacent_sequential_plugs_for_unplug() {
+        let page_size = page_size();
+        let base_range = range(0, page_size);
+        let first_dynamic = range(page_size, page_size);
+        let second_dynamic = range(page_size * 2, page_size);
+        let memory = memory_for_ranges(vec![base_range]);
+        let mapper = Arc::new(RecordingMapper::default());
+        let mut mapping = HvfGuestMemoryMapping::map_with_mapper(
+            memory,
+            HvfMemoryPermissions::GUEST_RAM,
+            mapper.clone(),
+        )
+        .expect("initial guest memory should map");
+
+        for dynamic_range in [first_dynamic, second_dynamic] {
+            let (memory, mut executor) = mapping
+                .memory_and_virtio_mem_executor_mut(HvfMemoryPermissions::GUEST_RAM)
+                .expect("virtio-mem executor should borrow mapped memory");
+            executor
+                .apply(
+                    memory,
+                    VirtioMemMutation::new(VirtioMemMutationKind::Plug(vec![dynamic_range])),
+                )
+                .expect("sequential block plug should map");
+        }
+
+        let applied = {
+            let (memory, mut executor) = mapping
+                .memory_and_virtio_mem_executor_mut(HvfMemoryPermissions::GUEST_RAM)
+                .expect("virtio-mem executor should borrow mapped memory");
+            executor
+                .apply(
+                    memory,
+                    VirtioMemMutation::new(VirtioMemMutationKind::Unplug(vec![
+                        first_dynamic,
+                        second_dynamic,
+                    ])),
+                )
+                .expect("combined unplug should remove adjacent exact owners")
+        };
+
+        assert_eq!(
+            memory_ranges(mapping.memory().expect("guest memory owner should exist")),
+            vec![base_range]
+        );
+        assert!(!mapping.has_dynamic_regions());
+        assert_eq!(mapper.unmap_count(), 2);
+
+        {
+            let (memory, mut executor) = mapping
+                .memory_and_virtio_mem_executor_mut(HvfMemoryPermissions::GUEST_RAM)
+                .expect("virtio-mem executor should borrow mapped memory");
+            executor
+                .rollback(memory, applied)
+                .expect("combined unplug rollback should restore both owners");
+        }
+
+        assert_eq!(
+            memory_ranges(mapping.memory().expect("guest memory owner should exist")),
+            vec![base_range, first_dynamic, second_dynamic]
+        );
+        assert_eq!(
+            mapping.state.dynamic_regions,
+            vec![second_dynamic, first_dynamic]
+        );
+        assert_eq!(mapper.map_count(), 5);
     }
 
     #[test]
@@ -2490,10 +2639,111 @@ mod tests {
     }
 
     #[test]
-    fn virtio_mem_executor_reports_rollback_failure() {
+    fn virtio_mem_executor_plug_rolls_back_partial_apply_failure() {
         let page_size = page_size();
         let base_range = range(0, page_size);
-        let dynamic_range = range(page_size, page_size);
+        let first_dynamic = range(page_size, page_size);
+        let second_dynamic = range(page_size * 2, page_size);
+        let memory = memory_for_ranges(vec![base_range]);
+        let mapper = Arc::new(RecordingMapper::new(Some(3), false));
+        let mut mapping = HvfGuestMemoryMapping::map_with_mapper(
+            memory,
+            HvfMemoryPermissions::GUEST_RAM,
+            mapper.clone(),
+        )
+        .expect("initial guest memory should map");
+
+        {
+            let (memory, mut executor) = mapping
+                .memory_and_virtio_mem_executor_mut(HvfMemoryPermissions::GUEST_RAM)
+                .expect("virtio-mem executor should borrow mapped memory");
+            let error = executor
+                .apply(
+                    memory,
+                    VirtioMemMutation::new(VirtioMemMutationKind::Plug(vec![
+                        first_dynamic,
+                        second_dynamic,
+                    ])),
+                )
+                .expect_err("second block map failure should roll back the first block");
+            assert!(
+                error.to_string().contains("injected map failure"),
+                "unexpected error: {error}"
+            );
+        }
+
+        assert_eq!(
+            memory_ranges(mapping.memory().expect("guest memory owner should exist")),
+            vec![base_range]
+        );
+        assert!(!mapping.has_dynamic_regions());
+        assert_eq!(mapper.map_count(), 3);
+        assert_eq!(mapper.unmap_count(), 1);
+    }
+
+    #[test]
+    fn virtio_mem_executor_plug_surfaces_partial_apply_rollback_failure() {
+        let page_size = page_size();
+        let base_range = range(0, page_size);
+        let first_dynamic = range(page_size, page_size);
+        let second_dynamic = range(page_size * 2, page_size);
+        let memory = memory_for_ranges(vec![base_range]);
+        let mapper = Arc::new(RecordingMapper::new(Some(3), true));
+        let mut mapping = HvfGuestMemoryMapping::map_with_mapper(
+            memory,
+            HvfMemoryPermissions::GUEST_RAM,
+            mapper.clone(),
+        )
+        .expect("initial guest memory should map");
+
+        {
+            let (memory, mut executor) = mapping
+                .memory_and_virtio_mem_executor_mut(HvfMemoryPermissions::GUEST_RAM)
+                .expect("virtio-mem executor should borrow mapped memory");
+            let error = executor
+                .apply(
+                    memory,
+                    VirtioMemMutation::new(VirtioMemMutationKind::Plug(vec![
+                        first_dynamic,
+                        second_dynamic,
+                    ])),
+                )
+                .expect_err("partial plug rollback failure should surface");
+            let message = error.to_string();
+            assert!(
+                message.contains("injected map failure"),
+                "unexpected error: {error}"
+            );
+            assert!(
+                message.contains("also failed to roll back partially applied plug"),
+                "unexpected error: {error}"
+            );
+            assert!(
+                message.contains("failed to unmap 1 guest memory region(s)"),
+                "unexpected error: {error}"
+            );
+        }
+
+        assert_eq!(
+            memory_ranges(mapping.memory().expect("guest memory owner should exist")),
+            vec![base_range, first_dynamic]
+        );
+        assert_eq!(mapping.state.dynamic_regions, vec![first_dynamic]);
+        assert_eq!(mapper.map_count(), 3);
+        assert_eq!(mapper.unmap_count(), 1);
+
+        mapper.set_fail_unmap(false);
+        mapping
+            .unmap_dynamic_region(first_dynamic)
+            .expect("retained block should remain cleanly removable");
+    }
+
+    #[test]
+    fn virtio_mem_executor_reports_vector_rollback_failure_and_attempts_every_block() {
+        let page_size = page_size();
+        let base_range = range(0, page_size);
+        let first_dynamic = range(page_size, page_size);
+        let second_dynamic = range(page_size * 2, page_size);
         let memory = memory_for_ranges(vec![base_range]);
         let mapper = Arc::new(RecordingMapper::default());
         let mut mapping = HvfGuestMemoryMapping::map_with_mapper(
@@ -2509,7 +2759,10 @@ mod tests {
             executor
                 .apply(
                     memory,
-                    VirtioMemMutation::new(VirtioMemMutationKind::Plug(dynamic_range)),
+                    VirtioMemMutation::new(VirtioMemMutationKind::Plug(vec![
+                        first_dynamic,
+                        second_dynamic,
+                    ])),
                 )
                 .expect("plug mutation should map dynamic memory")
         };
@@ -2530,9 +2783,21 @@ mod tests {
 
         assert_eq!(
             memory_ranges(mapping.memory().expect("guest memory owner should exist")),
-            vec![base_range, dynamic_range]
+            vec![base_range, first_dynamic, second_dynamic]
         );
-        assert_eq!(mapping.state.dynamic_regions, vec![dynamic_range]);
+        assert_eq!(
+            mapping.state.dynamic_regions,
+            vec![first_dynamic, second_dynamic]
+        );
+        assert_eq!(mapper.unmap_count(), 2);
+
+        mapper.set_fail_unmap(false);
+        mapping
+            .unmap_dynamic_region(second_dynamic)
+            .expect("second retained block should clean up");
+        mapping
+            .unmap_dynamic_region(first_dynamic)
+            .expect("first retained block should clean up");
     }
 
     #[test]

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -14205,9 +14205,9 @@ mod tests {
                 .expect("expected virtio-mem range should be valid");
         assert_eq!(
             mutation_executor.applied,
-            vec![VirtioMemMutation::new(VirtioMemMutationKind::Plug(
+            vec![VirtioMemMutation::new(VirtioMemMutationKind::Plug(vec![
                 expected_range
-            ))]
+            ]))]
         );
         assert!(mutation_executor.rolled_back.is_empty());
         assert_eq!(result.len(), 1);

--- a/crates/runtime/src/memory_hotplug.rs
+++ b/crates/runtime/src/memory_hotplug.rs
@@ -5,7 +5,7 @@ use std::fmt;
 
 use crate::interrupt::DeviceInterruptKind;
 use crate::memory::{
-    GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryError, GuestMemoryRange,
+    GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryError, GuestMemoryRange, aarch64,
 };
 use crate::mmio::{
     MmioAccessBytes, MmioAccessBytesError, MmioBusError, MmioDispatchError, MmioDispatcher,
@@ -27,8 +27,10 @@ const MIB: u64 = 1024 * 1024;
 
 pub const MEMORY_HOTPLUG_DEFAULT_BLOCK_SIZE_MIB: u64 = 2;
 pub const MEMORY_HOTPLUG_DEFAULT_SLOT_SIZE_MIB: u64 = 128;
-// Current aarch64 DRAM layout tops out immediately below this address.
-pub const VIRTIO_MEM_DEFAULT_REGION_ADDRESS: GuestAddress = GuestAddress::new(0x0140_0000_0000);
+pub const VIRTIO_MEM_DEFAULT_REGION_ADDRESS: GuestAddress =
+    GuestAddress::new(aarch64::FIRST_ADDR_PAST_64BITS_MMIO);
+const VIRTIO_MEM_REGION_ADDRESS_SPACE_END: u64 =
+    aarch64::DRAM_MEM_START + aarch64::DRAM_MEM_MAX_SIZE;
 pub const VIRTIO_MEM_DEVICE_ID: u32 = 24;
 pub const VIRTIO_MEM_QUEUE_COUNT: usize = 1;
 pub const VIRTIO_MEM_QUEUE_SIZE: u16 = 256;
@@ -457,15 +459,27 @@ pub struct PreparedVirtioMemDevice {
 
 impl PreparedVirtioMemDevice {
     pub fn from_config(config: MemoryHotplugConfig) -> Result<Self, VirtioMemPrepareError> {
-        Self::from_config_at(config, VIRTIO_MEM_DEFAULT_REGION_ADDRESS)
+        Self::from_config_with_reserved_ranges(config, &[])
+    }
+
+    pub fn from_config_with_reserved_ranges(
+        config: MemoryHotplugConfig,
+        reserved_ranges: &[GuestMemoryRange],
+    ) -> Result<Self, VirtioMemPrepareError> {
+        mib_to_bytes(config.block_size_mib(), VirtioMemSizeField::Block)?;
+        let region_size = mib_to_bytes(config.total_size_mib(), VirtioMemSizeField::Total)?;
+        let alignment = mib_to_bytes(config.slot_size_mib(), VirtioMemSizeField::Slot)?;
+        let address = allocate_virtio_mem_region(region_size, alignment, reserved_ranges)?;
+
+        Self::from_config_at(config, address)
     }
 
     pub fn from_config_at(
         config: MemoryHotplugConfig,
         address: GuestAddress,
     ) -> Result<Self, VirtioMemPrepareError> {
-        let block_size = mib_to_bytes(config.block_size_mib(), VirtioMemSizeField::BlockSize)?;
-        let region_size = mib_to_bytes(config.total_size_mib(), VirtioMemSizeField::TotalSize)?;
+        let block_size = mib_to_bytes(config.block_size_mib(), VirtioMemSizeField::Block)?;
+        let region_size = mib_to_bytes(config.total_size_mib(), VirtioMemSizeField::Total)?;
         if address.checked_add(region_size).is_none() {
             return Err(VirtioMemPrepareError::RegionAddressOverflow {
                 address,
@@ -500,8 +514,9 @@ impl PreparedVirtioMemDevice {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum VirtioMemSizeField {
-    BlockSize,
-    TotalSize,
+    Block,
+    Slot,
+    Total,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -513,6 +528,15 @@ pub enum VirtioMemPrepareError {
     RegionAddressOverflow {
         address: GuestAddress,
         region_size: u64,
+    },
+    RegionAlignmentOverflow {
+        address: GuestAddress,
+        alignment: u64,
+    },
+    RegionUnavailable {
+        region_size: u64,
+        alignment: u64,
+        address_space_end: GuestAddress,
     },
 }
 
@@ -528,6 +552,18 @@ impl fmt::Display for VirtioMemPrepareError {
             } => write!(
                 f,
                 "virtio-mem region at {address} with size {region_size} bytes overflows guest address space"
+            ),
+            Self::RegionAlignmentOverflow { address, alignment } => write!(
+                f,
+                "virtio-mem region address {address} cannot be aligned to {alignment} bytes"
+            ),
+            Self::RegionUnavailable {
+                region_size,
+                alignment,
+                address_space_end,
+            } => write!(
+                f,
+                "no {alignment}-byte-aligned virtio-mem region of {region_size} bytes fits below guest address-space end {address_space_end}"
             ),
         }
     }
@@ -1537,8 +1573,8 @@ impl VirtioMemMutation {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VirtioMemMutationKind {
-    Plug(GuestMemoryRange),
-    Unplug(GuestMemoryRange),
+    Plug(Vec<GuestMemoryRange>),
+    Unplug(Vec<GuestMemoryRange>),
     UnplugAll(Vec<GuestMemoryRange>),
 }
 
@@ -1649,26 +1685,14 @@ impl VirtioMemPendingMutation {
     ) -> Result<VirtioMemMutation, VirtioMemMutationError> {
         match self {
             Self::Plug(range) => Ok(VirtioMemMutation::new(VirtioMemMutationKind::Plug(
-                block_range_to_guest_range(range, config_space)?,
+                block_ranges_to_guest_ranges(&[range], config_space, "plug")?,
             ))),
             Self::Unplug(range) => Ok(VirtioMemMutation::new(VirtioMemMutationKind::Unplug(
-                block_range_to_guest_range(range, config_space)?,
+                block_ranges_to_guest_ranges(&[range], config_space, "unplug")?,
             ))),
-            Self::UnplugAll => {
-                let mut ranges = Vec::new();
-                ranges
-                    .try_reserve_exact(plugged_blocks.ranges.len())
-                    .map_err(|source| {
-                        VirtioMemMutationError::from_try_reserve_error("unplug-all", source)
-                    })?;
-                for range in plugged_blocks.ranges.iter().copied() {
-                    ranges.push(block_range_to_guest_range(range, config_space)?);
-                }
-
-                Ok(VirtioMemMutation::new(VirtioMemMutationKind::UnplugAll(
-                    ranges,
-                )))
-            }
+            Self::UnplugAll => Ok(VirtioMemMutation::new(VirtioMemMutationKind::UnplugAll(
+                block_ranges_to_guest_ranges(&plugged_blocks.ranges, config_space, "unplug-all")?,
+            ))),
         }
     }
 
@@ -1697,33 +1721,53 @@ impl VirtioMemMutationError {
     }
 }
 
-fn block_range_to_guest_range(
-    range: VirtioMemBlockRange,
+fn block_ranges_to_guest_ranges(
+    block_ranges: &[VirtioMemBlockRange],
     config_space: VirtioMemConfigSpace,
-) -> Result<GuestMemoryRange, VirtioMemMutationError> {
-    let block_size = config_space.block_size();
-    let Some(offset) = range.start().checked_mul(block_size) else {
-        return Err(VirtioMemMutationError::new(format!(
-            "virtio-mem block range start {} overflows block size {block_size}",
-            range.start()
-        )));
-    };
-    let Some(start) = config_space.addr().checked_add(offset) else {
-        return Err(VirtioMemMutationError::new(format!(
-            "virtio-mem block range start offset {offset} overflows base address {}",
-            config_space.addr()
-        )));
-    };
-    let Some(size) = range.len_bytes(block_size) else {
-        return Err(VirtioMemMutationError::new(format!(
-            "virtio-mem block range length {} overflows block size {block_size}",
-            range.block_count()
-        )));
-    };
+    context: &str,
+) -> Result<Vec<GuestMemoryRange>, VirtioMemMutationError> {
+    let block_count = block_ranges.iter().try_fold(0_u64, |count, range| {
+        count.checked_add(range.block_count()).ok_or_else(|| {
+            VirtioMemMutationError::new(format!(
+                "virtio-mem {context} block count overflows address space"
+            ))
+        })
+    })?;
+    let capacity = usize::try_from(block_count).map_err(|source| {
+        VirtioMemMutationError::new(format!(
+            "virtio-mem {context} block count {block_count} cannot be represented: {source}"
+        ))
+    })?;
+    let mut guest_ranges = Vec::new();
+    guest_ranges
+        .try_reserve_exact(capacity)
+        .map_err(|source| VirtioMemMutationError::from_try_reserve_error(context, source))?;
 
-    GuestMemoryRange::new(GuestAddress::new(start), size).map_err(|source| {
-        VirtioMemMutationError::new(format!("invalid virtio-mem mutation range: {source}"))
-    })
+    let block_size = config_space.block_size();
+    for range in block_ranges {
+        for block in range.start()..range.end() {
+            let Some(offset) = block.checked_mul(block_size) else {
+                return Err(VirtioMemMutationError::new(format!(
+                    "virtio-mem block {block} overflows block size {block_size}"
+                )));
+            };
+            let Some(start) = config_space.addr().checked_add(offset) else {
+                return Err(VirtioMemMutationError::new(format!(
+                    "virtio-mem block offset {offset} overflows base address {}",
+                    config_space.addr()
+                )));
+            };
+            let guest_range =
+                GuestMemoryRange::new(GuestAddress::new(start), block_size).map_err(|source| {
+                    VirtioMemMutationError::new(format!(
+                        "invalid virtio-mem mutation range: {source}"
+                    ))
+                })?;
+            guest_ranges.push(guest_range);
+        }
+    }
+
+    Ok(guest_ranges)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2882,12 +2926,68 @@ fn config_bytes_error(source: MmioAccessBytesError) -> VirtioMmioDeviceConfigErr
     }
 }
 
+fn allocate_virtio_mem_region(
+    region_size: u64,
+    alignment: u64,
+    reserved_ranges: &[GuestMemoryRange],
+) -> Result<GuestAddress, VirtioMemPrepareError> {
+    let mut address =
+        align_virtio_mem_region_address(VIRTIO_MEM_DEFAULT_REGION_ADDRESS, alignment)?;
+
+    loop {
+        let Some(end) = address.checked_add(region_size) else {
+            return Err(VirtioMemPrepareError::RegionAddressOverflow {
+                address,
+                region_size,
+            });
+        };
+        if end.raw_value() > VIRTIO_MEM_REGION_ADDRESS_SPACE_END {
+            return Err(VirtioMemPrepareError::RegionUnavailable {
+                region_size,
+                alignment,
+                address_space_end: GuestAddress::new(VIRTIO_MEM_REGION_ADDRESS_SPACE_END),
+            });
+        }
+        let candidate = GuestMemoryRange::new(address, region_size).map_err(|_| {
+            VirtioMemPrepareError::RegionAddressOverflow {
+                address,
+                region_size,
+            }
+        })?;
+        let Some(overlap) = reserved_ranges
+            .iter()
+            .copied()
+            .filter(|reserved| candidate.overlaps(*reserved))
+            .max_by_key(|reserved| reserved.end_exclusive().raw_value())
+        else {
+            return Ok(address);
+        };
+
+        address = align_virtio_mem_region_address(overlap.end_exclusive(), alignment)?;
+    }
+}
+
+fn align_virtio_mem_region_address(
+    address: GuestAddress,
+    alignment: u64,
+) -> Result<GuestAddress, VirtioMemPrepareError> {
+    let remainder = address.raw_value() % alignment;
+    if remainder == 0 {
+        return Ok(address);
+    }
+    let offset = alignment - remainder;
+    address
+        .checked_add(offset)
+        .ok_or(VirtioMemPrepareError::RegionAlignmentOverflow { address, alignment })
+}
+
 fn mib_to_bytes(mib: u64, field: VirtioMemSizeField) -> Result<u64, VirtioMemPrepareError> {
     mib.checked_mul(MIB)
         .ok_or(VirtioMemPrepareError::SizeOverflow {
             field: match field {
-                VirtioMemSizeField::BlockSize => "block_size_mib",
-                VirtioMemSizeField::TotalSize => "total_size_mib",
+                VirtioMemSizeField::Block => "block_size_mib",
+                VirtioMemSizeField::Slot => "slot_size_mib",
+                VirtioMemSizeField::Total => "total_size_mib",
             },
             mib,
         })
@@ -3043,6 +3143,45 @@ mod tests {
         assert_eq!(config_space.usable_region_size(), 0);
         assert_eq!(config_space.plugged_size(), 0);
         assert_eq!(config_space.requested_size(), 0);
+    }
+
+    #[test]
+    fn prepared_virtio_mem_device_allocates_after_reserved_ranges_on_slot_boundary() {
+        let config = MemoryHotplugConfig::try_from(MemoryHotplugConfigInput::new(128, 2, 128))
+            .expect("valid memory hotplug config should convert");
+        let high_dram = GuestMemoryRange::new(VIRTIO_MEM_DEFAULT_REGION_ADDRESS, 256 * MIB)
+            .expect("high DRAM reservation should be valid");
+        let pmem = GuestMemoryRange::new(high_dram.end_exclusive(), 2 * MIB)
+            .expect("pmem reservation should be valid");
+
+        let prepared =
+            PreparedVirtioMemDevice::from_config_with_reserved_ranges(config, &[pmem, high_dram])
+                .expect("virtio-mem region should skip reserved DRAM and pmem");
+
+        assert_eq!(
+            prepared.config_space().addr(),
+            VIRTIO_MEM_DEFAULT_REGION_ADDRESS.raw_value() + 384 * MIB
+        );
+    }
+
+    #[test]
+    fn prepared_virtio_mem_device_reports_exhausted_40_bit_region() {
+        let config = MemoryHotplugConfig::try_from(MemoryHotplugConfigInput::new(128, 2, 128))
+            .expect("valid memory hotplug config should convert");
+        let reserved = GuestMemoryRange::new(
+            VIRTIO_MEM_DEFAULT_REGION_ADDRESS,
+            VIRTIO_MEM_REGION_ADDRESS_SPACE_END - VIRTIO_MEM_DEFAULT_REGION_ADDRESS.raw_value(),
+        )
+        .expect("post-MMIO64 address space reservation should be valid");
+
+        assert_eq!(
+            PreparedVirtioMemDevice::from_config_with_reserved_ranges(config, &[reserved]),
+            Err(VirtioMemPrepareError::RegionUnavailable {
+                region_size: 128 * MIB,
+                alignment: 128 * MIB,
+                address_space_end: GuestAddress::new(VIRTIO_MEM_REGION_ADDRESS_SPACE_END),
+            })
+        );
     }
 
     #[test]
@@ -4131,18 +4270,18 @@ mod tests {
     }
 
     #[test]
-    fn virtio_mem_queue_dispatch_calls_mutation_executor_for_plug() {
+    fn virtio_mem_queue_dispatch_expands_multi_block_plug_and_partial_unplug() {
         let mut memory = request_memory();
-        write_virtio_mem_chain(&mut memory, VIRTIO_MEM_REQ_PLUG, 0x4000_0000, 1);
+        write_virtio_mem_chain(&mut memory, VIRTIO_MEM_REQ_PLUG, 0x4000_0000, 2);
         write_available_heads(&mut memory, &[0]);
         let mut queue = virtio_mem_queue();
         let mut config_space = virtio_mem_config_space()
-            .with_usable_region_size(0x20_0000)
-            .with_requested_size(0x20_0000);
+            .with_usable_region_size(0x40_0000)
+            .with_requested_size(0x40_0000);
         let mut plugged_blocks = VirtioMemPluggedBlocks::default();
         let mut executor = RecordingMutationExecutor::default();
 
-        let dispatch = queue
+        queue
             .dispatch_with_executor(
                 &mut memory,
                 &mut config_space,
@@ -4151,11 +4290,28 @@ mod tests {
             )
             .expect("plug should dispatch through executor");
 
+        write_virtio_mem_chain(&mut memory, VIRTIO_MEM_REQ_UNPLUG, 0x4020_0000, 1);
+        write_available_heads(&mut memory, &[0, 0]);
+        let dispatch = queue
+            .dispatch_with_executor(
+                &mut memory,
+                &mut config_space,
+                &mut plugged_blocks,
+                &mut executor,
+            )
+            .expect("partial unplug should dispatch through executor");
+
         assert_eq!(dispatch.processed_requests(), 1);
         assert_eq!(dispatch.mutation_failures(), 0);
         assert_eq!(
             executor.apply_calls,
-            [plug_mutation(0x4000_0000, 0x20_0000)]
+            [
+                plug_blocks_mutation(0x4000_0000, 0x20_0000, 2),
+                VirtioMemMutation::new(VirtioMemMutationKind::Unplug(vec![guest_range(
+                    0x4020_0000,
+                    0x20_0000,
+                )])),
+            ]
         );
         assert!(executor.rolled_back.is_empty());
         assert_eq!(config_space.plugged_size(), 0x20_0000);
@@ -4176,11 +4332,13 @@ mod tests {
         queue
             .dispatch(&mut memory, &mut config_space, &mut plugged_blocks)
             .expect("first plug should dispatch");
-        write_virtio_mem_chain(&mut memory, VIRTIO_MEM_REQ_PLUG, 0x4040_0000, 1);
+        write_virtio_mem_chain(&mut memory, VIRTIO_MEM_REQ_PLUG, 0x4020_0000, 1);
         write_available_heads(&mut memory, &[0, 0]);
         queue
             .dispatch(&mut memory, &mut config_space, &mut plugged_blocks)
             .expect("second plug should dispatch");
+        assert_eq!(plugged_blocks.ranges.len(), 1);
+        assert_eq!(plugged_blocks.ranges[0].block_count(), 2);
         let mut executor = RecordingMutationExecutor::default();
 
         write_virtio_mem_chain(&mut memory, VIRTIO_MEM_REQ_UNPLUG_ALL, 0, 0);
@@ -4200,12 +4358,96 @@ mod tests {
             [VirtioMemMutation::new(VirtioMemMutationKind::UnplugAll(
                 vec![
                     guest_range(0x4000_0000, 0x20_0000),
-                    guest_range(0x4040_0000, 0x20_0000),
+                    guest_range(0x4020_0000, 0x20_0000),
                 ]
             ))]
         );
         assert_eq!(config_space.plugged_size(), 0);
         assert_eq!(config_space.usable_region_size(), 0);
+    }
+
+    #[test]
+    fn virtio_mem_queue_dispatch_expands_request_across_conceptual_slot_boundary() {
+        let mut memory = request_memory();
+        let request_start = 0x47e0_0000;
+        write_virtio_mem_chain(&mut memory, VIRTIO_MEM_REQ_PLUG, request_start, 2);
+        write_available_heads(&mut memory, &[0]);
+        let mut queue = virtio_mem_queue();
+        let mut config_space = virtio_mem_config_space()
+            .with_usable_region_size(0x820_0000)
+            .with_requested_size(0x820_0000);
+        let mut plugged_blocks = VirtioMemPluggedBlocks::default();
+        let mut executor = RecordingMutationExecutor::default();
+
+        queue
+            .dispatch_with_executor(
+                &mut memory,
+                &mut config_space,
+                &mut plugged_blocks,
+                &mut executor,
+            )
+            .expect("boundary-crossing plug should dispatch");
+
+        assert_eq!(
+            executor.apply_calls,
+            [plug_blocks_mutation(request_start, 0x20_0000, 2)]
+        );
+        assert_eq!(
+            executor.apply_calls[0].kind(),
+            &VirtioMemMutationKind::Plug(vec![
+                guest_range(0x47e0_0000, 0x20_0000),
+                guest_range(0x4800_0000, 0x20_0000),
+            ])
+        );
+        assert_eq!(config_space.plugged_size(), 0x40_0000);
+    }
+
+    #[test]
+    fn virtio_mem_mutation_expansion_accepts_maximum_request_block_count() {
+        let block_size = 0x20_0000;
+        let block_count = u64::from(u16::MAX);
+        let region_size = block_count * block_size;
+        let config_space = VirtioMemConfigSpace::new(block_size, 0x4000_0000, region_size)
+            .with_usable_region_size(region_size)
+            .with_requested_size(region_size);
+        let mutation = VirtioMemPendingMutation::Plug(
+            VirtioMemBlockRange::new(0, block_count).expect("maximum request should be nonempty"),
+        )
+        .to_executable_mutation(config_space, &VirtioMemPluggedBlocks::default())
+        .expect("maximum request mutation metadata should be bounded");
+
+        let VirtioMemMutationKind::Plug(ranges) = mutation.kind() else {
+            panic!("expected plug mutation")
+        };
+        assert_eq!(ranges.len(), usize::from(u16::MAX));
+        assert_eq!(ranges[0], guest_range(0x4000_0000, block_size));
+        assert_eq!(
+            ranges.last(),
+            Some(&guest_range(
+                0x4000_0000 + (block_count - 1) * block_size,
+                block_size,
+            ))
+        );
+    }
+
+    #[test]
+    fn virtio_mem_mutation_expansion_reports_metadata_capacity_failure() {
+        let error = block_ranges_to_guest_ranges(
+            &[VirtioMemBlockRange {
+                start: 0,
+                end: u64::MAX,
+            }],
+            VirtioMemConfigSpace::new(1, 0, u64::MAX),
+            "plug",
+        )
+        .expect_err("unrepresentable mutation metadata should fail before range expansion");
+
+        assert!(
+            error
+                .to_string()
+                .contains("failed to allocate plug mutation metadata"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]
@@ -4314,7 +4556,7 @@ mod tests {
     #[test]
     fn virtio_mem_queue_dispatch_rolls_back_applied_mutation_after_response_write_failure() {
         let mut memory = request_memory();
-        write_virtio_mem_chain(&mut memory, VIRTIO_MEM_REQ_PLUG, 0x4000_0000, 1);
+        write_virtio_mem_chain(&mut memory, VIRTIO_MEM_REQ_PLUG, 0x4000_0000, 2);
         write_descriptor(
             &mut memory,
             1,
@@ -4327,8 +4569,8 @@ mod tests {
         write_available_heads(&mut memory, &[0]);
         let mut queue = virtio_mem_queue();
         let mut config_space = virtio_mem_config_space()
-            .with_usable_region_size(0x20_0000)
-            .with_requested_size(0x20_0000);
+            .with_usable_region_size(0x40_0000)
+            .with_requested_size(0x40_0000);
         let mut plugged_blocks = VirtioMemPluggedBlocks::default();
         let mut executor = RecordingMutationExecutor::default();
 
@@ -4346,18 +4588,18 @@ mod tests {
         assert_eq!(config_space.plugged_size(), 0);
         assert_eq!(
             executor.apply_calls,
-            [plug_mutation(0x4000_0000, 0x20_0000)]
+            [plug_blocks_mutation(0x4000_0000, 0x20_0000, 2)]
         );
         assert_eq!(
             executor.rolled_back_mutations(),
-            [plug_mutation(0x4000_0000, 0x20_0000)]
+            [plug_blocks_mutation(0x4000_0000, 0x20_0000, 2)]
         );
     }
 
     #[test]
     fn virtio_mem_queue_dispatch_rolls_back_applied_mutation_after_used_ring_failure() {
         let mut memory = request_memory();
-        write_virtio_mem_chain(&mut memory, VIRTIO_MEM_REQ_PLUG, 0x4000_0000, 1);
+        write_virtio_mem_chain(&mut memory, VIRTIO_MEM_REQ_PLUG, 0x4000_0000, 2);
         write_available_heads(&mut memory, &[0]);
         let available = VirtqueueAvailableRing::new(
             TEST_QUEUE_DESCRIPTOR_TABLE,
@@ -4369,8 +4611,8 @@ mod tests {
             .expect("used ring should build");
         let mut queue = VirtioMemQueue::new(available, used);
         let mut config_space = virtio_mem_config_space()
-            .with_usable_region_size(0x20_0000)
-            .with_requested_size(0x20_0000);
+            .with_usable_region_size(0x40_0000)
+            .with_requested_size(0x40_0000);
         let mut plugged_blocks = VirtioMemPluggedBlocks::default();
         let mut executor = RecordingMutationExecutor::default();
 
@@ -4392,11 +4634,11 @@ mod tests {
         assert_eq!(config_space.plugged_size(), 0);
         assert_eq!(
             executor.apply_calls,
-            [plug_mutation(0x4000_0000, 0x20_0000)]
+            [plug_blocks_mutation(0x4000_0000, 0x20_0000, 2)]
         );
         assert_eq!(
             executor.rolled_back_mutations(),
-            [plug_mutation(0x4000_0000, 0x20_0000)]
+            [plug_blocks_mutation(0x4000_0000, 0x20_0000, 2)]
         );
     }
 
@@ -5092,7 +5334,21 @@ mod tests {
     }
 
     fn plug_mutation(start: u64, size: u64) -> VirtioMemMutation {
-        VirtioMemMutation::new(VirtioMemMutationKind::Plug(guest_range(start, size)))
+        plug_blocks_mutation(start, size, 1)
+    }
+
+    fn plug_blocks_mutation(start: u64, block_size: u64, block_count: u16) -> VirtioMemMutation {
+        VirtioMemMutation::new(VirtioMemMutationKind::Plug(guest_block_ranges(
+            start,
+            block_size,
+            block_count,
+        )))
+    }
+
+    fn guest_block_ranges(start: u64, block_size: u64, block_count: u16) -> Vec<GuestMemoryRange> {
+        (0..u64::from(block_count))
+            .map(|block| guest_range(start + block * block_size, block_size))
+            .collect()
     }
 
     #[derive(Clone, Copy)]

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -2922,6 +2922,9 @@ pub enum Arm64BootResourceError {
     MemoryHotplugDeviceMetadataAllocation {
         source: TryReserveError,
     },
+    MemoryHotplugRangeMetadataAllocation {
+        source: TryReserveError,
+    },
     EntropyDeviceMetadataAllocation {
         source: TryReserveError,
     },
@@ -3068,6 +3071,10 @@ impl fmt::Display for Arm64BootResourceError {
                     "failed to allocate memory hotplug device metadata: {source}"
                 )
             }
+            Self::MemoryHotplugRangeMetadataAllocation { source } => write!(
+                f,
+                "failed to allocate memory hotplug reserved-range metadata: {source}"
+            ),
             Self::EntropyDeviceMetadataAllocation { source } => {
                 write!(f, "failed to allocate entropy device metadata: {source}")
             }
@@ -3108,6 +3115,7 @@ impl std::error::Error for Arm64BootResourceError {
             Self::VsockDeviceMetadataAllocation { source } => Some(source),
             Self::BalloonDeviceMetadataAllocation { source } => Some(source),
             Self::MemoryHotplugDeviceMetadataAllocation { source } => Some(source),
+            Self::MemoryHotplugRangeMetadataAllocation { source } => Some(source),
             Self::EntropyDeviceMetadataAllocation { source } => Some(source),
             Self::Fdt { source } => Some(source),
             Self::MissingBootSource
@@ -3370,10 +3378,27 @@ impl Arm64BootResources {
         let memory_hotplug_device =
             match (controller.memory_hotplug_config(), memory_hotplug_device) {
                 (Some(config), Some(device_config)) => {
-                    let prepared_mem =
-                        PreparedVirtioMemDevice::from_config(config).map_err(|source| {
-                            Arm64BootResourceError::PrepareMemoryHotplugDevice { source }
+                    let mut reserved_ranges = Vec::new();
+                    reserved_ranges
+                        .try_reserve_exact(layout.ranges().len())
+                        .map_err(|source| {
+                            Arm64BootResourceError::MemoryHotplugRangeMetadataAllocation { source }
                         })?;
+                    reserved_ranges.extend_from_slice(layout.ranges());
+                    reserved_ranges
+                        .try_reserve_exact(pmem_devices.len())
+                        .map_err(|source| {
+                            Arm64BootResourceError::MemoryHotplugRangeMetadataAllocation { source }
+                        })?;
+                    reserved_ranges
+                        .extend(pmem_devices.iter().map(PreparedPmemDevice::guest_range));
+                    let prepared_mem = PreparedVirtioMemDevice::from_config_with_reserved_ranges(
+                        config,
+                        &reserved_ranges,
+                    )
+                    .map_err(|source| {
+                        Arm64BootResourceError::PrepareMemoryHotplugDevice { source }
+                    })?;
                     let mem_mmio = prepared_mem
                         .register_mmio_with_dispatcher(device_config.mmio_layout, mmio_dispatcher)
                         .map_err(|source| Arm64BootResourceError::RegisterMemoryHotplugMmio {
@@ -8228,6 +8253,43 @@ mod tests {
 
         let tree = read_fdt(&resources);
         assert!(tree.find("/virtio_mmio@4000a000").is_some());
+    }
+
+    #[test]
+    fn memory_hotplug_region_skips_prepared_pmem_backing() {
+        let kernel = temp_file("kernel-memory-hotplug-pmem", &arm64_image());
+        let pmem = temp_file("memory-hotplug-pmem", b"pmem");
+        let mut controller = controller_with_kernel(kernel.path());
+        add_pmem(&mut controller, "pmem0", pmem.path(), false);
+        add_memory_hotplug(&mut controller);
+        let pmem_lines = [line(32)];
+        let mut config = valid_config_with_pmem_lines(&[], &pmem_lines);
+        config.memory_hotplug_device = Some(super::Arm64BootMemoryHotplugDeviceConfig::new(
+            VirtioMemMmioLayout::new(TEST_MEMORY_HOTPLUG_MMIO_BASE, MmioRegionId::new(120)),
+            line(33),
+        ));
+
+        let mut resources = Arm64BootResources::assemble_from_controller(&controller, config)
+            .expect("memory hotplug region should avoid prepared pmem backing");
+
+        assert_eq!(
+            resources.pmem_devices[0].guest_range().start(),
+            VIRTIO_MEM_DEFAULT_REGION_ADDRESS
+        );
+        let region_id = resources
+            .memory_hotplug_device
+            .as_ref()
+            .expect("memory hotplug metadata should exist")
+            .registration
+            .region_id();
+        let handler = resources
+            .mmio_dispatcher
+            .handler_mut::<VirtioMemMmioHandler>(region_id)
+            .expect("virtio-mem handler should be registered");
+        assert_eq!(
+            handler.device_config_handler().addr(),
+            VIRTIO_MEM_DEFAULT_REGION_ADDRESS.raw_value() + 128 * MIB
+        );
     }
 
     #[test]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -979,7 +979,8 @@ checks prove the kernel mounted the virtio-block root drive as `/`, give
 executable-boundary MMDS fetch coverage through the process-local MMDS-only
 packet path, prove guest-visible virtio-rng reads through `/dev/hwrng`, prove
 guest virtio-balloon driver binding, prove guest-visible virtio-mem driver
-binding plus the runtime requested-size signal, prove guest-visible PL031 RTC
+binding plus a guest-completed and public-API-observed requested/plugged
+`0 -> 128 MiB -> 0` lifecycle, prove guest-visible PL031 RTC
 device discovery, prove guest-visible VMGenID device-tree evidence, prove the
 current writeback virtio-block flush path, prove the current virtio-pmem
 read/flush path, and cover guest-initiated plus host-initiated virtio-vsock

--- a/scripts/fetch-firecracker-rootfs.sh
+++ b/scripts/fetch-firecracker-rootfs.sh
@@ -114,7 +114,7 @@ rootfs_arch="aarch64"
 rootfs_name="ubuntu-24.04"
 rootfs_sha256="0efb6a3ff2982baa6ca7e3d940966516ba7ddd2df5deb3e6c2161d369a15d608"
 rootfs_url="https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/${firecracker_minor}/${rootfs_arch}/${rootfs_name}.squashfs"
-direct_boot_variant="direct-boot-v33"
+direct_boot_variant="direct-boot-v34"
 
 cache_root="${BANGBANG_GUEST_ARTIFACTS_DIR:-$repo_root/.tmp/guest-artifacts}"
 upstream_dir="${cache_root}/firecracker-ci/${firecracker_minor}/${rootfs_arch}"
@@ -697,6 +697,7 @@ import time
 DEVICE = "/dev/vdb"
 EXPECTED_REQUESTED_SIZE = 128 * 1024 * 1024
 READY_MARKER = b"BANGBANG_MEMORY_HOTPLUG_GUEST_READY"
+GROWN_MARKER = b"BANGBANG_MEMORY_HOTPLUG_GUEST_GROWN"
 SUCCESS_MARKER = b"BANGBANG_MEMORY_HOTPLUG_GUEST_CHECK_OK"
 FAIL_MARKER = b"BANGBANG_MEMORY_HOTPLUG_GUEST_CHECK_FAIL"
 TIMEOUT_SECONDS = 20.0
@@ -755,19 +756,24 @@ try:
 
     deadline = time.monotonic() + TIMEOUT_SECONDS
     ready = False
+    grown = False
 
     while True:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            if ready:
-                fail("TIMEOUT")
-            fail("INIT_TIMEOUT")
+            if not ready:
+                fail("INIT_TIMEOUT")
+            if not grown:
+                fail("GROW_TIMEOUT")
+            fail("SHRINK_TIMEOUT")
 
         readable, _, _ = select.select([dmesg.stdout], [], [], remaining)
         if not readable:
-            if ready:
-                fail("TIMEOUT")
-            fail("INIT_TIMEOUT")
+            if not ready:
+                fail("INIT_TIMEOUT")
+            if not grown:
+                fail("GROW_TIMEOUT")
+            fail("SHRINK_TIMEOUT")
 
         line = dmesg.stdout.readline()
         if not line:
@@ -787,7 +793,14 @@ try:
             print(marker_text(READY_MARKER), flush=True)
             continue
 
-        if ready and requested_size == EXPECTED_REQUESTED_SIZE:
+        if ready and not grown and requested_size == EXPECTED_REQUESTED_SIZE:
+            grown = True
+            deadline = time.monotonic() + TIMEOUT_SECONDS
+            write_marker(GROWN_MARKER)
+            print(marker_text(GROWN_MARKER), flush=True)
+            continue
+
+        if grown and requested_size == 0:
             write_marker(SUCCESS_MARKER)
             print(marker_text(SUCCESS_MARKER))
             sys.exit(0)


### PR DESCRIPTION
## Summary

- expand every accepted virtio-mem request into exact block-sized guest-memory owners before applying it to HVF
- apply multi-block plug, unplug, and unplug-all mutations transactionally, including reverse-order rollback after partial or late failures
- allocate the virtio-mem aperture inside the HVF-addressable 40-bit window while avoiding startup DRAM and prepared pmem ranges
- strengthen the signed direct-rootfs test to prove a guest-completed, public-API-observed `0 -> 128 MiB -> 0` lifecycle

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

## Scope

This PR keeps the compact guest-visible plugged-block policy state and does not add balloon, pmem flush/rate-limit, or documentation-completion work owned by the remaining #544 slices.

Fixes #1333
