### PR TITLE
feat: define native-v2 snapshot state compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,16 @@ additional drives, serialized/restorable optional-device snapshot state,
 active SVE/SME/debug state, EL2 GIC CPU-interface state, and cross-host
 portability remain unsupported.
 
+Separately, the runtime library defines the allocation-free first-pass grammar
+for a future bangbang-native v2 arm64 state container. The initial `2.0.0`
+production catalog is structural only: its canonical state is empty, unknown
+explicitly nonsemantic extensions can be validated, and every required feature
+or semantic component rejects. No public create, load, describe, or version
+path emits or accepts v2 yet, and recognizing a pinned Firecracker bitcode
+prefix reports incompatibility rather than claiming decode or translation.
+The exact wire and compatibility contract is documented in
+[Snapshot Feasibility](docs/snapshot-feasibility.md#native-v2-structural-state-foundation).
+
 ## Process CLI
 
 Run the VMM process skeleton and API server:

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -37,6 +37,7 @@ pub mod snapshot_artifact;
 pub mod snapshot_commit;
 pub mod snapshot_device;
 pub mod snapshot_format;
+pub mod snapshot_format_v2;
 pub mod snapshot_memory;
 pub mod startup;
 pub mod storage_capture;

--- a/crates/runtime/src/snapshot_format.rs
+++ b/crates/runtime/src/snapshot_format.rs
@@ -4,6 +4,10 @@ use std::fmt;
 
 use crc64::crc64;
 
+use crate::snapshot_format_v2::{
+    NATIVE_V2_ARM64_MAGIC, SnapshotV2DecodeError, SnapshotV2State, decode_snapshot_v2_state,
+};
+
 const SNAPSHOT_MAGIC: [u8; 8] = *b"BANGSNAP";
 const SNAPSHOT_MAGIC_OFFSET: usize = 0;
 const SNAPSHOT_VERSION_MAJOR_OFFSET: usize = 8;
@@ -237,6 +241,115 @@ impl fmt::Display for SnapshotFormatError {
 
 impl std::error::Error for SnapshotFormatError {}
 
+// Firecracker v1.16.0 commit d83d72b710361a10294480131377b1b00b163af8
+// `src/vmm/src/snapshot/mod.rs` fixes these architecture-specific `u64`
+// magics. bitcode 0.6.9 places its leading field marker before the magic's
+// little-endian bytes. These prefixes classify a family only.
+const FIRECRACKER_AARCH64_BITCODE_MAGIC_PREFIX: [u8; 9] =
+    [0x00, 0x00, 0x00, 0xaa, 0xaa, 0x84, 0x19, 0x10, 0x07];
+const FIRECRACKER_X86_64_BITCODE_MAGIC_PREFIX: [u8; 9] =
+    [0x00, 0x00, 0x00, 0x64, 0x86, 0x84, 0x19, 0x10, 0x07];
+
+/// A fully validated native state-file family borrowing its input.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum NativeSnapshotState<'state> {
+    /// Exact bangbang-native v1 outer envelope.
+    V1(SnapshotEnvelope<'state>),
+    /// Compatible bangbang-native v2 structural container.
+    V2(SnapshotV2State<'state>),
+}
+
+impl NativeSnapshotState<'_> {
+    /// Returns the embedded semantic state-format version.
+    pub const fn version(&self) -> SnapshotFormatVersion {
+        match self {
+            Self::V1(envelope) => envelope.metadata().version(),
+            Self::V2(state) => state.metadata().version(),
+        }
+    }
+
+    /// Returns the architecture identified by the native state family.
+    pub const fn architecture(&self) -> SnapshotArchitecture {
+        match self {
+            Self::V1(envelope) => envelope.metadata().architecture(),
+            Self::V2(state) => state.metadata().architecture(),
+        }
+    }
+}
+
+impl fmt::Debug for NativeSnapshotState<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::V1(envelope) => formatter.debug_tuple("V1").field(envelope).finish(),
+            Self::V2(state) => formatter.debug_tuple("V2").field(state).finish(),
+        }
+    }
+}
+
+/// Native state-family dispatch or validation failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NativeSnapshotFormatError {
+    /// A bangbang-native v1 envelope is invalid.
+    NativeV1(SnapshotFormatError),
+    /// A bangbang-native v2 container is invalid or incompatible.
+    NativeV2(SnapshotV2DecodeError),
+    /// Input carries the pinned Firecracker bitcode format-family prefix.
+    IncompatibleFirecrackerFormat,
+    /// Input belongs to no supported native state-file family.
+    IncompatibleFormat,
+}
+
+impl fmt::Display for NativeSnapshotFormatError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NativeV1(source) => write!(formatter, "invalid native-v1 state: {source}"),
+            Self::NativeV2(source) => write!(formatter, "invalid native-v2 state: {source}"),
+            Self::IncompatibleFirecrackerFormat => {
+                formatter.write_str("Firecracker snapshot state format is incompatible")
+            }
+            Self::IncompatibleFormat => {
+                formatter.write_str("snapshot state format is incompatible")
+            }
+        }
+    }
+}
+
+impl std::error::Error for NativeSnapshotFormatError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::NativeV1(source) => Some(source),
+            Self::NativeV2(source) => Some(source),
+            Self::IncompatibleFirecrackerFormat | Self::IncompatibleFormat => None,
+        }
+    }
+}
+
+/// Classifies and validates one supported native state-file family.
+///
+/// The Firecracker branch recognizes only the pinned bitcode format-family
+/// prefix. It does not claim that the remaining bytes form a valid Firecracker
+/// snapshot and never attempts bitcode deserialization.
+pub fn decode_native_snapshot_state(
+    bytes: &[u8],
+) -> Result<NativeSnapshotState<'_>, NativeSnapshotFormatError> {
+    if bytes.starts_with(&SNAPSHOT_MAGIC) {
+        return decode_snapshot_envelope(bytes)
+            .map(NativeSnapshotState::V1)
+            .map_err(NativeSnapshotFormatError::NativeV1);
+    }
+    if bytes.starts_with(&NATIVE_V2_ARM64_MAGIC) {
+        return decode_snapshot_v2_state(bytes)
+            .map(NativeSnapshotState::V2)
+            .map_err(NativeSnapshotFormatError::NativeV2);
+    }
+    if bytes.starts_with(&FIRECRACKER_AARCH64_BITCODE_MAGIC_PREFIX)
+        || bytes.starts_with(&FIRECRACKER_X86_64_BITCODE_MAGIC_PREFIX)
+    {
+        return Err(NativeSnapshotFormatError::IncompatibleFirecrackerFormat);
+    }
+    Err(NativeSnapshotFormatError::IncompatibleFormat)
+}
+
 /// Encodes an opaque payload in the native-v1 snapshot envelope.
 pub fn encode_snapshot_envelope(payload: &[u8]) -> Result<Vec<u8>, SnapshotFormatError> {
     let payload_length =
@@ -394,21 +507,25 @@ mod tests {
     use super::*;
 
     const TEST_PAYLOAD: &[u8] = b"state";
+    const NATIVE_V1_FIXTURE: [u8; 45] = [
+        0x42, 0x41, 0x4e, 0x47, 0x53, 0x4e, 0x41, 0x50, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+        0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x73, 0x74, 0x61, 0x74, 0x65, 0x9e, 0xf0, 0xc0, 0x25, 0xe2, 0x0a, 0x82, 0x32,
+    ];
 
     #[test]
     fn native_v1_encoding_matches_golden_bytes() {
         let encoded = encode_snapshot_envelope(TEST_PAYLOAD).expect("fixture should encode");
-        let expected = [
-            0x42, 0x41, 0x4e, 0x47, 0x53, 0x4e, 0x41, 0x50, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x01, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x73, 0x74, 0x61, 0x74, 0x65, 0x9e, 0xf0, 0xc0, 0x25, 0xe2,
-            0x0a, 0x82, 0x32,
-        ];
-
-        assert_eq!(encoded, expected);
+        assert_eq!(encoded, NATIVE_V1_FIXTURE);
         assert_eq!(
             encode_snapshot_envelope(TEST_PAYLOAD).expect("fixture should re-encode"),
-            expected
+            NATIVE_V1_FIXTURE
+        );
+        assert_eq!(
+            decode_snapshot_envelope(&NATIVE_V1_FIXTURE)
+                .expect("immutable fixture should decode")
+                .payload(),
+            TEST_PAYLOAD
         );
     }
 

--- a/crates/runtime/src/snapshot_format_v2.rs
+++ b/crates/runtime/src/snapshot_format_v2.rs
@@ -1,0 +1,1032 @@
+//! Canonical bangbang-native v2 snapshot-state container.
+
+use std::collections::TryReserveError;
+use std::fmt;
+
+use crc64::crc64;
+
+use crate::snapshot_format::{SnapshotArchitecture, SnapshotFormatVersion, SnapshotIntegrity};
+
+pub(crate) const NATIVE_V2_ARM64_MAGIC: [u8; 8] = *b"BANGV2A\0";
+const MAGIC_OFFSET: usize = 0;
+const VERSION_MAJOR_OFFSET: usize = 8;
+const VERSION_MINOR_OFFSET: usize = 10;
+const VERSION_PATCH_OFFSET: usize = 12;
+const HEADER_BYTES_OFFSET: usize = 14;
+const FLAGS_OFFSET: usize = 16;
+const REQUIRED_FEATURE_COUNT_OFFSET: usize = 20;
+const COMPONENT_COUNT_OFFSET: usize = 24;
+const RESERVED_OFFSET: usize = 28;
+const TOTAL_LENGTH_OFFSET: usize = 32;
+const REQUIRED_FEATURE_OFFSET_OFFSET: usize = 40;
+const COMPONENT_DIRECTORY_OFFSET_OFFSET: usize = 48;
+const COMPONENT_PAYLOAD_OFFSET_OFFSET: usize = 56;
+const HEADER_FLAGS: u32 = 0;
+const HEADER_RESERVED: u32 = 0;
+const COMPONENT_KIND_OFFSET: usize = 0;
+const COMPONENT_INSTANCE_OFFSET: usize = 4;
+const COMPONENT_FLAGS_OFFSET: usize = 8;
+const COMPONENT_RESERVED_OFFSET: usize = 12;
+const COMPONENT_PAYLOAD_OFFSET: usize = 16;
+const COMPONENT_PAYLOAD_LENGTH_OFFSET: usize = 24;
+const COMPONENT_RESERVED: u32 = 0;
+const COMPONENT_FLAG_SEMANTIC: u32 = 0;
+const COMPONENT_FLAG_NONSEMANTIC: u32 = 1;
+const REDACTED: &str = "<redacted>";
+
+/// Semantic version of the structural native-v2 foundation.
+pub const NATIVE_V2_SNAPSHOT_VERSION: SnapshotFormatVersion = SnapshotFormatVersion::new(2, 0, 0);
+
+/// Fixed native-v2 state header size.
+pub const NATIVE_V2_SNAPSHOT_HEADER_BYTES: usize = 64;
+
+/// Native-v2 state integrity trailer size.
+pub const NATIVE_V2_SNAPSHOT_INTEGRITY_BYTES: usize = 8;
+
+/// Current maximum complete native-v2 state-file size.
+pub const NATIVE_V2_SNAPSHOT_MAX_FILE_BYTES: usize = 16 * 1024 * 1024;
+
+/// Maximum required features admitted by the structural reader.
+pub const NATIVE_V2_SNAPSHOT_MAX_REQUIRED_FEATURES: usize = 256;
+
+/// Maximum component directory entries admitted by the structural reader.
+pub const NATIVE_V2_SNAPSHOT_MAX_COMPONENTS: usize = 4096;
+
+/// Fixed native-v2 component directory entry size.
+pub const NATIVE_V2_COMPONENT_DIRECTORY_ENTRY_BYTES: usize = 32;
+
+#[derive(Clone, Copy)]
+struct CatalogEntry {
+    id: u32,
+    introduced_minor: u16,
+}
+
+const PRODUCTION_REQUIRED_FEATURES: &[CatalogEntry] = &[];
+const PRODUCTION_SEMANTIC_COMPONENTS: &[CatalogEntry] = &[];
+
+const _: () = assert!(catalog_is_canonical(PRODUCTION_REQUIRED_FEATURES));
+const _: () = assert!(catalog_is_canonical(PRODUCTION_SEMANTIC_COMPONENTS));
+
+const fn catalog_is_canonical(mut entries: &[CatalogEntry]) -> bool {
+    let mut previous = 0;
+    while let [entry, remaining @ ..] = entries {
+        if entry.id == 0 || entry.id <= previous {
+            return false;
+        }
+        previous = entry.id;
+        entries = remaining;
+    }
+    true
+}
+
+fn catalog_contains(entries: &[CatalogEntry], id: u32, encoded_minor: u16) -> bool {
+    entries
+        .binary_search_by_key(&id, |entry| entry.id)
+        .ok()
+        .and_then(|index| entries.get(index))
+        .is_some_and(|entry| entry.introduced_minor <= encoded_minor)
+}
+
+/// Canonical component identity inside a native-v2 state container.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SnapshotV2ComponentKey {
+    kind: u32,
+    instance: u32,
+}
+
+impl SnapshotV2ComponentKey {
+    /// Creates a component key. Encoding rejects kind zero.
+    pub const fn new(kind: u32, instance: u32) -> Self {
+        Self { kind, instance }
+    }
+
+    /// Returns the component kind to trusted typed-codec code.
+    pub const fn kind(self) -> u32 {
+        self.kind
+    }
+
+    /// Returns the component instance identifier to trusted typed-codec code.
+    pub const fn instance(self) -> u32 {
+        self.instance
+    }
+}
+
+impl fmt::Debug for SnapshotV2ComponentKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2ComponentKey")
+            .field("identity", &REDACTED)
+            .finish()
+    }
+}
+
+/// Whether a v2 component affects VM semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2ComponentDisposition {
+    /// The component must be understood before a VM can use the state.
+    Semantic,
+    /// The component is explicitly safe to ignore after structural validation.
+    NonSemantic,
+}
+
+impl SnapshotV2ComponentDisposition {
+    const fn flags(self) -> u32 {
+        match self {
+            Self::Semantic => COMPONENT_FLAG_SEMANTIC,
+            Self::NonSemantic => COMPONENT_FLAG_NONSEMANTIC,
+        }
+    }
+}
+
+/// One trusted encoding input or validated borrowed v2 component.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotV2Component<'payload> {
+    key: SnapshotV2ComponentKey,
+    disposition: SnapshotV2ComponentDisposition,
+    payload: &'payload [u8],
+}
+
+impl<'payload> SnapshotV2Component<'payload> {
+    /// Creates a component encoding input.
+    pub const fn new(
+        key: SnapshotV2ComponentKey,
+        disposition: SnapshotV2ComponentDisposition,
+        payload: &'payload [u8],
+    ) -> Self {
+        Self {
+            key,
+            disposition,
+            payload,
+        }
+    }
+
+    /// Returns the validated component key.
+    pub const fn key(self) -> SnapshotV2ComponentKey {
+        self.key
+    }
+
+    /// Returns whether the component affects VM semantics.
+    pub const fn disposition(self) -> SnapshotV2ComponentDisposition {
+        self.disposition
+    }
+
+    /// Returns the validated borrowed component payload.
+    pub const fn payload(self) -> &'payload [u8] {
+        self.payload
+    }
+}
+
+impl fmt::Debug for SnapshotV2Component<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2Component")
+            .field("key", &REDACTED)
+            .field("disposition", &self.disposition)
+            .field("payload", &REDACTED)
+            .field("payload_bytes", &self.payload.len())
+            .finish()
+    }
+}
+
+/// Stable non-sensitive metadata from a validated native-v2 container.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotV2Metadata {
+    version: SnapshotFormatVersion,
+    architecture: SnapshotArchitecture,
+    required_feature_count: u32,
+    component_count: u32,
+    total_length: u64,
+    integrity: SnapshotIntegrity,
+}
+
+impl SnapshotV2Metadata {
+    /// Returns the embedded semantic format version.
+    pub const fn version(self) -> SnapshotFormatVersion {
+        self.version
+    }
+
+    /// Returns the architecture identified by the format magic.
+    pub const fn architecture(self) -> SnapshotArchitecture {
+        self.architecture
+    }
+
+    /// Returns the bounded required-feature count.
+    pub const fn required_feature_count(self) -> u32 {
+        self.required_feature_count
+    }
+
+    /// Returns the bounded component count.
+    pub const fn component_count(self) -> u32 {
+        self.component_count
+    }
+
+    /// Returns the exact complete state-file size.
+    pub const fn total_length(self) -> u64 {
+        self.total_length
+    }
+
+    /// Returns the state-file integrity algorithm.
+    pub const fn integrity(self) -> SnapshotIntegrity {
+        self.integrity
+    }
+}
+
+/// A compatible native-v2 state container borrowing all source bytes.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotV2State<'state> {
+    bytes: &'state [u8],
+    metadata: SnapshotV2Metadata,
+    required_feature_offset: usize,
+    component_directory_offset: usize,
+    component_payload_offset: usize,
+}
+
+impl SnapshotV2State<'_> {
+    /// Returns stable non-sensitive metadata.
+    pub const fn metadata(&self) -> SnapshotV2Metadata {
+        self.metadata
+    }
+
+    /// Iterates over already validated required-feature identifiers.
+    pub fn required_features(&self) -> SnapshotV2RequiredFeatures<'_> {
+        SnapshotV2RequiredFeatures {
+            bytes: self.bytes,
+            position: self.required_feature_offset,
+            remaining: self.metadata.required_feature_count as usize,
+        }
+    }
+
+    /// Iterates over already validated borrowed components.
+    pub fn components(&self) -> SnapshotV2Components<'_> {
+        SnapshotV2Components {
+            bytes: self.bytes,
+            directory_position: self.component_directory_offset,
+            remaining: self.metadata.component_count as usize,
+        }
+    }
+
+    /// Finds one already validated component by its trusted key.
+    pub fn component(&self, key: SnapshotV2ComponentKey) -> Option<SnapshotV2Component<'_>> {
+        self.components().find(|component| component.key == key)
+    }
+
+    /// Returns the byte offset at which component payloads begin.
+    pub const fn component_payload_offset(&self) -> usize {
+        self.component_payload_offset
+    }
+}
+
+impl fmt::Debug for SnapshotV2State<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2State")
+            .field("metadata", &self.metadata)
+            .field("required_features", &REDACTED)
+            .field("components", &REDACTED)
+            .finish()
+    }
+}
+
+/// Borrowed iterator over a validated required-feature table.
+#[derive(Clone)]
+pub struct SnapshotV2RequiredFeatures<'state> {
+    bytes: &'state [u8],
+    position: usize,
+    remaining: usize,
+}
+
+impl Iterator for SnapshotV2RequiredFeatures<'_> {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+        let value = read_u32_option(self.bytes, self.position)?;
+        self.position = self.position.checked_add(size_of::<u32>())?;
+        self.remaining -= 1;
+        Some(value)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl ExactSizeIterator for SnapshotV2RequiredFeatures<'_> {}
+
+impl fmt::Debug for SnapshotV2RequiredFeatures<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2RequiredFeatures")
+            .field("remaining", &self.remaining)
+            .field("values", &REDACTED)
+            .finish()
+    }
+}
+
+/// Borrowed iterator over a validated component directory.
+#[derive(Clone)]
+pub struct SnapshotV2Components<'state> {
+    bytes: &'state [u8],
+    directory_position: usize,
+    remaining: usize,
+}
+
+impl<'state> Iterator for SnapshotV2Components<'state> {
+    type Item = SnapshotV2Component<'state>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+        let entry = self.bytes.get(
+            self.directory_position
+                ..self
+                    .directory_position
+                    .checked_add(NATIVE_V2_COMPONENT_DIRECTORY_ENTRY_BYTES)?,
+        )?;
+        let key = SnapshotV2ComponentKey::new(
+            read_u32_option(entry, COMPONENT_KIND_OFFSET)?,
+            read_u32_option(entry, COMPONENT_INSTANCE_OFFSET)?,
+        );
+        let disposition = match read_u32_option(entry, COMPONENT_FLAGS_OFFSET)? {
+            COMPONENT_FLAG_SEMANTIC => SnapshotV2ComponentDisposition::Semantic,
+            COMPONENT_FLAG_NONSEMANTIC => SnapshotV2ComponentDisposition::NonSemantic,
+            _ => return None,
+        };
+        let payload_offset =
+            usize::try_from(read_u64_option(entry, COMPONENT_PAYLOAD_OFFSET)?).ok()?;
+        let payload_length =
+            usize::try_from(read_u64_option(entry, COMPONENT_PAYLOAD_LENGTH_OFFSET)?).ok()?;
+        let payload_end = payload_offset.checked_add(payload_length)?;
+        let payload = self.bytes.get(payload_offset..payload_end)?;
+
+        self.directory_position = self
+            .directory_position
+            .checked_add(NATIVE_V2_COMPONENT_DIRECTORY_ENTRY_BYTES)?;
+        self.remaining -= 1;
+        Some(SnapshotV2Component::new(key, disposition, payload))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl ExactSizeIterator for SnapshotV2Components<'_> {}
+
+impl fmt::Debug for SnapshotV2Components<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2Components")
+            .field("remaining", &self.remaining)
+            .field("values", &REDACTED)
+            .finish()
+    }
+}
+
+/// Native-v2 structural or compatibility validation failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SnapshotV2DecodeError {
+    /// Input is smaller than the fixed header and integrity trailer.
+    Truncated { minimum: usize, actual: usize },
+    /// The input is not an arm64 native-v2 container.
+    InvalidMagic,
+    /// The semantic major is unsupported or the minor is newer than this reader.
+    UnsupportedVersion {
+        found: SnapshotFormatVersion,
+        supported: SnapshotFormatVersion,
+    },
+    /// Fixed header fields are noncanonical.
+    InvalidHeader,
+    /// A required-feature or component count exceeds reader policy.
+    CountOutOfBounds { count: u64, maximum: usize },
+    /// A declared length or offset cannot be represented safely.
+    LengthOverflow,
+    /// The complete input length differs from the declared total.
+    LengthMismatch { declared: u64, actual: usize },
+    /// The complete state file exceeds reader policy.
+    FileTooLarge { length: u64, maximum: usize },
+    /// State CRC-64/Jones validation failed.
+    IntegrityMismatch,
+    /// Required-feature entries are zero, duplicated, or not canonical.
+    InvalidRequiredFeatureInventory,
+    /// The container requires behavior not supported by this reader.
+    UnknownRequiredFeature,
+    /// Component entries, flags, ordering, or ranges are invalid.
+    InvalidComponentDirectory,
+    /// A semantic component kind is not supported by this reader.
+    UnknownSemanticComponent,
+}
+
+impl fmt::Display for SnapshotV2DecodeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Truncated { minimum, actual } => write!(
+                formatter,
+                "native-v2 state is truncated: requires at least {minimum} bytes, found {actual}"
+            ),
+            Self::InvalidMagic => {
+                formatter.write_str("native-v2 state architecture magic is invalid")
+            }
+            Self::UnsupportedVersion { found, supported } => write!(
+                formatter,
+                "native-v2 state version {found} is unsupported by {supported}"
+            ),
+            Self::InvalidHeader => formatter.write_str("native-v2 state header is noncanonical"),
+            Self::CountOutOfBounds { count, maximum } => write!(
+                formatter,
+                "native-v2 state metadata count {count} exceeds {maximum}"
+            ),
+            Self::LengthOverflow => {
+                formatter.write_str("native-v2 state length arithmetic overflowed")
+            }
+            Self::LengthMismatch { declared, actual } => write!(
+                formatter,
+                "native-v2 state declares {declared} bytes but contains {actual}"
+            ),
+            Self::FileTooLarge { length, maximum } => write!(
+                formatter,
+                "native-v2 state length {length} exceeds {maximum} byte limit"
+            ),
+            Self::IntegrityMismatch => {
+                formatter.write_str("native-v2 state CRC-64/Jones integrity check failed")
+            }
+            Self::InvalidRequiredFeatureInventory => {
+                formatter.write_str("native-v2 required-feature inventory is noncanonical")
+            }
+            Self::UnknownRequiredFeature => {
+                formatter.write_str("native-v2 state requires unsupported behavior")
+            }
+            Self::InvalidComponentDirectory => {
+                formatter.write_str("native-v2 component directory is noncanonical")
+            }
+            Self::UnknownSemanticComponent => {
+                formatter.write_str("native-v2 state contains an unsupported semantic component")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SnapshotV2DecodeError {}
+
+/// Native-v2 canonical encoding failure.
+#[derive(Debug)]
+pub enum SnapshotV2EncodeError {
+    /// A required-feature or component count exceeds writer policy.
+    CountOutOfBounds { count: usize, maximum: usize },
+    /// Required-feature inputs are zero, duplicated, or not canonical.
+    InvalidRequiredFeatureInventory,
+    /// A required feature is not declared by the current production catalog.
+    UnknownRequiredFeature,
+    /// Component inputs, flags, ordering, or payload lengths are invalid.
+    InvalidComponentDirectory,
+    /// A semantic component is not declared by the current production catalog.
+    UnknownSemanticComponent,
+    /// Encoded length arithmetic overflowed.
+    LengthOverflow,
+    /// The encoded state would exceed writer policy.
+    FileTooLarge { length: u64, maximum: usize },
+    /// The canonical output buffer could not be allocated.
+    AllocationFailed { source: TryReserveError },
+}
+
+impl fmt::Display for SnapshotV2EncodeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CountOutOfBounds { count, maximum } => write!(
+                formatter,
+                "native-v2 state metadata count {count} exceeds {maximum}"
+            ),
+            Self::InvalidRequiredFeatureInventory => {
+                formatter.write_str("native-v2 required-feature inventory is noncanonical")
+            }
+            Self::UnknownRequiredFeature => {
+                formatter.write_str("native-v2 state requires undeclared behavior")
+            }
+            Self::InvalidComponentDirectory => {
+                formatter.write_str("native-v2 component inputs are noncanonical")
+            }
+            Self::UnknownSemanticComponent => {
+                formatter.write_str("native-v2 semantic component is undeclared")
+            }
+            Self::LengthOverflow => {
+                formatter.write_str("native-v2 state length arithmetic overflowed")
+            }
+            Self::FileTooLarge { length, maximum } => write!(
+                formatter,
+                "native-v2 state length {length} exceeds {maximum} byte limit"
+            ),
+            Self::AllocationFailed { .. } => {
+                formatter.write_str("native-v2 state output allocation failed")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SnapshotV2EncodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::AllocationFailed { source } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// Decodes and fully validates the current production native-v2 profile.
+pub fn decode_snapshot_v2_state(
+    bytes: &[u8],
+) -> Result<SnapshotV2State<'_>, SnapshotV2DecodeError> {
+    decode_snapshot_v2_state_with_catalog(
+        bytes,
+        NATIVE_V2_SNAPSHOT_VERSION,
+        PRODUCTION_REQUIRED_FEATURES,
+        PRODUCTION_SEMANTIC_COMPONENTS,
+    )
+}
+
+/// Encodes the current production native-v2 profile canonically.
+pub fn encode_snapshot_v2_state(
+    required_features: &[u32],
+    components: &[SnapshotV2Component<'_>],
+) -> Result<Vec<u8>, SnapshotV2EncodeError> {
+    encode_snapshot_v2_state_with_catalog_and_reserve(
+        required_features,
+        components,
+        NATIVE_V2_SNAPSHOT_VERSION,
+        PRODUCTION_REQUIRED_FEATURES,
+        PRODUCTION_SEMANTIC_COMPONENTS,
+        Vec::try_reserve_exact,
+    )
+}
+
+fn decode_snapshot_v2_state_with_catalog<'state>(
+    bytes: &'state [u8],
+    supported_version: SnapshotFormatVersion,
+    required_feature_catalog: &[CatalogEntry],
+    semantic_component_catalog: &[CatalogEntry],
+) -> Result<SnapshotV2State<'state>, SnapshotV2DecodeError> {
+    let minimum = NATIVE_V2_SNAPSHOT_HEADER_BYTES + NATIVE_V2_SNAPSHOT_INTEGRITY_BYTES;
+    if bytes.len() < minimum {
+        return Err(SnapshotV2DecodeError::Truncated {
+            minimum,
+            actual: bytes.len(),
+        });
+    }
+    if read_array::<8>(bytes, MAGIC_OFFSET)? != NATIVE_V2_ARM64_MAGIC {
+        return Err(SnapshotV2DecodeError::InvalidMagic);
+    }
+
+    let version = SnapshotFormatVersion::new(
+        read_u16(bytes, VERSION_MAJOR_OFFSET)?,
+        read_u16(bytes, VERSION_MINOR_OFFSET)?,
+        read_u16(bytes, VERSION_PATCH_OFFSET)?,
+    );
+    if version.major() != supported_version.major() || version.minor() > supported_version.minor() {
+        return Err(SnapshotV2DecodeError::UnsupportedVersion {
+            found: version,
+            supported: supported_version,
+        });
+    }
+    if usize::from(read_u16(bytes, HEADER_BYTES_OFFSET)?) != NATIVE_V2_SNAPSHOT_HEADER_BYTES
+        || read_u32(bytes, FLAGS_OFFSET)? != HEADER_FLAGS
+        || read_u32(bytes, RESERVED_OFFSET)? != HEADER_RESERVED
+    {
+        return Err(SnapshotV2DecodeError::InvalidHeader);
+    }
+
+    let required_feature_count = read_u32(bytes, REQUIRED_FEATURE_COUNT_OFFSET)?;
+    let component_count = read_u32(bytes, COMPONENT_COUNT_OFFSET)?;
+    validate_decode_count(
+        u64::from(required_feature_count),
+        NATIVE_V2_SNAPSHOT_MAX_REQUIRED_FEATURES,
+    )?;
+    validate_decode_count(
+        u64::from(component_count),
+        NATIVE_V2_SNAPSHOT_MAX_COMPONENTS,
+    )?;
+
+    let total_length = read_u64(bytes, TOTAL_LENGTH_OFFSET)?;
+    if total_length
+        > u64::try_from(NATIVE_V2_SNAPSHOT_MAX_FILE_BYTES)
+            .map_err(|_| SnapshotV2DecodeError::LengthOverflow)?
+    {
+        return Err(SnapshotV2DecodeError::FileTooLarge {
+            length: total_length,
+            maximum: NATIVE_V2_SNAPSHOT_MAX_FILE_BYTES,
+        });
+    }
+    let total_length_usize =
+        usize::try_from(total_length).map_err(|_| SnapshotV2DecodeError::LengthOverflow)?;
+    if total_length_usize != bytes.len() {
+        return Err(SnapshotV2DecodeError::LengthMismatch {
+            declared: total_length,
+            actual: bytes.len(),
+        });
+    }
+
+    let required_feature_offset = usize::try_from(read_u64(bytes, REQUIRED_FEATURE_OFFSET_OFFSET)?)
+        .map_err(|_| SnapshotV2DecodeError::LengthOverflow)?;
+    let component_directory_offset =
+        usize::try_from(read_u64(bytes, COMPONENT_DIRECTORY_OFFSET_OFFSET)?)
+            .map_err(|_| SnapshotV2DecodeError::LengthOverflow)?;
+    let component_payload_offset =
+        usize::try_from(read_u64(bytes, COMPONENT_PAYLOAD_OFFSET_OFFSET)?)
+            .map_err(|_| SnapshotV2DecodeError::LengthOverflow)?;
+    let expected_directory_offset = NATIVE_V2_SNAPSHOT_HEADER_BYTES
+        .checked_add(
+            usize::try_from(required_feature_count)
+                .map_err(|_| SnapshotV2DecodeError::LengthOverflow)?
+                .checked_mul(size_of::<u32>())
+                .ok_or(SnapshotV2DecodeError::LengthOverflow)?,
+        )
+        .ok_or(SnapshotV2DecodeError::LengthOverflow)?;
+    let expected_payload_offset = expected_directory_offset
+        .checked_add(
+            usize::try_from(component_count)
+                .map_err(|_| SnapshotV2DecodeError::LengthOverflow)?
+                .checked_mul(NATIVE_V2_COMPONENT_DIRECTORY_ENTRY_BYTES)
+                .ok_or(SnapshotV2DecodeError::LengthOverflow)?,
+        )
+        .ok_or(SnapshotV2DecodeError::LengthOverflow)?;
+    let checksum_offset = total_length_usize
+        .checked_sub(NATIVE_V2_SNAPSHOT_INTEGRITY_BYTES)
+        .ok_or(SnapshotV2DecodeError::LengthOverflow)?;
+    if required_feature_offset != NATIVE_V2_SNAPSHOT_HEADER_BYTES
+        || component_directory_offset != expected_directory_offset
+        || component_payload_offset != expected_payload_offset
+        || component_payload_offset > checksum_offset
+    {
+        return Err(SnapshotV2DecodeError::InvalidHeader);
+    }
+
+    let stored_checksum = read_u64(bytes, checksum_offset)?;
+    let checksummed = bytes
+        .get(..checksum_offset)
+        .ok_or(SnapshotV2DecodeError::LengthOverflow)?;
+    if crc64(0, checksummed) != stored_checksum {
+        return Err(SnapshotV2DecodeError::IntegrityMismatch);
+    }
+
+    validate_required_features(
+        bytes,
+        required_feature_offset,
+        required_feature_count,
+        version.minor(),
+        required_feature_catalog,
+    )?;
+    validate_component_directory(
+        bytes,
+        component_directory_offset,
+        component_payload_offset,
+        checksum_offset,
+        component_count,
+        version.minor(),
+        semantic_component_catalog,
+    )?;
+
+    Ok(SnapshotV2State {
+        bytes,
+        metadata: SnapshotV2Metadata {
+            version,
+            architecture: SnapshotArchitecture::Arm64,
+            required_feature_count,
+            component_count,
+            total_length,
+            integrity: SnapshotIntegrity::Crc64Jones,
+        },
+        required_feature_offset,
+        component_directory_offset,
+        component_payload_offset,
+    })
+}
+
+fn validate_required_features(
+    bytes: &[u8],
+    mut position: usize,
+    count: u32,
+    encoded_minor: u16,
+    catalog: &[CatalogEntry],
+) -> Result<(), SnapshotV2DecodeError> {
+    let mut previous = 0;
+    for _ in 0..count {
+        let feature = read_u32(bytes, position)?;
+        if feature == 0 || feature <= previous {
+            return Err(SnapshotV2DecodeError::InvalidRequiredFeatureInventory);
+        }
+        if !catalog_contains(catalog, feature, encoded_minor) {
+            return Err(SnapshotV2DecodeError::UnknownRequiredFeature);
+        }
+        previous = feature;
+        position = position
+            .checked_add(size_of::<u32>())
+            .ok_or(SnapshotV2DecodeError::LengthOverflow)?;
+    }
+    Ok(())
+}
+
+fn validate_component_directory(
+    bytes: &[u8],
+    mut directory_position: usize,
+    component_payload_offset: usize,
+    checksum_offset: usize,
+    count: u32,
+    encoded_minor: u16,
+    catalog: &[CatalogEntry],
+) -> Result<(), SnapshotV2DecodeError> {
+    let mut previous_key = None;
+    let mut expected_payload_offset = component_payload_offset;
+    for _ in 0..count {
+        let entry_end = directory_position
+            .checked_add(NATIVE_V2_COMPONENT_DIRECTORY_ENTRY_BYTES)
+            .ok_or(SnapshotV2DecodeError::LengthOverflow)?;
+        let entry = bytes
+            .get(directory_position..entry_end)
+            .ok_or(SnapshotV2DecodeError::InvalidComponentDirectory)?;
+        let key = SnapshotV2ComponentKey::new(
+            read_u32(entry, COMPONENT_KIND_OFFSET)?,
+            read_u32(entry, COMPONENT_INSTANCE_OFFSET)?,
+        );
+        if key.kind == 0 || previous_key.is_some_and(|previous| key <= previous) {
+            return Err(SnapshotV2DecodeError::InvalidComponentDirectory);
+        }
+        let flags = read_u32(entry, COMPONENT_FLAGS_OFFSET)?;
+        if flags != COMPONENT_FLAG_SEMANTIC && flags != COMPONENT_FLAG_NONSEMANTIC {
+            return Err(SnapshotV2DecodeError::InvalidComponentDirectory);
+        }
+        if read_u32(entry, COMPONENT_RESERVED_OFFSET)? != COMPONENT_RESERVED {
+            return Err(SnapshotV2DecodeError::InvalidComponentDirectory);
+        }
+        let payload_offset = usize::try_from(read_u64(entry, COMPONENT_PAYLOAD_OFFSET)?)
+            .map_err(|_| SnapshotV2DecodeError::LengthOverflow)?;
+        let payload_length = usize::try_from(read_u64(entry, COMPONENT_PAYLOAD_LENGTH_OFFSET)?)
+            .map_err(|_| SnapshotV2DecodeError::LengthOverflow)?;
+        if payload_length == 0 || payload_offset != expected_payload_offset {
+            return Err(SnapshotV2DecodeError::InvalidComponentDirectory);
+        }
+        expected_payload_offset = payload_offset
+            .checked_add(payload_length)
+            .ok_or(SnapshotV2DecodeError::LengthOverflow)?;
+        if expected_payload_offset > checksum_offset {
+            return Err(SnapshotV2DecodeError::InvalidComponentDirectory);
+        }
+        if flags == COMPONENT_FLAG_SEMANTIC && !catalog_contains(catalog, key.kind, encoded_minor) {
+            return Err(SnapshotV2DecodeError::UnknownSemanticComponent);
+        }
+        previous_key = Some(key);
+        directory_position = entry_end;
+    }
+    if expected_payload_offset != checksum_offset {
+        return Err(SnapshotV2DecodeError::InvalidComponentDirectory);
+    }
+    Ok(())
+}
+
+fn validate_decode_count(count: u64, maximum: usize) -> Result<(), SnapshotV2DecodeError> {
+    if count > u64::try_from(maximum).map_err(|_| SnapshotV2DecodeError::LengthOverflow)? {
+        Err(SnapshotV2DecodeError::CountOutOfBounds { count, maximum })
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct EncodeLayout {
+    component_directory_offset: usize,
+    component_payload_offset: usize,
+    total_length: usize,
+}
+
+fn encode_snapshot_v2_state_with_catalog_and_reserve(
+    required_features: &[u32],
+    components: &[SnapshotV2Component<'_>],
+    version: SnapshotFormatVersion,
+    required_feature_catalog: &[CatalogEntry],
+    semantic_component_catalog: &[CatalogEntry],
+    reserve: impl FnOnce(&mut Vec<u8>, usize) -> Result<(), TryReserveError>,
+) -> Result<Vec<u8>, SnapshotV2EncodeError> {
+    let layout = validate_encode_inputs(
+        required_features,
+        components,
+        version,
+        required_feature_catalog,
+        semantic_component_catalog,
+    )?;
+    let mut bytes = Vec::new();
+    reserve(&mut bytes, layout.total_length)
+        .map_err(|source| SnapshotV2EncodeError::AllocationFailed { source })?;
+
+    bytes.extend_from_slice(&NATIVE_V2_ARM64_MAGIC);
+    bytes.extend_from_slice(&version.major().to_le_bytes());
+    bytes.extend_from_slice(&version.minor().to_le_bytes());
+    bytes.extend_from_slice(&version.patch().to_le_bytes());
+    bytes.extend_from_slice(
+        &u16::try_from(NATIVE_V2_SNAPSHOT_HEADER_BYTES)
+            .map_err(|_| SnapshotV2EncodeError::LengthOverflow)?
+            .to_le_bytes(),
+    );
+    bytes.extend_from_slice(&HEADER_FLAGS.to_le_bytes());
+    bytes.extend_from_slice(
+        &u32::try_from(required_features.len())
+            .map_err(|_| SnapshotV2EncodeError::LengthOverflow)?
+            .to_le_bytes(),
+    );
+    bytes.extend_from_slice(
+        &u32::try_from(components.len())
+            .map_err(|_| SnapshotV2EncodeError::LengthOverflow)?
+            .to_le_bytes(),
+    );
+    bytes.extend_from_slice(&HEADER_RESERVED.to_le_bytes());
+    bytes.extend_from_slice(
+        &u64::try_from(layout.total_length)
+            .map_err(|_| SnapshotV2EncodeError::LengthOverflow)?
+            .to_le_bytes(),
+    );
+    bytes.extend_from_slice(
+        &u64::try_from(NATIVE_V2_SNAPSHOT_HEADER_BYTES)
+            .map_err(|_| SnapshotV2EncodeError::LengthOverflow)?
+            .to_le_bytes(),
+    );
+    bytes.extend_from_slice(
+        &u64::try_from(layout.component_directory_offset)
+            .map_err(|_| SnapshotV2EncodeError::LengthOverflow)?
+            .to_le_bytes(),
+    );
+    bytes.extend_from_slice(
+        &u64::try_from(layout.component_payload_offset)
+            .map_err(|_| SnapshotV2EncodeError::LengthOverflow)?
+            .to_le_bytes(),
+    );
+    for feature in required_features {
+        bytes.extend_from_slice(&feature.to_le_bytes());
+    }
+
+    let mut payload_offset = layout.component_payload_offset;
+    for component in components {
+        bytes.extend_from_slice(&component.key.kind.to_le_bytes());
+        bytes.extend_from_slice(&component.key.instance.to_le_bytes());
+        bytes.extend_from_slice(&component.disposition.flags().to_le_bytes());
+        bytes.extend_from_slice(&COMPONENT_RESERVED.to_le_bytes());
+        bytes.extend_from_slice(
+            &u64::try_from(payload_offset)
+                .map_err(|_| SnapshotV2EncodeError::LengthOverflow)?
+                .to_le_bytes(),
+        );
+        bytes.extend_from_slice(
+            &u64::try_from(component.payload.len())
+                .map_err(|_| SnapshotV2EncodeError::LengthOverflow)?
+                .to_le_bytes(),
+        );
+        payload_offset = payload_offset
+            .checked_add(component.payload.len())
+            .ok_or(SnapshotV2EncodeError::LengthOverflow)?;
+    }
+    for component in components {
+        bytes.extend_from_slice(component.payload);
+    }
+    let checksum = crc64(0, &bytes);
+    bytes.extend_from_slice(&checksum.to_le_bytes());
+    debug_assert_eq!(bytes.len(), layout.total_length);
+    Ok(bytes)
+}
+
+fn validate_encode_inputs(
+    required_features: &[u32],
+    components: &[SnapshotV2Component<'_>],
+    version: SnapshotFormatVersion,
+    required_feature_catalog: &[CatalogEntry],
+    semantic_component_catalog: &[CatalogEntry],
+) -> Result<EncodeLayout, SnapshotV2EncodeError> {
+    validate_encode_count(
+        required_features.len(),
+        NATIVE_V2_SNAPSHOT_MAX_REQUIRED_FEATURES,
+    )?;
+    validate_encode_count(components.len(), NATIVE_V2_SNAPSHOT_MAX_COMPONENTS)?;
+
+    let mut previous_feature = 0;
+    for feature in required_features {
+        if *feature == 0 || *feature <= previous_feature {
+            return Err(SnapshotV2EncodeError::InvalidRequiredFeatureInventory);
+        }
+        if !catalog_contains(required_feature_catalog, *feature, version.minor()) {
+            return Err(SnapshotV2EncodeError::UnknownRequiredFeature);
+        }
+        previous_feature = *feature;
+    }
+
+    let mut previous_key = None;
+    let mut payload_bytes = 0usize;
+    for component in components {
+        if component.key.kind == 0
+            || previous_key.is_some_and(|previous| component.key <= previous)
+            || component.payload.is_empty()
+        {
+            return Err(SnapshotV2EncodeError::InvalidComponentDirectory);
+        }
+        if component.disposition == SnapshotV2ComponentDisposition::Semantic
+            && !catalog_contains(
+                semantic_component_catalog,
+                component.key.kind,
+                version.minor(),
+            )
+        {
+            return Err(SnapshotV2EncodeError::UnknownSemanticComponent);
+        }
+        payload_bytes = payload_bytes
+            .checked_add(component.payload.len())
+            .ok_or(SnapshotV2EncodeError::LengthOverflow)?;
+        previous_key = Some(component.key);
+    }
+
+    let component_directory_offset = NATIVE_V2_SNAPSHOT_HEADER_BYTES
+        .checked_add(
+            required_features
+                .len()
+                .checked_mul(size_of::<u32>())
+                .ok_or(SnapshotV2EncodeError::LengthOverflow)?,
+        )
+        .ok_or(SnapshotV2EncodeError::LengthOverflow)?;
+    let component_payload_offset = component_directory_offset
+        .checked_add(
+            components
+                .len()
+                .checked_mul(NATIVE_V2_COMPONENT_DIRECTORY_ENTRY_BYTES)
+                .ok_or(SnapshotV2EncodeError::LengthOverflow)?,
+        )
+        .ok_or(SnapshotV2EncodeError::LengthOverflow)?;
+    let total_length = component_payload_offset
+        .checked_add(payload_bytes)
+        .and_then(|length| length.checked_add(NATIVE_V2_SNAPSHOT_INTEGRITY_BYTES))
+        .ok_or(SnapshotV2EncodeError::LengthOverflow)?;
+    let total_length_u64 =
+        u64::try_from(total_length).map_err(|_| SnapshotV2EncodeError::LengthOverflow)?;
+    if total_length > NATIVE_V2_SNAPSHOT_MAX_FILE_BYTES {
+        return Err(SnapshotV2EncodeError::FileTooLarge {
+            length: total_length_u64,
+            maximum: NATIVE_V2_SNAPSHOT_MAX_FILE_BYTES,
+        });
+    }
+    Ok(EncodeLayout {
+        component_directory_offset,
+        component_payload_offset,
+        total_length,
+    })
+}
+
+fn validate_encode_count(count: usize, maximum: usize) -> Result<(), SnapshotV2EncodeError> {
+    if count > maximum {
+        Err(SnapshotV2EncodeError::CountOutOfBounds { count, maximum })
+    } else {
+        Ok(())
+    }
+}
+
+fn read_u16(bytes: &[u8], offset: usize) -> Result<u16, SnapshotV2DecodeError> {
+    Ok(u16::from_le_bytes(read_array(bytes, offset)?))
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32, SnapshotV2DecodeError> {
+    Ok(u32::from_le_bytes(read_array(bytes, offset)?))
+}
+
+fn read_u64(bytes: &[u8], offset: usize) -> Result<u64, SnapshotV2DecodeError> {
+    Ok(u64::from_le_bytes(read_array(bytes, offset)?))
+}
+
+fn read_array<const LENGTH: usize>(
+    bytes: &[u8],
+    offset: usize,
+) -> Result<[u8; LENGTH], SnapshotV2DecodeError> {
+    let end = offset
+        .checked_add(LENGTH)
+        .ok_or(SnapshotV2DecodeError::LengthOverflow)?;
+    let source = bytes
+        .get(offset..end)
+        .ok_or(SnapshotV2DecodeError::Truncated {
+            minimum: end,
+            actual: bytes.len(),
+        })?;
+    let mut result = [0; LENGTH];
+    result.copy_from_slice(source);
+    Ok(result)
+}
+
+fn read_u32_option(bytes: &[u8], offset: usize) -> Option<u32> {
+    let end = offset.checked_add(size_of::<u32>())?;
+    let source = bytes.get(offset..end)?;
+    let mut value = [0; size_of::<u32>()];
+    value.copy_from_slice(source);
+    Some(u32::from_le_bytes(value))
+}
+
+fn read_u64_option(bytes: &[u8], offset: usize) -> Option<u64> {
+    let end = offset.checked_add(size_of::<u64>())?;
+    let source = bytes.get(offset..end)?;
+    let mut value = [0; size_of::<u64>()];
+    value.copy_from_slice(source);
+    Some(u64::from_le_bytes(value))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/runtime/src/snapshot_format_v2/tests.rs
+++ b/crates/runtime/src/snapshot_format_v2/tests.rs
@@ -1,0 +1,723 @@
+use crate::snapshot_format::{
+    NativeSnapshotFormatError, NativeSnapshotState, decode_native_snapshot_state,
+    encode_snapshot_envelope,
+};
+
+use super::*;
+
+const TEST_REQUIRED_FEATURE_CATALOG: &[CatalogEntry] = &[
+    CatalogEntry {
+        id: 10,
+        introduced_minor: 0,
+    },
+    CatalogEntry {
+        id: 20,
+        introduced_minor: 0,
+    },
+];
+const TEST_SEMANTIC_COMPONENT_CATALOG: &[CatalogEntry] = &[
+    CatalogEntry {
+        id: 1,
+        introduced_minor: 0,
+    },
+    CatalogEntry {
+        id: 2,
+        introduced_minor: 0,
+    },
+];
+const EMPTY_V2_FIXTURE: [u8; 72] = [
+    0x42, 0x41, 0x4e, 0x47, 0x56, 0x32, 0x41, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x48, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x5e, 0xf9, 0x9d, 0x5f, 0xee, 0xdf, 0xc8, 0x6c,
+];
+const FIRECRACKER_AARCH64_PREFIX: [u8; 9] = [0x00, 0x00, 0x00, 0xaa, 0xaa, 0x84, 0x19, 0x10, 0x07];
+const FIRECRACKER_X86_64_PREFIX: [u8; 9] = [0x00, 0x00, 0x00, 0x64, 0x86, 0x84, 0x19, 0x10, 0x07];
+
+#[test]
+fn empty_foundation_encoding_matches_immutable_fixture() {
+    let encoded = encode_snapshot_v2_state(&[], &[]).expect("empty foundation should encode");
+
+    assert_eq!(encoded, EMPTY_V2_FIXTURE);
+    let decoded = decode_snapshot_v2_state(&EMPTY_V2_FIXTURE)
+        .expect("empty foundation fixture should decode");
+    assert_eq!(decoded.metadata().version(), NATIVE_V2_SNAPSHOT_VERSION);
+    assert_eq!(
+        decoded.metadata().architecture(),
+        SnapshotArchitecture::Arm64
+    );
+    assert_eq!(decoded.metadata().required_feature_count(), 0);
+    assert_eq!(decoded.metadata().component_count(), 0);
+    assert_eq!(decoded.metadata().total_length(), 72);
+    assert_eq!(
+        decoded.metadata().integrity(),
+        SnapshotIntegrity::Crc64Jones
+    );
+    assert_eq!(
+        decoded.component_payload_offset(),
+        NATIVE_V2_SNAPSHOT_HEADER_BYTES
+    );
+    assert_eq!(decoded.required_features().len(), 0);
+    assert_eq!(decoded.components().len(), 0);
+}
+
+#[test]
+fn canonical_test_directory_round_trips_borrowed_components() {
+    let components = test_components();
+    let encoded = encode_test_state(&[10, 20], &components);
+    let decoded = decode_test_state(&encoded).expect("test state should decode");
+
+    assert_eq!(
+        decoded.required_features().collect::<Vec<_>>(),
+        vec![10, 20]
+    );
+    let decoded_components = decoded.components().collect::<Vec<_>>();
+    assert_eq!(decoded_components, components);
+    for component in decoded_components {
+        let payload_range = encoded.as_ptr_range();
+        let payload_pointer = component.payload().as_ptr();
+        assert!(payload_range.start <= payload_pointer && payload_pointer < payload_range.end);
+        assert_eq!(decoded.component(component.key()), Some(component));
+    }
+}
+
+#[test]
+fn production_catalog_accepts_nonsemantic_extensions_only() {
+    let nonsemantic = [SnapshotV2Component::new(
+        SnapshotV2ComponentKey::new(77, 3),
+        SnapshotV2ComponentDisposition::NonSemantic,
+        b"diagnostic",
+    )];
+    let encoded =
+        encode_snapshot_v2_state(&[], &nonsemantic).expect("nonsemantic extension should encode");
+    let decoded = decode_snapshot_v2_state(&encoded).expect("nonsemantic extension should decode");
+    assert_eq!(decoded.components().collect::<Vec<_>>(), nonsemantic);
+
+    let semantic = [SnapshotV2Component::new(
+        SnapshotV2ComponentKey::new(1, 3),
+        SnapshotV2ComponentDisposition::Semantic,
+        b"semantic",
+    )];
+    assert!(matches!(
+        encode_snapshot_v2_state(&[], &semantic),
+        Err(SnapshotV2EncodeError::UnknownSemanticComponent)
+    ));
+
+    let encoded_semantic = encode_test_state(&[], &semantic);
+    assert_eq!(
+        decode_snapshot_v2_state(&encoded_semantic),
+        Err(SnapshotV2DecodeError::UnknownSemanticComponent)
+    );
+}
+
+#[test]
+fn family_dispatch_preserves_v1_recognizes_v2_and_rejects_firecracker() {
+    let v1 =
+        encode_snapshot_envelope(b"private-v1-state").expect("native-v1 fixture should encode");
+    let decoded_v1 = decode_native_snapshot_state(&v1).expect("native-v1 fixture should dispatch");
+    assert!(matches!(decoded_v1, NativeSnapshotState::V1(_)));
+    assert_eq!(decoded_v1.version().to_string(), "1.0.0");
+    assert_eq!(decoded_v1.architecture(), SnapshotArchitecture::Arm64);
+
+    let decoded_v2 =
+        decode_native_snapshot_state(&EMPTY_V2_FIXTURE).expect("native-v2 fixture should dispatch");
+    assert!(matches!(decoded_v2, NativeSnapshotState::V2(_)));
+    assert_eq!(decoded_v2.version(), NATIVE_V2_SNAPSHOT_VERSION);
+
+    for prefix in [
+        FIRECRACKER_AARCH64_PREFIX.as_slice(),
+        FIRECRACKER_X86_64_PREFIX.as_slice(),
+    ] {
+        assert_eq!(
+            decode_native_snapshot_state(prefix),
+            Err(NativeSnapshotFormatError::IncompatibleFirecrackerFormat)
+        );
+    }
+    assert_eq!(
+        decode_native_snapshot_state(b"unrecognized-state"),
+        Err(NativeSnapshotFormatError::IncompatibleFormat)
+    );
+}
+
+#[test]
+fn rejects_every_minimum_length_truncation() {
+    for actual in 0..EMPTY_V2_FIXTURE.len() {
+        let truncated = EMPTY_V2_FIXTURE
+            .get(..actual)
+            .expect("fixture prefix should exist");
+        assert_eq!(
+            decode_snapshot_v2_state(truncated),
+            Err(SnapshotV2DecodeError::Truncated {
+                minimum: NATIVE_V2_SNAPSHOT_HEADER_BYTES + NATIVE_V2_SNAPSHOT_INTEGRITY_BYTES,
+                actual,
+            })
+        );
+    }
+}
+
+#[test]
+fn version_policy_rejects_major_and_newer_minor_but_accepts_patch() {
+    let major = with_u16_field(&EMPTY_V2_FIXTURE, VERSION_MAJOR_OFFSET, 3);
+    assert_eq!(
+        decode_snapshot_v2_state(&major),
+        Err(SnapshotV2DecodeError::UnsupportedVersion {
+            found: SnapshotFormatVersion::new(3, 0, 0),
+            supported: NATIVE_V2_SNAPSHOT_VERSION,
+        })
+    );
+
+    let minor = with_u16_field(&EMPTY_V2_FIXTURE, VERSION_MINOR_OFFSET, 1);
+    assert_eq!(
+        decode_snapshot_v2_state(&minor),
+        Err(SnapshotV2DecodeError::UnsupportedVersion {
+            found: SnapshotFormatVersion::new(2, 1, 0),
+            supported: NATIVE_V2_SNAPSHOT_VERSION,
+        })
+    );
+
+    let patch = with_u16_field_and_checksum(&EMPTY_V2_FIXTURE, VERSION_PATCH_OFFSET, u16::MAX);
+    let decoded = decode_snapshot_v2_state(&patch).expect("patch should be nonsemantic");
+    assert_eq!(
+        decoded.metadata().version(),
+        SnapshotFormatVersion::new(2, 0, u16::MAX)
+    );
+}
+
+#[test]
+fn rejects_noncanonical_fixed_header_fields() {
+    let mut invalid_magic = EMPTY_V2_FIXTURE;
+    *invalid_magic
+        .get_mut(MAGIC_OFFSET)
+        .expect("fixture magic should exist") ^= 0x80;
+    assert_eq!(
+        decode_snapshot_v2_state(&invalid_magic),
+        Err(SnapshotV2DecodeError::InvalidMagic)
+    );
+
+    for (offset, value) in [(HEADER_BYTES_OFFSET, 63_u16), (HEADER_BYTES_OFFSET, 65_u16)] {
+        let encoded = with_u16_field_and_checksum(&EMPTY_V2_FIXTURE, offset, value);
+        assert_eq!(
+            decode_snapshot_v2_state(&encoded),
+            Err(SnapshotV2DecodeError::InvalidHeader)
+        );
+    }
+    for offset in [FLAGS_OFFSET, RESERVED_OFFSET] {
+        let encoded = with_u32_field_and_checksum(&EMPTY_V2_FIXTURE, offset, 1);
+        assert_eq!(
+            decode_snapshot_v2_state(&encoded),
+            Err(SnapshotV2DecodeError::InvalidHeader)
+        );
+    }
+    for offset in [
+        REQUIRED_FEATURE_OFFSET_OFFSET,
+        COMPONENT_DIRECTORY_OFFSET_OFFSET,
+        COMPONENT_PAYLOAD_OFFSET_OFFSET,
+    ] {
+        let encoded = with_u64_field_and_checksum(&EMPTY_V2_FIXTURE, offset, 63);
+        assert_eq!(
+            decode_snapshot_v2_state(&encoded),
+            Err(SnapshotV2DecodeError::InvalidHeader)
+        );
+    }
+}
+
+#[test]
+fn rejects_count_caps_before_table_walk() {
+    let required = with_u32_field(
+        &EMPTY_V2_FIXTURE,
+        REQUIRED_FEATURE_COUNT_OFFSET,
+        u32::try_from(NATIVE_V2_SNAPSHOT_MAX_REQUIRED_FEATURES)
+            .expect("feature cap should fit u32")
+            + 1,
+    );
+    assert_eq!(
+        decode_snapshot_v2_state(&required),
+        Err(SnapshotV2DecodeError::CountOutOfBounds {
+            count: u64::try_from(NATIVE_V2_SNAPSHOT_MAX_REQUIRED_FEATURES)
+                .expect("feature cap should fit u64")
+                + 1,
+            maximum: NATIVE_V2_SNAPSHOT_MAX_REQUIRED_FEATURES,
+        })
+    );
+
+    let components = with_u32_field(
+        &EMPTY_V2_FIXTURE,
+        COMPONENT_COUNT_OFFSET,
+        u32::try_from(NATIVE_V2_SNAPSHOT_MAX_COMPONENTS).expect("component cap should fit u32") + 1,
+    );
+    assert_eq!(
+        decode_snapshot_v2_state(&components),
+        Err(SnapshotV2DecodeError::CountOutOfBounds {
+            count: u64::try_from(NATIVE_V2_SNAPSHOT_MAX_COMPONENTS)
+                .expect("component cap should fit u64")
+                + 1,
+            maximum: NATIVE_V2_SNAPSHOT_MAX_COMPONENTS,
+        })
+    );
+}
+
+#[test]
+fn rejects_length_mismatch_limit_and_integrity() {
+    let mismatch = with_u64_field(&EMPTY_V2_FIXTURE, TOTAL_LENGTH_OFFSET, 73);
+    assert_eq!(
+        decode_snapshot_v2_state(&mismatch),
+        Err(SnapshotV2DecodeError::LengthMismatch {
+            declared: 73,
+            actual: EMPTY_V2_FIXTURE.len(),
+        })
+    );
+
+    let over_limit = with_u64_field(
+        &EMPTY_V2_FIXTURE,
+        TOTAL_LENGTH_OFFSET,
+        u64::try_from(NATIVE_V2_SNAPSHOT_MAX_FILE_BYTES).expect("file cap should fit u64") + 1,
+    );
+    assert_eq!(
+        decode_snapshot_v2_state(&over_limit),
+        Err(SnapshotV2DecodeError::FileTooLarge {
+            length: u64::try_from(NATIVE_V2_SNAPSHOT_MAX_FILE_BYTES)
+                .expect("file cap should fit u64")
+                + 1,
+            maximum: NATIVE_V2_SNAPSHOT_MAX_FILE_BYTES,
+        })
+    );
+
+    let mut trailing = EMPTY_V2_FIXTURE.to_vec();
+    trailing.push(0);
+    assert_eq!(
+        decode_snapshot_v2_state(&trailing),
+        Err(SnapshotV2DecodeError::LengthMismatch {
+            declared: u64::try_from(EMPTY_V2_FIXTURE.len()).expect("fixture length should fit u64"),
+            actual: EMPTY_V2_FIXTURE.len() + 1,
+        })
+    );
+
+    let mut corrupt = EMPTY_V2_FIXTURE;
+    let checksum_byte = corrupt.last_mut().expect("fixture checksum should exist");
+    *checksum_byte ^= 0x80;
+    assert_eq!(
+        decode_snapshot_v2_state(&corrupt),
+        Err(SnapshotV2DecodeError::IntegrityMismatch)
+    );
+}
+
+#[test]
+fn required_feature_inventory_rejects_zero_order_duplicates_and_unknowns() {
+    let components = test_components();
+    let fixture = encode_test_state(&[10, 20], &components);
+    let feature_offset = NATIVE_V2_SNAPSHOT_HEADER_BYTES;
+
+    let zero = with_u32_field_and_checksum(&fixture, feature_offset, 0);
+    assert_eq!(
+        decode_test_state(&zero),
+        Err(SnapshotV2DecodeError::InvalidRequiredFeatureInventory)
+    );
+
+    let duplicate = with_u32_field_and_checksum(&fixture, feature_offset + size_of::<u32>(), 10);
+    assert_eq!(
+        decode_test_state(&duplicate),
+        Err(SnapshotV2DecodeError::InvalidRequiredFeatureInventory)
+    );
+
+    let first_twenty = with_u32_field(&fixture, feature_offset, 20);
+    let reordered =
+        with_u32_field_and_checksum(&first_twenty, feature_offset + size_of::<u32>(), 10);
+    assert_eq!(
+        decode_test_state(&reordered),
+        Err(SnapshotV2DecodeError::InvalidRequiredFeatureInventory)
+    );
+
+    let unknown = with_u32_field_and_checksum(&fixture, feature_offset, 30);
+    assert_eq!(
+        decode_test_state(&unknown),
+        Err(SnapshotV2DecodeError::UnknownRequiredFeature)
+    );
+
+    assert_eq!(
+        decode_snapshot_v2_state(&fixture),
+        Err(SnapshotV2DecodeError::UnknownRequiredFeature)
+    );
+}
+
+#[test]
+fn component_directory_rejects_identity_flags_reserved_and_ranges() {
+    let components = test_components();
+    let fixture = encode_test_state(&[10, 20], &components);
+    let directory = NATIVE_V2_SNAPSHOT_HEADER_BYTES + 2 * size_of::<u32>();
+    let second = directory + NATIVE_V2_COMPONENT_DIRECTORY_ENTRY_BYTES;
+    let third = second + NATIVE_V2_COMPONENT_DIRECTORY_ENTRY_BYTES;
+    let payload = directory + 3 * NATIVE_V2_COMPONENT_DIRECTORY_ENTRY_BYTES;
+
+    for (case, encoded) in [
+        (
+            "zero kind",
+            with_u32_field_and_checksum(&fixture, directory + COMPONENT_KIND_OFFSET, 0),
+        ),
+        (
+            "unknown flags",
+            with_u32_field_and_checksum(&fixture, directory + COMPONENT_FLAGS_OFFSET, 2),
+        ),
+        (
+            "nonzero reserved",
+            with_u32_field_and_checksum(&fixture, directory + COMPONENT_RESERVED_OFFSET, 1),
+        ),
+        (
+            "payload gap",
+            with_u64_field_and_checksum(
+                &fixture,
+                directory + COMPONENT_PAYLOAD_OFFSET,
+                u64::try_from(payload + 1).expect("fixture offset should fit u64"),
+            ),
+        ),
+        (
+            "payload overlap",
+            with_u64_field_and_checksum(
+                &fixture,
+                second + COMPONENT_PAYLOAD_OFFSET,
+                u64::try_from(payload).expect("fixture offset should fit u64"),
+            ),
+        ),
+        (
+            "zero payload length",
+            with_u64_field_and_checksum(&fixture, directory + COMPONENT_PAYLOAD_LENGTH_OFFSET, 0),
+        ),
+        (
+            "payload length wrap",
+            with_u64_field_and_checksum(
+                &fixture,
+                directory + COMPONENT_PAYLOAD_LENGTH_OFFSET,
+                u64::MAX,
+            ),
+        ),
+        (
+            "unclaimed trailing payload byte",
+            with_u64_field_and_checksum(&fixture, third + COMPONENT_PAYLOAD_LENGTH_OFFSET, 9),
+        ),
+    ] {
+        assert!(
+            matches!(
+                decode_test_state(&encoded),
+                Err(SnapshotV2DecodeError::InvalidComponentDirectory
+                    | SnapshotV2DecodeError::LengthOverflow)
+            ),
+            "{case}"
+        );
+    }
+
+    let duplicate_kind = with_u32_field(&fixture, second + COMPONENT_KIND_OFFSET, 1);
+    let duplicate_key =
+        with_u32_field_and_checksum(&duplicate_kind, second + COMPONENT_INSTANCE_OFFSET, 0);
+    assert_eq!(
+        decode_test_state(&duplicate_key),
+        Err(SnapshotV2DecodeError::InvalidComponentDirectory)
+    );
+
+    let first_kind = with_u32_field(&fixture, directory + COMPONENT_KIND_OFFSET, 2);
+    let descending_key =
+        with_u32_field_and_checksum(&first_kind, directory + COMPONENT_INSTANCE_OFFSET, 2);
+    assert_eq!(
+        decode_test_state(&descending_key),
+        Err(SnapshotV2DecodeError::InvalidComponentDirectory)
+    );
+}
+
+#[test]
+fn unknown_semantic_component_rejects_without_affecting_nonsemantic_extension() {
+    let components = test_components();
+    let fixture = encode_test_state(&[10, 20], &components);
+    let directory = NATIVE_V2_SNAPSHOT_HEADER_BYTES + 2 * size_of::<u32>();
+    let third = directory + 2 * NATIVE_V2_COMPONENT_DIRECTORY_ENTRY_BYTES;
+
+    let unknown_semantic = with_u32_field_and_checksum(&fixture, third + COMPONENT_FLAGS_OFFSET, 0);
+    assert_eq!(
+        decode_test_state(&unknown_semantic),
+        Err(SnapshotV2DecodeError::UnknownSemanticComponent)
+    );
+
+    let decoded = decode_test_state(&fixture).expect("nonsemantic extension should decode");
+    assert_eq!(
+        decoded
+            .component(SnapshotV2ComponentKey::new(99, 0))
+            .expect("extension should exist")
+            .disposition(),
+        SnapshotV2ComponentDisposition::NonSemantic
+    );
+}
+
+#[test]
+fn encoder_rejects_noncanonical_and_undeclared_inputs() {
+    assert!(matches!(
+        encode_snapshot_v2_state(&[0], &[]),
+        Err(SnapshotV2EncodeError::InvalidRequiredFeatureInventory)
+    ));
+    assert!(matches!(
+        encode_snapshot_v2_state(&[10], &[]),
+        Err(SnapshotV2EncodeError::UnknownRequiredFeature)
+    ));
+
+    let first = SnapshotV2Component::new(
+        SnapshotV2ComponentKey::new(2, 0),
+        SnapshotV2ComponentDisposition::NonSemantic,
+        b"first",
+    );
+    let second = SnapshotV2Component::new(
+        SnapshotV2ComponentKey::new(1, 0),
+        SnapshotV2ComponentDisposition::NonSemantic,
+        b"second",
+    );
+    assert!(matches!(
+        encode_snapshot_v2_state(&[], &[first, second]),
+        Err(SnapshotV2EncodeError::InvalidComponentDirectory)
+    ));
+    let empty = SnapshotV2Component::new(
+        SnapshotV2ComponentKey::new(1, 0),
+        SnapshotV2ComponentDisposition::NonSemantic,
+        b"",
+    );
+    assert!(matches!(
+        encode_snapshot_v2_state(&[], &[empty]),
+        Err(SnapshotV2EncodeError::InvalidComponentDirectory)
+    ));
+}
+
+#[test]
+fn encoder_rejects_count_and_file_limits() {
+    let required_features = vec![0; NATIVE_V2_SNAPSHOT_MAX_REQUIRED_FEATURES + 1];
+    assert!(matches!(
+        encode_snapshot_v2_state(&required_features, &[]),
+        Err(SnapshotV2EncodeError::CountOutOfBounds {
+            maximum: NATIVE_V2_SNAPSHOT_MAX_REQUIRED_FEATURES,
+            ..
+        })
+    ));
+
+    let component = SnapshotV2Component::new(
+        SnapshotV2ComponentKey::new(1, 0),
+        SnapshotV2ComponentDisposition::NonSemantic,
+        b"x",
+    );
+    let components = vec![component; NATIVE_V2_SNAPSHOT_MAX_COMPONENTS + 1];
+    assert!(matches!(
+        encode_snapshot_v2_state(&[], &components),
+        Err(SnapshotV2EncodeError::CountOutOfBounds {
+            maximum: NATIVE_V2_SNAPSHOT_MAX_COMPONENTS,
+            ..
+        })
+    ));
+
+    let oversized_payload = vec![0; NATIVE_V2_SNAPSHOT_MAX_FILE_BYTES];
+    let oversized = [SnapshotV2Component::new(
+        SnapshotV2ComponentKey::new(1, 0),
+        SnapshotV2ComponentDisposition::NonSemantic,
+        &oversized_payload,
+    )];
+    assert!(matches!(
+        encode_snapshot_v2_state(&[], &oversized),
+        Err(SnapshotV2EncodeError::FileTooLarge {
+            maximum: NATIVE_V2_SNAPSHOT_MAX_FILE_BYTES,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn encoder_allocation_failure_returns_no_partial_value() {
+    let allocation_error = Vec::<u8>::new()
+        .try_reserve_exact(usize::MAX)
+        .expect_err("impossible allocation should fail");
+    let result = encode_snapshot_v2_state_with_catalog_and_reserve(
+        &[],
+        &[],
+        NATIVE_V2_SNAPSHOT_VERSION,
+        PRODUCTION_REQUIRED_FEATURES,
+        PRODUCTION_SEMANTIC_COMPONENTS,
+        move |_, _| Err(allocation_error),
+    );
+
+    assert!(matches!(
+        result,
+        Err(SnapshotV2EncodeError::AllocationFailed { .. })
+    ));
+}
+
+#[test]
+fn diagnostics_redact_identifiers_payloads_and_format_magic() {
+    let sensitive_payload = b"private-component-payload";
+    let sensitive_kind = 424_242;
+    let catalog = [CatalogEntry {
+        id: sensitive_kind,
+        introduced_minor: 0,
+    }];
+    let components = [SnapshotV2Component::new(
+        SnapshotV2ComponentKey::new(sensitive_kind, 313_131),
+        SnapshotV2ComponentDisposition::Semantic,
+        sensitive_payload,
+    )];
+    let encoded = encode_snapshot_v2_state_with_catalog_and_reserve(
+        &[],
+        &components,
+        NATIVE_V2_SNAPSHOT_VERSION,
+        &[],
+        &catalog,
+        Vec::try_reserve_exact,
+    )
+    .expect("sensitive fixture should encode");
+    let state =
+        decode_snapshot_v2_state_with_catalog(&encoded, NATIVE_V2_SNAPSHOT_VERSION, &[], &catalog)
+            .expect("sensitive fixture should decode");
+
+    for diagnostic in [
+        format!("{state:?}"),
+        format!("{:?}", state.components()),
+        format!(
+            "{:?}",
+            state.components().next().expect("component should exist")
+        ),
+        SnapshotV2DecodeError::UnknownSemanticComponent.to_string(),
+        format!("{:?}", SnapshotV2DecodeError::UnknownSemanticComponent),
+        NativeSnapshotFormatError::IncompatibleFirecrackerFormat.to_string(),
+    ] {
+        assert!(!diagnostic.contains("424242"));
+        assert!(!diagnostic.contains("313131"));
+        assert!(!diagnostic.contains("private-component-payload"));
+        assert!(!diagnostic.contains("BANGV2A"));
+        assert!(!diagnostic.contains("07101984"));
+    }
+}
+
+#[test]
+fn catalog_introduction_minor_is_enforced() {
+    let catalog = [CatalogEntry {
+        id: 10,
+        introduced_minor: 1,
+    }];
+    assert!(matches!(
+        encode_snapshot_v2_state_with_catalog_and_reserve(
+            &[10],
+            &[],
+            NATIVE_V2_SNAPSHOT_VERSION,
+            &catalog,
+            &[],
+            Vec::try_reserve_exact,
+        ),
+        Err(SnapshotV2EncodeError::UnknownRequiredFeature)
+    ));
+
+    let version_one = SnapshotFormatVersion::new(2, 1, 0);
+    let encoded = encode_snapshot_v2_state_with_catalog_and_reserve(
+        &[10],
+        &[],
+        version_one,
+        &catalog,
+        &[],
+        Vec::try_reserve_exact,
+    )
+    .expect("minor-one feature should encode");
+    let decoded = decode_snapshot_v2_state_with_catalog(&encoded, version_one, &catalog, &[])
+        .expect("minor-one feature should decode");
+    assert_eq!(decoded.required_features().collect::<Vec<_>>(), vec![10]);
+    assert!(matches!(
+        decode_snapshot_v2_state(&encoded),
+        Err(SnapshotV2DecodeError::UnsupportedVersion { .. })
+    ));
+}
+
+fn test_components() -> [SnapshotV2Component<'static>; 3] {
+    [
+        SnapshotV2Component::new(
+            SnapshotV2ComponentKey::new(1, 0),
+            SnapshotV2ComponentDisposition::Semantic,
+            b"machine",
+        ),
+        SnapshotV2Component::new(
+            SnapshotV2ComponentKey::new(2, 1),
+            SnapshotV2ComponentDisposition::Semantic,
+            b"platform",
+        ),
+        SnapshotV2Component::new(
+            SnapshotV2ComponentKey::new(99, 0),
+            SnapshotV2ComponentDisposition::NonSemantic,
+            b"diagnostic",
+        ),
+    ]
+}
+
+fn encode_test_state(required_features: &[u32], components: &[SnapshotV2Component<'_>]) -> Vec<u8> {
+    encode_snapshot_v2_state_with_catalog_and_reserve(
+        required_features,
+        components,
+        NATIVE_V2_SNAPSHOT_VERSION,
+        TEST_REQUIRED_FEATURE_CATALOG,
+        TEST_SEMANTIC_COMPONENT_CATALOG,
+        Vec::try_reserve_exact,
+    )
+    .expect("test state should encode")
+}
+
+fn decode_test_state(bytes: &[u8]) -> Result<SnapshotV2State<'_>, SnapshotV2DecodeError> {
+    decode_snapshot_v2_state_with_catalog(
+        bytes,
+        NATIVE_V2_SNAPSHOT_VERSION,
+        TEST_REQUIRED_FEATURE_CATALOG,
+        TEST_SEMANTIC_COMPONENT_CATALOG,
+    )
+}
+
+fn with_u16_field(bytes: &[u8], offset: usize, value: u16) -> Vec<u8> {
+    let mut encoded = bytes.to_vec();
+    replace_field(&mut encoded, offset, &value.to_le_bytes());
+    encoded
+}
+
+fn with_u16_field_and_checksum(bytes: &[u8], offset: usize, value: u16) -> Vec<u8> {
+    let mut encoded = with_u16_field(bytes, offset, value);
+    replace_checksum(&mut encoded);
+    encoded
+}
+
+fn with_u32_field(bytes: &[u8], offset: usize, value: u32) -> Vec<u8> {
+    let mut encoded = bytes.to_vec();
+    replace_field(&mut encoded, offset, &value.to_le_bytes());
+    encoded
+}
+
+fn with_u32_field_and_checksum(bytes: &[u8], offset: usize, value: u32) -> Vec<u8> {
+    let mut encoded = with_u32_field(bytes, offset, value);
+    replace_checksum(&mut encoded);
+    encoded
+}
+
+fn with_u64_field(bytes: &[u8], offset: usize, value: u64) -> Vec<u8> {
+    let mut encoded = bytes.to_vec();
+    replace_field(&mut encoded, offset, &value.to_le_bytes());
+    encoded
+}
+
+fn with_u64_field_and_checksum(bytes: &[u8], offset: usize, value: u64) -> Vec<u8> {
+    let mut encoded = with_u64_field(bytes, offset, value);
+    replace_checksum(&mut encoded);
+    encoded
+}
+
+fn replace_field(bytes: &mut [u8], offset: usize, value: &[u8]) {
+    let end = offset + value.len();
+    bytes
+        .get_mut(offset..end)
+        .expect("fixture field should exist")
+        .copy_from_slice(value);
+}
+
+fn replace_checksum(bytes: &mut [u8]) {
+    let checksum_offset = bytes.len() - NATIVE_V2_SNAPSHOT_INTEGRITY_BYTES;
+    let checksum = crc64(
+        0,
+        bytes
+            .get(..checksum_offset)
+            .expect("checksummed fixture bytes should exist"),
+    );
+    bytes
+        .get_mut(checksum_offset..)
+        .expect("fixture checksum should exist")
+        .copy_from_slice(&checksum.to_le_bytes());
+}

--- a/docs/security.md
+++ b/docs/security.md
@@ -1231,6 +1231,21 @@ is resource-specific:
   it is not authentication, and a party that can rewrite the file can recompute
   it. Future payload schemas must therefore stay memory-safe and fail closed
   even for checksum-valid attacker-controlled bytes.
+- Native-v2 structural state is currently a library-only, non-loadable format
+  foundation. Its first pass treats all bytes as hostile, caps the complete
+  file at 16 MiB, caps feature and component counts before table traversal,
+  uses checked conversions and arithmetic, requires canonical packed ranges
+  and exact EOF, and validates the whole-state CRC before publishing a borrowed
+  view. The pass performs no count-proportional allocation. The `2.0.0`
+  production catalogs contain no required feature or semantic component, so
+  unknown mandatory behavior fails closed; only explicitly marked
+  nonsemantic extensions can survive complete structural validation. Errors
+  and `Debug` omit identifiers, payloads, format magic, guest contents, and raw
+  state. CRC-64/Jones is corruption detection rather than authentication and
+  does not cover any future external guest-memory bytes. The Firecracker
+  prefix classifier proves only an incompatible family and never deserializes
+  or translates upstream bitcode. No public create, describe, load, or VM
+  action consumes v2 in this slice.
 - Native guest-memory bindings and images are also untrusted. The binding caps
   metadata at 4,096 exact GPA ranges / 98,376 encoded bytes and memory data at
   the current 1,022-GiB arm64 policy, checks every conversion, alignment,

--- a/docs/snapshot-feasibility.md
+++ b/docs/snapshot-feasibility.md
@@ -5,6 +5,12 @@ Firecracker-shaped snapshot APIs on macOS with Hypervisor.framework. bangbang
 supports one narrow public native-v1 full-snapshot profile; broader Firecracker
 snapshot and migration compatibility remains out of scope.
 
+The runtime library also has an isolated bangbang-native v2 structural state
+foundation. Its initial `2.0.0` production catalog contains no required feature
+or semantic component, so it is not loadable VM state and is not emitted,
+described, or loaded by any public process path. The public lifecycle and CLI
+remain native-v1 until later Wave 6 work explicitly changes them.
+
 ## Current Status
 
 bangbang implements a bangbang-native outer state envelope, read-only version
@@ -165,6 +171,81 @@ so every future payload decoder must remain safe for attacker-controlled input.
 The inspection CLI still treats the payload as opaque. The runtime additionally
 recognizes both commit kinds below, while the HVF crate alone validates the
 backend-specific composite payload.
+
+## Native V2 Structural State Foundation
+
+Native v2 is a bangbang-owned, arm64-specific state container. It is designed
+for future typed component codecs without changing any native-v1 bytes or
+production path in this slice. All numeric fields are little-endian. The fixed
+header is 64 bytes:
+
+| Offset | Width | Field | Native-v2 rule |
+| ---: | ---: | --- | --- |
+| 0 | 8 | magic | bytes `BANGV2A\0` |
+| 8 | 2 | version major | `2` |
+| 10 | 2 | version minor | compatibility-bearing minor |
+| 12 | 2 | version patch | nonsemantic patch; canonical writer emits `0` |
+| 14 | 2 | header bytes | exact `64` |
+| 16 | 4 | flags | must be zero |
+| 20 | 4 | required-feature count | at most `256` |
+| 24 | 4 | component count | at most `4096` |
+| 28 | 4 | reserved | must be zero |
+| 32 | 8 | total length | exact complete state-file length, including CRC |
+| 40 | 8 | required-feature offset | exact `64` |
+| 48 | 8 | component-directory offset | exact end of the feature table |
+| 56 | 8 | component-payload offset | exact end of the directory |
+
+The header is followed by zero or more sorted, unique, nonzero `u32`
+required-feature identifiers. Each component-directory entry is exactly 32
+bytes:
+
+| Entry offset | Width | Field | Native-v2 rule |
+| ---: | ---: | --- | --- |
+| 0 | 4 | kind | nonzero component kind identifier |
+| 4 | 4 | instance | instance identifier within the kind |
+| 8 | 4 | flags | `0` semantic; exact bit 0 means nonsemantic |
+| 12 | 4 | reserved | must be zero |
+| 16 | 8 | payload offset | exact next packed payload offset |
+| 24 | 8 | payload length | nonzero |
+
+Component keys `(kind, instance)` are strictly increasing. Payloads follow in
+directory order and are contiguous: gaps, overlap, padding, wraparound, and
+trailing bytes are invalid. The final eight bytes are CRC-64/Jones over every
+preceding state-container byte. The current complete-file policy is 16 MiB;
+raising that policy requires an explicit compatibility review and minor-version
+decision. The CRC detects accidental corruption but authenticates neither this
+state nor a separately stored guest-memory image.
+
+Compatibility is fail-closed. A reader requires major `2` and rejects a newer
+minor. For an older or equal minor it requires every mandatory feature and
+semantic component kind to exist in the reader catalog at that minor.
+Explicitly nonsemantic components may remain unknown after their complete
+directory and payload ranges validate. Patch changes do not alter semantics.
+The initial production `2.0.0` catalogs are empty: the canonical emitted
+fixture is the 64-byte header plus its eight-byte CRC, nonsemantic extensions
+can be structurally represented, and every required feature or semantic
+component rejects. No future identifier or minor is reserved by this
+foundation.
+
+Decoding first checks the fixed header, version, count caps, checked length and
+offset arithmetic, exact length, whole-state CRC, complete feature inventory,
+and complete component directory. This pass borrows the bounded input and
+performs no count-proportional vector, string, map, or payload allocation.
+Only after success do bounded borrowed iterators and lookups expose validated
+components to trusted future typed codecs. Diagnostics can report stable
+version, architecture, count, and limit information, but redact feature and
+component identifiers and payload bytes.
+
+The production encoder enforces the current catalogs, computes every size with
+checked arithmetic, performs one fallible exact output reservation, and emits
+only canonical bytes. Its generic catalog-aware encoder remains private and is
+used only for grammar tests. The library family dispatcher delegates exact
+`BANGSNAP` input to the unchanged v1 decoder and `BANGV2A\0` input to this v2
+decoder. It recognizes only the arm64/x86_64 bitcode family prefixes derived
+from Firecracker v1.16.0 at pinned commit
+`d83d72b710361a10294480131377b1b00b163af8` to return a named incompatible-format
+result; this is not bitcode decoding, validity proof, translation, or
+Firecracker artifact compatibility.
 
 ## Native V1 Guest-Memory Image and Binding
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -553,6 +553,21 @@ fixed write stage and successive 1 MiB chunks, prove that no binding escapes,
 and then reuse a fresh writer successfully. Run the focused module with
 `cargo test -p bangbang-runtime snapshot_memory --locked`.
 
+Native-v2 structural state tests pin an independent exact 72-byte empty
+`2.0.0` fixture and keep the named native-v1 fixture byte-for-byte stable. A
+private catalog-aware test codec exercises multiple required features,
+semantic components, instances, and an ignorable nonsemantic extension while
+the empty production catalog rejects every required feature and semantic
+component. The mutation corpus covers every fixed header field, both count
+caps, exact/trailing/oversized lengths, all three offsets, CRC and every
+truncation, feature zero/order/duplicate/unknown cases, and component
+key/order/flag/reserved/empty/gap/overlap/wrap/trailing-range cases. It also
+checks patch/minor/major policy, introduction-minor catalogs, borrowed views,
+redacted diagnostics, allocation failure, native-v1/v2 family dispatch, and
+named Firecracker-family incompatibility without invoking a typed decoder or
+resource action. Run the focused surface with
+`cargo test -p bangbang-runtime snapshot_format --locked`.
+
 Native snapshot commit/publication tests pin the fixed 32-byte `BANGCMT\0`
 record, preserve kind-1 bytes exactly, and pin kind 2's exact nested binding,
 non-empty backend state, and envelope composition. They must reject every


### PR DESCRIPTION
## Summary

- add the isolated bangbang-native v2 arm64 structural state container with canonical encoding, bounded allocation-free decoding, catalog-gated compatibility, and redacted borrowed views
- add native-v1/native-v2 format-family dispatch plus a named incompatible result for pinned Firecracker v1.16.0 bitcode prefixes, without deserializing or translating upstream state
- freeze native-v1 bytes with a named immutable fixture and document the exact v2 wire, compatibility, security, and test contracts

## Scope exclusions

- native v2 remains structural-only and is not loadable VM state
- public snapshot create/load/describe/version behavior remains native v1
- guest-memory format, semantic component IDs, future minor versions, Firecracker translation, and capability-ledger terminal states remain unchanged for later #1490 slices

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented Apple-target Clippy commands for executable, sandbox, HVF lifecycle, guest boot, and production bundle targets
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh` (no unsupported-host bypass; all signed suites passed)

Closes #1525
