### PR TITLE
feat(hvf): expose GICv2m MSI-frame delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ footprint reduction. See the
 [pinned remaining-device audit](docs/firecracker-compatibility.md#firecracker-v1160-remaining-device-audit)
 for exact upstream sources and classifications.
 
+On macOS 15 and later, the HVF backend also has an internal, explicitly
+opt-in foundation for a demand-sized public-HVF GICv2m MSI frame. It reserves
+the requested interrupt range from the top of Linux's usable GICv2m SPI domain,
+keeps the legacy SPI allocator disjoint, advertises an `arm,gic-v2m-frame` FDT
+child, and retains a typed send-only capability. Ordinary process startup and
+its FDT remain MSI-free. This is not Firecracker's KVM ITS path, does not expose
+a CLI or API switch, and does not implement PCI enumeration or guest-programmed
+MSI-X. Signed gates prove raw delivery of INTID 1018 and pinned Firecracker
+Linux discovery of the exact `SPI[1018:1018]` frame; native-v1 rejects
+MSI-bearing GIC metadata.
+
 ## Layout
 
 ```text

--- a/crates/hvf/src/backend.rs
+++ b/crates/hvf/src/backend.rs
@@ -10,7 +10,10 @@ use crate::dirty::{
     HvfDirtyWriteEpochResetError, HvfDirtyWriteTracker, HvfDirtyWriteTrackerStartError,
     HvfDirtyWriteTrackerStopError,
 };
-use crate::gic::{HvfGicCreator, HvfGicError, HvfGicMetadata, RealHvfGicCreator};
+use crate::gic::{
+    HvfGicCreator, HvfGicError, HvfGicMetadata, HvfGicMsiConfiguration, HvfGicMsiSignaler,
+    RealHvfGicCreator,
+};
 use crate::memory::{
     HvfGuestMemoryMapping, HvfGuestMemoryMappingError, HvfHostMemoryMapping, HvfMemoryMapper,
     HvfMemoryPermissions, HvfPmemFlushExecutor, HvfVirtioMemMutationExecutor, RealHvfMemoryMapper,
@@ -35,6 +38,7 @@ pub struct HvfBackend {
     vm_created: bool,
     guest_memory: Option<HvfGuestMemoryMapping>,
     gic: Option<HvfGicMetadata>,
+    gic_msi_signaler: Option<HvfGicMsiSignaler>,
     vcpu_topology_started: bool,
     memory_mapper: Arc<dyn HvfMemoryMapper>,
     gic_creator: Arc<dyn HvfGicCreator>,
@@ -46,6 +50,7 @@ impl Default for HvfBackend {
             vm_created: false,
             guest_memory: None,
             gic: None,
+            gic_msi_signaler: None,
             vcpu_topology_started: false,
             memory_mapper: Arc::new(RealHvfMemoryMapper),
             gic_creator: Arc::new(RealHvfGicCreator),
@@ -253,11 +258,33 @@ impl HvfBackend {
             ));
         }
 
-        self.create_gic_with_configured_creator()
+        self.create_gic_with_configured_creator(None)
+    }
+
+    /// Create a GIC with one demand-sized, message-only SPI range.
+    ///
+    /// The ordinary [`Self::create_gic`] path remains MSI-free. Callers must
+    /// select this before creating any vCPU.
+    pub fn create_gic_with_msi(
+        &mut self,
+        configuration: HvfGicMsiConfiguration,
+    ) -> Result<&HvfGicMetadata, HvfGicError> {
+        if !Self::is_supported_target() {
+            return Err(HvfGicError::Unsupported(
+                crate::ffi::UNSUPPORTED_TARGET_MESSAGE,
+            ));
+        }
+
+        self.create_gic_with_configured_creator(Some(configuration))
     }
 
     pub fn gic_metadata(&self) -> Option<&HvfGicMetadata> {
         self.gic.as_ref()
+    }
+
+    /// Return the send-only MSI capability retained by an MSI-enabled GIC.
+    pub fn gic_msi_signaler(&self) -> Option<&HvfGicMsiSignaler> {
+        self.gic_msi_signaler.as_ref()
     }
 
     pub(crate) const fn has_created_vm(&self) -> bool {
@@ -401,7 +428,10 @@ impl HvfBackend {
         Ok(())
     }
 
-    fn create_gic_with_configured_creator(&mut self) -> Result<&HvfGicMetadata, HvfGicError> {
+    fn create_gic_with_configured_creator(
+        &mut self,
+        msi: Option<HvfGicMsiConfiguration>,
+    ) -> Result<&HvfGicMetadata, HvfGicError> {
         if !self.vm_created {
             return Err(HvfGicError::InvalidState(VM_NOT_CREATED_FOR_GIC_MESSAGE));
         }
@@ -416,8 +446,17 @@ impl HvfBackend {
             ));
         }
 
-        let metadata = self.gic_creator.create_gic()?;
-        self.gic = Some(metadata);
+        let requested_msi = msi.is_some();
+        let created = self.gic_creator.create_gic(msi)?;
+        if created.metadata.msi.is_some() != requested_msi
+            || created.msi_signaler.is_some() != requested_msi
+        {
+            return Err(HvfGicError::InvalidState(
+                "GIC MSI request, metadata, and send capability disagree",
+            ));
+        }
+        self.gic = Some(created.metadata);
+        self.gic_msi_signaler = created.msi_signaler;
 
         self.gic
             .as_ref()
@@ -425,7 +464,11 @@ impl HvfBackend {
     }
 
     fn clear_vm_owned_state(&mut self) {
+        if let Some(signaler) = &self.gic_msi_signaler {
+            signaler.deactivate();
+        }
         self.gic = None;
+        self.gic_msi_signaler = None;
         self.vcpu_topology_started = false;
     }
 
@@ -499,6 +542,7 @@ impl HvfBackend {
             vm_created: false,
             guest_memory: None,
             gic: None,
+            gic_msi_signaler: None,
             vcpu_topology_started: false,
             memory_mapper,
             gic_creator: Arc::new(RealHvfGicCreator),
@@ -511,6 +555,7 @@ impl HvfBackend {
             vm_created: false,
             guest_memory: None,
             gic: None,
+            gic_msi_signaler: None,
             vcpu_topology_started: false,
             memory_mapper: Arc::new(RealHvfMemoryMapper),
             gic_creator,
@@ -736,6 +781,9 @@ impl VmBackend for HvfBackend {
 
     fn destroy_vm(&mut self) -> Result<(), BackendError> {
         if self.vm_created {
+            if let Some(signaler) = &self.gic_msi_signaler {
+                signaler.deactivate();
+            }
             self.unmap_guest_memory()
                 .map_err(|err| BackendError::Hypervisor(err.to_string()))?;
             crate::ffi::destroy_vm()?;
@@ -751,6 +799,9 @@ impl Drop for HvfBackend {
         if self.vm_created {
             let mut mapping_after_failed_unmap = None;
 
+            if let Some(signaler) = &self.gic_msi_signaler {
+                signaler.deactivate();
+            }
             if let Some(mut mapping) = self.guest_memory.take()
                 && mapping.unmap_all().is_err()
                 && mapping.has_mapped_regions()
@@ -771,6 +822,7 @@ impl Drop for HvfBackend {
 #[cfg(test)]
 mod tests {
     use std::io::{Seek, SeekFrom, Write};
+    use std::num::NonZeroU32;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
@@ -831,6 +883,26 @@ mod tests {
                 el1_physical_timer_intid: 30,
             },
             msi: None,
+        }
+    }
+
+    fn gic_metadata_with_msi() -> crate::gic::HvfGicMetadata {
+        crate::gic::HvfGicMetadata {
+            spi_interrupt_range: crate::gic::HvfGicInterruptRange {
+                base: 32,
+                count: 95,
+            },
+            msi: Some(crate::gic::HvfGicMsiMetadata {
+                region: crate::gic::HvfGicRegion {
+                    base: 0x3ffc_0000,
+                    size: 0x1_0000,
+                },
+                interrupt_range: crate::gic::HvfGicInterruptRange {
+                    base: 127,
+                    count: 1,
+                },
+            }),
+            ..gic_metadata()
         }
     }
 
@@ -1071,7 +1143,7 @@ mod tests {
         let mut backend = HvfBackend::new_with_gic_creator(creator.clone());
 
         assert_eq!(
-            backend.create_gic_with_configured_creator(),
+            backend.create_gic_with_configured_creator(None),
             Err(crate::gic::HvfGicError::InvalidState(
                 super::VM_NOT_CREATED_FOR_GIC_MESSAGE
             ))
@@ -1087,17 +1159,57 @@ mod tests {
         backend.vm_created = true;
 
         assert_eq!(
-            backend.create_gic_with_configured_creator(),
+            backend.create_gic_with_configured_creator(None),
             Ok(&gic_metadata())
         );
         assert_eq!(
-            backend.create_gic_with_configured_creator(),
+            backend.create_gic_with_configured_creator(None),
             Err(crate::gic::HvfGicError::InvalidState(
                 super::GIC_ALREADY_CREATED_MESSAGE
             ))
         );
         assert_eq!(creator.create_count(), 1);
         assert_eq!(backend.gic_metadata(), Some(&gic_metadata()));
+    }
+
+    #[test]
+    fn explicit_msi_configuration_is_forwarded_once_to_the_creator() {
+        let expected_metadata = gic_metadata_with_msi();
+        let creator = Arc::new(RecordingGicCreator::with_msi_metadata(expected_metadata));
+        let mut backend = HvfBackend::new_with_gic_creator(creator.clone());
+        backend.vm_created = true;
+        let configuration = crate::gic::HvfGicMsiConfiguration::new(
+            NonZeroU32::new(8).expect("test MSI count should be nonzero"),
+        );
+
+        assert_eq!(
+            backend.create_gic_with_configured_creator(Some(configuration)),
+            Ok(&expected_metadata)
+        );
+        assert_eq!(creator.requests(), vec![Some(configuration)]);
+        assert_eq!(creator.create_count(), 1);
+        assert_eq!(backend.gic_metadata(), Some(&expected_metadata));
+        assert!(backend.gic_msi_signaler().is_some());
+    }
+
+    #[test]
+    fn inconsistent_msi_creator_result_is_not_published() {
+        let creator = Arc::new(RecordingGicCreator::with_metadata(gic_metadata()));
+        let mut backend = HvfBackend::new_with_gic_creator(creator.clone());
+        backend.vm_created = true;
+        let configuration = crate::gic::HvfGicMsiConfiguration::new(
+            NonZeroU32::new(1).expect("test MSI count should be nonzero"),
+        );
+
+        assert_eq!(
+            backend.create_gic_with_configured_creator(Some(configuration)),
+            Err(crate::gic::HvfGicError::InvalidState(
+                "GIC MSI request, metadata, and send capability disagree"
+            ))
+        );
+        assert_eq!(creator.requests(), vec![Some(configuration)]);
+        assert_eq!(backend.gic_metadata(), None);
+        assert!(backend.gic_msi_signaler().is_none());
     }
 
     #[test]
@@ -1111,7 +1223,7 @@ mod tests {
         backend.vm_created = true;
 
         assert_eq!(
-            backend.create_gic_with_configured_creator(),
+            backend.create_gic_with_configured_creator(None),
             Err(crate::gic::HvfGicError::Backend(BackendError::Hypervisor(
                 "injected GIC failure".to_string()
             )))
@@ -1128,7 +1240,7 @@ mod tests {
         backend.vcpu_topology_started = true;
 
         assert_eq!(
-            backend.create_gic_with_configured_creator(),
+            backend.create_gic_with_configured_creator(None),
             Err(crate::gic::HvfGicError::InvalidState(
                 super::VCPU_TOPOLOGY_ALREADY_STARTED_MESSAGE
             ))
@@ -1140,13 +1252,30 @@ mod tests {
     #[test]
     fn clearing_vm_owned_state_removes_gic_metadata_and_topology_flag() {
         let mut backend = HvfBackend::new();
-        backend.gic = Some(gic_metadata());
+        let metadata = gic_metadata_with_msi();
+        backend.gic = Some(metadata);
+        let signaler = crate::gic::HvfGicMsiSignaler::for_backend_test(
+            metadata.msi.expect("test MSI metadata should exist"),
+        );
+        let retained_signaler = signaler.clone();
+        let interrupt = signaler
+            .allocator()
+            .allocate()
+            .expect("test MSI should allocate");
+        backend.gic_msi_signaler = Some(signaler);
         backend.vcpu_topology_started = true;
 
         backend.clear_vm_owned_state();
 
         assert_eq!(backend.gic_metadata(), None);
+        assert!(backend.gic_msi_signaler().is_none());
         assert!(!backend.vcpu_topology_started);
+        assert_eq!(
+            retained_signaler
+                .send(&interrupt)
+                .expect_err("cleared VM state should revoke retained MSI clones"),
+            crate::gic::HvfGicMsiSignalError::InvalidState("HVF GIC MSI signaler is inactive")
+        );
     }
 
     #[test]
@@ -1878,21 +2007,36 @@ mod tests {
     #[derive(Debug)]
     struct RecordingGicCreator {
         result: Result<crate::gic::HvfGicMetadata, crate::gic::HvfGicError>,
+        publish_signaler: bool,
         create_count: Mutex<usize>,
+        requests: Mutex<Vec<Option<crate::gic::HvfGicMsiConfiguration>>>,
     }
 
     impl RecordingGicCreator {
         fn with_metadata(metadata: crate::gic::HvfGicMetadata) -> Self {
             Self {
                 result: Ok(metadata),
+                publish_signaler: false,
                 create_count: Mutex::new(0),
+                requests: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn with_msi_metadata(metadata: crate::gic::HvfGicMetadata) -> Self {
+            Self {
+                result: Ok(metadata),
+                publish_signaler: true,
+                create_count: Mutex::new(0),
+                requests: Mutex::new(Vec::new()),
             }
         }
 
         fn with_error(error: crate::gic::HvfGicError) -> Self {
             Self {
                 result: Err(error),
+                publish_signaler: false,
                 create_count: Mutex::new(0),
+                requests: Mutex::new(Vec::new()),
             }
         }
 
@@ -1902,15 +2046,38 @@ mod tests {
                 .lock()
                 .expect("create count lock should not be poisoned")
         }
+
+        fn requests(&self) -> Vec<Option<crate::gic::HvfGicMsiConfiguration>> {
+            self.requests
+                .lock()
+                .expect("GIC request lock should not be poisoned")
+                .clone()
+        }
     }
 
     impl crate::gic::HvfGicCreator for RecordingGicCreator {
-        fn create_gic(&self) -> Result<crate::gic::HvfGicMetadata, crate::gic::HvfGicError> {
+        fn create_gic(
+            &self,
+            msi: Option<crate::gic::HvfGicMsiConfiguration>,
+        ) -> Result<crate::gic::CreatedHvfGic, crate::gic::HvfGicError> {
             *self
                 .create_count
                 .lock()
                 .expect("create count lock should not be poisoned") += 1;
-            self.result.clone()
+            self.requests
+                .lock()
+                .expect("GIC request lock should not be poisoned")
+                .push(msi);
+            self.result
+                .clone()
+                .map(|metadata| crate::gic::CreatedHvfGic {
+                    msi_signaler: self.publish_signaler.then(|| {
+                        crate::gic::HvfGicMsiSignaler::for_backend_test(
+                            metadata.msi.expect("test MSI metadata should exist"),
+                        )
+                    }),
+                    metadata,
+                })
         }
     }
 }

--- a/crates/hvf/src/gic.rs
+++ b/crates/hvf/src/gic.rs
@@ -3960,6 +3960,16 @@ mod tests {
 
     #[test]
     fn msi_signaler_serializes_sends_and_waits_before_deactivation() {
+        struct ReleaseBlockedMsiCallsOnDrop(mpsc::SyncSender<()>);
+
+        impl Drop for ReleaseBlockedMsiCallsOnDrop {
+            fn drop(&mut self) {
+                for _ in 0..2 {
+                    let _ = self.0.try_send(());
+                }
+            }
+        }
+
         struct BlockingMsiSignalApi {
             entered: mpsc::SyncSender<()>,
             releases: Mutex<mpsc::Receiver<()>>,
@@ -4003,6 +4013,9 @@ mod tests {
         let second_interrupt = allocator.allocate().expect("second MSI should allocate");
 
         std::thread::scope(|scope| {
+            // A failed ordering assertion must release any blocked fake host
+            // calls before the scope joins its threads during unwinding.
+            let _release_on_unwind = ReleaseBlockedMsiCallsOnDrop(release_sender.clone());
             let first_signaler = signaler.clone();
             let first_interrupt_ref = &first_interrupt;
             let first_send = scope.spawn(move || first_signaler.send(first_interrupt_ref));

--- a/crates/hvf/src/gic.rs
+++ b/crates/hvf/src/gic.rs
@@ -580,16 +580,12 @@ impl fmt::Debug for HvfGicMsiInterrupt {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HvfGicMsiInterruptAllocationError {
-    InvalidMetadata(&'static str),
     Exhausted,
 }
 
 impl fmt::Display for HvfGicMsiInterruptAllocationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::InvalidMetadata(message) => {
-                write!(f, "invalid HVF GIC MSI metadata: {message}")
-            }
             Self::Exhausted => f.write_str("HVF GIC MSI interrupt range is exhausted"),
         }
     }
@@ -605,17 +601,12 @@ pub struct HvfGicMsiInterruptAllocator {
 }
 
 impl HvfGicMsiInterruptAllocator {
-    fn from_metadata(
-        metadata: HvfGicMsiMetadata,
-    ) -> Result<Self, HvfGicMsiInterruptAllocationError> {
-        validate_msi_metadata(metadata)
-            .map_err(HvfGicMsiInterruptAllocationError::InvalidMetadata)?;
-
-        Ok(Self {
+    fn from_validated_metadata(metadata: HvfGicMsiMetadata) -> Self {
+        Self {
             range: metadata.interrupt_range,
             next: Arc::new(AtomicU32::new(metadata.interrupt_range.base)),
             provenance: Arc::new(HvfGicMsiProvenance),
-        })
+        }
     }
 
     pub fn remaining(&self) -> u32 {
@@ -742,15 +733,7 @@ impl HvfGicMsiSignaler {
         api: impl HvfGicMsiSignalApi + Send + 'static,
     ) -> Result<Self, HvfGicMsiSignalError> {
         validate_msi_metadata(metadata).map_err(HvfGicMsiSignalError::InvalidMetadata)?;
-        let allocator =
-            HvfGicMsiInterruptAllocator::from_metadata(metadata).map_err(|error| match error {
-                HvfGicMsiInterruptAllocationError::InvalidMetadata(message) => {
-                    HvfGicMsiSignalError::InvalidMetadata(message)
-                }
-                HvfGicMsiInterruptAllocationError::Exhausted => {
-                    HvfGicMsiSignalError::InvalidState("validated MSI metadata has no allocator")
-                }
-            })?;
+        let allocator = HvfGicMsiInterruptAllocator::from_validated_metadata(metadata);
         let address = metadata
             .region
             .base
@@ -3827,7 +3810,7 @@ mod tests {
     }
 
     #[test]
-    fn msi_interrupt_allocator_requires_valid_metadata() {
+    fn msi_signaler_requires_valid_metadata() {
         let malformed = HvfGicMsiMetadata {
             region: HvfGicRegion {
                 base: 0x3ffc_0000,
@@ -3839,16 +3822,14 @@ mod tests {
             },
         };
         assert_eq!(
-            HvfGicMsiInterruptAllocator::from_metadata(malformed)
+            HvfGicMsiSignaler::with_api(malformed, FakeGicApi::default())
                 .expect_err("short MSI frame should fail"),
-            HvfGicMsiInterruptAllocationError::InvalidMetadata(
-                "message frame does not contain SETSPI"
-            )
+            HvfGicMsiSignalError::InvalidMetadata("message frame does not contain SETSPI")
         );
     }
 
     #[test]
-    fn msi_allocator_and_signaler_reject_the_gicv2m_terminal_spi() {
+    fn msi_signaler_rejects_the_gicv2m_terminal_spi() {
         let terminal_metadata = HvfGicMsiMetadata {
             region: HvfGicRegion {
                 base: 0x3ffc_0000,
@@ -3860,13 +3841,6 @@ mod tests {
             },
         };
 
-        assert_eq!(
-            HvfGicMsiInterruptAllocator::from_metadata(terminal_metadata)
-                .expect_err("terminal SPI should not produce an MSI allocator"),
-            HvfGicMsiInterruptAllocationError::InvalidMetadata(
-                "interrupt range exceeds the GICv2m SPI domain"
-            )
-        );
         assert_eq!(
             HvfGicMsiSignaler::with_api(terminal_metadata, FakeGicApi::default())
                 .expect_err("terminal SPI should not produce an MSI signaler"),

--- a/crates/hvf/src/gic.rs
+++ b/crates/hvf/src/gic.rs
@@ -1,12 +1,15 @@
 //! HVF GIC v3 creation and metadata for later boot/FDT setup.
 
 use std::fmt;
-use std::sync::Mutex;
+use std::num::NonZeroU32;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
 
 use bangbang_runtime::BackendError;
 use bangbang_runtime::fdt::{
-    Arm64FdtError, Arm64FdtGic, Arm64FdtInterruptRange, Arm64FdtMsi, Arm64FdtRegion,
-    Arm64FdtTimerInterrupts,
+    ARM64_GICV2M_MSI_IIDR_OFFSET, ARM64_GICV2M_MSI_SET_SPI_NSR_OFFSET,
+    ARM64_GICV2M_SPI_END_EXCLUSIVE, Arm64FdtError, Arm64FdtGic, Arm64FdtInterruptRange,
+    Arm64FdtMsi, Arm64FdtRegion, Arm64FdtTimerInterrupts,
 };
 use bangbang_runtime::interrupt::{
     GuestInterruptLine, GuestInterruptLineError, InterruptSignalError, InterruptSink,
@@ -19,6 +22,9 @@ const DRAM_MEM_START: u64 = bangbang_runtime::memory::aarch64::DRAM_MEM_START;
 const DYNAMIC_SYMBOL_SIZE_MISMATCH_MESSAGE: &str =
     "function pointer size does not match a dynamic symbol pointer";
 const GIC_SPI_SIGNALER_LOCK_POISONED_MESSAGE: &str = "HVF GIC SPI signaler lock is poisoned";
+const GIC_MSI_SIGNALER_LOCK_POISONED_MESSAGE: &str = "HVF GIC MSI signaler lock is poisoned";
+const GIC_MSI_SIGNALER_INACTIVE_MESSAGE: &str = "HVF GIC MSI signaler is inactive";
+const GIC_MSI_REGISTER_SIZE: u64 = 4;
 const GIC_ICC_RPR_MISMATCH_MESSAGE: &str =
     "restored arm64 GIC ICC_RPR_EL1 does not match captured derived state";
 
@@ -147,10 +153,46 @@ pub struct HvfGicRedistributor {
     pub single_redistributor_size: u64,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct HvfGicMsiMetadata {
     pub region: HvfGicRegion,
     pub interrupt_range: HvfGicInterruptRange,
+}
+
+impl fmt::Debug for HvfGicMsiMetadata {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HvfGicMsiMetadata")
+            .field("region", &"<redacted>")
+            .field("interrupt_range", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Demand for a contiguous Hypervisor.framework GIC MSI interrupt range.
+///
+/// The exact count is available to trusted platform composition through its
+/// accessor, while automatic diagnostics redact it.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct HvfGicMsiConfiguration {
+    interrupt_count: NonZeroU32,
+}
+
+impl HvfGicMsiConfiguration {
+    pub const fn new(interrupt_count: NonZeroU32) -> Self {
+        Self { interrupt_count }
+    }
+
+    pub const fn interrupt_count(self) -> NonZeroU32 {
+        self.interrupt_count
+    }
+}
+
+impl fmt::Debug for HvfGicMsiConfiguration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HvfGicMsiConfiguration")
+            .field("interrupt_count", &"<redacted>")
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -500,6 +542,260 @@ impl HvfGicInterruptLineAllocator {
     }
 }
 
+/// One interrupt identifier allocated from a GIC MSI-only range.
+///
+/// Values can only be created by [`HvfGicMsiInterruptAllocator`]. They remain
+/// distinct from legacy [`GuestInterruptLine`] values accepted by
+/// `hv_gic_set_spi` paths.
+#[derive(Debug)]
+struct HvfGicMsiProvenance;
+
+#[derive(Clone)]
+pub struct HvfGicMsiInterrupt {
+    intid: u32,
+    provenance: Arc<HvfGicMsiProvenance>,
+}
+
+impl HvfGicMsiInterrupt {
+    pub const fn raw_value(&self) -> u32 {
+        self.intid
+    }
+}
+
+impl PartialEq for HvfGicMsiInterrupt {
+    fn eq(&self, other: &Self) -> bool {
+        self.intid == other.intid && Arc::ptr_eq(&self.provenance, &other.provenance)
+    }
+}
+
+impl Eq for HvfGicMsiInterrupt {}
+
+impl fmt::Debug for HvfGicMsiInterrupt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HvfGicMsiInterrupt")
+            .field("intid", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HvfGicMsiInterruptAllocationError {
+    InvalidMetadata(&'static str),
+    Exhausted,
+}
+
+impl fmt::Display for HvfGicMsiInterruptAllocationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidMetadata(message) => {
+                write!(f, "invalid HVF GIC MSI metadata: {message}")
+            }
+            Self::Exhausted => f.write_str("HVF GIC MSI interrupt range is exhausted"),
+        }
+    }
+}
+
+impl std::error::Error for HvfGicMsiInterruptAllocationError {}
+
+#[derive(Clone)]
+pub struct HvfGicMsiInterruptAllocator {
+    range: HvfGicInterruptRange,
+    next: Arc<AtomicU32>,
+    provenance: Arc<HvfGicMsiProvenance>,
+}
+
+impl HvfGicMsiInterruptAllocator {
+    fn from_metadata(
+        metadata: HvfGicMsiMetadata,
+    ) -> Result<Self, HvfGicMsiInterruptAllocationError> {
+        validate_msi_metadata(metadata)
+            .map_err(HvfGicMsiInterruptAllocationError::InvalidMetadata)?;
+
+        Ok(Self {
+            range: metadata.interrupt_range,
+            next: Arc::new(AtomicU32::new(metadata.interrupt_range.base)),
+            provenance: Arc::new(HvfGicMsiProvenance),
+        })
+    }
+
+    pub fn remaining(&self) -> u32 {
+        let end = self.range.base + self.range.count;
+        end.saturating_sub(self.next.load(Ordering::Relaxed))
+    }
+
+    pub const fn range(&self) -> HvfGicInterruptRange {
+        self.range
+    }
+
+    pub fn is_exhausted(&self) -> bool {
+        self.remaining() == 0
+    }
+
+    pub fn allocate(&self) -> Result<HvfGicMsiInterrupt, HvfGicMsiInterruptAllocationError> {
+        let end = self.range.base + self.range.count;
+        let intid = self
+            .next
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |next| {
+                (next < end).then_some(next + 1)
+            })
+            .map_err(|_| HvfGicMsiInterruptAllocationError::Exhausted)?;
+        Ok(HvfGicMsiInterrupt {
+            intid,
+            provenance: Arc::clone(&self.provenance),
+        })
+    }
+}
+
+impl fmt::Debug for HvfGicMsiInterruptAllocator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HvfGicMsiInterruptAllocator")
+            .field("range", &"<redacted>")
+            .field("remaining", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HvfGicMsiSignalError {
+    InvalidMetadata(&'static str),
+    InterruptOutOfRange,
+    Signal { source: HvfGicError },
+    InvalidState(&'static str),
+}
+
+impl fmt::Display for HvfGicMsiSignalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidMetadata(message) => {
+                write!(f, "invalid HVF GIC MSI signal metadata: {message}")
+            }
+            Self::InterruptOutOfRange => {
+                f.write_str("HVF GIC MSI interrupt is outside the configured range")
+            }
+            Self::Signal { source } => write!(f, "failed to send HVF GIC MSI: {source}"),
+            Self::InvalidState(message) => {
+                write!(f, "invalid HVF GIC MSI signaler state: {message}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for HvfGicMsiSignalError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Signal { source } => Some(source),
+            Self::InvalidMetadata(_) | Self::InterruptOutOfRange | Self::InvalidState(_) => None,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct HvfGicMsiSignaler {
+    address: u64,
+    range: HvfGicInterruptRange,
+    allocator: HvfGicMsiInterruptAllocator,
+    state: Arc<Mutex<HvfGicMsiSignalerState>>,
+}
+
+struct HvfGicMsiSignalerState {
+    active: bool,
+    api: Box<dyn HvfGicMsiSignalApi + Send>,
+}
+
+impl HvfGicMsiSignaler {
+    /// Return a handle to the one allocation sequence shared by this signaler.
+    pub fn allocator(&self) -> HvfGicMsiInterruptAllocator {
+        self.allocator.clone()
+    }
+
+    pub fn send(&self, interrupt: &HvfGicMsiInterrupt) -> Result<(), HvfGicMsiSignalError> {
+        if !Arc::ptr_eq(&self.allocator.provenance, &interrupt.provenance)
+            || !interrupt_range_contains(self.range, interrupt.intid)
+        {
+            return Err(HvfGicMsiSignalError::InterruptOutOfRange);
+        }
+
+        let state = self.state.lock().map_err(|_| {
+            HvfGicMsiSignalError::InvalidState(GIC_MSI_SIGNALER_LOCK_POISONED_MESSAGE)
+        })?;
+        if !state.active {
+            return Err(HvfGicMsiSignalError::InvalidState(
+                GIC_MSI_SIGNALER_INACTIVE_MESSAGE,
+            ));
+        }
+        state
+            .api
+            .send_msi(self.address, interrupt.intid)
+            .map_err(|source| HvfGicMsiSignalError::Signal { source })
+    }
+
+    /// Revoke every clone after waiting for any in-flight send to finish.
+    pub(crate) fn deactivate(&self) {
+        match self.state.lock() {
+            Ok(mut state) => state.active = false,
+            Err(poisoned) => poisoned.into_inner().active = false,
+        }
+    }
+
+    fn with_api(
+        metadata: HvfGicMsiMetadata,
+        api: impl HvfGicMsiSignalApi + Send + 'static,
+    ) -> Result<Self, HvfGicMsiSignalError> {
+        validate_msi_metadata(metadata).map_err(HvfGicMsiSignalError::InvalidMetadata)?;
+        let allocator =
+            HvfGicMsiInterruptAllocator::from_metadata(metadata).map_err(|error| match error {
+                HvfGicMsiInterruptAllocationError::InvalidMetadata(message) => {
+                    HvfGicMsiSignalError::InvalidMetadata(message)
+                }
+                HvfGicMsiInterruptAllocationError::Exhausted => {
+                    HvfGicMsiSignalError::InvalidState("validated MSI metadata has no allocator")
+                }
+            })?;
+        let address = metadata
+            .region
+            .base
+            .checked_add(ARM64_GICV2M_MSI_SET_SPI_NSR_OFFSET)
+            .ok_or(HvfGicMsiSignalError::InvalidMetadata(
+                "message address overflows",
+            ))?;
+
+        Ok(Self {
+            address,
+            range: metadata.interrupt_range,
+            allocator,
+            state: Arc::new(Mutex::new(HvfGicMsiSignalerState {
+                active: true,
+                api: Box::new(api),
+            })),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_backend_test(metadata: HvfGicMsiMetadata) -> Self {
+        Self::with_api(metadata, TestHvfGicMsiSignalApi)
+            .expect("backend test MSI metadata should be valid")
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+struct TestHvfGicMsiSignalApi;
+
+#[cfg(test)]
+impl HvfGicMsiSignalApi for TestHvfGicMsiSignalApi {
+    fn send_msi(&self, _: u64, _: u32) -> Result<(), HvfGicError> {
+        Ok(())
+    }
+}
+
+impl fmt::Debug for HvfGicMsiSignaler {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HvfGicMsiSignaler")
+            .field("message", &"<redacted>")
+            .finish_non_exhaustive()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HvfGicSpiSignalError {
     Backend(HvfGicError),
@@ -641,6 +937,10 @@ pub enum HvfGicError {
         name: &'static str,
         value: u64,
     },
+    InvalidMsiParameter {
+        name: &'static str,
+    },
+    InsufficientMsiInterruptCapacity,
     AddressUnderflow {
         region: &'static str,
         limit: u64,
@@ -694,6 +994,12 @@ impl fmt::Display for HvfGicError {
                     "invalid Hypervisor.framework GIC parameter {name}={value}"
                 )
             }
+            Self::InvalidMsiParameter { name } => {
+                write!(f, "invalid Hypervisor.framework GIC MSI parameter {name}")
+            }
+            Self::InsufficientMsiInterruptCapacity => {
+                f.write_str("insufficient Hypervisor.framework GIC MSI interrupt capacity")
+            }
             Self::AddressUnderflow {
                 region,
                 limit,
@@ -737,6 +1043,8 @@ impl std::error::Error for HvfGicError {
             | Self::StateAllocationFailed { .. }
             | Self::StateTooLarge { .. }
             | Self::InvalidParameter { .. }
+            | Self::InvalidMsiParameter { .. }
+            | Self::InsufficientMsiInterruptCapacity
             | Self::AddressUnderflow { .. }
             | Self::UnalignedAddress { .. }
             | Self::RegionOverlap { .. }
@@ -751,8 +1059,23 @@ impl From<BackendError> for HvfGicError {
     }
 }
 
+pub(crate) struct CreatedHvfGic {
+    pub(crate) metadata: HvfGicMetadata,
+    pub(crate) msi_signaler: Option<HvfGicMsiSignaler>,
+}
+
+impl fmt::Debug for CreatedHvfGic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CreatedHvfGic")
+            .field("metadata", &self.metadata)
+            .field("msi_signaler", &self.msi_signaler)
+            .finish()
+    }
+}
+
 pub(crate) trait HvfGicCreator: fmt::Debug + Send + Sync {
-    fn create_gic(&self) -> Result<HvfGicMetadata, HvfGicError>;
+    fn create_gic(&self, msi: Option<HvfGicMsiConfiguration>)
+    -> Result<CreatedHvfGic, HvfGicError>;
 }
 
 pub(crate) struct HvfGicStateSnapshotter {
@@ -967,10 +1290,22 @@ struct HvfGicParameters {
     redistributor_alignment: u64,
     spi_interrupt_range: HvfGicInterruptRange,
     timer_interrupts: HvfGicTimerInterrupts,
+    msi: Option<HvfGicMsiParameters>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct HvfGicMsiParameters {
+    region_size: u64,
+    region_alignment: u64,
+    interrupt_count: NonZeroU32,
 }
 
 trait HvfGicSpiSignalApi: fmt::Debug {
     fn set_spi(&self, intid: u32, level: bool) -> Result<(), HvfGicError>;
+}
+
+trait HvfGicMsiSignalApi: fmt::Debug {
+    fn send_msi(&self, address: u64, intid: u32) -> Result<(), HvfGicError>;
 }
 
 pub(crate) struct HvfGicPpiPendingWriter {
@@ -994,6 +1329,8 @@ trait HvfGicApi {
     fn redistributor_region_size(&self) -> Result<u64, HvfGicError>;
     fn redistributor_size(&self) -> Result<u64, HvfGicError>;
     fn redistributor_alignment(&self) -> Result<u64, HvfGicError>;
+    fn msi_region_size(&self) -> Result<u64, HvfGicError>;
+    fn msi_region_alignment(&self) -> Result<u64, HvfGicError>;
     fn spi_interrupt_range(&self) -> Result<HvfGicInterruptRange, HvfGicError>;
     fn intid(&self, interrupt: u16) -> Result<u32, HvfGicError>;
     fn create_config(&self) -> Result<Self::Config, HvfGicError>;
@@ -1004,13 +1341,22 @@ trait HvfGicApi {
         config: &mut Self::Config,
         base: u64,
     ) -> Result<(), HvfGicError>;
+    fn set_msi_region_base(&self, config: &mut Self::Config, base: u64) -> Result<(), HvfGicError>;
+    fn set_msi_interrupt_range(
+        &self,
+        config: &mut Self::Config,
+        range: HvfGicInterruptRange,
+    ) -> Result<(), HvfGicError>;
     fn create_gic(&self, config: &Self::Config) -> Result<(), HvfGicError>;
     fn release_config(&self, config: Self::Config);
 }
 
 impl HvfGicCreator for RealHvfGicCreator {
-    fn create_gic(&self) -> Result<HvfGicMetadata, HvfGicError> {
-        create_real_gic()
+    fn create_gic(
+        &self,
+        msi: Option<HvfGicMsiConfiguration>,
+    ) -> Result<CreatedHvfGic, HvfGicError> {
+        create_real_gic(msi)
     }
 }
 
@@ -1098,19 +1444,54 @@ impl HvfGicPpiPendingApi for UnsupportedHvfGicPpiPendingApi {
     }
 }
 
-fn create_gic_with_api(api: &impl HvfGicApi) -> Result<HvfGicMetadata, HvfGicError> {
-    let parameters = query_parameters(api)?;
-    let metadata = metadata_from_parameters(parameters)?;
+#[cfg(test)]
+fn create_gic_with_api(
+    api: &impl HvfGicApi,
+    msi: Option<HvfGicMsiConfiguration>,
+) -> Result<HvfGicMetadata, HvfGicError> {
+    let metadata = prepare_gic_metadata_with_api(api, msi)?;
+    configure_gic_with_api(api, metadata)?;
+    Ok(metadata)
+}
+
+fn prepare_gic_metadata_with_api(
+    api: &impl HvfGicApi,
+    msi: Option<HvfGicMsiConfiguration>,
+) -> Result<HvfGicMetadata, HvfGicError> {
+    let parameters = query_parameters(api, msi)?;
+    metadata_from_parameters(parameters)
+}
+
+fn configure_gic_with_api(
+    api: &impl HvfGicApi,
+    metadata: HvfGicMetadata,
+) -> Result<(), HvfGicError> {
     let mut config = GicConfigGuard::new(api)?;
 
     api.set_distributor_base(config.config_mut()?, metadata.distributor.base)?;
     api.set_redistributor_base(config.config_mut()?, metadata.redistributor.region.base)?;
+    if let Some(msi) = metadata.msi {
+        api.set_msi_region_base(config.config_mut()?, msi.region.base)?;
+        api.set_msi_interrupt_range(config.config_mut()?, msi.interrupt_range)?;
+    }
     api.create_gic(config.config()?)?;
-
-    Ok(metadata)
+    Ok(())
 }
 
-fn query_parameters(api: &impl HvfGicApi) -> Result<HvfGicParameters, HvfGicError> {
+fn query_parameters(
+    api: &impl HvfGicApi,
+    msi: Option<HvfGicMsiConfiguration>,
+) -> Result<HvfGicParameters, HvfGicError> {
+    let msi = msi
+        .map(|configuration| {
+            Ok::<HvfGicMsiParameters, HvfGicError>(HvfGicMsiParameters {
+                region_size: api.msi_region_size()?,
+                region_alignment: api.msi_region_alignment()?,
+                interrupt_count: configuration.interrupt_count(),
+            })
+        })
+        .transpose()?;
+
     Ok(HvfGicParameters {
         distributor_size: api.distributor_size()?,
         distributor_alignment: api.distributor_alignment()?,
@@ -1122,6 +1503,7 @@ fn query_parameters(api: &impl HvfGicApi) -> Result<HvfGicParameters, HvfGicErro
             el1_virtual_timer_intid: api.intid(HV_GIC_INT_EL1_VIRTUAL_TIMER)?,
             el1_physical_timer_intid: api.intid(HV_GIC_INT_EL1_PHYSICAL_TIMER)?,
         },
+        msi,
     })
 }
 
@@ -1160,6 +1542,31 @@ fn metadata_from_parameters(parameters: HvfGicParameters) -> Result<HvfGicMetada
     validate_spi_interrupt_range(parameters.spi_interrupt_range)?;
     validate_timer_interrupts(parameters.timer_interrupts)?;
 
+    let (spi_interrupt_range, msi_interrupt_range) = parameters.msi.map_or_else(
+        || Ok((parameters.spi_interrupt_range, None)),
+        |msi| {
+            validate_msi_parameter("region_size", msi.region_size, ParameterRule::NonZero)?;
+            validate_msi_parameter(
+                "region_base_alignment",
+                msi.region_alignment,
+                ParameterRule::PowerOfTwo,
+            )?;
+            let minimum_size = ARM64_GICV2M_MSI_IIDR_OFFSET
+                .checked_add(GIC_MSI_REGISTER_SIZE)
+                .ok_or(HvfGicError::InvalidMsiParameter {
+                    name: "region_size",
+                })?;
+            if msi.region_size < minimum_size {
+                return Err(HvfGicError::InvalidMsiParameter {
+                    name: "region_size",
+                });
+            }
+            let (legacy, reserved) =
+                partition_spi_interrupt_range(parameters.spi_interrupt_range, msi.interrupt_count)?;
+            Ok((legacy, Some(reserved)))
+        },
+    )?;
+
     let distributor = aligned_region_below(
         "distributor",
         MMIO32_MEM_START,
@@ -1177,15 +1584,53 @@ fn metadata_from_parameters(parameters: HvfGicParameters) -> Result<HvfGicMetada
     validate_region_below_dram("distributor", distributor)?;
     validate_region_below_dram("redistributor", redistributor)?;
 
+    let msi = match (parameters.msi, msi_interrupt_range) {
+        (Some(parameters), Some(interrupt_range)) => {
+            let region = aligned_region_below(
+                "msi",
+                redistributor.base,
+                parameters.region_size,
+                parameters.region_alignment,
+            )
+            .map_err(|_| HvfGicError::InvalidMsiParameter {
+                name: "region_placement",
+            })?;
+            validate_regions_do_not_overlap("distributor", distributor, "msi", region).map_err(
+                |_| HvfGicError::InvalidMsiParameter {
+                    name: "region_overlap",
+                },
+            )?;
+            validate_regions_do_not_overlap("redistributor", redistributor, "msi", region)
+                .map_err(|_| HvfGicError::InvalidMsiParameter {
+                    name: "region_overlap",
+                })?;
+            validate_region_below_dram("msi", region).map_err(|_| {
+                HvfGicError::InvalidMsiParameter {
+                    name: "region_placement",
+                }
+            })?;
+            Some(HvfGicMsiMetadata {
+                region,
+                interrupt_range,
+            })
+        }
+        (None, None) => None,
+        _ => {
+            return Err(HvfGicError::InvalidState(
+                "GIC MSI parameters and interrupt range disagree",
+            ));
+        }
+    };
+
     Ok(HvfGicMetadata {
         distributor,
         redistributor: HvfGicRedistributor {
             region: redistributor,
             single_redistributor_size: parameters.redistributor_size,
         },
-        spi_interrupt_range: parameters.spi_interrupt_range,
+        spi_interrupt_range,
         timer_interrupts: parameters.timer_interrupts,
-        msi: None,
+        msi,
     })
 }
 
@@ -1212,6 +1657,23 @@ fn validate_parameter(
     }
 }
 
+fn validate_msi_parameter(
+    name: &'static str,
+    value: u64,
+    rule: ParameterRule,
+) -> Result<(), HvfGicError> {
+    let valid = match rule {
+        ParameterRule::NonZero => value != 0,
+        ParameterRule::PowerOfTwo => value != 0 && value.is_power_of_two(),
+    };
+
+    if valid {
+        Ok(())
+    } else {
+        Err(HvfGicError::InvalidMsiParameter { name })
+    }
+}
+
 fn validate_spi_interrupt_range(range: HvfGicInterruptRange) -> Result<(), HvfGicError> {
     if range.base < FIRST_SPI_INTID {
         return Err(HvfGicError::InvalidParameter {
@@ -1233,6 +1695,94 @@ fn validate_spi_interrupt_range(range: HvfGicInterruptRange) -> Result<(), HvfGi
     }
 
     Ok(())
+}
+
+fn partition_spi_interrupt_range(
+    complete: HvfGicInterruptRange,
+    msi_count: NonZeroU32,
+) -> Result<(HvfGicInterruptRange, HvfGicInterruptRange), HvfGicError> {
+    validate_spi_interrupt_range(complete)?;
+    let complete_end =
+        complete
+            .base
+            .checked_add(complete.count)
+            .ok_or(HvfGicError::InvalidMsiParameter {
+                name: "interrupt_range",
+            })?;
+    let usable_end = complete_end.min(ARM64_GICV2M_SPI_END_EXCLUSIVE);
+    let Some(usable_count) = usable_end.checked_sub(complete.base) else {
+        return Err(HvfGicError::InsufficientMsiInterruptCapacity);
+    };
+    let msi_count = msi_count.get();
+    if msi_count >= usable_count {
+        return Err(HvfGicError::InsufficientMsiInterruptCapacity);
+    }
+
+    let msi_base = usable_end - msi_count;
+    let legacy_count = msi_base - complete.base;
+    let legacy = HvfGicInterruptRange {
+        base: complete.base,
+        count: legacy_count,
+    };
+    let msi = HvfGicInterruptRange {
+        base: msi_base,
+        count: msi_count,
+    };
+    validate_spi_interrupt_range(legacy).map_err(|_| HvfGicError::InvalidMsiParameter {
+        name: "legacy_interrupt_range",
+    })?;
+    validate_spi_interrupt_range(msi).map_err(|_| HvfGicError::InvalidMsiParameter {
+        name: "interrupt_range",
+    })?;
+
+    Ok((legacy, msi))
+}
+
+fn validate_msi_metadata(metadata: HvfGicMsiMetadata) -> Result<(), &'static str> {
+    if metadata.region.size == 0 {
+        return Err("message frame is empty");
+    }
+    let Some(region_end) = metadata.region.base.checked_add(metadata.region.size) else {
+        return Err("message frame overflows");
+    };
+    let Some(message_address) = metadata
+        .region
+        .base
+        .checked_add(ARM64_GICV2M_MSI_SET_SPI_NSR_OFFSET)
+    else {
+        return Err("message address overflows");
+    };
+    let Some(message_end) = message_address.checked_add(GIC_MSI_REGISTER_SIZE) else {
+        return Err("message register overflows");
+    };
+    if message_end > region_end {
+        return Err("message frame does not contain SETSPI");
+    }
+    if metadata.interrupt_range.base < FIRST_SPI_INTID {
+        return Err("interrupt range starts below the SPI domain");
+    }
+    if metadata.interrupt_range.count == 0 {
+        return Err("interrupt range is empty");
+    }
+    let Some(interrupt_end) = metadata
+        .interrupt_range
+        .base
+        .checked_add(metadata.interrupt_range.count)
+    else {
+        return Err("interrupt range overflows");
+    };
+    if interrupt_end > ARM64_GICV2M_SPI_END_EXCLUSIVE {
+        return Err("interrupt range exceeds the GICv2m SPI domain");
+    }
+
+    Ok(())
+}
+
+fn interrupt_range_contains(range: HvfGicInterruptRange, intid: u32) -> bool {
+    range
+        .base
+        .checked_add(range.count)
+        .is_some_and(|end| (range.base..end).contains(&intid))
 }
 
 fn validate_spi_signal_line(
@@ -1538,13 +2088,32 @@ pub(crate) fn restore_arm64_gic_icc_register_state_with(
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-fn create_real_gic() -> Result<HvfGicMetadata, HvfGicError> {
-    let api = LoadedHvfGicApi::load()?;
-    create_gic_with_api(&api)
+fn create_real_gic(msi: Option<HvfGicMsiConfiguration>) -> Result<CreatedHvfGic, HvfGicError> {
+    let api = LoadedHvfGicApi::load(msi.is_some())?;
+    let msi_api = msi.map(|_| LoadedHvfGicMsiSignalApi::load()).transpose()?;
+    let metadata = prepare_gic_metadata_with_api(&api, msi)?;
+    let msi_signaler = match (metadata.msi, msi_api) {
+        (Some(metadata), Some(api)) => Some(
+            HvfGicMsiSignaler::with_api(metadata, api)
+                .map_err(|_| HvfGicError::InvalidMsiParameter { name: "metadata" })?,
+        ),
+        (None, None) => None,
+        _ => {
+            return Err(HvfGicError::InvalidState(
+                "GIC MSI metadata and send capability disagree",
+            ));
+        }
+    };
+    configure_gic_with_api(&api, metadata)?;
+
+    Ok(CreatedHvfGic {
+        metadata,
+        msi_signaler,
+    })
 }
 
 #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
-fn create_real_gic() -> Result<HvfGicMetadata, HvfGicError> {
+fn create_real_gic(_: Option<HvfGicMsiConfiguration>) -> Result<CreatedHvfGic, HvfGicError> {
     Err(HvfGicError::Unsupported(
         crate::ffi::UNSUPPORTED_TARGET_MESSAGE,
     ))
@@ -1568,8 +2137,10 @@ mod dynamic {
     type HvGicConfig = NonNull<c_void>;
     type HvGicConfigCreate = unsafe extern "C" fn() -> *mut c_void;
     type HvGicSetBase = unsafe extern "C" fn(*mut c_void, u64) -> HvReturn;
+    type HvGicSetMsiRange = unsafe extern "C" fn(*mut c_void, u32, u32) -> HvReturn;
     type HvGicCreate = unsafe extern "C" fn(*mut c_void) -> HvReturn;
     type HvGicSetSpi = unsafe extern "C" fn(u32, bool) -> HvReturn;
+    type HvGicSendMsi = unsafe extern "C" fn(u64, u32) -> HvReturn;
     type HvGicSetRedistributorReg = unsafe extern "C" fn(u64, u32, u64) -> HvReturn;
     type HvGicStateCreate = unsafe extern "C" fn() -> *mut c_void;
     type HvGicStateGetSize = unsafe extern "C" fn(*mut c_void, *mut usize) -> HvReturn;
@@ -1593,6 +2164,11 @@ mod dynamic {
     pub(super) struct LoadedHvfGicSpiSignalApi {
         _library: DynamicLibrary,
         symbols: HvfGicSpiSignalSymbols,
+    }
+
+    pub(super) struct LoadedHvfGicMsiSignalApi {
+        _library: DynamicLibrary,
+        symbols: HvfGicMsiSignalSymbols,
     }
 
     pub(super) struct LoadedHvfGicPpiPendingApi {
@@ -1642,12 +2218,26 @@ mod dynamic {
         get_redistributor_base_alignment: HvGicGetSize,
         get_spi_interrupt_range: HvGicGetSpiRange,
         get_intid: HvGicGetIntid,
+        msi: Option<HvfGicMsiConfigSymbols>,
         os_release: OsRelease,
+    }
+
+    #[derive(Clone, Copy)]
+    struct HvfGicMsiConfigSymbols {
+        get_region_size: HvGicGetSize,
+        get_region_base_alignment: HvGicGetSize,
+        config_set_region_base: HvGicSetBase,
+        config_set_interrupt_range: HvGicSetMsiRange,
     }
 
     #[derive(Clone, Copy)]
     struct HvfGicSpiSignalSymbols {
         set_spi: HvGicSetSpi,
+    }
+
+    #[derive(Clone, Copy)]
+    struct HvfGicMsiSignalSymbols {
+        send_msi: HvGicSendMsi,
     }
 
     #[derive(Clone, Copy)]
@@ -1679,9 +2269,9 @@ mod dynamic {
     }
 
     impl LoadedHvfGicApi {
-        pub(super) fn load() -> Result<Self, HvfGicError> {
+        pub(super) fn load(include_msi: bool) -> Result<Self, HvfGicError> {
             let library = DynamicLibrary::open(HYPERVISOR_FRAMEWORK_PATH)?;
-            let symbols = HvfGicSymbols::load(library.handle())?;
+            let symbols = HvfGicSymbols::load(library.handle(), include_msi)?;
 
             Ok(Self {
                 _library: library,
@@ -1708,6 +2298,25 @@ mod dynamic {
     impl fmt::Debug for LoadedHvfGicApi {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("LoadedHvfGicApi").finish_non_exhaustive()
+        }
+    }
+
+    impl LoadedHvfGicMsiSignalApi {
+        pub(super) fn load() -> Result<Self, HvfGicError> {
+            let library = DynamicLibrary::open(HYPERVISOR_FRAMEWORK_PATH)?;
+            let symbols = HvfGicMsiSignalSymbols::load(library.handle())?;
+
+            Ok(Self {
+                _library: library,
+                symbols,
+            })
+        }
+    }
+
+    impl fmt::Debug for LoadedHvfGicMsiSignalApi {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("LoadedHvfGicMsiSignalApi")
+                .finish_non_exhaustive()
         }
     }
 
@@ -1859,7 +2468,10 @@ mod dynamic {
     }
 
     impl HvfGicSymbols {
-        fn load(library: NonNull<c_void>) -> Result<Self, HvfGicError> {
+        fn load(library: NonNull<c_void>, include_msi: bool) -> Result<Self, HvfGicError> {
+            let msi = include_msi
+                .then(|| HvfGicMsiConfigSymbols::load(library))
+                .transpose()?;
             Ok(Self {
                 config_create: load_symbol(
                     library,
@@ -1908,6 +2520,7 @@ mod dynamic {
                     "hv_gic_get_spi_interrupt_range",
                 )?,
                 get_intid: load_symbol(library, c"hv_gic_get_intid", "hv_gic_get_intid")?,
+                msi,
                 os_release: load_symbol(
                     NonNull::new(libc::RTLD_DEFAULT)
                         .ok_or(HvfGicError::MissingSymbol("os_release"))?,
@@ -1918,10 +2531,45 @@ mod dynamic {
         }
     }
 
+    impl HvfGicMsiConfigSymbols {
+        fn load(library: NonNull<c_void>) -> Result<Self, HvfGicError> {
+            Ok(Self {
+                get_region_size: load_symbol(
+                    library,
+                    c"hv_gic_get_msi_region_size",
+                    "hv_gic_get_msi_region_size",
+                )?,
+                get_region_base_alignment: load_symbol(
+                    library,
+                    c"hv_gic_get_msi_region_base_alignment",
+                    "hv_gic_get_msi_region_base_alignment",
+                )?,
+                config_set_region_base: load_symbol(
+                    library,
+                    c"hv_gic_config_set_msi_region_base",
+                    "hv_gic_config_set_msi_region_base",
+                )?,
+                config_set_interrupt_range: load_symbol(
+                    library,
+                    c"hv_gic_config_set_msi_interrupt_range",
+                    "hv_gic_config_set_msi_interrupt_range",
+                )?,
+            })
+        }
+    }
+
     impl HvfGicSpiSignalSymbols {
         fn load(library: NonNull<c_void>) -> Result<Self, HvfGicError> {
             Ok(Self {
                 set_spi: load_symbol(library, c"hv_gic_set_spi", "hv_gic_set_spi")?,
+            })
+        }
+    }
+
+    impl HvfGicMsiSignalSymbols {
+        fn load(library: NonNull<c_void>) -> Result<Self, HvfGicError> {
+            Ok(Self {
+                send_msi: load_symbol(library, c"hv_gic_send_msi", "hv_gic_send_msi")?,
             })
         }
     }
@@ -2048,6 +2696,23 @@ mod dynamic {
             )
         }
 
+        fn msi_region_size(&self) -> Result<u64, HvfGicError> {
+            let symbols = self.symbols.msi.as_ref().ok_or(HvfGicError::InvalidState(
+                "GIC MSI configuration symbols were not loaded",
+            ))?;
+            self.get_size(symbols.get_region_size, "hv_gic_get_msi_region_size")
+        }
+
+        fn msi_region_alignment(&self) -> Result<u64, HvfGicError> {
+            let symbols = self.symbols.msi.as_ref().ok_or(HvfGicError::InvalidState(
+                "GIC MSI configuration symbols were not loaded",
+            ))?;
+            self.get_size(
+                symbols.get_region_base_alignment,
+                "hv_gic_get_msi_region_base_alignment",
+            )
+        }
+
         fn spi_interrupt_range(&self) -> Result<HvfGicInterruptRange, HvfGicError> {
             let mut base = 0;
             let mut count = 0;
@@ -2111,6 +2776,44 @@ mod dynamic {
             Ok(())
         }
 
+        fn set_msi_region_base(
+            &self,
+            config: &mut Self::Config,
+            base: u64,
+        ) -> Result<(), HvfGicError> {
+            let symbols = self.symbols.msi.as_ref().ok_or(HvfGicError::InvalidState(
+                "GIC MSI configuration symbols were not loaded",
+            ))?;
+            // SAFETY: `config` is live and `base` was validated against the
+            // host-reported MSI frame geometry before this call.
+            unsafe {
+                crate::ffi::check(
+                    (symbols.config_set_region_base)(config.as_ptr(), base),
+                    "hv_gic_config_set_msi_region_base",
+                )?
+            };
+            Ok(())
+        }
+
+        fn set_msi_interrupt_range(
+            &self,
+            config: &mut Self::Config,
+            range: HvfGicInterruptRange,
+        ) -> Result<(), HvfGicError> {
+            let symbols = self.symbols.msi.as_ref().ok_or(HvfGicError::InvalidState(
+                "GIC MSI configuration symbols were not loaded",
+            ))?;
+            // SAFETY: `config` is live and the range is a validated suffix of
+            // the host-reported SPI domain.
+            unsafe {
+                crate::ffi::check(
+                    (symbols.config_set_interrupt_range)(config.as_ptr(), range.base, range.count),
+                    "hv_gic_config_set_msi_interrupt_range",
+                )?
+            };
+            Ok(())
+        }
+
         fn create_gic(&self, config: &Self::Config) -> Result<(), HvfGicError> {
             // SAFETY: The VM is live, and `config` has valid distributor and
             // redistributor bases configured before this call.
@@ -2132,6 +2835,17 @@ mod dynamic {
             // SAFETY: `intid` and `level` are plain values, and range validation
             // is performed before public callers reach this wrapper.
             unsafe { crate::ffi::check((self.symbols.set_spi)(intid, level), "hv_gic_set_spi")? };
+            Ok(())
+        }
+    }
+
+    impl super::HvfGicMsiSignalApi for LoadedHvfGicMsiSignalApi {
+        fn send_msi(&self, address: u64, intid: u32) -> Result<(), HvfGicError> {
+            // SAFETY: the signaler derives `address` from validated metadata
+            // and accepts only an allocated INTID inside the configured range.
+            unsafe {
+                crate::ffi::check((self.symbols.send_msi)(address, intid), "hv_gic_send_msi")?
+            };
             Ok(())
         }
     }
@@ -2311,21 +3025,25 @@ mod dynamic {
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use dynamic::{
     LoadedHvfGicApi, LoadedHvfGicIccRegisterApi, LoadedHvfGicIccRegisterWriteApi,
-    LoadedHvfGicPpiPendingApi, LoadedHvfGicSpiSignalApi, LoadedHvfGicStateCaptureApi,
-    LoadedHvfGicStateRestoreApi,
+    LoadedHvfGicMsiSignalApi, LoadedHvfGicPpiPendingApi, LoadedHvfGicSpiSignalApi,
+    LoadedHvfGicStateCaptureApi, LoadedHvfGicStateRestoreApi,
 };
 
 #[cfg(test)]
 mod tests {
     use std::cell::RefCell;
     use std::error::Error as _;
+    use std::fmt;
+    use std::num::NonZeroU32;
     use std::panic::{self, AssertUnwindSafe};
-    use std::sync::{Arc, Barrier, Mutex};
+    use std::sync::{Arc, Barrier, Mutex, mpsc};
+    use std::time::Duration;
 
     use bangbang_runtime::BackendError;
     use bangbang_runtime::fdt::{
         ARM64_FDT_HYPERVISOR_TIMER_PPI, ARM64_FDT_NON_SECURE_PHYSICAL_TIMER_PPI,
-        ARM64_FDT_SECURE_PHYSICAL_TIMER_PPI, ARM64_FDT_VIRTUAL_TIMER_PPI, Arm64FdtError,
+        ARM64_FDT_SECURE_PHYSICAL_TIMER_PPI, ARM64_FDT_VIRTUAL_TIMER_PPI,
+        ARM64_GICV2M_MSI_SET_SPI_NSR_OFFSET, ARM64_GICV2M_SPI_END_EXCLUSIVE, Arm64FdtError,
         Arm64FdtInterruptRange, Arm64FdtMsi, Arm64FdtRegion, Arm64FdtTimerInterrupts,
     };
     use bangbang_runtime::interrupt::{GuestInterruptLine, GuestInterruptLineError, InterruptSink};
@@ -2342,7 +3060,9 @@ mod tests {
         HvfArm64GicIccRegisterState, HvfGicApi, HvfGicDeviceState, HvfGicError,
         HvfGicIccRegisterApi, HvfGicIccRegisterReader, HvfGicIccRegisterRestorer,
         HvfGicIccRegisterWriteApi, HvfGicInterruptLineAllocator, HvfGicInterruptRange,
-        HvfGicMetadata, HvfGicMsiMetadata, HvfGicParameters, HvfGicPpiPendingWriter, HvfGicRegion,
+        HvfGicMetadata, HvfGicMsiConfiguration, HvfGicMsiInterruptAllocationError,
+        HvfGicMsiInterruptAllocator, HvfGicMsiMetadata, HvfGicMsiParameters, HvfGicMsiSignalError,
+        HvfGicMsiSignaler, HvfGicParameters, HvfGicPpiPendingWriter, HvfGicRegion,
         HvfGicSpiSignalError, HvfGicSpiSignaler, HvfGicStateApi, HvfGicStateRestoreApi,
         HvfGicStateRestorer, HvfGicTimerInterrupts, HvfInterruptLineAllocationError,
         capture_gic_device_state_with_api, capture_gic_device_state_with_api_bounded,
@@ -2950,6 +3670,475 @@ mod tests {
                 },
             })
         );
+    }
+
+    #[test]
+    fn msi_metadata_reserves_the_highest_usable_host_spis() {
+        let metadata = metadata_from_parameters(parameters_with_msi(8))
+            .expect("valid MSI demand should produce GIC metadata");
+
+        assert_eq!(
+            metadata.spi_interrupt_range,
+            HvfGicInterruptRange {
+                base: 32,
+                count: 88,
+            }
+        );
+        assert_eq!(
+            metadata.msi,
+            Some(HvfGicMsiMetadata {
+                region: HvfGicRegion {
+                    base: 0x3ffc_0000,
+                    size: 0x1_0000,
+                },
+                interrupt_range: HvfGicInterruptRange {
+                    base: 120,
+                    count: 8,
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn msi_metadata_excludes_the_gicv2m_terminal_spi_from_both_ranges() {
+        let mut parameters = parameters_with_msi(1);
+        parameters.spi_interrupt_range = HvfGicInterruptRange {
+            base: 32,
+            count: 988,
+        };
+
+        let metadata = metadata_from_parameters(parameters)
+            .expect("host range with a terminal guard should produce GIC metadata");
+
+        assert_eq!(
+            metadata.spi_interrupt_range,
+            HvfGicInterruptRange {
+                base: 32,
+                count: 986,
+            }
+        );
+        assert_eq!(
+            metadata.msi,
+            Some(HvfGicMsiMetadata {
+                region: HvfGicRegion {
+                    base: 0x3ffc_0000,
+                    size: 0x1_0000,
+                },
+                interrupt_range: HvfGicInterruptRange {
+                    base: ARM64_GICV2M_SPI_END_EXCLUSIVE - 1,
+                    count: 1,
+                },
+            })
+        );
+        assert_eq!(
+            metadata.spi_interrupt_range.base + metadata.spi_interrupt_range.count,
+            ARM64_GICV2M_SPI_END_EXCLUSIVE - 1
+        );
+    }
+
+    #[test]
+    fn msi_metadata_rejects_demand_that_consumes_the_usable_gicv2m_domain() {
+        let mut parameters = parameters_with_msi(987);
+        parameters.spi_interrupt_range = HvfGicInterruptRange {
+            base: 32,
+            count: 988,
+        };
+
+        assert_eq!(
+            metadata_from_parameters(parameters),
+            Err(HvfGicError::InsufficientMsiInterruptCapacity)
+        );
+    }
+
+    #[test]
+    fn msi_metadata_rejects_demand_that_would_empty_the_legacy_range() {
+        assert_eq!(
+            metadata_from_parameters(parameters_with_msi(96)),
+            Err(HvfGicError::InsufficientMsiInterruptCapacity)
+        );
+    }
+
+    #[test]
+    fn msi_metadata_rejects_invalid_frame_geometry_without_values_in_error() {
+        for (region_size, region_alignment, expected_name) in [
+            (0, 0x1_0000, "region_size"),
+            (0x40, 0x1_0000, "region_size"),
+            (0x1_0000, 3, "region_base_alignment"),
+        ] {
+            let mut parameters = parameters_with_msi(1);
+            let msi = parameters
+                .msi
+                .as_mut()
+                .expect("MSI parameters should exist");
+            msi.region_size = region_size;
+            msi.region_alignment = region_alignment;
+
+            let error = metadata_from_parameters(parameters)
+                .expect_err("invalid MSI frame geometry should fail");
+            assert_eq!(
+                error,
+                HvfGicError::InvalidMsiParameter {
+                    name: expected_name,
+                }
+            );
+            assert!(!error.to_string().contains(&region_size.to_string()));
+        }
+    }
+
+    #[test]
+    fn msi_interrupt_allocator_allocates_only_the_reserved_range() {
+        let metadata = metadata_from_parameters(parameters_with_msi(2))
+            .expect("valid MSI demand should produce metadata");
+        let signaler = HvfGicMsiSignaler::with_api(
+            metadata.msi.expect("MSI metadata should exist"),
+            FakeGicApi::default(),
+        )
+        .expect("MSI metadata should produce a signaler");
+        let allocator = signaler.allocator();
+        let peer_allocator = signaler.allocator();
+
+        assert_eq!(
+            allocator.range(),
+            HvfGicInterruptRange {
+                base: 126,
+                count: 2,
+            }
+        );
+        assert_eq!(
+            allocator
+                .allocate()
+                .expect("first MSI should allocate")
+                .raw_value(),
+            126
+        );
+        assert_eq!(
+            peer_allocator
+                .allocate()
+                .expect("last MSI should allocate")
+                .raw_value(),
+            127
+        );
+        assert!(allocator.is_exhausted());
+        assert!(peer_allocator.is_exhausted());
+        assert_eq!(
+            allocator.allocate(),
+            Err(HvfGicMsiInterruptAllocationError::Exhausted)
+        );
+    }
+
+    #[test]
+    fn msi_interrupt_allocator_requires_valid_metadata() {
+        let malformed = HvfGicMsiMetadata {
+            region: HvfGicRegion {
+                base: 0x3ffc_0000,
+                size: 0x40,
+            },
+            interrupt_range: HvfGicInterruptRange {
+                base: 127,
+                count: 1,
+            },
+        };
+        assert_eq!(
+            HvfGicMsiInterruptAllocator::from_metadata(malformed)
+                .expect_err("short MSI frame should fail"),
+            HvfGicMsiInterruptAllocationError::InvalidMetadata(
+                "message frame does not contain SETSPI"
+            )
+        );
+    }
+
+    #[test]
+    fn msi_allocator_and_signaler_reject_the_gicv2m_terminal_spi() {
+        let terminal_metadata = HvfGicMsiMetadata {
+            region: HvfGicRegion {
+                base: 0x3ffc_0000,
+                size: 0x1_0000,
+            },
+            interrupt_range: HvfGicInterruptRange {
+                base: ARM64_GICV2M_SPI_END_EXCLUSIVE,
+                count: 1,
+            },
+        };
+
+        assert_eq!(
+            HvfGicMsiInterruptAllocator::from_metadata(terminal_metadata)
+                .expect_err("terminal SPI should not produce an MSI allocator"),
+            HvfGicMsiInterruptAllocationError::InvalidMetadata(
+                "interrupt range exceeds the GICv2m SPI domain"
+            )
+        );
+        assert_eq!(
+            HvfGicMsiSignaler::with_api(terminal_metadata, FakeGicApi::default())
+                .expect_err("terminal SPI should not produce an MSI signaler"),
+            HvfGicMsiSignalError::InvalidMetadata("interrupt range exceeds the GICv2m SPI domain")
+        );
+    }
+
+    #[test]
+    fn msi_signaler_uses_set_spi_nsr_address_and_allocated_intid() {
+        let metadata = metadata_from_parameters(parameters_with_msi(2))
+            .expect("valid MSI demand should produce metadata");
+        let api = FakeGicApi::default();
+        let signaler = HvfGicMsiSignaler::with_api(
+            metadata.msi.expect("MSI metadata should exist"),
+            api.clone(),
+        )
+        .expect("valid MSI metadata should produce a signaler");
+        let allocator = signaler.allocator();
+        let interrupt = allocator.allocate().expect("MSI should allocate");
+
+        signaler
+            .send(&interrupt)
+            .expect("allocated MSI should signal");
+
+        assert_eq!(
+            api.msi_signals(),
+            vec![(0x3ffc_0000 + ARM64_GICV2M_MSI_SET_SPI_NSR_OFFSET, 126,)]
+        );
+        assert_eq!(api.calls(), vec!["hv_gic_send_msi"]);
+    }
+
+    #[test]
+    fn msi_signaler_rejects_interrupt_from_a_different_capability() {
+        let metadata = metadata_from_parameters(parameters_with_msi(2))
+            .expect("valid MSI demand should produce metadata");
+        let signaler_api = FakeGicApi::default();
+        let signaler = HvfGicMsiSignaler::with_api(
+            metadata.msi.expect("MSI metadata should exist"),
+            signaler_api.clone(),
+        )
+        .expect("valid MSI metadata should produce a signaler");
+        let other_signaler = HvfGicMsiSignaler::with_api(
+            metadata.msi.expect("alternate MSI metadata should exist"),
+            FakeGicApi::default(),
+        )
+        .expect("alternate metadata should produce a signaler");
+        let interrupt = other_signaler
+            .allocator()
+            .allocate()
+            .expect("alternate MSI should allocate");
+
+        assert_eq!(
+            signaler
+                .send(&interrupt)
+                .expect_err("capability provenance mismatch should fail"),
+            HvfGicMsiSignalError::InterruptOutOfRange
+        );
+        assert!(signaler_api.calls().is_empty());
+        assert!(signaler_api.msi_signals().is_empty());
+    }
+
+    #[test]
+    fn msi_signaler_deactivation_revokes_every_clone() {
+        let metadata = metadata_from_parameters(parameters_with_msi(1))
+            .expect("valid MSI demand should produce metadata");
+        let api = FakeGicApi::default();
+        let signaler = HvfGicMsiSignaler::with_api(
+            metadata.msi.expect("MSI metadata should exist"),
+            api.clone(),
+        )
+        .expect("valid MSI metadata should produce a signaler");
+        let clone = signaler.clone();
+        let interrupt = signaler
+            .allocator()
+            .allocate()
+            .expect("MSI should allocate");
+
+        signaler.deactivate();
+
+        for revoked in [&signaler, &clone] {
+            assert_eq!(
+                revoked
+                    .send(&interrupt)
+                    .expect_err("revoked signaler should reject sends"),
+                HvfGicMsiSignalError::InvalidState("HVF GIC MSI signaler is inactive")
+            );
+        }
+        assert!(api.calls().is_empty());
+        assert!(api.msi_signals().is_empty());
+    }
+
+    #[test]
+    fn msi_signaler_serializes_sends_and_waits_before_deactivation() {
+        struct BlockingMsiSignalApi {
+            entered: mpsc::SyncSender<()>,
+            releases: Mutex<mpsc::Receiver<()>>,
+        }
+
+        impl fmt::Debug for BlockingMsiSignalApi {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct("BlockingMsiSignalApi")
+                    .finish_non_exhaustive()
+            }
+        }
+
+        impl super::HvfGicMsiSignalApi for BlockingMsiSignalApi {
+            fn send_msi(&self, _: u64, _: u32) -> Result<(), HvfGicError> {
+                self.entered
+                    .send(())
+                    .expect("test should observe each entered send");
+                self.releases
+                    .lock()
+                    .expect("test release receiver should be lockable")
+                    .recv()
+                    .expect("test should release each entered send");
+                Ok(())
+            }
+        }
+
+        let metadata = metadata_from_parameters(parameters_with_msi(2))
+            .expect("valid MSI demand should produce metadata");
+        let (entered_sender, entered_receiver) = mpsc::sync_channel(2);
+        let (release_sender, release_receiver) = mpsc::sync_channel(2);
+        let signaler = HvfGicMsiSignaler::with_api(
+            metadata.msi.expect("MSI metadata should exist"),
+            BlockingMsiSignalApi {
+                entered: entered_sender,
+                releases: Mutex::new(release_receiver),
+            },
+        )
+        .expect("valid MSI metadata should produce a signaler");
+        let allocator = signaler.allocator();
+        let first_interrupt = allocator.allocate().expect("first MSI should allocate");
+        let second_interrupt = allocator.allocate().expect("second MSI should allocate");
+
+        std::thread::scope(|scope| {
+            let first_signaler = signaler.clone();
+            let first_interrupt_ref = &first_interrupt;
+            let first_send = scope.spawn(move || first_signaler.send(first_interrupt_ref));
+            entered_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .expect("first send should enter the host API");
+
+            let (second_started_sender, second_started_receiver) = mpsc::sync_channel(1);
+            let second_signaler = signaler.clone();
+            let second_send = scope.spawn(move || {
+                second_started_sender
+                    .send(())
+                    .expect("second send start should be observable");
+                second_signaler.send(&second_interrupt)
+            });
+            second_started_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .expect("second send should start while the first is blocked");
+            assert!(matches!(
+                entered_receiver.recv_timeout(Duration::from_millis(100)),
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ));
+
+            release_sender
+                .send(())
+                .expect("first host send should be released");
+            first_send
+                .join()
+                .expect("first send thread should not panic")
+                .expect("first send should succeed");
+            entered_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .expect("second send should enter after the first releases the signaler lock");
+
+            let (deactivate_started_sender, deactivate_started_receiver) = mpsc::sync_channel(1);
+            let (deactivated_sender, deactivated_receiver) = mpsc::sync_channel(1);
+            let retained_signaler = signaler.clone();
+            let deactivate = scope.spawn(move || {
+                deactivate_started_sender
+                    .send(())
+                    .expect("deactivation start should be observable");
+                retained_signaler.deactivate();
+                deactivated_sender
+                    .send(())
+                    .expect("deactivation completion should be observable");
+            });
+            deactivate_started_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .expect("deactivation should start while the second send is blocked");
+            assert!(matches!(
+                deactivated_receiver.recv_timeout(Duration::from_millis(100)),
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ));
+
+            release_sender
+                .send(())
+                .expect("second host send should be released");
+            second_send
+                .join()
+                .expect("second send thread should not panic")
+                .expect("second send should succeed");
+            deactivate
+                .join()
+                .expect("deactivation thread should not panic");
+            deactivated_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .expect("deactivation should complete after the in-flight send");
+        });
+
+        assert_eq!(
+            signaler
+                .send(&first_interrupt)
+                .expect_err("deactivation should revoke later sends"),
+            HvfGicMsiSignalError::InvalidState("HVF GIC MSI signaler is inactive")
+        );
+    }
+
+    #[test]
+    fn msi_signaler_preserves_hvf_failure_source() {
+        let metadata = metadata_from_parameters(parameters_with_msi(1))
+            .expect("valid MSI demand should produce metadata");
+        let api = FakeGicApi::default().with_failure("hv_gic_send_msi");
+        let signaler = HvfGicMsiSignaler::with_api(
+            metadata.msi.expect("MSI metadata should exist"),
+            api.clone(),
+        )
+        .expect("valid MSI metadata should produce a signaler");
+        let interrupt = signaler
+            .allocator()
+            .allocate()
+            .expect("MSI should allocate");
+
+        let error = signaler
+            .send(&interrupt)
+            .expect_err("injected send failure should propagate");
+
+        assert_eq!(
+            error,
+            HvfGicMsiSignalError::Signal {
+                source: HvfGicError::Backend(BackendError::Hypervisor(
+                    "injected hv_gic_send_msi failure".to_string(),
+                )),
+            }
+        );
+        assert!(error.source().is_some());
+        assert!(api.msi_signals().is_empty());
+    }
+
+    #[test]
+    fn msi_debug_output_redacts_configuration_and_capability_values() {
+        let metadata = metadata_from_parameters(parameters_with_msi(7))
+            .expect("valid MSI demand should produce metadata");
+        let signaler = HvfGicMsiSignaler::with_api(
+            metadata.msi.expect("MSI metadata should exist"),
+            FakeGicApi::default(),
+        )
+        .expect("valid MSI metadata should produce a signaler");
+        let allocator = signaler.allocator();
+        let interrupt = allocator.allocate().expect("MSI should allocate");
+
+        assert_eq!(
+            format!("{:?}", msi_configuration(7)),
+            "HvfGicMsiConfiguration { interrupt_count: \"<redacted>\" }"
+        );
+        assert!(!format!("{:?}", metadata.msi).contains("121"));
+        assert!(!format!("{allocator:?}").contains("121"));
+        assert!(!format!("{interrupt:?}").contains("121"));
+        assert!(!format!("{signaler:?}").contains("3ffc0040"));
+    }
+
+    #[test]
+    fn msi_allocator_and_signaler_are_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+
+        assert_send_sync::<HvfGicMsiInterruptAllocator>();
+        assert_send_sync::<HvfGicMsiSignaler>();
     }
 
     #[test]
@@ -3655,7 +4844,7 @@ mod tests {
         });
 
         assert_eq!(
-            create_gic_with_api(&api),
+            create_gic_with_api(&api, None),
             Err(HvfGicError::InvalidParameter {
                 name: "distributor_size",
                 value: 0,
@@ -3724,7 +4913,7 @@ mod tests {
         });
 
         assert_eq!(
-            create_gic_with_api(&api),
+            create_gic_with_api(&api, None),
             Err(HvfGicError::InvalidParameter {
                 name: "spi_interrupt_range.count",
                 value: 0,
@@ -3764,7 +4953,7 @@ mod tests {
         });
 
         assert_eq!(
-            create_gic_with_api(&api),
+            create_gic_with_api(&api, None),
             Err(HvfGicError::InvalidParameter {
                 name: "el1_virtual_timer_intid",
                 value: 15,
@@ -3835,7 +5024,7 @@ mod tests {
     fn create_gic_configures_hvf_before_returning_metadata() {
         let api = FakeGicApi::default();
 
-        let metadata = create_gic_with_api(&api).expect("GIC should be created");
+        let metadata = create_gic_with_api(&api, None).expect("GIC should be created");
 
         assert_eq!(metadata.distributor.base, 0x3fff_0000);
         assert_eq!(
@@ -3860,11 +5049,98 @@ mod tests {
     }
 
     #[test]
+    fn create_gic_with_msi_configures_exact_tail_range_and_frame() {
+        let api = FakeGicApi::new(parameters_with_msi(1));
+
+        let metadata = create_gic_with_api(&api, Some(msi_configuration(8)))
+            .expect("valid MSI GIC should be created");
+
+        assert_eq!(
+            metadata.spi_interrupt_range,
+            HvfGicInterruptRange {
+                base: 32,
+                count: 88,
+            }
+        );
+        assert_eq!(
+            metadata
+                .msi
+                .expect("MSI metadata should exist")
+                .interrupt_range,
+            HvfGicInterruptRange {
+                base: 120,
+                count: 8,
+            }
+        );
+        assert_eq!(api.msi_region_bases(), vec![0x3ffc_0000]);
+        assert_eq!(
+            api.msi_ranges(),
+            vec![HvfGicInterruptRange {
+                base: 120,
+                count: 8,
+            }]
+        );
+        assert_eq!(
+            api.calls(),
+            vec![
+                "hv_gic_get_msi_region_size",
+                "hv_gic_get_msi_region_base_alignment",
+                "hv_gic_get_distributor_size",
+                "hv_gic_get_distributor_base_alignment",
+                "hv_gic_get_redistributor_region_size",
+                "hv_gic_get_redistributor_size",
+                "hv_gic_get_redistributor_base_alignment",
+                "hv_gic_get_spi_interrupt_range",
+                "hv_gic_get_intid",
+                "hv_gic_get_intid",
+                "hv_gic_config_create",
+                "hv_gic_config_set_distributor_base",
+                "hv_gic_config_set_redistributor_base",
+                "hv_gic_config_set_msi_region_base",
+                "hv_gic_config_set_msi_interrupt_range",
+                "hv_gic_create",
+                "os_release",
+            ]
+        );
+        assert_eq!(api.released_configs(), vec![1]);
+    }
+
+    #[test]
+    fn invalid_msi_demand_fails_before_config_creation() {
+        let api = FakeGicApi::new(parameters_with_msi(1));
+
+        assert_eq!(
+            create_gic_with_api(&api, Some(msi_configuration(96))),
+            Err(HvfGicError::InsufficientMsiInterruptCapacity)
+        );
+        assert!(!api.created_config());
+        assert!(api.msi_region_bases().is_empty());
+        assert!(api.msi_ranges().is_empty());
+    }
+
+    #[test]
+    fn msi_configuration_failure_releases_config_without_creating_gic() {
+        let api = FakeGicApi::new(parameters_with_msi(1))
+            .with_failure("hv_gic_config_set_msi_interrupt_range");
+
+        assert_eq!(
+            create_gic_with_api(&api, Some(msi_configuration(8))),
+            Err(HvfGicError::Backend(BackendError::Hypervisor(
+                "injected hv_gic_config_set_msi_interrupt_range failure".to_string()
+            )))
+        );
+        assert_eq!(api.msi_region_bases(), vec![0x3ffc_0000]);
+        assert!(api.msi_ranges().is_empty());
+        assert!(!api.calls().contains(&"hv_gic_create"));
+        assert_eq!(api.released_configs(), vec![1]);
+    }
+
+    #[test]
     fn create_gic_releases_config_after_set_failure() {
         let api = FakeGicApi::default().with_failure("hv_gic_config_set_redistributor_base");
 
         assert_eq!(
-            create_gic_with_api(&api),
+            create_gic_with_api(&api, None),
             Err(HvfGicError::Backend(BackendError::Hypervisor(
                 "injected hv_gic_config_set_redistributor_base failure".to_string()
             )))
@@ -3893,7 +5169,7 @@ mod tests {
         let api = FakeGicApi::default().with_failure("hv_gic_create");
 
         assert_eq!(
-            create_gic_with_api(&api),
+            create_gic_with_api(&api, None),
             Err(HvfGicError::Backend(BackendError::Hypervisor(
                 "injected hv_gic_create failure".to_string()
             )))
@@ -3945,6 +5221,25 @@ mod tests {
                 el1_virtual_timer_intid: 27,
                 el1_physical_timer_intid: 30,
             },
+            msi: None,
+        }
+    }
+
+    fn msi_configuration(interrupt_count: u32) -> HvfGicMsiConfiguration {
+        HvfGicMsiConfiguration::new(
+            NonZeroU32::new(interrupt_count).expect("test MSI count should be nonzero"),
+        )
+    }
+
+    fn parameters_with_msi(interrupt_count: u32) -> HvfGicParameters {
+        HvfGicParameters {
+            msi: Some(HvfGicMsiParameters {
+                region_size: 0x1_0000,
+                region_alignment: 0x1_0000,
+                interrupt_count: NonZeroU32::new(interrupt_count)
+                    .expect("test MSI count should be nonzero"),
+            }),
+            ..default_parameters()
         }
     }
 
@@ -4315,6 +5610,9 @@ mod tests {
                     next_config: 1,
                     released_configs: Vec::new(),
                     spi_signals: Vec::new(),
+                    msi_region_bases: Vec::new(),
+                    msi_ranges: Vec::new(),
+                    msi_signals: Vec::new(),
                     ppi_pending_writes: Vec::new(),
                     failure: None,
                     created_config: false,
@@ -4351,6 +5649,30 @@ mod tests {
                 .lock()
                 .expect("fake GIC API state should be lockable")
                 .spi_signals
+                .clone()
+        }
+
+        fn msi_region_bases(&self) -> Vec<u64> {
+            self.state
+                .lock()
+                .expect("fake GIC API state should be lockable")
+                .msi_region_bases
+                .clone()
+        }
+
+        fn msi_ranges(&self) -> Vec<HvfGicInterruptRange> {
+            self.state
+                .lock()
+                .expect("fake GIC API state should be lockable")
+                .msi_ranges
+                .clone()
+        }
+
+        fn msi_signals(&self) -> Vec<(u64, u32)> {
+            self.state
+                .lock()
+                .expect("fake GIC API state should be lockable")
+                .msi_signals
                 .clone()
         }
 
@@ -4400,6 +5722,25 @@ mod tests {
                 )))
             } else {
                 state.spi_signals.push((intid, level));
+                Ok(())
+            }
+        }
+    }
+
+    impl super::HvfGicMsiSignalApi for FakeGicApi {
+        fn send_msi(&self, address: u64, intid: u32) -> Result<(), HvfGicError> {
+            let mut state = self
+                .state
+                .lock()
+                .expect("fake GIC API state should be lockable");
+            state.calls.push("hv_gic_send_msi");
+
+            if state.failure == Some("hv_gic_send_msi") {
+                Err(HvfGicError::Backend(BackendError::Hypervisor(
+                    "injected hv_gic_send_msi failure".to_string(),
+                )))
+            } else {
+                state.msi_signals.push((address, intid));
                 Ok(())
             }
         }
@@ -4466,6 +5807,26 @@ mod tests {
             Ok(self.parameters.redistributor_alignment)
         }
 
+        fn msi_region_size(&self) -> Result<u64, HvfGicError> {
+            self.record("hv_gic_get_msi_region_size")?;
+            self.parameters
+                .msi
+                .map(|parameters| parameters.region_size)
+                .ok_or(HvfGicError::InvalidMsiParameter {
+                    name: "region_size",
+                })
+        }
+
+        fn msi_region_alignment(&self) -> Result<u64, HvfGicError> {
+            self.record("hv_gic_get_msi_region_base_alignment")?;
+            self.parameters
+                .msi
+                .map(|parameters| parameters.region_alignment)
+                .ok_or(HvfGicError::InvalidMsiParameter {
+                    name: "region_base_alignment",
+                })
+        }
+
         fn spi_interrupt_range(&self) -> Result<HvfGicInterruptRange, HvfGicError> {
             self.record("hv_gic_get_spi_interrupt_range")?;
             Ok(self.parameters.spi_interrupt_range)
@@ -4507,6 +5868,30 @@ mod tests {
             self.record("hv_gic_config_set_redistributor_base")
         }
 
+        fn set_msi_region_base(&self, _: &mut Self::Config, base: u64) -> Result<(), HvfGicError> {
+            self.record("hv_gic_config_set_msi_region_base")?;
+            self.state
+                .lock()
+                .expect("fake GIC API state should be lockable")
+                .msi_region_bases
+                .push(base);
+            Ok(())
+        }
+
+        fn set_msi_interrupt_range(
+            &self,
+            _: &mut Self::Config,
+            range: HvfGicInterruptRange,
+        ) -> Result<(), HvfGicError> {
+            self.record("hv_gic_config_set_msi_interrupt_range")?;
+            self.state
+                .lock()
+                .expect("fake GIC API state should be lockable")
+                .msi_ranges
+                .push(range);
+            Ok(())
+        }
+
         fn create_gic(&self, _: &Self::Config) -> Result<(), HvfGicError> {
             self.record("hv_gic_create")
         }
@@ -4527,6 +5912,9 @@ mod tests {
         next_config: u64,
         released_configs: Vec<u64>,
         spi_signals: Vec<(u32, bool)>,
+        msi_region_bases: Vec<u64>,
+        msi_ranges: Vec<HvfGicInterruptRange>,
+        msi_signals: Vec<(u64, u32)>,
         ppi_pending_writes: Vec<(crate::ffi::HvVcpu, u32, u64)>,
         failure: Option<&'static str>,
         created_config: bool,

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -45,7 +45,9 @@ pub use gic::{
     HvfArm64GicIccRegister, HvfArm64GicIccRegisterRestoreError,
     HvfArm64GicIccRegisterRestoreOperation, HvfArm64GicIccRegisterState, HvfGicDeviceState,
     HvfGicError, HvfGicInterruptLineAllocator, HvfGicInterruptRange, HvfGicMetadata,
-    HvfGicMsiMetadata, HvfGicRedistributor, HvfGicRegion, HvfGicSpiSignalError, HvfGicSpiSignaler,
+    HvfGicMsiConfiguration, HvfGicMsiInterrupt, HvfGicMsiInterruptAllocationError,
+    HvfGicMsiInterruptAllocator, HvfGicMsiMetadata, HvfGicMsiSignalError, HvfGicMsiSignaler,
+    HvfGicRedistributor, HvfGicRegion, HvfGicSpiSignalError, HvfGicSpiSignaler,
     HvfGicTimerInterrupts, HvfInterruptLineAllocationError,
 };
 pub use memory::{HvfGuestMemoryMappingError, HvfGuestMemoryUnmapFailure, HvfMemoryPermissions};

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -71,7 +71,8 @@ use crate::coordinator::{HvfVcpuRunControl, HvfVcpuRunCoordinatorError, HvfVcpuR
 use crate::dirty::{HvfDirtyWriteEpochResetError, HvfDirtyWriteTrackerStartError};
 use crate::gic::{
     HvfArm64GicIccRegisterState, HvfGicDeviceState, HvfGicError, HvfGicInterruptLineAllocator,
-    HvfGicMetadata, HvfGicSpiSignalError, HvfGicSpiSignaler, HvfInterruptLineAllocationError,
+    HvfGicMetadata, HvfGicMsiConfiguration, HvfGicMsiSignaler, HvfGicSpiSignalError,
+    HvfGicSpiSignaler, HvfInterruptLineAllocationError,
 };
 use crate::memory::{HvfGuestMemoryMappingError, HvfMemoryPermissions, HvfPmemFlushExecutor};
 use crate::psci::PsciCpuPowerCoordinator;
@@ -126,6 +127,7 @@ pub struct HvfArm64BootSessionConfig {
     pub entropy_device: Option<HvfArm64BootEntropyDeviceConfig>,
     pub memory_hotplug_device: Option<HvfArm64BootMemoryHotplugDeviceConfig>,
     pub serial_device: Option<HvfArm64BootSerialDeviceConfig>,
+    pub gic_msi: Option<HvfGicMsiConfiguration>,
 }
 
 impl HvfArm64BootSessionConfig {
@@ -147,6 +149,7 @@ impl HvfArm64BootSessionConfig {
             entropy_device: None,
             memory_hotplug_device: None,
             serial_device: None,
+            gic_msi: None,
         }
     }
 
@@ -184,6 +187,15 @@ impl HvfArm64BootSessionConfig {
 
     pub fn with_serial_device(mut self, serial_device: HvfArm64BootSerialDeviceConfig) -> Self {
         self.serial_device = Some(serial_device);
+        self
+    }
+
+    /// Opt into a demand-sized public-HVF GICv2m range for platform validation.
+    ///
+    /// Ordinary process construction leaves this unset. PCI admission and
+    /// guest-programmed MSI-X remain outside this startup profile.
+    pub const fn with_gic_msi(mut self, configuration: HvfGicMsiConfiguration) -> Self {
+        self.gic_msi = Some(configuration);
         self
     }
 }
@@ -1628,6 +1640,11 @@ impl HvfArm64BootSession<'_> {
 
     pub const fn gic_metadata(&self) -> HvfGicMetadata {
         self.gic
+    }
+
+    /// Return the send-only capability retained by an MSI-enabled session.
+    pub fn gic_msi_signaler(&self) -> Option<&HvfGicMsiSignaler> {
+        self.backend.gic_msi_signaler()
     }
 
     pub fn primary_mpidr(&self) -> u64 {
@@ -3253,6 +3270,11 @@ impl OwnedHvfArm64BootSession {
 
     pub const fn gic_metadata(&self) -> HvfGicMetadata {
         self.gic
+    }
+
+    /// Return the send-only capability retained by an MSI-enabled session.
+    pub fn gic_msi_signaler(&self) -> Option<&HvfGicMsiSignaler> {
+        self.backend.gic_msi_signaler()
     }
 
     pub fn primary_mpidr(&self) -> u64 {
@@ -8093,9 +8115,11 @@ fn prepare_arm64_boot_session_parts_with_cache<'vm>(
     let retained_cache_hierarchy = cache_hierarchy.clone();
     <HvfBackend as VmBackend>::create_vm(backend)
         .map_err(|source| HvfArm64BootSessionError::CreateVm { source })?;
-    let gic = *backend
-        .create_gic()
-        .map_err(|source| HvfArm64BootSessionError::CreateGic { source })?;
+    let gic = *match config.gic_msi {
+        Some(configuration) => backend.create_gic_with_msi(configuration),
+        None => backend.create_gic(),
+    }
+    .map_err(|source| HvfArm64BootSessionError::CreateGic { source })?;
     let timer = gic
         .arm64_fdt_timer_interrupts()
         .map_err(|source| HvfArm64BootSessionError::TimerMetadata { source })?;
@@ -8456,7 +8480,7 @@ mod tests {
     use std::error::Error as _;
     use std::fs::{self, OpenOptions};
     use std::io::{self, Write};
-    use std::num::NonZeroUsize;
+    use std::num::{NonZeroU32, NonZeroUsize};
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Arc, Mutex, mpsc};
@@ -17095,6 +17119,26 @@ mod tests {
         assert!(config.serial_device.is_some());
         assert_eq!(config.network_mmio_layout, network_layout);
         assert_eq!(config.rtc_mmio_layout.base(), TEST_RTC_MMIO_BASE);
+    }
+
+    #[test]
+    fn session_config_opts_into_gic_msi_without_changing_the_default() {
+        let default = HvfArm64BootSessionConfig::new(
+            BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1)),
+            PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500)),
+            NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000)),
+            VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
+            RtcMmioLayout::new(TEST_RTC_MMIO_BASE, MmioRegionId::new(3000)),
+        );
+        let configuration = crate::gic::HvfGicMsiConfiguration::new(
+            NonZeroU32::new(8).expect("test MSI count should be nonzero"),
+        );
+
+        assert_eq!(default.gic_msi, None);
+        assert_eq!(
+            default.with_gic_msi(configuration).gic_msi,
+            Some(configuration)
+        );
     }
 
     #[test]

--- a/crates/hvf/tests/guest_boot.rs
+++ b/crates/hvf/tests/guest_boot.rs
@@ -113,6 +113,46 @@ fn boots_firecracker_kernel_to_guest_marker() {
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 #[test]
+fn boots_firecracker_kernel_with_the_advertised_gicv2m_frame() {
+    use std::num::NonZeroU32;
+
+    use bangbang_hvf::HvfGicMsiConfiguration;
+
+    let _test_lock = GUEST_BOOT_TEST_LOCK
+        .lock()
+        .expect("guest boot integration test lock should not be poisoned");
+    let observation = run_guest_boot_with_gic_msi_until_marker(
+        "guest-gicv2m",
+        BOOT_MARKER,
+        HvfGicMsiConfiguration::new(NonZeroU32::new(1).expect("test MSI count should be nonzero")),
+        |_| {},
+    );
+
+    assert_guest_boot_observed_marker(&observation, BOOT_MARKER, "boot marker");
+    let msi = observation
+        .gic_msi
+        .expect("MSI-enabled guest boot should retain GICv2m metadata");
+    let last_intid = msi
+        .interrupt_range
+        .base
+        .checked_add(msi.interrupt_range.count - 1)
+        .expect("validated GICv2m range should have an inclusive end");
+    let range_marker = format!("SPI[{}:{}]", msi.interrupt_range.base, last_intid);
+
+    assert!(
+        bytes_contain_marker(&observation.serial_bytes, b"GICv2m: range"),
+        "pinned Linux did not initialize the advertised GICv2m frame\nserial output:\n{}",
+        String::from_utf8_lossy(&observation.serial_bytes)
+    );
+    assert!(
+        bytes_contain_marker(&observation.serial_bytes, range_marker.as_bytes()),
+        "pinned Linux did not recognize the exact advertised GICv2m SPI range\nserial output:\n{}",
+        String::from_utf8_lossy(&observation.serial_bytes)
+    );
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
 fn boots_firecracker_kernel_and_executes_userspace_on_secondary_cpu() {
     use bangbang_runtime::VmmAction;
     use bangbang_runtime::cpu::{
@@ -764,6 +804,24 @@ fn run_guest_boot_until_marker(
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn run_guest_boot_with_gic_msi_until_marker(
+    instance_id: &str,
+    marker: &[u8],
+    gic_msi: bangbang_hvf::HvfGicMsiConfiguration,
+    configure_controller: impl FnOnce(&mut bangbang_runtime::VmmController),
+) -> GuestBootObservation {
+    let initrd_path = env_path("BANGBANG_GUEST_INITRD_PATH");
+    run_guest_boot_with_boot_source_and_gic_msi(
+        instance_id,
+        marker,
+        Some(initrd_path),
+        INITRD_BOOT_ARGS,
+        Some(gic_msi),
+        configure_controller,
+    )
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 fn run_guest_boot_without_initrd_until_marker(
     instance_id: &str,
     marker: &[u8],
@@ -779,6 +837,25 @@ fn run_guest_boot_with_boot_source(
     marker: &[u8],
     initrd_path: Option<std::path::PathBuf>,
     boot_args: &str,
+    configure_controller: impl FnOnce(&mut bangbang_runtime::VmmController),
+) -> GuestBootObservation {
+    run_guest_boot_with_boot_source_and_gic_msi(
+        instance_id,
+        marker,
+        initrd_path,
+        boot_args,
+        None,
+        configure_controller,
+    )
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn run_guest_boot_with_boot_source_and_gic_msi(
+    instance_id: &str,
+    marker: &[u8],
+    initrd_path: Option<std::path::PathBuf>,
+    boot_args: &str,
+    gic_msi: Option<bangbang_hvf::HvfGicMsiConfiguration>,
     configure_controller: impl FnOnce(&mut bangbang_runtime::VmmController),
 ) -> GuestBootObservation {
     use std::num::NonZeroUsize;
@@ -825,12 +902,17 @@ fn run_guest_boot_with_boot_source(
         serial_address,
         SharedSerialOutput::from(serial_output.clone()),
     ));
+    let config = match gic_msi {
+        Some(configuration) => config.with_gic_msi(configuration),
+        None => config,
+    };
     let mut session = OwnedHvfArm64BootSession::new(&controller, config)
         .expect("guest boot test session should prepare");
     let cache_hierarchy = session
         .arm64_fdt_cache_hierarchy()
         .expect("ordinary boot session should retain its cache hierarchy")
         .clone();
+    let gic_msi = session.gic_metadata().msi;
     let boot_diagnostics =
         GuestBootDiagnostics::from_session(&session, kernel_path, initrd_path, serial_address);
     validate_pre_run_boot_metadata(&session, &boot_diagnostics);
@@ -893,6 +975,7 @@ fn run_guest_boot_with_boot_source(
         run_diagnostics,
         serial_bytes,
         cache_hierarchy,
+        gic_msi,
     }
 }
 
@@ -923,6 +1006,7 @@ struct GuestBootObservation {
     run_diagnostics: GuestBootRunDiagnostics,
     serial_bytes: Vec<u8>,
     cache_hierarchy: bangbang_runtime::fdt::Arm64FdtCacheHierarchy,
+    gic_msi: Option<bangbang_hvf::HvfGicMsiMetadata>,
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -1642,6 +1726,50 @@ fn validate_pre_run_boot_metadata(
             assert!(!chosen.has_prop("linux,initrd-end"));
         }
         _ => panic!("guest boot test initrd diagnostics should be internally consistent"),
+    }
+
+    let gic = session.gic_metadata();
+    let intc = tree
+        .find("/intc")
+        .expect("guest boot test FDT should contain the GIC node");
+    assert_eq!(intc.prop_str("compatible").unwrap(), "arm,gic-v3");
+    assert_eq!(session.gic_msi_signaler().is_some(), gic.msi.is_some());
+    match gic.msi {
+        Some(msi) => {
+            assert!(!intc.has_prop("msi-controller"));
+            assert!(!intc.has_prop("mbi-ranges"));
+            assert!(!intc.has_prop("mbi-alias"));
+            assert!(!intc.has_prop("#msi-cells"));
+            assert_eq!(intc.children.len(), 1);
+            let frame_path = format!("/intc/v2m@{:x}", msi.region.base);
+            let frame = tree
+                .find(&frame_path)
+                .unwrap_or_else(|| panic!("guest boot test FDT should contain {frame_path}"));
+            assert_eq!(frame.prop_str("compatible").unwrap(), "arm,gic-v2m-frame");
+            assert!(
+                frame
+                    .prop_raw("msi-controller")
+                    .expect("MSI controller property should exist")
+                    .is_empty()
+            );
+            assert_eq!(frame.prop_u32("phandle").unwrap(), 3);
+            assert_eq!(
+                prop_u64_cells(frame, "reg"),
+                [msi.region.base, msi.region.size]
+            );
+            assert!(!frame.has_prop("arm,msi-base-spi"));
+            assert!(!frame.has_prop("arm,msi-num-spis"));
+            assert!(!frame.has_prop("#msi-cells"));
+            assert!(frame.children.is_empty());
+            assert!(tree.find("/intc/its").is_none());
+        }
+        None => {
+            assert!(!intc.has_prop("msi-controller"));
+            assert!(!intc.has_prop("mbi-ranges"));
+            assert!(!intc.has_prop("mbi-alias"));
+            assert!(!intc.has_prop("#msi-cells"));
+            assert!(intc.children.is_empty());
+        }
     }
 
     assert_eq!(session.vcpu_count(), diagnostics.vcpu_mpidrs.len());

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -520,6 +520,92 @@ const GIC_ICC_REGISTER_GUEST_CODE: [u32; 15] = [
     0xd400_0002, // hvc #0
 ];
 
+// Bare EL1 setup for one message-only SPI. X0 points at four little-endian
+// values: distributor base, redistributor base, INTID, and VBAR. The code
+// wakes redistributor 0, programs the SPI as Group-1 edge-triggered and routed
+// to affinity 0, enables the GICv3 system-register interface, then publishes
+// readiness with HVC #0 and waits for the message.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const GIC_MSI_GUEST_CODE: [u32; 69] = [
+    0xaa00_03f3, // mov x19, x0
+    0xf940_0274, // ldr x20, [x19]                 (GICD)
+    0xf940_0675, // ldr x21, [x19, #8]             (GICR)
+    0xb940_1276, // ldr w22, [x19, #16]            (INTID)
+    0xf940_0e77, // ldr x23, [x19, #24]            (VBAR)
+    0xd518_c017, // msr VBAR_EL1, x23
+    0xd503_3fdf, // isb
+    0x9100_52a1, // add x1, x21, #0x14             (GICR_WAKER)
+    0xb940_0022, // ldr w2, [x1]
+    0x121e_7842, // bic w2, w2, #2                 (ProcessorSleep)
+    0xb900_0022, // str w2, [x1]
+    0xb940_0022, // ldr w2, [x1]
+    0x3717_ffe2, // tbnz w2, #2, .-4               (ChildrenAsleep)
+    0x1200_12c3, // and w3, w22, #31
+    0x5280_0024, // mov w4, #1
+    0x1ac3_2084, // lsl w4, w4, w3
+    0x5305_7ec5, // lsr w5, w22, #5
+    0x9102_0286, // add x6, x20, #0x80             (GICD_IGROUPR)
+    0x8b05_08c6, // add x6, x6, x5, lsl #2
+    0xb940_00c7, // ldr w7, [x6]
+    0x2a04_00e7, // orr w7, w7, w4
+    0xb900_00c7, // str w7, [x6]
+    0x1200_0ec3, // and w3, w22, #15
+    0x531f_7863, // lsl w3, w3, #1
+    0x1100_0463, // add w3, w3, #1
+    0x5280_0024, // mov w4, #1
+    0x1ac3_2084, // lsl w4, w4, w3
+    0x9130_0286, // add x6, x20, #0xc00            (GICD_ICFGR)
+    0x5304_7ec5, // lsr w5, w22, #4
+    0x8b05_08c6, // add x6, x6, x5, lsl #2
+    0xb940_00c7, // ldr w7, [x6]
+    0x2a04_00e7, // orr w7, w7, w4
+    0xb900_00c7, // str w7, [x6]
+    0x9110_0286, // add x6, x20, #0x400            (GICD_IPRIORITYR)
+    0x8b16_00c6, // add x6, x6, x22
+    0x5280_1007, // mov w7, #0x80
+    0x3900_00c7, // strb w7, [x6]
+    0x9140_1a86, // add x6, x20, #0x6000           (GICD_IROUTER)
+    0x8b16_0cc6, // add x6, x6, x22, lsl #3
+    0xf900_00df, // str xzr, [x6]
+    0x1200_12c3, // and w3, w22, #31
+    0x5280_0024, // mov w4, #1
+    0x1ac3_2084, // lsl w4, w4, w3
+    0x5305_7ec5, // lsr w5, w22, #5
+    0x9104_0286, // add x6, x20, #0x100            (GICD_ISENABLER)
+    0x8b05_08c6, // add x6, x6, x5, lsl #2
+    0xb900_00c4, // str w4, [x6]
+    0xb940_0287, // ldr w7, [x20]                  (GICD_CTLR)
+    0x5280_0248, // mov w8, #0x12                  (ARE_NS | EnableGrp1NS)
+    0x2a08_00e7, // orr w7, w7, w8
+    0xb900_0287, // str w7, [x20]
+    0xd503_3f9f, // dsb sy
+    0xb940_0287, // ldr w7, [x20]
+    0x37ff_ffe7, // tbnz w7, #31, .-4              (RWP)
+    0xd538_cca1, // mrs x1, ICC_SRE_EL1
+    0xb240_0021, // orr x1, x1, #1
+    0xd518_cca1, // msr ICC_SRE_EL1, x1
+    0xd503_3fdf, // isb
+    0xd280_1fe1, // mov x1, #0xff
+    0xd518_4601, // msr ICC_PMR_EL1, x1
+    0xd518_cc7f, // msr ICC_BPR1_EL1, xzr
+    0xd280_0021, // mov x1, #1
+    0xd518_cce1, // msr ICC_IGRPEN1_EL1, x1
+    0xd503_3fdf, // isb
+    0xd503_42ff, // msr DAIFClr, #2
+    0xb940_0681, // ldr w1, [x20, #4]              (GICD_TYPER evidence)
+    0xd400_0002, // hvc #0                         (ready)
+    0xd503_207f, // wfi
+    0x17ff_ffff, // b .-4
+];
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const GIC_MSI_IRQ_HANDLER: [u32; 4] = [
+    0xd538_cc00, // mrs x0, ICC_IAR1_EL1
+    0xd518_cc20, // msr ICC_EOIR1_EL1, x0
+    0xd400_0022, // hvc #1
+    0x1400_0000, // b .
+];
+
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 fn test_rtc_mmio_layout() -> bangbang_runtime::rtc::RtcMmioLayout {
     bangbang_runtime::rtc::RtcMmioLayout::new(
@@ -2279,6 +2365,172 @@ fn creates_hvf_gic_before_vcpu() {
         vcpu.destroy().expect("vCPU should be destroyed");
     }
     backend.destroy_vm().expect("VM should be destroyed");
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn delivers_hvf_gic_msi_to_the_allocated_guest_intid() {
+    use std::num::NonZeroU32;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    use bangbang_hvf::{
+        HvfArm64BootRegisters, HvfBackend, HvfGicMsiConfiguration, HvfMemoryPermissions,
+        HvfVcpuExit,
+    };
+    use bangbang_runtime::VmBackend;
+    use bangbang_runtime::fdt::ARM64_GICV2M_SPI_END_EXCLUSIVE;
+    use bangbang_runtime::memory::{GuestAddress, GuestMemory, aarch64};
+
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let mut backend = HvfBackend::new();
+    backend.create_vm().expect("VM should be created");
+    let metadata = *backend
+        .create_gic_with_msi(HvfGicMsiConfiguration::new(
+            NonZeroU32::new(1).expect("test MSI count should be nonzero"),
+        ))
+        .expect("MSI-enabled GIC should be created");
+    let signaler = backend
+        .gic_msi_signaler()
+        .expect("MSI-enabled GIC should retain its sender")
+        .clone();
+    let interrupt = signaler
+        .allocator()
+        .allocate()
+        .expect("one MSI should allocate");
+    assert_eq!(
+        interrupt.raw_value(),
+        ARM64_GICV2M_SPI_END_EXCLUSIVE - 1,
+        "the host terminal SPI should remain outside the GICv2m allocation"
+    );
+    let layout = aarch64::dram_layout(host_page_size().expect("host page size should be valid"))
+        .expect("guest memory layout should be valid");
+    let mut memory =
+        GuestMemory::allocate(&layout).expect("guest memory allocation should succeed");
+    let guest_entry = GuestAddress::new(aarch64::DRAM_MEM_START);
+    let vector_base = guest_entry
+        .checked_add(0x800)
+        .expect("guest vector address should fit");
+    let irq_handler = vector_base
+        .checked_add(0x280)
+        .expect("current-EL SPx IRQ vector should fit");
+    let config_address = guest_entry
+        .checked_add(0x1000)
+        .expect("guest MSI config address should fit");
+    let guest_code = GIC_MSI_GUEST_CODE
+        .into_iter()
+        .flat_map(u32::to_le_bytes)
+        .collect::<Vec<_>>();
+    let irq_code = GIC_MSI_IRQ_HANDLER
+        .into_iter()
+        .flat_map(u32::to_le_bytes)
+        .collect::<Vec<_>>();
+    memory
+        .write_slice(&guest_code, guest_entry)
+        .expect("MSI guest setup code should be written");
+    memory
+        .write_slice(&irq_code, irq_handler)
+        .expect("MSI guest IRQ handler should be written");
+
+    let mut guest_config = Vec::with_capacity(32);
+    guest_config.extend_from_slice(&metadata.distributor.base.to_le_bytes());
+    guest_config.extend_from_slice(&metadata.redistributor.region.base.to_le_bytes());
+    guest_config.extend_from_slice(&interrupt.raw_value().to_le_bytes());
+    guest_config.extend_from_slice(&0_u32.to_le_bytes());
+    guest_config.extend_from_slice(&vector_base.raw_value().to_le_bytes());
+    memory
+        .write_slice(&guest_config, config_address)
+        .expect("MSI guest configuration should be written");
+
+    backend
+        .map_guest_memory(memory, HvfMemoryPermissions::GUEST_RAM)
+        .expect("guest memory should be mapped");
+    {
+        let runner = backend
+            .start_vcpu_runner()
+            .expect("vCPU runner should start");
+        runner
+            .configure_arm64_boot_registers(HvfArm64BootRegisters {
+                kernel_entry: guest_entry,
+                fdt_address: config_address,
+            })
+            .expect("MSI guest boot registers should be configured");
+
+        let HvfVcpuExit::Exception(ready) = runner
+            .run_once()
+            .expect("MSI guest should publish readiness through HVC")
+        else {
+            panic!("MSI guest readiness should produce an exception exit");
+        };
+        assert_eq!(
+            ready
+                .decode_hvc()
+                .expect("MSI guest readiness should decode as HVC")
+                .immediate(),
+            0
+        );
+        let ready_registers = runner
+            .capture_arm64_general_register_state()
+            .expect("MSI readiness registers should be captured");
+        assert_eq!(
+            ready_registers
+                .general_purpose_register(1)
+                .expect("X1 should contain GICD_TYPER")
+                & (1 << 17),
+            0,
+            "the validated GICv2m path requires a distributor without LPIs",
+        );
+
+        signaler
+            .send(&interrupt)
+            .expect("real Hypervisor.framework MSI should be sent");
+        let cancel = runner.run_cancel_handle();
+        let delivered = std::thread::scope(|scope| {
+            let (sender, receiver) = mpsc::sync_channel(1);
+            let runner_ref = &runner;
+            scope.spawn(move || {
+                let _ = sender.send(runner_ref.run_once());
+            });
+
+            match receiver.recv_timeout(Duration::from_secs(5)) {
+                Ok(result) => result.expect("MSI guest run should succeed"),
+                Err(error) => {
+                    cancel
+                        .cancel()
+                        .expect("timed-out MSI guest run should cancel");
+                    let _ = receiver.recv_timeout(Duration::from_secs(5));
+                    panic!("MSI guest did not observe an IRQ before the deadline: {error}");
+                }
+            }
+        });
+        let HvfVcpuExit::Exception(delivered) = delivered else {
+            panic!("delivered MSI should produce an exception exit");
+        };
+        assert_eq!(
+            delivered
+                .decode_hvc()
+                .expect("MSI IRQ handler exit should decode as HVC")
+                .immediate(),
+            1
+        );
+        let registers = runner
+            .capture_arm64_general_register_state()
+            .expect("MSI IRQ result registers should be captured");
+        assert_eq!(
+            registers.general_purpose_register(0),
+            Some(u64::from(interrupt.raw_value()))
+        );
+
+        runner
+            .shutdown()
+            .expect("MSI guest runner should shut down");
+    }
+    drop(signaler);
+    backend
+        .destroy_vm()
+        .expect("MSI guest VM should be destroyed");
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/crates/runtime/src/fdt.rs
+++ b/crates/runtime/src/fdt.rs
@@ -14,6 +14,7 @@ use crate::memory::{
 const ROOT_COMPATIBILITY: &str = "linux,dummy-virt";
 const GIC_PHANDLE: u32 = 1;
 const CLOCK_PHANDLE: u32 = 2;
+const MSI_PHANDLE: u32 = 3;
 const ADDRESS_CELLS: u32 = 2;
 const SIZE_CELLS: u32 = 2;
 const CPU_ADDRESS_CELLS: u32 = 2;
@@ -42,6 +43,7 @@ const IRQ_TYPE_EDGE_RISING: u32 = 1;
 const IRQ_TYPE_LEVEL_HIGH: u32 = 4;
 const FIRST_PPI_INTID: u32 = 16;
 const FIRST_SPI_INTID: u32 = 32;
+const GICV2M_REGISTER_SIZE: u64 = 4;
 const MEMORY_REG_CELLS_PER_RANGE: usize = 2;
 const MEMORY_REG_CELL_SIZE: usize = 8;
 
@@ -51,6 +53,10 @@ pub const ARM64_FDT_VIRTUAL_TIMER_PPI: u32 = 11;
 pub const ARM64_FDT_HYPERVISOR_TIMER_PPI: u32 = 10;
 pub const ARM64_FDT_VMGENID_SIZE: u64 = 16;
 pub const ARM64_FDT_VMCLOCK_SIZE: u64 = 0x1000;
+pub const ARM64_GICV2M_MSI_TYPER_OFFSET: u64 = 0x8;
+pub const ARM64_GICV2M_MSI_SET_SPI_NSR_OFFSET: u64 = 0x40;
+pub const ARM64_GICV2M_MSI_IIDR_OFFSET: u64 = 0xfcc;
+pub const ARM64_GICV2M_SPI_END_EXCLUSIVE: u32 = 1019;
 const LINUX_PCI_PROBE_ONLY: u32 = 1;
 const ARM64_FDT_RNG_SEED_SIZE: usize = 64;
 
@@ -398,10 +404,19 @@ pub struct Arm64FdtInterruptRange {
     pub count: u32,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Arm64FdtMsi {
     pub region: Arm64FdtRegion,
     pub interrupt_range: Arm64FdtInterruptRange,
+}
+
+impl fmt::Debug for Arm64FdtMsi {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Arm64FdtMsi")
+            .field("region", &"<redacted>")
+            .field("interrupt_range", &"<redacted>")
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -614,7 +629,12 @@ pub enum Arm64FdtError {
     RngSeed {
         source: Arm64FdtRngSeedError,
     },
-    UnsupportedMsi,
+    InvalidGicMsiRegion,
+    InvalidGicMsiInterruptRange,
+    GicMsiRegionOverlaps {
+        other: &'static str,
+    },
+    GicMsiRegionOverlapsMemory,
     InvalidVirtioMmioRegion {
         index: usize,
         region: Arm64FdtRegion,
@@ -872,7 +892,16 @@ impl fmt::Display for Arm64FdtError {
             Self::RngSeed { source } => {
                 write!(f, "failed to create arm64 FDT rng-seed: {source}")
             }
-            Self::UnsupportedMsi => f.write_str("arm64 FDT MSI/ITS nodes are not supported yet"),
+            Self::InvalidGicMsiRegion => f.write_str("arm64 FDT GICv2m frame is invalid"),
+            Self::InvalidGicMsiInterruptRange => {
+                f.write_str("arm64 FDT GICv2m interrupt range is invalid")
+            }
+            Self::GicMsiRegionOverlaps { other } => {
+                write!(f, "arm64 FDT GICv2m frame overlaps GIC {other} region")
+            }
+            Self::GicMsiRegionOverlapsMemory => {
+                f.write_str("arm64 FDT GICv2m frame overlaps guest memory")
+            }
             Self::InvalidVirtioMmioRegion {
                 index,
                 region,
@@ -1128,7 +1157,10 @@ impl std::error::Error for Arm64FdtError {
             | Self::InvalidPpi { .. }
             | Self::DuplicatePpi { .. }
             | Self::InvalidPpiIntid { .. }
-            | Self::UnsupportedMsi
+            | Self::InvalidGicMsiRegion
+            | Self::InvalidGicMsiInterruptRange
+            | Self::GicMsiRegionOverlaps { .. }
+            | Self::GicMsiRegionOverlapsMemory
             | Self::VirtioMmioRegionOverlapsMemory { .. }
             | Self::VirtioMmioRegionOverlapsGic { .. }
             | Self::VirtioMmioRegionsOverlap { .. }
@@ -1543,7 +1575,7 @@ fn cache_phandle(
     let phandle = LAST_CACHE_PHANDLE
         .checked_sub(offset)
         .ok_or(Arm64FdtCacheHierarchyError::PhandleOverflow)?;
-    if phandle <= CLOCK_PHANDLE {
+    if phandle <= MSI_PHANDLE {
         return Err(Arm64FdtCacheHierarchyError::PhandleCollision);
     }
     Ok(phandle)
@@ -1607,6 +1639,14 @@ fn create_gic_node(fdt: &mut FdtWriter, gic: Arm64FdtGic) -> Result<(), Arm64Fdt
             IRQ_TYPE_LEVEL_HIGH,
         ],
     )?;
+    if let Some(msi) = gic.msi {
+        let frame = fdt.begin_node(&format!("v2m@{:x}", msi.region.base))?;
+        fdt.property_string("compatible", "arm,gic-v2m-frame")?;
+        fdt.property_null("msi-controller")?;
+        fdt.property_phandle(MSI_PHANDLE)?;
+        fdt.property_array_u64("reg", &[msi.region.base, msi.region.size])?;
+        fdt.end_node(frame)?;
+    }
     fdt.end_node(interrupt)?;
     Ok(())
 }
@@ -1981,8 +2021,61 @@ fn validate_gic(layout: &GuestMemoryLayout, gic: Arm64FdtGic) -> Result<(), Arm6
 
     validate_ppi("maintenance_irq", gic.maintenance_irq)?;
 
-    if gic.msi.is_some() {
-        return Err(Arm64FdtError::UnsupportedMsi);
+    if let Some(msi) = gic.msi {
+        validate_gic_msi(layout, gic, msi)?;
+    }
+
+    Ok(())
+}
+
+fn validate_gic_msi(
+    layout: &GuestMemoryLayout,
+    gic: Arm64FdtGic,
+    msi: Arm64FdtMsi,
+) -> Result<(), Arm64FdtError> {
+    let msi_range = GuestMemoryRange::new(GuestAddress::new(msi.region.base), msi.region.size)
+        .map_err(|_| Arm64FdtError::InvalidGicMsiRegion)?;
+    for register_offset in [
+        ARM64_GICV2M_MSI_TYPER_OFFSET,
+        ARM64_GICV2M_MSI_SET_SPI_NSR_OFFSET,
+        ARM64_GICV2M_MSI_IIDR_OFFSET,
+    ] {
+        let required_frame_size = register_offset
+            .checked_add(GICV2M_REGISTER_SIZE)
+            .ok_or(Arm64FdtError::InvalidGicMsiRegion)?;
+        if msi.region.size < required_frame_size {
+            return Err(Arm64FdtError::InvalidGicMsiRegion);
+        }
+    }
+
+    for (name, region) in [
+        ("distributor", gic.distributor),
+        ("redistributor", gic.redistributor),
+    ] {
+        let range = validate_gic_region(name, region)?;
+        if msi_range.overlaps(range) {
+            return Err(Arm64FdtError::GicMsiRegionOverlaps { other: name });
+        }
+    }
+    if layout
+        .ranges()
+        .iter()
+        .copied()
+        .any(|memory_range| msi_range.overlaps(memory_range))
+    {
+        return Err(Arm64FdtError::GicMsiRegionOverlapsMemory);
+    }
+
+    let interrupt_end = msi
+        .interrupt_range
+        .base
+        .checked_add(msi.interrupt_range.count)
+        .ok_or(Arm64FdtError::InvalidGicMsiInterruptRange)?;
+    if msi.interrupt_range.base < FIRST_SPI_INTID
+        || msi.interrupt_range.count == 0
+        || interrupt_end > ARM64_GICV2M_SPI_END_EXCLUSIVE
+    {
+        return Err(Arm64FdtError::InvalidGicMsiInterruptRange);
     }
 
     Ok(())
@@ -2018,6 +2111,31 @@ fn validate_gic_region(
 ) -> Result<GuestMemoryRange, Arm64FdtError> {
     GuestMemoryRange::new(GuestAddress::new(region.base), region.size)
         .map_err(|_| Arm64FdtError::InvalidGicRegion { name, region })
+}
+
+fn validated_gic_regions(
+    gic: Arm64FdtGic,
+) -> Result<[Option<(&'static str, GuestMemoryRange)>; 3], Arm64FdtError> {
+    let msi = gic
+        .msi
+        .map(|msi| {
+            GuestMemoryRange::new(GuestAddress::new(msi.region.base), msi.region.size)
+                .map(|range| ("msi", range))
+                .map_err(|_| Arm64FdtError::InvalidGicMsiRegion)
+        })
+        .transpose()?;
+
+    Ok([
+        Some((
+            "distributor",
+            validate_gic_region("distributor", gic.distributor)?,
+        )),
+        Some((
+            "redistributor",
+            validate_gic_region("redistributor", gic.redistributor)?,
+        )),
+        msi,
+    ])
 }
 
 fn validate_gic_regions_do_not_overlap(
@@ -2119,18 +2237,7 @@ fn validate_rtc_region_does_not_overlap_gic(
     rtc_range: GuestMemoryRange,
     gic: Arm64FdtGic,
 ) -> Result<(), Arm64FdtError> {
-    let gic_ranges = [
-        (
-            "distributor",
-            validate_gic_region("distributor", gic.distributor)?,
-        ),
-        (
-            "redistributor",
-            validate_gic_region("redistributor", gic.redistributor)?,
-        ),
-    ];
-
-    for (gic_name, gic_range) in gic_ranges {
+    for (gic_name, gic_range) in validated_gic_regions(gic)?.into_iter().flatten() {
         if rtc_range.overlaps(gic_range) {
             return Err(Arm64FdtError::RtcRegionOverlapsGic {
                 region,
@@ -2187,18 +2294,7 @@ fn validate_serial_region_does_not_overlap_gic(
     serial_range: GuestMemoryRange,
     gic: Arm64FdtGic,
 ) -> Result<(), Arm64FdtError> {
-    let gic_ranges = [
-        (
-            "distributor",
-            validate_gic_region("distributor", gic.distributor)?,
-        ),
-        (
-            "redistributor",
-            validate_gic_region("redistributor", gic.redistributor)?,
-        ),
-    ];
-
-    for (gic_name, gic_range) in gic_ranges {
+    for (gic_name, gic_range) in validated_gic_regions(gic)?.into_iter().flatten() {
         if serial_range.overlaps(gic_range) {
             return Err(Arm64FdtError::SerialRegionOverlapsGic {
                 region,
@@ -2341,18 +2437,7 @@ fn validate_vmgenid_region_does_not_overlap_gic(
     vmgenid_range: GuestMemoryRange,
     gic: Arm64FdtGic,
 ) -> Result<(), Arm64FdtError> {
-    let gic_ranges = [
-        (
-            "distributor",
-            validate_gic_region("distributor", gic.distributor)?,
-        ),
-        (
-            "redistributor",
-            validate_gic_region("redistributor", gic.redistributor)?,
-        ),
-    ];
-
-    for (gic_name, gic_range) in gic_ranges {
+    for (gic_name, gic_range) in validated_gic_regions(gic)?.into_iter().flatten() {
         if vmgenid_range.overlaps(gic_range) {
             return Err(Arm64FdtError::VmGenIdRegionOverlapsGic {
                 region,
@@ -2485,18 +2570,7 @@ fn validate_vmclock_region_does_not_overlap_gic(
     vmclock_range: GuestMemoryRange,
     gic: Arm64FdtGic,
 ) -> Result<(), Arm64FdtError> {
-    let gic_ranges = [
-        (
-            "distributor",
-            validate_gic_region("distributor", gic.distributor)?,
-        ),
-        (
-            "redistributor",
-            validate_gic_region("redistributor", gic.redistributor)?,
-        ),
-    ];
-
-    for (gic_name, gic_range) in gic_ranges {
+    for (gic_name, gic_range) in validated_gic_regions(gic)?.into_iter().flatten() {
         if vmclock_range.overlaps(gic_range) {
             return Err(Arm64FdtError::VmClockRegionOverlapsGic {
                 region,
@@ -2649,18 +2723,7 @@ fn validate_virtio_mmio_region_does_not_overlap_gic(
     device_range: GuestMemoryRange,
     gic: Arm64FdtGic,
 ) -> Result<(), Arm64FdtError> {
-    let gic_ranges = [
-        (
-            "distributor",
-            validate_gic_region("distributor", gic.distributor)?,
-        ),
-        (
-            "redistributor",
-            validate_gic_region("redistributor", gic.redistributor)?,
-        ),
-    ];
-
-    for (gic_name, gic_range) in gic_ranges {
+    for (gic_name, gic_range) in validated_gic_regions(gic)?.into_iter().flatten() {
         if device_range.overlaps(gic_range) {
             return Err(Arm64FdtError::VirtioMmioRegionOverlapsGic {
                 index,
@@ -2993,6 +3056,24 @@ mod tests {
         assert_eq!(
             cache_phandle(800, 7, 0),
             Err(Arm64FdtCacheHierarchyError::PhandleCollision)
+        );
+        assert_eq!(
+            cache_phandle(
+                1,
+                2,
+                usize::try_from(LAST_CACHE_PHANDLE - MSI_PHANDLE)
+                    .expect("reserved phandle offset should fit usize"),
+            ),
+            Err(Arm64FdtCacheHierarchyError::PhandleCollision)
+        );
+        assert_eq!(
+            cache_phandle(
+                1,
+                2,
+                usize::try_from(LAST_CACHE_PHANDLE - MSI_PHANDLE - 1)
+                    .expect("first unreserved phandle offset should fit usize"),
+            ),
+            Ok(MSI_PHANDLE + 1)
         );
         assert_eq!(
             format!("{:?}", split_three_level_cache_hierarchy(4, 8)),
@@ -3660,6 +3741,10 @@ mod tests {
             vec![0x3fff_0000, 0x1_0000, 0x3ffd_0000, 0x2_0000]
         );
         assert_eq!(prop_u32_cells(intc, "interrupts"), vec![1, 9, 4]);
+        assert!(!intc.has_prop("msi-controller"));
+        assert!(!intc.has_prop("mbi-ranges"));
+        assert!(!intc.has_prop("mbi-alias"));
+        assert!(!intc.has_prop("#msi-cells"));
         assert!(intc.children.is_empty());
     }
 
@@ -5595,19 +5680,227 @@ mod tests {
     }
 
     #[test]
-    fn rejects_msi_metadata_until_its_node_is_supported() {
+    fn gic_node_publishes_hardware_described_gicv2m_child() {
         let layout = test_layout(TEST_MEMORY_SIZE);
         let config = Arm64FdtConfig {
             gic: Arm64FdtGic {
+                msi: Some(test_msi()),
+                ..test_gic()
+            },
+            ..test_config(
+                &layout,
+                Arm64FdtBootInfo {
+                    command_line: "panic=1",
+                    initrd: None,
+                },
+            )
+        };
+
+        let bytes = build_test_arm64_fdt(&config).expect("valid GICv2m metadata should build");
+        let tree = DeviceTree::load(&bytes).expect("GICv2m FDT should parse");
+        let intc = required_node(&tree, "/intc");
+        let frame = required_node(&tree, "/intc/v2m@3ffc0000");
+
+        assert!(!intc.has_prop("msi-controller"));
+        assert!(!intc.has_prop("mbi-ranges"));
+        assert!(!intc.has_prop("mbi-alias"));
+        assert!(!intc.has_prop("#msi-cells"));
+        assert_eq!(intc.children.len(), 1);
+        assert_eq!(frame.prop_str("compatible").unwrap(), "arm,gic-v2m-frame");
+        assert!(
+            frame
+                .prop_raw("msi-controller")
+                .expect("MSI controller property should exist")
+                .is_empty()
+        );
+        assert_eq!(frame.prop_u32("phandle").unwrap(), MSI_PHANDLE);
+        assert_eq!(prop_u64_cells(frame, "reg"), vec![0x3ffc_0000, 0x1_0000]);
+        assert!(!frame.has_prop("arm,msi-base-spi"));
+        assert!(!frame.has_prop("arm,msi-num-spis"));
+        assert!(!frame.has_prop("#msi-cells"));
+        assert!(frame.children.is_empty());
+        assert!(tree.find("/intc/msic").is_none());
+        assert_eq!(
+            format!("{:?}", test_msi()),
+            "Arm64FdtMsi { region: \"<redacted>\", interrupt_range: \"<redacted>\" }"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_gicv2m_frame_and_interrupt_range_without_raw_values() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let invalid_frames = [
+            Arm64FdtRegion {
+                base: 0x3ffc_0000,
+                size: 0,
+            },
+            Arm64FdtRegion {
+                base: 0x3ffc_0000,
+                size: ARM64_GICV2M_MSI_IIDR_OFFSET + GICV2M_REGISTER_SIZE - 1,
+            },
+            Arm64FdtRegion {
+                base: u64::MAX,
+                size: 0x1_0000,
+            },
+        ];
+        for region in invalid_frames {
+            let config = Arm64FdtConfig {
+                gic: Arm64FdtGic {
+                    msi: Some(Arm64FdtMsi {
+                        region,
+                        ..test_msi()
+                    }),
+                    ..test_gic()
+                },
+                ..test_config(
+                    &layout,
+                    Arm64FdtBootInfo {
+                        command_line: "panic=1",
+                        initrd: None,
+                    },
+                )
+            };
+
+            let err = build_test_arm64_fdt(&config).expect_err("invalid GICv2m frame should fail");
+            assert_eq!(err, Arm64FdtError::InvalidGicMsiRegion);
+            assert_eq!(err.to_string(), "arm64 FDT GICv2m frame is invalid");
+        }
+
+        let invalid_ranges = [
+            Arm64FdtInterruptRange { base: 31, count: 1 },
+            Arm64FdtInterruptRange {
+                base: FIRST_SPI_INTID,
+                count: 0,
+            },
+            Arm64FdtInterruptRange {
+                base: u32::MAX,
+                count: 2,
+            },
+            Arm64FdtInterruptRange {
+                base: ARM64_GICV2M_SPI_END_EXCLUSIVE - 1,
+                count: 2,
+            },
+        ];
+        for interrupt_range in invalid_ranges {
+            let config = Arm64FdtConfig {
+                gic: Arm64FdtGic {
+                    msi: Some(Arm64FdtMsi {
+                        interrupt_range,
+                        ..test_msi()
+                    }),
+                    ..test_gic()
+                },
+                ..test_config(
+                    &layout,
+                    Arm64FdtBootInfo {
+                        command_line: "panic=1",
+                        initrd: None,
+                    },
+                )
+            };
+
+            let err = build_test_arm64_fdt(&config)
+                .expect_err("invalid GICv2m interrupt range should fail");
+            assert_eq!(err, Arm64FdtError::InvalidGicMsiInterruptRange);
+            assert_eq!(
+                err.to_string(),
+                "arm64 FDT GICv2m interrupt range is invalid"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_gicv2m_frame_overlapping_gic_memory_or_device_regions() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        for (region, expected) in [
+            (
+                test_gic().distributor,
+                Arm64FdtError::GicMsiRegionOverlaps {
+                    other: "distributor",
+                },
+            ),
+            (
+                test_gic().redistributor,
+                Arm64FdtError::GicMsiRegionOverlaps {
+                    other: "redistributor",
+                },
+            ),
+            (
+                Arm64FdtRegion {
+                    base: aarch64::DRAM_MEM_START,
+                    size: 0x1_0000,
+                },
+                Arm64FdtError::GicMsiRegionOverlapsMemory,
+            ),
+        ] {
+            let config = Arm64FdtConfig {
+                gic: Arm64FdtGic {
+                    msi: Some(Arm64FdtMsi {
+                        region,
+                        ..test_msi()
+                    }),
+                    ..test_gic()
+                },
+                ..test_config(
+                    &layout,
+                    Arm64FdtBootInfo {
+                        command_line: "panic=1",
+                        initrd: None,
+                    },
+                )
+            };
+            assert_eq!(
+                build_test_arm64_fdt(&config).expect_err("overlapping GICv2m frame should fail"),
+                expected
+            );
+        }
+
+        let msi = Arm64FdtMsi {
+            region: Arm64FdtRegion {
+                base: 0x4000_1000,
+                size: 0x1000,
+            },
+            ..test_msi()
+        };
+        let device = virtio_mmio_device(msi.region.base, msi.region.size, FIRST_SPI_INTID);
+        let config = Arm64FdtConfig {
+            gic: Arm64FdtGic {
+                msi: Some(msi),
+                ..test_gic()
+            },
+            virtio_mmio_devices: &[device],
+            ..test_config(
+                &layout,
+                Arm64FdtBootInfo {
+                    command_line: "panic=1",
+                    initrd: None,
+                },
+            )
+        };
+        assert_eq!(
+            build_test_arm64_fdt(&config).expect_err("device-overlapping GICv2m frame should fail"),
+            Arm64FdtError::VirtioMmioRegionOverlapsGic {
+                index: 0,
+                region: device.region,
+                gic: "msi",
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_gicv2m_metadata_before_guest_memory_write() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let mut memory = GuestMemory::allocate(&layout).expect("test guest memory should allocate");
+        let address = aarch64::fdt_address(&layout).expect("test FDT address should resolve");
+        let before = [0xa5; 16];
+        memory
+            .write_slice(&before, address)
+            .expect("sentinel bytes should be writable");
+        let config = Arm64FdtConfig {
+            gic: Arm64FdtGic {
                 msi: Some(Arm64FdtMsi {
-                    region: Arm64FdtRegion {
-                        base: 0x3ffc_0000,
-                        size: 0x1_0000,
-                    },
-                    interrupt_range: Arm64FdtInterruptRange {
-                        base: 128,
-                        count: 32,
-                    },
+                    interrupt_range: Arm64FdtInterruptRange { base: 31, count: 1 },
+                    ..test_msi()
                 }),
                 ..test_gic()
             },
@@ -5620,10 +5913,16 @@ mod tests {
             )
         };
 
-        let err =
-            build_test_arm64_fdt(&config).expect_err("MSI should be explicit unsupported work");
-
-        assert_eq!(err, Arm64FdtError::UnsupportedMsi);
+        assert_eq!(
+            write_test_arm64_fdt(&config, &mut memory)
+                .expect_err("invalid GICv2m metadata should fail before writing"),
+            Arm64FdtError::InvalidGicMsiInterruptRange
+        );
+        let mut after = [0; 16];
+        memory
+            .read_slice(&mut after, address)
+            .expect("sentinel bytes should remain readable");
+        assert_eq!(after, before);
     }
 
     #[test]
@@ -6247,6 +6546,19 @@ mod tests {
             interrupt_cells: 3,
             maintenance_irq: 9,
             msi: None,
+        }
+    }
+
+    const fn test_msi() -> Arm64FdtMsi {
+        Arm64FdtMsi {
+            region: Arm64FdtRegion {
+                base: 0x3ffc_0000,
+                size: 0x1_0000,
+            },
+            interrupt_range: Arm64FdtInterruptRange {
+                base: 128,
+                count: 32,
+            },
         }
     }
 

--- a/crates/runtime/src/fdt.rs
+++ b/crates/runtime/src/fdt.rs
@@ -3749,6 +3749,24 @@ mod tests {
     }
 
     #[test]
+    fn msi_free_fdt_bytes_match_the_pre_msi_baseline() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: None,
+            },
+        );
+
+        let bytes = build_test_arm64_fdt(&config).expect("MSI-free FDT should build");
+
+        // Golden CRC from the fixed-seed FDT emitted by the pre-MSI base
+        // commit b6dade5f67550301521169c4f691519a6858f6c8.
+        assert_eq!(crc64::crc64(0, &bytes), 7_530_829_099_057_997_742);
+    }
+
+    #[test]
     fn rejects_overlapping_gic_regions() {
         let layout = test_layout(TEST_MEMORY_SIZE);
         let config = Arm64FdtConfig {

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -25,7 +25,7 @@ Hypervisor.framework VM create/destroy wrapper, a current-thread HVF vCPU
 create/destroy wrapper, typed HVF exit surface with MMIO data-abort decoding,
 registry resolution, vCPU exit classification, single resolved HVF MMIO
 exit dispatch/completion through runtime handlers, explicit runner-thread MMIO
-handling commands, narrow vCPU register wrappers, internal macOS 15+ HVF GIC v3 boot metadata without MSI/ITS, HVF SPI interrupt-line allocation and signaling, minimal internal
+handling commands, narrow vCPU register wrappers, internal macOS 15+ HVF GIC v3 boot metadata with an explicitly opt-in public-HVF GICv2m MSI frame but without ITS or PCI MSI-X, HVF SPI interrupt-line allocation and signaling, minimal internal
 arm64 FDT generation with optional RTC, serial, VMGenID, and virtio-mmio device-node descriptors and guest-memory writes, anonymous guest memory allocation
 for validated runtime layouts, HVF guest memory map/unmap ownership and
 controlled mapped-memory access for allocated regions, an internal MMIO region ownership registry and operation/data
@@ -92,6 +92,34 @@ recorded as pre-boot VM state and applied during startup preparation. Runtime
 `PATCH /drives/{drive_id}` can refresh the backing file of an existing active
 virtio-block device through the process-owned boot session, but public
 block-device attachment, boot selection changes, and hotplug remain deferred.
+
+## Internal GICv2m MSI Foundation
+
+On macOS 15 and later, an internal boot-session option may request a nonzero,
+demand-sized MSI interrupt range from Hypervisor.framework's public GIC API.
+The backend lazily loads the MSI-specific symbols only for that path, configures
+the host-reported frame, and partitions the host SPI range into a nonempty
+legacy prefix and a distinct MSI suffix. The pinned Linux GICv2m driver treats
+INTID 1019 as its exclusive upper boundary, so neither allocator advertises
+that terminal SPI even when HVF reports it. The ordinary GIC constructor,
+process startup path, and FDT remain unchanged and MSI-free.
+
+An enabled session advertises one `arm,gic-v2m-frame` child below the GICv3 FDT
+node and retains a typed allocator plus a serialized, send-only signaler. The
+message address is derived from the validated frame and its GICv2m `SETSPI`
+offset; callers supply only an interrupt allocated from the exact retained
+range. Message details stay out of `Debug` and errors. A failed send is
+nontransactional: callers cannot infer whether the guest observed the message
+and must apply device-specific retry or failure policy. VM teardown takes the
+same sender lock, waits for an in-flight call, and revokes every retained clone
+before unmapping or destroying VM-owned resources.
+
+This foundation is not Firecracker's KVM-backed GICv3 ITS implementation. It
+adds no public API or CLI control, PCI host bridge, enumeration, BAR layout,
+MSI/MSI-X table emulation, guest-programmed message routing, interrupt remapping,
+or guest PCI delivery claim. It is also outside the accepted native-v1 snapshot
+profile, which rejects MSI-bearing GIC metadata. The capability inventory is
+therefore not promoted by this internal foundation alone.
 
 ## Internal PSCI Power Sessions
 
@@ -2049,9 +2077,15 @@ FDT shape but does not imply PCI device support.
 Direct FDT configuration still validates that `bootargs` fits in the 2048-byte
 aarch64 command-line capacity including the trailing NUL byte and contains no
 embedded NUL bytes. The GIC node consumes backend-neutral distributor and
-redistributor metadata, advertises `arm,gic-v3`, and does not emit an ITS/MSI
-child while the HVF metadata has no MSI support. The FDT builder rejects empty
-or oversized CPU sets, duplicate CPU `reg` values, initrd ranges outside
+redistributor metadata and advertises `arm,gic-v3`. MSI-free metadata emits no
+MSI child or GICv3 MBI/ITS property. Optional HVF MSI metadata instead emits one
+hardware-described `arm,gic-v2m-frame` child with its own `msi-controller`,
+phandle, and exact MMIO `reg`; it deliberately emits no software range
+overrides. The builder requires the frame to contain the GICv2m TYPER, SETSPI,
+and IIDR registers, restricts its SPI range to Linux's accepted domain ending
+before INTID 1019, and rejects overlap with GIC, guest-memory, and device MMIO.
+The FDT builder also rejects empty or oversized CPU sets, duplicate CPU `reg`
+values, initrd ranges outside
 guest-advertised memory or overlapping the reserved FDT window, and GIC MMIO
 regions that are invalid, overlap each other, or overlap guest RAM. It also
 rejects unexpected GIC compatibility strings and PPI collisions between the GIC
@@ -2318,8 +2352,20 @@ against that supported range before setting explicit GIC SPI levels with
 `hv_gic_set_spi`. A narrow internal PPI pending primitive validates real GIC
 PPI INTIDs before writing `GICR_ISPENDR0` or `GICR_ICPENDR0` through
 `hv_gic_set_redistributor_reg` on the vCPU-owning thread. HVF timer INTIDs are
-converted to FDT PPI cells for the runtime timer node, and MSI/ITS metadata is
-intentionally absent until a later device path needs it.
+converted to FDT PPI cells for the runtime timer node.
+An explicit internal boot option additionally loads only the public HVF MSI
+geometry/configuration/send symbols, places the GICM region below the
+redistributor, and reserves a demand-sized message-only SPI suffix while
+preserving one contiguous legacy prefix. HVF reports SPIs 32 through 1019 on
+the tested host, but Linux's GICv2m driver rejects a frame reaching 1019, so the
+partition leaves that terminal INTID unallocatable and reserves downward from
+1018. Typed allocator tokens retain range provenance, and the cloneable,
+mutex-serialized sender accepts only a token from its exact configured range
+before calling `hv_gic_send_msi` at the frame's SETSPI address. Configuration,
+metadata, tokens, allocator state, and sender diagnostics redact counts,
+addresses, and INTIDs. Default creation does not query or publish MSI state;
+there is no GICv3 MBI/ITS claim, public API selection, PCI/MSI-X device
+composition, or delivery rollback guarantee.
 Separately, typed owner-thread HVF commands get or set CPU-level IRQ/FIQ pending
 injection levels, capture both in IRQ-then-FIQ order, and reapply the complete
 typed value in that same order. Those levels are not GIC state and HVF clears

--- a/docs/security.md
+++ b/docs/security.md
@@ -1509,6 +1509,28 @@ committed with cleanup uncertain. No claim is made that three split filenames
 are one crash-atomic transaction. Normal success leaves only complete final
 files and no private stages.
 
+## Public-HVF GICv2m Capability Boundary
+
+The macOS 15+ GICv2m path is an internal, explicit startup opt-in. MSI-specific
+Hypervisor.framework symbols are loaded only after that opt-in, and the default
+backend, public process configuration, and guest FDT expose no MSI controller.
+The configured frame and interrupt range are validated before publication; the
+legacy and MSI allocators are disjoint, INTID 1019 is kept outside the pinned
+Linux driver's usable domain, and the send address is derived internally from
+the frame's `SETSPI` register. The send-only capability accepts only an opaque
+typed value produced by its matching allocator, serializes host calls, and
+redacts message details from diagnostics. VM teardown waits on that same send
+lock and revokes all clones before releasing VM-owned resources, so a stale
+capability cannot target a later VM in the process.
+
+Hypervisor.framework does not make message delivery transactional. A returned
+error cannot prove that the guest did not observe the interrupt, so a future
+device owner must define its own retry and teardown policy. Current signed
+coverage separately proves raw host-to-vCPU delivery and pinned-Linux GICv2m
+domain discovery; it does not prove PCI enumeration, MSI/MSI-X programming,
+interrupt remapping, or Firecracker's KVM ITS behavior. MSI-bearing GIC metadata
+is rejected by the native-v1 snapshot profile rather than silently omitted.
+
 ## HVF Entitlements
 
 Real Hypervisor.framework execution requires macOS support, Apple Silicon, and

--- a/docs/snapshot-feasibility.md
+++ b/docs/snapshot-feasibility.md
@@ -22,6 +22,10 @@ path.
 - Create is paused-state-only and supports only `Full` for one vCPU, exactly
   one regular read-only root drive, default serial, and no optional devices or
   MMDS. Unsupported modes and profiles fail before artifact or capture work.
+- The optional internal GICv2m foundation is outside native-v1. Capture and
+  load validation reject MSI-bearing GIC metadata; the frame, reserved range,
+  allocator state, and any delivered or in-flight message are not persisted or
+  inferred during restore.
 - An admitted create holds one scoped supervisor transaction from FIFO
   admission through publication. It failure-atomically quiesces block, PMEM,
   network, and entropy retry schedulers, preflights both final namespaces,
@@ -298,7 +302,11 @@ added; Wave 6 owns any broader template-bearing profile.
 Construction and decode cross-check the machine memory size and one canonical
 DRAM range against the memory binding, the primary MPIDR against CPU identity,
 optional-feature absence/inactivity, the baseline GIC topology, fixed RTC
-mapping, and every nested device queue/platform range. The cache values come
+mapping, and every nested device queue/platform range. The native-v1
+compatibility gate requires MSI-free GIC metadata; an opt-in GICv2m session is
+rejected before capture publication or destination construction because no
+message-delivery or consuming-device state belongs to this profile. The cache
+values come
 from one retained default `hv_vcpu_config_t`; they describe same-environment
 compatibility and are not a cross-host portability claim. The opaque GIC blob
 is bounded before allocation and can still be rejected by Hypervisor.framework
@@ -960,6 +968,9 @@ some of the required state:
   and SPI state access and interrupt injection primitives. They also expose a
   retained state object whose stable, versioned opaque bytes cover the GIC
   device except separately captured CPU system registers.
+  The implemented internal MSI foundation configures HVF's GICM region as a
+  Linux GICv2m frame and exposes a range-bound send capability, but it does not
+  add device state, delivery rollback, or portable migration semantics.
 
 The inspected headers do not expose a KVM-style dirty log or dirty-page tracking
 API, so Firecracker-style diff snapshot parity is not a direct HVF API mapping.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -55,6 +55,20 @@ must run through
 `com.apple.security.hypervisor` entitlement. Do not add real HVF tests to the
 unsigned workspace test path.
 
+HVF GIC MSI changes require two complementary signed gates. The focused
+`hvf_lifecycle` test must create an opt-in GIC, prove the Linux-incompatible
+terminal INTID 1019 is not allocated, send the range-provenance token through
+the real `hv_gic_send_msi`, and observe that exact INTID through guest
+`ICC_IAR1_EL1` with a bounded cancellation fallback. The focused `guest_boot`
+test must parse the pre-run FDT, require one hardware-described
+`arm,gic-v2m-frame` child and no GICv3 MBI/ITS properties, boot the pinned
+Firecracker kernel, and match Linux's exact GICv2m SPI range. Unit tests must
+cover opt-in/default separation, dynamic-symbol loading, configuration order
+and cleanup, geometry/overlap/range validation, the 1019 guard, allocator
+exhaustion/provenance, sender serialization/errors/redaction, teardown
+revocation of retained clones, and FDT publication without raw values in
+formatted failures.
+
 Ordered HVF vCPU-topology changes require a signed `hvf_lifecycle` baseline
 that creates one VM and GIC before two permanent owner-thread runners, proves
 their exact ordered MPIDRs are `[0, 1]`, cancels both before their first bounded


### PR DESCRIPTION
## Summary

- add an internal, explicitly opt-in macOS 15+ HVF GICv2m MSI-frame profile
- partition a demand-sized MSI suffix below Linux's INTID 1019 boundary while preserving a disjoint legacy SPI allocator
- expose provenance-bound MSI allocation and serialized send-only delivery that is revoked before VM teardown
- publish the real hardware-described `arm,gic-v2m-frame` FDT child without MBI, ITS, or software range overrides
- cover raw host-to-vCPU delivery, pinned Linux V2M discovery, default-path compatibility, validation, redaction, and teardown behavior

## Scope exclusions

- no public CLI or API selection
- no PCI host bridge, enumeration, BARs, virtio-pci, or guest-programmed MSI/MSI-X
- no KVM ITS compatibility claim
- no native-v1 snapshot support for MSI-bearing GIC metadata

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five Apple-target integration-test Clippy commands from `AGENTS.md`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- signed Apple Silicon HVF lifecycle: 53 passed
- signed pinned-kernel guest boot: 20 passed, including exact GICv2m discovery
- signed executable HVF boundary: 45 passed
- signed App Sandbox process boundary: 6 passed
- signed production bundle boundary: 36 passed

Closes #1414

Parent: #1410
