### PR TITLE
fix: make background metrics flushing resilient

### DIFF
--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -107,7 +107,6 @@ pub(crate) enum ApiServerError {
     Bind(std::io::ErrorKind),
     Connection(std::io::ErrorKind),
     PeriodicBalloonStatisticsUpdate(VmmActionError),
-    PeriodicMetricsFlush(VmmActionError),
     ProcessSessionTerminal,
     SocketMetadata(std::io::ErrorKind),
     SocketPermissions(std::io::ErrorKind),
@@ -128,9 +127,6 @@ impl std::fmt::Display for ApiServerError {
                     f,
                     "failed to trigger periodic balloon statistics update: {err}"
                 )
-            }
-            Self::PeriodicMetricsFlush(err) => {
-                write!(f, "failed to flush periodic metrics: {err}")
             }
             Self::ProcessSessionTerminal => {
                 f.write_str("process-owned boot run loop exited with failure")
@@ -196,7 +192,7 @@ impl ApiServer {
         self.run_until_with_periodic_metrics_scheduler(
             vmm,
             shutdown_wakeup,
-            PeriodicMetricsScheduler::new(Instant::now()),
+            PeriodicMetricsScheduler::new(),
         )
     }
 
@@ -233,7 +229,8 @@ impl ApiServer {
 
         loop {
             let now = Instant::now();
-            let metrics_timeout = Some(metrics_scheduler.poll_timeout_ms(now));
+            let metrics_timeout =
+                metrics_scheduler.poll_timeout_ms(now, vmm.metrics_session_epoch());
             let balloon_timeout =
                 balloon_scheduler.poll_timeout_ms(now, vmm.balloon_statistics_update_interval());
             match wait_for_listener_or_shutdown(
@@ -303,10 +300,9 @@ fn handle_due_periodic_schedulers(
     }
 
     let now = Instant::now();
-    if metrics_scheduler.is_due(now) {
-        vmm.handle_periodic_metrics_flush()
-            .map_err(ApiServerError::PeriodicMetricsFlush)?;
-        metrics_scheduler.schedule_next(Instant::now());
+    if metrics_scheduler.is_due(now, vmm.metrics_session_epoch()) {
+        vmm.handle_periodic_metrics_flush();
+        metrics_scheduler.schedule_next(Instant::now(), vmm.metrics_session_epoch());
         handled = true;
     }
 
@@ -632,7 +628,9 @@ fn handle_request_bytes_with_limit(
     match parse_request_with_limit(bytes, http_api_max_payload_size) {
         Ok(request) => {
             log_api_request(&request, vmm);
-            handle_api_request(request, vmm)
+            let response = handle_api_request(request, vmm);
+            vmm.handle_initial_metrics_flush();
+            response
         }
         Err(err) => {
             if err == RequestError::SendCtrlAltDelUnsupported {
@@ -2885,12 +2883,19 @@ mod tests {
             self.inner.record_load_snapshot_latency_us(duration_us);
         }
 
-        fn handle_periodic_metrics_flush(&mut self) -> Result<bool, VmmActionError> {
-            let result = self.inner.handle_periodic_metrics_flush();
+        fn metrics_session_epoch(&self) -> Option<Instant> {
+            self.inner.metrics_session_epoch()
+        }
+
+        fn handle_initial_metrics_flush(&mut self) {
+            self.inner.handle_initial_metrics_flush();
+        }
+
+        fn handle_periodic_metrics_flush(&mut self) {
+            self.inner.handle_periodic_metrics_flush();
             self.shutdown_writer
                 .write_all(b"x")
                 .expect("periodic flush test should signal shutdown");
-            result
         }
 
         fn balloon_statistics_update_interval(&self) -> Option<Duration> {
@@ -2941,6 +2946,68 @@ mod tests {
             .collect::<Vec<_>>();
         paths.sort();
         paths
+    }
+
+    fn assert_two_line_api_metrics_total(path: &Path, expected: &str) -> String {
+        let output = fs::read_to_string(path).expect("metrics output should be readable");
+        let lines = output
+            .lines()
+            .map(|line| {
+                serde_json::from_str::<serde_json::Value>(line)
+                    .expect("metrics line should be valid JSON")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            lines.len(),
+            2,
+            "session initial and explicit flush should emit two lines: {output}"
+        );
+
+        let mut total = serde_json::Map::new();
+        for line in lines {
+            for (section, value) in line
+                .as_object()
+                .expect("metrics line should be a JSON object")
+            {
+                if matches!(
+                    section.as_str(),
+                    "deprecated_api"
+                        | "get_api_requests"
+                        | "patch_api_requests"
+                        | "put_api_requests"
+                ) {
+                    let target = total
+                        .entry(section.clone())
+                        .or_insert_with(|| serde_json::json!({}));
+                    let target = target
+                        .as_object_mut()
+                        .expect("aggregated API metrics section should be an object");
+                    for (field, value) in value
+                        .as_object()
+                        .expect("API metrics section should be an object")
+                    {
+                        let increment = value
+                            .as_u64()
+                            .expect("API metric value should be an unsigned integer");
+                        let current = target
+                            .get(field)
+                            .and_then(serde_json::Value::as_u64)
+                            .unwrap_or(0);
+                        target.insert(
+                            field.clone(),
+                            serde_json::Value::from(current.saturating_add(increment)),
+                        );
+                    }
+                } else {
+                    total.insert(section.clone(), value.clone());
+                }
+            }
+        }
+
+        let expected = serde_json::from_str::<serde_json::Value>(expected.trim())
+            .expect("expected metrics should be valid JSON");
+        assert_eq!(serde_json::Value::Object(total), expected, "{output}");
+        output
     }
 
     #[test]
@@ -4789,9 +4856,9 @@ mod tests {
         let flush_response = put_action_over_socket(&mut vmm, "flush-configured", "FlushMetrics");
 
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
-        assert_eq!(
-            fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+        assert_two_line_api_metrics_total(
+            &metrics_path,
+            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
 
         fs::remove_file(metrics_path).expect("fixture should clean up");
@@ -4837,9 +4904,9 @@ mod tests {
             put_action_over_socket(&mut vmm, "flush-after-failure", "FlushMetrics");
 
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
-        assert_eq!(
-            fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"put_api_requests\":{\"actions_count\":4,\"actions_fails\":1,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+        assert_two_line_api_metrics_total(
+            &metrics_path,
+            "{\"put_api_requests\":{\"actions_count\":4,\"actions_fails\":1,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
 
         fs::remove_file(metrics_path).expect("fixture should clean up");
@@ -4902,9 +4969,9 @@ mod tests {
         let flush_response = put_action_over_socket(&mut vmm, "g-f", "FlushMetrics");
 
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
-        assert_eq!(
-            fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"get_api_requests\":{\"balloon_count\":0,\"hotplug_memory_count\":0,\"instance_info_count\":1,\"machine_cfg_count\":1,\"mmds_count\":1,\"vmm_version_count\":1},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+        assert_two_line_api_metrics_total(
+            &metrics_path,
+            "{\"get_api_requests\":{\"balloon_count\":0,\"hotplug_memory_count\":0,\"instance_info_count\":1,\"machine_cfg_count\":1,\"mmds_count\":1,\"vmm_version_count\":1},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
 
         fs::remove_file(metrics_path).expect("fixture should clean up");
@@ -4996,9 +5063,9 @@ mod tests {
         let flush_response = put_action_over_socket(&mut vmm, "bf", "FlushMetrics");
 
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
-        assert_eq!(
-            fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"get_api_requests\":{\"balloon_count\":3,\"hotplug_memory_count\":0,\"instance_info_count\":0,\"machine_cfg_count\":0,\"mmds_count\":0,\"vmm_version_count\":0},\"patch_api_requests\":{\"balloon_count\":4,\"balloon_fails\":4,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":2,\"balloon_fails\":2,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+        assert_two_line_api_metrics_total(
+            &metrics_path,
+            "{\"get_api_requests\":{\"balloon_count\":3,\"hotplug_memory_count\":0,\"instance_info_count\":0,\"machine_cfg_count\":0,\"mmds_count\":0,\"vmm_version_count\":0},\"patch_api_requests\":{\"balloon_count\":4,\"balloon_fails\":4,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":2,\"balloon_fails\":2,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
 
         fs::remove_file(metrics_path).expect("fixture should clean up");
@@ -5099,9 +5166,9 @@ mod tests {
 
         let flush_response = put_action_over_socket(&mut vmm, "o-a2", "FlushMetrics");
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
-        assert_eq!(
-            fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":2,\"logger_fails\":1,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":2,\"metrics_fails\":1,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":2,\"serial_fails\":1,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+        assert_two_line_api_metrics_total(
+            &metrics_path,
+            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":2,\"logger_fails\":1,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":2,\"metrics_fails\":1,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":2,\"serial_fails\":1,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
 
         fs::remove_file(metrics_path).expect("metrics fixture should clean up");
@@ -5186,9 +5253,9 @@ mod tests {
         let flush_response = put_action_over_socket(&mut vmm, "op-a2", "FlushMetrics");
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
 
-        assert_eq!(
-            fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":1,\"logger_fails\":1,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":2,\"metrics_fails\":1,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":1,\"serial_fails\":1,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+        assert_two_line_api_metrics_total(
+            &metrics_path,
+            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":1,\"logger_fails\":1,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":2,\"metrics_fails\":1,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":1,\"serial_fails\":1,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
         assert!(!rejected_metrics_path.exists());
 
@@ -5557,9 +5624,9 @@ mod tests {
 
         let flush_response = put_action_over_socket(&mut vmm, "core-a2", "FlushMetrics");
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
-        assert_eq!(
-            fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":2,\"boot_source_fails\":1,\"cpu_cfg_count\":2,\"cpu_cfg_fails\":1,\"drive_count\":2,\"drive_fails\":1,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":1,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":2,\"network_fails\":1,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":2,\"vsock_fails\":1},\"vmm\":{\"metrics_flush_count\":1}}\n"
+        assert_two_line_api_metrics_total(
+            &metrics_path,
+            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":2,\"boot_source_fails\":1,\"cpu_cfg_count\":2,\"cpu_cfg_fails\":1,\"drive_count\":2,\"drive_fails\":1,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":1,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":2,\"network_fails\":1,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":2,\"vsock_fails\":1},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
 
         assert!(!drive_path.exists());
@@ -5645,9 +5712,9 @@ mod tests {
 
         let flush_response = put_action_over_socket(&mut vmm, "mmds-a2", "FlushMetrics");
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
-        assert_eq!(
-            fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":1,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":4,\"mmds_fails\":2,\"network_count\":1,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+        assert_two_line_api_metrics_total(
+            &metrics_path,
+            "{\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":1,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":4,\"mmds_fails\":2,\"network_count\":1,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
 
         fs::remove_file(metrics_path).expect("metrics fixture should clean up");
@@ -5727,11 +5794,9 @@ mod tests {
 
         let flush_response = put_action_over_socket(&mut vmm, "pm-a2", "FlushMetrics");
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
-        let metrics_output =
-            fs::read_to_string(&metrics_path).expect("metrics output should be readable");
-        assert_eq!(
-            metrics_output,
-            "{\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":3,\"pmem_fails\":2},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":2,\"pmem_fails\":1,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+        let metrics_output = assert_two_line_api_metrics_total(
+            &metrics_path,
+            "{\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":3,\"pmem_fails\":2},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":2,\"pmem_fails\":1,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
         assert!(!metrics_output.contains("pmem0"));
         assert!(!metrics_output.contains("/private/tmp/pmem.img"));
@@ -5840,11 +5905,9 @@ mod tests {
 
         let flush_response = put_action_over_socket(&mut vmm, "mh-m-a2", "FlushMetrics");
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
-        let metrics_output =
-            fs::read_to_string(&metrics_path).expect("metrics output should be readable");
-        assert_eq!(
-            metrics_output,
-            "{\"get_api_requests\":{\"balloon_count\":0,\"hotplug_memory_count\":1,\"instance_info_count\":0,\"machine_cfg_count\":0,\"mmds_count\":0,\"vmm_version_count\":0},\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":2,\"hotplug_memory_fails\":2,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":3,\"hotplug_memory_fails\":3,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+        let metrics_output = assert_two_line_api_metrics_total(
+            &metrics_path,
+            "{\"get_api_requests\":{\"balloon_count\":0,\"hotplug_memory_count\":1,\"instance_info_count\":0,\"machine_cfg_count\":0,\"mmds_count\":0,\"vmm_version_count\":0},\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":2,\"hotplug_memory_fails\":2,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":3,\"hotplug_memory_fails\":3,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
         assert!(!metrics_output.contains("222222222"));
         assert!(!metrics_output.contains("333333333"));
@@ -6020,11 +6083,9 @@ mod tests {
 
         let flush_response = put_action_over_socket(&mut vmm, "deprecated-a2", "FlushMetrics");
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
-        let metrics_output =
-            fs::read_to_string(&metrics_path).expect("metrics output should be readable");
-        assert_eq!(
-            metrics_output,
-            "{\"deprecated_api\":{\"deprecated_http_api_calls\":5},\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":1,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":3,\"machine_cfg_fails\":1,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":1,\"mmds_fails\":1,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":1,\"vsock_fails\":1},\"vmm\":{\"metrics_flush_count\":1}}\n"
+        let metrics_output = assert_two_line_api_metrics_total(
+            &metrics_path,
+            "{\"deprecated_api\":{\"deprecated_http_api_calls\":5},\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":1,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":3,\"machine_cfg_fails\":1,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":1,\"mmds_fails\":1,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":1,\"vsock_fails\":1},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
         assert!(!metrics_output.contains("vsock-secret"));
         assert!(!metrics_output.contains("deprecated-vsock-secret"));
@@ -6209,9 +6270,9 @@ mod tests {
 
         let flush_response = put_action_over_socket(&mut vmm, "patch-a2", "FlushMetrics");
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
-        assert_eq!(
-            fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":1,\"drive_fails\":1,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":1,\"mmds_count\":2,\"mmds_fails\":1,\"network_count\":4,\"network_fails\":4,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+        assert_two_line_api_metrics_total(
+            &metrics_path,
+            "{\"patch_api_requests\":{\"balloon_count\":0,\"balloon_fails\":0,\"drive_count\":1,\"drive_fails\":1,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"machine_cfg_count\":2,\"machine_cfg_fails\":1,\"mmds_count\":2,\"mmds_fails\":1,\"network_count\":4,\"network_fails\":4,\"pmem_count\":0,\"pmem_fails\":0},\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
 
         fs::remove_file(metrics_path).expect("metrics fixture should clean up");
@@ -6343,9 +6404,9 @@ mod tests {
             put_action_over_socket(&mut vmm, "flush-with-boot-loop", "FlushMetrics");
 
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
-        assert_eq!(
-            fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"boot_run_loop_status\":\"running\",\"metrics_flush_count\":1}}\n"
+        assert_two_line_api_metrics_total(
+            &metrics_path,
+            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":0,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"boot_run_loop_status\":\"running\",\"metrics_flush_count\":1}}\n",
         );
 
         fs::remove_file(metrics_path).expect("fixture should clean up");
@@ -6392,10 +6453,9 @@ mod tests {
         let flush_response = put_action_over_socket(&mut vmm, "met-flush", "FlushMetrics");
         assert!(flush_response.starts_with("HTTP/1.1 204 No Content\r\n"));
 
-        assert_eq!(
-            fs::read_to_string(&startup_metrics_path)
-                .expect("startup metrics output should be readable"),
-            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":1,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+        assert_two_line_api_metrics_total(
+            &startup_metrics_path,
+            "{\"put_api_requests\":{\"actions_count\":2,\"actions_fails\":0,\"balloon_count\":0,\"balloon_fails\":0,\"boot_source_count\":1,\"boot_source_fails\":0,\"cpu_cfg_count\":0,\"cpu_cfg_fails\":0,\"drive_count\":0,\"drive_fails\":0,\"hotplug_memory_count\":0,\"hotplug_memory_fails\":0,\"logger_count\":0,\"logger_fails\":0,\"machine_cfg_count\":0,\"machine_cfg_fails\":0,\"metrics_count\":1,\"metrics_fails\":1,\"mmds_count\":0,\"mmds_fails\":0,\"network_count\":0,\"network_fails\":0,\"pmem_count\":0,\"pmem_fails\":0,\"serial_count\":0,\"serial_fails\":0,\"vsock_count\":0,\"vsock_fails\":0},\"vmm\":{\"metrics_flush_count\":1}}\n",
         );
         assert!(!api_metrics_path.exists());
 
@@ -7074,11 +7134,20 @@ mod tests {
 
         let flush = put_action_over_socket(&mut resumed, "slf", "FlushMetrics");
         assert!(flush.starts_with("HTTP/1.1 204 No Content\r\n"));
-        let metrics = read_metrics_json(&metrics_path);
-        assert_metric(&metrics, "deprecated_api", "deprecated_http_api_calls", 1);
-        assert_latency_metric_present(&metrics, "load_snapshot");
         let raw_metrics =
             fs::read_to_string(&metrics_path).expect("metrics should remain readable");
+        let metrics_lines = raw_metrics
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("metrics line should be JSON"))
+            .collect::<Vec<serde_json::Value>>();
+        assert_eq!(metrics_lines.len(), 2);
+        assert_metric(
+            &metrics_lines[0],
+            "deprecated_api",
+            "deprecated_http_api_calls",
+            1,
+        );
+        assert_latency_metric_present(&metrics_lines[0], "load_snapshot");
         assert!(!raw_metrics.contains("private-resumed-state"));
         assert!(!raw_metrics.contains("private-resumed-memory"));
 
@@ -9927,23 +9996,37 @@ mod tests {
     }
 
     #[test]
-    fn run_until_periodic_metrics_timeout_flushes_after_start() {
+    fn run_until_periodic_metrics_timeout_flushes_restored_paused_session() {
         let path = unique_socket_path("periodic-metrics");
         let metrics_path = unique_socket_path("periodic-metrics-output").with_extension("metrics");
         let server = ApiServer::bind(&path).expect("server should bind");
         let (mut shutdown_reader, shutdown_writer) =
             UnixStream::pair().expect("shutdown stream pair should be created");
-        let mut vmm = test_controller_with_starter(TestInstanceStarter::success());
+        let mut vmm = test_controller_with_starter(TestInstanceStarter::snapshot_success());
         vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
             &metrics_path,
         )))
         .expect("metrics should configure");
-        vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
-            "/tmp/vmlinux",
-        )))
-        .expect("boot source should configure");
-        vmm.handle_action(VmmAction::InstanceStart)
-            .expect("instance should start");
+        let load_request = request_with_body(
+            "PUT",
+            "/snapshot/load",
+            r#"{"snapshot_path":"private-state","mem_backend":{"backend_path":"private-memory","backend_type":"File"}}"#,
+        );
+        assert_eq!(
+            handle_request_bytes(load_request.as_bytes(), &mut vmm).status(),
+            bangbang_api::http::StatusCode::NoContent
+        );
+        assert_eq!(
+            vmm.instance_info().state,
+            bangbang_runtime::InstanceState::Paused
+        );
+        assert_eq!(
+            fs::read_to_string(&metrics_path)
+                .expect("initial restored metrics output should be readable")
+                .lines()
+                .count(),
+            1
+        );
         let mut vmm = ShutdownAfterPeriodicFlush::new(vmm, &shutdown_writer);
 
         assert_eq!(
@@ -9955,10 +10038,14 @@ mod tests {
             Ok(())
         );
 
-        assert_eq!(
-            fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"vmm\":{\"metrics_flush_count\":1}}\n"
-        );
+        let output = fs::read_to_string(&metrics_path).expect("metrics output should be readable");
+        let lines = output.lines().collect::<Vec<_>>();
+        assert_eq!(lines.len(), 2);
+        for line in lines {
+            let metrics: serde_json::Value =
+                serde_json::from_str(line).expect("metrics line should be JSON");
+            assert_latency_metric_present(&metrics, "load_snapshot");
+        }
         fs::remove_file(metrics_path).expect("fixture should clean up");
         drop(server);
         assert!(!path.exists());
@@ -9970,13 +10057,16 @@ mod tests {
         let metrics_path =
             unique_socket_path("periodic-pre-start-output").with_extension("metrics");
         let server = ApiServer::bind(&path).expect("server should bind");
-        let (mut shutdown_reader, shutdown_writer) =
+        let (mut shutdown_reader, mut shutdown_writer) =
             UnixStream::pair().expect("shutdown stream pair should be created");
         let mut vmm = test_controller();
         vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
             &metrics_path,
         )))
         .expect("metrics should configure");
+        shutdown_writer
+            .write_all(b"x")
+            .expect("pre-start shutdown should wake the dormant scheduler");
         let mut vmm = ShutdownAfterPeriodicFlush::new(vmm, &shutdown_writer);
 
         assert_eq!(
@@ -10097,7 +10187,7 @@ mod tests {
             server.run_until_with_periodic_schedulers(
                 &mut vmm,
                 &mut shutdown_reader,
-                PeriodicMetricsScheduler::new(now),
+                PeriodicMetricsScheduler::new(),
                 PeriodicBalloonStatisticsScheduler::due_now(now, Duration::from_secs(1)),
             ),
             Ok(())

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -69,20 +69,20 @@ fn run() -> Result<(), ProcessError> {
     match args.command {
         Command::Help => {
             print_help();
-            return Ok(());
+            Ok(())
         }
         Command::Version => {
             println!("bangbang {}", env!("CARGO_PKG_VERSION"));
-            return Ok(());
+            Ok(())
         }
         Command::SnapshotVersion => {
             println!("v{NATIVE_V1_SNAPSHOT_VERSION}");
-            return Ok(());
+            Ok(())
         }
         Command::DescribeSnapshot(path) => {
             let metadata = describe_snapshot(path.as_str())?;
             println!("v{}", metadata.version());
-            return Ok(());
+            Ok(())
         }
         Command::Run(config) => {
             let config = *config;
@@ -127,25 +127,37 @@ fn run() -> Result<(), ProcessError> {
             let _fatal_signal_handlers = FatalSignalHandlers::install()?;
             let _sigpipe_signal_handler = SigpipeSignalHandler::install(signal_metrics)?;
             apply_startup_config_file(&mut vmm, config_file.as_deref())?;
-            let mut shutdown_signal = ShutdownSignal::install()?;
-            if no_api {
-                println!("status: VM running without API");
-                wait_for_no_api_shutdown(&mut shutdown_signal, &mut vmm)?;
-                return Ok(());
-            }
+            let result = (|| {
+                let mut shutdown_signal = ShutdownSignal::install()?;
+                if no_api {
+                    println!("status: VM running without API");
+                    return wait_for_no_api_shutdown(&mut shutdown_signal, &mut vmm);
+                }
 
-            let server =
-                ApiServer::bind_with_max_payload_size(&api_sock, http_api_max_payload_size)
-                    .map_err(ProcessError::ApiServer)?;
-            println!("status: API server listening");
-            let shutdown_wakeup = shutdown_signal.wakeup_reader();
-            server
-                .run_until(&mut vmm, shutdown_wakeup)
-                .map_err(ProcessError::ApiServer)?;
+                let server =
+                    ApiServer::bind_with_max_payload_size(&api_sock, http_api_max_payload_size)
+                        .map_err(ProcessError::ApiServer)?;
+                println!("status: API server listening");
+                let shutdown_wakeup = shutdown_signal.wakeup_reader();
+                server
+                    .run_until(&mut vmm, shutdown_wakeup)
+                    .map_err(ProcessError::ApiServer)
+            })();
+
+            finish_process_with_terminal_metrics(&mut vmm, result)
         }
     }
+}
 
-    Ok(())
+fn finish_process_with_terminal_metrics<S>(
+    vmm: &mut ProcessVmm<S>,
+    result: Result<(), ProcessError>,
+) -> Result<(), ProcessError>
+where
+    S: vmm::InstanceStartExecutor,
+{
+    vmm.handle_terminal_metrics_flush();
+    result
 }
 
 fn wait_for_no_api_shutdown(
@@ -155,7 +167,7 @@ fn wait_for_no_api_shutdown(
     wait_for_no_api_shutdown_with_periodic_metrics_scheduler(
         shutdown_signal,
         vmm,
-        PeriodicMetricsScheduler::new(Instant::now()),
+        PeriodicMetricsScheduler::new(),
     )
 }
 
@@ -185,7 +197,7 @@ fn wait_for_no_api_shutdown_with_periodic_schedulers(
 
     loop {
         let now = Instant::now();
-        let metrics_timeout = Some(metrics_scheduler.poll_timeout_ms(now));
+        let metrics_timeout = metrics_scheduler.poll_timeout_ms(now, vmm.metrics_session_epoch());
         let balloon_timeout =
             balloon_scheduler.poll_timeout_ms(now, vmm.balloon_statistics_update_interval());
         match wait_for_shutdown_or_process_exit(
@@ -235,10 +247,9 @@ fn handle_due_no_api_periodic_schedulers(
     }
 
     let now = Instant::now();
-    if metrics_scheduler.is_due(now) {
-        vmm.handle_periodic_metrics_flush()
-            .map_err(ProcessError::PeriodicMetricsFlush)?;
-        metrics_scheduler.schedule_next(Instant::now());
+    if metrics_scheduler.is_due(now, vmm.metrics_session_epoch()) {
+        vmm.handle_periodic_metrics_flush();
+        metrics_scheduler.schedule_next(Instant::now(), vmm.metrics_session_epoch());
         handled = true;
     }
 
@@ -258,19 +269,14 @@ where
     let actions = config_file_actions(config_file).map_err(ProcessError::ConfigFile)?;
 
     for action in actions {
-        let flush_startup_metrics = matches!(action, VmmAction::PutMetrics(_));
         vmm.handle_action(action)
             .map_err(ConfigFileError::Apply)
             .map_err(ProcessError::ConfigFile)?;
-        if flush_startup_metrics {
-            vmm.flush_startup_metrics()
-                .map(|_| ())
-                .map_err(ConfigFileError::Apply)
-                .map_err(ProcessError::ConfigFile)?;
-        }
     }
 
-    vmm.handle_action(VmmAction::InstanceStart)
+    let result = vmm.handle_action(VmmAction::InstanceStart);
+    vmm.handle_initial_metrics_flush();
+    result
         .map(|_| ())
         .map_err(ConfigFileError::Apply)
         .map_err(ProcessError::ConfigFile)
@@ -621,9 +627,6 @@ where
         vmm.handle_action(VmmAction::PutMetrics(metrics_config))
             .map(|_| ())
             .map_err(ProcessError::StartupConfiguration)?;
-        vmm.flush_startup_metrics()
-            .map(|_| ())
-            .map_err(ProcessError::StartupConfiguration)?;
     }
 
     Ok(())
@@ -877,7 +880,6 @@ enum ProcessError {
     FdTablePreallocation(FdTablePreallocationError),
     Metadata(MetadataFileError),
     PeriodicBalloonStatisticsUpdate(VmmActionError),
-    PeriodicMetricsFlush(VmmActionError),
     ProcessExitNotification(std::io::ErrorKind),
     ProcessSessionTerminal,
     SignalHandler(std::io::ErrorKind),
@@ -896,7 +898,6 @@ impl ProcessError {
             Self::FdTablePreallocation(_) => ProcessExitCode::ProcessFailure,
             Self::Metadata(_) => ProcessExitCode::BadConfiguration,
             Self::PeriodicBalloonStatisticsUpdate(_) => ProcessExitCode::ProcessFailure,
-            Self::PeriodicMetricsFlush(_) => ProcessExitCode::ProcessFailure,
             Self::ProcessExitNotification(_) => ProcessExitCode::ProcessFailure,
             Self::ProcessSessionTerminal => ProcessExitCode::ProcessFailure,
             Self::SignalHandler(_) => ProcessExitCode::ProcessFailure,
@@ -923,9 +924,6 @@ impl fmt::Display for ProcessError {
                     f,
                     "failed to trigger periodic balloon statistics update: {err}"
                 )
-            }
-            Self::PeriodicMetricsFlush(err) => {
-                write!(f, "failed to flush periodic metrics: {err}")
             }
             Self::ProcessExitNotification(kind) => {
                 write!(f, "process exit notification failed: {kind:?}")
@@ -2079,13 +2077,14 @@ fn unsupported_flag_equals_syntax(arg: &str) -> Option<&'static str> {
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::OsString;
+    use std::ffi::{CString, OsString};
     use std::fs;
     use std::io::{ErrorKind, Read, Write};
-    use std::os::unix::ffi::OsStringExt;
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+    use std::os::unix::fs::OpenOptionsExt;
     use std::os::unix::io::{AsRawFd, RawFd};
     use std::os::unix::net::UnixStream;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -2095,7 +2094,10 @@ mod tests {
     use bangbang_runtime::logger::{LoggerConfigError, LoggerConfigInput, LoggerLevel};
     use bangbang_runtime::machine::{MAX_MEM_SIZE_MIB, MachineConfigError};
     use bangbang_runtime::memory_hotplug::MemoryHotplugConfigInput;
-    use bangbang_runtime::metrics::{MetricsConfigError, MetricsConfigInput, MetricsDiagnostics};
+    use bangbang_runtime::metrics::{
+        MetricsConfigError, MetricsConfigInput, MetricsDiagnostics, MetricsFlushError,
+        SharedSignalMetrics,
+    };
     use bangbang_runtime::mmds::MmdsDataStoreError;
     use bangbang_runtime::network::NetworkInterfaceConfigInput;
     use bangbang_runtime::pmem::{PmemConfigError, PmemConfigInput};
@@ -2300,6 +2302,14 @@ mod tests {
     }
 
     impl ProcessSessionDiagnostics for TestProcessExitSession {
+        fn pause(&mut self) -> Result<(), BackendError> {
+            Ok(())
+        }
+
+        fn resume(&mut self) -> Result<(), BackendError> {
+            Ok(())
+        }
+
         fn trigger_balloon_statistics_update(
             &mut self,
         ) -> Result<(), bangbang_runtime::balloon::BalloonUpdateError> {
@@ -2481,11 +2491,18 @@ mod tests {
             self.inner.record_load_snapshot_latency_us(duration_us);
         }
 
-        fn handle_periodic_metrics_flush(&mut self) -> Result<bool, VmmActionError> {
-            let result = self.inner.handle_periodic_metrics_flush();
+        fn metrics_session_epoch(&self) -> Option<Instant> {
+            self.inner.metrics_session_epoch()
+        }
+
+        fn handle_initial_metrics_flush(&mut self) {
+            self.inner.handle_initial_metrics_flush();
+        }
+
+        fn handle_periodic_metrics_flush(&mut self) {
+            self.inner.handle_periodic_metrics_flush();
             self.process_exit_trigger
                 .trigger(ProcessSessionExitStatus::GuestRequestedStop);
-            result
         }
 
         fn balloon_statistics_update_interval(&self) -> Option<Duration> {
@@ -2543,6 +2560,73 @@ mod tests {
             "bangbang-main-test-{}-{nanos}-{name}.metrics",
             std::process::id()
         ))
+    }
+
+    #[derive(Debug)]
+    struct MetricsFifo {
+        path: PathBuf,
+        reader: fs::File,
+    }
+
+    impl MetricsFifo {
+        fn create(name: &str) -> Self {
+            let path = unique_metrics_path(name);
+            let c_path = CString::new(path.as_os_str().as_bytes())
+                .expect("metrics FIFO path should not contain NUL");
+            // SAFETY: `c_path` is a live NUL-terminated path owned by this test fixture.
+            let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+            assert_eq!(result, 0, "metrics FIFO should be created");
+            let reader = fs::OpenOptions::new()
+                .read(true)
+                .custom_flags(libc::O_NONBLOCK)
+                .open(&path)
+                .expect("metrics FIFO reader should open");
+
+            Self { path, reader }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+
+        fn fill_to_capacity(&self) {
+            let mut writer = fs::OpenOptions::new()
+                .write(true)
+                .custom_flags(libc::O_NONBLOCK)
+                .open(&self.path)
+                .expect("metrics FIFO filler should open");
+            let chunk = [b'x'; 4096];
+            let mut written = 0usize;
+            loop {
+                match writer.write(&chunk) {
+                    Ok(0) => panic!("metrics FIFO filler unexpectedly wrote zero bytes"),
+                    Ok(count) => written = written.saturating_add(count),
+                    Err(err) if err.kind() == ErrorKind::WouldBlock => break,
+                    Err(err) => panic!("metrics FIFO filler should reach capacity: {err}"),
+                }
+            }
+            assert!(written > 0, "metrics FIFO should accept filler bytes");
+        }
+
+        fn drain_available(&mut self) -> Vec<u8> {
+            let mut output = Vec::new();
+            let mut chunk = [0; 4096];
+            loop {
+                match self.reader.read(&mut chunk) {
+                    Ok(0) => break,
+                    Ok(count) => output.extend_from_slice(&chunk[..count]),
+                    Err(err) if err.kind() == ErrorKind::WouldBlock => break,
+                    Err(err) => panic!("metrics FIFO should drain: {err}"),
+                }
+            }
+            output
+        }
+    }
+
+    impl Drop for MetricsFifo {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.path);
+        }
     }
 
     fn test_shutdown_signal() -> super::ShutdownSignal {
@@ -2610,7 +2694,6 @@ mod tests {
                 ErrorKind::BrokenPipe,
             )),
             ProcessError::PeriodicBalloonStatisticsUpdate(VmmActionError::BalloonUnsupported),
-            ProcessError::PeriodicMetricsFlush(VmmActionError::EntropyUnsupported),
             ProcessError::ProcessExitNotification(std::io::ErrorKind::BrokenPipe),
             ProcessError::ProcessSessionTerminal,
             ProcessError::SignalHandler(std::io::ErrorKind::Interrupted),
@@ -4131,7 +4214,96 @@ mod tests {
     }
 
     #[test]
+    fn terminal_metrics_drain_initial_preserve_server_error_and_do_not_duplicate() {
+        let metrics_path = unique_metrics_path("server-error-final");
+        let mut vmm = ProcessVmm::with_starter(
+            "demo-1",
+            env!("CARGO_PKG_VERSION"),
+            "bangbang",
+            TestInstanceStarter,
+        );
+        vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+            &metrics_path,
+        )))
+        .expect("metrics should configure");
+        vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            "/tmp/vmlinux",
+        )))
+        .expect("boot source should configure");
+        vmm.handle_action(VmmAction::InstanceStart)
+            .expect("instance should start");
+
+        let result = Err(ProcessError::ApiServer(ApiServerError::Accept(
+            ErrorKind::BrokenPipe,
+        )));
+        assert_eq!(
+            super::finish_process_with_terminal_metrics(&mut vmm, result),
+            Err(ProcessError::ApiServer(ApiServerError::Accept(
+                ErrorKind::BrokenPipe
+            )))
+        );
+        let expected =
+            "{\"vmm\":{\"metrics_flush_count\":1}}\n{\"vmm\":{\"metrics_flush_count\":1}}\n";
+        assert_eq!(
+            fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
+            expected
+        );
+
+        assert_eq!(
+            super::finish_process_with_terminal_metrics(&mut vmm, Ok(())),
+            Ok(())
+        );
+        assert_eq!(
+            fs::read_to_string(&metrics_path).expect("metrics output should remain readable"),
+            expected
+        );
+        fs::remove_file(metrics_path).expect("metrics fixture should clean up");
+    }
+
+    #[test]
+    fn terminal_metrics_sink_failure_preserves_result_and_consumes_final_attempt() {
+        let mut metrics_fifo = MetricsFifo::create("terminal-failure");
+        let mut vmm = ProcessVmm::with_starter(
+            "demo-1",
+            env!("CARGO_PKG_VERSION"),
+            "bangbang",
+            TestInstanceStarter,
+        );
+        vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+            metrics_fifo.path(),
+        )))
+        .expect("metrics should configure");
+        vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            "/tmp/vmlinux",
+        )))
+        .expect("boot source should configure");
+        vmm.handle_action(VmmAction::InstanceStart)
+            .expect("instance should start");
+        vmm.handle_initial_metrics_flush();
+        let _initial = metrics_fifo.drain_available();
+        metrics_fifo.fill_to_capacity();
+
+        let result = Err(ProcessError::ApiServer(ApiServerError::Accept(
+            ErrorKind::BrokenPipe,
+        )));
+        assert_eq!(
+            super::finish_process_with_terminal_metrics(&mut vmm, result),
+            Err(ProcessError::ApiServer(ApiServerError::Accept(
+                ErrorKind::BrokenPipe
+            )))
+        );
+        let _failed_final = metrics_fifo.drain_available();
+
+        assert_eq!(
+            super::finish_process_with_terminal_metrics(&mut vmm, Ok(())),
+            Ok(())
+        );
+        assert_eq!(metrics_fifo.drain_available(), Vec::<u8>::new());
+    }
+
+    #[test]
     fn no_api_wait_returns_after_guest_requested_stop_notification() {
+        let metrics_path = unique_metrics_path("guest-stop-final");
         let process_exit_signal = TestProcessExitSignal::new();
         let process_exit_trigger = process_exit_signal.clone();
         let mut vmm = ProcessVmm::with_starter(
@@ -4142,22 +4314,36 @@ mod tests {
                 signal: process_exit_signal,
             },
         );
+        vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+            &metrics_path,
+        )))
+        .expect("metrics should configure");
         vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
             "/tmp/vmlinux",
         )))
         .expect("boot source should configure");
         vmm.handle_action(VmmAction::InstanceStart)
             .expect("instance should start");
+        vmm.handle_initial_metrics_flush();
         let mut shutdown_signal = test_shutdown_signal();
 
         process_exit_trigger.trigger(ProcessSessionExitStatus::GuestRequestedStop);
 
-        super::wait_for_no_api_shutdown(&mut shutdown_signal, &mut vmm)
-            .expect("guest-requested stop should stop no-api wait successfully");
+        let result = super::wait_for_no_api_shutdown(&mut shutdown_signal, &mut vmm);
+        assert_eq!(
+            super::finish_process_with_terminal_metrics(&mut vmm, result),
+            Ok(())
+        );
+        assert_eq!(
+            fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
+            "{\"vmm\":{\"metrics_flush_count\":1}}\n{\"vmm\":{\"metrics_flush_count\":1}}\n"
+        );
+        fs::remove_file(metrics_path).expect("metrics fixture should clean up");
     }
 
     #[test]
     fn no_api_wait_fails_after_process_terminal_notification() {
+        let metrics_path = unique_metrics_path("guest-terminal-final");
         let process_exit_signal = TestProcessExitSignal::new();
         let process_exit_trigger = process_exit_signal.clone();
         let mut vmm = ProcessVmm::with_starter(
@@ -4168,20 +4354,31 @@ mod tests {
                 signal: process_exit_signal,
             },
         );
+        vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+            &metrics_path,
+        )))
+        .expect("metrics should configure");
         vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
             "/tmp/vmlinux",
         )))
         .expect("boot source should configure");
         vmm.handle_action(VmmAction::InstanceStart)
             .expect("instance should start");
+        vmm.handle_initial_metrics_flush();
         let mut shutdown_signal = test_shutdown_signal();
 
         process_exit_trigger.trigger(ProcessSessionExitStatus::Terminal);
 
+        let result = super::wait_for_no_api_shutdown(&mut shutdown_signal, &mut vmm);
         assert_eq!(
-            super::wait_for_no_api_shutdown(&mut shutdown_signal, &mut vmm),
+            super::finish_process_with_terminal_metrics(&mut vmm, result),
             Err(super::ProcessError::ProcessSessionTerminal)
         );
+        assert_eq!(
+            fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
+            "{\"vmm\":{\"metrics_flush_count\":1}}\n{\"vmm\":{\"metrics_flush_count\":1}}\n"
+        );
+        fs::remove_file(metrics_path).expect("metrics fixture should clean up");
     }
 
     #[test]
@@ -4207,6 +4404,10 @@ mod tests {
         .expect("boot source should configure");
         vmm.handle_action(VmmAction::InstanceStart)
             .expect("instance should start");
+        vmm.handle_initial_metrics_flush();
+        vmm.handle_action(VmmAction::Pause)
+            .expect("running instance should pause");
+        assert_eq!(vmm.instance_info().state, InstanceState::Paused);
         let mut vmm = ProcessExitAfterPeriodicFlush::new(vmm, process_exit_trigger);
         let mut shutdown_signal = test_shutdown_signal();
 
@@ -4220,9 +4421,119 @@ mod tests {
         );
         assert_eq!(
             fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"vmm\":{\"metrics_flush_count\":1}}\n"
+            "{\"vmm\":{\"metrics_flush_count\":1}}\n{\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
         fs::remove_file(metrics_path).expect("fixture metrics should clean up");
+    }
+
+    #[test]
+    fn no_api_periodic_metrics_failure_reschedules_and_retries_delta() {
+        let mut metrics_fifo = MetricsFifo::create("periodic-retry");
+        let signal_metrics = SharedSignalMetrics::default();
+        let mut vmm = ProcessVmm::with_starter(
+            "demo-1",
+            env!("CARGO_PKG_VERSION"),
+            "bangbang",
+            TestInstanceStarter,
+        )
+        .with_process_signal_metrics(signal_metrics.clone());
+        vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+            metrics_fifo.path(),
+        )))
+        .expect("metrics should configure");
+        vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            "/tmp/vmlinux",
+        )))
+        .expect("boot source should configure");
+        vmm.handle_action(VmmAction::InstanceStart)
+            .expect("instance should start");
+        vmm.handle_initial_metrics_flush();
+        let initial = String::from_utf8(metrics_fifo.drain_available())
+            .expect("initial metrics should be UTF-8");
+        assert!(initial.contains(r#""metrics_flush_count":1"#));
+
+        metrics_fifo.fill_to_capacity();
+        signal_metrics.record_sigpipe();
+        let session_epoch = vmm
+            .metrics_session_epoch()
+            .expect("started session should have a metrics epoch");
+        let now = Instant::now();
+        let mut metrics_scheduler = super::PeriodicMetricsScheduler::due_now(now);
+        let mut balloon_scheduler = super::PeriodicBalloonStatisticsScheduler::new(now, None);
+
+        assert_eq!(
+            super::handle_due_no_api_periodic_schedulers(
+                &mut vmm,
+                &mut metrics_scheduler,
+                &mut balloon_scheduler,
+            ),
+            Ok(true)
+        );
+        assert!(matches!(
+            metrics_scheduler.poll_timeout_ms(Instant::now(), Some(session_epoch)),
+            Some(timeout_ms) if timeout_ms > 0
+        ));
+        let _failed_attempt = metrics_fifo.drain_available();
+
+        signal_metrics.record_sigpipe();
+        let now = Instant::now();
+        let mut retry_scheduler = super::PeriodicMetricsScheduler::due_now(now);
+        assert_eq!(
+            super::handle_due_no_api_periodic_schedulers(
+                &mut vmm,
+                &mut retry_scheduler,
+                &mut balloon_scheduler,
+            ),
+            Ok(true)
+        );
+        let retried = String::from_utf8(metrics_fifo.drain_available())
+            .expect("retried metrics should be UTF-8");
+        assert!(retried.contains(r#""missed_metrics_count":1"#));
+        assert!(retried.contains(r#""sigpipe":2"#));
+
+        metrics_fifo.fill_to_capacity();
+        let explicit_error = vmm
+            .handle_action(VmmAction::FlushMetrics)
+            .expect_err("explicit metrics flush should preserve sink errors");
+        assert!(matches!(
+            explicit_error,
+            VmmActionError::MetricsFlush(MetricsFlushError::Write(ErrorKind::WouldBlock))
+        ));
+        let _explicit_attempt = metrics_fifo.drain_available();
+    }
+
+    #[test]
+    fn initial_metrics_failure_preserves_session_and_consumes_initial_attempt() {
+        let mut metrics_fifo = MetricsFifo::create("initial-failure");
+        let mut vmm = ProcessVmm::with_starter(
+            "demo-1",
+            env!("CARGO_PKG_VERSION"),
+            "bangbang",
+            TestInstanceStarter,
+        );
+        vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+            metrics_fifo.path(),
+        )))
+        .expect("metrics should configure");
+        vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            "/tmp/vmlinux",
+        )))
+        .expect("boot source should configure");
+        metrics_fifo.fill_to_capacity();
+
+        vmm.handle_action(VmmAction::InstanceStart)
+            .expect("instance should start despite the full metrics sink");
+        vmm.handle_initial_metrics_flush();
+        assert_eq!(vmm.instance_info().state, InstanceState::Running);
+        assert!(vmm.has_started_session());
+        let _failed_initial = metrics_fifo.drain_available();
+
+        vmm.handle_initial_metrics_flush();
+        assert_eq!(metrics_fifo.drain_available(), Vec::<u8>::new());
+        vmm.handle_periodic_metrics_flush();
+        let retried = String::from_utf8(metrics_fifo.drain_available())
+            .expect("periodic retry metrics should be UTF-8");
+        assert!(retried.contains(r#""missed_metrics_count":1"#));
     }
 
     #[test]
@@ -4260,7 +4571,7 @@ mod tests {
             super::wait_for_no_api_shutdown_with_periodic_schedulers(
                 &mut shutdown_signal,
                 &mut vmm,
-                super::PeriodicMetricsScheduler::new(now),
+                super::PeriodicMetricsScheduler::new(),
                 super::PeriodicBalloonStatisticsScheduler::due_now(now, Duration::from_secs(1)),
             ),
             Ok(())
@@ -5375,7 +5686,7 @@ mod tests {
     }
 
     #[test]
-    fn applies_startup_metrics_config_before_actions() {
+    fn startup_metrics_config_waits_for_started_session_before_initial_write() {
         let path = unique_metrics_path("flush");
         let mut vmm = ProcessVmm::with_starter(
             "demo-1",
@@ -5390,7 +5701,7 @@ mod tests {
         assert!(!vmm.has_started_session());
         assert_eq!(
             fs::read_to_string(&path).expect("startup metrics output should be readable"),
-            "{\"vmm\":{\"metrics_flush_count\":1}}\n"
+            ""
         );
         vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
             "/tmp/vmlinux",
@@ -5398,6 +5709,7 @@ mod tests {
         .expect("boot source should configure");
         vmm.handle_action(VmmAction::InstanceStart)
             .expect("instance start should succeed");
+        vmm.handle_initial_metrics_flush();
         vmm.handle_action(VmmAction::FlushMetrics)
             .expect("flush metrics should succeed");
 
@@ -5410,7 +5722,7 @@ mod tests {
     }
 
     #[test]
-    fn applies_startup_metrics_config_with_startup_time_diagnostics() {
+    fn initial_metrics_write_includes_startup_time_diagnostics() {
         let path = unique_metrics_path("startup-time");
         let diagnostics = MetricsDiagnostics::new()
             .with_start_time_us(1000)
@@ -5431,6 +5743,19 @@ mod tests {
         assert!(!vmm.has_started_session());
         assert_eq!(
             fs::read_to_string(&path).expect("startup metrics output should be readable"),
+            ""
+        );
+
+        vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            "/tmp/vmlinux",
+        )))
+        .expect("boot source should configure");
+        vmm.handle_action(VmmAction::InstanceStart)
+            .expect("instance start should succeed");
+        vmm.handle_initial_metrics_flush();
+
+        assert_eq!(
+            fs::read_to_string(&path).expect("initial metrics output should be readable"),
             "{\"api_server\":{\"process_startup_time_cpu_us\":5000,\"process_startup_time_us\":1000},\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
 

--- a/crates/bangbang/src/periodic_metrics.rs
+++ b/crates/bangbang/src/periodic_metrics.rs
@@ -4,37 +4,67 @@ pub(crate) const FIRECRACKER_PERIODIC_METRICS_FLUSH_INTERVAL: Duration = Duratio
 
 #[derive(Debug, Clone)]
 pub(crate) struct PeriodicMetricsScheduler {
-    deadline: PeriodicDeadline,
+    deadline: Option<PeriodicDeadline>,
 }
 
 impl PeriodicMetricsScheduler {
-    pub(crate) fn new(now: Instant) -> Self {
-        Self::with_period(now, FIRECRACKER_PERIODIC_METRICS_FLUSH_INTERVAL)
+    pub(crate) const fn new() -> Self {
+        Self { deadline: None }
     }
 
     #[cfg(test)]
     pub(crate) fn due_now(now: Instant) -> Self {
         Self {
-            deadline: PeriodicDeadline::due_now(now, FIRECRACKER_PERIODIC_METRICS_FLUSH_INTERVAL),
+            deadline: Some(PeriodicDeadline::due_now(
+                now,
+                FIRECRACKER_PERIODIC_METRICS_FLUSH_INTERVAL,
+            )),
         }
     }
 
+    #[cfg(test)]
     fn with_period(now: Instant, period: Duration) -> Self {
         Self {
-            deadline: PeriodicDeadline::new(now, period),
+            deadline: Some(PeriodicDeadline::new(now, period)),
         }
     }
 
-    pub(crate) fn poll_timeout_ms(&self, now: Instant) -> i32 {
-        self.deadline.poll_timeout_ms(now)
+    pub(crate) fn poll_timeout_ms(
+        &mut self,
+        now: Instant,
+        session_epoch: Option<Instant>,
+    ) -> Option<i32> {
+        self.sync_session_epoch(session_epoch);
+        self.deadline
+            .as_ref()
+            .map(|deadline| deadline.poll_timeout_ms(now))
     }
 
-    pub(crate) fn is_due(&self, now: Instant) -> bool {
-        self.deadline.is_due(now)
+    pub(crate) fn is_due(&mut self, now: Instant, session_epoch: Option<Instant>) -> bool {
+        self.sync_session_epoch(session_epoch);
+        self.deadline
+            .as_ref()
+            .is_some_and(|deadline| deadline.is_due(now))
     }
 
-    pub(crate) fn schedule_next(&mut self, now: Instant) {
-        self.deadline.schedule_next(now);
+    pub(crate) fn schedule_next(&mut self, now: Instant, session_epoch: Option<Instant>) {
+        self.sync_session_epoch(session_epoch);
+        if let Some(deadline) = self.deadline.as_mut() {
+            deadline.schedule_next(now);
+        }
+    }
+
+    fn sync_session_epoch(&mut self, session_epoch: Option<Instant>) {
+        match (self.deadline.as_mut(), session_epoch) {
+            (Some(_), Some(_)) | (None, None) => {}
+            (Some(_), None) => self.deadline = None,
+            (None, Some(epoch)) => {
+                self.deadline = Some(PeriodicDeadline::new(
+                    epoch,
+                    FIRECRACKER_PERIODIC_METRICS_FLUSH_INTERVAL,
+                ));
+            }
+        }
     }
 }
 
@@ -168,53 +198,99 @@ mod tests {
     use super::*;
 
     #[test]
-    fn scheduler_uses_firecracker_interval_by_default() {
+    fn metrics_scheduler_is_dormant_without_session_epoch() {
         let now = Instant::now();
-        let scheduler = PeriodicMetricsScheduler::new(now);
+        let mut scheduler = PeriodicMetricsScheduler::new();
+
+        assert_eq!(scheduler.poll_timeout_ms(now, None), None);
+        assert!(!scheduler.is_due(now, None));
+    }
+
+    #[test]
+    fn metrics_scheduler_uses_firecracker_interval_from_session_epoch() {
+        let now = Instant::now();
+        let mut scheduler = PeriodicMetricsScheduler::new();
 
         assert_eq!(
-            scheduler.poll_timeout_ms(now),
-            FIRECRACKER_PERIODIC_METRICS_FLUSH_INTERVAL.as_millis() as i32
+            scheduler.poll_timeout_ms(now, Some(now)),
+            Some(FIRECRACKER_PERIODIC_METRICS_FLUSH_INTERVAL.as_millis() as i32)
+        );
+    }
+
+    #[test]
+    fn metrics_scheduler_preserves_elapsed_time_before_epoch_observation() {
+        let epoch = Instant::now();
+        let observed_at = epoch + Duration::from_secs(17);
+        let mut scheduler = PeriodicMetricsScheduler::new();
+
+        assert_eq!(
+            scheduler.poll_timeout_ms(observed_at, Some(epoch)),
+            Some(43_000)
+        );
+    }
+
+    #[test]
+    fn metrics_scheduler_reports_late_epoch_observation_due_immediately() {
+        let epoch = Instant::now();
+        let observed_at = epoch + FIRECRACKER_PERIODIC_METRICS_FLUSH_INTERVAL;
+        let mut scheduler = PeriodicMetricsScheduler::new();
+
+        assert_eq!(scheduler.poll_timeout_ms(observed_at, Some(epoch)), Some(0));
+        assert!(scheduler.is_due(observed_at, Some(epoch)));
+    }
+
+    #[test]
+    fn metrics_scheduler_does_not_reset_deadline_on_later_observation() {
+        let epoch = Instant::now();
+        let mut scheduler = PeriodicMetricsScheduler::new();
+        assert_eq!(
+            scheduler.poll_timeout_ms(epoch + Duration::from_secs(5), Some(epoch)),
+            Some(55_000)
+        );
+
+        assert_eq!(
+            scheduler.poll_timeout_ms(epoch + Duration::from_secs(11), Some(epoch)),
+            Some(49_000)
         );
     }
 
     #[test]
     fn scheduler_reports_due_deadline_without_waiting() {
         let now = Instant::now();
-        let scheduler = PeriodicMetricsScheduler::due_now(now);
+        let mut scheduler = PeriodicMetricsScheduler::due_now(now);
 
-        assert_eq!(scheduler.poll_timeout_ms(now), 0);
-        assert!(scheduler.is_due(now));
+        assert_eq!(scheduler.poll_timeout_ms(now, Some(now)), Some(0));
+        assert!(scheduler.is_due(now, Some(now)));
     }
 
     #[test]
     fn scheduler_rounds_submillisecond_timeout_up() {
         let now = Instant::now();
-        let scheduler = PeriodicMetricsScheduler::with_period(now, Duration::from_nanos(1));
+        let mut scheduler = PeriodicMetricsScheduler::with_period(now, Duration::from_nanos(1));
 
-        assert_eq!(scheduler.poll_timeout_ms(now), 1);
+        assert_eq!(scheduler.poll_timeout_ms(now, Some(now)), Some(1));
     }
 
     #[test]
     fn scheduler_rounds_partial_millisecond_timeout_up() {
         let now = Instant::now();
-        let scheduler = PeriodicMetricsScheduler::with_period(
+        let mut scheduler = PeriodicMetricsScheduler::with_period(
             now,
             Duration::from_millis(1) + Duration::from_nanos(1),
         );
 
-        assert_eq!(scheduler.poll_timeout_ms(now), 2);
+        assert_eq!(scheduler.poll_timeout_ms(now, Some(now)), Some(2));
     }
 
     #[test]
     fn scheduler_schedules_next_deadline_after_flush() {
         let now = Instant::now();
         let mut scheduler = PeriodicMetricsScheduler::due_now(now);
-        scheduler.schedule_next(now);
+        scheduler.schedule_next(now, Some(now));
 
         assert_eq!(
-            scheduler.poll_timeout_ms(now),
-            FIRECRACKER_PERIODIC_METRICS_FLUSH_INTERVAL.as_millis() as i32
+            scheduler.poll_timeout_ms(now, Some(now)),
+            Some(FIRECRACKER_PERIODIC_METRICS_FLUSH_INTERVAL.as_millis() as i32)
         );
     }
 

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -1137,9 +1137,13 @@ pub(crate) trait VmmRequestHandler {
 
     fn record_load_snapshot_latency_us(&mut self, duration_us: u64);
 
-    fn handle_periodic_metrics_flush(&mut self) -> Result<bool, VmmActionError> {
-        Ok(false)
+    fn metrics_session_epoch(&self) -> Option<Instant> {
+        None
     }
+
+    fn handle_initial_metrics_flush(&mut self) {}
+
+    fn handle_periodic_metrics_flush(&mut self) {}
 
     fn balloon_statistics_update_interval(&self) -> Option<Duration> {
         None
@@ -1170,6 +1174,9 @@ where
     controller: VmmController,
     starter: S,
     started_session: Option<S::Session>,
+    metrics_session_epoch: Option<Instant>,
+    initial_metrics_attempted: bool,
+    terminal_metrics_attempted: bool,
     process_metrics_diagnostics: MetricsDiagnostics,
     process_signal_metrics: Option<SharedSignalMetrics>,
     terminal_snapshot_load_failure: bool,
@@ -1233,6 +1240,9 @@ where
             ),
             starter,
             started_session: None,
+            metrics_session_epoch: None,
+            initial_metrics_attempted: false,
+            terminal_metrics_attempted: false,
             process_metrics_diagnostics: MetricsDiagnostics::default(),
             process_signal_metrics: None,
             terminal_snapshot_load_failure: false,
@@ -1252,9 +1262,12 @@ where
         self
     }
 
-    #[cfg(test)]
     pub(crate) const fn has_started_session(&self) -> bool {
         self.started_session.is_some()
+    }
+
+    pub(crate) const fn metrics_session_epoch(&self) -> Option<Instant> {
+        self.metrics_session_epoch
     }
 }
 
@@ -1293,7 +1306,8 @@ where
     }
 
     pub(crate) fn handle_action(&mut self, action: VmmAction) -> Result<VmmData, VmmActionError> {
-        match action {
+        let had_started_session = self.has_started_session();
+        let result = match action {
             VmmAction::InstanceStart => self.start_instance(),
             VmmAction::Pause => self.pause_instance(),
             VmmAction::Resume => self.resume_instance(),
@@ -1312,7 +1326,14 @@ where
             VmmAction::PatchBalloonHintingStop => self.stop_balloon_hinting(),
             VmmAction::FlushMetrics => self.flush_metrics(),
             action => self.controller.handle_action(action),
+        };
+
+        if !had_started_session && self.has_started_session() {
+            debug_assert!(self.metrics_session_epoch.is_none());
+            self.metrics_session_epoch.get_or_insert_with(Instant::now);
         }
+
+        result
     }
 
     fn handle_put_action_request(&mut self, action: VmmAction) -> Result<VmmData, VmmActionError> {
@@ -1729,18 +1750,34 @@ where
         })
     }
 
-    pub(crate) fn flush_startup_metrics(&mut self) -> Result<bool, VmmActionError> {
+    fn flush_automatic_metrics(&mut self) -> Result<bool, VmmActionError> {
         let diagnostics = self.metrics_diagnostics();
 
         self.controller
-            .flush_startup_metrics_with_diagnostics(&diagnostics)
+            .flush_automatic_metrics_with_diagnostics(&diagnostics)
     }
 
-    fn flush_periodic_metrics(&mut self) -> Result<bool, VmmActionError> {
-        let diagnostics = self.metrics_diagnostics();
+    pub(crate) fn handle_initial_metrics_flush(&mut self) {
+        if !self.has_started_session() || self.initial_metrics_attempted {
+            return;
+        }
 
-        self.controller
-            .flush_periodic_metrics_with_diagnostics(&diagnostics)
+        self.initial_metrics_attempted = true;
+        let _ = self.flush_automatic_metrics();
+    }
+
+    fn handle_periodic_metrics_flush(&mut self) {
+        let _ = self.flush_automatic_metrics();
+    }
+
+    pub(crate) fn handle_terminal_metrics_flush(&mut self) {
+        self.handle_initial_metrics_flush();
+        if !self.has_started_session() || self.terminal_metrics_attempted {
+            return;
+        }
+
+        self.terminal_metrics_attempted = true;
+        let _ = self.flush_automatic_metrics();
     }
 
     fn balloon_statistics_update_interval(&self) -> Option<Duration> {
@@ -1895,8 +1932,16 @@ where
         ProcessVmm::handle_put_action_request(self, action)
     }
 
-    fn handle_periodic_metrics_flush(&mut self) -> Result<bool, VmmActionError> {
-        ProcessVmm::flush_periodic_metrics(self)
+    fn metrics_session_epoch(&self) -> Option<Instant> {
+        ProcessVmm::metrics_session_epoch(self)
+    }
+
+    fn handle_initial_metrics_flush(&mut self) {
+        ProcessVmm::handle_initial_metrics_flush(self);
+    }
+
+    fn handle_periodic_metrics_flush(&mut self) {
+        ProcessVmm::handle_periodic_metrics_flush(self);
     }
 
     fn balloon_statistics_update_interval(&self) -> Option<Duration> {
@@ -7296,15 +7341,23 @@ mod tests {
 
     #[test]
     fn public_native_v1_load_commits_one_paused_session() {
+        let metrics = TempFilePath::create("snapshot-load-paused-metrics");
         let starter = FakeSnapshotLoadStarter::new(FakeSnapshotLoadResult::Success);
         let calls = starter.calls();
         let mut vmm = ProcessVmm::with_starter("demo-1", "0.1.0", "bangbang", starter);
+        vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+            metrics.path(),
+        )))
+        .expect("metrics should configure");
 
         assert_eq!(
             vmm.handle_action(VmmAction::LoadSnapshot(snapshot_load_input(false))),
             Ok(VmmData::Empty)
         );
 
+        let session_epoch = vmm
+            .metrics_session_epoch()
+            .expect("committed paused load should record a metrics epoch");
         assert_eq!(calls.load(Ordering::SeqCst), 1);
         assert_eq!(vmm.instance_info().state, InstanceState::Paused);
         let session = vmm
@@ -7314,6 +7367,12 @@ mod tests {
         assert_eq!(session.id, 77);
         assert_eq!(session.resume_count, 0);
         assert_eq!(vmm.drive_configs()[0].drive_id(), "root");
+        vmm.handle_initial_metrics_flush();
+        vmm.handle_initial_metrics_flush();
+        assert_eq!(
+            fs::read_to_string(metrics.path()).expect("metrics output should read"),
+            "{\"vmm\":{\"metrics_flush_count\":1}}\n"
+        );
 
         assert_eq!(
             vmm.handle_action(VmmAction::LoadSnapshot(snapshot_load_input(false))),
@@ -7323,13 +7382,25 @@ mod tests {
             })
         );
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(vmm.metrics_session_epoch(), Some(session_epoch));
+        vmm.handle_initial_metrics_flush();
+        vmm.handle_periodic_metrics_flush();
+        assert_eq!(
+            fs::read_to_string(metrics.path()).expect("metrics output should read"),
+            "{\"vmm\":{\"metrics_flush_count\":1}}\n{\"vmm\":{\"metrics_flush_count\":1}}\n"
+        );
     }
 
     #[test]
     fn public_native_v1_load_resumes_only_after_paused_commit() {
+        let metrics = TempFilePath::create("snapshot-load-resumed-metrics");
         let starter = FakeSnapshotLoadStarter::new(FakeSnapshotLoadResult::Success);
         let calls = starter.calls();
         let mut vmm = ProcessVmm::with_starter("demo-1", "0.1.0", "bangbang", starter);
+        vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+            metrics.path(),
+        )))
+        .expect("metrics should configure");
 
         assert_eq!(
             vmm.handle_action(VmmAction::LoadSnapshot(snapshot_load_input(true))),
@@ -7338,6 +7409,7 @@ mod tests {
 
         assert_eq!(calls.load(Ordering::SeqCst), 1);
         assert_eq!(vmm.instance_info().state, InstanceState::Running);
+        assert!(vmm.metrics_session_epoch().is_some());
         assert_eq!(
             vmm.started_session
                 .as_ref()
@@ -7345,13 +7417,24 @@ mod tests {
                 .resume_count,
             1
         );
+        vmm.handle_initial_metrics_flush();
+        vmm.handle_initial_metrics_flush();
+        assert_eq!(
+            fs::read_to_string(metrics.path()).expect("metrics output should read"),
+            "{\"vmm\":{\"metrics_flush_count\":1}}\n"
+        );
     }
 
     #[test]
     fn public_native_v1_resume_failure_returns_load_error_and_stays_paused() {
+        let metrics = TempFilePath::create("snapshot-load-resume-failure-metrics");
         let starter = FakeSnapshotLoadStarter::new(FakeSnapshotLoadResult::ResumeFailure);
         let calls = starter.calls();
         let mut vmm = ProcessVmm::with_starter("demo-1", "0.1.0", "bangbang", starter);
+        vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+            metrics.path(),
+        )))
+        .expect("metrics should configure");
 
         assert_eq!(
             vmm.handle_action(VmmAction::LoadSnapshot(snapshot_load_input(true))),
@@ -7362,6 +7445,7 @@ mod tests {
 
         assert_eq!(calls.load(Ordering::SeqCst), 1);
         assert_eq!(vmm.instance_info().state, InstanceState::Paused);
+        assert!(vmm.metrics_session_epoch().is_some());
         assert_eq!(
             vmm.started_session
                 .as_ref()
@@ -7370,13 +7454,24 @@ mod tests {
             1
         );
         assert_eq!(vmm.process_exit_status(), ProcessSessionExitStatus::Running);
+        vmm.handle_initial_metrics_flush();
+        vmm.handle_initial_metrics_flush();
+        assert_eq!(
+            fs::read_to_string(metrics.path()).expect("metrics output should read"),
+            "{\"vmm\":{\"metrics_flush_count\":1}}\n"
+        );
     }
 
     #[test]
     fn public_terminal_native_v1_load_error_latches_process() {
+        let metrics = TempFilePath::create("snapshot-load-precommit-failure-metrics");
         let starter = FakeSnapshotLoadStarter::new(FakeSnapshotLoadResult::Terminal);
         let calls = starter.calls();
         let mut vmm = ProcessVmm::with_starter("demo-1", "0.1.0", "bangbang", starter);
+        vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+            metrics.path(),
+        )))
+        .expect("metrics should configure");
 
         assert_eq!(
             vmm.handle_action(VmmAction::LoadSnapshot(snapshot_load_input(false))),
@@ -7387,9 +7482,16 @@ mod tests {
         assert_eq!(calls.load(Ordering::SeqCst), 1);
         assert_eq!(vmm.instance_info().state, InstanceState::NotStarted);
         assert!(!vmm.has_started_session());
+        assert_eq!(vmm.metrics_session_epoch(), None);
         assert_eq!(
             vmm.process_exit_status(),
             ProcessSessionExitStatus::Terminal
+        );
+        vmm.handle_initial_metrics_flush();
+        vmm.handle_terminal_metrics_flush();
+        assert_eq!(
+            fs::read_to_string(metrics.path()).expect("metrics output should read"),
+            ""
         );
     }
 
@@ -10792,6 +10894,7 @@ mod tests {
         assert_eq!(err, VmmActionError::MissingBootSource);
         assert_eq!(vmm.starter.calls, 0);
         assert!(!vmm.has_started_session());
+        assert_eq!(vmm.metrics_session_epoch(), None);
         assert_eq!(vmm.instance_info().state, InstanceState::NotStarted);
     }
 
@@ -10807,6 +10910,7 @@ mod tests {
         assert_eq!(vmm.instance_info().state, InstanceState::Running);
         assert_eq!(vmm.starter.calls, 1);
         assert_eq!(vmm.started_session, Some(FakeSession::new(7)));
+        assert!(vmm.metrics_session_epoch().is_some());
     }
 
     #[test]
@@ -12563,12 +12667,55 @@ mod tests {
         vmm.handle_action(VmmAction::InstanceStart)
             .expect("startup should succeed");
 
-        assert_eq!(vmm.flush_periodic_metrics(), Ok(true));
+        vmm.handle_periodic_metrics_flush();
 
         assert_eq!(vmm.starter.calls, 1);
         assert_eq!(
             fs::read_to_string(metrics.path()).expect("metrics output should read"),
             "{\"api_server\":{\"process_startup_time_us\":1000},\"vmm\":{\"boot_run_loop_status\":\"failed\",\"metrics_flush_count\":1}}\n"
+        );
+        assert_eq!(
+            fs::read_to_string(logger.path()).expect("logger output should read"),
+            "action=InstanceStart\n"
+        );
+    }
+
+    #[test]
+    fn automatic_initial_and_terminal_metrics_are_session_gated_and_idempotent() {
+        let metrics = TempFilePath::create("automatic-lifecycle-metrics");
+        let logger = TempFilePath::create("automatic-lifecycle-logger");
+        let mut vmm =
+            ProcessVmm::with_starter("demo-1", "0.1.0", "bangbang", FakeStarter::success(18));
+        vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+            metrics.path(),
+        )))
+        .expect("metrics should configure");
+        vmm.handle_action(VmmAction::PutLogger(
+            LoggerConfigInput::new().with_log_path(logger.path()),
+        ))
+        .expect("logger should configure");
+
+        vmm.handle_initial_metrics_flush();
+        vmm.handle_terminal_metrics_flush();
+        assert_eq!(
+            fs::read_to_string(metrics.path()).expect("pre-start metrics output should read"),
+            ""
+        );
+
+        vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            "/tmp/vmlinux",
+        )))
+        .expect("boot source should configure");
+        vmm.handle_action(VmmAction::InstanceStart)
+            .expect("startup should succeed");
+        vmm.handle_initial_metrics_flush();
+        vmm.handle_initial_metrics_flush();
+        vmm.handle_terminal_metrics_flush();
+        vmm.handle_terminal_metrics_flush();
+
+        assert_eq!(
+            fs::read_to_string(metrics.path()).expect("metrics output should read"),
+            "{\"vmm\":{\"metrics_flush_count\":1}}\n{\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
         assert_eq!(
             fs::read_to_string(logger.path()).expect("logger output should read"),
@@ -12679,6 +12826,7 @@ mod tests {
         assert_eq!(vmm.instance_info().state, InstanceState::NotStarted);
         assert_eq!(vmm.starter.calls, 1);
         assert!(!vmm.has_started_session());
+        assert_eq!(vmm.metrics_session_epoch(), None);
     }
 
     #[test]
@@ -12721,6 +12869,9 @@ mod tests {
         let mut vmm = configured_vmm(FakeStarter::success(9));
         vmm.handle_action(VmmAction::InstanceStart)
             .expect("first startup should succeed");
+        let session_epoch = vmm
+            .metrics_session_epoch()
+            .expect("successful start should record a metrics epoch");
 
         let err = vmm
             .handle_action(VmmAction::InstanceStart)
@@ -12735,6 +12886,7 @@ mod tests {
         );
         assert_eq!(vmm.starter.calls, 1);
         assert_eq!(vmm.started_session, Some(FakeSession::new(9)));
+        assert_eq!(vmm.metrics_session_epoch(), Some(session_epoch));
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -5960,33 +5960,73 @@ mod macos_arm64 {
                 path.display()
             )
         });
+        let lines = output
+            .lines()
+            .map(|line| {
+                serde_json::from_str::<serde_json::Value>(line).unwrap_or_else(|err| {
+                    panic!("metrics output line should be valid JSON: {err}; line:\n{line}")
+                })
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            lines.len(),
+            2,
+            "session initial and explicit flush should emit two metrics lines; output:\n{output}"
+        );
+        let sum_section = |section: &str| {
+            let mut total = serde_json::Map::new();
+            for line in &lines {
+                let Some(fields) = line.get(section).and_then(serde_json::Value::as_object) else {
+                    continue;
+                };
+                for (field, value) in fields {
+                    let value = value.as_u64().unwrap_or_else(|| {
+                        panic!("metrics field {section}.{field} should be an integer: {value}")
+                    });
+                    let entry = total
+                        .entry(field.clone())
+                        .or_insert(serde_json::Value::Number(0_u64.into()));
+                    let current = entry.as_u64().unwrap_or_else(|| {
+                        panic!("summed metrics field {section}.{field} should be an integer")
+                    });
+                    *entry = serde_json::Value::Number(current.saturating_add(value).into());
+                }
+            }
+            (!total.is_empty()).then_some(serde_json::Value::Object(total))
+        };
 
         assert!(
             output.contains(r#""metrics_flush_count":1"#),
             "metrics output should include first flush count; output:\n{output}"
         );
         if let Some(expected_get_api_requests) = expected_get_api_requests {
-            let expected_get_metrics = format!(r#""get_api_requests":{expected_get_api_requests}"#);
-            assert!(
-                output.contains(&expected_get_metrics),
-                "metrics output should include expected GET API request counters; output:\n{output}"
+            let expected = serde_json::from_str(expected_get_api_requests)
+                .expect("expected GET API request metrics should be valid JSON");
+            assert_eq!(
+                sum_section("get_api_requests"),
+                Some(expected),
+                "metrics output should sum to expected GET API request counters; output:\n{output}"
             );
         }
-        let expected_put_metrics = format!(r#""put_api_requests":{expected_put_api_requests}"#);
-        assert!(
-            output.contains(&expected_put_metrics),
-            "metrics output should include expected PUT API request counters; output:\n{output}"
+        let expected = serde_json::from_str(expected_put_api_requests)
+            .expect("expected PUT API request metrics should be valid JSON");
+        assert_eq!(
+            sum_section("put_api_requests"),
+            Some(expected),
+            "metrics output should sum to expected PUT API request counters; output:\n{output}"
         );
         if let Some(expected_patch_api_requests) = expected_patch_api_requests {
-            let expected_patch_metrics =
-                format!(r#""patch_api_requests":{expected_patch_api_requests}"#);
-            assert!(
-                output.contains(&expected_patch_metrics),
-                "metrics output should include expected PATCH API request counters; output:\n{output}"
+            let expected = serde_json::from_str(expected_patch_api_requests)
+                .expect("expected PATCH API request metrics should be valid JSON");
+            assert_eq!(
+                sum_section("patch_api_requests"),
+                Some(expected),
+                "metrics output should sum to expected PATCH API request counters; output:\n{output}"
             );
         } else {
-            assert!(
-                !output.contains(r#""patch_api_requests":"#),
+            assert_eq!(
+                sum_section("patch_api_requests"),
+                None,
                 "metrics output should not include PATCH API request counters; output:\n{output}"
             );
         }

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -378,7 +378,7 @@ fn executable_accepts_boot_timer_flag() {
 }
 
 #[test]
-fn executable_startup_metrics_path_writes_initial_metrics() {
+fn executable_startup_metrics_path_stays_empty_before_session() {
     let test_dir = TestDir::new();
     let socket_path = test_dir.path().join("api.socket");
     let metrics_path = test_dir.path().join("startup.metrics");
@@ -400,7 +400,7 @@ fn executable_startup_metrics_path_writes_initial_metrics() {
 
     assert_eq!(
         fs::read_to_string(&metrics_path).expect("startup metrics should be readable"),
-        "{\"api_server\":{\"process_startup_time_cpu_us\":3000,\"process_startup_time_us\":0},\"vmm\":{\"metrics_flush_count\":1}}\n"
+        ""
     );
 
     let instance_info = http_get(&socket_path, "/");
@@ -412,6 +412,11 @@ fn executable_startup_metrics_path_writes_initial_metrics() {
     );
 
     assert_clean_shutdown(bangbang.terminate(), &socket_path, "bangbang");
+    assert_eq!(
+        fs::read_to_string(&metrics_path).expect("terminal metrics output should be readable"),
+        "",
+        "a process without a retained session must not emit terminal metrics"
+    );
 }
 
 #[test]
@@ -3697,23 +3702,15 @@ fn concurrent_executables_keep_api_resources_isolated() {
         "first-user-data",
         "second bangbang",
     );
-    assert_startup_metrics_match(
-        &first_metrics_path,
-        &[
-            r#""process_startup_time_us":0"#,
-            r#""process_startup_time_cpu_us":1300"#,
-        ],
-        &[r#""process_startup_time_cpu_us":2300"#],
-        "first bangbang",
+    assert_eq!(
+        fs::read_to_string(&first_metrics_path)
+            .expect("first pre-session metrics output should be readable"),
+        ""
     );
-    assert_startup_metrics_match(
-        &second_metrics_path,
-        &[
-            r#""process_startup_time_us":0"#,
-            r#""process_startup_time_cpu_us":2300"#,
-        ],
-        &[r#""process_startup_time_cpu_us":1300"#],
-        "second bangbang",
+    assert_eq!(
+        fs::read_to_string(&second_metrics_path)
+            .expect("second pre-session metrics output should be readable"),
+        ""
     );
 
     assert_clean_shutdown(
@@ -4329,30 +4326,4 @@ fn assert_mmds_data_matches(
             && !response.contains(&format!(r#""user-data":"{unexpected_user_data}""#)),
         "{request_name} response should not contain another process MMDS data; response:\n{response}"
     );
-}
-
-fn assert_startup_metrics_match(
-    metrics_path: &std::path::Path,
-    expected_fragments: &[&str],
-    unexpected_fragments: &[&str],
-    process_name: &str,
-) {
-    let output = fs::read_to_string(metrics_path).unwrap_or_else(|err| {
-        panic!(
-            "{process_name} metrics output {} should be readable: {err}",
-            metrics_path.display()
-        )
-    });
-    for expected in expected_fragments {
-        assert!(
-            output.contains(expected),
-            "{process_name} metrics output should contain {expected:?}; output:\n{output}"
-        );
-    }
-    for unexpected in unexpected_fragments {
-        assert!(
-            !output.contains(unexpected),
-            "{process_name} metrics output should not contain another process value {unexpected:?}; output:\n{output}"
-        );
-    }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1654,20 +1654,11 @@ impl VmmController {
         Ok(VmmData::Empty)
     }
 
-    pub fn flush_startup_metrics_with_diagnostics(
+    pub fn flush_automatic_metrics_with_diagnostics(
         &mut self,
         diagnostics: &metrics::MetricsDiagnostics,
     ) -> Result<bool, VmmActionError> {
-        self.metrics_state
-            .flush_with_diagnostics(diagnostics)
-            .map_err(VmmActionError::MetricsFlush)
-    }
-
-    pub fn flush_periodic_metrics_with_diagnostics(
-        &mut self,
-        diagnostics: &metrics::MetricsDiagnostics,
-    ) -> Result<bool, VmmActionError> {
-        if self.instance_info.state != InstanceState::Running {
+        if self.instance_info.state == InstanceState::NotStarted {
             return Ok(false);
         }
 
@@ -4894,7 +4885,7 @@ mod tests {
 
         assert_eq!(controller.instance_info().state, InstanceState::Running);
         assert_eq!(
-            controller.flush_startup_metrics_with_diagnostics(&MetricsDiagnostics::default()),
+            controller.flush_automatic_metrics_with_diagnostics(&MetricsDiagnostics::default()),
             Ok(true)
         );
         assert_eq!(
@@ -4906,7 +4897,7 @@ mod tests {
     }
 
     #[test]
-    fn boot_timer_logger_write_failure_reports_missed_log_count_in_metrics() {
+    fn automatic_metrics_reports_preboot_boot_timer_logger_write_failure_after_start() {
         let metrics_path = unique_metrics_path("boot-timer-missed-log");
         let mut controller = VmmController::new("demo-1", "0.1.0", "bangbang");
         controller
@@ -4918,8 +4909,9 @@ mod tests {
         let boot_timer_logger = controller.boot_timer_logger();
 
         assert!(!boot_timer_logger.log_boot_time(1_000, 200));
+        controller.instance_info.state = InstanceState::Running;
         assert_eq!(
-            controller.flush_startup_metrics_with_diagnostics(&MetricsDiagnostics::default()),
+            controller.flush_automatic_metrics_with_diagnostics(&MetricsDiagnostics::default()),
             Ok(true)
         );
         assert_eq!(
@@ -4931,7 +4923,7 @@ mod tests {
     }
 
     #[test]
-    fn api_request_logger_write_failure_reports_missed_log_count_in_metrics() {
+    fn automatic_metrics_reports_preboot_api_logger_write_failure_after_start() {
         let metrics_path = unique_metrics_path("api-request-missed-log");
         let mut controller = VmmController::new("demo-1", "0.1.0", "bangbang");
         controller
@@ -4942,8 +4934,9 @@ mod tests {
         controller.logger_state.configure_test_writer(FailingWriter);
 
         assert!(!controller.log_api_request("Put", "/mmds"));
+        controller.instance_info.state = InstanceState::Running;
         assert_eq!(
-            controller.flush_startup_metrics_with_diagnostics(&MetricsDiagnostics::default()),
+            controller.flush_automatic_metrics_with_diagnostics(&MetricsDiagnostics::default()),
             Ok(true)
         );
         assert_eq!(
@@ -4974,13 +4967,15 @@ mod tests {
         let first_boot_timer_logger = first.boot_timer_logger();
 
         assert!(!first_boot_timer_logger.log_boot_time(1_000, 200));
+        first.instance_info.state = InstanceState::Running;
+        second.instance_info.state = InstanceState::Running;
 
         assert_eq!(
-            first.flush_startup_metrics_with_diagnostics(&MetricsDiagnostics::default()),
+            first.flush_automatic_metrics_with_diagnostics(&MetricsDiagnostics::default()),
             Ok(true)
         );
         assert_eq!(
-            second.flush_startup_metrics_with_diagnostics(&MetricsDiagnostics::default()),
+            second.flush_automatic_metrics_with_diagnostics(&MetricsDiagnostics::default()),
             Ok(true)
         );
         assert_eq!(
@@ -5247,7 +5242,7 @@ mod tests {
             Ok(VmmData::Empty)
         );
         assert_eq!(
-            controller.flush_periodic_metrics_with_diagnostics(&MetricsDiagnostics::default()),
+            controller.flush_automatic_metrics_with_diagnostics(&MetricsDiagnostics::default()),
             Ok(true)
         );
         assert_eq!(
@@ -5311,7 +5306,7 @@ mod tests {
     }
 
     #[test]
-    fn startup_metrics_before_start_writes_without_logger_action() {
+    fn automatic_metrics_before_start_does_not_write_or_log_action() {
         let metrics_path = unique_metrics_path("startup-preboot");
         let logger_path = unique_logger_path("startup-no-action");
         let mut controller = VmmController::new("demo-1", "0.1.0", "bangbang");
@@ -5327,14 +5322,14 @@ mod tests {
             .expect("logger config should be stored");
 
         assert_eq!(
-            controller.flush_startup_metrics_with_diagnostics(&MetricsDiagnostics::default()),
-            Ok(true)
+            controller.flush_automatic_metrics_with_diagnostics(&MetricsDiagnostics::default()),
+            Ok(false)
         );
 
         assert_eq!(controller.instance_info().state, InstanceState::NotStarted);
         assert_eq!(
             fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
-            "{\"vmm\":{\"metrics_flush_count\":1}}\n"
+            ""
         );
         assert_eq!(
             fs::read_to_string(&logger_path).expect("logger output should be readable"),
@@ -5353,7 +5348,7 @@ mod tests {
             .expect("metrics config should be stored");
 
         assert_eq!(
-            controller.flush_periodic_metrics_with_diagnostics(&MetricsDiagnostics::default()),
+            controller.flush_automatic_metrics_with_diagnostics(&MetricsDiagnostics::default()),
             Ok(false)
         );
 
@@ -5387,7 +5382,7 @@ mod tests {
             .expect("start commit should set running state");
 
         assert_eq!(
-            controller.flush_periodic_metrics_with_diagnostics(&MetricsDiagnostics::default()),
+            controller.flush_automatic_metrics_with_diagnostics(&MetricsDiagnostics::default()),
             Ok(true)
         );
 
@@ -5404,7 +5399,7 @@ mod tests {
     }
 
     #[test]
-    fn periodic_metrics_while_paused_does_not_write() {
+    fn automatic_metrics_while_paused_writes() {
         let path = unique_metrics_path("periodic-paused");
         let mut controller = VmmController::new("demo-1", "0.1.0", "bangbang");
         controller
@@ -5413,12 +5408,12 @@ mod tests {
         controller.instance_info.state = InstanceState::Paused;
 
         assert_eq!(
-            controller.flush_periodic_metrics_with_diagnostics(&MetricsDiagnostics::default()),
-            Ok(false)
+            controller.flush_automatic_metrics_with_diagnostics(&MetricsDiagnostics::default()),
+            Ok(true)
         );
         assert_eq!(
             fs::read_to_string(&path).expect("metrics output should be readable"),
-            ""
+            "{\"vmm\":{\"metrics_flush_count\":1}}\n"
         );
 
         fs::remove_file(path).expect("metrics fixture should clean up");


### PR DESCRIPTION
## Summary

- anchor automatic metrics to one retained VM-session epoch, with idempotent best-effort initial and terminal attempts
- keep API and no-API schedulers dormant before a session, flush every 60 seconds while Running or Paused, and continue/reschedule after sink failures
- preserve fallible explicit `FlushMetrics`, original process results, incremental retry semantics, and action/logger separation
- update focused, process, and signed HVF coverage for initial/delta/final output and pre-session emptiness

## Scope exclusions

- no global metrics ownership, panic hook, async fatal-signal writes, exit-policy changes, or sink rotation
- documentation reconciliation remains owned by #1343

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

Closes #1342

Parent context: #542  
Broader compatibility context: #534
