### PR TITLE
feat(runtime): add native v2 device graph codec

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -37,6 +37,7 @@ pub mod snapshot;
 pub mod snapshot_artifact;
 pub mod snapshot_commit;
 pub mod snapshot_device;
+pub mod snapshot_device_v2;
 pub mod snapshot_format;
 pub mod snapshot_format_v2;
 pub mod snapshot_memory;

--- a/crates/runtime/src/pci.rs
+++ b/crates/runtime/src/pci.rs
@@ -494,6 +494,163 @@ impl fmt::Debug for PciType0Configuration {
     }
 }
 
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct PciType0SnapshotProfile {
+    configuration: PciType0Configuration,
+}
+
+impl fmt::Debug for PciType0SnapshotProfile {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PciType0SnapshotProfile")
+            .field("profile", &"<redacted>")
+            .finish()
+    }
+}
+
+impl PciType0SnapshotProfile {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        vendor_id: u16,
+        device_id: u16,
+        revision_id: u8,
+        class_code: PciClassCode,
+        subclass: u8,
+        programming_interface: u8,
+        subsystem_vendor_id: u16,
+        subsystem_id: u16,
+    ) -> Self {
+        Self {
+            configuration: PciType0Configuration::new(
+                vendor_id,
+                device_id,
+                revision_id,
+                class_code,
+                subclass,
+                programming_interface,
+                subsystem_vendor_id,
+                subsystem_id,
+            ),
+        }
+    }
+
+    pub(crate) fn install_bar(
+        &mut self,
+        index: u8,
+        range: GuestMemoryRange,
+        address_space: PciBarAddressSpace,
+        prefetchable: PciBarPrefetchable,
+    ) -> Result<(), PciBarConfigurationError> {
+        self.configuration
+            .install_bar_range(index, range, address_space, prefetchable)
+    }
+
+    pub(crate) fn add_capability(
+        &mut self,
+        id: PciCapabilityId,
+        body: &[u8],
+        body_writable_mask: &[u8],
+    ) -> Result<u8, PciCapabilityError> {
+        self.configuration
+            .add_capability(id, body, body_writable_mask)
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct PciType0GuestState {
+    writable_bytes: Vec<PciType0WritableByte>,
+    bar_probes: Vec<PciType0BarProbeState>,
+}
+
+impl PciType0GuestState {
+    pub(crate) fn writable_bytes(&self) -> &[PciType0WritableByte] {
+        &self.writable_bytes
+    }
+
+    pub(crate) fn bar_probes(&self) -> &[PciType0BarProbeState] {
+        &self.bar_probes
+    }
+}
+
+impl fmt::Debug for PciType0GuestState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PciType0GuestState")
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PciType0WritableByte {
+    offset: u16,
+    value: u8,
+    writable_mask: u8,
+}
+
+impl PciType0WritableByte {
+    pub(crate) const fn offset(self) -> u16 {
+        self.offset
+    }
+
+    pub(crate) const fn value(self) -> u8 {
+        self.value
+    }
+
+    pub(crate) const fn writable_mask(self) -> u8 {
+        self.writable_mask
+    }
+}
+
+impl fmt::Debug for PciType0WritableByte {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("PciType0WritableByte(<redacted>)")
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PciType0BarProbeState {
+    index: u8,
+    pending: bool,
+}
+
+impl PciType0BarProbeState {
+    pub(crate) const fn index(self) -> u8 {
+        self.index
+    }
+
+    pub(crate) const fn pending(self) -> bool {
+        self.pending
+    }
+}
+
+impl fmt::Debug for PciType0BarProbeState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("PciType0BarProbeState(<redacted>)")
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PciType0SnapshotError {
+    ProfileMismatch,
+    Allocation,
+}
+
+impl fmt::Display for PciType0SnapshotError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ProfileMismatch => {
+                formatter.write_str("PCI type-0 configuration profile does not match")
+            }
+            Self::Allocation => {
+                formatter.write_str("failed to allocate PCI type-0 guest-state snapshot")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PciType0SnapshotError {}
+
 impl PciType0Configuration {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -550,11 +707,20 @@ impl PciType0Configuration {
         lease: &PciBarLease,
         prefetchable: PciBarPrefetchable,
     ) -> Result<(), PciBarConfigurationError> {
+        self.install_bar_range(index, lease.range(), lease.address_space(), prefetchable)
+    }
+
+    fn install_bar_range(
+        &mut self,
+        index: u8,
+        range: GuestMemoryRange,
+        address_space: PciBarAddressSpace,
+        prefetchable: PciBarPrefetchable,
+    ) -> Result<(), PciBarConfigurationError> {
         if index >= PCI_BAR_REGISTER_COUNT {
             return Err(PciBarConfigurationError::InvalidIndex { index });
         }
-        let range = lease.range();
-        let type_bits = match lease.address_space() {
+        let type_bits = match address_space {
             PciBarAddressSpace::Memory32 => {
                 if range.end_exclusive().raw_value() > 1_u64 << 32 {
                     return Err(PciBarConfigurationError::AddressExceeds32Bit { range });
@@ -568,7 +734,7 @@ impl PciType0Configuration {
                 0b100
             }
         };
-        let occupied_registers = if lease.address_space() == PciBarAddressSpace::Memory64 {
+        let occupied_registers = if address_space == PciBarAddressSpace::Memory64 {
             2
         } else {
             1
@@ -593,7 +759,7 @@ impl PciType0Configuration {
                 probe_pending: false,
             },
         );
-        if lease.address_space() == PciBarAddressSpace::Memory64 {
+        if address_space == PciBarAddressSpace::Memory64 {
             self.bars.insert(
                 index + 1,
                 PciBarRegister {
@@ -680,6 +846,97 @@ impl PciType0Configuration {
             offset = self.configuration_byte(usize::from(offset) + 1);
         }
         count
+    }
+
+    pub(crate) fn snapshot_guest_state(
+        &self,
+        profile: &PciType0SnapshotProfile,
+    ) -> Result<PciType0GuestState, PciType0SnapshotError> {
+        let expected = &profile.configuration;
+        if self.registers.len() != expected.registers.len()
+            || self.writable_masks != expected.writable_masks
+            || self.bars.len() != expected.bars.len()
+            || self.last_capability != expected.last_capability
+        {
+            return Err(PciType0SnapshotError::ProfileMismatch);
+        }
+
+        for ((actual, expected), writable_mask) in self
+            .registers
+            .iter()
+            .copied()
+            .zip(expected.registers.iter().copied())
+            .zip(self.writable_masks.iter().copied())
+        {
+            if (actual ^ expected) & !writable_mask != 0 {
+                return Err(PciType0SnapshotError::ProfileMismatch);
+            }
+        }
+        for ((actual_index, actual), (expected_index, expected)) in
+            self.bars.iter().zip(expected.bars.iter())
+        {
+            if actual_index != expected_index
+                || actual.encoded_address != expected.encoded_address
+                || actual.encoded_size != expected.encoded_size
+            {
+                return Err(PciType0SnapshotError::ProfileMismatch);
+            }
+        }
+
+        let writable_count = self
+            .writable_masks
+            .iter()
+            .flat_map(|mask| mask.to_le_bytes())
+            .filter(|mask| *mask != 0)
+            .count();
+        let mut writable_bytes = Vec::new();
+        writable_bytes
+            .try_reserve_exact(writable_count)
+            .map_err(|_| PciType0SnapshotError::Allocation)?;
+        for (register_index, (register, writable_mask)) in self
+            .registers
+            .iter()
+            .copied()
+            .zip(self.writable_masks.iter().copied())
+            .enumerate()
+        {
+            for (byte_index, (value, mask)) in register
+                .to_le_bytes()
+                .into_iter()
+                .zip(writable_mask.to_le_bytes())
+                .enumerate()
+            {
+                if mask == 0 {
+                    continue;
+                }
+                let offset = register_index
+                    .checked_mul(PCI_CONFIG_REGISTER_SIZE)
+                    .and_then(|offset| offset.checked_add(byte_index))
+                    .and_then(|offset| u16::try_from(offset).ok())
+                    .ok_or(PciType0SnapshotError::ProfileMismatch)?;
+                writable_bytes.push(PciType0WritableByte {
+                    offset,
+                    value: value & mask,
+                    writable_mask: mask,
+                });
+            }
+        }
+
+        let mut bar_probes = Vec::new();
+        bar_probes
+            .try_reserve_exact(self.bars.len())
+            .map_err(|_| PciType0SnapshotError::Allocation)?;
+        for (index, bar) in &self.bars {
+            bar_probes.push(PciType0BarProbeState {
+                index: *index,
+                pending: bar.probe_pending,
+            });
+        }
+
+        Ok(PciType0GuestState {
+            writable_bytes,
+            bar_probes,
+        })
     }
 
     fn configuration_byte(&self, offset: usize) -> u8 {
@@ -1426,6 +1683,34 @@ mod tests {
         u32::from_le_bytes(bytes)
     }
 
+    fn snapshot_configuration_pair() -> (PciType0Configuration, PciType0SnapshotProfile) {
+        let mut configuration = endpoint(0x1af4, 0x1042);
+        let mut profile = PciType0SnapshotProfile::new(
+            0x1af4,
+            0x1042,
+            1,
+            PciClassCode::Unclassified,
+            0,
+            0,
+            0x1af4,
+            0x1042,
+        );
+        let bar = range(PCI_BAR64_START, 0x80000);
+        configuration
+            .install_bar_range(0, bar, PciBarAddressSpace::Memory64, PciBarPrefetchable::No)
+            .expect("test configuration BAR should install");
+        profile
+            .install_bar(0, bar, PciBarAddressSpace::Memory64, PciBarPrefetchable::No)
+            .expect("test profile BAR should install");
+        configuration
+            .add_capability(PciCapabilityId::VendorSpecific, &[0xaa, 0x55], &[0xff, 0])
+            .expect("test configuration capability should install");
+        profile
+            .add_capability(PciCapabilityId::VendorSpecific, &[0xaa, 0x55], &[0xff, 0])
+            .expect("test profile capability should install");
+        (configuration, profile)
+    }
+
     #[test]
     fn sbdf_validates_and_encodes_firecracker_identity() {
         let sbdf = PciSbdf::new(0, 0, 31, 7).expect("maximum PCI SBDF should be valid");
@@ -1790,6 +2075,117 @@ mod tests {
         assert_eq!(
             read_config_u32(&mut configuration, (PCI_CONFIG_SPACE_SIZE - 4) as u16),
             0
+        );
+    }
+
+    #[test]
+    fn type0_snapshot_view_checks_profile_and_returns_only_guest_state_without_side_effects() {
+        let (mut configuration, profile) = snapshot_configuration_pair();
+        configuration
+            .write_config(4, &[0x07, 0x80])
+            .expect("test command bytes should write");
+        configuration
+            .write_config(0x42, &[0x12])
+            .expect("test capability byte should write");
+        configuration
+            .write_config(0x10, &[u8::MAX; 4])
+            .expect("test BAR probe should arm");
+
+        let first = configuration
+            .snapshot_guest_state(&profile)
+            .expect("matching profile should snapshot");
+        let second = configuration
+            .snapshot_guest_state(&profile)
+            .expect("snapshot should be side-effect-free");
+
+        assert_eq!(first, second);
+        assert_eq!(
+            first
+                .writable_bytes()
+                .iter()
+                .map(|byte| (byte.offset(), byte.value(), byte.writable_mask()))
+                .collect::<Vec<_>>(),
+            [
+                (0x04, 0x07, 0xff),
+                (0x05, 0x80, 0xff),
+                (0x0c, 0x00, 0xff),
+                (0x3c, 0x00, 0xff),
+                (0x42, 0x12, 0xff),
+            ]
+        );
+        assert_eq!(
+            first
+                .bar_probes()
+                .iter()
+                .map(|probe| (probe.index(), probe.pending()))
+                .collect::<Vec<_>>(),
+            [(0, true), (1, false)]
+        );
+        assert_eq!(
+            format!("{profile:?}"),
+            "PciType0SnapshotProfile { profile: \"<redacted>\" }"
+        );
+        assert_eq!(
+            format!("{first:?}"),
+            "PciType0GuestState { state: \"<redacted>\" }"
+        );
+        assert_eq!(
+            format!("{:?}", first.writable_bytes()[0]),
+            "PciType0WritableByte(<redacted>)"
+        );
+        assert_eq!(
+            format!("{:?}", first.bar_probes()[0]),
+            "PciType0BarProbeState(<redacted>)"
+        );
+    }
+
+    #[test]
+    fn type0_snapshot_view_rejects_every_private_profile_class() {
+        let (configuration, profile) = snapshot_configuration_pair();
+        let mut mismatches = Vec::new();
+
+        let mut mismatch = configuration.clone();
+        mismatch.registers[0] ^= 1;
+        mismatches.push(mismatch);
+
+        let mut mismatch = configuration.clone();
+        mismatch.registers[PCI_FIRST_CAPABILITY_OFFSET / PCI_CONFIG_REGISTER_SIZE] ^= 1 << 24;
+        mismatches.push(mismatch);
+
+        let mut mismatch = configuration.clone();
+        mismatch.writable_masks[1] ^= 1;
+        mismatches.push(mismatch);
+
+        let mut mismatch = configuration.clone();
+        mismatch
+            .bars
+            .get_mut(&0)
+            .expect("test BAR should exist")
+            .encoded_address ^= 0x10;
+        mismatches.push(mismatch);
+
+        let mut mismatch = configuration.clone();
+        mismatch.bars.remove(&1);
+        mismatches.push(mismatch);
+
+        let mut mismatch = configuration.clone();
+        mismatch.last_capability = None;
+        mismatches.push(mismatch);
+
+        let mut mismatch = configuration;
+        mismatch.registers[PCI_CONFIG_REGISTER_COUNT - 1] = 1;
+        mismatches.push(mismatch);
+
+        for (index, mismatch) in mismatches.iter().enumerate() {
+            assert_eq!(
+                mismatch.snapshot_guest_state(&profile),
+                Err(PciType0SnapshotError::ProfileMismatch),
+                "private profile mismatch {index} unexpectedly passed",
+            );
+        }
+        assert_eq!(
+            PciType0SnapshotError::ProfileMismatch.to_string(),
+            "PCI type-0 configuration profile does not match"
         );
     }
 

--- a/crates/runtime/src/snapshot_device.rs
+++ b/crates/runtime/src/snapshot_device.rs
@@ -809,6 +809,7 @@ fn validate_encode_transport(
         || transport.pending_notifications().len() != 1
         || queue.map(|queue| queue.max_size()) != Some(crate::block::VIRTIO_BLOCK_QUEUE_SIZE)
         || notification.copied() != Some(false)
+        || !transport.requires_device_config_write_status()
     {
         return Err(SnapshotV1DeviceEncodeError::InvalidState);
     }
@@ -1290,6 +1291,7 @@ fn decode_transport(
         pending_notifications,
         interrupt_status,
         device_activated,
+        true,
     );
     Ok((transport, active_queue))
 }
@@ -1660,6 +1662,7 @@ mod tests {
             vec![false],
             DeviceInterruptStatus::empty(),
             false,
+            true,
         );
         let runtime = VirtioBlockRuntimeState::new(
             transport,
@@ -1741,6 +1744,49 @@ mod tests {
     }
 
     #[test]
+    fn native_v1_codec_defaults_true_config_write_policy_and_rejects_lossy_false_state() {
+        let mut state = fixture();
+        let encoded = encode_snapshot_v1_device_state(&state)
+            .expect("canonical native-v1 state should encode");
+        let decoded = decode_snapshot_v1_device_state(&encoded)
+            .expect("canonical native-v1 bytes should decode");
+        assert!(
+            decoded
+                .root_block()
+                .runtime()
+                .transport()
+                .requires_device_config_write_status()
+        );
+        assert_eq!(
+            encode_snapshot_v1_device_state(&decoded)
+                .expect("decoded canonical native-v1 state should re-encode"),
+            encoded
+        );
+
+        let original = state.root_block.runtime();
+        let transport = original.transport();
+        let false_policy = VirtioMmioTransportState::from_parts(
+            *transport.device_registers(),
+            transport.queue_select(),
+            transport.queues().to_vec(),
+            transport.pending_notifications().to_vec(),
+            transport.interrupt_status(),
+            transport.is_device_activated(),
+            false,
+        );
+        state.root_block.runtime = VirtioBlockRuntimeState::new(
+            false_policy,
+            original.active_queue(),
+            original.rate_limiter(),
+        );
+        assert_eq!(
+            encode_snapshot_v1_device_state(&state)
+                .expect_err("unrepresentable native-v1 policy should reject"),
+            SnapshotV1DeviceEncodeError::InvalidState
+        );
+    }
+
+    #[test]
     fn native_v1_device_codec_retains_legacy_vmclock_page_policy() {
         let mut state = fixture();
         state.vmclock_abi = None;
@@ -1803,6 +1849,7 @@ mod tests {
             vec![queue],
             vec![false],
             interrupts,
+            true,
             true,
         );
         let bucket_config = DriveTokenBucketConfig::new(100, Some(10), 1000);

--- a/crates/runtime/src/snapshot_device_v2.rs
+++ b/crates/runtime/src/snapshot_device_v2.rs
@@ -1507,6 +1507,12 @@ fn capture_pci_writable_bytes(
 fn capture_msix_state(
     state: &VirtioPciMsixState,
 ) -> Result<SnapshotV2PciMsixState, SnapshotV2DeviceGraphCaptureError> {
+    if state.entries().len() != 2
+        || state.pending_words().len() != 1
+        || state.queue_vectors().len() != 1
+    {
+        return Err(SnapshotV2DeviceGraphCaptureError::InvalidPciState);
+    }
     let mut entries = Vec::new();
     entries
         .try_reserve_exact(state.entries().len())
@@ -1566,6 +1572,13 @@ fn validate_graph(graph: &SnapshotV2DeviceGraph) -> Result<(), GraphValidationEr
     if graph.record.block.active_queue.is_some() != graph.record.virtio.activated {
         return Err(GraphValidationError::Block);
     }
+    let queue = graph
+        .record
+        .virtio
+        .queues
+        .first()
+        .ok_or(GraphValidationError::Virtio)?;
+    validate_block_queue_cursors(&graph.record.block, queue)?;
     let placement = match &graph.record.transport {
         SnapshotV2DeviceTransport::Mmio(state) => {
             validate_mmio_state(state)?;
@@ -1576,12 +1589,6 @@ fn validate_graph(graph: &SnapshotV2DeviceGraph) -> Result<(), GraphValidationEr
             state.bar_range
         }
     };
-    let queue = graph
-        .record
-        .virtio
-        .queues
-        .first()
-        .ok_or(GraphValidationError::Virtio)?;
     if queue_ranges(queue)?
         .is_some_and(|ranges| ranges.iter().any(|range| range.overlaps(placement)))
     {
@@ -1593,6 +1600,13 @@ fn validate_graph(graph: &SnapshotV2DeviceGraph) -> Result<(), GraphValidationEr
 fn validate_root_config(config: &SnapshotV2RootBlockConfig) -> Result<(), GraphValidationError> {
     validate_nonempty_string(&config.drive_id, NATIVE_V2_DEVICE_GRAPH_MAX_DRIVE_ID_BYTES)
         .map_err(|_| GraphValidationError::Configuration)?;
+    if !config
+        .drive_id
+        .chars()
+        .all(|character| character == '_' || character.is_alphanumeric())
+    {
+        return Err(GraphValidationError::Configuration);
+    }
     if let Some(partuuid) = config.partuuid.as_deref() {
         validate_nonempty_string(partuuid, NATIVE_V2_DEVICE_GRAPH_MAX_PARTUUID_BYTES)
             .map_err(|_| GraphValidationError::Configuration)?;
@@ -1626,6 +1640,20 @@ fn validate_block_state(
         return Err(GraphValidationError::Block);
     }
     Ok(())
+}
+
+fn validate_block_queue_cursors(
+    block: &SnapshotV2BlockState,
+    queue: &SnapshotV2VirtioQueueState,
+) -> Result<(), GraphValidationError> {
+    if block
+        .active_queue
+        .is_some_and(|state| state.next_available().wrapping_sub(state.next_used()) > queue.size)
+    {
+        Err(GraphValidationError::Block)
+    } else {
+        Ok(())
+    }
 }
 
 fn validate_limiter_config(
@@ -1850,16 +1878,6 @@ fn validate_pci_state(state: &SnapshotV2PciDeviceState) -> Result<(), GraphValid
         || state.bar_range.start().raw_value() < PCI_BAR64_START
         || state.bar_range.end_exclusive().raw_value()
             > PCI_BAR64_START.saturating_add(PCI_BAR64_SIZE)
-        || state.device_feature_select > 1
-        || state.driver_feature_select > 1
-        || state.queue_select != 0
-        || state.pci_cfg_bar != state.bar_index
-        || !matches!(state.pci_cfg_length, 0 | 1 | 2 | 4)
-        || (state.pci_cfg_length == 0 && state.pci_cfg_offset != 0)
-        || (state.pci_cfg_length != 0
-            && u64::from(state.pci_cfg_offset)
-                .checked_add(u64::from(state.pci_cfg_length))
-                .is_none_or(|end| end > state.bar_range.size()))
         || state.writable_bytes.len() != PCI_GENERIC_WRITABLE_BYTES.len()
         || state.bar_probes.len() != 2
     {

--- a/crates/runtime/src/snapshot_device_v2.rs
+++ b/crates/runtime/src/snapshot_device_v2.rs
@@ -1,0 +1,3129 @@
+//! Canonical native-v2 device-graph artifact model and payload codec.
+
+use std::fmt;
+use std::mem::size_of;
+
+use crate::block::{
+    BlockCaptureIoEngine, DriveCacheType, DriveConfig, DriveIoEngine, DriveRateLimiterConfig,
+    DriveTokenBucketConfig, VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE, VIRTIO_BLOCK_DEVICE_ID,
+    VIRTIO_BLOCK_ID_BYTES, VIRTIO_BLOCK_QUEUE_SIZE, VIRTIO_BLOCK_SECTOR_SHIFT, VirtioBlockDeviceId,
+    VirtioBlockRateLimiterState, VirtioBlockTokenBucketState,
+};
+use crate::interrupt::{DeviceInterruptKind, GuestInterruptLine};
+use crate::memory::{GuestAddress, GuestMemoryRange};
+use crate::mmio::MmioRegion;
+use crate::pci::{
+    PCI_BAR64_SIZE, PCI_BAR64_START, PCI_BUS_ZERO, PCI_FIRST_ENDPOINT_DEVICE, PCI_FUNCTION_ZERO,
+    PCI_LAST_ENDPOINT_DEVICE, PCI_SEGMENT_ZERO, PciBarAddressSpace, PciBarPrefetchable, PciSbdf,
+    PciType0GuestState,
+};
+use crate::snapshot_format::SnapshotFormatVersion;
+use crate::storage_capture::{
+    CaptureReadyBlockDeviceState, StorageDeviceOrigin, StorageRetryState, StorageTransportState,
+};
+use crate::virtio::{
+    VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DEVICE_NEEDS_RESET,
+    VIRTIO_DEVICE_STATUS_DRIVER, VIRTIO_DEVICE_STATUS_DRIVER_OK, VIRTIO_DEVICE_STATUS_FAILED,
+    VIRTIO_DEVICE_STATUS_FEATURES_OK, VIRTIO_DEVICE_STATUS_INIT, VirtioInterruptIntent,
+};
+use crate::virtio_mmio::{
+    VIRTIO_MMIO_DEVICE_WINDOW_SIZE, VIRTIO_MMIO_VENDOR_ID, VIRTIO_MMIO_VERSION_1_FEATURE,
+    VirtioMmioDeviceRegisters, VirtioMmioQueueState, VirtioMmioTransportState,
+};
+use crate::virtio_pci::{
+    VIRTIO_PCI_CAPABILITY_BAR_INDEX, VIRTIO_PCI_CAPABILITY_BAR_SIZE, VIRTIO_PCI_MAX_MSIX_VECTORS,
+    VIRTIO_PCI_NO_VECTOR, VirtioPciEndpointPhase, VirtioPciMsixState, VirtioPciTransportState,
+};
+
+/// Exact outer native-v2 version understood by the first device-graph codec.
+///
+/// This is a payload compatibility constant. It does not change the advertised
+/// native-v2 writer version.
+pub const NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION: SnapshotFormatVersion =
+    SnapshotFormatVersion::new(2, 4, 0);
+
+/// Maximum encoded size of one native-v2 2.4 device graph.
+pub const NATIVE_V2_DEVICE_GRAPH_MAX_BYTES: usize = 64 * 1024;
+
+/// Maximum UTF-8 byte length of one public drive identifier.
+pub const NATIVE_V2_DEVICE_GRAPH_MAX_DRIVE_ID_BYTES: usize = 255;
+
+/// Maximum UTF-8 byte length of one optional partition identifier.
+pub const NATIVE_V2_DEVICE_GRAPH_MAX_PARTUUID_BYTES: usize = 255;
+
+/// Maximum UTF-8 byte length of one inert logical backing selector.
+pub const NATIVE_V2_DEVICE_GRAPH_MAX_SELECTOR_BYTES: usize = 4096;
+
+/// Fixed device-graph payload header size.
+pub const NATIVE_V2_DEVICE_GRAPH_HEADER_BYTES: usize = 64;
+
+/// Fixed encoded size of one record-directory entry.
+pub const NATIVE_V2_DEVICE_GRAPH_RECORD_ENTRY_BYTES: usize = 32;
+
+/// Fixed encoded size of one section-directory entry.
+pub const NATIVE_V2_DEVICE_GRAPH_SECTION_ENTRY_BYTES: usize = 32;
+
+const DEVICE_GRAPH_MAGIC: [u8; 8] = *b"BANGD2A\0";
+const DEVICE_GRAPH_PROFILE: u16 = 1;
+const DEVICE_GRAPH_FLAGS: u32 = 0;
+const DEVICE_GRAPH_ALIGNMENT: usize = 8;
+const DEVICE_GRAPH_RECORD_COUNT: u16 = 1;
+const DEVICE_GRAPH_SECTION_COUNT: u16 = 4;
+const DEVICE_GRAPH_SECTION_COUNT_USIZE: usize = 4;
+const DEVICE_GRAPH_SECTION_COUNT_U32: u32 = 4;
+const DEVICE_GRAPH_RECORD_DIRECTORY_OFFSET: usize = NATIVE_V2_DEVICE_GRAPH_HEADER_BYTES;
+const DEVICE_GRAPH_SECTION_DIRECTORY_OFFSET: usize =
+    DEVICE_GRAPH_RECORD_DIRECTORY_OFFSET + NATIVE_V2_DEVICE_GRAPH_RECORD_ENTRY_BYTES;
+const DEVICE_GRAPH_PAYLOAD_OFFSET: usize = DEVICE_GRAPH_SECTION_DIRECTORY_OFFSET
+    + NATIVE_V2_DEVICE_GRAPH_SECTION_ENTRY_BYTES * DEVICE_GRAPH_SECTION_COUNT_USIZE;
+
+const HEADER_MAGIC_OFFSET: usize = 0;
+const HEADER_BYTES_OFFSET: usize = 8;
+const HEADER_PROFILE_OFFSET: usize = 10;
+const HEADER_TRANSPORT_OFFSET: usize = 12;
+const HEADER_RECORD_COUNT_OFFSET: usize = 14;
+const HEADER_SECTION_COUNT_OFFSET: usize = 16;
+const HEADER_RESERVED_OFFSET: usize = 18;
+const HEADER_FLAGS_OFFSET: usize = 20;
+const HEADER_TOTAL_LENGTH_OFFSET: usize = 24;
+const HEADER_ROOT_KIND_OFFSET: usize = 32;
+const HEADER_ROOT_INSTANCE_OFFSET: usize = 36;
+const HEADER_RECORD_DIRECTORY_OFFSET_OFFSET: usize = 40;
+const HEADER_SECTION_DIRECTORY_OFFSET_OFFSET: usize = 48;
+const HEADER_PAYLOAD_OFFSET_OFFSET: usize = 56;
+
+const RECORD_KIND_OFFSET: usize = 0;
+const RECORD_INSTANCE_OFFSET: usize = 4;
+const RECORD_FIRST_SECTION_OFFSET: usize = 8;
+const RECORD_SECTION_COUNT_OFFSET: usize = 12;
+const RECORD_RESERVED_OFFSET: usize = 16;
+
+const SECTION_RECORD_INDEX_OFFSET: usize = 0;
+const SECTION_KIND_OFFSET: usize = 4;
+const SECTION_FLAGS_OFFSET: usize = 6;
+const SECTION_RESERVED_OFFSET: usize = 8;
+const SECTION_PAYLOAD_OFFSET: usize = 16;
+const SECTION_LENGTH_OFFSET: usize = 24;
+
+const CONFIG_FIXED_BYTES: usize = 80;
+const BLOCK_SECTION_BYTES: usize = 104;
+const COMMON_FIXED_BYTES: usize = 32;
+const COMMON_QUEUE_BYTES: usize = 32;
+const MMIO_SECTION_BYTES: usize = 48;
+const PCI_FIXED_BYTES: usize = 72;
+const PCI_WRITABLE_ENTRY_BYTES: usize = 4;
+const PCI_BAR_PROBE_ENTRY_BYTES: usize = 4;
+const PCI_MSIX_ENTRY_BYTES: usize = 16;
+const PCI_PENDING_WORD_BYTES: usize = 8;
+const PCI_QUEUE_VECTOR_BYTES: usize = 2;
+
+const DEVICE_KIND_BLOCK: u32 = 1;
+const DEVICE_INSTANCE_ROOT: u32 = 0;
+const SECTION_KIND_CONFIG: u16 = 1;
+const SECTION_KIND_BLOCK: u16 = 2;
+const SECTION_KIND_COMMON: u16 = 3;
+const SECTION_KIND_TRANSPORT: u16 = 4;
+const TRANSPORT_KIND_MMIO: u16 = 1;
+const TRANSPORT_KIND_PCI: u16 = 2;
+const CACHE_UNSAFE: u8 = 0;
+const CACHE_WRITEBACK: u8 = 1;
+const ENGINE_SYNC: u8 = 1;
+const RETRY_NONE: u8 = 0;
+const RETRY_IMMEDIATE: u8 = 1;
+const RETRY_AFTER: u8 = 2;
+const INTERRUPT_QUEUE: u8 = 1;
+const INTERRUPT_CONFIGURATION: u8 = 2;
+const PCI_PHASE_ACTIVE: u8 = 1;
+const PCI_ORIGIN_STARTUP: u8 = 1;
+const PCI_BAR_MEMORY64: u8 = 2;
+const PCI_BAR_NOT_PREFETCHABLE: u8 = 0;
+const PCI_GENERIC_WRITABLE_BYTES: [(u16, u8); 4] =
+    [(0x04, 0xff), (0x05, 0xff), (0x0c, 0xff), (0x3c, 0xff)];
+const REDACTED: &str = "<redacted>";
+
+macro_rules! redacted_debug {
+    ($type:ty, $name:literal) => {
+        impl fmt::Debug for $type {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter
+                    .debug_struct($name)
+                    .field("state", &REDACTED)
+                    .finish()
+            }
+        }
+    };
+}
+
+/// Canonical typed identity of one device-graph record.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SnapshotV2DeviceKey {
+    kind: u32,
+    instance: u32,
+}
+
+impl SnapshotV2DeviceKey {
+    /// Returns the stable record kind.
+    pub const fn kind(self) -> u32 {
+        self.kind
+    }
+
+    /// Returns the stable kind-local instance.
+    pub const fn instance(self) -> u32 {
+        self.instance
+    }
+}
+
+redacted_debug!(SnapshotV2DeviceKey, "SnapshotV2DeviceKey");
+
+/// Transport profile selected by the complete singleton graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2DeviceTransportKind {
+    /// Modern virtio-mmio placement.
+    Mmio,
+    /// Modern, non-transitional virtio-pci placement.
+    Pci,
+}
+
+/// One stable device-graph interrupt intent.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SnapshotV2InterruptIntent {
+    /// Completion on one concrete virtqueue.
+    Queue { queue_index: u16 },
+    /// Device configuration changed.
+    Configuration,
+}
+
+impl fmt::Debug for SnapshotV2InterruptIntent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SnapshotV2InterruptIntent(<redacted>)")
+    }
+}
+
+/// Canonical public configuration of the first root block record.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SnapshotV2RootBlockConfig {
+    drive_id: String,
+    partuuid: Option<String>,
+    cache_type: DriveCacheType,
+    rate_limiter: Option<DriveRateLimiterConfig>,
+    selector: String,
+}
+
+impl SnapshotV2RootBlockConfig {
+    /// Returns the stable public drive identifier.
+    pub fn drive_id(&self) -> &str {
+        &self.drive_id
+    }
+
+    /// Returns the optional stable partition identifier.
+    pub fn partuuid(&self) -> Option<&str> {
+        self.partuuid.as_deref()
+    }
+
+    /// Returns the public cache policy.
+    pub const fn cache_type(&self) -> DriveCacheType {
+        self.cache_type
+    }
+
+    /// Returns the public rate-limiter configuration.
+    pub const fn rate_limiter(&self) -> Option<DriveRateLimiterConfig> {
+        self.rate_limiter
+    }
+
+    /// Returns the inert logical backing selector.
+    pub fn selector(&self) -> &str {
+        &self.selector
+    }
+
+    /// Returns the fixed read-only policy.
+    pub const fn is_read_only(&self) -> bool {
+        true
+    }
+
+    /// Returns the fixed synchronous I/O policy.
+    pub const fn io_engine(&self) -> DriveIoEngine {
+        DriveIoEngine::Sync
+    }
+}
+
+redacted_debug!(SnapshotV2RootBlockConfig, "SnapshotV2RootBlockConfig");
+
+/// Live value of one configured block token bucket.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotV2BlockBucketState {
+    budget: u64,
+    remaining_burst: u64,
+    age_nanos: u64,
+}
+
+impl SnapshotV2BlockBucketState {
+    /// Returns the current ordinary-token budget.
+    pub const fn budget(self) -> u64 {
+        self.budget
+    }
+
+    /// Returns the remaining one-time burst.
+    pub const fn remaining_burst(self) -> u64 {
+        self.remaining_burst
+    }
+
+    /// Returns the monotonic age at capture.
+    pub const fn age_nanos(self) -> u64 {
+        self.age_nanos
+    }
+}
+
+redacted_debug!(SnapshotV2BlockBucketState, "SnapshotV2BlockBucketState");
+
+/// Live block rate-limiter state without duplicated configuration.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotV2BlockLimiterState {
+    bandwidth: Option<SnapshotV2BlockBucketState>,
+    ops: Option<SnapshotV2BlockBucketState>,
+}
+
+impl SnapshotV2BlockLimiterState {
+    /// Returns the live bandwidth bucket.
+    pub const fn bandwidth(self) -> Option<SnapshotV2BlockBucketState> {
+        self.bandwidth
+    }
+
+    /// Returns the live operations bucket.
+    pub const fn ops(self) -> Option<SnapshotV2BlockBucketState> {
+        self.ops
+    }
+
+    /// Returns whether neither bucket is present.
+    pub const fn is_empty(self) -> bool {
+        self.bandwidth.is_none() && self.ops.is_none()
+    }
+}
+
+redacted_debug!(SnapshotV2BlockLimiterState, "SnapshotV2BlockLimiterState");
+
+/// Guest-visible block-local continuation state.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SnapshotV2BlockState {
+    capacity_sectors: u64,
+    device_id: VirtioBlockDeviceId,
+    active_queue: Option<crate::block::VirtioBlockQueueState>,
+    limiter: SnapshotV2BlockLimiterState,
+    retry: StorageRetryState,
+}
+
+impl SnapshotV2BlockState {
+    /// Returns the guest-visible capacity in 512-byte sectors.
+    pub const fn capacity_sectors(&self) -> u64 {
+        self.capacity_sectors
+    }
+
+    /// Returns the exact guest-visible 20-byte block identifier.
+    pub const fn device_id(&self) -> VirtioBlockDeviceId {
+        self.device_id
+    }
+
+    /// Returns the optional active request cursor.
+    pub const fn active_queue(&self) -> Option<crate::block::VirtioBlockQueueState> {
+        self.active_queue
+    }
+
+    /// Returns the live limiter state.
+    pub const fn limiter(&self) -> SnapshotV2BlockLimiterState {
+        self.limiter
+    }
+
+    /// Returns the host-time-free retry disposition.
+    pub const fn retry(&self) -> StorageRetryState {
+        self.retry
+    }
+}
+
+redacted_debug!(SnapshotV2BlockState, "SnapshotV2BlockState");
+
+/// One canonical virtqueue state.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotV2VirtioQueueState {
+    max_size: u16,
+    size: u16,
+    ready: bool,
+    descriptor_table: GuestAddress,
+    driver_ring: GuestAddress,
+    device_ring: GuestAddress,
+}
+
+impl SnapshotV2VirtioQueueState {
+    /// Returns the device queue maximum.
+    pub const fn max_size(self) -> u16 {
+        self.max_size
+    }
+
+    /// Returns the guest-selected queue size.
+    pub const fn size(self) -> u16 {
+        self.size
+    }
+
+    /// Returns whether the queue is ready.
+    pub const fn ready(self) -> bool {
+        self.ready
+    }
+
+    /// Returns the descriptor-table address.
+    pub const fn descriptor_table(self) -> GuestAddress {
+        self.descriptor_table
+    }
+
+    /// Returns the driver-ring address.
+    pub const fn driver_ring(self) -> GuestAddress {
+        self.driver_ring
+    }
+
+    /// Returns the device-ring address.
+    pub const fn device_ring(self) -> GuestAddress {
+        self.device_ring
+    }
+}
+
+redacted_debug!(SnapshotV2VirtioQueueState, "SnapshotV2VirtioQueueState");
+
+/// Canonical transport-neutral virtio continuation state.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SnapshotV2VirtioState {
+    available_features: u64,
+    driver_features: u64,
+    config_generation: u32,
+    status: u32,
+    activated: bool,
+    queues: Vec<SnapshotV2VirtioQueueState>,
+    pending_notifications: Vec<u16>,
+    interrupt_intents: Vec<SnapshotV2InterruptIntent>,
+}
+
+impl SnapshotV2VirtioState {
+    /// Returns available virtio features.
+    pub const fn available_features(&self) -> u64 {
+        self.available_features
+    }
+
+    /// Returns guest-negotiated virtio features.
+    pub const fn driver_features(&self) -> u64 {
+        self.driver_features
+    }
+
+    /// Returns the device configuration generation.
+    pub const fn config_generation(&self) -> u32 {
+        self.config_generation
+    }
+
+    /// Returns the virtio device status.
+    pub const fn status(&self) -> u32 {
+        self.status
+    }
+
+    /// Returns whether device activation completed.
+    pub const fn is_activated(&self) -> bool {
+        self.activated
+    }
+
+    /// Returns canonical queue state.
+    pub fn queues(&self) -> &[SnapshotV2VirtioQueueState] {
+        &self.queues
+    }
+
+    /// Returns sorted pending notification queue indices.
+    pub fn pending_notifications(&self) -> &[u16] {
+        &self.pending_notifications
+    }
+
+    /// Returns sorted unique pending interrupt intents.
+    pub fn interrupt_intents(&self) -> &[SnapshotV2InterruptIntent] {
+        &self.interrupt_intents
+    }
+}
+
+redacted_debug!(SnapshotV2VirtioState, "SnapshotV2VirtioState");
+
+/// Canonical virtio-mmio selectors and placement.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SnapshotV2MmioDeviceState {
+    device_feature_select: u32,
+    driver_feature_select: u32,
+    queue_select: u32,
+    region: MmioRegion,
+    interrupt_line: GuestInterruptLine,
+}
+
+impl SnapshotV2MmioDeviceState {
+    /// Returns the selected device feature word.
+    pub const fn device_feature_select(&self) -> u32 {
+        self.device_feature_select
+    }
+
+    /// Returns the selected driver feature word.
+    pub const fn driver_feature_select(&self) -> u32 {
+        self.driver_feature_select
+    }
+
+    /// Returns the selected queue.
+    pub const fn queue_select(&self) -> u32 {
+        self.queue_select
+    }
+
+    /// Returns the exact MMIO region.
+    pub const fn region(&self) -> MmioRegion {
+        self.region
+    }
+
+    /// Returns the exact interrupt line.
+    pub const fn interrupt_line(&self) -> GuestInterruptLine {
+        self.interrupt_line
+    }
+}
+
+redacted_debug!(SnapshotV2MmioDeviceState, "SnapshotV2MmioDeviceState");
+
+/// One generic guest-writable PCI configuration byte.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotV2PciWritableByte {
+    offset: u16,
+    value: u8,
+}
+
+impl SnapshotV2PciWritableByte {
+    /// Returns the PCI configuration-space byte offset.
+    pub const fn offset(self) -> u16 {
+        self.offset
+    }
+
+    /// Returns the writable bits at that offset.
+    pub const fn value(self) -> u8 {
+        self.value
+    }
+}
+
+redacted_debug!(SnapshotV2PciWritableByte, "SnapshotV2PciWritableByte");
+
+/// One configured PCI BAR register's one-shot probe state.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotV2PciBarProbeState {
+    index: u8,
+    pending: bool,
+}
+
+impl SnapshotV2PciBarProbeState {
+    /// Returns the BAR register index.
+    pub const fn index(self) -> u8 {
+        self.index
+    }
+
+    /// Returns whether the next read reports the BAR size.
+    pub const fn pending(self) -> bool {
+        self.pending
+    }
+}
+
+redacted_debug!(SnapshotV2PciBarProbeState, "SnapshotV2PciBarProbeState");
+
+/// One exact guest-programmed MSI-X table entry.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotV2PciMsixTableEntry {
+    message_address_low: u32,
+    message_address_high: u32,
+    message_data: u32,
+    vector_control: u32,
+}
+
+impl SnapshotV2PciMsixTableEntry {
+    /// Returns the low message-address word.
+    pub const fn message_address_low(self) -> u32 {
+        self.message_address_low
+    }
+
+    /// Returns the high message-address word.
+    pub const fn message_address_high(self) -> u32 {
+        self.message_address_high
+    }
+
+    /// Returns the message data.
+    pub const fn message_data(self) -> u32 {
+        self.message_data
+    }
+
+    /// Returns guest vector-control bits.
+    pub const fn vector_control(self) -> u32 {
+        self.vector_control
+    }
+}
+
+redacted_debug!(SnapshotV2PciMsixTableEntry, "SnapshotV2PciMsixTableEntry");
+
+/// Exact MSI-X continuation state without live route authority.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SnapshotV2PciMsixState {
+    entries: Vec<SnapshotV2PciMsixTableEntry>,
+    pending_words: Vec<u64>,
+    enabled: bool,
+    function_masked: bool,
+    config_vector: u16,
+    queue_vectors: Vec<u16>,
+    pending_transition_observed: bool,
+}
+
+impl SnapshotV2PciMsixState {
+    /// Returns canonical MSI-X table entries.
+    pub fn entries(&self) -> &[SnapshotV2PciMsixTableEntry] {
+        &self.entries
+    }
+
+    /// Returns canonical pending-bit-array words.
+    pub fn pending_words(&self) -> &[u64] {
+        &self.pending_words
+    }
+
+    /// Returns whether MSI-X is enabled.
+    pub const fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Returns whether the function mask is set.
+    pub const fn function_masked(&self) -> bool {
+        self.function_masked
+    }
+
+    /// Returns the configuration vector or the no-vector sentinel.
+    pub const fn config_vector(&self) -> u16 {
+        self.config_vector
+    }
+
+    /// Returns one vector per virtqueue.
+    pub fn queue_vectors(&self) -> &[u16] {
+        &self.queue_vectors
+    }
+
+    /// Returns whether a pending-to-deliverable transition was observed.
+    pub const fn pending_transition_observed(&self) -> bool {
+        self.pending_transition_observed
+    }
+}
+
+redacted_debug!(SnapshotV2PciMsixState, "SnapshotV2PciMsixState");
+
+/// Canonical virtio-pci selectors, placement, guest configuration, and MSI-X.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SnapshotV2PciDeviceState {
+    phase: VirtioPciEndpointPhase,
+    origin: StorageDeviceOrigin,
+    sbdf: PciSbdf,
+    bar_index: u8,
+    bar_address_space: PciBarAddressSpace,
+    bar_prefetchable: PciBarPrefetchable,
+    bar_range: GuestMemoryRange,
+    device_feature_select: u32,
+    driver_feature_select: u32,
+    queue_select: u16,
+    pci_cfg_bar: u8,
+    pci_cfg_offset: u32,
+    pci_cfg_length: u32,
+    writable_bytes: Vec<SnapshotV2PciWritableByte>,
+    bar_probes: Vec<SnapshotV2PciBarProbeState>,
+    msix: SnapshotV2PciMsixState,
+}
+
+impl SnapshotV2PciDeviceState {
+    /// Returns the retained endpoint phase.
+    pub const fn phase(&self) -> VirtioPciEndpointPhase {
+        self.phase
+    }
+
+    /// Returns startup/runtime placement origin.
+    pub const fn origin(&self) -> StorageDeviceOrigin {
+        self.origin
+    }
+
+    /// Returns the exact PCI function identity.
+    pub const fn sbdf(&self) -> PciSbdf {
+        self.sbdf
+    }
+
+    /// Returns the capability BAR register index.
+    pub const fn bar_index(&self) -> u8 {
+        self.bar_index
+    }
+
+    /// Returns the BAR address-space kind.
+    pub const fn bar_address_space(&self) -> PciBarAddressSpace {
+        self.bar_address_space
+    }
+
+    /// Returns the BAR prefetchability policy.
+    pub const fn bar_prefetchable(&self) -> PciBarPrefetchable {
+        self.bar_prefetchable
+    }
+
+    /// Returns the exact capability BAR range.
+    pub const fn bar_range(&self) -> GuestMemoryRange {
+        self.bar_range
+    }
+
+    /// Returns the selected device feature word.
+    pub const fn device_feature_select(&self) -> u32 {
+        self.device_feature_select
+    }
+
+    /// Returns the selected driver feature word.
+    pub const fn driver_feature_select(&self) -> u32 {
+        self.driver_feature_select
+    }
+
+    /// Returns the selected queue.
+    pub const fn queue_select(&self) -> u16 {
+        self.queue_select
+    }
+
+    /// Returns the PCI capability BAR selector.
+    pub const fn pci_cfg_bar(&self) -> u8 {
+        self.pci_cfg_bar
+    }
+
+    /// Returns the PCI capability offset selector.
+    pub const fn pci_cfg_offset(&self) -> u32 {
+        self.pci_cfg_offset
+    }
+
+    /// Returns the PCI capability access-length selector.
+    pub const fn pci_cfg_length(&self) -> u32 {
+        self.pci_cfg_length
+    }
+
+    /// Returns the exact generic guest-writable PCI bytes.
+    pub fn writable_bytes(&self) -> &[SnapshotV2PciWritableByte] {
+        &self.writable_bytes
+    }
+
+    /// Returns the exact BAR probe state.
+    pub fn bar_probes(&self) -> &[SnapshotV2PciBarProbeState] {
+        &self.bar_probes
+    }
+
+    /// Returns exact MSI-X state.
+    pub const fn msix(&self) -> &SnapshotV2PciMsixState {
+        &self.msix
+    }
+}
+
+redacted_debug!(SnapshotV2PciDeviceState, "SnapshotV2PciDeviceState");
+
+/// Tagged transport-specific continuation state.
+#[derive(Clone, PartialEq, Eq)]
+pub enum SnapshotV2DeviceTransport {
+    /// Exact virtio-mmio selectors and placement.
+    Mmio(SnapshotV2MmioDeviceState),
+    /// Exact modern virtio-pci selectors and placement.
+    Pci(SnapshotV2PciDeviceState),
+}
+
+impl SnapshotV2DeviceTransport {
+    /// Returns the graph transport kind.
+    pub const fn kind(&self) -> SnapshotV2DeviceTransportKind {
+        match self {
+            Self::Mmio(_) => SnapshotV2DeviceTransportKind::Mmio,
+            Self::Pci(_) => SnapshotV2DeviceTransportKind::Pci,
+        }
+    }
+}
+
+impl fmt::Debug for SnapshotV2DeviceTransport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Mmio(_) => formatter.write_str("SnapshotV2DeviceTransport::Mmio(<redacted>)"),
+            Self::Pci(_) => formatter.write_str("SnapshotV2DeviceTransport::Pci(<redacted>)"),
+        }
+    }
+}
+
+/// One canonical root block record.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SnapshotV2DeviceRecord {
+    key: SnapshotV2DeviceKey,
+    config: SnapshotV2RootBlockConfig,
+    block: SnapshotV2BlockState,
+    virtio: SnapshotV2VirtioState,
+    transport: SnapshotV2DeviceTransport,
+}
+
+impl SnapshotV2DeviceRecord {
+    /// Returns the stable typed key.
+    pub const fn key(&self) -> SnapshotV2DeviceKey {
+        self.key
+    }
+
+    /// Returns the public root-block configuration.
+    pub const fn config(&self) -> &SnapshotV2RootBlockConfig {
+        &self.config
+    }
+
+    /// Returns block-local continuation state.
+    pub const fn block(&self) -> &SnapshotV2BlockState {
+        &self.block
+    }
+
+    /// Returns common virtio state.
+    pub const fn virtio(&self) -> &SnapshotV2VirtioState {
+        &self.virtio
+    }
+
+    /// Returns tagged transport state.
+    pub const fn transport(&self) -> &SnapshotV2DeviceTransport {
+        &self.transport
+    }
+}
+
+redacted_debug!(SnapshotV2DeviceRecord, "SnapshotV2DeviceRecord");
+
+/// Fully validated native-v2 2.4 singleton device graph.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SnapshotV2DeviceGraph {
+    root_key: SnapshotV2DeviceKey,
+    record: SnapshotV2DeviceRecord,
+}
+
+impl SnapshotV2DeviceGraph {
+    /// Returns the exact compatibility version of this graph profile.
+    pub const fn compatibility_version(&self) -> SnapshotFormatVersion {
+        NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION
+    }
+
+    /// Returns the sole root-record key.
+    pub const fn root_key(&self) -> SnapshotV2DeviceKey {
+        self.root_key
+    }
+
+    /// Returns the sole canonical record.
+    pub const fn record(&self) -> &SnapshotV2DeviceRecord {
+        &self.record
+    }
+
+    /// Returns the graph-wide transport profile.
+    pub const fn transport_kind(&self) -> SnapshotV2DeviceTransportKind {
+        self.record.transport.kind()
+    }
+
+    /// Returns whether the sole record is selected as root.
+    pub const fn record_is_root(&self) -> bool {
+        self.root_key.kind == self.record.key.kind
+            && self.root_key.instance == self.record.key.instance
+    }
+
+    /// Converts one capture-ready runtime root into the stable graph model.
+    pub fn from_capture_ready_root(
+        outer_version: SnapshotFormatVersion,
+        state: &CaptureReadyBlockDeviceState,
+    ) -> Result<Self, SnapshotV2DeviceGraphCaptureError> {
+        capture_device_graph(outer_version, state)
+    }
+
+    /// Encodes this graph using the exact supplied outer compatibility context.
+    pub fn encode(
+        &self,
+        outer_version: SnapshotFormatVersion,
+    ) -> Result<Vec<u8>, SnapshotV2DeviceGraphEncodeError> {
+        encode_snapshot_v2_device_graph(outer_version, self)
+    }
+
+    /// Decodes and validates one graph using its exact outer compatibility context.
+    pub fn decode(
+        outer_version: SnapshotFormatVersion,
+        bytes: &[u8],
+    ) -> Result<Self, SnapshotV2DeviceGraphDecodeError> {
+        decode_snapshot_v2_device_graph(outer_version, bytes)
+    }
+}
+
+redacted_debug!(SnapshotV2DeviceGraph, "SnapshotV2DeviceGraph");
+
+/// Failure while converting detached runtime state into an artifact graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2DeviceGraphCaptureError {
+    /// The outer version does not select the 2.4 graph profile.
+    UnsupportedVersion,
+    /// Public root configuration is outside the first profile.
+    UnsupportedConfiguration,
+    /// A bounded string is empty, non-UTF-8, or too large.
+    InvalidString,
+    /// Repeated configuration or block-local facts disagree.
+    InconsistentBlockState,
+    /// Common virtio state is invalid or inconsistent.
+    InvalidVirtioState,
+    /// MMIO placement or policy is invalid.
+    InvalidMmioState,
+    /// PCI placement, configuration, or MSI-X state is invalid.
+    InvalidPciState,
+    /// A bounded artifact collection could not be allocated.
+    Allocation,
+}
+
+impl fmt::Display for SnapshotV2DeviceGraphCaptureError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedVersion => {
+                formatter.write_str("native-v2 device graph compatibility version is unsupported")
+            }
+            Self::UnsupportedConfiguration => {
+                formatter.write_str("root block configuration is outside the device graph profile")
+            }
+            Self::InvalidString => formatter.write_str("root block string metadata is invalid"),
+            Self::InconsistentBlockState => {
+                formatter.write_str("captured root block state is inconsistent")
+            }
+            Self::InvalidVirtioState => {
+                formatter.write_str("captured common virtio state is invalid")
+            }
+            Self::InvalidMmioState => formatter.write_str("captured virtio-mmio state is invalid"),
+            Self::InvalidPciState => formatter.write_str("captured virtio-pci state is invalid"),
+            Self::Allocation => formatter.write_str("failed to allocate a native-v2 device graph"),
+        }
+    }
+}
+
+impl std::error::Error for SnapshotV2DeviceGraphCaptureError {}
+
+/// Failure while encoding a validated device graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2DeviceGraphEncodeError {
+    /// The outer version does not select the 2.4 graph profile.
+    UnsupportedVersion,
+    /// The in-memory graph violates the exact profile.
+    InvalidGraph,
+    /// Encoded length exceeds the device-graph maximum.
+    TooLarge,
+    /// A bounded output allocation failed.
+    Allocation,
+}
+
+impl fmt::Display for SnapshotV2DeviceGraphEncodeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedVersion => {
+                formatter.write_str("native-v2 device graph compatibility version is unsupported")
+            }
+            Self::InvalidGraph => formatter.write_str("native-v2 device graph is invalid"),
+            Self::TooLarge => formatter.write_str("native-v2 device graph exceeds 64 KiB"),
+            Self::Allocation => {
+                formatter.write_str("failed to allocate encoded native-v2 device graph")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SnapshotV2DeviceGraphEncodeError {}
+
+/// Failure while decoding a native-v2 device-graph payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2DeviceGraphDecodeError {
+    /// The outer version does not select the 2.4 graph profile.
+    UnsupportedVersion,
+    /// The payload is shorter than its fixed header.
+    TooSmall,
+    /// The payload exceeds the 64 KiB graph bound.
+    TooLarge,
+    /// The graph magic is invalid.
+    InvalidMagic,
+    /// Header profile, transport, count, or flag fields are unsupported.
+    UnsupportedProfile,
+    /// A reserved field or terminal padding byte is nonzero.
+    NonzeroReserved,
+    /// Header or directory bounds are noncanonical.
+    InvalidStructure,
+    /// A declared field or section is truncated.
+    Truncated,
+    /// A scalar discriminant or boolean is invalid.
+    InvalidValue,
+    /// A bounded string is empty, non-UTF-8, or too large.
+    InvalidString,
+    /// A bounded decoded collection could not be allocated.
+    Allocation,
+    /// Decoded semantics violate the exact one-root profile.
+    InvalidGraph,
+}
+
+impl fmt::Display for SnapshotV2DeviceGraphDecodeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedVersion => {
+                formatter.write_str("native-v2 device graph compatibility version is unsupported")
+            }
+            Self::TooSmall => {
+                formatter.write_str("native-v2 device graph is smaller than 64 bytes")
+            }
+            Self::TooLarge => formatter.write_str("native-v2 device graph exceeds 64 KiB"),
+            Self::InvalidMagic => formatter.write_str("native-v2 device graph magic is invalid"),
+            Self::UnsupportedProfile => {
+                formatter.write_str("native-v2 device graph profile is unsupported")
+            }
+            Self::NonzeroReserved => {
+                formatter.write_str("native-v2 device graph reserved bytes are nonzero")
+            }
+            Self::InvalidStructure => {
+                formatter.write_str("native-v2 device graph structure is noncanonical")
+            }
+            Self::Truncated => formatter.write_str("native-v2 device graph is truncated"),
+            Self::InvalidValue => {
+                formatter.write_str("native-v2 device graph scalar value is invalid")
+            }
+            Self::InvalidString => {
+                formatter.write_str("native-v2 device graph string metadata is invalid")
+            }
+            Self::Allocation => {
+                formatter.write_str("failed to allocate decoded native-v2 device graph")
+            }
+            Self::InvalidGraph => {
+                formatter.write_str("native-v2 device graph semantics are invalid")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SnapshotV2DeviceGraphDecodeError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GraphValidationError {
+    Root,
+    Configuration,
+    Block,
+    Virtio,
+    Mmio,
+    Pci,
+}
+
+fn capture_device_graph(
+    outer_version: SnapshotFormatVersion,
+    state: &CaptureReadyBlockDeviceState,
+) -> Result<SnapshotV2DeviceGraph, SnapshotV2DeviceGraphCaptureError> {
+    validate_compatibility_version(outer_version)
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::UnsupportedVersion)?;
+    let config = capture_root_config(state.config())?;
+    let block = capture_block_state(state, &config)?;
+    let expected_features = expected_block_features(config.cache_type());
+
+    let (virtio, transport) = match state.transport() {
+        StorageTransportState::Mmio(mmio) => {
+            let virtio = capture_mmio_common(mmio.transport(), expected_features)?;
+            let transport =
+                capture_mmio_transport(mmio.region(), mmio.interrupt_line(), mmio.transport())?;
+            (virtio, SnapshotV2DeviceTransport::Mmio(transport))
+        }
+        StorageTransportState::Pci(pci) => {
+            let virtio = capture_pci_common(pci.transport(), expected_features)?;
+            let transport =
+                capture_pci_transport(pci.origin(), pci.sbdf(), pci.bar_range(), pci.transport())?;
+            (virtio, SnapshotV2DeviceTransport::Pci(transport))
+        }
+    };
+
+    let key = SnapshotV2DeviceKey {
+        kind: DEVICE_KIND_BLOCK,
+        instance: DEVICE_INSTANCE_ROOT,
+    };
+    let graph = SnapshotV2DeviceGraph {
+        root_key: key,
+        record: SnapshotV2DeviceRecord {
+            key,
+            config,
+            block,
+            virtio,
+            transport,
+        },
+    };
+    validate_graph(&graph).map_err(capture_validation_error)?;
+    Ok(graph)
+}
+
+fn capture_root_config(
+    config: &DriveConfig,
+) -> Result<SnapshotV2RootBlockConfig, SnapshotV2DeviceGraphCaptureError> {
+    if !config.is_root_device()
+        || config.is_vhost_user()
+        || config.is_read_only() != Some(true)
+        || config.io_engine() != Some(DriveIoEngine::Sync)
+    {
+        return Err(SnapshotV2DeviceGraphCaptureError::UnsupportedConfiguration);
+    }
+    validate_nonempty_string(config.drive_id(), NATIVE_V2_DEVICE_GRAPH_MAX_DRIVE_ID_BYTES)
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::InvalidString)?;
+    if let Some(partuuid) = config.partuuid() {
+        validate_nonempty_string(partuuid, NATIVE_V2_DEVICE_GRAPH_MAX_PARTUUID_BYTES)
+            .map_err(|_| SnapshotV2DeviceGraphCaptureError::InvalidString)?;
+    }
+    let selector = config
+        .path_on_host()
+        .and_then(|path| path.to_str())
+        .ok_or(SnapshotV2DeviceGraphCaptureError::InvalidString)?;
+    validate_nonempty_string(selector, NATIVE_V2_DEVICE_GRAPH_MAX_SELECTOR_BYTES)
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::InvalidString)?;
+    validate_limiter_config(config.rate_limiter())
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::UnsupportedConfiguration)?;
+
+    let mut drive_id = String::new();
+    drive_id
+        .try_reserve_exact(config.drive_id().len())
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::Allocation)?;
+    drive_id.push_str(config.drive_id());
+    let partuuid = match config.partuuid() {
+        Some(value) => {
+            let mut owned = String::new();
+            owned
+                .try_reserve_exact(value.len())
+                .map_err(|_| SnapshotV2DeviceGraphCaptureError::Allocation)?;
+            owned.push_str(value);
+            Some(owned)
+        }
+        None => None,
+    };
+    let mut selector_owned = String::new();
+    selector_owned
+        .try_reserve_exact(selector.len())
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::Allocation)?;
+    selector_owned.push_str(selector);
+
+    Ok(SnapshotV2RootBlockConfig {
+        drive_id,
+        partuuid,
+        cache_type: config.cache_type(),
+        rate_limiter: config.rate_limiter(),
+        selector: selector_owned,
+    })
+}
+
+fn capture_block_state(
+    state: &CaptureReadyBlockDeviceState,
+    config: &SnapshotV2RootBlockConfig,
+) -> Result<SnapshotV2BlockState, SnapshotV2DeviceGraphCaptureError> {
+    let device = state.device();
+    let config_space = device.config_space();
+    let backing = device.backing();
+    if !matches!(device.io_engine(), BlockCaptureIoEngine::Sync)
+        || config_space.config_len() != VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE
+        || !config_space.is_read_only()
+        || config_space.cache_type() != config.cache_type
+        || !backing.kind().is_regular_file()
+        || backing.len() >> VIRTIO_BLOCK_SECTOR_SHIFT != config_space.capacity_sectors()
+    {
+        return Err(SnapshotV2DeviceGraphCaptureError::InconsistentBlockState);
+    }
+    let limiter = capture_limiter_state(config.rate_limiter, device.rate_limiter())
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::InconsistentBlockState)?;
+    let active_queue = device.active_queue();
+    let retry = state.retry();
+    if retry != StorageRetryState::None && (active_queue.is_none() || limiter.is_empty()) {
+        return Err(SnapshotV2DeviceGraphCaptureError::InconsistentBlockState);
+    }
+    if matches!(retry, StorageRetryState::After { remaining_nanos: 0 }) {
+        return Err(SnapshotV2DeviceGraphCaptureError::InconsistentBlockState);
+    }
+    Ok(SnapshotV2BlockState {
+        capacity_sectors: config_space.capacity_sectors(),
+        device_id: device.device_id(),
+        active_queue,
+        limiter,
+        retry,
+    })
+}
+
+fn capture_limiter_state(
+    config: Option<DriveRateLimiterConfig>,
+    state: VirtioBlockRateLimiterState,
+) -> Result<SnapshotV2BlockLimiterState, ()> {
+    if config.is_none() && !state.is_empty() {
+        return Err(());
+    }
+    Ok(SnapshotV2BlockLimiterState {
+        bandwidth: capture_bucket_state(
+            config.and_then(DriveRateLimiterConfig::bandwidth),
+            state.bandwidth(),
+        )?,
+        ops: capture_bucket_state(config.and_then(DriveRateLimiterConfig::ops), state.ops())?,
+    })
+}
+
+fn capture_bucket_state(
+    config: Option<DriveTokenBucketConfig>,
+    state: Option<VirtioBlockTokenBucketState>,
+) -> Result<Option<SnapshotV2BlockBucketState>, ()> {
+    match (config, state) {
+        (Some(config), Some(state))
+            if token_bucket_is_enabled(config)
+                && state.config() == config
+                && state.budget() <= config.size()
+                && state.remaining_burst() <= config.one_time_burst().unwrap_or(0) =>
+        {
+            Ok(Some(SnapshotV2BlockBucketState {
+                budget: state.budget(),
+                remaining_burst: state.remaining_burst(),
+                age_nanos: state.age_nanos(),
+            }))
+        }
+        (None, None) => Ok(None),
+        _ => Err(()),
+    }
+}
+
+fn capture_mmio_common(
+    state: &VirtioMmioTransportState,
+    expected_features: u64,
+) -> Result<SnapshotV2VirtioState, SnapshotV2DeviceGraphCaptureError> {
+    if !state.requires_device_config_write_status() {
+        return Err(SnapshotV2DeviceGraphCaptureError::InvalidMmioState);
+    }
+    let mut intents = Vec::new();
+    intents
+        .try_reserve_exact(2)
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::Allocation)?;
+    if state
+        .interrupt_status()
+        .contains(DeviceInterruptKind::Queue)
+    {
+        intents.push(SnapshotV2InterruptIntent::Queue { queue_index: 0 });
+    }
+    if state
+        .interrupt_status()
+        .contains(DeviceInterruptKind::Config)
+    {
+        intents.push(SnapshotV2InterruptIntent::Configuration);
+    }
+    capture_common_state(
+        *state.device_registers(),
+        state.queues(),
+        state.pending_notifications(),
+        state.is_device_activated(),
+        intents,
+        expected_features,
+    )
+}
+
+fn capture_pci_common(
+    state: &VirtioPciTransportState,
+    expected_features: u64,
+) -> Result<SnapshotV2VirtioState, SnapshotV2DeviceGraphCaptureError> {
+    if state.requires_device_config_write_status() {
+        return Err(SnapshotV2DeviceGraphCaptureError::InvalidPciState);
+    }
+    let queue_count = state.queues().queue_count();
+    if queue_count != 1 || state.interrupt_intents().len() > 2 {
+        return Err(SnapshotV2DeviceGraphCaptureError::InvalidVirtioState);
+    }
+    let mut queues = Vec::new();
+    queues
+        .try_reserve_exact(queue_count)
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::Allocation)?;
+    for index in 0..queue_count {
+        let index = u32::try_from(index)
+            .map_err(|_| SnapshotV2DeviceGraphCaptureError::InvalidVirtioState)?;
+        let queue = state
+            .queues()
+            .queue(index)
+            .map_err(|_| SnapshotV2DeviceGraphCaptureError::InvalidVirtioState)?;
+        queues.push(*queue);
+    }
+    let pending_indices = state.queue_notifications().pending_queue_notifications();
+    if pending_indices.len() > 1 {
+        return Err(SnapshotV2DeviceGraphCaptureError::InvalidVirtioState);
+    }
+    let mut pending = Vec::new();
+    pending
+        .try_reserve_exact(pending_indices.len())
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::Allocation)?;
+    for index in pending_indices {
+        pending.push(
+            u16::try_from(index)
+                .map_err(|_| SnapshotV2DeviceGraphCaptureError::InvalidVirtioState)?,
+        );
+    }
+
+    let mut intents = Vec::new();
+    intents
+        .try_reserve_exact(state.interrupt_intents().len())
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::Allocation)?;
+    for intent in state.interrupt_intents() {
+        intents.push(match *intent {
+            VirtioInterruptIntent::Queue { queue_index } => {
+                SnapshotV2InterruptIntent::Queue { queue_index }
+            }
+            VirtioInterruptIntent::Configuration => SnapshotV2InterruptIntent::Configuration,
+        });
+    }
+    intents.sort_unstable();
+    if intents
+        .windows(2)
+        .any(|window| matches!(window, [first, second] if first == second))
+    {
+        return Err(SnapshotV2DeviceGraphCaptureError::InvalidVirtioState);
+    }
+    capture_common_state_from_owned_queues(
+        *state.device_registers(),
+        queues,
+        pending,
+        state.is_device_activated(),
+        intents,
+        expected_features,
+    )
+}
+
+fn capture_common_state(
+    registers: VirtioMmioDeviceRegisters,
+    queues: &[VirtioMmioQueueState],
+    pending_notifications: &[bool],
+    activated: bool,
+    intents: Vec<SnapshotV2InterruptIntent>,
+    expected_features: u64,
+) -> Result<SnapshotV2VirtioState, SnapshotV2DeviceGraphCaptureError> {
+    if queues.len() != 1 || pending_notifications.len() != 1 || intents.len() > 2 {
+        return Err(SnapshotV2DeviceGraphCaptureError::InvalidVirtioState);
+    }
+    let mut owned_queues = Vec::new();
+    owned_queues
+        .try_reserve_exact(queues.len())
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::Allocation)?;
+    for queue in queues {
+        owned_queues.push(*queue);
+    }
+    let mut pending = Vec::new();
+    pending
+        .try_reserve_exact(pending_notifications.len())
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::Allocation)?;
+    for (index, is_pending) in pending_notifications.iter().copied().enumerate() {
+        if is_pending {
+            pending.push(
+                u16::try_from(index)
+                    .map_err(|_| SnapshotV2DeviceGraphCaptureError::InvalidVirtioState)?,
+            );
+        }
+    }
+    capture_common_state_from_owned_queues(
+        registers,
+        owned_queues,
+        pending,
+        activated,
+        intents,
+        expected_features,
+    )
+}
+
+fn capture_common_state_from_owned_queues(
+    registers: VirtioMmioDeviceRegisters,
+    queues: Vec<VirtioMmioQueueState>,
+    pending_notifications: Vec<u16>,
+    activated: bool,
+    intents: Vec<SnapshotV2InterruptIntent>,
+    expected_features: u64,
+) -> Result<SnapshotV2VirtioState, SnapshotV2DeviceGraphCaptureError> {
+    if queues.len() != 1 || pending_notifications.len() > 1 || intents.len() > 2 {
+        return Err(SnapshotV2DeviceGraphCaptureError::InvalidVirtioState);
+    }
+    if registers.device_id() != VIRTIO_BLOCK_DEVICE_ID
+        || registers.vendor_id() != VIRTIO_MMIO_VENDOR_ID
+        || registers.device_features() != expected_features
+    {
+        return Err(SnapshotV2DeviceGraphCaptureError::InvalidVirtioState);
+    }
+    let mut artifact_queues = Vec::new();
+    artifact_queues
+        .try_reserve_exact(queues.len())
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::Allocation)?;
+    for queue in queues {
+        artifact_queues.push(SnapshotV2VirtioQueueState {
+            max_size: queue.max_size(),
+            size: queue.size(),
+            ready: queue.ready(),
+            descriptor_table: queue.descriptor_table(),
+            driver_ring: queue.driver_ring(),
+            device_ring: queue.device_ring(),
+        });
+    }
+    let state = SnapshotV2VirtioState {
+        available_features: registers.device_features(),
+        driver_features: registers.driver_features(),
+        config_generation: registers.config_generation(),
+        status: registers.status(),
+        activated,
+        queues: artifact_queues,
+        pending_notifications,
+        interrupt_intents: intents,
+    };
+    validate_virtio_state(&state, expected_features)
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::InvalidVirtioState)?;
+    Ok(state)
+}
+
+fn capture_mmio_transport(
+    region: MmioRegion,
+    interrupt_line: GuestInterruptLine,
+    state: &VirtioMmioTransportState,
+) -> Result<SnapshotV2MmioDeviceState, SnapshotV2DeviceGraphCaptureError> {
+    let registers = state.device_registers();
+    let mmio = SnapshotV2MmioDeviceState {
+        device_feature_select: registers.device_features_select(),
+        driver_feature_select: registers.driver_features_select(),
+        queue_select: state.queue_select(),
+        region,
+        interrupt_line,
+    };
+    validate_mmio_state(&mmio).map_err(|_| SnapshotV2DeviceGraphCaptureError::InvalidMmioState)?;
+    Ok(mmio)
+}
+
+fn capture_pci_transport(
+    origin: StorageDeviceOrigin,
+    sbdf: PciSbdf,
+    bar_range: GuestMemoryRange,
+    state: &VirtioPciTransportState,
+) -> Result<SnapshotV2PciDeviceState, SnapshotV2DeviceGraphCaptureError> {
+    let guest_state = state
+        .checked_configuration_guest_state(bar_range)
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::InvalidPciState)?;
+    let writable_bytes = capture_pci_writable_bytes(state, &guest_state)?;
+    let mut bar_probes = Vec::new();
+    bar_probes
+        .try_reserve_exact(guest_state.bar_probes().len())
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::Allocation)?;
+    for probe in guest_state.bar_probes() {
+        bar_probes.push(SnapshotV2PciBarProbeState {
+            index: probe.index(),
+            pending: probe.pending(),
+        });
+    }
+    let msix = capture_msix_state(state.msix_state())?;
+    let pci = SnapshotV2PciDeviceState {
+        phase: state.phase(),
+        origin,
+        sbdf,
+        bar_index: VIRTIO_PCI_CAPABILITY_BAR_INDEX,
+        bar_address_space: PciBarAddressSpace::Memory64,
+        bar_prefetchable: PciBarPrefetchable::No,
+        bar_range,
+        device_feature_select: state.device_feature_select(),
+        driver_feature_select: state.driver_feature_select(),
+        queue_select: state.queue_select(),
+        pci_cfg_bar: state.pci_cfg_bar(),
+        pci_cfg_offset: state.pci_cfg_offset(),
+        pci_cfg_length: state.pci_cfg_length(),
+        writable_bytes,
+        bar_probes,
+        msix,
+    };
+    validate_pci_state(&pci).map_err(|_| SnapshotV2DeviceGraphCaptureError::InvalidPciState)?;
+    Ok(pci)
+}
+
+fn capture_pci_writable_bytes(
+    state: &VirtioPciTransportState,
+    guest_state: &PciType0GuestState,
+) -> Result<Vec<SnapshotV2PciWritableByte>, SnapshotV2DeviceGraphCaptureError> {
+    let pci_cfg_cap = state.pci_cfg_cap_offset();
+    let msix_cap = state.msix_cap_offset();
+    let selector_bar_offset = pci_cfg_cap
+        .checked_add(4)
+        .ok_or(SnapshotV2DeviceGraphCaptureError::InvalidPciState)?;
+    let selector_offset_start = pci_cfg_cap
+        .checked_add(8)
+        .ok_or(SnapshotV2DeviceGraphCaptureError::InvalidPciState)?;
+    let selector_length_start = pci_cfg_cap
+        .checked_add(12)
+        .ok_or(SnapshotV2DeviceGraphCaptureError::InvalidPciState)?;
+    let data_start = pci_cfg_cap
+        .checked_add(16)
+        .ok_or(SnapshotV2DeviceGraphCaptureError::InvalidPciState)?;
+    let data_end = data_start
+        .checked_add(4)
+        .ok_or(SnapshotV2DeviceGraphCaptureError::InvalidPciState)?;
+    let msix_control_high = msix_cap
+        .checked_add(3)
+        .ok_or(SnapshotV2DeviceGraphCaptureError::InvalidPciState)?;
+    let selector_offset = state.pci_cfg_offset().to_le_bytes();
+    let selector_length = state.pci_cfg_length().to_le_bytes();
+    let expected_msix_control = (u8::from(state.msix_state().enabled()) << 7)
+        | (u8::from(state.msix_state().function_masked()) << 6);
+
+    let mut generic = Vec::new();
+    generic
+        .try_reserve_exact(PCI_GENERIC_WRITABLE_BYTES.len())
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::Allocation)?;
+    for writable in guest_state.writable_bytes() {
+        let offset = writable.offset();
+        let value = writable.value();
+        let mask = writable.writable_mask();
+        if offset == selector_bar_offset {
+            if mask != u8::MAX || value != state.pci_cfg_bar() {
+                return Err(SnapshotV2DeviceGraphCaptureError::InvalidPciState);
+            }
+            continue;
+        }
+        if (selector_offset_start..selector_length_start).contains(&offset) {
+            let index = usize::from(offset - selector_offset_start);
+            if mask != u8::MAX || selector_offset.get(index).copied() != Some(value) {
+                return Err(SnapshotV2DeviceGraphCaptureError::InvalidPciState);
+            }
+            continue;
+        }
+        if (selector_length_start..data_start).contains(&offset) {
+            let index = usize::from(offset - selector_length_start);
+            if mask != u8::MAX || selector_length.get(index).copied() != Some(value) {
+                return Err(SnapshotV2DeviceGraphCaptureError::InvalidPciState);
+            }
+            continue;
+        }
+        if (data_start..data_end).contains(&offset) {
+            if mask != u8::MAX {
+                return Err(SnapshotV2DeviceGraphCaptureError::InvalidPciState);
+            }
+            continue;
+        }
+        if offset == msix_control_high {
+            if mask != 0xc0 || value != expected_msix_control {
+                return Err(SnapshotV2DeviceGraphCaptureError::InvalidPciState);
+            }
+            continue;
+        }
+        let Some((_, expected_mask)) = PCI_GENERIC_WRITABLE_BYTES
+            .iter()
+            .copied()
+            .find(|(expected_offset, _)| *expected_offset == offset)
+        else {
+            return Err(SnapshotV2DeviceGraphCaptureError::InvalidPciState);
+        };
+        if mask != expected_mask {
+            return Err(SnapshotV2DeviceGraphCaptureError::InvalidPciState);
+        }
+        generic.push(SnapshotV2PciWritableByte { offset, value });
+    }
+    if generic
+        .iter()
+        .map(|byte| (byte.offset, u8::MAX))
+        .ne(PCI_GENERIC_WRITABLE_BYTES)
+    {
+        return Err(SnapshotV2DeviceGraphCaptureError::InvalidPciState);
+    }
+    Ok(generic)
+}
+
+fn capture_msix_state(
+    state: &VirtioPciMsixState,
+) -> Result<SnapshotV2PciMsixState, SnapshotV2DeviceGraphCaptureError> {
+    let mut entries = Vec::new();
+    entries
+        .try_reserve_exact(state.entries().len())
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::Allocation)?;
+    for entry in state.entries() {
+        entries.push(SnapshotV2PciMsixTableEntry {
+            message_address_low: entry.message_address_low(),
+            message_address_high: entry.message_address_high(),
+            message_data: entry.message_data(),
+            vector_control: entry.vector_control(),
+        });
+    }
+    let mut pending_words = Vec::new();
+    pending_words
+        .try_reserve_exact(state.pending_words().len())
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::Allocation)?;
+    pending_words.extend_from_slice(state.pending_words());
+    let mut queue_vectors = Vec::new();
+    queue_vectors
+        .try_reserve_exact(state.queue_vectors().len())
+        .map_err(|_| SnapshotV2DeviceGraphCaptureError::Allocation)?;
+    queue_vectors.extend_from_slice(state.queue_vectors());
+    Ok(SnapshotV2PciMsixState {
+        entries,
+        pending_words,
+        enabled: state.enabled(),
+        function_masked: state.function_masked(),
+        config_vector: state.config_vector(),
+        queue_vectors,
+        pending_transition_observed: state.pending_transition_observed(),
+    })
+}
+
+fn capture_validation_error(error: GraphValidationError) -> SnapshotV2DeviceGraphCaptureError {
+    match error {
+        GraphValidationError::Root | GraphValidationError::Configuration => {
+            SnapshotV2DeviceGraphCaptureError::UnsupportedConfiguration
+        }
+        GraphValidationError::Block => SnapshotV2DeviceGraphCaptureError::InconsistentBlockState,
+        GraphValidationError::Virtio => SnapshotV2DeviceGraphCaptureError::InvalidVirtioState,
+        GraphValidationError::Mmio => SnapshotV2DeviceGraphCaptureError::InvalidMmioState,
+        GraphValidationError::Pci => SnapshotV2DeviceGraphCaptureError::InvalidPciState,
+    }
+}
+
+fn validate_graph(graph: &SnapshotV2DeviceGraph) -> Result<(), GraphValidationError> {
+    if graph.root_key.kind != DEVICE_KIND_BLOCK
+        || graph.root_key.instance != DEVICE_INSTANCE_ROOT
+        || graph.record.key != graph.root_key
+    {
+        return Err(GraphValidationError::Root);
+    }
+    validate_root_config(&graph.record.config)?;
+    validate_block_state(&graph.record.config, &graph.record.block)?;
+    let expected_features = expected_block_features(graph.record.config.cache_type);
+    validate_virtio_state(&graph.record.virtio, expected_features)?;
+    if graph.record.block.active_queue.is_some() != graph.record.virtio.activated {
+        return Err(GraphValidationError::Block);
+    }
+    let placement = match &graph.record.transport {
+        SnapshotV2DeviceTransport::Mmio(state) => {
+            validate_mmio_state(state)?;
+            state.region.range()
+        }
+        SnapshotV2DeviceTransport::Pci(state) => {
+            validate_pci_state(state)?;
+            state.bar_range
+        }
+    };
+    let queue = graph
+        .record
+        .virtio
+        .queues
+        .first()
+        .ok_or(GraphValidationError::Virtio)?;
+    if queue_ranges(queue)?
+        .is_some_and(|ranges| ranges.iter().any(|range| range.overlaps(placement)))
+    {
+        return Err(GraphValidationError::Virtio);
+    }
+    Ok(())
+}
+
+fn validate_root_config(config: &SnapshotV2RootBlockConfig) -> Result<(), GraphValidationError> {
+    validate_nonempty_string(&config.drive_id, NATIVE_V2_DEVICE_GRAPH_MAX_DRIVE_ID_BYTES)
+        .map_err(|_| GraphValidationError::Configuration)?;
+    if let Some(partuuid) = config.partuuid.as_deref() {
+        validate_nonempty_string(partuuid, NATIVE_V2_DEVICE_GRAPH_MAX_PARTUUID_BYTES)
+            .map_err(|_| GraphValidationError::Configuration)?;
+    }
+    validate_nonempty_string(&config.selector, NATIVE_V2_DEVICE_GRAPH_MAX_SELECTOR_BYTES)
+        .map_err(|_| GraphValidationError::Configuration)?;
+    validate_limiter_config(config.rate_limiter)
+}
+
+fn validate_block_state(
+    config: &SnapshotV2RootBlockConfig,
+    block: &SnapshotV2BlockState,
+) -> Result<(), GraphValidationError> {
+    if block.device_id.as_bytes().iter().all(|byte| *byte == 0) {
+        return Err(GraphValidationError::Block);
+    }
+    validate_limiter_relationship(config.rate_limiter, block.limiter)?;
+    if block.retry != StorageRetryState::None
+        && (block.active_queue.is_none() || block.limiter.is_empty())
+    {
+        return Err(GraphValidationError::Block);
+    }
+    if matches!(block.retry, StorageRetryState::After { remaining_nanos: 0 }) {
+        return Err(GraphValidationError::Block);
+    }
+    if block.retry != StorageRetryState::None
+        && block
+            .active_queue
+            .is_some_and(|queue| queue.next_available() == queue.next_used())
+    {
+        return Err(GraphValidationError::Block);
+    }
+    Ok(())
+}
+
+fn validate_limiter_config(
+    config: Option<DriveRateLimiterConfig>,
+) -> Result<(), GraphValidationError> {
+    if let Some(config) = config {
+        for bucket in [config.bandwidth(), config.ops()].into_iter().flatten() {
+            if !token_bucket_is_enabled(bucket) {
+                return Err(GraphValidationError::Configuration);
+            }
+        }
+        if !config.is_configured() {
+            return Err(GraphValidationError::Configuration);
+        }
+    }
+    Ok(())
+}
+
+fn validate_limiter_relationship(
+    config: Option<DriveRateLimiterConfig>,
+    state: SnapshotV2BlockLimiterState,
+) -> Result<(), GraphValidationError> {
+    validate_bucket_relationship(
+        config.and_then(DriveRateLimiterConfig::bandwidth),
+        state.bandwidth,
+    )?;
+    validate_bucket_relationship(config.and_then(DriveRateLimiterConfig::ops), state.ops)
+}
+
+fn validate_bucket_relationship(
+    config: Option<DriveTokenBucketConfig>,
+    state: Option<SnapshotV2BlockBucketState>,
+) -> Result<(), GraphValidationError> {
+    match (config, state) {
+        (Some(config), Some(state))
+            if token_bucket_is_enabled(config)
+                && state.budget <= config.size()
+                && state.remaining_burst <= config.one_time_burst().unwrap_or(0) =>
+        {
+            Ok(())
+        }
+        (None, None) => Ok(()),
+        _ => Err(GraphValidationError::Block),
+    }
+}
+
+fn validate_virtio_state(
+    state: &SnapshotV2VirtioState,
+    expected_features: u64,
+) -> Result<(), GraphValidationError> {
+    if state.available_features != expected_features
+        || state.driver_features & !state.available_features != 0
+        || state.queues.len() != 1
+        || state.pending_notifications.len() > 1
+        || state.interrupt_intents.len() > 2
+    {
+        return Err(GraphValidationError::Virtio);
+    }
+    let healthy_driver_ok = VIRTIO_DEVICE_STATUS_ACKNOWLEDGE
+        | VIRTIO_DEVICE_STATUS_DRIVER
+        | VIRTIO_DEVICE_STATUS_FEATURES_OK
+        | VIRTIO_DEVICE_STATUS_DRIVER_OK;
+    let healthy_statuses = [
+        VIRTIO_DEVICE_STATUS_INIT,
+        VIRTIO_DEVICE_STATUS_ACKNOWLEDGE,
+        VIRTIO_DEVICE_STATUS_ACKNOWLEDGE | VIRTIO_DEVICE_STATUS_DRIVER,
+        VIRTIO_DEVICE_STATUS_ACKNOWLEDGE
+            | VIRTIO_DEVICE_STATUS_DRIVER
+            | VIRTIO_DEVICE_STATUS_FEATURES_OK,
+        healthy_driver_ok,
+    ];
+    if !healthy_statuses.contains(&state.status)
+        || state.status & (VIRTIO_DEVICE_STATUS_FAILED | VIRTIO_DEVICE_STATUS_DEVICE_NEEDS_RESET)
+            != 0
+    {
+        return Err(GraphValidationError::Virtio);
+    }
+    if state.status & VIRTIO_DEVICE_STATUS_DRIVER == 0 && state.driver_features != 0 {
+        return Err(GraphValidationError::Virtio);
+    }
+    if state.status & VIRTIO_DEVICE_STATUS_FEATURES_OK != 0
+        && state.driver_features & VIRTIO_MMIO_VERSION_1_FEATURE == 0
+    {
+        return Err(GraphValidationError::Virtio);
+    }
+    if state.activated != (state.status == healthy_driver_ok) {
+        return Err(GraphValidationError::Virtio);
+    }
+    let queue = state.queues.first().ok_or(GraphValidationError::Virtio)?;
+    validate_queue(queue)?;
+    if state.activated && !queue.ready {
+        return Err(GraphValidationError::Virtio);
+    }
+    if state.status & VIRTIO_DEVICE_STATUS_FEATURES_OK == 0
+        && (queue.size != 0
+            || queue.ready
+            || queue.descriptor_table.raw_value() != 0
+            || queue.driver_ring.raw_value() != 0
+            || queue.device_ring.raw_value() != 0)
+    {
+        return Err(GraphValidationError::Virtio);
+    }
+    if !state.activated && !state.pending_notifications.is_empty() {
+        return Err(GraphValidationError::Virtio);
+    }
+    if state
+        .pending_notifications
+        .iter()
+        .copied()
+        .any(|index| index != 0)
+    {
+        return Err(GraphValidationError::Virtio);
+    }
+    if !state
+        .interrupt_intents
+        .windows(2)
+        .all(|window| matches!(window, [first, second] if first < second))
+        || state.interrupt_intents.iter().any(|intent| {
+            matches!(
+                intent,
+                SnapshotV2InterruptIntent::Queue { queue_index } if *queue_index != 0
+            )
+        })
+    {
+        return Err(GraphValidationError::Virtio);
+    }
+    Ok(())
+}
+
+fn validate_queue(queue: &SnapshotV2VirtioQueueState) -> Result<(), GraphValidationError> {
+    if queue.max_size != VIRTIO_BLOCK_QUEUE_SIZE
+        || (queue.size != 0 && (!queue.size.is_power_of_two() || queue.size > queue.max_size))
+        || (queue.ready && queue.size == 0)
+        || !queue
+            .descriptor_table
+            .raw_value()
+            .is_multiple_of(crate::virtio_queue::VIRTQUEUE_DESCRIPTOR_ALIGNMENT)
+        || !queue
+            .driver_ring
+            .raw_value()
+            .is_multiple_of(crate::virtio_queue::VIRTQUEUE_AVAILABLE_RING_ALIGNMENT)
+        || !queue
+            .device_ring
+            .raw_value()
+            .is_multiple_of(crate::virtio_queue::VIRTQUEUE_USED_RING_ALIGNMENT)
+    {
+        return Err(GraphValidationError::Virtio);
+    }
+    if queue.size == 0 {
+        return Ok(());
+    }
+    let ranges = queue_ranges(queue)?.ok_or(GraphValidationError::Virtio)?;
+    if ranges[0].overlaps(ranges[1])
+        || ranges[0].overlaps(ranges[2])
+        || ranges[1].overlaps(ranges[2])
+    {
+        return Err(GraphValidationError::Virtio);
+    }
+    Ok(())
+}
+
+fn queue_ranges(
+    queue: &SnapshotV2VirtioQueueState,
+) -> Result<Option<[GuestMemoryRange; 3]>, GraphValidationError> {
+    if queue.size == 0 {
+        return Ok(None);
+    }
+    let descriptor_size = u64::from(queue.size)
+        .checked_mul(16)
+        .ok_or(GraphValidationError::Virtio)?;
+    let available_size = u64::from(queue.size)
+        .checked_mul(2)
+        .and_then(|size| size.checked_add(6))
+        .ok_or(GraphValidationError::Virtio)?;
+    let used_size = u64::from(queue.size)
+        .checked_mul(8)
+        .and_then(|size| size.checked_add(6))
+        .ok_or(GraphValidationError::Virtio)?;
+    let descriptor = GuestMemoryRange::new(queue.descriptor_table, descriptor_size)
+        .map_err(|_| GraphValidationError::Virtio)?;
+    let available = GuestMemoryRange::new(queue.driver_ring, available_size)
+        .map_err(|_| GraphValidationError::Virtio)?;
+    let used = GuestMemoryRange::new(queue.device_ring, used_size)
+        .map_err(|_| GraphValidationError::Virtio)?;
+    Ok(Some([descriptor, available, used]))
+}
+
+fn validate_mmio_state(state: &SnapshotV2MmioDeviceState) -> Result<(), GraphValidationError> {
+    if state.device_feature_select > 1
+        || state.driver_feature_select > 1
+        || state.queue_select != 0
+        || state.region.id().raw_value() == 0
+        || state.region.range().size() != VIRTIO_MMIO_DEVICE_WINDOW_SIZE
+        || state
+            .region
+            .range()
+            .validate_alignment(VIRTIO_MMIO_DEVICE_WINDOW_SIZE)
+            .is_err()
+        || state.interrupt_line.raw_value() < 32
+    {
+        Err(GraphValidationError::Mmio)
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_pci_state(state: &SnapshotV2PciDeviceState) -> Result<(), GraphValidationError> {
+    if state.phase != VirtioPciEndpointPhase::Active
+        || state.origin != StorageDeviceOrigin::Startup
+        || state.sbdf.segment() != PCI_SEGMENT_ZERO
+        || state.sbdf.bus() != PCI_BUS_ZERO
+        || !(PCI_FIRST_ENDPOINT_DEVICE..=PCI_LAST_ENDPOINT_DEVICE).contains(&state.sbdf.device())
+        || state.sbdf.function() != PCI_FUNCTION_ZERO
+        || state.bar_index != VIRTIO_PCI_CAPABILITY_BAR_INDEX
+        || state.bar_address_space != PciBarAddressSpace::Memory64
+        || state.bar_prefetchable != PciBarPrefetchable::No
+        || state.bar_range.size() != VIRTIO_PCI_CAPABILITY_BAR_SIZE
+        || state
+            .bar_range
+            .validate_alignment(VIRTIO_PCI_CAPABILITY_BAR_SIZE)
+            .is_err()
+        || state.bar_range.start().raw_value() < PCI_BAR64_START
+        || state.bar_range.end_exclusive().raw_value()
+            > PCI_BAR64_START.saturating_add(PCI_BAR64_SIZE)
+        || state.device_feature_select > 1
+        || state.driver_feature_select > 1
+        || state.queue_select != 0
+        || state.pci_cfg_bar != state.bar_index
+        || !matches!(state.pci_cfg_length, 0 | 1 | 2 | 4)
+        || (state.pci_cfg_length == 0 && state.pci_cfg_offset != 0)
+        || (state.pci_cfg_length != 0
+            && u64::from(state.pci_cfg_offset)
+                .checked_add(u64::from(state.pci_cfg_length))
+                .is_none_or(|end| end > state.bar_range.size()))
+        || state.writable_bytes.len() != PCI_GENERIC_WRITABLE_BYTES.len()
+        || state.bar_probes.len() != 2
+    {
+        return Err(GraphValidationError::Pci);
+    }
+    for (actual, (expected_offset, _)) in
+        state.writable_bytes.iter().zip(PCI_GENERIC_WRITABLE_BYTES)
+    {
+        if actual.offset != expected_offset {
+            return Err(GraphValidationError::Pci);
+        }
+    }
+    if state.bar_probes.iter().map(|probe| probe.index).ne([0, 1]) {
+        return Err(GraphValidationError::Pci);
+    }
+    validate_msix_state(&state.msix)
+}
+
+fn validate_msix_state(state: &SnapshotV2PciMsixState) -> Result<(), GraphValidationError> {
+    if state.entries.len() != 2
+        || state.entries.len() > VIRTIO_PCI_MAX_MSIX_VECTORS
+        || state.pending_words.len() != 1
+        || state.queue_vectors.len() != 1
+        || state
+            .pending_words
+            .first()
+            .copied()
+            .is_none_or(|pending| pending & !0b11 != 0)
+        || !valid_msix_vector(state.config_vector, state.entries.len())
+        || state
+            .queue_vectors
+            .iter()
+            .copied()
+            .any(|vector| !valid_msix_vector(vector, state.entries.len()))
+        || state
+            .entries
+            .iter()
+            .any(|entry| entry.vector_control & !1 != 0)
+    {
+        Err(GraphValidationError::Pci)
+    } else {
+        Ok(())
+    }
+}
+
+fn valid_msix_vector(vector: u16, vector_count: usize) -> bool {
+    vector == VIRTIO_PCI_NO_VECTOR || usize::from(vector) < vector_count
+}
+
+fn validate_nonempty_string(value: &str, max: usize) -> Result<(), ()> {
+    if value.is_empty() || value.len() > max {
+        Err(())
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_compatibility_version(version: SnapshotFormatVersion) -> Result<(), ()> {
+    if version == NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION {
+        Ok(())
+    } else {
+        Err(())
+    }
+}
+
+fn expected_block_features(cache_type: DriveCacheType) -> u64 {
+    crate::block::VirtioBlockConfigSpace::new(0, true, cache_type).available_features()
+}
+
+fn token_bucket_is_enabled(config: DriveTokenBucketConfig) -> bool {
+    config.size() != 0
+        && config
+            .refill_time()
+            .checked_mul(1_000_000)
+            .is_some_and(|nanos| nanos != 0)
+}
+
+/// Encodes one validated native-v2 device-graph payload.
+pub fn encode_snapshot_v2_device_graph(
+    outer_version: SnapshotFormatVersion,
+    graph: &SnapshotV2DeviceGraph,
+) -> Result<Vec<u8>, SnapshotV2DeviceGraphEncodeError> {
+    validate_compatibility_version(outer_version)
+        .map_err(|_| SnapshotV2DeviceGraphEncodeError::UnsupportedVersion)?;
+    validate_graph(graph).map_err(|_| SnapshotV2DeviceGraphEncodeError::InvalidGraph)?;
+
+    let sections = [
+        encode_config_section(&graph.record.config)?,
+        encode_block_section(&graph.record.block)?,
+        encode_common_section(&graph.record.virtio)?,
+        encode_transport_section(&graph.record.transport)?,
+    ];
+    let mut section_offsets = [0_usize; DEVICE_GRAPH_SECTION_COUNT_USIZE];
+    let mut cursor = DEVICE_GRAPH_PAYLOAD_OFFSET;
+    for (index, section) in sections.iter().enumerate() {
+        let slot = section_offsets
+            .get_mut(index)
+            .ok_or(SnapshotV2DeviceGraphEncodeError::InvalidGraph)?;
+        *slot = cursor;
+        cursor = cursor
+            .checked_add(section.len())
+            .ok_or(SnapshotV2DeviceGraphEncodeError::TooLarge)?;
+    }
+    if cursor > NATIVE_V2_DEVICE_GRAPH_MAX_BYTES {
+        return Err(SnapshotV2DeviceGraphEncodeError::TooLarge);
+    }
+
+    let mut output = Vec::new();
+    output
+        .try_reserve_exact(cursor)
+        .map_err(|_| SnapshotV2DeviceGraphEncodeError::Allocation)?;
+    output.extend_from_slice(&DEVICE_GRAPH_MAGIC);
+    write_u16(
+        &mut output,
+        u16::try_from(NATIVE_V2_DEVICE_GRAPH_HEADER_BYTES)
+            .map_err(|_| SnapshotV2DeviceGraphEncodeError::InvalidGraph)?,
+    );
+    write_u16(&mut output, DEVICE_GRAPH_PROFILE);
+    write_u16(&mut output, transport_kind_tag(graph.transport_kind()));
+    write_u16(&mut output, DEVICE_GRAPH_RECORD_COUNT);
+    write_u16(&mut output, DEVICE_GRAPH_SECTION_COUNT);
+    write_u16(&mut output, 0);
+    write_u32(&mut output, DEVICE_GRAPH_FLAGS);
+    write_u64(
+        &mut output,
+        u64::try_from(cursor).map_err(|_| SnapshotV2DeviceGraphEncodeError::TooLarge)?,
+    );
+    write_u32(&mut output, graph.root_key.kind);
+    write_u32(&mut output, graph.root_key.instance);
+    write_u64(
+        &mut output,
+        u64::try_from(DEVICE_GRAPH_RECORD_DIRECTORY_OFFSET)
+            .map_err(|_| SnapshotV2DeviceGraphEncodeError::InvalidGraph)?,
+    );
+    write_u64(
+        &mut output,
+        u64::try_from(DEVICE_GRAPH_SECTION_DIRECTORY_OFFSET)
+            .map_err(|_| SnapshotV2DeviceGraphEncodeError::InvalidGraph)?,
+    );
+    write_u64(
+        &mut output,
+        u64::try_from(DEVICE_GRAPH_PAYLOAD_OFFSET)
+            .map_err(|_| SnapshotV2DeviceGraphEncodeError::InvalidGraph)?,
+    );
+
+    write_u32(&mut output, graph.record.key.kind);
+    write_u32(&mut output, graph.record.key.instance);
+    write_u32(&mut output, 0);
+    write_u32(&mut output, DEVICE_GRAPH_SECTION_COUNT_U32);
+    output.extend_from_slice(&[0; 16]);
+
+    for (index, ((kind, section), offset)) in [
+        SECTION_KIND_CONFIG,
+        SECTION_KIND_BLOCK,
+        SECTION_KIND_COMMON,
+        SECTION_KIND_TRANSPORT,
+    ]
+    .into_iter()
+    .zip(sections.iter())
+    .zip(section_offsets)
+    .enumerate()
+    {
+        let record_index = u32::try_from(index / usize::from(DEVICE_GRAPH_SECTION_COUNT))
+            .map_err(|_| SnapshotV2DeviceGraphEncodeError::InvalidGraph)?;
+        write_u32(&mut output, record_index);
+        write_u16(&mut output, kind);
+        write_u16(&mut output, 0);
+        write_u64(&mut output, 0);
+        write_u64(
+            &mut output,
+            u64::try_from(offset).map_err(|_| SnapshotV2DeviceGraphEncodeError::TooLarge)?,
+        );
+        write_u64(
+            &mut output,
+            u64::try_from(section.len()).map_err(|_| SnapshotV2DeviceGraphEncodeError::TooLarge)?,
+        );
+    }
+    for section in &sections {
+        output.extend_from_slice(section);
+    }
+    if output.len() != cursor {
+        return Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph);
+    }
+    Ok(output)
+}
+
+fn encode_config_section(
+    config: &SnapshotV2RootBlockConfig,
+) -> Result<Vec<u8>, SnapshotV2DeviceGraphEncodeError> {
+    let partuuid_len = config.partuuid.as_ref().map_or(0, String::len);
+    let semantic_len = CONFIG_FIXED_BYTES
+        .checked_add(config.drive_id.len())
+        .and_then(|len| len.checked_add(partuuid_len))
+        .and_then(|len| len.checked_add(config.selector.len()))
+        .ok_or(SnapshotV2DeviceGraphEncodeError::TooLarge)?;
+    let capacity = aligned_len(semantic_len).ok_or(SnapshotV2DeviceGraphEncodeError::TooLarge)?;
+    let mut output = Vec::new();
+    output
+        .try_reserve_exact(capacity)
+        .map_err(|_| SnapshotV2DeviceGraphEncodeError::Allocation)?;
+    write_u8(&mut output, 1);
+    write_u8(&mut output, ENGINE_SYNC);
+    write_u8(
+        &mut output,
+        match config.cache_type {
+            DriveCacheType::Unsafe => CACHE_UNSAFE,
+            DriveCacheType::Writeback => CACHE_WRITEBACK,
+        },
+    );
+    write_u8(&mut output, u8::from(config.partuuid.is_some()));
+    let bandwidth = config
+        .rate_limiter
+        .and_then(DriveRateLimiterConfig::bandwidth);
+    let ops = config.rate_limiter.and_then(DriveRateLimiterConfig::ops);
+    write_u8(&mut output, u8::from(bandwidth.is_some()));
+    write_u8(&mut output, u8::from(ops.is_some()));
+    output.extend_from_slice(&[0; 2]);
+    write_u16(
+        &mut output,
+        u16::try_from(config.drive_id.len())
+            .map_err(|_| SnapshotV2DeviceGraphEncodeError::TooLarge)?,
+    );
+    write_u16(
+        &mut output,
+        u16::try_from(partuuid_len).map_err(|_| SnapshotV2DeviceGraphEncodeError::TooLarge)?,
+    );
+    write_u16(
+        &mut output,
+        u16::try_from(config.selector.len())
+            .map_err(|_| SnapshotV2DeviceGraphEncodeError::TooLarge)?,
+    );
+    write_u16(&mut output, 0);
+    encode_bucket_config(&mut output, bandwidth);
+    encode_bucket_config(&mut output, ops);
+    output.extend_from_slice(config.drive_id.as_bytes());
+    if let Some(partuuid) = &config.partuuid {
+        output.extend_from_slice(partuuid.as_bytes());
+    }
+    output.extend_from_slice(config.selector.as_bytes());
+    pad_section(&mut output, capacity);
+    Ok(output)
+}
+
+fn encode_bucket_config(output: &mut Vec<u8>, bucket: Option<DriveTokenBucketConfig>) {
+    match bucket {
+        Some(bucket) => {
+            write_u64(output, bucket.size());
+            write_u64(output, bucket.one_time_burst().unwrap_or(0));
+            write_u64(output, bucket.refill_time());
+            write_u8(output, u8::from(bucket.one_time_burst().is_some()));
+            output.extend_from_slice(&[0; 7]);
+        }
+        None => output.extend_from_slice(&[0; 32]),
+    }
+}
+
+fn encode_block_section(
+    block: &SnapshotV2BlockState,
+) -> Result<Vec<u8>, SnapshotV2DeviceGraphEncodeError> {
+    let mut output = Vec::new();
+    output
+        .try_reserve_exact(BLOCK_SECTION_BYTES)
+        .map_err(|_| SnapshotV2DeviceGraphEncodeError::Allocation)?;
+    write_u16(
+        &mut output,
+        u16::try_from(VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE)
+            .map_err(|_| SnapshotV2DeviceGraphEncodeError::InvalidGraph)?,
+    );
+    write_u8(&mut output, u8::from(block.active_queue.is_some()));
+    write_u8(&mut output, u8::from(block.limiter.bandwidth.is_some()));
+    write_u8(&mut output, u8::from(block.limiter.ops.is_some()));
+    let (retry_tag, retry_nanos) = match block.retry {
+        StorageRetryState::None => (RETRY_NONE, 0),
+        StorageRetryState::Immediate => (RETRY_IMMEDIATE, 0),
+        StorageRetryState::After { remaining_nanos } => (RETRY_AFTER, remaining_nanos),
+    };
+    write_u8(&mut output, retry_tag);
+    output.extend_from_slice(&[0; 2]);
+    write_u64(&mut output, block.capacity_sectors);
+    output.extend_from_slice(block.device_id.as_bytes());
+    output.extend_from_slice(&[0; 4]);
+    let (next_available, next_used) = block
+        .active_queue
+        .map(|queue| (queue.next_available(), queue.next_used()))
+        .unwrap_or((0, 0));
+    write_u16(&mut output, next_available);
+    write_u16(&mut output, next_used);
+    write_u32(&mut output, 0);
+    encode_bucket_state(&mut output, block.limiter.bandwidth);
+    encode_bucket_state(&mut output, block.limiter.ops);
+    write_u64(&mut output, retry_nanos);
+    if output.len() != BLOCK_SECTION_BYTES {
+        return Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph);
+    }
+    Ok(output)
+}
+
+fn encode_bucket_state(output: &mut Vec<u8>, bucket: Option<SnapshotV2BlockBucketState>) {
+    match bucket {
+        Some(bucket) => {
+            write_u64(output, bucket.budget);
+            write_u64(output, bucket.remaining_burst);
+            write_u64(output, bucket.age_nanos);
+        }
+        None => output.extend_from_slice(&[0; 24]),
+    }
+}
+
+fn encode_common_section(
+    state: &SnapshotV2VirtioState,
+) -> Result<Vec<u8>, SnapshotV2DeviceGraphEncodeError> {
+    let notification_bytes = state
+        .pending_notifications
+        .len()
+        .checked_mul(size_of::<u16>())
+        .ok_or(SnapshotV2DeviceGraphEncodeError::TooLarge)?;
+    let intent_bytes = state
+        .interrupt_intents
+        .len()
+        .checked_mul(4)
+        .ok_or(SnapshotV2DeviceGraphEncodeError::TooLarge)?;
+    let semantic_len = COMMON_FIXED_BYTES
+        .checked_add(COMMON_QUEUE_BYTES)
+        .and_then(|len| len.checked_add(notification_bytes))
+        .and_then(|len| len.checked_add(intent_bytes))
+        .ok_or(SnapshotV2DeviceGraphEncodeError::TooLarge)?;
+    let capacity = aligned_len(semantic_len).ok_or(SnapshotV2DeviceGraphEncodeError::TooLarge)?;
+    let mut output = Vec::new();
+    output
+        .try_reserve_exact(capacity)
+        .map_err(|_| SnapshotV2DeviceGraphEncodeError::Allocation)?;
+    write_u64(&mut output, state.available_features);
+    write_u64(&mut output, state.driver_features);
+    write_u32(&mut output, state.config_generation);
+    write_u32(&mut output, state.status);
+    write_u8(&mut output, u8::from(state.activated));
+    write_u8(&mut output, 0);
+    write_u16(
+        &mut output,
+        u16::try_from(state.queues.len())
+            .map_err(|_| SnapshotV2DeviceGraphEncodeError::InvalidGraph)?,
+    );
+    write_u16(
+        &mut output,
+        u16::try_from(state.pending_notifications.len())
+            .map_err(|_| SnapshotV2DeviceGraphEncodeError::InvalidGraph)?,
+    );
+    write_u16(
+        &mut output,
+        u16::try_from(state.interrupt_intents.len())
+            .map_err(|_| SnapshotV2DeviceGraphEncodeError::InvalidGraph)?,
+    );
+    for queue in &state.queues {
+        write_u16(&mut output, queue.max_size);
+        write_u16(&mut output, queue.size);
+        write_u8(&mut output, u8::from(queue.ready));
+        output.extend_from_slice(&[0; 3]);
+        write_u64(&mut output, queue.descriptor_table.raw_value());
+        write_u64(&mut output, queue.driver_ring.raw_value());
+        write_u64(&mut output, queue.device_ring.raw_value());
+    }
+    for notification in &state.pending_notifications {
+        write_u16(&mut output, *notification);
+    }
+    for intent in &state.interrupt_intents {
+        match intent {
+            SnapshotV2InterruptIntent::Queue { queue_index } => {
+                write_u8(&mut output, INTERRUPT_QUEUE);
+                write_u8(&mut output, 0);
+                write_u16(&mut output, *queue_index);
+            }
+            SnapshotV2InterruptIntent::Configuration => {
+                write_u8(&mut output, INTERRUPT_CONFIGURATION);
+                write_u8(&mut output, 0);
+                write_u16(&mut output, 0);
+            }
+        }
+    }
+    pad_section(&mut output, capacity);
+    Ok(output)
+}
+
+fn encode_transport_section(
+    transport: &SnapshotV2DeviceTransport,
+) -> Result<Vec<u8>, SnapshotV2DeviceGraphEncodeError> {
+    match transport {
+        SnapshotV2DeviceTransport::Mmio(state) => encode_mmio_section(state),
+        SnapshotV2DeviceTransport::Pci(state) => encode_pci_section(state),
+    }
+}
+
+fn encode_mmio_section(
+    state: &SnapshotV2MmioDeviceState,
+) -> Result<Vec<u8>, SnapshotV2DeviceGraphEncodeError> {
+    let mut output = Vec::new();
+    output
+        .try_reserve_exact(MMIO_SECTION_BYTES)
+        .map_err(|_| SnapshotV2DeviceGraphEncodeError::Allocation)?;
+    write_u32(&mut output, state.device_feature_select);
+    write_u32(&mut output, state.driver_feature_select);
+    write_u32(&mut output, state.queue_select);
+    write_u32(&mut output, state.interrupt_line.raw_value());
+    write_u64(&mut output, state.region.id().raw_value());
+    write_u64(&mut output, state.region.range().start().raw_value());
+    write_u64(&mut output, state.region.range().size());
+    write_u64(&mut output, 0);
+    Ok(output)
+}
+
+fn encode_pci_section(
+    state: &SnapshotV2PciDeviceState,
+) -> Result<Vec<u8>, SnapshotV2DeviceGraphEncodeError> {
+    let writable_bytes = state
+        .writable_bytes
+        .len()
+        .checked_mul(PCI_WRITABLE_ENTRY_BYTES)
+        .ok_or(SnapshotV2DeviceGraphEncodeError::TooLarge)?;
+    let probe_bytes = state
+        .bar_probes
+        .len()
+        .checked_mul(PCI_BAR_PROBE_ENTRY_BYTES)
+        .ok_or(SnapshotV2DeviceGraphEncodeError::TooLarge)?;
+    let entry_bytes = state
+        .msix
+        .entries
+        .len()
+        .checked_mul(PCI_MSIX_ENTRY_BYTES)
+        .ok_or(SnapshotV2DeviceGraphEncodeError::TooLarge)?;
+    let pending_bytes = state
+        .msix
+        .pending_words
+        .len()
+        .checked_mul(PCI_PENDING_WORD_BYTES)
+        .ok_or(SnapshotV2DeviceGraphEncodeError::TooLarge)?;
+    let vector_bytes = state
+        .msix
+        .queue_vectors
+        .len()
+        .checked_mul(PCI_QUEUE_VECTOR_BYTES)
+        .ok_or(SnapshotV2DeviceGraphEncodeError::TooLarge)?;
+    let semantic_len = PCI_FIXED_BYTES
+        .checked_add(writable_bytes)
+        .and_then(|len| len.checked_add(probe_bytes))
+        .and_then(|len| len.checked_add(entry_bytes))
+        .and_then(|len| len.checked_add(pending_bytes))
+        .and_then(|len| len.checked_add(vector_bytes))
+        .ok_or(SnapshotV2DeviceGraphEncodeError::TooLarge)?;
+    let capacity = aligned_len(semantic_len).ok_or(SnapshotV2DeviceGraphEncodeError::TooLarge)?;
+    let mut output = Vec::new();
+    output
+        .try_reserve_exact(capacity)
+        .map_err(|_| SnapshotV2DeviceGraphEncodeError::Allocation)?;
+    write_u8(&mut output, PCI_PHASE_ACTIVE);
+    write_u8(&mut output, PCI_ORIGIN_STARTUP);
+    write_u8(&mut output, state.bar_index);
+    write_u8(&mut output, PCI_BAR_MEMORY64);
+    write_u8(&mut output, PCI_BAR_NOT_PREFETCHABLE);
+    write_u8(&mut output, state.pci_cfg_bar);
+    write_u8(&mut output, state.sbdf.function());
+    write_u8(&mut output, 0);
+    write_u16(&mut output, state.sbdf.segment());
+    write_u8(&mut output, state.sbdf.bus());
+    write_u8(&mut output, state.sbdf.device());
+    write_u32(&mut output, 0);
+    write_u64(&mut output, state.bar_range.start().raw_value());
+    write_u64(&mut output, state.bar_range.size());
+    write_u32(&mut output, state.device_feature_select);
+    write_u32(&mut output, state.driver_feature_select);
+    write_u16(&mut output, state.queue_select);
+    write_u16(
+        &mut output,
+        u16::try_from(state.writable_bytes.len())
+            .map_err(|_| SnapshotV2DeviceGraphEncodeError::InvalidGraph)?,
+    );
+    write_u16(
+        &mut output,
+        u16::try_from(state.bar_probes.len())
+            .map_err(|_| SnapshotV2DeviceGraphEncodeError::InvalidGraph)?,
+    );
+    write_u16(
+        &mut output,
+        u16::try_from(state.msix.entries.len())
+            .map_err(|_| SnapshotV2DeviceGraphEncodeError::InvalidGraph)?,
+    );
+    write_u16(
+        &mut output,
+        u16::try_from(state.msix.pending_words.len())
+            .map_err(|_| SnapshotV2DeviceGraphEncodeError::InvalidGraph)?,
+    );
+    write_u16(
+        &mut output,
+        u16::try_from(state.msix.queue_vectors.len())
+            .map_err(|_| SnapshotV2DeviceGraphEncodeError::InvalidGraph)?,
+    );
+    write_u32(&mut output, 0);
+    write_u32(&mut output, state.pci_cfg_offset);
+    write_u32(&mut output, state.pci_cfg_length);
+    write_u8(&mut output, u8::from(state.msix.enabled));
+    write_u8(&mut output, u8::from(state.msix.function_masked));
+    write_u8(
+        &mut output,
+        u8::from(state.msix.pending_transition_observed),
+    );
+    write_u8(&mut output, 0);
+    write_u16(&mut output, state.msix.config_vector);
+    write_u16(&mut output, 0);
+    for writable in &state.writable_bytes {
+        write_u16(&mut output, writable.offset);
+        write_u8(&mut output, writable.value);
+        write_u8(&mut output, 0);
+    }
+    for probe in &state.bar_probes {
+        write_u8(&mut output, probe.index);
+        write_u8(&mut output, u8::from(probe.pending));
+        write_u16(&mut output, 0);
+    }
+    for entry in &state.msix.entries {
+        write_u32(&mut output, entry.message_address_low);
+        write_u32(&mut output, entry.message_address_high);
+        write_u32(&mut output, entry.message_data);
+        write_u32(&mut output, entry.vector_control);
+    }
+    for pending in &state.msix.pending_words {
+        write_u64(&mut output, *pending);
+    }
+    for vector in &state.msix.queue_vectors {
+        write_u16(&mut output, *vector);
+    }
+    pad_section(&mut output, capacity);
+    Ok(output)
+}
+
+/// Decodes and validates one native-v2 device-graph payload.
+pub fn decode_snapshot_v2_device_graph(
+    outer_version: SnapshotFormatVersion,
+    bytes: &[u8],
+) -> Result<SnapshotV2DeviceGraph, SnapshotV2DeviceGraphDecodeError> {
+    validate_compatibility_version(outer_version)
+        .map_err(|_| SnapshotV2DeviceGraphDecodeError::UnsupportedVersion)?;
+    if bytes.len() < NATIVE_V2_DEVICE_GRAPH_HEADER_BYTES {
+        return Err(SnapshotV2DeviceGraphDecodeError::TooSmall);
+    }
+    if bytes.len() > NATIVE_V2_DEVICE_GRAPH_MAX_BYTES {
+        return Err(SnapshotV2DeviceGraphDecodeError::TooLarge);
+    }
+    if read_array_at::<8>(bytes, HEADER_MAGIC_OFFSET)? != DEVICE_GRAPH_MAGIC {
+        return Err(SnapshotV2DeviceGraphDecodeError::InvalidMagic);
+    }
+    let header_bytes = usize::from(read_u16_at(bytes, HEADER_BYTES_OFFSET)?);
+    let profile = read_u16_at(bytes, HEADER_PROFILE_OFFSET)?;
+    let transport = decode_transport_kind(read_u16_at(bytes, HEADER_TRANSPORT_OFFSET)?)?;
+    let record_count = read_u16_at(bytes, HEADER_RECORD_COUNT_OFFSET)?;
+    let section_count = read_u16_at(bytes, HEADER_SECTION_COUNT_OFFSET)?;
+    if header_bytes != NATIVE_V2_DEVICE_GRAPH_HEADER_BYTES
+        || profile != DEVICE_GRAPH_PROFILE
+        || record_count != DEVICE_GRAPH_RECORD_COUNT
+        || section_count != DEVICE_GRAPH_SECTION_COUNT
+        || read_u32_at(bytes, HEADER_FLAGS_OFFSET)? != DEVICE_GRAPH_FLAGS
+    {
+        return Err(SnapshotV2DeviceGraphDecodeError::UnsupportedProfile);
+    }
+    if read_u16_at(bytes, HEADER_RESERVED_OFFSET)? != 0 {
+        return Err(SnapshotV2DeviceGraphDecodeError::NonzeroReserved);
+    }
+    let total_length = read_usize_u64_at(bytes, HEADER_TOTAL_LENGTH_OFFSET)?;
+    if total_length != bytes.len()
+        || read_usize_u64_at(bytes, HEADER_RECORD_DIRECTORY_OFFSET_OFFSET)?
+            != DEVICE_GRAPH_RECORD_DIRECTORY_OFFSET
+        || read_usize_u64_at(bytes, HEADER_SECTION_DIRECTORY_OFFSET_OFFSET)?
+            != DEVICE_GRAPH_SECTION_DIRECTORY_OFFSET
+        || read_usize_u64_at(bytes, HEADER_PAYLOAD_OFFSET_OFFSET)? != DEVICE_GRAPH_PAYLOAD_OFFSET
+    {
+        return Err(SnapshotV2DeviceGraphDecodeError::InvalidStructure);
+    }
+    let root_key = SnapshotV2DeviceKey {
+        kind: read_u32_at(bytes, HEADER_ROOT_KIND_OFFSET)?,
+        instance: read_u32_at(bytes, HEADER_ROOT_INSTANCE_OFFSET)?,
+    };
+
+    let record = bytes
+        .get(
+            DEVICE_GRAPH_RECORD_DIRECTORY_OFFSET
+                ..DEVICE_GRAPH_RECORD_DIRECTORY_OFFSET + NATIVE_V2_DEVICE_GRAPH_RECORD_ENTRY_BYTES,
+        )
+        .ok_or(SnapshotV2DeviceGraphDecodeError::Truncated)?;
+    let record_key = SnapshotV2DeviceKey {
+        kind: read_u32_at(record, RECORD_KIND_OFFSET)?,
+        instance: read_u32_at(record, RECORD_INSTANCE_OFFSET)?,
+    };
+    if read_u32_at(record, RECORD_FIRST_SECTION_OFFSET)? != 0
+        || read_u32_at(record, RECORD_SECTION_COUNT_OFFSET)? != DEVICE_GRAPH_SECTION_COUNT_U32
+    {
+        return Err(SnapshotV2DeviceGraphDecodeError::InvalidStructure);
+    }
+    if record
+        .get(RECORD_RESERVED_OFFSET..)
+        .is_none_or(|reserved| reserved.iter().any(|byte| *byte != 0))
+    {
+        return Err(SnapshotV2DeviceGraphDecodeError::NonzeroReserved);
+    }
+
+    let mut sections = [SectionBounds {
+        offset: 0,
+        length: 0,
+    }; DEVICE_GRAPH_SECTION_COUNT_USIZE];
+    let mut expected_offset = DEVICE_GRAPH_PAYLOAD_OFFSET;
+    for (index, expected_kind) in [
+        SECTION_KIND_CONFIG,
+        SECTION_KIND_BLOCK,
+        SECTION_KIND_COMMON,
+        SECTION_KIND_TRANSPORT,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let entry_offset = DEVICE_GRAPH_SECTION_DIRECTORY_OFFSET
+            .checked_add(
+                index
+                    .checked_mul(NATIVE_V2_DEVICE_GRAPH_SECTION_ENTRY_BYTES)
+                    .ok_or(SnapshotV2DeviceGraphDecodeError::InvalidStructure)?,
+            )
+            .ok_or(SnapshotV2DeviceGraphDecodeError::InvalidStructure)?;
+        let entry = bytes
+            .get(
+                entry_offset
+                    ..entry_offset
+                        .checked_add(NATIVE_V2_DEVICE_GRAPH_SECTION_ENTRY_BYTES)
+                        .ok_or(SnapshotV2DeviceGraphDecodeError::InvalidStructure)?,
+            )
+            .ok_or(SnapshotV2DeviceGraphDecodeError::Truncated)?;
+        if read_u32_at(entry, SECTION_RECORD_INDEX_OFFSET)? != 0
+            || read_u16_at(entry, SECTION_KIND_OFFSET)? != expected_kind
+            || read_u16_at(entry, SECTION_FLAGS_OFFSET)? != 0
+        {
+            return Err(SnapshotV2DeviceGraphDecodeError::InvalidStructure);
+        }
+        if read_u64_at(entry, SECTION_RESERVED_OFFSET)? != 0 {
+            return Err(SnapshotV2DeviceGraphDecodeError::NonzeroReserved);
+        }
+        let offset = read_usize_u64_at(entry, SECTION_PAYLOAD_OFFSET)?;
+        let length = read_usize_u64_at(entry, SECTION_LENGTH_OFFSET)?;
+        let end = offset
+            .checked_add(length)
+            .ok_or(SnapshotV2DeviceGraphDecodeError::InvalidStructure)?;
+        if offset != expected_offset
+            || length == 0
+            || !offset.is_multiple_of(DEVICE_GRAPH_ALIGNMENT)
+            || !length.is_multiple_of(DEVICE_GRAPH_ALIGNMENT)
+            || end > bytes.len()
+        {
+            return Err(SnapshotV2DeviceGraphDecodeError::InvalidStructure);
+        }
+        let slot = sections
+            .get_mut(index)
+            .ok_or(SnapshotV2DeviceGraphDecodeError::InvalidStructure)?;
+        *slot = SectionBounds { offset, length };
+        expected_offset = end;
+    }
+    if expected_offset != bytes.len() {
+        return Err(SnapshotV2DeviceGraphDecodeError::InvalidStructure);
+    }
+
+    let config = decode_config_section(section_bytes(bytes, sections[0])?)?;
+    let block = decode_block_section(section_bytes(bytes, sections[1])?)?;
+    let virtio = decode_common_section(section_bytes(bytes, sections[2])?)?;
+    let transport = match transport {
+        SnapshotV2DeviceTransportKind::Mmio => SnapshotV2DeviceTransport::Mmio(
+            decode_mmio_section(section_bytes(bytes, sections[3])?)?,
+        ),
+        SnapshotV2DeviceTransportKind::Pci => {
+            SnapshotV2DeviceTransport::Pci(decode_pci_section(section_bytes(bytes, sections[3])?)?)
+        }
+    };
+    let graph = SnapshotV2DeviceGraph {
+        root_key,
+        record: SnapshotV2DeviceRecord {
+            key: record_key,
+            config,
+            block,
+            virtio,
+            transport,
+        },
+    };
+    validate_graph(&graph).map_err(|_| SnapshotV2DeviceGraphDecodeError::InvalidGraph)?;
+    Ok(graph)
+}
+
+#[derive(Clone, Copy)]
+struct SectionBounds {
+    offset: usize,
+    length: usize,
+}
+
+fn section_bytes(
+    bytes: &[u8],
+    section: SectionBounds,
+) -> Result<&[u8], SnapshotV2DeviceGraphDecodeError> {
+    let end = section
+        .offset
+        .checked_add(section.length)
+        .ok_or(SnapshotV2DeviceGraphDecodeError::InvalidStructure)?;
+    bytes
+        .get(section.offset..end)
+        .ok_or(SnapshotV2DeviceGraphDecodeError::Truncated)
+}
+
+fn decode_config_section(
+    bytes: &[u8],
+) -> Result<SnapshotV2RootBlockConfig, SnapshotV2DeviceGraphDecodeError> {
+    if bytes.len() < CONFIG_FIXED_BYTES {
+        return Err(SnapshotV2DeviceGraphDecodeError::Truncated);
+    }
+    let mut reader = DeviceGraphReader::new(bytes);
+    if !reader.read_bool()? || reader.read_u8()? != ENGINE_SYNC {
+        return Err(SnapshotV2DeviceGraphDecodeError::InvalidValue);
+    }
+    let cache_type = match reader.read_u8()? {
+        CACHE_UNSAFE => DriveCacheType::Unsafe,
+        CACHE_WRITEBACK => DriveCacheType::Writeback,
+        _ => return Err(SnapshotV2DeviceGraphDecodeError::InvalidValue),
+    };
+    let partuuid_present = reader.read_bool()?;
+    let bandwidth_present = reader.read_bool()?;
+    let ops_present = reader.read_bool()?;
+    reader.read_zeroes(2)?;
+    let drive_id_len = usize::from(reader.read_u16()?);
+    let partuuid_len = usize::from(reader.read_u16()?);
+    let selector_len = usize::from(reader.read_u16()?);
+    reader.read_zeroes(2)?;
+    let bandwidth = decode_bucket_config(&mut reader, bandwidth_present)?;
+    let ops = decode_bucket_config(&mut reader, ops_present)?;
+    if drive_id_len == 0
+        || drive_id_len > NATIVE_V2_DEVICE_GRAPH_MAX_DRIVE_ID_BYTES
+        || selector_len == 0
+        || selector_len > NATIVE_V2_DEVICE_GRAPH_MAX_SELECTOR_BYTES
+        || partuuid_present != (partuuid_len != 0)
+        || partuuid_len > NATIVE_V2_DEVICE_GRAPH_MAX_PARTUUID_BYTES
+    {
+        return Err(SnapshotV2DeviceGraphDecodeError::InvalidString);
+    }
+    let drive_id = reader.read_string(drive_id_len)?;
+    let partuuid = if partuuid_present {
+        Some(reader.read_string(partuuid_len)?)
+    } else {
+        None
+    };
+    let selector = reader.read_string(selector_len)?;
+    reader.finish_padded()?;
+    let rate_limiter = if bandwidth.is_some() || ops.is_some() {
+        Some(DriveRateLimiterConfig::new(bandwidth, ops))
+    } else {
+        None
+    };
+    Ok(SnapshotV2RootBlockConfig {
+        drive_id,
+        partuuid,
+        cache_type,
+        rate_limiter,
+        selector,
+    })
+}
+
+fn decode_bucket_config(
+    reader: &mut DeviceGraphReader<'_>,
+    present: bool,
+) -> Result<Option<DriveTokenBucketConfig>, SnapshotV2DeviceGraphDecodeError> {
+    let size = reader.read_u64()?;
+    let burst = reader.read_u64()?;
+    let refill_time = reader.read_u64()?;
+    let burst_present = reader.read_bool()?;
+    reader.read_zeroes(7)?;
+    if !present {
+        if size != 0 || burst != 0 || refill_time != 0 || burst_present {
+            return Err(SnapshotV2DeviceGraphDecodeError::InvalidValue);
+        }
+        return Ok(None);
+    }
+    let config = DriveTokenBucketConfig::new(
+        size,
+        if burst_present { Some(burst) } else { None },
+        refill_time,
+    );
+    if (!burst_present && burst != 0) || !token_bucket_is_enabled(config) {
+        return Err(SnapshotV2DeviceGraphDecodeError::InvalidValue);
+    }
+    Ok(Some(config))
+}
+
+fn decode_block_section(
+    bytes: &[u8],
+) -> Result<SnapshotV2BlockState, SnapshotV2DeviceGraphDecodeError> {
+    if bytes.len() != BLOCK_SECTION_BYTES {
+        return Err(SnapshotV2DeviceGraphDecodeError::InvalidStructure);
+    }
+    let mut reader = DeviceGraphReader::new(bytes);
+    if usize::from(reader.read_u16()?) != VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE {
+        return Err(SnapshotV2DeviceGraphDecodeError::InvalidValue);
+    }
+    let active_present = reader.read_bool()?;
+    let bandwidth_present = reader.read_bool()?;
+    let ops_present = reader.read_bool()?;
+    let retry_tag = reader.read_u8()?;
+    reader.read_zeroes(2)?;
+    let capacity_sectors = reader.read_u64()?;
+    let device_id =
+        VirtioBlockDeviceId::new(reader.read_array::<{ VIRTIO_BLOCK_ID_BYTES as usize }>()?);
+    reader.read_zeroes(4)?;
+    let next_available = reader.read_u16()?;
+    let next_used = reader.read_u16()?;
+    reader.read_zeroes(4)?;
+    let bandwidth = decode_bucket_state(&mut reader, bandwidth_present)?;
+    let ops = decode_bucket_state(&mut reader, ops_present)?;
+    let retry_nanos = reader.read_u64()?;
+    if !reader.is_finished() {
+        return Err(SnapshotV2DeviceGraphDecodeError::InvalidStructure);
+    }
+    let active_queue = if active_present {
+        Some(crate::block::VirtioBlockQueueState::new(
+            next_available,
+            next_used,
+        ))
+    } else {
+        if next_available != 0 || next_used != 0 {
+            return Err(SnapshotV2DeviceGraphDecodeError::InvalidValue);
+        }
+        None
+    };
+    let retry = match retry_tag {
+        RETRY_NONE if retry_nanos == 0 => StorageRetryState::None,
+        RETRY_IMMEDIATE if retry_nanos == 0 => StorageRetryState::Immediate,
+        RETRY_AFTER if retry_nanos != 0 => StorageRetryState::After {
+            remaining_nanos: retry_nanos,
+        },
+        _ => return Err(SnapshotV2DeviceGraphDecodeError::InvalidValue),
+    };
+    Ok(SnapshotV2BlockState {
+        capacity_sectors,
+        device_id,
+        active_queue,
+        limiter: SnapshotV2BlockLimiterState { bandwidth, ops },
+        retry,
+    })
+}
+
+fn decode_bucket_state(
+    reader: &mut DeviceGraphReader<'_>,
+    present: bool,
+) -> Result<Option<SnapshotV2BlockBucketState>, SnapshotV2DeviceGraphDecodeError> {
+    let budget = reader.read_u64()?;
+    let remaining_burst = reader.read_u64()?;
+    let age_nanos = reader.read_u64()?;
+    if present {
+        Ok(Some(SnapshotV2BlockBucketState {
+            budget,
+            remaining_burst,
+            age_nanos,
+        }))
+    } else if budget == 0 && remaining_burst == 0 && age_nanos == 0 {
+        Ok(None)
+    } else {
+        Err(SnapshotV2DeviceGraphDecodeError::InvalidValue)
+    }
+}
+
+fn decode_common_section(
+    bytes: &[u8],
+) -> Result<SnapshotV2VirtioState, SnapshotV2DeviceGraphDecodeError> {
+    if bytes.len() < COMMON_FIXED_BYTES + COMMON_QUEUE_BYTES {
+        return Err(SnapshotV2DeviceGraphDecodeError::Truncated);
+    }
+    let mut reader = DeviceGraphReader::new(bytes);
+    let available_features = reader.read_u64()?;
+    let driver_features = reader.read_u64()?;
+    let config_generation = reader.read_u32()?;
+    let status = reader.read_u32()?;
+    let activated = reader.read_bool()?;
+    reader.read_zeroes(1)?;
+    let queue_count = usize::from(reader.read_u16()?);
+    let notification_count = usize::from(reader.read_u16()?);
+    let intent_count = usize::from(reader.read_u16()?);
+    if queue_count != 1 || notification_count > 1 || intent_count > 2 {
+        return Err(SnapshotV2DeviceGraphDecodeError::InvalidValue);
+    }
+    let mut queues = Vec::new();
+    queues
+        .try_reserve_exact(queue_count)
+        .map_err(|_| SnapshotV2DeviceGraphDecodeError::Allocation)?;
+    for _ in 0..queue_count {
+        let max_size = reader.read_u16()?;
+        let size = reader.read_u16()?;
+        let ready = reader.read_bool()?;
+        reader.read_zeroes(3)?;
+        queues.push(SnapshotV2VirtioQueueState {
+            max_size,
+            size,
+            ready,
+            descriptor_table: GuestAddress::new(reader.read_u64()?),
+            driver_ring: GuestAddress::new(reader.read_u64()?),
+            device_ring: GuestAddress::new(reader.read_u64()?),
+        });
+    }
+    let mut pending_notifications = Vec::new();
+    pending_notifications
+        .try_reserve_exact(notification_count)
+        .map_err(|_| SnapshotV2DeviceGraphDecodeError::Allocation)?;
+    for _ in 0..notification_count {
+        pending_notifications.push(reader.read_u16()?);
+    }
+    let mut interrupt_intents = Vec::new();
+    interrupt_intents
+        .try_reserve_exact(intent_count)
+        .map_err(|_| SnapshotV2DeviceGraphDecodeError::Allocation)?;
+    for _ in 0..intent_count {
+        let tag = reader.read_u8()?;
+        reader.read_zeroes(1)?;
+        let queue_index = reader.read_u16()?;
+        interrupt_intents.push(match tag {
+            INTERRUPT_QUEUE => SnapshotV2InterruptIntent::Queue { queue_index },
+            INTERRUPT_CONFIGURATION if queue_index == 0 => SnapshotV2InterruptIntent::Configuration,
+            _ => return Err(SnapshotV2DeviceGraphDecodeError::InvalidValue),
+        });
+    }
+    reader.finish_padded()?;
+    Ok(SnapshotV2VirtioState {
+        available_features,
+        driver_features,
+        config_generation,
+        status,
+        activated,
+        queues,
+        pending_notifications,
+        interrupt_intents,
+    })
+}
+
+fn decode_mmio_section(
+    bytes: &[u8],
+) -> Result<SnapshotV2MmioDeviceState, SnapshotV2DeviceGraphDecodeError> {
+    if bytes.len() != MMIO_SECTION_BYTES {
+        return Err(SnapshotV2DeviceGraphDecodeError::InvalidStructure);
+    }
+    let mut reader = DeviceGraphReader::new(bytes);
+    let device_feature_select = reader.read_u32()?;
+    let driver_feature_select = reader.read_u32()?;
+    let queue_select = reader.read_u32()?;
+    let interrupt_line = GuestInterruptLine::new(reader.read_u32()?)
+        .map_err(|_| SnapshotV2DeviceGraphDecodeError::InvalidValue)?;
+    let region_id = crate::mmio::MmioRegionId::new(reader.read_u64()?);
+    let start = GuestAddress::new(reader.read_u64()?);
+    let size = reader.read_u64()?;
+    reader.read_zeroes(8)?;
+    let region = MmioRegion::new(region_id, start, size)
+        .map_err(|_| SnapshotV2DeviceGraphDecodeError::InvalidValue)?;
+    Ok(SnapshotV2MmioDeviceState {
+        device_feature_select,
+        driver_feature_select,
+        queue_select,
+        region,
+        interrupt_line,
+    })
+}
+
+fn decode_pci_section(
+    bytes: &[u8],
+) -> Result<SnapshotV2PciDeviceState, SnapshotV2DeviceGraphDecodeError> {
+    if bytes.len() < PCI_FIXED_BYTES {
+        return Err(SnapshotV2DeviceGraphDecodeError::Truncated);
+    }
+    let mut reader = DeviceGraphReader::new(bytes);
+    let phase = match reader.read_u8()? {
+        PCI_PHASE_ACTIVE => VirtioPciEndpointPhase::Active,
+        _ => return Err(SnapshotV2DeviceGraphDecodeError::InvalidValue),
+    };
+    let origin = match reader.read_u8()? {
+        PCI_ORIGIN_STARTUP => StorageDeviceOrigin::Startup,
+        _ => return Err(SnapshotV2DeviceGraphDecodeError::InvalidValue),
+    };
+    let bar_index = reader.read_u8()?;
+    let bar_address_space = match reader.read_u8()? {
+        PCI_BAR_MEMORY64 => PciBarAddressSpace::Memory64,
+        _ => return Err(SnapshotV2DeviceGraphDecodeError::InvalidValue),
+    };
+    let bar_prefetchable = match reader.read_u8()? {
+        PCI_BAR_NOT_PREFETCHABLE => PciBarPrefetchable::No,
+        _ => return Err(SnapshotV2DeviceGraphDecodeError::InvalidValue),
+    };
+    let pci_cfg_bar = reader.read_u8()?;
+    let function = reader.read_u8()?;
+    reader.read_zeroes(1)?;
+    let segment = reader.read_u16()?;
+    let bus = reader.read_u8()?;
+    let device = reader.read_u8()?;
+    reader.read_zeroes(4)?;
+    let bar_start = GuestAddress::new(reader.read_u64()?);
+    let bar_size = reader.read_u64()?;
+    let device_feature_select = reader.read_u32()?;
+    let driver_feature_select = reader.read_u32()?;
+    let queue_select = reader.read_u16()?;
+    let writable_count = usize::from(reader.read_u16()?);
+    let probe_count = usize::from(reader.read_u16()?);
+    let msix_entry_count = usize::from(reader.read_u16()?);
+    let pending_word_count = usize::from(reader.read_u16()?);
+    let queue_vector_count = usize::from(reader.read_u16()?);
+    reader.read_zeroes(4)?;
+    let pci_cfg_offset = reader.read_u32()?;
+    let pci_cfg_length = reader.read_u32()?;
+    let enabled = reader.read_bool()?;
+    let function_masked = reader.read_bool()?;
+    let pending_transition_observed = reader.read_bool()?;
+    reader.read_zeroes(1)?;
+    let config_vector = reader.read_u16()?;
+    reader.read_zeroes(2)?;
+    if writable_count != PCI_GENERIC_WRITABLE_BYTES.len()
+        || probe_count != 2
+        || msix_entry_count != 2
+        || pending_word_count != 1
+        || queue_vector_count != 1
+    {
+        return Err(SnapshotV2DeviceGraphDecodeError::InvalidValue);
+    }
+
+    let mut writable_bytes = Vec::new();
+    writable_bytes
+        .try_reserve_exact(writable_count)
+        .map_err(|_| SnapshotV2DeviceGraphDecodeError::Allocation)?;
+    for _ in 0..writable_count {
+        let offset = reader.read_u16()?;
+        let value = reader.read_u8()?;
+        reader.read_zeroes(1)?;
+        writable_bytes.push(SnapshotV2PciWritableByte { offset, value });
+    }
+    let mut bar_probes = Vec::new();
+    bar_probes
+        .try_reserve_exact(probe_count)
+        .map_err(|_| SnapshotV2DeviceGraphDecodeError::Allocation)?;
+    for _ in 0..probe_count {
+        let index = reader.read_u8()?;
+        let pending = reader.read_bool()?;
+        reader.read_zeroes(2)?;
+        bar_probes.push(SnapshotV2PciBarProbeState { index, pending });
+    }
+    let mut entries = Vec::new();
+    entries
+        .try_reserve_exact(msix_entry_count)
+        .map_err(|_| SnapshotV2DeviceGraphDecodeError::Allocation)?;
+    for _ in 0..msix_entry_count {
+        entries.push(SnapshotV2PciMsixTableEntry {
+            message_address_low: reader.read_u32()?,
+            message_address_high: reader.read_u32()?,
+            message_data: reader.read_u32()?,
+            vector_control: reader.read_u32()?,
+        });
+    }
+    let mut pending_words = Vec::new();
+    pending_words
+        .try_reserve_exact(pending_word_count)
+        .map_err(|_| SnapshotV2DeviceGraphDecodeError::Allocation)?;
+    for _ in 0..pending_word_count {
+        pending_words.push(reader.read_u64()?);
+    }
+    let mut queue_vectors = Vec::new();
+    queue_vectors
+        .try_reserve_exact(queue_vector_count)
+        .map_err(|_| SnapshotV2DeviceGraphDecodeError::Allocation)?;
+    for _ in 0..queue_vector_count {
+        queue_vectors.push(reader.read_u16()?);
+    }
+    reader.finish_padded()?;
+    let sbdf = PciSbdf::new(segment, bus, device, function)
+        .map_err(|_| SnapshotV2DeviceGraphDecodeError::InvalidValue)?;
+    let bar_range = GuestMemoryRange::new(bar_start, bar_size)
+        .map_err(|_| SnapshotV2DeviceGraphDecodeError::InvalidValue)?;
+    Ok(SnapshotV2PciDeviceState {
+        phase,
+        origin,
+        sbdf,
+        bar_index,
+        bar_address_space,
+        bar_prefetchable,
+        bar_range,
+        device_feature_select,
+        driver_feature_select,
+        queue_select,
+        pci_cfg_bar,
+        pci_cfg_offset,
+        pci_cfg_length,
+        writable_bytes,
+        bar_probes,
+        msix: SnapshotV2PciMsixState {
+            entries,
+            pending_words,
+            enabled,
+            function_masked,
+            config_vector,
+            queue_vectors,
+            pending_transition_observed,
+        },
+    })
+}
+
+struct DeviceGraphReader<'a> {
+    bytes: &'a [u8],
+    position: usize,
+}
+
+impl<'a> DeviceGraphReader<'a> {
+    const fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, position: 0 }
+    }
+
+    const fn is_finished(&self) -> bool {
+        self.position == self.bytes.len()
+    }
+
+    fn remaining(&self) -> usize {
+        self.bytes.len().saturating_sub(self.position)
+    }
+
+    fn read_u8(&mut self) -> Result<u8, SnapshotV2DeviceGraphDecodeError> {
+        Ok(self.read_array::<1>()?[0])
+    }
+
+    fn read_u16(&mut self) -> Result<u16, SnapshotV2DeviceGraphDecodeError> {
+        Ok(u16::from_le_bytes(self.read_array()?))
+    }
+
+    fn read_u32(&mut self) -> Result<u32, SnapshotV2DeviceGraphDecodeError> {
+        Ok(u32::from_le_bytes(self.read_array()?))
+    }
+
+    fn read_u64(&mut self) -> Result<u64, SnapshotV2DeviceGraphDecodeError> {
+        Ok(u64::from_le_bytes(self.read_array()?))
+    }
+
+    fn read_bool(&mut self) -> Result<bool, SnapshotV2DeviceGraphDecodeError> {
+        match self.read_u8()? {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(SnapshotV2DeviceGraphDecodeError::InvalidValue),
+        }
+    }
+
+    fn read_zeroes(&mut self, len: usize) -> Result<(), SnapshotV2DeviceGraphDecodeError> {
+        if self.read_bytes(len)?.iter().any(|byte| *byte != 0) {
+            Err(SnapshotV2DeviceGraphDecodeError::NonzeroReserved)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn read_string(&mut self, len: usize) -> Result<String, SnapshotV2DeviceGraphDecodeError> {
+        let value = std::str::from_utf8(self.read_bytes(len)?)
+            .map_err(|_| SnapshotV2DeviceGraphDecodeError::InvalidString)?;
+        let mut owned = String::new();
+        owned
+            .try_reserve_exact(value.len())
+            .map_err(|_| SnapshotV2DeviceGraphDecodeError::Allocation)?;
+        owned.push_str(value);
+        Ok(owned)
+    }
+
+    fn read_array<const N: usize>(&mut self) -> Result<[u8; N], SnapshotV2DeviceGraphDecodeError> {
+        self.read_bytes(N)?
+            .try_into()
+            .map_err(|_| SnapshotV2DeviceGraphDecodeError::Truncated)
+    }
+
+    fn read_bytes(&mut self, len: usize) -> Result<&'a [u8], SnapshotV2DeviceGraphDecodeError> {
+        let end = self
+            .position
+            .checked_add(len)
+            .ok_or(SnapshotV2DeviceGraphDecodeError::Truncated)?;
+        let value = self
+            .bytes
+            .get(self.position..end)
+            .ok_or(SnapshotV2DeviceGraphDecodeError::Truncated)?;
+        self.position = end;
+        Ok(value)
+    }
+
+    fn finish_padded(&mut self) -> Result<(), SnapshotV2DeviceGraphDecodeError> {
+        let remaining = self.remaining();
+        if remaining >= DEVICE_GRAPH_ALIGNMENT {
+            return Err(SnapshotV2DeviceGraphDecodeError::InvalidStructure);
+        }
+        self.read_zeroes(remaining)
+    }
+}
+
+fn transport_kind_tag(kind: SnapshotV2DeviceTransportKind) -> u16 {
+    match kind {
+        SnapshotV2DeviceTransportKind::Mmio => TRANSPORT_KIND_MMIO,
+        SnapshotV2DeviceTransportKind::Pci => TRANSPORT_KIND_PCI,
+    }
+}
+
+fn decode_transport_kind(
+    value: u16,
+) -> Result<SnapshotV2DeviceTransportKind, SnapshotV2DeviceGraphDecodeError> {
+    match value {
+        TRANSPORT_KIND_MMIO => Ok(SnapshotV2DeviceTransportKind::Mmio),
+        TRANSPORT_KIND_PCI => Ok(SnapshotV2DeviceTransportKind::Pci),
+        _ => Err(SnapshotV2DeviceGraphDecodeError::UnsupportedProfile),
+    }
+}
+
+fn aligned_len(len: usize) -> Option<usize> {
+    len.checked_add(DEVICE_GRAPH_ALIGNMENT - 1)
+        .map(|value| value & !(DEVICE_GRAPH_ALIGNMENT - 1))
+}
+
+fn pad_section(output: &mut Vec<u8>, capacity: usize) {
+    output.resize(capacity, 0);
+}
+
+fn write_u8(output: &mut Vec<u8>, value: u8) {
+    output.push(value);
+}
+
+fn write_u16(output: &mut Vec<u8>, value: u16) {
+    output.extend_from_slice(&value.to_le_bytes());
+}
+
+fn write_u32(output: &mut Vec<u8>, value: u32) {
+    output.extend_from_slice(&value.to_le_bytes());
+}
+
+fn write_u64(output: &mut Vec<u8>, value: u64) {
+    output.extend_from_slice(&value.to_le_bytes());
+}
+
+fn read_array_at<const N: usize>(
+    bytes: &[u8],
+    offset: usize,
+) -> Result<[u8; N], SnapshotV2DeviceGraphDecodeError> {
+    let end = offset
+        .checked_add(N)
+        .ok_or(SnapshotV2DeviceGraphDecodeError::Truncated)?;
+    bytes
+        .get(offset..end)
+        .ok_or(SnapshotV2DeviceGraphDecodeError::Truncated)?
+        .try_into()
+        .map_err(|_| SnapshotV2DeviceGraphDecodeError::Truncated)
+}
+
+fn read_u16_at(bytes: &[u8], offset: usize) -> Result<u16, SnapshotV2DeviceGraphDecodeError> {
+    Ok(u16::from_le_bytes(read_array_at(bytes, offset)?))
+}
+
+fn read_u32_at(bytes: &[u8], offset: usize) -> Result<u32, SnapshotV2DeviceGraphDecodeError> {
+    Ok(u32::from_le_bytes(read_array_at(bytes, offset)?))
+}
+
+fn read_u64_at(bytes: &[u8], offset: usize) -> Result<u64, SnapshotV2DeviceGraphDecodeError> {
+    Ok(u64::from_le_bytes(read_array_at(bytes, offset)?))
+}
+
+fn read_usize_u64_at(
+    bytes: &[u8],
+    offset: usize,
+) -> Result<usize, SnapshotV2DeviceGraphDecodeError> {
+    usize::try_from(read_u64_at(bytes, offset)?)
+        .map_err(|_| SnapshotV2DeviceGraphDecodeError::InvalidStructure)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/runtime/src/snapshot_device_v2/tests.rs
+++ b/crates/runtime/src/snapshot_device_v2/tests.rs
@@ -710,6 +710,20 @@ fn invalid_utf8_and_noncanonical_string_presence_fail_closed() {
         SnapshotV2DeviceGraph::decode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, &bytes,),
         Err(SnapshotV2DeviceGraphDecodeError::InvalidString)
     );
+
+    let mut invalid = mmio_graph();
+    invalid.record.config.drive_id = "bad/id".to_string();
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+
+    let mut bytes = original;
+    bytes[config + CONFIG_FIXED_BYTES] = b'/';
+    assert_eq!(
+        SnapshotV2DeviceGraph::decode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, &bytes,),
+        Err(SnapshotV2DeviceGraphDecodeError::InvalidGraph)
+    );
 }
 
 #[test]
@@ -785,6 +799,13 @@ fn hostile_config_block_and_common_section_mutations_fail_closed() {
     cases.push(bytes);
     let mut bytes = original.clone();
     overwrite_u64(&mut bytes, block + 96, 0);
+    cases.push(bytes);
+    let mut bytes = original.clone();
+    overwrite_u16(
+        &mut bytes,
+        block + 40,
+        6_u16.wrapping_add(VIRTIO_BLOCK_QUEUE_SIZE).wrapping_add(1),
+    );
     cases.push(bytes);
 
     let mut bytes = original.clone();
@@ -865,7 +886,6 @@ fn hostile_mmio_and_pci_transport_section_mutations_fail_closed() {
         (pci + 2, 1),
         (pci + 3, 1),
         (pci + 4, 1),
-        (pci + 5, 1),
         (pci + 6, 1),
         (pci + 7, 1),
         (pci + 10, 1),
@@ -881,7 +901,6 @@ fn hostile_mmio_and_pci_transport_section_mutations_fail_closed() {
     }
     for (offset, value) in [
         (pci + 8, 1_u16),
-        (pci + 40, 1),
         (pci + 42, 3),
         (pci + 44, 1),
         (pci + 46, 1),
@@ -893,16 +912,9 @@ fn hostile_mmio_and_pci_transport_section_mutations_fail_closed() {
         overwrite_u16(&mut bytes, offset, value);
         pci_cases.push(bytes);
     }
-    for (offset, value) in [
-        (pci + 32, 2_u32),
-        (pci + 36, 2),
-        (pci + 52, 1),
-        (pci + 60, 3),
-    ] {
-        let mut bytes = pci_original.clone();
-        overwrite_u32(&mut bytes, offset, value);
-        pci_cases.push(bytes);
-    }
+    let mut bytes = pci_original.clone();
+    overwrite_u32(&mut bytes, pci + 52, 1);
+    pci_cases.push(bytes);
     for (offset, value) in [
         (pci + 16, PCI_BAR64_START + 1),
         (pci + 24, VIRTIO_PCI_CAPABILITY_BAR_SIZE - 1),
@@ -953,6 +965,15 @@ fn invalid_block_common_and_mmio_semantics_are_rejected_before_encode() {
     );
     let mut invalid = graph.clone();
     invalid.record.block.active_queue = Some(crate::block::VirtioBlockQueueState::new(7, 7));
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+    let mut invalid = graph.clone();
+    invalid.record.block.active_queue = Some(crate::block::VirtioBlockQueueState::new(
+        6_u16.wrapping_add(VIRTIO_BLOCK_QUEUE_SIZE).wrapping_add(1),
+        6,
+    ));
     assert_eq!(
         invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
         Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
@@ -1025,7 +1046,7 @@ fn invalid_block_common_and_mmio_semantics_are_rejected_before_encode() {
 }
 
 #[test]
-fn invalid_pci_placement_configuration_and_msix_semantics_are_rejected() {
+fn invalid_pci_placement_and_msix_semantics_are_rejected() {
     let graph = pci_graph();
 
     let mut invalid = graph.clone();
@@ -1033,26 +1054,6 @@ fn invalid_pci_placement_configuration_and_msix_semantics_are_rejected() {
         panic!("fixture should use PCI");
     };
     pci.origin = StorageDeviceOrigin::Runtime;
-    assert_eq!(
-        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
-        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
-    );
-
-    let mut invalid = graph.clone();
-    let SnapshotV2DeviceTransport::Pci(pci) = &mut invalid.record.transport else {
-        panic!("fixture should use PCI");
-    };
-    pci.device_feature_select = 2;
-    assert_eq!(
-        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
-        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
-    );
-
-    let mut invalid = graph.clone();
-    let SnapshotV2DeviceTransport::Pci(pci) = &mut invalid.record.transport else {
-        panic!("fixture should use PCI");
-    };
-    pci.pci_cfg_length = 3;
     assert_eq!(
         invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
         Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
@@ -1751,6 +1752,97 @@ fn real_pci_capture_uses_checked_configuration_profile_and_preserves_stable_id()
             .expect("converted PCI graph should decode")
         ),
         encoded(&graph)
+    );
+}
+
+#[test]
+fn real_pci_capture_preserves_inert_guest_selectors_exactly() {
+    let file = TempFile::new("pci-selectors.img", 8192);
+    let fixture = PciRuntimeFixture::new(file.path());
+    let mut bus = MmioBus::new();
+    bus.insert(
+        MmioRegionId::new(78),
+        fixture.bar.range().start(),
+        fixture.bar.range().size(),
+    )
+    .expect("test PCI BAR should register");
+    let mut handler = fixture.endpoint.bar_handler();
+    pci_bar_write(
+        &mut handler,
+        &bus,
+        &fixture.bar,
+        0x00,
+        &u32::MAX.to_le_bytes(),
+    );
+    pci_bar_write(
+        &mut handler,
+        &bus,
+        &fixture.bar,
+        0x08,
+        &0x8000_0002_u32.to_le_bytes(),
+    );
+    pci_bar_write(
+        &mut handler,
+        &bus,
+        &fixture.bar,
+        0x16,
+        &u16::MAX.to_le_bytes(),
+    );
+    drop(handler);
+
+    let pci_cfg_cap_offset = fixture
+        .endpoint
+        .transport_state()
+        .expect("test PCI transport should capture")
+        .pci_cfg_cap_offset();
+    let mut configuration = fixture.endpoint.config_function();
+    configuration
+        .write_config(
+            pci_cfg_cap_offset
+                .checked_add(4)
+                .expect("test PCI selector BAR should fit"),
+            &[5],
+        )
+        .expect("test PCI selector BAR should write");
+    configuration
+        .write_config(
+            pci_cfg_cap_offset
+                .checked_add(8)
+                .expect("test PCI selector offset should fit"),
+            &u32::MAX.to_le_bytes(),
+        )
+        .expect("test PCI selector offset should write");
+    configuration
+        .write_config(
+            pci_cfg_cap_offset
+                .checked_add(12)
+                .expect("test PCI selector length should fit"),
+            &3_u32.to_le_bytes(),
+        )
+        .expect("test PCI selector length should write");
+    drop(configuration);
+
+    let graph = SnapshotV2DeviceGraph::from_capture_ready_root(
+        NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+        &fixture.capture(),
+    )
+    .expect("reachable inert PCI selectors should convert");
+    let SnapshotV2DeviceTransport::Pci(pci) = graph.record().transport() else {
+        panic!("converted graph should retain PCI");
+    };
+    assert_eq!(pci.device_feature_select(), u32::MAX);
+    assert_eq!(pci.driver_feature_select(), 0x8000_0002);
+    assert_eq!(pci.queue_select(), u16::MAX);
+    assert_eq!(pci.pci_cfg_bar(), 5);
+    assert_eq!(pci.pci_cfg_offset(), u32::MAX);
+    assert_eq!(pci.pci_cfg_length(), 3);
+    assert_eq!(
+        SnapshotV2DeviceGraph::decode(
+            NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            &encoded(&graph),
+        )
+        .expect("reachable inert PCI selectors should decode"),
+        graph
     );
 }
 

--- a/crates/runtime/src/snapshot_device_v2/tests.rs
+++ b/crates/runtime/src/snapshot_device_v2/tests.rs
@@ -1,0 +1,1891 @@
+use super::*;
+
+use std::fs::{self, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use crate::block::{
+    BlockFileBacking, DriveConfigInput, PreparedBlockDevice, VIRTIO_BLOCK_QUEUE_SIZES,
+    VirtioBlockConfigSpace, VirtioBlockDevice,
+};
+use crate::message_interrupt::{
+    GuestMessage, GuestMessageInterrupt, GuestMessageInterruptRegistry,
+    GuestMessageInterruptSignalError,
+};
+use crate::mmio::{MmioAccessBytes, MmioBus, MmioHandler, MmioRegionId};
+use crate::pci::{
+    PCI_BAR64_START, PCI_FIRST_ENDPOINT_DEVICE, PciBarAddressSpace, PciBarAllocator, PciBarLease,
+    PciConfigFunction,
+};
+use crate::snapshot_format_v2::NATIVE_V2_SNAPSHOT_VERSION;
+use crate::storage_capture::{StorageMmioTransportState, StoragePciTransportState};
+use crate::virtio::{VirtioDeviceType, VirtioInterruptIntent};
+use crate::virtio_mmio::{VirtioMmioRegister, VirtioMmioRegisterHandler};
+use crate::virtio_pci::{VIRTIO_PCI_NOTIFICATION_OFFSET, VirtioPciEndpoint, VirtioPciIdentity};
+
+const MMIO_FIXTURE_HEX: &str = "42414e4744324100400001000100010004000000000000003802000000000000010000000000000040000000000000006000000000000000e000000000000000010000000000000000000000040000000000000000000000000000000000000000000000010000000000000000000000e0000000000000007000000000000000000000000200000000000000000000005001000000000000680000000000000000000000030000000000000000000000b801000000000000500000000000000000000000040000000000000000000000080200000000000030000000000000000101010101010000060009000d00000040420f000000000000100000000000000a000000000000000100000000000000e803000000000000000000000000000014000000000000000000000000000000726f6f746673313131312d32323232726f6f742d73656c6563746f7200000000080001010102000000080000000000000102030405060708090a0b0c0d0e0f1011121314000000000700060000000000b0710b0000000000000400000000000040e2010000000000ee020000000000000000000000000000f1fb090000000000630000000000000020020030010000002002003001000000090000000f0000000100010001000200000100010100000000000100000000000000020000000000000003000000000000000100000002000000000000000000010000000000000000000000200000000900000000000000000000d00000000000100000000000000000000000000000";
+const PCI_FIXTURE_HEX: &str = "42414e4744324100400001000200010004000000000000009802000000000000010000000000000040000000000000006000000000000000e000000000000000010000000000000000000000040000000000000000000000000000000000000000000000010000000000000000000000e0000000000000007000000000000000000000000200000000000000000000005001000000000000680000000000000000000000030000000000000000000000b801000000000000500000000000000000000000040000000000000000000000080200000000000090000000000000000101010101010000060009000d00000040420f000000000000100000000000000a000000000000000100000000000000e803000000000000000000000000000014000000000000000000000000000000726f6f746673313131312d32323232726f6f742d73656c6563746f7200000000080001010102000000080000000000000102030405060708090a0b0c0d0e0f1011121314000000000700060000000000b0710b0000000000000400000000000040e2010000000000ee020000000000000000000000000000f1fb090000000000630000000000000020020030010000002002003001000000090000000f000000010001000100020000010001010000000000010000000000000002000000000000000300000000000000010000000200000000000000000001010002000000000000000100000000000000004000000000000800000000000100000000000000000004000200020001000100000000002400000004000000010001000000000004000700050080000c0040003c002a000000000001010000400000080000000040000000000000004000000800000000410000000100000002000000000000000100000000000000";
+
+fn fixture_config() -> SnapshotV2RootBlockConfig {
+    SnapshotV2RootBlockConfig {
+        drive_id: "rootfs".to_string(),
+        partuuid: Some("1111-2222".to_string()),
+        cache_type: DriveCacheType::Writeback,
+        rate_limiter: Some(DriveRateLimiterConfig::new(
+            Some(DriveTokenBucketConfig::new(1_000_000, Some(4096), 10)),
+            Some(DriveTokenBucketConfig::new(1_000, None, 20)),
+        )),
+        selector: "root-selector".to_string(),
+    }
+}
+
+fn fixture_block() -> SnapshotV2BlockState {
+    let mut device_id = [0_u8; VIRTIO_BLOCK_ID_BYTES as usize];
+    for (index, byte) in device_id.iter_mut().enumerate() {
+        *byte = u8::try_from(index + 1).expect("fixture block ID index should fit");
+    }
+    SnapshotV2BlockState {
+        capacity_sectors: 2048,
+        device_id: VirtioBlockDeviceId::new(device_id),
+        active_queue: Some(crate::block::VirtioBlockQueueState::new(7, 6)),
+        limiter: SnapshotV2BlockLimiterState {
+            bandwidth: Some(SnapshotV2BlockBucketState {
+                budget: 750_000,
+                remaining_burst: 1024,
+                age_nanos: 123_456,
+            }),
+            ops: Some(SnapshotV2BlockBucketState {
+                budget: 750,
+                remaining_burst: 0,
+                age_nanos: 654_321,
+            }),
+        },
+        retry: StorageRetryState::After {
+            remaining_nanos: 99,
+        },
+    }
+}
+
+fn fixture_virtio() -> SnapshotV2VirtioState {
+    let features = expected_block_features(DriveCacheType::Writeback);
+    SnapshotV2VirtioState {
+        available_features: features,
+        driver_features: features,
+        config_generation: 9,
+        status: VIRTIO_DEVICE_STATUS_ACKNOWLEDGE
+            | VIRTIO_DEVICE_STATUS_DRIVER
+            | VIRTIO_DEVICE_STATUS_FEATURES_OK
+            | VIRTIO_DEVICE_STATUS_DRIVER_OK,
+        activated: true,
+        queues: vec![SnapshotV2VirtioQueueState {
+            max_size: VIRTIO_BLOCK_QUEUE_SIZE,
+            size: VIRTIO_BLOCK_QUEUE_SIZE,
+            ready: true,
+            descriptor_table: GuestAddress::new(0x1_0000),
+            driver_ring: GuestAddress::new(0x2_0000),
+            device_ring: GuestAddress::new(0x3_0000),
+        }],
+        pending_notifications: vec![0],
+        interrupt_intents: vec![
+            SnapshotV2InterruptIntent::Queue { queue_index: 0 },
+            SnapshotV2InterruptIntent::Configuration,
+        ],
+    }
+}
+
+fn fixture_graph(transport: SnapshotV2DeviceTransport) -> SnapshotV2DeviceGraph {
+    let key = SnapshotV2DeviceKey {
+        kind: DEVICE_KIND_BLOCK,
+        instance: DEVICE_INSTANCE_ROOT,
+    };
+    let graph = SnapshotV2DeviceGraph {
+        root_key: key,
+        record: SnapshotV2DeviceRecord {
+            key,
+            config: fixture_config(),
+            block: fixture_block(),
+            virtio: fixture_virtio(),
+            transport,
+        },
+    };
+    validate_graph(&graph).expect("fixture graph should validate");
+    graph
+}
+
+fn mmio_graph() -> SnapshotV2DeviceGraph {
+    let region = MmioRegion::new(
+        MmioRegionId::new(9),
+        GuestAddress::new(0xd000_0000),
+        VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+    )
+    .expect("fixture MMIO region should validate");
+    fixture_graph(SnapshotV2DeviceTransport::Mmio(SnapshotV2MmioDeviceState {
+        device_feature_select: 1,
+        driver_feature_select: 0,
+        queue_select: 0,
+        region,
+        interrupt_line: GuestInterruptLine::new(32)
+            .expect("fixture interrupt line should validate"),
+    }))
+}
+
+fn pci_graph() -> SnapshotV2DeviceGraph {
+    let sbdf = PciSbdf::new(
+        PCI_SEGMENT_ZERO,
+        PCI_BUS_ZERO,
+        PCI_FIRST_ENDPOINT_DEVICE,
+        PCI_FUNCTION_ZERO,
+    )
+    .expect("fixture SBDF should validate");
+    let bar_range = GuestMemoryRange::new(
+        GuestAddress::new(PCI_BAR64_START),
+        VIRTIO_PCI_CAPABILITY_BAR_SIZE,
+    )
+    .expect("fixture capability BAR should validate");
+    fixture_graph(SnapshotV2DeviceTransport::Pci(SnapshotV2PciDeviceState {
+        phase: VirtioPciEndpointPhase::Active,
+        origin: StorageDeviceOrigin::Startup,
+        sbdf,
+        bar_index: VIRTIO_PCI_CAPABILITY_BAR_INDEX,
+        bar_address_space: PciBarAddressSpace::Memory64,
+        bar_prefetchable: PciBarPrefetchable::No,
+        bar_range,
+        device_feature_select: 1,
+        driver_feature_select: 0,
+        queue_select: 0,
+        pci_cfg_bar: VIRTIO_PCI_CAPABILITY_BAR_INDEX,
+        pci_cfg_offset: 0x24,
+        pci_cfg_length: 4,
+        writable_bytes: vec![
+            SnapshotV2PciWritableByte {
+                offset: 0x04,
+                value: 0x07,
+            },
+            SnapshotV2PciWritableByte {
+                offset: 0x05,
+                value: 0x80,
+            },
+            SnapshotV2PciWritableByte {
+                offset: 0x0c,
+                value: 0x40,
+            },
+            SnapshotV2PciWritableByte {
+                offset: 0x3c,
+                value: 0x2a,
+            },
+        ],
+        bar_probes: vec![
+            SnapshotV2PciBarProbeState {
+                index: 0,
+                pending: false,
+            },
+            SnapshotV2PciBarProbeState {
+                index: 1,
+                pending: true,
+            },
+        ],
+        msix: SnapshotV2PciMsixState {
+            entries: vec![
+                SnapshotV2PciMsixTableEntry {
+                    message_address_low: 0x0800_0040,
+                    message_address_high: 0,
+                    message_data: 64,
+                    vector_control: 0,
+                },
+                SnapshotV2PciMsixTableEntry {
+                    message_address_low: 0x0800_0040,
+                    message_address_high: 0,
+                    message_data: 65,
+                    vector_control: 1,
+                },
+            ],
+            pending_words: vec![0b10],
+            enabled: true,
+            function_masked: false,
+            config_vector: 0,
+            queue_vectors: vec![1],
+            pending_transition_observed: true,
+        },
+    }))
+}
+
+fn fixture_bytes(hex: &str) -> Vec<u8> {
+    assert!(hex.len().is_multiple_of(2));
+    let mut bytes = Vec::with_capacity(hex.len() / 2);
+    for pair in hex.as_bytes().chunks_exact(2) {
+        let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
+        bytes.push(u8::from_str_radix(pair, 16).expect("fixture hex should decode"));
+    }
+    bytes
+}
+
+fn encoded(graph: &SnapshotV2DeviceGraph) -> Vec<u8> {
+    graph
+        .encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION)
+        .expect("fixture graph should encode")
+}
+
+fn section_offset(bytes: &[u8], index: usize) -> usize {
+    let entry =
+        DEVICE_GRAPH_SECTION_DIRECTORY_OFFSET + index * NATIVE_V2_DEVICE_GRAPH_SECTION_ENTRY_BYTES;
+    usize::try_from(u64::from_le_bytes(
+        bytes[entry + SECTION_PAYLOAD_OFFSET..entry + SECTION_PAYLOAD_OFFSET + 8]
+            .try_into()
+            .expect("fixture section offset should exist"),
+    ))
+    .expect("fixture section offset should fit")
+}
+
+fn section_length(bytes: &[u8], index: usize) -> usize {
+    let entry =
+        DEVICE_GRAPH_SECTION_DIRECTORY_OFFSET + index * NATIVE_V2_DEVICE_GRAPH_SECTION_ENTRY_BYTES;
+    usize::try_from(u64::from_le_bytes(
+        bytes[entry + SECTION_LENGTH_OFFSET..entry + SECTION_LENGTH_OFFSET + 8]
+            .try_into()
+            .expect("fixture section length should exist"),
+    ))
+    .expect("fixture section length should fit")
+}
+
+fn overwrite_u16(bytes: &mut [u8], offset: usize, value: u16) {
+    bytes[offset..offset + 2].copy_from_slice(&value.to_le_bytes());
+}
+
+fn overwrite_u32(bytes: &mut [u8], offset: usize, value: u32) {
+    bytes[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+}
+
+fn overwrite_u64(bytes: &mut [u8], offset: usize, value: u64) {
+    bytes[offset..offset + 8].copy_from_slice(&value.to_le_bytes());
+}
+
+fn assert_decode_cases_reject(cases: &[Vec<u8>], context: &str) {
+    for (index, bytes) in cases.iter().enumerate() {
+        assert!(
+            SnapshotV2DeviceGraph::decode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, bytes,)
+                .is_err(),
+            "{context} case {index} unexpectedly decoded",
+        );
+    }
+}
+
+#[test]
+fn exact_mmio_fixture_is_deterministic_and_round_trips() {
+    let graph = mmio_graph();
+    let actual = encoded(&graph);
+    assert_eq!(actual, fixture_bytes(MMIO_FIXTURE_HEX));
+    assert_eq!(encoded(&graph), actual);
+
+    let decoded =
+        SnapshotV2DeviceGraph::decode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, &actual)
+            .expect("exact MMIO fixture should decode");
+    assert_eq!(decoded, graph);
+    assert_eq!(encoded(&decoded), actual);
+}
+
+#[test]
+fn exact_pci_fixture_is_deterministic_and_round_trips() {
+    let graph = pci_graph();
+    let actual = encoded(&graph);
+    assert_eq!(actual, fixture_bytes(PCI_FIXTURE_HEX));
+    assert_eq!(encoded(&graph), actual);
+
+    let decoded =
+        SnapshotV2DeviceGraph::decode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, &actual)
+            .expect("exact PCI fixture should decode");
+    assert_eq!(decoded, graph);
+    assert_eq!(encoded(&decoded), actual);
+}
+
+#[test]
+fn semantic_accessors_and_debug_output_are_stable_and_redacted() {
+    let graph = pci_graph();
+    assert_eq!(
+        graph.compatibility_version(),
+        SnapshotFormatVersion::new(2, 4, 0)
+    );
+    assert_eq!(graph.root_key().kind(), DEVICE_KIND_BLOCK);
+    assert_eq!(graph.root_key().instance(), 0);
+    assert!(graph.record_is_root());
+    assert_eq!(graph.transport_kind(), SnapshotV2DeviceTransportKind::Pci);
+    assert_eq!(graph.record().config().drive_id(), "rootfs");
+    assert_eq!(graph.record().config().partuuid(), Some("1111-2222"));
+    assert_eq!(graph.record().config().selector(), "root-selector");
+    assert!(graph.record().config().is_read_only());
+    assert_eq!(graph.record().config().io_engine(), DriveIoEngine::Sync);
+    assert_eq!(graph.record().block().capacity_sectors(), 2048);
+    assert_eq!(graph.record().virtio().queues().len(), 1);
+    let SnapshotV2DeviceTransport::Pci(pci) = graph.record().transport() else {
+        panic!("fixture should use PCI");
+    };
+    assert_eq!(pci.writable_bytes().len(), 4);
+    assert_eq!(pci.msix().entries().len(), 2);
+    assert_eq!(pci.msix().queue_vectors(), [1]);
+
+    let sensitive = ["rootfs", "1111-2222", "root-selector", "134217792", "65"];
+    for debug in [
+        format!("{graph:?}"),
+        format!("{:?}", graph.record()),
+        format!("{:?}", graph.record().config()),
+        format!("{:?}", graph.record().block()),
+        format!("{:?}", graph.record().virtio()),
+        format!("{:?}", graph.record().transport()),
+        format!("{pci:?}"),
+        format!("{:?}", pci.msix()),
+    ] {
+        assert!(debug.contains("<redacted>"));
+        for value in sensitive {
+            assert!(!debug.contains(value));
+        }
+    }
+    for error in [
+        SnapshotV2DeviceGraphCaptureError::InvalidString.to_string(),
+        SnapshotV2DeviceGraphEncodeError::InvalidGraph.to_string(),
+        SnapshotV2DeviceGraphDecodeError::InvalidString.to_string(),
+    ] {
+        for value in sensitive {
+            assert!(!error.contains(value));
+        }
+    }
+}
+
+#[test]
+fn exact_outer_version_is_required_without_advancing_public_native_v2() {
+    assert_eq!(
+        NATIVE_V2_SNAPSHOT_VERSION,
+        SnapshotFormatVersion::new(2, 3, 0)
+    );
+    let graph = mmio_graph();
+    let bytes = encoded(&graph);
+    for version in [
+        SnapshotFormatVersion::new(1, 4, 0),
+        SnapshotFormatVersion::new(2, 3, 0),
+        SnapshotFormatVersion::new(2, 4, 1),
+        SnapshotFormatVersion::new(2, 5, 0),
+        SnapshotFormatVersion::new(3, 4, 0),
+    ] {
+        assert_eq!(
+            graph.encode(version),
+            Err(SnapshotV2DeviceGraphEncodeError::UnsupportedVersion)
+        );
+        assert_eq!(
+            SnapshotV2DeviceGraph::decode(version, &bytes),
+            Err(SnapshotV2DeviceGraphDecodeError::UnsupportedVersion)
+        );
+    }
+}
+
+#[test]
+fn every_reachable_healthy_pre_activation_status_round_trips_for_both_transports() {
+    let statuses = [
+        VIRTIO_DEVICE_STATUS_INIT,
+        VIRTIO_DEVICE_STATUS_ACKNOWLEDGE,
+        VIRTIO_DEVICE_STATUS_ACKNOWLEDGE | VIRTIO_DEVICE_STATUS_DRIVER,
+        VIRTIO_DEVICE_STATUS_ACKNOWLEDGE
+            | VIRTIO_DEVICE_STATUS_DRIVER
+            | VIRTIO_DEVICE_STATUS_FEATURES_OK,
+    ];
+    for template in [mmio_graph(), pci_graph()] {
+        for status in statuses {
+            let mut graph = template.clone();
+            graph.record.block.active_queue = None;
+            graph.record.block.retry = StorageRetryState::None;
+            graph.record.virtio.status = status;
+            graph.record.virtio.activated = false;
+            graph.record.virtio.driver_features = if status & VIRTIO_DEVICE_STATUS_FEATURES_OK == 0
+            {
+                0
+            } else {
+                graph.record.virtio.available_features
+            };
+            graph.record.virtio.queues[0].size = 0;
+            graph.record.virtio.queues[0].ready = false;
+            graph.record.virtio.queues[0].descriptor_table = GuestAddress::new(0);
+            graph.record.virtio.queues[0].driver_ring = GuestAddress::new(0);
+            graph.record.virtio.queues[0].device_ring = GuestAddress::new(0);
+            graph.record.virtio.pending_notifications.clear();
+            graph.record.virtio.interrupt_intents.clear();
+
+            let bytes = graph
+                .encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION)
+                .expect("healthy pre-activation state should encode");
+            assert_eq!(
+                SnapshotV2DeviceGraph::decode(
+                    NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                    &bytes,
+                )
+                .expect("healthy pre-activation state should decode"),
+                graph
+            );
+        }
+    }
+}
+
+#[test]
+fn every_truncated_prefix_and_oversized_payload_fails_closed() {
+    let bytes = encoded(&pci_graph());
+    for end in 0..bytes.len() {
+        assert!(
+            SnapshotV2DeviceGraph::decode(
+                NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                &bytes[..end],
+            )
+            .is_err(),
+            "prefix ending at {end} unexpectedly decoded",
+        );
+    }
+    let oversized = vec![0; NATIVE_V2_DEVICE_GRAPH_MAX_BYTES + 1];
+    assert_eq!(
+        SnapshotV2DeviceGraph::decode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, &oversized,),
+        Err(SnapshotV2DeviceGraphDecodeError::TooLarge)
+    );
+}
+
+#[test]
+fn hostile_header_record_and_directory_mutations_fail_closed() {
+    let original = encoded(&mmio_graph());
+    let mut cases = Vec::new();
+
+    let mut bytes = original.clone();
+    bytes[HEADER_MAGIC_OFFSET] ^= 1;
+    cases.push(bytes);
+
+    for (offset, value) in [
+        (HEADER_BYTES_OFFSET, 63_u16),
+        (HEADER_PROFILE_OFFSET, 2),
+        (HEADER_TRANSPORT_OFFSET, 3),
+        (HEADER_RECORD_COUNT_OFFSET, 2),
+        (HEADER_SECTION_COUNT_OFFSET, 3),
+        (HEADER_RESERVED_OFFSET, 1),
+    ] {
+        let mut bytes = original.clone();
+        overwrite_u16(&mut bytes, offset, value);
+        cases.push(bytes);
+    }
+    for (offset, value) in [
+        (HEADER_FLAGS_OFFSET, 1_u32),
+        (HEADER_ROOT_KIND_OFFSET, 2),
+        (HEADER_ROOT_INSTANCE_OFFSET, 1),
+    ] {
+        let mut bytes = original.clone();
+        overwrite_u32(&mut bytes, offset, value);
+        cases.push(bytes);
+    }
+    for (offset, value) in [
+        (HEADER_TOTAL_LENGTH_OFFSET, 1_u64),
+        (HEADER_RECORD_DIRECTORY_OFFSET_OFFSET, 0),
+        (HEADER_SECTION_DIRECTORY_OFFSET_OFFSET, 0),
+        (HEADER_PAYLOAD_OFFSET_OFFSET, 0),
+    ] {
+        let mut bytes = original.clone();
+        overwrite_u64(&mut bytes, offset, value);
+        cases.push(bytes);
+    }
+
+    let record = DEVICE_GRAPH_RECORD_DIRECTORY_OFFSET;
+    for (offset, value) in [
+        (record + RECORD_KIND_OFFSET, 2_u32),
+        (record + RECORD_INSTANCE_OFFSET, 1),
+        (record + RECORD_FIRST_SECTION_OFFSET, 1),
+        (record + RECORD_SECTION_COUNT_OFFSET, 3),
+    ] {
+        let mut bytes = original.clone();
+        overwrite_u32(&mut bytes, offset, value);
+        cases.push(bytes);
+    }
+    let mut bytes = original.clone();
+    bytes[record + RECORD_RESERVED_OFFSET] = 1;
+    cases.push(bytes);
+
+    for index in 0..DEVICE_GRAPH_SECTION_COUNT_USIZE {
+        let entry = DEVICE_GRAPH_SECTION_DIRECTORY_OFFSET
+            + index * NATIVE_V2_DEVICE_GRAPH_SECTION_ENTRY_BYTES;
+        for (offset, value) in [
+            (entry + SECTION_RECORD_INDEX_OFFSET, 1_u32),
+            (
+                entry + SECTION_PAYLOAD_OFFSET,
+                u32::try_from(DEVICE_GRAPH_PAYLOAD_OFFSET + 1)
+                    .expect("test payload offset should fit"),
+            ),
+            (entry + SECTION_LENGTH_OFFSET, 0),
+        ] {
+            let mut bytes = original.clone();
+            if offset == entry + SECTION_RECORD_INDEX_OFFSET {
+                overwrite_u32(&mut bytes, offset, value);
+            } else {
+                overwrite_u64(&mut bytes, offset, u64::from(value));
+            }
+            cases.push(bytes);
+        }
+        let mut bytes = original.clone();
+        overwrite_u16(&mut bytes, entry + SECTION_KIND_OFFSET, 99);
+        cases.push(bytes);
+        let mut bytes = original.clone();
+        overwrite_u16(&mut bytes, entry + SECTION_FLAGS_OFFSET, 1);
+        cases.push(bytes);
+        let mut bytes = original.clone();
+        bytes[entry + SECTION_RESERVED_OFFSET] = 1;
+        cases.push(bytes);
+    }
+
+    let mut trailing = original.clone();
+    trailing.push(0);
+    let trailing_len = u64::try_from(trailing.len()).expect("test length should fit");
+    overwrite_u64(&mut trailing, HEADER_TOTAL_LENGTH_OFFSET, trailing_len);
+    cases.push(trailing);
+
+    for (index, bytes) in cases.iter().enumerate() {
+        assert!(
+            SnapshotV2DeviceGraph::decode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, bytes,)
+                .is_err(),
+            "hostile structural case {index} unexpectedly decoded",
+        );
+    }
+}
+
+#[test]
+fn section_directory_rejects_gaps_overlaps_unaligned_bounds_and_reordering() {
+    let original = encoded(&mmio_graph());
+    let first_entry = DEVICE_GRAPH_SECTION_DIRECTORY_OFFSET;
+    let second_entry = first_entry + NATIVE_V2_DEVICE_GRAPH_SECTION_ENTRY_BYTES;
+    let last_entry = first_entry
+        + (DEVICE_GRAPH_SECTION_COUNT_USIZE - 1) * NATIVE_V2_DEVICE_GRAPH_SECTION_ENTRY_BYTES;
+    let first_length = section_length(&original, 0);
+    let second_offset = section_offset(&original, 1);
+    let last_length = section_length(&original, 3);
+    let mut cases = Vec::new();
+
+    let mut bytes = original.clone();
+    overwrite_u64(
+        &mut bytes,
+        first_entry + SECTION_LENGTH_OFFSET,
+        u64::try_from(first_length - DEVICE_GRAPH_ALIGNMENT)
+            .expect("test first section length should fit"),
+    );
+    cases.push(bytes);
+
+    for offset in [
+        second_offset - DEVICE_GRAPH_ALIGNMENT,
+        second_offset + DEVICE_GRAPH_ALIGNMENT,
+        second_offset + 1,
+    ] {
+        let mut bytes = original.clone();
+        overwrite_u64(
+            &mut bytes,
+            second_entry + SECTION_PAYLOAD_OFFSET,
+            u64::try_from(offset).expect("test section offset should fit"),
+        );
+        cases.push(bytes);
+    }
+
+    let mut bytes = original.clone();
+    overwrite_u64(
+        &mut bytes,
+        first_entry + SECTION_LENGTH_OFFSET,
+        u64::try_from(first_length + 1).expect("test unaligned length should fit"),
+    );
+    cases.push(bytes);
+
+    let mut bytes = original.clone();
+    overwrite_u64(
+        &mut bytes,
+        last_entry + SECTION_LENGTH_OFFSET,
+        u64::try_from(last_length + DEVICE_GRAPH_ALIGNMENT)
+            .expect("test oversized last section should fit"),
+    );
+    cases.push(bytes);
+
+    let mut bytes = original.clone();
+    let first =
+        bytes[first_entry..first_entry + NATIVE_V2_DEVICE_GRAPH_SECTION_ENTRY_BYTES].to_vec();
+    let second =
+        bytes[second_entry..second_entry + NATIVE_V2_DEVICE_GRAPH_SECTION_ENTRY_BYTES].to_vec();
+    bytes[first_entry..first_entry + NATIVE_V2_DEVICE_GRAPH_SECTION_ENTRY_BYTES]
+        .copy_from_slice(&second);
+    bytes[second_entry..second_entry + NATIVE_V2_DEVICE_GRAPH_SECTION_ENTRY_BYTES]
+        .copy_from_slice(&first);
+    cases.push(bytes);
+
+    assert_decode_cases_reject(&cases, "section directory canonicality");
+}
+
+#[test]
+fn nonzero_section_padding_is_rejected() {
+    let mut bytes = encoded(&mmio_graph());
+    let config_offset = section_offset(&bytes, 0);
+    let config_length = section_length(&bytes, 0);
+    let semantic_length =
+        CONFIG_FIXED_BYTES + "rootfs".len() + "1111-2222".len() + "root-selector".len();
+    assert!(semantic_length < config_length);
+    bytes[config_offset + semantic_length] = 1;
+    assert_eq!(
+        SnapshotV2DeviceGraph::decode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, &bytes,),
+        Err(SnapshotV2DeviceGraphDecodeError::NonzeroReserved)
+    );
+
+    let mut bytes = encoded(&pci_graph());
+    let pci_offset = section_offset(&bytes, 3);
+    let pci_length = section_length(&bytes, 3);
+    bytes[pci_offset + pci_length - 1] = 1;
+    assert_eq!(
+        SnapshotV2DeviceGraph::decode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, &bytes,),
+        Err(SnapshotV2DeviceGraphDecodeError::NonzeroReserved)
+    );
+}
+
+#[test]
+fn bounded_strings_accept_each_maximum_and_reject_empty_or_one_past() {
+    let mut graph = mmio_graph();
+    graph.record.config.drive_id = "d".repeat(NATIVE_V2_DEVICE_GRAPH_MAX_DRIVE_ID_BYTES);
+    graph.record.config.partuuid = Some("p".repeat(NATIVE_V2_DEVICE_GRAPH_MAX_PARTUUID_BYTES));
+    graph.record.config.selector = "s".repeat(NATIVE_V2_DEVICE_GRAPH_MAX_SELECTOR_BYTES);
+    let bytes = encoded(&graph);
+    assert_eq!(
+        SnapshotV2DeviceGraph::decode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, &bytes,)
+            .expect("maximum strings should decode"),
+        graph
+    );
+
+    let mut invalid = graph.clone();
+    invalid.record.config.drive_id.clear();
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+    let mut invalid = graph.clone();
+    invalid.record.config.partuuid = Some(String::new());
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+    let mut invalid = graph.clone();
+    invalid.record.config.selector.clear();
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+    let mut invalid = graph.clone();
+    invalid.record.config.drive_id.push('d');
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+    let mut invalid = graph.clone();
+    invalid
+        .record
+        .config
+        .partuuid
+        .as_mut()
+        .expect("fixture partuuid should exist")
+        .push('p');
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+    let mut invalid = graph;
+    invalid.record.config.selector.push('s');
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+}
+
+#[test]
+fn invalid_utf8_and_noncanonical_string_presence_fail_closed() {
+    let original = encoded(&mmio_graph());
+    let config = section_offset(&original, 0);
+
+    let mut bytes = original.clone();
+    bytes[config + CONFIG_FIXED_BYTES] = 0xff;
+    assert_eq!(
+        SnapshotV2DeviceGraph::decode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, &bytes,),
+        Err(SnapshotV2DeviceGraphDecodeError::InvalidString)
+    );
+
+    let mut bytes = original.clone();
+    bytes[config + 3] = 0;
+    assert_eq!(
+        SnapshotV2DeviceGraph::decode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, &bytes,),
+        Err(SnapshotV2DeviceGraphDecodeError::InvalidString)
+    );
+}
+
+#[test]
+fn hostile_config_block_and_common_section_mutations_fail_closed() {
+    let original = encoded(&mmio_graph());
+    let config = section_offset(&original, 0);
+    let block = section_offset(&original, 1);
+    let common = section_offset(&original, 2);
+    let mut cases = Vec::new();
+
+    for (offset, value) in [
+        (config, 0_u8),
+        (config + 1, 2),
+        (config + 2, 2),
+        (config + 3, 2),
+        (config + 4, 0),
+        (config + 5, 0),
+        (config + 6, 1),
+        (config + 40, 2),
+    ] {
+        let mut bytes = original.clone();
+        bytes[offset] = value;
+        cases.push(bytes);
+    }
+    for (offset, value) in [
+        (config + 8, 0_u16),
+        (
+            config + 10,
+            u16::try_from(NATIVE_V2_DEVICE_GRAPH_MAX_PARTUUID_BYTES + 1)
+                .expect("test string bound should fit"),
+        ),
+        (
+            config + 12,
+            u16::try_from(NATIVE_V2_DEVICE_GRAPH_MAX_SELECTOR_BYTES + 1)
+                .expect("test string bound should fit"),
+        ),
+    ] {
+        let mut bytes = original.clone();
+        overwrite_u16(&mut bytes, offset, value);
+        cases.push(bytes);
+    }
+    let mut bytes = original.clone();
+    overwrite_u64(&mut bytes, config + 16, 0);
+    cases.push(bytes);
+
+    let mut bytes = original.clone();
+    overwrite_u16(
+        &mut bytes,
+        block,
+        u16::try_from(VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE + 1)
+            .expect("test block config size should fit"),
+    );
+    cases.push(bytes);
+    for (offset, value) in [
+        (block + 2, 2_u8),
+        (block + 3, 0),
+        (block + 4, 0),
+        (block + 5, 3),
+        (block + 6, 1),
+    ] {
+        let mut bytes = original.clone();
+        bytes[offset] = value;
+        cases.push(bytes);
+    }
+    let mut bytes = original.clone();
+    bytes[block + 16..block + 16 + VIRTIO_BLOCK_ID_BYTES as usize].fill(0);
+    cases.push(bytes);
+    let mut bytes = original.clone();
+    bytes[block + 2] = 0;
+    cases.push(bytes);
+    let mut bytes = original.clone();
+    overwrite_u64(&mut bytes, block + 48, 1_000_001);
+    cases.push(bytes);
+    let mut bytes = original.clone();
+    overwrite_u64(&mut bytes, block + 96, 0);
+    cases.push(bytes);
+
+    let mut bytes = original.clone();
+    overwrite_u64(&mut bytes, common, 0);
+    cases.push(bytes);
+    let mut bytes = original.clone();
+    overwrite_u64(&mut bytes, common + 8, u64::MAX);
+    cases.push(bytes);
+    let mut bytes = original.clone();
+    overwrite_u32(&mut bytes, common + 20, VIRTIO_DEVICE_STATUS_FAILED);
+    cases.push(bytes);
+    for (offset, value) in [
+        (common + 24, 0_u8),
+        (common + 25, 1),
+        (common + 36, 2),
+        (common + 37, 1),
+    ] {
+        let mut bytes = original.clone();
+        bytes[offset] = value;
+        cases.push(bytes);
+    }
+    for (offset, value) in [
+        (common + 26, 0_u16),
+        (common + 28, 2),
+        (common + 30, 3),
+        (common + 32, VIRTIO_BLOCK_QUEUE_SIZE - 1),
+        (common + 34, 3),
+        (common + 64, 1),
+    ] {
+        let mut bytes = original.clone();
+        overwrite_u16(&mut bytes, offset, value);
+        cases.push(bytes);
+    }
+    let mut bytes = original.clone();
+    overwrite_u64(&mut bytes, common + 40, 0x1_0001);
+    cases.push(bytes);
+    let mut bytes = original.clone();
+    let first_intent = bytes[common + 66..common + 70].to_vec();
+    let second_intent = bytes[common + 70..common + 74].to_vec();
+    bytes[common + 66..common + 70].copy_from_slice(&second_intent);
+    bytes[common + 70..common + 74].copy_from_slice(&first_intent);
+    cases.push(bytes);
+    let mut bytes = original.clone();
+    bytes[common + 70..common + 74].copy_from_slice(&[INTERRUPT_QUEUE, 0, 0, 0]);
+    cases.push(bytes);
+
+    assert_decode_cases_reject(&cases, "config/block/common mutation");
+}
+
+#[test]
+fn hostile_mmio_and_pci_transport_section_mutations_fail_closed() {
+    let mmio_original = encoded(&mmio_graph());
+    let mmio = section_offset(&mmio_original, 3);
+    let mut mmio_cases = Vec::new();
+    for (offset, value) in [(mmio, 2_u32), (mmio + 4, 2), (mmio + 8, 1), (mmio + 12, 31)] {
+        let mut bytes = mmio_original.clone();
+        overwrite_u32(&mut bytes, offset, value);
+        mmio_cases.push(bytes);
+    }
+    for (offset, value) in [
+        (mmio + 16, 0_u64),
+        (mmio + 24, 0xd000_0001),
+        (mmio + 32, VIRTIO_MMIO_DEVICE_WINDOW_SIZE - 1),
+        (mmio + 40, 1),
+    ] {
+        let mut bytes = mmio_original.clone();
+        overwrite_u64(&mut bytes, offset, value);
+        mmio_cases.push(bytes);
+    }
+    assert_decode_cases_reject(&mmio_cases, "MMIO mutation");
+
+    let pci_original = encoded(&pci_graph());
+    let pci = section_offset(&pci_original, 3);
+    let mut pci_cases = Vec::new();
+    for (offset, value) in [
+        (pci, 2_u8),
+        (pci + 1, 2),
+        (pci + 2, 1),
+        (pci + 3, 1),
+        (pci + 4, 1),
+        (pci + 5, 1),
+        (pci + 6, 1),
+        (pci + 7, 1),
+        (pci + 10, 1),
+        (pci + 11, 0),
+        (pci + 64, 2),
+        (pci + 65, 2),
+        (pci + 66, 2),
+        (pci + 67, 1),
+    ] {
+        let mut bytes = pci_original.clone();
+        bytes[offset] = value;
+        pci_cases.push(bytes);
+    }
+    for (offset, value) in [
+        (pci + 8, 1_u16),
+        (pci + 40, 1),
+        (pci + 42, 3),
+        (pci + 44, 1),
+        (pci + 46, 1),
+        (pci + 48, 2),
+        (pci + 50, 2),
+        (pci + 68, 2),
+    ] {
+        let mut bytes = pci_original.clone();
+        overwrite_u16(&mut bytes, offset, value);
+        pci_cases.push(bytes);
+    }
+    for (offset, value) in [
+        (pci + 32, 2_u32),
+        (pci + 36, 2),
+        (pci + 52, 1),
+        (pci + 60, 3),
+    ] {
+        let mut bytes = pci_original.clone();
+        overwrite_u32(&mut bytes, offset, value);
+        pci_cases.push(bytes);
+    }
+    for (offset, value) in [
+        (pci + 16, PCI_BAR64_START + 1),
+        (pci + 24, VIRTIO_PCI_CAPABILITY_BAR_SIZE - 1),
+    ] {
+        let mut bytes = pci_original.clone();
+        overwrite_u64(&mut bytes, offset, value);
+        pci_cases.push(bytes);
+    }
+    let writable_start = pci + PCI_FIXED_BYTES;
+    let mut bytes = pci_original.clone();
+    overwrite_u16(&mut bytes, writable_start, 0x05);
+    pci_cases.push(bytes);
+    let probes_start = writable_start + PCI_GENERIC_WRITABLE_BYTES.len() * PCI_WRITABLE_ENTRY_BYTES;
+    let mut bytes = pci_original.clone();
+    bytes[probes_start + PCI_BAR_PROBE_ENTRY_BYTES] = 0;
+    pci_cases.push(bytes);
+    let entries_start = probes_start + 2 * PCI_BAR_PROBE_ENTRY_BYTES;
+    let mut bytes = pci_original.clone();
+    overwrite_u32(&mut bytes, entries_start + 12, 2);
+    pci_cases.push(bytes);
+    let pending_start = entries_start + 2 * PCI_MSIX_ENTRY_BYTES;
+    let mut bytes = pci_original.clone();
+    overwrite_u64(&mut bytes, pending_start, 0b100);
+    pci_cases.push(bytes);
+    let vectors_start = pending_start + PCI_PENDING_WORD_BYTES;
+    let mut bytes = pci_original.clone();
+    overwrite_u16(&mut bytes, vectors_start, 2);
+    pci_cases.push(bytes);
+
+    assert_decode_cases_reject(&pci_cases, "PCI mutation");
+}
+
+#[test]
+fn invalid_block_common_and_mmio_semantics_are_rejected_before_encode() {
+    let graph = mmio_graph();
+
+    let mut invalid = graph.clone();
+    invalid.record.block.device_id = VirtioBlockDeviceId::new([0; VIRTIO_BLOCK_ID_BYTES as usize]);
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+    let mut invalid = graph.clone();
+    invalid.record.block.limiter.bandwidth = None;
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+    let mut invalid = graph.clone();
+    invalid.record.block.active_queue = Some(crate::block::VirtioBlockQueueState::new(7, 7));
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+    let mut invalid = graph.clone();
+    invalid.record.block.retry = StorageRetryState::After { remaining_nanos: 0 };
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+    let mut invalid = graph.clone();
+    invalid.record.virtio.queues[0].ready = false;
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+    let mut invalid = graph.clone();
+    invalid.record.virtio.driver_features |= 1_u64 << 63;
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+    let mut invalid = graph.clone();
+    invalid.record.virtio.status = VIRTIO_DEVICE_STATUS_FAILED;
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+    let mut invalid = graph.clone();
+    invalid.record.virtio.pending_notifications = vec![1];
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+    let mut invalid = graph.clone();
+    invalid.record.virtio.interrupt_intents.swap(0, 1);
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+    let mut invalid = graph.clone();
+    invalid.record.virtio.queues[0].descriptor_table = GuestAddress::new(0x2_0000);
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+    let mut invalid = graph.clone();
+    let SnapshotV2DeviceTransport::Mmio(mmio) = &mut invalid.record.transport else {
+        panic!("fixture should use MMIO");
+    };
+    mmio.region = MmioRegion::new(
+        MmioRegionId::new(9),
+        invalid.record.virtio.queues[0].descriptor_table,
+        VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+    )
+    .expect("overlapping MMIO range should be structurally valid");
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+    let mut invalid = graph;
+    let SnapshotV2DeviceTransport::Mmio(mmio) = &mut invalid.record.transport else {
+        panic!("fixture should use MMIO");
+    };
+    mmio.queue_select = 1;
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+}
+
+#[test]
+fn invalid_pci_placement_configuration_and_msix_semantics_are_rejected() {
+    let graph = pci_graph();
+
+    let mut invalid = graph.clone();
+    let SnapshotV2DeviceTransport::Pci(pci) = &mut invalid.record.transport else {
+        panic!("fixture should use PCI");
+    };
+    pci.origin = StorageDeviceOrigin::Runtime;
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+
+    let mut invalid = graph.clone();
+    let SnapshotV2DeviceTransport::Pci(pci) = &mut invalid.record.transport else {
+        panic!("fixture should use PCI");
+    };
+    pci.device_feature_select = 2;
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+
+    let mut invalid = graph.clone();
+    let SnapshotV2DeviceTransport::Pci(pci) = &mut invalid.record.transport else {
+        panic!("fixture should use PCI");
+    };
+    pci.pci_cfg_length = 3;
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+
+    let mut invalid = graph.clone();
+    let SnapshotV2DeviceTransport::Pci(pci) = &mut invalid.record.transport else {
+        panic!("fixture should use PCI");
+    };
+    pci.writable_bytes.swap(0, 1);
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+
+    let mut invalid = graph.clone();
+    let SnapshotV2DeviceTransport::Pci(pci) = &mut invalid.record.transport else {
+        panic!("fixture should use PCI");
+    };
+    pci.bar_probes[1].index = 0;
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+
+    let mut invalid = graph.clone();
+    let SnapshotV2DeviceTransport::Pci(pci) = &mut invalid.record.transport else {
+        panic!("fixture should use PCI");
+    };
+    pci.msix.pending_words[0] = 0b100;
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+
+    let mut invalid = graph.clone();
+    let SnapshotV2DeviceTransport::Pci(pci) = &mut invalid.record.transport else {
+        panic!("fixture should use PCI");
+    };
+    pci.msix.entries[0].vector_control = 2;
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+
+    let mut invalid = graph;
+    let SnapshotV2DeviceTransport::Pci(pci) = &mut invalid.record.transport else {
+        panic!("fixture should use PCI");
+    };
+    pci.msix.queue_vectors[0] = 2;
+    assert_eq!(
+        invalid.encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION),
+        Err(SnapshotV2DeviceGraphEncodeError::InvalidGraph)
+    );
+}
+
+#[test]
+fn every_supported_pci_endpoint_slot_is_canonical() {
+    for device in PCI_FIRST_ENDPOINT_DEVICE..=PCI_LAST_ENDPOINT_DEVICE {
+        let mut graph = pci_graph();
+        let SnapshotV2DeviceTransport::Pci(pci) = &mut graph.record.transport else {
+            panic!("fixture should use PCI");
+        };
+        pci.sbdf = PciSbdf::new(PCI_SEGMENT_ZERO, PCI_BUS_ZERO, device, PCI_FUNCTION_ZERO)
+            .expect("endpoint SBDF should validate");
+        assert!(
+            graph
+                .encode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION)
+                .is_ok(),
+            "endpoint device {device} unexpectedly rejected",
+        );
+    }
+}
+
+static NEXT_TEMP_FILE: AtomicU64 = AtomicU64::new(0);
+
+struct TempFile {
+    path: PathBuf,
+}
+
+impl TempFile {
+    fn new(name: &str, len: u64) -> Self {
+        let sequence = NEXT_TEMP_FILE.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "bangbang-snapshot-v2-device-{name}-{}-{sequence}",
+            std::process::id(),
+        ));
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .expect("test block backing should create");
+        file.set_len(len).expect("test block backing should resize");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn root_config(path: &Path) -> DriveConfig {
+    DriveConfigInput::new("rootfs", "rootfs", path, true)
+        .with_is_read_only(true)
+        .with_cache_type(DriveCacheType::Writeback)
+        .with_io_engine(DriveIoEngine::Sync)
+        .with_partuuid("1111-2222")
+        .validate()
+        .expect("test root configuration should validate")
+}
+
+fn activate_mmio_block(
+    handler: &mut VirtioMmioRegisterHandler<VirtioBlockConfigSpace, VirtioBlockDevice>,
+    features: u64,
+) {
+    handler
+        .write_register(VirtioMmioRegister::Status, VIRTIO_DEVICE_STATUS_ACKNOWLEDGE)
+        .expect("MMIO acknowledge status should write");
+    handler
+        .write_register(
+            VirtioMmioRegister::Status,
+            VIRTIO_DEVICE_STATUS_ACKNOWLEDGE | VIRTIO_DEVICE_STATUS_DRIVER,
+        )
+        .expect("MMIO driver status should write");
+    handler
+        .write_register(VirtioMmioRegister::DriverFeaturesSel, 0)
+        .expect("MMIO low feature page should select");
+    handler
+        .write_register(VirtioMmioRegister::DriverFeatures, features as u32)
+        .expect("MMIO low driver features should write");
+    handler
+        .write_register(VirtioMmioRegister::DriverFeaturesSel, 1)
+        .expect("MMIO high feature page should select");
+    handler
+        .write_register(
+            VirtioMmioRegister::DriverFeatures,
+            u32::try_from(features >> 32).expect("MMIO high feature page should fit"),
+        )
+        .expect("MMIO high driver features should write");
+    handler
+        .write_register(VirtioMmioRegister::DeviceFeaturesSel, 1)
+        .expect("MMIO device feature page should select");
+    handler
+        .write_register(
+            VirtioMmioRegister::Status,
+            VIRTIO_DEVICE_STATUS_ACKNOWLEDGE
+                | VIRTIO_DEVICE_STATUS_DRIVER
+                | VIRTIO_DEVICE_STATUS_FEATURES_OK,
+        )
+        .expect("MMIO features-ok status should write");
+    for (register, value) in [
+        (
+            VirtioMmioRegister::QueueNum,
+            u32::from(VIRTIO_BLOCK_QUEUE_SIZE),
+        ),
+        (VirtioMmioRegister::QueueDescLow, 0x1_0000),
+        (VirtioMmioRegister::QueueDriverLow, 0x2_0000),
+        (VirtioMmioRegister::QueueDeviceLow, 0x3_0000),
+        (VirtioMmioRegister::QueueReady, 1),
+    ] {
+        handler
+            .write_register(register, value)
+            .expect("MMIO queue state should write");
+    }
+    handler
+        .write_register(
+            VirtioMmioRegister::Status,
+            VIRTIO_DEVICE_STATUS_ACKNOWLEDGE
+                | VIRTIO_DEVICE_STATUS_DRIVER
+                | VIRTIO_DEVICE_STATUS_FEATURES_OK
+                | VIRTIO_DEVICE_STATUS_DRIVER_OK,
+        )
+        .expect("MMIO driver-ok status should activate");
+    handler
+        .write_register(VirtioMmioRegister::QueueNotify, 0)
+        .expect("MMIO queue notification should retain");
+    handler.mark_interrupt_pending(DeviceInterruptKind::Queue);
+    handler.mark_interrupt_pending(DeviceInterruptKind::Config);
+}
+
+fn capture_ready_mmio(path: &Path) -> CaptureReadyBlockDeviceState {
+    let config = root_config(path);
+    let prepared = PreparedBlockDevice::from_config_with_backing(&config, None)
+        .expect("test block device should prepare");
+    let (_, _, config_space, device) = prepared.into_parts();
+    let mut handler = VirtioMmioRegisterHandler::with_device_config_and_activation(
+        VIRTIO_BLOCK_DEVICE_ID,
+        config_space.available_features(),
+        &VIRTIO_BLOCK_QUEUE_SIZES,
+        config_space,
+        device,
+    )
+    .expect("test MMIO block handler should build");
+    activate_mmio_block(&mut handler, config_space.available_features());
+    let device = handler
+        .capture_block_device_state_at(&config, Instant::now())
+        .expect("test MMIO block state should capture");
+    let transport = handler.transport_state();
+    let region = MmioRegion::new(
+        MmioRegionId::new(7),
+        GuestAddress::new(0xd000_0000),
+        VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+    )
+    .expect("test MMIO region should validate");
+    CaptureReadyBlockDeviceState::new(
+        config,
+        StorageTransportState::Mmio(StorageMmioTransportState::new(
+            region,
+            GuestInterruptLine::new(32).expect("test IRQ should validate"),
+            transport,
+        )),
+        StorageRetryState::None,
+        device,
+    )
+}
+
+fn capture_ready_mmio_with_legacy_device_id(path: &Path) -> CaptureReadyBlockDeviceState {
+    let config = root_config(path);
+    let backing = BlockFileBacking::open(&config).expect("legacy test backing should open");
+    let config_space = VirtioBlockConfigSpace::from_backing(&backing, config.cache_type());
+    let legacy_id = VirtioBlockDeviceId::from_bytes(config.drive_id().as_bytes());
+    let device = VirtioBlockDevice::new(backing, legacy_id);
+    let handler = VirtioMmioRegisterHandler::with_device_config_and_activation(
+        VIRTIO_BLOCK_DEVICE_ID,
+        config_space.available_features(),
+        &VIRTIO_BLOCK_QUEUE_SIZES,
+        config_space,
+        device,
+    )
+    .expect("legacy MMIO block handler should build");
+    let device = handler
+        .capture_block_device_state_at(&config, Instant::now())
+        .expect("legacy-compatible block state should capture");
+    let region = MmioRegion::new(
+        MmioRegionId::new(7),
+        GuestAddress::new(0xd000_0000),
+        VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+    )
+    .expect("legacy test MMIO region should validate");
+    CaptureReadyBlockDeviceState::new(
+        config,
+        StorageTransportState::Mmio(StorageMmioTransportState::new(
+            region,
+            GuestInterruptLine::new(32).expect("legacy test IRQ should validate"),
+            handler.transport_state(),
+        )),
+        StorageRetryState::None,
+        device,
+    )
+}
+
+#[derive(Debug)]
+struct TestMessageRoute(GuestMessage);
+
+impl GuestMessageInterrupt for TestMessageRoute {
+    fn matches(&self, message: GuestMessage) -> bool {
+        self.0 == message
+    }
+
+    fn signal(&self, message: GuestMessage) -> Result<(), GuestMessageInterruptSignalError> {
+        if self.matches(message) {
+            Ok(())
+        } else {
+            Err(GuestMessageInterruptSignalError::new(
+                "test route rejected an unknown message",
+                false,
+            ))
+        }
+    }
+}
+
+fn pci_bar_write(
+    handler: &mut impl MmioHandler,
+    bus: &MmioBus,
+    bar: &PciBarLease,
+    offset: u64,
+    data: &[u8],
+) {
+    let address = bar
+        .range()
+        .start()
+        .checked_add(offset)
+        .expect("test PCI BAR address should not overflow");
+    let access = bus
+        .lookup(
+            address,
+            u64::try_from(data.len()).expect("test PCI write width should fit"),
+        )
+        .expect("test PCI BAR access should resolve");
+    handler
+        .write(
+            access,
+            MmioAccessBytes::new(data).expect("test PCI BAR bytes should validate"),
+        )
+        .expect("test PCI BAR write should succeed");
+}
+
+fn activate_pci_block(
+    endpoint: &VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice>,
+    bar: &PciBarLease,
+    features: u64,
+) {
+    let mut bus = MmioBus::new();
+    bus.insert(
+        MmioRegionId::new(77),
+        bar.range().start(),
+        bar.range().size(),
+    )
+    .expect("test PCI BAR should register");
+    let mut handler = endpoint.bar_handler();
+
+    pci_bar_write(&mut handler, &bus, bar, 0x14, &[1]);
+    pci_bar_write(&mut handler, &bus, bar, 0x14, &[3]);
+    pci_bar_write(&mut handler, &bus, bar, 0x08, &0_u32.to_le_bytes());
+    pci_bar_write(
+        &mut handler,
+        &bus,
+        bar,
+        0x0c,
+        &(features as u32).to_le_bytes(),
+    );
+    pci_bar_write(&mut handler, &bus, bar, 0x08, &1_u32.to_le_bytes());
+    pci_bar_write(
+        &mut handler,
+        &bus,
+        bar,
+        0x0c,
+        &u32::try_from(features >> 32)
+            .expect("test high PCI feature page should fit")
+            .to_le_bytes(),
+    );
+    pci_bar_write(&mut handler, &bus, bar, 0x00, &1_u32.to_le_bytes());
+    pci_bar_write(&mut handler, &bus, bar, 0x14, &[11]);
+    pci_bar_write(&mut handler, &bus, bar, 0x16, &0_u16.to_le_bytes());
+    pci_bar_write(
+        &mut handler,
+        &bus,
+        bar,
+        0x18,
+        &VIRTIO_BLOCK_QUEUE_SIZE.to_le_bytes(),
+    );
+    pci_bar_write(&mut handler, &bus, bar, 0x20, &0x1_0000_u32.to_le_bytes());
+    pci_bar_write(&mut handler, &bus, bar, 0x28, &0x2_0000_u32.to_le_bytes());
+    pci_bar_write(&mut handler, &bus, bar, 0x30, &0x3_0000_u32.to_le_bytes());
+    pci_bar_write(&mut handler, &bus, bar, 0x1c, &1_u16.to_le_bytes());
+    pci_bar_write(&mut handler, &bus, bar, 0x14, &[15]);
+    pci_bar_write(
+        &mut handler,
+        &bus,
+        bar,
+        VIRTIO_PCI_NOTIFICATION_OFFSET,
+        &0_u16.to_le_bytes(),
+    );
+    drop(handler);
+    let work = endpoint
+        .admit_device_work()
+        .expect("test PCI device work should admit");
+    work.with_core_mut(|core| {
+        core.record_interrupt_intent(VirtioInterruptIntent::Queue { queue_index: 0 });
+        core.record_interrupt_intent(VirtioInterruptIntent::Configuration);
+    })
+    .expect("test PCI interrupt intents should record");
+}
+
+struct PciRuntimeFixture {
+    config: DriveConfig,
+    endpoint: VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice>,
+    bar: PciBarLease,
+    _allocator: PciBarAllocator,
+}
+
+impl PciRuntimeFixture {
+    fn new(path: &Path) -> Self {
+        let config = root_config(path);
+        let prepared = PreparedBlockDevice::from_config_with_backing(&config, None)
+            .expect("test block device should prepare");
+        let (_, _, config_space, device) = prepared.into_parts();
+        let capacity = GuestMemoryRange::new(
+            GuestAddress::new(PCI_BAR64_START),
+            VIRTIO_PCI_CAPABILITY_BAR_SIZE * 2,
+        )
+        .expect("test PCI BAR allocator range should validate");
+        let mut allocator = PciBarAllocator::new(PciBarAddressSpace::Memory64, capacity);
+        let bar = allocator
+            .allocate(VIRTIO_PCI_CAPABILITY_BAR_SIZE)
+            .expect("test PCI BAR should allocate");
+        let routes: Vec<Arc<dyn GuestMessageInterrupt>> = (0..2)
+            .map(|index| {
+                Arc::new(TestMessageRoute(GuestMessage::new(0x0800_0040, 64 + index)))
+                    as Arc<dyn GuestMessageInterrupt>
+            })
+            .collect();
+        let registry =
+            GuestMessageInterruptRegistry::new(routes).expect("test PCI routes should validate");
+        let endpoint = VirtioPciEndpoint::new(
+            VirtioPciIdentity::new(
+                VirtioDeviceType::new(VIRTIO_BLOCK_DEVICE_ID)
+                    .expect("block virtio type should validate"),
+                config_space.available_features(),
+            ),
+            &VIRTIO_BLOCK_QUEUE_SIZES,
+            config_space,
+            device,
+            false,
+            &bar,
+            registry,
+        )
+        .expect("test PCI block endpoint should build");
+        activate_pci_block(&endpoint, &bar, config_space.available_features());
+        Self {
+            config,
+            endpoint,
+            bar,
+            _allocator: allocator,
+        }
+    }
+
+    fn capture(&self) -> CaptureReadyBlockDeviceState {
+        let (device, transport) = self
+            .endpoint
+            .capture_block_device_state_at(&self.config, Instant::now())
+            .expect("test PCI block state should capture");
+        let sbdf = PciSbdf::new(
+            PCI_SEGMENT_ZERO,
+            PCI_BUS_ZERO,
+            PCI_FIRST_ENDPOINT_DEVICE,
+            PCI_FUNCTION_ZERO,
+        )
+        .expect("test PCI identity should validate");
+        CaptureReadyBlockDeviceState::new(
+            self.config.clone(),
+            StorageTransportState::Pci(StoragePciTransportState::new(
+                StorageDeviceOrigin::Startup,
+                sbdf,
+                self.bar.range(),
+                transport,
+            )),
+            StorageRetryState::None,
+            device,
+        )
+    }
+}
+
+fn capture_ready_pci(path: &Path) -> CaptureReadyBlockDeviceState {
+    PciRuntimeFixture::new(path).capture()
+}
+
+#[test]
+fn real_mmio_capture_converts_without_host_identity_and_preserves_stable_id() {
+    let file = TempFile::new("mmio.img", 4096);
+    let state = capture_ready_mmio(file.path());
+    let captured_id = state.device().device_id();
+    assert_ne!(
+        captured_id,
+        VirtioBlockDeviceId::from_bytes(state.drive_id().as_bytes())
+    );
+
+    let graph = SnapshotV2DeviceGraph::from_capture_ready_root(
+        NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+        &state,
+    )
+    .expect("real MMIO capture should convert");
+    assert_eq!(graph.record().block().device_id(), captured_id);
+    assert_eq!(
+        graph.record().config().selector(),
+        file.path().to_str().unwrap()
+    );
+    assert_eq!(graph.transport_kind(), SnapshotV2DeviceTransportKind::Mmio);
+    assert!(graph.record().virtio().is_activated());
+    assert!(graph.record().block().active_queue().is_some());
+    assert_eq!(graph.record().virtio().pending_notifications(), [0]);
+    assert_eq!(
+        graph.record().virtio().interrupt_intents(),
+        [
+            SnapshotV2InterruptIntent::Queue { queue_index: 0 },
+            SnapshotV2InterruptIntent::Configuration,
+        ]
+    );
+    let SnapshotV2DeviceTransport::Mmio(mmio) = graph.record().transport() else {
+        panic!("converted graph should retain MMIO");
+    };
+    assert_eq!(mmio.device_feature_select(), 1);
+    assert_eq!(mmio.driver_feature_select(), 1);
+    let bytes = encoded(&graph);
+    assert_eq!(
+        SnapshotV2DeviceGraph::decode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, &bytes,)
+            .expect("converted MMIO graph should decode"),
+        graph
+    );
+}
+
+#[test]
+fn legacy_drive_derived_guest_block_id_remains_admitted_and_independent() {
+    let file = TempFile::new("legacy-id.img", 4096);
+    let state = capture_ready_mmio_with_legacy_device_id(file.path());
+    let legacy_id = VirtioBlockDeviceId::from_bytes(state.drive_id().as_bytes());
+    assert_eq!(state.device().device_id(), legacy_id);
+
+    let graph = SnapshotV2DeviceGraph::from_capture_ready_root(
+        NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+        &state,
+    )
+    .expect("legacy-compatible block ID should convert");
+    assert_eq!(graph.record().block().device_id(), legacy_id);
+    assert_eq!(
+        SnapshotV2DeviceGraph::decode(
+            NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            &encoded(&graph),
+        )
+        .expect("legacy-compatible graph should decode")
+        .record()
+        .block()
+        .device_id(),
+        legacy_id
+    );
+}
+
+#[test]
+fn runtime_conversion_rejects_configuration_limiter_retry_and_mmio_policy_mismatches() {
+    let file = TempFile::new("capture-rejections.img", 4096);
+    let state = capture_ready_mmio(file.path());
+
+    let configurations = [
+        (
+            DriveConfigInput::new("rootfs", "rootfs", file.path(), false)
+                .with_is_read_only(true)
+                .with_cache_type(DriveCacheType::Writeback)
+                .with_io_engine(DriveIoEngine::Sync)
+                .validate()
+                .expect("non-root test config should validate"),
+            SnapshotV2DeviceGraphCaptureError::UnsupportedConfiguration,
+        ),
+        (
+            DriveConfigInput::new("rootfs", "rootfs", file.path(), true)
+                .with_is_read_only(false)
+                .with_cache_type(DriveCacheType::Writeback)
+                .with_io_engine(DriveIoEngine::Sync)
+                .validate()
+                .expect("writable test config should validate"),
+            SnapshotV2DeviceGraphCaptureError::UnsupportedConfiguration,
+        ),
+        (
+            DriveConfigInput::new("rootfs", "rootfs", file.path(), true)
+                .with_is_read_only(true)
+                .with_cache_type(DriveCacheType::Writeback)
+                .with_io_engine(DriveIoEngine::Async)
+                .validate()
+                .expect("Async test config should validate"),
+            SnapshotV2DeviceGraphCaptureError::UnsupportedConfiguration,
+        ),
+        (
+            DriveConfigInput::new("rootfs", "rootfs", file.path(), true)
+                .with_is_read_only(true)
+                .with_cache_type(DriveCacheType::Unsafe)
+                .with_io_engine(DriveIoEngine::Sync)
+                .validate()
+                .expect("cache-mismatch test config should validate"),
+            SnapshotV2DeviceGraphCaptureError::InconsistentBlockState,
+        ),
+        (
+            DriveConfigInput::new("rootfs", "rootfs", file.path(), true)
+                .with_is_read_only(true)
+                .with_cache_type(DriveCacheType::Writeback)
+                .with_io_engine(DriveIoEngine::Sync)
+                .with_rate_limiter(DriveRateLimiterConfig::new(
+                    Some(DriveTokenBucketConfig::new(100, None, 1)),
+                    None,
+                ))
+                .validate()
+                .expect("limiter-mismatch test config should validate"),
+            SnapshotV2DeviceGraphCaptureError::InconsistentBlockState,
+        ),
+    ];
+    for (config, expected) in configurations {
+        let invalid = CaptureReadyBlockDeviceState::new(
+            config,
+            state.transport().clone(),
+            state.retry(),
+            *state.device(),
+        );
+        assert_eq!(
+            SnapshotV2DeviceGraph::from_capture_ready_root(
+                NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                &invalid,
+            ),
+            Err(expected)
+        );
+    }
+
+    let invalid_retry = CaptureReadyBlockDeviceState::new(
+        state.config().clone(),
+        state.transport().clone(),
+        StorageRetryState::Immediate,
+        *state.device(),
+    );
+    assert_eq!(
+        SnapshotV2DeviceGraph::from_capture_ready_root(
+            NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            &invalid_retry,
+        ),
+        Err(SnapshotV2DeviceGraphCaptureError::InconsistentBlockState)
+    );
+
+    let StorageTransportState::Mmio(mmio) = state.transport() else {
+        panic!("test capture should use MMIO");
+    };
+    let transport = mmio.transport();
+    let false_policy = VirtioMmioTransportState::from_parts(
+        *transport.device_registers(),
+        transport.queue_select(),
+        transport.queues().to_vec(),
+        transport.pending_notifications().to_vec(),
+        transport.interrupt_status(),
+        transport.is_device_activated(),
+        false,
+    );
+    let invalid_policy = CaptureReadyBlockDeviceState::new(
+        state.config().clone(),
+        StorageTransportState::Mmio(StorageMmioTransportState::new(
+            mmio.region(),
+            mmio.interrupt_line(),
+            false_policy,
+        )),
+        state.retry(),
+        *state.device(),
+    );
+    assert_eq!(
+        SnapshotV2DeviceGraph::from_capture_ready_root(
+            NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            &invalid_policy,
+        ),
+        Err(SnapshotV2DeviceGraphCaptureError::InvalidMmioState)
+    );
+}
+
+#[test]
+fn real_pci_capture_uses_checked_configuration_profile_and_preserves_stable_id() {
+    let file = TempFile::new("pci.img", 8192);
+    let state = capture_ready_pci(file.path());
+    let captured_id = state.device().device_id();
+    assert_ne!(
+        captured_id,
+        VirtioBlockDeviceId::from_bytes(state.drive_id().as_bytes())
+    );
+
+    let graph = SnapshotV2DeviceGraph::from_capture_ready_root(
+        NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+        &state,
+    )
+    .expect("real PCI capture should convert");
+    assert_eq!(graph.record().block().device_id(), captured_id);
+    assert_eq!(graph.transport_kind(), SnapshotV2DeviceTransportKind::Pci);
+    let SnapshotV2DeviceTransport::Pci(pci) = graph.record().transport() else {
+        panic!("converted graph should retain PCI");
+    };
+    assert!(graph.record().virtio().is_activated());
+    assert!(graph.record().block().active_queue().is_some());
+    assert_eq!(graph.record().virtio().pending_notifications(), [0]);
+    assert_eq!(
+        graph.record().virtio().interrupt_intents(),
+        [
+            SnapshotV2InterruptIntent::Queue { queue_index: 0 },
+            SnapshotV2InterruptIntent::Configuration,
+        ]
+    );
+    assert_eq!(pci.device_feature_select(), 1);
+    assert_eq!(pci.driver_feature_select(), 1);
+    assert_eq!(
+        pci.writable_bytes()
+            .iter()
+            .map(|byte| byte.offset())
+            .collect::<Vec<_>>(),
+        [0x04, 0x05, 0x0c, 0x3c]
+    );
+    assert_eq!(
+        pci.bar_probes()
+            .iter()
+            .map(|probe| probe.index())
+            .collect::<Vec<_>>(),
+        [0, 1]
+    );
+    assert_eq!(pci.msix().entries().len(), 2);
+    assert_eq!(
+        encoded(
+            &SnapshotV2DeviceGraph::decode(
+                NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                &encoded(&graph),
+            )
+            .expect("converted PCI graph should decode")
+        ),
+        encoded(&graph)
+    );
+}
+
+#[test]
+fn runtime_conversion_rejects_noncanonical_pci_origin_identity_and_bar() {
+    let file = TempFile::new("pci-placement-rejections.img", 8192);
+    let state = capture_ready_pci(file.path());
+    let StorageTransportState::Pci(pci) = state.transport() else {
+        panic!("test capture should use PCI");
+    };
+    let host_bridge = PciSbdf::new(PCI_SEGMENT_ZERO, PCI_BUS_ZERO, 0, PCI_FUNCTION_ZERO)
+        .expect("host-bridge SBDF should be structurally valid");
+    let unaligned_bar = GuestMemoryRange::new(
+        GuestAddress::new(PCI_BAR64_START + 1),
+        VIRTIO_PCI_CAPABILITY_BAR_SIZE,
+    )
+    .expect("unaligned BAR should be a valid raw range");
+    for transport in [
+        StoragePciTransportState::new(
+            StorageDeviceOrigin::Runtime,
+            pci.sbdf(),
+            pci.bar_range(),
+            pci.transport().clone(),
+        ),
+        StoragePciTransportState::new(
+            StorageDeviceOrigin::Startup,
+            host_bridge,
+            pci.bar_range(),
+            pci.transport().clone(),
+        ),
+        StoragePciTransportState::new(
+            StorageDeviceOrigin::Startup,
+            pci.sbdf(),
+            unaligned_bar,
+            pci.transport().clone(),
+        ),
+    ] {
+        let invalid = CaptureReadyBlockDeviceState::new(
+            state.config().clone(),
+            StorageTransportState::Pci(transport),
+            state.retry(),
+            *state.device(),
+        );
+        assert_eq!(
+            SnapshotV2DeviceGraph::from_capture_ready_root(
+                NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                &invalid,
+            ),
+            Err(SnapshotV2DeviceGraphCaptureError::InvalidPciState)
+        );
+    }
+}
+
+#[test]
+fn pci_config_data_aperture_scratch_is_not_artifact_state() {
+    let file = TempFile::new("pci-scratch.img", 8192);
+    let fixture = PciRuntimeFixture::new(file.path());
+    let transport_before = fixture
+        .endpoint
+        .transport_state()
+        .expect("test PCI transport should capture");
+    let before = SnapshotV2DeviceGraph::from_capture_ready_root(
+        NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+        &fixture.capture(),
+    )
+    .expect("test PCI graph should convert");
+
+    let mut configuration = fixture.endpoint.config_function();
+    configuration
+        .write_config(
+            transport_before
+                .pci_cfg_cap_offset()
+                .checked_add(16)
+                .expect("test PCI data aperture should fit"),
+            &[0xde, 0xad, 0xbe, 0xef],
+        )
+        .expect("test PCI data aperture should write");
+    drop(configuration);
+
+    let transport_after = fixture
+        .endpoint
+        .transport_state()
+        .expect("updated PCI transport should capture");
+    assert_ne!(transport_after, transport_before);
+    let after = SnapshotV2DeviceGraph::from_capture_ready_root(
+        NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+        &fixture.capture(),
+    )
+    .expect("updated PCI graph should convert");
+    assert_eq!(after, before);
+    assert_eq!(encoded(&after), encoded(&before));
+}
+
+#[test]
+fn real_pci_generic_writes_and_bar_probe_state_are_captured_canonically() {
+    let file = TempFile::new("pci-guest-state.img", 8192);
+    let fixture = PciRuntimeFixture::new(file.path());
+    let mut configuration = fixture.endpoint.config_function();
+    for (offset, value) in [(0x04, 0x07_u8), (0x05, 0x80), (0x0c, 0x40), (0x3c, 0x2a)] {
+        configuration
+            .write_config(offset, &[value])
+            .expect("test generic PCI byte should write");
+    }
+    configuration
+        .write_config(0x10, &[u8::MAX; 4])
+        .expect("test PCI BAR probe should arm");
+    drop(configuration);
+
+    let graph = SnapshotV2DeviceGraph::from_capture_ready_root(
+        NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+        &fixture.capture(),
+    )
+    .expect("test PCI graph should convert");
+    let SnapshotV2DeviceTransport::Pci(pci) = graph.record().transport() else {
+        panic!("converted graph should retain PCI");
+    };
+    assert_eq!(
+        pci.writable_bytes()
+            .iter()
+            .map(|byte| (byte.offset(), byte.value()))
+            .collect::<Vec<_>>(),
+        [(0x04, 0x07), (0x05, 0x80), (0x0c, 0x40), (0x3c, 0x2a)]
+    );
+    assert_eq!(
+        pci.bar_probes()
+            .iter()
+            .map(|probe| (probe.index(), probe.pending()))
+            .collect::<Vec<_>>(),
+        [(0, true), (1, false)]
+    );
+
+    let recaptured = SnapshotV2DeviceGraph::from_capture_ready_root(
+        NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+        &fixture.capture(),
+    )
+    .expect("side-effect-free PCI graph recapture should convert");
+    assert_eq!(recaptured, graph);
+}

--- a/crates/runtime/src/virtio_mmio.rs
+++ b/crates/runtime/src/virtio_mmio.rs
@@ -1186,6 +1186,7 @@ pub struct VirtioMmioTransportState {
     pending_notifications: Vec<bool>,
     interrupt_status: DeviceInterruptStatus,
     device_activated: bool,
+    requires_device_config_write_status: bool,
 }
 
 impl VirtioMmioTransportState {
@@ -1196,6 +1197,7 @@ impl VirtioMmioTransportState {
         pending_notifications: Vec<bool>,
         interrupt_status: DeviceInterruptStatus,
         device_activated: bool,
+        requires_device_config_write_status: bool,
     ) -> Self {
         Self {
             device,
@@ -1204,6 +1206,7 @@ impl VirtioMmioTransportState {
             pending_notifications,
             interrupt_status,
             device_activated,
+            requires_device_config_write_status,
         }
     }
 
@@ -1230,6 +1233,11 @@ impl VirtioMmioTransportState {
     pub const fn is_device_activated(&self) -> bool {
         self.device_activated
     }
+
+    /// Returns whether device-configuration writes require driver-ready status.
+    pub const fn requires_device_config_write_status(&self) -> bool {
+        self.requires_device_config_write_status
+    }
 }
 
 impl fmt::Debug for VirtioMmioTransportState {
@@ -1249,6 +1257,7 @@ pub(crate) enum VirtioMmioTransportStateError {
     MissingVersionOneDriverFeature,
     UnhealthyDeviceStatus,
     ActivationMismatch,
+    DeviceConfigWritePolicyMismatch,
     QueueCountMismatch,
     QueueSelectorOutOfBounds,
     QueueMaxSizeMismatch,
@@ -1283,6 +1292,9 @@ impl fmt::Display for VirtioMmioTransportStateError {
             }
             Self::ActivationMismatch => {
                 f.write_str("persisted virtio-mmio activation state is inconsistent")
+            }
+            Self::DeviceConfigWritePolicyMismatch => {
+                f.write_str("persisted virtio-mmio device-config write policy does not match")
             }
             Self::QueueCountMismatch => {
                 f.write_str("persisted virtio-mmio queue count does not match")
@@ -1885,6 +1897,7 @@ impl<C: VirtioMmioDeviceConfigHandler, A: VirtioMmioDeviceActivationHandler>
             self.queue_notifications.pending_notifications.clone(),
             self.interrupts.pending_status,
             self.device_activated,
+            self.core.requires_device_config_write_status,
         )
     }
 
@@ -2956,6 +2969,10 @@ fn validate_transport_state<C, A>(
     {
         return Err(VirtioMmioTransportStateError::ActivationMismatch);
     }
+    if state.requires_device_config_write_status != handler.core.requires_device_config_write_status
+    {
+        return Err(VirtioMmioTransportStateError::DeviceConfigWritePolicyMismatch);
+    }
 
     if state.queues.len() != handler.queues.queues.len() {
         return Err(VirtioMmioTransportStateError::QueueCountMismatch);
@@ -3221,8 +3238,9 @@ mod tests {
     use std::error::Error as _;
 
     use super::{
-        VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DEVICE_NEEDS_RESET,
-        VIRTIO_DEVICE_STATUS_DRIVER, VIRTIO_DEVICE_STATUS_DRIVER_OK, VIRTIO_DEVICE_STATUS_FAILED,
+        UnsupportedVirtioMmioDeviceConfig, VIRTIO_DEVICE_STATUS_ACKNOWLEDGE,
+        VIRTIO_DEVICE_STATUS_DEVICE_NEEDS_RESET, VIRTIO_DEVICE_STATUS_DRIVER,
+        VIRTIO_DEVICE_STATUS_DRIVER_OK, VIRTIO_DEVICE_STATUS_FAILED,
         VIRTIO_DEVICE_STATUS_FEATURES_OK, VIRTIO_DEVICE_STATUS_INIT,
         VIRTIO_MMIO_DEVICE_CONFIG_OFFSET, VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
         VIRTIO_MMIO_FEATURE_VERSION_1, VIRTIO_MMIO_MAGIC_VALUE, VIRTIO_MMIO_NOTIFY_OFFSET,
@@ -5640,6 +5658,35 @@ mod tests {
                 .restore_transport_state(&invalid, false)
                 .expect_err("failed state should reject"),
             VirtioMmioTransportStateError::UnhealthyDeviceStatus
+        );
+        assert_eq!(target.transport_state(), before);
+    }
+
+    #[test]
+    fn transport_restore_rejects_device_config_write_policy_mismatch_without_mutation() {
+        let source =
+            VirtioMmioRegisterHandler::new(2, 0, &[256]).expect("source transport should build");
+        assert!(
+            !source
+                .transport_state()
+                .requires_device_config_write_status()
+        );
+        let state = source.transport_state();
+        let mut target = VirtioMmioRegisterHandler::with_device_config(
+            2,
+            0,
+            &[256],
+            UnsupportedVirtioMmioDeviceConfig,
+        )
+        .expect("device-config transport should build");
+        let before = target.transport_state();
+        assert!(before.requires_device_config_write_status());
+
+        assert_eq!(
+            target
+                .restore_transport_state(&state, false)
+                .expect_err("policy mismatch should reject"),
+            VirtioMmioTransportStateError::DeviceConfigWritePolicyMismatch
         );
         assert_eq!(target.transport_state(), before);
     }

--- a/crates/runtime/src/virtio_pci.rs
+++ b/crates/runtime/src/virtio_pci.rs
@@ -8,7 +8,7 @@
 use std::fmt;
 use std::sync::{Arc, Mutex, MutexGuard};
 
-use crate::memory::GuestAddress;
+use crate::memory::{GuestAddress, GuestMemoryRange};
 use crate::message_interrupt::{
     GuestMessage, GuestMessageInterruptRegistry, GuestMessageInterruptRegistryError,
     GuestMessageInterruptRegistryPhase, GuestMessageInterruptResources,
@@ -24,15 +24,16 @@ use crate::pci::{
     PciBarLease, PciBarPrefetchable, PciBarReleaseError, PciCapabilityError, PciCapabilityId,
     PciClassCode, PciConfigAccessError, PciConfigFunction, PciFunctionLease,
     PciFunctionReleaseError, PciSegmentError, PciSegmentLockError, PciType0Configuration,
-    SharedPciSegment,
+    PciType0GuestState, PciType0SnapshotError, PciType0SnapshotProfile, SharedPciSegment,
 };
 use crate::virtio::{
     VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DRIVER, VIRTIO_DEVICE_STATUS_DRIVER_OK,
     VIRTIO_DEVICE_STATUS_FAILED, VIRTIO_DEVICE_STATUS_FEATURES_OK, VIRTIO_DEVICE_STATUS_INIT,
     VirtioDeviceActivation, VirtioDeviceActivationHandler, VirtioDeviceConfigAccess,
     VirtioDeviceConfigError, VirtioDeviceConfigHandler, VirtioDeviceCore, VirtioDeviceResetError,
-    VirtioDeviceResetOutcome, VirtioDeviceType, VirtioDeviceWorkGuard, VirtioInterruptIntent,
-    VirtioQueueError, VirtioQueueNotificationError, VirtioQueueNotificationState, VirtioQueues,
+    VirtioDeviceResetOutcome, VirtioDeviceType, VirtioDeviceTypeError, VirtioDeviceWorkGuard,
+    VirtioInterruptIntent, VirtioQueueError, VirtioQueueNotificationError,
+    VirtioQueueNotificationState, VirtioQueues,
 };
 use crate::virtio_mmio::{
     VirtioMmioDeviceRegisters, VirtioMmioQueueRegisterError, VirtioMmioRegister,
@@ -229,6 +230,113 @@ impl VirtioPciTransportState {
 
     pub const fn msix_state(&self) -> &VirtioPciMsixState {
         &self.msix
+    }
+
+    pub(crate) fn checked_configuration_guest_state(
+        &self,
+        bar_range: GuestMemoryRange,
+    ) -> Result<PciType0GuestState, VirtioPciConfigurationSnapshotError> {
+        if bar_range.size() != VIRTIO_PCI_CAPABILITY_BAR_SIZE {
+            return Err(VirtioPciConfigurationSnapshotError::BarSize);
+        }
+        let device_type = VirtioDeviceType::new(self.device.device_id())
+            .map_err(VirtioPciConfigurationSnapshotError::DeviceType)?;
+        let (class_code, subclass) = pci_class(device_type);
+        let device_id = device_type.modern_pci_device_id();
+        let mut profile = PciType0SnapshotProfile::new(
+            VIRTIO_PCI_VENDOR_ID,
+            device_id,
+            VIRTIO_PCI_REVISION_ID,
+            class_code,
+            subclass,
+            0,
+            VIRTIO_PCI_VENDOR_ID,
+            device_id,
+        );
+        profile
+            .install_bar(
+                VIRTIO_PCI_CAPABILITY_BAR_INDEX,
+                bar_range,
+                PciBarAddressSpace::Memory64,
+                PciBarPrefetchable::No,
+            )
+            .map_err(VirtioPciConfigurationSnapshotError::Bar)?;
+        let (pci_cfg_cap_offset, msix_cap_offset) =
+            add_virtio_pci_snapshot_capabilities(&mut profile, self.msix.vector_count())?;
+        if self.pci_cfg_cap_offset != pci_cfg_cap_offset || self.msix_cap_offset != msix_cap_offset
+        {
+            return Err(VirtioPciConfigurationSnapshotError::CapabilityOffset);
+        }
+        self.configuration
+            .snapshot_guest_state(&profile)
+            .map_err(VirtioPciConfigurationSnapshotError::Configuration)
+    }
+}
+
+pub(crate) enum VirtioPciConfigurationSnapshotError {
+    DeviceType(VirtioDeviceTypeError),
+    BarSize,
+    Bar(PciBarConfigurationError),
+    TooManyVectors,
+    Capability(PciCapabilityError),
+    CapabilityOffset,
+    Configuration(PciType0SnapshotError),
+}
+
+impl fmt::Debug for VirtioPciConfigurationSnapshotError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::DeviceType(_) => "DeviceType",
+            Self::BarSize => "BarSize",
+            Self::Bar(_) => "Bar",
+            Self::TooManyVectors => "TooManyVectors",
+            Self::Capability(_) => "Capability",
+            Self::CapabilityOffset => "CapabilityOffset",
+            Self::Configuration(_) => "Configuration",
+        };
+        formatter
+            .debug_struct("VirtioPciConfigurationSnapshotError")
+            .field("kind", &kind)
+            .field("detail", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for VirtioPciConfigurationSnapshotError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DeviceType(_) => {
+                formatter.write_str("virtio-pci snapshot device type is invalid")
+            }
+            Self::BarSize => {
+                formatter.write_str("virtio-pci snapshot capability BAR size is invalid")
+            }
+            Self::Bar(_) => formatter.write_str("virtio-pci snapshot BAR profile is invalid"),
+            Self::TooManyVectors => {
+                formatter.write_str("virtio-pci snapshot vector count is invalid")
+            }
+            Self::Capability(_) => {
+                formatter.write_str("virtio-pci snapshot capability profile is invalid")
+            }
+            Self::CapabilityOffset => {
+                formatter.write_str("virtio-pci snapshot capability offsets do not match")
+            }
+            Self::Configuration(_) => {
+                formatter.write_str("virtio-pci snapshot configuration profile does not match")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VirtioPciConfigurationSnapshotError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::DeviceType(source) => Some(source),
+            Self::Bar(source) => Some(source),
+            Self::Capability(source) => Some(source),
+            Self::Configuration(source) => Some(source),
+            Self::BarSize | Self::TooManyVectors | Self::CapabilityOffset => None,
+        }
     }
 }
 
@@ -976,43 +1084,53 @@ fn add_virtio_pci_capabilities(
     configuration: &mut PciType0Configuration,
     vector_count: usize,
 ) -> Result<(u16, u16), VirtioPciEndpointError> {
+    add_virtio_pci_capability_profile(
+        vector_count,
+        |id, body, writable_mask| {
+            configuration
+                .add_capability(id, body, writable_mask)
+                .map_err(|source| VirtioPciEndpointError::Capability { source })
+        },
+        || VirtioPciEndpointError::TooManyVectors { vector_count },
+    )
+}
+
+fn add_virtio_pci_capability_profile<E>(
+    vector_count: usize,
+    mut add: impl FnMut(PciCapabilityId, &[u8], &[u8]) -> Result<u8, E>,
+    mut too_many_vectors: impl FnMut() -> E,
+) -> Result<(u16, u16), E> {
     let empty_mask = [0_u8; 14];
-    configuration
-        .add_capability(
-            PciCapabilityId::VendorSpecific,
-            &virtio_capability_body(
-                VIRTIO_PCI_GENERIC_CAP_TOTAL_SIZE,
-                VIRTIO_PCI_CAP_COMMON,
-                VIRTIO_PCI_COMMON_CONFIG_OFFSET,
-                VIRTIO_PCI_COMMON_CONFIG_SIZE,
-            ),
-            &empty_mask,
-        )
-        .map_err(|source| VirtioPciEndpointError::Capability { source })?;
-    configuration
-        .add_capability(
-            PciCapabilityId::VendorSpecific,
-            &virtio_capability_body(
-                VIRTIO_PCI_GENERIC_CAP_TOTAL_SIZE,
-                VIRTIO_PCI_CAP_ISR,
-                VIRTIO_PCI_ISR_CONFIG_OFFSET,
-                VIRTIO_PCI_ISR_CONFIG_SIZE,
-            ),
-            &empty_mask,
-        )
-        .map_err(|source| VirtioPciEndpointError::Capability { source })?;
-    configuration
-        .add_capability(
-            PciCapabilityId::VendorSpecific,
-            &virtio_capability_body(
-                VIRTIO_PCI_GENERIC_CAP_TOTAL_SIZE,
-                VIRTIO_PCI_CAP_DEVICE,
-                VIRTIO_PCI_DEVICE_CONFIG_OFFSET,
-                VIRTIO_PCI_DEVICE_CONFIG_SIZE,
-            ),
-            &empty_mask,
-        )
-        .map_err(|source| VirtioPciEndpointError::Capability { source })?;
+    add(
+        PciCapabilityId::VendorSpecific,
+        &virtio_capability_body(
+            VIRTIO_PCI_GENERIC_CAP_TOTAL_SIZE,
+            VIRTIO_PCI_CAP_COMMON,
+            VIRTIO_PCI_COMMON_CONFIG_OFFSET,
+            VIRTIO_PCI_COMMON_CONFIG_SIZE,
+        ),
+        &empty_mask,
+    )?;
+    add(
+        PciCapabilityId::VendorSpecific,
+        &virtio_capability_body(
+            VIRTIO_PCI_GENERIC_CAP_TOTAL_SIZE,
+            VIRTIO_PCI_CAP_ISR,
+            VIRTIO_PCI_ISR_CONFIG_OFFSET,
+            VIRTIO_PCI_ISR_CONFIG_SIZE,
+        ),
+        &empty_mask,
+    )?;
+    add(
+        PciCapabilityId::VendorSpecific,
+        &virtio_capability_body(
+            VIRTIO_PCI_GENERIC_CAP_TOTAL_SIZE,
+            VIRTIO_PCI_CAP_DEVICE,
+            VIRTIO_PCI_DEVICE_CONFIG_OFFSET,
+            VIRTIO_PCI_DEVICE_CONFIG_SIZE,
+        ),
+        &empty_mask,
+    )?;
 
     let mut notify = virtio_capability_body(
         VIRTIO_PCI_NOTIFY_CAP_TOTAL_SIZE,
@@ -1021,9 +1139,7 @@ fn add_virtio_pci_capabilities(
         VIRTIO_PCI_NOTIFICATION_SIZE,
     );
     notify.extend_from_slice(&VIRTIO_PCI_NOTIFICATION_MULTIPLIER.to_le_bytes());
-    configuration
-        .add_capability(PciCapabilityId::VendorSpecific, &notify, &[0; 18])
-        .map_err(|source| VirtioPciEndpointError::Capability { source })?;
+    add(PciCapabilityId::VendorSpecific, &notify, &[0; 18])?;
 
     let mut pci_cfg =
         virtio_capability_body(VIRTIO_PCI_CFG_CAP_TOTAL_SIZE, VIRTIO_PCI_CAP_PCI_CFG, 0, 0);
@@ -1035,24 +1151,39 @@ fn add_virtio_pci_capabilities(
     if let Some(masks) = pci_cfg_mask.get_mut(6..18) {
         masks.fill(u8::MAX);
     }
-    let pci_cfg_cap_offset = configuration
-        .add_capability(PciCapabilityId::VendorSpecific, &pci_cfg, &pci_cfg_mask)
-        .map_err(|source| VirtioPciEndpointError::Capability { source })?;
+    let pci_cfg_cap_offset = add(PciCapabilityId::VendorSpecific, &pci_cfg, &pci_cfg_mask)?;
 
-    let table_size = u16::try_from(vector_count - 1)
-        .map_err(|_| VirtioPciEndpointError::TooManyVectors { vector_count })?;
+    let Some(table_size) = vector_count
+        .checked_sub(1)
+        .and_then(|value| u16::try_from(value).ok())
+    else {
+        return Err(too_many_vectors());
+    };
     let mut msix_body = Vec::with_capacity(10);
     msix_body.extend_from_slice(&(MSIX_ENABLE | table_size).to_le_bytes());
     msix_body.extend_from_slice(&(VIRTIO_PCI_MSIX_TABLE_OFFSET as u32).to_le_bytes());
     msix_body.extend_from_slice(&(VIRTIO_PCI_MSIX_PBA_OFFSET as u32).to_le_bytes());
-    let msix_cap_offset = configuration
-        .add_capability(
-            PciCapabilityId::MsiX,
-            &msix_body,
-            &[0, 0xc0, 0, 0, 0, 0, 0, 0, 0, 0],
-        )
-        .map_err(|source| VirtioPciEndpointError::Capability { source })?;
+    let msix_cap_offset = add(
+        PciCapabilityId::MsiX,
+        &msix_body,
+        &[0, 0xc0, 0, 0, 0, 0, 0, 0, 0, 0],
+    )?;
     Ok((u16::from(pci_cfg_cap_offset), u16::from(msix_cap_offset)))
+}
+
+fn add_virtio_pci_snapshot_capabilities(
+    profile: &mut PciType0SnapshotProfile,
+    vector_count: usize,
+) -> Result<(u16, u16), VirtioPciConfigurationSnapshotError> {
+    add_virtio_pci_capability_profile(
+        vector_count,
+        |id, body, writable_mask| {
+            profile
+                .add_capability(id, body, writable_mask)
+                .map_err(VirtioPciConfigurationSnapshotError::Capability)
+        },
+        || VirtioPciConfigurationSnapshotError::TooManyVectors,
+    )
 }
 
 fn virtio_capability_body(total_size: u8, kind: u8, offset: u64, length: u64) -> Vec<u8> {
@@ -3781,6 +3912,32 @@ mod tests {
         assert_eq!(debug, "VirtioPciTransportState { state: \"<redacted>\" }");
         assert!(!debug.contains("dead_beef"));
         assert!(!debug.contains("3735928559"));
+    }
+
+    #[test]
+    fn configuration_snapshot_errors_redact_private_detail() {
+        let fixture = fixture_for_identity(&[8], 4, 0b0101);
+        let state = fixture
+            .endpoint
+            .transport_state()
+            .expect("test PCI transport should capture");
+        let invalid_range = GuestMemoryRange::new(
+            fixture.bar.range().start(),
+            VIRTIO_PCI_CAPABILITY_BAR_SIZE / 2,
+        )
+        .expect("test invalid-size BAR range should be structurally valid");
+        let error = state
+            .checked_configuration_guest_state(invalid_range)
+            .expect_err("wrong BAR size should reject");
+        assert_eq!(
+            format!("{error:?}"),
+            "VirtioPciConfigurationSnapshotError { kind: \"BarSize\", detail: \"<redacted>\" }"
+        );
+        assert!(!format!("{error:?}").contains("262144"));
+        assert_eq!(
+            error.to_string(),
+            "virtio-pci snapshot capability BAR size is invalid"
+        );
     }
 
     #[test]

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -12742,6 +12742,7 @@ mod tests {
             original.pending_notifications().to_vec(),
             original.interrupt_status(),
             device_activated,
+            original.requires_device_config_write_status(),
         )
     }
 


### PR DESCRIPTION
## Summary

- add the exact native-v2 2.4 singleton root-block device graph model and deterministic 64 KiB-bounded section codec
- capture backend-neutral MMIO and modern PCI transport state, including queue continuation, limiter/retry state, PCI writable bytes, BAR probes, and MSI-X state
- preserve the transport-specific device-config write policy and validate immutable PCI type-0 profiles without mutating live configuration
- add exact MMIO/PCI fixtures plus structural, semantic, lifecycle, redaction, hostile-input, and real-capture coverage

## Scope exclusions

- this slice does not connect the graph codec to the composite native-v2 snapshot artifact; that work remains in the dependent delivery slices
- the first profile supports exactly one regular-file, read-only, Sync root block device with one queue
- the logical backing selector is stored as inert UTF-8 metadata and does not grant or reopen host authority

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

Closes #1583

Parent delivery: #1531
