### PR TITLE
feat: broker contained macOS block device control

### DIFF
--- a/crates/bangbang/src/contained_session.rs
+++ b/crates/bangbang/src/contained_session.rs
@@ -277,10 +277,17 @@ mod platform {
     use std::thread::{self, JoinHandle};
     use std::time::{Duration, Instant};
 
+    use bangbang_runtime::block::{
+        BlockDeviceControl, BlockDeviceControlError, BlockDeviceGeometry, BlockFileBacking,
+    };
     use bangbang_runtime::boot::BootSourceFiles;
     use bangbang_runtime::snapshot_artifact::{
         SnapshotArtifactKind, SnapshotArtifactOutput, SnapshotStagingOwnership,
         SnapshotStagingTracker, SnapshotStagingTrackingError,
+    };
+    use bangbang_session::macos::block_control::{
+        BlockControlError, BlockControlMessage, BlockControlOperation, BlockControlTarget,
+        receive_block_control_message, send_block_control_message,
     };
     use bangbang_session::macos::grant_registry::{
         CommittedGrantBatch, DirectoryGrantRegistry, FileGrantRegistry, GrantRegistry,
@@ -297,8 +304,9 @@ mod platform {
     };
     use bangbang_session::macos::{set_cloexec, verify_peer, verify_peer_pid};
     use bangbang_session::{
-        Frame, FrameDecoder, GRANT_FD, GrantAccess, GrantId, Message, ObjectIdentity, Readiness,
-        ResourceRole, SESSION_ENV_KEY, SESSION_ENV_VALUE, SESSION_FD, SOCKET_BROKER_FD, SessionId,
+        BLOCK_CONTROL_BROKER_FD, BlockDeviceGrant, Frame, FrameDecoder, GRANT_FD, GrantAccess,
+        GrantId, GrantObjectKind, Message, ObjectIdentity, Readiness, ResourceRole,
+        SESSION_ENV_KEY, SESSION_ENV_VALUE, SESSION_FD, SOCKET_BROKER_FD, SessionId,
         SnapshotOutputChild, TerminalCategory, VHOST_USER_BROKER_FD, VmnetAuthority,
         WorkerLifecycle, WorkerPolicy, encode_frame,
     };
@@ -310,6 +318,7 @@ mod platform {
 
     const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
     const VHOST_USER_BROKER_TIMEOUT: Duration = Duration::from_secs(2);
+    const BLOCK_CONTROL_BROKER_TIMEOUT: Duration = Duration::from_secs(2);
     #[cfg(feature = "grant-integration-probe")]
     const GRANT_DELAY_PROBE: &str = "--bangbang-internal-grant-delay-v1";
     #[cfg(feature = "grant-integration-probe")]
@@ -373,6 +382,7 @@ mod platform {
     #[derive(Clone)]
     pub(crate) struct GrantAuthority {
         registry: Arc<Mutex<Option<FileGrantRegistry>>>,
+        block_control: Option<BlockControlBrokerAuthority>,
     }
 
     /// One exact file grant reserved for a failure-atomic runtime transaction.
@@ -381,6 +391,15 @@ mod platform {
         id: GrantId,
         original: Option<GrantedFile>,
         duplicate: Option<File>,
+    }
+
+    /// One exact drive grant reserved for a failure-atomic runtime transaction.
+    pub(crate) struct PreparedDriveBackingClaim {
+        registry: Arc<Mutex<Option<FileGrantRegistry>>>,
+        block_control: Option<BlockControlBrokerAuthority>,
+        id: GrantId,
+        original: Option<GrantedFile>,
+        duplicate: Option<GrantedFile>,
     }
 
     impl std::fmt::Debug for PreparedFileGrantClaim {
@@ -420,6 +439,93 @@ mod platform {
         }
     }
 
+    impl std::fmt::Debug for PreparedDriveBackingClaim {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter
+                .debug_struct("PreparedDriveBackingClaim")
+                .field("authority", &"<redacted>")
+                .field(
+                    "block_control",
+                    &self.block_control.as_ref().map(|_| "<redacted>"),
+                )
+                .field("original", &self.original.as_ref().map(|_| "<reserved>"))
+                .field("duplicate", &self.duplicate.as_ref().map(|_| "<owned>"))
+                .finish()
+        }
+    }
+
+    impl PreparedDriveBackingClaim {
+        pub(crate) fn take_snapshot_read_only_file(&mut self) -> Result<File, GrantClaimError> {
+            let duplicate = self.duplicate.take().ok_or(GrantClaimError)?;
+            if duplicate.access() != GrantAccess::ReadOnly
+                || duplicate.kind() != GrantObjectKind::RegularFile
+                || duplicate.block_device().is_some()
+            {
+                return Err(GrantClaimError);
+            }
+            Ok(File::from(duplicate.into_owned_fd()))
+        }
+
+        pub(crate) fn take_backing(
+            &mut self,
+            is_read_only: bool,
+        ) -> Result<BlockFileBacking, GrantClaimError> {
+            let duplicate = self.duplicate.take().ok_or(GrantClaimError)?;
+            let expected_access = if is_read_only {
+                GrantAccess::ReadOnly
+            } else {
+                GrantAccess::ReadWrite
+            };
+            if duplicate.access() != expected_access {
+                return Err(GrantClaimError);
+            }
+            match (duplicate.kind(), duplicate.block_device()) {
+                (GrantObjectKind::RegularFile, None) => {
+                    BlockFileBacking::from_file(File::from(duplicate.into_owned_fd()), is_read_only)
+                        .map_err(|_| GrantClaimError)
+                }
+                (GrantObjectKind::BlockDevice, Some(block_device)) => {
+                    let target = BlockControlTarget::new(
+                        self.id.clone(),
+                        duplicate.access(),
+                        duplicate.identity(),
+                        duplicate.status_flags(),
+                        block_device,
+                    )
+                    .ok_or(GrantClaimError)?;
+                    let control = self.block_control.clone().ok_or(GrantClaimError)?;
+                    BlockFileBacking::from_file_with_block_device_control(
+                        File::from(duplicate.into_owned_fd()),
+                        is_read_only,
+                        Arc::new(ContainedBlockDeviceControl { control, target }),
+                    )
+                    .map_err(|_| GrantClaimError)
+                }
+                _ => Err(GrantClaimError),
+            }
+        }
+
+        pub(crate) fn commit(mut self) {
+            self.original.take();
+        }
+    }
+
+    impl Drop for PreparedDriveBackingClaim {
+        fn drop(&mut self) {
+            let Some(original) = self.original.take() else {
+                return;
+            };
+            let mut registry = match self.registry.lock() {
+                Ok(registry) => registry,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            let Some(registry) = registry.as_mut() else {
+                return;
+            };
+            let _ = registry.restore_drive_backing(self.id.clone(), original);
+        }
+    }
+
     impl std::fmt::Debug for GrantAuthority {
         fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             formatter
@@ -430,9 +536,21 @@ mod platform {
     }
 
     impl GrantAuthority {
+        #[cfg(test)]
         fn new(registry: FileGrantRegistry) -> Self {
             Self {
                 registry: Arc::new(Mutex::new(Some(registry))),
+                block_control: None,
+            }
+        }
+
+        fn new_with_block_control(
+            registry: FileGrantRegistry,
+            block_control: BlockControlBrokerAuthority,
+        ) -> Self {
+            Self {
+                registry: Arc::new(Mutex::new(Some(registry))),
+                block_control: Some(block_control),
             }
         }
 
@@ -493,6 +611,34 @@ mod platform {
                 id,
                 original: Some(original),
                 duplicate: Some(File::from(duplicate.into_owned_fd())),
+            }))
+        }
+
+        pub(crate) fn prepare_drive_backing_claim(
+            &self,
+            reference: &Path,
+            access: GrantAccess,
+        ) -> Result<Option<PreparedDriveBackingClaim>, GrantClaimError> {
+            let Some(id) = grant_reference_id(reference)? else {
+                return Ok(None);
+            };
+            if !matches!(access, GrantAccess::ReadOnly | GrantAccess::ReadWrite) {
+                return Err(GrantClaimError);
+            }
+            let mut registry = self.registry.lock().map_err(|_| GrantClaimError)?;
+            let registry = registry.as_mut().ok_or(GrantClaimError)?;
+            let duplicate = registry
+                .duplicate_drive_backing(&id, access)
+                .map_err(|_| GrantClaimError)?;
+            let original = registry
+                .take_drive_backing(&id, access)
+                .map_err(|_| GrantClaimError)?;
+            Ok(Some(PreparedDriveBackingClaim {
+                registry: Arc::clone(&self.registry),
+                block_control: self.block_control.clone(),
+                id,
+                original: Some(original),
+                duplicate: Some(duplicate),
             }))
         }
 
@@ -586,6 +732,9 @@ mod platform {
         }
 
         fn invalidate(&self) {
+            if let Some(block_control) = &self.block_control {
+                block_control.invalidate();
+            }
             let mut registry = match self.registry.lock() {
                 Ok(registry) => registry,
                 Err(error) => error.into_inner(),
@@ -1129,6 +1278,357 @@ mod platform {
         }
     }
 
+    struct BlockControlBrokerState {
+        socket: UnixDatagram,
+        session: SessionId,
+        launcher_pid: libc::pid_t,
+        next_sequence: u64,
+    }
+
+    /// Shared serial authority for exact launcher-brokered block controls.
+    #[derive(Clone)]
+    struct BlockControlBrokerAuthority {
+        state: Arc<Mutex<Option<BlockControlBrokerState>>>,
+        shutdown: Arc<UnixDatagram>,
+    }
+
+    impl std::fmt::Debug for BlockControlBrokerAuthority {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter
+                .debug_struct("BlockControlBrokerAuthority")
+                .field("state", &"<redacted>")
+                .field("shutdown", &"<owned>")
+                .finish()
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum BlockControlResponse {
+        Inspected(BlockDeviceGrant),
+        Synchronized,
+    }
+
+    impl BlockControlBrokerAuthority {
+        fn new(
+            socket: UnixDatagram,
+            session: SessionId,
+            launcher_pid: libc::pid_t,
+        ) -> Result<Self, ContainedSessionError> {
+            let shutdown = socket.try_clone().map_err(|_| ContainedSessionError)?;
+            Ok(Self {
+                state: Arc::new(Mutex::new(Some(BlockControlBrokerState {
+                    socket,
+                    session,
+                    launcher_pid,
+                    next_sequence: 1,
+                }))),
+                shutdown: Arc::new(shutdown),
+            })
+        }
+
+        fn request(
+            &self,
+            operation: BlockControlOperation,
+            target: &BlockControlTarget,
+        ) -> Result<BlockControlResponse, BlockDeviceControlError> {
+            let mut locked = match self.state.lock() {
+                Ok(locked) => locked,
+                Err(_) => {
+                    let _ = self.shutdown.shutdown(std::net::Shutdown::Both);
+                    return Err(BlockDeviceControlError::new(io::ErrorKind::InvalidData));
+                }
+            };
+            let Some(mut state) = locked.take() else {
+                return Err(BlockDeviceControlError::new(io::ErrorKind::BrokenPipe));
+            };
+            let Some(next_sequence) = state.next_sequence.checked_add(1) else {
+                return Err(poison_block_control_state(
+                    state,
+                    &self.shutdown,
+                    io::ErrorKind::InvalidData,
+                ));
+            };
+            let Some(deadline) = Instant::now().checked_add(BLOCK_CONTROL_BROKER_TIMEOUT) else {
+                return Err(poison_block_control_state(
+                    state,
+                    &self.shutdown,
+                    io::ErrorKind::TimedOut,
+                ));
+            };
+            if verify_peer_pid(state.socket.as_raw_fd(), state.launcher_pid).is_err() {
+                return Err(poison_block_control_state(
+                    state,
+                    &self.shutdown,
+                    io::ErrorKind::PermissionDenied,
+                ));
+            }
+            let request = match operation {
+                BlockControlOperation::Inspect => BlockControlMessage::Inspect {
+                    session: state.session,
+                    sequence: state.next_sequence,
+                    target: target.clone(),
+                },
+                BlockControlOperation::SynchronizeCache => BlockControlMessage::SynchronizeCache {
+                    session: state.session,
+                    sequence: state.next_sequence,
+                    target: target.clone(),
+                },
+            };
+            loop {
+                let Some(remaining) = broker_remaining(deadline) else {
+                    return Err(poison_block_control_state(
+                        state,
+                        &self.shutdown,
+                        io::ErrorKind::TimedOut,
+                    ));
+                };
+                if state.socket.set_write_timeout(Some(remaining)).is_err() {
+                    return Err(poison_block_control_state(
+                        state,
+                        &self.shutdown,
+                        io::ErrorKind::Other,
+                    ));
+                }
+                match send_block_control_message(&state.socket, &request) {
+                    Ok(()) => break,
+                    Err(BlockControlError::Io(io::ErrorKind::Interrupted)) => continue,
+                    Err(BlockControlError::Io(
+                        io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut,
+                    )) => {
+                        return Err(poison_block_control_state(
+                            state,
+                            &self.shutdown,
+                            io::ErrorKind::TimedOut,
+                        ));
+                    }
+                    Err(BlockControlError::Io(kind)) => {
+                        return Err(poison_block_control_state(state, &self.shutdown, kind));
+                    }
+                    Err(BlockControlError::Invalid) => {
+                        return Err(poison_block_control_state(
+                            state,
+                            &self.shutdown,
+                            io::ErrorKind::InvalidData,
+                        ));
+                    }
+                }
+            }
+
+            let response = loop {
+                let Some(remaining) = broker_remaining(deadline) else {
+                    return Err(poison_block_control_state(
+                        state,
+                        &self.shutdown,
+                        io::ErrorKind::TimedOut,
+                    ));
+                };
+                if state.socket.set_read_timeout(Some(remaining)).is_err() {
+                    return Err(poison_block_control_state(
+                        state,
+                        &self.shutdown,
+                        io::ErrorKind::Other,
+                    ));
+                }
+                match receive_block_control_message(&state.socket) {
+                    Ok(response) => break response,
+                    Err(BlockControlError::Io(io::ErrorKind::Interrupted)) => continue,
+                    Err(BlockControlError::Io(
+                        io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut,
+                    )) => {
+                        return Err(poison_block_control_state(
+                            state,
+                            &self.shutdown,
+                            io::ErrorKind::TimedOut,
+                        ));
+                    }
+                    Err(BlockControlError::Io(kind)) => {
+                        return Err(poison_block_control_state(state, &self.shutdown, kind));
+                    }
+                    Err(BlockControlError::Invalid) => {
+                        return Err(poison_block_control_state(
+                            state,
+                            &self.shutdown,
+                            io::ErrorKind::InvalidData,
+                        ));
+                    }
+                }
+            };
+            if verify_peer_pid(state.socket.as_raw_fd(), state.launcher_pid).is_err()
+                || response.session() != state.session
+                || response.sequence() != state.next_sequence
+                || response.target() != target
+                || response.operation() != operation
+            {
+                return Err(poison_block_control_state(
+                    state,
+                    &self.shutdown,
+                    io::ErrorKind::InvalidData,
+                ));
+            }
+            let result = match (operation, response) {
+                (
+                    BlockControlOperation::Inspect,
+                    BlockControlMessage::Inspected { observed, .. },
+                ) => Ok(BlockControlResponse::Inspected(observed)),
+                (
+                    BlockControlOperation::SynchronizeCache,
+                    BlockControlMessage::Synchronized { .. },
+                ) => Ok(BlockControlResponse::Synchronized),
+                (_, BlockControlMessage::Failed { kind, .. }) => {
+                    Err(BlockDeviceControlError::new(kind))
+                }
+                _ => {
+                    return Err(poison_block_control_state(
+                        state,
+                        &self.shutdown,
+                        io::ErrorKind::InvalidData,
+                    ));
+                }
+            };
+            state.next_sequence = next_sequence;
+            *locked = Some(state);
+            result
+        }
+
+        fn invalidate(&self) {
+            // This independently owned handle is intentionally used before the
+            // request mutex so a blocked exchange wakes immediately.
+            let _ = self.shutdown.shutdown(std::net::Shutdown::Both);
+            let mut locked = match self.state.lock() {
+                Ok(locked) => locked,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            if let Some(state) = locked.take() {
+                let _ = state.socket.shutdown(std::net::Shutdown::Both);
+            }
+        }
+    }
+
+    fn poison_block_control_state(
+        state: BlockControlBrokerState,
+        shutdown: &UnixDatagram,
+        kind: io::ErrorKind,
+    ) -> BlockDeviceControlError {
+        let _ = shutdown.shutdown(std::net::Shutdown::Both);
+        let _ = state.socket.shutdown(std::net::Shutdown::Both);
+        BlockDeviceControlError::new(kind)
+    }
+
+    struct ContainedBlockDeviceControl {
+        control: BlockControlBrokerAuthority,
+        target: BlockControlTarget,
+    }
+
+    impl std::fmt::Debug for ContainedBlockDeviceControl {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter
+                .debug_struct("ContainedBlockDeviceControl")
+                .field("control", &"<redacted>")
+                .field("target", &"<redacted>")
+                .finish()
+        }
+    }
+
+    impl BlockDeviceControl for ContainedBlockDeviceControl {
+        fn inspect(&self, file: &File) -> Result<BlockDeviceGeometry, BlockDeviceControlError> {
+            validate_contained_block_descriptor(file, &self.target)?;
+            let BlockControlResponse::Inspected(observed) = self
+                .control
+                .request(BlockControlOperation::Inspect, &self.target)?
+            else {
+                return Err(BlockDeviceControlError::new(io::ErrorKind::InvalidData));
+            };
+            checked_observed_geometry(&self.target, observed)
+        }
+
+        fn synchronize_cache(&self, file: &File) -> Result<(), BlockDeviceControlError> {
+            validate_contained_block_descriptor(file, &self.target)?;
+            match self
+                .control
+                .request(BlockControlOperation::SynchronizeCache, &self.target)?
+            {
+                BlockControlResponse::Synchronized => Ok(()),
+                BlockControlResponse::Inspected(_) => {
+                    Err(BlockDeviceControlError::new(io::ErrorKind::InvalidData))
+                }
+            }
+        }
+    }
+
+    fn checked_observed_geometry(
+        target: &BlockControlTarget,
+        observed: BlockDeviceGrant,
+    ) -> Result<BlockDeviceGeometry, BlockDeviceControlError> {
+        let geometry =
+            BlockDeviceGeometry::new(observed.logical_block_size(), observed.block_count())
+                .ok_or(BlockDeviceControlError::new(io::ErrorKind::InvalidData))?;
+        if geometry.len() != observed.capacity() || observed != target.block_device() {
+            return Err(BlockDeviceControlError::new(io::ErrorKind::InvalidData));
+        }
+        Ok(geometry)
+    }
+
+    fn validate_contained_block_descriptor(
+        file: &File,
+        target: &BlockControlTarget,
+    ) -> Result<(), BlockDeviceControlError> {
+        // SAFETY: F_GETFD and F_GETFL inspect the live transferred descriptor.
+        let descriptor_flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFD) };
+        // SAFETY: F_GETFL inspects status flags on the same descriptor.
+        let status_flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFL) };
+        if descriptor_flags < 0 || status_flags < 0 {
+            return Err(BlockDeviceControlError::new(
+                io::Error::last_os_error().kind(),
+            ));
+        }
+        if descriptor_flags & libc::FD_CLOEXEC == 0 {
+            return Err(BlockDeviceControlError::new(io::ErrorKind::InvalidData));
+        }
+        if bangbang_session::macos::normalized_block_status_flags(status_flags)
+            != Some(target.status_flags())
+        {
+            return Err(BlockDeviceControlError::new(io::ErrorKind::InvalidData));
+        }
+        if !block_access_matches(status_flags, target.access()) {
+            return Err(BlockDeviceControlError::new(io::ErrorKind::InvalidData));
+        }
+        let mut stat = MaybeUninit::<libc::stat>::uninit();
+        // SAFETY: stat is writable and the transferred descriptor remains live.
+        if unsafe { libc::fstat(file.as_raw_fd(), stat.as_mut_ptr()) } != 0 {
+            return Err(BlockDeviceControlError::new(
+                io::Error::last_os_error().kind(),
+            ));
+        }
+        // SAFETY: Successful fstat initialized the complete structure.
+        let stat = unsafe { stat.assume_init() };
+        let identity = ObjectIdentity {
+            device: u64::from(u32::from_ne_bytes(stat.st_dev.to_ne_bytes())),
+            inode: stat.st_ino,
+        };
+        if stat.st_mode & libc::S_IFMT != libc::S_IFBLK {
+            return Err(BlockDeviceControlError::new(io::ErrorKind::InvalidData));
+        }
+        if identity != target.identity() {
+            return Err(BlockDeviceControlError::new(io::ErrorKind::InvalidData));
+        }
+        if u64::from(u32::from_ne_bytes(stat.st_rdev.to_ne_bytes()))
+            != target.block_device().target_device()
+        {
+            return Err(BlockDeviceControlError::new(io::ErrorKind::InvalidData));
+        }
+        Ok(())
+    }
+
+    fn block_access_matches(flags: libc::c_int, access: GrantAccess) -> bool {
+        match access {
+            GrantAccess::ReadOnly => flags & libc::O_ACCMODE == libc::O_RDONLY,
+            GrantAccess::ReadWrite => flags & libc::O_ACCMODE == libc::O_RDWR,
+            GrantAccess::WriteOnly | GrantAccess::CreateChildren | GrantAccess::ConnectChildren => {
+                false
+            }
+        }
+    }
+
     /// Fixed redacted contained vhost-user broker failure.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub(crate) enum VhostUserBrokerConnectError {
@@ -1409,6 +1909,7 @@ mod platform {
             set_cloexec(GRANT_FD).map_err(|_| ContainedSessionError)?;
             set_cloexec(SOCKET_BROKER_FD).map_err(|_| ContainedSessionError)?;
             set_cloexec(VHOST_USER_BROKER_FD).map_err(|_| ContainedSessionError)?;
+            set_cloexec(BLOCK_CONTROL_BROKER_FD).map_err(|_| ContainedSessionError)?;
             // SAFETY: The validated private bootstrap contract transfers the
             // fixed descriptor exactly once into this process object.
             let owned = unsafe { OwnedFd::from_raw_fd(SESSION_FD) };
@@ -1423,6 +1924,9 @@ mod platform {
             // SAFETY: The private bootstrap contract transfers fixed vhost broker fd 6 once.
             let vhost_broker_owned = unsafe { OwnedFd::from_raw_fd(VHOST_USER_BROKER_FD) };
             let vhost_broker_socket = UnixDatagram::from(vhost_broker_owned);
+            // SAFETY: The private bootstrap contract transfers fixed block-control fd 7 once.
+            let block_control_owned = unsafe { OwnedFd::from_raw_fd(BLOCK_CONTROL_BROKER_FD) };
+            let block_control_socket = UnixDatagram::from(block_control_owned);
             stream
                 .set_write_timeout(Some(HANDSHAKE_TIMEOUT))
                 .map_err(|_| ContainedSessionError)?;
@@ -1433,6 +1937,8 @@ mod platform {
             verify_peer_pid(broker_socket.as_raw_fd(), parent)
                 .map_err(|_| ContainedSessionError)?;
             verify_peer_pid(vhost_broker_socket.as_raw_fd(), parent)
+                .map_err(|_| ContainedSessionError)?;
+            verify_peer_pid(block_control_socket.as_raw_fd(), parent)
                 .map_err(|_| ContainedSessionError)?;
 
             let mut decoder = FrameDecoder::default();
@@ -1527,7 +2033,10 @@ mod platform {
                 ControlState::Cancelled
             };
             let control = Arc::new(SharedControl::new(initial_state));
-            let file_grants = GrantAuthority::new(grants.take_file_registry());
+            let block_control =
+                BlockControlBrokerAuthority::new(block_control_socket, session, parent)?;
+            let file_grants =
+                GrantAuthority::new_with_block_control(grants.take_file_registry(), block_control);
             let directory_grants = DirectoryGrantAuthority::new(grants.take_directory_registry());
             let socket_broker = SocketBrokerAuthority::new(broker_socket, session, parent);
             let vhost_user_broker =
@@ -2093,7 +2602,7 @@ mod platform {
     #[cfg(test)]
     mod tests {
         use std::fs::{self, OpenOptions};
-        use std::io::Read as _;
+        use std::io::{self, Read as _};
         use std::mem::MaybeUninit;
         use std::os::fd::{AsRawFd, OwnedFd};
         use std::os::unix::fs::OpenOptionsExt;
@@ -2103,7 +2612,12 @@ mod platform {
         use std::sync::atomic::{AtomicU64, Ordering};
         use std::sync::{Arc, Barrier};
         use std::thread;
+        use std::time::{Duration, Instant};
 
+        use bangbang_session::macos::block_control::{
+            BlockControlError, BlockControlMessage, BlockControlOperation, BlockControlTarget,
+            receive_block_control_message, send_block_control_message,
+        };
         use bangbang_session::macos::bookmark::create_implicit_bookmark;
         use bangbang_session::macos::grant_registry::{GrantRegistry, StagedGrantBatch};
         use bangbang_session::macos::grant_transport::ReceivedGrant;
@@ -2112,13 +2626,14 @@ mod platform {
             send_vhost_user_broker_message,
         };
         use bangbang_session::{
-            BatchId, GrantAccess, GrantFrame, GrantId, GrantObjectKind, GrantRecord,
-            ObjectIdentity, ResourceRole, SessionId,
+            BatchId, BlockDeviceGrant, GrantAccess, GrantFrame, GrantId, GrantObjectKind,
+            GrantRecord, ObjectIdentity, ResourceRole, SessionId,
         };
 
         use super::{
-            DirectoryGrantAuthority, GrantAuthority, GrantClaimError, VhostUserBrokerAuthority,
-            VhostUserBrokerConnectError, exact_resource_limit,
+            BlockControlBrokerAuthority, BlockControlResponse, DirectoryGrantAuthority,
+            GrantAuthority, GrantClaimError, VhostUserBrokerAuthority, VhostUserBrokerConnectError,
+            checked_observed_geometry, exact_resource_limit,
         };
 
         static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
@@ -2226,6 +2741,7 @@ mod platform {
                         inode: stat.st_ino,
                     },
                     status_flags: u32::try_from(flags).expect("status flags should fit"),
+                    block_device: None,
                 },
                 descriptor,
             )
@@ -2510,9 +3026,21 @@ mod platform {
                         ResourceRole::DriveBacking,
                         GrantAccess::ReadWrite,
                     )
-                    .expect("exact read-write drive claim should validate")
-                    .is_some()
+                    .is_err()
             );
+            let mut drive = authority
+                .prepare_drive_backing_claim(
+                    Path::new("bangbang-grant:drive-rw"),
+                    GrantAccess::ReadWrite,
+                )
+                .expect("dedicated read-write drive claim should validate")
+                .expect("drive reference should reserve a backing");
+            drop(
+                drive
+                    .take_backing(false)
+                    .expect("regular drive backing should adopt"),
+            );
+            drive.commit();
             assert!(
                 authority
                     .claim_file(
@@ -2577,9 +3105,21 @@ mod platform {
                         ResourceRole::DriveBacking,
                         GrantAccess::ReadOnly,
                     )
-                    .expect("wrong-role failure should preserve drive grant")
-                    .is_some()
+                    .is_err()
             );
+            let mut drive = authority
+                .prepare_drive_backing_claim(
+                    Path::new("bangbang-grant:drive-ro"),
+                    GrantAccess::ReadOnly,
+                )
+                .expect("wrong-role failure should preserve drive grant")
+                .expect("drive reference should reserve a backing");
+            drop(
+                drive
+                    .take_backing(true)
+                    .expect("regular drive backing should adopt"),
+            );
+            drive.commit();
 
             let mut mixed_registry = file_registry();
             let mixed_authority = GrantAuthority::new(mixed_registry.take_file_registry());
@@ -2641,54 +3181,72 @@ mod platform {
         }
 
         #[test]
-        fn prepared_file_claim_restores_exact_authority_on_abort_and_consumes_on_commit() {
+        fn prepared_drive_claim_restores_exact_authority_on_abort_and_consumes_on_commit() {
             let mut registry = file_registry();
             let authority = GrantAuthority::new(registry.take_file_registry());
+            let mut snapshot_root = authority
+                .prepare_drive_backing_claim(
+                    Path::new("bangbang-grant:drive-ro"),
+                    GrantAccess::ReadOnly,
+                )
+                .expect("read-only snapshot root should prepare")
+                .expect("explicit snapshot root should reserve a grant");
+            drop(
+                snapshot_root
+                    .take_snapshot_read_only_file()
+                    .expect("regular read-only root should remain a dedicated drive claim"),
+            );
+            drop(snapshot_root);
+            assert!(
+                authority
+                    .prepare_drive_backing_claim(
+                        Path::new("bangbang-grant:drive-ro"),
+                        GrantAccess::ReadOnly,
+                    )
+                    .expect("aborted snapshot root should restore authority")
+                    .is_some()
+            );
+
             let mut prepared = authority
-                .prepare_file_claim(
+                .prepare_drive_backing_claim(
                     Path::new("bangbang-grant:drive-rw"),
-                    ResourceRole::DriveBacking,
                     GrantAccess::ReadWrite,
                 )
                 .expect("exact runtime grant should prepare")
                 .expect("explicit reference should reserve a grant");
             let duplicate = prepared
-                .take_file()
-                .expect("prepared claim should expose one duplicate");
+                .take_backing(false)
+                .expect("prepared claim should expose one backing");
             drop(duplicate);
             drop(prepared);
-            assert!(
-                authority
-                    .claim_file(
-                        Path::new("bangbang-grant:drive-rw"),
-                        ResourceRole::DriveBacking,
-                        GrantAccess::ReadWrite,
-                    )
-                    .expect("aborted claim should restore authority")
-                    .is_some()
-            );
+            let restored = authority
+                .prepare_drive_backing_claim(
+                    Path::new("bangbang-grant:drive-rw"),
+                    GrantAccess::ReadWrite,
+                )
+                .expect("aborted claim should restore authority")
+                .expect("aborted claim should reserve again");
+            drop(restored);
 
             let mut commit_registry = file_registry();
             let commit_authority = GrantAuthority::new(commit_registry.take_file_registry());
             let mut committed = commit_authority
-                .prepare_file_claim(
+                .prepare_drive_backing_claim(
                     Path::new("bangbang-grant:drive-rw"),
-                    ResourceRole::DriveBacking,
                     GrantAccess::ReadWrite,
                 )
                 .expect("exact runtime grant should prepare")
                 .expect("explicit reference should reserve a grant");
             drop(
                 committed
-                    .take_file()
-                    .expect("committed claim should expose one duplicate"),
+                    .take_backing(false)
+                    .expect("committed claim should expose one backing"),
             );
             committed.commit();
             assert!(
                 commit_authority
-                    .claim_file(
+                    .prepare_drive_backing_claim(
                         Path::new("bangbang-grant:drive-rw"),
-                        ResourceRole::DriveBacking,
                         GrantAccess::ReadWrite,
                     )
                     .is_err()
@@ -2838,6 +3396,336 @@ mod platform {
             drop(peer.join().expect("broker peer should join"));
         }
 
+        fn block_control_target() -> BlockControlTarget {
+            BlockControlTarget::new(
+                GrantId::parse("block-drive").expect("grant should parse"),
+                GrantAccess::ReadWrite,
+                ObjectIdentity {
+                    device: 71,
+                    inode: 72,
+                },
+                u32::try_from(libc::O_RDWR | libc::O_NONBLOCK).expect("flags should fit"),
+                BlockDeviceGrant::new(73, 512, 32).expect("block tuple should validate"),
+            )
+            .expect("block target should validate")
+        }
+
+        #[test]
+        fn contained_block_geometry_must_match_the_adopted_grant_exactly() {
+            let target = block_control_target();
+            let expected = target.block_device();
+            let geometry = checked_observed_geometry(&target, expected)
+                .expect("exact adopted geometry should validate");
+            assert_eq!(geometry.logical_block_size(), expected.logical_block_size());
+            assert_eq!(geometry.block_count(), expected.block_count());
+            assert_eq!(geometry.len(), expected.capacity());
+
+            let changed = BlockDeviceGrant::new(
+                expected.target_device(),
+                expected.logical_block_size(),
+                expected.block_count() - 1,
+            )
+            .expect("changed geometry should remain structurally valid");
+            assert_eq!(
+                checked_observed_geometry(&target, changed)
+                    .expect_err("fresh geometry drift must fail closed")
+                    .kind(),
+                io::ErrorKind::InvalidData
+            );
+        }
+
+        fn respond_to_block_control(
+            socket: &UnixDatagram,
+            request: BlockControlMessage,
+        ) -> BlockControlOperation {
+            let operation = request.operation();
+            let response = match request {
+                BlockControlMessage::Inspect {
+                    session,
+                    sequence,
+                    target,
+                } => BlockControlMessage::Inspected {
+                    session,
+                    sequence,
+                    observed: target.block_device(),
+                    target,
+                },
+                BlockControlMessage::SynchronizeCache {
+                    session,
+                    sequence,
+                    target,
+                } => BlockControlMessage::Synchronized {
+                    session,
+                    sequence,
+                    target,
+                },
+                _ => panic!("worker must send only block-control requests"),
+            };
+            send_block_control_message(socket, &response).expect("response should send");
+            operation
+        }
+
+        #[test]
+        fn block_control_authority_reuses_failure_and_serializes_concurrent_requests() {
+            let session = SessionId::from_bytes([61; 32]);
+            let target = block_control_target();
+            let (worker, launcher) = UnixDatagram::pair().expect("block broker pair should open");
+            // SAFETY: Both connected peers belong to this test process.
+            let pid = unsafe { libc::getpid() };
+            let authority = BlockControlBrokerAuthority::new(worker, session, pid)
+                .expect("block authority should initialize");
+            let launcher_target = target.clone();
+            let (release_peer, hold_peer) = std::sync::mpsc::channel();
+            let peer = thread::spawn(move || {
+                let first = receive_block_control_message(&launcher)
+                    .expect("initial block request should receive");
+                assert_eq!(
+                    first,
+                    BlockControlMessage::Inspect {
+                        session,
+                        sequence: 1,
+                        target: launcher_target.clone(),
+                    }
+                );
+                send_block_control_message(
+                    &launcher,
+                    &BlockControlMessage::Failed {
+                        session,
+                        sequence: 1,
+                        target: launcher_target,
+                        operation: BlockControlOperation::Inspect,
+                        kind: io::ErrorKind::PermissionDenied,
+                    },
+                )
+                .expect("correlated endpoint failure should send");
+
+                let second = receive_block_control_message(&launcher)
+                    .expect("one serialized request should receive");
+                assert_eq!(second.sequence(), 2);
+                launcher
+                    .set_read_timeout(Some(Duration::from_millis(50)))
+                    .expect("serialization probe timeout should set");
+                assert!(matches!(
+                    receive_block_control_message(&launcher),
+                    Err(BlockControlError::Io(
+                        io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+                    ))
+                ));
+                launcher
+                    .set_read_timeout(None)
+                    .expect("serialization probe timeout should clear");
+                let first_operation = respond_to_block_control(&launcher, second);
+                let third = receive_block_control_message(&launcher)
+                    .expect("second serialized request should receive");
+                assert_eq!(third.sequence(), 3);
+                let second_operation = respond_to_block_control(&launcher, third);
+                hold_peer
+                    .recv()
+                    .expect("peer should remain live through response validation");
+                (first_operation, second_operation)
+            });
+
+            let failure = authority
+                .request(BlockControlOperation::Inspect, &target)
+                .expect_err("correlated failure should return to the caller");
+            assert_eq!(failure.kind(), io::ErrorKind::PermissionDenied);
+
+            let barrier = Arc::new(Barrier::new(3));
+            let inspect_authority = authority.clone();
+            let inspect_target = target.clone();
+            let inspect_barrier = Arc::clone(&barrier);
+            let inspect = thread::spawn(move || {
+                inspect_barrier.wait();
+                inspect_authority.request(BlockControlOperation::Inspect, &inspect_target)
+            });
+            let sync_authority = authority.clone();
+            let sync_target = target.clone();
+            let sync_barrier = Arc::clone(&barrier);
+            let synchronize = thread::spawn(move || {
+                sync_barrier.wait();
+                sync_authority.request(BlockControlOperation::SynchronizeCache, &sync_target)
+            });
+            barrier.wait();
+
+            let inspect_result = inspect.join().expect("inspect caller should join");
+            let synchronize_result = synchronize.join().expect("sync caller should join");
+            release_peer
+                .send(())
+                .expect("peer should release after caller validation");
+            let operations = peer.join().expect("block broker peer should join");
+            assert_ne!(operations.0, operations.1);
+            assert_eq!(
+                inspect_result,
+                Ok(BlockControlResponse::Inspected(target.block_device())),
+                "serialized operation order: {operations:?}; sync result: {synchronize_result:?}"
+            );
+            assert_eq!(synchronize_result, Ok(BlockControlResponse::Synchronized));
+        }
+
+        #[test]
+        fn block_control_authority_poison_is_permanent_after_ambiguous_response() {
+            let session = SessionId::from_bytes([62; 32]);
+            let target = block_control_target();
+            let (worker, launcher) = UnixDatagram::pair().expect("block broker pair should open");
+            // SAFETY: Both connected peers belong to this test process.
+            let pid = unsafe { libc::getpid() };
+            let authority = BlockControlBrokerAuthority::new(worker, session, pid)
+                .expect("block authority should initialize");
+            let peer = thread::spawn(move || {
+                let request = receive_block_control_message(&launcher)
+                    .expect("ambiguous request should receive");
+                let target = request.target().clone();
+                send_block_control_message(
+                    &launcher,
+                    &BlockControlMessage::Inspected {
+                        session,
+                        sequence: request.sequence() + 1,
+                        observed: target.block_device(),
+                        target,
+                    },
+                )
+                .expect("wrong-sequence response should send");
+            });
+            assert_eq!(
+                authority
+                    .request(BlockControlOperation::Inspect, &target)
+                    .expect_err("wrong response must poison authority")
+                    .kind(),
+                io::ErrorKind::InvalidData
+            );
+            peer.join().expect("ambiguous peer should join");
+            assert_eq!(
+                authority
+                    .request(BlockControlOperation::Inspect, &target)
+                    .expect_err("poisoned authority must remain closed")
+                    .kind(),
+                io::ErrorKind::BrokenPipe
+            );
+            let debug = format!("{authority:?}");
+            assert!(!debug.contains("block-drive"));
+            assert!(!debug.contains("6161"));
+        }
+
+        #[test]
+        fn block_control_authority_timeout_poison_and_shutdown_wakeup_are_bounded() {
+            let session = SessionId::from_bytes([63; 32]);
+            let target = block_control_target();
+            let (worker, launcher) = UnixDatagram::pair().expect("timeout pair should open");
+            // SAFETY: Both connected peers belong to this test process.
+            let pid = unsafe { libc::getpid() };
+            let timed = BlockControlBrokerAuthority::new(worker, session, pid)
+                .expect("timeout authority should initialize");
+            let started = Instant::now();
+            assert_eq!(
+                timed
+                    .request(BlockControlOperation::Inspect, &target)
+                    .expect_err("missing response should time out")
+                    .kind(),
+                io::ErrorKind::TimedOut
+            );
+            assert!(started.elapsed() >= Duration::from_secs(1));
+            assert!(started.elapsed() < Duration::from_secs(4));
+            drop(launcher);
+            assert_eq!(
+                timed
+                    .request(BlockControlOperation::Inspect, &target)
+                    .expect_err("timed-out authority must remain poisoned")
+                    .kind(),
+                io::ErrorKind::BrokenPipe
+            );
+
+            let (worker, launcher) = UnixDatagram::pair().expect("shutdown pair should open");
+            let authority = BlockControlBrokerAuthority::new(worker, session, pid)
+                .expect("shutdown authority should initialize");
+            let requesting = authority.clone();
+            let request_target = target.clone();
+            let requester = thread::spawn(move || {
+                requesting.request(BlockControlOperation::Inspect, &request_target)
+            });
+            receive_block_control_message(&launcher)
+                .expect("blocked request should reach the peer");
+            let started = Instant::now();
+            authority.invalidate();
+            assert!(
+                started.elapsed() < Duration::from_secs(1),
+                "independent shutdown must wake the serialized request"
+            );
+            assert!(
+                requester
+                    .join()
+                    .expect("blocked requester should join")
+                    .is_err()
+            );
+            assert_eq!(
+                authority
+                    .request(BlockControlOperation::Inspect, &target)
+                    .expect_err("invalidated authority must remain closed")
+                    .kind(),
+                io::ErrorKind::BrokenPipe
+            );
+        }
+
+        #[test]
+        fn block_control_authority_rejects_wrong_peer_sequence_overflow_and_lock_poison() {
+            let session = SessionId::from_bytes([64; 32]);
+            let target = block_control_target();
+            // SAFETY: `getpid` has no pointer or ownership contract.
+            let pid = unsafe { libc::getpid() };
+
+            let (worker, _launcher) = UnixDatagram::pair().expect("peer pair should open");
+            let wrong_peer = BlockControlBrokerAuthority::new(
+                worker,
+                session,
+                pid.checked_add(1).expect("test PID should fit"),
+            )
+            .expect("wrong-peer authority should initialize");
+            assert_eq!(
+                wrong_peer
+                    .request(BlockControlOperation::Inspect, &target)
+                    .expect_err("wrong peer must poison before sending")
+                    .kind(),
+                io::ErrorKind::PermissionDenied
+            );
+
+            let (worker, _launcher) = UnixDatagram::pair().expect("overflow pair should open");
+            let overflow = BlockControlBrokerAuthority::new(worker, session, pid)
+                .expect("overflow authority should initialize");
+            overflow
+                .state
+                .lock()
+                .expect("overflow state should lock")
+                .as_mut()
+                .expect("overflow state should be active")
+                .next_sequence = u64::MAX;
+            assert_eq!(
+                overflow
+                    .request(BlockControlOperation::Inspect, &target)
+                    .expect_err("wrapped sequence must poison before sending")
+                    .kind(),
+                io::ErrorKind::InvalidData
+            );
+
+            let (worker, _launcher) = UnixDatagram::pair().expect("poison pair should open");
+            let poisoned = BlockControlBrokerAuthority::new(worker, session, pid)
+                .expect("poison authority should initialize");
+            let state = Arc::clone(&poisoned.state);
+            assert!(
+                thread::spawn(move || {
+                    let _held = state.lock().expect("state should lock before poisoning");
+                    panic!("intentional block-control lock poison");
+                })
+                .join()
+                .is_err()
+            );
+            assert_eq!(
+                poisoned
+                    .request(BlockControlOperation::Inspect, &target)
+                    .expect_err("lock poison must close the authority")
+                    .kind(),
+                io::ErrorKind::InvalidData
+            );
+        }
+
         #[test]
         fn file_authority_invalidation_serializes_with_a_claim() {
             let mut registry = file_registry();
@@ -2896,8 +3784,22 @@ mod platform {
     #[derive(Debug)]
     pub(crate) struct PreparedFileGrantClaim;
 
+    #[derive(Debug)]
+    pub(crate) struct PreparedDriveBackingClaim;
+
     impl PreparedFileGrantClaim {
         pub(crate) fn take_file(&mut self) -> Result<std::fs::File, GrantClaimError> {
+            Err(GrantClaimError)
+        }
+
+        pub(crate) fn commit(self) {}
+    }
+
+    impl PreparedDriveBackingClaim {
+        pub(crate) fn take_backing(
+            &mut self,
+            _is_read_only: bool,
+        ) -> Result<bangbang_runtime::block::BlockFileBacking, GrantClaimError> {
             Err(GrantClaimError)
         }
 
@@ -2937,6 +3839,17 @@ mod platform {
             _role: ResourceRole,
             _access: GrantAccess,
         ) -> Result<Option<PreparedFileGrantClaim>, GrantClaimError> {
+            match grant_reference_id(reference)? {
+                Some(_) => Err(GrantClaimError),
+                None => Ok(None),
+            }
+        }
+
+        pub(crate) fn prepare_drive_backing_claim(
+            &self,
+            reference: &Path,
+            _access: GrantAccess,
+        ) -> Result<Option<PreparedDriveBackingClaim>, GrantClaimError> {
             match grant_reference_id(reference)? {
                 Some(_) => Err(GrantClaimError),
                 None => Ok(None),
@@ -3029,7 +3942,7 @@ mod platform {
 
 pub(crate) use platform::{
     ClaimedSocketDirectory, ContainedSession, DirectoryGrantAuthority, GrantAuthority,
-    PreparedFileGrantClaim,
+    PreparedDriveBackingClaim, PreparedFileGrantClaim,
 };
 #[cfg(target_os = "macos")]
 pub(crate) use platform::{

--- a/crates/bangbang/src/grant_integration_probe.rs
+++ b/crates/bangbang/src/grant_integration_probe.rs
@@ -4,20 +4,25 @@ use std::ffi::OsString;
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd, RawFd};
-use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::fs::{FileExt, OpenOptionsExt};
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use bangbang_hvf::{HvfBackend, HvfMemoryPermissions};
 use bangbang_runtime::VmBackend;
 use bangbang_runtime::memory::{GuestAddress, GuestMemory, GuestMemoryBacking, aarch64};
-use bangbang_session::{GrantAccess, GrantId, ResourceRole};
+use bangbang_session::{GrantAccess, GrantId, GrantObjectKind, ResourceRole};
 
 use crate::contained_session::{ContainedSession, ContainedSessionError};
 
 const OPTION: &str = "--bangbang-internal-grant-probe-v1";
 const READY_LINE: &str = "status: grant integration probe ready";
 const OUTSIDE_FILE: &str = "bangbang-grant-probe-outside";
+const BLOCK_CONTROL_GRANT_REF: &str = "bangbang-grant:probe-block-control";
+const BLOCK_CONTROL_INITIAL_MARKER: &[u8] = b"BANGBANG_BLOCK_CONTROL_INITIAL";
+const BLOCK_CONTROL_WRITTEN_MARKER: &[u8] = b"BANGBANG_BLOCK_CONTROL_WRITTEN";
+const BLOCK_CONTROL_WRITE_BLOCK: u64 = 8;
 const SNAPSHOT_STAGING_HOLD_OPTION: &str = "--bangbang-internal-snapshot-staging-hold-v1";
 static SNAPSHOT_STAGING_HOLD: AtomicBool = AtomicBool::new(false);
 
@@ -52,6 +57,9 @@ pub(crate) fn run(
     let probe = ProbeCase::parse(probe_args(args).ok_or(ContainedSessionError)?)?;
     session.verify_launch_policy(probe.expected_no_file, probe.expected_file_size, false)?;
     let authority = session.grant_authority().ok_or(ContainedSessionError)?;
+    if probe.verifies_block_control() {
+        return verify_block_control_in_containment(&authority);
+    }
 
     let read_id =
         GrantId::parse(&format!("probe-read-{}", probe.name)).map_err(|_| ContainedSessionError)?;
@@ -165,6 +173,93 @@ pub(crate) fn run(
             }
         }
     }
+    Ok(())
+}
+
+fn verify_block_control_in_containment(
+    authority: &crate::contained_session::GrantAuthority,
+) -> Result<(), ContainedSessionError> {
+    let grant_id = GrantId::parse("probe-block-control").map_err(|_| ContainedSessionError)?;
+    let granted = authority.with_registry(|registry| {
+        registry
+            .duplicate_drive_backing(&grant_id, GrantAccess::ReadWrite)
+            .map_err(|_| ContainedSessionError)
+    })?;
+    if granted.kind() != GrantObjectKind::BlockDevice {
+        return Err(ContainedSessionError);
+    }
+    let authenticated = granted.block_device().ok_or(ContainedSessionError)?;
+    let block_size =
+        usize::try_from(authenticated.logical_block_size()).map_err(|_| ContainedSessionError)?;
+    if block_size < BLOCK_CONTROL_INITIAL_MARKER.len()
+        || block_size < BLOCK_CONTROL_WRITTEN_MARKER.len()
+        || authenticated.capacity()
+            < u64::from(authenticated.logical_block_size())
+                .saturating_mul(BLOCK_CONTROL_WRITE_BLOCK.saturating_add(1))
+    {
+        return Err(ContainedSessionError);
+    }
+    let direct = File::from(granted.into_owned_fd());
+    let mut initial = vec![0_u8; block_size];
+    direct
+        .read_exact_at(&mut initial, 0)
+        .map_err(|_| ContainedSessionError)?;
+    if initial.get(..BLOCK_CONTROL_INITIAL_MARKER.len()) != Some(BLOCK_CONTROL_INITIAL_MARKER)
+        || initial
+            .get(BLOCK_CONTROL_INITIAL_MARKER.len()..)
+            .is_none_or(|remainder| remainder.iter().any(|byte| *byte != 0))
+    {
+        return Err(ContainedSessionError);
+    }
+    let mut written = vec![0_u8; block_size];
+    written
+        .get_mut(..BLOCK_CONTROL_WRITTEN_MARKER.len())
+        .ok_or(ContainedSessionError)?
+        .copy_from_slice(BLOCK_CONTROL_WRITTEN_MARKER);
+    let write_offset = u64::from(authenticated.logical_block_size())
+        .checked_mul(BLOCK_CONTROL_WRITE_BLOCK)
+        .ok_or(ContainedSessionError)?;
+    direct
+        .write_all_at(&written, write_offset)
+        .map_err(|_| ContainedSessionError)?;
+    drop(direct);
+
+    let mut claim = authority
+        .prepare_drive_backing_claim(Path::new(BLOCK_CONTROL_GRANT_REF), GrantAccess::ReadWrite)
+        .map_err(|_| ContainedSessionError)?
+        .ok_or(ContainedSessionError)?;
+    let backing = claim
+        .take_backing(false)
+        .map_err(|_| ContainedSessionError)?;
+    let geometry = backing
+        .kind()
+        .block_geometry()
+        .ok_or(ContainedSessionError)?;
+    let block_size =
+        usize::try_from(geometry.logical_block_size()).map_err(|_| ContainedSessionError)?;
+    if geometry.logical_block_size() != authenticated.logical_block_size()
+        || geometry.block_count() != authenticated.block_count()
+        || backing.len() != authenticated.capacity()
+    {
+        return Err(ContainedSessionError);
+    }
+
+    let mut observed = vec![0_u8; block_size];
+    backing
+        .read_at(write_offset, &mut observed)
+        .map_err(|_| ContainedSessionError)?;
+    if observed != written {
+        return Err(ContainedSessionError);
+    }
+
+    backing
+        .snapshot_identity()
+        .map_err(|_| ContainedSessionError)?;
+    backing.flush().map_err(|_| ContainedSessionError)?;
+    backing
+        .snapshot_identity()
+        .map_err(|_| ContainedSessionError)?;
+    claim.commit();
     Ok(())
 }
 
@@ -371,6 +466,12 @@ impl ProbeCase {
                 expected_no_file: 2048,
                 expected_file_size: None,
             }),
+            Some("block-control") => Ok(Self {
+                name: "block-control",
+                hold: false,
+                expected_no_file: 2048,
+                expected_file_size: None,
+            }),
             _ => Err(ContainedSessionError),
         }
     }
@@ -385,6 +486,10 @@ impl ProbeCase {
 
     fn verifies_shared_memory(self) -> bool {
         self.name == "shared-memory"
+    }
+
+    fn verifies_block_control(self) -> bool {
+        self.name == "block-control"
     }
 }
 

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -131,7 +131,8 @@ use crate::contained_session::{
     VhostUserBrokerAuthority, socket_directory_reference,
 };
 use crate::contained_session::{
-    GrantAuthority, GrantClaimError, PreparedFileGrantClaim, grant_reference_id,
+    GrantAuthority, GrantClaimError, PreparedDriveBackingClaim, PreparedFileGrantClaim,
+    grant_reference_id,
 };
 use crate::direct_vhost_user;
 use crate::host_network::virtio_vmnet::{
@@ -2309,25 +2310,30 @@ where
             } else {
                 None
             };
-        let backing = match (&self.grant_authority, config.backend()) {
-            (
-                Some(authority),
-                DriveBackendConfig::File {
-                    path_on_host,
-                    is_read_only,
-                    ..
-                },
-            ) => authority
-                .claim_file(
-                    path_on_host,
-                    ResourceRole::DriveBacking,
-                    grant_access_for_read_only(*is_read_only),
-                )
-                .map_err(|_| VmmActionError::ResourceGrant)?
-                .map(|file| BlockFileBacking::from_file(file, *is_read_only))
-                .transpose()
-                .map_err(|_| VmmActionError::ResourceGrant)?,
-            (None, _) | (Some(_), DriveBackendConfig::VhostUser { .. }) => None,
+        let mut grant_claim: Option<PreparedDriveBackingClaim> =
+            match (&self.grant_authority, config.backend()) {
+                (
+                    Some(authority),
+                    DriveBackendConfig::File {
+                        path_on_host,
+                        is_read_only,
+                        ..
+                    },
+                ) => authority
+                    .prepare_drive_backing_claim(
+                        path_on_host,
+                        grant_access_for_read_only(*is_read_only),
+                    )
+                    .map_err(|_| VmmActionError::ResourceGrant)?,
+                (None, _) | (Some(_), DriveBackendConfig::VhostUser { .. }) => None,
+            };
+        let backing = match (grant_claim.as_mut(), config.backend()) {
+            (Some(claim), DriveBackendConfig::File { is_read_only, .. }) => Some(
+                claim
+                    .take_backing(*is_read_only)
+                    .map_err(|_| VmmActionError::ResourceGrant)?,
+            ),
+            _ => None,
         };
         let drive_id = config.drive_id().to_string();
         let is_vhost_user = config.is_vhost_user();
@@ -2360,6 +2366,9 @@ where
             self.grant_authority.is_none()
                 || is_vhost_user == self.vhost_user_grant_states.contains_key(&drive_id)
         );
+        if let Some(claim) = grant_claim {
+            claim.commit();
+        }
         Ok(VmmData::Empty)
     }
 
@@ -2378,11 +2387,10 @@ where
                 DriveUpdateError::UnsupportedBackend,
             ));
         };
-        let mut grant_claim: Option<PreparedFileGrantClaim> = match &self.grant_authority {
+        let mut grant_claim: Option<PreparedDriveBackingClaim> = match &self.grant_authority {
             Some(authority) => authority
-                .prepare_file_claim(
+                .prepare_drive_backing_claim(
                     path_on_host,
-                    ResourceRole::DriveBacking,
                     grant_access_for_read_only(*is_read_only),
                 )
                 .map_err(|_| VmmActionError::ResourceGrant)?,
@@ -2390,13 +2398,9 @@ where
         };
         let backing_update = match grant_claim.as_mut() {
             Some(claim) => BlockBackingUpdate::Provided(
-                BlockFileBacking::from_file(
-                    claim
-                        .take_file()
-                        .map_err(|_| VmmActionError::ResourceGrant)?,
-                    *is_read_only,
-                )
-                .map_err(|_| VmmActionError::ResourceGrant)?,
+                claim
+                    .take_backing(*is_read_only)
+                    .map_err(|_| VmmActionError::ResourceGrant)?,
             ),
             None => BlockBackingUpdate::ConfiguredPath,
         };
@@ -2543,12 +2547,12 @@ where
                 is_read_only,
                 ..
             } => {
-                let mut grant_claim: Option<PreparedFileGrantClaim> = match &self.grant_authority {
+                let mut grant_claim: Option<PreparedDriveBackingClaim> = match &self.grant_authority
+                {
                     Some(authority) => Some(
                         authority
-                            .prepare_file_claim(
+                            .prepare_drive_backing_claim(
                                 path_on_host,
-                                ResourceRole::DriveBacking,
                                 grant_access_for_read_only(*is_read_only),
                             )
                             .map_err(|_| VmmActionError::ResourceGrant)?
@@ -2558,13 +2562,9 @@ where
                 };
                 let backing = match grant_claim.as_mut() {
                     Some(claim) => Some(
-                        BlockFileBacking::from_file(
-                            claim
-                                .take_file()
-                                .map_err(|_| VmmActionError::ResourceGrant)?,
-                            *is_read_only,
-                        )
-                        .map_err(|_| VmmActionError::ResourceGrant)?,
+                        claim
+                            .take_backing(*is_read_only)
+                            .map_err(|_| VmmActionError::ResourceGrant)?,
                     ),
                     None => None,
                 };
@@ -2949,7 +2949,7 @@ where
         let refresh_backing = input.path_on_host().is_some();
         let rate_limiter_update = input.rate_limiter();
         let updated_config = self.controller.updated_drive_config(input)?;
-        let mut grant_claim: Option<PreparedFileGrantClaim> = None;
+        let mut grant_claim: Option<PreparedDriveBackingClaim> = None;
         match updated_config.backend() {
             DriveBackendConfig::VhostUser { .. } => {
                 debug_assert!(!refresh_backing);
@@ -2984,21 +2984,16 @@ where
                     match &self.grant_authority {
                         Some(authority) => {
                             grant_claim = authority
-                                .prepare_file_claim(
+                                .prepare_drive_backing_claim(
                                     path_on_host,
-                                    ResourceRole::DriveBacking,
                                     grant_access_for_read_only(*is_read_only),
                                 )
                                 .map_err(|_| VmmActionError::ResourceGrant)?;
                             match grant_claim.as_mut() {
                                 Some(claim) => BlockBackingUpdate::Provided(
-                                    BlockFileBacking::from_file(
-                                        claim
-                                            .take_file()
-                                            .map_err(|_| VmmActionError::ResourceGrant)?,
-                                        *is_read_only,
-                                    )
-                                    .map_err(|_| VmmActionError::ResourceGrant)?,
+                                    claim
+                                        .take_backing(*is_read_only)
+                                        .map_err(|_| VmmActionError::ResourceGrant)?,
                                 ),
                                 None => BlockBackingUpdate::ConfiguredPath,
                             }
@@ -3428,10 +3423,16 @@ where
         .map_err(NativeV1SnapshotLoadError::Artifact)?;
         let state = PreparedHvfSnapshotV1State::from_prepared_state(state)
             .map_err(NativeV1SnapshotLoadError::Prepare)?;
-        let root_id = grant_reference_id(state.root_backing_path())
+        let mut root_claim = authority
+            .prepare_drive_backing_claim(state.root_backing_path(), GrantAccess::ReadOnly)
+            .map_err(NativeV1SnapshotLoadError::Resource)?;
+        let root = root_claim
+            .as_mut()
+            .map(PreparedDriveBackingClaim::take_snapshot_read_only_file)
+            .transpose()
             .map_err(NativeV1SnapshotLoadError::Resource)?;
 
-        let mut requests = Vec::with_capacity(3);
+        let mut requests = Vec::with_capacity(2);
         if let Some(id) = &state_id {
             requests.push((
                 id.clone(),
@@ -3443,13 +3444,6 @@ where
             requests.push((
                 id.clone(),
                 ResourceRole::SnapshotMemoryInput,
-                GrantAccess::ReadOnly,
-            ));
-        }
-        if let Some(id) = &root_id {
-            requests.push((
-                id.clone(),
-                ResourceRole::DriveBacking,
                 GrantAccess::ReadOnly,
             ));
         }
@@ -3469,11 +3463,6 @@ where
             .map(|_| claimed.next().ok_or(GrantClaimError))
             .transpose()
             .map_err(NativeV1SnapshotLoadError::Resource)?;
-        let root = root_id
-            .as_ref()
-            .map(|_| claimed.next().ok_or(GrantClaimError))
-            .transpose()
-            .map_err(NativeV1SnapshotLoadError::Resource)?;
         debug_assert!(claimed.next().is_none());
 
         let prepared = match memory {
@@ -3481,10 +3470,13 @@ where
             None => state.load_memory_path(Path::new(memory_path)),
         }
         .map_err(NativeV1SnapshotLoadError::Artifact)?;
-        prepared
+        let prepared = prepared
             .finish(root, Instant::now())
-            .map(Some)
-            .map_err(NativeV1SnapshotLoadError::Prepare)
+            .map_err(NativeV1SnapshotLoadError::Prepare)?;
+        if let Some(claim) = root_claim {
+            claim.commit();
+        }
+        Ok(Some(prepared))
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -19959,9 +19951,8 @@ mod tests {
         assert_eq!(vmm.drive_configs()[0].path_on_host(), Some(original.path()));
 
         let restored = observer
-            .prepare_file_claim(
+            .prepare_drive_backing_claim(
                 Path::new(REPLACEMENT),
-                bangbang_session::ResourceRole::DriveBacking,
                 bangbang_session::GrantAccess::ReadWrite,
             )
             .expect("failed patch should restore the exact grant")
@@ -19981,9 +19972,8 @@ mod tests {
         );
         assert!(
             observer
-                .claim_file(
+                .prepare_drive_backing_claim(
                     Path::new(REPLACEMENT),
-                    bangbang_session::ResourceRole::DriveBacking,
                     bangbang_session::GrantAccess::ReadWrite,
                 )
                 .is_err(),

--- a/crates/launcher/src/error.rs
+++ b/crates/launcher/src/error.rs
@@ -80,6 +80,8 @@ pub enum LauncherError {
     SocketBroker,
     /// The closed launcher-vhost-user broker protocol failed.
     VhostUserBroker,
+    /// The closed launcher block-control broker protocol failed.
+    BlockControlBroker,
     /// The private per-VM runtime namespace failed validation or cleanup.
     RuntimeNamespace,
     /// Waiting for the embedded worker failed.
@@ -133,6 +135,7 @@ impl fmt::Display for LauncherError {
             Self::GrantProtocol => formatter.write_str("private resource grant failed"),
             Self::SocketBroker => formatter.write_str("private socket broker failed"),
             Self::VhostUserBroker => formatter.write_str("private vhost-user broker failed"),
+            Self::BlockControlBroker => formatter.write_str("private block-control broker failed"),
             Self::RuntimeNamespace => {
                 formatter.write_str("private worker runtime namespace failed")
             }

--- a/crates/launcher/src/grant_manifest.rs
+++ b/crates/launcher/src/grant_manifest.rs
@@ -10,9 +10,10 @@ use std::path::{Path, PathBuf};
 
 use bangbang_session::macos::bookmark::create_implicit_bookmark;
 use bangbang_session::{
-    BatchId, GRANT_HEADER_BYTES, GrantAccess, GrantFrame, GrantId, GrantObjectKind, GrantRecord,
-    MAX_BATCH_BOOKMARK_BYTES, MAX_BOOKMARK_BYTES, MAX_GRANT_DATAGRAM_BYTES, MAX_GRANT_RECORDS,
-    MAX_GRANTS, ObjectIdentity, ResourceRole, SessionId,
+    BatchId, BlockDeviceGrant, GRANT_HEADER_BYTES, GrantAccess, GrantFrame, GrantId,
+    GrantObjectKind, GrantRecord, MAX_BATCH_BOOKMARK_BYTES, MAX_BOOKMARK_BYTES,
+    MAX_GRANT_DATAGRAM_BYTES, MAX_GRANT_RECORDS, MAX_GRANTS, ObjectIdentity, ResourceRole,
+    SessionId,
 };
 use serde::Deserialize;
 
@@ -253,6 +254,16 @@ pub(crate) struct SnapshotDirectoryAnchor {
     identity: ObjectIdentity,
 }
 
+/// Borrowed exact launcher authority for one block-special drive grant.
+#[derive(Clone, Copy)]
+pub(crate) struct BlockDriveAnchor {
+    descriptor: RawFd,
+    access: GrantAccess,
+    identity: ObjectIdentity,
+    status_flags: u32,
+    block_device: BlockDeviceGrant,
+}
+
 impl std::fmt::Debug for SocketDirectoryAnchor {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
@@ -291,6 +302,19 @@ impl std::fmt::Debug for SnapshotDirectoryAnchor {
     }
 }
 
+impl std::fmt::Debug for BlockDriveAnchor {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("BlockDriveAnchor")
+            .field("descriptor", &"<borrowed>")
+            .field("access", &self.access)
+            .field("identity", &"<redacted>")
+            .field("status_flags", &"<redacted>")
+            .field("block_device", &"<redacted>")
+            .finish()
+    }
+}
+
 impl SnapshotDirectoryAnchor {
     pub(crate) const fn descriptor(self) -> RawFd {
         self.descriptor
@@ -298,6 +322,45 @@ impl SnapshotDirectoryAnchor {
 
     pub(crate) const fn identity(self) -> ObjectIdentity {
         self.identity
+    }
+}
+
+impl BlockDriveAnchor {
+    #[cfg(test)]
+    pub(crate) const fn for_test(
+        descriptor: RawFd,
+        access: GrantAccess,
+        identity: ObjectIdentity,
+        status_flags: u32,
+        block_device: BlockDeviceGrant,
+    ) -> Self {
+        Self {
+            descriptor,
+            access,
+            identity,
+            status_flags,
+            block_device,
+        }
+    }
+
+    pub(crate) const fn descriptor(self) -> RawFd {
+        self.descriptor
+    }
+
+    pub(crate) const fn access(self) -> GrantAccess {
+        self.access
+    }
+
+    pub(crate) const fn identity(self) -> ObjectIdentity {
+        self.identity
+    }
+
+    pub(crate) const fn status_flags(self) -> u32 {
+        self.status_flags
+    }
+
+    pub(crate) const fn block_device(self) -> BlockDeviceGrant {
+        self.block_device
     }
 }
 
@@ -376,9 +439,10 @@ impl PreparedGrantBatch {
                         id: grant.id,
                         role: grant.role,
                         access: grant.access,
-                        kind: GrantObjectKind::RegularFile,
+                        kind: prepared.kind,
                         identity: prepared.identity,
                         status_flags: prepared.status_flags,
+                        block_device: prepared.block_device,
                     },
                     descriptor: Some(prepared.descriptor),
                 });
@@ -531,6 +595,35 @@ impl PreparedGrantBatch {
                 _ => None,
             })
     }
+
+    /// Borrows one exact retained block-special drive descriptor by grant ID.
+    pub(crate) fn block_drive_anchor(&self, requested_id: &GrantId) -> Option<BlockDriveAnchor> {
+        self.records
+            .iter()
+            .find_map(|prepared| match &prepared.record {
+                GrantRecord::Descriptor {
+                    id,
+                    role: ResourceRole::DriveBacking,
+                    access,
+                    kind: GrantObjectKind::BlockDevice,
+                    identity,
+                    status_flags,
+                    block_device: Some(block_device),
+                } if id == requested_id => {
+                    prepared
+                        .descriptor
+                        .as_ref()
+                        .map(|descriptor| BlockDriveAnchor {
+                            descriptor: descriptor.as_raw_fd(),
+                            access: *access,
+                            identity: *identity,
+                            status_flags: *status_flags,
+                            block_device: *block_device,
+                        })
+                }
+                _ => None,
+            })
+    }
 }
 
 /// One borrowed outbound record. The owning batch must remain live while sent.
@@ -551,8 +644,10 @@ impl std::fmt::Debug for OutboundGrant {
 
 struct PreparedResource {
     descriptor: OwnedFd,
+    kind: GrantObjectKind,
     identity: ObjectIdentity,
     status_flags: u32,
+    block_device: Option<BlockDeviceGrant>,
 }
 
 fn open_resource(grant: &ManifestGrant) -> Result<PreparedResource, LauncherError> {
@@ -579,41 +674,75 @@ fn open_resource(grant: &ManifestGrant) -> Result<PreparedResource, LauncherErro
         descriptor = unsafe { OwnedFd::from_raw_fd(opened) };
     }
     let stat = descriptor_stat(descriptor.as_raw_fd())?;
-    if grant.role.is_scoped_directory() {
-        if stat.st_mode & libc::S_IFMT != libc::S_IFDIR {
+    let object_kind = stat.st_mode & libc::S_IFMT;
+    let (kind, block_device) = if grant.role.is_scoped_directory() {
+        if object_kind != libc::S_IFDIR {
             return Err(LauncherError::GrantPreparation);
         }
-    } else if stat.st_mode & libc::S_IFMT != libc::S_IFREG {
-        return Err(LauncherError::GrantPreparation);
-    }
+        (GrantObjectKind::Directory, None)
+    } else {
+        match object_kind {
+            libc::S_IFREG => (GrantObjectKind::RegularFile, None),
+            libc::S_IFBLK
+                if grant.role == ResourceRole::DriveBacking
+                    && matches!(grant.access, GrantAccess::ReadOnly | GrantAccess::ReadWrite) =>
+            {
+                let target_device = normalized_device(stat.st_rdev);
+                if target_device == 0 {
+                    return Err(LauncherError::GrantPreparation);
+                }
+                let block =
+                    crate::macos::block_device::inspect(descriptor.as_raw_fd(), target_device)
+                        .map_err(|_| LauncherError::GrantPreparation)?;
+                (GrantObjectKind::BlockDevice, Some(block))
+            }
+            _ => return Err(LauncherError::GrantPreparation),
+        }
+    };
     // The nonblocking probe prevents a malicious special file from stalling
-    // preparation. It is removed before the exact status flags are recorded.
+    // preparation. Regular files and directories remove it before recording;
+    // Darwin block descriptors retain it because F_SETFL rejects the change.
     // SAFETY: F_GETFL inspects the live owned descriptor.
     let probe_flags = unsafe { libc::fcntl(descriptor.as_raw_fd(), libc::F_GETFL) };
-    // SAFETY: F_SETFL updates status flags on the same live descriptor.
-    let set_flags = unsafe {
-        libc::fcntl(
-            descriptor.as_raw_fd(),
-            libc::F_SETFL,
-            probe_flags & !libc::O_NONBLOCK,
-        )
-    };
-    if probe_flags < 0 || set_flags < 0 {
+    if probe_flags < 0 {
         return Err(LauncherError::GrantPreparation);
+    }
+    if kind != GrantObjectKind::BlockDevice {
+        // SAFETY: F_SETFL updates status flags on the same live descriptor.
+        if unsafe {
+            libc::fcntl(
+                descriptor.as_raw_fd(),
+                libc::F_SETFL,
+                probe_flags & !libc::O_NONBLOCK,
+            )
+        } < 0
+        {
+            return Err(LauncherError::GrantPreparation);
+        }
     }
     // SAFETY: F_GETFL reads status flags from the same live descriptor.
     let flags = unsafe { libc::fcntl(descriptor.as_raw_fd(), libc::F_GETFL) };
-    if flags < 0 || !access_matches(flags, grant.access) {
+    if flags < 0
+        || !access_matches(flags, grant.access)
+        || (kind == GrantObjectKind::BlockDevice && flags & libc::O_NONBLOCK == 0)
+    {
         return Err(LauncherError::GrantPreparation);
     }
-    let status_flags = u32::try_from(flags).map_err(|_| LauncherError::GrantPreparation)?;
+    let status_flags = if kind == GrantObjectKind::BlockDevice {
+        bangbang_session::macos::normalized_block_status_flags(flags)
+            .ok_or(LauncherError::GrantPreparation)?
+    } else {
+        u32::try_from(flags).map_err(|_| LauncherError::GrantPreparation)?
+    };
     Ok(PreparedResource {
         descriptor,
+        kind,
         identity: ObjectIdentity {
             device: normalized_device(stat.st_dev),
             inode: stat.st_ino,
         },
         status_flags,
+        block_device,
     })
 }
 

--- a/crates/launcher/src/macos/block_control.rs
+++ b/crates/launcher/src/macos/block_control.rs
@@ -1,0 +1,422 @@
+//! Launcher-side controller for exact retained block-special grants.
+
+use std::io;
+use std::mem::MaybeUninit;
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::net::UnixDatagram;
+
+use bangbang_session::macos::block_control::{
+    BlockControlError, BlockControlMessage, BlockControlOperation, BlockControlTarget,
+    receive_block_control_message, send_block_control_message,
+};
+use bangbang_session::macos::{normalized_block_status_flags, verify_peer_pid};
+use bangbang_session::{BlockDeviceGrant, GrantAccess, LauncherState, ObjectIdentity, SessionId};
+
+use super::block_device;
+use crate::LauncherError;
+use crate::grant_manifest::{BlockDriveAnchor, PreparedGrantBatch};
+
+/// Session-bound serial controller for worker block-control requests.
+pub(crate) struct LauncherBlockControlBroker {
+    session: SessionId,
+    next_sequence: u64,
+}
+
+impl std::fmt::Debug for LauncherBlockControlBroker {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("LauncherBlockControlBroker")
+            .field("session", &"<redacted>")
+            .field("next_sequence", &"<redacted>")
+            .finish()
+    }
+}
+
+impl LauncherBlockControlBroker {
+    pub(crate) const fn new(session: SessionId) -> Self {
+        Self {
+            session,
+            next_sequence: 1,
+        }
+    }
+
+    pub(crate) fn drain(
+        &mut self,
+        socket: &UnixDatagram,
+        worker_pid: libc::pid_t,
+        lifecycle_state: LauncherState,
+        lifecycle_cancelled: bool,
+        grants: &PreparedGrantBatch,
+    ) -> Result<(), LauncherError> {
+        loop {
+            let message = match receive_block_control_message(socket) {
+                Ok(message) => message,
+                Err(BlockControlError::Io(io::ErrorKind::WouldBlock)) => return Ok(()),
+                Err(_) => return Err(LauncherError::BlockControlBroker),
+            };
+            verify_peer_pid(socket.as_raw_fd(), worker_pid)
+                .map_err(|_| LauncherError::BlockControlBroker)?;
+            if message.session() != self.session
+                || message.sequence() != self.next_sequence
+                || lifecycle_cancelled
+                || !matches!(
+                    lifecycle_state,
+                    LauncherState::Starting | LauncherState::Ready(_)
+                )
+                || !matches!(
+                    &message,
+                    BlockControlMessage::Inspect { .. }
+                        | BlockControlMessage::SynchronizeCache { .. }
+                )
+            {
+                return Err(LauncherError::BlockControlBroker);
+            }
+            let sequence = self.next_sequence;
+            self.next_sequence = self
+                .next_sequence
+                .checked_add(1)
+                .ok_or(LauncherError::BlockControlBroker)?;
+            let anchor = grants
+                .block_drive_anchor(message.target().grant_id())
+                .ok_or(LauncherError::BlockControlBroker)?;
+            if !target_matches_anchor(message.target(), anchor) {
+                return Err(LauncherError::BlockControlBroker);
+            }
+
+            match message {
+                BlockControlMessage::Inspect { target, .. } => match inspect_anchor(anchor) {
+                    Ok(observed) => send(
+                        socket,
+                        &BlockControlMessage::Inspected {
+                            session: self.session,
+                            sequence,
+                            target,
+                            observed,
+                        },
+                    )?,
+                    Err(ControlFailure::Endpoint(kind)) => send(
+                        socket,
+                        &BlockControlMessage::Failed {
+                            session: self.session,
+                            sequence,
+                            target,
+                            operation: BlockControlOperation::Inspect,
+                            kind,
+                        },
+                    )?,
+                    Err(ControlFailure::Rejected) => {
+                        return Err(LauncherError::BlockControlBroker);
+                    }
+                },
+                BlockControlMessage::SynchronizeCache { target, .. } => {
+                    match synchronize_anchor(anchor) {
+                        Ok(()) => send(
+                            socket,
+                            &BlockControlMessage::Synchronized {
+                                session: self.session,
+                                sequence,
+                                target,
+                            },
+                        )?,
+                        Err(ControlFailure::Endpoint(kind)) => send(
+                            socket,
+                            &BlockControlMessage::Failed {
+                                session: self.session,
+                                sequence,
+                                target,
+                                operation: BlockControlOperation::SynchronizeCache,
+                                kind,
+                            },
+                        )?,
+                        Err(ControlFailure::Rejected) => {
+                            return Err(LauncherError::BlockControlBroker);
+                        }
+                    }
+                }
+                BlockControlMessage::Inspected { .. }
+                | BlockControlMessage::Synchronized { .. }
+                | BlockControlMessage::Failed { .. } => {
+                    return Err(LauncherError::BlockControlBroker);
+                }
+            }
+        }
+    }
+}
+
+fn send(socket: &UnixDatagram, message: &BlockControlMessage) -> Result<(), LauncherError> {
+    send_block_control_message(socket, message).map_err(|_| LauncherError::BlockControlBroker)
+}
+
+fn target_matches_anchor(target: &BlockControlTarget, anchor: BlockDriveAnchor) -> bool {
+    target.access() == anchor.access()
+        && target.identity() == anchor.identity()
+        && target.status_flags() == anchor.status_flags()
+        && target.block_device() == anchor.block_device()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ControlFailure {
+    Endpoint(io::ErrorKind),
+    Rejected,
+}
+
+fn inspect_anchor(anchor: BlockDriveAnchor) -> Result<BlockDeviceGrant, ControlFailure> {
+    validate_descriptor(anchor)?;
+    block_device::inspect(anchor.descriptor(), anchor.block_device().target_device())
+        .map_err(|error| ControlFailure::Endpoint(error.kind()))
+}
+
+fn synchronize_anchor(anchor: BlockDriveAnchor) -> Result<(), ControlFailure> {
+    if inspect_anchor(anchor)? != anchor.block_device() {
+        return Err(ControlFailure::Rejected);
+    }
+    block_device::synchronize_cache(anchor.descriptor())
+        .map_err(|error| ControlFailure::Endpoint(error.kind()))?;
+    match inspect_anchor(anchor) {
+        Ok(observed) if observed == anchor.block_device() => Ok(()),
+        Ok(_) | Err(_) => Err(ControlFailure::Rejected),
+    }
+}
+
+fn validate_descriptor(anchor: BlockDriveAnchor) -> Result<(), ControlFailure> {
+    // SAFETY: F_GETFD and F_GETFL inspect the live retained descriptor.
+    let descriptor_flags = unsafe { libc::fcntl(anchor.descriptor(), libc::F_GETFD) };
+    // SAFETY: F_GETFL inspects status on the same live descriptor.
+    let status_flags = unsafe { libc::fcntl(anchor.descriptor(), libc::F_GETFL) };
+    if descriptor_flags < 0 || status_flags < 0 {
+        return Err(ControlFailure::Endpoint(io::Error::last_os_error().kind()));
+    }
+    if descriptor_flags & libc::FD_CLOEXEC == 0
+        || normalized_block_status_flags(status_flags) != Some(anchor.status_flags())
+        || !access_matches(status_flags, anchor.access())
+    {
+        return Err(ControlFailure::Rejected);
+    }
+    let stat = descriptor_stat(anchor.descriptor())?;
+    let identity = ObjectIdentity {
+        device: normalized_device(stat.st_dev),
+        inode: stat.st_ino,
+    };
+    if stat.st_mode & libc::S_IFMT != libc::S_IFBLK
+        || identity != anchor.identity()
+        || normalized_device(stat.st_rdev) != anchor.block_device().target_device()
+    {
+        return Err(ControlFailure::Rejected);
+    }
+    Ok(())
+}
+
+fn descriptor_stat(descriptor: RawFd) -> Result<libc::stat, ControlFailure> {
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: stat points to writable storage and descriptor remains live.
+    if unsafe { libc::fstat(descriptor, stat.as_mut_ptr()) } != 0 {
+        return Err(ControlFailure::Endpoint(io::Error::last_os_error().kind()));
+    }
+    // SAFETY: Successful fstat initialized the complete structure.
+    Ok(unsafe { stat.assume_init() })
+}
+
+fn access_matches(flags: libc::c_int, access: GrantAccess) -> bool {
+    let actual = flags & libc::O_ACCMODE;
+    match access {
+        GrantAccess::ReadOnly => actual == libc::O_RDONLY,
+        GrantAccess::ReadWrite => actual == libc::O_RDWR,
+        GrantAccess::WriteOnly | GrantAccess::CreateChildren | GrantAccess::ConnectChildren => {
+            false
+        }
+    }
+}
+
+fn normalized_device(device: libc::dev_t) -> u64 {
+    u64::from(u32::from_ne_bytes(device.to_ne_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::os::fd::AsRawFd;
+
+    use bangbang_session::macos::block_control::{BlockControlMessage, send_block_control_message};
+
+    use super::*;
+
+    fn session() -> SessionId {
+        SessionId::from_bytes([81; 32])
+    }
+
+    fn target() -> BlockControlTarget {
+        BlockControlTarget::new(
+            bangbang_session::GrantId::parse("block-drive").expect("grant should parse"),
+            GrantAccess::ReadWrite,
+            ObjectIdentity {
+                device: 82,
+                inode: 83,
+            },
+            u32::try_from(libc::O_RDWR | libc::O_NONBLOCK).expect("status flags should fit"),
+            BlockDeviceGrant::new(84, 512, 32).expect("block tuple should validate"),
+        )
+        .expect("target should validate")
+    }
+
+    fn assert_drain_rejects(
+        broker_session: SessionId,
+        message: BlockControlMessage,
+        worker_pid: libc::pid_t,
+        lifecycle_state: LauncherState,
+        cancelled: bool,
+    ) {
+        let (worker, launcher) = UnixDatagram::pair().expect("block broker pair should open");
+        launcher
+            .set_nonblocking(true)
+            .expect("launcher endpoint should become nonblocking");
+        send_block_control_message(&worker, &message).expect("test request should send");
+        let mut broker = LauncherBlockControlBroker::new(broker_session);
+        assert_eq!(
+            broker.drain(
+                &launcher,
+                worker_pid,
+                lifecycle_state,
+                cancelled,
+                &PreparedGrantBatch::empty_for_test(),
+            ),
+            Err(LauncherError::BlockControlBroker)
+        );
+    }
+
+    #[test]
+    fn broker_state_and_error_are_redacted() {
+        let mut broker = LauncherBlockControlBroker::new(session());
+        broker.next_sequence = 918;
+        let debug = format!("{broker:?}");
+        assert!(!debug.contains("5151"));
+        assert!(!debug.contains("918"));
+        assert_eq!(
+            LauncherError::BlockControlBroker.to_string(),
+            "private block-control broker failed"
+        );
+    }
+
+    #[test]
+    fn drain_rejects_wrong_peer_session_sequence_phase_cancellation_and_operation() {
+        // SAFETY: The connected socketpair peer is the current test process.
+        let pid = unsafe { libc::getpid() };
+        let request = |message_session, sequence| BlockControlMessage::Inspect {
+            session: message_session,
+            sequence,
+            target: target(),
+        };
+        assert_drain_rejects(
+            session(),
+            request(SessionId::from_bytes([82; 32]), 1),
+            pid,
+            LauncherState::Starting,
+            false,
+        );
+        assert_drain_rejects(
+            session(),
+            request(session(), 2),
+            pid,
+            LauncherState::Starting,
+            false,
+        );
+        assert_drain_rejects(
+            session(),
+            request(session(), 1),
+            pid,
+            LauncherState::AwaitHello,
+            false,
+        );
+        assert_drain_rejects(
+            session(),
+            request(session(), 1),
+            pid,
+            LauncherState::Starting,
+            true,
+        );
+        assert_drain_rejects(
+            session(),
+            request(session(), 1),
+            pid.checked_add(1).expect("test PID should fit"),
+            LauncherState::Starting,
+            false,
+        );
+        assert_drain_rejects(
+            session(),
+            BlockControlMessage::Synchronized {
+                session: session(),
+                sequence: 1,
+                target: target(),
+            },
+            pid,
+            LauncherState::Starting,
+            false,
+        );
+        assert_drain_rejects(
+            session(),
+            request(session(), 1),
+            pid,
+            LauncherState::Ready(bangbang_session::Readiness::NoApi),
+            false,
+        );
+    }
+
+    #[test]
+    fn target_match_requires_every_immutable_anchor_field() {
+        let file = File::open("/dev/null").expect("descriptor fixture should open");
+        let target = target();
+        let anchor = BlockDriveAnchor::for_test(
+            file.as_raw_fd(),
+            target.access(),
+            target.identity(),
+            target.status_flags(),
+            target.block_device(),
+        );
+        assert!(target_matches_anchor(&target, anchor));
+
+        let different_access = BlockControlTarget::new(
+            target.grant_id().clone(),
+            GrantAccess::ReadOnly,
+            target.identity(),
+            u32::try_from(libc::O_RDONLY | libc::O_NONBLOCK).expect("status should fit"),
+            target.block_device(),
+        )
+        .expect("read-only target should validate");
+        assert!(!target_matches_anchor(&different_access, anchor));
+        let different_identity = BlockControlTarget::new(
+            target.grant_id().clone(),
+            target.access(),
+            ObjectIdentity {
+                device: target.identity().device,
+                inode: target.identity().inode + 1,
+            },
+            target.status_flags(),
+            target.block_device(),
+        )
+        .expect("identity variant should validate");
+        assert!(!target_matches_anchor(&different_identity, anchor));
+        let different_status = BlockControlTarget::new(
+            target.grant_id().clone(),
+            target.access(),
+            target.identity(),
+            target.status_flags() ^ u32::try_from(libc::O_NONBLOCK).expect("flag should fit"),
+            target.block_device(),
+        )
+        .expect("status variant should validate");
+        assert!(!target_matches_anchor(&different_status, anchor));
+        let different_geometry = BlockControlTarget::new(
+            target.grant_id().clone(),
+            target.access(),
+            target.identity(),
+            target.status_flags(),
+            BlockDeviceGrant::new(
+                target.block_device().target_device(),
+                512,
+                target.block_device().block_count() - 1,
+            )
+            .expect("geometry variant should validate"),
+        )
+        .expect("geometry target should validate");
+        assert!(!target_matches_anchor(&different_geometry, anchor));
+        assert!(format!("{anchor:?}").contains("<redacted>"));
+    }
+}

--- a/crates/launcher/src/macos/block_device.rs
+++ b/crates/launcher/src/macos/block_device.rs
@@ -1,0 +1,67 @@
+//! Narrow public macOS block-device controls used by retained grant descriptors.
+
+use std::io;
+use std::os::fd::RawFd;
+
+use bangbang_session::BlockDeviceGrant;
+
+const DARWIN_IOC_OUT: libc::c_ulong = 0x4000_0000;
+const DARWIN_IOC_VOID: libc::c_ulong = 0x2000_0000;
+const DARWIN_IOCPARM_MASK: libc::c_ulong = 0x1fff;
+
+const fn darwin_ioctl_request(
+    direction: libc::c_ulong,
+    group: u8,
+    number: u8,
+    len: usize,
+) -> libc::c_ulong {
+    direction
+        | (((len as libc::c_ulong) & DARWIN_IOCPARM_MASK) << 16)
+        | ((group as libc::c_ulong) << 8)
+        | number as libc::c_ulong
+}
+
+const DKIOCGETBLOCKSIZE: libc::c_ulong =
+    darwin_ioctl_request(DARWIN_IOC_OUT, b'd', 24, std::mem::size_of::<u32>());
+const DKIOCGETBLOCKCOUNT: libc::c_ulong =
+    darwin_ioctl_request(DARWIN_IOC_OUT, b'd', 25, std::mem::size_of::<u64>());
+const DKIOCSYNCHRONIZECACHE: libc::c_ulong = darwin_ioctl_request(DARWIN_IOC_VOID, b'd', 22, 0);
+
+pub(crate) fn inspect(descriptor: RawFd, target_device: u64) -> io::Result<BlockDeviceGrant> {
+    let mut logical_block_size = 0_u32;
+    // SAFETY: DKIOCGETBLOCKSIZE writes one u32 to the valid out pointer and
+    // inspects only the live borrowed descriptor for this synchronous call.
+    if unsafe { libc::ioctl(descriptor, DKIOCGETBLOCKSIZE, &raw mut logical_block_size) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let mut block_count = 0_u64;
+    // SAFETY: DKIOCGETBLOCKCOUNT writes one u64 to the valid out pointer and
+    // inspects only the same live borrowed descriptor.
+    if unsafe { libc::ioctl(descriptor, DKIOCGETBLOCKCOUNT, &raw mut block_count) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    BlockDeviceGrant::new(target_device, logical_block_size, block_count)
+        .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidData))
+}
+
+pub(crate) fn synchronize_cache(descriptor: RawFd) -> io::Result<()> {
+    // SAFETY: DKIOCSYNCHRONIZECACHE has no pointer payload and operates only on
+    // the live borrowed descriptor for this synchronous call.
+    if unsafe { libc::ioctl(descriptor, DKIOCSYNCHRONIZECACHE) } < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_sdk_request_numbers_remain_exact() {
+        assert_eq!(DKIOCGETBLOCKSIZE, 0x4004_6418);
+        assert_eq!(DKIOCGETBLOCKCOUNT, 0x4008_6419);
+        assert_eq!(DKIOCSYNCHRONIZECACHE, 0x2000_6416);
+    }
+}

--- a/crates/launcher/src/macos/daemon.rs
+++ b/crates/launcher/src/macos/daemon.rs
@@ -616,7 +616,8 @@ impl FailureCategory {
             LauncherError::SessionProtocol
             | LauncherError::GrantProtocol
             | LauncherError::SocketBroker
-            | LauncherError::VhostUserBroker => Self::Session,
+            | LauncherError::VhostUserBroker
+            | LauncherError::BlockControlBroker => Self::Session,
             LauncherError::WorkerPolicy | LauncherError::RuntimeNamespace => Self::Runtime,
             LauncherError::SignalSetup(_)
             | LauncherError::DaemonHandoff

--- a/crates/launcher/src/macos/mod.rs
+++ b/crates/launcher/src/macos/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) mod block_control;
+pub(crate) mod block_device;
 pub(crate) mod code_sign;
 pub(crate) mod daemon;
 pub(crate) mod publish;

--- a/crates/launcher/src/macos/spawn.rs
+++ b/crates/launcher/src/macos/spawn.rs
@@ -9,8 +9,8 @@ use std::path::Path;
 use std::process::ExitStatus;
 
 use bangbang_session::{
-    GRANT_FD, SESSION_ENV_KEY, SESSION_ENV_VALUE, SESSION_FD, SOCKET_BROKER_FD,
-    VHOST_USER_BROKER_FD,
+    BLOCK_CONTROL_BROKER_FD, GRANT_FD, SESSION_ENV_KEY, SESSION_ENV_VALUE, SESSION_FD,
+    SOCKET_BROKER_FD, VHOST_USER_BROKER_FD,
 };
 
 use crate::LauncherError;
@@ -140,6 +140,7 @@ pub(crate) struct SuspendedWorker {
     pub(crate) grants: UnixDatagram,
     pub(crate) socket_broker: UnixDatagram,
     pub(crate) vhost_user_broker: UnixDatagram,
+    pub(crate) block_control_broker: UnixDatagram,
 }
 
 pub(crate) fn spawn_suspended(
@@ -162,6 +163,10 @@ pub(crate) fn spawn_suspended(
         UnixDatagram::pair().map_err(|error| LauncherError::SessionSetup(error.kind()))?;
     let vhost_parent = duplicate_datagram_at_or_above(vhost_parent, MIN_TRANSPORT_FD)?;
     let vhost_child = duplicate_datagram_at_or_above(vhost_child, MIN_TRANSPORT_FD)?;
+    let (block_parent, block_child) =
+        UnixDatagram::pair().map_err(|error| LauncherError::SessionSetup(error.kind()))?;
+    let block_parent = duplicate_datagram_at_or_above(block_parent, MIN_TRANSPORT_FD)?;
+    let block_child = duplicate_datagram_at_or_above(block_child, MIN_TRANSPORT_FD)?;
 
     let executable = cstring(executable.as_os_str())
         .map_err(|_| LauncherError::WorkerSpawn(io::ErrorKind::InvalidInput))?;
@@ -194,6 +199,10 @@ pub(crate) fn spawn_suspended(
     if vhost_child.as_raw_fd() != VHOST_USER_BROKER_FD {
         actions.close(vhost_child.as_raw_fd())?;
     }
+    actions.duplicate(block_child.as_raw_fd(), BLOCK_CONTROL_BROKER_FD)?;
+    if block_child.as_raw_fd() != BLOCK_CONTROL_BROKER_FD {
+        actions.close(block_child.as_raw_fd())?;
+    }
 
     let mut pid = 0;
     // SAFETY: All C strings and null-terminated pointer arrays remain live for
@@ -218,6 +227,7 @@ pub(crate) fn spawn_suspended(
     drop(grant_child);
     drop(broker_child);
     drop(vhost_child);
+    drop(block_child);
     Ok(SuspendedWorker {
         worker: OwnedWorker {
             pid,
@@ -228,6 +238,7 @@ pub(crate) fn spawn_suspended(
         grants: grant_parent,
         socket_broker: broker_parent,
         vhost_user_broker: vhost_parent,
+        block_control_broker: block_parent,
     })
 }
 

--- a/crates/launcher/src/macos/supervise.rs
+++ b/crates/launcher/src/macos/supervise.rs
@@ -19,6 +19,7 @@ use bangbang_session::{
 use signal_hook::consts::signal::{SIGINT, SIGTERM};
 use signal_hook::{SigId, low_level};
 
+use super::block_control::LauncherBlockControlBroker;
 use super::daemon::{DaemonNotifier, NotifierEvent};
 use super::socket_broker::LauncherSocketBroker;
 use super::spawn::OwnedWorker;
@@ -191,6 +192,9 @@ pub(crate) fn wait_session(
         let _ = auxiliary
             .vhost_user_broker
             .shutdown(std::net::Shutdown::Both);
+        let _ = auxiliary
+            .block_control_broker
+            .shutdown(std::net::Shutdown::Both);
         worker.terminate_and_reap();
     }
 
@@ -354,6 +358,7 @@ pub(crate) struct AuxiliaryChannels<'a> {
     grant_socket: &'a mut UnixDatagram,
     socket_broker: &'a mut UnixDatagram,
     vhost_user_broker: &'a mut UnixDatagram,
+    block_control_broker: &'a mut UnixDatagram,
 }
 
 impl<'a> AuxiliaryChannels<'a> {
@@ -361,11 +366,13 @@ impl<'a> AuxiliaryChannels<'a> {
         grant_socket: &'a mut UnixDatagram,
         socket_broker: &'a mut UnixDatagram,
         vhost_user_broker: &'a mut UnixDatagram,
+        block_control_broker: &'a mut UnixDatagram,
     ) -> Self {
         Self {
             grant_socket,
             socket_broker,
             vhost_user_broker,
+            block_control_broker,
         }
     }
 }
@@ -387,6 +394,7 @@ fn wait_session_inner(
     let grant_socket = &mut *auxiliary.grant_socket;
     let socket_broker = &mut *auxiliary.socket_broker;
     let vhost_user_broker = &mut *auxiliary.vhost_user_broker;
+    let block_control_broker = &mut *auxiliary.block_control_broker;
     let SessionHooks {
         observation,
         mut notifier,
@@ -403,6 +411,9 @@ fn wait_session_inner(
     vhost_user_broker
         .set_nonblocking(true)
         .map_err(|err| LauncherError::SessionSetup(err.kind()))?;
+    block_control_broker
+        .set_nonblocking(true)
+        .map_err(|err| LauncherError::SessionSetup(err.kind()))?;
     let kqueue = create_kqueue()?;
     let child_pid = usize::try_from(worker.pid())
         .map_err(|_| LauncherError::WorkerWait(io::ErrorKind::InvalidInput))?;
@@ -413,6 +424,8 @@ fn wait_session_inner(
     let broker_fd = usize::try_from(socket_broker.as_raw_fd())
         .map_err(|_| LauncherError::SessionSetup(io::ErrorKind::InvalidInput))?;
     let vhost_broker_fd = usize::try_from(vhost_user_broker.as_raw_fd())
+        .map_err(|_| LauncherError::SessionSetup(io::ErrorKind::InvalidInput))?;
+    let block_control_fd = usize::try_from(block_control_broker.as_raw_fd())
         .map_err(|_| LauncherError::SessionSetup(io::ErrorKind::InvalidInput))?;
     let mut changes = vec![
         event(
@@ -459,6 +472,12 @@ fn wait_session_inner(
             libc::EV_ADD | libc::EV_ENABLE | libc::EV_CLEAR,
             0,
         ),
+        event(
+            block_control_fd,
+            libc::EVFILT_READ,
+            libc::EV_ADD | libc::EV_ENABLE | libc::EV_CLEAR,
+            0,
+        ),
     ];
     let notifier_fd = notifier
         .as_ref()
@@ -480,9 +499,11 @@ fn wait_session_inner(
     let mut cancellation_deadline: Option<Instant> = None;
     let mut exit_deadline: Option<Instant> = None;
     let mut session_closed = false;
+    let mut block_control_closed = false;
     let mut grant_send = GrantSendState::new(grants, lifecycle.session());
     let mut broker = LauncherSocketBroker::new(lifecycle.session());
     let mut vhost_broker = LauncherVhostUserBroker::new(lifecycle.session());
+    let mut block_control = LauncherBlockControlBroker::new(lifecycle.session());
     loop {
         let notifier_deadline = notifier.as_ref().and_then(|notifier| notifier.deadline());
         let deadline = [
@@ -526,6 +547,15 @@ fn wait_session_inner(
         if observation.terminal.is_some() {
             exit_deadline.get_or_insert(Instant::now() + SESSION_EXIT_GRACE);
         }
+        if session_closed || observation.terminal.is_some() {
+            BlockControlShutdown {
+                kqueue: kqueue.as_raw_fd(),
+                descriptor: block_control_fd,
+                socket: block_control_broker,
+                closed: &mut block_control_closed,
+            }
+            .close()?;
+        }
 
         if observation.readiness.is_some()
             && let Some(notifier) = notifier.as_deref_mut()
@@ -566,6 +596,12 @@ fn wait_session_inner(
                             session,
                             &mut grant_send,
                             grant_socket,
+                            BlockControlShutdown {
+                                kqueue: kqueue.as_raw_fd(),
+                                descriptor: block_control_fd,
+                                socket: block_control_broker,
+                                closed: &mut block_control_closed,
+                            },
                             &mut cancellation_deadline,
                             CancelSignal::Terminate,
                         )?;
@@ -581,6 +617,21 @@ fn wait_session_inner(
         {
             broker.drain(
                 socket_broker,
+                worker.pid(),
+                lifecycle.state(),
+                lifecycle.is_cancelled(),
+                grants,
+            )?;
+        }
+
+        if !child_exited
+            && !block_control_closed
+            && events.iter().any(|queued| {
+                queued.filter == libc::EVFILT_READ && queued.ident == block_control_fd
+            })
+        {
+            block_control.drain(
+                block_control_broker,
                 worker.pid(),
                 lifecycle.state(),
                 lifecycle.is_cancelled(),
@@ -624,6 +675,12 @@ fn wait_session_inner(
                         session,
                         &mut grant_send,
                         grant_socket,
+                        BlockControlShutdown {
+                            kqueue: kqueue.as_raw_fd(),
+                            descriptor: block_control_fd,
+                            socket: block_control_broker,
+                            closed: &mut block_control_closed,
+                        },
                         &mut cancellation_deadline,
                         signal,
                     )?;
@@ -696,6 +753,7 @@ fn request_cancellation(
     session: &mut UnixStream,
     grant_send: &mut GrantSendState,
     grant_socket: &UnixDatagram,
+    block_control: BlockControlShutdown<'_>,
     cancellation_deadline: &mut Option<Instant>,
     signal: CancelSignal,
 ) -> Result<(), LauncherError> {
@@ -705,8 +763,36 @@ fn request_cancellation(
     write_frame(session, frame)?;
     grant_send.cancel();
     shutdown_grants(grant_socket);
+    block_control.close()?;
     *cancellation_deadline = Some(Instant::now() + CANCELLATION_GRACE);
     Ok(())
+}
+
+struct BlockControlShutdown<'a> {
+    kqueue: RawFd,
+    descriptor: usize,
+    socket: &'a UnixDatagram,
+    closed: &'a mut bool,
+}
+
+impl BlockControlShutdown<'_> {
+    fn close(self) -> Result<(), LauncherError> {
+        if *self.closed {
+            return Ok(());
+        }
+        register_events(
+            self.kqueue,
+            &[event(
+                self.descriptor,
+                libc::EVFILT_READ,
+                libc::EV_DELETE,
+                0,
+            )],
+        )?;
+        shutdown_grants(self.socket);
+        *self.closed = true;
+        Ok(())
+    }
 }
 
 fn timeout_until(deadline: Option<Instant>) -> Option<Duration> {

--- a/crates/launcher/src/supervisor.rs
+++ b/crates/launcher/src/supervisor.rs
@@ -123,6 +123,7 @@ fn launch_prepared(
             &mut spawned.grants,
             &mut spawned.socket_broker,
             &mut spawned.vhost_user_broker,
+            &mut spawned.block_control_broker,
         ),
         lifecycle,
         wakeups,

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -5,6 +5,8 @@
     clippy::unwrap_used
 )]
 
+#[path = "../../../tests/support/macos_virtual_block.rs"]
+mod macos_virtual_block;
 #[path = "../../../tests/support/vhost_user_block.rs"]
 mod vhost_user_block;
 
@@ -29,9 +31,11 @@ use bangbang_launcher::{
     OUTER_BUNDLE_NAME, WORKER_BUNDLE_IDENTIFIER, WORKER_BUNDLE_NAME, WORKER_EXECUTABLE_NAME,
 };
 use bangbang_session::{
-    Frame, FrameDecoder, GRANT_FD, Message, SESSION_ENV_KEY, SESSION_ENV_VALUE, SESSION_FD,
-    SOCKET_BROKER_FD, SessionId, VHOST_USER_BROKER_FD, WorkerPolicy, encode_frame,
+    BLOCK_CONTROL_BROKER_FD, Frame, FrameDecoder, GRANT_FD, Message, SESSION_ENV_KEY,
+    SESSION_ENV_VALUE, SESSION_FD, SOCKET_BROKER_FD, SessionId, VHOST_USER_BROKER_FD, WorkerPolicy,
+    encode_frame,
 };
+use macos_virtual_block::{MacosVirtualBlock, MacosVirtualBlockAccess};
 use vhost_user_block::{VhostUserBlockBackend, VhostUserBlockBackendOptions};
 
 const BUNDLE_ENV: &str = "BANGBANG_PRODUCTION_BUNDLE_PATH";
@@ -45,6 +49,11 @@ const GRANT_DELAY_OPTION: &str = "--bangbang-internal-grant-delay-v1";
 const GRANT_DELAY_READY: &str = "status: grant integration delay ready";
 const GRANT_PROBE_MARKER: &str = "grant-integration-probe.enabled";
 const GRANT_PROBE_OUTSIDE: &str = "bangbang-grant-probe-outside";
+const BLOCK_CONTROL_GRANT_ID: &str = "probe-block-control";
+const BLOCK_CONTROL_GRANT_REF: &str = "bangbang-grant:probe-block-control";
+const BLOCK_CONTROL_INITIAL_MARKER: &[u8] = b"BANGBANG_BLOCK_CONTROL_INITIAL";
+const BLOCK_CONTROL_WRITTEN_MARKER: &[u8] = b"BANGBANG_BLOCK_CONTROL_WRITTEN";
+const BLOCK_CONTROL_WRITE_BLOCK: u64 = 8;
 const STARTUP_CONFIG_ID: &str = "grant-config-1360";
 const STARTUP_METADATA_ID: &str = "grant-metadata-1360";
 const KERNEL_ID: &str = "grant-kernel-1360";
@@ -3906,6 +3915,127 @@ fn signed_grants_authorize_only_typed_read_write_and_directory_operations() {
 }
 
 #[test]
+fn signed_contained_block_device_uses_launcher_control_broker() {
+    let bundle = grant_test_bundle();
+    let launcher_entitlements = codesign_entitlements(&bundle);
+    let worker_entitlements = codesign_entitlements(&worker_bundle(&bundle));
+    assert!(!launcher_entitlements.contains("com.apple.security.app-sandbox"));
+    assert!(!launcher_entitlements.contains("com.apple.security.hypervisor"));
+    assert_eq!(worker_entitlements.matches("<key>").count(), 2);
+    assert!(worker_entitlements.contains("<key>com.apple.security.app-sandbox</key>"));
+    assert!(worker_entitlements.contains("<key>com.apple.security.hypervisor</key>"));
+    let mut media = MacosVirtualBlock::create(MacosVirtualBlockAccess::ReadWrite)
+        .expect("temporary block media should attach read-write");
+    let logical_block_size = usize::try_from(
+        media
+            .logical_block_size()
+            .expect("temporary media should report logical geometry"),
+    )
+    .expect("logical block size should fit usize");
+    let block_count = media
+        .block_count()
+        .expect("temporary media should report a block count");
+    let identity = media
+        .identity()
+        .expect("temporary media should report exact identity");
+    assert_ne!(identity.device(), 0);
+    assert_ne!(identity.inode(), 0);
+    assert_ne!(identity.target_device(), 0);
+    assert_eq!(
+        media.len().expect("temporary media should report capacity"),
+        u64::try_from(logical_block_size)
+            .expect("block size should fit u64")
+            .checked_mul(block_count)
+            .expect("temporary media capacity should not overflow")
+    );
+    assert!(logical_block_size >= BLOCK_CONTROL_INITIAL_MARKER.len());
+    assert!(logical_block_size >= BLOCK_CONTROL_WRITTEN_MARKER.len());
+
+    let mut initial_block = vec![0_u8; logical_block_size];
+    initial_block[..BLOCK_CONTROL_INITIAL_MARKER.len()]
+        .copy_from_slice(BLOCK_CONTROL_INITIAL_MARKER);
+    media
+        .write_at(0, &initial_block)
+        .expect("initial block marker should persist before launch");
+
+    let root = TestDir::new("block-control-grant");
+    let manifest = fs::canonicalize(root.path())
+        .expect("block-control fixture should canonicalize")
+        .join("grant-manifest.json");
+    let device_path = media
+        .device_path()
+        .expect("attached media should expose a device path")
+        .to_path_buf();
+    let manifest_json = serde_json::json!({
+        "version": 1,
+        "grants": [{
+            "id": BLOCK_CONTROL_GRANT_ID,
+            "role": "drive-backing",
+            "access": "read-write",
+            "source": path_text(&device_path),
+        }],
+    });
+    fs::write(
+        &manifest,
+        serde_json::to_vec(&manifest_json).expect("block-control manifest should serialize"),
+    )
+    .expect("block-control manifest should write");
+
+    let output = run_with_timeout(
+        Command::new(launcher(&bundle))
+            .arg(GRANT_MANIFEST_OPTION)
+            .arg(&manifest)
+            .arg("--")
+            .arg(GRANT_PROBE_OPTION)
+            .arg("block-control"),
+        PROCESS_TIMEOUT,
+        "signed block-control grant probe",
+    );
+    assert_output_success(&output, "signed block-control grant probe");
+    let diagnostics = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    for sensitive in [
+        path_text(&device_path),
+        path_text(&manifest),
+        BLOCK_CONTROL_GRANT_ID,
+        BLOCK_CONTROL_GRANT_REF,
+    ] {
+        assert!(!diagnostics.contains(sensitive));
+    }
+
+    media
+        .reattach(MacosVirtualBlockAccess::ReadOnly)
+        .expect("completed broker session should release media for read-only reattach");
+    assert_eq!(
+        media
+            .read_at(0, logical_block_size)
+            .expect("initial block should remain readable"),
+        initial_block
+    );
+    let mut expected_written = vec![0_u8; logical_block_size];
+    expected_written[..BLOCK_CONTROL_WRITTEN_MARKER.len()]
+        .copy_from_slice(BLOCK_CONTROL_WRITTEN_MARKER);
+    assert_eq!(
+        media
+            .read_at(
+                u64::try_from(logical_block_size)
+                    .expect("block size should fit u64")
+                    .checked_mul(BLOCK_CONTROL_WRITE_BLOCK)
+                    .expect("marker offset should not overflow"),
+                logical_block_size,
+            )
+            .expect("broker-synchronized block should persist"),
+        expected_written
+    );
+    media
+        .cleanup()
+        .expect("temporary block media should detach and clean up");
+}
+
+#[test]
 fn contained_worker_maps_unlinked_shared_guest_memory_with_hvf() {
     let bundle = grant_test_bundle();
     let fixture = GrantProbeFixture::new("shared-memory", false);
@@ -4108,6 +4238,8 @@ fn worker_rejects_malformed_forged_bootstrap_before_public_processing() {
         UnixDatagram::pair().expect("broker socketpair should open");
     let (_vhost_broker_parent, vhost_broker_child_endpoint) =
         UnixDatagram::pair().expect("vhost broker socketpair should open");
+    let (_block_control_parent, block_control_child_endpoint) =
+        UnixDatagram::pair().expect("block-control socketpair should open");
     parent
         .set_read_timeout(Some(Duration::from_secs(5)))
         .expect("bootstrap read timeout should set");
@@ -4115,6 +4247,7 @@ fn worker_rejects_malformed_forged_bootstrap_before_public_processing() {
     let grant_child_fd = grant_child_endpoint.as_raw_fd();
     let broker_child_fd = broker_child_endpoint.as_raw_fd();
     let vhost_broker_child_fd = vhost_broker_child_endpoint.as_raw_fd();
+    let block_control_child_fd = block_control_child_endpoint.as_raw_fd();
     let mut command = Command::new(worker_executable(&bundle));
     command
         .env_clear()
@@ -4139,6 +4272,9 @@ fn worker_rejects_malformed_forged_bootstrap_before_public_processing() {
             if libc::dup2(vhost_broker_child_fd, VHOST_USER_BROKER_FD) < 0 {
                 return Err(std::io::Error::last_os_error());
             }
+            if libc::dup2(block_control_child_fd, BLOCK_CONTROL_BROKER_FD) < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
             Ok(())
         });
     }
@@ -4149,6 +4285,7 @@ fn worker_rejects_malformed_forged_bootstrap_before_public_processing() {
     drop(grant_child_endpoint);
     drop(broker_child_endpoint);
     drop(vhost_broker_child_endpoint);
+    drop(block_control_child_endpoint);
 
     let mut hello_bytes = vec![0_u8; 56];
     parent

--- a/crates/session/src/grant.rs
+++ b/crates/session/src/grant.rs
@@ -21,8 +21,8 @@ pub const MAX_BOOKMARK_BYTES: u32 = 64 * 1024;
 /// Maximum bookmark bytes across one batch.
 pub const MAX_BATCH_BOOKMARK_BYTES: u32 = 256 * 1024;
 
-const GRANT_MAGIC: [u8; 4] = *b"BBG1";
-const GRANT_VERSION: u16 = 1;
+const GRANT_MAGIC: [u8; 4] = *b"BBG2";
+const GRANT_VERSION: u16 = 2;
 const GRANT_MAX_PAYLOAD_BYTES: usize = MAX_GRANT_DATAGRAM_BYTES - GRANT_HEADER_BYTES;
 
 /// Random identity bound to one startup grant batch.
@@ -307,6 +307,8 @@ pub enum GrantObjectKind {
     RegularFile = 1,
     /// Existing directory.
     Directory = 2,
+    /// Existing macOS block-special device.
+    BlockDevice = 3,
 }
 
 impl GrantObjectKind {
@@ -314,6 +316,7 @@ impl GrantObjectKind {
         match value {
             1 => Ok(Self::RegularFile),
             2 => Ok(Self::Directory),
+            3 => Ok(Self::BlockDevice),
             _ => Err(ProtocolError::InvalidFrame),
         }
     }
@@ -331,6 +334,79 @@ pub struct ObjectIdentity {
 impl fmt::Debug for ObjectIdentity {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("ObjectIdentity(<redacted>)")
+    }
+}
+
+/// Checked block-special descriptor metadata authenticated by one grant.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BlockDeviceGrant {
+    target_device: u64,
+    logical_block_size: u32,
+    block_count: u64,
+    capacity: u64,
+}
+
+impl BlockDeviceGrant {
+    /// Builds one internally consistent, virtio-sector-aligned block tuple.
+    pub fn new(target_device: u64, logical_block_size: u32, block_count: u64) -> Option<Self> {
+        let block_size = u64::from(logical_block_size);
+        if target_device == 0
+            || block_size == 0
+            || block_count == 0
+            || !block_size.is_multiple_of(512)
+        {
+            return None;
+        }
+        let capacity = block_size.checked_mul(block_count)?;
+        if capacity == 0 || !capacity.is_multiple_of(512) || i64::try_from(capacity).is_err() {
+            return None;
+        }
+        Some(Self {
+            target_device,
+            logical_block_size,
+            block_count,
+            capacity,
+        })
+    }
+
+    fn from_wire(
+        target_device: u64,
+        logical_block_size: u32,
+        block_count: u64,
+        capacity: u64,
+    ) -> Option<Self> {
+        let value = Self::new(target_device, logical_block_size, block_count)?;
+        (value.capacity == capacity).then_some(value)
+    }
+
+    /// Returns the normalized target-device identity (`st_rdev`).
+    #[must_use]
+    pub const fn target_device(self) -> u64 {
+        self.target_device
+    }
+
+    /// Returns the logical media block size.
+    #[must_use]
+    pub const fn logical_block_size(self) -> u32 {
+        self.logical_block_size
+    }
+
+    /// Returns the logical media block count.
+    #[must_use]
+    pub const fn block_count(self) -> u64 {
+        self.block_count
+    }
+
+    /// Returns the checked byte capacity.
+    #[must_use]
+    pub const fn capacity(self) -> u64 {
+        self.capacity
+    }
+}
+
+impl fmt::Debug for BlockDeviceGrant {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("BlockDeviceGrant(<redacted>)")
     }
 }
 
@@ -360,6 +436,8 @@ pub enum GrantRecord {
         identity: ObjectIdentity,
         /// Expected file status flags after masking mutable noise.
         status_flags: u32,
+        /// Authenticated block-special metadata, absent for regular files.
+        block_device: Option<BlockDeviceGrant>,
     },
     /// Transfers a directory anchor and declares its bookmark fragments.
     ScopedDirectory {
@@ -531,15 +609,29 @@ fn encode_record(record: &GrantRecord) -> Result<(u16, Vec<u8>), ProtocolError> 
             kind,
             identity,
             status_flags,
+            block_device,
         } => {
             if role.is_scoped_directory()
                 || !role.permits(*access)
-                || *kind != GrantObjectKind::RegularFile
+                || !valid_descriptor_kind(*role, *access, *kind, *block_device)
             {
                 return Err(ProtocolError::InvalidFrame);
             }
             let mut payload = encode_grant_prefix(id, *role, *access, *kind, *identity)?;
             payload.extend_from_slice(&status_flags.to_be_bytes());
+            let (target_device, logical_block_size, block_count, capacity) =
+                block_device.map_or((0, 0, 0, 0), |block| {
+                    (
+                        block.target_device(),
+                        block.logical_block_size(),
+                        block.block_count(),
+                        block.capacity(),
+                    )
+                });
+            payload.extend_from_slice(&target_device.to_be_bytes());
+            payload.extend_from_slice(&logical_block_size.to_be_bytes());
+            payload.extend_from_slice(&block_count.to_be_bytes());
+            payload.extend_from_slice(&capacity.to_be_bytes());
             Ok((2, payload))
         }
         GrantRecord::ScopedDirectory {
@@ -621,11 +713,34 @@ fn decode_record(kind: u16, payload: &[u8]) -> Result<GrantRecord, ProtocolError
         }
         2 => {
             let (id, role, access, object_kind, identity, offset) = decode_grant_prefix(payload)?;
-            if payload.len() != offset.saturating_add(4)
+            if payload.len() != offset.saturating_add(32)
                 || role.is_scoped_directory()
                 || !role.permits(access)
-                || object_kind != GrantObjectKind::RegularFile
             {
+                return Err(ProtocolError::InvalidFrame);
+            }
+            let target_device = read_u64(payload, offset.saturating_add(4))?;
+            let logical_block_size = read_u32(payload, offset.saturating_add(12))?;
+            let block_count = read_u64(payload, offset.saturating_add(16))?;
+            let capacity = read_u64(payload, offset.saturating_add(24))?;
+            let block_device = if target_device == 0
+                && logical_block_size == 0
+                && block_count == 0
+                && capacity == 0
+            {
+                None
+            } else {
+                Some(
+                    BlockDeviceGrant::from_wire(
+                        target_device,
+                        logical_block_size,
+                        block_count,
+                        capacity,
+                    )
+                    .ok_or(ProtocolError::InvalidFrame)?,
+                )
+            };
+            if !valid_descriptor_kind(role, access, object_kind, block_device) {
                 return Err(ProtocolError::InvalidFrame);
             }
             Ok(GrantRecord::Descriptor {
@@ -635,6 +750,7 @@ fn decode_record(kind: u16, payload: &[u8]) -> Result<GrantRecord, ProtocolError
                 kind: object_kind,
                 identity,
                 status_flags: read_u32(payload, offset)?,
+                block_device,
             })
         }
         3 => {
@@ -690,6 +806,22 @@ fn decode_record(kind: u16, payload: &[u8]) -> Result<GrantRecord, ProtocolError
             })
         }
         _ => Err(ProtocolError::InvalidFrame),
+    }
+}
+
+fn valid_descriptor_kind(
+    role: ResourceRole,
+    access: GrantAccess,
+    kind: GrantObjectKind,
+    block_device: Option<BlockDeviceGrant>,
+) -> bool {
+    match (kind, block_device) {
+        (GrantObjectKind::RegularFile, None) => true,
+        (GrantObjectKind::BlockDevice, Some(_)) => {
+            role == ResourceRole::DriveBacking
+                && matches!(access, GrantAccess::ReadOnly | GrantAccess::ReadWrite)
+        }
+        _ => false,
     }
 }
 
@@ -836,6 +968,21 @@ mod tests {
                     inode: 5,
                 },
                 status_flags: 0,
+                block_device: None,
+            },
+            GrantRecord::Descriptor {
+                id: id("block"),
+                role: ResourceRole::DriveBacking,
+                access: GrantAccess::ReadWrite,
+                kind: GrantObjectKind::BlockDevice,
+                identity: ObjectIdentity {
+                    device: 10,
+                    inode: 11,
+                },
+                status_flags: 4,
+                block_device: Some(
+                    BlockDeviceGrant::new(12, 512, 8).expect("block tuple should be valid"),
+                ),
             },
             GrantRecord::ScopedDirectory {
                 id: id("api"),
@@ -920,6 +1067,7 @@ mod tests {
                 inode: 2,
             },
             status_flags: 0,
+            block_device: None,
         });
         assert_eq!(
             encode_grant_frame(&invalid),
@@ -945,6 +1093,144 @@ mod tests {
             encode_grant_frame(&invalid),
             Err(ProtocolError::InvalidFrame)
         );
+    }
+
+    #[test]
+    fn block_descriptor_geometry_and_role_are_closed() {
+        let valid = BlockDeviceGrant::new(3, 4096, 8).expect("geometry should validate");
+        assert_eq!(valid.target_device(), 3);
+        assert_eq!(valid.logical_block_size(), 4096);
+        assert_eq!(valid.block_count(), 8);
+        assert_eq!(valid.capacity(), 32_768);
+        assert_eq!(format!("{valid:?}"), "BlockDeviceGrant(<redacted>)");
+        assert!(BlockDeviceGrant::new(0, 512, 8).is_none());
+        assert!(BlockDeviceGrant::new(3, 0, 8).is_none());
+        assert!(BlockDeviceGrant::new(3, 768, 8).is_none());
+        assert!(BlockDeviceGrant::new(3, 512, 0).is_none());
+        assert!(BlockDeviceGrant::new(3, 4096, u64::MAX).is_none());
+
+        for (role, access, kind, block_device) in [
+            (
+                ResourceRole::KernelImage,
+                GrantAccess::ReadOnly,
+                GrantObjectKind::BlockDevice,
+                Some(valid),
+            ),
+            (
+                ResourceRole::DriveBacking,
+                GrantAccess::ReadOnly,
+                GrantObjectKind::RegularFile,
+                Some(valid),
+            ),
+            (
+                ResourceRole::DriveBacking,
+                GrantAccess::ReadOnly,
+                GrantObjectKind::BlockDevice,
+                None,
+            ),
+        ] {
+            let invalid = frame(GrantRecord::Descriptor {
+                id: id("invalid-block"),
+                role,
+                access,
+                kind,
+                identity: ObjectIdentity {
+                    device: 1,
+                    inode: 2,
+                },
+                status_flags: 0,
+                block_device,
+            });
+            assert_eq!(
+                encode_grant_frame(&invalid),
+                Err(ProtocolError::InvalidFrame)
+            );
+        }
+    }
+
+    #[test]
+    fn block_descriptor_wire_rejects_noncanonical_and_inconsistent_tuples() {
+        let block_id = id("block-wire");
+        let block = frame(GrantRecord::Descriptor {
+            id: block_id.clone(),
+            role: ResourceRole::DriveBacking,
+            access: GrantAccess::ReadWrite,
+            kind: GrantObjectKind::BlockDevice,
+            identity: ObjectIdentity {
+                device: 21,
+                inode: 22,
+            },
+            status_flags: 4,
+            block_device: Some(
+                BlockDeviceGrant::new(23, 512, 16).expect("block tuple should validate"),
+            ),
+        });
+        let encoded = encode_grant_frame(&block).expect("block record should encode");
+        let record_offset = GRANT_HEADER_BYTES + 20 + block_id.as_bytes().len();
+        let target_offset = record_offset + 4;
+        let capacity_offset = record_offset + 24;
+
+        let mut inconsistent_capacity = encoded.clone();
+        inconsistent_capacity[capacity_offset + 7] ^= 1;
+        assert_eq!(
+            decode_grant_frame(&inconsistent_capacity),
+            Err(ProtocolError::InvalidFrame)
+        );
+
+        let mut zero_geometry = encoded.clone();
+        zero_geometry[target_offset..record_offset + 32].fill(0);
+        assert_eq!(
+            decode_grant_frame(&zero_geometry),
+            Err(ProtocolError::InvalidFrame)
+        );
+
+        let regular_id = id("regular-wire");
+        let regular = frame(GrantRecord::Descriptor {
+            id: regular_id.clone(),
+            role: ResourceRole::DriveBacking,
+            access: GrantAccess::ReadOnly,
+            kind: GrantObjectKind::RegularFile,
+            identity: ObjectIdentity {
+                device: 31,
+                inode: 32,
+            },
+            status_flags: 0,
+            block_device: None,
+        });
+        let regular = encode_grant_frame(&regular).expect("regular record should encode");
+        let regular_record_offset = GRANT_HEADER_BYTES + 20 + regular_id.as_bytes().len();
+        assert!(
+            regular[regular_record_offset + 4..regular_record_offset + 32]
+                .iter()
+                .all(|byte| *byte == 0)
+        );
+        let mut noncanonical_regular = regular;
+        noncanonical_regular[regular_record_offset + 11] = 1;
+        assert_eq!(
+            decode_grant_frame(&noncanonical_regular),
+            Err(ProtocolError::InvalidFrame)
+        );
+
+        let mut truncated = encoded.clone();
+        truncated.pop();
+        assert_eq!(
+            decode_grant_frame(&truncated),
+            Err(ProtocolError::InvalidFrame)
+        );
+        let mut surplus = encoded.clone();
+        surplus.push(0);
+        assert_eq!(
+            decode_grant_frame(&surplus),
+            Err(ProtocolError::InvalidFrame)
+        );
+        for index in [0, 4, 5, 12, 13] {
+            let mut corrupted = encoded.clone();
+            corrupted[index] ^= 1;
+            assert_eq!(
+                decode_grant_frame(&corrupted),
+                Err(ProtocolError::InvalidFrame)
+            );
+        }
     }
 
     #[test]

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -12,11 +12,11 @@ pub use codec::{
     VmnetAuthority, VmnetAuthorityError, WorkerPolicy, encode_frame,
 };
 pub use grant::{
-    BatchId, GRANT_HEADER_BYTES, GrantAccess, GrantFrame, GrantId, GrantObjectKind, GrantRecord,
-    MAX_BATCH_BOOKMARK_BYTES, MAX_BOOKMARK_BYTES, MAX_GRANT_DATAGRAM_BYTES, MAX_GRANT_ID_BYTES,
-    MAX_GRANT_RECORDS, MAX_GRANTS, MAX_SNAPSHOT_OUTPUT_CHILD_BYTES, MAX_SOCKET_CHILD_BYTES,
-    ObjectIdentity, ResourceRole, SnapshotOutputChild, SocketChild, decode_grant_frame,
-    encode_grant_frame,
+    BatchId, BlockDeviceGrant, GRANT_HEADER_BYTES, GrantAccess, GrantFrame, GrantId,
+    GrantObjectKind, GrantRecord, MAX_BATCH_BOOKMARK_BYTES, MAX_BOOKMARK_BYTES,
+    MAX_GRANT_DATAGRAM_BYTES, MAX_GRANT_ID_BYTES, MAX_GRANT_RECORDS, MAX_GRANTS,
+    MAX_SNAPSHOT_OUTPUT_CHILD_BYTES, MAX_SOCKET_CHILD_BYTES, ObjectIdentity, ResourceRole,
+    SnapshotOutputChild, SocketChild, decode_grant_frame, encode_grant_frame,
 };
 pub use state::{LauncherLifecycle, LauncherState, WorkerLifecycle, WorkerState};
 
@@ -32,8 +32,11 @@ pub const SOCKET_BROKER_FD: libc::c_int = 5;
 /// Fixed descriptor used only by the private launcher-vhost-user broker.
 pub const VHOST_USER_BROKER_FD: libc::c_int = 6;
 
+/// Fixed descriptor used only by the private launcher block-control broker.
+pub const BLOCK_CONTROL_BROKER_FD: libc::c_int = 7;
+
 /// Private environment marker installed by the production launcher.
-pub const SESSION_ENV_KEY: &str = "BANGBANG_INTERNAL_SESSION_V5";
+pub const SESSION_ENV_KEY: &str = "BANGBANG_INTERNAL_SESSION_V6";
 
 /// Exact value required for [`SESSION_ENV_KEY`].
-pub const SESSION_ENV_VALUE: &str = "5";
+pub const SESSION_ENV_VALUE: &str = "6";

--- a/crates/session/src/macos.rs
+++ b/crates/session/src/macos.rs
@@ -3,12 +3,23 @@
 use std::io;
 use std::os::fd::RawFd;
 
+pub mod block_control;
 pub mod bookmark;
 pub mod grant_registry;
 pub mod grant_transport;
 pub mod runtime;
 pub mod socket_broker;
 pub mod vhost_user_broker;
+
+/// Canonicalizes the stable security-relevant status of a block descriptor.
+///
+/// Darwin may discard pathname-resolution flags such as `O_NOFOLLOW` after
+/// the open file description is used. Access, append, and nonblocking state
+/// remain meaningful for capability revalidation.
+#[must_use]
+pub fn normalized_block_status_flags(flags: libc::c_int) -> Option<u32> {
+    u32::try_from(flags & (libc::O_ACCMODE | libc::O_APPEND | libc::O_NONBLOCK)).ok()
+}
 
 /// Kernel-authenticated identity of a connected local-socket peer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -133,6 +144,15 @@ mod tests {
         assert_eq!(
             verify_peer_pid(left.as_raw_fd(), current).expect("datagram peer PID should verify"),
             current
+        );
+    }
+
+    #[test]
+    fn block_status_normalization_excludes_path_resolution_flags() {
+        let flags = libc::O_RDWR | libc::O_NONBLOCK | libc::O_NOFOLLOW;
+        assert_eq!(
+            normalized_block_status_flags(flags),
+            u32::try_from(libc::O_RDWR | libc::O_NONBLOCK).ok()
         );
     }
 }

--- a/crates/session/src/macos/block_control.rs
+++ b/crates/session/src/macos/block_control.rs
@@ -1,0 +1,799 @@
+//! Closed launcher-worker transport for contained block-device control.
+
+use std::fmt;
+use std::io;
+use std::os::fd::AsRawFd;
+use std::os::unix::net::UnixDatagram;
+
+use crate::{
+    BlockDeviceGrant, GrantAccess, GrantId, MAX_GRANT_ID_BYTES, ObjectIdentity, SessionId,
+};
+
+use super::grant_transport::{GrantTransportError, receive_raw, send_raw};
+
+const FRAME_BYTES: usize = 256;
+const MAGIC: [u8; 4] = *b"BBC1";
+const VERSION: u8 = 1;
+const OBJECT_KIND_BLOCK_DEVICE: u8 = 3;
+const KIND_INSPECT: u8 = 1;
+const KIND_INSPECTED: u8 = 2;
+const KIND_SYNCHRONIZE_CACHE: u8 = 3;
+const KIND_SYNCHRONIZED: u8 = 4;
+const KIND_FAILED: u8 = 5;
+const OPERATION_NONE: u8 = 0;
+const OPERATION_INSPECT: u8 = 1;
+const OPERATION_SYNCHRONIZE_CACHE: u8 = 2;
+const STATUS_OK: u8 = 0;
+const STATUS_PERMISSION_DENIED: u8 = 1;
+const STATUS_TIMED_OUT: u8 = 2;
+const STATUS_INVALID_DATA: u8 = 3;
+const STATUS_NOT_FOUND: u8 = 4;
+const STATUS_OTHER: u8 = 5;
+const SESSION_OFFSET: usize = 8;
+const SEQUENCE_OFFSET: usize = 40;
+const GRANT_LENGTH_OFFSET: usize = 48;
+const ACCESS_OFFSET: usize = 49;
+const OPERATION_OFFSET: usize = 50;
+const STATUS_FLAGS_OFFSET: usize = 52;
+const DEVICE_OFFSET: usize = 56;
+const INODE_OFFSET: usize = 64;
+const TARGET_DEVICE_OFFSET: usize = 72;
+const LOGICAL_BLOCK_SIZE_OFFSET: usize = 80;
+const BLOCK_COUNT_OFFSET: usize = 88;
+const CAPACITY_OFFSET: usize = 96;
+const OBSERVED_BLOCK_SIZE_OFFSET: usize = 104;
+const OBSERVED_BLOCK_COUNT_OFFSET: usize = 112;
+const OBSERVED_CAPACITY_OFFSET: usize = 120;
+const GRANT_OFFSET: usize = 128;
+const GRANT_END: usize = GRANT_OFFSET + MAX_GRANT_ID_BYTES;
+
+/// Immutable grant tuple bound to every block-control exchange.
+#[derive(Clone, PartialEq, Eq)]
+pub struct BlockControlTarget {
+    grant_id: GrantId,
+    access: GrantAccess,
+    identity: ObjectIdentity,
+    status_flags: u32,
+    block_device: BlockDeviceGrant,
+}
+
+impl BlockControlTarget {
+    /// Builds one role-restricted authenticated block target.
+    pub fn new(
+        grant_id: GrantId,
+        access: GrantAccess,
+        identity: ObjectIdentity,
+        status_flags: u32,
+        block_device: BlockDeviceGrant,
+    ) -> Option<Self> {
+        if !matches!(access, GrantAccess::ReadOnly | GrantAccess::ReadWrite)
+            || !target_status_matches_access(status_flags, access)
+        {
+            return None;
+        }
+        Some(Self {
+            grant_id,
+            access,
+            identity,
+            status_flags,
+            block_device,
+        })
+    }
+
+    /// Returns the exact redacted grant identifier.
+    #[must_use]
+    pub const fn grant_id(&self) -> &GrantId {
+        &self.grant_id
+    }
+
+    /// Returns the authenticated opened access.
+    #[must_use]
+    pub const fn access(&self) -> GrantAccess {
+        self.access
+    }
+
+    /// Returns the authenticated containing-device and inode identity.
+    #[must_use]
+    pub const fn identity(&self) -> ObjectIdentity {
+        self.identity
+    }
+
+    /// Returns the authenticated stable status flags.
+    #[must_use]
+    pub const fn status_flags(&self) -> u32 {
+        self.status_flags
+    }
+
+    /// Returns the authenticated target-device and adopted geometry tuple.
+    #[must_use]
+    pub const fn block_device(&self) -> BlockDeviceGrant {
+        self.block_device
+    }
+}
+
+fn target_status_matches_access(status_flags: u32, access: GrantAccess) -> bool {
+    let Ok(flags) = libc::c_int::try_from(status_flags) else {
+        return false;
+    };
+    if super::normalized_block_status_flags(flags) != Some(status_flags)
+        || flags & libc::O_APPEND != 0
+    {
+        return false;
+    }
+    match access {
+        GrantAccess::ReadOnly => flags & libc::O_ACCMODE == libc::O_RDONLY,
+        GrantAccess::ReadWrite => flags & libc::O_ACCMODE == libc::O_RDWR,
+        GrantAccess::WriteOnly | GrantAccess::CreateChildren | GrantAccess::ConnectChildren => {
+            false
+        }
+    }
+}
+
+impl fmt::Debug for BlockControlTarget {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("BlockControlTarget(<redacted>)")
+    }
+}
+
+/// Closed block-control operation used to correlate bounded failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockControlOperation {
+    /// Read live logical geometry.
+    Inspect,
+    /// Persist writes through the media cache.
+    SynchronizeCache,
+}
+
+/// One session-bound block-control message.
+#[derive(Clone, PartialEq, Eq)]
+pub enum BlockControlMessage {
+    /// Requests a fresh live geometry observation.
+    Inspect {
+        /// Exact lifecycle session.
+        session: SessionId,
+        /// Nonzero monotonic request sequence.
+        sequence: u64,
+        /// Exact adopted grant tuple.
+        target: BlockControlTarget,
+    },
+    /// Returns a fresh checked geometry while echoing the immutable target.
+    Inspected {
+        /// Exact lifecycle session.
+        session: SessionId,
+        /// Matching request sequence.
+        sequence: u64,
+        /// Exact adopted grant tuple.
+        target: BlockControlTarget,
+        /// Fresh checked geometry for the same target device.
+        observed: BlockDeviceGrant,
+    },
+    /// Requests cache synchronization for the exact adopted geometry.
+    SynchronizeCache {
+        /// Exact lifecycle session.
+        session: SessionId,
+        /// Nonzero monotonic request sequence.
+        sequence: u64,
+        /// Exact adopted grant tuple.
+        target: BlockControlTarget,
+    },
+    /// Acknowledges cache synchronization and post-operation reinspection.
+    Synchronized {
+        /// Exact lifecycle session.
+        session: SessionId,
+        /// Matching request sequence.
+        sequence: u64,
+        /// Exact adopted grant tuple.
+        target: BlockControlTarget,
+    },
+    /// Reports one bounded, unambiguous endpoint failure.
+    Failed {
+        /// Exact lifecycle session.
+        session: SessionId,
+        /// Matching request sequence.
+        sequence: u64,
+        /// Exact adopted grant tuple.
+        target: BlockControlTarget,
+        /// Operation that failed.
+        operation: BlockControlOperation,
+        /// Stable redacted failure category.
+        kind: io::ErrorKind,
+    },
+}
+
+impl fmt::Debug for BlockControlMessage {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Inspect { .. } => "Inspect(<redacted>)",
+            Self::Inspected { .. } => "Inspected(<redacted>)",
+            Self::SynchronizeCache { .. } => "SynchronizeCache(<redacted>)",
+            Self::Synchronized { .. } => "Synchronized(<redacted>)",
+            Self::Failed { .. } => "Failed(<redacted>)",
+        })
+    }
+}
+
+impl BlockControlMessage {
+    /// Returns the lifecycle session without formatting it.
+    #[must_use]
+    pub const fn session(&self) -> SessionId {
+        match self {
+            Self::Inspect { session, .. }
+            | Self::Inspected { session, .. }
+            | Self::SynchronizeCache { session, .. }
+            | Self::Synchronized { session, .. }
+            | Self::Failed { session, .. } => *session,
+        }
+    }
+
+    /// Returns the request sequence without formatting it.
+    #[must_use]
+    pub const fn sequence(&self) -> u64 {
+        match self {
+            Self::Inspect { sequence, .. }
+            | Self::Inspected { sequence, .. }
+            | Self::SynchronizeCache { sequence, .. }
+            | Self::Synchronized { sequence, .. }
+            | Self::Failed { sequence, .. } => *sequence,
+        }
+    }
+
+    /// Returns the exact immutable grant tuple.
+    #[must_use]
+    pub const fn target(&self) -> &BlockControlTarget {
+        match self {
+            Self::Inspect { target, .. }
+            | Self::Inspected { target, .. }
+            | Self::SynchronizeCache { target, .. }
+            | Self::Synchronized { target, .. }
+            | Self::Failed { target, .. } => target,
+        }
+    }
+
+    /// Returns the operation represented by this message.
+    #[must_use]
+    pub const fn operation(&self) -> BlockControlOperation {
+        match self {
+            Self::Inspect { .. } | Self::Inspected { .. } => BlockControlOperation::Inspect,
+            Self::SynchronizeCache { .. } | Self::Synchronized { .. } => {
+                BlockControlOperation::SynchronizeCache
+            }
+            Self::Failed { operation, .. } => *operation,
+        }
+    }
+}
+
+/// Redacted block-control framing or transport failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockControlError {
+    /// One local-socket operation failed.
+    Io(io::ErrorKind),
+    /// Payload or ancillary data violated the closed protocol.
+    Invalid,
+}
+
+impl fmt::Display for BlockControlError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("private block-control broker failure")
+    }
+}
+
+impl std::error::Error for BlockControlError {}
+
+impl From<GrantTransportError> for BlockControlError {
+    fn from(error: GrantTransportError) -> Self {
+        match error {
+            GrantTransportError::Io(kind) => Self::Io(kind),
+            GrantTransportError::Invalid => Self::Invalid,
+        }
+    }
+}
+
+/// Sends one exact block-control datagram with no ancillary rights.
+pub fn send_block_control_message(
+    socket: &UnixDatagram,
+    message: &BlockControlMessage,
+) -> Result<(), BlockControlError> {
+    let frame = encode(message)?;
+    send_raw(socket.as_raw_fd(), &frame, &[]).map_err(Into::into)
+}
+
+/// Receives one exact block-control datagram and rejects all ancillary rights.
+pub fn receive_block_control_message(
+    socket: &UnixDatagram,
+) -> Result<BlockControlMessage, BlockControlError> {
+    let mut frame = [0_u8; FRAME_BYTES];
+    let (length, descriptors) = receive_raw(socket, &mut frame)?;
+    if length != FRAME_BYTES || !descriptors.is_empty() {
+        return Err(BlockControlError::Invalid);
+    }
+    decode(&frame)
+}
+
+fn encode(message: &BlockControlMessage) -> Result<[u8; FRAME_BYTES], BlockControlError> {
+    if message.session().is_pre_session() || message.sequence() == 0 {
+        return Err(BlockControlError::Invalid);
+    }
+    let target = message.target();
+    let grant = target.grant_id().as_bytes();
+    let grant_length = u8::try_from(grant.len()).map_err(|_| BlockControlError::Invalid)?;
+    let mut frame = [0_u8; FRAME_BYTES];
+    frame[..4].copy_from_slice(&MAGIC);
+    frame[4] = VERSION;
+    frame[7] = OBJECT_KIND_BLOCK_DEVICE;
+    frame[SESSION_OFFSET..SEQUENCE_OFFSET].copy_from_slice(message.session().as_bytes());
+    frame[SEQUENCE_OFFSET..GRANT_LENGTH_OFFSET].copy_from_slice(&message.sequence().to_be_bytes());
+    frame[GRANT_LENGTH_OFFSET] = grant_length;
+    frame[ACCESS_OFFSET] = access_byte(target.access());
+    frame[STATUS_FLAGS_OFFSET..DEVICE_OFFSET].copy_from_slice(&target.status_flags().to_be_bytes());
+    frame[DEVICE_OFFSET..INODE_OFFSET].copy_from_slice(&target.identity().device.to_be_bytes());
+    frame[INODE_OFFSET..TARGET_DEVICE_OFFSET]
+        .copy_from_slice(&target.identity().inode.to_be_bytes());
+    let block = target.block_device();
+    frame[TARGET_DEVICE_OFFSET..LOGICAL_BLOCK_SIZE_OFFSET]
+        .copy_from_slice(&block.target_device().to_be_bytes());
+    frame[LOGICAL_BLOCK_SIZE_OFFSET..LOGICAL_BLOCK_SIZE_OFFSET + 4]
+        .copy_from_slice(&block.logical_block_size().to_be_bytes());
+    frame[BLOCK_COUNT_OFFSET..CAPACITY_OFFSET].copy_from_slice(&block.block_count().to_be_bytes());
+    frame[CAPACITY_OFFSET..OBSERVED_BLOCK_SIZE_OFFSET]
+        .copy_from_slice(&block.capacity().to_be_bytes());
+    frame
+        .get_mut(GRANT_OFFSET..GRANT_OFFSET + grant.len())
+        .ok_or(BlockControlError::Invalid)?
+        .copy_from_slice(grant);
+
+    match message {
+        BlockControlMessage::Inspect { .. } => frame[5] = KIND_INSPECT,
+        BlockControlMessage::Inspected { observed, .. } => {
+            if observed.target_device() != block.target_device() {
+                return Err(BlockControlError::Invalid);
+            }
+            frame[5] = KIND_INSPECTED;
+            frame[OBSERVED_BLOCK_SIZE_OFFSET..OBSERVED_BLOCK_SIZE_OFFSET + 4]
+                .copy_from_slice(&observed.logical_block_size().to_be_bytes());
+            frame[OBSERVED_BLOCK_COUNT_OFFSET..OBSERVED_CAPACITY_OFFSET]
+                .copy_from_slice(&observed.block_count().to_be_bytes());
+            frame[OBSERVED_CAPACITY_OFFSET..GRANT_OFFSET]
+                .copy_from_slice(&observed.capacity().to_be_bytes());
+        }
+        BlockControlMessage::SynchronizeCache { .. } => frame[5] = KIND_SYNCHRONIZE_CACHE,
+        BlockControlMessage::Synchronized { .. } => frame[5] = KIND_SYNCHRONIZED,
+        BlockControlMessage::Failed {
+            operation, kind, ..
+        } => {
+            frame[5] = KIND_FAILED;
+            frame[6] = failure_status(*kind);
+            frame[OPERATION_OFFSET] = operation_byte(*operation);
+        }
+    }
+    Ok(frame)
+}
+
+fn decode(frame: &[u8; FRAME_BYTES]) -> Result<BlockControlMessage, BlockControlError> {
+    if frame[..4] != MAGIC
+        || frame[4] != VERSION
+        || frame[7] != OBJECT_KIND_BLOCK_DEVICE
+        || frame[51] != 0
+        || frame[84..BLOCK_COUNT_OFFSET].iter().any(|byte| *byte != 0)
+        || frame[108..OBSERVED_BLOCK_COUNT_OFFSET]
+            .iter()
+            .any(|byte| *byte != 0)
+        || frame[GRANT_END..].iter().any(|byte| *byte != 0)
+    {
+        return Err(BlockControlError::Invalid);
+    }
+    let session = SessionId::from_bytes(
+        frame[SESSION_OFFSET..SEQUENCE_OFFSET]
+            .try_into()
+            .map_err(|_| BlockControlError::Invalid)?,
+    );
+    let sequence = u64::from_be_bytes(
+        frame[SEQUENCE_OFFSET..GRANT_LENGTH_OFFSET]
+            .try_into()
+            .map_err(|_| BlockControlError::Invalid)?,
+    );
+    let grant_length = usize::from(frame[GRANT_LENGTH_OFFSET]);
+    if session.is_pre_session()
+        || sequence == 0
+        || grant_length == 0
+        || grant_length > MAX_GRANT_ID_BYTES
+        || frame
+            .get(GRANT_OFFSET + grant_length..GRANT_END)
+            .is_none_or(|padding| padding.iter().any(|byte| *byte != 0))
+    {
+        return Err(BlockControlError::Invalid);
+    }
+    let grant = frame
+        .get(GRANT_OFFSET..GRANT_OFFSET + grant_length)
+        .ok_or(BlockControlError::Invalid)?;
+    let grant_id = std::str::from_utf8(grant)
+        .map_err(|_| BlockControlError::Invalid)
+        .and_then(|value| GrantId::parse(value).map_err(|_| BlockControlError::Invalid))?;
+    let access = decode_access(frame[ACCESS_OFFSET])?;
+    let identity = ObjectIdentity {
+        device: read_u64(frame, DEVICE_OFFSET)?,
+        inode: read_u64(frame, INODE_OFFSET)?,
+    };
+    let target_device = read_u64(frame, TARGET_DEVICE_OFFSET)?;
+    let block_device = checked_block(
+        target_device,
+        read_u32(frame, LOGICAL_BLOCK_SIZE_OFFSET)?,
+        read_u64(frame, BLOCK_COUNT_OFFSET)?,
+        read_u64(frame, CAPACITY_OFFSET)?,
+    )?;
+    let target = BlockControlTarget::new(
+        grant_id,
+        access,
+        identity,
+        read_u32(frame, STATUS_FLAGS_OFFSET)?,
+        block_device,
+    )
+    .ok_or(BlockControlError::Invalid)?;
+    let observed_values = (
+        read_u32(frame, OBSERVED_BLOCK_SIZE_OFFSET)?,
+        read_u64(frame, OBSERVED_BLOCK_COUNT_OFFSET)?,
+        read_u64(frame, OBSERVED_CAPACITY_OFFSET)?,
+    );
+    let observed = if observed_values == (0, 0, 0) {
+        None
+    } else {
+        Some(checked_block(
+            target_device,
+            observed_values.0,
+            observed_values.1,
+            observed_values.2,
+        )?)
+    };
+
+    match (frame[5], frame[6], frame[OPERATION_OFFSET], observed) {
+        (KIND_INSPECT, STATUS_OK, OPERATION_NONE, None) => Ok(BlockControlMessage::Inspect {
+            session,
+            sequence,
+            target,
+        }),
+        (KIND_INSPECTED, STATUS_OK, OPERATION_NONE, Some(observed)) => {
+            Ok(BlockControlMessage::Inspected {
+                session,
+                sequence,
+                target,
+                observed,
+            })
+        }
+        (KIND_SYNCHRONIZE_CACHE, STATUS_OK, OPERATION_NONE, None) => {
+            Ok(BlockControlMessage::SynchronizeCache {
+                session,
+                sequence,
+                target,
+            })
+        }
+        (KIND_SYNCHRONIZED, STATUS_OK, OPERATION_NONE, None) => {
+            Ok(BlockControlMessage::Synchronized {
+                session,
+                sequence,
+                target,
+            })
+        }
+        (KIND_FAILED, status, operation, None) if status != STATUS_OK => {
+            Ok(BlockControlMessage::Failed {
+                session,
+                sequence,
+                target,
+                operation: decode_operation(operation)?,
+                kind: failure_kind(status)?,
+            })
+        }
+        _ => Err(BlockControlError::Invalid),
+    }
+}
+
+fn checked_block(
+    target_device: u64,
+    logical_block_size: u32,
+    block_count: u64,
+    capacity: u64,
+) -> Result<BlockDeviceGrant, BlockControlError> {
+    BlockDeviceGrant::new(target_device, logical_block_size, block_count)
+        .filter(|block| block.capacity() == capacity)
+        .ok_or(BlockControlError::Invalid)
+}
+
+const fn access_byte(access: GrantAccess) -> u8 {
+    match access {
+        GrantAccess::ReadOnly => 1,
+        GrantAccess::ReadWrite => 3,
+        GrantAccess::WriteOnly | GrantAccess::CreateChildren | GrantAccess::ConnectChildren => 0,
+    }
+}
+
+const fn decode_access(value: u8) -> Result<GrantAccess, BlockControlError> {
+    match value {
+        1 => Ok(GrantAccess::ReadOnly),
+        3 => Ok(GrantAccess::ReadWrite),
+        _ => Err(BlockControlError::Invalid),
+    }
+}
+
+const fn operation_byte(operation: BlockControlOperation) -> u8 {
+    match operation {
+        BlockControlOperation::Inspect => OPERATION_INSPECT,
+        BlockControlOperation::SynchronizeCache => OPERATION_SYNCHRONIZE_CACHE,
+    }
+}
+
+const fn decode_operation(value: u8) -> Result<BlockControlOperation, BlockControlError> {
+    match value {
+        OPERATION_INSPECT => Ok(BlockControlOperation::Inspect),
+        OPERATION_SYNCHRONIZE_CACHE => Ok(BlockControlOperation::SynchronizeCache),
+        _ => Err(BlockControlError::Invalid),
+    }
+}
+
+const fn failure_status(kind: io::ErrorKind) -> u8 {
+    match kind {
+        io::ErrorKind::PermissionDenied => STATUS_PERMISSION_DENIED,
+        io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut => STATUS_TIMED_OUT,
+        io::ErrorKind::InvalidData => STATUS_INVALID_DATA,
+        io::ErrorKind::NotFound => STATUS_NOT_FOUND,
+        _ => STATUS_OTHER,
+    }
+}
+
+const fn failure_kind(status: u8) -> Result<io::ErrorKind, BlockControlError> {
+    match status {
+        STATUS_PERMISSION_DENIED => Ok(io::ErrorKind::PermissionDenied),
+        STATUS_TIMED_OUT => Ok(io::ErrorKind::TimedOut),
+        STATUS_INVALID_DATA => Ok(io::ErrorKind::InvalidData),
+        STATUS_NOT_FOUND => Ok(io::ErrorKind::NotFound),
+        STATUS_OTHER => Ok(io::ErrorKind::Other),
+        _ => Err(BlockControlError::Invalid),
+    }
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32, BlockControlError> {
+    let value: [u8; 4] = bytes
+        .get(offset..offset.saturating_add(4))
+        .ok_or(BlockControlError::Invalid)?
+        .try_into()
+        .map_err(|_| BlockControlError::Invalid)?;
+    Ok(u32::from_be_bytes(value))
+}
+
+fn read_u64(bytes: &[u8], offset: usize) -> Result<u64, BlockControlError> {
+    let value: [u8; 8] = bytes
+        .get(offset..offset.saturating_add(8))
+        .ok_or(BlockControlError::Invalid)?
+        .try_into()
+        .map_err(|_| BlockControlError::Invalid)?;
+    Ok(u64::from_be_bytes(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+
+    use super::*;
+
+    fn session() -> SessionId {
+        SessionId::from_bytes([7; 32])
+    }
+
+    fn target() -> BlockControlTarget {
+        BlockControlTarget::new(
+            GrantId::parse("block-drive").expect("grant should parse"),
+            GrantAccess::ReadWrite,
+            ObjectIdentity {
+                device: 11,
+                inode: 12,
+            },
+            u32::try_from(libc::O_RDWR | libc::O_NONBLOCK).expect("flags should fit"),
+            BlockDeviceGrant::new(14, 512, 8).expect("block tuple should validate"),
+        )
+        .expect("target should validate")
+    }
+
+    fn inspect() -> BlockControlMessage {
+        BlockControlMessage::Inspect {
+            session: session(),
+            sequence: 1,
+            target: target(),
+        }
+    }
+
+    #[test]
+    fn every_message_round_trips_without_rights() {
+        let observed = BlockDeviceGrant::new(14, 4096, 2).expect("observation should validate");
+        let messages = [
+            inspect(),
+            BlockControlMessage::Inspected {
+                session: session(),
+                sequence: 1,
+                target: target(),
+                observed,
+            },
+            BlockControlMessage::SynchronizeCache {
+                session: session(),
+                sequence: 2,
+                target: target(),
+            },
+            BlockControlMessage::Synchronized {
+                session: session(),
+                sequence: 2,
+                target: target(),
+            },
+            BlockControlMessage::Failed {
+                session: session(),
+                sequence: 3,
+                target: target(),
+                operation: BlockControlOperation::Inspect,
+                kind: io::ErrorKind::PermissionDenied,
+            },
+        ];
+        let (left, right) = UnixDatagram::pair().expect("pair should open");
+        for expected in messages {
+            send_block_control_message(&left, &expected).expect("message should send");
+            assert_eq!(
+                receive_block_control_message(&right).expect("message should receive"),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_closed_frame_corruption_and_rights() {
+        let frame = encode(&inspect()).expect("inspect should encode");
+        for index in [0, 4, 5, 6, 7, 48, 49, 51, 84, 108, GRANT_END] {
+            let mut corrupted = frame;
+            corrupted[index] ^= 0xff;
+            assert_eq!(decode(&corrupted), Err(BlockControlError::Invalid));
+        }
+        let mut zero_session = frame;
+        zero_session[SESSION_OFFSET..SEQUENCE_OFFSET].fill(0);
+        assert_eq!(decode(&zero_session), Err(BlockControlError::Invalid));
+        let mut zero_sequence = frame;
+        zero_sequence[SEQUENCE_OFFSET..GRANT_LENGTH_OFFSET].fill(0);
+        assert_eq!(decode(&zero_sequence), Err(BlockControlError::Invalid));
+
+        let (left, right) = UnixDatagram::pair().expect("pair should open");
+        left.send(&frame[..FRAME_BYTES - 1])
+            .expect("short frame should send");
+        assert_eq!(
+            receive_block_control_message(&right),
+            Err(BlockControlError::Invalid)
+        );
+
+        let descriptor = File::open("/dev/null").expect("fixture should open");
+        send_raw(left.as_raw_fd(), &frame, &[descriptor.as_raw_fd()])
+            .expect("rights frame should send");
+        assert_eq!(
+            receive_block_control_message(&right),
+            Err(BlockControlError::Invalid)
+        );
+
+        let mut long = frame.to_vec();
+        long.push(0);
+        send_raw(left.as_raw_fd(), &long, &[]).expect("long frame should send");
+        assert_eq!(
+            receive_block_control_message(&right),
+            Err(BlockControlError::Invalid)
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_correlation_geometry_and_redacts_values() {
+        let mut zero_sequence = inspect();
+        if let BlockControlMessage::Inspect { sequence, .. } = &mut zero_sequence {
+            *sequence = 0;
+        }
+        assert_eq!(encode(&zero_sequence), Err(BlockControlError::Invalid));
+
+        let wrong_target = BlockDeviceGrant::new(99, 512, 8).expect("tuple should validate");
+        let wrong_observation = BlockControlMessage::Inspected {
+            session: session(),
+            sequence: 1,
+            target: target(),
+            observed: wrong_target,
+        };
+        assert_eq!(encode(&wrong_observation), Err(BlockControlError::Invalid));
+
+        assert!(
+            BlockControlTarget::new(
+                GrantId::parse("block-drive").expect("grant should parse"),
+                GrantAccess::ReadOnly,
+                ObjectIdentity {
+                    device: 11,
+                    inode: 12,
+                },
+                u32::try_from(libc::O_RDWR | libc::O_NONBLOCK).expect("flags should fit"),
+                BlockDeviceGrant::new(14, 512, 8).expect("block tuple should validate"),
+            )
+            .is_none()
+        );
+        assert!(
+            BlockControlTarget::new(
+                GrantId::parse("block-drive").expect("grant should parse"),
+                GrantAccess::ReadWrite,
+                ObjectIdentity {
+                    device: 11,
+                    inode: 12,
+                },
+                u32::try_from(libc::O_RDWR | libc::O_NONBLOCK | libc::O_NOFOLLOW)
+                    .expect("flags should fit"),
+                BlockDeviceGrant::new(14, 512, 8).expect("block tuple should validate"),
+            )
+            .is_none()
+        );
+
+        let message = inspect();
+        assert_eq!(format!("{message:?}"), "Inspect(<redacted>)");
+        assert_eq!(
+            format!("{:?}", message.target()),
+            "BlockControlTarget(<redacted>)"
+        );
+        assert_eq!(
+            BlockControlError::Invalid.to_string(),
+            "private block-control broker failure"
+        );
+    }
+
+    #[test]
+    fn bounded_failure_categories_round_trip() {
+        for kind in [
+            io::ErrorKind::PermissionDenied,
+            io::ErrorKind::TimedOut,
+            io::ErrorKind::InvalidData,
+            io::ErrorKind::NotFound,
+            io::ErrorKind::Other,
+        ] {
+            let message = BlockControlMessage::Failed {
+                session: session(),
+                sequence: 9,
+                target: target(),
+                operation: BlockControlOperation::SynchronizeCache,
+                kind,
+            };
+            assert_eq!(
+                decode(&encode(&message).expect("encode should work")),
+                Ok(message)
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_geometry_status_operation_and_grant_bytes() {
+        let encoded = encode(&BlockControlMessage::Inspected {
+            session: session(),
+            sequence: u64::MAX,
+            target: target(),
+            observed: BlockDeviceGrant::new(14, 512, 8).expect("observed tuple should validate"),
+        })
+        .expect("maximum nonzero sequence should encode");
+        assert_eq!(
+            decode(&encoded)
+                .expect("maximum sequence should decode")
+                .sequence(),
+            u64::MAX
+        );
+
+        for mutate in [
+            |frame: &mut [u8; FRAME_BYTES]| frame[6] = STATUS_OTHER,
+            |frame: &mut [u8; FRAME_BYTES]| frame[OPERATION_OFFSET] = OPERATION_INSPECT,
+            |frame: &mut [u8; FRAME_BYTES]| frame[OBSERVED_CAPACITY_OFFSET + 7] ^= 1,
+            |frame: &mut [u8; FRAME_BYTES]| frame[GRANT_OFFSET] = b'/',
+        ] {
+            let mut malformed = encoded;
+            mutate(&mut malformed);
+            assert_eq!(decode(&malformed), Err(BlockControlError::Invalid));
+        }
+
+        let failed = encode(&BlockControlMessage::Failed {
+            session: session(),
+            sequence: 4,
+            target: target(),
+            operation: BlockControlOperation::SynchronizeCache,
+            kind: io::ErrorKind::Other,
+        })
+        .expect("failed response should encode");
+        let mut missing_operation = failed;
+        missing_operation[OPERATION_OFFSET] = OPERATION_NONE;
+        assert_eq!(decode(&missing_operation), Err(BlockControlError::Invalid));
+    }
+}

--- a/crates/session/src/macos/grant_registry.rs
+++ b/crates/session/src/macos/grant_registry.rs
@@ -10,9 +10,11 @@ use std::path::Path;
 
 use crate::macos::bookmark::{BookmarkError, ScopedBookmark};
 use crate::macos::grant_transport::ReceivedGrant;
+use crate::macos::normalized_block_status_flags;
 use crate::{
-    BatchId, GrantAccess, GrantId, GrantObjectKind, GrantRecord, MAX_BATCH_BOOKMARK_BYTES,
-    MAX_BOOKMARK_BYTES, MAX_GRANT_RECORDS, MAX_GRANTS, ObjectIdentity, ResourceRole, SessionId,
+    BatchId, BlockDeviceGrant, GrantAccess, GrantId, GrantObjectKind, GrantRecord,
+    MAX_BATCH_BOOKMARK_BYTES, MAX_BOOKMARK_BYTES, MAX_GRANT_RECORDS, MAX_GRANTS, ObjectIdentity,
+    ResourceRole, SessionId,
 };
 
 /// Redacted staging or adoption failure.
@@ -85,6 +87,15 @@ impl GrantRegistry {
         take_file(&mut self.files, id, role, access)
     }
 
+    /// Adopts one exact regular or block-special drive backing once.
+    pub fn take_drive_backing(
+        &mut self,
+        id: &GrantId,
+        access: GrantAccess,
+    ) -> Result<GrantedFile, GrantRegistryError> {
+        take_drive_backing(&mut self.files, id, access)
+    }
+
     /// Atomically adopts an ordered set of exact existing-file descriptors.
     ///
     /// Every request is validated, including duplicate IDs, before any entry is
@@ -107,7 +118,7 @@ impl GrantRegistry {
         duplicate_files(&self.files, requests)
     }
 
-    /// Moves all regular-file grants into a sendable one-time registry.
+    /// Moves all existing-file grants into a sendable one-time registry.
     pub fn take_file_registry(&mut self) -> FileGrantRegistry {
         FileGrantRegistry {
             entries: std::mem::take(&mut self.files),
@@ -177,6 +188,15 @@ impl FileGrantRegistry {
         take_file(&mut self.entries, id, role, access)
     }
 
+    /// Adopts one exact regular or block-special drive backing once.
+    pub fn take_drive_backing(
+        &mut self,
+        id: &GrantId,
+        access: GrantAccess,
+    ) -> Result<GrantedFile, GrantRegistryError> {
+        take_drive_backing(&mut self.entries, id, access)
+    }
+
     /// Atomically adopts an ordered set of exact existing-file descriptors.
     pub fn take_files(
         &mut self,
@@ -193,6 +213,19 @@ impl FileGrantRegistry {
         duplicate_files(&self.entries, requests)
     }
 
+    /// Duplicates one exact drive backing without adopting the original.
+    pub fn duplicate_drive_backing(
+        &self,
+        id: &GrantId,
+        access: GrantAccess,
+    ) -> Result<GrantedFile, GrantRegistryError> {
+        let file = self.entries.get(id).ok_or(GrantRegistryError)?;
+        if !matches_drive_backing(file, access) {
+            return Err(GrantRegistryError);
+        }
+        duplicate_file(file)
+    }
+
     /// Returns one reserved file grant to the same registry after an aborted
     /// consumer transaction.
     pub fn restore_file(
@@ -200,7 +233,24 @@ impl FileGrantRegistry {
         id: GrantId,
         file: GrantedFile,
     ) -> Result<(), GrantRegistryError> {
-        if self.entries.contains_key(&id) {
+        if self.entries.contains_key(&id) || file.role == ResourceRole::DriveBacking {
+            return Err(GrantRegistryError);
+        }
+        let previous = self.entries.insert(id, file);
+        debug_assert!(previous.is_none());
+        Ok(())
+    }
+
+    /// Returns one reserved drive backing after an aborted transaction.
+    pub fn restore_drive_backing(
+        &mut self,
+        id: GrantId,
+        file: GrantedFile,
+    ) -> Result<(), GrantRegistryError> {
+        if self.entries.contains_key(&id)
+            || file.role != ResourceRole::DriveBacking
+            || !matches!(file.access, GrantAccess::ReadOnly | GrantAccess::ReadWrite)
+        {
             return Err(GrantRegistryError);
         }
         let previous = self.entries.insert(id, file);
@@ -332,9 +382,23 @@ fn take_file(
 ) -> Result<GrantedFile, GrantRegistryError> {
     let matches = matches!(
         entries.get(id),
-        Some(file) if file.role == role && file.access == access
+        Some(file) if matches_generic_file(file, role, access)
     );
     if !matches {
+        return Err(GrantRegistryError);
+    }
+    entries.remove(id).ok_or(GrantRegistryError)
+}
+
+fn take_drive_backing(
+    entries: &mut HashMap<GrantId, GrantedFile>,
+    id: &GrantId,
+    access: GrantAccess,
+) -> Result<GrantedFile, GrantRegistryError> {
+    if !entries
+        .get(id)
+        .is_some_and(|file| matches_drive_backing(file, access))
+    {
         return Err(GrantRegistryError);
     }
     entries.remove(id).ok_or(GrantRegistryError)
@@ -349,7 +413,7 @@ fn take_files(
         if !ids.insert(id)
             || !matches!(
                 entries.get(id),
-                Some(file) if file.role == *role && file.access == *access
+                Some(file) if matches_generic_file(file, *role, *access)
             )
         {
             return Err(GrantRegistryError);
@@ -385,7 +449,7 @@ fn duplicate_files(
         if !ids.insert(id)
             || !matches!(
                 entries.get(id),
-                Some(file) if file.role == *role && file.access == *access
+                Some(file) if matches_generic_file(file, *role, *access)
             )
         {
             return Err(GrantRegistryError);
@@ -398,30 +462,57 @@ fn duplicate_files(
         .map_err(|_| GrantRegistryError)?;
     for (id, _, _) in requests {
         let file = entries.get(id).ok_or(GrantRegistryError)?;
-        // SAFETY: the source descriptor remains live for fcntl; success returns
-        // an independently owned close-on-exec descriptor.
-        let descriptor =
-            unsafe { libc::fcntl(file.descriptor.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
-        if descriptor < 0 {
-            return Err(GrantRegistryError);
-        }
-        // SAFETY: descriptor is the fresh duplicate returned above.
-        let descriptor = unsafe { OwnedFd::from_raw_fd(descriptor) };
-        files.push(GrantedFile {
-            role: file.role,
-            access: file.access,
-            identity: file.identity,
-            descriptor,
-        });
+        files.push(duplicate_file(file)?);
     }
     Ok(files)
+}
+
+fn matches_generic_file(file: &GrantedFile, role: ResourceRole, access: GrantAccess) -> bool {
+    role != ResourceRole::DriveBacking
+        && file.role == role
+        && file.access == access
+        && file.kind == GrantObjectKind::RegularFile
+        && file.block_device.is_none()
+}
+
+fn matches_drive_backing(file: &GrantedFile, access: GrantAccess) -> bool {
+    file.role == ResourceRole::DriveBacking
+        && file.access == access
+        && matches!(access, GrantAccess::ReadOnly | GrantAccess::ReadWrite)
+        && matches!(
+            (file.kind, file.block_device),
+            (GrantObjectKind::RegularFile, None) | (GrantObjectKind::BlockDevice, Some(_))
+        )
+}
+
+fn duplicate_file(file: &GrantedFile) -> Result<GrantedFile, GrantRegistryError> {
+    // SAFETY: the source descriptor remains live for fcntl; success returns
+    // an independently owned close-on-exec descriptor.
+    let descriptor = unsafe { libc::fcntl(file.descriptor.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
+    if descriptor < 0 {
+        return Err(GrantRegistryError);
+    }
+    // SAFETY: descriptor is the fresh duplicate returned above.
+    let descriptor = unsafe { OwnedFd::from_raw_fd(descriptor) };
+    Ok(GrantedFile {
+        role: file.role,
+        access: file.access,
+        kind: file.kind,
+        identity: file.identity,
+        status_flags: file.status_flags,
+        block_device: file.block_device,
+        descriptor,
+    })
 }
 
 /// Adopted existing-file capability.
 pub struct GrantedFile {
     role: ResourceRole,
     access: GrantAccess,
+    kind: GrantObjectKind,
     identity: ObjectIdentity,
+    status_flags: u32,
+    block_device: Option<BlockDeviceGrant>,
     descriptor: OwnedFd,
 }
 
@@ -431,7 +522,13 @@ impl fmt::Debug for GrantedFile {
             .debug_struct("GrantedFile")
             .field("role", &self.role)
             .field("access", &self.access)
+            .field("kind", &self.kind)
             .field("identity", &"<redacted>")
+            .field("status_flags", &"<redacted>")
+            .field(
+                "block_device",
+                &self.block_device.as_ref().map(|_| "<redacted>"),
+            )
             .field("descriptor", &"<owned>")
             .finish()
     }
@@ -444,10 +541,28 @@ impl GrantedFile {
         self.access
     }
 
+    /// Returns the authenticated descriptor kind.
+    #[must_use]
+    pub const fn kind(&self) -> GrantObjectKind {
+        self.kind
+    }
+
     /// Returns the verified stable identity without exposing a path.
     #[must_use]
     pub const fn identity(&self) -> ObjectIdentity {
         self.identity
+    }
+
+    /// Returns the authenticated stable status flags.
+    #[must_use]
+    pub const fn status_flags(&self) -> u32 {
+        self.status_flags
+    }
+
+    /// Returns authenticated block metadata, if this is a block-special drive.
+    #[must_use]
+    pub const fn block_device(&self) -> Option<BlockDeviceGrant> {
+        self.block_device
     }
 
     /// Returns the live descriptor without transferring ownership.
@@ -618,21 +733,28 @@ impl StagedGrantBatch {
                 kind,
                 identity,
                 status_flags,
+                block_device,
             } => {
                 self.require_open_batch()?;
-                if kind != GrantObjectKind::RegularFile
-                    || role.is_scoped_directory()
+                if role.is_scoped_directory()
                     || !role.permits(access)
+                    || !matches!(
+                        (kind, block_device),
+                        (GrantObjectKind::RegularFile, None)
+                            | (GrantObjectKind::BlockDevice, Some(_))
+                    )
+                    || (kind == GrantObjectKind::BlockDevice && role != ResourceRole::DriveBacking)
                 {
                     return Err(GrantRegistryError);
                 }
                 let descriptor = descriptor.ok_or(GrantRegistryError)?;
                 validate_descriptor(
                     descriptor.as_raw_fd(),
-                    GrantObjectKind::RegularFile,
+                    kind,
                     access,
                     identity,
                     Some(status_flags),
+                    block_device,
                 )?;
                 self.insert_identity_role(&id, role, identity)?;
                 self.entries.insert(
@@ -640,7 +762,10 @@ impl StagedGrantBatch {
                     StagedResource::File {
                         role,
                         access,
+                        kind,
                         identity,
+                        status_flags,
+                        block_device,
                         descriptor,
                     },
                 );
@@ -670,6 +795,7 @@ impl StagedGrantBatch {
                     GrantObjectKind::Directory,
                     access,
                     identity,
+                    None,
                     None,
                 )?;
                 self.insert_identity_role(&id, role, identity)?;
@@ -808,7 +934,10 @@ impl StagedGrantBatch {
                 StagedResource::File {
                     role,
                     access,
+                    kind,
                     identity,
+                    status_flags,
+                    block_device,
                     descriptor,
                 } => {
                     files.insert(
@@ -816,7 +945,10 @@ impl StagedGrantBatch {
                         GrantedFile {
                             role,
                             access,
+                            kind,
                             identity,
+                            status_flags,
+                            block_device,
                             descriptor,
                         },
                     );
@@ -867,7 +999,10 @@ enum StagedResource {
     File {
         role: ResourceRole,
         access: GrantAccess,
+        kind: GrantObjectKind,
         identity: ObjectIdentity,
+        status_flags: u32,
+        block_device: Option<BlockDeviceGrant>,
         descriptor: OwnedFd,
     },
     Directory {
@@ -888,6 +1023,7 @@ fn validate_descriptor(
     access: GrantAccess,
     identity: ObjectIdentity,
     expected_status_flags: Option<u32>,
+    expected_block_device: Option<BlockDeviceGrant>,
 ) -> Result<(), GrantRegistryError> {
     // SAFETY: F_GETFD and F_GETFL inspect the live received descriptor.
     let descriptor_flags = unsafe { libc::fcntl(descriptor, libc::F_GETFD) };
@@ -897,8 +1033,15 @@ fn validate_descriptor(
         || status_flags < 0
         || descriptor_flags & libc::FD_CLOEXEC == 0
         || !access_matches(status_flags, access)
-        || expected_status_flags
-            .is_some_and(|expected| u32::try_from(status_flags).ok() != Some(expected))
+        || (kind == GrantObjectKind::BlockDevice && status_flags & libc::O_APPEND != 0)
+        || expected_status_flags.is_some_and(|expected| {
+            let actual = if kind == GrantObjectKind::BlockDevice {
+                normalized_block_status_flags(status_flags)
+            } else {
+                u32::try_from(status_flags).ok()
+            };
+            actual != Some(expected)
+        })
     {
         return Err(GrantRegistryError);
     }
@@ -906,13 +1049,22 @@ fn validate_descriptor(
     let actual_kind = match stat.st_mode & libc::S_IFMT {
         libc::S_IFREG => GrantObjectKind::RegularFile,
         libc::S_IFDIR => GrantObjectKind::Directory,
+        libc::S_IFBLK => GrantObjectKind::BlockDevice,
         _ => return Err(GrantRegistryError),
     };
     let actual_identity = ObjectIdentity {
         device: normalized_device(stat.st_dev),
         inode: stat.st_ino,
     };
-    if actual_kind != kind || actual_identity != identity {
+    let target_device = normalized_device(stat.st_rdev);
+    if actual_kind != kind
+        || actual_identity != identity
+        || match (kind, expected_block_device) {
+            (GrantObjectKind::BlockDevice, Some(block)) => target_device != block.target_device(),
+            (GrantObjectKind::RegularFile | GrantObjectKind::Directory, None) => target_device != 0,
+            _ => true,
+        }
+    {
         return Err(GrantRegistryError);
     }
     Ok(())
@@ -1206,6 +1358,7 @@ mod tests {
                         inode: stat.st_ino,
                     },
                     status_flags: u32::try_from(flags).expect("flags should fit"),
+                    block_device: None,
                 },
                 Some(descriptor),
             ))
@@ -1238,6 +1391,76 @@ mod tests {
     }
 
     #[test]
+    fn dedicated_drive_operations_preserve_complete_block_metadata() {
+        let source = File::open("/dev/null").expect("descriptor fixture should open");
+        let descriptor = duplicate(&source);
+        let stat = descriptor_stat(descriptor.as_raw_fd()).expect("fixture stat should read");
+        // SAFETY: F_GETFL only observes the live fixture descriptor.
+        let flags = unsafe { libc::fcntl(descriptor.as_raw_fd(), libc::F_GETFL) };
+        let status_flags = normalized_block_status_flags(flags)
+            .expect("normalized status flags should fit the wire");
+        let identity = ObjectIdentity {
+            device: normalized_device(stat.st_dev),
+            inode: stat.st_ino,
+        };
+        let block_device =
+            BlockDeviceGrant::new(77, 4096, 16).expect("block metadata should validate");
+        let id = GrantId::parse("block-drive").expect("grant ID should parse");
+        let mut registry = FileGrantRegistry {
+            entries: HashMap::from([(
+                id.clone(),
+                GrantedFile {
+                    role: ResourceRole::DriveBacking,
+                    access: GrantAccess::ReadOnly,
+                    kind: GrantObjectKind::BlockDevice,
+                    identity,
+                    status_flags,
+                    block_device: Some(block_device),
+                    descriptor,
+                },
+            )]),
+        };
+
+        assert!(
+            registry
+                .take_file(&id, ResourceRole::DriveBacking, GrantAccess::ReadOnly)
+                .is_err(),
+            "generic adoption must not erase drive authority"
+        );
+        let duplicated = registry
+            .duplicate_drive_backing(&id, GrantAccess::ReadOnly)
+            .expect("dedicated duplication should succeed");
+        assert_ne!(
+            duplicated.as_raw_fd(),
+            registry
+                .entries
+                .get(&id)
+                .expect("original block grant should remain")
+                .as_raw_fd()
+        );
+        assert_eq!(duplicated.kind(), GrantObjectKind::BlockDevice);
+        assert_eq!(duplicated.identity(), identity);
+        assert_eq!(duplicated.status_flags(), status_flags);
+        assert_eq!(duplicated.block_device(), Some(block_device));
+        drop(duplicated);
+
+        let reserved = registry
+            .take_drive_backing(&id, GrantAccess::ReadOnly)
+            .expect("dedicated take should reserve the block grant");
+        assert!(registry.is_empty());
+        registry
+            .restore_drive_backing(id.clone(), reserved)
+            .expect("dedicated restore should preserve the block grant");
+        let restored = registry
+            .take_drive_backing(&id, GrantAccess::ReadOnly)
+            .expect("restored block grant should remain adoptable");
+        assert_eq!(restored.kind(), GrantObjectKind::BlockDevice);
+        assert_eq!(restored.identity(), identity);
+        assert_eq!(restored.status_flags(), status_flags);
+        assert_eq!(restored.block_device(), Some(block_device));
+    }
+
+    #[test]
     fn file_registry_batch_adoption_is_failure_atomic() {
         let kernel_id = GrantId::parse("kernel").expect("kernel ID should parse");
         let initrd_id = GrantId::parse("initrd").expect("initrd ID should parse");
@@ -1258,10 +1481,13 @@ mod tests {
                     GrantedFile {
                         role: ResourceRole::KernelImage,
                         access: GrantAccess::ReadOnly,
+                        kind: GrantObjectKind::RegularFile,
                         identity: ObjectIdentity {
                             device: normalized_device(kernel_stat.st_dev),
                             inode: kernel_stat.st_ino,
                         },
+                        status_flags: 0,
+                        block_device: None,
                         descriptor: kernel_descriptor,
                     },
                 ),
@@ -1270,10 +1496,13 @@ mod tests {
                     GrantedFile {
                         role: ResourceRole::InitrdImage,
                         access: GrantAccess::ReadOnly,
+                        kind: GrantObjectKind::RegularFile,
                         identity: ObjectIdentity {
                             device: normalized_device(initrd_stat.st_dev),
                             inode: initrd_stat.st_ino,
                         },
+                        status_flags: 0,
+                        block_device: None,
                         descriptor: initrd_descriptor,
                     },
                 ),
@@ -1546,6 +1775,7 @@ mod tests {
                     kind: GrantObjectKind::RegularFile,
                     identity,
                     status_flags: u32::try_from(flags).expect("flags should fit"),
+                    block_device: None,
                 },
                 Some(descriptor),
             ))
@@ -1689,6 +1919,7 @@ mod tests {
                             inode: u64::MAX,
                         },
                         status_flags: u32::try_from(flags).expect("flags should fit"),
+                        block_device: None,
                     },
                     Some(descriptor),
                 ))
@@ -1739,6 +1970,7 @@ mod tests {
                     kind: GrantObjectKind::RegularFile,
                     identity,
                     status_flags: u32::try_from(flags).expect("flags should fit"),
+                    block_device: None,
                 },
                 Some(first),
             ))
@@ -1756,6 +1988,7 @@ mod tests {
                         kind: GrantObjectKind::RegularFile,
                         identity,
                         status_flags: u32::try_from(flags).expect("flags should fit"),
+                        block_device: None,
                     },
                     Some(second),
                 ))

--- a/crates/session/src/macos/grant_transport.rs
+++ b/crates/session/src/macos/grant_transport.rs
@@ -333,6 +333,7 @@ mod tests {
                 inode: 2,
             },
             status_flags: 0,
+            block_device: None,
         };
         GrantFrame {
             session: SessionId::from_bytes([1; 32]),


### PR DESCRIPTION
## Summary

- atomically revise startup grants to `BBG2`, authenticating canonical regular-file records and exact macOS block-special drive kind, identity, status, geometry, capacity, and descriptor metadata
- add a dedicated failure-atomic `DriveBacking` claim plus a session-bound fd 7 protocol that delegates only fresh geometry inspection and cache synchronization to the launcher's exact retained descriptor
- serialize and bound worker control exchanges with exact response correlation, reusable endpoint failures, permanent poison on ambiguity, and independent cancellation/teardown wakeup across startup, replacement, hotplug, PATCH, and capture paths
- prove the signed App Sandbox worker can first perform positional I/O on the authenticated block fd, then use brokered inspection/synchronization, with persistence after read-only reattachment and unchanged production entitlements

## Scope

- Closes #1465.
- The exhaustive direct/contained Sync/Async × MMIO/PCI lifecycle matrix, final documentation, and inventory promotion remain in #1466.
- Native-v1 block serialization and restore remain Wave 6 work; contained native-v1 restore continues to accept only a regular-file root through the dedicated drive claim.

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test production_bundle -- signed_contained_block_device_uses_launcher_control_broker --exact`
- `scripts/run-integration-tests.sh`
