### PR TITLE
feat: add PCI segment and address-space leases

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,19 @@ the requested interrupt range from the top of Linux's usable GICv2m SPI domain,
 keeps the legacy SPI allocator disjoint, advertises an `arm,gic-v2m-frame` FDT
 child, and retains a typed send-only capability. Ordinary process startup and
 its FDT remain MSI-free. This is not Firecracker's KVM ITS path, does not expose
-a CLI or API switch, and does not implement PCI enumeration or guest-programmed
-MSI-X. Signed gates prove raw delivery of INTID 1018 and pinned Firecracker
-Linux discovery of the exact `SPI[1018:1018]` frame; native-v1 rejects
-MSI-bearing GIC metadata.
+a CLI or API switch, and does not implement guest-programmed MSI-X. Signed
+gates prove raw delivery of INTID 1018 and pinned Firecracker Linux discovery
+of the exact `SPI[1018:1018]` frame; native-v1 rejects MSI-bearing GIC metadata.
+
+An additional validation-only boot-session option composes a backend-neutral
+PCI segment-0/bus-0 foundation with that frame. It reserves Firecracker's
+configuration and 32/64-bit BAR apertures, publishes a 1 MiB ECAM window through
+an atomically owned MMIO lease, and emits a generic ECAM FDT host. The pinned
+Linux gate enumerates the fixed `[8086:0d57]` host bridge and one identity-only
+`[0042:0000]` test endpoint from Firecracker's pinned PCI mock. Default process
+startup remains byte-for-byte PCI-free: there is no public flag or API path,
+modern virtio-pci device,
+guest-programmed MSI/MSI-X delivery, hotplug, or PCI snapshot state yet.
 
 ## Layout
 

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -51,7 +51,7 @@ use bangbang_runtime::startup::{
     Arm64BootMemoryHotplugNotificationDispatch, Arm64BootMemoryHotplugNotificationDispatchError,
     Arm64BootMemoryHotplugNotificationDispatches, Arm64BootNetworkNotificationDispatch,
     Arm64BootNetworkNotificationDispatchError, Arm64BootNetworkNotificationDispatches,
-    Arm64BootNetworkPacketIoProvider, Arm64BootPmemFlushProvider,
+    Arm64BootNetworkPacketIoProvider, Arm64BootPciValidationConfig, Arm64BootPmemFlushProvider,
     Arm64BootPmemNotificationDispatch, Arm64BootPmemNotificationDispatchError,
     Arm64BootPmemNotificationDispatches, Arm64BootResourceConfig, Arm64BootResourceError,
     Arm64BootResourceParts, Arm64BootResources,
@@ -128,6 +128,7 @@ pub struct HvfArm64BootSessionConfig {
     pub memory_hotplug_device: Option<HvfArm64BootMemoryHotplugDeviceConfig>,
     pub serial_device: Option<HvfArm64BootSerialDeviceConfig>,
     pub gic_msi: Option<HvfGicMsiConfiguration>,
+    pub pci_validation: Option<Arm64BootPciValidationConfig>,
 }
 
 impl HvfArm64BootSessionConfig {
@@ -150,6 +151,7 @@ impl HvfArm64BootSessionConfig {
             memory_hotplug_device: None,
             serial_device: None,
             gic_msi: None,
+            pci_validation: None,
         }
     }
 
@@ -196,6 +198,16 @@ impl HvfArm64BootSessionConfig {
     /// guest-programmed MSI-X remain outside this startup profile.
     pub const fn with_gic_msi(mut self, configuration: HvfGicMsiConfiguration) -> Self {
         self.gic_msi = Some(configuration);
+        self
+    }
+
+    /// Adds the internal endpoint used by the signed Linux PCI enumeration test.
+    ///
+    /// This requires the same configuration to opt into GICv2m with
+    /// [`Self::with_gic_msi`]. It does not expose PCI through the production
+    /// process configuration.
+    pub const fn with_pci_validation(mut self, validation: Arm64BootPciValidationConfig) -> Self {
+        self.pci_validation = Some(validation);
         self
     }
 }
@@ -8155,38 +8167,40 @@ fn prepare_arm64_boot_session_parts_with_cache<'vm>(
         .memory_hotplug_device
         .zip(interrupt_lines.memory_hotplug)
         .map(|(memory_hotplug, interrupt_line)| memory_hotplug.into_runtime(interrupt_line));
-    let resources = Arm64BootResources::assemble_from_controller_with_startup_resources(
-        controller,
-        Arm64BootResourceConfig {
-            vcpu_mpidrs: &mpidrs,
-            cache_hierarchy,
-            gic: gic.arm64_fdt_gic(),
-            timer,
-            rtc_device: Some(RuntimeArm64BootRtcDeviceConfig::new(config.rtc_mmio_layout)),
-            serial_device: runtime_serial,
-            vmgenid_interrupt_line: interrupt_lines.vmgenid,
-            vmclock_interrupt_line: interrupt_lines.vmclock,
-            block_mmio_layout: config.block_mmio_layout,
-            block_interrupt_lines: &interrupt_lines.block,
-            pmem_mmio_layout: config.pmem_mmio_layout,
-            pmem_interrupt_lines: &interrupt_lines.pmem,
-            network_mmio_layout: config.network_mmio_layout,
-            network_interrupt_lines: &interrupt_lines.network,
-            vsock_mmio_layout: config.vsock_mmio_layout,
-            vsock_interrupt_line: interrupt_lines.vsock,
-            balloon_mmio_layout: config
-                .balloon_device
-                .map(|balloon| balloon.mmio_layout)
-                .unwrap_or_else(|| {
-                    BalloonMmioLayout::new(GuestAddress::new(0), MmioRegionId::new(0))
-                }),
-            balloon_interrupt_line: interrupt_lines.balloon,
-            memory_hotplug_device: runtime_memory_hotplug,
-            entropy_device: runtime_entropy,
-        },
-        startup_resources,
-    )
-    .map_err(|source| HvfArm64BootSessionError::AssembleResources { source })?;
+    let resources =
+        Arm64BootResources::assemble_from_controller_with_startup_resources_and_pci_validation(
+            controller,
+            Arm64BootResourceConfig {
+                vcpu_mpidrs: &mpidrs,
+                cache_hierarchy,
+                gic: gic.arm64_fdt_gic(),
+                timer,
+                rtc_device: Some(RuntimeArm64BootRtcDeviceConfig::new(config.rtc_mmio_layout)),
+                serial_device: runtime_serial,
+                vmgenid_interrupt_line: interrupt_lines.vmgenid,
+                vmclock_interrupt_line: interrupt_lines.vmclock,
+                block_mmio_layout: config.block_mmio_layout,
+                block_interrupt_lines: &interrupt_lines.block,
+                pmem_mmio_layout: config.pmem_mmio_layout,
+                pmem_interrupt_lines: &interrupt_lines.pmem,
+                network_mmio_layout: config.network_mmio_layout,
+                network_interrupt_lines: &interrupt_lines.network,
+                vsock_mmio_layout: config.vsock_mmio_layout,
+                vsock_interrupt_line: interrupt_lines.vsock,
+                balloon_mmio_layout: config
+                    .balloon_device
+                    .map(|balloon| balloon.mmio_layout)
+                    .unwrap_or_else(|| {
+                        BalloonMmioLayout::new(GuestAddress::new(0), MmioRegionId::new(0))
+                    }),
+                balloon_interrupt_line: interrupt_lines.balloon,
+                memory_hotplug_device: runtime_memory_hotplug,
+                entropy_device: runtime_entropy,
+            },
+            startup_resources,
+            config.pci_validation,
+        )
+        .map_err(|source| HvfArm64BootSessionError::AssembleResources { source })?;
     let boot_registers = HvfArm64BootRegisters {
         kernel_entry: resources.loaded_boot_source.kernel.entry_address,
         fdt_address: resources.fdt.address,
@@ -8555,10 +8569,10 @@ mod tests {
         Arm64BootMemoryHotplugDeviceConfig, Arm64BootMemoryHotplugNotificationDispatches,
         Arm64BootNetworkNotificationDispatches, Arm64BootNetworkNotificationOutcome,
         Arm64BootNetworkPacketIo, Arm64BootNetworkPacketIoError, Arm64BootNetworkPacketIoProvider,
-        Arm64BootPmemFlushProvider, Arm64BootPmemNotificationDispatches, Arm64BootResourceConfig,
-        Arm64BootResources, Arm64BootRuntimeResources, Arm64BootVmGenIdDevice,
-        Arm64BootVmGenIdReplacementError, Arm64BootVsockNotificationDispatches,
-        update_memory_hotplug_config_for_device,
+        Arm64BootPciValidationConfig, Arm64BootPmemFlushProvider,
+        Arm64BootPmemNotificationDispatches, Arm64BootResourceConfig, Arm64BootResources,
+        Arm64BootRuntimeResources, Arm64BootVmGenIdDevice, Arm64BootVmGenIdReplacementError,
+        Arm64BootVsockNotificationDispatches, update_memory_hotplug_config_for_device,
     };
     use bangbang_runtime::virtio_mmio::{
         VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DRIVER,
@@ -17122,7 +17136,7 @@ mod tests {
     }
 
     #[test]
-    fn session_config_opts_into_gic_msi_without_changing_the_default() {
+    fn session_config_opts_into_internal_platform_validation_without_changing_the_default() {
         let default = HvfArm64BootSessionConfig::new(
             BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1)),
             PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500)),
@@ -17135,9 +17149,15 @@ mod tests {
         );
 
         assert_eq!(default.gic_msi, None);
+        assert_eq!(default.pci_validation, None);
         assert_eq!(
-            default.with_gic_msi(configuration).gic_msi,
+            default.clone().with_gic_msi(configuration).gic_msi,
             Some(configuration)
+        );
+        let validation = Arm64BootPciValidationConfig::firecracker_test_endpoint();
+        assert_eq!(
+            default.with_pci_validation(validation).pci_validation,
+            Some(validation)
         );
     }
 

--- a/crates/hvf/tests/guest_boot.rs
+++ b/crates/hvf/tests/guest_boot.rs
@@ -153,6 +153,44 @@ fn boots_firecracker_kernel_with_the_advertised_gicv2m_frame() {
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 #[test]
+fn boots_firecracker_kernel_and_enumerates_the_internal_pci_segment() {
+    use std::num::NonZeroU32;
+
+    use bangbang_hvf::HvfGicMsiConfiguration;
+    use bangbang_runtime::startup::Arm64BootPciValidationConfig;
+
+    let _test_lock = GUEST_BOOT_TEST_LOCK
+        .lock()
+        .expect("guest boot integration test lock should not be poisoned");
+    let initrd_path = env_path("BANGBANG_GUEST_INITRD_PATH");
+    let observation = run_guest_boot_with_boot_source_gic_msi_and_pci_validation(
+        "guest-pci-enumeration",
+        BOOT_MARKER,
+        Some(initrd_path),
+        INITRD_BOOT_ARGS,
+        Some(HvfGicMsiConfiguration::new(
+            NonZeroU32::new(1).expect("test MSI count should be nonzero"),
+        )),
+        Some(Arm64BootPciValidationConfig::firecracker_test_endpoint()),
+        |_| {},
+    );
+
+    assert_guest_boot_observed_marker(&observation, BOOT_MARKER, "boot marker");
+    for identity in [
+        b"pci 0000:00:00.0: [8086:0d57]",
+        b"pci 0000:00:01.0: [0042:0000]",
+    ] {
+        assert!(
+            bytes_contain_marker(&observation.serial_bytes, identity),
+            "pinned Linux did not enumerate PCI identity {:?}\nserial output:\n{}",
+            String::from_utf8_lossy(identity),
+            String::from_utf8_lossy(&observation.serial_bytes)
+        );
+    }
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
 fn boots_firecracker_kernel_and_executes_userspace_on_secondary_cpu() {
     use bangbang_runtime::VmmAction;
     use bangbang_runtime::cpu::{
@@ -858,6 +896,27 @@ fn run_guest_boot_with_boot_source_and_gic_msi(
     gic_msi: Option<bangbang_hvf::HvfGicMsiConfiguration>,
     configure_controller: impl FnOnce(&mut bangbang_runtime::VmmController),
 ) -> GuestBootObservation {
+    run_guest_boot_with_boot_source_gic_msi_and_pci_validation(
+        instance_id,
+        marker,
+        initrd_path,
+        boot_args,
+        gic_msi,
+        None,
+        configure_controller,
+    )
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn run_guest_boot_with_boot_source_gic_msi_and_pci_validation(
+    instance_id: &str,
+    marker: &[u8],
+    initrd_path: Option<std::path::PathBuf>,
+    boot_args: &str,
+    gic_msi: Option<bangbang_hvf::HvfGicMsiConfiguration>,
+    pci_validation: Option<bangbang_runtime::startup::Arm64BootPciValidationConfig>,
+    configure_controller: impl FnOnce(&mut bangbang_runtime::VmmController),
+) -> GuestBootObservation {
     use std::num::NonZeroUsize;
     use std::time::Instant;
 
@@ -904,6 +963,10 @@ fn run_guest_boot_with_boot_source_and_gic_msi(
     ));
     let config = match gic_msi {
         Some(configuration) => config.with_gic_msi(configuration),
+        None => config,
+    };
+    let config = match pci_validation {
+        Some(validation) => config.with_pci_validation(validation),
         None => config,
     };
     let mut session = OwnedHvfArm64BootSession::new(&controller, config)
@@ -1770,6 +1833,64 @@ fn validate_pre_run_boot_metadata(
             assert!(!intc.has_prop("#msi-cells"));
             assert!(intc.children.is_empty());
         }
+    }
+
+    match resources.pci_validation.as_ref() {
+        Some(validation) => {
+            assert_eq!(
+                validation
+                    .segment()
+                    .with_segment(|segment| segment.function_count())
+                    .expect("PCI validation segment should remain accessible"),
+                2,
+                "PCI validation segment should retain the host bridge and endpoint"
+            );
+            let pci = tree
+                .find("/pci@70000000")
+                .expect("PCI validation FDT should contain the ECAM host node");
+            assert_eq!(pci.prop_str("compatible").unwrap(), "pci-host-ecam-generic");
+            assert_eq!(pci.prop_str("device_type").unwrap(), "pci");
+            assert_eq!(prop_u64_cells(pci, "reg"), [0x7000_0000, 0x10_0000]);
+            assert_eq!(prop_u32_cells(pci, "bus-range"), [0, 0]);
+            assert_eq!(pci.prop_u32("linux,pci-domain").unwrap(), 0);
+            assert_eq!(pci.prop_u32("#address-cells").unwrap(), 3);
+            assert_eq!(pci.prop_u32("#size-cells").unwrap(), 2);
+            assert_eq!(pci.prop_u32("#interrupt-cells").unwrap(), 1);
+            assert_eq!(pci.prop_u32("msi-parent").unwrap(), 3);
+            assert_eq!(
+                prop_u32_cells(pci, "ranges"),
+                [
+                    0x0200_0000,
+                    0,
+                    0x4000_3000,
+                    0,
+                    0x4000_3000,
+                    0,
+                    0x2fff_d000,
+                    0x0300_0000,
+                    0x40,
+                    0,
+                    0x40,
+                    0,
+                    0x40,
+                    0,
+                ]
+            );
+            for property in ["interrupt-map", "interrupt-map-mask", "dma-coherent"] {
+                assert!(
+                    pci.prop_raw(property)
+                        .expect("empty PCI property should exist")
+                        .is_empty()
+                );
+            }
+            assert!(!pci.has_prop("msi-map"));
+            assert!(!pci.has_prop("iommu-map"));
+            assert!(tree.find("/intc/its").is_none());
+        }
+        None => assert!(
+            tree.find("/pci@70000000").is_none(),
+            "ordinary guest boot should not publish PCI"
+        ),
     }
 
     assert_eq!(session.vcpu_count(), diagnostics.vcpu_mpidrs.len());

--- a/crates/runtime/src/fdt.rs
+++ b/crates/runtime/src/fdt.rs
@@ -6286,6 +6286,131 @@ mod tests {
     }
 
     #[test]
+    fn pci_host_rejects_malformed_overflowing_and_overlapping_ranges() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let config = Arm64FdtConfig {
+            gic: Arm64FdtGic {
+                msi: Some(test_msi()),
+                ..test_gic()
+            },
+            ..test_config(
+                &layout,
+                Arm64FdtBootInfo {
+                    command_line: "panic=1",
+                    initrd: None,
+                },
+            )
+        };
+
+        let mut host = test_pci_host();
+        host.ecam.size = 0;
+        assert!(matches!(
+            build_test_arm64_fdt_with_pci(&config, host),
+            Err(Arm64FdtError::InvalidPciHostRange { name: "ECAM", .. })
+        ));
+
+        let mut host = test_pci_host();
+        host.bar64 = Arm64FdtRegion {
+            base: u64::MAX - 1,
+            size: 2,
+        };
+        assert!(matches!(
+            build_test_arm64_fdt_with_pci(&config, host),
+            Err(Arm64FdtError::InvalidPciHostRange {
+                name: "64-bit BAR",
+                ..
+            })
+        ));
+
+        let mut host = test_pci_host();
+        host.segment = 1;
+        assert!(matches!(
+            build_test_arm64_fdt_with_pci(&config, host),
+            Err(Arm64FdtError::InvalidPciHost {
+                reason: "only segment 0 is supported"
+            })
+        ));
+
+        let mut host = test_pci_host();
+        host.bus_end = 1;
+        assert!(matches!(
+            build_test_arm64_fdt_with_pci(&config, host),
+            Err(Arm64FdtError::InvalidPciHost {
+                reason: "only bus range 0 through 0 is supported"
+            })
+        ));
+
+        let mut host = test_pci_host();
+        host.ecam.size /= 2;
+        assert!(matches!(
+            build_test_arm64_fdt_with_pci(&config, host),
+            Err(Arm64FdtError::InvalidPciHost {
+                reason: "bus-0 ECAM size must be 1 MiB"
+            })
+        ));
+
+        let mut host = test_pci_host();
+        host.ecam_reservation.size /= 2;
+        assert!(matches!(
+            build_test_arm64_fdt_with_pci(&config, host),
+            Err(Arm64FdtError::InvalidPciHost {
+                reason: "ECAM reservation size must be 256 MiB"
+            })
+        ));
+
+        let mut host = test_pci_host();
+        host.ecam.base += 0x1000;
+        host.ecam_reservation.base += 0x1000;
+        assert!(matches!(
+            build_test_arm64_fdt_with_pci(&config, host),
+            Err(Arm64FdtError::InvalidPciHost {
+                reason: "ECAM base must be aligned to its 1 MiB bus window"
+            })
+        ));
+
+        let mut host = test_pci_host();
+        host.ecam.base += PCI_ECAM_BUS_ZERO_SIZE;
+        assert!(matches!(
+            build_test_arm64_fdt_with_pci(&config, host),
+            Err(Arm64FdtError::InvalidPciHost {
+                reason: "published ECAM window must begin the reserved configuration aperture"
+            })
+        ));
+
+        let mut host = test_pci_host();
+        host.bar32 = Arm64FdtRegion {
+            base: 0xffff_f000,
+            size: 0x2000,
+        };
+        assert!(matches!(
+            build_test_arm64_fdt_with_pci(&config, host),
+            Err(Arm64FdtError::InvalidPciHost {
+                reason: "32-bit BAR window exceeds the 32-bit address space"
+            })
+        ));
+
+        let mut host = test_pci_host();
+        host.bar32 = host.ecam_reservation;
+        assert!(matches!(
+            build_test_arm64_fdt_with_pci(&config, host),
+            Err(Arm64FdtError::PciHostRangesOverlap {
+                first: "32-bit BAR",
+                second: "ECAM reservation"
+            })
+        ));
+
+        let mut host = test_pci_host();
+        host.bar64 = config.gic.distributor;
+        assert!(matches!(
+            build_test_arm64_fdt_with_pci(&config, host),
+            Err(Arm64FdtError::PciHostRangeOverlapsGic {
+                name: "64-bit BAR",
+                gic: "distributor"
+            })
+        ));
+    }
+
+    #[test]
     fn no_pci_fdt_path_preserves_existing_bytes() {
         let layout = test_layout(TEST_MEMORY_SIZE);
         let config = test_config(

--- a/crates/runtime/src/fdt.rs
+++ b/crates/runtime/src/fdt.rs
@@ -10,6 +10,10 @@ use crate::memory::{
     GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryError, GuestMemoryLayout,
     GuestMemoryRange, aarch64,
 };
+use crate::pci::{
+    Arm64PciAddressPlan, PCI_BUS_ZERO, PCI_ECAM_BUS_ZERO_SIZE, PCI_ECAM_RESERVED_SIZE,
+    PCI_SEGMENT_ZERO,
+};
 
 const ROOT_COMPATIBILITY: &str = "linux,dummy-virt";
 const GIC_PHANDLE: u32 = 1;
@@ -398,6 +402,13 @@ pub struct Arm64FdtRegion {
     pub size: u64,
 }
 
+const fn fdt_region_from_range(range: GuestMemoryRange) -> Arm64FdtRegion {
+    Arm64FdtRegion {
+        base: range.start().raw_value(),
+        size: range.size(),
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Arm64FdtInterruptRange {
     pub base: u32,
@@ -408,6 +419,31 @@ pub struct Arm64FdtInterruptRange {
 pub struct Arm64FdtMsi {
     pub region: Arm64FdtRegion,
     pub interrupt_range: Arm64FdtInterruptRange,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Arm64FdtPciHost {
+    pub segment: u16,
+    pub bus_start: u8,
+    pub bus_end: u8,
+    pub ecam: Arm64FdtRegion,
+    pub ecam_reservation: Arm64FdtRegion,
+    pub bar32: Arm64FdtRegion,
+    pub bar64: Arm64FdtRegion,
+}
+
+impl Arm64FdtPciHost {
+    pub fn from_address_plan(plan: Arm64PciAddressPlan) -> Self {
+        Self {
+            segment: PCI_SEGMENT_ZERO,
+            bus_start: PCI_BUS_ZERO,
+            bus_end: PCI_BUS_ZERO,
+            ecam: fdt_region_from_range(plan.ecam()),
+            ecam_reservation: fdt_region_from_range(plan.ecam_reservation()),
+            bar32: fdt_region_from_range(plan.bar32()),
+            bar64: fdt_region_from_range(plan.bar64()),
+        }
+    }
 }
 
 impl fmt::Debug for Arm64FdtMsi {
@@ -635,6 +671,31 @@ pub enum Arm64FdtError {
         other: &'static str,
     },
     GicMsiRegionOverlapsMemory,
+    InvalidPciHost {
+        reason: &'static str,
+    },
+    InvalidPciHostRange {
+        name: &'static str,
+        region: Arm64FdtRegion,
+        source: GuestMemoryError,
+    },
+    PciHostRangesOverlap {
+        first: &'static str,
+        second: &'static str,
+    },
+    PciHostRangeOverlapsMemory {
+        name: &'static str,
+        memory_range: GuestMemoryRange,
+    },
+    PciHostRangeOverlapsGic {
+        name: &'static str,
+        gic: &'static str,
+    },
+    PciHostRangeOverlapsDevice {
+        name: &'static str,
+        device: &'static str,
+        device_region: Arm64FdtRegion,
+    },
     InvalidVirtioMmioRegion {
         index: usize,
         region: Arm64FdtRegion,
@@ -902,6 +963,37 @@ impl fmt::Display for Arm64FdtError {
             Self::GicMsiRegionOverlapsMemory => {
                 f.write_str("arm64 FDT GICv2m frame overlaps guest memory")
             }
+            Self::InvalidPciHost { reason } => {
+                write!(f, "invalid arm64 FDT PCI host: {reason}")
+            }
+            Self::InvalidPciHostRange {
+                name,
+                region,
+                source,
+            } => write!(
+                f,
+                "invalid arm64 FDT PCI {name} range base=0x{:x}, size={}: {source}",
+                region.base, region.size
+            ),
+            Self::PciHostRangesOverlap { first, second } => {
+                write!(f, "arm64 FDT PCI {first} range overlaps {second} range")
+            }
+            Self::PciHostRangeOverlapsMemory { name, memory_range } => write!(
+                f,
+                "arm64 FDT PCI {name} range overlaps guest memory range {memory_range}"
+            ),
+            Self::PciHostRangeOverlapsGic { name, gic } => {
+                write!(f, "arm64 FDT PCI {name} range overlaps GIC {gic} region")
+            }
+            Self::PciHostRangeOverlapsDevice {
+                name,
+                device,
+                device_region,
+            } => write!(
+                f,
+                "arm64 FDT PCI {name} range overlaps {device} region base=0x{:x}, size={}",
+                device_region.base, device_region.size
+            ),
             Self::InvalidVirtioMmioRegion {
                 index,
                 region,
@@ -1136,6 +1228,7 @@ impl std::error::Error for Arm64FdtError {
             Self::InvalidRtcRegion { source, .. } => Some(source),
             Self::InvalidVmGenIdRegion { source, .. } => Some(source),
             Self::InvalidVmClockRegion { source, .. } => Some(source),
+            Self::InvalidPciHostRange { source, .. } => Some(source),
             Self::RngSeed { source } => Some(source),
             Self::CreateFdt { source } => Some(source),
             Self::GuestMemoryWrite { source } => Some(source),
@@ -1161,6 +1254,11 @@ impl std::error::Error for Arm64FdtError {
             | Self::InvalidGicMsiInterruptRange
             | Self::GicMsiRegionOverlaps { .. }
             | Self::GicMsiRegionOverlapsMemory
+            | Self::InvalidPciHost { .. }
+            | Self::PciHostRangesOverlap { .. }
+            | Self::PciHostRangeOverlapsMemory { .. }
+            | Self::PciHostRangeOverlapsGic { .. }
+            | Self::PciHostRangeOverlapsDevice { .. }
             | Self::VirtioMmioRegionOverlapsMemory { .. }
             | Self::VirtioMmioRegionOverlapsGic { .. }
             | Self::VirtioMmioRegionsOverlap { .. }
@@ -1209,11 +1307,20 @@ impl From<Arm64FdtCacheHierarchyError> for Arm64FdtError {
 #[derive(Debug)]
 struct ValidatedArm64FdtConfig {
     memory_reg_cells: Vec<u64>,
+    pci_host: Option<ValidatedArm64FdtPciHost>,
     rtc_device: Option<ValidatedArm64FdtRtcDevice>,
     serial_device: Option<ValidatedArm64FdtSerialDevice>,
     vmgenid_device: Option<ValidatedArm64FdtVmGenIdDevice>,
     vmclock_device: Option<ValidatedArm64FdtVmClockDevice>,
     virtio_mmio_devices: Vec<ValidatedArm64FdtVirtioMmioDevice>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ValidatedArm64FdtPciHost {
+    host: Arm64FdtPciHost,
+    ecam: GuestMemoryRange,
+    bar32: GuestMemoryRange,
+    bar64: GuestMemoryRange,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1239,6 +1346,7 @@ struct ValidatedArm64FdtVmGenIdDevice {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ValidatedArm64FdtVmClockDevice {
     region: Arm64FdtRegion,
+    range: GuestMemoryRange,
     interrupt_cell: u32,
 }
 
@@ -1255,6 +1363,18 @@ pub fn build_arm64_fdt(config: &Arm64FdtConfig<'_>) -> Result<Vec<u8>, Arm64FdtE
     build_arm64_fdt_with_rng_seed_source(config, &mut rng_seed_source)
 }
 
+pub fn build_arm64_fdt_with_pci(
+    config: &Arm64FdtConfig<'_>,
+    pci_host: Arm64FdtPciHost,
+) -> Result<Vec<u8>, Arm64FdtError> {
+    let mut rng_seed_source = Arm64FdtOsRngSeedSource::new();
+    build_arm64_fdt_with_optional_pci_and_rng_seed_source(
+        config,
+        Some(pci_host),
+        &mut rng_seed_source,
+    )
+}
+
 fn build_arm64_fdt_with_rng_seed_source<Source>(
     config: &Arm64FdtConfig<'_>,
     rng_seed_source: &mut Source,
@@ -1262,7 +1382,18 @@ fn build_arm64_fdt_with_rng_seed_source<Source>(
 where
     Source: Arm64FdtRngSeedSource + ?Sized,
 {
-    let validated = validate_config(config)?;
+    build_arm64_fdt_with_optional_pci_and_rng_seed_source(config, None, rng_seed_source)
+}
+
+fn build_arm64_fdt_with_optional_pci_and_rng_seed_source<Source>(
+    config: &Arm64FdtConfig<'_>,
+    pci_host: Option<Arm64FdtPciHost>,
+    rng_seed_source: &mut Source,
+) -> Result<Vec<u8>, Arm64FdtError>
+where
+    Source: Arm64FdtRngSeedSource + ?Sized,
+{
+    let validated = validate_config(config, pci_host)?;
     let mut rng_seed = [0; ARM64_FDT_RNG_SEED_SIZE];
     rng_seed_source
         .fill_rng_seed(&mut rng_seed)
@@ -1296,6 +1427,9 @@ where
     if let Some(vmclock_device) = validated.vmclock_device {
         create_vmclock_node(&mut fdt, vmclock_device)?;
     }
+    if let Some(pci_host) = validated.pci_host {
+        create_pci_host_node(&mut fdt, pci_host)?;
+    }
     create_virtio_mmio_nodes(&mut fdt, &validated.virtio_mmio_devices)?;
 
     fdt.end_node(root)?;
@@ -1312,6 +1446,20 @@ pub fn write_arm64_fdt(
     write_arm64_fdt_with_rng_seed_source(config, memory, &mut rng_seed_source)
 }
 
+pub fn write_arm64_fdt_with_pci(
+    config: &Arm64FdtConfig<'_>,
+    pci_host: Arm64FdtPciHost,
+    memory: &mut GuestMemory,
+) -> Result<Arm64FdtGuestMemoryWrite, Arm64FdtError> {
+    let mut rng_seed_source = Arm64FdtOsRngSeedSource::new();
+    write_arm64_fdt_with_optional_pci_and_rng_seed_source(
+        config,
+        Some(pci_host),
+        memory,
+        &mut rng_seed_source,
+    )
+}
+
 fn write_arm64_fdt_with_rng_seed_source<Source>(
     config: &Arm64FdtConfig<'_>,
     memory: &mut GuestMemory,
@@ -1320,12 +1468,28 @@ fn write_arm64_fdt_with_rng_seed_source<Source>(
 where
     Source: Arm64FdtRngSeedSource + ?Sized,
 {
+    write_arm64_fdt_with_optional_pci_and_rng_seed_source(config, None, memory, rng_seed_source)
+}
+
+fn write_arm64_fdt_with_optional_pci_and_rng_seed_source<Source>(
+    config: &Arm64FdtConfig<'_>,
+    pci_host: Option<Arm64FdtPciHost>,
+    memory: &mut GuestMemory,
+    rng_seed_source: &mut Source,
+) -> Result<Arm64FdtGuestMemoryWrite, Arm64FdtError>
+where
+    Source: Arm64FdtRngSeedSource + ?Sized,
+{
     validate_guest_memory_matches_layout(config.layout, memory)?;
-    let bytes = build_arm64_fdt_with_rng_seed_source(config, rng_seed_source)?;
+    let bytes =
+        build_arm64_fdt_with_optional_pci_and_rng_seed_source(config, pci_host, rng_seed_source)?;
     write_arm64_fdt_bytes(config.layout, memory, &bytes)
 }
 
-fn validate_config(config: &Arm64FdtConfig<'_>) -> Result<ValidatedArm64FdtConfig, Arm64FdtError> {
+fn validate_config(
+    config: &Arm64FdtConfig<'_>,
+    pci_host: Option<Arm64FdtPciHost>,
+) -> Result<ValidatedArm64FdtConfig, Arm64FdtError> {
     if config.vcpu_mpidrs.is_empty() {
         return Err(Arm64FdtError::MissingCpu);
     }
@@ -1392,12 +1556,27 @@ fn validate_config(config: &Arm64FdtConfig<'_>) -> Result<ValidatedArm64FdtConfi
             )
         })
         .transpose()?;
+    let pci_host = pci_host
+        .map(|host| {
+            validate_pci_host(
+                config.layout,
+                config.gic,
+                host,
+                &virtio_mmio_devices,
+                rtc_device.as_ref(),
+                serial_device.as_ref(),
+                vmgenid_device.as_ref(),
+                vmclock_device.as_ref(),
+            )
+        })
+        .transpose()?;
     if let Some(initrd) = config.boot.initrd {
         validate_initrd(config.layout, initrd)?;
     }
 
     Ok(ValidatedArm64FdtConfig {
         memory_reg_cells,
+        pci_host,
         rtc_device,
         serial_device,
         vmgenid_device,
@@ -1769,6 +1948,55 @@ fn create_vmclock_node(
     Ok(())
 }
 
+fn create_pci_host_node(
+    fdt: &mut FdtWriter,
+    pci: ValidatedArm64FdtPciHost,
+) -> Result<(), Arm64FdtError> {
+    let ranges = [
+        0x0200_0000,
+        high_u32(pci.bar32.start().raw_value()),
+        low_u32(pci.bar32.start().raw_value()),
+        high_u32(pci.bar32.start().raw_value()),
+        low_u32(pci.bar32.start().raw_value()),
+        high_u32(pci.bar32.size()),
+        low_u32(pci.bar32.size()),
+        0x0300_0000,
+        high_u32(pci.bar64.start().raw_value()),
+        low_u32(pci.bar64.start().raw_value()),
+        high_u32(pci.bar64.start().raw_value()),
+        low_u32(pci.bar64.start().raw_value()),
+        high_u32(pci.bar64.size()),
+        low_u32(pci.bar64.size()),
+    ];
+    let node = fdt.begin_node(&format!("pci@{:x}", pci.ecam.start().raw_value()))?;
+    fdt.property_string("compatible", "pci-host-ecam-generic")?;
+    fdt.property_string("device_type", "pci")?;
+    fdt.property_array_u32("ranges", &ranges)?;
+    fdt.property_array_u32(
+        "bus-range",
+        &[u32::from(pci.host.bus_start), u32::from(pci.host.bus_end)],
+    )?;
+    fdt.property_u32("linux,pci-domain", u32::from(pci.host.segment))?;
+    fdt.property_u32("#address-cells", 3)?;
+    fdt.property_u32("#size-cells", 2)?;
+    fdt.property_array_u64("reg", &[pci.ecam.start().raw_value(), pci.ecam.size()])?;
+    fdt.property_u32("#interrupt-cells", 1)?;
+    fdt.property_null("interrupt-map")?;
+    fdt.property_null("interrupt-map-mask")?;
+    fdt.property_null("dma-coherent")?;
+    fdt.property_u32("msi-parent", MSI_PHANDLE)?;
+    fdt.end_node(node)?;
+    Ok(())
+}
+
+const fn high_u32(value: u64) -> u32 {
+    (value >> 32) as u32
+}
+
+const fn low_u32(value: u64) -> u32 {
+    value as u32
+}
+
 fn create_virtio_mmio_nodes(
     fdt: &mut FdtWriter,
     devices: &[ValidatedArm64FdtVirtioMmioDevice],
@@ -2103,6 +2331,181 @@ fn validate_gic_timer_ppis(
     }
 
     Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_pci_host(
+    layout: &GuestMemoryLayout,
+    gic: Arm64FdtGic,
+    host: Arm64FdtPciHost,
+    virtio_mmio_devices: &[ValidatedArm64FdtVirtioMmioDevice],
+    rtc_device: Option<&ValidatedArm64FdtRtcDevice>,
+    serial_device: Option<&ValidatedArm64FdtSerialDevice>,
+    vmgenid_device: Option<&ValidatedArm64FdtVmGenIdDevice>,
+    vmclock_device: Option<&ValidatedArm64FdtVmClockDevice>,
+) -> Result<ValidatedArm64FdtPciHost, Arm64FdtError> {
+    if host.segment != PCI_SEGMENT_ZERO {
+        return Err(Arm64FdtError::InvalidPciHost {
+            reason: "only segment 0 is supported",
+        });
+    }
+    if host.bus_start != PCI_BUS_ZERO || host.bus_end != PCI_BUS_ZERO {
+        return Err(Arm64FdtError::InvalidPciHost {
+            reason: "only bus range 0 through 0 is supported",
+        });
+    }
+    if gic.msi.is_none() {
+        return Err(Arm64FdtError::InvalidPciHost {
+            reason: "a GICv2m MSI parent is required",
+        });
+    }
+
+    let ecam = validate_pci_host_range("ECAM", host.ecam)?;
+    let ecam_reservation = validate_pci_host_range("ECAM reservation", host.ecam_reservation)?;
+    let bar32 = validate_pci_host_range("32-bit BAR", host.bar32)?;
+    let bar64 = validate_pci_host_range("64-bit BAR", host.bar64)?;
+    if ecam.size() != PCI_ECAM_BUS_ZERO_SIZE {
+        return Err(Arm64FdtError::InvalidPciHost {
+            reason: "bus-0 ECAM size must be 1 MiB",
+        });
+    }
+    if ecam_reservation.size() != PCI_ECAM_RESERVED_SIZE {
+        return Err(Arm64FdtError::InvalidPciHost {
+            reason: "ECAM reservation size must be 256 MiB",
+        });
+    }
+    if !ecam
+        .start()
+        .raw_value()
+        .is_multiple_of(PCI_ECAM_BUS_ZERO_SIZE)
+    {
+        return Err(Arm64FdtError::InvalidPciHost {
+            reason: "ECAM base must be aligned to its 1 MiB bus window",
+        });
+    }
+    if ecam.start() != ecam_reservation.start()
+        || ecam.end_exclusive() > ecam_reservation.end_exclusive()
+    {
+        return Err(Arm64FdtError::InvalidPciHost {
+            reason: "published ECAM window must begin the reserved configuration aperture",
+        });
+    }
+    if bar32.end_exclusive().raw_value() > 1_u64 << 32 {
+        return Err(Arm64FdtError::InvalidPciHost {
+            reason: "32-bit BAR window exceeds the 32-bit address space",
+        });
+    }
+
+    for (first_name, first, second_name, second) in [
+        ("32-bit BAR", bar32, "ECAM reservation", ecam_reservation),
+        ("32-bit BAR", bar32, "64-bit BAR", bar64),
+        ("ECAM reservation", ecam_reservation, "64-bit BAR", bar64),
+    ] {
+        if first.overlaps(second) {
+            return Err(Arm64FdtError::PciHostRangesOverlap {
+                first: first_name,
+                second: second_name,
+            });
+        }
+    }
+
+    for (name, range) in [
+        ("32-bit BAR", bar32),
+        ("ECAM reservation", ecam_reservation),
+        ("64-bit BAR", bar64),
+    ] {
+        validate_pci_host_range_is_unoccupied(
+            layout,
+            gic,
+            name,
+            range,
+            virtio_mmio_devices,
+            rtc_device,
+            serial_device,
+            vmgenid_device,
+            vmclock_device,
+        )?;
+    }
+
+    Ok(ValidatedArm64FdtPciHost {
+        host,
+        ecam,
+        bar32,
+        bar64,
+    })
+}
+
+fn validate_pci_host_range(
+    name: &'static str,
+    region: Arm64FdtRegion,
+) -> Result<GuestMemoryRange, Arm64FdtError> {
+    GuestMemoryRange::new(GuestAddress::new(region.base), region.size).map_err(|source| {
+        Arm64FdtError::InvalidPciHostRange {
+            name,
+            region,
+            source,
+        }
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_pci_host_range_is_unoccupied(
+    layout: &GuestMemoryLayout,
+    gic: Arm64FdtGic,
+    name: &'static str,
+    range: GuestMemoryRange,
+    virtio_mmio_devices: &[ValidatedArm64FdtVirtioMmioDevice],
+    rtc_device: Option<&ValidatedArm64FdtRtcDevice>,
+    serial_device: Option<&ValidatedArm64FdtSerialDevice>,
+    vmgenid_device: Option<&ValidatedArm64FdtVmGenIdDevice>,
+    vmclock_device: Option<&ValidatedArm64FdtVmClockDevice>,
+) -> Result<(), Arm64FdtError> {
+    for memory_range in layout.ranges().iter().copied() {
+        if range.overlaps(memory_range) {
+            return Err(Arm64FdtError::PciHostRangeOverlapsMemory { name, memory_range });
+        }
+    }
+    for (gic_name, gic_range) in validated_gic_regions(gic)?.into_iter().flatten() {
+        if range.overlaps(gic_range) {
+            return Err(Arm64FdtError::PciHostRangeOverlapsGic {
+                name,
+                gic: gic_name,
+            });
+        }
+    }
+    for device in virtio_mmio_devices {
+        reject_pci_host_device_overlap(name, range, "virtio-mmio", device.region, device.range)?;
+    }
+    for (device_name, device_region, device_range) in [
+        rtc_device.map(|device| ("RTC", device.region, device.range)),
+        serial_device.map(|device| ("serial", device.region, device.range)),
+        vmgenid_device.map(|device| ("VMGenID", device.region, device.range)),
+        vmclock_device.map(|device| ("VMClock", device.region, device.range)),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        reject_pci_host_device_overlap(name, range, device_name, device_region, device_range)?;
+    }
+    Ok(())
+}
+
+fn reject_pci_host_device_overlap(
+    name: &'static str,
+    range: GuestMemoryRange,
+    device: &'static str,
+    device_region: Arm64FdtRegion,
+    device_range: GuestMemoryRange,
+) -> Result<(), Arm64FdtError> {
+    if range.overlaps(device_range) {
+        Err(Arm64FdtError::PciHostRangeOverlapsDevice {
+            name,
+            device,
+            device_region,
+        })
+    } else {
+        Ok(())
+    }
 }
 
 fn validate_gic_region(
@@ -2530,6 +2933,7 @@ fn validate_vmclock_device(
 
     Ok(ValidatedArm64FdtVmClockDevice {
         region: device.region,
+        range,
         interrupt_cell: vmclock_interrupt_cell(device.interrupt_line)?,
     })
 }
@@ -5745,6 +6149,167 @@ mod tests {
     }
 
     #[test]
+    fn pci_host_node_publishes_firecracker_ecam_ranges_and_gicv2m_parent() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let config = Arm64FdtConfig {
+            gic: Arm64FdtGic {
+                msi: Some(test_msi()),
+                ..test_gic()
+            },
+            ..test_config(
+                &layout,
+                Arm64FdtBootInfo {
+                    command_line: "panic=1",
+                    initrd: None,
+                },
+            )
+        };
+        let pci_host = test_pci_host();
+
+        let bytes = build_test_arm64_fdt_with_pci(&config, pci_host)
+            .expect("valid PCI host metadata should build");
+        let tree = DeviceTree::load(&bytes).expect("PCI host FDT should parse");
+        let pci = required_node(&tree, "/pci@70000000");
+
+        assert_eq!(pci.prop_str("compatible").unwrap(), "pci-host-ecam-generic");
+        assert_eq!(pci.prop_str("device_type").unwrap(), "pci");
+        assert_eq!(prop_u64_cells(pci, "reg"), vec![0x7000_0000, 0x10_0000]);
+        assert_eq!(prop_u32_cells(pci, "bus-range"), vec![0, 0]);
+        assert_eq!(pci.prop_u32("linux,pci-domain").unwrap(), 0);
+        assert_eq!(pci.prop_u32("#address-cells").unwrap(), 3);
+        assert_eq!(pci.prop_u32("#size-cells").unwrap(), 2);
+        assert_eq!(pci.prop_u32("#interrupt-cells").unwrap(), 1);
+        assert_eq!(pci.prop_u32("msi-parent").unwrap(), MSI_PHANDLE);
+        assert_eq!(
+            prop_u32_cells(pci, "ranges"),
+            vec![
+                0x0200_0000,
+                0,
+                0x4000_3000,
+                0,
+                0x4000_3000,
+                0,
+                0x2fff_d000,
+                0x0300_0000,
+                0x40,
+                0,
+                0x40,
+                0,
+                0x40,
+                0,
+            ]
+        );
+        for property in ["interrupt-map", "interrupt-map-mask", "dma-coherent"] {
+            assert!(
+                pci.prop_raw(property)
+                    .expect("empty PCI property should exist")
+                    .is_empty()
+            );
+        }
+        assert!(!pci.has_prop("msi-map"));
+        assert!(!pci.has_prop("iommu-map"));
+    }
+
+    #[test]
+    fn pci_host_requires_gicv2m_and_rejects_address_conflicts() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: None,
+            },
+        );
+
+        let err = build_test_arm64_fdt_with_pci(&config, test_pci_host())
+            .expect_err("PCI without an MSI parent should fail");
+        assert_eq!(
+            err,
+            Arm64FdtError::InvalidPciHost {
+                reason: "a GICv2m MSI parent is required",
+            }
+        );
+
+        let devices = [virtio_mmio_device(crate::pci::PCI_BAR32_START, 0x1000, 32)];
+        let config = Arm64FdtConfig {
+            gic: Arm64FdtGic {
+                msi: Some(test_msi()),
+                ..test_gic()
+            },
+            ..test_config_with_virtio_mmio_devices(
+                &layout,
+                Arm64FdtBootInfo {
+                    command_line: "panic=1",
+                    initrd: None,
+                },
+                &devices,
+            )
+        };
+        let err = build_test_arm64_fdt_with_pci(&config, test_pci_host())
+            .expect_err("PCI BAR range overlapping a device should fail");
+        assert_eq!(
+            err,
+            Arm64FdtError::PciHostRangeOverlapsDevice {
+                name: "32-bit BAR",
+                device: "virtio-mmio",
+                device_region: devices[0].region,
+            }
+        );
+
+        let mut pci_host = test_pci_host();
+        pci_host.bar64 = Arm64FdtRegion {
+            base: aarch64::DRAM_MEM_START,
+            size: 0x1000,
+        };
+        let config = Arm64FdtConfig {
+            gic: Arm64FdtGic {
+                msi: Some(test_msi()),
+                ..test_gic()
+            },
+            ..test_config(
+                &layout,
+                Arm64FdtBootInfo {
+                    command_line: "panic=1",
+                    initrd: None,
+                },
+            )
+        };
+        let err = build_test_arm64_fdt_with_pci(&config, pci_host)
+            .expect_err("PCI BAR range overlapping guest RAM should fail");
+        assert!(matches!(
+            err,
+            Arm64FdtError::PciHostRangeOverlapsMemory {
+                name: "64-bit BAR",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn no_pci_fdt_path_preserves_existing_bytes() {
+        let layout = test_layout(TEST_MEMORY_SIZE);
+        let config = test_config(
+            &layout,
+            Arm64FdtBootInfo {
+                command_line: "panic=1",
+                initrd: None,
+            },
+        );
+        let mut original_source = FixedRngSeedSource::new(TEST_RNG_SEED);
+        let original = build_arm64_fdt_with_rng_seed_source(&config, &mut original_source)
+            .expect("existing FDT path should build");
+        let mut optional_source = FixedRngSeedSource::new(TEST_RNG_SEED);
+        let optional = build_arm64_fdt_with_optional_pci_and_rng_seed_source(
+            &config,
+            None,
+            &mut optional_source,
+        )
+        .expect("optional PCI FDT path should build without PCI");
+
+        assert_eq!(optional, original);
+    }
+
+    #[test]
     fn rejects_invalid_gicv2m_frame_and_interrupt_range_without_raw_values() {
         let layout = test_layout(TEST_MEMORY_SIZE);
         let invalid_frames = [
@@ -6327,6 +6892,14 @@ mod tests {
         build_arm64_fdt_with_rng_seed_source(config, &mut source)
     }
 
+    fn build_test_arm64_fdt_with_pci(
+        config: &Arm64FdtConfig<'_>,
+        pci_host: Arm64FdtPciHost,
+    ) -> Result<Vec<u8>, Arm64FdtError> {
+        let mut source = FixedRngSeedSource::new(TEST_RNG_SEED);
+        build_arm64_fdt_with_optional_pci_and_rng_seed_source(config, Some(pci_host), &mut source)
+    }
+
     fn write_test_arm64_fdt(
         config: &Arm64FdtConfig<'_>,
         memory: &mut GuestMemory,
@@ -6578,6 +7151,13 @@ mod tests {
                 count: 32,
             },
         }
+    }
+
+    fn test_pci_host() -> Arm64FdtPciHost {
+        Arm64FdtPciHost::from_address_plan(
+            Arm64PciAddressPlan::firecracker_v1_16()
+                .expect("Firecracker PCI address plan should be valid"),
+        )
     }
 
     const fn test_initrd() -> LoadedInitrd {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -18,6 +18,7 @@ pub mod mmds;
 pub mod mmio;
 pub mod network;
 pub(crate) mod output_file;
+pub mod pci;
 pub mod pmem;
 pub mod rtc;
 pub mod serial;

--- a/crates/runtime/src/mmio.rs
+++ b/crates/runtime/src/mmio.rs
@@ -3,6 +3,7 @@
 use std::any::{Any, type_name};
 use std::collections::{BTreeMap, btree_map::Entry};
 use std::fmt;
+use std::sync::Arc;
 
 use crate::memory::{GuestAddress, GuestMemoryError, GuestMemoryRange};
 
@@ -29,6 +30,83 @@ impl fmt::Display for MmioRegionId {
 pub struct MmioRegion {
     id: MmioRegionId,
     range: GuestMemoryRange,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MmioRegionRequest {
+    start: GuestAddress,
+    size: u64,
+}
+
+impl MmioRegionRequest {
+    pub const fn new(start: GuestAddress, size: u64) -> Self {
+        Self { start, size }
+    }
+
+    pub const fn start(self) -> GuestAddress {
+        self.start
+    }
+
+    pub const fn size(self) -> u64 {
+        self.size
+    }
+}
+
+struct MmioRegistrationOwnerProvenance;
+
+#[derive(Clone)]
+pub struct MmioRegistrationOwner {
+    provenance: Arc<MmioRegistrationOwnerProvenance>,
+}
+
+impl MmioRegistrationOwner {
+    pub fn new() -> Self {
+        Self {
+            provenance: Arc::new(MmioRegistrationOwnerProvenance),
+        }
+    }
+}
+
+impl Default for MmioRegistrationOwner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for MmioRegistrationOwner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MmioRegistrationOwner")
+            .field("provenance", &"<redacted>")
+            .finish()
+    }
+}
+
+struct MmioDispatcherProvenance;
+
+pub struct MmioRegistrationLease {
+    dispatcher: Arc<MmioDispatcherProvenance>,
+    owner: Arc<MmioRegistrationOwnerProvenance>,
+    generation: u64,
+    region_id: MmioRegionId,
+    regions: Vec<MmioRegion>,
+}
+
+impl MmioRegistrationLease {
+    pub const fn region_id(&self) -> MmioRegionId {
+        self.region_id
+    }
+
+    pub fn regions(&self) -> &[MmioRegion] {
+        &self.regions
+    }
+}
+
+impl fmt::Debug for MmioRegistrationLease {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MmioRegistrationLease")
+            .field("ownership", &"<redacted>")
+            .finish()
+    }
 }
 
 impl MmioRegion {
@@ -338,6 +416,29 @@ pub enum MmioDispatchOutcome {
 pub struct MmioDispatcher {
     bus: MmioBus,
     handlers: BTreeMap<MmioRegionId, Box<dyn StoredMmioHandler>>,
+    provenance: Arc<MmioDispatcherProvenance>,
+    next_registration_generation: u64,
+    registrations: BTreeMap<u64, MmioRegistrationRecord>,
+}
+
+struct MmioRegistrationRecord {
+    owner: Arc<MmioRegistrationOwnerProvenance>,
+    region_id: MmioRegionId,
+    regions: Vec<MmioRegion>,
+}
+
+impl fmt::Debug for MmioRegistrationRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MmioRegistrationRecord")
+            .field("ownership", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Debug for MmioDispatcherProvenance {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<redacted>")
+    }
 }
 
 impl MmioDispatcher {
@@ -345,6 +446,9 @@ impl MmioDispatcher {
         Self {
             bus: MmioBus::new(),
             handlers: BTreeMap::new(),
+            provenance: Arc::new(MmioDispatcherProvenance),
+            next_registration_generation: 0,
+            registrations: BTreeMap::new(),
         }
     }
 
@@ -362,6 +466,9 @@ impl MmioDispatcher {
         start: GuestAddress,
         size: u64,
     ) -> Result<MmioRegion, MmioBusError> {
+        if self.has_leased_region_id(id) {
+            return Err(MmioBusError::LeasedRegionId { region_id: id });
+        }
         self.bus.insert(id, start, size)
     }
 
@@ -374,6 +481,9 @@ impl MmioDispatcher {
         region_id: MmioRegionId,
         handler: impl MmioHandler + 'static,
     ) -> Result<(), MmioDispatchError> {
+        if self.has_leased_region_id(region_id) {
+            return Err(MmioDispatchError::LeasedHandler { region_id });
+        }
         match self.handlers.entry(region_id) {
             Entry::Vacant(entry) => {
                 entry.insert(Box::new(handler));
@@ -381,6 +491,127 @@ impl MmioDispatcher {
             }
             Entry::Occupied(_) => Err(MmioDispatchError::DuplicateHandler { region_id }),
         }
+    }
+
+    pub fn register_owned_handler(
+        &mut self,
+        owner: &MmioRegistrationOwner,
+        region_id: MmioRegionId,
+        regions: &[MmioRegionRequest],
+        handler: impl MmioHandler + 'static,
+    ) -> Result<MmioRegistrationLease, MmioRegistrationError> {
+        if regions.is_empty() {
+            return Err(MmioRegistrationError::EmptyRegionBatch);
+        }
+        if self.handlers.contains_key(&region_id) {
+            return Err(MmioRegistrationError::ExistingHandler { region_id });
+        }
+        if self
+            .bus
+            .regions()
+            .iter()
+            .any(|region| region.id() == region_id)
+        {
+            return Err(MmioRegistrationError::ExistingRegionId { region_id });
+        }
+
+        let next_generation = self
+            .next_registration_generation
+            .checked_add(1)
+            .ok_or(MmioRegistrationError::GenerationExhausted)?;
+        let generation = self.next_registration_generation;
+        let mut candidate_bus = self.bus.clone();
+        let mut registered_regions = Vec::new();
+        registered_regions
+            .try_reserve_exact(regions.len())
+            .map_err(|_| MmioRegistrationError::RegionMetadataAllocation)?;
+        for (index, request) in regions.iter().copied().enumerate() {
+            let region = candidate_bus
+                .insert(region_id, request.start(), request.size())
+                .map_err(|source| MmioRegistrationError::Region {
+                    index,
+                    source: Box::new(source),
+                })?;
+            registered_regions.push(region);
+        }
+        registered_regions.sort_by_key(|region| region.range().start());
+        let mut record_regions = Vec::new();
+        record_regions
+            .try_reserve_exact(registered_regions.len())
+            .map_err(|_| MmioRegistrationError::RegionMetadataAllocation)?;
+        record_regions.extend_from_slice(&registered_regions);
+        let handler: Box<dyn StoredMmioHandler> = Box::new(handler);
+
+        self.bus = candidate_bus;
+        let replaced_handler = self.handlers.insert(region_id, handler);
+        debug_assert!(replaced_handler.is_none());
+        let replaced_registration = self.registrations.insert(
+            generation,
+            MmioRegistrationRecord {
+                owner: Arc::clone(&owner.provenance),
+                region_id,
+                regions: record_regions,
+            },
+        );
+        debug_assert!(replaced_registration.is_none());
+        self.next_registration_generation = next_generation;
+
+        Ok(MmioRegistrationLease {
+            dispatcher: Arc::clone(&self.provenance),
+            owner: Arc::clone(&owner.provenance),
+            generation,
+            region_id,
+            regions: registered_regions,
+        })
+    }
+
+    pub fn release_owned_handler(
+        &mut self,
+        owner: &MmioRegistrationOwner,
+        lease: &MmioRegistrationLease,
+    ) -> Result<(), MmioRegistrationReleaseError> {
+        if !Arc::ptr_eq(&self.provenance, &lease.dispatcher) {
+            return Err(MmioRegistrationReleaseError::WrongDispatcher);
+        }
+        if !Arc::ptr_eq(&owner.provenance, &lease.owner) {
+            return Err(MmioRegistrationReleaseError::WrongOwner);
+        }
+
+        let record = self.registrations.get(&lease.generation).ok_or(
+            MmioRegistrationReleaseError::StaleLease {
+                region_id: lease.region_id,
+            },
+        )?;
+        if !Arc::ptr_eq(&record.owner, &owner.provenance) {
+            return Err(MmioRegistrationReleaseError::WrongOwner);
+        }
+        if record.region_id != lease.region_id || record.regions != lease.regions {
+            return Err(MmioRegistrationReleaseError::RegistrationMismatch {
+                region_id: lease.region_id,
+            });
+        }
+        if !self.handlers.contains_key(&record.region_id)
+            || !self
+                .bus
+                .contains_exact_regions(record.region_id, &record.regions)
+        {
+            return Err(MmioRegistrationReleaseError::RegistrationMismatch {
+                region_id: lease.region_id,
+            });
+        }
+
+        self.bus.remove_exact_regions(&record.regions);
+        let removed_handler = self.handlers.remove(&record.region_id);
+        debug_assert!(removed_handler.is_some());
+        let removed_record = self.registrations.remove(&lease.generation);
+        debug_assert!(removed_record.is_some());
+        Ok(())
+    }
+
+    fn has_leased_region_id(&self, region_id: MmioRegionId) -> bool {
+        self.registrations
+            .values()
+            .any(|registration| registration.region_id == region_id)
     }
 
     pub(crate) fn handler_mut<T: MmioHandler + 'static>(
@@ -475,7 +706,103 @@ impl Default for MmioDispatcher {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MmioRegistrationError {
+    EmptyRegionBatch,
+    ExistingHandler {
+        region_id: MmioRegionId,
+    },
+    ExistingRegionId {
+        region_id: MmioRegionId,
+    },
+    GenerationExhausted,
+    RegionMetadataAllocation,
+    Region {
+        index: usize,
+        source: Box<MmioBusError>,
+    },
+}
+
+impl fmt::Display for MmioRegistrationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyRegionBatch => {
+                f.write_str("owned MMIO registration requires at least one region")
+            }
+            Self::ExistingHandler { region_id } => write!(
+                f,
+                "owned MMIO registration region id={region_id} already has a handler"
+            ),
+            Self::ExistingRegionId { region_id } => write!(
+                f,
+                "owned MMIO registration region id={region_id} already has legacy regions"
+            ),
+            Self::GenerationExhausted => {
+                f.write_str("owned MMIO registration generation is exhausted")
+            }
+            Self::RegionMetadataAllocation => {
+                f.write_str("owned MMIO registration region metadata allocation failed")
+            }
+            Self::Region { index, source } => {
+                write!(
+                    f,
+                    "owned MMIO registration region {index} is invalid: {source}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for MmioRegistrationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Region { source, .. } => Some(source),
+            Self::EmptyRegionBatch
+            | Self::ExistingHandler { .. }
+            | Self::ExistingRegionId { .. }
+            | Self::GenerationExhausted
+            | Self::RegionMetadataAllocation => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MmioRegistrationReleaseError {
+    WrongDispatcher,
+    WrongOwner,
+    StaleLease { region_id: MmioRegionId },
+    RegistrationMismatch { region_id: MmioRegionId },
+}
+
+impl fmt::Display for MmioRegistrationReleaseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::WrongDispatcher => {
+                f.write_str("owned MMIO registration lease belongs to another dispatcher")
+            }
+            Self::WrongOwner => {
+                f.write_str("owned MMIO registration lease belongs to another owner")
+            }
+            Self::StaleLease { region_id } => {
+                write!(
+                    f,
+                    "owned MMIO registration lease for region id={region_id} is stale"
+                )
+            }
+            Self::RegistrationMismatch { region_id } => write!(
+                f,
+                "owned MMIO registration lease for region id={region_id} does not match dispatcher state"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for MmioRegistrationReleaseError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MmioDispatchError {
+    LeasedHandler {
+        region_id: MmioRegionId,
+    },
     DuplicateHandler {
         region_id: MmioRegionId,
     },
@@ -507,6 +834,10 @@ pub enum MmioDispatchError {
 impl fmt::Display for MmioDispatchError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::LeasedHandler { region_id } => write!(
+                f,
+                "MMIO handler for region id={region_id} is owned by an active lease"
+            ),
             Self::DuplicateHandler { region_id } => {
                 write!(
                     f,
@@ -569,7 +900,8 @@ impl std::error::Error for MmioDispatchError {
         match self {
             Self::UnregisteredAccess { source, .. } => Some(source),
             Self::HandlerFailed { source, .. } => Some(source),
-            Self::DuplicateHandler { .. }
+            Self::LeasedHandler { .. }
+            | Self::DuplicateHandler { .. }
             | Self::MissingHandler { .. }
             | Self::AccessMismatch { .. }
             | Self::ReadDataLengthMismatch { .. } => None,
@@ -660,6 +992,22 @@ impl MmioBus {
             offset: access_range.start().raw_value() - region.range().start().raw_value(),
         })
     }
+
+    fn contains_exact_regions(&self, region_id: MmioRegionId, regions: &[MmioRegion]) -> bool {
+        self.regions
+            .iter()
+            .filter(|region| region.id() == region_id)
+            .count()
+            == regions.len()
+            && regions
+                .iter()
+                .all(|candidate| self.regions.iter().any(|region| region == candidate))
+    }
+
+    fn remove_exact_regions(&mut self, regions: &[MmioRegion]) {
+        self.regions
+            .retain(|region| !regions.iter().any(|candidate| candidate == region));
+    }
 }
 
 impl Default for MmioBus {
@@ -670,6 +1018,9 @@ impl Default for MmioBus {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MmioBusError {
+    LeasedRegionId {
+        region_id: MmioRegionId,
+    },
     InvalidRegionRange {
         start: GuestAddress,
         size: u64,
@@ -692,6 +1043,10 @@ pub enum MmioBusError {
 impl fmt::Display for MmioBusError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::LeasedRegionId { region_id } => write!(
+                f,
+                "MMIO region id={region_id} is owned by an active registration lease"
+            ),
             Self::InvalidRegionRange {
                 start,
                 size,
@@ -735,7 +1090,9 @@ impl std::error::Error for MmioBusError {
             Self::InvalidRegionRange { source, .. } | Self::InvalidAccessRange { source, .. } => {
                 Some(source)
             }
-            Self::OverlappingRegion { .. } | Self::UnownedAccess { .. } => None,
+            Self::LeasedRegionId { .. }
+            | Self::OverlappingRegion { .. }
+            | Self::UnownedAccess { .. } => None,
         }
     }
 }
@@ -784,7 +1141,8 @@ mod tests {
         MAX_MMIO_ACCESS_BYTES, MmioAccess, MmioAccessBytes, MmioAccessBytesError, MmioBus,
         MmioBusError, MmioDispatchError, MmioDispatchOutcome, MmioDispatcher, MmioHandler,
         MmioHandlerError, MmioHandlerLookupError, MmioOperation, MmioOperationError,
-        MmioOperationKind, MmioRegion, MmioRegionId,
+        MmioOperationKind, MmioRegion, MmioRegionId, MmioRegionRequest, MmioRegistrationError,
+        MmioRegistrationOwner, MmioRegistrationReleaseError,
     };
     use crate::memory::{GuestAddress, GuestMemoryError, GuestMemoryRange};
 
@@ -1928,5 +2286,299 @@ mod tests {
             "MMIO operation data length 2 does not match access size 4 for range [0x7000..0x7004) (4 bytes)"
         );
         assert!(err.source().is_none());
+    }
+
+    #[test]
+    fn owned_registration_publishes_and_removes_multiple_regions_atomically() {
+        let owner = MmioRegistrationOwner::new();
+        let mut dispatcher = MmioDispatcher::new();
+        let (_state, handler) = ScriptedHandler::returning(&[0x5a]);
+        let lease = dispatcher
+            .register_owned_handler(
+                &owner,
+                id(40),
+                &[
+                    MmioRegionRequest::new(address(0x6000), 0x100),
+                    MmioRegionRequest::new(address(0x4000), 0x100),
+                ],
+                handler,
+            )
+            .expect("owned MMIO registration should succeed");
+
+        assert_eq!(lease.region_id(), id(40));
+        assert_eq!(
+            lease.regions(),
+            &[region(40, 0x4000, 0x100), region(40, 0x6000, 0x100)]
+        );
+        for start in [0x4000, 0x6000] {
+            let access = dispatcher
+                .lookup(address(start), 1)
+                .expect("leased MMIO region should resolve");
+            assert_eq!(
+                dispatcher
+                    .dispatch(MmioOperation::read(access).expect("leased read should build"))
+                    .expect("leased read should dispatch"),
+                MmioDispatchOutcome::Read {
+                    data: MmioAccessBytes::new(&[0x5a])
+                        .expect("leased response bytes should be valid")
+                }
+            );
+        }
+
+        dispatcher
+            .release_owned_handler(&owner, &lease)
+            .expect("owned MMIO registration should release");
+        assert!(dispatcher.regions().is_empty());
+        assert!(matches!(
+            dispatcher.handler_mut::<ScriptedHandler>(id(40)),
+            Err(MmioHandlerLookupError::MissingHandler { region_id }) if region_id == id(40)
+        ));
+    }
+
+    #[test]
+    fn owned_registration_rejects_empty_batch_without_handler_publication() {
+        let owner = MmioRegistrationOwner::new();
+        let mut dispatcher = MmioDispatcher::new();
+        let (_state, handler) = ScriptedHandler::returning(&[0]);
+
+        assert!(matches!(
+            dispatcher.register_owned_handler(&owner, id(41), &[], handler),
+            Err(MmioRegistrationError::EmptyRegionBatch)
+        ));
+        assert!(dispatcher.regions().is_empty());
+        assert!(matches!(
+            dispatcher.handler_mut::<ScriptedHandler>(id(41)),
+            Err(MmioHandlerLookupError::MissingHandler { .. })
+        ));
+    }
+
+    #[test]
+    fn owned_registration_overlap_failure_does_not_publish_prefix_or_handler() {
+        let owner = MmioRegistrationOwner::new();
+        let mut dispatcher = MmioDispatcher::new();
+        dispatcher
+            .insert_region(id(1), address(0x5000), 0x100)
+            .expect("existing MMIO region should insert");
+        let before = dispatcher.regions().to_vec();
+        let (_state, handler) = ScriptedHandler::returning(&[0]);
+
+        assert!(matches!(
+            dispatcher.register_owned_handler(
+                &owner,
+                id(42),
+                &[
+                    MmioRegionRequest::new(address(0x3000), 0x100),
+                    MmioRegionRequest::new(address(0x5080), 0x100),
+                ],
+                handler,
+            ),
+            Err(MmioRegistrationError::Region { index: 1, .. })
+        ));
+        assert_eq!(dispatcher.regions(), before);
+        assert!(matches!(
+            dispatcher.handler_mut::<ScriptedHandler>(id(42)),
+            Err(MmioHandlerLookupError::MissingHandler { .. })
+        ));
+    }
+
+    #[test]
+    fn owned_registration_rejects_preexisting_handler_and_same_id_regions() {
+        let owner = MmioRegistrationOwner::new();
+        let mut handler_dispatcher = MmioDispatcher::new();
+        let (_state, handler) = ScriptedHandler::returning(&[0]);
+        handler_dispatcher
+            .register_handler(id(43), handler)
+            .expect("legacy handler should register");
+        let (_state, owned_handler) = ScriptedHandler::returning(&[0]);
+        assert!(matches!(
+            handler_dispatcher.register_owned_handler(
+                &owner,
+                id(43),
+                &[MmioRegionRequest::new(address(0x3000), 0x100)],
+                owned_handler,
+            ),
+            Err(MmioRegistrationError::ExistingHandler { region_id }) if region_id == id(43)
+        ));
+
+        let mut region_dispatcher = MmioDispatcher::new();
+        region_dispatcher
+            .insert_region(id(44), address(0x3000), 0x100)
+            .expect("legacy region should register");
+        let (_state, handler) = ScriptedHandler::returning(&[0]);
+        assert!(matches!(
+            region_dispatcher.register_owned_handler(
+                &owner,
+                id(44),
+                &[MmioRegionRequest::new(address(0x5000), 0x100)],
+                handler,
+            ),
+            Err(MmioRegistrationError::ExistingRegionId { region_id }) if region_id == id(44)
+        ));
+    }
+
+    #[test]
+    fn active_owned_registration_excludes_legacy_same_id_mutations() {
+        let owner = MmioRegistrationOwner::new();
+        let mut dispatcher = MmioDispatcher::new();
+        let (_state, handler) = ScriptedHandler::returning(&[0]);
+        let lease = dispatcher
+            .register_owned_handler(
+                &owner,
+                id(45),
+                &[MmioRegionRequest::new(address(0x3000), 0x100)],
+                handler,
+            )
+            .expect("owned MMIO registration should succeed");
+
+        assert_eq!(
+            dispatcher.insert_region(id(45), address(0x5000), 0x100),
+            Err(MmioBusError::LeasedRegionId { region_id: id(45) })
+        );
+        let (_state, second_handler) = ScriptedHandler::returning(&[0]);
+        assert_eq!(
+            dispatcher.register_handler(id(45), second_handler),
+            Err(MmioDispatchError::LeasedHandler { region_id: id(45) })
+        );
+        dispatcher
+            .release_owned_handler(&owner, &lease)
+            .expect("owned MMIO registration should release cleanly");
+    }
+
+    #[test]
+    fn owned_release_rejects_unrecorded_same_id_region_without_mutation() {
+        let owner = MmioRegistrationOwner::new();
+        let mut dispatcher = MmioDispatcher::new();
+        let (_state, handler) = ScriptedHandler::returning(&[0]);
+        let lease = dispatcher
+            .register_owned_handler(
+                &owner,
+                id(50),
+                &[MmioRegionRequest::new(address(0x3000), 0x100)],
+                handler,
+            )
+            .expect("owned MMIO registration should succeed");
+        dispatcher
+            .bus
+            .insert(id(50), address(0x5000), 0x100)
+            .expect("test should inject an unrecorded same-id region");
+        let regions_before_release = dispatcher.regions().to_vec();
+
+        assert_eq!(
+            dispatcher.release_owned_handler(&owner, &lease),
+            Err(MmioRegistrationReleaseError::RegistrationMismatch { region_id: id(50) })
+        );
+        assert_eq!(dispatcher.regions(), regions_before_release);
+        assert!(dispatcher.handler_mut::<ScriptedHandler>(id(50)).is_ok());
+    }
+
+    #[test]
+    fn owned_release_rejects_wrong_owner_and_dispatcher_without_mutation() {
+        let owner = MmioRegistrationOwner::new();
+        let wrong_owner = MmioRegistrationOwner::new();
+        let mut dispatcher = MmioDispatcher::new();
+        let mut wrong_dispatcher = MmioDispatcher::new();
+        let (_state, handler) = ScriptedHandler::returning(&[0]);
+        let lease = dispatcher
+            .register_owned_handler(
+                &owner,
+                id(46),
+                &[MmioRegionRequest::new(address(0x3000), 0x100)],
+                handler,
+            )
+            .expect("owned MMIO registration should succeed");
+
+        assert_eq!(
+            dispatcher.release_owned_handler(&wrong_owner, &lease),
+            Err(MmioRegistrationReleaseError::WrongOwner)
+        );
+        assert_eq!(
+            wrong_dispatcher.release_owned_handler(&owner, &lease),
+            Err(MmioRegistrationReleaseError::WrongDispatcher)
+        );
+        assert!(dispatcher.lookup(address(0x3000), 1).is_ok());
+        dispatcher
+            .release_owned_handler(&owner, &lease)
+            .expect("correct owner should release registration");
+    }
+
+    #[test]
+    fn stale_owned_lease_cannot_delete_identical_reused_registration() {
+        let owner = MmioRegistrationOwner::new();
+        let mut dispatcher = MmioDispatcher::new();
+        let request = [MmioRegionRequest::new(address(0x3000), 0x100)];
+        let (_state, first_handler) = ScriptedHandler::returning(&[1]);
+        let first = dispatcher
+            .register_owned_handler(&owner, id(47), &request, first_handler)
+            .expect("first owned MMIO registration should succeed");
+        dispatcher
+            .release_owned_handler(&owner, &first)
+            .expect("first owned MMIO registration should release");
+        let (_state, second_handler) = ScriptedHandler::returning(&[2]);
+        let second = dispatcher
+            .register_owned_handler(&owner, id(47), &request, second_handler)
+            .expect("identical owned MMIO registration should be reusable");
+
+        assert_eq!(
+            dispatcher.release_owned_handler(&owner, &first),
+            Err(MmioRegistrationReleaseError::StaleLease { region_id: id(47) })
+        );
+        assert!(dispatcher.lookup(address(0x3000), 1).is_ok());
+        dispatcher
+            .release_owned_handler(&owner, &second)
+            .expect("current owned MMIO registration should release");
+    }
+
+    #[test]
+    fn owned_registration_generation_exhaustion_is_mutation_free() {
+        let owner = MmioRegistrationOwner::new();
+        let mut dispatcher = MmioDispatcher::new();
+        dispatcher.next_registration_generation = u64::MAX;
+        let (_state, handler) = ScriptedHandler::returning(&[0]);
+
+        assert!(matches!(
+            dispatcher.register_owned_handler(
+                &owner,
+                id(48),
+                &[MmioRegionRequest::new(address(0x3000), 0x100)],
+                handler,
+            ),
+            Err(MmioRegistrationError::GenerationExhausted)
+        ));
+        assert!(dispatcher.regions().is_empty());
+        assert!(dispatcher.handlers.is_empty());
+        assert!(dispatcher.registrations.is_empty());
+    }
+
+    #[test]
+    fn owned_registration_errors_preserve_sources_and_redact_tokens() {
+        let source = MmioBusError::UnownedAccess {
+            range: range(0x1000, 4),
+        };
+        let error = MmioRegistrationError::Region {
+            index: 2,
+            source: Box::new(source),
+        };
+        assert!(error.source().is_some());
+        assert!(error.to_string().contains("region 2 is invalid"));
+
+        let owner = MmioRegistrationOwner::new();
+        let mut dispatcher = MmioDispatcher::new();
+        let (_state, handler) = ScriptedHandler::returning(&[0]);
+        let lease = dispatcher
+            .register_owned_handler(
+                &owner,
+                id(49),
+                &[MmioRegionRequest::new(address(0x3000), 0x100)],
+                handler,
+            )
+            .expect("owned MMIO registration should succeed");
+        assert_eq!(
+            format!("{owner:?}"),
+            "MmioRegistrationOwner { provenance: \"<redacted>\" }"
+        );
+        assert_eq!(
+            format!("{lease:?}"),
+            "MmioRegistrationLease { ownership: \"<redacted>\" }"
+        );
     }
 }

--- a/crates/runtime/src/pci.rs
+++ b/crates/runtime/src/pci.rs
@@ -1238,6 +1238,115 @@ mod tests {
     }
 
     #[test]
+    fn bar_allocator_exhaustively_reuses_fragmented_small_ranges() {
+        for start_offset in 0..16 {
+            for size in [16, 32, 64] {
+                let capacity = range(0x1000 + start_offset, 0x180);
+                let mut allocator = PciBarAllocator::new(PciBarAddressSpace::Memory32, capacity);
+                let mut leases = Vec::new();
+
+                loop {
+                    let expected = allocator.available_ranges().iter().find_map(|free| {
+                        let start = align_up(free.start().raw_value(), size)?;
+                        let end = start.checked_add(size)?;
+                        (end <= free.end_exclusive().raw_value()).then(|| range(start, size))
+                    });
+                    let Some(expected) = expected else {
+                        assert!(matches!(
+                            allocator.allocate(size),
+                            Err(PciBarAllocationError::Exhausted { size: exhausted })
+                                if exhausted == size
+                        ));
+                        break;
+                    };
+                    let lease = allocator
+                        .allocate(size)
+                        .expect("reference-model PCI BAR allocation should fit");
+                    assert_eq!(lease.range(), expected);
+                    leases.push(Some(lease));
+                }
+
+                let released_count = leases.len().div_ceil(2);
+                for lease in leases.iter_mut().step_by(2) {
+                    allocator
+                        .release(
+                            lease
+                                .take()
+                                .as_ref()
+                                .expect("fragmented PCI BAR lease should exist"),
+                        )
+                        .expect("fragmented PCI BAR release should succeed");
+                }
+
+                let mut replacements = Vec::new();
+                for _ in 0..released_count {
+                    let expected = allocator
+                        .available_ranges()
+                        .iter()
+                        .find_map(|free| {
+                            let start = align_up(free.start().raw_value(), size)?;
+                            let end = start.checked_add(size)?;
+                            (end <= free.end_exclusive().raw_value()).then(|| range(start, size))
+                        })
+                        .expect("each released aligned hole should be reusable");
+                    let replacement = allocator
+                        .allocate(size)
+                        .expect("released PCI BAR hole should allocate");
+                    assert_eq!(replacement.range(), expected);
+                    replacements.push(replacement);
+                }
+
+                for lease in leases.into_iter().flatten().chain(replacements) {
+                    allocator
+                        .release(&lease)
+                        .expect("remaining PCI BAR lease should release");
+                }
+                assert_eq!(allocator.available_ranges(), &[capacity]);
+            }
+        }
+    }
+
+    #[test]
+    fn bar_allocator_overflow_generation_and_lease_mismatch_are_mutation_free() {
+        let overflow_capacity = range(u64::MAX - 7, 7);
+        let mut overflow = PciBarAllocator::new(PciBarAddressSpace::Memory64, overflow_capacity);
+        assert!(matches!(
+            overflow.allocate(16),
+            Err(PciBarAllocationError::AddressOverflow)
+        ));
+        assert_eq!(overflow.available_ranges(), &[overflow_capacity]);
+
+        let capacity = range(0x1000, 0x2000);
+        let mut exhausted = PciBarAllocator::new(PciBarAddressSpace::Memory32, capacity);
+        exhausted.next_generation = u64::MAX;
+        assert!(matches!(
+            exhausted.allocate(0x1000),
+            Err(PciBarAllocationError::GenerationExhausted)
+        ));
+        assert_eq!(exhausted.available_ranges(), &[capacity]);
+        assert!(exhausted.allocations.is_empty());
+
+        let mut allocator = PciBarAllocator::new(PciBarAddressSpace::Memory32, capacity);
+        let mut lease = allocator
+            .allocate(0x1000)
+            .expect("test PCI BAR should allocate");
+        let original_range = lease.range;
+        let free_before = allocator.available_ranges().to_vec();
+        lease.range = range(0x4000, 0x1000);
+        assert_eq!(
+            allocator.release(&lease),
+            Err(PciBarReleaseError::LeaseMismatch)
+        );
+        assert_eq!(allocator.available_ranges(), free_before);
+        assert_eq!(allocator.allocations.len(), 1);
+        lease.range = original_range;
+        allocator
+            .release(&lease)
+            .expect("original exact PCI BAR lease should still release");
+        assert_eq!(allocator.available_ranges(), &[capacity]);
+    }
+
+    #[test]
     fn bar_allocator_aligns_splits_releases_and_reuses_lowest_range() {
         let capacity = range(0x1003, 0x3ffd);
         let mut allocator = PciBarAllocator::new(PciBarAddressSpace::Memory32, capacity);
@@ -1355,6 +1464,43 @@ mod tests {
     }
 
     #[test]
+    fn type0_configuration_supports_partial_little_endian_accesses_and_masks() {
+        let mut configuration = endpoint(0x1af4, 0x10ff);
+        let mut identity_slice = [0; 2];
+        configuration
+            .read_config(1, &mut identity_slice)
+            .expect("in-dword identity read should succeed");
+        assert_eq!(identity_slice, [0x1a, 0xff]);
+
+        configuration
+            .write_config(0, &[0, 0])
+            .expect("partial immutable identity write should be ignored");
+        assert_eq!(read_config_u32(&mut configuration, 0), 0x10ff_1af4);
+
+        configuration
+            .write_config(4, &[0x07])
+            .expect("command low-byte write should succeed");
+        configuration
+            .write_config(5, &[0x80])
+            .expect("command high-byte write should succeed");
+        assert_eq!(read_config_u32(&mut configuration, 4), 0x0000_8007);
+
+        configuration
+            .write_config(12, &[0x40, 0xff, 0xff, 0xff])
+            .expect("cacheline/header partial mask write should succeed");
+        assert_eq!(read_config_u32(&mut configuration, 12), 0x0000_0040);
+
+        configuration
+            .write_config(60, &[0x2a, 0xff])
+            .expect("interrupt line/pin write should succeed");
+        assert_eq!(read_config_u32(&mut configuration, 60), 0x0000_002a);
+        assert_eq!(
+            read_config_u32(&mut configuration, (PCI_CONFIG_SPACE_SIZE - 4) as u16),
+            0
+        );
+    }
+
+    #[test]
     fn type0_configuration_probes_and_preserves_32_bit_bar() {
         let mut allocator =
             PciBarAllocator::new(PciBarAddressSpace::Memory32, range(0x5000_0000, 0x20_0000));
@@ -1462,6 +1608,38 @@ mod tests {
             first.remove_function(&lease),
             Err(PciFunctionReleaseError::StaleLease { sbdf })
         );
+    }
+
+    #[test]
+    fn segment_generation_and_lease_mismatch_fail_without_mutation() {
+        let mut exhausted = PciSegment::new();
+        exhausted.next_generation = u64::MAX;
+        assert!(matches!(
+            exhausted.add_function(endpoint(0x1af4, 0x10ff)),
+            Err(PciSegmentError::GenerationExhausted)
+        ));
+        assert_eq!(exhausted.function_count(), 1);
+        assert!(exhausted.records.is_empty());
+
+        let mut segment = PciSegment::new();
+        let mut lease = segment
+            .add_function(endpoint(0x1af4, 0x10ff))
+            .expect("test PCI endpoint should allocate");
+        let original_generation = lease.generation;
+        lease.generation = lease
+            .generation
+            .checked_add(1)
+            .expect("test lease generation should increment");
+        assert_eq!(
+            segment.remove_function(&lease),
+            Err(PciFunctionReleaseError::LeaseMismatch { sbdf: lease.sbdf() })
+        );
+        assert_eq!(segment.function_count(), 2);
+        lease.generation = original_generation;
+        segment
+            .remove_function(&lease)
+            .expect("original exact PCI function lease should still release");
+        assert_eq!(segment.function_count(), 1);
     }
 
     #[test]

--- a/crates/runtime/src/pci.rs
+++ b/crates/runtime/src/pci.rs
@@ -1,0 +1,1638 @@
+//! Backend-neutral PCI identity, configuration, ECAM, and resource ownership.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use crate::memory::{GuestAddress, GuestMemoryError, GuestMemoryRange};
+use crate::mmio::{
+    MmioAccess, MmioAccessBytes, MmioHandler, MmioHandlerError, MmioRegionId, MmioRegionRequest,
+    MmioRegistrationError, MmioRegistrationLease, MmioRegistrationOwner,
+};
+
+pub const PCI_SEGMENT_ZERO: u16 = 0;
+pub const PCI_BUS_ZERO: u8 = 0;
+pub const PCI_HOST_BRIDGE_DEVICE: u8 = 0;
+pub const PCI_FIRST_ENDPOINT_DEVICE: u8 = 1;
+pub const PCI_LAST_ENDPOINT_DEVICE: u8 = 31;
+pub const PCI_FUNCTION_ZERO: u8 = 0;
+pub const PCI_ECAM_FUNCTION_SIZE: u64 = 4096;
+pub const PCI_ECAM_BUS_ZERO_SIZE: u64 = 1 << 20;
+pub const PCI_ECAM_RESERVED_START: u64 = 0x7000_0000;
+pub const PCI_ECAM_RESERVED_SIZE: u64 = 256 << 20;
+pub const PCI_BAR32_START: u64 = 0x4000_3000;
+pub const PCI_BAR32_END_EXCLUSIVE: u64 = PCI_ECAM_RESERVED_START;
+pub const PCI_BAR64_START: u64 = 256 << 30;
+pub const PCI_BAR64_SIZE: u64 = 256 << 30;
+pub const PCI_HOST_BRIDGE_VENDOR_ID: u16 = 0x8086;
+pub const PCI_HOST_BRIDGE_DEVICE_ID: u16 = 0x0d57;
+
+const PCI_CONFIG_SPACE_SIZE: usize = 4096;
+const PCI_CONFIG_REGISTER_SIZE: usize = 4;
+const PCI_CONFIG_REGISTER_COUNT: usize = PCI_CONFIG_SPACE_SIZE / PCI_CONFIG_REGISTER_SIZE;
+const PCI_BAR_REGISTER_FIRST: u16 = 4;
+const PCI_BAR_REGISTER_COUNT: u8 = 6;
+const PCI_BAR_MINIMUM_SIZE: u64 = 16;
+const PCI_COMMAND_WRITABLE_MASK: u32 = 0x0000_ffff;
+const PCI_CACHELINE_WRITABLE_MASK: u32 = 0x0000_00ff;
+const PCI_INTERRUPT_LINE_WRITABLE_MASK: u32 = 0x0000_00ff;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PciSbdf {
+    segment: u16,
+    bus: u8,
+    device: u8,
+    function: u8,
+}
+
+impl PciSbdf {
+    pub fn new(segment: u16, bus: u8, device: u8, function: u8) -> Result<Self, PciIdentityError> {
+        if device > PCI_LAST_ENDPOINT_DEVICE {
+            return Err(PciIdentityError::InvalidDevice { device });
+        }
+        if function > 7 {
+            return Err(PciIdentityError::InvalidFunction { function });
+        }
+        Ok(Self {
+            segment,
+            bus,
+            device,
+            function,
+        })
+    }
+
+    pub const fn segment(self) -> u16 {
+        self.segment
+    }
+
+    pub const fn bus(self) -> u8 {
+        self.bus
+    }
+
+    pub const fn device(self) -> u8 {
+        self.device
+    }
+
+    pub const fn function(self) -> u8 {
+        self.function
+    }
+
+    pub const fn ecam_offset(self) -> u32 {
+        (self.bus as u32) << 20 | (self.device as u32) << 15 | (self.function as u32) << 12
+    }
+}
+
+impl fmt::Display for PciSbdf {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{:04x}:{:02x}:{:02x}.{}",
+            self.segment, self.bus, self.device, self.function
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PciIdentityError {
+    InvalidDevice { device: u8 },
+    InvalidFunction { function: u8 },
+}
+
+impl fmt::Display for PciIdentityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidDevice { device } => {
+                write!(f, "PCI device number {device} exceeds 31")
+            }
+            Self::InvalidFunction { function } => {
+                write!(f, "PCI function number {function} exceeds 7")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PciIdentityError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Arm64PciAddressPlan {
+    ecam: GuestMemoryRange,
+    ecam_reservation: GuestMemoryRange,
+    bar32: GuestMemoryRange,
+    bar64: GuestMemoryRange,
+}
+
+impl Arm64PciAddressPlan {
+    pub fn firecracker_v1_16() -> Result<Self, GuestMemoryError> {
+        Ok(Self {
+            ecam: GuestMemoryRange::new(
+                GuestAddress::new(PCI_ECAM_RESERVED_START),
+                PCI_ECAM_BUS_ZERO_SIZE,
+            )?,
+            ecam_reservation: GuestMemoryRange::new(
+                GuestAddress::new(PCI_ECAM_RESERVED_START),
+                PCI_ECAM_RESERVED_SIZE,
+            )?,
+            bar32: GuestMemoryRange::new(
+                GuestAddress::new(PCI_BAR32_START),
+                PCI_BAR32_END_EXCLUSIVE - PCI_BAR32_START,
+            )?,
+            bar64: GuestMemoryRange::new(GuestAddress::new(PCI_BAR64_START), PCI_BAR64_SIZE)?,
+        })
+    }
+
+    pub const fn ecam(self) -> GuestMemoryRange {
+        self.ecam
+    }
+
+    pub const fn ecam_reservation(self) -> GuestMemoryRange {
+        self.ecam_reservation
+    }
+
+    pub const fn bar32(self) -> GuestMemoryRange {
+        self.bar32
+    }
+
+    pub const fn bar64(self) -> GuestMemoryRange {
+        self.bar64
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PciBarAddressSpace {
+    Memory32,
+    Memory64,
+}
+
+struct PciBarAllocatorProvenance;
+
+pub struct PciBarLease {
+    allocator: Arc<PciBarAllocatorProvenance>,
+    generation: u64,
+    address_space: PciBarAddressSpace,
+    range: GuestMemoryRange,
+}
+
+impl PciBarLease {
+    pub const fn address_space(&self) -> PciBarAddressSpace {
+        self.address_space
+    }
+
+    pub const fn range(&self) -> GuestMemoryRange {
+        self.range
+    }
+}
+
+impl fmt::Debug for PciBarLease {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PciBarLease")
+            .field("ownership", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PciBarAllocation {
+    address_space: PciBarAddressSpace,
+    range: GuestMemoryRange,
+}
+
+pub struct PciBarAllocator {
+    provenance: Arc<PciBarAllocatorProvenance>,
+    address_space: PciBarAddressSpace,
+    capacity: GuestMemoryRange,
+    free: Vec<GuestMemoryRange>,
+    allocations: BTreeMap<u64, PciBarAllocation>,
+    next_generation: u64,
+}
+
+impl PciBarAllocator {
+    pub fn new(address_space: PciBarAddressSpace, capacity: GuestMemoryRange) -> Self {
+        Self {
+            provenance: Arc::new(PciBarAllocatorProvenance),
+            address_space,
+            capacity,
+            free: vec![capacity],
+            allocations: BTreeMap::new(),
+            next_generation: 0,
+        }
+    }
+
+    pub const fn address_space(&self) -> PciBarAddressSpace {
+        self.address_space
+    }
+
+    pub const fn capacity(&self) -> GuestMemoryRange {
+        self.capacity
+    }
+
+    pub fn allocate(&mut self, size: u64) -> Result<PciBarLease, PciBarAllocationError> {
+        if size < PCI_BAR_MINIMUM_SIZE || !size.is_power_of_two() {
+            return Err(PciBarAllocationError::InvalidSize { size });
+        }
+        let next_generation = self
+            .next_generation
+            .checked_add(1)
+            .ok_or(PciBarAllocationError::GenerationExhausted)?;
+
+        let mut selected = None;
+        for range in self.free.iter().copied() {
+            let start = align_up(range.start().raw_value(), size)
+                .ok_or(PciBarAllocationError::AddressOverflow)?;
+            let end = start
+                .checked_add(size)
+                .ok_or(PciBarAllocationError::AddressOverflow)?;
+            if end <= range.end_exclusive().raw_value() {
+                selected = Some((
+                    range,
+                    GuestMemoryRange::new(GuestAddress::new(start), size)?,
+                ));
+                break;
+            }
+        }
+        let Some((selected_free, allocation)) = selected else {
+            return Err(PciBarAllocationError::Exhausted { size });
+        };
+
+        let mut next_free = Vec::new();
+        next_free
+            .try_reserve_exact(self.free.len().saturating_add(1))
+            .map_err(|_| PciBarAllocationError::MetadataAllocation)?;
+        for range in self.free.iter().copied() {
+            if range != selected_free {
+                next_free.push(range);
+                continue;
+            }
+            if range.start() < allocation.start() {
+                next_free.push(GuestMemoryRange::new(
+                    range.start(),
+                    allocation.start().raw_value() - range.start().raw_value(),
+                )?);
+            }
+            if allocation.end_exclusive() < range.end_exclusive() {
+                next_free.push(GuestMemoryRange::new(
+                    allocation.end_exclusive(),
+                    range.end_exclusive().raw_value() - allocation.end_exclusive().raw_value(),
+                )?);
+            }
+        }
+        next_free.sort_by_key(|range| range.start());
+
+        let generation = self.next_generation;
+        self.free = next_free;
+        let replaced = self.allocations.insert(
+            generation,
+            PciBarAllocation {
+                address_space: self.address_space,
+                range: allocation,
+            },
+        );
+        debug_assert!(replaced.is_none());
+        self.next_generation = next_generation;
+        Ok(PciBarLease {
+            allocator: Arc::clone(&self.provenance),
+            generation,
+            address_space: self.address_space,
+            range: allocation,
+        })
+    }
+
+    pub fn release(&mut self, lease: &PciBarLease) -> Result<(), PciBarReleaseError> {
+        if !Arc::ptr_eq(&self.provenance, &lease.allocator) {
+            return Err(PciBarReleaseError::WrongAllocator);
+        }
+        let allocation = self
+            .allocations
+            .get(&lease.generation)
+            .copied()
+            .ok_or(PciBarReleaseError::StaleLease)?;
+        if allocation.address_space != lease.address_space || allocation.range != lease.range {
+            return Err(PciBarReleaseError::LeaseMismatch);
+        }
+
+        let mut ranges = self.free.clone();
+        ranges.push(allocation.range);
+        ranges.sort_by_key(|range| range.start());
+        let free = coalesce_ranges(&ranges).ok_or(PciBarReleaseError::AllocatorStateMismatch)?;
+        let removed = self.allocations.remove(&lease.generation);
+        debug_assert!(removed.is_some());
+        self.free = free;
+        Ok(())
+    }
+
+    pub fn available_ranges(&self) -> &[GuestMemoryRange] {
+        &self.free
+    }
+}
+
+impl fmt::Debug for PciBarAllocator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PciBarAllocator")
+            .field("address_space", &self.address_space)
+            .field("capacity", &"<redacted>")
+            .field("free_ranges", &self.free.len())
+            .field("allocations", &self.allocations.len())
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PciBarAllocationError {
+    InvalidSize { size: u64 },
+    AddressOverflow,
+    Exhausted { size: u64 },
+    GenerationExhausted,
+    MetadataAllocation,
+    InvalidRange { source: GuestMemoryError },
+}
+
+impl From<GuestMemoryError> for PciBarAllocationError {
+    fn from(source: GuestMemoryError) -> Self {
+        Self::InvalidRange { source }
+    }
+}
+
+impl fmt::Display for PciBarAllocationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidSize { size } => {
+                write!(
+                    f,
+                    "PCI BAR size {size} is not a power of two of at least 16 bytes"
+                )
+            }
+            Self::AddressOverflow => f.write_str("PCI BAR allocation address overflowed"),
+            Self::Exhausted { size } => {
+                write!(f, "PCI BAR address space cannot fit {size} bytes")
+            }
+            Self::GenerationExhausted => f.write_str("PCI BAR lease generation is exhausted"),
+            Self::MetadataAllocation => f.write_str("PCI BAR allocator metadata allocation failed"),
+            Self::InvalidRange { source } => write!(f, "invalid PCI BAR range: {source}"),
+        }
+    }
+}
+
+impl std::error::Error for PciBarAllocationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidRange { source } => Some(source),
+            Self::InvalidSize { .. }
+            | Self::AddressOverflow
+            | Self::Exhausted { .. }
+            | Self::GenerationExhausted
+            | Self::MetadataAllocation => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PciBarReleaseError {
+    WrongAllocator,
+    StaleLease,
+    LeaseMismatch,
+    AllocatorStateMismatch,
+}
+
+impl fmt::Display for PciBarReleaseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::WrongAllocator => f.write_str("PCI BAR lease belongs to another allocator"),
+            Self::StaleLease => f.write_str("PCI BAR lease is stale"),
+            Self::LeaseMismatch => f.write_str("PCI BAR lease does not match allocator state"),
+            Self::AllocatorStateMismatch => {
+                f.write_str("PCI BAR allocator free ranges overlap or are invalid")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PciBarReleaseError {}
+
+fn align_up(value: u64, alignment: u64) -> Option<u64> {
+    value
+        .checked_add(alignment.checked_sub(1)?)
+        .map(|candidate| candidate & !(alignment - 1))
+}
+
+fn coalesce_ranges(ranges: &[GuestMemoryRange]) -> Option<Vec<GuestMemoryRange>> {
+    let mut coalesced: Vec<GuestMemoryRange> = Vec::new();
+    coalesced.try_reserve_exact(ranges.len()).ok()?;
+    for range in ranges.iter().copied() {
+        let Some(previous) = coalesced.last_mut() else {
+            coalesced.push(range);
+            continue;
+        };
+        if previous.overlaps(range) {
+            return None;
+        }
+        if previous.is_adjacent_to(range) {
+            *previous = GuestMemoryRange::new(
+                previous.start(),
+                range.end_exclusive().raw_value() - previous.start().raw_value(),
+            )
+            .ok()?;
+        } else {
+            coalesced.push(range);
+        }
+    }
+    Some(coalesced)
+}
+
+pub trait PciConfigFunction: fmt::Debug + Send {
+    fn read_config(&mut self, offset: u16, data: &mut [u8]) -> Result<(), PciConfigAccessError>;
+
+    fn write_config(&mut self, offset: u16, data: &[u8]) -> Result<(), PciConfigAccessError>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PciClassCode {
+    Unclassified = 0x00,
+    Bridge = 0x06,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PciBarPrefetchable {
+    No,
+    Yes,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PciBarRegister {
+    encoded_address: u32,
+    encoded_size: u32,
+    probe_pending: bool,
+}
+
+pub struct PciType0Configuration {
+    registers: Vec<u32>,
+    writable_masks: Vec<u32>,
+    bars: BTreeMap<u8, PciBarRegister>,
+}
+
+impl fmt::Debug for PciType0Configuration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PciType0Configuration")
+            .field("configuration", &"<redacted>")
+            .field("configured_bar_registers", &self.bars.len())
+            .finish()
+    }
+}
+
+impl PciType0Configuration {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        vendor_id: u16,
+        device_id: u16,
+        revision_id: u8,
+        class_code: PciClassCode,
+        subclass: u8,
+        programming_interface: u8,
+        subsystem_vendor_id: u16,
+        subsystem_id: u16,
+    ) -> Self {
+        let mut configuration = Self {
+            registers: vec![0; PCI_CONFIG_REGISTER_COUNT],
+            writable_masks: vec![0; PCI_CONFIG_REGISTER_COUNT],
+            bars: BTreeMap::new(),
+        };
+        configuration.set_register(0, (u32::from(device_id) << 16) | u32::from(vendor_id));
+        configuration.set_register(
+            2,
+            (u32::from(class_code as u8) << 24)
+                | (u32::from(subclass) << 16)
+                | (u32::from(programming_interface) << 8)
+                | u32::from(revision_id),
+        );
+        configuration.set_register(3, 0);
+        configuration.set_register(
+            11,
+            (u32::from(subsystem_id) << 16) | u32::from(subsystem_vendor_id),
+        );
+        configuration.set_writable_mask(1, PCI_COMMAND_WRITABLE_MASK);
+        configuration.set_writable_mask(3, PCI_CACHELINE_WRITABLE_MASK);
+        configuration.set_writable_mask(15, PCI_INTERRUPT_LINE_WRITABLE_MASK);
+        configuration
+    }
+
+    pub fn firecracker_host_bridge() -> Self {
+        Self::new(
+            PCI_HOST_BRIDGE_VENDOR_ID,
+            PCI_HOST_BRIDGE_DEVICE_ID,
+            0,
+            PciClassCode::Bridge,
+            0,
+            0,
+            0,
+            0,
+        )
+    }
+
+    pub fn install_bar(
+        &mut self,
+        index: u8,
+        lease: &PciBarLease,
+        prefetchable: PciBarPrefetchable,
+    ) -> Result<(), PciBarConfigurationError> {
+        if index >= PCI_BAR_REGISTER_COUNT {
+            return Err(PciBarConfigurationError::InvalidIndex { index });
+        }
+        let range = lease.range();
+        let type_bits = match lease.address_space() {
+            PciBarAddressSpace::Memory32 => {
+                if range.end_exclusive().raw_value() > 1_u64 << 32 {
+                    return Err(PciBarConfigurationError::AddressExceeds32Bit { range });
+                }
+                0
+            }
+            PciBarAddressSpace::Memory64 => {
+                if index >= PCI_BAR_REGISTER_COUNT - 1 {
+                    return Err(PciBarConfigurationError::MissingHighRegister { index });
+                }
+                0b100
+            }
+        };
+        let occupied_registers = if lease.address_space() == PciBarAddressSpace::Memory64 {
+            2
+        } else {
+            1
+        };
+        for register in index..index + occupied_registers {
+            if self.bars.contains_key(&register) {
+                return Err(PciBarConfigurationError::DuplicateRegister { index: register });
+            }
+        }
+        let prefetchable_bit = match prefetchable {
+            PciBarPrefetchable::No => 0,
+            PciBarPrefetchable::Yes => 0b1000,
+        };
+        let size_mask = !(range.size() - 1);
+        self.bars.insert(
+            index,
+            PciBarRegister {
+                encoded_address: (range.start().raw_value() as u32 & 0xffff_fff0)
+                    | type_bits
+                    | prefetchable_bit,
+                encoded_size: size_mask as u32,
+                probe_pending: false,
+            },
+        );
+        if lease.address_space() == PciBarAddressSpace::Memory64 {
+            self.bars.insert(
+                index + 1,
+                PciBarRegister {
+                    encoded_address: (range.start().raw_value() >> 32) as u32,
+                    encoded_size: (size_mask >> 32) as u32,
+                    probe_pending: false,
+                },
+            );
+        }
+        Ok(())
+    }
+
+    fn set_register(&mut self, index: usize, value: u32) {
+        if let Some(register) = self.registers.get_mut(index) {
+            *register = value;
+        }
+    }
+
+    fn set_writable_mask(&mut self, index: usize, value: u32) {
+        if let Some(mask) = self.writable_masks.get_mut(index) {
+            *mask = value;
+        }
+    }
+
+    fn validate_access(offset: u16, len: usize) -> Result<(usize, usize), PciConfigAccessError> {
+        if !matches!(len, 1 | 2 | 4) {
+            return Err(PciConfigAccessError::InvalidWidth { len });
+        }
+        let byte_offset = usize::from(offset);
+        let end = byte_offset
+            .checked_add(len)
+            .ok_or(PciConfigAccessError::OutsideConfigurationSpace { offset, len })?;
+        if end > PCI_CONFIG_SPACE_SIZE {
+            return Err(PciConfigAccessError::OutsideConfigurationSpace { offset, len });
+        }
+        let register_offset = byte_offset % PCI_CONFIG_REGISTER_SIZE;
+        if register_offset + len > PCI_CONFIG_REGISTER_SIZE {
+            return Err(PciConfigAccessError::CrossesRegister { offset, len });
+        }
+        Ok((byte_offset / PCI_CONFIG_REGISTER_SIZE, register_offset))
+    }
+}
+
+impl PciConfigFunction for PciType0Configuration {
+    fn read_config(&mut self, offset: u16, data: &mut [u8]) -> Result<(), PciConfigAccessError> {
+        let (register_index, register_offset) = Self::validate_access(offset, data.len())?;
+        let bar_index = register_index
+            .checked_sub(usize::from(PCI_BAR_REGISTER_FIRST))
+            .and_then(|index| u8::try_from(index).ok())
+            .filter(|index| *index < PCI_BAR_REGISTER_COUNT);
+        let value = if let Some(bar) = bar_index.and_then(|index| self.bars.get_mut(&index)) {
+            if bar.probe_pending {
+                bar.probe_pending = false;
+                bar.encoded_size
+            } else {
+                bar.encoded_address
+            }
+        } else {
+            self.registers
+                .get(register_index)
+                .copied()
+                .unwrap_or(u32::MAX)
+        };
+        copy_register_bytes(value, register_offset, data);
+        Ok(())
+    }
+
+    fn write_config(&mut self, offset: u16, data: &[u8]) -> Result<(), PciConfigAccessError> {
+        let (register_index, register_offset) = Self::validate_access(offset, data.len())?;
+        let bar_index = register_index
+            .checked_sub(usize::from(PCI_BAR_REGISTER_FIRST))
+            .and_then(|index| u8::try_from(index).ok())
+            .filter(|index| *index < PCI_BAR_REGISTER_COUNT);
+        if let Some(bar) = bar_index.and_then(|index| self.bars.get_mut(&index)) {
+            bar.probe_pending = register_offset == 0
+                && data.len() == PCI_CONFIG_REGISTER_SIZE
+                && data.iter().all(|byte| *byte == u8::MAX);
+            return Ok(());
+        }
+
+        let Some(register) = self.registers.get_mut(register_index) else {
+            return Ok(());
+        };
+        let writable = self
+            .writable_masks
+            .get(register_index)
+            .copied()
+            .unwrap_or(0);
+        let mut write_value = 0_u32;
+        let mut byte_mask = 0_u32;
+        for (index, byte) in data.iter().copied().enumerate() {
+            let shift = (register_offset + index) * 8;
+            write_value |= u32::from(byte) << shift;
+            byte_mask |= 0xff_u32 << shift;
+        }
+        let mask = byte_mask & writable;
+        *register = (*register & !mask) | (write_value & mask);
+        Ok(())
+    }
+}
+
+fn copy_register_bytes(value: u32, register_offset: usize, destination: &mut [u8]) {
+    let bytes = value.to_le_bytes();
+    for (index, destination_byte) in destination.iter_mut().enumerate() {
+        if let Some(source) = bytes.get(register_offset + index) {
+            *destination_byte = *source;
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PciConfigAccessError {
+    InvalidWidth { len: usize },
+    OutsideConfigurationSpace { offset: u16, len: usize },
+    CrossesRegister { offset: u16, len: usize },
+}
+
+impl fmt::Display for PciConfigAccessError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidWidth { len } => write!(
+                f,
+                "PCI configuration access width {len} is not 1, 2, or 4 bytes"
+            ),
+            Self::OutsideConfigurationSpace { offset, len } => write!(
+                f,
+                "PCI configuration access offset 0x{offset:x} width {len} exceeds 4 KiB"
+            ),
+            Self::CrossesRegister { offset, len } => write!(
+                f,
+                "PCI configuration access offset 0x{offset:x} width {len} crosses a dword boundary"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PciConfigAccessError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PciBarConfigurationError {
+    InvalidIndex { index: u8 },
+    MissingHighRegister { index: u8 },
+    DuplicateRegister { index: u8 },
+    AddressExceeds32Bit { range: GuestMemoryRange },
+}
+
+impl fmt::Display for PciBarConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidIndex { index } => write!(f, "PCI BAR index {index} exceeds 5"),
+            Self::MissingHighRegister { index } => {
+                write!(f, "64-bit PCI BAR at index {index} has no high register")
+            }
+            Self::DuplicateRegister { index } => {
+                write!(f, "PCI BAR register {index} is already configured")
+            }
+            Self::AddressExceeds32Bit { range } => {
+                write!(
+                    f,
+                    "32-bit PCI BAR range {range} exceeds the 32-bit address space"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for PciBarConfigurationError {}
+
+struct PciSegmentProvenance;
+
+pub struct PciFunctionLease {
+    segment: Arc<PciSegmentProvenance>,
+    generation: u64,
+    sbdf: PciSbdf,
+}
+
+impl PciFunctionLease {
+    pub const fn sbdf(&self) -> PciSbdf {
+        self.sbdf
+    }
+}
+
+impl fmt::Debug for PciFunctionLease {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PciFunctionLease")
+            .field("ownership", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PciFunctionRecord {
+    generation: u64,
+}
+
+pub struct PciSegment {
+    provenance: Arc<PciSegmentProvenance>,
+    functions: BTreeMap<u8, Box<dyn PciConfigFunction>>,
+    records: BTreeMap<u8, PciFunctionRecord>,
+    next_generation: u64,
+}
+
+impl PciSegment {
+    pub fn new() -> Self {
+        let mut functions: BTreeMap<u8, Box<dyn PciConfigFunction>> = BTreeMap::new();
+        functions.insert(
+            PCI_HOST_BRIDGE_DEVICE,
+            Box::new(PciType0Configuration::firecracker_host_bridge()),
+        );
+        Self {
+            provenance: Arc::new(PciSegmentProvenance),
+            functions,
+            records: BTreeMap::new(),
+            next_generation: 0,
+        }
+    }
+
+    pub fn add_function(
+        &mut self,
+        function: impl PciConfigFunction + 'static,
+    ) -> Result<PciFunctionLease, PciSegmentError> {
+        let device = (PCI_FIRST_ENDPOINT_DEVICE..=PCI_LAST_ENDPOINT_DEVICE)
+            .find(|device| !self.functions.contains_key(device))
+            .ok_or(PciSegmentError::NoDeviceSlot)?;
+        let sbdf = PciSbdf::new(PCI_SEGMENT_ZERO, PCI_BUS_ZERO, device, PCI_FUNCTION_ZERO)
+            .map_err(|source| PciSegmentError::InvalidIdentity { source })?;
+        self.add_function_at(sbdf, function)
+    }
+
+    pub fn add_function_at(
+        &mut self,
+        sbdf: PciSbdf,
+        function: impl PciConfigFunction + 'static,
+    ) -> Result<PciFunctionLease, PciSegmentError> {
+        if sbdf.segment() != PCI_SEGMENT_ZERO
+            || sbdf.bus() != PCI_BUS_ZERO
+            || sbdf.function() != PCI_FUNCTION_ZERO
+            || !(PCI_FIRST_ENDPOINT_DEVICE..=PCI_LAST_ENDPOINT_DEVICE).contains(&sbdf.device())
+        {
+            return Err(PciSegmentError::UnsupportedIdentity { sbdf });
+        }
+        if self.functions.contains_key(&sbdf.device()) {
+            return Err(PciSegmentError::DuplicateIdentity { sbdf });
+        }
+        let next_generation = self
+            .next_generation
+            .checked_add(1)
+            .ok_or(PciSegmentError::GenerationExhausted)?;
+        let generation = self.next_generation;
+        let previous = self.functions.insert(sbdf.device(), Box::new(function));
+        debug_assert!(previous.is_none());
+        let previous = self
+            .records
+            .insert(sbdf.device(), PciFunctionRecord { generation });
+        debug_assert!(previous.is_none());
+        self.next_generation = next_generation;
+        Ok(PciFunctionLease {
+            segment: Arc::clone(&self.provenance),
+            generation,
+            sbdf,
+        })
+    }
+
+    pub fn remove_function(
+        &mut self,
+        lease: &PciFunctionLease,
+    ) -> Result<(), PciFunctionReleaseError> {
+        if !Arc::ptr_eq(&self.provenance, &lease.segment) {
+            return Err(PciFunctionReleaseError::WrongSegment);
+        }
+        let device = lease.sbdf.device();
+        let record = self
+            .records
+            .get(&device)
+            .copied()
+            .ok_or(PciFunctionReleaseError::StaleLease { sbdf: lease.sbdf })?;
+        if record.generation != lease.generation || !self.functions.contains_key(&device) {
+            return Err(PciFunctionReleaseError::LeaseMismatch { sbdf: lease.sbdf });
+        }
+        self.functions.remove(&device);
+        self.records.remove(&device);
+        Ok(())
+    }
+
+    pub fn function_count(&self) -> usize {
+        self.functions.len()
+    }
+
+    pub fn read_ecam(&mut self, offset: u64, data: &mut [u8]) -> Result<(), PciEcamAccessError> {
+        let decoded = decode_ecam_access(offset, data.len())?;
+        if decoded.bus != PCI_BUS_ZERO || decoded.function != PCI_FUNCTION_ZERO {
+            data.fill(u8::MAX);
+            return Ok(());
+        }
+        let Some(function) = self.functions.get_mut(&decoded.device) else {
+            data.fill(u8::MAX);
+            return Ok(());
+        };
+        function
+            .read_config(decoded.register_offset, data)
+            .map_err(|source| PciEcamAccessError::Configuration { source })
+    }
+
+    pub fn write_ecam(&mut self, offset: u64, data: &[u8]) -> Result<(), PciEcamAccessError> {
+        let decoded = decode_ecam_access(offset, data.len())?;
+        if decoded.bus != PCI_BUS_ZERO || decoded.function != PCI_FUNCTION_ZERO {
+            return Ok(());
+        }
+        let Some(function) = self.functions.get_mut(&decoded.device) else {
+            return Ok(());
+        };
+        function
+            .write_config(decoded.register_offset, data)
+            .map_err(|source| PciEcamAccessError::Configuration { source })
+    }
+}
+
+impl Default for PciSegment {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for PciSegment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PciSegment")
+            .field("identity", &"<redacted>")
+            .field("function_count", &self.functions.len())
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub enum PciSegmentError {
+    NoDeviceSlot,
+    GenerationExhausted,
+    InvalidIdentity { source: PciIdentityError },
+    UnsupportedIdentity { sbdf: PciSbdf },
+    DuplicateIdentity { sbdf: PciSbdf },
+}
+
+impl fmt::Display for PciSegmentError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoDeviceSlot => f.write_str("PCI segment has no available device slot"),
+            Self::GenerationExhausted => f.write_str("PCI function lease generation is exhausted"),
+            Self::InvalidIdentity { source } => {
+                write!(f, "invalid PCI function identity: {source}")
+            }
+            Self::UnsupportedIdentity { sbdf } => {
+                write!(f, "PCI segment does not support function identity {sbdf}")
+            }
+            Self::DuplicateIdentity { sbdf } => {
+                write!(f, "PCI function identity {sbdf} is already in use")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PciSegmentError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidIdentity { source } => Some(source),
+            Self::NoDeviceSlot
+            | Self::GenerationExhausted
+            | Self::UnsupportedIdentity { .. }
+            | Self::DuplicateIdentity { .. } => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PciFunctionReleaseError {
+    WrongSegment,
+    StaleLease { sbdf: PciSbdf },
+    LeaseMismatch { sbdf: PciSbdf },
+}
+
+impl fmt::Display for PciFunctionReleaseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::WrongSegment => f.write_str("PCI function lease belongs to another segment"),
+            Self::StaleLease { sbdf } => write!(f, "PCI function lease for {sbdf} is stale"),
+            Self::LeaseMismatch { sbdf } => {
+                write!(
+                    f,
+                    "PCI function lease for {sbdf} does not match segment state"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for PciFunctionReleaseError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DecodedEcamAccess {
+    bus: u8,
+    device: u8,
+    function: u8,
+    register_offset: u16,
+}
+
+fn decode_ecam_access(offset: u64, len: usize) -> Result<DecodedEcamAccess, PciEcamAccessError> {
+    if !matches!(len, 1 | 2 | 4) {
+        return Err(PciEcamAccessError::InvalidWidth { len });
+    }
+    if offset >= PCI_ECAM_BUS_ZERO_SIZE {
+        return Err(PciEcamAccessError::OutsideBusZero { offset });
+    }
+    let end = offset
+        .checked_add(u64::try_from(len).map_err(|_| PciEcamAccessError::AddressOverflow)?)
+        .ok_or(PciEcamAccessError::AddressOverflow)?;
+    if end > PCI_ECAM_BUS_ZERO_SIZE {
+        return Err(PciEcamAccessError::OutsideBusZero { offset });
+    }
+    let register_offset = (offset & (PCI_ECAM_FUNCTION_SIZE - 1)) as u16;
+    if usize::from(register_offset % 4) + len > PCI_CONFIG_REGISTER_SIZE {
+        return Err(PciEcamAccessError::CrossesRegister { offset, len });
+    }
+    Ok(DecodedEcamAccess {
+        bus: ((offset >> 20) & 0xff) as u8,
+        device: ((offset >> 15) & 0x1f) as u8,
+        function: ((offset >> 12) & 0x7) as u8,
+        register_offset,
+    })
+}
+
+#[derive(Debug)]
+pub enum PciEcamAccessError {
+    InvalidWidth { len: usize },
+    OutsideBusZero { offset: u64 },
+    AddressOverflow,
+    CrossesRegister { offset: u64, len: usize },
+    Configuration { source: PciConfigAccessError },
+}
+
+impl fmt::Display for PciEcamAccessError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidWidth { len } => {
+                write!(f, "PCI ECAM access width {len} is not 1, 2, or 4 bytes")
+            }
+            Self::OutsideBusZero { offset } => {
+                write!(f, "PCI ECAM offset 0x{offset:x} is outside bus 0")
+            }
+            Self::AddressOverflow => f.write_str("PCI ECAM access address overflowed"),
+            Self::CrossesRegister { offset, len } => write!(
+                f,
+                "PCI ECAM access offset 0x{offset:x} width {len} crosses a dword boundary"
+            ),
+            Self::Configuration { source } => write!(f, "PCI ECAM configuration failed: {source}"),
+        }
+    }
+}
+
+impl std::error::Error for PciEcamAccessError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Configuration { source } => Some(source),
+            Self::InvalidWidth { .. }
+            | Self::OutsideBusZero { .. }
+            | Self::AddressOverflow
+            | Self::CrossesRegister { .. } => None,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct SharedPciSegment {
+    state: Arc<Mutex<PciSegment>>,
+}
+
+impl SharedPciSegment {
+    pub fn new(segment: PciSegment) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(segment)),
+        }
+    }
+
+    pub fn with_segment<T>(
+        &self,
+        operation: impl FnOnce(&mut PciSegment) -> T,
+    ) -> Result<T, PciSegmentLockError> {
+        let mut segment = self
+            .state
+            .lock()
+            .map_err(|_| PciSegmentLockError::Poisoned)?;
+        Ok(operation(&mut segment))
+    }
+}
+
+impl fmt::Debug for SharedPciSegment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SharedPciSegment")
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PciSegmentLockError {
+    Poisoned,
+}
+
+impl fmt::Display for PciSegmentLockError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("PCI segment state lock is poisoned")
+    }
+}
+
+impl std::error::Error for PciSegmentLockError {}
+
+#[derive(Debug)]
+pub struct PciEcamHandler {
+    segment: SharedPciSegment,
+}
+
+impl PciEcamHandler {
+    pub fn new(segment: SharedPciSegment) -> Self {
+        Self { segment }
+    }
+}
+
+impl MmioHandler for PciEcamHandler {
+    fn read(&mut self, access: MmioAccess) -> Result<MmioAccessBytes, MmioHandlerError> {
+        let mut bytes = [0_u8; 4];
+        let len = usize::try_from(access.range().size())
+            .map_err(|_| MmioHandlerError::new("PCI ECAM read width is not representable"))?;
+        let destination = bytes
+            .get_mut(..len)
+            .ok_or_else(|| MmioHandlerError::new("PCI ECAM read width exceeds four bytes"))?;
+        let result = self
+            .segment
+            .with_segment(|segment| segment.read_ecam(access.offset(), destination))
+            .map_err(|source| MmioHandlerError::new(source.to_string()))?;
+        match result {
+            Ok(()) => {}
+            Err(PciEcamAccessError::CrossesRegister { .. }) => destination.fill(u8::MAX),
+            Err(source) => return Err(MmioHandlerError::new(source.to_string())),
+        }
+        MmioAccessBytes::new(destination)
+            .map_err(|source| MmioHandlerError::new(source.to_string()))
+    }
+
+    fn write(&mut self, access: MmioAccess, data: MmioAccessBytes) -> Result<(), MmioHandlerError> {
+        let result = self
+            .segment
+            .with_segment(|segment| segment.write_ecam(access.offset(), data.as_slice()))
+            .map_err(|source| MmioHandlerError::new(source.to_string()))?;
+        match result {
+            Ok(()) | Err(PciEcamAccessError::CrossesRegister { .. }) => Ok(()),
+            Err(source) => Err(MmioHandlerError::new(source.to_string())),
+        }
+    }
+}
+
+pub fn register_ecam_handler(
+    dispatcher: &mut crate::mmio::MmioDispatcher,
+    owner: &MmioRegistrationOwner,
+    region_id: MmioRegionId,
+    plan: Arm64PciAddressPlan,
+    segment: SharedPciSegment,
+) -> Result<MmioRegistrationLease, MmioRegistrationError> {
+    dispatcher.register_owned_handler(
+        owner,
+        region_id,
+        &[MmioRegionRequest::new(
+            plan.ecam().start(),
+            plan.ecam().size(),
+        )],
+        PciEcamHandler::new(segment),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mmio::{
+        MmioBusError, MmioDispatchOutcome, MmioDispatcher, MmioOperation,
+        MmioRegistrationReleaseError,
+    };
+
+    fn range(start: u64, size: u64) -> GuestMemoryRange {
+        GuestMemoryRange::new(GuestAddress::new(start), size)
+            .expect("test PCI range should be valid")
+    }
+
+    fn endpoint(vendor_id: u16, device_id: u16) -> PciType0Configuration {
+        PciType0Configuration::new(
+            vendor_id,
+            device_id,
+            1,
+            PciClassCode::Unclassified,
+            0,
+            0,
+            vendor_id,
+            device_id,
+        )
+    }
+
+    fn read_config_u32(function: &mut impl PciConfigFunction, offset: u16) -> u32 {
+        let mut bytes = [0; 4];
+        function
+            .read_config(offset, &mut bytes)
+            .expect("test PCI configuration read should succeed");
+        u32::from_le_bytes(bytes)
+    }
+
+    fn read_ecam_u32(segment: &mut PciSegment, offset: u64) -> u32 {
+        let mut bytes = [0; 4];
+        segment
+            .read_ecam(offset, &mut bytes)
+            .expect("test PCI ECAM read should succeed");
+        u32::from_le_bytes(bytes)
+    }
+
+    #[test]
+    fn sbdf_validates_and_encodes_firecracker_identity() {
+        let sbdf = PciSbdf::new(0, 0, 31, 7).expect("maximum PCI SBDF should be valid");
+
+        assert_eq!(sbdf.to_string(), "0000:00:1f.7");
+        assert_eq!(sbdf.ecam_offset(), 31 << 15 | 7 << 12);
+        assert_eq!(
+            PciSbdf::new(0, 0, 32, 0),
+            Err(PciIdentityError::InvalidDevice { device: 32 })
+        );
+        assert_eq!(
+            PciSbdf::new(0, 0, 0, 8),
+            Err(PciIdentityError::InvalidFunction { function: 8 })
+        );
+    }
+
+    #[test]
+    fn arm64_address_plan_matches_pinned_firecracker_boundaries() {
+        let plan = Arm64PciAddressPlan::firecracker_v1_16()
+            .expect("pinned PCI address plan should be valid");
+
+        assert_eq!(plan.ecam(), range(0x7000_0000, 1 << 20));
+        assert_eq!(plan.ecam_reservation(), range(0x7000_0000, 256 << 20));
+        assert_eq!(plan.bar32().start(), GuestAddress::new(0x4000_3000));
+        assert_eq!(plan.bar32().end_exclusive(), GuestAddress::new(0x7000_0000));
+        assert_eq!(plan.bar64(), range(256 << 30, 256 << 30));
+        assert!(!plan.bar32().overlaps(plan.ecam_reservation()));
+        assert!(!plan.ecam_reservation().overlaps(plan.bar64()));
+    }
+
+    #[test]
+    fn bar_allocator_rejects_invalid_sizes_without_mutation() {
+        let capacity = range(0x1000, 0x4000);
+        let mut allocator = PciBarAllocator::new(PciBarAddressSpace::Memory32, capacity);
+
+        for size in [0, 8, 24] {
+            assert!(matches!(
+                allocator.allocate(size),
+                Err(PciBarAllocationError::InvalidSize { size: actual }) if actual == size
+            ));
+        }
+        assert_eq!(allocator.available_ranges(), &[capacity]);
+    }
+
+    #[test]
+    fn bar_allocator_aligns_splits_releases_and_reuses_lowest_range() {
+        let capacity = range(0x1003, 0x3ffd);
+        let mut allocator = PciBarAllocator::new(PciBarAddressSpace::Memory32, capacity);
+        let first = allocator
+            .allocate(0x1000)
+            .expect("first aligned PCI BAR should allocate");
+        let second = allocator
+            .allocate(0x1000)
+            .expect("second aligned PCI BAR should allocate");
+
+        assert_eq!(first.range(), range(0x2000, 0x1000));
+        assert_eq!(second.range(), range(0x3000, 0x1000));
+        allocator
+            .release(&first)
+            .expect("first PCI BAR release should succeed");
+        let reused = allocator
+            .allocate(0x1000)
+            .expect("released PCI BAR should be reusable");
+        assert_eq!(reused.range(), first.range());
+        allocator
+            .release(&second)
+            .expect("second PCI BAR release should succeed");
+        allocator
+            .release(&reused)
+            .expect("reused PCI BAR release should succeed");
+        assert_eq!(allocator.available_ranges(), &[capacity]);
+    }
+
+    #[test]
+    fn bar_allocator_rejects_foreign_and_stale_leases() {
+        let mut first = PciBarAllocator::new(
+            PciBarAddressSpace::Memory64,
+            range(PCI_BAR64_START, 0x20_0000),
+        );
+        let mut second = PciBarAllocator::new(
+            PciBarAddressSpace::Memory64,
+            range(PCI_BAR64_START, 0x20_0000),
+        );
+        let lease = first
+            .allocate(0x10_0000)
+            .expect("test PCI BAR should allocate");
+
+        assert_eq!(
+            second.release(&lease),
+            Err(PciBarReleaseError::WrongAllocator)
+        );
+        first
+            .release(&lease)
+            .expect("test PCI BAR should release once");
+        assert_eq!(first.release(&lease), Err(PciBarReleaseError::StaleLease));
+    }
+
+    #[test]
+    fn bar_allocator_reports_deterministic_exhaustion() {
+        let mut allocator =
+            PciBarAllocator::new(PciBarAddressSpace::Memory32, range(0x1000, 0x2000));
+        let _first = allocator
+            .allocate(0x1000)
+            .expect("first PCI BAR should fit");
+        let _second = allocator
+            .allocate(0x1000)
+            .expect("second PCI BAR should fit");
+
+        assert!(matches!(
+            allocator.allocate(0x1000),
+            Err(PciBarAllocationError::Exhausted { size: 0x1000 })
+        ));
+    }
+
+    #[test]
+    fn type0_host_bridge_header_and_masks_match_firecracker() {
+        let mut configuration = PciType0Configuration::firecracker_host_bridge();
+
+        assert_eq!(read_config_u32(&mut configuration, 0), 0x0d57_8086);
+        assert_eq!(read_config_u32(&mut configuration, 8), 0x0600_0000);
+        configuration
+            .write_config(0, &u32::MAX.to_le_bytes())
+            .expect("identity write should be accepted and masked");
+        assert_eq!(read_config_u32(&mut configuration, 0), 0x0d57_8086);
+        configuration
+            .write_config(4, &0x0000_0007_u32.to_le_bytes())
+            .expect("command write should succeed");
+        assert_eq!(read_config_u32(&mut configuration, 4) & 0xffff, 7);
+    }
+
+    #[test]
+    fn type0_configuration_rejects_invalid_width_and_crossing() {
+        let mut configuration = endpoint(0x1af4, 0x10ff);
+        let mut three = [0; 3];
+        let mut outside = [0xa5];
+
+        assert_eq!(
+            configuration.read_config(0, &mut three),
+            Err(PciConfigAccessError::InvalidWidth { len: 3 })
+        );
+        assert_eq!(
+            configuration.write_config(3, &[1, 2]),
+            Err(PciConfigAccessError::CrossesRegister { offset: 3, len: 2 })
+        );
+        assert_eq!(
+            configuration.read_config(PCI_CONFIG_SPACE_SIZE as u16, &mut outside),
+            Err(PciConfigAccessError::OutsideConfigurationSpace {
+                offset: PCI_CONFIG_SPACE_SIZE as u16,
+                len: 1,
+            })
+        );
+        assert_eq!(outside, [0xa5]);
+        assert_eq!(
+            configuration.write_config((PCI_CONFIG_SPACE_SIZE - 1) as u16, &[1, 2]),
+            Err(PciConfigAccessError::OutsideConfigurationSpace {
+                offset: (PCI_CONFIG_SPACE_SIZE - 1) as u16,
+                len: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn type0_configuration_probes_and_preserves_32_bit_bar() {
+        let mut allocator =
+            PciBarAllocator::new(PciBarAddressSpace::Memory32, range(0x5000_0000, 0x20_0000));
+        let lease = allocator
+            .allocate(0x1000)
+            .expect("test 32-bit BAR should allocate");
+        let mut configuration = endpoint(0x1af4, 0x10ff);
+        configuration
+            .install_bar(0, &lease, PciBarPrefetchable::No)
+            .expect("test 32-bit BAR should install");
+
+        assert_eq!(read_config_u32(&mut configuration, 0x10), 0x5000_0000);
+        configuration
+            .write_config(0x10, &u32::MAX.to_le_bytes())
+            .expect("BAR probe write should succeed");
+        assert_eq!(read_config_u32(&mut configuration, 0x10), 0xffff_f000);
+        assert_eq!(read_config_u32(&mut configuration, 0x10), 0x5000_0000);
+        configuration
+            .write_config(0x10, &0x6000_0000_u32.to_le_bytes())
+            .expect("unsupported BAR relocation write should be ignored");
+        assert_eq!(read_config_u32(&mut configuration, 0x10), 0x5000_0000);
+    }
+
+    #[test]
+    fn type0_configuration_encodes_64_bit_prefetchable_bar() {
+        let mut allocator = PciBarAllocator::new(
+            PciBarAddressSpace::Memory64,
+            range(PCI_BAR64_START, 0x20_0000),
+        );
+        let lease = allocator
+            .allocate(0x80_000)
+            .expect("test 64-bit BAR should allocate");
+        let mut configuration = endpoint(0x1af4, 0x10ff);
+        configuration
+            .install_bar(0, &lease, PciBarPrefetchable::Yes)
+            .expect("test 64-bit BAR should install");
+
+        assert_eq!(read_config_u32(&mut configuration, 0x10), 0x0000_000c);
+        assert_eq!(read_config_u32(&mut configuration, 0x14), 0x0000_0040);
+        configuration
+            .write_config(0x10, &u32::MAX.to_le_bytes())
+            .expect("low BAR probe write should succeed");
+        configuration
+            .write_config(0x14, &u32::MAX.to_le_bytes())
+            .expect("high BAR probe write should succeed");
+        assert_eq!(read_config_u32(&mut configuration, 0x10), 0xfff8_0000);
+        assert_eq!(read_config_u32(&mut configuration, 0x14), 0xffff_ffff);
+    }
+
+    #[test]
+    fn segment_allocates_all_slots_then_reuses_released_slot() {
+        let mut segment = PciSegment::new();
+        let mut leases = Vec::new();
+        for expected_device in PCI_FIRST_ENDPOINT_DEVICE..=PCI_LAST_ENDPOINT_DEVICE {
+            let lease = segment
+                .add_function(endpoint(0x1af4, 0x10ff))
+                .expect("PCI endpoint slot should allocate");
+            assert_eq!(lease.sbdf().device(), expected_device);
+            leases.push(lease);
+        }
+        assert_eq!(segment.function_count(), 32);
+        assert!(matches!(
+            segment.add_function(endpoint(0x1af4, 0x10ff)),
+            Err(PciSegmentError::NoDeviceSlot)
+        ));
+
+        let released = leases
+            .get(7)
+            .expect("test PCI lease should exist at slot 8");
+        segment
+            .remove_function(released)
+            .expect("test PCI function should remove");
+        let reused = segment
+            .add_function(endpoint(0x1af4, 0x10ff))
+            .expect("released PCI function slot should be reused");
+        assert_eq!(reused.sbdf().device(), 8);
+    }
+
+    #[test]
+    fn segment_rejects_duplicate_unsupported_foreign_and_stale_leases() {
+        let mut first = PciSegment::new();
+        let mut second = PciSegment::new();
+        let sbdf = PciSbdf::new(0, 0, 1, 0).expect("test PCI SBDF should be valid");
+        let lease = first
+            .add_function_at(sbdf, endpoint(0x1af4, 0x10ff))
+            .expect("test endpoint should insert");
+
+        assert!(matches!(
+            first.add_function_at(sbdf, endpoint(0x1af4, 0x10ff)),
+            Err(PciSegmentError::DuplicateIdentity { sbdf: duplicate }) if duplicate == sbdf
+        ));
+        let unsupported = PciSbdf::new(1, 0, 2, 0).expect("test PCI SBDF should be valid");
+        assert!(matches!(
+            first.add_function_at(unsupported, endpoint(0x1af4, 0x10ff)),
+            Err(PciSegmentError::UnsupportedIdentity { sbdf: actual }) if actual == unsupported
+        ));
+        assert_eq!(
+            second.remove_function(&lease),
+            Err(PciFunctionReleaseError::WrongSegment)
+        );
+        first
+            .remove_function(&lease)
+            .expect("test endpoint should remove once");
+        assert_eq!(
+            first.remove_function(&lease),
+            Err(PciFunctionReleaseError::StaleLease { sbdf })
+        );
+    }
+
+    #[test]
+    fn ecam_exposes_host_endpoint_and_absent_functions() {
+        let mut segment = PciSegment::new();
+        let endpoint_lease = segment
+            .add_function(endpoint(0x1af4, 0x10ff))
+            .expect("test endpoint should insert");
+
+        assert_eq!(read_ecam_u32(&mut segment, 0), 0x0d57_8086);
+        assert_eq!(
+            read_ecam_u32(&mut segment, u64::from(endpoint_lease.sbdf().ecam_offset())),
+            0x10ff_1af4
+        );
+        assert_eq!(read_ecam_u32(&mut segment, 2 << 15), u32::MAX);
+        assert_eq!(read_ecam_u32(&mut segment, 1 << 12), u32::MAX);
+        assert_eq!(
+            read_ecam_u32(
+                &mut segment,
+                u64::from(endpoint_lease.sbdf().ecam_offset()) + 0x100
+            ),
+            0
+        );
+        assert_eq!(read_ecam_u32(&mut segment, (2 << 15) + 0x100), u32::MAX);
+    }
+
+    #[test]
+    fn ecam_rejects_invalid_width_crossing_and_bus_overflow() {
+        let mut segment = PciSegment::new();
+        let mut invalid = [0; 8];
+
+        assert!(matches!(
+            segment.read_ecam(0, &mut invalid),
+            Err(PciEcamAccessError::InvalidWidth { len: 8 })
+        ));
+        assert!(matches!(
+            segment.write_ecam(3, &[1, 2]),
+            Err(PciEcamAccessError::CrossesRegister { offset: 3, len: 2 })
+        ));
+        assert!(matches!(
+            segment.read_ecam(PCI_ECAM_BUS_ZERO_SIZE, &mut invalid[..4]),
+            Err(PciEcamAccessError::OutsideBusZero { .. })
+        ));
+    }
+
+    #[test]
+    fn leased_ecam_handler_dispatches_and_removes_atomically() {
+        let plan = Arm64PciAddressPlan::firecracker_v1_16()
+            .expect("test PCI address plan should be valid");
+        let shared = SharedPciSegment::new(PciSegment::new());
+        let endpoint_lease = shared
+            .with_segment(|segment| segment.add_function(endpoint(0x1af4, 0x10ff)))
+            .expect("test PCI segment lock should succeed")
+            .expect("test endpoint should insert");
+        let owner = MmioRegistrationOwner::new();
+        let mut dispatcher = MmioDispatcher::new();
+        let lease = register_ecam_handler(
+            &mut dispatcher,
+            &owner,
+            MmioRegionId::new(9000),
+            plan,
+            shared,
+        )
+        .expect("test ECAM handler should register");
+        let address = plan
+            .ecam()
+            .start()
+            .checked_add(u64::from(endpoint_lease.sbdf().ecam_offset()))
+            .expect("test ECAM address should not overflow");
+        let access = dispatcher
+            .lookup(address, 4)
+            .expect("test ECAM access should resolve");
+
+        assert_eq!(
+            dispatcher
+                .dispatch(MmioOperation::read(access).expect("test ECAM read should build"))
+                .expect("test ECAM read should dispatch"),
+            MmioDispatchOutcome::Read {
+                data: MmioAccessBytes::new(&0x10ff_1af4_u32.to_le_bytes())
+                    .expect("test ECAM bytes should be valid")
+            }
+        );
+        dispatcher
+            .release_owned_handler(&owner, &lease)
+            .expect("test ECAM lease should release");
+        assert!(matches!(
+            dispatcher.lookup(address, 4),
+            Err(MmioBusError::UnownedAccess { .. })
+        ));
+        assert_eq!(
+            dispatcher.release_owned_handler(&owner, &lease),
+            Err(MmioRegistrationReleaseError::StaleLease {
+                region_id: MmioRegionId::new(9000)
+            })
+        );
+    }
+
+    #[test]
+    fn ecam_handler_returns_ones_and_ignores_writes_crossing_a_dword() {
+        let plan = Arm64PciAddressPlan::firecracker_v1_16()
+            .expect("test PCI address plan should be valid");
+        let owner = MmioRegistrationOwner::new();
+        let mut dispatcher = MmioDispatcher::new();
+        let _lease = register_ecam_handler(
+            &mut dispatcher,
+            &owner,
+            MmioRegionId::new(9001),
+            plan,
+            SharedPciSegment::new(PciSegment::new()),
+        )
+        .expect("test ECAM handler should register");
+        let crossing_address = plan
+            .ecam()
+            .start()
+            .checked_add(3)
+            .expect("test crossing address should not overflow");
+        let crossing_access = dispatcher
+            .lookup(crossing_address, 2)
+            .expect("test crossing ECAM access should resolve");
+
+        assert_eq!(
+            dispatcher
+                .dispatch(MmioOperation::read(crossing_access).expect("test read should build"))
+                .expect("crossing ECAM read should dispatch"),
+            MmioDispatchOutcome::Read {
+                data: MmioAccessBytes::new(&[u8::MAX; 2])
+                    .expect("test all-ones bytes should be valid")
+            }
+        );
+        assert_eq!(
+            dispatcher
+                .dispatch(
+                    MmioOperation::write(
+                        crossing_access,
+                        MmioAccessBytes::new(&[1, 2]).expect("test write bytes should be valid"),
+                    )
+                    .expect("test write should build"),
+                )
+                .expect("crossing ECAM write should be ignored"),
+            MmioDispatchOutcome::Write
+        );
+    }
+
+    #[test]
+    fn ownership_debug_output_is_redacted() {
+        let mut allocator =
+            PciBarAllocator::new(PciBarAddressSpace::Memory32, range(0x1000, 0x1000));
+        let bar = allocator
+            .allocate(0x1000)
+            .expect("test PCI BAR should allocate");
+        let mut segment = PciSegment::new();
+        let function = segment
+            .add_function(endpoint(0x1af4, 0x10ff))
+            .expect("test PCI function should allocate");
+
+        assert_eq!(
+            format!("{bar:?}"),
+            "PciBarLease { ownership: \"<redacted>\" }"
+        );
+        assert_eq!(
+            format!("{function:?}"),
+            "PciFunctionLease { ownership: \"<redacted>\" }"
+        );
+
+        let mut configuration = endpoint(0x1af4, 0x10ff);
+        configuration
+            .install_bar(0, &bar, PciBarPrefetchable::No)
+            .expect("test PCI BAR should install");
+        assert_eq!(
+            format!("{configuration:?}"),
+            "PciType0Configuration { configuration: \"<redacted>\", configured_bar_registers: 1 }"
+        );
+    }
+}

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -251,8 +251,8 @@ pub struct Arm64BootPciValidationConfig {
 }
 
 impl Arm64BootPciValidationConfig {
-    pub const FIRECRACKER_TEST_VENDOR_ID: u16 = 0x1af4;
-    pub const FIRECRACKER_TEST_DEVICE_ID: u16 = 0x10ff;
+    pub const FIRECRACKER_TEST_VENDOR_ID: u16 = 0x0042;
+    pub const FIRECRACKER_TEST_DEVICE_ID: u16 = 0x0000;
 
     pub const fn firecracker_test_endpoint() -> Self {
         Self {

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -34,9 +34,10 @@ use crate::entropy::{
 };
 use crate::fdt::{
     ARM64_FDT_VMCLOCK_SIZE, ARM64_FDT_VMGENID_SIZE, Arm64FdtBootInfo, Arm64FdtCacheHierarchy,
-    Arm64FdtConfig, Arm64FdtError, Arm64FdtGic, Arm64FdtGuestMemoryWrite, Arm64FdtRegion,
-    Arm64FdtRtcDevice, Arm64FdtSerialDevice, Arm64FdtTimerInterrupts, Arm64FdtVirtioMmioDevice,
-    Arm64FdtVmClockDevice, Arm64FdtVmGenIdDevice, write_arm64_fdt,
+    Arm64FdtConfig, Arm64FdtError, Arm64FdtGic, Arm64FdtGuestMemoryWrite, Arm64FdtPciHost,
+    Arm64FdtRegion, Arm64FdtRtcDevice, Arm64FdtSerialDevice, Arm64FdtTimerInterrupts,
+    Arm64FdtVirtioMmioDevice, Arm64FdtVmClockDevice, Arm64FdtVmGenIdDevice, write_arm64_fdt,
+    write_arm64_fdt_with_pci,
 };
 use crate::interrupt::GuestInterruptLine;
 use crate::machine::MachineConfig;
@@ -55,7 +56,7 @@ use crate::memory_hotplug::{
 use crate::metrics::SharedRtcDeviceMetrics;
 use crate::mmio::{
     MmioBusError, MmioDispatchError, MmioDispatcher, MmioHandlerLookupError, MmioRegion,
-    MmioRegionId,
+    MmioRegionId, MmioRegistrationError, MmioRegistrationLease, MmioRegistrationOwner,
 };
 use crate::network::{
     NetworkInterfaceUpdate, NetworkInterfaceUpdateError, NetworkMmioDeviceRegistration,
@@ -63,6 +64,10 @@ use crate::network::{
     PreparedNetworkDevices, VirtioNetworkDeviceNotificationDispatch,
     VirtioNetworkDeviceNotificationError, VirtioNetworkMmioHandler, VirtioNetworkRxPacketSource,
     VirtioNetworkTxPacketSink,
+};
+use crate::pci::{
+    Arm64PciAddressPlan, PciClassCode, PciFunctionLease, PciSegment, PciSegmentError,
+    PciType0Configuration, SharedPciSegment, register_ecam_handler,
 };
 use crate::pmem::{
     PmemFileBacking, PmemMmioDeviceRegistration, PmemMmioLayout, PmemMmioRegistrationError,
@@ -96,6 +101,7 @@ const ARM64_BOOT_VMCLOCK_ABI_SIZE: usize = 112;
 const ARM64_BOOT_VMCLOCK_MAGIC: u32 = 1_263_289_174;
 const ARM64_BOOT_VMCLOCK_VERSION: u16 = 1;
 const ARM64_BOOT_VMCLOCK_COUNTER_INVALID: u8 = 255;
+const ARM64_BOOT_PCI_ECAM_REGION_ID: MmioRegionId = MmioRegionId::new(u64::MAX);
 
 /// Move-only files supplied by an authority owner for one VM startup attempt.
 #[derive(Default)]
@@ -237,6 +243,33 @@ pub struct Arm64BootResourceConfig<'a> {
     pub entropy_device: Option<Arm64BootEntropyDeviceConfig>,
 }
 
+/// Explicit internal-only endpoint used by signed Linux PCI enumeration validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Arm64BootPciValidationConfig {
+    vendor_id: u16,
+    device_id: u16,
+}
+
+impl Arm64BootPciValidationConfig {
+    pub const FIRECRACKER_TEST_VENDOR_ID: u16 = 0x1af4;
+    pub const FIRECRACKER_TEST_DEVICE_ID: u16 = 0x10ff;
+
+    pub const fn firecracker_test_endpoint() -> Self {
+        Self {
+            vendor_id: Self::FIRECRACKER_TEST_VENDOR_ID,
+            device_id: Self::FIRECRACKER_TEST_DEVICE_ID,
+        }
+    }
+
+    pub const fn vendor_id(self) -> u16 {
+        self.vendor_id
+    }
+
+    pub const fn device_id(self) -> u16 {
+        self.device_id
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Arm64BootRtcDeviceConfig {
     pub mmio_layout: RtcMmioLayout,
@@ -322,6 +355,21 @@ pub struct Arm64BootResources {
     pub balloon_device: Option<Arm64BootBalloonDevice>,
     pub memory_hotplug_device: Option<Arm64BootMemoryHotplugDevice>,
     pub entropy_device: Option<Arm64BootEntropyDevice>,
+    pub pci_validation: Option<Arm64BootPciValidationResources>,
+}
+
+#[derive(Debug)]
+pub struct Arm64BootPciValidationResources {
+    segment: SharedPciSegment,
+    _function_lease: PciFunctionLease,
+    _registration_owner: MmioRegistrationOwner,
+    _registration_lease: MmioRegistrationLease,
+}
+
+impl Arm64BootPciValidationResources {
+    pub const fn segment(&self) -> &SharedPciSegment {
+        &self.segment
+    }
 }
 
 #[derive(Debug)]
@@ -354,6 +402,7 @@ pub struct Arm64BootRuntimeResources {
     pub balloon_device: Option<Arm64BootBalloonDevice>,
     pub memory_hotplug_device: Option<Arm64BootMemoryHotplugDevice>,
     pub entropy_device: Option<Arm64BootEntropyDevice>,
+    pub pci_validation: Option<Arm64BootPciValidationResources>,
 }
 
 #[derive(Debug)]
@@ -953,6 +1002,7 @@ pub fn install_snapshot_v1_runtime(
         balloon_device: None,
         memory_hotplug_device: None,
         entropy_device: None,
+        pci_validation: None,
     };
 
     Ok(InstalledSnapshotV1Runtime {
@@ -2272,6 +2322,7 @@ impl Arm64BootRuntimeResources {
             || self.balloon_device.is_some()
             || self.memory_hotplug_device.is_some()
             || self.entropy_device.is_some()
+            || self.pci_validation.is_some()
         {
             return Err(Arm64BootSnapshotV1DeviceCaptureError::UnsupportedInventory);
         }
@@ -3060,6 +3111,15 @@ pub enum Arm64BootResourceError {
     RegisterSerialMmio {
         source: Box<Arm64BootSerialMmioRegistrationError>,
     },
+    PciAddressPlan {
+        source: GuestMemoryError,
+    },
+    PreparePciValidationFunction {
+        source: PciSegmentError,
+    },
+    RegisterPciEcam {
+        source: MmioRegistrationError,
+    },
     VmGenIdRegion {
         source: GuestMemoryError,
     },
@@ -3207,6 +3267,15 @@ impl fmt::Display for Arm64BootResourceError {
             Self::RegisterSerialMmio { source } => {
                 write!(f, "failed to register serial MMIO device: {source}")
             }
+            Self::PciAddressPlan { source } => {
+                write!(f, "failed to prepare the arm64 PCI address plan: {source}")
+            }
+            Self::PreparePciValidationFunction { source } => {
+                write!(f, "failed to prepare the PCI validation function: {source}")
+            }
+            Self::RegisterPciEcam { source } => {
+                write!(f, "failed to register the PCI ECAM window: {source}")
+            }
             Self::VmGenIdRegion { source } => {
                 write!(f, "failed to prepare VMGenID guest memory range: {source}")
             }
@@ -3313,6 +3382,9 @@ impl std::error::Error for Arm64BootResourceError {
             Self::RegisterEntropyMmio { source } => Some(source.as_ref()),
             Self::RegisterRtcMmio { source } => Some(source.as_ref()),
             Self::RegisterSerialMmio { source } => Some(source.as_ref()),
+            Self::PciAddressPlan { source } => Some(source),
+            Self::PreparePciValidationFunction { source } => Some(source),
+            Self::RegisterPciEcam { source } => Some(source),
             Self::VmGenIdRegion { source } => Some(source),
             Self::VmGenIdGuestMemoryWrite { source } => Some(source),
             Self::VmClockRegion { source } => Some(source),
@@ -3453,6 +3525,22 @@ impl Arm64BootResources {
         controller: &VmmController,
         config: Arm64BootResourceConfig<'_>,
         startup_resources: VmStartupResources,
+    ) -> Result<Self, Arm64BootResourceError> {
+        Self::assemble_from_controller_with_startup_resources_and_pci_validation(
+            controller,
+            config,
+            startup_resources,
+            None,
+        )
+    }
+
+    /// Assembles resources with an optional internal PCI enumeration endpoint.
+    #[doc(hidden)]
+    pub fn assemble_from_controller_with_startup_resources_and_pci_validation(
+        controller: &VmmController,
+        config: Arm64BootResourceConfig<'_>,
+        startup_resources: VmStartupResources,
+        pci_validation: Option<Arm64BootPciValidationConfig>,
     ) -> Result<Self, Arm64BootResourceError> {
         let (boot_files, block_backings, pmem_backings, supplied_vsock_listener) =
             startup_resources.into_parts();
@@ -3736,26 +3824,34 @@ impl Arm64BootResources {
         let serial_device = serial_device
             .map(|serial| register_serial_mmio(&mut mmio_dispatcher, serial))
             .transpose()?;
+        let (pci_validation, pci_host) = match pci_validation {
+            Some(config) => {
+                let (resources, host) = prepare_pci_validation(&mut mmio_dispatcher, config)?;
+                (Some(resources), Some(host))
+            }
+            None => (None, None),
+        };
         let rtc_fdt_device = rtc_device.as_ref().map(|device| device.fdt_device);
         let serial_fdt_device = serial_device.as_ref().map(|device| device.fdt_device);
         let vmgenid_device = create_initial_vmgenid_device(&mut memory, vmgenid_interrupt_line)?;
         let vmclock_device = create_initial_vmclock_device(&mut memory, vmclock_interrupt_line)?;
-        let fdt = write_arm64_fdt(
-            &Arm64FdtConfig {
-                layout: &layout,
-                boot: Arm64FdtBootInfo::from(&loaded_boot_source),
-                vcpu_mpidrs,
-                cache_hierarchy: &cache_hierarchy,
-                gic,
-                timer,
-                rtc_device: rtc_fdt_device,
-                serial_device: serial_fdt_device,
-                vmgenid_device: Some(vmgenid_device.fdt_device),
-                vmclock_device: Some(vmclock_device.fdt_device),
-                virtio_mmio_devices: &fdt_devices,
-            },
-            &mut memory,
-        )
+        let fdt_config = Arm64FdtConfig {
+            layout: &layout,
+            boot: Arm64FdtBootInfo::from(&loaded_boot_source),
+            vcpu_mpidrs,
+            cache_hierarchy: &cache_hierarchy,
+            gic,
+            timer,
+            rtc_device: rtc_fdt_device,
+            serial_device: serial_fdt_device,
+            vmgenid_device: Some(vmgenid_device.fdt_device),
+            vmclock_device: Some(vmclock_device.fdt_device),
+            virtio_mmio_devices: &fdt_devices,
+        };
+        let fdt = match pci_host {
+            Some(host) => write_arm64_fdt_with_pci(&fdt_config, host, &mut memory),
+            None => write_arm64_fdt(&fdt_config, &mut memory),
+        }
         .map_err(|source| Arm64BootResourceError::Fdt { source })?;
 
         Ok(Self {
@@ -3777,6 +3873,7 @@ impl Arm64BootResources {
             balloon_device,
             memory_hotplug_device,
             entropy_device,
+            pci_validation,
         })
     }
 
@@ -3803,9 +3900,51 @@ impl Arm64BootResources {
                 balloon_device: self.balloon_device,
                 memory_hotplug_device: self.memory_hotplug_device,
                 entropy_device: self.entropy_device,
+                pci_validation: self.pci_validation,
             },
         }
     }
+}
+
+fn prepare_pci_validation(
+    dispatcher: &mut MmioDispatcher,
+    config: Arm64BootPciValidationConfig,
+) -> Result<(Arm64BootPciValidationResources, Arm64FdtPciHost), Arm64BootResourceError> {
+    let plan = Arm64PciAddressPlan::firecracker_v1_16()
+        .map_err(|source| Arm64BootResourceError::PciAddressPlan { source })?;
+    let mut segment = PciSegment::new();
+    let function_lease = segment
+        .add_function(PciType0Configuration::new(
+            config.vendor_id(),
+            config.device_id(),
+            0,
+            PciClassCode::Unclassified,
+            0,
+            0,
+            config.vendor_id(),
+            config.device_id(),
+        ))
+        .map_err(|source| Arm64BootResourceError::PreparePciValidationFunction { source })?;
+    let segment = SharedPciSegment::new(segment);
+    let registration_owner = MmioRegistrationOwner::new();
+    let registration_lease = register_ecam_handler(
+        dispatcher,
+        &registration_owner,
+        ARM64_BOOT_PCI_ECAM_REGION_ID,
+        plan,
+        segment.clone(),
+    )
+    .map_err(|source| Arm64BootResourceError::RegisterPciEcam { source })?;
+
+    Ok((
+        Arm64BootPciValidationResources {
+            segment,
+            _function_lease: function_lease,
+            _registration_owner: registration_owner,
+            _registration_lease: registration_lease,
+        },
+        Arm64FdtPciHost::from_address_plan(plan),
+    ))
 }
 
 fn memory_size_bytes(config: MachineConfig) -> Result<u64, Arm64BootResourceError> {
@@ -4359,14 +4498,14 @@ mod tests {
         ARM64_BOOT_VMGENID_SIZE, Arm64BootEntropySource, Arm64BootEntropySourceError,
         Arm64BootEntropySourceProvider, Arm64BootNetworkNotificationOutcome,
         Arm64BootNetworkPacketIo, Arm64BootNetworkPacketIoError, Arm64BootNetworkPacketIoProvider,
-        Arm64BootResourceConfig, Arm64BootResourceError, Arm64BootResources,
-        Arm64BootRtcDeviceConfig, Arm64BootRtcMmioRegistrationError, Arm64BootSerialDeviceConfig,
-        Arm64BootSerialMmioRegistrationError, Arm64BootVmGenIdDevice,
+        Arm64BootPciValidationConfig, Arm64BootResourceConfig, Arm64BootResourceError,
+        Arm64BootResources, Arm64BootRtcDeviceConfig, Arm64BootRtcMmioRegistrationError,
+        Arm64BootSerialDeviceConfig, Arm64BootSerialMmioRegistrationError, Arm64BootVmGenIdDevice,
         Arm64BootVmGenIdReplacementError, MIB, VmStartupResources,
         arm64_boot_network_device_metadata, balloon_hinting_status_for_device,
         balloon_stats_for_device, block_device_metadata, ensure_nonzero_vmgenid_generation_id,
         initial_vmclock_abi_bytes, initial_vmclock_range, initial_vmgenid_range,
-        replace_arm64_boot_vmgenid_with, start_balloon_hinting_for_device,
+        prepare_pci_validation, replace_arm64_boot_vmgenid_with, start_balloon_hinting_for_device,
         stop_balloon_hinting_for_device, update_balloon_config_for_device,
         update_balloon_statistics_for_device, update_block_device_for_devices_with_opened,
     };
@@ -4397,7 +4536,8 @@ mod tests {
     };
     use crate::fdt::{
         ARM64_FDT_VMCLOCK_SIZE, ARM64_FDT_VMGENID_SIZE, Arm64FdtCache, Arm64FdtCacheHierarchy,
-        Arm64FdtCacheType, Arm64FdtError, Arm64FdtGic, Arm64FdtRegion, Arm64FdtTimerInterrupts,
+        Arm64FdtCacheType, Arm64FdtError, Arm64FdtGic, Arm64FdtInterruptRange, Arm64FdtMsi,
+        Arm64FdtRegion, Arm64FdtTimerInterrupts,
     };
     use crate::interrupt::{DeviceInterruptKind, GuestInterruptLine};
     use crate::machine::{MachineConfig, MachineConfigInput};
@@ -4420,6 +4560,9 @@ mod tests {
         VirtioNetworkRxPacketSource, VirtioNetworkRxPacketSourceError, VirtioNetworkTxFrame,
         VirtioNetworkTxPacketDisposition, VirtioNetworkTxPacketSink,
         VirtioNetworkTxPacketSinkError,
+    };
+    use crate::pci::{
+        PCI_ECAM_RESERVED_START, PCI_HOST_BRIDGE_DEVICE_ID, PCI_HOST_BRIDGE_VENDOR_ID,
     };
     use crate::pmem::{
         PmemConfigInput, PmemMmioLayout, PreparedPmemDeviceError, VIRTIO_PMEM_ALIGNMENT,
@@ -4966,6 +5109,22 @@ mod tests {
             interrupt_cells: 3,
             maintenance_irq: 9,
             msi: None,
+        }
+    }
+
+    fn valid_gic_with_msi() -> Arm64FdtGic {
+        Arm64FdtGic {
+            msi: Some(Arm64FdtMsi {
+                region: Arm64FdtRegion {
+                    base: 0x3ffb_0000,
+                    size: 0x1_0000,
+                },
+                interrupt_range: Arm64FdtInterruptRange {
+                    base: 128,
+                    count: 32,
+                },
+            }),
+            ..valid_gic()
         }
     }
 
@@ -7159,6 +7318,120 @@ mod tests {
         assert!(read_fdt(&resources).find("/virtio_mmio@40006000").is_none());
         assert!(read_fdt(&resources).find("/virtio_mmio@40007000").is_none());
         assert!(read_fdt(&resources).find("/virtio_mmio@40008000").is_none());
+    }
+
+    #[test]
+    fn assembles_and_retains_internal_pci_validation_resources() {
+        let kernel = temp_file("kernel-with-pci-validation", &arm64_image());
+        let controller = controller_with_kernel(kernel.path());
+        let mut config = valid_config(&[]);
+        config.gic = valid_gic_with_msi();
+        let mut resources =
+            Arm64BootResources::assemble_from_controller_with_startup_resources_and_pci_validation(
+                &controller,
+                config,
+                VmStartupResources::default(),
+                Some(Arm64BootPciValidationConfig::firecracker_test_endpoint()),
+            )
+            .expect("boot resources should assemble with PCI validation");
+
+        let tree = read_fdt(&resources);
+        let pci = tree
+            .find("/pci@70000000")
+            .expect("assembled FDT should publish the PCI host");
+        assert_eq!(
+            prop_u64_cells(pci, "reg"),
+            vec![PCI_ECAM_RESERVED_START, 1 << 20]
+        );
+        assert_eq!(pci.prop_u32("msi-parent").unwrap(), 3);
+        assert_eq!(
+            resources
+                .pci_validation
+                .as_ref()
+                .expect("PCI validation resources should be retained")
+                .segment()
+                .with_segment(|segment| segment.function_count())
+                .expect("PCI validation segment should not be poisoned"),
+            2
+        );
+
+        for (offset, expected) in [
+            (
+                0,
+                (u32::from(PCI_HOST_BRIDGE_DEVICE_ID) << 16) | u32::from(PCI_HOST_BRIDGE_VENDOR_ID),
+            ),
+            (
+                1 << 15,
+                (u32::from(Arm64BootPciValidationConfig::FIRECRACKER_TEST_DEVICE_ID) << 16)
+                    | u32::from(Arm64BootPciValidationConfig::FIRECRACKER_TEST_VENDOR_ID),
+            ),
+        ] {
+            let address = GuestAddress::new(PCI_ECAM_RESERVED_START + offset);
+            let access = resources
+                .mmio_dispatcher
+                .lookup(address, 4)
+                .expect("PCI ECAM access should resolve");
+            let outcome = resources
+                .mmio_dispatcher
+                .dispatch(MmioOperation::read(access).expect("PCI ECAM read should build"))
+                .expect("PCI ECAM read should dispatch");
+            assert_eq!(
+                outcome,
+                MmioDispatchOutcome::Read {
+                    data: MmioAccessBytes::new(&expected.to_le_bytes())
+                        .expect("expected PCI identity bytes should be valid")
+                }
+            );
+        }
+
+        let parts = resources.into_parts();
+        assert!(parts.runtime.pci_validation.is_some());
+    }
+
+    #[test]
+    fn pci_validation_requires_gicv2m_metadata() {
+        let kernel = temp_file("kernel-pci-without-msi", &arm64_image());
+        let controller = controller_with_kernel(kernel.path());
+
+        let err =
+            Arm64BootResources::assemble_from_controller_with_startup_resources_and_pci_validation(
+                &controller,
+                valid_config(&[]),
+                VmStartupResources::default(),
+                Some(Arm64BootPciValidationConfig::firecracker_test_endpoint()),
+            )
+            .expect_err("PCI validation without GICv2m metadata should fail");
+        assert!(matches!(
+            err,
+            Arm64BootResourceError::Fdt {
+                source: Arm64FdtError::InvalidPciHost {
+                    reason: "a GICv2m MSI parent is required"
+                }
+            }
+        ));
+    }
+
+    #[test]
+    fn pci_validation_ecam_collision_is_atomic() {
+        let mut dispatcher = MmioDispatcher::new();
+        let existing = dispatcher
+            .insert_region(
+                MmioRegionId::new(1),
+                GuestAddress::new(PCI_ECAM_RESERVED_START),
+                0x1000,
+            )
+            .expect("existing test region should register");
+
+        let err = prepare_pci_validation(
+            &mut dispatcher,
+            Arm64BootPciValidationConfig::firecracker_test_endpoint(),
+        )
+        .expect_err("overlapping PCI ECAM registration should fail");
+        assert!(matches!(
+            err,
+            Arm64BootResourceError::RegisterPciEcam { .. }
+        ));
+        assert_eq!(dispatcher.regions(), &[existing]);
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -115,11 +115,43 @@ same sender lock, waits for an in-flight call, and revokes every retained clone
 before unmapping or destroying VM-owned resources.
 
 This foundation is not Firecracker's KVM-backed GICv3 ITS implementation. It
-adds no public API or CLI control, PCI host bridge, enumeration, BAR layout,
-MSI/MSI-X table emulation, guest-programmed message routing, interrupt remapping,
-or guest PCI delivery claim. It is also outside the accepted native-v1 snapshot
-profile, which rejects MSI-bearing GIC metadata. The capability inventory is
-therefore not promoted by this internal foundation alone.
+adds no public API or CLI control, MSI/MSI-X table emulation,
+guest-programmed message routing, or interrupt remapping. It is also outside
+the accepted native-v1 snapshot profile, which rejects MSI-bearing GIC
+metadata. The capability inventory is therefore not promoted by this internal
+foundation alone.
+
+## Internal PCI Segment and Address-Space Foundation
+
+An explicit validation-only boot-session option now composes the GICv2m frame
+with a backend-neutral PCI segment 0, bus 0. Device 0 is the fixed
+`[8086:0d57]` host bridge; devices 1 through 31 use deterministic,
+generation-bound slot leases, and the signed gate installs one identity-only
+`[0042:0000]` endpoint from Firecracker's pinned PCI mock at `0000:00:01.0`.
+The endpoint has no virtio or product semantics.
+
+The arm64 plan reserves the full Firecracker configuration aperture at
+`0x70000000..0x80000000`, publishes only the bus-0 1 MiB ECAM window, uses
+`0x40003000..0x70000000` for 32-bit BAR ownership, and uses 256–512 GiB for
+64-bit BAR ownership. Local lowest-fit allocators return provenance- and
+generation-bound leases, deterministically reuse released ranges, and reject
+foreign or stale release. Type-0 configuration supports fixed 32/64-bit BAR
+encoding and one-shot all-ones size probing; guest relocation writes do not
+move an owned range.
+
+ECAM publication uses one atomic MMIO owner lease. The complete region batch,
+handler ID, owner provenance, dispatcher provenance, and generation are
+validated before mutation; checked release removes only the exact registered
+state. The FDT path validates the reserved aperture and BAR windows against
+RAM, GIC/GICv2m, and every published platform/MMIO device before emitting a
+`pci-host-ecam-generic` node with `msi-parent = <3>`. With the option absent,
+the previous FDT bytes and startup inventory are unchanged.
+
+This slice provides discovery and ownership primitives only. No process flag,
+HTTP action, modern virtio-pci device, guest-programmed MSI/MSI-X delivery,
+runtime attach/delete, hotplug, or snapshot persistence reaches production.
+Those transport and lifecycle steps remain later work, so the public capability
+inventory and the existing `--enable-pci` rejection do not change.
 
 ## Internal PSCI Power Sessions
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1527,9 +1527,34 @@ Hypervisor.framework does not make message delivery transactional. A returned
 error cannot prove that the guest did not observe the interrupt, so a future
 device owner must define its own retry and teardown policy. Current signed
 coverage separately proves raw host-to-vCPU delivery and pinned-Linux GICv2m
-domain discovery; it does not prove PCI enumeration, MSI/MSI-X programming,
-interrupt remapping, or Firecracker's KVM ITS behavior. MSI-bearing GIC metadata
-is rejected by the native-v1 snapshot profile rather than silently omitted.
+domain discovery. The validation-only PCI gate additionally proves enumeration
+of its fixed host bridge and identity-only endpoint; it does not prove
+MSI/MSI-X programming, interrupt remapping, product-device transport, or
+Firecracker's KVM ITS behavior. MSI-bearing GIC metadata is rejected by the
+native-v1 snapshot profile rather than silently omitted.
+
+## Internal PCI Ownership Boundary
+
+PCI is reachable only from an explicit HVF validation-session constructor; the
+production process parser, HTTP controller, and default boot-session
+constructors never select it. That path publishes one 1 MiB ECAM handler only
+after the complete Firecracker-shaped configuration aperture and 32/64-bit BAR
+windows validate against guest RAM, GIC/GICv2m, and all configured platform and
+virtio-MMIO devices. The FDT binds the host to the validated GICv2m phandle and
+advertises neither an ITS nor an `msi-map`.
+
+MMIO publication and PCI slot/BAR allocation use opaque owner provenance plus
+monotonic generations. Registration builds a complete candidate bus before
+committing its handler and regions; failure leaves the live dispatcher
+unchanged. Release checks the originating dispatcher or allocator, owner,
+generation, and exact registered state before mutation, so a stale capability
+cannot remove a later occupant after reuse. Ownership and address details are
+redacted from capability `Debug` output.
+
+The retained `[0042:0000]` endpoint is pinned mock identity only. It grants no host
+resource authority and implements no product I/O, MSI/MSI-X table, hotplug, or
+snapshot contract. Native-v1 treats any PCI validation resources as an
+unsupported inventory rather than persisting or silently dropping them.
 
 ## HVF Entitlements
 

--- a/docs/snapshot-feasibility.md
+++ b/docs/snapshot-feasibility.md
@@ -26,6 +26,10 @@ path.
   load validation reject MSI-bearing GIC metadata; the frame, reserved range,
   allocator state, and any delivered or in-flight message are not persisted or
   inferred during restore.
+- The validation-only PCI segment is also outside native-v1. Capture rejects
+  its retained ECAM owner/lease and segment/function lease rather than omitting
+  them; no slot, BAR, configuration-space, or
+  guest discovery state is serialized or reconstructed on load.
 - An admitted create holds one scoped supervisor transaction from FIFO
   admission through publication. It failure-atomically quiesces block, PMEM,
   network, and entropy retry schedulers, preflights both final namespaces,
@@ -970,7 +974,10 @@ some of the required state:
   device except separately captured CPU system registers.
   The implemented internal MSI foundation configures HVF's GICM region as a
   Linux GICv2m frame and exposes a range-bound send capability, but it does not
-  add device state, delivery rollback, or portable migration semantics.
+  add device state, delivery rollback, or portable migration semantics. The
+  validation-only PCI segment can bind its generic ECAM FDT host to that frame,
+  but its leases and configuration state likewise have no snapshot schema or
+  restore path.
 
 The inspected headers do not expose a KVM-style dirty log or dirty-page tracking
 API, so Firecracker-style diff snapshot parity is not a direct HVF API mapping.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -69,6 +69,19 @@ exhaustion/provenance, sender serialization/errors/redaction, teardown
 revocation of retained clones, and FDT publication without raw values in
 formatted failures.
 
+PCI foundation changes additionally require atomic MMIO registration/release,
+slot and BAR lease, type-0 configuration, ECAM, address-plan, FDT, and startup
+unit coverage. Failure cases must prove rollback for a prefix overlap or
+handler collision, reject wrong-owner/allocator/dispatcher and stale leases,
+and keep the no-PCI FDT bytes unchanged. The signed `guest_boot` case
+`boots_firecracker_kernel_and_enumerates_the_internal_pci_segment` must run
+through `scripts/run-integration-tests.sh --test guest_boot`, inspect the exact
+generic-ECAM node and GICv2m parent before execution, then require pinned Linux
+to enumerate both `0000:00:00.0 [8086:0d57]` and the identity-only
+`0000:00:01.0 [0042:0000]` before the normal boot marker. This is discovery
+evidence only; it is not an unsigned-test substitute or a product PCI,
+MSI/MSI-X, hotplug, or snapshot claim.
+
 Ordered HVF vCPU-topology changes require a signed `hvf_lifecycle` baseline
 that creates one VM and GIC before two permanent owner-thread runners, proves
 their exact ordered MPIDRs are `[0, 1]`, cancels both before their first bounded


### PR DESCRIPTION
## Summary

- add atomic owner/generation-bound MMIO batch leases with checked release and rollback
- add a backend-neutral segment 0/bus 0 PCI model, deterministic function and BAR allocators, Type-0 configuration space, ECAM dispatch, and validated Firecracker-compatible arm64 host-bridge FDT metadata
- add an explicit validation-only HVF startup path plus signed pinned-Linux discovery coverage for the host bridge and test endpoint

## Scope

- does not add a production CLI/API opt-in, a product virtio-pci transport, MSI/MSI-X programming, hotplug, snapshot persistence, or capability-inventory claims
- parent delivery context: #1410

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five signed-target Clippy commands documented in `AGENTS.md`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

Closes #1416
Parent: #1410
