### PR TITLE
feat(hvf): preserve paused topology lifecycle state

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,20 @@ nontransactional and one-attempt: a failure permanently prevents that runner
 from executing and requires discarding the vCPU. This is an internal
 wire-format-neutral foundation; native-v1 bytes and its inactive-optional
 policy remain unchanged.
+The public boot-vCPU session can also capture and import one stable in-memory
+topology graph at a completed pause barrier. The graph preserves canonical
+index/MPIDR ordering, the virtual-timer PPI, offline and runnable members, and
+deferred PSCI `CPU_SUSPEND32/64` continuations with their X1-X3 arguments and
+post-trap PC. Capture cross-checks the coordinator, PSCI power model, session
+bookkeeping, runner-owned deferred call, and architectural registers before
+publication. Import validates the complete source and proves every destination
+owner is never-run before mutation, allocates fresh destination-local power and
+runner transaction identities, constructs the destination already Paused, and
+rolls back installed suspend calls in reverse order before consuming a failed
+destination. Explicit resume starts generation 1. This is still a
+wire-format-neutral lifecycle foundation:
+native-v1 and native-v2 bytes are unchanged, and no public multi-vCPU snapshot
+create/load path is claimed.
 A native-v1 optional-state classifier fails closed for active SVE/SME and
 enabled hardware breakpoint/watchpoint state. Prepared boot sessions can also
 replace the 16-byte VMGenID buffer and retained metadata before first run, then

--- a/crates/hvf/src/coordinator.rs
+++ b/crates/hvf/src/coordinator.rs
@@ -5,12 +5,15 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use bangbang_runtime::mmio::MmioDispatcher;
 
+use crate::paused_topology::{
+    HvfArm64StableCpuSuspendState, HvfArm64StablePausedTopologyState, HvfArm64StableVcpuDisposition,
+};
 use crate::psci::{PsciCoordinatorRequest, PsciCoordinatorResponse};
 use crate::pvtime::{HvfArm64PvTimeAccountingConfig, HvfArm64PvTimeCaptureState};
 use crate::runner::{
     HvfVcpuCoordinatedRunStepOutcome, HvfVcpuPsciCallToken, HvfVcpuRetainedVtimerWaitOutcome,
     HvfVcpuRunCompletion, HvfVcpuRunToken, HvfVcpuRunner, HvfVcpuRunnerError,
-    cancel_vcpu_run_batch_with,
+    HvfVcpuStableCpuSuspendObservation, cancel_vcpu_run_batch_with,
 };
 use crate::topology::{HvfVcpuTopology, HvfVcpuTopologyError, shutdown_runner_topology};
 use crate::vcpu::{HvfArm64BootRegisters, HvfArm64SecondaryBootRegisters};
@@ -91,6 +94,18 @@ pub struct HvfVcpuCoordinatorWork {
 }
 
 impl HvfVcpuCoordinatorWork {
+    pub(crate) const fn restored_cpu_suspend(
+        function_id: u64,
+        runner_token: HvfVcpuPsciCallToken,
+    ) -> Self {
+        Self {
+            exit: HvfHvcExit::restored_hvc0(),
+            function_id,
+            runner_token,
+            request: PsciCoordinatorRequest::CpuSuspend,
+        }
+    }
+
     pub(crate) const fn into_parts(
         self,
     ) -> (
@@ -476,6 +491,41 @@ enum MemberDispatch {
         psci_token: HvfVcpuPsciCallToken,
         timer_intid: u32,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HvfVcpuStableMemberDispatch {
+    Runnable,
+    Suspended {
+        psci_token: HvfVcpuPsciCallToken,
+        timer_intid: u32,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct HvfVcpuStablePausedMemberObservation {
+    index: usize,
+    mpidr: u64,
+    online: bool,
+    dispatch: HvfVcpuStableMemberDispatch,
+}
+
+impl HvfVcpuStablePausedMemberObservation {
+    pub(crate) const fn index(self) -> usize {
+        self.index
+    }
+
+    pub(crate) const fn mpidr(self) -> u64 {
+        self.mpidr
+    }
+
+    pub(crate) const fn online(self) -> bool {
+        self.online
+    }
+
+    pub(crate) const fn dispatch(self) -> HvfVcpuStableMemberDispatch {
+        self.dispatch
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -995,6 +1045,61 @@ where
         })
     }
 
+    fn new_paused_for_stable_import(
+        members: Vec<M>,
+        mpidrs: &[u64],
+        dispatcher: Arc<Mutex<MmioDispatcher>>,
+        stable: &HvfArm64StablePausedTopologyState,
+        batch_cancel: BatchCancel,
+    ) -> Result<Self, HvfVcpuRunCoordinatorError> {
+        if members.len() != mpidrs.len() || members.len() != stable.members().len() {
+            return Err(HvfVcpuRunCoordinatorError::InvalidState(
+                "stable paused topology metadata length does not match members",
+            ));
+        }
+        for (index, (mpidr, stable_member)) in mpidrs.iter().zip(stable.members()).enumerate() {
+            if stable_member.index() != index || stable_member.mpidr() != *mpidr {
+                return Err(HvfVcpuRunCoordinatorError::InvalidState(
+                    "stable paused topology identity does not match destination members",
+                ));
+            }
+        }
+
+        let members =
+            NonEmptyMembers::new(members).ok_or(HvfVcpuRunCoordinatorError::InvalidState(
+                "vCPU run coordinator requires at least one topology member",
+            ))?;
+        let member_states = stable
+            .members()
+            .iter()
+            .map(|member| MemberState {
+                online: !matches!(member.disposition(), HvfArm64StableVcpuDisposition::Offline),
+                // Deferred runner calls are installed after this unpublished
+                // coordinator owns shutdown authority.
+                dispatch: MemberDispatch::Runnable,
+                active: None,
+                next_generation: 1,
+                cancellation_debt: None,
+            })
+            .collect::<Vec<_>>();
+        let (completion_sender, completion_receiver) = mpsc::channel();
+        Ok(Self {
+            members,
+            dispatcher,
+            completion_sender,
+            completion_receiver,
+            shared: Arc::new(CoordinatorShared {
+                state: Mutex::new(CoordinatorState {
+                    phase: CoordinatorPhase::Paused,
+                    members: member_states,
+                    pending_events: VecDeque::new(),
+                }),
+                mpidrs: Arc::from(mpidrs.to_vec()),
+                batch_cancel,
+            }),
+        })
+    }
+
     fn control(&self) -> HvfVcpuRunControl {
         HvfVcpuRunControl {
             shared: Arc::clone(&self.shared),
@@ -1345,6 +1450,141 @@ where
             ));
         }
         state.phase = CoordinatorPhase::Running;
+        Ok(())
+    }
+
+    fn capture_stable_paused_members(
+        &mut self,
+    ) -> Result<Vec<HvfVcpuStablePausedMemberObservation>, HvfVcpuRunCoordinatorError> {
+        let mut state = self.shared.lock_state()?;
+        if !matches!(state.phase, CoordinatorPhase::Paused) {
+            return Err(HvfVcpuRunCoordinatorError::InvalidState(
+                PAUSED_PHASE_REQUIRED_MESSAGE,
+            ));
+        }
+        let consumes_idle_pause = state.pending_events.len() == 1
+            && matches!(
+                state.pending_events.front(),
+                Some(HvfVcpuRunEvent::Barrier(HvfVcpuRunBarrierReport {
+                    reason: HvfVcpuRunControlReason::Pause,
+                    acknowledgements,
+                })) if acknowledgements.is_empty()
+            );
+        if !state.pending_events.is_empty() && !consumes_idle_pause {
+            return Err(HvfVcpuRunCoordinatorError::InvalidState(
+                "stable paused topology capture has a pending coordinator event",
+            ));
+        }
+        for member in &state.members {
+            if member.active.is_some() || member.cancellation_debt.is_some() {
+                return Err(HvfVcpuRunCoordinatorError::InvalidState(
+                    "stable paused topology capture requires idle debt-free members",
+                ));
+            }
+            if !member.online && member.dispatch != MemberDispatch::Runnable {
+                return Err(HvfVcpuRunCoordinatorError::InvalidState(
+                    "stable paused topology has an offline suspended member",
+                ));
+            }
+        }
+
+        let observations = state
+            .members
+            .iter()
+            .enumerate()
+            .zip(self.shared.mpidrs.iter().copied())
+            .map(|((index, member), mpidr)| {
+                let dispatch = match member.dispatch {
+                    MemberDispatch::Runnable => HvfVcpuStableMemberDispatch::Runnable,
+                    MemberDispatch::Suspended {
+                        psci_token,
+                        timer_intid,
+                    } => HvfVcpuStableMemberDispatch::Suspended {
+                        psci_token,
+                        timer_intid,
+                    },
+                };
+                HvfVcpuStablePausedMemberObservation {
+                    index,
+                    mpidr,
+                    online: member.online,
+                    dispatch,
+                }
+            })
+            .collect();
+        if consumes_idle_pause {
+            let _ = state.pending_events.pop_front();
+        }
+        drop(state);
+        Ok(observations)
+    }
+
+    fn install_imported_cpu_suspend_dispatch(
+        &mut self,
+        index: usize,
+        psci_token: HvfVcpuPsciCallToken,
+        timer_intid: u32,
+    ) -> Result<(), HvfVcpuRunCoordinatorError> {
+        let mut state = self.shared.lock_state()?;
+        if !matches!(state.phase, CoordinatorPhase::Paused) || !state.pending_events.is_empty() {
+            return Err(HvfVcpuRunCoordinatorError::InvalidState(
+                PAUSED_PHASE_REQUIRED_MESSAGE,
+            ));
+        }
+        let member_count = state.members.len();
+        let member =
+            state
+                .members
+                .get_mut(index)
+                .ok_or(HvfVcpuRunCoordinatorError::InvalidMember {
+                    index,
+                    member_count,
+                })?;
+        if !member.online
+            || member.active.is_some()
+            || member.cancellation_debt.is_some()
+            || member.dispatch != MemberDispatch::Runnable
+        {
+            return Err(HvfVcpuRunCoordinatorError::InvalidState(
+                "stable CPU_SUSPEND import requires one idle runnable online member",
+            ));
+        }
+        member.dispatch = MemberDispatch::Suspended {
+            psci_token,
+            timer_intid,
+        };
+        Ok(())
+    }
+
+    fn clear_imported_cpu_suspend_dispatch(
+        &mut self,
+        index: usize,
+        psci_token: HvfVcpuPsciCallToken,
+    ) -> Result<(), HvfVcpuRunCoordinatorError> {
+        let mut state = self.shared.lock_state()?;
+        let member_count = state.members.len();
+        let member =
+            state
+                .members
+                .get_mut(index)
+                .ok_or(HvfVcpuRunCoordinatorError::InvalidMember {
+                    index,
+                    member_count,
+                })?;
+        if member.active.is_some()
+            || !matches!(
+                member.dispatch,
+                MemberDispatch::Suspended {
+                    psci_token: active_token,
+                    ..
+                } if active_token == psci_token
+            )
+        {
+            return Err(HvfVcpuRunCoordinatorError::InvalidState(
+                "stable CPU_SUSPEND rollback token does not match member dispatch",
+            ));
+        }
+        member.dispatch = MemberDispatch::Runnable;
         Ok(())
     }
 
@@ -1761,6 +2001,76 @@ impl<'vm> HvfVcpuRunCoordinator<'vm> {
         Self::from_parts(vec![runner], vec![mpidr], dispatcher, online_indexes)
     }
 
+    pub(crate) fn from_stable_paused_topology(
+        topology: HvfVcpuTopology<'vm>,
+        dispatcher: Arc<Mutex<MmioDispatcher>>,
+        stable: &HvfArm64StablePausedTopologyState,
+    ) -> Result<Self, HvfVcpuRunCoordinatorError> {
+        let validation = if topology.len() != stable.members().len() {
+            Err(HvfVcpuRunCoordinatorError::InvalidState(
+                "stable paused topology count does not match destination owners",
+            ))
+        } else if topology
+            .mpidrs()
+            .iter()
+            .zip(stable.members())
+            .enumerate()
+            .any(|(index, (mpidr, member))| member.index() != index || member.mpidr() != *mpidr)
+        {
+            Err(HvfVcpuRunCoordinatorError::InvalidState(
+                "stable paused topology MPIDRs do not match destination owners",
+            ))
+        } else {
+            Ok(())
+        };
+        if let Err(primary) = validation {
+            return match topology.shutdown() {
+                Ok(()) => Err(primary),
+                Err(cleanup) => Err(HvfVcpuRunCoordinatorError::ConstructionCleanup {
+                    primary: Box::new(primary),
+                    cleanup: Box::new(cleanup),
+                }),
+            };
+        }
+
+        let (runners, mpidrs) = topology.into_parts();
+        let primary_mpidr =
+            mpidrs
+                .first()
+                .copied()
+                .ok_or(HvfVcpuRunCoordinatorError::InvalidState(
+                    "stable paused topology requires primary metadata",
+                ))?;
+        let handles = Arc::new(
+            runners
+                .iter()
+                .map(HvfVcpuRunner::run_cancel_handle)
+                .collect::<Vec<_>>(),
+        );
+        let batch_cancel: BatchCancel = Arc::new(move |indexes| {
+            let mut selected = Vec::with_capacity(indexes.len());
+            for index in indexes.iter().copied() {
+                let handle = handles
+                    .get(index)
+                    .ok_or(HvfVcpuRunnerError::InvalidState(BATCH_CANCEL_INDEX_MESSAGE))?;
+                selected.push(handle.clone());
+            }
+            cancel_vcpu_run_batch_with(&selected, crate::ffi::exit_vcpus)
+        });
+        let inner = RunCoordinator::new_paused_for_stable_import(
+            runners,
+            &mpidrs,
+            dispatcher,
+            stable,
+            batch_cancel,
+        )?;
+        Ok(Self {
+            inner,
+            primary_mpidr,
+            shutdown_complete: false,
+        })
+    }
+
     fn from_parts(
         runners: Vec<HvfVcpuRunner<'vm>>,
         mpidrs: Vec<u64>,
@@ -1847,6 +2157,76 @@ impl<'vm> HvfVcpuRunCoordinator<'vm> {
 
     pub(crate) fn primary_runner(&self) -> &HvfVcpuRunner<'vm> {
         self.inner.primary_member()
+    }
+
+    pub(crate) fn capture_stable_paused_members(
+        &mut self,
+    ) -> Result<Vec<HvfVcpuStablePausedMemberObservation>, HvfVcpuRunCoordinatorError> {
+        self.inner.capture_stable_paused_members()
+    }
+
+    pub(crate) fn capture_stable_cpu_suspend(
+        &self,
+        index: usize,
+    ) -> Result<HvfVcpuStableCpuSuspendObservation, HvfVcpuRunCoordinatorError> {
+        self.inner.member_operation(
+            index,
+            "stable CPU_SUSPEND capture",
+            false,
+            HvfVcpuRunner::capture_stable_cpu_suspend,
+        )
+    }
+
+    pub(crate) fn ensure_no_stable_deferred_psci_call(
+        &self,
+        index: usize,
+    ) -> Result<(), HvfVcpuRunCoordinatorError> {
+        self.inner.member_operation(
+            index,
+            "stable deferred PSCI absence check",
+            false,
+            HvfVcpuRunner::ensure_no_stable_deferred_psci_call,
+        )
+    }
+
+    pub(crate) fn restore_stable_cpu_suspend(
+        &self,
+        index: usize,
+        state: &HvfArm64StableCpuSuspendState,
+    ) -> Result<HvfVcpuPsciCallToken, HvfVcpuRunCoordinatorError> {
+        self.inner
+            .member_operation(index, "stable CPU_SUSPEND restore", false, |runner| {
+                runner.restore_stable_cpu_suspend(state)
+            })
+    }
+
+    pub(crate) fn abort_stable_cpu_suspend(
+        &self,
+        index: usize,
+        token: HvfVcpuPsciCallToken,
+    ) -> Result<(), HvfVcpuRunCoordinatorError> {
+        self.inner
+            .member_operation(index, "stable CPU_SUSPEND rollback", false, |runner| {
+                runner.abort_stable_cpu_suspend(token)
+            })
+    }
+
+    pub(crate) fn install_imported_cpu_suspend_dispatch(
+        &mut self,
+        index: usize,
+        token: HvfVcpuPsciCallToken,
+        timer_intid: u32,
+    ) -> Result<(), HvfVcpuRunCoordinatorError> {
+        self.inner
+            .install_imported_cpu_suspend_dispatch(index, token, timer_intid)
+    }
+
+    pub(crate) fn clear_imported_cpu_suspend_dispatch(
+        &mut self,
+        index: usize,
+        token: HvfVcpuPsciCallToken,
+    ) -> Result<(), HvfVcpuRunCoordinatorError> {
+        self.inner.clear_imported_cpu_suspend_dispatch(index, token)
     }
 
     /// Wait for the next member, barrier, or fully drained terminal event.
@@ -2073,6 +2453,16 @@ impl<'vm> HvfVcpuRunCoordinator<'vm> {
         }
     }
 
+    pub(crate) fn shutdown_after_failed_stable_import(
+        &mut self,
+    ) -> Result<(), HvfVcpuRunCoordinatorError> {
+        let result = self.shutdown();
+        // A consuming import never republishes failed owners. Preserve the
+        // first reverse shutdown evidence and prevent Drop from retrying it.
+        self.shutdown_complete = true;
+        result
+    }
+
     fn drain_waiter(
         &mut self,
         waiter: &HvfVcpuRunBarrierWaiter,
@@ -2125,11 +2515,17 @@ mod tests {
     use bangbang_runtime::mmio::MmioDispatcher;
 
     use super::{
-        BatchCancel, CoordinatorMember, HvfVcpuRunControlReason, HvfVcpuRunCoordinator,
-        HvfVcpuRunCoordinatorError, HvfVcpuRunEvent, RunCoordinator,
+        BatchCancel, CoordinatorMember, HvfVcpuRunBarrierReport, HvfVcpuRunControlReason,
+        HvfVcpuRunCoordinator, HvfVcpuRunCoordinatorError, HvfVcpuRunEvent,
+        HvfVcpuStableMemberDispatch, RunCoordinator,
     };
     use crate::HvfVcpuRunStepOutcome;
     use crate::exit::{HvfExceptionExit, HvfHvcExit};
+    use crate::paused_topology::{
+        HvfArm64CpuSuspendConvention, HvfArm64StableCpuSuspendState,
+        HvfArm64StablePausedTopologyMember, HvfArm64StablePausedTopologyState,
+        HvfArm64StableVcpuDisposition,
+    };
     use crate::psci::{PsciCoordinatorRequest, PsciCoordinatorResponse};
     use crate::pvtime::HvfArm64PvTimeAccountingConfig;
     use crate::runner::tests::start_destroy_order_recording_runner;
@@ -2444,6 +2840,154 @@ mod tests {
             online_indexes,
             batch_cancel,
         )
+    }
+
+    #[test]
+    fn stable_import_coordinator_is_born_paused_and_resumes_at_generation_one() {
+        let members = fake_members(3);
+        let stable_suspend = HvfArm64StableCpuSuspendState::new(
+            HvfArm64CpuSuspendConvention::Call32,
+            [1, 2, 3],
+            0x8000,
+        )
+        .expect("stable suspend should build");
+        let stable = HvfArm64StablePausedTopologyState::new(
+            27,
+            vec![
+                HvfArm64StablePausedTopologyMember::new(
+                    0,
+                    0,
+                    HvfArm64StableVcpuDisposition::Runnable,
+                ),
+                HvfArm64StablePausedTopologyMember::new(
+                    1,
+                    1,
+                    HvfArm64StableVcpuDisposition::Offline,
+                ),
+                HvfArm64StablePausedTopologyMember::new(
+                    2,
+                    2,
+                    HvfArm64StableVcpuDisposition::Suspended(stable_suspend),
+                ),
+            ],
+        )
+        .expect("stable topology should build");
+        let mut coordinator = RunCoordinator::new_paused_for_stable_import(
+            members.clone(),
+            &[0, 1, 2],
+            Arc::new(Mutex::new(MmioDispatcher::new())),
+            &stable,
+            BatchHarness::default().callback(),
+        )
+        .expect("paused coordinator should build");
+        let psci_token = HvfVcpuPsciCallToken::new(9, 1);
+        coordinator
+            .install_imported_cpu_suspend_dispatch(2, psci_token, 27)
+            .expect("suspended dispatch should install");
+
+        assert!(matches!(
+            coordinator.dispatch_online(),
+            Err(HvfVcpuRunCoordinatorError::InvalidState(
+                super::RUNNING_PHASE_REQUIRED_MESSAGE
+            ))
+        ));
+        let observations = coordinator
+            .capture_stable_paused_members()
+            .expect("paused observations should capture");
+        assert!(!observations[1].online());
+        assert_eq!(
+            observations[2].dispatch(),
+            HvfVcpuStableMemberDispatch::Suspended {
+                psci_token,
+                timer_intid: 27
+            }
+        );
+
+        coordinator
+            .resume()
+            .expect("explicit resume should succeed");
+        assert_eq!(
+            coordinator
+                .dispatch_online()
+                .expect("online members should dispatch"),
+            2
+        );
+        assert_eq!(members[0].pending_tokens()[0].generation(), 1);
+        assert!(members[1].pending_tokens().is_empty());
+        assert_eq!(members[2].pending_tokens()[0].generation(), 1);
+        assert_eq!(members[2].retained_wait(1), (psci_token, 27));
+    }
+
+    #[test]
+    fn stable_capture_consumes_only_the_idle_pause_notification() {
+        let members = fake_members(1);
+        let mut coordinator = coordinator(&members, &[0], BatchHarness::default().callback())
+            .expect("coordinator should build");
+        coordinator
+            .control()
+            .request_pause()
+            .expect("idle pause should start")
+            .wait()
+            .expect("idle pause should complete");
+
+        assert_eq!(
+            coordinator
+                .capture_stable_paused_members()
+                .expect("exact idle pause notification should finalize")
+                .len(),
+            1
+        );
+        assert_eq!(
+            coordinator
+                .capture_stable_paused_members()
+                .expect("capture should remain stable after finalization")
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn stable_capture_rejects_active_debt_and_unrelated_pending_events() {
+        let stable = HvfArm64StablePausedTopologyState::new(
+            27,
+            vec![HvfArm64StablePausedTopologyMember::new(
+                0,
+                0,
+                HvfArm64StableVcpuDisposition::Runnable,
+            )],
+        )
+        .expect("stable topology should build");
+        let mut coordinator = RunCoordinator::new_paused_for_stable_import(
+            fake_members(1),
+            &[0],
+            Arc::new(Mutex::new(MmioDispatcher::new())),
+            &stable,
+            BatchHarness::default().callback(),
+        )
+        .expect("paused coordinator should build");
+
+        {
+            let mut state = coordinator.shared.lock_state().expect("state should lock");
+            state.members[0].active = Some(HvfVcpuRunToken::new(0, 1));
+        }
+        assert!(coordinator.capture_stable_paused_members().is_err());
+        {
+            let mut state = coordinator.shared.lock_state().expect("state should lock");
+            state.members[0].active = None;
+            state.members[0].cancellation_debt = Some(1);
+        }
+        assert!(coordinator.capture_stable_paused_members().is_err());
+        {
+            let mut state = coordinator.shared.lock_state().expect("state should lock");
+            state.members[0].cancellation_debt = None;
+            state
+                .pending_events
+                .push_back(HvfVcpuRunEvent::Barrier(HvfVcpuRunBarrierReport {
+                    reason: HvfVcpuRunControlReason::Wakeup,
+                    acknowledgements: Vec::new(),
+                }));
+        }
+        assert!(coordinator.capture_stable_paused_members().is_err());
     }
 
     fn handled(outcome: HvfVcpuRunStepOutcome) -> FakeRunResult {

--- a/crates/hvf/src/exit.rs
+++ b/crates/hvf/src/exit.rs
@@ -315,6 +315,17 @@ pub struct HvfHvcExit {
 }
 
 impl HvfHvcExit {
+    pub(crate) const fn restored_hvc0() -> Self {
+        Self {
+            exit: HvfExceptionExit {
+                syndrome: (ESR_EC_HVC as u64) << ESR_EC_SHIFT,
+                virtual_address: 0,
+                physical_address: 0,
+            },
+            immediate: 0,
+        }
+    }
+
     pub const fn exception_exit(self) -> HvfExceptionExit {
         self.exit
     }

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -15,6 +15,7 @@ mod mach_lazy;
 mod memory;
 mod mmio;
 mod optional_state;
+mod paused_topology;
 mod psci;
 mod pvtime;
 mod runner;
@@ -81,6 +82,11 @@ pub use optional_state::{
     HvfArm64ReviewedOptionalStateRestoreRejection, HvfArm64ReviewedOptionalStateRestoreStage,
     HvfArm64SmeRestoreState, HvfArm64SmeRestoreStateInput,
 };
+pub use paused_topology::{
+    HvfArm64CpuSuspendConvention, HvfArm64StableCpuSuspendState,
+    HvfArm64StablePausedTopologyBuildError, HvfArm64StablePausedTopologyMember,
+    HvfArm64StablePausedTopologyState, HvfArm64StableVcpuDisposition,
+};
 pub use pvtime::{
     HvfArm64PvTimeAccountingError, HvfArm64PvTimeAccountingStage, HvfArm64PvTimeCaptureState,
     HvfArm64PvTimeContentionProbe, HvfArm64PvTimeMeasurementError, HvfArm64PvTimeVcpuCaptureState,
@@ -93,7 +99,11 @@ pub use runner::{
     HvfVcpuRetainedVtimerWaitStage, HvfVcpuRunCancelHandle, HvfVcpuRunStepOutcome, HvfVcpuRunner,
     HvfVcpuRunnerError,
 };
-pub use session_vcpu::HvfArm64BootVcpuError;
+pub use session_vcpu::{
+    HvfArm64BootVcpuError, HvfArm64BootVcpuSession, HvfArm64StablePausedTopologyCaptureError,
+    HvfArm64StablePausedTopologyCleanupFailure, HvfArm64StablePausedTopologyCleanupStage,
+    HvfArm64StablePausedTopologyImportError,
+};
 pub use sme::HvfArm64SmeConfiguration;
 pub use snapshot::{
     HvfArm64SnapshotOptionalStateRejection, HvfArm64SnapshotTimerPolicyError,

--- a/crates/hvf/src/paused_topology.rs
+++ b/crates/hvf/src/paused_topology.rs
@@ -1,0 +1,447 @@
+use std::fmt;
+
+use bangbang_runtime::machine::MAX_SUPPORTED_VCPUS;
+
+use crate::gic::validate_gic_ppi_pending_intid;
+
+pub(crate) const PSCI_CPU_SUSPEND_32: u64 = 0x8400_0001;
+pub(crate) const PSCI_CPU_SUSPEND_64: u64 = 0xc400_0001;
+
+/// Architecturally distinct PSCI CPU_SUSPEND call forms accepted by the
+/// coordinated arm64 runner.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum HvfArm64CpuSuspendConvention {
+    /// The SMCCC 32-bit calling convention.
+    Call32,
+    /// The SMCCC 64-bit calling convention.
+    Call64,
+}
+
+impl HvfArm64CpuSuspendConvention {
+    /// Return the PSCI function ID placed in X0 by the guest.
+    pub const fn function_id(self) -> u64 {
+        match self {
+            Self::Call32 => PSCI_CPU_SUSPEND_32,
+            Self::Call64 => PSCI_CPU_SUSPEND_64,
+        }
+    }
+
+    /// Interpret one supported PSCI CPU_SUSPEND function ID.
+    pub const fn from_function_id(function_id: u64) -> Option<Self> {
+        match function_id {
+            PSCI_CPU_SUSPEND_32 => Some(Self::Call32),
+            PSCI_CPU_SUSPEND_64 => Some(Self::Call64),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Debug for HvfArm64CpuSuspendConvention {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Call32 => f.write_str("Call32"),
+            Self::Call64 => f.write_str("Call64"),
+        }
+    }
+}
+
+/// Redacted architectural continuation for one deferred PSCI CPU_SUSPEND.
+#[derive(Clone, PartialEq, Eq)]
+pub struct HvfArm64StableCpuSuspendState {
+    convention: HvfArm64CpuSuspendConvention,
+    arguments: [u64; 3],
+    return_pc: u64,
+}
+
+impl HvfArm64StableCpuSuspendState {
+    /// Construct one checked deferred CPU_SUSPEND continuation.
+    pub fn new(
+        convention: HvfArm64CpuSuspendConvention,
+        arguments: [u64; 3],
+        return_pc: u64,
+    ) -> Result<Self, HvfArm64StablePausedTopologyBuildError> {
+        if !return_pc.is_multiple_of(4) {
+            return Err(HvfArm64StablePausedTopologyBuildError::MisalignedCpuSuspendReturnPc);
+        }
+        Ok(Self {
+            convention,
+            arguments,
+            return_pc,
+        })
+    }
+
+    /// Return the closed PSCI call convention.
+    pub const fn convention(&self) -> HvfArm64CpuSuspendConvention {
+        self.convention
+    }
+
+    /// Return the architectural X1-X3 arguments.
+    pub const fn arguments(&self) -> [u64; 3] {
+        self.arguments
+    }
+
+    /// Return the post-trap guest PC at which execution will resume.
+    pub const fn return_pc(&self) -> u64 {
+        self.return_pc
+    }
+}
+
+impl fmt::Debug for HvfArm64StableCpuSuspendState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HvfArm64StableCpuSuspendState")
+            .field("convention", &self.convention)
+            .field("architectural_state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Stable software disposition for one member of a paused arm64 topology.
+#[derive(Clone, PartialEq, Eq)]
+pub enum HvfArm64StableVcpuDisposition {
+    /// The permanent owner exists but PSCI reports the member offline.
+    Offline,
+    /// The member is online and becomes runnable only after explicit resume.
+    Runnable,
+    /// The member is online in a deferred PSCI CPU_SUSPEND.
+    Suspended(HvfArm64StableCpuSuspendState),
+}
+
+impl fmt::Debug for HvfArm64StableVcpuDisposition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Offline => f.write_str("Offline"),
+            Self::Runnable => f.write_str("Runnable"),
+            Self::Suspended(_) => f.write_str("Suspended(<redacted>)"),
+        }
+    }
+}
+
+/// One topology-ordered member in a stable paused arm64 lifecycle graph.
+#[derive(Clone, PartialEq, Eq)]
+pub struct HvfArm64StablePausedTopologyMember {
+    index: usize,
+    mpidr: u64,
+    disposition: HvfArm64StableVcpuDisposition,
+}
+
+impl HvfArm64StablePausedTopologyMember {
+    /// Construct one member. Whole-topology canonicality is checked by
+    /// [`HvfArm64StablePausedTopologyState::new`].
+    pub const fn new(index: usize, mpidr: u64, disposition: HvfArm64StableVcpuDisposition) -> Self {
+        Self {
+            index,
+            mpidr,
+            disposition,
+        }
+    }
+
+    /// Return the stable topology index.
+    pub const fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Return the canonical MPIDR bound to the member.
+    pub const fn mpidr(&self) -> u64 {
+        self.mpidr
+    }
+
+    /// Return the member's stable lifecycle disposition.
+    pub const fn disposition(&self) -> &HvfArm64StableVcpuDisposition {
+        &self.disposition
+    }
+}
+
+impl fmt::Debug for HvfArm64StablePausedTopologyMember {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HvfArm64StablePausedTopologyMember")
+            .field("index", &self.index)
+            .field("mpidr", &"<redacted>")
+            .field("disposition", &self.disposition)
+            .finish()
+    }
+}
+
+/// Canonical, redacted software lifecycle state captured at a completed
+/// topology-wide pause barrier.
+#[derive(Clone, PartialEq, Eq)]
+pub struct HvfArm64StablePausedTopologyState {
+    virtual_timer_intid: u32,
+    members: Vec<HvfArm64StablePausedTopologyMember>,
+}
+
+impl HvfArm64StablePausedTopologyState {
+    /// Validate and construct one stable paused topology state.
+    pub fn new(
+        virtual_timer_intid: u32,
+        members: Vec<HvfArm64StablePausedTopologyMember>,
+    ) -> Result<Self, HvfArm64StablePausedTopologyBuildError> {
+        let member_count = members.len();
+        let max = usize::from(MAX_SUPPORTED_VCPUS);
+        if member_count == 0 || member_count > max {
+            return Err(HvfArm64StablePausedTopologyBuildError::InvalidMemberCount {
+                member_count,
+                max,
+            });
+        }
+        if validate_gic_ppi_pending_intid(virtual_timer_intid).is_err() {
+            return Err(HvfArm64StablePausedTopologyBuildError::InvalidVirtualTimerPpi);
+        }
+        for (position, member) in members.iter().enumerate() {
+            if member.index != position {
+                return Err(
+                    HvfArm64StablePausedTopologyBuildError::NonCanonicalMemberIndex {
+                        position,
+                        member_index: member.index,
+                    },
+                );
+            }
+            if member.mpidr != position as u64 {
+                return Err(
+                    HvfArm64StablePausedTopologyBuildError::NonCanonicalMemberMpidr {
+                        index: position,
+                    },
+                );
+            }
+        }
+        if matches!(
+            members.first().map(|member| &member.disposition),
+            Some(HvfArm64StableVcpuDisposition::Offline)
+        ) {
+            return Err(HvfArm64StablePausedTopologyBuildError::PrimaryOffline);
+        }
+
+        Ok(Self {
+            virtual_timer_intid,
+            members,
+        })
+    }
+
+    /// Return the validated EL1 virtual-timer PPI.
+    pub const fn virtual_timer_intid(&self) -> u32 {
+        self.virtual_timer_intid
+    }
+
+    /// Return members in canonical topology order.
+    pub fn members(&self) -> &[HvfArm64StablePausedTopologyMember] {
+        &self.members
+    }
+}
+
+impl fmt::Debug for HvfArm64StablePausedTopologyState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HvfArm64StablePausedTopologyState")
+            .field("member_count", &self.members.len())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Rejection while constructing a stable paused topology value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HvfArm64StablePausedTopologyBuildError {
+    /// The member count is empty or exceeds the product topology limit.
+    InvalidMemberCount { member_count: usize, max: usize },
+    /// The topology vector and explicit member index disagree.
+    NonCanonicalMemberIndex {
+        position: usize,
+        member_index: usize,
+    },
+    /// The member MPIDR is not the canonical arm64 MPIDR for its index.
+    NonCanonicalMemberMpidr { index: usize },
+    /// The primary member cannot be represented offline.
+    PrimaryOffline,
+    /// The virtual-timer interrupt is not a valid PPI.
+    InvalidVirtualTimerPpi,
+    /// The deferred CPU_SUSPEND return PC is not instruction-aligned.
+    MisalignedCpuSuspendReturnPc,
+}
+
+impl fmt::Display for HvfArm64StablePausedTopologyBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidMemberCount { member_count, max } => write!(
+                f,
+                "stable paused topology member count {member_count} is outside 1..={max}"
+            ),
+            Self::NonCanonicalMemberIndex {
+                position,
+                member_index,
+            } => write!(
+                f,
+                "stable paused topology position {position} contains member index {member_index}"
+            ),
+            Self::NonCanonicalMemberMpidr { index } => write!(
+                f,
+                "stable paused topology member {index} has a noncanonical MPIDR"
+            ),
+            Self::PrimaryOffline => {
+                f.write_str("stable paused topology primary member cannot be offline")
+            }
+            Self::InvalidVirtualTimerPpi => {
+                f.write_str("stable paused topology virtual timer interrupt is not a PPI")
+            }
+            Self::MisalignedCpuSuspendReturnPc => {
+                f.write_str("stable CPU_SUSPEND return PC is not instruction-aligned")
+            }
+        }
+    }
+}
+
+impl std::error::Error for HvfArm64StablePausedTopologyBuildError {}
+
+#[cfg(test)]
+mod tests {
+    use bangbang_runtime::machine::MAX_SUPPORTED_VCPUS;
+
+    use super::{
+        HvfArm64CpuSuspendConvention, HvfArm64StableCpuSuspendState,
+        HvfArm64StablePausedTopologyBuildError, HvfArm64StablePausedTopologyMember,
+        HvfArm64StablePausedTopologyState, HvfArm64StableVcpuDisposition,
+    };
+
+    fn runnable(index: usize) -> HvfArm64StablePausedTopologyMember {
+        HvfArm64StablePausedTopologyMember::new(
+            index,
+            index as u64,
+            HvfArm64StableVcpuDisposition::Runnable,
+        )
+    }
+
+    #[test]
+    fn validates_canonical_member_shapes_and_accessors() {
+        let suspended = HvfArm64StableCpuSuspendState::new(
+            HvfArm64CpuSuspendConvention::Call64,
+            [1, 2, 3],
+            0x8000,
+        )
+        .expect("aligned continuation should build");
+        let state = HvfArm64StablePausedTopologyState::new(
+            27,
+            vec![
+                runnable(0),
+                HvfArm64StablePausedTopologyMember::new(
+                    1,
+                    1,
+                    HvfArm64StableVcpuDisposition::Offline,
+                ),
+                HvfArm64StablePausedTopologyMember::new(
+                    2,
+                    2,
+                    HvfArm64StableVcpuDisposition::Suspended(suspended.clone()),
+                ),
+            ],
+        )
+        .expect("canonical topology should build");
+
+        assert_eq!(state.virtual_timer_intid(), 27);
+        assert_eq!(state.members().len(), 3);
+        assert_eq!(state.members()[2].index(), 2);
+        assert_eq!(state.members()[2].mpidr(), 2);
+        assert_eq!(
+            suspended.convention().function_id(),
+            HvfArm64CpuSuspendConvention::Call64.function_id()
+        );
+        assert_eq!(suspended.arguments(), [1, 2, 3]);
+        assert_eq!(suspended.return_pc(), 0x8000);
+    }
+
+    #[test]
+    fn rejects_invalid_topology_and_continuation_boundaries() {
+        assert!(matches!(
+            HvfArm64StablePausedTopologyState::new(27, Vec::new()),
+            Err(HvfArm64StablePausedTopologyBuildError::InvalidMemberCount {
+                member_count: 0,
+                ..
+            })
+        ));
+        assert_eq!(
+            HvfArm64StablePausedTopologyState::new(15, vec![runnable(0)]),
+            Err(HvfArm64StablePausedTopologyBuildError::InvalidVirtualTimerPpi)
+        );
+        assert_eq!(
+            HvfArm64StablePausedTopologyState::new(
+                27,
+                vec![HvfArm64StablePausedTopologyMember::new(
+                    1,
+                    0,
+                    HvfArm64StableVcpuDisposition::Runnable
+                )]
+            ),
+            Err(
+                HvfArm64StablePausedTopologyBuildError::NonCanonicalMemberIndex {
+                    position: 0,
+                    member_index: 1
+                }
+            )
+        );
+        assert_eq!(
+            HvfArm64StablePausedTopologyState::new(
+                27,
+                vec![HvfArm64StablePausedTopologyMember::new(
+                    0,
+                    1,
+                    HvfArm64StableVcpuDisposition::Runnable
+                )]
+            ),
+            Err(HvfArm64StablePausedTopologyBuildError::NonCanonicalMemberMpidr { index: 0 })
+        );
+        assert_eq!(
+            HvfArm64StablePausedTopologyState::new(
+                27,
+                vec![HvfArm64StablePausedTopologyMember::new(
+                    0,
+                    0,
+                    HvfArm64StableVcpuDisposition::Offline
+                )]
+            ),
+            Err(HvfArm64StablePausedTopologyBuildError::PrimaryOffline)
+        );
+        assert_eq!(
+            HvfArm64StableCpuSuspendState::new(HvfArm64CpuSuspendConvention::Call32, [0; 3], 3),
+            Err(HvfArm64StablePausedTopologyBuildError::MisalignedCpuSuspendReturnPc)
+        );
+    }
+
+    #[test]
+    fn accepts_the_maximum_topology_and_rejects_one_more_member() {
+        let max = usize::from(MAX_SUPPORTED_VCPUS);
+        let maximum = (0..max).map(runnable).collect();
+        let state = HvfArm64StablePausedTopologyState::new(27, maximum)
+            .expect("maximum supported topology should build");
+        assert_eq!(state.members().len(), max);
+
+        let oversized = (0..=max).map(runnable).collect();
+        assert_eq!(
+            HvfArm64StablePausedTopologyState::new(27, oversized),
+            Err(HvfArm64StablePausedTopologyBuildError::InvalidMemberCount {
+                member_count: max + 1,
+                max,
+            })
+        );
+    }
+
+    #[test]
+    fn debug_output_redacts_architectural_values() {
+        let suspended = HvfArm64StableCpuSuspendState::new(
+            HvfArm64CpuSuspendConvention::Call32,
+            [0x1111, 0x2222, 0x3333],
+            0x4444,
+        )
+        .expect("test continuation should build");
+        let state = HvfArm64StablePausedTopologyState::new(
+            27,
+            vec![HvfArm64StablePausedTopologyMember::new(
+                0,
+                0,
+                HvfArm64StableVcpuDisposition::Suspended(suspended),
+            )],
+        )
+        .expect("test topology should build");
+
+        let formatted = format!("{state:?}");
+        assert!(formatted.contains("<redacted>"));
+        for raw in ["1111", "2222", "3333", "4444"] {
+            assert!(!formatted.contains(raw));
+        }
+    }
+}

--- a/crates/hvf/src/psci.rs
+++ b/crates/hvf/src/psci.rs
@@ -1,11 +1,15 @@
 //! PSCI-over-HVC decoding and secondary-vCPU power-state coordination.
 
 use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
 
+use crate::paused_topology::{
+    HvfArm64StablePausedTopologyState, HvfArm64StableVcpuDisposition, PSCI_CPU_SUSPEND_32,
+    PSCI_CPU_SUSPEND_64,
+};
 use crate::pvtime::{ARM_SMCCC_PV_TIME_FEATURES_64, HvfArm64PvTimeHvcPolicy, dispatch_pvtime_call};
 
 const PSCI_VERSION: u64 = 0x8400_0000;
-const PSCI_CPU_SUSPEND_32: u64 = 0x8400_0001;
 const PSCI_CPU_OFF: u64 = 0x8400_0002;
 const PSCI_CPU_ON_32: u64 = 0x8400_0003;
 const PSCI_AFFINITY_INFO_32: u64 = 0x8400_0004;
@@ -13,7 +17,6 @@ const PSCI_MIGRATE_INFO_TYPE: u64 = 0x8400_0006;
 const PSCI_SYSTEM_OFF: u64 = 0x8400_0008;
 const PSCI_SYSTEM_RESET: u64 = 0x8400_0009;
 const PSCI_FEATURES: u64 = 0x8400_000a;
-const PSCI_CPU_SUSPEND_64: u64 = 0xc400_0001;
 const PSCI_CPU_ON_64: u64 = 0xc400_0003;
 const PSCI_AFFINITY_INFO_64: u64 = 0xc400_0004;
 const ARM_SMCCC_VERSION: u64 = 0x8000_0000;
@@ -23,6 +26,15 @@ const ARM_SMCCC_VERSION_1_1: u64 = 0x0001_0001;
 const PSCI_MIGRATE_INFO_TYPE_TRUSTED_OS_NOT_REQUIRED: u64 = 2;
 const PSCI_MPIDR_AFFINITY_MASK: u64 = 0x0000_00ff_00ff_ffff;
 const PSCI_MPIDR_32_RESERVED_MASK: u64 = 0xff00_0000;
+static NEXT_POWER_COORDINATOR_ID: AtomicU64 = AtomicU64::new(1);
+
+fn allocate_power_coordinator_id() -> Result<u64, PsciCpuPowerError> {
+    NEXT_POWER_COORDINATOR_ID
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |identity| {
+            identity.checked_add(1)
+        })
+        .map_err(|_| PsciCpuPowerError::TokenExhausted)
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PsciCall {
@@ -499,7 +511,10 @@ impl PsciCpuSuspendResponse {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) struct PsciCpuSuspendToken(u64);
+pub(crate) struct PsciCpuSuspendToken {
+    coordinator: u64,
+    sequence: u64,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PsciCpuSuspendWork {
@@ -533,7 +548,10 @@ impl PsciCpuOffResponse {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) struct PsciCpuOffToken(u64);
+pub(crate) struct PsciCpuOffToken {
+    coordinator: u64,
+    sequence: u64,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PsciCpuOffWork {
@@ -594,7 +612,10 @@ impl PsciCpuOnResponse {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) struct PsciCpuOnToken(u64);
+pub(crate) struct PsciCpuOnToken {
+    coordinator: u64,
+    sequence: u64,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PsciCpuOnWork {
@@ -716,9 +737,46 @@ struct PsciCpuState {
     cpu_off_transaction: Option<PsciCpuOffWork>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PsciCpuStableMemberObservation {
+    index: usize,
+    mpidr: u64,
+    power: PsciCpuPowerState,
+    cpu_on_token: Option<PsciCpuOnToken>,
+    cpu_suspend_work: Option<PsciCpuSuspendWork>,
+    cpu_off_work: Option<PsciCpuOffWork>,
+}
+
+impl PsciCpuStableMemberObservation {
+    pub(crate) const fn index(self) -> usize {
+        self.index
+    }
+
+    pub(crate) const fn mpidr(self) -> u64 {
+        self.mpidr
+    }
+
+    pub(crate) const fn power(self) -> PsciCpuPowerState {
+        self.power
+    }
+
+    pub(crate) const fn cpu_on_token(self) -> Option<PsciCpuOnToken> {
+        self.cpu_on_token
+    }
+
+    pub(crate) const fn cpu_suspend_work(self) -> Option<PsciCpuSuspendWork> {
+        self.cpu_suspend_work
+    }
+
+    pub(crate) const fn cpu_off_work(self) -> Option<PsciCpuOffWork> {
+        self.cpu_off_work
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PsciCpuPowerCoordinator {
     cpus: Vec<PsciCpuState>,
+    identity: u64,
     next_token: u64,
 }
 
@@ -753,7 +811,89 @@ impl PsciCpuPowerCoordinator {
 
         Ok(Self {
             cpus,
+            identity: allocate_power_coordinator_id()?,
             next_token: 1,
+        })
+    }
+
+    pub(crate) fn from_stable_paused_topology(
+        stable: &HvfArm64StablePausedTopologyState,
+    ) -> Result<(Self, Vec<Option<PsciCpuSuspendWork>>), PsciCpuPowerError> {
+        let mut cpus = Vec::new();
+        cpus.try_reserve_exact(stable.members().len())
+            .map_err(|_| PsciCpuPowerError::InvalidTopology)?;
+        let mut suspended = Vec::new();
+        suspended
+            .try_reserve_exact(stable.members().len())
+            .map_err(|_| PsciCpuPowerError::InvalidTopology)?;
+        let mut next_token = 1_u64;
+        let identity = allocate_power_coordinator_id()?;
+
+        for member in stable.members() {
+            if member.index() != cpus.len() || member.mpidr() != member.index() as u64 {
+                return Err(PsciCpuPowerError::InvalidTopology);
+            }
+            let (power, cpu_suspend_transaction) = match member.disposition() {
+                HvfArm64StableVcpuDisposition::Offline => (PsciCpuPowerState::Off, None),
+                HvfArm64StableVcpuDisposition::Runnable => (PsciCpuPowerState::On, None),
+                HvfArm64StableVcpuDisposition::Suspended(_) => {
+                    let token = PsciCpuSuspendToken {
+                        coordinator: identity,
+                        sequence: next_token,
+                    };
+                    next_token = next_token
+                        .checked_add(1)
+                        .ok_or(PsciCpuPowerError::TokenExhausted)?;
+                    (
+                        PsciCpuPowerState::On,
+                        Some(PsciCpuSuspendWork {
+                            token,
+                            caller_index: member.index(),
+                        }),
+                    )
+                }
+            };
+            cpus.push(PsciCpuState {
+                mpidr: member.mpidr(),
+                power,
+                transaction: None,
+                cpu_suspend_transaction,
+                cpu_off_transaction: None,
+            });
+            suspended.push(cpu_suspend_transaction);
+        }
+        if cpus
+            .first()
+            .is_none_or(|cpu| cpu.power != PsciCpuPowerState::On)
+        {
+            return Err(PsciCpuPowerError::InvalidTopology);
+        }
+
+        Ok((
+            Self {
+                cpus,
+                identity,
+                next_token,
+            },
+            suspended,
+        ))
+    }
+
+    pub(crate) fn stable_member_observation(
+        &self,
+        index: usize,
+    ) -> Result<PsciCpuStableMemberObservation, PsciCpuPowerError> {
+        let cpu = self
+            .cpus
+            .get(index)
+            .ok_or(PsciCpuPowerError::InvalidCpuIndex { index })?;
+        Ok(PsciCpuStableMemberObservation {
+            index,
+            mpidr: cpu.mpidr,
+            power: cpu.power,
+            cpu_on_token: cpu.transaction.map(|transaction| transaction.work.token),
+            cpu_suspend_work: cpu.cpu_suspend_transaction,
+            cpu_off_work: cpu.cpu_off_transaction,
         })
     }
 
@@ -800,7 +940,10 @@ impl PsciCpuPowerCoordinator {
             PsciCpuPowerState::Off => {}
         }
 
-        let token = PsciCpuOnToken(self.next_token);
+        let token = PsciCpuOnToken {
+            coordinator: self.identity,
+            sequence: self.next_token,
+        };
         self.next_token = self
             .next_token
             .checked_add(1)
@@ -852,7 +995,10 @@ impl PsciCpuPowerCoordinator {
             return Ok(PsciCpuOffBegin::Complete(PsciCpuOffResponse::Denied));
         }
 
-        let token = PsciCpuOffToken(self.next_token);
+        let token = PsciCpuOffToken {
+            coordinator: self.identity,
+            sequence: self.next_token,
+        };
         self.next_token = self
             .next_token
             .checked_add(1)
@@ -890,7 +1036,10 @@ impl PsciCpuPowerCoordinator {
             });
         }
 
-        let token = PsciCpuSuspendToken(self.next_token);
+        let token = PsciCpuSuspendToken {
+            coordinator: self.identity,
+            sequence: self.next_token,
+        };
         self.next_token = self
             .next_token
             .checked_add(1)
@@ -1171,6 +1320,11 @@ mod tests {
         handle_call_with_pvtime, handle_coordinated_call, handle_coordinated_call_with_pvtime,
         not_supported_result,
     };
+    use crate::paused_topology::{
+        HvfArm64CpuSuspendConvention, HvfArm64StableCpuSuspendState,
+        HvfArm64StablePausedTopologyMember, HvfArm64StablePausedTopologyState,
+        HvfArm64StableVcpuDisposition,
+    };
     use crate::pvtime::{
         ARM_SMCCC_PV_TIME_FEATURES_32, ARM_SMCCC_PV_TIME_FEATURES_64, ARM_SMCCC_PV_TIME_ST_32,
         ARM_SMCCC_PV_TIME_ST_64, HvfArm64PvTimeHvcPolicy,
@@ -1206,6 +1360,65 @@ mod tests {
         coordinator
             .mark_target_entered(work.token())
             .expect("secondary should enter");
+    }
+
+    #[test]
+    fn stable_paused_preparation_builds_closed_power_state_with_fresh_tokens() {
+        let mut source =
+            PsciCpuPowerCoordinator::new(&[0, 1, 2]).expect("source power topology should build");
+        let source_suspend = source
+            .begin_cpu_suspend(0)
+            .expect("source primary should suspend");
+        let stable_suspend = HvfArm64StableCpuSuspendState::new(
+            HvfArm64CpuSuspendConvention::Call64,
+            [1, 2, 3],
+            0x8000,
+        )
+        .expect("stable continuation should build");
+        let stable = HvfArm64StablePausedTopologyState::new(
+            27,
+            vec![
+                HvfArm64StablePausedTopologyMember::new(
+                    0,
+                    0,
+                    HvfArm64StableVcpuDisposition::Suspended(stable_suspend),
+                ),
+                HvfArm64StablePausedTopologyMember::new(
+                    1,
+                    1,
+                    HvfArm64StableVcpuDisposition::Offline,
+                ),
+                HvfArm64StablePausedTopologyMember::new(
+                    2,
+                    2,
+                    HvfArm64StableVcpuDisposition::Runnable,
+                ),
+            ],
+        )
+        .expect("stable topology should build");
+
+        let (destination, suspended) =
+            PsciCpuPowerCoordinator::from_stable_paused_topology(&stable)
+                .expect("stable power topology should prepare");
+        let destination_suspend = suspended[0].expect("primary suspension should prepare");
+        assert_ne!(destination_suspend.token(), source_suspend.token());
+        assert_eq!(suspended[1], None);
+        assert_eq!(suspended[2], None);
+        for (index, expected_power, suspended_expected) in [
+            (0, PsciCpuPowerState::On, true),
+            (1, PsciCpuPowerState::Off, false),
+            (2, PsciCpuPowerState::On, false),
+        ] {
+            let observation = destination
+                .stable_member_observation(index)
+                .expect("member should be observable");
+            assert_eq!(observation.index(), index);
+            assert_eq!(observation.mpidr(), index as u64);
+            assert_eq!(observation.power(), expected_power);
+            assert_eq!(observation.cpu_suspend_work().is_some(), suspended_expected);
+            assert_eq!(observation.cpu_on_token(), None);
+            assert_eq!(observation.cpu_off_work(), None);
+        }
     }
 
     #[test]
@@ -1871,11 +2084,13 @@ mod tests {
             coordinator.begin_cpu_suspend(0),
             Err(PsciCpuPowerError::TokenExhausted)
         );
+        let unknown = PsciCpuSuspendToken {
+            coordinator: coordinator.identity,
+            sequence: u64::MAX,
+        };
         assert_eq!(
-            coordinator.validate_cpu_suspend(PsciCpuSuspendToken(u64::MAX), 0),
-            Err(PsciCpuPowerError::UnknownCpuSuspendTransaction {
-                token: PsciCpuSuspendToken(u64::MAX)
-            })
+            coordinator.validate_cpu_suspend(unknown, 0),
+            Err(PsciCpuPowerError::UnknownCpuSuspendTransaction { token: unknown })
         );
         assert_eq!(coordinator.power_state(0), Some(PsciCpuPowerState::On));
     }
@@ -1985,7 +2200,10 @@ mod tests {
     fn stale_and_duplicate_transitions_are_mutation_free() {
         let mut coordinator = coordinator();
         let work = pending_work(&mut coordinator);
-        let stale = super::PsciCpuOnToken(99);
+        let stale = super::PsciCpuOnToken {
+            coordinator: coordinator.identity,
+            sequence: 99,
+        };
         assert_eq!(
             coordinator.finish_target_setup(stale, true),
             Err(PsciCpuPowerError::UnknownTransaction { token: stale })

--- a/crates/hvf/src/runner.rs
+++ b/crates/hvf/src/runner.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::marker::PhantomData;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, TryLockError};
 use std::thread::{self, JoinHandle};
@@ -34,6 +34,7 @@ use crate::optional_state::{
     HvfArm64ReviewedOptionalStateAccess, HvfArm64ReviewedOptionalStateRestore,
     HvfArm64ReviewedOptionalStateRestoreError, restore_arm64_reviewed_optional_state_with,
 };
+use crate::paused_topology::{HvfArm64CpuSuspendConvention, HvfArm64StableCpuSuspendState};
 use crate::psci::{
     PsciCall, PsciCallAction, PsciCoordinatedDispatch, PsciCoordinatorRequest,
     PsciCoordinatorResponse, call_uses_arg0, coordinated_call_argument_count,
@@ -162,10 +163,25 @@ const PSCI_CALL_REQUEST_MISMATCH_MESSAGE: &str =
     "deferred PSCI request does not match the completion operation";
 const PSCI_COMPLETION_IN_FLIGHT_MESSAGE: &str = "vCPU runner already has PSCI completion in flight";
 const PSCI_CALL_TOKEN_EXHAUSTED_MESSAGE: &str = "deferred PSCI call token space is exhausted";
+const PSCI_CALL_OWNER_EXHAUSTED_MESSAGE: &str =
+    "deferred PSCI call owner identity space is exhausted";
+const STABLE_CPU_SUSPEND_REQUEST_MISMATCH_MESSAGE: &str =
+    "deferred PSCI call is not a restorable CPU_SUSPEND";
+const STABLE_CPU_SUSPEND_REGISTER_MISMATCH_MESSAGE: &str =
+    "restored CPU_SUSPEND architectural state does not match";
 const RETAINED_VTIMER_WAIT_IN_FLIGHT_MESSAGE: &str =
     "vCPU runner already has a retained virtual-timer wait in flight";
 const RETAINED_VTIMER_WAIT_TOKEN_EXHAUSTED_MESSAGE: &str =
     "retained virtual-timer wait token space is exhausted";
+static NEXT_PSCI_CALL_OWNER_ID: AtomicU64 = AtomicU64::new(1);
+
+fn allocate_psci_call_owner_id() -> Result<u64, HvfVcpuRunnerError> {
+    NEXT_PSCI_CALL_OWNER_ID
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |identity| {
+            identity.checked_add(1)
+        })
+        .map_err(|_| HvfVcpuRunnerError::InvalidState(PSCI_CALL_OWNER_EXHAUSTED_MESSAGE))
+}
 const RETAINED_VTIMER_WAIT_SIGNAL_POISONED_MESSAGE: &str =
     "retained virtual-timer wait signal lock is poisoned";
 const RETAINED_VTIMER_WAIT_IDENTITY_MISMATCH_MESSAGE: &str =
@@ -608,14 +624,43 @@ pub enum HvfVcpuRunStepOutcome {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct HvfVcpuPsciCallToken {
+    owner: u64,
     vcpu: crate::ffi::HvVcpu,
     sequence: u64,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct HvfVcpuStableCpuSuspendObservation {
+    token: HvfVcpuPsciCallToken,
+    state: HvfArm64StableCpuSuspendState,
+}
+
+impl HvfVcpuStableCpuSuspendObservation {
+    pub(crate) const fn token(&self) -> HvfVcpuPsciCallToken {
+        self.token
+    }
+
+    pub(crate) const fn state(&self) -> &HvfArm64StableCpuSuspendState {
+        &self.state
+    }
+}
+
+impl fmt::Debug for HvfVcpuStableCpuSuspendObservation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HvfVcpuStableCpuSuspendObservation")
+            .field("state", &"<redacted>")
+            .finish()
+    }
 }
 
 #[cfg(test)]
 impl HvfVcpuPsciCallToken {
     pub(crate) const fn new(vcpu: crate::ffi::HvVcpu, sequence: u64) -> Self {
-        Self { vcpu, sequence }
+        Self {
+            owner: vcpu,
+            vcpu,
+            sequence,
+        }
     }
 }
 
@@ -1143,14 +1188,16 @@ struct RunnerThreadPendingPsciCall {
 
 #[derive(Debug)]
 struct RunnerThreadPsciState {
+    owner: u64,
     vcpu: crate::ffi::HvVcpu,
     next_token: u64,
     pending: Option<RunnerThreadPendingPsciCall>,
 }
 
 impl RunnerThreadPsciState {
-    const fn new(vcpu: crate::ffi::HvVcpu) -> Self {
+    const fn new(owner: u64, vcpu: crate::ffi::HvVcpu) -> Self {
         Self {
+            owner,
             vcpu,
             next_token: 1,
             pending: None,
@@ -1171,6 +1218,7 @@ impl RunnerThreadPsciState {
                 PSCI_CALL_TOKEN_EXHAUSTED_MESSAGE,
             ))?;
         let token = HvfVcpuPsciCallToken {
+            owner: self.owner,
             vcpu: self.vcpu,
             sequence: self.next_token,
         };
@@ -1232,6 +1280,28 @@ enum RunnerCommand {
     },
     CommitPsciCpuOff {
         token: HvfVcpuPsciCallToken,
+        response_sender: mpsc::Sender<Result<(), HvfVcpuRunnerError>>,
+    },
+    CaptureStableCpuSuspend {
+        admission: InFlightCoreRegisterOperation,
+        expected_token: HvfVcpuPsciCallToken,
+        response_sender:
+            mpsc::Sender<Result<HvfVcpuStableCpuSuspendObservation, HvfVcpuRunnerError>>,
+    },
+    RestoreStableCpuSuspend {
+        admission: InFlightCoreRegisterOperation,
+        handle_state: RunnerState,
+        state: HvfArm64StableCpuSuspendState,
+        response_sender: mpsc::Sender<Result<HvfVcpuPsciCallToken, HvfVcpuRunnerError>>,
+    },
+    AbortStableCpuSuspend {
+        admission: InFlightCoreRegisterOperation,
+        handle_state: RunnerState,
+        token: HvfVcpuPsciCallToken,
+        response_sender: mpsc::Sender<Result<(), HvfVcpuRunnerError>>,
+    },
+    ProbeNoDeferredPsciCall {
+        admission: InFlightCoreRegisterOperation,
         response_sender: mpsc::Sender<Result<(), HvfVcpuRunnerError>>,
     },
     DispatchMmioAccess {
@@ -3340,6 +3410,117 @@ impl<'vm> HvfVcpuRunner<'vm> {
         Ok(self.lock_state()?.retained_vtimer_wait.is_some())
     }
 
+    pub(crate) fn capture_stable_cpu_suspend(
+        &self,
+    ) -> Result<HvfVcpuStableCpuSuspendObservation, HvfVcpuRunnerError> {
+        let (admission, expected_token) =
+            self.reserve_stable_cpu_suspend_operation(false, |state| {
+                match state.pending_psci_call {
+                    Some(token) => Ok(token),
+                    None => Err(HvfVcpuRunnerError::InvalidState(
+                        PSCI_CALL_NOT_PENDING_MESSAGE,
+                    )),
+                }
+            })?;
+        let (response_sender, response_receiver) = mpsc::channel();
+        self.command_sender
+            .send(RunnerCommand::CaptureStableCpuSuspend {
+                admission,
+                expected_token,
+                response_sender,
+            })
+            .map_err(|_| HvfVcpuRunnerError::ChannelClosed(COMMAND_CHANNEL_CLOSED_MESSAGE))?;
+
+        response_receiver
+            .recv()
+            .map_err(|_| HvfVcpuRunnerError::ChannelClosed(RESPONSE_CHANNEL_CLOSED_MESSAGE))?
+    }
+
+    pub(crate) fn restore_stable_cpu_suspend(
+        &self,
+        state: &HvfArm64StableCpuSuspendState,
+    ) -> Result<HvfVcpuPsciCallToken, HvfVcpuRunnerError> {
+        let (admission, ()) = self.reserve_stable_cpu_suspend_operation(true, |runner_state| {
+            ensure_no_pending_psci_call(runner_state)
+        })?;
+        let (response_sender, response_receiver) = mpsc::channel();
+        self.command_sender
+            .send(RunnerCommand::RestoreStableCpuSuspend {
+                admission,
+                handle_state: Arc::clone(&self.state),
+                state: state.clone(),
+                response_sender,
+            })
+            .map_err(|_| HvfVcpuRunnerError::ChannelClosed(COMMAND_CHANNEL_CLOSED_MESSAGE))?;
+
+        response_receiver
+            .recv()
+            .map_err(|_| HvfVcpuRunnerError::ChannelClosed(RESPONSE_CHANNEL_CLOSED_MESSAGE))?
+    }
+
+    pub(crate) fn abort_stable_cpu_suspend(
+        &self,
+        token: HvfVcpuPsciCallToken,
+    ) -> Result<(), HvfVcpuRunnerError> {
+        let (admission, ()) =
+            self.reserve_stable_cpu_suspend_operation(false, |state| {
+                match state.pending_psci_call {
+                    None => Err(HvfVcpuRunnerError::InvalidState(
+                        PSCI_CALL_NOT_PENDING_MESSAGE,
+                    )),
+                    Some(pending) if pending != token => Err(HvfVcpuRunnerError::InvalidState(
+                        PSCI_CALL_TOKEN_MISMATCH_MESSAGE,
+                    )),
+                    Some(_) => Ok(()),
+                }
+            })?;
+        let (response_sender, response_receiver) = mpsc::channel();
+        self.command_sender
+            .send(RunnerCommand::AbortStableCpuSuspend {
+                admission,
+                handle_state: Arc::clone(&self.state),
+                token,
+                response_sender,
+            })
+            .map_err(|_| HvfVcpuRunnerError::ChannelClosed(COMMAND_CHANNEL_CLOSED_MESSAGE))?;
+
+        response_receiver
+            .recv()
+            .map_err(|_| HvfVcpuRunnerError::ChannelClosed(RESPONSE_CHANNEL_CLOSED_MESSAGE))?
+    }
+
+    pub(crate) fn ensure_no_stable_deferred_psci_call(&self) -> Result<(), HvfVcpuRunnerError> {
+        let admission = self.reserve_core_register_operation()?;
+        let (response_sender, response_receiver) = mpsc::channel();
+        self.command_sender
+            .send(RunnerCommand::ProbeNoDeferredPsciCall {
+                admission,
+                response_sender,
+            })
+            .map_err(|_| HvfVcpuRunnerError::ChannelClosed(COMMAND_CHANNEL_CLOSED_MESSAGE))?;
+
+        response_receiver
+            .recv()
+            .map_err(|_| HvfVcpuRunnerError::ChannelClosed(RESPONSE_CHANNEL_CLOSED_MESSAGE))?
+    }
+
+    pub(crate) fn ensure_stable_import_ready(&self) -> Result<(), HvfVcpuRunnerError> {
+        let (admission, ()) = self.reserve_stable_cpu_suspend_operation(true, |state| {
+            ensure_no_pending_psci_call(state)
+        })?;
+        let (response_sender, response_receiver) = mpsc::channel();
+        self.command_sender
+            .send(RunnerCommand::ProbeNoDeferredPsciCall {
+                admission,
+                response_sender,
+            })
+            .map_err(|_| HvfVcpuRunnerError::ChannelClosed(COMMAND_CHANNEL_CLOSED_MESSAGE))?;
+
+        response_receiver
+            .recv()
+            .map_err(|_| HvfVcpuRunnerError::ChannelClosed(RESPONSE_CHANNEL_CLOSED_MESSAGE))?
+    }
+
     #[cfg(test)]
     pub(crate) fn run_once_and_handle_mmio_coordinated(
         &self,
@@ -5168,6 +5349,90 @@ impl<'vm> HvfVcpuRunner<'vm> {
             ));
         }
         Ok(state)
+    }
+
+    fn reserve_stable_cpu_suspend_operation<T>(
+        &self,
+        require_never_run: bool,
+        validate_pending: impl FnOnce(&RunnerHandleState) -> Result<T, HvfVcpuRunnerError>,
+    ) -> Result<(InFlightCoreRegisterOperation, T), HvfVcpuRunnerError> {
+        let mut state = self.lock_state()?;
+        if state.thread.is_none() {
+            return Err(HvfVcpuRunnerError::InvalidState(RUNNER_SHUT_DOWN_MESSAGE));
+        }
+        if state.shutting_down {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                RUNNER_SHUTTING_DOWN_MESSAGE,
+            ));
+        }
+        if !state.mpidr_configured {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                MPIDR_NOT_CONFIGURED_MESSAGE,
+            ));
+        }
+        if require_never_run && state.run_started {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                RUN_ALREADY_STARTED_MESSAGE,
+            ));
+        }
+        if state.in_flight_runs > 0 {
+            return Err(HvfVcpuRunnerError::InvalidState(RUN_IN_FLIGHT_MESSAGE));
+        }
+        if state.retained_vtimer_wait.is_some() {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                RETAINED_VTIMER_WAIT_IN_FLIGHT_MESSAGE,
+            ));
+        }
+        if state.mmio_dispatch_in_flight {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                MMIO_DISPATCH_IN_FLIGHT_MESSAGE,
+            ));
+        }
+        if state.boot_register_setup_in_flight {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                BOOT_REGISTER_SETUP_IN_FLIGHT_MESSAGE,
+            ));
+        }
+        if state.metadata_read_in_flight {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                METADATA_READ_IN_FLIGHT_MESSAGE,
+            ));
+        }
+        if state.core_register_operation_in_flight {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                CORE_REGISTER_OPERATION_IN_FLIGHT_MESSAGE,
+            ));
+        }
+        if state.timer_operation_in_flight {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                TIMER_OPERATION_IN_FLIGHT_MESSAGE,
+            ));
+        }
+        if state.interrupt_operation_in_flight {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                INTERRUPT_OPERATION_IN_FLIGHT_MESSAGE,
+            ));
+        }
+        if state.psci_completion_in_flight {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                PSCI_COMPLETION_IN_FLIGHT_MESSAGE,
+            ));
+        }
+        if state.boot_register_setup_failed {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                BOOT_REGISTER_SETUP_FAILED_MESSAGE,
+            ));
+        }
+        if state.reviewed_optional_restore_failed {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                REVIEWED_OPTIONAL_STATE_RESTORE_FAILED_MESSAGE,
+            ));
+        }
+        let validated = validate_pending(&state)?;
+
+        state.core_register_operation_in_flight = true;
+        drop(state);
+        Ok((InFlightCoreRegisterOperation::new(&self.state), validated))
     }
 
     fn start_mmio_dispatch(
@@ -7323,11 +7588,19 @@ fn run_runner_thread<C, V>(
         }
     };
 
+    let psci_owner = match allocate_psci_call_owner_id() {
+        Ok(identity) => identity,
+        Err(error) => {
+            let _ = startup_sender.send(Err(error));
+            return;
+        }
+    };
+
     if startup_sender.send(Ok(vcpu_id)).is_err() {
         return;
     }
 
-    let mut psci_state = RunnerThreadPsciState::new(vcpu_id);
+    let mut psci_state = RunnerThreadPsciState::new(psci_owner, vcpu_id);
     let mut pvtime = HvfArm64PvTimeAccounting::disabled();
 
     while let Ok(command) = command_receiver.recv() {
@@ -7474,6 +7747,60 @@ fn run_runner_thread<C, V>(
                 if sent && result.is_ok() {
                     psci_state.pending = None;
                 }
+            }
+            RunnerCommand::CaptureStableCpuSuspend {
+                mut admission,
+                expected_token,
+                response_sender,
+            } => {
+                let result = capture_stable_cpu_suspend_on_runner_thread(
+                    &mut vcpu,
+                    &psci_state,
+                    expected_token,
+                );
+                admission.release();
+                let _ = response_sender.send(result);
+            }
+            RunnerCommand::RestoreStableCpuSuspend {
+                mut admission,
+                handle_state,
+                state,
+                response_sender,
+            } => {
+                let result = restore_stable_cpu_suspend_on_runner_thread(
+                    &mut vcpu,
+                    &mut psci_state,
+                    &handle_state,
+                    &state,
+                );
+                admission.release();
+                let _ = response_sender.send(result);
+            }
+            RunnerCommand::AbortStableCpuSuspend {
+                mut admission,
+                handle_state,
+                token,
+                response_sender,
+            } => {
+                let result = abort_stable_cpu_suspend_on_runner_thread(
+                    &mut psci_state,
+                    &handle_state,
+                    token,
+                );
+                admission.release();
+                let _ = response_sender.send(result);
+            }
+            RunnerCommand::ProbeNoDeferredPsciCall {
+                mut admission,
+                response_sender,
+            } => {
+                let result = if psci_state.pending.is_none() {
+                    Ok(())
+                } else {
+                    Err(HvfVcpuRunnerError::InvalidState(PSCI_CALL_PENDING_MESSAGE))
+                };
+                admission.release();
+                let _ = response_sender.send(result);
             }
             RunnerCommand::DispatchMmioAccess {
                 access,
@@ -8826,6 +9153,139 @@ fn handle_coordinated_hvc_on_runner_thread(
     }
 }
 
+fn capture_stable_cpu_suspend_on_runner_thread(
+    vcpu: &mut impl RunnerVcpu,
+    psci_state: &RunnerThreadPsciState,
+    expected_token: HvfVcpuPsciCallToken,
+) -> Result<HvfVcpuStableCpuSuspendObservation, HvfVcpuRunnerError> {
+    let Some(pending) = psci_state.pending.as_ref() else {
+        return Err(HvfVcpuRunnerError::InvalidState(
+            PSCI_CALL_NOT_PENDING_MESSAGE,
+        ));
+    };
+    if pending.token != expected_token {
+        return Err(HvfVcpuRunnerError::InvalidState(
+            PSCI_CALL_TOKEN_MISMATCH_MESSAGE,
+        ));
+    }
+    if pending.request != PsciCoordinatorRequest::CpuSuspend || pending.written_response.is_some() {
+        return Err(HvfVcpuRunnerError::InvalidState(
+            STABLE_CPU_SUSPEND_REQUEST_MISMATCH_MESSAGE,
+        ));
+    }
+
+    let function_id = vcpu
+        .read_register(HvfRegister::X0)
+        .map_err(HvfVcpuRunnerError::Backend)?;
+    let convention = HvfArm64CpuSuspendConvention::from_function_id(function_id).ok_or(
+        HvfVcpuRunnerError::InvalidState(STABLE_CPU_SUSPEND_REQUEST_MISMATCH_MESSAGE),
+    )?;
+    let mut arguments = [0; 3];
+    for (argument, register) in
+        arguments
+            .iter_mut()
+            .zip([HvfRegister::X1, HvfRegister::X2, HvfRegister::X3])
+    {
+        *argument = vcpu
+            .read_register(register)
+            .map_err(HvfVcpuRunnerError::Backend)?;
+    }
+    let return_pc = vcpu
+        .read_register(HvfRegister::PC)
+        .map_err(HvfVcpuRunnerError::Backend)?;
+    let state =
+        HvfArm64StableCpuSuspendState::new(convention, arguments, return_pc).map_err(|_| {
+            HvfVcpuRunnerError::InvalidState(STABLE_CPU_SUSPEND_REGISTER_MISMATCH_MESSAGE)
+        })?;
+
+    Ok(HvfVcpuStableCpuSuspendObservation {
+        token: expected_token,
+        state,
+    })
+}
+
+fn restore_stable_cpu_suspend_on_runner_thread(
+    vcpu: &mut impl RunnerVcpu,
+    psci_state: &mut RunnerThreadPsciState,
+    handle_state: &RunnerState,
+    stable_state: &HvfArm64StableCpuSuspendState,
+) -> Result<HvfVcpuPsciCallToken, HvfVcpuRunnerError> {
+    let function_id = vcpu
+        .read_register(HvfRegister::X0)
+        .map_err(HvfVcpuRunnerError::Backend)?;
+    let mut arguments = [0; 3];
+    for (argument, register) in
+        arguments
+            .iter_mut()
+            .zip([HvfRegister::X1, HvfRegister::X2, HvfRegister::X3])
+    {
+        *argument = vcpu
+            .read_register(register)
+            .map_err(HvfVcpuRunnerError::Backend)?;
+    }
+    let return_pc = vcpu
+        .read_register(HvfRegister::PC)
+        .map_err(HvfVcpuRunnerError::Backend)?;
+    if function_id != stable_state.convention().function_id()
+        || arguments != stable_state.arguments()
+        || return_pc != stable_state.return_pc()
+    {
+        return Err(HvfVcpuRunnerError::InvalidState(
+            STABLE_CPU_SUSPEND_REGISTER_MISMATCH_MESSAGE,
+        ));
+    }
+
+    let mut state = lock_runner_state(handle_state)?;
+    ensure_no_pending_psci_call(&state)?;
+    let token = psci_state.begin(PsciCoordinatorRequest::CpuSuspend)?;
+    state.pending_psci_call = Some(token);
+    drop(state);
+
+    Ok(token)
+}
+
+fn abort_stable_cpu_suspend_on_runner_thread(
+    psci_state: &mut RunnerThreadPsciState,
+    handle_state: &RunnerState,
+    token: HvfVcpuPsciCallToken,
+) -> Result<(), HvfVcpuRunnerError> {
+    let Some(pending) = psci_state.pending.as_ref() else {
+        return Err(HvfVcpuRunnerError::InvalidState(
+            PSCI_CALL_NOT_PENDING_MESSAGE,
+        ));
+    };
+    if pending.token != token {
+        return Err(HvfVcpuRunnerError::InvalidState(
+            PSCI_CALL_TOKEN_MISMATCH_MESSAGE,
+        ));
+    }
+    if pending.request != PsciCoordinatorRequest::CpuSuspend || pending.written_response.is_some() {
+        return Err(HvfVcpuRunnerError::InvalidState(
+            STABLE_CPU_SUSPEND_REQUEST_MISMATCH_MESSAGE,
+        ));
+    }
+
+    let mut state = lock_runner_state(handle_state)?;
+    match state.pending_psci_call {
+        None => {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                PSCI_CALL_NOT_PENDING_MESSAGE,
+            ));
+        }
+        Some(pending) if pending != token => {
+            return Err(HvfVcpuRunnerError::InvalidState(
+                PSCI_CALL_TOKEN_MISMATCH_MESSAGE,
+            ));
+        }
+        Some(_) => {}
+    }
+    state.pending_psci_call = None;
+    psci_state.pending = None;
+    drop(state);
+
+    Ok(())
+}
+
 fn complete_psci_call_on_runner_thread(
     vcpu: &mut impl RunnerVcpu,
     psci_state: &mut RunnerThreadPsciState,
@@ -9033,6 +9493,7 @@ pub(crate) mod tests {
         HvfArm64DebugRegisterRestoreState, HvfArm64OptionalStateValue,
         HvfArm64ReviewedOptionalStateRestore,
     };
+    use crate::paused_topology::{HvfArm64CpuSuspendConvention, HvfArm64StableCpuSuspendState};
     use crate::psci::{
         PsciAffinityInfoResponse, PsciCoordinatorRequest, PsciCoordinatorResponse, PsciCpuOnBegin,
         PsciCpuOnResponse, PsciCpuPowerCoordinator, PsciCpuPowerState, PsciCpuSuspendResponse,
@@ -10821,6 +11282,7 @@ pub(crate) mod tests {
     struct CoordinatedPsciRecordingVcpu {
         run_once_result: Result<HvfVcpuExit, BackendError>,
         registers: [u64; 4],
+        pc: u64,
         register_read_sender: mpsc::Sender<HvfRegister>,
         register_write_sender: mpsc::Sender<(HvfRegister, u64)>,
         fail_next_x0_write: bool,
@@ -10829,6 +11291,7 @@ pub(crate) mod tests {
         vtimer_counter_samples: VecDeque<Result<u64, BackendError>>,
         vtimer_sample_sender: Option<mpsc::Sender<()>>,
         ppi_sender: Option<mpsc::Sender<(u32, bool)>>,
+        destroy_observation: Option<(usize, bool, mpsc::Sender<usize>)>,
     }
 
     struct SecondaryConfigureRecordingVcpu {
@@ -17673,6 +18136,7 @@ pub(crate) mod tests {
                 HvfRegister::X1 => Ok(self.registers[1]),
                 HvfRegister::X2 => Ok(self.registers[2]),
                 HvfRegister::X3 => Ok(self.registers[3]),
+                HvfRegister::PC => Ok(self.pc),
                 _ => Err(BackendError::InvalidState("unexpected fake register read")),
             }
         }
@@ -17737,7 +18201,19 @@ pub(crate) mod tests {
         }
 
         fn destroy(&mut self) -> Result<(), BackendError> {
-            Ok(())
+            let Some((index, fail_destroy, sender)) = &self.destroy_observation else {
+                return Ok(());
+            };
+            sender
+                .send(*index)
+                .map_err(|_| BackendError::InvalidState("fake destroy receiver closed"))?;
+            if *fail_destroy {
+                Err(BackendError::InvalidState(
+                    "fake coordinated PSCI destroy failed",
+                ))
+            } else {
+                Ok(())
+            }
         }
     }
 
@@ -19366,12 +19842,35 @@ pub(crate) mod tests {
         mpsc::Receiver<HvfRegister>,
         mpsc::Receiver<(HvfRegister, u64)>,
     ) {
+        start_coordinated_psci_run_step_recording_runner_with_destroy(
+            function_id,
+            arguments,
+            hvc_immediate,
+            fail_next_x0_write,
+            None,
+        )
+    }
+
+    pub(crate) type CoordinatedPsciDestroyObservation = (usize, bool, mpsc::Sender<usize>);
+
+    pub(crate) fn start_coordinated_psci_run_step_recording_runner_with_destroy(
+        function_id: u64,
+        arguments: [u64; 3],
+        hvc_immediate: u16,
+        fail_next_x0_write: bool,
+        destroy_observation: Option<CoordinatedPsciDestroyObservation>,
+    ) -> (
+        HvfVcpuRunner<'static>,
+        mpsc::Receiver<HvfRegister>,
+        mpsc::Receiver<(HvfRegister, u64)>,
+    ) {
         let (register_read_sender, register_read_receiver) = mpsc::channel();
         let (register_write_sender, register_write_receiver) = mpsc::channel();
         let started = spawn_runner_thread(move || {
             Ok(CoordinatedPsciRecordingVcpu {
                 run_once_result: Ok(hvc_exception_exit(hvc_immediate)),
                 registers: [function_id, arguments[0], arguments[1], arguments[2]],
+                pc: 0x8000,
                 register_read_sender,
                 register_write_sender,
                 fail_next_x0_write,
@@ -19380,6 +19879,7 @@ pub(crate) mod tests {
                 vtimer_counter_samples: VecDeque::from([Ok(100)]),
                 vtimer_sample_sender: None,
                 ppi_sender: None,
+                destroy_observation,
             })
         })
         .expect("fake coordinated PSCI runner should start");
@@ -19416,6 +19916,7 @@ pub(crate) mod tests {
             Ok(CoordinatedPsciRecordingVcpu {
                 run_once_result: Ok(hvc_exception_exit(0)),
                 registers: [function_id, arguments[0], arguments[1], arguments[2]],
+                pc: 0x8000,
                 register_read_sender,
                 register_write_sender,
                 fail_next_x0_write: false,
@@ -19424,6 +19925,7 @@ pub(crate) mod tests {
                 vtimer_counter_samples,
                 vtimer_sample_sender: Some(vtimer_sample_sender),
                 ppi_sender: Some(ppi_sender),
+                destroy_observation: None,
             })
         })
         .expect("fake CPU_SUSPEND runner should start");
@@ -34790,6 +35292,175 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn stable_cpu_suspend_capture_closes_owner_and_architectural_identity() {
+        for (function_id, convention) in [
+            (PSCI_CPU_SUSPEND, HvfArm64CpuSuspendConvention::Call32),
+            (PSCI_CPU_SUSPEND_64, HvfArm64CpuSuspendConvention::Call64),
+        ] {
+            let arguments = [0x11, 0x22, 0x33];
+            let (runner, register_reads, register_writes) =
+                start_coordinated_psci_run_step_recording_runner(function_id, arguments, 0, false);
+            let HvfVcpuCoordinatedRunStepOutcome::Psci {
+                token,
+                request: PsciCoordinatorRequest::CpuSuspend,
+                ..
+            } = runner
+                .run_once_and_handle_mmio_coordinated(shared_dispatcher())
+                .expect("CPU_SUSPEND should defer")
+            else {
+                panic!("CPU_SUSPEND should return coordinator work");
+            };
+
+            let observation = runner
+                .capture_stable_cpu_suspend()
+                .expect("quiescent deferred CPU_SUSPEND should capture");
+            assert_eq!(observation.token(), token);
+            assert_eq!(observation.state().convention(), convention);
+            assert_eq!(observation.state().arguments(), arguments);
+            assert_eq!(observation.state().return_pc(), 0x8000);
+            assert!(format!("{observation:?}").contains("<redacted>"));
+            assert_eq!(
+                register_reads.try_iter().collect::<Vec<_>>(),
+                vec![
+                    HvfRegister::X0,
+                    HvfRegister::X1,
+                    HvfRegister::X2,
+                    HvfRegister::X3,
+                    HvfRegister::X0,
+                    HvfRegister::X1,
+                    HvfRegister::X2,
+                    HvfRegister::X3,
+                    HvfRegister::PC,
+                ]
+            );
+            assert_eq!(register_writes.try_recv(), Err(mpsc::TryRecvError::Empty));
+
+            runner
+                .abort_stable_cpu_suspend(token)
+                .expect("exact deferred call should abort");
+            runner
+                .ensure_no_stable_deferred_psci_call()
+                .expect("abort should clear both owner records");
+            runner.shutdown().expect("runner should shut down");
+        }
+    }
+
+    #[test]
+    fn stable_cpu_suspend_restore_allocates_a_fresh_destination_owner_token() {
+        let arguments = [7, 8, 9];
+        let (source, _, _) = start_coordinated_psci_run_step_recording_runner(
+            PSCI_CPU_SUSPEND_64,
+            arguments,
+            0,
+            false,
+        );
+        let HvfVcpuCoordinatedRunStepOutcome::Psci {
+            token: source_token,
+            request: PsciCoordinatorRequest::CpuSuspend,
+            ..
+        } = source
+            .run_once_and_handle_mmio_coordinated(shared_dispatcher())
+            .expect("source CPU_SUSPEND should defer")
+        else {
+            panic!("source CPU_SUSPEND should return coordinator work");
+        };
+        let stable = source
+            .capture_stable_cpu_suspend()
+            .expect("source suspension should capture")
+            .state()
+            .clone();
+
+        let (destination, _, _) = start_coordinated_psci_run_step_recording_runner(
+            PSCI_CPU_SUSPEND_64,
+            arguments,
+            0,
+            false,
+        );
+        let destination_token = destination
+            .restore_stable_cpu_suspend(&stable)
+            .expect("destination suspension should install");
+        assert_ne!(destination_token, source_token);
+
+        destination
+            .abort_stable_cpu_suspend(destination_token)
+            .expect("destination token should abort");
+        source
+            .abort_stable_cpu_suspend(source_token)
+            .expect("source token should abort");
+        destination
+            .shutdown()
+            .expect("destination should shut down");
+        source.shutdown().expect("source should shut down");
+    }
+
+    #[test]
+    fn stable_cpu_suspend_restore_validates_before_install_and_aborts_exactly() {
+        let arguments = [7, 8, 9];
+        let (runner, register_reads, register_writes) =
+            start_coordinated_psci_run_step_recording_runner(
+                PSCI_CPU_SUSPEND_64,
+                arguments,
+                0,
+                false,
+            );
+        let mismatch = HvfArm64StableCpuSuspendState::new(
+            HvfArm64CpuSuspendConvention::Call64,
+            [7, 8, 10],
+            0x8000,
+        )
+        .expect("test state should build");
+        assert_eq!(
+            runner.restore_stable_cpu_suspend(&mismatch),
+            Err(HvfVcpuRunnerError::InvalidState(
+                super::STABLE_CPU_SUSPEND_REGISTER_MISMATCH_MESSAGE
+            ))
+        );
+        runner
+            .ensure_no_stable_deferred_psci_call()
+            .expect("failed validation must not install owner state");
+
+        let stable = HvfArm64StableCpuSuspendState::new(
+            HvfArm64CpuSuspendConvention::Call64,
+            arguments,
+            0x8000,
+        )
+        .expect("test state should build");
+        let token = runner
+            .restore_stable_cpu_suspend(&stable)
+            .expect("matching never-run registers should install a fresh token");
+        assert_eq!(
+            runner
+                .capture_stable_cpu_suspend()
+                .expect("installed state should recapture")
+                .state(),
+            &stable
+        );
+        let stale = HvfVcpuPsciCallToken::new(7, token.sequence + 1);
+        assert_eq!(
+            runner.abort_stable_cpu_suspend(stale),
+            Err(HvfVcpuRunnerError::InvalidState(
+                super::PSCI_CALL_TOKEN_MISMATCH_MESSAGE
+            ))
+        );
+        runner
+            .abort_stable_cpu_suspend(token)
+            .expect("exact installed token should abort");
+        assert_eq!(
+            runner.abort_stable_cpu_suspend(token),
+            Err(HvfVcpuRunnerError::InvalidState(
+                super::PSCI_CALL_NOT_PENDING_MESSAGE
+            ))
+        );
+        assert_eq!(register_writes.try_recv(), Err(mpsc::TryRecvError::Empty));
+        assert!(
+            register_reads
+                .try_iter()
+                .any(|read| read == HvfRegister::PC)
+        );
+        runner.shutdown().expect("runner should shut down");
+    }
+
+    #[test]
     fn coordinated_cpu_suspend_wait_rejects_stale_and_wrong_requests() {
         let (runner, _, register_writes) = start_coordinated_psci_run_step_recording_runner(
             PSCI_CPU_ON,
@@ -34806,6 +35477,7 @@ pub(crate) mod tests {
             panic!("CPU_ON should return coordinator work");
         };
         let stale = HvfVcpuPsciCallToken {
+            owner: psci_token.owner,
             vcpu: psci_token.vcpu,
             sequence: psci_token.sequence + 1,
         };
@@ -35706,6 +36378,7 @@ pub(crate) mod tests {
             panic!("CPU_ON should return coordinator work");
         };
         let stale = HvfVcpuPsciCallToken {
+            owner: token.owner,
             vcpu: token.vcpu,
             sequence: token.sequence + 1,
         };

--- a/crates/hvf/src/session_vcpu.rs
+++ b/crates/hvf/src/session_vcpu.rs
@@ -10,16 +10,22 @@ use crate::HvfVcpuRunStepOutcome;
 use crate::coordinator::{
     HvfVcpuCoordinatorWork, HvfVcpuRunAdmission, HvfVcpuRunControl, HvfVcpuRunControlReason,
     HvfVcpuRunCoordinator, HvfVcpuRunCoordinatorError, HvfVcpuRunEvent, HvfVcpuRunMemberOutcome,
-    HvfVcpuRunMemberResult, HvfVcpuRunTerminalReport,
+    HvfVcpuRunMemberResult, HvfVcpuRunTerminalReport, HvfVcpuStableMemberDispatch,
+    HvfVcpuStablePausedMemberObservation,
 };
 use crate::memory::HvfGuestMemoryMappingError;
+use crate::paused_topology::{
+    HvfArm64StablePausedTopologyMember, HvfArm64StablePausedTopologyState,
+    HvfArm64StableVcpuDisposition,
+};
 use crate::psci::{
     PsciCoordinatorRequest, PsciCoordinatorResponse, PsciCpuOffBegin, PsciCpuOnBegin,
-    PsciCpuOnToken, PsciCpuOnWork, PsciCpuPowerCoordinator, PsciCpuSuspendResponse,
-    PsciCpuSuspendToken,
+    PsciCpuOnToken, PsciCpuOnWork, PsciCpuPowerCoordinator, PsciCpuPowerState,
+    PsciCpuStableMemberObservation, PsciCpuSuspendResponse, PsciCpuSuspendToken,
 };
 use crate::pvtime::HvfArm64PvTimeCaptureState;
 use crate::runner::{HvfVcpuRetainedVtimerWaitOutcome, HvfVcpuRunner, HvfVcpuRunnerError};
+use crate::topology::HvfVcpuTopology;
 use crate::vcpu::HvfArm64SecondaryBootRegisters;
 
 /// Failure while translating aggregate vCPU events into boot-session steps.
@@ -111,6 +117,232 @@ impl From<HvfVcpuRunnerError> for HvfArm64BootVcpuError {
     }
 }
 
+/// Failure while exporting one completed paused vCPU lifecycle graph.
+pub struct HvfArm64StablePausedTopologyCaptureError {
+    stage: &'static str,
+    index: Option<usize>,
+    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+}
+
+impl HvfArm64StablePausedTopologyCaptureError {
+    fn new(stage: &'static str, index: Option<usize>) -> Self {
+        Self {
+            stage,
+            index,
+            source: None,
+        }
+    }
+
+    fn with_source(
+        stage: &'static str,
+        index: Option<usize>,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            stage,
+            index,
+            source: Some(Box::new(source)),
+        }
+    }
+
+    /// Return the value-free capture stage.
+    pub const fn stage(&self) -> &'static str {
+        self.stage
+    }
+
+    /// Return the affected topology member, when the stage is member-scoped.
+    pub const fn index(&self) -> Option<usize> {
+        self.index
+    }
+}
+
+impl fmt::Debug for HvfArm64StablePausedTopologyCaptureError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HvfArm64StablePausedTopologyCaptureError")
+            .field("stage", &self.stage)
+            .field("index", &self.index)
+            .field("source", &self.source.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfArm64StablePausedTopologyCaptureError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "stable paused topology capture failed at {}", self.stage)?;
+        if let Some(index) = self.index {
+            write!(f, " for member {index}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for HvfArm64StablePausedTopologyCaptureError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_ref()
+            .map(|source| source.as_ref() as &(dyn std::error::Error + 'static))
+    }
+}
+
+/// Cleanup operation attempted after a stable paused topology import failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfArm64StablePausedTopologyCleanupStage {
+    RunnerAbort,
+    CoordinatorDispatch,
+    TopologyShutdown,
+}
+
+impl fmt::Display for HvfArm64StablePausedTopologyCleanupStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RunnerAbort => f.write_str("runner abort"),
+            Self::CoordinatorDispatch => f.write_str("coordinator dispatch rollback"),
+            Self::TopologyShutdown => f.write_str("topology shutdown"),
+        }
+    }
+}
+
+/// One value-free cleanup failure retained by an import error.
+pub struct HvfArm64StablePausedTopologyCleanupFailure {
+    stage: HvfArm64StablePausedTopologyCleanupStage,
+    index: Option<usize>,
+    source: Box<dyn std::error::Error + Send + Sync + 'static>,
+}
+
+impl HvfArm64StablePausedTopologyCleanupFailure {
+    /// Return the failed cleanup class.
+    pub const fn stage(&self) -> HvfArm64StablePausedTopologyCleanupStage {
+        self.stage
+    }
+
+    /// Return the affected member for member-scoped cleanup.
+    pub const fn index(&self) -> Option<usize> {
+        self.index
+    }
+
+    /// Return the detailed internal cleanup source.
+    pub fn source_error(&self) -> &(dyn std::error::Error + 'static) {
+        self.source.as_ref()
+    }
+}
+
+impl fmt::Debug for HvfArm64StablePausedTopologyCleanupFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HvfArm64StablePausedTopologyCleanupFailure")
+            .field("stage", &self.stage)
+            .field("index", &self.index)
+            .field("source", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfArm64StablePausedTopologyCleanupFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "stable paused topology cleanup failed at {}", self.stage)?;
+        if let Some(index) = self.index {
+            write!(f, " for member {index}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for HvfArm64StablePausedTopologyCleanupFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
+/// Failure while consuming a destination topology into paused lifecycle state.
+pub struct HvfArm64StablePausedTopologyImportError {
+    stage: &'static str,
+    index: Option<usize>,
+    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    cleanup: Vec<HvfArm64StablePausedTopologyCleanupFailure>,
+}
+
+impl HvfArm64StablePausedTopologyImportError {
+    fn new(stage: &'static str, index: Option<usize>) -> Self {
+        Self {
+            stage,
+            index,
+            source: None,
+            cleanup: Vec::new(),
+        }
+    }
+
+    fn with_source(
+        stage: &'static str,
+        index: Option<usize>,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            stage,
+            index,
+            source: Some(Box::new(source)),
+            cleanup: Vec::new(),
+        }
+    }
+
+    fn with_cleanup_storage(
+        mut self,
+        cleanup: Vec<HvfArm64StablePausedTopologyCleanupFailure>,
+    ) -> Self {
+        self.cleanup = cleanup;
+        self
+    }
+
+    /// Return the value-free primary import stage.
+    pub const fn stage(&self) -> &'static str {
+        self.stage
+    }
+
+    /// Return the affected topology member, when applicable.
+    pub const fn index(&self) -> Option<usize> {
+        self.index
+    }
+
+    /// Return every reverse cleanup failure in attempt order.
+    pub fn cleanup_failures(&self) -> &[HvfArm64StablePausedTopologyCleanupFailure] {
+        &self.cleanup
+    }
+}
+
+impl fmt::Debug for HvfArm64StablePausedTopologyImportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HvfArm64StablePausedTopologyImportError")
+            .field("stage", &self.stage)
+            .field("index", &self.index)
+            .field("source", &self.source.as_ref().map(|_| "<redacted>"))
+            .field("cleanup", &self.cleanup)
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfArm64StablePausedTopologyImportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "stable paused topology import failed at {}", self.stage)?;
+        if let Some(index) = self.index {
+            write!(f, " for member {index}")?;
+        }
+        if !self.cleanup.is_empty() {
+            write!(
+                f,
+                "; {} cleanup operation(s) also failed",
+                self.cleanup.len()
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for HvfArm64StablePausedTopologyImportError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_ref()
+            .map(|source| source.as_ref() as &(dyn std::error::Error + 'static))
+    }
+}
+
 #[derive(Debug)]
 struct IndexedBootStep {
     index: usize,
@@ -123,9 +355,19 @@ struct PendingCpuSuspend {
     coordinator_work: HvfVcpuCoordinatorWork,
 }
 
-/// Boot-session aggregate that owns every vCPU runner and its PSCI power model.
-#[derive(Debug)]
-pub(crate) struct HvfArm64BootVcpuSession<'vm> {
+#[derive(Debug, Clone, Copy)]
+struct InstalledStableCpuSuspend {
+    index: usize,
+    runner_token: crate::runner::HvfVcpuPsciCallToken,
+    dispatch_installed: bool,
+}
+
+/// Boot-session vCPU aggregate that owns every runner and its PSCI power model.
+///
+/// The stable paused topology methods expose the in-memory lifecycle
+/// foundation used by snapshot reconstruction. They do not encode snapshot
+/// bytes or restore memory, devices, registers, or time state.
+pub struct HvfArm64BootVcpuSession<'vm> {
     coordinator: HvfVcpuRunCoordinator<'vm>,
     power: PsciCpuPowerCoordinator,
     virtual_timer_intid: u32,
@@ -133,6 +375,15 @@ pub(crate) struct HvfArm64BootVcpuSession<'vm> {
     pending_steps: VecDeque<Result<IndexedBootStep, HvfArm64BootVcpuError>>,
     last_step_index: usize,
     last_terminal_report: Option<HvfVcpuRunTerminalReport>,
+}
+
+impl fmt::Debug for HvfArm64BootVcpuSession<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HvfArm64BootVcpuSession")
+            .field("member_count", &self.coordinator.member_count())
+            .field("state", &"<redacted>")
+            .finish()
+    }
 }
 
 impl<'vm> HvfArm64BootVcpuSession<'vm> {
@@ -200,6 +451,309 @@ impl<'vm> HvfArm64BootVcpuSession<'vm> {
         self.coordinator.pause_idle_for_arm64_pvtime_capture()
     }
 
+    /// Export one fully quiesced paused lifecycle graph.
+    pub fn capture_stable_paused_topology(
+        &mut self,
+    ) -> Result<HvfArm64StablePausedTopologyState, HvfArm64StablePausedTopologyCaptureError> {
+        if !self.pending_steps.is_empty() {
+            return Err(HvfArm64StablePausedTopologyCaptureError::new(
+                "pending boot-session step",
+                None,
+            ));
+        }
+        if self.last_terminal_report.is_some() {
+            return Err(HvfArm64StablePausedTopologyCaptureError::new(
+                "terminal boot-session state",
+                None,
+            ));
+        }
+
+        let before = self
+            .coordinator
+            .capture_stable_paused_members()
+            .map_err(|source| {
+                HvfArm64StablePausedTopologyCaptureError::with_source(
+                    "coordinator pause validation",
+                    None,
+                    source,
+                )
+            })?;
+        if before.len() != self.pending_cpu_suspends.len()
+            || before.len() != self.coordinator.member_count()
+        {
+            return Err(HvfArm64StablePausedTopologyCaptureError::new(
+                "cross-owner member count",
+                None,
+            ));
+        }
+
+        let mut members = Vec::new();
+        members.try_reserve_exact(before.len()).map_err(|source| {
+            HvfArm64StablePausedTopologyCaptureError::with_source(
+                "stable member allocation",
+                None,
+                source,
+            )
+        })?;
+        for coordinator in before.iter().copied() {
+            let index = coordinator.index();
+            let power = self
+                .power
+                .stable_member_observation(index)
+                .map_err(|source| {
+                    HvfArm64StablePausedTopologyCaptureError::with_source(
+                        "PSCI power observation",
+                        Some(index),
+                        source,
+                    )
+                })?;
+            let disposition = self.capture_stable_member_disposition(coordinator, power)?;
+            members.push(HvfArm64StablePausedTopologyMember::new(
+                index,
+                coordinator.mpidr(),
+                disposition,
+            ));
+        }
+
+        let after = self
+            .coordinator
+            .capture_stable_paused_members()
+            .map_err(|source| {
+                HvfArm64StablePausedTopologyCaptureError::with_source(
+                    "coordinator revalidation",
+                    None,
+                    source,
+                )
+            })?;
+        if before != after || !self.pending_steps.is_empty() || self.last_terminal_report.is_some()
+        {
+            return Err(HvfArm64StablePausedTopologyCaptureError::new(
+                "cross-owner revalidation",
+                None,
+            ));
+        }
+
+        HvfArm64StablePausedTopologyState::new(self.virtual_timer_intid, members).map_err(
+            |source| {
+                HvfArm64StablePausedTopologyCaptureError::with_source(
+                    "stable value construction",
+                    None,
+                    source,
+                )
+            },
+        )
+    }
+
+    /// Consume never-run destination owners into one coordinator born paused.
+    ///
+    /// Register restore must already have completed on every owner. Any
+    /// failure consumes and shuts down the topology; callers must create fresh
+    /// destination owners before retrying.
+    pub fn from_stable_paused_topology(
+        topology: HvfVcpuTopology<'vm>,
+        stable: &HvfArm64StablePausedTopologyState,
+        dispatcher: Arc<Mutex<MmioDispatcher>>,
+        virtual_timer_intid: u32,
+    ) -> Result<Self, HvfArm64StablePausedTopologyImportError> {
+        if stable.virtual_timer_intid() != virtual_timer_intid {
+            let mut error =
+                HvfArm64StablePausedTopologyImportError::new("virtual timer PPI validation", None);
+            shutdown_unmodified_stable_import(&topology, &mut error);
+            return Err(error);
+        }
+        if topology.len() != stable.members().len() {
+            let mut error = HvfArm64StablePausedTopologyImportError::new(
+                "destination member count validation",
+                None,
+            );
+            shutdown_unmodified_stable_import(&topology, &mut error);
+            return Err(error);
+        }
+        for (index, (mpidr, member)) in topology.mpidrs().iter().zip(stable.members()).enumerate() {
+            if member.index() != index || member.mpidr() != *mpidr {
+                let mut error = HvfArm64StablePausedTopologyImportError::new(
+                    "destination MPIDR validation",
+                    Some(index),
+                );
+                shutdown_unmodified_stable_import(&topology, &mut error);
+                return Err(error);
+            }
+        }
+        for index in 0..stable.members().len() {
+            if let Err(source) = topology.ensure_stable_import_ready(index) {
+                let mut error = HvfArm64StablePausedTopologyImportError::with_source(
+                    "destination owner readiness",
+                    Some(index),
+                    source,
+                );
+                shutdown_unmodified_stable_import(&topology, &mut error);
+                return Err(error);
+            }
+        }
+
+        let mut pending_cpu_suspends = Vec::new();
+        if let Err(source) = pending_cpu_suspends.try_reserve_exact(stable.members().len()) {
+            let mut error = HvfArm64StablePausedTopologyImportError::with_source(
+                "pending CPU_SUSPEND allocation",
+                None,
+                source,
+            );
+            shutdown_unmodified_stable_import(&topology, &mut error);
+            return Err(error);
+        }
+        pending_cpu_suspends.resize(stable.members().len(), None);
+        let mut installed = Vec::new();
+        if let Err(source) = installed.try_reserve_exact(stable.members().len()) {
+            let mut error = HvfArm64StablePausedTopologyImportError::with_source(
+                "rollback allocation",
+                None,
+                source,
+            );
+            shutdown_unmodified_stable_import(&topology, &mut error);
+            return Err(error);
+        }
+        let cleanup_capacity = stable
+            .members()
+            .len()
+            .checked_mul(2)
+            .and_then(|capacity| capacity.checked_add(1))
+            .ok_or_else(|| {
+                HvfArm64StablePausedTopologyImportError::new("cleanup allocation size", None)
+            });
+        let cleanup_capacity = match cleanup_capacity {
+            Ok(capacity) => capacity,
+            Err(mut error) => {
+                shutdown_unmodified_stable_import(&topology, &mut error);
+                return Err(error);
+            }
+        };
+        let mut rollback_cleanup = Vec::new();
+        if let Err(source) = rollback_cleanup.try_reserve_exact(cleanup_capacity) {
+            let mut error = HvfArm64StablePausedTopologyImportError::with_source(
+                "cleanup allocation",
+                None,
+                source,
+            );
+            shutdown_unmodified_stable_import(&topology, &mut error);
+            return Err(error);
+        }
+        let (power, power_suspends) =
+            match PsciCpuPowerCoordinator::from_stable_paused_topology(stable) {
+                Ok(prepared) => prepared,
+                Err(source) => {
+                    let mut error = HvfArm64StablePausedTopologyImportError::with_source(
+                        "PSCI power preparation",
+                        None,
+                        source,
+                    );
+                    shutdown_unmodified_stable_import(&topology, &mut error);
+                    return Err(error);
+                }
+            };
+        let mut coordinator =
+            HvfVcpuRunCoordinator::from_stable_paused_topology(topology, dispatcher, stable)
+                .map_err(|source| {
+                    HvfArm64StablePausedTopologyImportError::with_source(
+                        "paused coordinator construction",
+                        None,
+                        source,
+                    )
+                })?;
+
+        for member in stable.members() {
+            let index = member.index();
+            let HvfArm64StableVcpuDisposition::Suspended(stable_suspend) = member.disposition()
+            else {
+                if power_suspends.get(index).copied().flatten().is_some() {
+                    let mut error = HvfArm64StablePausedTopologyImportError::new(
+                        "PSCI power preparation identity",
+                        Some(index),
+                    )
+                    .with_cleanup_storage(rollback_cleanup);
+                    rollback_stable_import(&mut coordinator, &installed, &mut error);
+                    return Err(error);
+                }
+                continue;
+            };
+            let Some(power_suspend) = power_suspends.get(index).copied().flatten() else {
+                let mut error = HvfArm64StablePausedTopologyImportError::new(
+                    "PSCI CPU_SUSPEND preparation",
+                    Some(index),
+                )
+                .with_cleanup_storage(rollback_cleanup);
+                rollback_stable_import(&mut coordinator, &installed, &mut error);
+                return Err(error);
+            };
+            let runner_token = match coordinator.restore_stable_cpu_suspend(index, stable_suspend) {
+                Ok(token) => token,
+                Err(source) => {
+                    let mut error = HvfArm64StablePausedTopologyImportError::with_source(
+                        "runner CPU_SUSPEND install",
+                        Some(index),
+                        source,
+                    )
+                    .with_cleanup_storage(rollback_cleanup);
+                    rollback_stable_import(&mut coordinator, &installed, &mut error);
+                    return Err(error);
+                }
+            };
+            installed.push(InstalledStableCpuSuspend {
+                index,
+                runner_token,
+                dispatch_installed: false,
+            });
+            if let Err(source) = coordinator.install_imported_cpu_suspend_dispatch(
+                index,
+                runner_token,
+                virtual_timer_intid,
+            ) {
+                let mut error = HvfArm64StablePausedTopologyImportError::with_source(
+                    "coordinator CPU_SUSPEND install",
+                    Some(index),
+                    source,
+                )
+                .with_cleanup_storage(rollback_cleanup);
+                rollback_stable_import(&mut coordinator, &installed, &mut error);
+                return Err(error);
+            }
+            if let Some(record) = installed.last_mut() {
+                record.dispatch_installed = true;
+            }
+            let work = HvfVcpuCoordinatorWork::restored_cpu_suspend(
+                stable_suspend.convention().function_id(),
+                runner_token,
+            );
+            let Some(slot) = pending_cpu_suspends.get_mut(index) else {
+                let mut error = HvfArm64StablePausedTopologyImportError::new(
+                    "pending CPU_SUSPEND identity",
+                    Some(index),
+                )
+                .with_cleanup_storage(rollback_cleanup);
+                rollback_stable_import(&mut coordinator, &installed, &mut error);
+                return Err(error);
+            };
+            *slot = Some(PendingCpuSuspend {
+                power_token: power_suspend.token(),
+                coordinator_work: work,
+            });
+        }
+
+        Ok(Self {
+            coordinator,
+            power,
+            virtual_timer_intid,
+            pending_cpu_suspends,
+            pending_steps: VecDeque::new(),
+            last_step_index: 0,
+            last_terminal_report: None,
+        })
+    }
+
+    /// Allow the imported paused topology to begin fresh run generation 1.
+    pub fn resume(&mut self) -> Result<(), HvfVcpuRunCoordinatorError> {
+        self.coordinator.resume()
+    }
+
     pub(crate) fn singular_runner(&self) -> Result<&HvfVcpuRunner<'vm>, HvfVcpuRunnerError> {
         if self.member_count() != 1 {
             return Err(HvfVcpuRunnerError::InvalidState(
@@ -211,6 +765,119 @@ impl<'vm> HvfArm64BootVcpuSession<'vm> {
 
     pub(crate) const fn last_terminal_report(&self) -> Option<&HvfVcpuRunTerminalReport> {
         self.last_terminal_report.as_ref()
+    }
+
+    fn capture_stable_member_disposition(
+        &self,
+        coordinator: HvfVcpuStablePausedMemberObservation,
+        power: PsciCpuStableMemberObservation,
+    ) -> Result<HvfArm64StableVcpuDisposition, HvfArm64StablePausedTopologyCaptureError> {
+        let index = coordinator.index();
+        if power.index() != index
+            || power.mpidr() != coordinator.mpidr()
+            || self.coordinator.mpidrs().get(index).copied() != Some(coordinator.mpidr())
+        {
+            return Err(HvfArm64StablePausedTopologyCaptureError::new(
+                "member identity agreement",
+                Some(index),
+            ));
+        }
+        if power.cpu_on_token().is_some() || power.cpu_off_work().is_some() {
+            return Err(HvfArm64StablePausedTopologyCaptureError::new(
+                "transient PSCI power work",
+                Some(index),
+            ));
+        }
+        let pending = self.pending_cpu_suspends.get(index).copied().flatten();
+
+        match (
+            coordinator.online(),
+            coordinator.dispatch(),
+            power.power(),
+            power.cpu_suspend_work(),
+            pending,
+        ) {
+            (false, HvfVcpuStableMemberDispatch::Runnable, PsciCpuPowerState::Off, None, None) => {
+                self.coordinator
+                    .ensure_no_stable_deferred_psci_call(index)
+                    .map_err(|source| {
+                        HvfArm64StablePausedTopologyCaptureError::with_source(
+                            "offline runner validation",
+                            Some(index),
+                            source,
+                        )
+                    })?;
+                Ok(HvfArm64StableVcpuDisposition::Offline)
+            }
+            (true, HvfVcpuStableMemberDispatch::Runnable, PsciCpuPowerState::On, None, None) => {
+                self.coordinator
+                    .ensure_no_stable_deferred_psci_call(index)
+                    .map_err(|source| {
+                        HvfArm64StablePausedTopologyCaptureError::with_source(
+                            "runnable runner validation",
+                            Some(index),
+                            source,
+                        )
+                    })?;
+                Ok(HvfArm64StableVcpuDisposition::Runnable)
+            }
+            (
+                true,
+                HvfVcpuStableMemberDispatch::Suspended {
+                    psci_token,
+                    timer_intid,
+                },
+                PsciCpuPowerState::On,
+                Some(power_suspend),
+                Some(pending),
+            ) => {
+                if timer_intid != self.virtual_timer_intid
+                    || power_suspend.caller_index() != index
+                    || power_suspend.token() != pending.power_token
+                {
+                    return Err(HvfArm64StablePausedTopologyCaptureError::new(
+                        "CPU_SUSPEND lifecycle identity",
+                        Some(index),
+                    ));
+                }
+                let (exit, function_id, work_runner_token, request) =
+                    pending.coordinator_work.into_parts();
+                if exit.immediate() != 0
+                    || request != PsciCoordinatorRequest::CpuSuspend
+                    || work_runner_token != psci_token
+                {
+                    return Err(HvfArm64StablePausedTopologyCaptureError::new(
+                        "CPU_SUSPEND coordinator work",
+                        Some(index),
+                    ));
+                }
+                let runner =
+                    self.coordinator
+                        .capture_stable_cpu_suspend(index)
+                        .map_err(|source| {
+                            HvfArm64StablePausedTopologyCaptureError::with_source(
+                                "CPU_SUSPEND runner capture",
+                                Some(index),
+                                source,
+                            )
+                        })?;
+                if runner.token() != psci_token
+                    || runner.state().convention().function_id() != function_id
+                {
+                    return Err(HvfArm64StablePausedTopologyCaptureError::new(
+                        "CPU_SUSPEND runner agreement",
+                        Some(index),
+                    ));
+                }
+                Ok(HvfArm64StableVcpuDisposition::Suspended(
+                    runner.state().clone(),
+                ))
+            }
+            _ => Err(HvfArm64StablePausedTopologyCaptureError::new(
+                "member lifecycle agreement",
+                Some(index),
+            )),
+        }
     }
 
     pub(crate) fn run_step(
@@ -798,6 +1465,62 @@ fn with_cleanup_evidence(
     }
 }
 
+fn rollback_stable_import(
+    coordinator: &mut HvfVcpuRunCoordinator<'_>,
+    installed: &[InstalledStableCpuSuspend],
+    error: &mut HvfArm64StablePausedTopologyImportError,
+) {
+    for installed in installed.iter().rev().copied() {
+        if let Err(source) =
+            coordinator.abort_stable_cpu_suspend(installed.index, installed.runner_token)
+        {
+            error
+                .cleanup
+                .push(HvfArm64StablePausedTopologyCleanupFailure {
+                    stage: HvfArm64StablePausedTopologyCleanupStage::RunnerAbort,
+                    index: Some(installed.index),
+                    source: Box::new(source),
+                });
+        }
+        if installed.dispatch_installed
+            && let Err(source) = coordinator
+                .clear_imported_cpu_suspend_dispatch(installed.index, installed.runner_token)
+        {
+            error
+                .cleanup
+                .push(HvfArm64StablePausedTopologyCleanupFailure {
+                    stage: HvfArm64StablePausedTopologyCleanupStage::CoordinatorDispatch,
+                    index: Some(installed.index),
+                    source: Box::new(source),
+                });
+        }
+    }
+    if let Err(source) = coordinator.shutdown_after_failed_stable_import() {
+        error
+            .cleanup
+            .push(HvfArm64StablePausedTopologyCleanupFailure {
+                stage: HvfArm64StablePausedTopologyCleanupStage::TopologyShutdown,
+                index: None,
+                source: Box::new(source),
+            });
+    }
+}
+
+fn shutdown_unmodified_stable_import(
+    topology: &HvfVcpuTopology<'_>,
+    error: &mut HvfArm64StablePausedTopologyImportError,
+) {
+    if let Err(source) = topology.shutdown() {
+        error
+            .cleanup
+            .push(HvfArm64StablePausedTopologyCleanupFailure {
+                stage: HvfArm64StablePausedTopologyCleanupStage::TopologyShutdown,
+                index: None,
+                source: Box::new(source),
+            });
+    }
+}
+
 impl<'vm> Deref for HvfArm64BootVcpuSession<'vm> {
     type Target = HvfVcpuRunner<'vm>;
 
@@ -814,17 +1537,27 @@ mod tests {
     use bangbang_runtime::memory::GuestAddress;
     use bangbang_runtime::mmio::MmioDispatcher;
 
-    use super::{HvfArm64BootVcpuSession, barrier_cpu_on_admission};
+    use super::{
+        HvfArm64BootVcpuSession, HvfArm64StablePausedTopologyCleanupStage, barrier_cpu_on_admission,
+    };
     use crate::HvfVcpuRunStepOutcome;
     use crate::coordinator::{HvfVcpuRunControlReason, HvfVcpuRunCoordinator, HvfVcpuRunEvent};
+    use crate::paused_topology::{
+        HvfArm64CpuSuspendConvention, HvfArm64StableCpuSuspendState,
+        HvfArm64StablePausedTopologyMember, HvfArm64StablePausedTopologyState,
+        HvfArm64StableVcpuDisposition,
+    };
     use crate::psci::{
-        PsciCall, PsciCoordinatedDispatch, PsciCoordinatorRequest, PsciCpuOnBegin,
+        PsciCall, PsciCoordinatedDispatch, PsciCoordinatorRequest, PsciCpuOffBegin, PsciCpuOnBegin,
         PsciCpuPowerCoordinator, PsciCpuPowerState, PsciStatus, handle_coordinated_call,
     };
     use crate::runner::tests::{
-        start_coordinated_psci_run_step_recording_runner, start_cpu_suspend_retained_runner,
+        start_coordinated_psci_run_step_recording_runner,
+        start_coordinated_psci_run_step_recording_runner_with_destroy,
+        start_cpu_suspend_retained_runner, start_destroy_order_recording_runner,
         start_secondary_configure_recording_runner,
     };
+    use crate::topology::HvfVcpuTopology;
     use crate::vcpu::{HvfArm64SecondaryBootRegisters, HvfRegister};
 
     const PSCI_CPU_ON_64: u64 = 0xc400_0003;
@@ -839,6 +1572,425 @@ mod tests {
         mpsc::Receiver<(HvfRegister, u64)>,
         mpsc::Receiver<HvfArm64SecondaryBootRegisters>,
     );
+
+    #[test]
+    fn completed_pause_exports_live_cpu_suspend_architectural_state() {
+        let arguments = [0x11, 0x22, 0x33];
+        let (runner, _reads, writes, timer_samples, _ppi) =
+            start_cpu_suspend_retained_runner(PSCI_CPU_SUSPEND, arguments, 1, 100, [Ok(100)]);
+        let coordinator = HvfVcpuRunCoordinator::from_test_runners(
+            vec![runner],
+            vec![0],
+            Arc::new(Mutex::new(MmioDispatcher::new())),
+            &[0],
+        )
+        .expect("single test coordinator should build");
+        let power = PsciCpuPowerCoordinator::new(&[0]).expect("power topology should build");
+        let mut session = HvfArm64BootVcpuSession::new(coordinator, power, 27);
+
+        let wrong_phase = session
+            .capture_stable_paused_topology()
+            .expect_err("running topology should not export");
+        assert_eq!(wrong_phase.stage(), "coordinator pause validation");
+        assert!(matches!(
+            session.run_step(|_| true),
+            Ok(HvfVcpuRunStepOutcome::CpuSuspend {
+                index: 0,
+                function_id: PSCI_CPU_SUSPEND,
+                ..
+            })
+        ));
+        session
+            .control()
+            .request_pause()
+            .expect("idle pause should start")
+            .wait()
+            .expect("idle pause should complete");
+
+        let pending = session.pending_cpu_suspends[0].take();
+        let partial = session
+            .capture_stable_paused_topology()
+            .expect_err("partial CPU_SUSPEND ownership should not export");
+        assert_eq!(partial.stage(), "member lifecycle agreement");
+        assert_eq!(partial.index(), Some(0));
+        session.pending_cpu_suspends[0] = pending;
+
+        let stable = session
+            .capture_stable_paused_topology()
+            .expect("completed pause should export");
+        assert_eq!(stable.virtual_timer_intid(), 27);
+        assert_eq!(stable.members().len(), 1);
+        let HvfArm64StableVcpuDisposition::Suspended(suspend) = stable.members()[0].disposition()
+        else {
+            panic!("live CPU_SUSPEND should export as suspended");
+        };
+        assert_eq!(suspend.convention(), HvfArm64CpuSuspendConvention::Call32);
+        assert_eq!(suspend.arguments(), arguments);
+        assert_eq!(suspend.return_pc(), 0x8000);
+        assert_eq!(writes.try_recv(), Err(mpsc::TryRecvError::Empty));
+        assert_eq!(timer_samples.try_recv(), Err(mpsc::TryRecvError::Empty));
+        session.shutdown().expect("session should shut down");
+    }
+
+    #[test]
+    fn stable_paused_import_recaptures_equivalent_lifecycle_graph() {
+        let arguments = [0x11, 0x22, 0x33];
+        let stable_suspend = HvfArm64StableCpuSuspendState::new(
+            HvfArm64CpuSuspendConvention::Call64,
+            arguments,
+            0x8000,
+        )
+        .expect("stable suspend should build");
+        let stable = HvfArm64StablePausedTopologyState::new(
+            27,
+            vec![
+                HvfArm64StablePausedTopologyMember::new(
+                    0,
+                    0,
+                    HvfArm64StableVcpuDisposition::Suspended(stable_suspend),
+                ),
+                HvfArm64StablePausedTopologyMember::new(
+                    1,
+                    1,
+                    HvfArm64StableVcpuDisposition::Offline,
+                ),
+                HvfArm64StablePausedTopologyMember::new(
+                    2,
+                    2,
+                    HvfArm64StableVcpuDisposition::Runnable,
+                ),
+            ],
+        )
+        .expect("stable topology should build");
+        let (primary, _, primary_writes) =
+            start_coordinated_psci_run_step_recording_runner(0xc400_0001, arguments, 0, false);
+        let (secondary, _, secondary_writes) =
+            start_coordinated_psci_run_step_recording_runner(0, [0; 3], 0, false);
+        let (runnable, _, runnable_writes) =
+            start_coordinated_psci_run_step_recording_runner(0, [0; 3], 0, false);
+        let topology =
+            HvfVcpuTopology::from_test_parts(vec![primary, secondary, runnable], vec![0, 1, 2]);
+        let mut session = HvfArm64BootVcpuSession::from_stable_paused_topology(
+            topology,
+            &stable,
+            Arc::new(Mutex::new(MmioDispatcher::new())),
+            27,
+        )
+        .expect("stable topology should import");
+
+        assert_eq!(
+            session
+                .capture_stable_paused_topology()
+                .expect("imported graph should immediately recapture"),
+            stable
+        );
+        let formatted = format!("{session:?}");
+        assert!(formatted.contains("<redacted>"));
+        for raw in ["11", "22", "33", "8000"] {
+            assert!(!formatted.contains(raw));
+        }
+        assert_eq!(primary_writes.try_recv(), Err(mpsc::TryRecvError::Empty));
+        assert_eq!(secondary_writes.try_recv(), Err(mpsc::TryRecvError::Empty));
+        assert_eq!(runnable_writes.try_recv(), Err(mpsc::TryRecvError::Empty));
+        assert!(session.coordinator.dispatch_online().is_err());
+        session.shutdown().expect("session should shut down");
+    }
+
+    #[test]
+    fn imported_stable_cpu_suspend_cancels_rearms_and_wakes_after_resume() {
+        let arguments = [0x11, 0x22, 0x33];
+        let stable = HvfArm64StablePausedTopologyState::new(
+            27,
+            vec![HvfArm64StablePausedTopologyMember::new(
+                0,
+                0,
+                HvfArm64StableVcpuDisposition::Suspended(
+                    HvfArm64StableCpuSuspendState::new(
+                        HvfArm64CpuSuspendConvention::Call32,
+                        arguments,
+                        0x8000,
+                    )
+                    .expect("stable suspend should build"),
+                ),
+            )],
+        )
+        .expect("stable topology should build");
+        let (runner, _reads, writes, timer_samples, ppi) = start_cpu_suspend_retained_runner(
+            PSCI_CPU_SUSPEND,
+            arguments,
+            1,
+            1_000_000_000,
+            [Ok(1), Ok(1_000_000_000)],
+        );
+        let topology = HvfVcpuTopology::from_test_parts(vec![runner], vec![0]);
+        let mut session = HvfArm64BootVcpuSession::from_stable_paused_topology(
+            topology,
+            &stable,
+            Arc::new(Mutex::new(MmioDispatcher::new())),
+            27,
+        )
+        .expect("stable topology should import");
+
+        assert_eq!(timer_samples.try_recv(), Err(mpsc::TryRecvError::Empty));
+        assert_eq!(writes.try_recv(), Err(mpsc::TryRecvError::Empty));
+        session.resume().expect("imported session should resume");
+
+        let pause_control = session.control();
+        thread::scope(|scope| {
+            let step = scope.spawn(|| session.run_step(|_| true));
+            timer_samples
+                .recv()
+                .expect("first retained wait should sample");
+            let waiter = pause_control
+                .request_pause()
+                .expect("pause should cancel the retained wait");
+            assert!(matches!(
+                step.join().expect("session step should not panic"),
+                Ok(HvfVcpuRunStepOutcome::Canceled)
+            ));
+            waiter.wait().expect("pause barrier should complete");
+        });
+        assert!(session.pending_cpu_suspends[0].is_some());
+        assert_eq!(writes.try_recv(), Err(mpsc::TryRecvError::Empty));
+
+        session
+            .resume()
+            .expect("explicit resume should rearm the imported suspension");
+        assert!(matches!(
+            session.run_step(|_| true),
+            Ok(HvfVcpuRunStepOutcome::Hvc {
+                function_id: PSCI_CPU_SUSPEND,
+                return_value: 0,
+                ..
+            })
+        ));
+        timer_samples
+            .recv()
+            .expect("rearmed retained wait should sample again");
+        assert_eq!(
+            ppi.recv()
+                .expect("timer wake should publish the configured PPI"),
+            (27, true)
+        );
+        assert_eq!(
+            writes
+                .recv()
+                .expect("timer wake should complete imported CPU_SUSPEND"),
+            (HvfRegister::X0, 0)
+        );
+        assert!(session.pending_cpu_suspends[0].is_none());
+        session.shutdown().expect("session should shut down");
+    }
+
+    #[test]
+    fn stable_import_prevalidation_consumes_topology_and_retains_shutdown_failure() {
+        let stable = HvfArm64StablePausedTopologyState::new(
+            27,
+            (0..3)
+                .map(|index| {
+                    HvfArm64StablePausedTopologyMember::new(
+                        index,
+                        index as u64,
+                        HvfArm64StableVcpuDisposition::Runnable,
+                    )
+                })
+                .collect(),
+        )
+        .expect("stable topology should build");
+        let (destroyed_sender, destroyed_receiver) = mpsc::channel();
+        let runners = (0..3)
+            .map(|index| {
+                start_destroy_order_recording_runner(index, index == 1, destroyed_sender.clone())
+            })
+            .collect();
+        let topology = HvfVcpuTopology::from_test_parts(runners, vec![0, 1, 2]);
+
+        let error = HvfArm64BootVcpuSession::from_stable_paused_topology(
+            topology,
+            &stable,
+            Arc::new(Mutex::new(MmioDispatcher::new())),
+            26,
+        )
+        .expect_err("destination PPI mismatch should fail");
+
+        assert_eq!(error.stage(), "virtual timer PPI validation");
+        assert_eq!(error.index(), None);
+        assert_eq!(error.cleanup_failures().len(), 1);
+        assert_eq!(
+            error.cleanup_failures()[0].stage(),
+            HvfArm64StablePausedTopologyCleanupStage::TopologyShutdown
+        );
+        assert_eq!(error.cleanup_failures()[0].index(), None);
+        assert_eq!(destroyed_receiver.try_iter().collect::<Vec<_>>(), [2, 1, 0]);
+    }
+
+    #[test]
+    fn stable_import_rejects_wrong_and_duplicate_destination_mpidrs_before_owner_access() {
+        let stable = HvfArm64StablePausedTopologyState::new(
+            27,
+            vec![
+                HvfArm64StablePausedTopologyMember::new(
+                    0,
+                    0,
+                    HvfArm64StableVcpuDisposition::Runnable,
+                ),
+                HvfArm64StablePausedTopologyMember::new(
+                    1,
+                    1,
+                    HvfArm64StableVcpuDisposition::Offline,
+                ),
+            ],
+        )
+        .expect("stable topology should build");
+
+        for mpidrs in [vec![0, 0], vec![0, 2]] {
+            let (destroyed_sender, destroyed_receiver) = mpsc::channel();
+            let runners = (0..2)
+                .map(|index| {
+                    start_destroy_order_recording_runner(index, false, destroyed_sender.clone())
+                })
+                .collect();
+            let topology = HvfVcpuTopology::from_test_parts(runners, mpidrs);
+
+            let error = HvfArm64BootVcpuSession::from_stable_paused_topology(
+                topology,
+                &stable,
+                Arc::new(Mutex::new(MmioDispatcher::new())),
+                27,
+            )
+            .expect_err("destination MPIDR mismatch should fail");
+
+            assert_eq!(error.stage(), "destination MPIDR validation");
+            assert_eq!(error.index(), Some(1));
+            assert!(error.cleanup_failures().is_empty());
+            assert_eq!(destroyed_receiver.try_iter().collect::<Vec<_>>(), [1, 0]);
+        }
+    }
+
+    #[test]
+    fn stable_import_rejects_an_already_run_runnable_destination() {
+        let stable = HvfArm64StablePausedTopologyState::new(
+            27,
+            vec![HvfArm64StablePausedTopologyMember::new(
+                0,
+                0,
+                HvfArm64StableVcpuDisposition::Runnable,
+            )],
+        )
+        .expect("stable topology should build");
+        let (runner, _reads, _writes) =
+            start_coordinated_psci_run_step_recording_runner(0x8400_0000, [0; 3], 0, false);
+        runner
+            .run_once_and_handle_mmio_coordinated(Arc::new(Mutex::new(MmioDispatcher::new())))
+            .expect("test destination should run once");
+        let topology = HvfVcpuTopology::from_test_parts(vec![runner], vec![0]);
+
+        let error = HvfArm64BootVcpuSession::from_stable_paused_topology(
+            topology,
+            &stable,
+            Arc::new(Mutex::new(MmioDispatcher::new())),
+            27,
+        )
+        .expect_err("already-run destination should fail");
+
+        assert_eq!(error.stage(), "destination owner readiness");
+        assert_eq!(error.index(), Some(0));
+    }
+
+    #[test]
+    fn stable_import_reverses_every_installed_failure_prefix_before_shutdown() {
+        let arguments = [[0x11, 0x12, 0x13], [0x21, 0x22, 0x23], [0x31, 0x32, 0x33]];
+        let stable = HvfArm64StablePausedTopologyState::new(
+            27,
+            arguments
+                .iter()
+                .copied()
+                .enumerate()
+                .map(|(index, arguments)| {
+                    HvfArm64StablePausedTopologyMember::new(
+                        index,
+                        index as u64,
+                        HvfArm64StableVcpuDisposition::Suspended(
+                            HvfArm64StableCpuSuspendState::new(
+                                HvfArm64CpuSuspendConvention::Call32,
+                                arguments,
+                                0x8000,
+                            )
+                            .expect("stable suspend should build"),
+                        ),
+                    )
+                })
+                .collect(),
+        )
+        .expect("stable topology should build");
+
+        for failure_index in 0..3 {
+            let (destroyed_sender, destroyed_receiver) = mpsc::channel();
+            let mut read_receivers = Vec::new();
+            let mut write_receivers = Vec::new();
+            let mut runners = Vec::new();
+            for (index, arguments) in arguments.iter().copied().enumerate() {
+                let function_id = if index == failure_index {
+                    HvfArm64CpuSuspendConvention::Call64.function_id()
+                } else {
+                    HvfArm64CpuSuspendConvention::Call32.function_id()
+                };
+                let (runner, reads, writes) =
+                    start_coordinated_psci_run_step_recording_runner_with_destroy(
+                        function_id,
+                        arguments,
+                        0,
+                        false,
+                        Some((
+                            index,
+                            failure_index == 2 && index == 1,
+                            destroyed_sender.clone(),
+                        )),
+                    );
+                runners.push(runner);
+                read_receivers.push(reads);
+                write_receivers.push(writes);
+            }
+            let topology = HvfVcpuTopology::from_test_parts(runners, vec![0, 1, 2]);
+
+            let error = HvfArm64BootVcpuSession::from_stable_paused_topology(
+                topology,
+                &stable,
+                Arc::new(Mutex::new(MmioDispatcher::new())),
+                27,
+            )
+            .expect_err("injected register mismatch should fail import");
+
+            assert_eq!(error.stage(), "runner CPU_SUSPEND install");
+            assert_eq!(error.index(), Some(failure_index));
+            assert_eq!(
+                error.cleanup_failures().len(),
+                usize::from(failure_index == 2)
+            );
+            if let Some(cleanup) = error.cleanup_failures().first() {
+                assert_eq!(
+                    cleanup.stage(),
+                    HvfArm64StablePausedTopologyCleanupStage::TopologyShutdown
+                );
+                assert_eq!(cleanup.index(), None);
+            }
+            assert_eq!(destroyed_receiver.try_iter().collect::<Vec<_>>(), [2, 1, 0]);
+            for (index, reads) in read_receivers.into_iter().enumerate() {
+                assert_eq!(
+                    reads.try_iter().count(),
+                    usize::from(index <= failure_index) * 5
+                );
+            }
+            for writes in write_receivers {
+                assert_eq!(writes.try_recv(), Err(mpsc::TryRecvError::Disconnected));
+            }
+            let formatted = format!("{error:?}");
+            assert!(formatted.contains("<redacted>"));
+            for raw in ["11", "12", "13", "21", "22", "23", "31", "32", "33"] {
+                assert!(!formatted.contains(raw));
+            }
+        }
+    }
 
     fn cpu_on_session(fail_secondary_setup: bool) -> CpuOnSessionFixture {
         let (primary, reads, writes) = start_coordinated_psci_run_step_recording_runner(
@@ -894,6 +2046,70 @@ mod tests {
             .mark_target_entered(work.token())
             .expect("test secondary should enter");
         power
+    }
+
+    fn paused_two_member_session(
+        power: PsciCpuPowerCoordinator,
+        online_indexes: &[usize],
+    ) -> HvfArm64BootVcpuSession<'static> {
+        let (primary, _, _) = start_coordinated_psci_run_step_recording_runner(0, [0; 3], 0, false);
+        let (secondary, _, _) =
+            start_coordinated_psci_run_step_recording_runner(0, [0; 3], 0, false);
+        let coordinator = HvfVcpuRunCoordinator::from_test_runners(
+            vec![primary, secondary],
+            vec![0, 1],
+            Arc::new(Mutex::new(MmioDispatcher::new())),
+            online_indexes,
+        )
+        .expect("two-member coordinator should build");
+        let session = HvfArm64BootVcpuSession::new(coordinator, power, 27);
+        session
+            .control()
+            .request_pause()
+            .expect("idle pause should start")
+            .wait()
+            .expect("idle pause should complete");
+        session
+    }
+
+    #[test]
+    fn stable_export_rejects_staged_cpu_on_and_cpu_off_transactions() {
+        let PsciCoordinatedDispatch::Coordinate(PsciCoordinatorRequest::CpuOn(request)) =
+            handle_coordinated_call(PsciCall::from_arguments(
+                PSCI_CPU_ON_64,
+                [1, SECONDARY_ENTRY, SECONDARY_CONTEXT],
+            ))
+        else {
+            panic!("test CPU_ON should decode");
+        };
+        let mut on_pending =
+            PsciCpuPowerCoordinator::new(&[0, 1]).expect("power topology should build");
+        assert!(matches!(
+            on_pending
+                .begin_cpu_on(request, |_| true)
+                .expect("CPU_ON should begin"),
+            PsciCpuOnBegin::Pending(_)
+        ));
+        let mut session = paused_two_member_session(on_pending, &[0]);
+        let error = session
+            .capture_stable_paused_topology()
+            .expect_err("staged CPU_ON should reject export");
+        assert_eq!(error.stage(), "transient PSCI power work");
+        assert_eq!(error.index(), Some(1));
+        session.shutdown().expect("session should shut down");
+
+        let mut off_pending = power_with_secondary_online();
+        assert!(matches!(
+            off_pending.begin_cpu_off(1).expect("CPU_OFF should begin"),
+            PsciCpuOffBegin::Pending(_)
+        ));
+        let mut session = paused_two_member_session(off_pending, &[0, 1]);
+        let error = session
+            .capture_stable_paused_topology()
+            .expect_err("staged CPU_OFF should reject export");
+        assert_eq!(error.stage(), "transient PSCI power work");
+        assert_eq!(error.index(), Some(1));
+        session.shutdown().expect("session should shut down");
     }
 
     #[test]

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -159,6 +159,7 @@ use crate::memory::{
     HvfGuestMemoryMappingError, HvfMemoryPermissions, HvfPmemFlushExecutor,
     HvfVirtioMemMappingCaptureError, HvfVirtioMemMappingCaptureState,
 };
+use crate::paused_topology::HvfArm64StablePausedTopologyState;
 use crate::psci::PsciCpuPowerCoordinator;
 use crate::pvtime::{
     HvfArm64PvTimeAccountingConfig, HvfArm64PvTimeCaptureState, HvfArm64PvTimeContentionProbe,
@@ -168,7 +169,9 @@ use crate::runner::{
     HvfArm64SnapshotV1Capture, HvfArm64SnapshotV1Restore, HvfVcpuRunCancelHandle,
     HvfVcpuRunStepOutcome, HvfVcpuRunner, HvfVcpuRunnerError,
 };
-use crate::session_vcpu::{HvfArm64BootVcpuError, HvfArm64BootVcpuSession};
+use crate::session_vcpu::{
+    HvfArm64BootVcpuError, HvfArm64BootVcpuSession, HvfArm64StablePausedTopologyCaptureError,
+};
 use crate::snapshot::HvfArm64SnapshotTimerState;
 use crate::snapshot_bundle::{
     HvfSnapshotV1CompatibilityState, HvfSnapshotV1EncodeError, HvfSnapshotV1State,
@@ -7932,6 +7935,16 @@ impl HvfArm64BootSession<'_> {
         self.runner.capture_arm64_pvtime()
     }
 
+    /// Export the stable vCPU lifecycle graph after a completed pause barrier.
+    ///
+    /// This in-memory value excludes register, memory, device, and persistent
+    /// snapshot state.
+    pub fn capture_stable_paused_vcpu_topology(
+        &mut self,
+    ) -> Result<HvfArm64StablePausedTopologyState, HvfArm64StablePausedTopologyCaptureError> {
+        self.runner.capture_stable_paused_topology()
+    }
+
     /// Establish an empty-snapshot pause barrier for signed PVTime certification.
     #[doc(hidden)]
     pub fn pause_idle_for_arm64_pvtime_capture(&self) -> Result<(), HvfVcpuRunCoordinatorError> {
@@ -10350,6 +10363,16 @@ impl OwnedHvfArm64BootSession {
         &self,
     ) -> Result<HvfArm64PvTimeCaptureState, HvfVcpuRunCoordinatorError> {
         self.runner.capture_arm64_pvtime()
+    }
+
+    /// Export the stable vCPU lifecycle graph after a completed pause barrier.
+    ///
+    /// This in-memory value excludes register, memory, device, and persistent
+    /// snapshot state.
+    pub fn capture_stable_paused_vcpu_topology(
+        &mut self,
+    ) -> Result<HvfArm64StablePausedTopologyState, HvfArm64StablePausedTopologyCaptureError> {
+        self.runner.capture_stable_paused_topology()
     }
 
     /// Establish an empty-snapshot pause barrier for signed PVTime certification.

--- a/crates/hvf/src/topology.rs
+++ b/crates/hvf/src/topology.rs
@@ -347,6 +347,18 @@ impl<'vm> HvfVcpuTopology<'vm> {
         )
     }
 
+    pub(crate) fn ensure_stable_import_ready(
+        &self,
+        index: usize,
+    ) -> Result<(), HvfVcpuRunnerError> {
+        self.runners
+            .get(index)
+            .ok_or(HvfVcpuRunnerError::InvalidState(
+                "stable import destination member index is invalid",
+            ))?
+            .ensure_stable_import_ready()
+    }
+
     #[cfg(test)]
     pub(crate) fn from_test_parts(runners: Vec<HvfVcpuRunner<'vm>>, mpidrs: Vec<u64>) -> Self {
         Self { runners, mpidrs }

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -3327,7 +3327,25 @@ runtime-resolved macOS 15.2 boundary. Errors expose only
 family/stage/index/completed-write metadata; a failed nontransactional attempt
 permanently prevents guest execution on that runner. This wire-format-neutral
 foundation does not change native-v1 bytes or its inactive-optional rejection
-policy, and native-v2 encoding plus multi-vCPU orchestration remain separate.
+policy.
+A separate stable paused-topology lifecycle value canonically binds every
+member to topology index and MPIDR, records the virtual-timer PPI, and
+distinguishes offline, runnable, and deferred PSCI `CPU_SUSPEND32/64` members.
+The suspended form retains the call convention, X1-X3 arguments, and post-trap
+PC while redacting architectural values from diagnostics. Public boot-vCPU
+session capture succeeds only after a completed pause barrier and cross-checks
+coordinator membership, PSCI power/transaction state, session bookkeeping, the
+runner-owned deferred call, and owner-thread registers before publication.
+Import validates the complete graph and the never-run readiness of every
+destination owner before mutation, allocates fresh destination power and runner
+identities, creates the coordinator directly in Paused state, and requires
+explicit resume before generation 1 can dispatch.
+Post-mutation failure aborts installed suspend calls in reverse topology order,
+clears coordinator dispatch metadata, records every cleanup failure, and
+consumes the unpublished topology. This is an in-memory, wire-format-neutral
+foundation: native-v1 and native-v2 bytes are unchanged, while native-v2
+encoding, the complete multi-vCPU aggregate, and public snapshot reconstruction
+remain separate.
 The separate system-context capture uses macOS 15.2 SDK register ids through the
 same owner-thread getter and preserves raw backend errors. Its paired restore
 writes `SCXTNUM_EL0` then `SCXTNUM_EL1` through the same owner and reports the

--- a/docs/firecracker-validation-matrix.md
+++ b/docs/firecracker-validation-matrix.md
@@ -591,9 +591,31 @@ prevents guest execution on that runner. Unit coverage exhausts static
 rejections, sparse reads, operation failures, ordering, admission, channels,
 panic, and execution poisoning; signed HVF coverage proves real same-owner
 debug and active-SME restore/recapture on supported Apple Silicon. Native-v1
-bytes and inactive-optional policy remain unchanged; stable topology/PSCI
-state, native-v2 encoding, multi-vCPU aggregate construction, and public
-lifecycle remain #1528 follow-up work.
+bytes and inactive-optional policy remain unchanged. The stable topology/PSCI
+lifecycle follows below; native-v2 encoding, complete multi-vCPU aggregate
+construction, and public snapshot reconstruction remain #1528 follow-up work.
+
+#1567 adds a public, wire-format-neutral stable paused-topology graph and
+capture/import transaction for the boot-vCPU session. The graph canonically
+binds `1..=32` members to topology index and MPIDR, retains the virtual-timer
+PPI, and distinguishes offline, runnable, and deferred PSCI
+`CPU_SUSPEND32/64` members. Suspended members preserve the closed call
+convention, X1-X3 arguments, and post-trap PC without exposing those values in
+diagnostics. Capture requires a completed Paused barrier and cross-checks the
+coordinator, PSCI power transactions, session records, runner-owned deferred
+call, and architectural registers before publishing. Import validates all
+topology and PPI facts plus the never-run readiness of every owner before
+mutation, prepares fresh destination-local PSCI and runner identities, installs
+suspended members in topology order, and publishes a coordinator born Paused
+with no dispatch or cancellation debt.
+Failures unwind installed calls in reverse order, retain every cleanup failure,
+and consume the unpublished topology; explicit resume begins generation 1.
+Unit coverage includes empty, maximum, oversized, malformed, offline,
+runnable, both suspend conventions, token inequality, no pre-resume dispatch,
+recapture equivalence, redaction, rollback, and shutdown behavior. Native-v1
+and native-v2 bytes remain unchanged; native-v2 topology encoding, the complete
+multi-vCPU state aggregate, and public snapshot reconstruction remain #1528
+follow-up work.
 
 ## Update Rule
 

--- a/docs/snapshot-feasibility.md
+++ b/docs/snapshot-feasibility.md
@@ -339,6 +339,44 @@ checked
 [snapshot paging contract](../compat/firecracker/v1.16.0/snapshot-paging-contract.md);
 File/COW remains a distinct backend.
 
+### Stable Paused vCPU Topology State
+
+#1567 adds a wire-format-neutral lifecycle graph for a completed arm64
+topology-wide pause. Its checked public value contains exactly `1..=32`
+canonical index/MPIDR members, one validated EL1 virtual-timer PPI, and a
+closed disposition for each vCPU: offline, runnable after explicit resume, or
+suspended in PSCI `CPU_SUSPEND32/64`. The suspended form preserves X1-X3 and
+the post-trap PC, rejects a misaligned PC, and redacts all architectural values
+from `Debug`.
+
+Capture is available on the public boot-vCPU session only while its coordinator
+has completed the Paused barrier and no per-vCPU step or terminal result is
+pending. It reconciles the topology snapshot with the PSCI power coordinator,
+all pending CPU_ON/OFF/SUSPEND transactions, session-owned deferred work,
+runner-owned suspend identity and request, timer PPI, HVC form, and X0-X3/PC.
+Offline and ordinary runnable members are also probed for absence of an
+unreported deferred PSCI call. A second coordinator observation must match
+before the immutable graph is published.
+
+Import validates PPI, member count, topology order, MPIDRs, and the never-run
+readiness of every destination owner before the first mutation. It constructs a
+fresh PSCI power model and a coordinator born Paused, installs each suspended
+continuation through its destination owner, and assigns fresh destination-only
+power and runner transaction identities.
+Nothing can dispatch until explicit resume, whose first run generation is 1.
+If any installation or publication step fails, the transaction aborts all
+installed runner calls in reverse order, clears coordinator dispatch state,
+records every cleanup failure without replacing the primary error, and shuts
+down the consumed unpublished topology. A successful immediate recapture is
+equivalent to the source stable graph but contains none of its process-local
+tokens.
+
+This state is not encoded by either snapshot family yet. Native-v1 bytes and
+its one-vCPU profile remain unchanged; native-v2 component tags, composition
+with the complete reviewed vCPU register aggregate, public create/load
+reconstruction, and resumed-guest end-to-end evidence remain later #1528
+delivery slices.
+
 ## Native V1 Guest-Memory Image and Binding
 
 The internal memory image is bangbang-owned and uses a fixed 48-byte
@@ -1623,6 +1661,7 @@ when each slice landed; later rows supersede earlier deferred-work clauses.
 
 | Slice | Scope | Minimum validation |
 | --- | --- | --- |
+| Stable paused arm64 topology capture/import (wire-format-neutral foundation implemented) | #1567 adds a checked `1..=32` topology graph with canonical index/MPIDR identity, virtual-timer PPI, offline/runnable dispositions, and redacted CPU_SUSPEND32/64 X1-X3/post-trap-PC continuations. Capture requires a completed topology pause and cross-validates coordinator, PSCI, session, runner, HVC, and owner registers before publication. Import prevalidates before mutation, allocates fresh destination tokens, constructs the coordinator born Paused, installs suspended members in order, and dispatches nothing until explicit resume generation 1. Failure aborts installed calls in reverse order, clears dispatch state, retains cleanup evidence, and consumes the unpublished topology. Native-v1/native-v2 bytes and public snapshot reconstruction remain unchanged. | Empty/maximum/oversized/canonicality/PPI/primary-offline/PC-alignment boundaries; both suspend conventions and exact register checks; power/runner token inequality; paused admission and no pre-resume dispatch; offline/runnable/suspended import and equivalent recapture; reverse rollback, shutdown, redaction, and existing pause/resume/timer-wake lifecycle coverage. |
 | Supervisor lease and admission (foundation implemented) | #1160 adds atomic admission/FIFO ordering, worker-side pause revalidation, one scoped lease-owned operation, normal-command rejection, structured release, and out-of-band shutdown invalidation. Real capture work and admission across the remaining owners are deferred. | Supervisor and `ProcessVmm` unit tests plus API/process pause-state tests. |
 | Auxiliary quiescence and complete publication transaction (implemented for native-v1 baseline) | #1162 introduced acknowledged RAII quiescence for block and entropy; #1389 added the topology-wide SMP pause barrier and PMEM guard; #1390 includes network, acquires all four failure-atomically, drains tokens only after complete acknowledgement, preserves in-flight/deferred/deadline work, and holds the worker lease through commit plus the post-publication hook. Process API/MMDS/controller and periodic work are serialized by the synchronous owner borrow. | Deterministic scheduler, supervisor, cancellation/seal, publication-visibility, process/API serialization, and fresh-retry tests plus combined signed SMP pause and one-vCPU baseline publication evidence. |
 | Complete dirty epochs and public tracking (implemented) | #1395 supplies fail-closed HVF protection/fault retry. #1396 adds the shared `GuestMemory` bitmap, exact initial/reprotected DFSC `0x07`/`0x0f` ownership checks, every current bounded host/device writer, conservative discard, protected wholly-dirty dynamic RAM, destination load ordering, and post-visible-Full reset/rollback/poison semantics. Machine and load tracking flags are enabled without adding Diff artifacts. | Exact/repeated/concurrent host and CPU union, discard, dynamic mapping, load override/VMGenID, publication/cancellation/reset failures, and public transaction tests plus signed normal boot/load, two-vCPU current-device, and two-epoch exact-set evidence. |


### PR DESCRIPTION
## Summary

- add a checked, redacted stable paused arm64 topology graph covering offline, runnable, and retained CPU_SUSPEND32/64 members
- cross-check paused export across coordinator, PSCI power, session, runner, HVC, timer-PPI, and architectural state owners
- import only into never-run owners with fresh destination identities, a coordinator born Paused, and reverse failure cleanup
- preserve suspend timer wake, cancellation/rearm, equivalent recapture, and document the wire-format-neutral boundary

## Scope

Native-v1 and native-v2 bytes are unchanged. Native-v2 encoding and complete VM/GIC reconstruction remain #1568 and #1569.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked` (1316 passed)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five repository-required Apple-target Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test hvf_lifecycle` (80 passed)

Part of #1528.
Closes #1567.