### PR TITLE
test: isolate completed dirty-epoch vCPUs

### DIFF
--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -3220,7 +3220,11 @@ fn tracks_concurrent_guest_writes_with_exact_retry_and_bounded_cancellation() {
                         );
                     }
                     Ok(HvfVcpuRunMemberOutcome::Handled(HvfVcpuRunStepOutcome::Hvc { .. })) => {
-                        reached_hvc[result.index()] = true;
+                        let index = result.index();
+                        reached_hvc[index] = true;
+                        coordinator
+                            .set_online(index, false)
+                            .expect("an idle epoch-complete member should go offline");
                     }
                     outcome => panic!("unexpected tracked member outcome: {outcome:?}"),
                 }
@@ -3271,6 +3275,11 @@ fn tracks_concurrent_guest_writes_with_exact_retry_and_bounded_cancellation() {
                     .expect("advanced epoch should be clean")
                     .is_empty()
             );
+            for index in 0..2 {
+                coordinator
+                    .set_online(index, true)
+                    .expect("an idle epoch-complete member should return online");
+            }
             if epoch_index == 0 {
                 assert_eq!(
                     coordinator.dispatch_online(),


### PR DESCRIPTION
## Summary

- mark each idle vCPU offline after it reaches the epoch-ending HVC boundary, keeping it out of later `dispatch_online()` retries for that epoch
- restore both vCPUs online only after both HVC completions and dirty-page assertions finish
- preserve the existing two-epoch stale-fault, quiescence, exact-retry, and bounded-cancellation coverage without changing production coordinator semantics

## Scope exclusions

- no HVF coordinator, vCPU runner, dirty-page tracker, or production runtime behavior changes
- no weakened `Ok(1)` retry assertion and no timing-delay workaround
- no changes outside the single signed lifecycle regression test

## Validation

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf` (2209 passed, 1 ignored in the main executable target; all remaining workspace targets passed)
- `cargo test -p bangbang-hvf --lib --all-features --locked` (1178 passed)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented macOS Apple-Silicon integration-target Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- 10 consecutive signed exact runs of `tracks_concurrent_guest_writes_with_exact_retry_and_bounded_cancellation`
- `scripts/run-integration-tests.sh --test hvf_lifecycle` (53 passed)

Closes #1427
