### PR TITLE
fix: scope pmem flushes to notified device

### DIFF
--- a/crates/hvf/src/backend.rs
+++ b/crates/hvf/src/backend.rs
@@ -9,7 +9,7 @@ use bangbang_runtime::{BackendError, VmBackend};
 use crate::gic::{HvfGicCreator, HvfGicError, HvfGicMetadata, RealHvfGicCreator};
 use crate::memory::{
     HvfGuestMemoryMapping, HvfGuestMemoryMappingError, HvfHostMemoryMapping, HvfMemoryMapper,
-    HvfMemoryPermissions, HvfVirtioMemMutationExecutor, RealHvfMemoryMapper,
+    HvfMemoryPermissions, HvfPmemFlushExecutor, HvfVirtioMemMutationExecutor, RealHvfMemoryMapper,
 };
 use crate::runner::{HvfVcpuRunner, HvfVcpuRunnerError};
 use crate::topology::{HvfVcpuTopology, HvfVcpuTopologyError};
@@ -129,6 +129,17 @@ impl HvfBackend {
             .memory_and_virtio_mem_executor_mut(permissions)
     }
 
+    pub(crate) fn mapped_guest_memory_and_pmem_flush_executor_mut(
+        &mut self,
+    ) -> Result<(&mut GuestMemory, HvfPmemFlushExecutor<'_>), HvfGuestMemoryMappingError> {
+        self.guest_memory
+            .as_mut()
+            .ok_or(HvfGuestMemoryMappingError::InvalidState(
+                GUEST_MEMORY_NOT_MAPPED_MESSAGE,
+            ))?
+            .memory_and_pmem_flush_executor_mut()
+    }
+
     /// Insert one owned guest memory region and map it into the active HVF VM.
     ///
     /// This keeps the process-owned `GuestMemory` region and the HVF mapping in
@@ -181,15 +192,6 @@ impl HvfBackend {
                 GUEST_MEMORY_NOT_MAPPED_MESSAGE,
             ))?
             .unmap_dynamic_region(range)
-    }
-
-    pub(crate) fn flush_mapped_pmem_shadows(&self) -> Result<(), HvfGuestMemoryMappingError> {
-        self.guest_memory
-            .as_ref()
-            .ok_or(HvfGuestMemoryMappingError::InvalidState(
-                GUEST_MEMORY_NOT_MAPPED_MESSAGE,
-            ))?
-            .flush_host_memory_now()
     }
 
     pub fn create_gic(&mut self) -> Result<&HvfGicMetadata, HvfGicError> {

--- a/crates/hvf/src/memory.rs
+++ b/crates/hvf/src/memory.rs
@@ -131,6 +131,9 @@ pub enum HvfGuestMemoryMappingError {
     FlushFailed {
         failures: Vec<HvfGuestMemoryFlushFailure>,
     },
+    PmemShadowMissing {
+        range: GuestMemoryRange,
+    },
     MappingMetadataAllocationFailed {
         source: TryReserveError,
     },
@@ -283,6 +286,12 @@ impl fmt::Display for HvfGuestMemoryMappingError {
                 },
                 [] => f.write_str("failed to flush host-backed guest memory mapping(s)"),
             },
+            Self::PmemShadowMissing { range } => {
+                write!(
+                    f,
+                    "HVF pmem shadow for guest memory range {range} is missing"
+                )
+            }
             Self::MappingMetadataAllocationFailed { source } => {
                 write!(
                     f,
@@ -343,7 +352,8 @@ impl std::error::Error for HvfGuestMemoryMappingError {
             | Self::HostSizeMismatch { .. }
             | Self::DynamicRegionOverlapsMapped { .. }
             | Self::DynamicRegionMissing { .. }
-            | Self::DynamicRegionOwnerMissing { .. } => None,
+            | Self::DynamicRegionOwnerMissing { .. }
+            | Self::PmemShadowMissing { .. } => None,
         }
     }
 }
@@ -485,10 +495,6 @@ impl HvfGuestMemoryMapping {
             ))
     }
 
-    pub(crate) fn flush_host_memory_now(&self) -> Result<(), HvfGuestMemoryMappingError> {
-        self.state.flush_host_memory_now()
-    }
-
     // HVF destroys guest mappings with the VM. Use this only after `hv_vm_destroy`
     // succeeds following an earlier unmap failure.
     pub(crate) fn release_after_vm_destroy(mut self) {
@@ -522,6 +528,13 @@ impl HvfGuestMemoryMapping {
             memory,
             HvfVirtioMemMutationExecutor::new(state, permissions),
         ))
+    }
+
+    pub(crate) fn memory_and_pmem_flush_executor_mut(
+        &mut self,
+    ) -> Result<(&mut GuestMemory, HvfPmemFlushExecutor<'_>), HvfGuestMemoryMappingError> {
+        let (memory, state) = self.memory_and_state_mut()?;
+        Ok((memory, HvfPmemFlushExecutor::new(state)))
     }
 
     fn memory_and_state_mut(
@@ -574,6 +587,20 @@ impl HvfGuestMemoryMappingState {
         } else {
             Err(HvfGuestMemoryMappingError::FlushFailed { failures })
         }
+    }
+
+    fn flush_pmem_shadow(&self, range: GuestMemoryRange) -> Result<(), HvfGuestMemoryMappingError> {
+        let mapping = self
+            .host_memory
+            .iter()
+            .find(|mapping| mapping.pmem_shadow_range() == Some(range))
+            .ok_or(HvfGuestMemoryMappingError::PmemShadowMissing { range })?;
+
+        mapping
+            .flush()
+            .map_err(|failure| HvfGuestMemoryMappingError::FlushFailed {
+                failures: vec![failure],
+            })
     }
 
     fn release_after_vm_destroy(&mut self) {
@@ -779,6 +806,24 @@ impl HvfGuestMemoryMappingState {
         self.flush_host_memory_now()?;
         self.host_memory_flushed = true;
         Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct HvfPmemFlushExecutor<'a> {
+    state: &'a HvfGuestMemoryMappingState,
+}
+
+impl<'a> HvfPmemFlushExecutor<'a> {
+    fn new(state: &'a HvfGuestMemoryMappingState) -> Self {
+        Self { state }
+    }
+
+    pub(crate) fn flush(
+        &mut self,
+        range: GuestMemoryRange,
+    ) -> Result<(), HvfGuestMemoryMappingError> {
+        self.state.flush_pmem_shadow(range)
     }
 }
 
@@ -1069,6 +1114,16 @@ impl HvfHostMemoryMapping {
         writeback
             .write_shadow_to_backing(&self.memory)
             .map_err(|source| self.flush_failure(source))
+    }
+
+    fn pmem_shadow_range(&self) -> Option<GuestMemoryRange> {
+        match &self.writeback {
+            #[cfg(test)]
+            HvfHostMemoryWriteback::None => None,
+            HvfHostMemoryWriteback::PmemShadow(_) => {
+                self.memory.regions().first().map(GuestMemoryRegion::range)
+            }
+        }
     }
 
     fn flush_failure(&self, source: BackendError) -> HvfGuestMemoryFlushFailure {
@@ -2895,7 +2950,7 @@ mod tests {
             &file,
             false,
         )];
-        let mapping = HvfGuestMemoryMapping::map_with_mapper_and_host_mappings(
+        let mut mapping = HvfGuestMemoryMapping::map_with_mapper_and_host_mappings(
             guest_memory,
             HvfMemoryPermissions::GUEST_RAM,
             host_mappings,
@@ -2903,9 +2958,12 @@ mod tests {
         )
         .expect("guest and pmem memory should map");
 
-        mapping
-            .flush_host_memory_now()
-            .expect("explicit flush should write writable pmem shadow");
+        let (_, mut executor) = mapping
+            .memory_and_pmem_flush_executor_mut()
+            .expect("pmem flush executor should borrow mapped memory");
+        executor
+            .flush(pmem_range)
+            .expect("targeted flush should write writable pmem shadow");
 
         assert_eq!(file.read_all(), b"after!");
     }
@@ -2926,7 +2984,7 @@ mod tests {
             &file,
             true,
         )];
-        let mapping = HvfGuestMemoryMapping::map_with_mapper_and_host_mappings(
+        let mut mapping = HvfGuestMemoryMapping::map_with_mapper_and_host_mappings(
             guest_memory,
             HvfMemoryPermissions::GUEST_RAM,
             host_mappings,
@@ -2934,10 +2992,161 @@ mod tests {
         )
         .expect("guest and read-only pmem memory should map");
 
-        mapping
-            .flush_host_memory_now()
-            .expect("explicit flush should skip read-only pmem shadow");
+        let (_, mut executor) = mapping
+            .memory_and_pmem_flush_executor_mut()
+            .expect("pmem flush executor should borrow mapped memory");
+        executor
+            .flush(pmem_range)
+            .expect("targeted flush should skip read-only pmem shadow");
 
+        assert_eq!(file.read_all(), b"before");
+    }
+
+    #[test]
+    fn explicit_pmem_shadow_flush_writes_only_selected_shadow() {
+        let page_size = page_size();
+        let guest_memory = memory_for_ranges(vec![range(0, page_size)]);
+        let first_range = range(page_size * 8, page_size);
+        let second_range = range(page_size * 9, page_size);
+        let first_file = TempFile::with_bytes("first-targeted-pmem-flush", b"first-old");
+        let second_file = TempFile::with_bytes("second-targeted-pmem-flush", b"second-old");
+        let host_mappings = vec![
+            host_pmem_mapping(
+                "pmem device `pmem0`",
+                memory_for_ranges(vec![first_range]),
+                first_range,
+                b"first-new",
+                &first_file,
+                false,
+            ),
+            host_pmem_mapping(
+                "pmem device `pmem1`",
+                memory_for_ranges(vec![second_range]),
+                second_range,
+                b"second-new",
+                &second_file,
+                false,
+            ),
+        ];
+        let mut mapping = HvfGuestMemoryMapping::map_with_mapper_and_host_mappings(
+            guest_memory,
+            HvfMemoryPermissions::GUEST_RAM,
+            host_mappings,
+            Arc::new(RecordingMapper::default()),
+        )
+        .expect("guest and pmem memory should map");
+
+        let (_, mut executor) = mapping
+            .memory_and_pmem_flush_executor_mut()
+            .expect("pmem flush executor should borrow mapped memory");
+        executor
+            .flush(second_range)
+            .expect("targeted flush should write only the selected pmem shadow");
+
+        assert_eq!(first_file.read_all(), b"first-old");
+        assert_eq!(second_file.read_all(), b"second-new");
+    }
+
+    #[test]
+    fn explicit_pmem_shadow_flush_failure_does_not_flush_peer_shadow() {
+        let page_size = page_size();
+        let guest_memory = memory_for_ranges(vec![range(0, page_size)]);
+        let selected_range = range(page_size * 8, page_size);
+        let peer_range = range(page_size * 9, page_size);
+        let selected_file = TempFile::with_bytes("secret-selected-pmem-flush", b"selected-old");
+        let peer_file = TempFile::with_bytes("peer-targeted-pmem-flush", b"peer-old");
+        let mut selected_memory = memory_for_ranges(vec![selected_range]);
+        selected_memory
+            .write_slice(b"selected-new", selected_range.start())
+            .expect("test should write selected pmem shadow contents");
+        let host_mappings = vec![
+            HvfHostMemoryMapping::new_pmem_shadow(
+                "pmem device `pmem0`",
+                selected_memory,
+                writable_pmem_permissions(),
+                selected_file
+                    .open_read_only()
+                    .expect("test should open selected backing read-only"),
+                12,
+                false,
+            ),
+            host_pmem_mapping(
+                "pmem device `pmem1`",
+                memory_for_ranges(vec![peer_range]),
+                peer_range,
+                b"peer-new",
+                &peer_file,
+                false,
+            ),
+        ];
+        let mut mapping = HvfGuestMemoryMapping::map_with_mapper_and_host_mappings(
+            guest_memory,
+            HvfMemoryPermissions::GUEST_RAM,
+            host_mappings,
+            Arc::new(RecordingMapper::default()),
+        )
+        .expect("guest and pmem memory should map");
+
+        let (_, mut executor) = mapping
+            .memory_and_pmem_flush_executor_mut()
+            .expect("pmem flush executor should borrow mapped memory");
+        let err = executor
+            .flush(selected_range)
+            .expect_err("selected read-only backing descriptor should fail writeback");
+        let message = err.to_string();
+
+        assert!(matches!(
+            err,
+            HvfGuestMemoryMappingError::FlushFailed { failures }
+                if failures.len() == 1
+                    && failures.first().is_some_and(|failure| {
+                        failure.label() == "pmem device `pmem0`"
+                            && failure.range() == Some(selected_range)
+                    })
+        ));
+        assert!(message.contains("pmem device `pmem0`"));
+        assert!(message.contains(&selected_range.to_string()));
+        assert!(!message.contains("pmem device `pmem1`"));
+        assert!(!message.contains(&selected_file.path_text()));
+        assert_eq!(selected_file.read_all(), b"selected-old");
+        assert_eq!(peer_file.read_all(), b"peer-old");
+    }
+
+    #[test]
+    fn explicit_pmem_shadow_flush_rejects_missing_range_without_flushing() {
+        let page_size = page_size();
+        let guest_memory = memory_for_ranges(vec![range(0, page_size)]);
+        let pmem_range = range(page_size * 8, page_size);
+        let missing_range = range(page_size * 9, page_size);
+        let file = TempFile::with_bytes("missing-targeted-pmem-flush", b"before");
+        let host_mappings = vec![host_pmem_mapping(
+            "pmem device `pmem0`",
+            memory_for_ranges(vec![pmem_range]),
+            pmem_range,
+            b"after!",
+            &file,
+            false,
+        )];
+        let mut mapping = HvfGuestMemoryMapping::map_with_mapper_and_host_mappings(
+            guest_memory,
+            HvfMemoryPermissions::GUEST_RAM,
+            host_mappings,
+            Arc::new(RecordingMapper::default()),
+        )
+        .expect("guest and pmem memory should map");
+
+        let (_, mut executor) = mapping
+            .memory_and_pmem_flush_executor_mut()
+            .expect("pmem flush executor should borrow mapped memory");
+        let err = executor
+            .flush(missing_range)
+            .expect_err("unknown pmem range should fail closed");
+
+        assert!(matches!(
+            err,
+            HvfGuestMemoryMappingError::PmemShadowMissing { range }
+                if range == missing_range
+        ));
         assert_eq!(file.read_all(), b"before");
     }
 

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -35,7 +35,7 @@ use bangbang_runtime::metrics::{
 };
 use bangbang_runtime::mmio::{MmioDispatcher, MmioRegionId};
 use bangbang_runtime::network::NetworkMmioLayout;
-use bangbang_runtime::pmem::{PmemMmioLayout, VirtioPmemFlushStatus};
+use bangbang_runtime::pmem::{PmemMmioDeviceRegistration, PmemMmioLayout, VirtioPmemFlushStatus};
 use bangbang_runtime::rtc::RtcMmioLayout;
 use bangbang_runtime::serial::{SerialConfig, SharedSerialOutput, SharedSerialOutputBuffer};
 use bangbang_runtime::snapshot_device::{SnapshotV1BlockRetryState, SnapshotV1DeviceState};
@@ -50,9 +50,10 @@ use bangbang_runtime::startup::{
     Arm64BootMemoryHotplugNotificationDispatch, Arm64BootMemoryHotplugNotificationDispatchError,
     Arm64BootMemoryHotplugNotificationDispatches, Arm64BootNetworkNotificationDispatch,
     Arm64BootNetworkNotificationDispatchError, Arm64BootNetworkNotificationDispatches,
-    Arm64BootNetworkPacketIoProvider, Arm64BootPmemNotificationDispatch,
-    Arm64BootPmemNotificationDispatchError, Arm64BootPmemNotificationDispatches,
-    Arm64BootResourceConfig, Arm64BootResourceError, Arm64BootResourceParts, Arm64BootResources,
+    Arm64BootNetworkPacketIoProvider, Arm64BootPmemFlushProvider,
+    Arm64BootPmemNotificationDispatch, Arm64BootPmemNotificationDispatchError,
+    Arm64BootPmemNotificationDispatches, Arm64BootResourceConfig, Arm64BootResourceError,
+    Arm64BootResourceParts, Arm64BootResources,
     Arm64BootRtcDeviceConfig as RuntimeArm64BootRtcDeviceConfig, Arm64BootRuntimeResources,
     Arm64BootSerialDeviceConfig as RuntimeArm64BootSerialDeviceConfig, Arm64BootVmGenIdDevice,
     Arm64BootVmGenIdReplacementError, Arm64BootVsockNotificationDispatch,
@@ -69,7 +70,7 @@ use crate::gic::{
     HvfArm64GicIccRegisterState, HvfGicDeviceState, HvfGicError, HvfGicInterruptLineAllocator,
     HvfGicMetadata, HvfGicSpiSignalError, HvfGicSpiSignaler, HvfInterruptLineAllocationError,
 };
-use crate::memory::{HvfGuestMemoryMappingError, HvfMemoryPermissions};
+use crate::memory::{HvfGuestMemoryMappingError, HvfMemoryPermissions, HvfPmemFlushExecutor};
 use crate::psci::PsciCpuPowerCoordinator;
 use crate::runner::{
     HvfArm64SnapshotV1Capture, HvfArm64SnapshotV1Restore, HvfVcpuRunCancelHandle,
@@ -6390,23 +6391,13 @@ fn dispatch_pmem_queue_notifications_and_signal_interrupts(
     gic: &HvfGicMetadata,
     metrics: &SharedPmemDeviceMetricsRegistry,
 ) -> Result<HvfArm64BootPmemNotificationDispatches, HvfArm64BootPmemNotificationDispatchError> {
-    let flush_status = {
-        let mut mmio_dispatcher =
-            lock_boot_mmio_dispatcher_runtime(dispatcher).map_err(|source| {
-                HvfArm64BootPmemNotificationDispatchError::MmioDispatcher { source }
-            })?;
-
-        if runtime_resources.has_pending_pmem_queue_notifications(&mut mmio_dispatcher) {
-            VirtioPmemFlushStatus::from_result(backend.flush_mapped_pmem_shadows().is_ok())
-        } else {
-            VirtioPmemFlushStatus::Success
-        }
-    };
-
     let dispatches = {
-        let memory = backend.mapped_guest_memory_mut().map_err(|source| {
-            HvfArm64BootPmemNotificationDispatchError::MapGuestMemory { source }
-        })?;
+        let (memory, executor) = backend
+            .mapped_guest_memory_and_pmem_flush_executor_mut()
+            .map_err(
+                |source| HvfArm64BootPmemNotificationDispatchError::MapGuestMemory { source },
+            )?;
+        let mut flush_provider = HvfArm64BootPmemFlushProvider::new(executor);
         let mut mmio_dispatcher =
             lock_boot_mmio_dispatcher_runtime(dispatcher).map_err(|source| {
                 HvfArm64BootPmemNotificationDispatchError::MmioDispatcher { source }
@@ -6416,7 +6407,7 @@ fn dispatch_pmem_queue_notifications_and_signal_interrupts(
             memory,
             runtime_resources,
             &mut mmio_dispatcher,
-            flush_status,
+            &mut flush_provider,
         )?
     };
 
@@ -6433,13 +6424,30 @@ fn dispatch_pmem_runtime_notifications(
     memory: &mut GuestMemory,
     runtime_resources: &mut Arm64BootRuntimeResources,
     mmio_dispatcher: &mut MmioDispatcher,
-    flush_status: VirtioPmemFlushStatus,
+    flush_provider: &mut impl Arm64BootPmemFlushProvider,
 ) -> Result<Arm64BootPmemNotificationDispatches, HvfArm64BootPmemNotificationDispatchError> {
     runtime_resources
-        .dispatch_pmem_queue_notifications(memory, mmio_dispatcher, flush_status)
+        .dispatch_pmem_queue_notifications(memory, mmio_dispatcher, flush_provider)
         .map_err(
             |source| HvfArm64BootPmemNotificationDispatchError::DispatchNotifications { source },
         )
+}
+
+#[derive(Debug)]
+struct HvfArm64BootPmemFlushProvider<'a> {
+    executor: HvfPmemFlushExecutor<'a>,
+}
+
+impl<'a> HvfArm64BootPmemFlushProvider<'a> {
+    fn new(executor: HvfPmemFlushExecutor<'a>) -> Self {
+        Self { executor }
+    }
+}
+
+impl Arm64BootPmemFlushProvider for HvfArm64BootPmemFlushProvider<'_> {
+    fn flush(&mut self, registration: &PmemMmioDeviceRegistration) -> VirtioPmemFlushStatus {
+        VirtioPmemFlushStatus::from_result(self.executor.flush(registration.guest_range()).is_ok())
+    }
 }
 
 fn dispatch_network_runtime_notifications(
@@ -8012,8 +8020,9 @@ mod tests {
         VirtioNetworkTxPacketSink, VirtioNetworkTxPacketSinkError,
     };
     use bangbang_runtime::pmem::{
-        PmemConfigInput, PmemMmioLayout, VIRTIO_PMEM_ALIGNMENT, VIRTIO_PMEM_REQUEST_SIZE,
-        VIRTIO_PMEM_REQUEST_TYPE_FLUSH, VIRTIO_PMEM_STATUS_SIZE, VirtioPmemFlushStatus,
+        PmemConfigInput, PmemMmioDeviceRegistration, PmemMmioLayout, VIRTIO_PMEM_ALIGNMENT,
+        VIRTIO_PMEM_REQUEST_SIZE, VIRTIO_PMEM_REQUEST_TYPE_FLUSH, VIRTIO_PMEM_STATUS_SIZE,
+        VirtioPmemFlushStatus,
     };
     use bangbang_runtime::rtc::RtcMmioLayout;
     use bangbang_runtime::serial::{SharedSerialOutput, SharedSerialOutputBuffer};
@@ -8026,9 +8035,10 @@ mod tests {
         Arm64BootMemoryHotplugDeviceConfig, Arm64BootMemoryHotplugNotificationDispatches,
         Arm64BootNetworkNotificationDispatches, Arm64BootNetworkNotificationOutcome,
         Arm64BootNetworkPacketIo, Arm64BootNetworkPacketIoError, Arm64BootNetworkPacketIoProvider,
-        Arm64BootPmemNotificationDispatches, Arm64BootResourceConfig, Arm64BootResources,
-        Arm64BootRuntimeResources, Arm64BootVmGenIdDevice, Arm64BootVmGenIdReplacementError,
-        Arm64BootVsockNotificationDispatches, update_memory_hotplug_config_for_device,
+        Arm64BootPmemFlushProvider, Arm64BootPmemNotificationDispatches, Arm64BootResourceConfig,
+        Arm64BootResources, Arm64BootRuntimeResources, Arm64BootVmGenIdDevice,
+        Arm64BootVmGenIdReplacementError, Arm64BootVsockNotificationDispatches,
+        update_memory_hotplug_config_for_device,
     };
     use bangbang_runtime::virtio_mmio::{
         VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DRIVER,
@@ -10499,12 +10509,23 @@ mod tests {
         runtime: &mut Arm64BootRuntimeResources,
         mmio_dispatcher: &mut MmioDispatcher,
     ) -> Arm64BootPmemNotificationDispatches {
+        let mut flush_provider = |_: &PmemMmioDeviceRegistration| VirtioPmemFlushStatus::Success;
+        dispatch_boot_pmem_notifications_with_provider(
+            memory,
+            runtime,
+            mmio_dispatcher,
+            &mut flush_provider,
+        )
+    }
+
+    fn dispatch_boot_pmem_notifications_with_provider(
+        memory: &mut GuestMemory,
+        runtime: &mut Arm64BootRuntimeResources,
+        mmio_dispatcher: &mut MmioDispatcher,
+        flush_provider: &mut impl Arm64BootPmemFlushProvider,
+    ) -> Arm64BootPmemNotificationDispatches {
         runtime
-            .dispatch_pmem_queue_notifications(
-                memory,
-                mmio_dispatcher,
-                VirtioPmemFlushStatus::Success,
-            )
+            .dispatch_pmem_queue_notifications(memory, mmio_dispatcher, flush_provider)
             .expect("pmem notification dispatch result should allocate")
     }
 
@@ -12709,6 +12730,92 @@ mod tests {
         assert!(!device.queue_interrupt_signaled());
         assert!(device.signal_error().is_none());
         assert!(recorded_lines(&lines).is_empty());
+    }
+
+    #[test]
+    fn pmem_notification_dispatch_flushes_only_notified_device_identity() {
+        let (mut memory, mut runtime, mut mmio_dispatcher) =
+            boot_runtime_with_pmem(&["pmem0", "pmem1"]);
+        configure_boot_pmem_queue(&mut runtime, &mut mmio_dispatcher, 1, TEST_USED_RING);
+        write_queued_pmem_flush_request(&mut memory);
+        notify_boot_pmem_queue(&mut runtime, &mut mmio_dispatcher, 1);
+        let selected = runtime.pmem_mmio_devices[1].registration.clone();
+        let mut flush_calls = Vec::new();
+        let mut flush_provider = |registration: &PmemMmioDeviceRegistration| {
+            flush_calls.push((
+                registration.pmem_id().to_string(),
+                registration.guest_range(),
+                registration.file_len(),
+            ));
+            VirtioPmemFlushStatus::Failure
+        };
+
+        let dispatches = dispatch_boot_pmem_notifications_with_provider(
+            &mut memory,
+            &mut runtime,
+            &mut mmio_dispatcher,
+            &mut flush_provider,
+        );
+
+        assert_eq!(
+            flush_calls,
+            [(
+                selected.pmem_id().to_string(),
+                selected.guest_range(),
+                selected.file_len(),
+            )]
+        );
+        assert!(
+            dispatches.as_slice()[0]
+                .outcome()
+                .dispatched()
+                .expect("idle peer should dispatch as a no-op")
+                .queue_dispatch()
+                .is_none()
+        );
+        let selected_dispatch = dispatches.as_slice()[1]
+            .outcome()
+            .dispatched()
+            .expect("notified pmem device should dispatch")
+            .queue_dispatch()
+            .expect("notified pmem queue should be present");
+        assert_eq!(selected_dispatch.failed_flushes(), 1);
+        assert_eq!(selected_dispatch.successful_flushes(), 0);
+        assert_eq!(
+            read_guest_bytes(&memory, STATUS_ADDR, VIRTIO_PMEM_STATUS_SIZE as usize),
+            bangbang_runtime::pmem::VIRTIO_PMEM_STATUS_FAILURE.to_le_bytes()
+        );
+    }
+
+    #[test]
+    fn pmem_notification_dispatch_skips_flush_for_malformed_only_event() {
+        let (mut memory, mut runtime, mut mmio_dispatcher) = boot_runtime_with_pmem(&["pmem0"]);
+        configure_boot_pmem_queue(&mut runtime, &mut mmio_dispatcher, 0, TEST_USED_RING);
+        write_partially_invalid_queued_pmem_flush_request(&mut memory);
+        notify_boot_pmem_queue(&mut runtime, &mut mmio_dispatcher, 0);
+        let mut flush_calls = 0;
+        let mut flush_provider = |_: &PmemMmioDeviceRegistration| {
+            flush_calls += 1;
+            VirtioPmemFlushStatus::Success
+        };
+
+        let dispatches = dispatch_boot_pmem_notifications_with_provider(
+            &mut memory,
+            &mut runtime,
+            &mut mmio_dispatcher,
+            &mut flush_provider,
+        );
+
+        assert_eq!(flush_calls, 0);
+        let dispatch = dispatches.as_slice()[0]
+            .outcome()
+            .dispatched()
+            .expect("malformed pmem event should still dispatch")
+            .queue_dispatch()
+            .expect("malformed pmem queue should be present");
+        assert_eq!(dispatch.parse_failures(), 1);
+        assert_eq!(dispatch.successful_flushes(), 0);
+        assert_eq!(dispatch.failed_flushes(), 0);
     }
 
     #[test]

--- a/crates/runtime/src/pmem.rs
+++ b/crates/runtime/src/pmem.rs
@@ -438,9 +438,10 @@ impl VirtioPmemQueue {
     pub fn dispatch(
         &mut self,
         memory: &mut GuestMemory,
-        flush_status: VirtioPmemFlushStatus,
+        flush: &mut impl FnMut() -> VirtioPmemFlushStatus,
     ) -> Result<VirtioPmemQueueDispatch, VirtioPmemQueueDispatchError> {
         let mut dispatch = VirtioPmemQueueDispatch::default();
+        let mut cached_flush_status = None;
         while let Some(chain) = self
             .available
             .pop_descriptor_chain(memory)
@@ -456,6 +457,14 @@ impl VirtioPmemQueue {
             })?;
             let (completion, outcome) = match VirtioPmemRequest::parse(memory, &chain) {
                 Ok(request) => {
+                    let flush_status = match cached_flush_status {
+                        Some(status) => status,
+                        None => {
+                            let status = flush();
+                            cached_flush_status = Some(status);
+                            status
+                        }
+                    };
                     let execution = request.execute(memory, flush_status);
                     (
                         execution.completion(),
@@ -701,7 +710,7 @@ impl VirtioPmemDevice {
         &mut self,
         memory: &mut GuestMemory,
         drained_notifications: Vec<usize>,
-        flush_status: VirtioPmemFlushStatus,
+        flush: &mut impl FnMut() -> VirtioPmemFlushStatus,
     ) -> Result<VirtioPmemDeviceNotificationDispatch, VirtioPmemDeviceNotificationError> {
         if drained_notifications.is_empty() {
             return Ok(VirtioPmemDeviceNotificationDispatch::new(
@@ -727,7 +736,7 @@ impl VirtioPmemDevice {
             });
         };
 
-        match queue.dispatch(memory, flush_status) {
+        match queue.dispatch(memory, flush) {
             Ok(dispatch) => Ok(VirtioPmemDeviceNotificationDispatch::new(
                 drained_notifications,
                 Some(dispatch),
@@ -776,12 +785,12 @@ impl<C: VirtioMmioDeviceConfigHandler> VirtioMmioRegisterHandler<C, VirtioPmemDe
     pub fn dispatch_pmem_queue_notifications(
         &mut self,
         memory: &mut GuestMemory,
-        flush_status: VirtioPmemFlushStatus,
+        flush: &mut impl FnMut() -> VirtioPmemFlushStatus,
     ) -> Result<VirtioPmemDeviceNotificationDispatch, VirtioPmemDeviceNotificationError> {
         let drained_notifications = self.take_pending_queue_notifications();
         let dispatch = self
             .activation_handler_mut()
-            .dispatch_drained_queue_notifications(memory, drained_notifications, flush_status);
+            .dispatch_drained_queue_notifications(memory, drained_notifications, flush);
         let needs_queue_interrupt = match &dispatch {
             Ok(dispatch) => dispatch.needs_queue_interrupt(),
             Err(error) => error
@@ -2135,6 +2144,8 @@ pub struct PmemMmioDeviceRegistration {
     index: usize,
     pmem_id: String,
     region: MmioRegion,
+    guest_range: GuestMemoryRange,
+    file_len: u64,
     config_space: VirtioPmemConfigSpace,
 }
 
@@ -2149,6 +2160,14 @@ impl PmemMmioDeviceRegistration {
 
     pub const fn region(&self) -> MmioRegion {
         self.region
+    }
+
+    pub const fn guest_range(&self) -> GuestMemoryRange {
+        self.guest_range
+    }
+
+    pub const fn file_len(&self) -> u64 {
+        self.file_len
     }
 
     pub const fn region_id(&self) -> MmioRegionId {
@@ -2201,6 +2220,8 @@ impl PmemMmioDevices {
         let mut dispatcher = dispatcher;
         for (prepared_device, placement) in prepared.as_slice().iter().zip(placements) {
             let pmem_id = prepared_device.id().to_string();
+            let guest_range = prepared_device.guest_range();
+            let file_len = prepared_device.mapping().file_len();
             let config_space = prepared_device.config_space();
             let handler = VirtioMmioRegisterHandler::with_device_config_and_activation(
                 VIRTIO_PMEM_DEVICE_ID,
@@ -2238,6 +2259,8 @@ impl PmemMmioDevices {
                 index: placement.index,
                 pmem_id,
                 region,
+                guest_range,
+                file_len,
                 config_space,
             });
         }
@@ -3085,8 +3108,12 @@ mod tests {
     }
 
     fn write_request_type(memory: &mut GuestMemory, request_type: u32) {
+        write_request_type_at(memory, TEST_PMEM_REQUEST_ADDR, request_type);
+    }
+
+    fn write_request_type_at(memory: &mut GuestMemory, address: GuestAddress, request_type: u32) {
         memory
-            .write_slice(&request_type.to_le_bytes(), TEST_PMEM_REQUEST_ADDR)
+            .write_slice(&request_type.to_le_bytes(), address)
             .expect("pmem request type should write");
     }
 
@@ -3215,18 +3242,32 @@ mod tests {
     }
 
     fn write_pmem_flush_chain(memory: &mut GuestMemory) {
-        write_request_type(memory, VIRTIO_PMEM_REQUEST_TYPE_FLUSH);
-        write_descriptor(
-            memory,
-            0,
-            TestDescriptor::readable(TEST_PMEM_REQUEST_ADDR, VIRTIO_PMEM_REQUEST_SIZE, Some(1)),
-        );
-        write_descriptor(
-            memory,
-            1,
-            TestDescriptor::writable(TEST_PMEM_STATUS_ADDR, VIRTIO_PMEM_STATUS_SIZE, None),
-        );
+        write_pmem_flush_chain_at(memory, 0, 1, TEST_PMEM_REQUEST_ADDR, TEST_PMEM_STATUS_ADDR);
         write_available_heads(memory, &[0]);
+    }
+
+    fn write_pmem_flush_chain_at(
+        memory: &mut GuestMemory,
+        request_index: u16,
+        status_index: u16,
+        request_address: GuestAddress,
+        status_address: GuestAddress,
+    ) {
+        write_request_type_at(memory, request_address, VIRTIO_PMEM_REQUEST_TYPE_FLUSH);
+        write_descriptor(
+            memory,
+            request_index,
+            TestDescriptor::readable(
+                request_address,
+                VIRTIO_PMEM_REQUEST_SIZE,
+                Some(status_index),
+            ),
+        );
+        write_descriptor(
+            memory,
+            status_index,
+            TestDescriptor::writable(status_address, VIRTIO_PMEM_STATUS_SIZE, None),
+        );
     }
 
     #[test]
@@ -3340,11 +3381,17 @@ mod tests {
         let mut memory = request_memory();
         write_pmem_flush_chain(&mut memory);
         let mut queue = pmem_queue();
+        let mut flush_calls = 0;
+        let mut flush = || {
+            flush_calls += 1;
+            VirtioPmemFlushStatus::Success
+        };
 
         let dispatch = queue
-            .dispatch(&mut memory, VirtioPmemFlushStatus::Success)
+            .dispatch(&mut memory, &mut flush)
             .expect("pmem flush queue should dispatch");
 
+        assert_eq!(flush_calls, 1);
         assert_eq!(dispatch.processed_requests(), 1);
         assert_eq!(dispatch.successful_flushes(), 1);
         assert_eq!(dispatch.failed_flushes(), 0);
@@ -3367,11 +3414,17 @@ mod tests {
         let mut memory = request_memory();
         write_pmem_flush_chain(&mut memory);
         let mut queue = pmem_queue();
+        let mut flush_calls = 0;
+        let mut flush = || {
+            flush_calls += 1;
+            VirtioPmemFlushStatus::Failure
+        };
 
         let dispatch = queue
-            .dispatch(&mut memory, VirtioPmemFlushStatus::Failure)
+            .dispatch(&mut memory, &mut flush)
             .expect("pmem flush queue should dispatch");
 
+        assert_eq!(flush_calls, 1);
         assert_eq!(dispatch.processed_requests(), 1);
         assert_eq!(dispatch.successful_flushes(), 0);
         assert_eq!(dispatch.failed_flushes(), 1);
@@ -3384,6 +3437,114 @@ mod tests {
         );
         assert_eq!(read_used_index(&memory), 1);
         assert_eq!(read_used_element(&memory, 0), (0, VIRTIO_PMEM_STATUS_SIZE));
+    }
+
+    #[test]
+    fn pmem_queue_dispatch_skips_flush_for_empty_queue() {
+        let mut memory = request_memory();
+        let mut queue = pmem_queue();
+        let mut flush_calls = 0;
+        let mut flush = || {
+            flush_calls += 1;
+            VirtioPmemFlushStatus::Success
+        };
+
+        let dispatch = queue
+            .dispatch(&mut memory, &mut flush)
+            .expect("empty pmem queue should dispatch");
+
+        assert_eq!(flush_calls, 0);
+        assert_eq!(dispatch.processed_requests(), 0);
+        assert!(!dispatch.needs_queue_interrupt());
+        assert_eq!(read_used_index(&memory), 0);
+    }
+
+    #[test]
+    fn pmem_queue_dispatch_flushes_once_after_first_valid_chain() {
+        let mut memory = request_memory();
+        write_request_type(&mut memory, VIRTIO_PMEM_REQUEST_TYPE_FLUSH);
+        write_descriptor(
+            &mut memory,
+            0,
+            TestDescriptor::writable(TEST_PMEM_REQUEST_ADDR, VIRTIO_PMEM_REQUEST_SIZE, Some(1)),
+        );
+        write_descriptor(
+            &mut memory,
+            1,
+            TestDescriptor::writable(TEST_PMEM_STATUS_ADDR, VIRTIO_PMEM_STATUS_SIZE, None),
+        );
+        let first_request = GuestAddress::new(0x2010);
+        let first_status = GuestAddress::new(0x3010);
+        let second_request = GuestAddress::new(0x2020);
+        let second_status = GuestAddress::new(0x3020);
+        write_pmem_flush_chain_at(&mut memory, 2, 3, first_request, first_status);
+        write_pmem_flush_chain_at(&mut memory, 4, 5, second_request, second_status);
+        memory
+            .write_slice(&99_i32.to_le_bytes(), TEST_PMEM_STATUS_ADDR)
+            .expect("invalid-chain status sentinel should write");
+        write_available_heads(&mut memory, &[0, 2, 4]);
+        let mut queue = pmem_queue();
+        let mut flush_calls = 0;
+        let mut flush = || {
+            flush_calls += 1;
+            VirtioPmemFlushStatus::Success
+        };
+
+        let dispatch = queue
+            .dispatch(&mut memory, &mut flush)
+            .expect("mixed pmem chains should dispatch");
+
+        assert_eq!(flush_calls, 1);
+        assert_eq!(dispatch.processed_requests(), 3);
+        assert_eq!(dispatch.successful_flushes(), 2);
+        assert_eq!(dispatch.parse_failures(), 1);
+        assert_eq!(read_guest_i32(&memory, TEST_PMEM_STATUS_ADDR), 99);
+        assert_eq!(
+            read_guest_i32(&memory, first_status),
+            VIRTIO_PMEM_STATUS_SUCCESS
+        );
+        assert_eq!(
+            read_guest_i32(&memory, second_status),
+            VIRTIO_PMEM_STATUS_SUCCESS
+        );
+        assert_eq!(read_used_index(&memory), 3);
+        assert_eq!(read_used_element(&memory, 0), (0, 0));
+        assert_eq!(read_used_element(&memory, 1), (2, VIRTIO_PMEM_STATUS_SIZE));
+        assert_eq!(read_used_element(&memory, 2), (4, VIRTIO_PMEM_STATUS_SIZE));
+    }
+
+    #[test]
+    fn pmem_queue_dispatch_caches_failed_flush_for_all_valid_chains() {
+        let mut memory = request_memory();
+        let first_request = GuestAddress::new(0x2010);
+        let first_status = GuestAddress::new(0x3010);
+        let second_request = GuestAddress::new(0x2020);
+        let second_status = GuestAddress::new(0x3020);
+        write_pmem_flush_chain_at(&mut memory, 0, 1, first_request, first_status);
+        write_pmem_flush_chain_at(&mut memory, 2, 3, second_request, second_status);
+        write_available_heads(&mut memory, &[0, 2]);
+        let mut queue = pmem_queue();
+        let mut flush_calls = 0;
+        let mut flush = || {
+            flush_calls += 1;
+            VirtioPmemFlushStatus::Failure
+        };
+
+        let dispatch = queue
+            .dispatch(&mut memory, &mut flush)
+            .expect("valid pmem chains should share failed flush result");
+
+        assert_eq!(flush_calls, 1);
+        assert_eq!(dispatch.processed_requests(), 2);
+        assert_eq!(dispatch.failed_flushes(), 2);
+        assert_eq!(
+            read_guest_i32(&memory, first_status),
+            VIRTIO_PMEM_STATUS_FAILURE
+        );
+        assert_eq!(
+            read_guest_i32(&memory, second_status),
+            VIRTIO_PMEM_STATUS_FAILURE
+        );
     }
 
     #[test]
@@ -3405,11 +3566,17 @@ mod tests {
             .expect("sentinel status should write");
         write_available_heads(&mut memory, &[0]);
         let mut queue = pmem_queue();
+        let mut flush_calls = 0;
+        let mut flush = || {
+            flush_calls += 1;
+            VirtioPmemFlushStatus::Success
+        };
 
         let dispatch = queue
-            .dispatch(&mut memory, VirtioPmemFlushStatus::Success)
+            .dispatch(&mut memory, &mut flush)
             .expect("invalid pmem request should still publish a completion");
 
+        assert_eq!(flush_calls, 0);
         assert_eq!(dispatch.processed_requests(), 1);
         assert_eq!(dispatch.successful_flushes(), 0);
         assert_eq!(dispatch.failed_flushes(), 0);
@@ -3451,11 +3618,17 @@ mod tests {
         );
         write_available_heads(&mut memory, &[0]);
         let mut queue = pmem_queue();
+        let mut flush_calls = 0;
+        let mut flush = || {
+            flush_calls += 1;
+            VirtioPmemFlushStatus::Success
+        };
 
         let dispatch = queue
-            .dispatch(&mut memory, VirtioPmemFlushStatus::Success)
+            .dispatch(&mut memory, &mut flush)
             .expect("status write failure should still publish a completion");
 
+        assert_eq!(flush_calls, 1);
         assert_eq!(dispatch.processed_requests(), 1);
         assert_eq!(dispatch.successful_flushes(), 0);
         assert_eq!(dispatch.failed_flushes(), 0);
@@ -3470,6 +3643,41 @@ mod tests {
         );
         assert_eq!(read_used_index(&memory), 1);
         assert_eq!(read_used_element(&memory, 0), (0, 0));
+    }
+
+    #[test]
+    fn pmem_queue_dispatch_does_not_repeat_flush_after_used_ring_failure() {
+        let mut memory = request_memory();
+        write_pmem_flush_chain(&mut memory);
+        let available = VirtqueueAvailableRing::new(
+            TEST_DESCRIPTOR_TABLE,
+            TEST_AVAILABLE_RING,
+            TEST_QUEUE_SIZE,
+        )
+        .expect("available ring should build");
+        let used = VirtqueueUsedRing::new(GuestAddress::new(TEST_MEMORY_SIZE), TEST_QUEUE_SIZE)
+            .expect("used ring should build");
+        let mut queue = VirtioPmemQueue::new(available, used);
+        let mut flush_calls = 0;
+        let mut flush = || {
+            flush_calls += 1;
+            VirtioPmemFlushStatus::Success
+        };
+
+        let error = queue
+            .dispatch(&mut memory, &mut flush)
+            .expect_err("unmapped used ring should fail after one targeted flush");
+
+        assert_eq!(flush_calls, 1);
+        assert!(matches!(
+            error,
+            VirtioPmemQueueDispatchError::UsedRing { .. }
+        ));
+        assert_eq!(error.completed_dispatch().processed_requests(), 0);
+        assert_eq!(
+            read_guest_i32(&memory, TEST_PMEM_STATUS_ADDR),
+            VIRTIO_PMEM_STATUS_SUCCESS
+        );
     }
 
     #[test]
@@ -3496,6 +3704,14 @@ mod tests {
         assert_eq!(registration.pmem_id(), "pmem0");
         assert_eq!(registration.region_id(), TEST_PMEM_MMIO_REGION_ID);
         assert_eq!(registration.address(), TEST_PMEM_MMIO_BASE);
+        assert_eq!(
+            registration.guest_range(),
+            devices.pmem_devices()[0].guest_range()
+        );
+        assert_eq!(
+            registration.file_len(),
+            devices.pmem_devices()[0].mapping().file_len()
+        );
         assert_eq!(
             registration.region().range().size(),
             VIRTIO_MMIO_DEVICE_WINDOW_SIZE

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -2006,6 +2006,19 @@ pub struct Arm64BootPmemDevice {
     pub fdt_device: Arm64FdtVirtioMmioDevice,
 }
 
+pub trait Arm64BootPmemFlushProvider {
+    fn flush(&mut self, registration: &PmemMmioDeviceRegistration) -> VirtioPmemFlushStatus;
+}
+
+impl<F> Arm64BootPmemFlushProvider for F
+where
+    F: FnMut(&PmemMmioDeviceRegistration) -> VirtioPmemFlushStatus,
+{
+    fn flush(&mut self, registration: &PmemMmioDeviceRegistration) -> VirtioPmemFlushStatus {
+        self(registration)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Arm64BootNetworkDevice {
     pub registration: NetworkMmioDeviceRegistration,
@@ -2240,23 +2253,11 @@ impl Arm64BootRuntimeResources {
         Ok(Arm64BootBlockNotificationDispatches::new(devices))
     }
 
-    pub fn has_pending_pmem_queue_notifications(
-        &self,
-        mmio_dispatcher: &mut MmioDispatcher,
-    ) -> bool {
-        self.pmem_mmio_devices.iter().any(|device| {
-            let region_id = device.registration.region_id();
-            mmio_dispatcher
-                .handler_mut::<VirtioPmemMmioHandler>(region_id)
-                .is_ok_and(|handler| handler.has_pending_queue_notifications())
-        })
-    }
-
     pub fn dispatch_pmem_queue_notifications(
         &mut self,
         memory: &mut GuestMemory,
         mmio_dispatcher: &mut MmioDispatcher,
-        flush_status: VirtioPmemFlushStatus,
+        flush_provider: &mut impl Arm64BootPmemFlushProvider,
     ) -> Result<Arm64BootPmemNotificationDispatches, Arm64BootPmemNotificationDispatchError> {
         let mut devices = Vec::new();
         devices
@@ -2269,7 +2270,8 @@ impl Arm64BootRuntimeResources {
             let region_id = device.registration.region_id();
             let outcome = match mmio_dispatcher.handler_mut::<VirtioPmemMmioHandler>(region_id) {
                 Ok(handler) => {
-                    match handler.dispatch_pmem_queue_notifications(memory, flush_status) {
+                    let mut flush = || flush_provider.flush(&device.registration);
+                    match handler.dispatch_pmem_queue_notifications(memory, &mut flush) {
                         Ok(dispatch) => Arm64BootPmemNotificationOutcome::Dispatched(dispatch),
                         Err(source) => Arm64BootPmemNotificationOutcome::DispatchFailed(source),
                     }


### PR DESCRIPTION
## Summary

- invoke pmem writeback lazily after the first fully valid FLUSH chain and reuse that result for the rest of the device dispatch
- retain path-free pmem identity and route each notification to the exact HVF shadow guest range
- preserve read-only no-op and clean-unmap writeback while adding two-device selection and failure-isolation coverage

## Scope exclusions

- pmem rate limiting and runtime limiter replacement remain in #1331
- direct file-backed HVF mapping, dirty-range tracking, root-pmem semantics, PCI, and snapshot state remain out of scope

## Verification

- cargo fmt --all -- --check
- cargo check --workspace --all-targets --all-features --locked
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo clippy for executable_hvf_e2e, app_sandbox_process_e2e, hvf_lifecycle, and guest_boot on aarch64-apple-darwin
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
- scripts/run-integration-tests.sh --test executable_hvf_e2e -- macos_arm64::signed_executable_flushes_virtio_pmem_from_direct_rootfs_guest --exact
- scripts/run-integration-tests.sh

Fixes #1330