### PR TITLE
feat: add direct macOS block-special backing core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,7 @@ dependencies = [
  "cc",
  "device_tree",
  "libc",
+ "plist",
  "serde_json",
 ]
 

--- a/crates/hvf/Cargo.toml
+++ b/crates/hvf/Cargo.toml
@@ -13,6 +13,7 @@ cc = "1"
 
 [dev-dependencies]
 device_tree = "1.1.0"
+plist = "1"
 serde_json = "1.0.140"
 
 [[test]]

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -1,3 +1,7 @@
+#[cfg(target_os = "macos")]
+#[path = "../../../tests/support/macos_virtual_block.rs"]
+mod macos_virtual_block;
+
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 static HVF_LIFECYCLE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -32,6 +36,602 @@ struct MachTimebaseInfo {
 unsafe extern "C" {
     fn mach_absolute_time() -> u64;
     fn mach_timebase_info(info: *mut MachTimebaseInfo) -> i32;
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn is_app_sandbox_hvf_lifecycle_replay() -> bool {
+    std::env::current_exe().ok().is_some_and(|executable| {
+        executable.ancestors().any(|ancestor| {
+            ancestor.file_name() == Some(std::ffi::OsStr::new("BangbangHvfLifecycleSandbox.app"))
+        })
+    })
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn temporary_virtual_block_fixture_preserves_rw_ro_bytes_and_exact_cleanup() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+    use crate::macos_virtual_block::{MacosVirtualBlock, MacosVirtualBlockAccess};
+    use bangbang_runtime::block::{
+        BlockDeviceControl, BlockDeviceControlError, BlockDeviceGeometry, BlockFileBacking,
+        BlockFileBackingError, SnapshotBlockFileBackingError, VirtioBlockDeviceId,
+    };
+
+    #[derive(Debug)]
+    struct RejectInspectControl;
+
+    impl BlockDeviceControl for RejectInspectControl {
+        fn inspect(
+            &self,
+            _file: &std::fs::File,
+        ) -> Result<BlockDeviceGeometry, BlockDeviceControlError> {
+            Err(BlockDeviceControlError::new(
+                std::io::ErrorKind::PermissionDenied,
+            ))
+        }
+
+        fn synchronize_cache(&self, _file: &std::fs::File) -> Result<(), BlockDeviceControlError> {
+            panic!("failed inspection must not publish a backing")
+        }
+    }
+
+    #[derive(Debug)]
+    struct RejectSyncControl {
+        geometry: BlockDeviceGeometry,
+    }
+
+    impl BlockDeviceControl for RejectSyncControl {
+        fn inspect(
+            &self,
+            _file: &std::fs::File,
+        ) -> Result<BlockDeviceGeometry, BlockDeviceControlError> {
+            Ok(self.geometry)
+        }
+
+        fn synchronize_cache(&self, _file: &std::fs::File) -> Result<(), BlockDeviceControlError> {
+            Err(BlockDeviceControlError::new(
+                std::io::ErrorKind::PermissionDenied,
+            ))
+        }
+    }
+
+    #[derive(Debug)]
+    struct ChangingGeometryControl {
+        initial: BlockDeviceGeometry,
+        changed: BlockDeviceGeometry,
+        inspections: AtomicUsize,
+    }
+
+    impl BlockDeviceControl for ChangingGeometryControl {
+        fn inspect(
+            &self,
+            _file: &std::fs::File,
+        ) -> Result<BlockDeviceGeometry, BlockDeviceControlError> {
+            if self.inspections.fetch_add(1, AtomicOrdering::Relaxed) == 0 {
+                Ok(self.initial)
+            } else {
+                Ok(self.changed)
+            }
+        }
+
+        fn synchronize_cache(&self, _file: &std::fs::File) -> Result<(), BlockDeviceControlError> {
+            Ok(())
+        }
+    }
+
+    // The wrapper already runs this test as a directly signed binary. Its App Sandbox replay
+    // cannot launch the test-only `hdiutil` fixture process and is covered by #1465 instead.
+    if is_app_sandbox_hvf_lifecycle_replay() {
+        return;
+    }
+    let _guard = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let mut media = MacosVirtualBlock::create(MacosVirtualBlockAccess::ReadWrite)
+        .expect("temporary virtual block media should create");
+    let marker = b"bangbang-virtual-block";
+    let device = media
+        .device_path()
+        .expect("attached device path should exist")
+        .to_path_buf();
+    let identity = media
+        .identity()
+        .expect("attached identity should be available");
+
+    assert_eq!(
+        media.len().expect("media length should read"),
+        4 * 1024 * 1024
+    );
+    assert_ne!(identity.target_device(), 0);
+    assert_eq!(
+        u64::from(
+            media
+                .logical_block_size()
+                .expect("logical block size should read")
+        ) * media.block_count().expect("block count should read"),
+        media.len().expect("media length should read")
+    );
+    assert!(format!("{media:?}").contains("<redacted>"));
+    assert!(!format!("{media:?}").contains(device.to_string_lossy().as_ref()));
+    assert!(!format!("{identity:?}").contains(&identity.target_device().to_string()));
+
+    let logical_block_size = media
+        .logical_block_size()
+        .expect("logical block size should read");
+    let block_count = media.block_count().expect("block count should read");
+    let geometry = BlockDeviceGeometry::new(logical_block_size, block_count)
+        .expect("fixture geometry should validate");
+    let inspect_error = BlockFileBacking::from_file_with_block_device_control(
+        media
+            .open_descriptor()
+            .expect("inspect-failure block descriptor should open"),
+        false,
+        Arc::new(RejectInspectControl),
+    )
+    .expect_err("control inspection failure should reject adoption");
+    assert!(matches!(
+        inspect_error,
+        BlockFileBackingError::ReadBlockGeometry { source }
+            if source.kind() == std::io::ErrorKind::PermissionDenied
+    ));
+
+    let rejecting_sync = BlockFileBacking::from_file_with_block_device_control(
+        media
+            .open_descriptor()
+            .expect("sync-failure block descriptor should open"),
+        false,
+        Arc::new(RejectSyncControl { geometry }),
+    )
+    .expect("valid injected inspection should adopt the real block descriptor");
+    assert!(matches!(
+        rejecting_sync.flush(),
+        Err(BlockFileBackingError::FlushBlockDevice { source })
+            if source.kind() == std::io::ErrorKind::PermissionDenied
+    ));
+    drop(rejecting_sync);
+
+    let changed_geometry = BlockDeviceGeometry::new(
+        logical_block_size,
+        block_count
+            .checked_sub(1)
+            .expect("fixture should have more than one logical block"),
+    )
+    .expect("changed fixture geometry should remain structurally valid");
+    let changing = BlockFileBacking::from_file_with_block_device_control(
+        media
+            .open_descriptor()
+            .expect("geometry-change block descriptor should open"),
+        false,
+        Arc::new(ChangingGeometryControl {
+            initial: geometry,
+            changed: changed_geometry,
+            inspections: AtomicUsize::new(0),
+        }),
+    )
+    .expect("initial injected geometry should adopt the real block descriptor");
+    assert_eq!(
+        changing.snapshot_identity(),
+        Err(SnapshotBlockFileBackingError::InvalidMetadata)
+    );
+    drop(changing);
+
+    {
+        let backing = BlockFileBacking::from_file(
+            media
+                .open_descriptor()
+                .expect("read-write block descriptor should open"),
+            false,
+        )
+        .expect("runtime should adopt read-write block descriptor");
+        assert!(backing.kind().is_block_device());
+        assert_eq!(
+            backing.kind().logical_block_size(),
+            Some(
+                media
+                    .logical_block_size()
+                    .expect("logical block size should read")
+            )
+        );
+        assert_eq!(
+            backing.len(),
+            media.len().expect("media length should read")
+        );
+        assert_eq!(
+            backing.device_id(),
+            VirtioBlockDeviceId::from_bytes(
+                format!(
+                    "{}{}{}",
+                    identity.device(),
+                    identity.target_device(),
+                    identity.inode()
+                )
+                .as_bytes()
+            )
+        );
+        let backing_debug = format!("{backing:?}");
+        assert!(backing_debug.contains("<redacted>"));
+        assert!(!backing_debug.contains(&backing.len().to_string()));
+        assert!(!backing_debug.contains(&identity.target_device().to_string()));
+        backing
+            .write_at(4096, marker)
+            .expect("runtime block write should succeed");
+        backing
+            .flush()
+            .expect("runtime block cache synchronization should succeed");
+        let mut readback = vec![0_u8; marker.len()];
+        backing
+            .read_at(4096, &mut readback)
+            .expect("runtime block read should succeed");
+        assert_eq!(readback, marker);
+        let capture_identity = backing
+            .snapshot_identity()
+            .expect("runtime block capture identity should revalidate");
+        assert!(capture_identity.kind().is_block_device());
+        assert_eq!(
+            capture_identity.target_device(),
+            Some(identity.target_device())
+        );
+        assert_eq!(
+            capture_identity.block_count(),
+            Some(media.block_count().expect("block count should read"))
+        );
+    }
+    assert_eq!(
+        media
+            .read_at(4096, marker.len())
+            .expect("read-write attachment should read marker"),
+        marker
+    );
+    media
+        .reattach(MacosVirtualBlockAccess::ReadOnly)
+        .expect("media should reattach read-only");
+    assert_eq!(
+        media
+            .read_at(4096, marker.len())
+            .expect("read-only attachment should read persisted marker"),
+        marker
+    );
+    let read_only_backing = BlockFileBacking::from_file(
+        media
+            .open_descriptor()
+            .expect("read-only block descriptor should open"),
+        true,
+    )
+    .expect("runtime should adopt read-only block descriptor");
+    let mut readback = vec![0_u8; marker.len()];
+    read_only_backing
+        .read_at(4096, &mut readback)
+        .expect("runtime read-only block read should succeed");
+    assert_eq!(readback, marker);
+    assert!(matches!(
+        read_only_backing.write_at(4096, b"rejected"),
+        Err(BlockFileBackingError::ReadOnlyWrite)
+    ));
+    drop(read_only_backing);
+    assert!(media.write_at(4096, b"rejected").is_err());
+    media
+        .cleanup()
+        .expect("temporary virtual block media should detach and clean up");
+    assert!(!device.exists());
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn temporary_virtual_block_traverses_async_flush_and_capture_ready_owner() {
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    use crate::macos_virtual_block::{MacosVirtualBlock, MacosVirtualBlockAccess};
+    use bangbang_hvf::{HvfArm64BootSessionConfig, OwnedHvfArm64BootSession};
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::block::async_executor::{
+        BlockAsyncApplyOutcome, BlockAsyncCompletionDisposition, BlockAsyncDrive,
+        BlockAsyncDriveGeneration, BlockAsyncExecutor, BlockAsyncOperation,
+        BlockAsyncOperationKind, BlockAsyncOperationStatus, BlockAsyncRequestIdentity,
+        BlockAsyncScheduleOutcome,
+    };
+    use bangbang_runtime::block::{
+        BlockCaptureIoEngine, BlockDeviceControl, BlockDeviceControlError, BlockDeviceGeometry,
+        BlockFileBacking, BlockFileBackingError, BlockMmioLayout, DriveCacheType, DriveConfigInput,
+        DriveIoEngine, DriveLiveUpdateMode,
+    };
+    use bangbang_runtime::boot::BootSourceConfigInput;
+    use bangbang_runtime::memory::{
+        GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange,
+    };
+    use bangbang_runtime::mmio::MmioRegionId;
+    use bangbang_runtime::network::NetworkMmioLayout;
+    use bangbang_runtime::pmem::PmemMmioLayout;
+    use bangbang_runtime::storage_capture::{CaptureReadyStorageConfigs, StorageTransportState};
+    use bangbang_runtime::vsock::VsockMmioLayout;
+
+    #[derive(Debug)]
+    struct RejectReplacementInspectControl;
+
+    impl BlockDeviceControl for RejectReplacementInspectControl {
+        fn inspect(
+            &self,
+            _file: &std::fs::File,
+        ) -> Result<BlockDeviceGeometry, BlockDeviceControlError> {
+            Err(BlockDeviceControlError::new(
+                std::io::ErrorKind::PermissionDenied,
+            ))
+        }
+
+        fn synchronize_cache(&self, _file: &std::fs::File) -> Result<(), BlockDeviceControlError> {
+            panic!("failed replacement inspection must not publish a backing")
+        }
+    }
+
+    // The wrapper already runs this test as a directly signed binary. Its App Sandbox replay
+    // cannot launch the test-only `hdiutil` fixture process and is covered by #1465 instead.
+    if is_app_sandbox_hvf_lifecycle_replay() {
+        return;
+    }
+    let _guard = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let media = MacosVirtualBlock::create(MacosVirtualBlockAccess::ReadWrite)
+        .expect("temporary virtual block media should create");
+    let device = media
+        .device_path()
+        .expect("attached device path should exist")
+        .to_path_buf();
+    let media_identity = media
+        .identity()
+        .expect("attached identity should be available");
+    let media_len = media.len().expect("media length should read");
+    let logical_block_size = media
+        .logical_block_size()
+        .expect("logical block size should read");
+    let block_count = media.block_count().expect("block count should read");
+
+    let backing = Arc::new(
+        BlockFileBacking::from_file(
+            media
+                .open_descriptor()
+                .expect("async block descriptor should open"),
+            false,
+        )
+        .expect("runtime should adopt the async block descriptor"),
+    );
+    let expected_device_id = backing.device_id();
+    let mut executor = BlockAsyncExecutor::new().expect("production async executor should start");
+    let completion_fd = executor
+        .completion_fd()
+        .expect("production async executor should expose a completion descriptor");
+    let mut drive = BlockAsyncDrive::new(
+        BlockAsyncDriveGeneration::new(1),
+        Arc::clone(&backing),
+        DriveCacheType::Writeback,
+        executor.handle(),
+    )
+    .expect("block drive should bind to the production async executor");
+    let layout = GuestMemoryLayout::new(vec![
+        GuestMemoryRange::new(GuestAddress::new(0), 16 * 1024)
+            .expect("async flush guest range should validate"),
+    ])
+    .expect("async flush guest layout should validate");
+    let mut memory =
+        GuestMemory::allocate(&layout).expect("async flush guest memory should allocate");
+    let operation = drive
+        .admit(BlockAsyncOperation::flush(BlockAsyncRequestIdentity::new(
+            0,
+            0,
+            GuestAddress::new(0),
+        )))
+        .expect("real block flush should admit");
+    assert!(matches!(
+        drive
+            .schedule_one(&memory)
+            .expect("real block flush should schedule"),
+        BlockAsyncScheduleOutcome::Submitted {
+            operation: submitted,
+            chunk_offset: 0,
+            chunk_len: 0,
+        } if submitted == operation
+    ));
+    let mut readiness = libc::pollfd {
+        fd: completion_fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    // SAFETY: One initialized pollfd is writable for the bounded wait.
+    let ready = unsafe { libc::poll(&raw mut readiness, 1, 5_000) };
+    assert_eq!(
+        ready, 1,
+        "real block flush should complete before the deadline"
+    );
+    assert_ne!(readiness.revents & libc::POLLIN, 0);
+    let completion = executor
+        .try_recv_completion()
+        .expect("production completion queue should remain connected")
+        .expect("readiness should publish the real block flush completion");
+    let BlockAsyncApplyOutcome::Completed(applied) = drive
+        .apply_completion(
+            &mut memory,
+            completion,
+            BlockAsyncCompletionDisposition::Apply,
+        )
+        .expect("real block flush completion should apply")
+    else {
+        panic!("real block flush should complete in one host operation");
+    };
+    assert_eq!(applied.kind(), BlockAsyncOperationKind::Flush);
+    assert_eq!(applied.status(), BlockAsyncOperationStatus::Success);
+    assert_eq!(applied.bytes_transferred(), 0);
+    drop(drive);
+    executor
+        .shutdown()
+        .expect("production async executor should stop");
+    drop(executor);
+    drop(backing);
+
+    let image = arm64_image().expect("test arm64 image should build");
+    let kernel = TempFile::new("block-capture-ready-kernel", &image)
+        .expect("block capture kernel should create");
+    let root = TempFile::new_len("block-capture-ready-root", 4096)
+        .expect("regular block capture root should create");
+    let mut controller = bangbang_runtime::VmmController::new("test", "0.1.0", "bangbang");
+    controller
+        .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            kernel.path(),
+        )))
+        .expect("block capture boot source should configure");
+    controller
+        .handle_action(VmmAction::PutDrive(
+            DriveConfigInput::new("rootfs", "rootfs", root.path(), true)
+                .with_is_read_only(true)
+                .with_io_engine(DriveIoEngine::Sync),
+        ))
+        .expect("regular capture root should configure");
+    controller
+        .handle_action(VmmAction::PutDrive(
+            DriveConfigInput::new("blockdata", "blockdata", device.as_path(), false)
+                .with_is_read_only(false)
+                .with_cache_type(DriveCacheType::Writeback)
+                .with_io_engine(DriveIoEngine::Async),
+        ))
+        .expect("real block data drive should configure");
+    let session_config = HvfArm64BootSessionConfig::new(
+        BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1)),
+        PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500)),
+        NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000)),
+        VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
+        test_rtc_mmio_layout(),
+    );
+    let mut session = OwnedHvfArm64BootSession::new(&controller, session_config)
+        .expect("signed block capture session should prepare");
+    let configs = CaptureReadyStorageConfigs::new(controller.drive_configs().to_vec(), Vec::new());
+    let retry_guard = session
+        .quiesce_limiter_retry_wakeups()
+        .expect("block capture retry publishers should quiesce");
+    let first = session
+        .capture_ready_storage_state_at(&configs, &retry_guard, Instant::now())
+        .expect("real block drive should become capture-ready");
+    let second = session
+        .capture_ready_storage_state_at(&configs, &retry_guard, Instant::now())
+        .expect("real block Async admission should reopen for a second capture");
+    assert_eq!(first.block_devices().len(), 2);
+    assert_eq!(
+        first.block_devices()[1].config(),
+        &controller.drive_configs()[1]
+    );
+    assert!(
+        first.block_devices()[0]
+            .device()
+            .backing()
+            .kind()
+            .is_regular_file()
+    );
+    assert!(matches!(
+        first.block_devices()[1].transport(),
+        StorageTransportState::Mmio(_)
+    ));
+    let first_device = first.block_devices()[1].device();
+    let second_device = second.block_devices()[1].device();
+    let captured_backing = first_device.backing();
+    assert!(captured_backing.kind().is_block_device());
+    assert_eq!(
+        captured_backing.target_device(),
+        Some(media_identity.target_device())
+    );
+    assert_eq!(captured_backing.len(), media_len);
+    assert_eq!(
+        captured_backing.kind().logical_block_size(),
+        Some(logical_block_size)
+    );
+    assert_eq!(captured_backing.block_count(), Some(block_count));
+    assert_eq!(
+        first_device.config_space().capacity_sectors(),
+        media_len / 512
+    );
+    assert_eq!(first_device.device_id(), expected_device_id);
+    assert_eq!(second_device.backing(), captured_backing);
+    assert_eq!(second_device.device_id(), first_device.device_id());
+    let BlockCaptureIoEngine::Async(first_async) = first_device.io_engine() else {
+        panic!("real block drive should retain Async continuation state");
+    };
+    let BlockCaptureIoEngine::Async(second_async) = second_device.io_engine() else {
+        panic!("second real block capture should retain Async continuation state");
+    };
+    assert_eq!(second_async.generation(), first_async.generation());
+    assert!(first_async.admission_stopped());
+    assert_eq!(first_async.owned_operations(), 0);
+    assert_eq!(first_async.parked_host_completions(), 0);
+    assert_eq!(first_async.final_completions(), 0);
+
+    let failed_replacement = BlockFileBacking::from_file_with_block_device_control(
+        media
+            .open_descriptor()
+            .expect("failed replacement block descriptor should open"),
+        false,
+        Arc::new(RejectReplacementInspectControl),
+    )
+    .expect_err("failed replacement inspection should reject before publication");
+    assert!(matches!(
+        failed_replacement,
+        BlockFileBackingError::ReadBlockGeometry { source }
+            if source.kind() == std::io::ErrorKind::PermissionDenied
+    ));
+    let after_failed_replacement = session
+        .capture_ready_storage_state_at(&configs, &retry_guard, Instant::now())
+        .expect("failed replacement preparation must leave the prior owner capture-ready");
+    let failed_device = after_failed_replacement.block_devices()[1].device();
+    assert_eq!(failed_device.backing(), captured_backing);
+    assert_eq!(failed_device.device_id(), expected_device_id);
+    let BlockCaptureIoEngine::Async(failed_async) = failed_device.io_engine() else {
+        panic!("failed replacement must retain the prior Async engine");
+    };
+    assert_eq!(failed_async.generation(), second_async.generation());
+
+    drop(retry_guard);
+    let replacement_config = controller.drive_configs()[1].clone();
+    let replacement_backing = BlockFileBacking::from_file(
+        media
+            .open_descriptor()
+            .expect("successful replacement block descriptor should open"),
+        false,
+    )
+    .expect("successful replacement block backing should prepare");
+    session
+        .update_live_block_device_with_opened(
+            &replacement_config,
+            Some(replacement_backing),
+            None,
+            DriveLiveUpdateMode::Replacement,
+        )
+        .expect("real block replacement should commit through the MMIO owner");
+    let replacement_guard = session
+        .quiesce_limiter_retry_wakeups()
+        .expect("replacement capture retry publishers should quiesce");
+    let after_successful_replacement = session
+        .capture_ready_storage_state_at(&configs, &replacement_guard, Instant::now())
+        .expect("successfully replaced real block drive should become capture-ready");
+    let replacement_device = after_successful_replacement.block_devices()[1].device();
+    assert_eq!(replacement_device.backing(), captured_backing);
+    assert_eq!(replacement_device.device_id(), expected_device_id);
+    assert_eq!(
+        replacement_device.config_space().capacity_sectors(),
+        media_len / 512
+    );
+    let BlockCaptureIoEngine::Async(replacement_async) = replacement_device.io_engine() else {
+        panic!("successful block replacement should retain the configured Async engine");
+    };
+    assert_ne!(replacement_async.generation(), second_async.generation());
+    assert!(replacement_async.admission_stopped());
+    assert_eq!(replacement_async.owned_operations(), 0);
+    drop(replacement_guard);
+    session
+        .shutdown()
+        .expect("signed block capture session should shut down");
+    drop(session);
+    media
+        .cleanup()
+        .expect("temporary virtual block media should detach and clean up");
+    assert!(!device.exists());
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -40,11 +40,45 @@ unsafe extern "C" {
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 fn is_app_sandbox_hvf_lifecycle_replay() -> bool {
-    std::env::current_exe().ok().is_some_and(|executable| {
-        executable.ancestors().any(|ancestor| {
-            ancestor.file_name() == Some(std::ffi::OsStr::new("BangbangHvfLifecycleSandbox.app"))
-        })
-    })
+    std::env::current_exe()
+        .ok()
+        .is_some_and(|executable| is_app_sandbox_hvf_lifecycle_executable(&executable))
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn is_app_sandbox_hvf_lifecycle_executable(executable: &std::path::Path) -> bool {
+    let Some(macos) = executable.parent() else {
+        return false;
+    };
+    let Some(contents) = macos.parent() else {
+        return false;
+    };
+    let Some(bundle) = contents.parent() else {
+        return false;
+    };
+    executable.file_name() == Some(std::ffi::OsStr::new("hvf_lifecycle"))
+        && macos.file_name() == Some(std::ffi::OsStr::new("MacOS"))
+        && contents.file_name() == Some(std::ffi::OsStr::new("Contents"))
+        && bundle.file_name() == Some(std::ffi::OsStr::new("BangbangHvfLifecycleSandbox.app"))
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn app_sandbox_hvf_lifecycle_replay_requires_exact_bundle_layout() {
+    use std::path::Path;
+
+    assert!(is_app_sandbox_hvf_lifecycle_executable(Path::new(
+        "/tmp/BangbangHvfLifecycleSandbox.app/Contents/MacOS/hvf_lifecycle"
+    )));
+    assert!(!is_app_sandbox_hvf_lifecycle_executable(Path::new(
+        "/tmp/BangbangHvfLifecycleSandbox.app/target/hvf_lifecycle"
+    )));
+    assert!(!is_app_sandbox_hvf_lifecycle_executable(Path::new(
+        "/tmp/BangbangHvfLifecycleSandbox.app/Contents/MacOS/hvf_lifecycle-deadbeef"
+    )));
+    assert!(!is_app_sandbox_hvf_lifecycle_executable(Path::new(
+        "/tmp/Other.app/Contents/MacOS/hvf_lifecycle"
+    )));
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/crates/runtime/src/block.rs
+++ b/crates/runtime/src/block.rs
@@ -4098,9 +4098,190 @@ impl std::error::Error for VirtioBlockRequestError {
 pub struct BlockFileBacking {
     file: File,
     len: u64,
+    kind: BlockFileBackingKind,
+    descriptor_identity: BlockFileDescriptorIdentity,
+    descriptor_status: BlockFileDescriptorStatus,
+    block_control: Option<Arc<dyn BlockDeviceControl>>,
     device_id: VirtioBlockDeviceId,
     is_read_only: bool,
     origin: BlockFileBackingOrigin,
+}
+
+/// Checked logical geometry for one block-special backing.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct BlockDeviceGeometry {
+    logical_block_size: u32,
+    block_count: u64,
+    len: u64,
+}
+
+impl BlockDeviceGeometry {
+    /// Validates logical geometry against the virtio-block and host-I/O bounds.
+    pub fn new(logical_block_size: u32, block_count: u64) -> Option<Self> {
+        let block_size = u64::from(logical_block_size);
+        if block_size == 0 || block_count == 0 || block_size % VIRTIO_BLOCK_SECTOR_SIZE != 0 {
+            return None;
+        }
+        let len = block_size.checked_mul(block_count)?;
+        if len == 0 || len % VIRTIO_BLOCK_SECTOR_SIZE != 0 || i64::try_from(len).is_err() {
+            return None;
+        }
+        Some(Self {
+            logical_block_size,
+            block_count,
+            len,
+        })
+    }
+
+    fn from_len(logical_block_size: u32, len: u64) -> Option<Self> {
+        let block_size = u64::from(logical_block_size);
+        if block_size == 0 || len == 0 || !len.is_multiple_of(block_size) {
+            return None;
+        }
+        Self::new(logical_block_size, len / block_size)
+    }
+
+    /// Returns the logical media block size.
+    pub const fn logical_block_size(self) -> u32 {
+        self.logical_block_size
+    }
+
+    /// Returns the logical media block count.
+    pub const fn block_count(self) -> u64 {
+        self.block_count
+    }
+
+    /// Returns the checked byte capacity.
+    pub const fn len(self) -> u64 {
+        self.len
+    }
+
+    /// Returns whether the byte capacity is empty (always false for validated geometry).
+    pub const fn is_empty(self) -> bool {
+        self.len == 0
+    }
+}
+
+impl fmt::Debug for BlockDeviceGeometry {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("BlockDeviceGeometry(<redacted>)")
+    }
+}
+
+/// Stable redacted failure from one exact block-device control capability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockDeviceControlError {
+    kind: io::ErrorKind,
+}
+
+impl BlockDeviceControlError {
+    /// Creates a failure from a bounded I/O category.
+    pub const fn new(kind: io::ErrorKind) -> Self {
+        Self { kind }
+    }
+
+    /// Returns the bounded I/O category without private operation details.
+    pub const fn kind(self) -> io::ErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for BlockDeviceControlError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("block-device control failed")
+    }
+}
+
+impl std::error::Error for BlockDeviceControlError {}
+
+/// Exact block-special operations whose implementation follows backing ownership.
+pub trait BlockDeviceControl: fmt::Debug + Send + Sync {
+    /// Reads fresh logical geometry from the borrowed exact backing descriptor.
+    fn inspect(&self, file: &File) -> Result<BlockDeviceGeometry, BlockDeviceControlError>;
+
+    /// Persists prior writes through the borrowed exact backing descriptor.
+    fn synchronize_cache(&self, file: &File) -> Result<(), BlockDeviceControlError>;
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct BlockFileBackingKind {
+    value: BlockFileBackingKindValue,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum BlockFileBackingKindValue {
+    RegularFile,
+    BlockDevice { geometry: BlockDeviceGeometry },
+}
+
+impl BlockFileBackingKind {
+    const REGULAR_FILE: Self = Self {
+        value: BlockFileBackingKindValue::RegularFile,
+    };
+
+    const fn block_device(geometry: BlockDeviceGeometry) -> Self {
+        Self {
+            value: BlockFileBackingKindValue::BlockDevice { geometry },
+        }
+    }
+
+    pub const fn is_regular_file(self) -> bool {
+        matches!(self.value, BlockFileBackingKindValue::RegularFile)
+    }
+
+    pub const fn is_block_device(self) -> bool {
+        matches!(self.value, BlockFileBackingKindValue::BlockDevice { .. })
+    }
+
+    pub const fn logical_block_size(self) -> Option<u32> {
+        match self.value {
+            BlockFileBackingKindValue::RegularFile => None,
+            BlockFileBackingKindValue::BlockDevice { geometry } => {
+                Some(geometry.logical_block_size())
+            }
+        }
+    }
+
+    /// Returns the checked logical geometry for block-special media.
+    pub const fn block_geometry(self) -> Option<BlockDeviceGeometry> {
+        match self.value {
+            BlockFileBackingKindValue::RegularFile => None,
+            BlockFileBackingKindValue::BlockDevice { geometry } => Some(geometry),
+        }
+    }
+}
+
+impl fmt::Debug for BlockFileBackingKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.value {
+            BlockFileBackingKindValue::RegularFile => formatter.write_str("RegularFile"),
+            BlockFileBackingKindValue::BlockDevice { .. } => formatter
+                .debug_struct("BlockDevice")
+                .field("logical_block_size", &"<redacted>")
+                .finish(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BlockFileDescriptorIdentity {
+    device: u64,
+    inode: u64,
+    target_device: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BlockFileDescriptorStatus {
+    normalized_flags: u32,
+}
+
+struct InspectedBlockFileDescriptor {
+    metadata: std::fs::Metadata,
+    len: u64,
+    kind: BlockFileBackingKind,
+    identity: BlockFileDescriptorIdentity,
+    status: BlockFileDescriptorStatus,
+    device_id: VirtioBlockDeviceId,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4111,10 +4292,14 @@ enum BlockFileBackingOrigin {
 
 impl fmt::Debug for BlockFileBacking {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("BlockFileBacking")
-            .field("file", &"<owned>")
-            .field("len", &self.len)
+        let mut debug = formatter.debug_struct("BlockFileBacking");
+        debug.field("file", &"<owned>");
+        match self.kind.value {
+            BlockFileBackingKindValue::RegularFile => debug.field("len", &self.len),
+            BlockFileBackingKindValue::BlockDevice { .. } => debug.field("len", &"<redacted>"),
+        };
+        debug
+            .field("kind", &self.kind)
             .field("is_read_only", &self.is_read_only)
             .finish()
     }
@@ -4125,6 +4310,8 @@ pub struct BlockFileBackingIdentity {
     device: u64,
     inode: u64,
     len: u64,
+    kind: BlockFileBackingKind,
+    target_device: u64,
     mode: u32,
     modified_seconds: i64,
     modified_nanos: u32,
@@ -4134,6 +4321,43 @@ pub struct BlockFileBackingIdentity {
 
 impl BlockFileBackingIdentity {
     pub fn new(file: [u64; 3], mode: u32, modified: [i64; 2], changed: [i64; 2]) -> Option<Self> {
+        if mode & u32::from(libc::S_IFMT) != u32::from(libc::S_IFREG) {
+            return None;
+        }
+        Self::new_with_kind(
+            file,
+            BlockFileBackingKind::REGULAR_FILE,
+            0,
+            mode,
+            modified,
+            changed,
+        )
+    }
+
+    pub fn new_block_device(
+        file: [u64; 3],
+        target_device: u64,
+        logical_block_size: u32,
+        mode: u32,
+        modified: [i64; 2],
+        changed: [i64; 2],
+    ) -> Option<Self> {
+        let geometry = BlockDeviceGeometry::from_len(logical_block_size, file[2])?;
+        let kind = BlockFileBackingKind::block_device(geometry);
+        if target_device == 0 || mode & u32::from(libc::S_IFMT) != u32::from(libc::S_IFBLK) {
+            return None;
+        }
+        Self::new_with_kind(file, kind, target_device, mode, modified, changed)
+    }
+
+    fn new_with_kind(
+        file: [u64; 3],
+        kind: BlockFileBackingKind,
+        target_device: u64,
+        mode: u32,
+        modified: [i64; 2],
+        changed: [i64; 2],
+    ) -> Option<Self> {
         let Ok(modified_nanos) = u32::try_from(modified[1]) else {
             return None;
         };
@@ -4148,6 +4372,8 @@ impl BlockFileBackingIdentity {
             device: file[0],
             inode: file[1],
             len: file[2],
+            kind,
+            target_device,
             mode,
             modified_seconds: modified[0],
             modified_nanos,
@@ -4166,6 +4392,25 @@ impl BlockFileBackingIdentity {
 
     pub const fn len(self) -> u64 {
         self.len
+    }
+
+    pub const fn kind(self) -> BlockFileBackingKind {
+        self.kind
+    }
+
+    pub const fn target_device(self) -> Option<u64> {
+        if self.kind.is_block_device() {
+            Some(self.target_device)
+        } else {
+            None
+        }
+    }
+
+    pub const fn block_count(self) -> Option<u64> {
+        match self.kind.block_geometry() {
+            Some(geometry) => Some(geometry.block_count()),
+            None => None,
+        }
     }
 
     pub const fn is_empty(self) -> bool {
@@ -4245,23 +4490,78 @@ impl BlockFileBacking {
         Self::from_file_with_origin(file, is_read_only, BlockFileBackingOrigin::SuppliedFile)
     }
 
+    /// Adopts an authenticated block-special fd with its exact host control.
+    ///
+    /// Runtime still derives and validates descriptor kind, identity, access,
+    /// status, and byte capacity. The control supplies only live geometry and
+    /// cache synchronization for the same borrowed fd.
+    pub fn from_file_with_block_device_control(
+        file: File,
+        is_read_only: bool,
+        control: Arc<dyn BlockDeviceControl>,
+    ) -> Result<Self, BlockFileBackingError> {
+        if !cfg!(target_os = "macos") {
+            return Err(BlockFileBackingError::UnsupportedFileType);
+        }
+        Self::from_file_with_origin_and_control(
+            file,
+            is_read_only,
+            BlockFileBackingOrigin::SuppliedFile,
+            Some(BlockDeviceControlCandidate::Supplied(control)),
+            true,
+        )
+    }
+
     fn from_file_with_origin(
         file: File,
         is_read_only: bool,
         origin: BlockFileBackingOrigin,
     ) -> Result<Self, BlockFileBackingError> {
-        let metadata = file
-            .metadata()
-            .map_err(|source| BlockFileBackingError::ReadMetadata { source })?;
+        Self::from_file_with_origin_and_control(
+            file,
+            is_read_only,
+            origin,
+            direct_block_device_control(),
+            false,
+        )
+    }
 
-        if !metadata.file_type().is_file() {
-            return Err(BlockFileBackingError::NonRegularFile);
+    fn from_file_with_origin_and_control(
+        file: File,
+        is_read_only: bool,
+        origin: BlockFileBackingOrigin,
+        candidate_control: Option<BlockDeviceControlCandidate>,
+        require_block_device: bool,
+    ) -> Result<Self, BlockFileBackingError> {
+        let inspected = inspect_block_file_descriptor(
+            &file,
+            is_read_only,
+            candidate_control
+                .as_ref()
+                .map(BlockDeviceControlCandidate::as_control),
+            DescriptorCloexecPolicy::SetIfMissing,
+        )?;
+        if require_block_device && !inspected.kind.is_block_device() {
+            return Err(BlockFileBackingError::UnsupportedFileType);
         }
+        let block_control = if inspected.kind.is_block_device() {
+            Some(
+                candidate_control
+                    .ok_or(BlockFileBackingError::UnsupportedFileType)?
+                    .into_control(),
+            )
+        } else {
+            None
+        };
 
         Ok(Self {
             file,
-            len: metadata.len(),
-            device_id: virtio_block_device_id_from_metadata(&metadata),
+            len: inspected.len,
+            kind: inspected.kind,
+            descriptor_identity: inspected.identity,
+            descriptor_status: inspected.status,
+            block_control,
+            device_id: inspected.device_id,
             is_read_only,
             origin,
         })
@@ -4285,10 +4585,22 @@ impl BlockFileBacking {
             if !metadata.file_type().is_file() {
                 return Err(SnapshotBlockFileBackingError::NonRegularFile);
             }
-            let identity = snapshot_block_file_identity(&metadata)?;
+            let descriptor_status = validate_block_file_descriptor_status(
+                &file,
+                true,
+                DescriptorCloexecPolicy::SetIfMissing,
+            )
+            .map_err(|_| SnapshotBlockFileBackingError::InvalidMetadata)?;
+            let kind = BlockFileBackingKind::REGULAR_FILE;
+            let descriptor_identity = block_file_descriptor_identity(&metadata, kind);
+            let identity = snapshot_block_file_identity(&metadata, kind, metadata.len())?;
             let backing = Self {
                 file,
                 len: metadata.len(),
+                kind,
+                descriptor_identity,
+                descriptor_status,
+                block_control: None,
                 device_id: virtio_block_device_id_from_metadata(&metadata),
                 is_read_only: true,
                 origin: BlockFileBackingOrigin::Path,
@@ -4309,21 +4621,28 @@ impl BlockFileBacking {
     ) -> Result<(Self, BlockFileBackingIdentity), SnapshotBlockFileBackingError> {
         #[cfg(unix)]
         {
-            // SAFETY: F_GETFL only inspects the live owned descriptor.
-            let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFL) };
-            if flags < 0 || flags & libc::O_ACCMODE != libc::O_RDONLY {
-                return Err(SnapshotBlockFileBackingError::InvalidMetadata);
-            }
+            let descriptor_status = validate_block_file_descriptor_status(
+                &file,
+                true,
+                DescriptorCloexecPolicy::SetIfMissing,
+            )
+            .map_err(|_| SnapshotBlockFileBackingError::InvalidMetadata)?;
             let metadata = file
                 .metadata()
                 .map_err(|_| SnapshotBlockFileBackingError::ReadMetadata)?;
             if !metadata.file_type().is_file() {
                 return Err(SnapshotBlockFileBackingError::NonRegularFile);
             }
-            let identity = snapshot_block_file_identity(&metadata)?;
+            let kind = BlockFileBackingKind::REGULAR_FILE;
+            let descriptor_identity = block_file_descriptor_identity(&metadata, kind);
+            let identity = snapshot_block_file_identity(&metadata, kind, metadata.len())?;
             let backing = Self {
                 file,
                 len: metadata.len(),
+                kind,
+                descriptor_identity,
+                descriptor_status,
+                block_control: None,
                 device_id: virtio_block_device_id_from_metadata(&metadata),
                 is_read_only: true,
                 origin: BlockFileBackingOrigin::SuppliedFile,
@@ -4343,14 +4662,10 @@ impl BlockFileBacking {
     ) -> Result<BlockFileBackingIdentity, SnapshotBlockFileBackingError> {
         #[cfg(unix)]
         {
-            let metadata = self
-                .file
-                .metadata()
-                .map_err(|_| SnapshotBlockFileBackingError::ReadMetadata)?;
-            if !metadata.file_type().is_file() {
-                return Err(SnapshotBlockFileBackingError::NonRegularFile);
-            }
-            snapshot_block_file_identity(&metadata)
+            let inspected = self
+                .validated_current_inspection()
+                .map_err(|_| SnapshotBlockFileBackingError::InvalidMetadata)?;
+            snapshot_block_file_identity(&inspected.metadata, inspected.kind, inspected.len)
         }
 
         #[cfg(not(unix))]
@@ -4365,6 +4680,10 @@ impl BlockFileBacking {
 
     pub const fn len(&self) -> u64 {
         self.len
+    }
+
+    pub const fn kind(&self) -> BlockFileBackingKind {
+        self.kind
     }
 
     pub const fn is_empty(&self) -> bool {
@@ -4415,9 +4734,291 @@ impl BlockFileBacking {
     }
 
     pub fn flush(&self) -> Result<(), BlockFileBackingError> {
-        self.file
-            .sync_all()
-            .map_err(|source| BlockFileBackingError::FlushFile { source })
+        match self.kind.value {
+            BlockFileBackingKindValue::RegularFile => self
+                .file
+                .sync_all()
+                .map_err(|source| BlockFileBackingError::FlushFile { source }),
+            BlockFileBackingKindValue::BlockDevice { .. } => {
+                self.validated_current_inspection()?;
+                self.block_control
+                    .as_ref()
+                    .ok_or(BlockFileBackingError::BackingChanged)?
+                    .synchronize_cache(&self.file)
+                    .map_err(|source| BlockFileBackingError::FlushBlockDevice { source })?;
+                self.validated_current_inspection()?;
+                Ok(())
+            }
+        }
+    }
+
+    pub(super) fn flush_for_async(&self) -> Result<(), io::ErrorKind> {
+        self.flush().map_err(|source| source.io_error_kind())
+    }
+
+    fn validated_current_inspection(
+        &self,
+    ) -> Result<InspectedBlockFileDescriptor, BlockFileBackingError> {
+        let inspected = inspect_block_file_descriptor(
+            &self.file,
+            self.is_read_only,
+            self.block_control.as_deref(),
+            DescriptorCloexecPolicy::Require,
+        )?;
+        if inspected.kind != self.kind
+            || inspected.len != self.len
+            || inspected.identity != self.descriptor_identity
+            || inspected.status != self.descriptor_status
+            || inspected.device_id != self.device_id
+        {
+            return Err(BlockFileBackingError::BackingChanged);
+        }
+        Ok(inspected)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DescriptorCloexecPolicy {
+    SetIfMissing,
+    Require,
+}
+
+enum BlockDeviceControlCandidate {
+    #[cfg(target_os = "macos")]
+    DirectMacos(DirectMacosBlockDeviceControl),
+    Supplied(Arc<dyn BlockDeviceControl>),
+}
+
+impl BlockDeviceControlCandidate {
+    fn as_control(&self) -> &dyn BlockDeviceControl {
+        match self {
+            #[cfg(target_os = "macos")]
+            Self::DirectMacos(control) => control,
+            Self::Supplied(control) => control.as_ref(),
+        }
+    }
+
+    fn into_control(self) -> Arc<dyn BlockDeviceControl> {
+        match self {
+            #[cfg(target_os = "macos")]
+            Self::DirectMacos(control) => Arc::new(control),
+            Self::Supplied(control) => control,
+        }
+    }
+}
+
+fn direct_block_device_control() -> Option<BlockDeviceControlCandidate> {
+    #[cfg(target_os = "macos")]
+    {
+        Some(BlockDeviceControlCandidate::DirectMacos(
+            DirectMacosBlockDeviceControl,
+        ))
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        None
+    }
+}
+
+#[cfg(unix)]
+fn inspect_block_file_descriptor(
+    file: &File,
+    is_read_only: bool,
+    block_control: Option<&dyn BlockDeviceControl>,
+    cloexec_policy: DescriptorCloexecPolicy,
+) -> Result<InspectedBlockFileDescriptor, BlockFileBackingError> {
+    let status = validate_block_file_descriptor_status(file, is_read_only, cloexec_policy)?;
+    let metadata = file
+        .metadata()
+        .map_err(|source| BlockFileBackingError::ReadMetadata { source })?;
+
+    let (kind, len) = if metadata.file_type().is_file() {
+        (BlockFileBackingKind::REGULAR_FILE, metadata.len())
+    } else {
+        if metadata.mode() & u32::from(libc::S_IFMT) != u32::from(libc::S_IFBLK)
+            || metadata.rdev() == 0
+        {
+            return Err(BlockFileBackingError::UnsupportedFileType);
+        }
+        let geometry = block_control
+            .ok_or(BlockFileBackingError::UnsupportedFileType)?
+            .inspect(file)
+            .map_err(|source| BlockFileBackingError::ReadBlockGeometry { source })?;
+        (BlockFileBackingKind::block_device(geometry), geometry.len())
+    };
+    let identity = block_file_descriptor_identity(&metadata, kind);
+    let device_id = virtio_block_device_id_from_metadata(&metadata);
+
+    Ok(InspectedBlockFileDescriptor {
+        metadata,
+        len,
+        kind,
+        identity,
+        status,
+        device_id,
+    })
+}
+
+#[cfg(not(unix))]
+fn inspect_block_file_descriptor(
+    _file: &File,
+    _is_read_only: bool,
+    _block_control: Option<&dyn BlockDeviceControl>,
+    _cloexec_policy: DescriptorCloexecPolicy,
+) -> Result<InspectedBlockFileDescriptor, BlockFileBackingError> {
+    Err(BlockFileBackingError::UnsupportedFileType)
+}
+
+#[cfg(unix)]
+fn validate_block_file_descriptor_status(
+    file: &File,
+    is_read_only: bool,
+    cloexec_policy: DescriptorCloexecPolicy,
+) -> Result<BlockFileDescriptorStatus, BlockFileBackingError> {
+    // SAFETY: F_GETFD only reads per-descriptor flags from the live owned fd.
+    let mut descriptor_flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFD) };
+    if descriptor_flags < 0 {
+        return Err(BlockFileBackingError::ReadDescriptorFlags {
+            source: io::Error::last_os_error(),
+        });
+    }
+    if descriptor_flags & libc::FD_CLOEXEC == 0
+        && cloexec_policy == DescriptorCloexecPolicy::SetIfMissing
+    {
+        // SAFETY: F_SETFD changes only per-descriptor flags on the live owned fd.
+        if unsafe {
+            libc::fcntl(
+                file.as_raw_fd(),
+                libc::F_SETFD,
+                descriptor_flags | libc::FD_CLOEXEC,
+            )
+        } < 0
+        {
+            return Err(BlockFileBackingError::SetDescriptorFlags {
+                source: io::Error::last_os_error(),
+            });
+        }
+        // SAFETY: F_GETFD verifies the same live descriptor after F_SETFD.
+        descriptor_flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFD) };
+        if descriptor_flags < 0 {
+            return Err(BlockFileBackingError::ReadDescriptorFlags {
+                source: io::Error::last_os_error(),
+            });
+        }
+    }
+    if descriptor_flags & libc::FD_CLOEXEC == 0 {
+        return Err(BlockFileBackingError::InvalidDescriptorFlags);
+    }
+
+    // SAFETY: F_GETFL only reads status flags from the live owned descriptor.
+    let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFL) };
+    if flags < 0 {
+        return Err(BlockFileBackingError::ReadDescriptorFlags {
+            source: io::Error::last_os_error(),
+        });
+    }
+    let expected = if is_read_only {
+        libc::O_RDONLY
+    } else {
+        libc::O_RDWR
+    };
+    if flags & libc::O_ACCMODE != expected {
+        return Err(BlockFileBackingError::AccessModeMismatch);
+    }
+    if flags & libc::O_APPEND != 0 {
+        return Err(BlockFileBackingError::InvalidDescriptorFlags);
+    }
+    let normalized_flags =
+        u32::try_from(flags & (libc::O_ACCMODE | libc::O_APPEND | libc::O_NONBLOCK))
+            .map_err(|_| BlockFileBackingError::InvalidDescriptorFlags)?;
+    Ok(BlockFileDescriptorStatus { normalized_flags })
+}
+
+#[cfg(unix)]
+fn block_file_descriptor_identity(
+    metadata: &std::fs::Metadata,
+    kind: BlockFileBackingKind,
+) -> BlockFileDescriptorIdentity {
+    BlockFileDescriptorIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+        target_device: if kind.is_block_device() {
+            metadata.rdev()
+        } else {
+            0
+        },
+    }
+}
+
+#[cfg(target_os = "macos")]
+const DARWIN_IOC_OUT: libc::c_ulong = 0x4000_0000;
+#[cfg(target_os = "macos")]
+const DARWIN_IOC_VOID: libc::c_ulong = 0x2000_0000;
+#[cfg(target_os = "macos")]
+const DARWIN_IOCPARM_MASK: libc::c_ulong = 0x1fff;
+
+#[cfg(target_os = "macos")]
+const fn darwin_ioctl_request(
+    direction: libc::c_ulong,
+    group: u8,
+    number: u8,
+    len: usize,
+) -> libc::c_ulong {
+    direction
+        | (((len as libc::c_ulong) & DARWIN_IOCPARM_MASK) << 16)
+        | ((group as libc::c_ulong) << 8)
+        | number as libc::c_ulong
+}
+
+#[cfg(target_os = "macos")]
+const DKIOCGETBLOCKSIZE: libc::c_ulong =
+    darwin_ioctl_request(DARWIN_IOC_OUT, b'd', 24, std::mem::size_of::<u32>());
+#[cfg(target_os = "macos")]
+const DKIOCGETBLOCKCOUNT: libc::c_ulong =
+    darwin_ioctl_request(DARWIN_IOC_OUT, b'd', 25, std::mem::size_of::<u64>());
+#[cfg(target_os = "macos")]
+const DKIOCSYNCHRONIZECACHE: libc::c_ulong = darwin_ioctl_request(DARWIN_IOC_VOID, b'd', 22, 0);
+
+#[cfg(target_os = "macos")]
+#[derive(Debug)]
+struct DirectMacosBlockDeviceControl;
+
+#[cfg(target_os = "macos")]
+impl BlockDeviceControl for DirectMacosBlockDeviceControl {
+    fn inspect(&self, file: &File) -> Result<BlockDeviceGeometry, BlockDeviceControlError> {
+        let mut logical_block_size = 0_u32;
+        // SAFETY: DKIOCGETBLOCKSIZE writes one u32 to the valid out pointer for
+        // this call and only inspects the live borrowed disk descriptor.
+        if unsafe { libc::ioctl(file.as_raw_fd(), DKIOCGETBLOCKSIZE, &mut logical_block_size) } < 0
+        {
+            return Err(BlockDeviceControlError::new(
+                io::Error::last_os_error().kind(),
+            ));
+        }
+
+        let mut block_count = 0_u64;
+        // SAFETY: DKIOCGETBLOCKCOUNT writes one u64 to the valid out pointer for
+        // this call and only inspects the live borrowed disk descriptor.
+        if unsafe { libc::ioctl(file.as_raw_fd(), DKIOCGETBLOCKCOUNT, &mut block_count) } < 0 {
+            return Err(BlockDeviceControlError::new(
+                io::Error::last_os_error().kind(),
+            ));
+        }
+        BlockDeviceGeometry::new(logical_block_size, block_count)
+            .ok_or(BlockDeviceControlError::new(io::ErrorKind::InvalidData))
+    }
+
+    fn synchronize_cache(&self, file: &File) -> Result<(), BlockDeviceControlError> {
+        // SAFETY: DKIOCSYNCHRONIZECACHE has no pointer payload and operates only
+        // on the live borrowed disk descriptor for this call.
+        if unsafe { libc::ioctl(file.as_raw_fd(), DKIOCSYNCHRONIZECACHE) } < 0 {
+            Err(BlockDeviceControlError::new(
+                io::Error::last_os_error().kind(),
+            ))
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -4430,13 +5031,25 @@ fn virtio_block_device_id_from_metadata(metadata: &std::fs::Metadata) -> VirtioB
 #[cfg(unix)]
 fn snapshot_block_file_identity(
     metadata: &std::fs::Metadata,
+    kind: BlockFileBackingKind,
+    len: u64,
 ) -> Result<BlockFileBackingIdentity, SnapshotBlockFileBackingError> {
-    BlockFileBackingIdentity::new(
-        [metadata.dev(), metadata.ino(), metadata.len()],
-        metadata.mode(),
-        [metadata.mtime(), metadata.mtime_nsec()],
-        [metadata.ctime(), metadata.ctime_nsec()],
-    )
+    let file = [metadata.dev(), metadata.ino(), len];
+    let modified = [metadata.mtime(), metadata.mtime_nsec()];
+    let changed = [metadata.ctime(), metadata.ctime_nsec()];
+    if kind.is_block_device() {
+        BlockFileBackingIdentity::new_block_device(
+            file,
+            metadata.rdev(),
+            kind.logical_block_size()
+                .ok_or(SnapshotBlockFileBackingError::InvalidMetadata)?,
+            metadata.mode(),
+            modified,
+            changed,
+        )
+    } else {
+        BlockFileBackingIdentity::new(file, metadata.mode(), modified, changed)
+    }
     .ok_or(SnapshotBlockFileBackingError::InvalidMetadata)
 }
 
@@ -4446,7 +5059,7 @@ fn open_block_file(path: &Path, is_read_only: bool) -> Result<File, BlockFileBac
 
     #[cfg(unix)]
     {
-        options.custom_flags(libc::O_NONBLOCK);
+        options.custom_flags(libc::O_NONBLOCK | libc::O_NOFOLLOW | libc::O_CLOEXEC);
     }
 
     options
@@ -4485,7 +5098,19 @@ pub enum BlockFileBackingError {
     ReadMetadata {
         source: io::Error,
     },
-    NonRegularFile,
+    ReadDescriptorFlags {
+        source: io::Error,
+    },
+    SetDescriptorFlags {
+        source: io::Error,
+    },
+    InvalidDescriptorFlags,
+    AccessModeMismatch,
+    UnsupportedFileType,
+    ReadBlockGeometry {
+        source: BlockDeviceControlError,
+    },
+    BackingChanged,
     AccessLengthTooLarge {
         len: usize,
     },
@@ -4508,6 +5133,30 @@ pub enum BlockFileBackingError {
     FlushFile {
         source: io::Error,
     },
+    FlushBlockDevice {
+        source: BlockDeviceControlError,
+    },
+}
+
+impl BlockFileBackingError {
+    fn io_error_kind(&self) -> io::ErrorKind {
+        match self {
+            Self::OpenFile { source }
+            | Self::ReadMetadata { source }
+            | Self::ReadDescriptorFlags { source }
+            | Self::SetDescriptorFlags { source }
+            | Self::ReadFile { source }
+            | Self::WriteFile { source }
+            | Self::FlushFile { source } => source.kind(),
+            Self::ReadBlockGeometry { source } | Self::FlushBlockDevice { source } => source.kind(),
+            Self::UnsupportedBackend | Self::UnsupportedFileType => io::ErrorKind::Unsupported,
+            Self::AccessModeMismatch | Self::ReadOnlyWrite => io::ErrorKind::PermissionDenied,
+            Self::InvalidDescriptorFlags | Self::BackingChanged => io::ErrorKind::InvalidData,
+            Self::AccessLengthTooLarge { .. }
+            | Self::AccessOverflow { .. }
+            | Self::AccessOutOfBounds { .. } => io::ErrorKind::InvalidInput,
+        }
+    }
 }
 
 impl fmt::Display for BlockFileBackingError {
@@ -4520,9 +5169,25 @@ impl fmt::Display for BlockFileBackingError {
             Self::ReadMetadata { source } => {
                 write!(f, "failed to read block backing file metadata: {source}")
             }
-            Self::NonRegularFile => {
-                f.write_str("block backing path does not reference a regular file")
+            Self::ReadDescriptorFlags { source } => {
+                write!(f, "failed to read block backing descriptor flags: {source}")
             }
+            Self::SetDescriptorFlags { source } => {
+                write!(f, "failed to set block backing descriptor flags: {source}")
+            }
+            Self::InvalidDescriptorFlags => {
+                f.write_str("block backing descriptor flags are invalid")
+            }
+            Self::AccessModeMismatch => {
+                f.write_str("block backing descriptor access mode does not match the drive")
+            }
+            Self::UnsupportedFileType => f.write_str(
+                "block backing descriptor is neither a regular file nor a supported block device",
+            ),
+            Self::ReadBlockGeometry { source } => {
+                write!(f, "failed to read block backing geometry: {source}")
+            }
+            Self::BackingChanged => f.write_str("block backing descriptor changed"),
             Self::AccessLengthTooLarge { len } => {
                 write!(f, "block backing access length {len} is too large")
             }
@@ -4544,6 +5209,9 @@ impl fmt::Display for BlockFileBackingError {
             Self::FlushFile { source } => {
                 write!(f, "failed to flush block backing file: {source}")
             }
+            Self::FlushBlockDevice { source } => {
+                write!(f, "failed to synchronize block backing cache: {source}")
+            }
         }
     }
 }
@@ -4553,11 +5221,17 @@ impl std::error::Error for BlockFileBackingError {
         match self {
             Self::OpenFile { source }
             | Self::ReadMetadata { source }
+            | Self::ReadDescriptorFlags { source }
+            | Self::SetDescriptorFlags { source }
             | Self::ReadFile { source }
             | Self::WriteFile { source }
             | Self::FlushFile { source } => Some(source),
+            Self::ReadBlockGeometry { source } | Self::FlushBlockDevice { source } => Some(source),
             Self::UnsupportedBackend
-            | Self::NonRegularFile
+            | Self::InvalidDescriptorFlags
+            | Self::AccessModeMismatch
+            | Self::UnsupportedFileType
+            | Self::BackingChanged
             | Self::AccessLengthTooLarge { .. }
             | Self::AccessOverflow { .. }
             | Self::AccessOutOfBounds { .. }
@@ -7830,7 +8504,8 @@ mod tests {
     };
 
     use super::{
-        BlockCaptureIoEngine, BlockFileBacking, BlockFileBackingError, BlockMmioDevices,
+        BlockCaptureIoEngine, BlockDeviceControl, BlockDeviceControlError, BlockDeviceGeometry,
+        BlockFileBacking, BlockFileBackingError, BlockFileBackingIdentity, BlockMmioDevices,
         BlockMmioLayout, BlockMmioRegistrationError, DriveCacheType, DriveConfig, DriveConfigError,
         DriveConfigInput, DriveConfigs, DriveIdSource, DriveIoEngine, DriveLiveUpdateMode,
         DriveRateLimiterConfig, DriveReplacementIdentityField, DriveRuntimeMutationError,
@@ -10903,7 +11578,8 @@ mod tests {
                 assert_eq!(drive_id, "rootfs");
                 assert!(matches!(
                     source,
-                    BlockFileBackingError::OpenFile { .. } | BlockFileBackingError::NonRegularFile
+                    BlockFileBackingError::OpenFile { .. }
+                        | BlockFileBackingError::UnsupportedFileType
                 ));
             }
             PreparedBlockDeviceError::AllocateDevices { .. } => {
@@ -10941,7 +11617,8 @@ mod tests {
                 assert_eq!(drive_id, "rootfs");
                 assert!(matches!(
                     source,
-                    BlockFileBackingError::OpenFile { .. } | BlockFileBackingError::NonRegularFile
+                    BlockFileBackingError::OpenFile { .. }
+                        | BlockFileBackingError::UnsupportedFileType
                 ));
             }
             PreparedBlockDeviceError::AllocateDevices { .. } => {
@@ -15563,7 +16240,7 @@ mod tests {
         let err = BlockFileBacking::from_file(provided_dir, true)
             .expect_err("provided directory should fail");
 
-        assert!(matches!(err, BlockFileBackingError::NonRegularFile));
+        assert!(matches!(err, BlockFileBackingError::UnsupportedFileType));
     }
 
     #[test]
@@ -15725,16 +16402,256 @@ mod tests {
     }
 
     #[test]
-    fn rejects_directory_backing_as_non_regular() {
+    fn rejects_directory_backing_as_unsupported_type() {
         let dir = temp_dir("dir.img");
         let err = open_backing(dir.as_path(), true).expect_err("directory backing should fail");
 
-        assert!(matches!(err, BlockFileBackingError::NonRegularFile));
+        assert!(matches!(err, BlockFileBackingError::UnsupportedFileType));
         assert_eq!(
             err.to_string(),
-            "block backing path does not reference a regular file"
+            "block backing descriptor is neither a regular file nor a supported block device"
         );
         assert!(err.source().is_none());
+    }
+
+    #[test]
+    fn direct_backing_open_rejects_final_symlink_and_character_device() {
+        let file = temp_file("direct-nofollow-source.img", b"source");
+        let link = TempPath {
+            path: temp_path("direct-nofollow-link.img"),
+        };
+        std::os::unix::fs::symlink(file.as_path(), link.as_path())
+            .expect("test symlink should be created");
+
+        let symlink_error =
+            open_backing(link.as_path(), true).expect_err("final symlink should fail");
+        let character_error =
+            open_backing("/dev/null", true).expect_err("character device should fail");
+
+        assert!(matches!(
+            symlink_error,
+            BlockFileBackingError::OpenFile { .. }
+        ));
+        assert!(matches!(
+            character_error,
+            BlockFileBackingError::UnsupportedFileType
+        ));
+        assert!(!symlink_error.to_string().contains("direct-nofollow"));
+        assert!(!character_error.to_string().contains("/dev/null"));
+    }
+
+    #[test]
+    fn supplied_backing_requires_exact_descriptor_access_mode() {
+        let file = temp_file("descriptor-access.img", b"access");
+        let read_write = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(file.as_path())
+            .expect("read-write descriptor should open");
+        let read_only = OpenOptions::new()
+            .read(true)
+            .open(file.as_path())
+            .expect("read-only descriptor should open");
+        let write_only = OpenOptions::new()
+            .write(true)
+            .open(file.as_path())
+            .expect("write-only descriptor should open");
+
+        for error in [
+            BlockFileBacking::from_file(read_write, true)
+                .expect_err("read-write descriptor should not satisfy read-only"),
+            BlockFileBacking::from_file(read_only, false)
+                .expect_err("read-only descriptor should not satisfy read-write"),
+            BlockFileBacking::from_file(write_only, false)
+                .expect_err("write-only descriptor should not satisfy read-write"),
+        ] {
+            assert!(matches!(error, BlockFileBackingError::AccessModeMismatch));
+            assert_eq!(
+                error.to_string(),
+                "block backing descriptor access mode does not match the drive"
+            );
+            assert!(!error.to_string().contains("descriptor-access"));
+        }
+    }
+
+    #[derive(Debug)]
+    struct UnexpectedBlockControl;
+
+    impl BlockDeviceControl for UnexpectedBlockControl {
+        fn inspect(&self, _file: &File) -> Result<BlockDeviceGeometry, BlockDeviceControlError> {
+            panic!("regular descriptors must not invoke block control")
+        }
+
+        fn synchronize_cache(&self, _file: &File) -> Result<(), BlockDeviceControlError> {
+            panic!("regular descriptors must not invoke block control")
+        }
+    }
+
+    #[test]
+    fn supplied_block_control_cannot_forge_regular_descriptor_kind() {
+        let file = temp_file("control-regular.img", b"regular");
+        let descriptor = File::open(file.as_path()).expect("regular descriptor should open");
+        let error = BlockFileBacking::from_file_with_block_device_control(
+            descriptor,
+            true,
+            Arc::new(UnexpectedBlockControl),
+        )
+        .expect_err("block-only construction must reject a regular descriptor");
+
+        assert!(matches!(error, BlockFileBackingError::UnsupportedFileType));
+        let control_error = BlockDeviceControlError::new(io::ErrorKind::PermissionDenied);
+        assert_eq!(control_error.kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(control_error.to_string(), "block-device control failed");
+        assert!(!format!("{control_error:?}").contains("control-regular"));
+        assert_eq!(
+            BlockFileBackingError::ReadBlockGeometry {
+                source: control_error,
+            }
+            .io_error_kind(),
+            io::ErrorKind::PermissionDenied
+        );
+        assert_eq!(
+            BlockFileBackingError::FlushBlockDevice {
+                source: control_error,
+            }
+            .io_error_kind(),
+            io::ErrorKind::PermissionDenied
+        );
+    }
+
+    #[test]
+    fn supplied_backing_rejects_append_and_normalizes_cloexec() {
+        let file = temp_file("descriptor-status.img", b"status");
+        let append = OpenOptions::new()
+            .read(true)
+            .append(true)
+            .open(file.as_path())
+            .expect("append descriptor should open");
+        assert!(matches!(
+            BlockFileBacking::from_file(append, false),
+            Err(BlockFileBackingError::InvalidDescriptorFlags)
+        ));
+
+        let descriptor = File::open(file.as_path()).expect("read-only descriptor should open");
+        // SAFETY: F_SETFD clears only per-descriptor flags on this owned test fd.
+        let clear_result = unsafe { libc::fcntl(descriptor.as_raw_fd(), libc::F_SETFD, 0) };
+        assert_eq!(clear_result, 0);
+        let backing = BlockFileBacking::from_file(descriptor, true)
+            .expect("adoption should restore descriptor-local CLOEXEC");
+        // SAFETY: F_GETFD only reads per-descriptor flags from the retained fd.
+        let descriptor_flags = unsafe { libc::fcntl(backing.file.as_raw_fd(), libc::F_GETFD) };
+        assert_ne!(descriptor_flags & libc::FD_CLOEXEC, 0);
+
+        // SAFETY: This deliberately violates the retained descriptor invariant.
+        let clear_result = unsafe { libc::fcntl(backing.file.as_raw_fd(), libc::F_SETFD, 0) };
+        assert_eq!(clear_result, 0);
+        assert_eq!(
+            backing.snapshot_identity(),
+            Err(SnapshotBlockFileBackingError::InvalidMetadata)
+        );
+    }
+
+    #[test]
+    fn capture_rejects_changed_semantic_status_flags() {
+        let file = temp_file("descriptor-status-change.img", b"status");
+        let descriptor = File::open(file.as_path()).expect("read-only descriptor should open");
+        let backing =
+            BlockFileBacking::from_file(descriptor, true).expect("regular descriptor should adopt");
+        // SAFETY: F_GETFL inspects the retained live descriptor.
+        let flags = unsafe { libc::fcntl(backing.file.as_raw_fd(), libc::F_GETFL) };
+        assert!(flags >= 0);
+        // SAFETY: F_SETFL changes only status flags on the retained test descriptor.
+        let set_result = unsafe {
+            libc::fcntl(
+                backing.file.as_raw_fd(),
+                libc::F_SETFL,
+                flags | libc::O_NONBLOCK,
+            )
+        };
+        assert_eq!(set_result, 0);
+        assert_eq!(
+            backing.snapshot_identity(),
+            Err(SnapshotBlockFileBackingError::InvalidMetadata)
+        );
+    }
+
+    #[test]
+    fn block_geometry_validation_is_exact_bounded_and_sector_aligned() {
+        let geometry = BlockDeviceGeometry::new(512, 8).expect("valid geometry should pass");
+        assert_eq!(geometry.logical_block_size(), 512);
+        assert_eq!(geometry.block_count(), 8);
+        assert_eq!(geometry.len(), 4096);
+        assert!(!geometry.is_empty());
+        assert!(format!("{geometry:?}").contains("<redacted>"));
+        assert!(!format!("{geometry:?}").contains("512"));
+
+        assert!(BlockDeviceGeometry::new(0, 8).is_none());
+        assert!(BlockDeviceGeometry::new(512, 0).is_none());
+        assert!(BlockDeviceGeometry::new(768, 8).is_none());
+        assert!(BlockDeviceGeometry::new(4096, u64::MAX).is_none());
+        assert!(BlockDeviceGeometry::new(512, i64::MAX as u64 / 512 + 1).is_none());
+    }
+
+    #[test]
+    fn block_capture_identity_binds_target_and_logical_geometry() {
+        let identity = BlockFileBackingIdentity::new_block_device(
+            [11, 12, 4096],
+            13,
+            512,
+            u32::from(libc::S_IFBLK),
+            [14, 15],
+            [16, 17],
+        )
+        .expect("valid block identity should build");
+
+        assert!(identity.kind().is_block_device());
+        assert_eq!(identity.kind().logical_block_size(), Some(512));
+        assert_eq!(identity.target_device(), Some(13));
+        assert_eq!(identity.block_count(), Some(8));
+        assert!(format!("{identity:?}").contains("<redacted>"));
+        assert!(!format!("{identity:?}").contains("13"));
+        assert!(
+            BlockFileBackingIdentity::new_block_device(
+                [11, 12, 4096],
+                0,
+                512,
+                u32::from(libc::S_IFBLK),
+                [14, 15],
+                [16, 17],
+            )
+            .is_none()
+        );
+        assert!(
+            BlockFileBackingIdentity::new_block_device(
+                [11, 12, 4097],
+                13,
+                512,
+                u32::from(libc::S_IFBLK),
+                [14, 15],
+                [16, 17],
+            )
+            .is_none()
+        );
+        assert!(
+            BlockFileBackingIdentity::new_block_device(
+                [11, 12, 4096],
+                13,
+                512,
+                u32::from(libc::S_IFREG),
+                [14, 15],
+                [16, 17],
+            )
+            .is_none()
+        );
+        assert!(
+            BlockFileBackingIdentity::new(
+                [11, 12, 4096],
+                u32::from(libc::S_IFBLK),
+                [14, 15],
+                [16, 17],
+            )
+            .is_none()
+        );
     }
 
     #[test]
@@ -15742,7 +16659,7 @@ mod tests {
         let fifo = temp_fifo("fifo.img");
         let err = open_backing(fifo.as_path(), true).expect_err("FIFO backing should fail");
 
-        assert!(matches!(err, BlockFileBackingError::NonRegularFile));
+        assert!(matches!(err, BlockFileBackingError::UnsupportedFileType));
     }
 
     #[test]
@@ -15753,7 +16670,7 @@ mod tests {
 
         assert!(matches!(
             err,
-            BlockFileBackingError::OpenFile { .. } | BlockFileBackingError::NonRegularFile
+            BlockFileBackingError::OpenFile { .. } | BlockFileBackingError::UnsupportedFileType
         ));
         assert!(!err.to_string().contains("socket.img"));
     }

--- a/crates/runtime/src/block/async_executor.rs
+++ b/crates/runtime/src/block/async_executor.rs
@@ -601,7 +601,7 @@ impl BlockAsyncHostIo for SystemBlockAsyncHostIo {
     }
 
     fn flush(&self, backing: &BlockFileBacking) -> Result<(), io::ErrorKind> {
-        backing.file.sync_all().map_err(|source| source.kind())
+        backing.flush_for_async()
     }
 }
 

--- a/crates/runtime/src/snapshot_device.rs
+++ b/crates/runtime/src/snapshot_device.rs
@@ -418,7 +418,7 @@ pub fn capture_snapshot_v1_device_state(
     let live_backing = live_device
         .backing()
         .ok_or(SnapshotV1DeviceCaptureError::UnsupportedDriveProfile)?;
-    if !live_backing.is_read_only() {
+    if !live_backing.is_read_only() || !live_backing.kind().is_regular_file() {
         return Err(SnapshotV1DeviceCaptureError::UnsupportedDriveProfile);
     }
     let live_identity = live_backing
@@ -652,6 +652,9 @@ pub fn encode_snapshot_v1_device_state(
             SnapshotV1DeviceEncodeError::EmptyPartuuid,
             SnapshotV1DeviceEncodeError::PartuuidTooLong,
         )?;
+    }
+    if !root.backing_identity().kind().is_regular_file() {
+        return Err(SnapshotV1DeviceEncodeError::InvalidState);
     }
 
     validate_encode_transport(root.runtime())?;
@@ -1658,12 +1661,39 @@ mod tests {
 
         assert_eq!(first, second);
         assert_eq!(decoded, state);
+        assert!(
+            decoded
+                .root_block()
+                .backing_identity()
+                .kind()
+                .is_regular_file()
+        );
         assert_eq!(&first[..8], &SNAPSHOT_V1_DEVICE_MAGIC);
         assert_eq!(first.len(), 566);
         assert_eq!(
             u32::from_le_bytes(first[20..24].try_into().expect("body length should exist")),
             u32::try_from(first.len() - SNAPSHOT_V1_DEVICE_HEADER_SIZE)
                 .expect("fixture length should fit")
+        );
+    }
+
+    #[test]
+    fn native_v1_device_encoder_rejects_in_memory_block_backing_identity() {
+        let block_identity = BlockFileBackingIdentity::new_block_device(
+            [1, 2, 512],
+            3,
+            512,
+            u32::from(libc::S_IFBLK | 0o444),
+            [4, 5],
+            [6, 7],
+        )
+        .expect("synthetic block identity should validate");
+        let state = fixture_with_path(PathBuf::from("/tmp/block-device"), block_identity);
+
+        assert_eq!(
+            encode_snapshot_v1_device_state(&state)
+                .expect_err("native-v1 must remain regular-file-only"),
+            SnapshotV1DeviceEncodeError::InvalidState
         );
     }
 

--- a/tests/support/macos_virtual_block.rs
+++ b/tests/support/macos_virtual_block.rs
@@ -1,0 +1,626 @@
+// Shared by signed macOS block-device integration targets.
+#![cfg(target_os = "macos")]
+
+use std::ffi::OsString;
+use std::fmt;
+use std::fs::{self, File, OpenOptions};
+use std::io::Cursor;
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::fs::{FileExt, MetadataExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use plist::{Dictionary, Value};
+
+const HDIUTIL: &str = "/usr/bin/hdiutil";
+const IMAGE_SIZE_ARGUMENT: &str = "4m";
+const EXPECTED_IMAGE_BYTES: u64 = 4 * 1024 * 1024;
+const DEVICE_PREFIX: &str = "/dev/disk";
+const VIRTIO_SECTOR_BYTES: u64 = 512;
+const DARWIN_IOC_OUT: libc::c_ulong = 0x4000_0000;
+const DARWIN_IOC_VOID: libc::c_ulong = 0x2000_0000;
+const DARWIN_IOCPARM_MASK: libc::c_ulong = 0x1fff;
+
+const fn darwin_ioctl_request(
+    direction: libc::c_ulong,
+    group: u8,
+    number: u8,
+    len: usize,
+) -> libc::c_ulong {
+    direction
+        | (((len as libc::c_ulong) & DARWIN_IOCPARM_MASK) << 16)
+        | ((group as libc::c_ulong) << 8)
+        | number as libc::c_ulong
+}
+
+const DKIOCGETBLOCKSIZE: libc::c_ulong =
+    darwin_ioctl_request(DARWIN_IOC_OUT, b'd', 24, std::mem::size_of::<u32>());
+const DKIOCGETBLOCKCOUNT: libc::c_ulong =
+    darwin_ioctl_request(DARWIN_IOC_OUT, b'd', 25, std::mem::size_of::<u64>());
+const DKIOCSYNCHRONIZECACHE: libc::c_ulong = darwin_ioctl_request(DARWIN_IOC_VOID, b'd', 22, 0);
+
+static NEXT_FIXTURE_ID: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MacosVirtualBlockError;
+
+impl fmt::Display for MacosVirtualBlockError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("temporary virtual block media failure")
+    }
+}
+
+impl std::error::Error for MacosVirtualBlockError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MacosVirtualBlockAccess {
+    ReadOnly,
+    ReadWrite,
+}
+
+impl MacosVirtualBlockAccess {
+    const fn open_flags(self) -> libc::c_int {
+        match self {
+            Self::ReadOnly => libc::O_RDONLY,
+            Self::ReadWrite => libc::O_RDWR,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MacosVirtualBlockIdentity {
+    device: u64,
+    inode: u64,
+    target_device: u64,
+}
+
+impl MacosVirtualBlockIdentity {
+    pub(crate) const fn device(self) -> u64 {
+        self.device
+    }
+
+    pub(crate) const fn inode(self) -> u64 {
+        self.inode
+    }
+
+    pub(crate) const fn target_device(self) -> u64 {
+        self.target_device
+    }
+}
+
+impl fmt::Debug for MacosVirtualBlockIdentity {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("MacosVirtualBlockIdentity(<redacted>)")
+    }
+}
+
+#[derive(Clone)]
+struct Attachment {
+    device_path: PathBuf,
+    access: MacosVirtualBlockAccess,
+    identity: MacosVirtualBlockIdentity,
+    logical_block_size: u32,
+    block_count: u64,
+}
+
+impl Attachment {
+    fn len(&self) -> Option<u64> {
+        u64::from(self.logical_block_size).checked_mul(self.block_count)
+    }
+}
+
+pub(crate) struct MacosVirtualBlock {
+    directory: PathBuf,
+    image: PathBuf,
+    attachment: Option<Attachment>,
+    attachment_uncertain: bool,
+    cleaned: bool,
+}
+
+impl fmt::Debug for MacosVirtualBlock {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MacosVirtualBlock")
+            .field("storage", &"<redacted>")
+            .field(
+                "attachment",
+                &self.attachment.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
+}
+
+impl MacosVirtualBlock {
+    pub(crate) fn create(access: MacosVirtualBlockAccess) -> Result<Self, MacosVirtualBlockError> {
+        let directory = unique_fixture_directory()?;
+        let image = directory.join("media.dmg");
+        let output = run_hdiutil(&[
+            OsString::from("create"),
+            OsString::from("-size"),
+            OsString::from(IMAGE_SIZE_ARGUMENT),
+            OsString::from("-layout"),
+            OsString::from("NONE"),
+            image.as_os_str().to_os_string(),
+        ]);
+        if output.is_err() {
+            let _ = fs::remove_file(&image);
+            let _ = fs::remove_dir(&directory);
+            return Err(MacosVirtualBlockError);
+        }
+        let mut media = Self {
+            directory,
+            image,
+            attachment: None,
+            attachment_uncertain: false,
+            cleaned: false,
+        };
+        media.image = fs::canonicalize(&media.image).map_err(|_| MacosVirtualBlockError)?;
+        media.attach(access)?;
+        Ok(media)
+    }
+
+    pub(crate) fn attach(
+        &mut self,
+        access: MacosVirtualBlockAccess,
+    ) -> Result<(), MacosVirtualBlockError> {
+        if self.cleaned || self.attachment.is_some() || self.attachment_uncertain {
+            return Err(MacosVirtualBlockError);
+        }
+        let mut arguments = vec![
+            OsString::from("attach"),
+            OsString::from("-nomount"),
+            OsString::from("-plist"),
+        ];
+        if access == MacosVirtualBlockAccess::ReadOnly {
+            arguments.push(OsString::from("-readonly"));
+        }
+        arguments.push(self.image.as_os_str().to_os_string());
+        self.attachment_uncertain = true;
+        let output = match run_hdiutil(&arguments) {
+            Ok(output) => output,
+            Err(error) => {
+                if matches!(mapped_device_for_image(&self.image), Ok(None)) {
+                    self.attachment_uncertain = false;
+                }
+                return Err(error);
+            }
+        };
+        let attachment = match parse_single_unmounted_device(&output.stdout).and_then(|path| {
+            if mapped_device_for_image(&self.image)? != Some(path.clone()) {
+                return Err(MacosVirtualBlockError);
+            }
+            let descriptor = open_device(&path, access)?;
+            inspect_attachment(&descriptor, path, access)
+        }) {
+            Ok(attachment) => attachment,
+            Err(error) => {
+                if matches!(mapped_device_for_image(&self.image), Ok(None)) {
+                    self.attachment_uncertain = false;
+                }
+                return Err(error);
+            }
+        };
+        let valid_length = attachment.len() == Some(EXPECTED_IMAGE_BYTES);
+        self.attachment = Some(attachment);
+        self.attachment_uncertain = false;
+        if !valid_length {
+            return Err(MacosVirtualBlockError);
+        }
+        if !self.mapping_matches()? {
+            return Err(MacosVirtualBlockError);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn detach(&mut self) -> Result<(), MacosVirtualBlockError> {
+        self.detach_inner()
+    }
+
+    pub(crate) fn reattach(
+        &mut self,
+        access: MacosVirtualBlockAccess,
+    ) -> Result<(), MacosVirtualBlockError> {
+        self.detach()?;
+        self.attach(access)
+    }
+
+    pub(crate) fn device_path(&self) -> Result<&Path, MacosVirtualBlockError> {
+        self.attachment
+            .as_ref()
+            .map(|attachment| attachment.device_path.as_path())
+            .ok_or(MacosVirtualBlockError)
+    }
+
+    pub(crate) fn access(&self) -> Result<MacosVirtualBlockAccess, MacosVirtualBlockError> {
+        self.attachment
+            .as_ref()
+            .map(|attachment| attachment.access)
+            .ok_or(MacosVirtualBlockError)
+    }
+
+    pub(crate) fn identity(&self) -> Result<MacosVirtualBlockIdentity, MacosVirtualBlockError> {
+        self.attachment
+            .as_ref()
+            .map(|attachment| attachment.identity)
+            .ok_or(MacosVirtualBlockError)
+    }
+
+    pub(crate) fn logical_block_size(&self) -> Result<u32, MacosVirtualBlockError> {
+        self.attachment
+            .as_ref()
+            .map(|attachment| attachment.logical_block_size)
+            .ok_or(MacosVirtualBlockError)
+    }
+
+    pub(crate) fn block_count(&self) -> Result<u64, MacosVirtualBlockError> {
+        self.attachment
+            .as_ref()
+            .map(|attachment| attachment.block_count)
+            .ok_or(MacosVirtualBlockError)
+    }
+
+    pub(crate) fn len(&self) -> Result<u64, MacosVirtualBlockError> {
+        self.attachment
+            .as_ref()
+            .and_then(Attachment::len)
+            .ok_or(MacosVirtualBlockError)
+    }
+
+    pub(crate) fn open_descriptor(&self) -> Result<File, MacosVirtualBlockError> {
+        let attachment = self.attachment.as_ref().ok_or(MacosVirtualBlockError)?;
+        let descriptor = open_device(&attachment.device_path, attachment.access)?;
+        if inspect_attachment(
+            &descriptor,
+            attachment.device_path.clone(),
+            attachment.access,
+        )? != *attachment
+        {
+            return Err(MacosVirtualBlockError);
+        }
+        Ok(descriptor)
+    }
+
+    pub(crate) fn read_at(
+        &self,
+        offset: u64,
+        len: usize,
+    ) -> Result<Vec<u8>, MacosVirtualBlockError> {
+        let end = offset
+            .checked_add(u64::try_from(len).map_err(|_| MacosVirtualBlockError)?)
+            .ok_or(MacosVirtualBlockError)?;
+        if end > self.len()? {
+            return Err(MacosVirtualBlockError);
+        }
+        let descriptor = self.open_descriptor()?;
+        let mut bytes = vec![0_u8; len];
+        descriptor
+            .read_exact_at(&mut bytes, offset)
+            .map_err(|_| MacosVirtualBlockError)?;
+        Ok(bytes)
+    }
+
+    pub(crate) fn write_at(&self, offset: u64, bytes: &[u8]) -> Result<(), MacosVirtualBlockError> {
+        if self.access()? != MacosVirtualBlockAccess::ReadWrite {
+            return Err(MacosVirtualBlockError);
+        }
+        let end = offset
+            .checked_add(u64::try_from(bytes.len()).map_err(|_| MacosVirtualBlockError)?)
+            .ok_or(MacosVirtualBlockError)?;
+        if end > self.len()? {
+            return Err(MacosVirtualBlockError);
+        }
+        let descriptor = self.open_descriptor()?;
+        descriptor
+            .write_all_at(bytes, offset)
+            .map_err(|_| MacosVirtualBlockError)?;
+        synchronize_cache(descriptor.as_raw_fd())
+    }
+
+    pub(crate) fn cleanup(mut self) -> Result<(), MacosVirtualBlockError> {
+        self.detach_inner()?;
+        self.remove_storage()
+    }
+
+    fn mapping_matches(&self) -> Result<bool, MacosVirtualBlockError> {
+        let attachment = self.attachment.as_ref().ok_or(MacosVirtualBlockError)?;
+        let Some(reported_device) = mapped_device_for_image(&self.image)? else {
+            return Ok(false);
+        };
+        if reported_device != attachment.device_path {
+            return Ok(false);
+        }
+        let descriptor = open_device(&attachment.device_path, MacosVirtualBlockAccess::ReadOnly)?;
+        Ok(inspect_attachment(
+            &descriptor,
+            attachment.device_path.clone(),
+            MacosVirtualBlockAccess::ReadOnly,
+        )?
+        .same_media(attachment))
+    }
+
+    fn detach_inner(&mut self) -> Result<(), MacosVirtualBlockError> {
+        let Some(attachment) = self.attachment.clone() else {
+            return if self.attachment_uncertain {
+                Err(MacosVirtualBlockError)
+            } else {
+                Ok(())
+            };
+        };
+        if !self.mapping_matches()? {
+            if self.clear_attachment_if_mapping_absent()? {
+                return Ok(());
+            }
+            return Err(MacosVirtualBlockError);
+        }
+        let ordinary = run_hdiutil(&[
+            OsString::from("detach"),
+            attachment.device_path.as_os_str().to_os_string(),
+        ]);
+        if ordinary.is_err() {
+            if self.clear_attachment_if_mapping_absent()? {
+                return Ok(());
+            }
+            if !self.mapping_matches()? {
+                return Err(MacosVirtualBlockError);
+            }
+            let forced = run_hdiutil(&[
+                OsString::from("detach"),
+                attachment.device_path.as_os_str().to_os_string(),
+                OsString::from("-force"),
+            ]);
+            if forced.is_err() && !self.clear_attachment_if_mapping_absent()? {
+                return Err(MacosVirtualBlockError);
+            }
+        }
+        if !self.clear_attachment_if_mapping_absent()? {
+            return Err(MacosVirtualBlockError);
+        }
+        Ok(())
+    }
+
+    fn clear_attachment_if_mapping_absent(&mut self) -> Result<bool, MacosVirtualBlockError> {
+        if mapped_device_for_image(&self.image)?.is_some() {
+            return Ok(false);
+        }
+        self.attachment = None;
+        self.attachment_uncertain = false;
+        Ok(true)
+    }
+
+    fn remove_storage(&mut self) -> Result<(), MacosVirtualBlockError> {
+        if self.attachment.is_some() || self.attachment_uncertain || self.cleaned {
+            return if self.cleaned {
+                Ok(())
+            } else {
+                Err(MacosVirtualBlockError)
+            };
+        }
+        fs::remove_file(&self.image).map_err(|_| MacosVirtualBlockError)?;
+        fs::remove_dir(&self.directory).map_err(|_| MacosVirtualBlockError)?;
+        self.cleaned = true;
+        Ok(())
+    }
+}
+
+impl Drop for MacosVirtualBlock {
+    fn drop(&mut self) {
+        if self.cleaned || self.attachment_uncertain {
+            return;
+        }
+        if self.attachment.is_some() && self.detach_inner().is_err() {
+            return;
+        }
+        let _ = self.remove_storage();
+    }
+}
+
+impl PartialEq for Attachment {
+    fn eq(&self, other: &Self) -> bool {
+        self.device_path == other.device_path
+            && self.access == other.access
+            && self.identity == other.identity
+            && self.logical_block_size == other.logical_block_size
+            && self.block_count == other.block_count
+    }
+}
+
+impl Attachment {
+    fn same_media(&self, other: &Self) -> bool {
+        self.device_path == other.device_path
+            && self.identity == other.identity
+            && self.logical_block_size == other.logical_block_size
+            && self.block_count == other.block_count
+    }
+}
+
+fn unique_fixture_directory() -> Result<PathBuf, MacosVirtualBlockError> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| MacosVirtualBlockError)?
+        .as_nanos();
+    for _ in 0..1_024 {
+        let sequence = NEXT_FIXTURE_ID.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "bangbang-virtual-block-{}-{timestamp}-{sequence}",
+            std::process::id()
+        ));
+        match fs::create_dir(&path) {
+            Ok(()) => return fs::canonicalize(path).map_err(|_| MacosVirtualBlockError),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(_) => return Err(MacosVirtualBlockError),
+        }
+    }
+    Err(MacosVirtualBlockError)
+}
+
+fn run_hdiutil(arguments: &[OsString]) -> Result<Output, MacosVirtualBlockError> {
+    let output = Command::new(HDIUTIL)
+        .args(arguments)
+        .output()
+        .map_err(|_| MacosVirtualBlockError)?;
+    if output.status.success() {
+        Ok(output)
+    } else {
+        Err(MacosVirtualBlockError)
+    }
+}
+
+fn parse_single_unmounted_device(bytes: &[u8]) -> Result<PathBuf, MacosVirtualBlockError> {
+    let value = Value::from_reader(Cursor::new(bytes)).map_err(|_| MacosVirtualBlockError)?;
+    let dictionary = value.as_dictionary().ok_or(MacosVirtualBlockError)?;
+    let entities = system_entities(dictionary)?;
+    let [entity] = entities else {
+        return Err(MacosVirtualBlockError);
+    };
+    entity_device(entity)
+}
+
+fn mapped_device_for_image(image: &Path) -> Result<Option<PathBuf>, MacosVirtualBlockError> {
+    let output = run_hdiutil(&[OsString::from("info"), OsString::from("-plist")])?;
+    let value =
+        Value::from_reader(Cursor::new(output.stdout)).map_err(|_| MacosVirtualBlockError)?;
+    let dictionary = value.as_dictionary().ok_or(MacosVirtualBlockError)?;
+    let images = dictionary
+        .get("images")
+        .and_then(Value::as_array)
+        .ok_or(MacosVirtualBlockError)?;
+    let mut matched = None;
+    for candidate in images {
+        let Some(candidate) = candidate.as_dictionary() else {
+            continue;
+        };
+        let Some(reported_path) = candidate.get("image-path").and_then(Value::as_string) else {
+            continue;
+        };
+        if Path::new(reported_path) != image {
+            continue;
+        }
+        if matched.is_some() {
+            return Err(MacosVirtualBlockError);
+        }
+        let entities = system_entities(candidate)?;
+        let [entity] = entities else {
+            return Err(MacosVirtualBlockError);
+        };
+        matched = Some(entity_device(entity)?);
+    }
+    Ok(matched)
+}
+
+fn system_entities(dictionary: &Dictionary) -> Result<&[Value], MacosVirtualBlockError> {
+    dictionary
+        .get("system-entities")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .ok_or(MacosVirtualBlockError)
+}
+
+fn entity_device(value: &Value) -> Result<PathBuf, MacosVirtualBlockError> {
+    let dictionary = value.as_dictionary().ok_or(MacosVirtualBlockError)?;
+    if dictionary.contains_key("mount-point") {
+        return Err(MacosVirtualBlockError);
+    }
+    let device = dictionary
+        .get("dev-entry")
+        .and_then(Value::as_string)
+        .ok_or(MacosVirtualBlockError)?;
+    let Some(suffix) = device.strip_prefix(DEVICE_PREFIX) else {
+        return Err(MacosVirtualBlockError);
+    };
+    if suffix.is_empty() || !suffix.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(MacosVirtualBlockError);
+    }
+    Ok(PathBuf::from(device))
+}
+
+fn open_device(
+    path: &Path,
+    access: MacosVirtualBlockAccess,
+) -> Result<File, MacosVirtualBlockError> {
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .write(access == MacosVirtualBlockAccess::ReadWrite)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC);
+    let descriptor = options.open(path).map_err(|_| MacosVirtualBlockError)?;
+    // SAFETY: F_GETFL only reads status flags from the live descriptor.
+    let flags = unsafe { libc::fcntl(descriptor.as_raw_fd(), libc::F_GETFL) };
+    // SAFETY: F_GETFD only reads per-descriptor flags from the same live fd.
+    let descriptor_flags = unsafe { libc::fcntl(descriptor.as_raw_fd(), libc::F_GETFD) };
+    if flags < 0
+        || descriptor_flags < 0
+        || descriptor_flags & libc::FD_CLOEXEC == 0
+        || flags & libc::O_ACCMODE != access.open_flags()
+        || flags & libc::O_APPEND != 0
+    {
+        return Err(MacosVirtualBlockError);
+    }
+    Ok(descriptor)
+}
+
+fn inspect_attachment(
+    descriptor: &File,
+    device_path: PathBuf,
+    access: MacosVirtualBlockAccess,
+) -> Result<Attachment, MacosVirtualBlockError> {
+    let metadata = descriptor.metadata().map_err(|_| MacosVirtualBlockError)?;
+    if metadata.mode() & u32::from(libc::S_IFMT) != u32::from(libc::S_IFBLK) {
+        return Err(MacosVirtualBlockError);
+    }
+    let target_device = metadata.rdev();
+    if target_device == 0 {
+        return Err(MacosVirtualBlockError);
+    }
+    let (logical_block_size, block_count) = block_geometry(descriptor.as_raw_fd())?;
+    let len = u64::from(logical_block_size)
+        .checked_mul(block_count)
+        .ok_or(MacosVirtualBlockError)?;
+    if logical_block_size == 0
+        || block_count == 0
+        || u64::from(logical_block_size) % VIRTIO_SECTOR_BYTES != 0
+        || len == 0
+        || len % VIRTIO_SECTOR_BYTES != 0
+        || i64::try_from(len).is_err()
+    {
+        return Err(MacosVirtualBlockError);
+    }
+    Ok(Attachment {
+        device_path,
+        access,
+        identity: MacosVirtualBlockIdentity {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+            target_device,
+        },
+        logical_block_size,
+        block_count,
+    })
+}
+
+fn block_geometry(descriptor: RawFd) -> Result<(u32, u64), MacosVirtualBlockError> {
+    let mut logical_block_size = 0_u32;
+    // SAFETY: DKIOCGETBLOCKSIZE writes one u32 through the valid pointer and
+    // only inspects the live block descriptor during this call.
+    if unsafe { libc::ioctl(descriptor, DKIOCGETBLOCKSIZE, &mut logical_block_size) } < 0 {
+        return Err(MacosVirtualBlockError);
+    }
+    let mut block_count = 0_u64;
+    // SAFETY: DKIOCGETBLOCKCOUNT writes one u64 through the valid pointer and
+    // only inspects the live block descriptor during this call.
+    if unsafe { libc::ioctl(descriptor, DKIOCGETBLOCKCOUNT, &mut block_count) } < 0 {
+        return Err(MacosVirtualBlockError);
+    }
+    Ok((logical_block_size, block_count))
+}
+
+fn synchronize_cache(descriptor: RawFd) -> Result<(), MacosVirtualBlockError> {
+    // SAFETY: DKIOCSYNCHRONIZECACHE has no pointer payload and only operates on
+    // the live block descriptor during this call.
+    if unsafe { libc::ioctl(descriptor, DKIOCSYNCHRONIZECACHE) } < 0 {
+        Err(MacosVirtualBlockError)
+    } else {
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

- admit exact macOS block-special drive descriptors through a backend-neutral geometry/cache-control capability while preserving regular-file behavior
- bind access mode, semantic descriptor flags, dev/inode/rdev, checked geometry, capacity, and backing-derived GET_ID; route Sync and production Async Writeback flushes through the same persistence boundary
- carry block kind and geometry through capture-ready state while keeping native-v1 regular-only and byte-compatible
- add a strict repository-owned `hdiutil -plist` virtual-media fixture plus signed direct I/O, read-only persistence, Async flush, capture, replacement rollback/commit, and exact cleanup evidence

## Scope exclusions

- no launcher/worker grant-wire, contained block-control broker, entitlement, or production-bundle behavior changes; those remain in #1465
- no exhaustive direct/contained × Sync/Async × MMIO/PCI lifecycle certification; that remains in #1466
- no physical-media access, `/dev` enumeration, or native-v1 block-special serialization

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test hvf_lifecycle -- temporary_virtual_block`
- `scripts/run-integration-tests.sh`

Closes #1464

Parent: #1461
