### PR TITLE
fix: reap short-lived socket binders

### DIFF
--- a/crates/bangbang/src/anchored_socket.rs
+++ b/crates/bangbang/src/anchored_socket.rs
@@ -1235,6 +1235,26 @@ struct OwnedHelper {
     reaped: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HelperExitRegistrationRecovery {
+    Reaped(i32),
+    ReapBlocking,
+    Error(io::ErrorKind),
+}
+
+fn helper_exit_registration_recovery(
+    error: &io::Error,
+    reaped: Option<i32>,
+) -> HelperExitRegistrationRecovery {
+    match reaped {
+        Some(status) => HelperExitRegistrationRecovery::Reaped(status),
+        None if error.raw_os_error() == Some(libc::ESRCH) => {
+            HelperExitRegistrationRecovery::ReapBlocking
+        }
+        None => HelperExitRegistrationRecovery::Error(error.kind()),
+    }
+}
+
 impl OwnedHelper {
     const fn new(pid: libc::pid_t) -> Self {
         Self { pid, reaped: false }
@@ -1279,10 +1299,13 @@ impl OwnedHelper {
             )
         } != 0
         {
-            let error = io::Error::last_os_error().kind();
-            return match self.try_reap()? {
-                Some(status) => helper_status(status),
-                None => Err(AnchoredSocketError::Io(error)),
+            let error = io::Error::last_os_error();
+            return match helper_exit_registration_recovery(&error, self.try_reap()?) {
+                HelperExitRegistrationRecovery::Reaped(status) => helper_status(status),
+                HelperExitRegistrationRecovery::ReapBlocking => {
+                    helper_status(self.reap_blocking()?)
+                }
+                HelperExitRegistrationRecovery::Error(kind) => Err(AnchoredSocketError::Io(kind)),
             };
         }
 
@@ -1323,7 +1346,7 @@ impl OwnedHelper {
             {
                 return Err(AnchoredSocketError::Binder);
             }
-            return helper_status(self.reap_after_exit()?);
+            return helper_status(self.reap_blocking()?);
         }
     }
 
@@ -1346,11 +1369,11 @@ impl OwnedHelper {
         }
     }
 
-    fn reap_after_exit(&mut self) -> Result<i32, AnchoredSocketError> {
+    fn reap_blocking(&mut self) -> Result<i32, AnchoredSocketError> {
         loop {
             let mut status = 0;
-            // SAFETY: NOTE_EXIT established that this owned child exited;
-            // `status` remains writable while it is synchronously reaped.
+            // SAFETY: NOTE_EXIT or an ESRCH registration race established that
+            // this owned child exited; status is writable for the blocking reap.
             let result = unsafe { libc::waitpid(self.pid, &raw mut status, 0) };
             if result == self.pid {
                 self.reaped = true;
@@ -1544,6 +1567,25 @@ mod tests {
         assert_eq!(
             AnchoredSocketError::Invalid.to_string(),
             "private anchored socket operation failed"
+        );
+    }
+
+    #[test]
+    fn missing_fast_helper_registration_falls_back_to_blocking_reap() {
+        let missing = io::Error::from_raw_os_error(libc::ESRCH);
+        assert_eq!(
+            helper_exit_registration_recovery(&missing, None),
+            HelperExitRegistrationRecovery::ReapBlocking
+        );
+        assert_eq!(
+            helper_exit_registration_recovery(&missing, Some(0)),
+            HelperExitRegistrationRecovery::Reaped(0)
+        );
+
+        let invalid = io::Error::from_raw_os_error(libc::EINVAL);
+        assert_eq!(
+            helper_exit_registration_recovery(&invalid, None),
+            HelperExitRegistrationRecovery::Error(io::ErrorKind::InvalidInput)
         );
     }
 }

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -157,6 +157,7 @@ const BAD_CONFIGURATION_EXIT_CODE: i32 = 152;
 const ARGUMENT_PARSING_EXIT_CODE: i32 = 153;
 const PROCESS_FAILURE_EXIT_CODE: i32 = 1;
 const PROCESS_TIMEOUT: Duration = Duration::from_secs(30);
+const DROP_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
 static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(0);
 
 fn production_bundle() -> PathBuf {
@@ -4359,8 +4360,30 @@ impl RunningApiLauncher {
 impl Drop for RunningApiLauncher {
     fn drop(&mut self) {
         if !self.completed {
-            kill_child_group(&mut self.child);
-            let _ = self.child.wait();
+            let pid = i32::try_from(self.child.id()).expect("launcher PID should fit");
+            // SAFETY: The unreaped launcher owns this PID. Give it a bounded
+            // chance to cancel and reap its worker so namespace cleanup runs.
+            let _ = unsafe { libc::kill(pid, libc::SIGTERM) };
+            let deadline = Instant::now() + DROP_CLEANUP_TIMEOUT;
+            loop {
+                match self.child.try_wait() {
+                    Ok(Some(_)) => break,
+                    Ok(None) if Instant::now() < deadline => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Ok(None) | Err(_) => {
+                        kill_child_group(&mut self.child);
+                        let _ = self.child.wait();
+                        break;
+                    }
+                }
+            }
+            if let Some(reader) = self.stdout_reader.take() {
+                let _ = reader.join();
+            }
+            if let Some(reader) = self.stderr_reader.take() {
+                let _ = reader.join();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- recognize the narrow Darwin race where an owned, successfully spawned socket binder exits between `waitpid(WNOHANG)` and `EVFILT_PROC` registration
- synchronously reap that child on `ESRCH` and still require its exact zero exit status; preserve fail-closed handling for all other registration errors
- add focused classification coverage and let panic-unwinding production tests attempt bounded graceful launcher cleanup before the existing process-group SIGKILL fallback

## Scope exclusions

- no socket grant protocol, sandbox entitlement, public API, socket naming, or virtio behavior changes
- no broad acceptance of missing processes; the fallback is limited to the owned unreaped helper and still validates its wait status
- dirty-tracking test stabilization is tracked separately in #1427

## Validation

- `cargo fmt --all -- --check`
- `git diff --check main...HEAD`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked` (1178 passed)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- 20 consecutive signed runs of `normal_bundle_granted_socket_cleanup_preserves_replacements_in_both_death_orders`
- `scripts/run-integration-tests.sh --test production_bundle` (36 passed)

Closes #1426
