### PR TITLE
fix: bound observability logger delivery

### DIFF
--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -630,10 +630,10 @@ fn handle_request_bytes_with_limit(
     http_api_max_payload_size: usize,
 ) -> HttpResponse {
     match parse_request_with_limit(bytes, http_api_max_payload_size) {
-        Ok(request) => match log_api_request(&request, vmm) {
-            Ok(_) => handle_api_request(request, vmm),
-            Err(err) => handle_empty(Err(err)),
-        },
+        Ok(request) => {
+            log_api_request(&request, vmm);
+            handle_api_request(request, vmm)
+        }
         Err(err) => {
             if err == RequestError::SendCtrlAltDelUnsupported {
                 record_unsupported_put_action_request(bytes, vmm);
@@ -649,10 +649,7 @@ fn handle_request_bytes_with_limit(
     }
 }
 
-fn log_api_request(
-    request: &ApiRequest,
-    vmm: &mut impl VmmRequestHandler,
-) -> Result<bool, VmmActionError> {
+fn log_api_request(request: &ApiRequest, vmm: &mut impl VmmRequestHandler) -> bool {
     match request {
         ApiRequest::GetInstanceInfo => vmm.log_api_request("Get", "/"),
         ApiRequest::GetBalloon => vmm.log_api_request("Get", "/balloon"),
@@ -2200,7 +2197,7 @@ mod tests {
         VirtioBalloonStat,
     };
     use bangbang_runtime::block::DriveUpdateError;
-    use bangbang_runtime::logger::{LoggerConfigInput, LoggerWriteError};
+    use bangbang_runtime::logger::LoggerConfigInput;
     use bangbang_runtime::machine::MAX_MEM_SIZE_MIB;
     use bangbang_runtime::memory::{
         GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange,
@@ -2709,18 +2706,6 @@ mod tests {
         assert_eq!(body.get("swap_in"), None);
     }
 
-    #[test]
-    fn handle_empty_maps_logger_write_errors_to_fault() {
-        let response = handle_empty(Err(VmmActionError::LoggerWrite(LoggerWriteError::Write(
-            std::io::ErrorKind::BrokenPipe,
-        ))));
-
-        assert_eq!(
-            response.body(),
-            r#"{"fault_message":"failed to write logger output: BrokenPipe"}"#
-        );
-    }
-
     fn unique_socket_path(name: &str) -> PathBuf {
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -2874,11 +2859,7 @@ mod tests {
         }
 
         #[track_caller]
-        fn log_api_request(
-            &mut self,
-            method: &str,
-            path: impl std::fmt::Display,
-        ) -> Result<bool, VmmActionError> {
+        fn log_api_request(&mut self, method: &str, path: impl std::fmt::Display) -> bool {
             self.inner.log_api_request(method, path)
         }
 

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -2455,11 +2455,7 @@ mod tests {
         }
 
         #[track_caller]
-        fn log_api_request(
-            &mut self,
-            method: &str,
-            path: impl std::fmt::Display,
-        ) -> Result<bool, VmmActionError> {
+        fn log_api_request(&mut self, method: &str, path: impl std::fmt::Display) -> bool {
             self.inner.log_api_request(method, path)
         }
 

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -1125,11 +1125,7 @@ pub(crate) trait VmmRequestHandler {
     fn record_deprecated_api_call(&mut self);
 
     #[track_caller]
-    fn log_api_request(
-        &mut self,
-        method: &str,
-        path: impl fmt::Display,
-    ) -> Result<bool, VmmActionError>;
+    fn log_api_request(&mut self, method: &str, path: impl fmt::Display) -> bool;
 
     fn record_pause_vm_latency_us(&mut self, duration_us: u64);
 
@@ -1371,11 +1367,7 @@ where
     }
 
     #[track_caller]
-    fn log_api_request(
-        &mut self,
-        method: &str,
-        path: impl fmt::Display,
-    ) -> Result<bool, VmmActionError> {
+    fn log_api_request(&mut self, method: &str, path: impl fmt::Display) -> bool {
         self.controller.log_api_request(method, path)
     }
 
@@ -1943,11 +1935,7 @@ where
     }
 
     #[track_caller]
-    fn log_api_request(
-        &mut self,
-        method: &str,
-        path: impl fmt::Display,
-    ) -> Result<bool, VmmActionError> {
+    fn log_api_request(&mut self, method: &str, path: impl fmt::Display) -> bool {
         ProcessVmm::log_api_request(self, method, path)
     }
 
@@ -8306,7 +8294,6 @@ mod tests {
             | VmmActionError::DriveUpdate(_)
             | VmmActionError::DriveUpdateUnsupported
             | VmmActionError::LoggerConfig(_)
-            | VmmActionError::LoggerWrite(_)
             | VmmActionError::MachineConfig(_)
             | VmmActionError::MetricsConfig(_)
             | VmmActionError::MetricsFlush(_)

--- a/crates/runtime/src/boot_timer.rs
+++ b/crates/runtime/src/boot_timer.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 use std::mem::MaybeUninit;
 
-use crate::logger::{BootTimerLogger, LoggerWriteError};
+use crate::logger::BootTimerLogger;
 use crate::memory::GuestAddress;
 use crate::mmio::{
     MmioAccess, MmioAccessBytes, MmioAccessBytesError, MmioBusError, MmioDispatchError,
@@ -152,8 +152,7 @@ where
             .map_err(|source| BootTimerMmioError::Clock { source })?
             .elapsed_since(self.start);
         self.logger
-            .log_boot_time(elapsed.wall_time_us(), elapsed.cpu_time_us())
-            .map_err(|source| BootTimerMmioError::Logger { source })?;
+            .log_boot_time(elapsed.wall_time_us(), elapsed.cpu_time_us());
         Ok(())
     }
 }
@@ -192,9 +191,6 @@ pub enum BootTimerMmioError {
     Clock {
         source: BootTimerClockError,
     },
-    Logger {
-        source: LoggerWriteError,
-    },
 }
 
 impl fmt::Display for BootTimerMmioError {
@@ -225,9 +221,6 @@ impl fmt::Display for BootTimerMmioError {
                 write!(f, "failed to build boot timer MMIO read bytes: {source}")
             }
             Self::Clock { source } => write!(f, "failed to read boot timer clock: {source}"),
-            Self::Logger { source } => {
-                write!(f, "failed to write boot timer logger output: {source}")
-            }
         }
     }
 }
@@ -237,7 +230,6 @@ impl std::error::Error for BootTimerMmioError {
         match self {
             Self::BuildReadBytes { source } => Some(source),
             Self::Clock { source } => Some(source),
-            Self::Logger { source } => Some(source),
             Self::UnsupportedAccessSize { .. }
             | Self::UnsupportedWriteDataLength { .. }
             | Self::InvalidRegisterOffset { .. } => None,
@@ -391,6 +383,7 @@ fn timespec_time_us(time: libc::timespec) -> Result<u64, std::io::ErrorKind> {
 mod tests {
     use std::collections::VecDeque;
     use std::fs;
+    use std::io::{Error, ErrorKind, Write};
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -400,7 +393,7 @@ mod tests {
         BootTimerClock, BootTimerClockError, BootTimerMmioDevice, BootTimerMmioError,
         BootTimerMmioLayout, BootTimerTimestamp, register_boot_timer_mmio,
     };
-    use crate::logger::{LoggerConfigInput, LoggerState};
+    use crate::logger::{LoggerConfigInput, LoggerState, SharedLoggerMetrics};
     use crate::memory::GuestAddress;
     use crate::mmio::{
         MmioAccessBytes, MmioDispatchError, MmioDispatchOutcome, MmioDispatcher, MmioOperation,
@@ -429,6 +422,19 @@ mod tests {
             self.timestamps
                 .pop_front()
                 .expect("test clock should have a timestamp")
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingWriter;
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(Error::from(ErrorKind::BrokenPipe))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
         }
     }
 
@@ -505,6 +511,35 @@ mod tests {
             "Guest-boot-time =   7123 us 7 ms,   1456 CPU us 1 CPU ms\n"
         );
         fs::remove_file(path).expect("fixture should clean up");
+    }
+
+    #[test]
+    fn magic_write_succeeds_when_logger_delivery_fails() {
+        let metrics = SharedLoggerMetrics::default();
+        let mut logger_state = LoggerState::with_shared_metrics(metrics.clone());
+        logger_state.configure_test_writer(FailingWriter);
+        let device = BootTimerMmioDevice::with_clock(
+            ScriptedClock::new(VecDeque::from([
+                Ok(BootTimerTimestamp::new(10_000, 1_000)),
+                Ok(BootTimerTimestamp::new(17_123, 2_456)),
+            ])),
+            logger_state.boot_timer_logger(),
+        )
+        .expect("boot timer should build");
+        let mut dispatcher = dispatcher_with_device(device);
+        let access = dispatcher
+            .lookup(GuestAddress::new(0x1000), 1)
+            .expect("boot timer access should resolve");
+        let operation = MmioOperation::write(access, bytes(&[BOOT_TIMER_MAGIC_VALUE]))
+            .expect("write operation should build");
+
+        assert_eq!(
+            dispatcher
+                .dispatch(operation)
+                .expect("logger failure should not fail MMIO write"),
+            MmioDispatchOutcome::Write
+        );
+        assert_eq!(metrics.missed_log_count(), 1);
     }
 
     #[test]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -382,7 +382,6 @@ pub enum VmmActionError {
     DriveUpdateUnsupported,
     EntropyConfig(entropy::EntropyConfigError),
     LoggerConfig(logger::LoggerConfigError),
-    LoggerWrite(logger::LoggerWriteError),
     MachineConfig(machine::MachineConfigError),
     MetricsConfig(metrics::MetricsConfigError),
     MetricsFlush(metrics::MetricsFlushError),
@@ -438,7 +437,6 @@ impl fmt::Display for VmmActionError {
             Self::DriveUpdateUnsupported => f.write_str("Drive updates are not supported."),
             Self::EntropyConfig(err) => write!(f, "{err}"),
             Self::LoggerConfig(err) => write!(f, "{err}"),
-            Self::LoggerWrite(err) => write!(f, "{err}"),
             Self::MachineConfig(err) => write!(f, "{err}"),
             Self::MetricsConfig(err) => write!(f, "{err}"),
             Self::MetricsFlush(err) => write!(f, "{err}"),
@@ -483,7 +481,6 @@ impl std::error::Error for VmmActionError {
             Self::DriveUpdate(err) => Some(err),
             Self::EntropyConfig(err) => Some(err),
             Self::LoggerConfig(err) => Some(err),
-            Self::LoggerWrite(err) => Some(err),
             Self::MachineConfig(err) => Some(err),
             Self::MetricsConfig(err) => Some(err),
             Self::MetricsFlush(err) => Some(err),
@@ -556,6 +553,7 @@ impl VmmController {
         app_name: impl Into<String>,
         mmds_data_store_limit_bytes: usize,
     ) -> Self {
+        let shared_logger_metrics = logger::SharedLoggerMetrics::default();
         Self {
             instance_info: InstanceInfo::new(
                 instance_id,
@@ -574,8 +572,8 @@ impl VmmController {
             balloon_config: None,
             pmem_configs: pmem::PmemConfigs::new(),
             serial_config: serial::SerialConfig::default(),
-            logger_state: logger::LoggerState::default(),
-            metrics_state: metrics::MetricsState::default(),
+            logger_state: logger::LoggerState::with_shared_metrics(shared_logger_metrics.clone()),
+            metrics_state: metrics::MetricsState::with_shared_logger_metrics(shared_logger_metrics),
             mmds_state: mmds::MmdsStateHandle::new(mmds::MmdsState::new(
                 mmds_data_store_limit_bytes,
             )),
@@ -646,9 +644,7 @@ impl VmmController {
     }
 
     pub fn boot_timer_logger(&self) -> logger::BootTimerLogger {
-        self.logger_state
-            .boot_timer_logger()
-            .with_missed_log_counter(self.metrics_state.missed_log_counter())
+        self.logger_state.boot_timer_logger()
     }
 
     pub fn vm_config(&self) -> Result<VmConfiguration, mmds::MmdsStateLockError> {
@@ -877,7 +873,7 @@ impl VmmController {
     {
         self.preflight_instance_start()?;
         executor(self).map_err(VmmActionError::InstanceStart)?;
-        self.log_action(VmmAction::InstanceStart.name())?;
+        self.log_action(VmmAction::InstanceStart.name());
         self.instance_info.state = InstanceState::Running;
         Ok(VmmData::Empty)
     }
@@ -1017,25 +1013,13 @@ impl VmmController {
     }
 
     #[track_caller]
-    fn log_action(&mut self, action: &str) -> Result<(), VmmActionError> {
-        if let Err(err) = self.logger_state.log_action(action) {
-            self.metrics_state.record_missed_log();
-            return Err(VmmActionError::LoggerWrite(err));
-        }
-
-        Ok(())
+    fn log_action(&self, action: &str) -> bool {
+        self.logger_state.log_action(action)
     }
 
     #[track_caller]
-    pub fn log_api_request(
-        &mut self,
-        method: &str,
-        path: impl fmt::Display,
-    ) -> Result<bool, VmmActionError> {
-        self.logger_state
-            .log_api_request(method, path)
-            .inspect_err(|_| self.metrics_state.record_missed_log())
-            .map_err(VmmActionError::LoggerWrite)
+    pub fn log_api_request(&mut self, method: &str, path: impl fmt::Display) -> bool {
+        self.logger_state.log_api_request(method, path)
     }
 
     pub fn record_put_actions_request(&mut self) {
@@ -1666,7 +1650,7 @@ impl VmmController {
         self.metrics_state
             .flush_with_diagnostics(diagnostics)
             .map_err(VmmActionError::MetricsFlush)?;
-        self.log_action(VmmAction::FlushMetrics.name())?;
+        self.log_action(VmmAction::FlushMetrics.name());
         Ok(VmmData::Empty)
     }
 
@@ -1742,7 +1726,7 @@ mod tests {
         entropy::{
             EntropyConfig, EntropyConfigInput, EntropyRateLimiterConfig, EntropyTokenBucketConfig,
         },
-        logger::{LoggerConfigError, LoggerConfigInput, LoggerLevel, LoggerWriteError},
+        logger::{LoggerConfigError, LoggerConfigInput, LoggerLevel},
         machine::{
             DEFAULT_MEM_SIZE_MIB, DEFAULT_VCPU_COUNT, MAX_MEM_SIZE_MIB, MachineConfigError,
             MachineConfigInput, MachineConfigPatchInput,
@@ -4891,7 +4875,7 @@ mod tests {
     }
 
     #[test]
-    fn start_instance_logger_write_failure_reports_missed_log_count_in_metrics() {
+    fn start_instance_logger_write_failure_does_not_fail_startup() {
         let metrics_path = unique_metrics_path("start-missed-log");
         let mut controller = VmmController::new("demo-1", "0.1.0", "bangbang");
         controller
@@ -4904,15 +4888,11 @@ mod tests {
             .expect("boot source config should be stored");
         controller.logger_state.configure_test_writer(FailingWriter);
 
-        let err = controller
+        controller
             .commit_instance_start()
-            .expect_err("logger write should fail startup commit");
+            .expect("logger write failure should not fail startup commit");
 
-        assert_eq!(
-            err,
-            VmmActionError::LoggerWrite(LoggerWriteError::Write(ErrorKind::BrokenPipe))
-        );
-        assert_eq!(controller.instance_info().state, InstanceState::NotStarted);
+        assert_eq!(controller.instance_info().state, InstanceState::Running);
         assert_eq!(
             controller.flush_startup_metrics_with_diagnostics(&MetricsDiagnostics::default()),
             Ok(true)
@@ -4937,11 +4917,7 @@ mod tests {
         controller.logger_state.configure_test_writer(FailingWriter);
         let boot_timer_logger = controller.boot_timer_logger();
 
-        let err = boot_timer_logger
-            .log_boot_time(1_000, 200)
-            .expect_err("boot timer logger write should fail");
-
-        assert_eq!(err, LoggerWriteError::Write(ErrorKind::BrokenPipe));
+        assert!(!boot_timer_logger.log_boot_time(1_000, 200));
         assert_eq!(
             controller.flush_startup_metrics_with_diagnostics(&MetricsDiagnostics::default()),
             Ok(true)
@@ -4965,14 +4941,7 @@ mod tests {
             .expect("metrics config should be stored");
         controller.logger_state.configure_test_writer(FailingWriter);
 
-        let err = controller
-            .log_api_request("Put", "/mmds")
-            .expect_err("API request logger write should fail");
-
-        assert_eq!(
-            err,
-            VmmActionError::LoggerWrite(LoggerWriteError::Write(ErrorKind::BrokenPipe))
-        );
+        assert!(!controller.log_api_request("Put", "/mmds"));
         assert_eq!(
             controller.flush_startup_metrics_with_diagnostics(&MetricsDiagnostics::default()),
             Ok(true)
@@ -5004,10 +4973,7 @@ mod tests {
         first.logger_state.configure_test_writer(FailingWriter);
         let first_boot_timer_logger = first.boot_timer_logger();
 
-        assert_eq!(
-            first_boot_timer_logger.log_boot_time(1_000, 200),
-            Err(LoggerWriteError::Write(ErrorKind::BrokenPipe))
-        );
+        assert!(!first_boot_timer_logger.log_boot_time(1_000, 200));
 
         assert_eq!(
             first.flush_startup_metrics_with_diagnostics(&MetricsDiagnostics::default()),
@@ -5260,7 +5226,7 @@ mod tests {
     }
 
     #[test]
-    fn flush_metrics_logger_write_failure_reports_missed_log_count_in_metrics() {
+    fn flush_metrics_logger_write_failure_does_not_fail_action() {
         let metrics_path = unique_metrics_path("flush-missed-log");
         let mut controller = VmmController::new("demo-1", "0.1.0", "bangbang");
         controller
@@ -5276,13 +5242,9 @@ mod tests {
             .expect("start commit should set running state");
         controller.logger_state.configure_test_writer(FailingWriter);
 
-        let err = controller
-            .handle_action(VmmAction::FlushMetrics)
-            .expect_err("flush metrics action logger write should fail");
-
         assert_eq!(
-            err,
-            VmmActionError::LoggerWrite(LoggerWriteError::Write(ErrorKind::BrokenPipe))
+            controller.handle_action(VmmAction::FlushMetrics),
+            Ok(VmmData::Empty)
         );
         assert_eq!(
             controller.flush_periodic_metrics_with_diagnostics(&MetricsDiagnostics::default()),
@@ -5708,15 +5670,6 @@ mod tests {
         );
         assert!(!controller.logger_state.is_configured());
         assert_eq!(controller.logger_state.level(), LoggerLevel::Info);
-    }
-
-    #[test]
-    fn logger_write_error_preserves_redacted_source() {
-        let err =
-            VmmActionError::LoggerWrite(LoggerWriteError::Write(std::io::ErrorKind::BrokenPipe));
-
-        assert_eq!(err.to_string(), "failed to write logger output: BrokenPipe");
-        assert!(err.source().is_some());
     }
 
     #[test]

--- a/crates/runtime/src/logger.rs
+++ b/crates/runtime/src/logger.rs
@@ -6,11 +6,16 @@ use std::panic::Location;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, TryLockError};
+use std::time::Instant;
 
 const BOOT_TIMER_LOG_MODULE: &str = "bangbang_runtime::boot_timer";
 const API_REQUEST_LOG_MODULE: &str = "bangbang_runtime::api_server";
 const MINIMAL_ACTION_LOG_MODULE: &str = "bangbang_runtime::vmm_action";
+const DEFAULT_LOG_RATE_LIMIT_BURST: u64 = 10;
+const DEFAULT_LOG_RATE_LIMIT_REFILL_MS: u64 = 5_000;
+const DEFAULT_LOG_RATE_LIMIT_PERIOD_MS: u64 =
+    DEFAULT_LOG_RATE_LIMIT_REFILL_MS / DEFAULT_LOG_RATE_LIMIT_BURST;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum LoggerLevel {
@@ -186,47 +191,143 @@ impl fmt::Display for LoggerConfigError {
 
 impl std::error::Error for LoggerConfigError {}
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum LoggerWriteError {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LoggerDeliveryError {
+    LockContended,
     LockPoisoned,
-    Write(std::io::ErrorKind),
+    Write,
 }
 
-impl fmt::Display for LoggerWriteError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::LockPoisoned => f.write_str("logger output lock was poisoned"),
-            Self::Write(kind) => write!(f, "failed to write logger output: {kind:?}"),
-        }
-    }
+#[derive(Debug, Default)]
+struct SharedLoggerMetricsInner {
+    missed_log_count: AtomicU64,
+    rate_limited_log_count: AtomicU64,
 }
-
-impl std::error::Error for LoggerWriteError {}
 
 #[derive(Debug, Clone, Default)]
-pub(crate) struct MissedLogCounter {
-    count: Arc<AtomicU64>,
+pub(crate) struct SharedLoggerMetrics {
+    inner: Arc<SharedLoggerMetricsInner>,
 }
 
-impl MissedLogCounter {
-    pub(crate) fn record(&self) {
-        let mut current = self.count.load(Ordering::Relaxed);
+impl SharedLoggerMetrics {
+    fn record_saturating(counter: &AtomicU64) {
+        let mut current = counter.load(Ordering::Relaxed);
         while current != u64::MAX {
             let next = current.saturating_add(1);
-            match self.count.compare_exchange_weak(
-                current,
-                next,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            ) {
+            match counter.compare_exchange_weak(current, next, Ordering::Relaxed, Ordering::Relaxed)
+            {
                 Ok(_) => return,
                 Err(actual) => current = actual,
             }
         }
     }
 
-    pub(crate) fn count(&self) -> u64 {
-        self.count.load(Ordering::Relaxed)
+    pub(crate) fn record_missed_log(&self) {
+        Self::record_saturating(&self.inner.missed_log_count);
+    }
+
+    pub(crate) fn record_rate_limited_log(&self) {
+        Self::record_saturating(&self.inner.rate_limited_log_count);
+    }
+
+    pub(crate) fn missed_log_count(&self) -> u64 {
+        self.inner.missed_log_count.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn rate_limited_log_count(&self) -> u64 {
+        self.inner.rate_limited_log_count.load(Ordering::Relaxed)
+    }
+}
+
+trait LogRateLimiterClock: fmt::Debug + Send + Sync {
+    fn now_ms(&self) -> u64;
+}
+
+#[derive(Debug)]
+struct SystemLogRateLimiterClock {
+    epoch: Instant,
+}
+
+impl Default for SystemLogRateLimiterClock {
+    fn default() -> Self {
+        Self {
+            epoch: Instant::now(),
+        }
+    }
+}
+
+impl LogRateLimiterClock for SystemLogRateLimiterClock {
+    fn now_ms(&self) -> u64 {
+        let elapsed = self.epoch.elapsed();
+        elapsed
+            .as_secs()
+            .saturating_mul(1_000)
+            .saturating_add(u64::from(elapsed.subsec_millis()))
+    }
+}
+
+#[derive(Debug, Default)]
+struct LogRateLimiterState {
+    theoretical_arrival_time_ms: u64,
+    suppressed: u64,
+}
+
+#[derive(Debug)]
+struct LogRateLimiterInner {
+    clock: Arc<dyn LogRateLimiterClock>,
+    state: Mutex<LogRateLimiterState>,
+}
+
+#[derive(Debug, Clone)]
+struct BootTimerLogRateLimiter {
+    inner: Arc<LogRateLimiterInner>,
+}
+
+impl Default for BootTimerLogRateLimiter {
+    fn default() -> Self {
+        Self::with_clock(Arc::new(SystemLogRateLimiterClock::default()))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LogRateLimitDecision {
+    Admitted { suppressed: u64 },
+    Denied,
+}
+
+impl BootTimerLogRateLimiter {
+    fn with_clock(clock: Arc<dyn LogRateLimiterClock>) -> Self {
+        Self {
+            inner: Arc::new(LogRateLimiterInner {
+                clock,
+                state: Mutex::new(LogRateLimiterState::default()),
+            }),
+        }
+    }
+
+    fn check(&self) -> LogRateLimitDecision {
+        let now_ms = self.inner.clock.now_ms();
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let next_theoretical_arrival_time_ms = state
+            .theoretical_arrival_time_ms
+            .max(now_ms)
+            .saturating_add(DEFAULT_LOG_RATE_LIMIT_PERIOD_MS);
+
+        if next_theoretical_arrival_time_ms.saturating_sub(now_ms)
+            > DEFAULT_LOG_RATE_LIMIT_REFILL_MS
+        {
+            state.suppressed = state.suppressed.saturating_add(1);
+            return LogRateLimitDecision::Denied;
+        }
+
+        state.theoretical_arrival_time_ms = next_theoretical_arrival_time_ms;
+        let suppressed = state.suppressed;
+        state.suppressed = 0;
+        LogRateLimitDecision::Admitted { suppressed }
     }
 }
 
@@ -237,53 +338,62 @@ pub struct BootTimerLogger {
     show_level: bool,
     show_log_origin: bool,
     module: Option<String>,
-    missed_log_counter: Option<MissedLogCounter>,
+    metrics: SharedLoggerMetrics,
+    rate_limiter: BootTimerLogRateLimiter,
 }
 
 impl BootTimerLogger {
-    pub(crate) fn with_missed_log_counter(mut self, counter: MissedLogCounter) -> Self {
-        self.missed_log_counter = Some(counter);
-        self
-    }
-
-    fn record_missed_log(&self) {
-        if let Some(counter) = &self.missed_log_counter {
-            counter.record();
+    fn record_delivery(&self, result: Result<(), LoggerDeliveryError>) -> bool {
+        if result.is_err() {
+            self.metrics.record_missed_log();
+            return false;
         }
+        true
     }
 
     #[track_caller]
-    pub fn log_boot_time(
-        &self,
-        wall_time_us: u64,
-        cpu_time_us: u64,
-    ) -> Result<bool, LoggerWriteError> {
+    pub fn log_boot_time(&self, wall_time_us: u64, cpu_time_us: u64) -> bool {
         const BOOT_TIMER_LEVEL: LoggerLevel = LoggerLevel::Info;
 
         if !self.level.allows(BOOT_TIMER_LEVEL) {
-            return Ok(false);
+            return false;
         }
 
         if !module_filter_allows(self.module.as_deref(), BOOT_TIMER_LOG_MODULE) {
-            return Ok(false);
+            return false;
         }
 
         let Some(sink) = &self.sink else {
-            return Ok(false);
+            return false;
         };
 
-        if let Err(err) = sink.write_boot_timer(
+        let suppressed = match self.rate_limiter.check() {
+            LogRateLimitDecision::Admitted { suppressed } => suppressed,
+            LogRateLimitDecision::Denied => {
+                self.metrics.record_rate_limited_log();
+                return false;
+            }
+        };
+        let origin = Location::caller();
+
+        if suppressed != 0 {
+            self.record_delivery(sink.write_rate_limit_recovery(
+                self.show_level,
+                self.show_log_origin,
+                origin,
+                LoggerLevel::Warn,
+                suppressed,
+            ));
+        }
+
+        self.record_delivery(sink.write_boot_timer(
             self.show_level,
             self.show_log_origin,
-            Location::caller(),
+            origin,
             BOOT_TIMER_LEVEL,
             wall_time_us,
             cpu_time_us,
-        ) {
-            self.record_missed_log();
-            return Err(err);
-        }
-        Ok(true)
+        ))
     }
 }
 
@@ -294,6 +404,8 @@ pub struct LoggerState {
     show_level: bool,
     show_log_origin: bool,
     module: Option<String>,
+    metrics: SharedLoggerMetrics,
+    boot_timer_rate_limiter: BootTimerLogRateLimiter,
 }
 
 impl Default for LoggerState {
@@ -304,11 +416,28 @@ impl Default for LoggerState {
             show_level: false,
             show_log_origin: false,
             module: None,
+            metrics: SharedLoggerMetrics::default(),
+            boot_timer_rate_limiter: BootTimerLogRateLimiter::default(),
         }
     }
 }
 
 impl LoggerState {
+    pub(crate) fn with_shared_metrics(metrics: SharedLoggerMetrics) -> Self {
+        Self {
+            metrics,
+            ..Self::default()
+        }
+    }
+
+    fn record_delivery(&self, result: Result<(), LoggerDeliveryError>) -> bool {
+        if result.is_err() {
+            self.metrics.record_missed_log();
+            return false;
+        }
+        true
+    }
+
     pub fn configure(&mut self, input: LoggerConfigInput) -> Result<(), LoggerConfigError> {
         let config = input.validate()?;
         let sink = config.log_path().map(LoggerSink::open).transpose()?;
@@ -333,60 +462,54 @@ impl LoggerState {
     }
 
     #[track_caller]
-    pub(crate) fn log_action(&mut self, action: &str) -> Result<bool, LoggerWriteError> {
+    pub(crate) fn log_action(&self, action: &str) -> bool {
         const ACTION_LEVEL: LoggerLevel = LoggerLevel::Info;
 
         if !self.level.allows(ACTION_LEVEL) {
-            return Ok(false);
+            return false;
         }
 
         if !module_filter_allows(self.module.as_deref(), MINIMAL_ACTION_LOG_MODULE) {
-            return Ok(false);
+            return false;
         }
 
         let Some(sink) = &self.sink else {
-            return Ok(false);
+            return false;
         };
 
-        sink.write_action(
+        self.record_delivery(sink.write_action(
             self.show_level,
             self.show_log_origin,
             Location::caller(),
             ACTION_LEVEL,
             action,
-        )?;
-        Ok(true)
+        ))
     }
 
     #[track_caller]
-    pub fn log_api_request(
-        &mut self,
-        method: &str,
-        path: impl fmt::Display,
-    ) -> Result<bool, LoggerWriteError> {
+    pub fn log_api_request(&self, method: &str, path: impl fmt::Display) -> bool {
         const API_REQUEST_LEVEL: LoggerLevel = LoggerLevel::Info;
 
         if !self.level.allows(API_REQUEST_LEVEL) {
-            return Ok(false);
+            return false;
         }
 
         if !module_filter_allows(self.module.as_deref(), API_REQUEST_LOG_MODULE) {
-            return Ok(false);
+            return false;
         }
 
         let Some(sink) = &self.sink else {
-            return Ok(false);
+            return false;
         };
 
-        sink.write_api_request(
+        self.record_delivery(sink.write_api_request(
             self.show_level,
             self.show_log_origin,
             Location::caller(),
             API_REQUEST_LEVEL,
             method,
             path,
-        )?;
-        Ok(true)
+        ))
     }
 
     pub fn boot_timer_logger(&self) -> BootTimerLogger {
@@ -396,16 +519,13 @@ impl LoggerState {
             show_level: self.show_level,
             show_log_origin: self.show_log_origin,
             module: self.module.clone(),
-            missed_log_counter: None,
+            metrics: self.metrics.clone(),
+            rate_limiter: self.boot_timer_rate_limiter.clone(),
         }
     }
 
     #[track_caller]
-    pub fn log_boot_timer(
-        &mut self,
-        wall_time_us: u64,
-        cpu_time_us: u64,
-    ) -> Result<bool, LoggerWriteError> {
+    pub fn log_boot_timer(&self, wall_time_us: u64, cpu_time_us: u64) -> bool {
         self.boot_timer_logger()
             .log_boot_time(wall_time_us, cpu_time_us)
     }
@@ -474,7 +594,7 @@ impl LoggerSink {
         origin: &Location<'_>,
         level: LoggerLevel,
         action: &str,
-    ) -> Result<(), LoggerWriteError> {
+    ) -> Result<(), LoggerDeliveryError> {
         self.write_message(
             show_level,
             show_log_origin,
@@ -492,7 +612,7 @@ impl LoggerSink {
         level: LoggerLevel,
         method: &str,
         path: impl fmt::Display,
-    ) -> Result<(), LoggerWriteError> {
+    ) -> Result<(), LoggerDeliveryError> {
         self.write_message(
             show_level,
             show_log_origin,
@@ -510,7 +630,7 @@ impl LoggerSink {
         level: LoggerLevel,
         wall_time_us: u64,
         cpu_time_us: u64,
-    ) -> Result<(), LoggerWriteError> {
+    ) -> Result<(), LoggerDeliveryError> {
         let wall_time_ms = wall_time_us / 1_000;
         let cpu_time_ms = cpu_time_us / 1_000;
         self.write_message(
@@ -524,6 +644,23 @@ impl LoggerSink {
         )
     }
 
+    fn write_rate_limit_recovery(
+        &self,
+        show_level: bool,
+        show_log_origin: bool,
+        origin: &Location<'_>,
+        level: LoggerLevel,
+        suppressed: u64,
+    ) -> Result<(), LoggerDeliveryError> {
+        self.write_message(
+            show_level,
+            show_log_origin,
+            origin,
+            level,
+            format_args!("{suppressed} messages were suppressed due to rate limiting"),
+        )
+    }
+
     fn write_message(
         &self,
         show_level: bool,
@@ -531,11 +668,12 @@ impl LoggerSink {
         origin: &Location<'_>,
         level: LoggerLevel,
         message: fmt::Arguments<'_>,
-    ) -> Result<(), LoggerWriteError> {
-        let mut writer = self
-            .writer
-            .lock()
-            .map_err(|_| LoggerWriteError::LockPoisoned)?;
+    ) -> Result<(), LoggerDeliveryError> {
+        let mut writer = match self.writer.try_lock() {
+            Ok(writer) => writer,
+            Err(TryLockError::WouldBlock) => return Err(LoggerDeliveryError::LockContended),
+            Err(TryLockError::Poisoned(_)) => return Err(LoggerDeliveryError::LockPoisoned),
+        };
 
         match (show_level, show_log_origin) {
             (true, true) => writeln!(
@@ -554,10 +692,8 @@ impl LoggerSink {
             ),
             (false, false) => writeln!(writer, "{message}"),
         }
-        .map_err(|err| LoggerWriteError::Write(err.kind()))?;
-        writer
-            .flush()
-            .map_err(|err| LoggerWriteError::Write(err.kind()))
+        .map_err(|_| LoggerDeliveryError::Write)?;
+        writer.flush().map_err(|_| LoggerDeliveryError::Write)
     }
 }
 
@@ -570,13 +706,15 @@ mod tests {
     use std::fs;
     use std::io::{Error, ErrorKind, Write};
     use std::path::PathBuf;
+    use std::sync::Arc;
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::thread;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{
-        API_REQUEST_LOG_MODULE, BOOT_TIMER_LOG_MODULE, LoggerConfigError, LoggerConfigInput,
-        LoggerLevel, LoggerSink, LoggerState, LoggerWriteError, MINIMAL_ACTION_LOG_MODULE,
-        MissedLogCounter,
+        API_REQUEST_LOG_MODULE, BOOT_TIMER_LOG_MODULE, BootTimerLogRateLimiter,
+        LogRateLimitDecision, LogRateLimiterClock, LoggerConfigError, LoggerConfigInput,
+        LoggerLevel, LoggerState, MINIMAL_ACTION_LOG_MODULE, SharedLoggerMetrics,
     };
 
     static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
@@ -607,6 +745,36 @@ mod tests {
     }
 
     #[derive(Debug)]
+    struct FlushFailingWriter;
+
+    impl Write for FlushFailingWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Err(Error::from(ErrorKind::BrokenPipe))
+        }
+    }
+
+    #[derive(Debug, Clone, Default)]
+    struct TestLogRateLimiterClock {
+        now_ms: Arc<AtomicU64>,
+    }
+
+    impl TestLogRateLimiterClock {
+        fn advance_ms(&self, elapsed_ms: u64) {
+            self.now_ms.fetch_add(elapsed_ms, Ordering::Relaxed);
+        }
+    }
+
+    impl LogRateLimiterClock for TestLogRateLimiterClock {
+        fn now_ms(&self) -> u64 {
+            self.now_ms.load(Ordering::Relaxed)
+        }
+    }
+
+    #[derive(Debug)]
     struct PanickingDisplay;
 
     impl std::fmt::Display for PanickingDisplay {
@@ -616,14 +784,24 @@ mod tests {
     }
 
     #[test]
-    fn missed_log_counter_saturates_at_u64_max() {
-        let counter = MissedLogCounter::default();
-        counter.count.store(u64::MAX - 1, Ordering::Relaxed);
+    fn shared_logger_metrics_saturate_at_u64_max() {
+        let metrics = SharedLoggerMetrics::default();
+        metrics
+            .inner
+            .missed_log_count
+            .store(u64::MAX - 1, Ordering::Relaxed);
+        metrics
+            .inner
+            .rate_limited_log_count
+            .store(u64::MAX - 1, Ordering::Relaxed);
 
-        counter.record();
-        assert_eq!(counter.count(), u64::MAX);
-        counter.record();
-        assert_eq!(counter.count(), u64::MAX);
+        metrics.record_missed_log();
+        metrics.record_missed_log();
+        metrics.record_rate_limited_log();
+        metrics.record_rate_limited_log();
+
+        assert_eq!(metrics.missed_log_count(), u64::MAX);
+        assert_eq!(metrics.rate_limited_log_count(), u64::MAX);
     }
 
     fn assert_action_output_with_origin(output: &str, level: Option<LoggerLevel>, action: &str) {
@@ -744,9 +922,9 @@ mod tests {
 
     #[test]
     fn log_action_without_configuration_is_noop() {
-        let mut state = LoggerState::default();
+        let state = LoggerState::default();
 
-        assert_eq!(state.log_action("InstanceStart"), Ok(false));
+        assert!(!state.log_action("InstanceStart"));
         assert!(!state.is_configured());
     }
 
@@ -758,8 +936,8 @@ mod tests {
             .configure(LoggerConfigInput::new().with_log_path(&path))
             .expect("logger should configure");
 
-        assert_eq!(state.log_action("InstanceStart"), Ok(true));
-        assert_eq!(state.log_action("FlushMetrics"), Ok(true));
+        assert!(state.log_action("InstanceStart"));
+        assert!(state.log_action("FlushMetrics"));
 
         let output = fs::read_to_string(&path).expect("logger output should be readable");
         assert_eq!(output, "action=InstanceStart\naction=FlushMetrics\n");
@@ -774,7 +952,7 @@ mod tests {
             .configure(LoggerConfigInput::new().with_log_path(&path))
             .expect("logger should configure");
 
-        assert_eq!(state.log_api_request("Put", "/mmds"), Ok(true));
+        assert!(state.log_api_request("Put", "/mmds"));
 
         let output = fs::read_to_string(&path).expect("logger output should be readable");
         assert_eq!(
@@ -796,7 +974,7 @@ mod tests {
             )
             .expect("logger should configure");
 
-        assert_eq!(state.log_api_request("Get", "/version"), Ok(false));
+        assert!(!state.log_api_request("Get", "/version"));
         assert_eq!(
             fs::read_to_string(&path).expect("logger output should be readable"),
             ""
@@ -805,7 +983,7 @@ mod tests {
         state
             .configure(LoggerConfigInput::new().with_level(LoggerLevel::Info))
             .expect("logger should update level");
-        assert_eq!(state.log_api_request("Get", "/version"), Ok(true));
+        assert!(state.log_api_request("Get", "/version"));
 
         let output = fs::read_to_string(&path).expect("logger output should be readable");
         assert_eq!(
@@ -827,12 +1005,12 @@ mod tests {
             )
             .expect("logger should configure");
 
-        assert_eq!(state.log_api_request("Get", "/version"), Ok(false));
+        assert!(!state.log_api_request("Get", "/version"));
 
         state
             .configure(LoggerConfigInput::new().with_module(API_REQUEST_LOG_MODULE))
             .expect("logger should update module filter");
-        assert_eq!(state.log_api_request("Get", "/version"), Ok(true));
+        assert!(state.log_api_request("Get", "/version"));
 
         let output = fs::read_to_string(&path).expect("logger output should be readable");
         assert_eq!(
@@ -847,7 +1025,7 @@ mod tests {
         let path = unique_logger_path("api-request-suppressed");
         let mut state = LoggerState::default();
 
-        assert_eq!(state.log_api_request("Get", PanickingDisplay), Ok(false));
+        assert!(!state.log_api_request("Get", PanickingDisplay));
 
         state
             .configure(
@@ -856,7 +1034,7 @@ mod tests {
                     .with_level(LoggerLevel::Warn),
             )
             .expect("logger should configure");
-        assert_eq!(state.log_api_request("Get", PanickingDisplay), Ok(false));
+        assert!(!state.log_api_request("Get", PanickingDisplay));
 
         state
             .configure(
@@ -865,7 +1043,7 @@ mod tests {
                     .with_module(MINIMAL_ACTION_LOG_MODULE),
             )
             .expect("logger should update filters");
-        assert_eq!(state.log_api_request("Get", PanickingDisplay), Ok(false));
+        assert!(!state.log_api_request("Get", PanickingDisplay));
 
         assert_eq!(
             fs::read_to_string(&path).expect("logger output should be readable"),
@@ -875,21 +1053,12 @@ mod tests {
     }
 
     #[test]
-    fn log_api_request_reports_write_errors_without_path_details() {
-        let mut state = LoggerState {
-            sink: Some(LoggerSink::from_writer(FailingWriter)),
-            level: LoggerLevel::Info,
-            show_level: false,
-            show_log_origin: false,
-            module: None,
-        };
+    fn log_api_request_records_write_failure_without_failing_caller() {
+        let mut state = LoggerState::default();
+        state.configure_test_writer(FailingWriter);
 
-        let err = state
-            .log_api_request("Patch", "/mmds")
-            .expect_err("failing writer should report logger write error");
-
-        assert_eq!(err, LoggerWriteError::Write(ErrorKind::BrokenPipe));
-        assert_eq!(err.to_string(), "failed to write logger output: BrokenPipe");
+        assert!(!state.log_api_request("Patch", "/mmds"));
+        assert_eq!(state.metrics.missed_log_count(), 1);
     }
 
     #[test]
@@ -900,7 +1069,7 @@ mod tests {
             .configure(LoggerConfigInput::new().with_log_path(&path))
             .expect("logger should configure");
 
-        assert_eq!(state.log_boot_timer(7_123, 1_456), Ok(true));
+        assert!(state.log_boot_timer(7_123, 1_456));
 
         let output = fs::read_to_string(&path).expect("logger output should be readable");
         assert_eq!(
@@ -919,8 +1088,8 @@ mod tests {
             .expect("logger should configure");
         let boot_timer_logger = state.boot_timer_logger();
 
-        assert_eq!(state.log_action("InstanceStart"), Ok(true));
-        assert_eq!(boot_timer_logger.log_boot_time(1_000, 200), Ok(true));
+        assert!(state.log_action("InstanceStart"));
+        assert!(boot_timer_logger.log_boot_time(1_000, 200));
 
         let output = fs::read_to_string(&path).expect("logger output should be readable");
         assert_eq!(
@@ -934,16 +1103,10 @@ mod tests {
     fn boot_timer_logger_records_missed_log_on_write_failure() {
         let mut state = LoggerState::default();
         state.configure_test_writer(FailingWriter);
-        let counter = MissedLogCounter::default();
-        let boot_timer_logger = state
-            .boot_timer_logger()
-            .with_missed_log_counter(counter.clone());
+        let boot_timer_logger = state.boot_timer_logger();
 
-        assert_eq!(
-            boot_timer_logger.log_boot_time(1_000, 200),
-            Err(LoggerWriteError::Write(ErrorKind::BrokenPipe))
-        );
-        assert_eq!(counter.count(), 1);
+        assert!(!boot_timer_logger.log_boot_time(1_000, 200));
+        assert_eq!(state.metrics.missed_log_count(), 1);
     }
 
     #[test]
@@ -953,25 +1116,17 @@ mod tests {
         state
             .configure(LoggerConfigInput::new().with_log_path(&path))
             .expect("logger should configure");
-        let counter = MissedLogCounter::default();
 
-        assert_eq!(
-            state
-                .boot_timer_logger()
-                .with_missed_log_counter(counter.clone())
-                .log_boot_time(1_000, 200),
-            Ok(true)
-        );
-        assert_eq!(counter.count(), 0);
+        assert!(state.boot_timer_logger().log_boot_time(1_000, 200));
+        assert_eq!(state.metrics.missed_log_count(), 0);
 
-        assert_eq!(
-            LoggerState::default()
+        let unconfigured_state = LoggerState::default();
+        assert!(
+            !unconfigured_state
                 .boot_timer_logger()
-                .with_missed_log_counter(counter.clone())
-                .log_boot_time(1_000, 200),
-            Ok(false)
+                .log_boot_time(1_000, 200)
         );
-        assert_eq!(counter.count(), 0);
+        assert_eq!(unconfigured_state.metrics.missed_log_count(), 0);
 
         fs::remove_file(path).expect("fixture should clean up");
     }
@@ -983,13 +1138,11 @@ mod tests {
         state
             .configure(LoggerConfigInput::new().with_module(MINIMAL_ACTION_LOG_MODULE))
             .expect("logger should update module filter");
-        let counter = MissedLogCounter::default();
-        let boot_timer_logger = state
-            .boot_timer_logger()
-            .with_missed_log_counter(counter.clone());
+        let boot_timer_logger = state.boot_timer_logger();
 
-        assert_eq!(boot_timer_logger.log_boot_time(1_000, 200), Ok(false));
-        assert_eq!(counter.count(), 0);
+        assert!(!boot_timer_logger.log_boot_time(1_000, 200));
+        assert_eq!(state.metrics.missed_log_count(), 0);
+        assert_eq!(state.metrics.rate_limited_log_count(), 0);
     }
 
     #[test]
@@ -1004,7 +1157,7 @@ mod tests {
             )
             .expect("logger should configure");
 
-        assert_eq!(state.log_action("InstanceStart"), Ok(true));
+        assert!(state.log_action("InstanceStart"));
 
         let output = fs::read_to_string(&path).expect("logger output should be readable");
         assert_eq!(output, "level=Info action=InstanceStart\n");
@@ -1023,7 +1176,7 @@ mod tests {
             )
             .expect("logger should configure");
 
-        assert_eq!(state.log_action("InstanceStart"), Ok(true));
+        assert!(state.log_action("InstanceStart"));
 
         let output = fs::read_to_string(&path).expect("logger output should be readable");
         assert_action_output_with_origin(&output, None, "InstanceStart");
@@ -1043,7 +1196,7 @@ mod tests {
             )
             .expect("logger should configure");
 
-        assert_eq!(state.log_action("FlushMetrics"), Ok(true));
+        assert!(state.log_action("FlushMetrics"));
 
         let output = fs::read_to_string(&path).expect("logger output should be readable");
         assert_action_output_with_origin(&output, Some(LoggerLevel::Info), "FlushMetrics");
@@ -1062,7 +1215,7 @@ mod tests {
             )
             .expect("logger should configure");
 
-        assert_eq!(state.log_action("InstanceStart"), Ok(false));
+        assert!(!state.log_action("InstanceStart"));
         assert_eq!(
             fs::read_to_string(&path).expect("logger output should be readable"),
             ""
@@ -1071,7 +1224,7 @@ mod tests {
         state
             .configure(LoggerConfigInput::new().with_level(LoggerLevel::Debug))
             .expect("logger should update level without replacing sink");
-        assert_eq!(state.log_action("FlushMetrics"), Ok(true));
+        assert!(state.log_action("FlushMetrics"));
 
         let output = fs::read_to_string(&path).expect("logger output should be readable");
         assert_eq!(output, "action=FlushMetrics\n");
@@ -1090,17 +1243,17 @@ mod tests {
             )
             .expect("logger should configure");
 
-        assert_eq!(state.log_action("InstanceStart"), Ok(true));
+        assert!(state.log_action("InstanceStart"));
 
         state
             .configure(LoggerConfigInput::new().with_module(MINIMAL_ACTION_LOG_MODULE))
             .expect("logger should update module filter");
-        assert_eq!(state.log_action("FlushMetrics"), Ok(true));
+        assert!(state.log_action("FlushMetrics"));
 
         state
             .configure(LoggerConfigInput::new().with_module("api_server"))
             .expect("logger should update module filter");
-        assert_eq!(state.log_action("Suppressed"), Ok(false));
+        assert!(!state.log_action("Suppressed"));
 
         let output = fs::read_to_string(&path).expect("logger output should be readable");
         assert_eq!(output, "action=InstanceStart\naction=FlushMetrics\n");
@@ -1119,12 +1272,12 @@ mod tests {
             )
             .expect("logger should configure");
 
-        assert_eq!(state.log_boot_timer(1, 1), Ok(false));
+        assert!(!state.log_boot_timer(1, 1));
 
         state
             .configure(LoggerConfigInput::new().with_module(BOOT_TIMER_LOG_MODULE))
             .expect("logger should update module filter");
-        assert_eq!(state.log_boot_timer(1, 1), Ok(true));
+        assert!(state.log_boot_timer(1, 1));
 
         let output = fs::read_to_string(&path).expect("logger output should be readable");
         assert_eq!(
@@ -1146,7 +1299,7 @@ mod tests {
             )
             .expect("logger should configure");
 
-        assert_eq!(state.log_action("InstanceStart"), Ok(true));
+        assert!(state.log_action("InstanceStart"));
 
         let output = fs::read_to_string(&path).expect("logger output should be readable");
         assert_eq!(output, "action=InstanceStart\n");
@@ -1154,21 +1307,186 @@ mod tests {
     }
 
     #[test]
-    fn log_action_reports_write_errors_without_path_details() {
+    fn log_action_records_write_failure_without_failing_caller() {
+        let mut state = LoggerState::default();
+        state.configure_test_writer(FailingWriter);
+
+        assert!(!state.log_action("InstanceStart"));
+        assert_eq!(state.metrics.missed_log_count(), 1);
+    }
+
+    #[test]
+    fn log_action_records_flush_failure_without_failing_caller() {
+        let mut state = LoggerState::default();
+        state.configure_test_writer(FlushFailingWriter);
+
+        assert!(!state.log_action("InstanceStart"));
+        assert_eq!(state.metrics.missed_log_count(), 1);
+    }
+
+    #[test]
+    fn log_action_drops_contended_sink_without_blocking() {
+        let mut state = LoggerState::default();
+        state.configure_test_writer(std::io::sink());
+        let sink = state.sink.as_ref().expect("sink should exist").clone();
+        let guard = sink.writer.lock().expect("sink lock should be available");
+
+        assert!(!state.log_action("InstanceStart"));
+        assert_eq!(state.metrics.missed_log_count(), 1);
+
+        drop(guard);
+    }
+
+    #[test]
+    fn log_action_drops_poisoned_sink_without_panicking() {
+        let mut state = LoggerState::default();
+        state.configure_test_writer(std::io::sink());
+        let writer = state
+            .sink
+            .as_ref()
+            .expect("sink should exist")
+            .writer
+            .clone();
+        let poison_result = thread::spawn(move || {
+            let _guard = writer.lock().expect("sink lock should be available");
+            panic!("poison logger sink for test");
+        })
+        .join();
+        assert!(poison_result.is_err());
+
+        assert!(!state.log_action("InstanceStart"));
+        assert_eq!(state.metrics.missed_log_count(), 1);
+    }
+
+    #[test]
+    fn boot_timer_rate_limit_allows_burst_then_reports_recovery() {
+        let path = unique_logger_path("boot-timer-rate-limit");
+        let clock = TestLogRateLimiterClock::default();
         let mut state = LoggerState {
-            sink: Some(LoggerSink::from_writer(FailingWriter)),
-            level: LoggerLevel::Info,
-            show_level: false,
-            show_log_origin: false,
-            module: None,
+            boot_timer_rate_limiter: BootTimerLogRateLimiter::with_clock(Arc::new(clock.clone())),
+            ..LoggerState::default()
+        };
+        state
+            .configure(
+                LoggerConfigInput::new()
+                    .with_log_path(&path)
+                    .with_show_level(true),
+            )
+            .expect("logger should configure");
+        let first_session_logger = state.boot_timer_logger();
+
+        for _ in 0..10 {
+            assert!(first_session_logger.log_boot_time(1_000, 200));
+        }
+
+        let reconstructed_session_logger = state.boot_timer_logger();
+        assert!(!reconstructed_session_logger.log_boot_time(1_000, 200));
+        assert_eq!(state.metrics.rate_limited_log_count(), 1);
+        assert_eq!(state.metrics.missed_log_count(), 0);
+
+        clock.advance_ms(500);
+        assert!(reconstructed_session_logger.log_boot_time(2_000, 300));
+
+        let output = fs::read_to_string(&path).expect("logger output should be readable");
+        let lines = output.lines().collect::<Vec<_>>();
+        assert_eq!(lines.len(), 12);
+        assert_eq!(
+            lines[10],
+            "level=Warn 1 messages were suppressed due to rate limiting"
+        );
+        assert_eq!(
+            lines[11],
+            "level=Info Guest-boot-time =   2000 us 2 ms,    300 CPU us 0 CPU ms"
+        );
+
+        fs::remove_file(path).expect("fixture should clean up");
+    }
+
+    #[test]
+    fn boot_timer_local_policy_does_not_consume_rate_limit_or_record_misses() {
+        let path = unique_logger_path("boot-timer-local-policy");
+        let clock = TestLogRateLimiterClock::default();
+        let mut state = LoggerState {
+            boot_timer_rate_limiter: BootTimerLogRateLimiter::with_clock(Arc::new(clock)),
+            ..LoggerState::default()
         };
 
-        let err = state
-            .log_action("InstanceStart")
-            .expect_err("failing writer should report logger write error");
+        for _ in 0..20 {
+            assert!(!state.log_boot_timer(1_000, 200));
+        }
 
-        assert_eq!(err, LoggerWriteError::Write(ErrorKind::BrokenPipe));
-        assert_eq!(err.to_string(), "failed to write logger output: BrokenPipe");
+        state
+            .configure(
+                LoggerConfigInput::new()
+                    .with_log_path(&path)
+                    .with_level(LoggerLevel::Warn),
+            )
+            .expect("logger should configure");
+        for _ in 0..20 {
+            assert!(!state.log_boot_timer(1_000, 200));
+        }
+
+        state
+            .configure(
+                LoggerConfigInput::new()
+                    .with_level(LoggerLevel::Info)
+                    .with_module(MINIMAL_ACTION_LOG_MODULE),
+            )
+            .expect("logger should update filters");
+        for _ in 0..20 {
+            assert!(!state.log_boot_timer(1_000, 200));
+        }
+
+        state
+            .configure(LoggerConfigInput::new().with_module(BOOT_TIMER_LOG_MODULE))
+            .expect("logger should update module filter");
+        for _ in 0..10 {
+            assert!(state.log_boot_timer(1_000, 200));
+        }
+        assert!(!state.log_boot_timer(1_000, 200));
+
+        assert_eq!(state.metrics.missed_log_count(), 0);
+        assert_eq!(state.metrics.rate_limited_log_count(), 1);
+        fs::remove_file(path).expect("fixture should clean up");
+    }
+
+    #[test]
+    fn boot_timer_rate_limit_suppressed_count_saturates() {
+        let clock = TestLogRateLimiterClock::default();
+        let limiter = BootTimerLogRateLimiter::with_clock(Arc::new(clock.clone()));
+        {
+            let mut state = limiter
+                .inner
+                .state
+                .lock()
+                .expect("rate limiter lock should be available");
+            state.theoretical_arrival_time_ms = 5_000;
+            state.suppressed = u64::MAX - 1;
+        }
+
+        assert_eq!(limiter.check(), LogRateLimitDecision::Denied);
+        assert_eq!(limiter.check(), LogRateLimitDecision::Denied);
+        clock.advance_ms(500);
+        assert_eq!(
+            limiter.check(),
+            LogRateLimitDecision::Admitted {
+                suppressed: u64::MAX
+            }
+        );
+    }
+
+    #[test]
+    fn boot_timer_rate_limiters_are_independent_between_logger_states() {
+        let mut first = LoggerState::default();
+        first.configure_test_writer(std::io::sink());
+        let mut second = LoggerState::default();
+        second.configure_test_writer(std::io::sink());
+
+        for _ in 0..10 {
+            assert!(first.log_boot_timer(1_000, 200));
+        }
+        assert!(!first.log_boot_timer(1_000, 200));
+        assert!(second.log_boot_timer(1_000, 200));
     }
 
     #[test]

--- a/crates/runtime/src/logger.rs
+++ b/crates/runtime/src/logger.rs
@@ -766,6 +766,10 @@ mod tests {
         fn advance_ms(&self, elapsed_ms: u64) {
             self.now_ms.fetch_add(elapsed_ms, Ordering::Relaxed);
         }
+
+        fn set_ms(&self, now_ms: u64) {
+            self.now_ms.store(now_ms, Ordering::Relaxed);
+        }
     }
 
     impl LogRateLimiterClock for TestLogRateLimiterClock {
@@ -1473,6 +1477,69 @@ mod tests {
                 suppressed: u64::MAX
             }
         );
+    }
+
+    #[test]
+    fn boot_timer_rate_limit_matches_refill_recovery_and_backwards_time_contract() {
+        let clock = TestLogRateLimiterClock::default();
+        clock.set_ms(1_000);
+        let limiter = BootTimerLogRateLimiter::with_clock(Arc::new(clock.clone()));
+
+        for _ in 0..10 {
+            assert_eq!(
+                limiter.check(),
+                LogRateLimitDecision::Admitted { suppressed: 0 }
+            );
+        }
+        for _ in 0..3 {
+            assert_eq!(limiter.check(), LogRateLimitDecision::Denied);
+        }
+
+        clock.advance_ms(499);
+        assert_eq!(limiter.check(), LogRateLimitDecision::Denied);
+        clock.advance_ms(1);
+        assert_eq!(
+            limiter.check(),
+            LogRateLimitDecision::Admitted { suppressed: 4 }
+        );
+
+        clock.advance_ms(5_000);
+        for _ in 0..10 {
+            assert_eq!(
+                limiter.check(),
+                LogRateLimitDecision::Admitted { suppressed: 0 }
+            );
+        }
+        assert_eq!(limiter.check(), LogRateLimitDecision::Denied);
+
+        clock.set_ms(6_000);
+        assert_eq!(limiter.check(), LogRateLimitDecision::Denied);
+        clock.set_ms(7_000);
+        assert_eq!(
+            limiter.check(),
+            LogRateLimitDecision::Admitted { suppressed: 2 }
+        );
+    }
+
+    #[test]
+    fn boot_timer_recovery_and_original_delivery_failures_are_counted_independently() {
+        let clock = TestLogRateLimiterClock::default();
+        let mut state = LoggerState {
+            boot_timer_rate_limiter: BootTimerLogRateLimiter::with_clock(Arc::new(clock.clone())),
+            ..LoggerState::default()
+        };
+        state.configure_test_writer(std::io::sink());
+
+        for _ in 0..10 {
+            assert!(state.log_boot_timer(1_000, 200));
+        }
+        assert!(!state.log_boot_timer(1_000, 200));
+        state.configure_test_writer(FailingWriter);
+        clock.advance_ms(500);
+
+        assert!(!state.log_boot_timer(2_000, 300));
+        assert_eq!(state.metrics.missed_log_count(), 2);
+        assert_eq!(state.metrics.rate_limited_log_count(), 1);
     }
 
     #[test]

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -14,7 +14,7 @@ use crate::block::{
 use crate::entropy::{
     VirtioRngDeviceNotificationDispatch, VirtioRngDeviceNotificationError, VirtioRngQueueDispatch,
 };
-use crate::logger::MissedLogCounter;
+use crate::logger::SharedLoggerMetrics;
 use crate::network::{
     VIRTIO_NET_RX_QUEUE_INDEX, VIRTIO_NET_TX_QUEUE_INDEX, VirtioNetworkDeviceNotificationDispatch,
     VirtioNetworkDeviceNotificationError, VirtioNetworkRxQueueDispatch,
@@ -107,12 +107,19 @@ pub struct MetricsState {
     get_api_requests: GetApiRequestMetrics,
     latencies_us: LatencyMetrics,
     logger_metrics: LoggerMetrics,
-    missed_log_counter: MissedLogCounter,
+    shared_logger_metrics: SharedLoggerMetrics,
     patch_api_requests: PatchApiRequestMetrics,
     put_api_requests: PutApiRequestMetrics,
 }
 
 impl MetricsState {
+    pub(crate) fn with_shared_logger_metrics(shared_logger_metrics: SharedLoggerMetrics) -> Self {
+        Self {
+            shared_logger_metrics,
+            ..Self::default()
+        }
+    }
+
     pub fn configure(&mut self, input: MetricsConfigInput) -> Result<(), MetricsConfigError> {
         if self.sink.is_some() {
             return Err(MetricsConfigError::AlreadyInitialized);
@@ -344,14 +351,6 @@ impl MetricsState {
         self.get_api_requests.record_hotplug_memory_request();
     }
 
-    pub(crate) fn record_missed_log(&self) {
-        self.missed_log_counter.record();
-    }
-
-    pub(crate) fn missed_log_counter(&self) -> MissedLogCounter {
-        self.missed_log_counter.clone()
-    }
-
     pub fn flush_with_diagnostics(
         &mut self,
         diagnostics: &MetricsDiagnostics,
@@ -366,9 +365,10 @@ impl MetricsState {
             deprecated_api: self.deprecated_api,
             get_api_requests: self.get_api_requests,
             latencies_us: self.latencies_us,
-            logger_metrics: self
-                .logger_metrics
-                .with_missed_log_count(self.missed_log_counter.count()),
+            logger_metrics: self.logger_metrics.with_log_counts(
+                self.shared_logger_metrics.missed_log_count(),
+                self.shared_logger_metrics.rate_limited_log_count(),
+            ),
             patch_api_requests: self.patch_api_requests,
             put_api_requests: self.put_api_requests,
         };
@@ -428,15 +428,19 @@ struct GetApiRequestMetrics {
 struct LoggerMetrics {
     missed_log_count: u64,
     missed_metrics_count: u64,
+    rate_limited_log_count: u64,
 }
 
 impl LoggerMetrics {
     const fn is_empty(self) -> bool {
-        self.missed_log_count == 0 && self.missed_metrics_count == 0
+        self.missed_log_count == 0
+            && self.missed_metrics_count == 0
+            && self.rate_limited_log_count == 0
     }
 
-    const fn with_missed_log_count(mut self, missed_log_count: u64) -> Self {
+    const fn with_log_counts(mut self, missed_log_count: u64, rate_limited_log_count: u64) -> Self {
         self.missed_log_count = missed_log_count;
+        self.rate_limited_log_count = rate_limited_log_count;
         self
     }
 
@@ -450,6 +454,10 @@ impl LoggerMetrics {
 
     const fn missed_metrics_count(self) -> u64 {
         self.missed_metrics_count
+    }
+
+    const fn rate_limited_log_count(self) -> u64 {
+        self.rate_limited_log_count
     }
 }
 
@@ -5269,6 +5277,12 @@ impl MetricsSink {
                     serde_json::Value::Number(logger_metrics.missed_metrics_count().into()),
                 );
             }
+            if logger_metrics.rate_limited_log_count() != 0 {
+                logger.insert(
+                    "rate_limited_log_count".to_string(),
+                    serde_json::Value::Number(logger_metrics.rate_limited_log_count().into()),
+                );
+            }
             root.insert("logger".to_string(), serde_json::Value::Object(logger));
         }
         if !latencies_us.is_empty() {
@@ -5504,6 +5518,7 @@ mod tests {
         SharedSignalMetrics, SharedVsockDeviceMetrics, SignalMetrics, VsockDeviceMetrics,
     };
     use crate::block::VirtioBlockLatencyAggregate;
+    use crate::logger::SharedLoggerMetrics;
     use crate::serial::SerialOutputMetrics;
 
     static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
@@ -5749,11 +5764,14 @@ mod tests {
     }
 
     #[test]
-    fn logger_metrics_include_log_and_metrics_miss_counts() {
+    fn logger_metrics_include_delivery_and_rate_limit_counts() {
         let output = TestMetricsOutput::default();
         let mut state = MetricsState::with_test_output(output.clone());
+        let shared_logger_metrics = SharedLoggerMetrics::default();
+        state.shared_logger_metrics = shared_logger_metrics.clone();
 
-        state.record_missed_log();
+        shared_logger_metrics.record_missed_log();
+        shared_logger_metrics.record_rate_limited_log();
         output.fail_next_write();
         assert_eq!(
             state.flush(),
@@ -5764,7 +5782,7 @@ mod tests {
         assert_eq!(
             output.lines(),
             [
-                r#"{"logger":{"missed_log_count":1,"missed_metrics_count":1},"vmm":{"metrics_flush_count":1}}"#
+                r#"{"logger":{"missed_log_count":1,"missed_metrics_count":1,"rate_limited_log_count":1},"vmm":{"metrics_flush_count":1}}"#
             ]
         );
     }


### PR DESCRIPTION
## Summary

- make logger sink delivery non-blocking and best-effort while recording saturating missed-log metrics
- rate-limit boot-timer log messages with a shared 10-message burst, 500 ms refill period, and recovery warning
- keep API actions, VM startup, metrics flushes, and boot-timer MMIO outcomes independent from logger failures
- expose cumulative sparse `logger.rate_limited_log_count` metrics for the follow-up delta-flush work

## Scope exclusions

- incremental metrics deltas remain in #1341
- resilient background metrics flushing remains in #1342

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- signed-target clippy commands from `AGENTS.md`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- signed HVF integration targets; an initial full-sequence run exposed transient unrelated vsock/SMP failures, then the complete 45-test `executable_hvf_e2e` target passed

Closes #1340
Parent: #542