### PR TITLE
feat: add bounded MMDS TCP core

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -18,6 +18,8 @@ pub mod metrics;
 pub mod mmds;
 #[doc(hidden)]
 pub mod mmds_network;
+#[doc(hidden)]
+pub mod mmds_tcp;
 mod mmds_token;
 pub mod mmio;
 pub mod network;

--- a/crates/runtime/src/mmds_tcp/LICENSE-APACHE-2.0
+++ b/crates/runtime/src/mmds_tcp/LICENSE-APACHE-2.0
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crates/runtime/src/mmds_tcp/NOTICE.md
+++ b/crates/runtime/src/mmds_tcp/NOTICE.md
@@ -1,0 +1,21 @@
+# Firecracker-derived MMDS TCP core
+
+The Rust sources in this directory are a focused semantic adaptation of the
+Firecracker v1.16.0 MMDS/Dumbo TCP implementation at commit
+`d83d72b710361a10294480131377b1b00b163af8`, specifically:
+
+- `src/vmm/src/dumbo/pdu/tcp.rs`
+- `src/vmm/src/dumbo/tcp/mod.rs`
+- `src/vmm/src/dumbo/tcp/connection.rs`
+- `src/vmm/src/dumbo/tcp/endpoint.rs`
+- `src/vmm/src/dumbo/tcp/handler.rs`
+- the 30-connection and 100-reset defaults in `src/vmm/src/mmds/ns.rs`
+
+Firecracker
+Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+
+The adaptation is distributed under the Apache License, Version 2.0, included
+as `LICENSE-APACHE-2.0` in this directory. It deliberately excludes
+Firecracker's Linux event loop, TAP/device model, guest-memory types,
+`micro_http`, global metrics, and platform time/randomness.

--- a/crates/runtime/src/mmds_tcp/connection.rs
+++ b/crates/runtime/src/mmds_tcp/connection.rs
@@ -1,0 +1,893 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Passive-open connection state adapted from Firecracker v1.16.0
+//! `dumbo/tcp/connection.rs`.
+
+use std::fmt;
+use std::num::{NonZeroU16, NonZeroU64};
+use std::ops::{BitOr, BitOrAssign};
+
+use super::{
+    DEFAULT_MSS, MAX_WINDOW_SIZE, NextSegmentStatus, OutgoingSegment, ResetConfig, TcpFlags,
+    TcpSegment, TimestampRegression, sequence_after, sequence_at_or_after,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ConnectionStatus(u8);
+
+impl ConnectionStatus {
+    const SYN_RECEIVED: Self = Self(1);
+    const SYN_ACK_SENT: Self = Self(1 << 1);
+    const ESTABLISHED: Self = Self(1 << 2);
+    const FIN_SENT: Self = Self(1 << 3);
+    const FIN_ACKED: Self = Self(1 << 4);
+    const RESET: Self = Self(1 << 5);
+
+    const fn intersects(self, flags: Self) -> bool {
+        self.0 & flags.0 != 0
+    }
+
+    fn insert(&mut self, flags: Self) {
+        self.0 |= flags.0;
+    }
+
+    fn remove(&mut self, flags: Self) {
+        self.0 &= !flags.0;
+    }
+}
+
+/// Unusual but non-fatal conditions observed while receiving a segment.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ReceiveStatus(u16);
+
+impl ReceiveStatus {
+    /// The acknowledgement number was outside the valid sent interval.
+    pub const INVALID_ACK: Self = Self(1);
+    /// The peer repeated the highest acknowledgement while data remains outstanding.
+    pub const DUPLICATE_ACK: Self = Self(1 << 1);
+    /// Payload extended beyond the advertised local receive window.
+    pub const SEGMENT_BEYOND_RECEIVE_WINDOW: Self = Self(1 << 2);
+    /// Payload did not start at the next expected sequence number.
+    pub const UNEXPECTED_SEQUENCE: Self = Self(1 << 3);
+    /// The peer moved its advertised receive-window edge backwards.
+    pub const REMOTE_RECEIVE_WINDOW_EDGE: Self = Self(1 << 4);
+    /// The peer sent data after its accepted FIN.
+    pub const DATA_BEYOND_FIN: Self = Self(1 << 5);
+    /// A valid reset was received.
+    pub const RESET_RECEIVED: Self = Self(1 << 6);
+    /// A reset was outside the local receive window.
+    pub const INVALID_RESET: Self = Self(1 << 7);
+    /// The segment was invalid for the connection state.
+    pub const INVALID_SEGMENT: Self = Self(1 << 8);
+    /// The connection has queued a reset and will stop after sending it.
+    pub const CONNECTION_RESETTING: Self = Self(1 << 9);
+    /// A FIN did not occupy the next expected sequence number.
+    pub const INVALID_FIN: Self = Self(1 << 10);
+
+    /// Empty receive status.
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+
+    /// Whether no unusual condition was observed.
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Whether any supplied status is present.
+    pub const fn intersects(self, flags: Self) -> bool {
+        self.0 & flags.0 != 0
+    }
+}
+
+impl BitOr for ReceiveStatus {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl BitOrAssign for ReceiveStatus {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+/// Caller-owned bytes and the sequence number of their first byte.
+#[derive(Debug, Clone, Copy)]
+pub struct PayloadSource<'a> {
+    bytes: &'a [u8],
+    initial_sequence_number: u32,
+}
+
+impl<'a> PayloadSource<'a> {
+    /// Creates a payload source anchored at `initial_sequence_number`.
+    pub const fn new(bytes: &'a [u8], initial_sequence_number: u32) -> Self {
+        Self {
+            bytes,
+            initial_sequence_number,
+        }
+    }
+
+    /// Complete bytes available for original sends and retransmissions.
+    pub const fn bytes(self) -> &'a [u8] {
+        self.bytes
+    }
+
+    /// Sequence number associated with the first byte.
+    pub const fn initial_sequence_number(self) -> u32 {
+        self.initial_sequence_number
+    }
+}
+
+/// Minimal passive-open TCP connection.
+#[derive(Debug, Clone)]
+pub struct Connection {
+    acknowledgement_to_send: u32,
+    highest_acknowledgement_received: u32,
+    first_not_sent: u32,
+    local_receive_window_edge: u32,
+    remote_receive_window_edge: u32,
+    retransmission_started_at: u64,
+    retransmission_period: u64,
+    retransmission_count: u16,
+    retransmission_limit: u16,
+    fin_received: Option<u32>,
+    send_fin: Option<u32>,
+    send_reset: Option<ResetConfig>,
+    maximum_segment_size: u16,
+    pending_acknowledgement: bool,
+    duplicate_acknowledgement: bool,
+    status: ConnectionStatus,
+    last_timestamp: u64,
+}
+
+impl Connection {
+    /// Creates a connection in response to a pure SYN segment.
+    pub fn passive_open(
+        segment: &TcpSegment<'_>,
+        local_receive_window_size: u32,
+        retransmission_period: NonZeroU64,
+        retransmission_limit: NonZeroU16,
+        initial_sequence_number: u32,
+        now: u64,
+    ) -> Result<Self, PassiveOpenError> {
+        if segment.flags() != TcpFlags::SYNCHRONIZE || !segment.payload().is_empty() {
+            return Err(PassiveOpenError::InvalidSyn);
+        }
+        if local_receive_window_size > MAX_WINDOW_SIZE {
+            return Err(PassiveOpenError::ReceiveWindowTooLarge {
+                size: local_receive_window_size,
+                limit: MAX_WINDOW_SIZE,
+            });
+        }
+
+        let acknowledgement_to_send = segment.sequence_number().wrapping_add(1);
+        let first_not_sent = initial_sequence_number.wrapping_add(1);
+        Ok(Self {
+            acknowledgement_to_send,
+            highest_acknowledgement_received: initial_sequence_number,
+            first_not_sent,
+            local_receive_window_edge: acknowledgement_to_send
+                .wrapping_add(local_receive_window_size),
+            remote_receive_window_edge: first_not_sent
+                .wrapping_add(u32::from(segment.window_size())),
+            retransmission_started_at: now,
+            retransmission_period: retransmission_period.get(),
+            retransmission_count: 0,
+            retransmission_limit: retransmission_limit.get(),
+            fin_received: None,
+            send_fin: None,
+            send_reset: None,
+            maximum_segment_size: segment.maximum_segment_size().unwrap_or(DEFAULT_MSS),
+            pending_acknowledgement: false,
+            duplicate_acknowledgement: false,
+            status: ConnectionStatus::SYN_RECEIVED,
+            last_timestamp: now,
+        })
+    }
+
+    /// Closes the local sending half after all currently known payload bytes.
+    pub fn close(&mut self) {
+        if self.send_fin.is_none() {
+            self.send_fin = Some(self.first_not_sent);
+        }
+    }
+
+    /// Queues a reset unless one is already pending.
+    pub fn reset(&mut self) {
+        if self.send_reset.is_none() {
+            self.send_reset = Some(self.make_reset_config());
+        }
+    }
+
+    /// Reset shape appropriate for the current state.
+    pub fn make_reset_config(&self) -> ResetConfig {
+        if self.is_established() {
+            ResetConfig::Sequence(self.first_not_sent)
+        } else {
+            ResetConfig::Acknowledgement(self.acknowledgement_to_send)
+        }
+    }
+
+    /// Whether the handshake is complete.
+    pub const fn is_established(&self) -> bool {
+        self.status.intersects(ConnectionStatus::ESTABLISHED)
+    }
+
+    /// Whether the peer sent an accepted FIN.
+    pub const fn fin_received(&self) -> bool {
+        self.fin_received.is_some()
+    }
+
+    /// Whether this connection can be removed.
+    pub const fn is_done(&self) -> bool {
+        self.status.intersects(ConnectionStatus::RESET)
+            || (self.fin_received.is_some() && self.status.intersects(ConnectionStatus::FIN_SENT))
+    }
+
+    /// First sequence number that has never been sent.
+    pub const fn first_not_sent(&self) -> u32 {
+        self.first_not_sent
+    }
+
+    /// Highest cumulative acknowledgement received.
+    pub const fn highest_acknowledgement_received(&self) -> u32 {
+        self.highest_acknowledgement_received
+    }
+
+    /// Right edge advertised by the peer.
+    pub const fn remote_receive_window_edge(&self) -> u32 {
+        self.remote_receive_window_edge
+    }
+
+    /// Negotiated maximum segment size.
+    pub const fn maximum_segment_size(&self) -> u16 {
+        self.maximum_segment_size
+    }
+
+    /// Whether a duplicate-ACK retransmission is pending.
+    pub const fn duplicate_acknowledgement_pending(&self) -> bool {
+        self.duplicate_acknowledgement
+    }
+
+    /// Advances the local receive-window edge without exceeding the pinned window.
+    pub fn advance_local_receive_window(&mut self, value: u32) {
+        let current = self
+            .local_receive_window_edge
+            .wrapping_sub(self.acknowledgement_to_send);
+        if current == 0 {
+            self.pending_acknowledgement = true;
+        }
+        let advance = value.min(MAX_WINDOW_SIZE.saturating_sub(current));
+        self.local_receive_window_edge = self.local_receive_window_edge.wrapping_add(advance);
+    }
+
+    /// Pending control output or retransmission deadline.
+    pub fn control_segment_or_timeout_status(&self) -> NextSegmentStatus {
+        if self.syn_ack_pending()
+            || self.send_reset.is_some()
+            || self.can_send_first_fin()
+            || self.pending_acknowledgement
+        {
+            NextSegmentStatus::Available
+        } else if self.highest_acknowledgement_received != self.first_not_sent {
+            NextSegmentStatus::Timeout(
+                self.retransmission_started_at
+                    .saturating_add(self.retransmission_period),
+            )
+        } else {
+            NextSegmentStatus::Nothing
+        }
+    }
+
+    /// Receives one validated segment into a caller-owned payload buffer.
+    pub fn receive_segment(
+        &mut self,
+        segment: &TcpSegment<'_>,
+        receive_buffer: &mut [u8],
+        now: u64,
+    ) -> Result<(usize, ReceiveStatus), ConnectionReceiveError> {
+        self.validate_timestamp(now)?;
+        if self.send_reset.is_some() || self.status.intersects(ConnectionStatus::RESET) {
+            return Err(ConnectionReceiveError::ConnectionReset);
+        }
+
+        let flags = segment.flags();
+        if flags.intersects(TcpFlags::RESET) {
+            let sequence_number = segment.sequence_number();
+            let status = if sequence_at_or_after(sequence_number, self.acknowledgement_to_send)
+                && sequence_after(self.local_receive_window_edge, sequence_number)
+            {
+                self.status.insert(ConnectionStatus::RESET);
+                ReceiveStatus::RESET_RECEIVED
+            } else {
+                ReceiveStatus::INVALID_RESET
+            };
+            self.last_timestamp = now;
+            return Ok((0, status));
+        }
+        if segment.payload().len() > receive_buffer.len() {
+            return Err(ConnectionReceiveError::BufferTooSmall {
+                payload_len: segment.payload().len(),
+                buffer_len: receive_buffer.len(),
+            });
+        }
+
+        if !self.syn_ack_sent() {
+            if self.is_same_syn(segment) {
+                self.last_timestamp = now;
+                return Ok((0, ReceiveStatus::empty()));
+            }
+            return self.reset_for_segment_result(segment, ReceiveStatus::INVALID_SEGMENT, now);
+        }
+        if !self.is_established() {
+            if self.is_same_syn(segment) {
+                self.status.remove(ConnectionStatus::SYN_ACK_SENT);
+                self.last_timestamp = now;
+                return Ok((0, ReceiveStatus::empty()));
+            }
+            if flags.intersects(TcpFlags::SYNCHRONIZE) {
+                return self.reset_for_segment_result(segment, ReceiveStatus::INVALID_SEGMENT, now);
+            }
+        } else if flags.intersects(TcpFlags::SYNCHRONIZE) {
+            return self.reset_for_segment_result(segment, ReceiveStatus::INVALID_SEGMENT, now);
+        }
+
+        let mut receive_status = ReceiveStatus::empty();
+        if flags.intersects(TcpFlags::ACK) {
+            let acknowledgement = segment.acknowledgement_number();
+            if sequence_at_or_after(acknowledgement, self.highest_acknowledgement_received)
+                && sequence_at_or_after(self.first_not_sent, acknowledgement)
+            {
+                self.retransmission_count = 0;
+                if acknowledgement == self.highest_acknowledgement_received
+                    && acknowledgement != self.first_not_sent
+                {
+                    if !self.is_established() {
+                        return self.reset_for_segment_result(
+                            segment,
+                            ReceiveStatus::INVALID_ACK,
+                            now,
+                        );
+                    }
+                    self.duplicate_acknowledgement = true;
+                    receive_status |= ReceiveStatus::DUPLICATE_ACK;
+                } else {
+                    self.highest_acknowledgement_received = acknowledgement;
+                    self.retransmission_started_at = now;
+                    if !self.is_established() && self.syn_ack_sent() {
+                        self.status.insert(ConnectionStatus::ESTABLISHED);
+                    }
+                    if self.status.intersects(ConnectionStatus::FIN_SENT)
+                        && acknowledgement == self.first_not_sent
+                    {
+                        self.status.insert(ConnectionStatus::FIN_ACKED);
+                    }
+                }
+
+                if self.is_established() {
+                    let edge = acknowledgement.wrapping_add(u32::from(segment.window_size()));
+                    if sequence_after(edge, self.remote_receive_window_edge) {
+                        self.remote_receive_window_edge = edge;
+                    } else if edge != self.remote_receive_window_edge {
+                        receive_status |= ReceiveStatus::REMOTE_RECEIVE_WINDOW_EDGE;
+                    }
+                }
+            } else {
+                receive_status |= ReceiveStatus::INVALID_ACK;
+                if !self.is_established() {
+                    return self.reset_for_segment_result(segment, receive_status, now);
+                }
+            }
+        }
+
+        if !self.is_established() {
+            self.last_timestamp = now;
+            return Ok((0, receive_status));
+        }
+
+        let sequence_number = segment.sequence_number();
+        let payload_len = u32::try_from(segment.payload().len()).map_err(|_| {
+            ConnectionReceiveError::BufferTooSmall {
+                payload_len: segment.payload().len(),
+                buffer_len: receive_buffer.len(),
+            }
+        })?;
+        let data_end_sequence = sequence_number.wrapping_add(payload_len);
+        let mut enqueue_acknowledgement = false;
+
+        if payload_len > 0 {
+            if let Some(fin_sequence) = self.fin_received
+                && !sequence_at_or_after(fin_sequence, data_end_sequence)
+            {
+                self.last_timestamp = now;
+                return Ok((0, receive_status | ReceiveStatus::DATA_BEYOND_FIN));
+            }
+            if !sequence_at_or_after(self.local_receive_window_edge, data_end_sequence) {
+                self.last_timestamp = now;
+                return Ok((
+                    0,
+                    receive_status | ReceiveStatus::SEGMENT_BEYOND_RECEIVE_WINDOW,
+                ));
+            }
+            if sequence_number != self.acknowledgement_to_send {
+                self.pending_acknowledgement = true;
+                self.last_timestamp = now;
+                return Ok((0, receive_status | ReceiveStatus::UNEXPECTED_SEQUENCE));
+            }
+            self.acknowledgement_to_send = data_end_sequence;
+            enqueue_acknowledgement = true;
+        }
+
+        if flags.intersects(TcpFlags::FINISH) && self.fin_received.is_none() {
+            let fin_sequence = data_end_sequence;
+            if fin_sequence == self.acknowledgement_to_send {
+                self.fin_received = Some(fin_sequence);
+                self.acknowledgement_to_send = self.acknowledgement_to_send.wrapping_add(1);
+                enqueue_acknowledgement = true;
+            } else {
+                receive_status |= ReceiveStatus::INVALID_FIN;
+            }
+        }
+
+        if enqueue_acknowledgement {
+            self.pending_acknowledgement = true;
+        }
+        let received = segment.payload().len();
+        if received > 0 {
+            let buffer_len = receive_buffer.len();
+            let destination = receive_buffer.get_mut(..received).ok_or(
+                ConnectionReceiveError::BufferTooSmall {
+                    payload_len: received,
+                    buffer_len,
+                },
+            )?;
+            destination.copy_from_slice(segment.payload());
+        }
+        self.last_timestamp = now;
+        Ok((received, receive_status))
+    }
+
+    /// Writes metadata for the next segment and copies any payload into `output_payload`.
+    pub fn write_next_segment(
+        &mut self,
+        output_payload: &mut [u8],
+        mss_reserved: u16,
+        payload_source: Option<PayloadSource<'_>>,
+        now: u64,
+    ) -> Result<Option<OutgoingSegment>, ConnectionWriteError> {
+        self.validate_timestamp(now)?;
+        if self.status.intersects(ConnectionStatus::RESET) {
+            return Err(ConnectionWriteError::ConnectionReset);
+        }
+        let mss_remaining = self.maximum_segment_size.checked_sub(mss_reserved).ok_or(
+            ConnectionWriteError::MssRemaining {
+                maximum_segment_size: self.maximum_segment_size,
+                reserved: mss_reserved,
+            },
+        )?;
+
+        if let Some(reset) = self.send_reset {
+            let segment = self.reset_segment(reset);
+            self.status.insert(ConnectionStatus::RESET);
+            self.last_timestamp = now;
+            return Ok(Some(segment));
+        }
+
+        if self.syn_ack_pending() {
+            let segment = self.control_segment();
+            self.status.insert(ConnectionStatus::SYN_ACK_SENT);
+            self.retransmission_started_at = now;
+            self.last_timestamp = now;
+            return Ok(Some(segment));
+        }
+
+        if !self.is_established() {
+            if self.retransmission_expired(now) {
+                let next_count = self.retransmission_count.saturating_add(1);
+                if next_count >= self.retransmission_limit {
+                    self.retransmission_count = next_count;
+                    let reset = self.make_reset_config();
+                    self.send_reset = Some(reset);
+                    let segment = self.reset_segment(reset);
+                    self.status.insert(ConnectionStatus::RESET);
+                    self.last_timestamp = now;
+                    return Ok(Some(segment));
+                }
+                let segment = self.control_segment();
+                self.retransmission_count = next_count;
+                self.retransmission_started_at = now;
+                self.last_timestamp = now;
+                return Ok(Some(segment));
+            }
+            self.last_timestamp = now;
+            return Ok(None);
+        }
+
+        if let Some(source) = payload_source {
+            let source_len = u32::try_from(source.bytes.len()).map_err(|_| {
+                ConnectionWriteError::PayloadTooLarge {
+                    len: source.bytes.len(),
+                    limit: MAX_WINDOW_SIZE,
+                }
+            })?;
+            if source_len > MAX_WINDOW_SIZE {
+                return Err(ConnectionWriteError::PayloadTooLarge {
+                    len: source.bytes.len(),
+                    limit: MAX_WINDOW_SIZE,
+                });
+            }
+            let payload_end = source.initial_sequence_number.wrapping_add(source_len);
+            let timeout_retransmission = self.highest_acknowledgement_received
+                != self.first_not_sent
+                && self.retransmission_expired(now);
+            let next_timeout_count =
+                timeout_retransmission.then(|| self.retransmission_count.saturating_add(1));
+
+            if next_timeout_count.is_some_and(|count| count >= self.retransmission_limit) {
+                self.retransmission_count = next_timeout_count.unwrap_or(self.retransmission_limit);
+                let reset = self.make_reset_config();
+                self.send_reset = Some(reset);
+                let segment = self.reset_segment(reset);
+                self.status.insert(ConnectionStatus::RESET);
+                self.last_timestamp = now;
+                return Ok(Some(segment));
+            }
+
+            let sequence_to_send = if timeout_retransmission || self.duplicate_acknowledgement {
+                self.highest_acknowledgement_received
+            } else {
+                self.first_not_sent
+            };
+
+            if timeout_retransmission
+                && self.send_fin == Some(self.highest_acknowledgement_received)
+            {
+                let segment = self.control_segment();
+                self.retransmission_count = next_timeout_count.unwrap_or(0);
+                self.retransmission_started_at = now;
+                self.last_timestamp = now;
+                return Ok(Some(segment));
+            }
+
+            if !sequence_at_or_after(sequence_to_send, source.initial_sequence_number) {
+                return Err(ConnectionWriteError::PayloadMissingSequence {
+                    sequence_number: sequence_to_send,
+                });
+            }
+            let source_offset = sequence_to_send.wrapping_sub(source.initial_sequence_number);
+            if source_offset > source_len {
+                return Err(ConnectionWriteError::PayloadMissingSequence {
+                    sequence_number: sequence_to_send,
+                });
+            }
+
+            let actual_end = if sequence_at_or_after(self.remote_receive_window_edge, payload_end) {
+                payload_end
+            } else {
+                self.remote_receive_window_edge
+            };
+            if let Some(fin_sequence) = self.send_fin
+                && sequence_after(actual_end, fin_sequence)
+            {
+                return Err(ConnectionWriteError::DataAfterFin);
+            }
+
+            if sequence_after(actual_end, sequence_to_send) {
+                let available = usize::try_from(actual_end.wrapping_sub(sequence_to_send))
+                    .unwrap_or(usize::MAX);
+                let source_offset = usize::try_from(source_offset).unwrap_or(usize::MAX);
+                let source_bytes = source.bytes.get(source_offset..).ok_or(
+                    ConnectionWriteError::PayloadMissingSequence {
+                        sequence_number: sequence_to_send,
+                    },
+                )?;
+                let send_len = available
+                    .min(source_bytes.len())
+                    .min(usize::from(mss_remaining))
+                    .min(output_payload.len());
+                if send_len == 0 {
+                    return Err(ConnectionWriteError::PayloadBufferTooSmall);
+                }
+                let destination = output_payload
+                    .get_mut(..send_len)
+                    .ok_or(ConnectionWriteError::PayloadBufferTooSmall)?;
+                let source_bytes = source_bytes.get(..send_len).ok_or(
+                    ConnectionWriteError::PayloadMissingSequence {
+                        sequence_number: sequence_to_send,
+                    },
+                )?;
+                destination.copy_from_slice(source_bytes);
+
+                let mut flags = TcpFlags::ACK;
+                let mut first_sequence_after =
+                    sequence_to_send.wrapping_add(u32::try_from(send_len).unwrap_or(u32::MAX));
+                let send_fin = self.send_fin == Some(first_sequence_after);
+                if send_fin {
+                    flags |= TcpFlags::FINISH;
+                    first_sequence_after = first_sequence_after.wrapping_add(1);
+                }
+
+                self.pending_acknowledgement = false;
+                self.duplicate_acknowledgement = false;
+                if send_fin {
+                    self.status.insert(ConnectionStatus::FIN_SENT);
+                }
+                if let Some(count) = next_timeout_count {
+                    self.retransmission_count = count;
+                }
+                if timeout_retransmission
+                    || self.first_not_sent == self.highest_acknowledgement_received
+                {
+                    self.retransmission_started_at = now;
+                }
+                if sequence_after(first_sequence_after, self.first_not_sent) {
+                    self.first_not_sent = first_sequence_after;
+                }
+                let segment = OutgoingSegment::new(
+                    sequence_to_send,
+                    self.acknowledgement_to_send,
+                    flags,
+                    self.local_receive_window(),
+                    None,
+                    send_len,
+                );
+                self.last_timestamp = now;
+                return Ok(Some(segment));
+            }
+        }
+
+        let send_first_fin = self.can_send_first_fin();
+        if self.pending_acknowledgement || send_first_fin {
+            let segment = self.control_segment();
+            self.pending_acknowledgement = false;
+            if send_first_fin {
+                self.first_not_sent = self.first_not_sent.wrapping_add(1);
+                self.status.insert(ConnectionStatus::FIN_SENT);
+            }
+            self.last_timestamp = now;
+            return Ok(Some(segment));
+        }
+
+        self.last_timestamp = now;
+        Ok(None)
+    }
+
+    fn validate_timestamp(&self, now: u64) -> Result<(), TimestampRegression> {
+        if now < self.last_timestamp {
+            Err(TimestampRegression::new(self.last_timestamp, now))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn syn_ack_pending(&self) -> bool {
+        self.status.intersects(ConnectionStatus::SYN_RECEIVED) && !self.syn_ack_sent()
+    }
+
+    fn syn_ack_sent(&self) -> bool {
+        self.status.intersects(ConnectionStatus::SYN_ACK_SENT)
+    }
+
+    fn is_same_syn(&self, segment: &TcpSegment<'_>) -> bool {
+        segment.flags() == TcpFlags::SYNCHRONIZE
+            && segment.payload().is_empty()
+            && self.acknowledgement_to_send == segment.sequence_number().wrapping_add(1)
+            && self.maximum_segment_size == segment.maximum_segment_size().unwrap_or(DEFAULT_MSS)
+    }
+
+    fn reset_for_segment_result(
+        &mut self,
+        segment: &TcpSegment<'_>,
+        status: ReceiveStatus,
+        now: u64,
+    ) -> Result<(usize, ReceiveStatus), ConnectionReceiveError> {
+        if self.send_reset.is_none() {
+            self.send_reset = Some(ResetConfig::from_segment(segment));
+        }
+        self.last_timestamp = now;
+        Ok((0, status | ReceiveStatus::CONNECTION_RESETTING))
+    }
+
+    fn retransmission_expired(&self, now: u64) -> bool {
+        now.saturating_sub(self.retransmission_started_at) >= self.retransmission_period
+    }
+
+    fn can_send_first_fin(&self) -> bool {
+        !self.status.intersects(ConnectionStatus::FIN_SENT)
+            && self.send_fin == Some(self.highest_acknowledgement_received)
+    }
+
+    fn local_receive_window(&self) -> u16 {
+        let window = self
+            .local_receive_window_edge
+            .wrapping_sub(self.acknowledgement_to_send);
+        u16::try_from(window).unwrap_or(u16::MAX)
+    }
+
+    fn control_segment(&self) -> OutgoingSegment {
+        if let Some(reset) = self.send_reset {
+            return self.reset_segment(reset);
+        }
+        if !self.is_established() {
+            return OutgoingSegment::new(
+                self.first_not_sent.wrapping_sub(1),
+                self.acknowledgement_to_send,
+                TcpFlags::SYNCHRONIZE | TcpFlags::ACK,
+                self.local_receive_window(),
+                Some(self.maximum_segment_size),
+                0,
+            );
+        }
+
+        let mut sequence_number = self.highest_acknowledgement_received;
+        let mut flags = TcpFlags::ACK;
+        if let Some(fin_sequence) = self.send_fin
+            && !self.status.intersects(ConnectionStatus::FIN_ACKED)
+            && sequence_at_or_after(sequence_number, fin_sequence)
+        {
+            sequence_number = fin_sequence;
+            flags |= TcpFlags::FINISH;
+        }
+        OutgoingSegment::new(
+            sequence_number,
+            self.acknowledgement_to_send,
+            flags,
+            self.local_receive_window(),
+            None,
+            0,
+        )
+    }
+
+    fn reset_segment(&self, reset: ResetConfig) -> OutgoingSegment {
+        let (sequence_number, acknowledgement_number, flags) = reset.fields();
+        OutgoingSegment::new(
+            sequence_number,
+            acknowledgement_number,
+            flags,
+            self.local_receive_window(),
+            None,
+            0,
+        )
+    }
+}
+
+/// Error while creating a passive-open connection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PassiveOpenError {
+    /// The input was not a payload-free pure SYN.
+    InvalidSyn,
+    /// The configured local receive window exceeds the supported sequence interval.
+    ReceiveWindowTooLarge { size: u32, limit: u32 },
+}
+
+impl fmt::Display for PassiveOpenError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidSyn => formatter.write_str("incoming segment is not a valid TCP SYN"),
+            Self::ReceiveWindowTooLarge { size, limit } => write!(
+                formatter,
+                "TCP receive window {size} exceeds supported limit {limit}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PassiveOpenError {}
+
+/// Error while receiving a segment on an existing connection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConnectionReceiveError {
+    /// Caller-provided receive storage cannot hold the segment payload.
+    BufferTooSmall {
+        payload_len: usize,
+        buffer_len: usize,
+    },
+    /// The connection is already reset or has a reset queued.
+    ConnectionReset,
+    /// The injected monotonic timestamp moved backwards.
+    TimestampRegression(TimestampRegression),
+}
+
+impl fmt::Display for ConnectionReceiveError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BufferTooSmall {
+                payload_len,
+                buffer_len,
+            } => write!(
+                formatter,
+                "TCP payload length {payload_len} exceeds receive buffer length {buffer_len}"
+            ),
+            Self::ConnectionReset => formatter.write_str("TCP connection is reset"),
+            Self::TimestampRegression(source) => source.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for ConnectionReceiveError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::TimestampRegression(source) => Some(source),
+            Self::BufferTooSmall { .. } | Self::ConnectionReset => None,
+        }
+    }
+}
+
+impl From<TimestampRegression> for ConnectionReceiveError {
+    fn from(source: TimestampRegression) -> Self {
+        Self::TimestampRegression(source)
+    }
+}
+
+/// Error while producing the next segment for a connection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConnectionWriteError {
+    /// The connection is already reset.
+    ConnectionReset,
+    /// Payload was supplied after the local FIN boundary.
+    DataAfterFin,
+    /// Lower-layer reservation exceeds the negotiated MSS.
+    MssRemaining {
+        maximum_segment_size: u16,
+        reserved: u16,
+    },
+    /// Payload source exceeds the pinned sequence window.
+    PayloadTooLarge { len: usize, limit: u32 },
+    /// Payload source does not contain the required sequence number.
+    PayloadMissingSequence { sequence_number: u32 },
+    /// Caller output storage cannot hold even one available payload byte.
+    PayloadBufferTooSmall,
+    /// The injected monotonic timestamp moved backwards.
+    TimestampRegression(TimestampRegression),
+}
+
+impl fmt::Display for ConnectionWriteError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ConnectionReset => formatter.write_str("TCP connection is reset"),
+            Self::DataAfterFin => formatter.write_str("TCP payload extends past the local FIN"),
+            Self::MssRemaining {
+                maximum_segment_size,
+                reserved,
+            } => write!(
+                formatter,
+                "TCP MSS {maximum_segment_size} cannot reserve {reserved} lower-layer bytes"
+            ),
+            Self::PayloadTooLarge { len, limit } => {
+                write!(formatter, "TCP payload length {len} exceeds limit {limit}")
+            }
+            Self::PayloadMissingSequence { sequence_number } => write!(
+                formatter,
+                "TCP payload source does not contain sequence number {sequence_number}"
+            ),
+            Self::PayloadBufferTooSmall => {
+                formatter.write_str("TCP output payload buffer is empty")
+            }
+            Self::TimestampRegression(source) => source.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for ConnectionWriteError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::TimestampRegression(source) => Some(source),
+            Self::ConnectionReset
+            | Self::DataAfterFin
+            | Self::MssRemaining { .. }
+            | Self::PayloadTooLarge { .. }
+            | Self::PayloadMissingSequence { .. }
+            | Self::PayloadBufferTooSmall => None,
+        }
+    }
+}
+
+impl From<TimestampRegression> for ConnectionWriteError {
+    fn from(source: TimestampRegression) -> Self {
+        Self::TimestampRegression(source)
+    }
+}

--- a/crates/runtime/src/mmds_tcp/endpoint.rs
+++ b/crates/runtime/src/mmds_tcp/endpoint.rs
@@ -1,0 +1,302 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Bounded MMDS endpoint adapted from Firecracker v1.16.0
+//! `dumbo/tcp/endpoint.rs`.
+
+use std::fmt;
+use std::num::{NonZeroU16, NonZeroU64};
+
+use super::{
+    Connection, ConnectionReceiveError, ConnectionWriteError, MAX_WINDOW_SIZE,
+    MMDS_TCP_EVICTION_THRESHOLD_TICKS, MMDS_TCP_RECEIVE_BUFFER_SIZE, MMDS_TCP_RETRANSMISSION_LIMIT,
+    MMDS_TCP_RETRANSMISSION_PERIOD_TICKS, NextSegmentStatus, OutgoingSegment, PassiveOpenError,
+    PayloadSource, ReceiveStatus, TcpSegment, TimestampRegression, sequence_after,
+};
+
+/// One bounded HTTP-over-TCP endpoint.
+#[derive(Debug)]
+pub struct Endpoint {
+    receive_buffer: [u8; MMDS_TCP_RECEIVE_BUFFER_SIZE],
+    receive_buffer_len: usize,
+    response: Option<Vec<u8>>,
+    response_initial_sequence: u32,
+    response_len_limit: u32,
+    connection: Connection,
+    last_segment_received_at: u64,
+    last_timestamp: u64,
+    stop_receiving: bool,
+}
+
+impl Endpoint {
+    /// Creates an endpoint from a pure SYN using the pinned MMDS limits.
+    pub fn new(
+        segment: &TcpSegment<'_>,
+        initial_sequence_number: u32,
+        now: u64,
+    ) -> Result<Self, PassiveOpenError> {
+        let connection = Connection::passive_open(
+            segment,
+            u32::try_from(MMDS_TCP_RECEIVE_BUFFER_SIZE).unwrap_or(MAX_WINDOW_SIZE),
+            NonZeroU64::new(MMDS_TCP_RETRANSMISSION_PERIOD_TICKS)
+                .ok_or(PassiveOpenError::InvalidSyn)?,
+            NonZeroU16::new(MMDS_TCP_RETRANSMISSION_LIMIT).ok_or(PassiveOpenError::InvalidSyn)?,
+            initial_sequence_number,
+            now,
+        )?;
+        let response_initial_sequence = connection.first_not_sent();
+        Ok(Self {
+            receive_buffer: [0; MMDS_TCP_RECEIVE_BUFFER_SIZE],
+            receive_buffer_len: 0,
+            response: None,
+            response_initial_sequence,
+            response_len_limit: MAX_WINDOW_SIZE,
+            connection,
+            last_segment_received_at: now,
+            last_timestamp: now,
+            stop_receiving: false,
+        })
+    }
+
+    /// Receives one segment and invokes `callback` for at most one complete request.
+    ///
+    /// A callback failure or oversized response queues a reset because the accepted
+    /// request cannot otherwise be completed safely.
+    pub fn receive_segment<E, F>(
+        &mut self,
+        segment: &TcpSegment<'_>,
+        now: u64,
+        callback: F,
+    ) -> Result<ReceiveStatus, EndpointReceiveError<E>>
+    where
+        F: FnOnce(&[u8]) -> Result<Vec<u8>, E>,
+    {
+        self.validate_timestamp(now)
+            .map_err(EndpointReceiveError::TimestampRegression)?;
+        if self.stop_receiving {
+            self.last_timestamp = now;
+            return Ok(ReceiveStatus::empty());
+        }
+
+        let receive_slice = self
+            .receive_buffer
+            .get_mut(self.receive_buffer_len..)
+            .ok_or(EndpointReceiveError::ReceiveBufferInvariant)?;
+        let (received, status) = self
+            .connection
+            .receive_segment(segment, receive_slice, now)
+            .map_err(EndpointReceiveError::Connection)?;
+        self.last_segment_received_at = now;
+        self.last_timestamp = now;
+        self.receive_buffer_len = self
+            .receive_buffer_len
+            .checked_add(received)
+            .filter(|len| *len <= MMDS_TCP_RECEIVE_BUFFER_SIZE)
+            .ok_or(EndpointReceiveError::ReceiveBufferInvariant)?;
+
+        if status.intersects(ReceiveStatus::CONNECTION_RESETTING) {
+            self.stop_receiving = true;
+            return Ok(status);
+        }
+
+        self.clear_acknowledged_response();
+        if self.response.is_none()
+            && let Some(request_end) = complete_request_end(
+                self.receive_buffer
+                    .get(..self.receive_buffer_len)
+                    .ok_or(EndpointReceiveError::ReceiveBufferInvariant)?,
+            )
+        {
+            let request = self
+                .receive_buffer
+                .get(..request_end)
+                .ok_or(EndpointReceiveError::ReceiveBufferInvariant)?;
+            let response = match callback(request) {
+                Ok(response) => response,
+                Err(source) => {
+                    self.connection.reset();
+                    self.stop_receiving = true;
+                    return Err(EndpointReceiveError::Callback(source));
+                }
+            };
+            if response.len() > usize::try_from(self.response_len_limit).unwrap_or(usize::MAX) {
+                let len = response.len();
+                self.connection.reset();
+                self.stop_receiving = true;
+                return Err(EndpointReceiveError::ResponseTooLarge {
+                    len,
+                    limit: self.response_len_limit,
+                });
+            }
+
+            self.response_initial_sequence = self.connection.first_not_sent();
+            if !response.is_empty() {
+                self.response = Some(response);
+            }
+            self.receive_buffer
+                .copy_within(request_end..self.receive_buffer_len, 0);
+            self.receive_buffer_len -= request_end;
+            self.connection
+                .advance_local_receive_window(u32::try_from(request_end).unwrap_or(u32::MAX));
+        }
+
+        if self.response.is_none() && self.receive_buffer_len == MMDS_TCP_RECEIVE_BUFFER_SIZE {
+            self.connection.reset();
+            self.stop_receiving = true;
+        }
+        if self.connection.fin_received() && self.response.is_none() {
+            self.connection.close();
+        }
+        Ok(status)
+    }
+
+    /// Writes the next segment and copies response bytes into `output_payload`.
+    pub fn write_next_segment(
+        &mut self,
+        output_payload: &mut [u8],
+        mss_reserved: u16,
+        now: u64,
+    ) -> Result<Option<OutgoingSegment>, ConnectionWriteError> {
+        let payload_source = self.response.as_ref().map(|response| {
+            PayloadSource::new(response.as_slice(), self.response_initial_sequence)
+        });
+        let result =
+            self.connection
+                .write_next_segment(output_payload, mss_reserved, payload_source, now);
+        if result.is_ok() {
+            self.last_timestamp = now;
+        }
+        result
+    }
+
+    /// Whether the connection has completed or reset.
+    pub const fn is_done(&self) -> bool {
+        self.connection.is_done()
+    }
+
+    /// Whether the endpoint has been inactive beyond the pinned eviction threshold.
+    pub fn is_evictable(&self, now: u64) -> Result<bool, TimestampRegression> {
+        self.validate_timestamp(now)?;
+        Ok(now.saturating_sub(self.last_segment_received_at) > MMDS_TCP_EVICTION_THRESHOLD_TICKS)
+    }
+
+    /// Pending output or the earliest retransmission deadline.
+    pub fn next_segment_status(&self) -> NextSegmentStatus {
+        let can_send_new_data = self.response.as_ref().is_some_and(|response| {
+            let response_len = u32::try_from(response.len()).unwrap_or(MAX_WINDOW_SIZE);
+            let response_end = self.response_initial_sequence.wrapping_add(response_len);
+            sequence_after(response_end, self.connection.first_not_sent())
+                && sequence_after(
+                    self.connection.remote_receive_window_edge(),
+                    self.connection.first_not_sent(),
+                )
+        });
+        if can_send_new_data || self.connection.duplicate_acknowledgement_pending() {
+            NextSegmentStatus::Available
+        } else {
+            self.connection.control_segment_or_timeout_status()
+        }
+    }
+
+    /// Underlying portable connection state.
+    pub const fn connection(&self) -> &Connection {
+        &self.connection
+    }
+
+    /// Number of request bytes retained in the fixed receive buffer.
+    pub const fn buffered_request_len(&self) -> usize {
+        self.receive_buffer_len
+    }
+
+    /// Whether one response is awaiting send or acknowledgement.
+    pub const fn response_pending(&self) -> bool {
+        self.response.is_some()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_response_len_limit_for_test(&mut self, limit: u32) {
+        self.response_len_limit = limit;
+    }
+
+    fn validate_timestamp(&self, now: u64) -> Result<(), TimestampRegression> {
+        if now < self.last_timestamp {
+            Err(TimestampRegression::new(self.last_timestamp, now))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn clear_acknowledged_response(&mut self) {
+        let Some(response) = self.response.as_ref() else {
+            return;
+        };
+        let response_len = u32::try_from(response.len()).unwrap_or(MAX_WINDOW_SIZE);
+        if self.connection.highest_acknowledgement_received()
+            == self.response_initial_sequence.wrapping_add(response_len)
+        {
+            self.response = None;
+            self.response_initial_sequence = self.connection.first_not_sent();
+        }
+    }
+}
+
+/// Error while accepting data into an endpoint.
+#[derive(Debug)]
+pub enum EndpointReceiveError<E> {
+    /// The connection rejected the segment.
+    Connection(ConnectionReceiveError),
+    /// The request callback could not generate a response.
+    Callback(E),
+    /// Generated response exceeds the connection sequence-window bound.
+    ResponseTooLarge { len: usize, limit: u32 },
+    /// The injected monotonic timestamp moved backwards.
+    TimestampRegression(TimestampRegression),
+    /// Internal fixed-buffer accounting was inconsistent.
+    ReceiveBufferInvariant,
+}
+
+impl<E: fmt::Display> fmt::Display for EndpointReceiveError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Connection(source) => source.fmt(formatter),
+            Self::Callback(source) => write!(formatter, "MMDS request callback failed: {source}"),
+            Self::ResponseTooLarge { len, limit } => write!(
+                formatter,
+                "MMDS TCP response length {len} exceeds sequence-window limit {limit}"
+            ),
+            Self::TimestampRegression(source) => source.fmt(formatter),
+            Self::ReceiveBufferInvariant => {
+                formatter.write_str("MMDS TCP receive-buffer invariant failed")
+            }
+        }
+    }
+}
+
+impl<E> std::error::Error for EndpointReceiveError<E>
+where
+    E: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Connection(source) => Some(source),
+            Self::Callback(source) => Some(source),
+            Self::TimestampRegression(source) => Some(source),
+            Self::ResponseTooLarge { .. } | Self::ReceiveBufferInvariant => None,
+        }
+    }
+}
+
+fn complete_request_end(bytes: &[u8]) -> Option<usize> {
+    for (index, byte) in bytes.iter().copied().enumerate() {
+        if byte != b'\n' {
+            continue;
+        }
+        if bytes.get(index + 1) == Some(&b'\n') {
+            return index.checked_add(2);
+        }
+        if bytes.get(index + 1..index + 3) == Some(b"\r\n") {
+            return index.checked_add(3);
+        }
+    }
+    None
+}

--- a/crates/runtime/src/mmds_tcp/handler.rs
+++ b/crates/runtime/src/mmds_tcp/handler.rs
@@ -1,0 +1,533 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Bounded connection handler adapted from Firecracker v1.16.0
+//! `dumbo/tcp/handler.rs` and `mmds/ns.rs`.
+
+use std::collections::TryReserveError;
+use std::fmt;
+use std::net::Ipv4Addr;
+
+use super::{
+    ConnectionWriteError, Endpoint, EndpointReceiveError, MMDS_TCP_MAX_CONNECTIONS,
+    MMDS_TCP_MAX_PENDING_RESETS, NextSegmentStatus, OutgoingSegment, ResetConfig,
+    SegmentParseError, TcpFlags, TcpSegment, TimestampRegression,
+};
+
+/// Remote half of an MMDS TCP connection key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Peer {
+    ipv4_address: Ipv4Addr,
+    port: u16,
+}
+
+impl Peer {
+    /// Creates a remote connection key.
+    pub const fn new(ipv4_address: Ipv4Addr, port: u16) -> Self {
+        Self { ipv4_address, port }
+    }
+
+    /// Remote IPv4 address.
+    pub const fn ipv4_address(self) -> Ipv4Addr {
+        self.ipv4_address
+    }
+
+    /// Remote TCP port.
+    pub const fn port(self) -> u16 {
+        self.port
+    }
+}
+
+#[derive(Debug)]
+struct ConnectionEntry {
+    peer: Peer,
+    endpoint: Endpoint,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PendingReset {
+    peer: Peer,
+    config: ResetConfig,
+}
+
+/// Fixed-capacity MMDS TCP connection and reset handler.
+#[derive(Debug)]
+pub struct MmdsTcpHandler {
+    local_port: u16,
+    connections: Vec<ConnectionEntry>,
+    connection_limit: usize,
+    pending_resets: Vec<PendingReset>,
+    pending_reset_limit: usize,
+    next_connection: usize,
+    last_timestamp: u64,
+}
+
+impl MmdsTcpHandler {
+    /// Allocates the exact logical Firecracker MMDS limits.
+    pub fn try_new(local_port: u16) -> Result<Self, HandlerBuildError> {
+        Self::try_new_with_limits(
+            local_port,
+            MMDS_TCP_MAX_CONNECTIONS,
+            MMDS_TCP_MAX_PENDING_RESETS,
+        )
+    }
+
+    fn try_new_with_limits(
+        local_port: u16,
+        connection_limit: usize,
+        pending_reset_limit: usize,
+    ) -> Result<Self, HandlerBuildError> {
+        let mut connections = Vec::new();
+        connections
+            .try_reserve_exact(connection_limit)
+            .map_err(HandlerBuildError::ConnectionStorage)?;
+        let mut pending_resets = Vec::new();
+        pending_resets
+            .try_reserve_exact(pending_reset_limit)
+            .map_err(HandlerBuildError::ResetStorage)?;
+        Ok(Self {
+            local_port,
+            connections,
+            connection_limit,
+            pending_resets,
+            pending_reset_limit,
+            next_connection: 0,
+            last_timestamp: 0,
+        })
+    }
+
+    /// Receives a raw TCP segment from `remote_ipv4_address`.
+    ///
+    /// `initial_sequence_number` is consumed only when this is a new pure SYN.
+    pub fn receive_segment<E, F>(
+        &mut self,
+        remote_ipv4_address: Ipv4Addr,
+        bytes: &[u8],
+        initial_sequence_number: u32,
+        now: u64,
+        callback: F,
+    ) -> Result<HandlerReceiveEvent, HandlerReceiveError<E>>
+    where
+        F: FnOnce(&[u8]) -> Result<Vec<u8>, E>,
+    {
+        let segment = TcpSegment::parse(bytes).map_err(HandlerReceiveError::Segment)?;
+        self.validate_timestamp(now)
+            .map_err(HandlerReceiveError::TimestampRegression)?;
+        if segment.destination_port() != self.local_port {
+            return Err(HandlerReceiveError::InvalidPort {
+                expected: self.local_port,
+                actual: segment.destination_port(),
+            });
+        }
+        self.last_timestamp = now;
+        let peer = Peer::new(remote_ipv4_address, segment.source_port());
+
+        if let Some(index) = self.connections.iter().position(|entry| entry.peer == peer) {
+            let status = self
+                .connections
+                .get_mut(index)
+                .ok_or(HandlerReceiveError::ConnectionTableInvariant)?
+                .endpoint
+                .receive_segment(&segment, now, callback)
+                .map_err(HandlerReceiveError::Endpoint)?;
+            if self
+                .connections
+                .get(index)
+                .is_some_and(|entry| entry.endpoint.is_done())
+            {
+                self.remove_connection(index);
+                return Ok(HandlerReceiveEvent::EndpointDone);
+            }
+            return Ok(HandlerReceiveEvent::ExistingConnection { status });
+        }
+
+        if segment.flags() == TcpFlags::SYNCHRONIZE {
+            let endpoint = match Endpoint::new(&segment, initial_sequence_number, now) {
+                Ok(endpoint) => endpoint,
+                Err(_) => return Ok(HandlerReceiveEvent::FailedNewConnection),
+            };
+            if self.connections.len() < self.connection_limit {
+                self.connections.push(ConnectionEntry { peer, endpoint });
+                return Ok(HandlerReceiveEvent::NewConnection);
+            }
+
+            let mut evict_index = None;
+            for (index, entry) in self.connections.iter().enumerate() {
+                if entry
+                    .endpoint
+                    .is_evictable(now)
+                    .map_err(HandlerReceiveError::TimestampRegression)?
+                {
+                    evict_index = Some(index);
+                    break;
+                }
+            }
+            if let Some(index) = evict_index {
+                let evicted = self
+                    .connections
+                    .get(index)
+                    .ok_or(HandlerReceiveError::ConnectionTableInvariant)?;
+                self.enqueue_reset(PendingReset {
+                    peer: evicted.peer,
+                    config: evicted.endpoint.connection().make_reset_config(),
+                });
+                self.remove_connection(index);
+                self.connections.push(ConnectionEntry { peer, endpoint });
+                return Ok(HandlerReceiveEvent::NewConnectionReplacing);
+            }
+
+            self.enqueue_reset(PendingReset {
+                peer,
+                config: ResetConfig::from_segment(&segment),
+            });
+            return Ok(HandlerReceiveEvent::NewConnectionDropped);
+        }
+
+        if !segment.flags().intersects(TcpFlags::RESET) {
+            self.enqueue_reset(PendingReset {
+                peer,
+                config: ResetConfig::from_segment(&segment),
+            });
+        }
+        Ok(HandlerReceiveEvent::UnexpectedSegment)
+    }
+
+    /// Produces at most one reset or endpoint segment.
+    pub fn write_next_segment(
+        &mut self,
+        output_payload: &mut [u8],
+        mss_reserved: u16,
+        now: u64,
+    ) -> Result<Option<HandlerOutput>, HandlerWriteError> {
+        self.validate_timestamp(now)
+            .map_err(HandlerWriteError::TimestampRegression)?;
+        self.last_timestamp = now;
+
+        if let Some(pending) = self.pending_resets.pop() {
+            let (sequence_number, acknowledgement_number, flags) = pending.config.fields();
+            return Ok(Some(HandlerOutput {
+                peer: pending.peer,
+                local_port: self.local_port,
+                segment: OutgoingSegment::new(
+                    sequence_number,
+                    acknowledgement_number,
+                    flags,
+                    10_000,
+                    None,
+                    0,
+                ),
+                event: HandlerWriteEvent::Nothing,
+            }));
+        }
+
+        let Some(index) = self.next_output_connection() else {
+            return Ok(None);
+        };
+        let entry = self
+            .connections
+            .get_mut(index)
+            .ok_or(HandlerWriteError::ConnectionTableInvariant)?;
+        let peer = entry.peer;
+        let Some(segment) = entry
+            .endpoint
+            .write_next_segment(output_payload, mss_reserved, now)
+            .map_err(HandlerWriteError::Connection)?
+        else {
+            return Ok(None);
+        };
+        let done = entry.endpoint.is_done();
+        self.next_connection = index.saturating_add(1);
+        let event = if done {
+            self.remove_connection(index);
+            HandlerWriteEvent::EndpointDone
+        } else {
+            if !self.connections.is_empty() {
+                self.next_connection %= self.connections.len();
+            } else {
+                self.next_connection = 0;
+            }
+            HandlerWriteEvent::Nothing
+        };
+        Ok(Some(HandlerOutput {
+            peer,
+            local_port: self.local_port,
+            segment,
+            event,
+        }))
+    }
+
+    /// Aggregate immediate-output or earliest-timeout status.
+    pub fn next_segment_status(&self) -> NextSegmentStatus {
+        if !self.pending_resets.is_empty()
+            || self
+                .connections
+                .iter()
+                .any(|entry| entry.endpoint.next_segment_status() == NextSegmentStatus::Available)
+        {
+            return NextSegmentStatus::Available;
+        }
+        self.connections
+            .iter()
+            .filter_map(|entry| match entry.endpoint.next_segment_status() {
+                NextSegmentStatus::Timeout(deadline) => Some(deadline),
+                NextSegmentStatus::Available | NextSegmentStatus::Nothing => None,
+            })
+            .min()
+            .map_or(NextSegmentStatus::Nothing, NextSegmentStatus::Timeout)
+    }
+
+    /// Bound local TCP port.
+    pub const fn local_port(&self) -> u16 {
+        self.local_port
+    }
+
+    /// Current number of live endpoints.
+    pub const fn connection_count(&self) -> usize {
+        self.connections.len()
+    }
+
+    /// Configured logical connection limit.
+    pub const fn connection_limit(&self) -> usize {
+        self.connection_limit
+    }
+
+    /// Number of reset replies waiting for output.
+    pub const fn pending_reset_count(&self) -> usize {
+        self.pending_resets.len()
+    }
+
+    /// Configured logical pending-reset limit.
+    pub const fn pending_reset_limit(&self) -> usize {
+        self.pending_reset_limit
+    }
+
+    #[cfg(test)]
+    pub(crate) fn try_new_for_test(
+        local_port: u16,
+        connection_limit: usize,
+        pending_reset_limit: usize,
+    ) -> Result<Self, HandlerBuildError> {
+        Self::try_new_with_limits(local_port, connection_limit, pending_reset_limit)
+    }
+
+    fn validate_timestamp(&self, now: u64) -> Result<(), TimestampRegression> {
+        if now < self.last_timestamp {
+            Err(TimestampRegression::new(self.last_timestamp, now))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn enqueue_reset(&mut self, reset: PendingReset) {
+        if self.pending_resets.len() < self.pending_reset_limit {
+            self.pending_resets.push(reset);
+        }
+    }
+
+    fn remove_connection(&mut self, index: usize) {
+        if index < self.connections.len() {
+            self.connections.remove(index);
+        }
+        if self.connections.is_empty() {
+            self.next_connection = 0;
+        } else if self.next_connection >= self.connections.len() {
+            self.next_connection %= self.connections.len();
+        }
+    }
+
+    fn next_output_connection(&self) -> Option<usize> {
+        if self.connections.is_empty() {
+            return None;
+        }
+        let len = self.connections.len();
+        let start = self.next_connection % len;
+        let mut earliest_timeout = None;
+        for offset in 0..len {
+            let index = (start + offset) % len;
+            let status = self.connections.get(index)?.endpoint.next_segment_status();
+            match status {
+                NextSegmentStatus::Available => return Some(index),
+                NextSegmentStatus::Timeout(deadline) => match earliest_timeout {
+                    Some((current, _)) if current <= deadline => {}
+                    _ => earliest_timeout = Some((deadline, index)),
+                },
+                NextSegmentStatus::Nothing => {}
+            }
+        }
+        earliest_timeout.map(|(_, index)| index)
+    }
+}
+
+/// Handler receive-side state change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HandlerReceiveEvent {
+    /// An endpoint became done and was removed.
+    EndpointDone,
+    /// Existing connection accepted or classified a segment.
+    ExistingConnection { status: super::ReceiveStatus },
+    /// A new endpoint was created.
+    NewConnection,
+    /// The incoming SYN could not create an endpoint.
+    FailedNewConnection,
+    /// Capacity was full and no stale endpoint could be evicted.
+    NewConnectionDropped,
+    /// A stale endpoint was reset and replaced.
+    NewConnectionReplacing,
+    /// A non-SYN segment did not match an endpoint.
+    UnexpectedSegment,
+}
+
+/// Handler write-side state change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HandlerWriteEvent {
+    /// The endpoint became done and was removed after this segment.
+    EndpointDone,
+    /// No endpoint lifecycle transition occurred.
+    Nothing,
+}
+
+/// One handler-produced segment and its destination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HandlerOutput {
+    peer: Peer,
+    local_port: u16,
+    segment: OutgoingSegment,
+    event: HandlerWriteEvent,
+}
+
+impl HandlerOutput {
+    /// Remote destination.
+    pub const fn peer(self) -> Peer {
+        self.peer
+    }
+
+    /// Local source port.
+    pub const fn local_port(self) -> u16 {
+        self.local_port
+    }
+
+    /// TCP segment metadata; payload bytes occupy the caller buffer prefix.
+    pub const fn segment(self) -> OutgoingSegment {
+        self.segment
+    }
+
+    /// Lifecycle event caused by this output.
+    pub const fn event(self) -> HandlerWriteEvent {
+        self.event
+    }
+}
+
+/// Failure while allocating fixed handler storage.
+#[derive(Debug)]
+pub enum HandlerBuildError {
+    /// Could not reserve connection slots.
+    ConnectionStorage(TryReserveError),
+    /// Could not reserve pending-reset slots.
+    ResetStorage(TryReserveError),
+}
+
+impl fmt::Display for HandlerBuildError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ConnectionStorage(source) => {
+                write!(
+                    formatter,
+                    "failed to reserve MMDS TCP connection slots: {source}"
+                )
+            }
+            Self::ResetStorage(source) => {
+                write!(
+                    formatter,
+                    "failed to reserve MMDS TCP reset slots: {source}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for HandlerBuildError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::ConnectionStorage(source) | Self::ResetStorage(source) => Some(source),
+        }
+    }
+}
+
+/// Error while routing an incoming raw segment.
+#[derive(Debug)]
+pub enum HandlerReceiveError<E> {
+    /// Raw TCP segment was malformed.
+    Segment(SegmentParseError),
+    /// Destination port does not match the handler.
+    InvalidPort { expected: u16, actual: u16 },
+    /// Endpoint processing failed.
+    Endpoint(EndpointReceiveError<E>),
+    /// The injected monotonic timestamp moved backwards.
+    TimestampRegression(TimestampRegression),
+    /// Internal bounded connection indexing was inconsistent.
+    ConnectionTableInvariant,
+}
+
+impl<E: fmt::Display> fmt::Display for HandlerReceiveError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Segment(source) => source.fmt(formatter),
+            Self::InvalidPort { expected, actual } => write!(
+                formatter,
+                "MMDS TCP destination port {actual} does not match {expected}"
+            ),
+            Self::Endpoint(source) => source.fmt(formatter),
+            Self::TimestampRegression(source) => source.fmt(formatter),
+            Self::ConnectionTableInvariant => {
+                formatter.write_str("MMDS TCP connection-table invariant failed")
+            }
+        }
+    }
+}
+
+impl<E> std::error::Error for HandlerReceiveError<E>
+where
+    E: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Segment(source) => Some(source),
+            Self::Endpoint(source) => Some(source),
+            Self::TimestampRegression(source) => Some(source),
+            Self::InvalidPort { .. } | Self::ConnectionTableInvariant => None,
+        }
+    }
+}
+
+/// Error while producing handler output.
+#[derive(Debug)]
+pub enum HandlerWriteError {
+    /// Selected connection could not produce output.
+    Connection(ConnectionWriteError),
+    /// The injected monotonic timestamp moved backwards.
+    TimestampRegression(TimestampRegression),
+    /// Internal bounded connection indexing was inconsistent.
+    ConnectionTableInvariant,
+}
+
+impl fmt::Display for HandlerWriteError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Connection(source) => source.fmt(formatter),
+            Self::TimestampRegression(source) => source.fmt(formatter),
+            Self::ConnectionTableInvariant => {
+                formatter.write_str("MMDS TCP connection-table invariant failed")
+            }
+        }
+    }
+}
+
+impl std::error::Error for HandlerWriteError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Connection(source) => Some(source),
+            Self::TimestampRegression(source) => Some(source),
+            Self::ConnectionTableInvariant => None,
+        }
+    }
+}

--- a/crates/runtime/src/mmds_tcp/mod.rs
+++ b/crates/runtime/src/mmds_tcp/mod.rs
@@ -1,0 +1,147 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Portable, bounded MMDS TCP state.
+//!
+//! The algorithms in this module are a focused semantic adaptation of
+//! Firecracker v1.16.0 `dumbo/tcp` at commit
+//! `d83d72b710361a10294480131377b1b00b163af8`. The adaptation keeps the
+//! passive-open connection, endpoint, and handler behavior while replacing
+//! Firecracker-specific packet, time, allocation, HTTP, and metrics ownership.
+//! See the colocated `NOTICE.md` and `LICENSE-APACHE-2.0` files.
+//!
+//! This module is staged for the production integration owned by issue #1499.
+//! The current MMDS packet detour does not call it yet.
+
+mod connection;
+mod endpoint;
+mod handler;
+mod segment;
+
+pub use connection::{
+    Connection, ConnectionReceiveError, ConnectionWriteError, PassiveOpenError, PayloadSource,
+    ReceiveStatus,
+};
+pub use endpoint::{Endpoint, EndpointReceiveError};
+pub use handler::{
+    HandlerBuildError, HandlerOutput, HandlerReceiveError, HandlerReceiveEvent, HandlerWriteError,
+    HandlerWriteEvent, MmdsTcpHandler, Peer,
+};
+pub use segment::{OutgoingSegment, SegmentParseError, TcpFlags, TcpSegment};
+
+/// Largest sequence-space interval recognized as a valid TCP window.
+pub const MAX_WINDOW_SIZE: u32 = 1_073_725_440;
+
+/// Default maximum segment size when the peer does not advertise one.
+pub const DEFAULT_MSS: u16 = 536;
+
+/// Smallest accepted advertised maximum segment size.
+pub const MIN_MSS: u16 = 100;
+
+/// Maximum number of simultaneous MMDS TCP connections.
+pub const MMDS_TCP_MAX_CONNECTIONS: usize = 30;
+
+/// Maximum number of reset replies waiting for output.
+pub const MMDS_TCP_MAX_PENDING_RESETS: usize = 100;
+
+/// Fixed request receive-buffer size for each MMDS TCP endpoint.
+pub const MMDS_TCP_RECEIVE_BUFFER_SIZE: usize = 2_500;
+
+/// Inactivity interval after which a connection can be evicted.
+pub const MMDS_TCP_EVICTION_THRESHOLD_TICKS: u64 = 40_000_000_000;
+
+/// Time between retransmission attempts.
+pub const MMDS_TCP_RETRANSMISSION_PERIOD_TICKS: u64 = 1_200_000_000;
+
+/// Timeout count at which a connection emits a reset instead of retransmitting.
+pub const MMDS_TCP_RETRANSMISSION_LIMIT: u16 = 15;
+
+/// Describes whether an entity has TCP output available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NextSegmentStatus {
+    /// Output can be produced immediately.
+    Available,
+    /// No output or deadline is pending.
+    Nothing,
+    /// Output becomes eligible at the supplied monotonic tick.
+    Timeout(u64),
+}
+
+/// Sequence and acknowledgement fields for an outgoing reset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResetConfig {
+    /// Send the supplied sequence number without the ACK flag.
+    Sequence(u32),
+    /// Send sequence zero and acknowledge the supplied number.
+    Acknowledgement(u32),
+}
+
+impl ResetConfig {
+    pub(crate) fn from_segment(segment: &TcpSegment<'_>) -> Self {
+        if segment.flags().intersects(TcpFlags::ACK) {
+            Self::Sequence(segment.acknowledgement_number())
+        } else {
+            let payload_len = u32::try_from(segment.payload().len()).unwrap_or(u32::MAX);
+            Self::Acknowledgement(segment.sequence_number().wrapping_add(payload_len))
+        }
+    }
+
+    pub(crate) const fn fields(self) -> (u32, u32, TcpFlags) {
+        match self {
+            Self::Sequence(sequence_number) => (sequence_number, 0, TcpFlags::RESET),
+            Self::Acknowledgement(acknowledgement_number) => (
+                0,
+                acknowledgement_number,
+                TcpFlags::RESET.union(TcpFlags::ACK),
+            ),
+        }
+    }
+}
+
+/// Error returned when an injected timestamp moves backwards.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TimestampRegression {
+    previous: u64,
+    current: u64,
+}
+
+impl TimestampRegression {
+    pub(crate) const fn new(previous: u64, current: u64) -> Self {
+        Self { previous, current }
+    }
+
+    /// Most recently accepted timestamp.
+    pub const fn previous(self) -> u64 {
+        self.previous
+    }
+
+    /// Regressed timestamp supplied by the caller.
+    pub const fn current(self) -> u64 {
+        self.current
+    }
+}
+
+impl std::fmt::Display for TimestampRegression {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "MMDS TCP timestamp regressed from {} to {}",
+            self.previous, self.current
+        )
+    }
+}
+
+impl std::error::Error for TimestampRegression {}
+
+/// Returns whether `candidate` follows `reference` in the pinned sequence window.
+pub const fn sequence_after(candidate: u32, reference: u32) -> bool {
+    candidate != reference && candidate.wrapping_sub(reference) < MAX_WINDOW_SIZE
+}
+
+/// Returns whether `candidate` equals or follows `reference` in the pinned sequence window.
+pub const fn sequence_at_or_after(candidate: u32, reference: u32) -> bool {
+    candidate.wrapping_sub(reference) < MAX_WINDOW_SIZE
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/runtime/src/mmds_tcp/segment.rs
+++ b/crates/runtime/src/mmds_tcp/segment.rs
@@ -1,0 +1,424 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Safe TCP segment values adapted from Firecracker v1.16.0 `dumbo/pdu/tcp.rs`.
+
+use std::fmt;
+use std::ops::{BitOr, BitOrAssign};
+
+use super::MIN_MSS;
+
+const MIN_HEADER_LEN: usize = 20;
+const MAX_HEADER_LEN: usize = 60;
+const SOURCE_PORT_OFFSET: usize = 0;
+const DESTINATION_PORT_OFFSET: usize = 2;
+const SEQUENCE_NUMBER_OFFSET: usize = 4;
+const ACKNOWLEDGEMENT_NUMBER_OFFSET: usize = 8;
+const DATA_OFFSET_OFFSET: usize = 12;
+const FLAGS_OFFSET: usize = 13;
+const WINDOW_SIZE_OFFSET: usize = 14;
+const OPTIONS_OFFSET: usize = 20;
+const OPTION_END: u8 = 0;
+const OPTION_NOP: u8 = 1;
+const OPTION_MSS: u8 = 2;
+const OPTION_MSS_LEN: usize = 4;
+
+/// TCP flags carried in the second control byte.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct TcpFlags(u8);
+
+impl TcpFlags {
+    /// Congestion-window-reduced flag.
+    pub const CWR: Self = Self(1 << 7);
+    /// ECN-echo flag.
+    pub const ECE: Self = Self(1 << 6);
+    /// Urgent-pointer flag.
+    pub const URGENT: Self = Self(1 << 5);
+    /// Acknowledgement-number-valid flag.
+    pub const ACK: Self = Self(1 << 4);
+    /// Push flag.
+    pub const PUSH: Self = Self(1 << 3);
+    /// Reset flag.
+    pub const RESET: Self = Self(1 << 2);
+    /// Synchronize flag.
+    pub const SYNCHRONIZE: Self = Self(1 << 1);
+    /// Finish flag.
+    pub const FINISH: Self = Self(1);
+
+    /// Creates flags from the raw control byte.
+    pub const fn from_bits(bits: u8) -> Self {
+        Self(bits)
+    }
+
+    /// Returns the raw control byte.
+    pub const fn bits(self) -> u8 {
+        self.0
+    }
+
+    /// Returns whether every supplied flag is present.
+    pub const fn contains(self, flags: Self) -> bool {
+        self.0 & flags.0 == flags.0
+    }
+
+    /// Returns whether any supplied flag is present.
+    pub const fn intersects(self, flags: Self) -> bool {
+        self.0 & flags.0 != 0
+    }
+
+    /// Returns the union of two flag sets.
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+}
+
+impl BitOr for TcpFlags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        self.union(rhs)
+    }
+}
+
+impl BitOrAssign for TcpFlags {
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self = self.union(rhs);
+    }
+}
+
+/// A validated, borrowed TCP segment.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct TcpSegment<'a> {
+    source_port: u16,
+    destination_port: u16,
+    sequence_number: u32,
+    acknowledgement_number: u32,
+    flags: TcpFlags,
+    window_size: u16,
+    maximum_segment_size: Option<u16>,
+    payload: &'a [u8],
+}
+
+impl fmt::Debug for TcpSegment<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TcpSegment")
+            .field("source_port", &self.source_port)
+            .field("destination_port", &self.destination_port)
+            .field("sequence_number", &self.sequence_number)
+            .field("acknowledgement_number", &self.acknowledgement_number)
+            .field("flags", &self.flags)
+            .field("window_size", &self.window_size)
+            .field("maximum_segment_size", &self.maximum_segment_size)
+            .field("payload", &"[REDACTED]")
+            .field("payload_len", &self.payload.len())
+            .finish()
+    }
+}
+
+impl<'a> TcpSegment<'a> {
+    /// Parses a complete TCP segment without validating its checksum.
+    pub fn parse(bytes: &'a [u8]) -> Result<Self, SegmentParseError> {
+        if bytes.len() > usize::from(u16::MAX) {
+            return Err(SegmentParseError::SegmentTooLong { len: bytes.len() });
+        }
+        if bytes.len() < MIN_HEADER_LEN {
+            return Err(SegmentParseError::SliceTooShort { len: bytes.len() });
+        }
+
+        let data_offset = bytes
+            .get(DATA_OFFSET_OFFSET)
+            .copied()
+            .map(|value| usize::from(value >> 4) * 4)
+            .ok_or(SegmentParseError::SliceTooShort { len: bytes.len() })?;
+        if !(MIN_HEADER_LEN..=MAX_HEADER_LEN).contains(&data_offset) || data_offset > bytes.len() {
+            return Err(SegmentParseError::HeaderLength {
+                header_len: data_offset,
+                segment_len: bytes.len(),
+            });
+        }
+
+        let maximum_segment_size = parse_options(bytes.get(OPTIONS_OFFSET..data_offset).ok_or(
+            SegmentParseError::HeaderLength {
+                header_len: data_offset,
+                segment_len: bytes.len(),
+            },
+        )?)?;
+        let payload = bytes
+            .get(data_offset..)
+            .ok_or(SegmentParseError::HeaderLength {
+                header_len: data_offset,
+                segment_len: bytes.len(),
+            })?;
+
+        Ok(Self {
+            source_port: read_u16(bytes, SOURCE_PORT_OFFSET)?,
+            destination_port: read_u16(bytes, DESTINATION_PORT_OFFSET)?,
+            sequence_number: read_u32(bytes, SEQUENCE_NUMBER_OFFSET)?,
+            acknowledgement_number: read_u32(bytes, ACKNOWLEDGEMENT_NUMBER_OFFSET)?,
+            flags: TcpFlags::from_bits(
+                bytes
+                    .get(FLAGS_OFFSET)
+                    .copied()
+                    .ok_or(SegmentParseError::SliceTooShort { len: bytes.len() })?,
+            ),
+            window_size: read_u16(bytes, WINDOW_SIZE_OFFSET)?,
+            maximum_segment_size,
+            payload,
+        })
+    }
+
+    /// Source TCP port.
+    pub const fn source_port(self) -> u16 {
+        self.source_port
+    }
+
+    /// Destination TCP port.
+    pub const fn destination_port(self) -> u16 {
+        self.destination_port
+    }
+
+    /// First sequence number carried by the segment.
+    pub const fn sequence_number(self) -> u32 {
+        self.sequence_number
+    }
+
+    /// Acknowledgement number carried by the segment.
+    pub const fn acknowledgement_number(self) -> u32 {
+        self.acknowledgement_number
+    }
+
+    /// TCP control flags.
+    pub const fn flags(self) -> TcpFlags {
+        self.flags
+    }
+
+    /// Advertised receive-window size.
+    pub const fn window_size(self) -> u16 {
+        self.window_size
+    }
+
+    /// Parsed MSS option, if present.
+    pub const fn maximum_segment_size(self) -> Option<u16> {
+        self.maximum_segment_size
+    }
+
+    /// Borrowed TCP payload.
+    pub const fn payload(self) -> &'a [u8] {
+        self.payload
+    }
+}
+
+/// Metadata for one outgoing TCP segment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OutgoingSegment {
+    sequence_number: u32,
+    acknowledgement_number: u32,
+    flags: TcpFlags,
+    window_size: u16,
+    maximum_segment_size: Option<u16>,
+    payload_len: usize,
+}
+
+impl OutgoingSegment {
+    pub(crate) const fn new(
+        sequence_number: u32,
+        acknowledgement_number: u32,
+        flags: TcpFlags,
+        window_size: u16,
+        maximum_segment_size: Option<u16>,
+        payload_len: usize,
+    ) -> Self {
+        Self {
+            sequence_number,
+            acknowledgement_number,
+            flags,
+            window_size,
+            maximum_segment_size,
+            payload_len,
+        }
+    }
+
+    /// First sequence number carried by the segment.
+    pub const fn sequence_number(self) -> u32 {
+        self.sequence_number
+    }
+
+    /// Acknowledgement number carried by the segment.
+    pub const fn acknowledgement_number(self) -> u32 {
+        self.acknowledgement_number
+    }
+
+    /// TCP control flags.
+    pub const fn flags(self) -> TcpFlags {
+        self.flags
+    }
+
+    /// Advertised receive-window size.
+    pub const fn window_size(self) -> u16 {
+        self.window_size
+    }
+
+    /// MSS option to encode, if present.
+    pub const fn maximum_segment_size(self) -> Option<u16> {
+        self.maximum_segment_size
+    }
+
+    /// Bytes written into the caller-provided payload buffer.
+    pub const fn payload_len(self) -> usize {
+        self.payload_len
+    }
+}
+
+/// Error returned while parsing a raw TCP segment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SegmentParseError {
+    /// The slice is shorter than a basic TCP header.
+    SliceTooShort { len: usize },
+    /// The segment cannot fit in an IPv4 packet.
+    SegmentTooLong { len: usize },
+    /// The encoded header length is invalid.
+    HeaderLength {
+        header_len: usize,
+        segment_len: usize,
+    },
+    /// An option is missing its length byte.
+    TruncatedOption { offset: usize },
+    /// An option length is smaller than its kind/length prefix.
+    InvalidOptionLength { offset: usize, len: usize },
+    /// An option extends past the validated TCP header.
+    TruncatedOptionValue {
+        offset: usize,
+        len: usize,
+        options_len: usize,
+    },
+    /// An MSS option has an invalid encoded length.
+    InvalidMssLength { len: usize },
+    /// An MSS option advertises a value below the supported minimum.
+    InvalidMssValue { value: u16 },
+    /// More than one MSS option was supplied.
+    DuplicateMss,
+}
+
+impl fmt::Display for SegmentParseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SliceTooShort { len } => {
+                write!(formatter, "TCP segment is only {len} bytes")
+            }
+            Self::SegmentTooLong { len } => {
+                write!(formatter, "TCP segment length {len} exceeds the IPv4 limit")
+            }
+            Self::HeaderLength {
+                header_len,
+                segment_len,
+            } => write!(
+                formatter,
+                "TCP header length {header_len} is invalid for a {segment_len}-byte segment"
+            ),
+            Self::TruncatedOption { offset } => {
+                write!(formatter, "TCP option at offset {offset} has no length")
+            }
+            Self::InvalidOptionLength { offset, len } => write!(
+                formatter,
+                "TCP option at offset {offset} has invalid length {len}"
+            ),
+            Self::TruncatedOptionValue {
+                offset,
+                len,
+                options_len,
+            } => write!(
+                formatter,
+                "TCP option at offset {offset} with length {len} exceeds {options_len} option bytes"
+            ),
+            Self::InvalidMssLength { len } => {
+                write!(formatter, "TCP MSS option has invalid length {len}")
+            }
+            Self::InvalidMssValue { value } => {
+                write!(formatter, "TCP MSS value {value} is below {MIN_MSS}")
+            }
+            Self::DuplicateMss => formatter.write_str("TCP segment contains duplicate MSS options"),
+        }
+    }
+}
+
+impl std::error::Error for SegmentParseError {}
+
+fn parse_options(options: &[u8]) -> Result<Option<u16>, SegmentParseError> {
+    let mut maximum_segment_size = None;
+    let mut offset = 0;
+    while offset < options.len() {
+        let Some(&kind) = options.get(offset) else {
+            break;
+        };
+        match kind {
+            OPTION_END => break,
+            OPTION_NOP => {
+                offset += 1;
+            }
+            _ => {
+                let len = options
+                    .get(offset + 1)
+                    .copied()
+                    .map(usize::from)
+                    .ok_or(SegmentParseError::TruncatedOption { offset })?;
+                if len < 2 {
+                    return Err(SegmentParseError::InvalidOptionLength { offset, len });
+                }
+                let end =
+                    offset
+                        .checked_add(len)
+                        .ok_or(SegmentParseError::TruncatedOptionValue {
+                            offset,
+                            len,
+                            options_len: options.len(),
+                        })?;
+                let option =
+                    options
+                        .get(offset..end)
+                        .ok_or(SegmentParseError::TruncatedOptionValue {
+                            offset,
+                            len,
+                            options_len: options.len(),
+                        })?;
+                if kind == OPTION_MSS {
+                    if len != OPTION_MSS_LEN {
+                        return Err(SegmentParseError::InvalidMssLength { len });
+                    }
+                    if maximum_segment_size.is_some() {
+                        return Err(SegmentParseError::DuplicateMss);
+                    }
+                    let value = u16::from_be_bytes([
+                        *option
+                            .get(2)
+                            .ok_or(SegmentParseError::InvalidMssLength { len })?,
+                        *option
+                            .get(3)
+                            .ok_or(SegmentParseError::InvalidMssLength { len })?,
+                    ]);
+                    if value < MIN_MSS {
+                        return Err(SegmentParseError::InvalidMssValue { value });
+                    }
+                    maximum_segment_size = Some(value);
+                }
+                offset = end;
+            }
+        }
+    }
+    Ok(maximum_segment_size)
+}
+
+fn read_u16(bytes: &[u8], offset: usize) -> Result<u16, SegmentParseError> {
+    let value = bytes
+        .get(offset..offset + 2)
+        .and_then(|slice| <[u8; 2]>::try_from(slice).ok())
+        .ok_or(SegmentParseError::SliceTooShort { len: bytes.len() })?;
+    Ok(u16::from_be_bytes(value))
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32, SegmentParseError> {
+    let value = bytes
+        .get(offset..offset + 4)
+        .and_then(|slice| <[u8; 4]>::try_from(slice).ok())
+        .ok_or(SegmentParseError::SliceTooShort { len: bytes.len() })?;
+    Ok(u32::from_be_bytes(value))
+}

--- a/crates/runtime/src/mmds_tcp/tests.rs
+++ b/crates/runtime/src/mmds_tcp/tests.rs
@@ -1,0 +1,1198 @@
+use std::cell::Cell;
+use std::fmt;
+use std::net::Ipv4Addr;
+use std::num::{NonZeroU16, NonZeroU64};
+
+use super::handler::MmdsTcpHandler;
+use super::*;
+
+const LOCAL_PORT: u16 = 80;
+const REMOTE_PORT: u16 = 49_152;
+const REMOTE_ADDRESS: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 10);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CallbackError;
+
+impl fmt::Display for CallbackError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("callback error")
+    }
+}
+
+impl std::error::Error for CallbackError {}
+
+fn no_response(_: &[u8]) -> Result<Vec<u8>, CallbackError> {
+    Ok(Vec::new())
+}
+
+fn segment_bytes(
+    ports: (u16, u16),
+    sequence_number: u32,
+    acknowledgement_number: u32,
+    flags: TcpFlags,
+    window_size: u16,
+    options: &[u8],
+    payload: &[u8],
+) -> Vec<u8> {
+    let (source_port, destination_port) = ports;
+    assert_eq!(options.len() % 4, 0);
+    let header_len = 20 + options.len();
+    assert!(header_len <= 60);
+    let mut bytes = Vec::with_capacity(header_len + payload.len());
+    bytes.extend_from_slice(&source_port.to_be_bytes());
+    bytes.extend_from_slice(&destination_port.to_be_bytes());
+    bytes.extend_from_slice(&sequence_number.to_be_bytes());
+    bytes.extend_from_slice(&acknowledgement_number.to_be_bytes());
+    bytes.push(u8::try_from(header_len / 4).expect("test header length fits") << 4);
+    bytes.push(flags.bits());
+    bytes.extend_from_slice(&window_size.to_be_bytes());
+    bytes.extend_from_slice(&0_u16.to_be_bytes());
+    bytes.extend_from_slice(&0_u16.to_be_bytes());
+    bytes.extend_from_slice(options);
+    bytes.extend_from_slice(payload);
+    bytes
+}
+
+fn basic_segment(
+    sequence_number: u32,
+    acknowledgement_number: u32,
+    flags: TcpFlags,
+    window_size: u16,
+    payload: &[u8],
+) -> Vec<u8> {
+    segment_bytes(
+        (REMOTE_PORT, LOCAL_PORT),
+        sequence_number,
+        acknowledgement_number,
+        flags,
+        window_size,
+        &[],
+        payload,
+    )
+}
+
+fn syn_segment(sequence_number: u32, window_size: u16, mss: Option<u16>) -> Vec<u8> {
+    let options = mss.map_or_else(Vec::new, |value| {
+        let mut option = vec![2, 4];
+        option.extend_from_slice(&value.to_be_bytes());
+        option
+    });
+    segment_bytes(
+        (REMOTE_PORT, LOCAL_PORT),
+        sequence_number,
+        0,
+        TcpFlags::SYNCHRONIZE,
+        window_size,
+        &options,
+        &[],
+    )
+}
+
+fn open_connection(
+    remote_initial_sequence: u32,
+    local_initial_sequence: u32,
+    local_window: u32,
+    remote_window: u16,
+    mss: Option<u16>,
+    retransmission: (u64, u16),
+    now: u64,
+) -> Connection {
+    let (retransmission_period, retransmission_limit) = retransmission;
+    let syn_bytes = syn_segment(remote_initial_sequence, remote_window, mss);
+    let syn = TcpSegment::parse(&syn_bytes).expect("test SYN parses");
+    Connection::passive_open(
+        &syn,
+        local_window,
+        NonZeroU64::new(retransmission_period).expect("test RTO is nonzero"),
+        NonZeroU16::new(retransmission_limit).expect("test retry limit is nonzero"),
+        local_initial_sequence,
+        now,
+    )
+    .expect("test passive open succeeds")
+}
+
+fn establish_connection(
+    connection: &mut Connection,
+    remote_initial_sequence: u32,
+    local_initial_sequence: u32,
+    remote_window: u16,
+    now: u64,
+) {
+    let mut output = [];
+    let syn_ack = connection
+        .write_next_segment(&mut output, 0, None, now)
+        .expect("test SYN-ACK write succeeds")
+        .expect("test SYN-ACK is available");
+    assert_eq!(syn_ack.flags(), TcpFlags::SYNCHRONIZE | TcpFlags::ACK);
+    assert_eq!(syn_ack.sequence_number(), local_initial_sequence);
+    assert_eq!(
+        syn_ack.acknowledgement_number(),
+        remote_initial_sequence.wrapping_add(1)
+    );
+
+    let ack_bytes = basic_segment(
+        remote_initial_sequence.wrapping_add(1),
+        local_initial_sequence.wrapping_add(1),
+        TcpFlags::ACK,
+        remote_window,
+        &[],
+    );
+    let ack = TcpSegment::parse(&ack_bytes).expect("test ACK parses");
+    let mut receive = [];
+    assert_eq!(
+        connection
+            .receive_segment(&ack, &mut receive, now)
+            .expect("test ACK is accepted"),
+        (0, ReceiveStatus::empty())
+    );
+    assert!(connection.is_established());
+}
+
+fn establish_endpoint(
+    remote_initial_sequence: u32,
+    local_initial_sequence: u32,
+    mss: Option<u16>,
+    now: u64,
+) -> Endpoint {
+    let syn_bytes = syn_segment(remote_initial_sequence, 4_096, mss);
+    let syn = TcpSegment::parse(&syn_bytes).expect("test SYN parses");
+    let mut endpoint =
+        Endpoint::new(&syn, local_initial_sequence, now).expect("test endpoint opens");
+    let mut output = [];
+    let syn_ack = endpoint
+        .write_next_segment(&mut output, 0, now)
+        .expect("test SYN-ACK write succeeds")
+        .expect("test SYN-ACK is available");
+    assert_eq!(syn_ack.sequence_number(), local_initial_sequence);
+    let ack_bytes = basic_segment(
+        remote_initial_sequence.wrapping_add(1),
+        local_initial_sequence.wrapping_add(1),
+        TcpFlags::ACK,
+        4_096,
+        &[],
+    );
+    let ack = TcpSegment::parse(&ack_bytes).expect("test ACK parses");
+    assert_eq!(
+        endpoint
+            .receive_segment(&ack, now, no_response)
+            .expect("test handshake ACK succeeds"),
+        ReceiveStatus::empty()
+    );
+    endpoint
+}
+
+#[test]
+fn segment_parser_is_bounded_and_strict() {
+    assert_eq!(
+        TcpSegment::parse(&[0; 19]).expect_err("short segment is rejected"),
+        SegmentParseError::SliceTooShort { len: 19 }
+    );
+
+    let mut invalid_header = basic_segment(1, 2, TcpFlags::ACK, 10, &[]);
+    invalid_header[12] = 4 << 4;
+    assert!(matches!(
+        TcpSegment::parse(&invalid_header),
+        Err(SegmentParseError::HeaderLength {
+            header_len: 16,
+            segment_len: 20
+        })
+    ));
+    invalid_header[12] = 15 << 4;
+    assert!(matches!(
+        TcpSegment::parse(&invalid_header),
+        Err(SegmentParseError::HeaderLength {
+            header_len: 60,
+            segment_len: 20
+        })
+    ));
+
+    let malformed_option = segment_bytes(
+        (REMOTE_PORT, LOCAL_PORT),
+        1,
+        0,
+        TcpFlags::SYNCHRONIZE,
+        10,
+        &[0xff, 0, 0, 0],
+        &[],
+    );
+    assert!(matches!(
+        TcpSegment::parse(&malformed_option),
+        Err(SegmentParseError::InvalidOptionLength { offset: 0, len: 0 })
+    ));
+
+    let truncated_option = segment_bytes(
+        (REMOTE_PORT, LOCAL_PORT),
+        1,
+        0,
+        TcpFlags::SYNCHRONIZE,
+        10,
+        &[0xff, 8, 0, 0],
+        &[],
+    );
+    assert!(matches!(
+        TcpSegment::parse(&truncated_option),
+        Err(SegmentParseError::TruncatedOptionValue { .. })
+    ));
+
+    let low_mss = syn_segment(1, 10, Some(MIN_MSS - 1));
+    assert_eq!(
+        TcpSegment::parse(&low_mss).expect_err("small MSS is rejected"),
+        SegmentParseError::InvalidMssValue { value: MIN_MSS - 1 }
+    );
+
+    let duplicate_mss = segment_bytes(
+        (REMOTE_PORT, LOCAL_PORT),
+        1,
+        0,
+        TcpFlags::SYNCHRONIZE,
+        10,
+        &[2, 4, 0, 100, 2, 4, 0, 101],
+        &[],
+    );
+    assert_eq!(
+        TcpSegment::parse(&duplicate_mss).expect_err("duplicate MSS is rejected"),
+        SegmentParseError::DuplicateMss
+    );
+
+    let payload = b"secret payload";
+    let valid = segment_bytes(
+        (REMOTE_PORT, LOCAL_PORT),
+        123,
+        456,
+        TcpFlags::ACK | TcpFlags::PUSH,
+        789,
+        &[1, 1, 0, 0],
+        payload,
+    );
+    let parsed = TcpSegment::parse(&valid).expect("valid segment parses");
+    assert_eq!(parsed.source_port(), REMOTE_PORT);
+    assert_eq!(parsed.destination_port(), LOCAL_PORT);
+    assert_eq!(parsed.sequence_number(), 123);
+    assert_eq!(parsed.acknowledgement_number(), 456);
+    assert_eq!(parsed.window_size(), 789);
+    assert_eq!(parsed.payload(), payload);
+    assert!(!format!("{parsed:?}").contains("secret payload"));
+}
+
+#[test]
+fn malformed_segment_matrix_never_panics_or_owns_input() {
+    for len in 0..=80 {
+        for data_offset_words in 0_u8..=15 {
+            let mut bytes = vec![0xff; len];
+            if let Some(data_offset) = bytes.get_mut(12) {
+                *data_offset = data_offset_words << 4;
+            }
+            let _ = TcpSegment::parse(&bytes);
+        }
+    }
+
+    let oversized = vec![0; usize::from(u16::MAX) + 1];
+    assert_eq!(
+        TcpSegment::parse(&oversized).expect_err("oversized segment is rejected"),
+        SegmentParseError::SegmentTooLong {
+            len: usize::from(u16::MAX) + 1
+        }
+    );
+}
+
+#[test]
+fn sequence_and_reset_rules_match_the_pinned_core() {
+    let reference = u32::MAX - 3;
+    let wrapped = 2;
+    assert!(sequence_after(wrapped, reference));
+    assert!(sequence_at_or_after(wrapped, reference));
+    assert!(sequence_at_or_after(reference, reference));
+    assert!(!sequence_after(reference, reference));
+    assert!(!sequence_after(
+        reference.wrapping_add(MAX_WINDOW_SIZE),
+        reference
+    ));
+
+    let without_ack = basic_segment(100, 900, TcpFlags::PUSH, 10, b"abc");
+    let without_ack = TcpSegment::parse(&without_ack).expect("test segment parses");
+    assert_eq!(
+        ResetConfig::from_segment(&without_ack),
+        ResetConfig::Acknowledgement(103)
+    );
+
+    let with_ack = basic_segment(100, 900, TcpFlags::ACK, 10, b"abc");
+    let with_ack = TcpSegment::parse(&with_ack).expect("test segment parses");
+    assert_eq!(
+        ResetConfig::from_segment(&with_ack),
+        ResetConfig::Sequence(900)
+    );
+}
+
+#[test]
+fn connection_handshake_retransmits_and_uses_default_or_explicit_mss() {
+    let remote_initial = 10_000;
+    let local_initial = 20_000;
+    let period = 100;
+    let mut connection = open_connection(
+        remote_initial,
+        local_initial,
+        2_500,
+        4_096,
+        None,
+        (period, 15),
+        0,
+    );
+    assert_eq!(connection.maximum_segment_size(), DEFAULT_MSS);
+    assert_eq!(
+        connection.control_segment_or_timeout_status(),
+        NextSegmentStatus::Available
+    );
+
+    let mut output = [];
+    let syn_ack = connection
+        .write_next_segment(&mut output, 0, None, 0)
+        .expect("SYN-ACK write succeeds")
+        .expect("SYN-ACK is available");
+    assert_eq!(syn_ack.maximum_segment_size(), Some(DEFAULT_MSS));
+    assert_eq!(
+        connection.control_segment_or_timeout_status(),
+        NextSegmentStatus::Timeout(period)
+    );
+    assert!(
+        connection
+            .write_next_segment(&mut output, 0, None, period - 1)
+            .expect("early output check succeeds")
+            .is_none()
+    );
+    let retransmission = connection
+        .write_next_segment(&mut output, 0, None, period)
+        .expect("timeout retransmission succeeds")
+        .expect("SYN-ACK retransmission is available");
+    assert_eq!(
+        retransmission.flags(),
+        TcpFlags::SYNCHRONIZE | TcpFlags::ACK
+    );
+
+    let syn_bytes = syn_segment(remote_initial, 4_096, None);
+    let syn = TcpSegment::parse(&syn_bytes).expect("test SYN parses");
+    let mut receive = [];
+    assert_eq!(
+        connection
+            .receive_segment(&syn, &mut receive, period)
+            .expect("repeated SYN succeeds"),
+        (0, ReceiveStatus::empty())
+    );
+    assert_eq!(
+        connection.control_segment_or_timeout_status(),
+        NextSegmentStatus::Available
+    );
+
+    let explicit = open_connection(1, 2, 100, 100, Some(1_200), (10, 2), 0);
+    assert_eq!(explicit.maximum_segment_size(), 1_200);
+
+    let invalid = basic_segment(1, 0, TcpFlags::ACK, 100, &[]);
+    let invalid = TcpSegment::parse(&invalid).expect("test invalid SYN input parses");
+    assert!(matches!(
+        Connection::passive_open(
+            &invalid,
+            100,
+            NonZeroU64::new(1).expect("nonzero"),
+            NonZeroU16::new(1).expect("nonzero"),
+            2,
+            0,
+        ),
+        Err(PassiveOpenError::InvalidSyn)
+    ));
+}
+
+#[test]
+fn connection_receive_window_reorder_duplicate_and_wrap_are_bounded() {
+    let remote_initial = u32::MAX - 2;
+    let local_initial = 1_000;
+    let mut connection = open_connection(
+        remote_initial,
+        local_initial,
+        4,
+        4_096,
+        Some(400),
+        (100, 15),
+        0,
+    );
+    establish_connection(&mut connection, remote_initial, local_initial, 4_096, 0);
+
+    let reordered = basic_segment(
+        remote_initial.wrapping_add(2),
+        local_initial.wrapping_add(1),
+        TcpFlags::ACK,
+        4_096,
+        b"x",
+    );
+    let reordered = TcpSegment::parse(&reordered).expect("reordered segment parses");
+    let mut receive = [0; 4];
+    let (_, status) = connection
+        .receive_segment(&reordered, &mut receive, 1)
+        .expect("reordered segment is classified");
+    assert!(status.intersects(ReceiveStatus::UNEXPECTED_SEQUENCE));
+
+    let ordered = basic_segment(
+        remote_initial.wrapping_add(1),
+        local_initial.wrapping_add(1),
+        TcpFlags::ACK,
+        4_096,
+        b"abcd",
+    );
+    let ordered = TcpSegment::parse(&ordered).expect("ordered segment parses");
+    assert_eq!(
+        connection
+            .receive_segment(&ordered, &mut receive, 2)
+            .expect("ordered segment is accepted"),
+        (4, ReceiveStatus::empty())
+    );
+    assert_eq!(&receive, b"abcd");
+
+    let beyond = basic_segment(
+        remote_initial.wrapping_add(5),
+        local_initial.wrapping_add(1),
+        TcpFlags::ACK,
+        4_096,
+        b"e",
+    );
+    let beyond = TcpSegment::parse(&beyond).expect("beyond-window segment parses");
+    let (_, status) = connection
+        .receive_segment(&beyond, &mut receive, 3)
+        .expect("beyond-window segment is classified");
+    assert!(status.intersects(ReceiveStatus::SEGMENT_BEYOND_RECEIVE_WINDOW));
+
+    connection.advance_local_receive_window(1);
+    assert_eq!(
+        connection
+            .receive_segment(&beyond, &mut receive, 4)
+            .expect("reopened window accepts byte"),
+        (1, ReceiveStatus::empty())
+    );
+    assert_eq!(
+        connection.highest_acknowledgement_received(),
+        local_initial.wrapping_add(1)
+    );
+
+    let duplicate = ordered;
+    let (_, status) = connection
+        .receive_segment(&duplicate, &mut receive, 5)
+        .expect("duplicate data is classified");
+    assert!(status.intersects(ReceiveStatus::UNEXPECTED_SEQUENCE));
+
+    let mut output = [];
+    let acknowledgement = connection
+        .write_next_segment(&mut output, 0, None, 5)
+        .expect("ACK write succeeds")
+        .expect("ACK is pending");
+    assert_eq!(acknowledgement.flags(), TcpFlags::ACK);
+    assert_eq!(acknowledgement.acknowledgement_number(), 3);
+}
+
+#[test]
+fn connection_segments_replays_partial_ack_and_retransmits() {
+    let remote_initial = 100;
+    let local_initial = 1_000;
+    let period = 50;
+    let mut connection = open_connection(
+        remote_initial,
+        local_initial,
+        2_500,
+        2_000,
+        Some(300),
+        (period, 15),
+        0,
+    );
+    establish_connection(&mut connection, remote_initial, local_initial, 2_000, 0);
+
+    let mut payload = vec![0; 700];
+    for (index, byte) in payload.iter_mut().enumerate() {
+        *byte = u8::try_from(index % 251).expect("test byte fits");
+    }
+    let initial_sequence = local_initial.wrapping_add(1);
+    let source = PayloadSource::new(&payload, initial_sequence);
+    let mut output = [0; 512];
+    let first = connection
+        .write_next_segment(&mut output, 50, Some(source), 0)
+        .expect("first data segment succeeds")
+        .expect("first data segment exists");
+    assert_eq!(first.payload_len(), 250);
+    assert_eq!(&output[..250], &payload[..250]);
+    let second = connection
+        .write_next_segment(&mut output, 50, Some(source), 0)
+        .expect("second data segment succeeds")
+        .expect("second data segment exists");
+    assert_eq!(second.sequence_number(), initial_sequence.wrapping_add(250));
+    assert_eq!(second.payload_len(), 250);
+    let third = connection
+        .write_next_segment(&mut output, 50, Some(source), 0)
+        .expect("third data segment succeeds")
+        .expect("third data segment exists");
+    assert_eq!(third.payload_len(), 200);
+    assert!(
+        connection
+            .write_next_segment(&mut output, 50, Some(source), 0)
+            .expect("drained output check succeeds")
+            .is_none()
+    );
+
+    let partial_ack_number = initial_sequence.wrapping_add(125);
+    let partial_ack = basic_segment(
+        remote_initial.wrapping_add(1),
+        partial_ack_number,
+        TcpFlags::ACK,
+        2_000,
+        &[],
+    );
+    let partial_ack = TcpSegment::parse(&partial_ack).expect("partial ACK parses");
+    let mut receive = [];
+    assert_eq!(
+        connection
+            .receive_segment(&partial_ack, &mut receive, 1)
+            .expect("partial ACK advances"),
+        (0, ReceiveStatus::empty())
+    );
+
+    let (_, duplicate_status) = connection
+        .receive_segment(&partial_ack, &mut receive, 2)
+        .expect("duplicate ACK is classified");
+    assert!(duplicate_status.intersects(ReceiveStatus::DUPLICATE_ACK));
+    let duplicate_replay = connection
+        .write_next_segment(&mut output, 50, Some(source), 2)
+        .expect("duplicate replay succeeds")
+        .expect("duplicate replay exists");
+    assert_eq!(duplicate_replay.sequence_number(), partial_ack_number);
+    assert_eq!(duplicate_replay.payload_len(), 250);
+    assert_eq!(&output[..250], &payload[125..375]);
+
+    let timeout_replay = connection
+        .write_next_segment(&mut output, 50, Some(source), 1 + period)
+        .expect("timeout replay succeeds")
+        .expect("timeout replay exists");
+    assert_eq!(timeout_replay.sequence_number(), partial_ack_number);
+    assert_eq!(&output[..250], &payload[125..375]);
+
+    let mut tiny = [];
+    assert_eq!(
+        connection.write_next_segment(&mut tiny, 50, Some(source), 1 + period * 2),
+        Err(ConnectionWriteError::PayloadBufferTooSmall)
+    );
+}
+
+#[test]
+fn remote_window_exhaustion_reopens_only_with_valid_ack_progress() {
+    let remote_initial = 700;
+    let local_initial = 900;
+    let mut connection =
+        open_connection(remote_initial, local_initial, 100, 300, None, (50, 15), 0);
+    establish_connection(&mut connection, remote_initial, local_initial, 300, 0);
+
+    let payload = vec![b'x'; 500];
+    let initial_sequence = local_initial.wrapping_add(1);
+    let source = PayloadSource::new(&payload, initial_sequence);
+    let mut output = [0; 600];
+    let first = connection
+        .write_next_segment(&mut output, 0, Some(source), 0)
+        .expect("window-sized segment succeeds")
+        .expect("window-sized segment exists");
+    assert_eq!(first.payload_len(), 300);
+    assert!(
+        connection
+            .write_next_segment(&mut output, 0, Some(source), 0)
+            .expect("closed window check succeeds")
+            .is_none()
+    );
+
+    let future_ack = basic_segment(
+        remote_initial.wrapping_add(1),
+        connection.first_not_sent().wrapping_add(1),
+        TcpFlags::ACK,
+        300,
+        &[],
+    );
+    let future_ack = TcpSegment::parse(&future_ack).expect("future ACK parses");
+    let mut receive = [];
+    let (_, status) = connection
+        .receive_segment(&future_ack, &mut receive, 1)
+        .expect("future ACK is classified");
+    assert!(status.intersects(ReceiveStatus::INVALID_ACK));
+    assert!(
+        connection
+            .write_next_segment(&mut output, 0, Some(source), 1)
+            .expect("invalid ACK does not open window")
+            .is_none()
+    );
+
+    let progress_ack_number = initial_sequence.wrapping_add(100);
+    let progress_ack = basic_segment(
+        remote_initial.wrapping_add(1),
+        progress_ack_number,
+        TcpFlags::ACK,
+        300,
+        &[],
+    );
+    let progress_ack = TcpSegment::parse(&progress_ack).expect("progress ACK parses");
+    connection
+        .receive_segment(&progress_ack, &mut receive, 2)
+        .expect("progress ACK opens window");
+    let reopened = connection
+        .write_next_segment(&mut output, 0, Some(source), 2)
+        .expect("reopened window write succeeds")
+        .expect("reopened window output exists");
+    assert_eq!(
+        reopened.sequence_number(),
+        initial_sequence.wrapping_add(300)
+    );
+    assert_eq!(reopened.payload_len(), 100);
+
+    let stale_ack = basic_segment(
+        remote_initial.wrapping_add(1),
+        progress_ack_number.wrapping_sub(1),
+        TcpFlags::ACK,
+        300,
+        &[],
+    );
+    let stale_ack = TcpSegment::parse(&stale_ack).expect("stale ACK parses");
+    let (_, status) = connection
+        .receive_segment(&stale_ack, &mut receive, 3)
+        .expect("stale ACK is classified");
+    assert!(status.intersects(ReceiveStatus::INVALID_ACK));
+    assert_eq!(
+        connection.highest_acknowledgement_received(),
+        progress_ack_number
+    );
+}
+
+#[test]
+fn fifteenth_timeout_emits_reset_without_timestamp_regression_mutation() {
+    let mut connection = open_connection(100, 200, 100, 100, None, (10, 15), 5);
+    let mut output = [];
+    connection
+        .write_next_segment(&mut output, 0, None, 5)
+        .expect("initial SYN-ACK succeeds")
+        .expect("initial SYN-ACK exists");
+    let original_status = connection.control_segment_or_timeout_status();
+    assert!(matches!(
+        connection.write_next_segment(&mut output, 0, None, 4),
+        Err(ConnectionWriteError::TimestampRegression(_))
+    ));
+    assert_eq!(
+        connection.control_segment_or_timeout_status(),
+        original_status
+    );
+
+    for timeout in 1_u64..15 {
+        let segment = connection
+            .write_next_segment(&mut output, 0, None, 5 + timeout * 10)
+            .expect("timeout write succeeds")
+            .expect("timeout output exists");
+        assert_eq!(segment.flags(), TcpFlags::SYNCHRONIZE | TcpFlags::ACK);
+    }
+    let reset = connection
+        .write_next_segment(&mut output, 0, None, 5 + 15 * 10)
+        .expect("fifteenth timeout write succeeds")
+        .expect("fifteenth timeout emits output");
+    assert!(reset.flags().intersects(TcpFlags::RESET));
+    assert!(connection.is_done());
+    assert_eq!(
+        connection.write_next_segment(&mut output, 0, None, 5 + 15 * 10),
+        Err(ConnectionWriteError::ConnectionReset)
+    );
+}
+
+#[test]
+fn connection_fin_and_reset_paths_match_pinned_behavior() {
+    let remote_initial = 500;
+    let local_initial = 900;
+    let mut connection =
+        open_connection(remote_initial, local_initial, 100, 100, None, (10, 15), 0);
+    establish_connection(&mut connection, remote_initial, local_initial, 100, 0);
+    let fin = basic_segment(
+        remote_initial.wrapping_add(1),
+        local_initial.wrapping_add(1),
+        TcpFlags::FINISH | TcpFlags::ACK,
+        100,
+        &[],
+    );
+    let fin = TcpSegment::parse(&fin).expect("FIN parses");
+    let mut receive = [];
+    assert_eq!(
+        connection
+            .receive_segment(&fin, &mut receive, 1)
+            .expect("FIN is accepted"),
+        (0, ReceiveStatus::empty())
+    );
+    assert!(connection.fin_received());
+    let mut output = [];
+    let ack = connection
+        .write_next_segment(&mut output, 0, None, 1)
+        .expect("FIN ACK succeeds")
+        .expect("FIN ACK exists");
+    assert_eq!(ack.flags(), TcpFlags::ACK);
+    assert_eq!(ack.acknowledgement_number(), remote_initial.wrapping_add(2));
+    connection.close();
+    let local_fin = connection
+        .write_next_segment(&mut output, 0, None, 1)
+        .expect("local FIN succeeds")
+        .expect("local FIN exists");
+    assert_eq!(local_fin.flags(), TcpFlags::FINISH | TcpFlags::ACK);
+    assert!(connection.is_done());
+
+    let mut reset_connection = open_connection(10, 20, 100, 100, None, (10, 15), 0);
+    establish_connection(&mut reset_connection, 10, 20, 100, 0);
+    let invalid_reset = basic_segment(10, 0, TcpFlags::RESET, 0, &[]);
+    let invalid_reset = TcpSegment::parse(&invalid_reset).expect("invalid RST parses");
+    let (_, status) = reset_connection
+        .receive_segment(&invalid_reset, &mut receive, 1)
+        .expect("invalid RST is classified");
+    assert!(status.intersects(ReceiveStatus::INVALID_RESET));
+    let valid_reset = basic_segment(11, 0, TcpFlags::RESET, 0, &[]);
+    let valid_reset = TcpSegment::parse(&valid_reset).expect("valid RST parses");
+    let (_, status) = reset_connection
+        .receive_segment(&valid_reset, &mut receive, 2)
+        .expect("valid RST is accepted");
+    assert!(status.intersects(ReceiveStatus::RESET_RECEIVED));
+    assert!(reset_connection.is_done());
+}
+
+#[test]
+fn endpoint_holds_one_response_and_replays_from_partial_ack() {
+    let remote_initial = 1_000;
+    let local_initial = 5_000;
+    let mut endpoint = establish_endpoint(remote_initial, local_initial, Some(100), 0);
+    let callbacks = Cell::new(0_u32);
+
+    let first_part = b"GET /one HTTP/1.1\r\n";
+    let first = basic_segment(
+        remote_initial.wrapping_add(1),
+        local_initial.wrapping_add(1),
+        TcpFlags::ACK,
+        4_096,
+        first_part,
+    );
+    let first = TcpSegment::parse(&first).expect("first request part parses");
+    endpoint
+        .receive_segment(&first, 1, |_| -> Result<Vec<u8>, CallbackError> {
+            callbacks.set(callbacks.get() + 1);
+            Ok(Vec::new())
+        })
+        .expect("first request part is accepted");
+    assert_eq!(callbacks.get(), 0);
+    assert_eq!(endpoint.buffered_request_len(), first_part.len());
+
+    let response_one = vec![b'A'; 230];
+    let second_part = b"\r\nGET /two";
+    let second_sequence = remote_initial
+        .wrapping_add(1)
+        .wrapping_add(u32::try_from(first_part.len()).expect("test length fits"));
+    let second = basic_segment(
+        second_sequence,
+        local_initial.wrapping_add(1),
+        TcpFlags::ACK,
+        4_096,
+        second_part,
+    );
+    let second = TcpSegment::parse(&second).expect("second request part parses");
+    endpoint
+        .receive_segment(&second, 2, |_| -> Result<Vec<u8>, CallbackError> {
+            callbacks.set(callbacks.get() + 1);
+            Ok(response_one.clone())
+        })
+        .expect("complete first request is accepted");
+    assert_eq!(callbacks.get(), 1);
+    assert!(endpoint.response_pending());
+    assert_eq!(endpoint.buffered_request_len(), b"GET /two".len());
+
+    let third_part = b" HTTP/1.1\r\n\r\n";
+    let third_sequence =
+        second_sequence.wrapping_add(u32::try_from(second_part.len()).expect("test length fits"));
+    let third = basic_segment(
+        third_sequence,
+        local_initial.wrapping_add(1),
+        TcpFlags::ACK,
+        4_096,
+        third_part,
+    );
+    let third = TcpSegment::parse(&third).expect("pipelined request part parses");
+    endpoint
+        .receive_segment(&third, 3, |_| -> Result<Vec<u8>, CallbackError> {
+            callbacks.set(callbacks.get() + 1);
+            Ok(vec![b'X'])
+        })
+        .expect("pipelined request bytes are buffered");
+    assert_eq!(callbacks.get(), 1);
+
+    let mut output = [0; 200];
+    let response_initial = local_initial.wrapping_add(1);
+    let mut sent = Vec::new();
+    for expected_len in [100, 100, 30] {
+        let segment = endpoint
+            .write_next_segment(&mut output, 0, 3)
+            .expect("response segment succeeds")
+            .expect("response segment exists");
+        assert_eq!(segment.payload_len(), expected_len);
+        sent.extend_from_slice(&output[..expected_len]);
+    }
+    assert_eq!(sent, response_one);
+    assert!(matches!(
+        endpoint.next_segment_status(),
+        NextSegmentStatus::Timeout(_)
+    ));
+
+    let partial_ack_number = response_initial.wrapping_add(50);
+    let peer_sequence =
+        third_sequence.wrapping_add(u32::try_from(third_part.len()).expect("test length fits"));
+    let partial_ack = basic_segment(peer_sequence, partial_ack_number, TcpFlags::ACK, 4_096, &[]);
+    let partial_ack = TcpSegment::parse(&partial_ack).expect("partial response ACK parses");
+    endpoint
+        .receive_segment(&partial_ack, 4, no_response)
+        .expect("partial response ACK succeeds");
+    endpoint
+        .receive_segment(&partial_ack, 5, no_response)
+        .expect("duplicate response ACK succeeds");
+    let replay = endpoint
+        .write_next_segment(&mut output, 0, 5)
+        .expect("response replay succeeds")
+        .expect("response replay exists");
+    assert_eq!(replay.sequence_number(), partial_ack_number);
+    assert_eq!(replay.payload_len(), 100);
+    assert_eq!(&output[..100], &response_one[50..150]);
+    assert_eq!(callbacks.get(), 1);
+
+    let timeout_at = 4 + MMDS_TCP_RETRANSMISSION_PERIOD_TICKS;
+    let timeout_replay = endpoint
+        .write_next_segment(&mut output, 0, timeout_at)
+        .expect("response timeout replay succeeds")
+        .expect("response timeout replay exists");
+    assert_eq!(timeout_replay.sequence_number(), partial_ack_number);
+    assert_eq!(timeout_replay.payload_len(), 100);
+    assert_eq!(&output[..100], &response_one[50..150]);
+
+    let full_ack = basic_segment(
+        peer_sequence,
+        response_initial.wrapping_add(230),
+        TcpFlags::ACK,
+        4_096,
+        &[],
+    );
+    let full_ack = TcpSegment::parse(&full_ack).expect("full response ACK parses");
+    let response_two = b"second response".to_vec();
+    endpoint
+        .receive_segment(
+            &full_ack,
+            timeout_at + 1,
+            |_| -> Result<Vec<u8>, CallbackError> {
+                callbacks.set(callbacks.get() + 1);
+                Ok(response_two.clone())
+            },
+        )
+        .expect("full ACK releases and processes pipelined request");
+    assert_eq!(callbacks.get(), 2);
+    assert!(endpoint.response_pending());
+    assert_eq!(endpoint.buffered_request_len(), 0);
+}
+
+#[test]
+fn endpoint_resets_on_callback_response_or_receive_bound_failure() {
+    let remote_initial = 10;
+    let local_initial = 20;
+    let mut callback_failure = establish_endpoint(remote_initial, local_initial, None, 0);
+    let request = b"GET / HTTP/1.1\r\n\r\n";
+    let request_bytes = basic_segment(
+        remote_initial.wrapping_add(1),
+        local_initial.wrapping_add(1),
+        TcpFlags::ACK,
+        4_096,
+        request,
+    );
+    let request_segment = TcpSegment::parse(&request_bytes).expect("request segment parses");
+    assert!(matches!(
+        callback_failure.receive_segment(&request_segment, 1, |_| Err(CallbackError)),
+        Err(EndpointReceiveError::Callback(CallbackError))
+    ));
+    let mut output = [];
+    let reset = callback_failure
+        .write_next_segment(&mut output, 0, 1)
+        .expect("callback reset write succeeds")
+        .expect("callback reset exists");
+    assert!(reset.flags().intersects(TcpFlags::RESET));
+
+    let mut oversized = establish_endpoint(remote_initial, local_initial, None, 0);
+    oversized.set_response_len_limit_for_test(4);
+    assert!(matches!(
+        oversized.receive_segment(&request_segment, 1, |_| {
+            Ok::<_, CallbackError>(vec![0; 5])
+        }),
+        Err(EndpointReceiveError::ResponseTooLarge { len: 5, limit: 4 })
+    ));
+    let reset = oversized
+        .write_next_segment(&mut output, 0, 1)
+        .expect("oversized response reset write succeeds")
+        .expect("oversized response reset exists");
+    assert!(reset.flags().intersects(TcpFlags::RESET));
+
+    let mut full = establish_endpoint(remote_initial, local_initial, None, 0);
+    let full_payload = vec![b'x'; MMDS_TCP_RECEIVE_BUFFER_SIZE];
+    let full_bytes = basic_segment(
+        remote_initial.wrapping_add(1),
+        local_initial.wrapping_add(1),
+        TcpFlags::ACK,
+        4_096,
+        &full_payload,
+    );
+    let full_segment = TcpSegment::parse(&full_bytes).expect("full request segment parses");
+    full.receive_segment(&full_segment, 1, no_response)
+        .expect("full incomplete request is bounded");
+    let reset = full
+        .write_next_segment(&mut output, 0, 1)
+        .expect("full request reset write succeeds")
+        .expect("full request reset exists");
+    assert!(reset.flags().intersects(TcpFlags::RESET));
+}
+
+#[test]
+fn endpoint_eviction_and_timestamp_regression_are_safe() {
+    let mut endpoint = establish_endpoint(10, 20, None, 100);
+    let mut output = [];
+    assert!(
+        endpoint
+            .write_next_segment(&mut output, 0, 200)
+            .expect("idle output check succeeds")
+            .is_none()
+    );
+    assert!(matches!(
+        endpoint.is_evictable(199),
+        Err(TimestampRegression { .. })
+    ));
+    assert!(
+        !endpoint
+            .is_evictable(100 + MMDS_TCP_EVICTION_THRESHOLD_TICKS)
+            .expect("threshold timestamp is valid")
+    );
+    assert!(
+        endpoint
+            .is_evictable(101 + MMDS_TCP_EVICTION_THRESHOLD_TICKS)
+            .expect("post-threshold timestamp is valid")
+    );
+    assert!(matches!(
+        endpoint.is_evictable(99),
+        Err(TimestampRegression { .. })
+    ));
+}
+
+#[test]
+fn handler_routes_handshake_and_prioritizes_bounded_resets() {
+    let mut handler = MmdsTcpHandler::try_new(LOCAL_PORT).expect("handler allocation succeeds");
+    assert_eq!(handler.connection_limit(), MMDS_TCP_MAX_CONNECTIONS);
+    assert_eq!(handler.pending_reset_limit(), MMDS_TCP_MAX_PENDING_RESETS);
+    assert_eq!(handler.connection_count(), 0);
+
+    assert!(matches!(
+        handler.receive_segment(REMOTE_ADDRESS, &[0; 5], 1, 0, no_response),
+        Err(HandlerReceiveError::Segment(
+            SegmentParseError::SliceTooShort { len: 5 }
+        ))
+    ));
+    let wrong_port = segment_bytes(
+        (REMOTE_PORT, LOCAL_PORT + 1),
+        1,
+        0,
+        TcpFlags::SYNCHRONIZE,
+        100,
+        &[],
+        &[],
+    );
+    assert!(matches!(
+        handler.receive_segment(REMOTE_ADDRESS, &wrong_port, 10, 0, no_response),
+        Err(HandlerReceiveError::InvalidPort {
+            expected: LOCAL_PORT,
+            actual
+        }) if actual == LOCAL_PORT + 1
+    ));
+
+    let syn = syn_segment(100, 4_096, Some(1_200));
+    assert_eq!(
+        handler
+            .receive_segment(REMOTE_ADDRESS, &syn, 500, 0, no_response)
+            .expect("new SYN succeeds"),
+        HandlerReceiveEvent::NewConnection
+    );
+    assert_eq!(handler.connection_count(), 1);
+    let mut output = [];
+    let syn_ack = handler
+        .write_next_segment(&mut output, 0, 0)
+        .expect("handler SYN-ACK write succeeds")
+        .expect("handler SYN-ACK exists");
+    assert_eq!(syn_ack.peer(), Peer::new(REMOTE_ADDRESS, REMOTE_PORT));
+    assert_eq!(syn_ack.local_port(), LOCAL_PORT);
+    assert_eq!(
+        syn_ack.segment().flags(),
+        TcpFlags::SYNCHRONIZE | TcpFlags::ACK
+    );
+    assert_eq!(syn_ack.segment().maximum_segment_size(), Some(1_200));
+
+    let ack = basic_segment(101, 501, TcpFlags::ACK, 4_096, &[]);
+    assert!(matches!(
+        handler
+            .receive_segment(REMOTE_ADDRESS, &ack, 0, 0, no_response)
+            .expect("handler ACK succeeds"),
+        HandlerReceiveEvent::ExistingConnection { status } if status.is_empty()
+    ));
+    assert_eq!(handler.next_segment_status(), NextSegmentStatus::Nothing);
+
+    let unexpected = segment_bytes(
+        (REMOTE_PORT + 1, LOCAL_PORT),
+        1,
+        7,
+        TcpFlags::ACK,
+        100,
+        &[],
+        &[],
+    );
+    assert_eq!(
+        handler
+            .receive_segment(REMOTE_ADDRESS, &unexpected, 0, 1, no_response)
+            .expect("unexpected segment is classified"),
+        HandlerReceiveEvent::UnexpectedSegment
+    );
+    assert_eq!(handler.pending_reset_count(), 1);
+    let reset = handler
+        .write_next_segment(&mut output, 0, 1)
+        .expect("handler reset write succeeds")
+        .expect("handler reset exists");
+    assert!(reset.segment().flags().intersects(TcpFlags::RESET));
+    assert_eq!(reset.peer().port(), REMOTE_PORT + 1);
+}
+
+#[test]
+fn handler_enforces_exact_connection_eviction_and_reset_limits() {
+    let mut handler = MmdsTcpHandler::try_new(LOCAL_PORT).expect("handler allocation succeeds");
+    for index in 0..MMDS_TCP_MAX_CONNECTIONS {
+        let source_port = 10_000_u16
+            .checked_add(u16::try_from(index).expect("test index fits"))
+            .expect("test source port fits");
+        let syn = segment_bytes(
+            (source_port, LOCAL_PORT),
+            u32::try_from(index).expect("test index fits"),
+            0,
+            TcpFlags::SYNCHRONIZE,
+            100,
+            &[],
+            &[],
+        );
+        assert_eq!(
+            handler
+                .receive_segment(
+                    REMOTE_ADDRESS,
+                    &syn,
+                    100_u32
+                        .checked_add(u32::try_from(index).expect("test index fits"))
+                        .expect("test ISN fits"),
+                    0,
+                    no_response,
+                )
+                .expect("bounded connection opens"),
+            HandlerReceiveEvent::NewConnection
+        );
+    }
+    assert_eq!(handler.connection_count(), MMDS_TCP_MAX_CONNECTIONS);
+
+    let at_threshold = segment_bytes(
+        (20_000, LOCAL_PORT),
+        99,
+        0,
+        TcpFlags::SYNCHRONIZE,
+        100,
+        &[],
+        &[],
+    );
+    assert_eq!(
+        handler
+            .receive_segment(
+                REMOTE_ADDRESS,
+                &at_threshold,
+                999,
+                MMDS_TCP_EVICTION_THRESHOLD_TICKS,
+                no_response,
+            )
+            .expect("threshold SYN is classified"),
+        HandlerReceiveEvent::NewConnectionDropped
+    );
+    assert_eq!(handler.connection_count(), MMDS_TCP_MAX_CONNECTIONS);
+
+    let stale = segment_bytes(
+        (20_001, LOCAL_PORT),
+        100,
+        0,
+        TcpFlags::SYNCHRONIZE,
+        100,
+        &[],
+        &[],
+    );
+    assert_eq!(
+        handler
+            .receive_segment(
+                REMOTE_ADDRESS,
+                &stale,
+                1_000,
+                MMDS_TCP_EVICTION_THRESHOLD_TICKS + 1,
+                no_response,
+            )
+            .expect("stale endpoint can be replaced"),
+        HandlerReceiveEvent::NewConnectionReplacing
+    );
+    assert_eq!(handler.connection_count(), MMDS_TCP_MAX_CONNECTIONS);
+    assert_eq!(handler.pending_reset_count(), 2);
+
+    let mut reset_handler =
+        MmdsTcpHandler::try_new(LOCAL_PORT).expect("reset handler allocation succeeds");
+    for index in 0..=MMDS_TCP_MAX_PENDING_RESETS {
+        let source_port = 30_000_u16
+            .checked_add(u16::try_from(index).expect("test index fits"))
+            .expect("test source port fits");
+        let unexpected = segment_bytes(
+            (source_port, LOCAL_PORT),
+            u32::try_from(index).expect("test index fits"),
+            7,
+            TcpFlags::ACK,
+            100,
+            &[],
+            &[],
+        );
+        assert_eq!(
+            reset_handler
+                .receive_segment(
+                    REMOTE_ADDRESS,
+                    &unexpected,
+                    0,
+                    u64::try_from(index).expect("test index fits"),
+                    no_response,
+                )
+                .expect("unexpected segment is classified"),
+            HandlerReceiveEvent::UnexpectedSegment
+        );
+    }
+    assert_eq!(
+        reset_handler.pending_reset_count(),
+        MMDS_TCP_MAX_PENDING_RESETS
+    );
+}
+
+#[test]
+fn handler_time_and_allocation_failures_do_not_mutate_queues() {
+    assert!(MmdsTcpHandler::try_new_for_test(LOCAL_PORT, usize::MAX, 1).is_err());
+
+    let mut handler = MmdsTcpHandler::try_new(LOCAL_PORT).expect("handler allocation succeeds");
+    let unexpected = basic_segment(1, 2, TcpFlags::ACK, 100, &[]);
+    handler
+        .receive_segment(REMOTE_ADDRESS, &unexpected, 0, 10, no_response)
+        .expect("first timestamp succeeds");
+    assert_eq!(handler.pending_reset_count(), 1);
+    assert!(matches!(
+        handler.receive_segment(REMOTE_ADDRESS, &unexpected, 0, 9, no_response),
+        Err(HandlerReceiveError::TimestampRegression(_))
+    ));
+    assert_eq!(handler.pending_reset_count(), 1);
+    let mut output = [];
+    assert!(matches!(
+        handler.write_next_segment(&mut output, 0, 9),
+        Err(HandlerWriteError::TimestampRegression(_))
+    ));
+    assert_eq!(handler.pending_reset_count(), 1);
+}


### PR DESCRIPTION
## Summary

- add a source-attributed, portable Firecracker v1.16 MMDS TCP segment/connection/endpoint/handler core
- enforce the pinned 30-connection, 100-reset, 2,500-byte request, one-response, MSS/window, eviction, and retransmission bounds
- cover handshake, ACK/window/sequence behavior, segmentation/replay, FIN/RST, timeout, eviction, malformed input, time regression, and allocation failure
- leave the production `MmdsPacketDetour` unchanged for the later integration slice

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented Apple-target Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

Parent: #1493
Closes #1500
