### PR TITLE
feat: restore exact retained virtio-pci endpoints

### DIFF
--- a/crates/hvf/src/gic.rs
+++ b/crates/hvf/src/gic.rs
@@ -608,6 +608,9 @@ impl fmt::Debug for HvfGicMsiInterrupt {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HvfGicMsiInterruptAllocationError {
     Exhausted,
+    ExactDuplicate,
+    ExactOutOfRange,
+    ExactOccupied,
     StatePoisoned,
     GenerationExhausted,
     MetadataAllocation,
@@ -617,6 +620,13 @@ impl fmt::Display for HvfGicMsiInterruptAllocationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Exhausted => f.write_str("HVF GIC MSI interrupt range is exhausted"),
+            Self::ExactDuplicate => {
+                f.write_str("exact HVF GIC MSI interrupt batch contains a duplicate")
+            }
+            Self::ExactOutOfRange => {
+                f.write_str("exact HVF GIC MSI interrupt is outside the configured range")
+            }
+            Self::ExactOccupied => f.write_str("exact HVF GIC MSI interrupt is already allocated"),
             Self::StatePoisoned => {
                 f.write_str("HVF GIC MSI interrupt allocator state is unavailable")
             }
@@ -740,6 +750,73 @@ impl HvfGicMsiInterruptAllocator {
                 generation: slot.generation,
                 provenance: Arc::clone(&self.provenance),
             });
+        }
+        Ok(interrupts)
+    }
+
+    /// Atomically allocate one caller-ordered exact INTID batch.
+    pub fn allocate_many_exact(
+        &self,
+        intids: &[u32],
+    ) -> Result<Vec<HvfGicMsiInterrupt>, HvfGicMsiInterruptAllocationError> {
+        if intids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut state = self
+            .provenance
+            .state
+            .lock()
+            .map_err(|_| HvfGicMsiInterruptAllocationError::StatePoisoned)?;
+        let mut indices = Vec::new();
+        indices
+            .try_reserve_exact(intids.len())
+            .map_err(|_| HvfGicMsiInterruptAllocationError::MetadataAllocation)?;
+        for intid in intids {
+            let index = intid
+                .checked_sub(self.range.base)
+                .and_then(|offset| usize::try_from(offset).ok())
+                .filter(|index| *index < state.slots.len())
+                .ok_or(HvfGicMsiInterruptAllocationError::ExactOutOfRange)?;
+            if indices.contains(&index) {
+                return Err(HvfGicMsiInterruptAllocationError::ExactDuplicate);
+            }
+            indices.push(index);
+        }
+        for index in &indices {
+            let slot = state
+                .slots
+                .get(*index)
+                .ok_or(HvfGicMsiInterruptAllocationError::StatePoisoned)?;
+            if slot.live {
+                return Err(HvfGicMsiInterruptAllocationError::ExactOccupied);
+            }
+            if slot.generation == u64::MAX {
+                return Err(HvfGicMsiInterruptAllocationError::GenerationExhausted);
+            }
+        }
+
+        let mut interrupts = Vec::new();
+        interrupts
+            .try_reserve_exact(intids.len())
+            .map_err(|_| HvfGicMsiInterruptAllocationError::MetadataAllocation)?;
+        for (intid, index) in intids.iter().copied().zip(indices.iter().copied()) {
+            let slot = state
+                .slots
+                .get(index)
+                .ok_or(HvfGicMsiInterruptAllocationError::StatePoisoned)?;
+            interrupts.push(HvfGicMsiInterrupt {
+                intid,
+                generation: slot.generation + 1,
+                provenance: Arc::clone(&self.provenance),
+            });
+        }
+        for index in indices {
+            let slot = state
+                .slots
+                .get_mut(index)
+                .ok_or(HvfGicMsiInterruptAllocationError::StatePoisoned)?;
+            slot.generation += 1;
+            slot.live = true;
         }
         Ok(interrupts)
     }
@@ -1061,13 +1138,14 @@ impl fmt::Debug for HvfGicMsiSharedInterruptOwner {
     }
 }
 
-/// One independently revocable registry backed by a shared VM GICv2m pool.
+/// One independently revocable registry backed by a shared GICv2m lease batch.
 ///
 /// Linux assigns MSI messages according to the vectors that each driver
 /// actually requests, which can be fewer than a device's maximum MSI-X table
-/// size. Every PCI function therefore resolves against the complete VM pool
-/// instead of a host-predicted device subrange. Exact leases remain live until
-/// the last registry releases them.
+/// size. Fresh startup can therefore share the complete VM pool instead of a
+/// host-predicted device subrange, while retained restore can bind an exact
+/// caller-supplied batch. In either case the leases remain live until the last
+/// registry releases them.
 pub struct HvfGicMsiDeviceInterruptResources {
     owner: Arc<HvfGicMsiSharedInterruptOwner>,
     registry: GuestMessageInterruptRegistry,
@@ -1084,6 +1162,27 @@ impl HvfGicMsiDeviceInterruptResources {
         let interrupts = allocator
             .allocate_many(count)
             .map_err(|source| HvfGicMsiDeviceInterruptResourceError::Allocate { source })?;
+        Self::from_interrupts(signaler, allocator, interrupts)
+    }
+
+    /// Atomically allocate and bind one caller-ordered exact GICv2m INTID
+    /// batch.
+    pub fn allocate_exact(
+        signaler: &HvfGicMsiSignaler,
+        intids: &[u32],
+    ) -> Result<Self, HvfGicMsiDeviceInterruptResourceError> {
+        let allocator = signaler.allocator();
+        let interrupts = allocator
+            .allocate_many_exact(intids)
+            .map_err(|source| HvfGicMsiDeviceInterruptResourceError::Allocate { source })?;
+        Self::from_interrupts(signaler, allocator, interrupts)
+    }
+
+    fn from_interrupts(
+        signaler: &HvfGicMsiSignaler,
+        allocator: HvfGicMsiInterruptAllocator,
+        interrupts: Vec<HvfGicMsiInterrupt>,
+    ) -> Result<Self, HvfGicMsiDeviceInterruptResourceError> {
         let mut routes: Vec<Arc<dyn GuestMessageInterrupt>> = Vec::new();
         if routes.try_reserve_exact(interrupts.len()).is_err() {
             return Err(rollback_device_interrupts(
@@ -3606,12 +3705,12 @@ mod tests {
         HvfArm64GicIccRegisterState, HvfGicApi, HvfGicDeviceState, HvfGicError,
         HvfGicIccRegisterApi, HvfGicIccRegisterReader, HvfGicIccRegisterRestorer,
         HvfGicIccRegisterWriteApi, HvfGicInterruptLineAllocator, HvfGicInterruptRange,
-        HvfGicMetadata, HvfGicMsiConfiguration, HvfGicMsiDeviceInterruptResources,
-        HvfGicMsiInterrupt, HvfGicMsiInterruptAllocationError, HvfGicMsiInterruptAllocator,
-        HvfGicMsiInterruptReleaseError, HvfGicMsiMetadata, HvfGicMsiParameters,
-        HvfGicMsiSignalError, HvfGicMsiSignaler, HvfGicParameters, HvfGicPpiPendingWriter,
-        HvfGicRegion, HvfGicSpiSignalError, HvfGicSpiSignaler, HvfGicStateApi,
-        HvfGicStateRestoreApi, HvfGicStateRestorer, HvfGicTimerInterrupts,
+        HvfGicMetadata, HvfGicMsiConfiguration, HvfGicMsiDeviceInterruptResourceError,
+        HvfGicMsiDeviceInterruptResources, HvfGicMsiInterrupt, HvfGicMsiInterruptAllocationError,
+        HvfGicMsiInterruptAllocator, HvfGicMsiInterruptReleaseError, HvfGicMsiMetadata,
+        HvfGicMsiParameters, HvfGicMsiSignalError, HvfGicMsiSignaler, HvfGicParameters,
+        HvfGicPpiPendingWriter, HvfGicRegion, HvfGicSpiSignalError, HvfGicSpiSignaler,
+        HvfGicStateApi, HvfGicStateRestoreApi, HvfGicStateRestorer, HvfGicTimerInterrupts,
         HvfInterruptLineAllocationError, capture_gic_device_state_with_api,
         capture_gic_device_state_with_api_bounded, create_gic_with_api, metadata_from_parameters,
         restore_arm64_gic_icc_register_state_with,
@@ -4408,6 +4507,165 @@ mod tests {
                 .raw_value(),
             127
         );
+    }
+
+    #[test]
+    fn msi_interrupt_allocator_reserves_exact_batches_atomically_in_caller_order() {
+        let metadata = metadata_from_parameters(parameters_with_msi(4))
+            .expect("valid MSI demand should produce metadata");
+        let signaler = HvfGicMsiSignaler::with_api(
+            metadata.msi.expect("MSI metadata should exist"),
+            FakeGicApi::default(),
+        )
+        .expect("MSI metadata should produce a signaler");
+        let allocator = signaler.allocator();
+
+        let leases = allocator
+            .allocate_many_exact(&[127, 124, 126])
+            .expect("mixed-order exact INTIDs should allocate");
+        assert_eq!(
+            leases
+                .iter()
+                .map(HvfGicMsiInterrupt::raw_value)
+                .collect::<Vec<_>>(),
+            vec![127, 124, 126]
+        );
+        assert_eq!(allocator.remaining(), 1);
+        allocator
+            .release_many(&leases)
+            .expect("exact batch should release atomically");
+        assert_eq!(allocator.remaining(), 4);
+        let reused = allocator
+            .allocate_many_exact(&[127, 124, 126])
+            .expect("released exact batch should be immediately reusable");
+        assert_eq!(
+            reused
+                .iter()
+                .map(HvfGicMsiInterrupt::raw_value)
+                .collect::<Vec<_>>(),
+            vec![127, 124, 126]
+        );
+        allocator
+            .release_many(&reused)
+            .expect("reused exact batch should release atomically");
+        assert_eq!(allocator.remaining(), 4);
+    }
+
+    #[test]
+    fn exact_msi_batch_rejections_preserve_incumbents_and_other_slots() {
+        let metadata = metadata_from_parameters(parameters_with_msi(4))
+            .expect("valid MSI demand should produce metadata");
+        let api = FakeGicApi::default();
+        let signaler = HvfGicMsiSignaler::with_api(
+            metadata.msi.expect("MSI metadata should exist"),
+            api.clone(),
+        )
+        .expect("MSI metadata should produce a signaler");
+        let allocator = signaler.allocator();
+        let incumbent = allocator
+            .allocate_many_exact(&[125])
+            .expect("incumbent exact vector should allocate")
+            .pop()
+            .expect("incumbent lease should exist");
+        let incumbent_message = GuestMessage::new(signaler.address, incumbent.raw_value());
+        let incumbent_route = signaler
+            .route(&incumbent)
+            .expect("incumbent route should remain live");
+
+        for (requested, expected) in [
+            (
+                vec![124, 124],
+                HvfGicMsiInterruptAllocationError::ExactDuplicate,
+            ),
+            (
+                vec![123],
+                HvfGicMsiInterruptAllocationError::ExactOutOfRange,
+            ),
+            (
+                vec![124, 125, 127],
+                HvfGicMsiInterruptAllocationError::ExactOccupied,
+            ),
+        ] {
+            assert_eq!(allocator.allocate_many_exact(&requested), Err(expected),);
+            assert_eq!(allocator.remaining(), 3);
+            incumbent_route
+                .signal(incumbent_message)
+                .expect("rejected batch must not disturb incumbent route");
+        }
+        assert_eq!(api.msi_signals().len(), 3);
+
+        {
+            let mut state = allocator.provenance.state.lock().unwrap();
+            state.slots[2].generation = u64::MAX;
+        }
+        assert_eq!(
+            allocator.allocate_many_exact(&[124, 126, 127]),
+            Err(HvfGicMsiInterruptAllocationError::GenerationExhausted)
+        );
+        assert_eq!(allocator.remaining(), 3);
+        {
+            let mut state = allocator.provenance.state.lock().unwrap();
+            state.slots[2].generation = 0;
+        }
+
+        let peers = allocator
+            .allocate_many_exact(&[124, 127, 126])
+            .expect("all non-incumbent slots should remain free");
+        allocator
+            .release_many(&peers)
+            .expect("peer exact leases should release");
+        allocator
+            .release(&incumbent)
+            .expect("incumbent should remain releasable");
+        assert_eq!(allocator.remaining(), 4);
+    }
+
+    #[test]
+    fn exact_msi_device_resources_bind_routes_release_and_drop() {
+        let metadata = metadata_from_parameters(parameters_with_msi(3))
+            .expect("valid MSI demand should produce metadata");
+        let signaler = HvfGicMsiSignaler::with_api(
+            metadata.msi.expect("MSI metadata should exist"),
+            FakeGicApi::default(),
+        )
+        .expect("MSI metadata should produce a signaler");
+        let allocator = signaler.allocator();
+        assert!(matches!(
+            HvfGicMsiDeviceInterruptResources::allocate_exact(&signaler, &[]),
+            Err(HvfGicMsiDeviceInterruptResourceError::Registry {
+                source: GuestMessageInterruptRegistryError::Empty
+            })
+        ));
+        assert_eq!(allocator.remaining(), 3);
+
+        let mut resources =
+            HvfGicMsiDeviceInterruptResources::allocate_exact(&signaler, &[127, 125])
+                .expect("exact route resources should allocate");
+        assert_eq!(resources.lease_count(), 2);
+        for intid in [127, 125] {
+            resources
+                .registry()
+                .signal(GuestMessage::new(signaler.address, intid))
+                .expect("exact registry route should signal");
+        }
+        resources
+            .release()
+            .expect("exact resources should release explicitly");
+        assert_eq!(allocator.remaining(), 3);
+
+        {
+            let _dropped =
+                HvfGicMsiDeviceInterruptResources::allocate_exact(&signaler, &[126, 125])
+                    .expect("exact resources should allocate for Drop");
+            assert_eq!(allocator.remaining(), 1);
+        }
+        assert_eq!(allocator.remaining(), 3);
+        let reused = allocator
+            .allocate_many_exact(&[126, 125])
+            .expect("dropped exact resources should be reusable");
+        allocator
+            .release_many(&reused)
+            .expect("reused exact resources should release");
     }
 
     #[test]

--- a/crates/runtime/src/message_interrupt.rs
+++ b/crates/runtime/src/message_interrupt.rs
@@ -134,6 +134,28 @@ impl GuestMessageInterruptRegistry {
             .map_err(|_| GuestMessageInterruptRegistryError::StatePoisoned)
     }
 
+    /// Validate that one message resolves to exactly one active opaque route
+    /// without delivering it.
+    pub(crate) fn validate_message(
+        &self,
+        message: GuestMessage,
+    ) -> Result<(), GuestMessageInterruptRegistryError> {
+        let state = self
+            .inner
+            .state
+            .lock()
+            .map_err(|_| GuestMessageInterruptRegistryError::StatePoisoned)?;
+        if state.phase != GuestMessageInterruptRegistryPhase::Active {
+            return Err(GuestMessageInterruptRegistryError::NotActive { phase: state.phase });
+        }
+        self.resolve_route(message)?;
+        Ok(())
+    }
+
+    pub(crate) fn is_same_registry(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
     /// Resolve and signal one tuple while holding an in-flight lifecycle guard.
     pub fn signal(&self, message: GuestMessage) -> Result<(), GuestMessageInterruptRegistryError> {
         let route = {
@@ -146,18 +168,7 @@ impl GuestMessageInterruptRegistry {
                 return Err(GuestMessageInterruptRegistryError::NotActive { phase: state.phase });
             }
 
-            let mut matches = self
-                .inner
-                .routes
-                .iter()
-                .filter(|route| route.matches(message));
-            let route = matches
-                .next()
-                .cloned()
-                .ok_or(GuestMessageInterruptRegistryError::UnknownMessage)?;
-            if matches.next().is_some() {
-                return Err(GuestMessageInterruptRegistryError::AmbiguousMessage);
-            }
+            let route = self.resolve_route(message)?;
             state.in_flight = state
                 .in_flight
                 .checked_add(1)
@@ -171,6 +182,25 @@ impl GuestMessageInterruptRegistry {
         route
             .signal(message)
             .map_err(|source| GuestMessageInterruptRegistryError::Signal { source })
+    }
+
+    fn resolve_route(
+        &self,
+        message: GuestMessage,
+    ) -> Result<Arc<dyn GuestMessageInterrupt>, GuestMessageInterruptRegistryError> {
+        let mut matches = self
+            .inner
+            .routes
+            .iter()
+            .filter(|route| route.matches(message));
+        let route = matches
+            .next()
+            .cloned()
+            .ok_or(GuestMessageInterruptRegistryError::UnknownMessage)?;
+        if matches.next().is_some() {
+            return Err(GuestMessageInterruptRegistryError::AmbiguousMessage);
+        }
+        Ok(route)
     }
 
     /// Close admission without waiting for already admitted sends.
@@ -492,6 +522,15 @@ mod tests {
         let registry = GuestMessageInterruptRegistry::new(vec![first_route, second_route])
             .expect("registry should build");
 
+        registry
+            .validate_message(second)
+            .expect("second route should validate without signaling");
+        assert!(
+            second_sent
+                .lock()
+                .expect("second lock should work")
+                .is_empty()
+        );
         registry.signal(second).expect("second route should signal");
 
         assert!(
@@ -503,6 +542,10 @@ mod tests {
         assert_eq!(
             *second_sent.lock().expect("second lock should work"),
             vec![second]
+        );
+        assert_eq!(
+            registry.validate_message(GuestMessage::new(0x1000, 34)),
+            Err(GuestMessageInterruptRegistryError::UnknownMessage)
         );
         assert_eq!(
             registry.signal(GuestMessage::new(0x1000, 34)),
@@ -519,9 +562,28 @@ mod tests {
             GuestMessageInterruptRegistry::new(vec![first, second]).expect("registry should build");
 
         assert_eq!(
+            registry.validate_message(message),
+            Err(GuestMessageInterruptRegistryError::AmbiguousMessage)
+        );
+        assert_eq!(
             registry.signal(message),
             Err(GuestMessageInterruptRegistryError::AmbiguousMessage)
         );
+    }
+
+    #[test]
+    fn registry_identity_matches_only_clones_of_the_same_authority() {
+        let message = GuestMessage::new(0x1000, 32);
+        let (_, first_route) = route(message);
+        let (_, second_route) = route(message);
+        let first =
+            GuestMessageInterruptRegistry::new(vec![first_route]).expect("registry should build");
+        let clone = first.clone();
+        let second =
+            GuestMessageInterruptRegistry::new(vec![second_route]).expect("registry should build");
+
+        assert!(first.is_same_registry(&clone));
+        assert!(!first.is_same_registry(&second));
     }
 
     #[test]
@@ -573,6 +635,12 @@ mod tests {
             GuestMessageInterruptRegistry::new(vec![route]).expect("registry should build");
 
         registry.begin_quiesce().expect("quiesce should start");
+        assert_eq!(
+            registry.validate_message(message),
+            Err(GuestMessageInterruptRegistryError::NotActive {
+                phase: GuestMessageInterruptRegistryPhase::Quiescing,
+            })
+        );
         assert_eq!(
             registry.signal(message),
             Err(GuestMessageInterruptRegistryError::NotActive {

--- a/crates/runtime/src/mmio.rs
+++ b/crates/runtime/src/mmio.rs
@@ -428,6 +428,14 @@ struct MmioRegistrationRecord {
     suspended_handler: Option<Box<dyn StoredMmioHandler>>,
 }
 
+struct MmioRegistrationPlan {
+    bus: MmioBus,
+    generation: u64,
+    next_generation: u64,
+    regions: Vec<MmioRegion>,
+    record_regions: Vec<MmioRegion>,
+}
+
 impl fmt::Debug for MmioRegistrationRecord {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MmioRegistrationRecord")
@@ -514,6 +522,49 @@ impl MmioDispatcher {
         regions: &[MmioRegionRequest],
         handler: impl MmioHandler + 'static,
     ) -> Result<MmioRegistrationLease, MmioRegistrationError> {
+        let plan = self.plan_owned_handler(region_id, regions)?;
+        let handler: Box<dyn StoredMmioHandler> = Box::new(handler);
+
+        self.bus = plan.bus;
+        let replaced_handler = self.handlers.insert(region_id, handler);
+        debug_assert!(replaced_handler.is_none());
+        let replaced_registration = self.registrations.insert(
+            plan.generation,
+            MmioRegistrationRecord {
+                owner: Arc::clone(&owner.provenance),
+                region_id,
+                regions: plan.record_regions,
+                suspended_handler: None,
+            },
+        );
+        debug_assert!(replaced_registration.is_none());
+        self.next_registration_generation = plan.next_generation;
+
+        Ok(MmioRegistrationLease {
+            dispatcher: Arc::clone(&self.provenance),
+            owner: Arc::clone(&owner.provenance),
+            generation: plan.generation,
+            region_id,
+            regions: plan.regions,
+        })
+    }
+
+    /// Validate one exact owned handler registration without changing the
+    /// dispatcher.
+    pub fn validate_owned_handler(
+        &self,
+        region_id: MmioRegionId,
+        regions: &[MmioRegionRequest],
+    ) -> Result<(), MmioRegistrationError> {
+        self.plan_owned_handler(region_id, regions)?;
+        Ok(())
+    }
+
+    fn plan_owned_handler(
+        &self,
+        region_id: MmioRegionId,
+        regions: &[MmioRegionRequest],
+    ) -> Result<MmioRegistrationPlan, MmioRegistrationError> {
         if regions.is_empty() {
             return Err(MmioRegistrationError::EmptyRegionBatch);
         }
@@ -554,29 +605,12 @@ impl MmioDispatcher {
             .try_reserve_exact(registered_regions.len())
             .map_err(|_| MmioRegistrationError::RegionMetadataAllocation)?;
         record_regions.extend_from_slice(&registered_regions);
-        let handler: Box<dyn StoredMmioHandler> = Box::new(handler);
-
-        self.bus = candidate_bus;
-        let replaced_handler = self.handlers.insert(region_id, handler);
-        debug_assert!(replaced_handler.is_none());
-        let replaced_registration = self.registrations.insert(
+        Ok(MmioRegistrationPlan {
+            bus: candidate_bus,
             generation,
-            MmioRegistrationRecord {
-                owner: Arc::clone(&owner.provenance),
-                region_id,
-                regions: record_regions,
-                suspended_handler: None,
-            },
-        );
-        debug_assert!(replaced_registration.is_none());
-        self.next_registration_generation = next_generation;
-
-        Ok(MmioRegistrationLease {
-            dispatcher: Arc::clone(&self.provenance),
-            owner: Arc::clone(&owner.provenance),
-            generation,
-            region_id,
+            next_generation,
             regions: registered_regions,
+            record_regions,
         })
     }
 
@@ -2420,16 +2454,16 @@ mod tests {
         let owner = MmioRegistrationOwner::new();
         let mut dispatcher = MmioDispatcher::new();
         let (_state, handler) = ScriptedHandler::returning(&[0x5a]);
+        let requests = [
+            MmioRegionRequest::new(address(0x6000), 0x100),
+            MmioRegionRequest::new(address(0x4000), 0x100),
+        ];
+        dispatcher
+            .validate_owned_handler(id(40), &requests)
+            .expect("owned MMIO registration should preflight");
+        assert!(dispatcher.regions().is_empty());
         let lease = dispatcher
-            .register_owned_handler(
-                &owner,
-                id(40),
-                &[
-                    MmioRegionRequest::new(address(0x6000), 0x100),
-                    MmioRegionRequest::new(address(0x4000), 0x100),
-                ],
-                handler,
-            )
+            .register_owned_handler(&owner, id(40), &requests, handler)
             .expect("owned MMIO registration should succeed");
 
         assert_eq!(lease.region_id(), id(40));
@@ -2496,6 +2530,10 @@ mod tests {
         let (_state, handler) = ScriptedHandler::returning(&[0]);
 
         assert!(matches!(
+            dispatcher.validate_owned_handler(id(41), &[]),
+            Err(MmioRegistrationError::EmptyRegionBatch)
+        ));
+        assert!(matches!(
             dispatcher.register_owned_handler(&owner, id(41), &[], handler),
             Err(MmioRegistrationError::EmptyRegionBatch)
         ));
@@ -2515,17 +2553,18 @@ mod tests {
             .expect("existing MMIO region should insert");
         let before = dispatcher.regions().to_vec();
         let (_state, handler) = ScriptedHandler::returning(&[0]);
+        let requests = [
+            MmioRegionRequest::new(address(0x3000), 0x100),
+            MmioRegionRequest::new(address(0x5080), 0x100),
+        ];
 
         assert!(matches!(
-            dispatcher.register_owned_handler(
-                &owner,
-                id(42),
-                &[
-                    MmioRegionRequest::new(address(0x3000), 0x100),
-                    MmioRegionRequest::new(address(0x5080), 0x100),
-                ],
-                handler,
-            ),
+            dispatcher.validate_owned_handler(id(42), &requests),
+            Err(MmioRegistrationError::Region { index: 1, .. })
+        ));
+        assert_eq!(dispatcher.regions(), before);
+        assert!(matches!(
+            dispatcher.register_owned_handler(&owner, id(42), &requests, handler),
             Err(MmioRegistrationError::Region { index: 1, .. })
         ));
         assert_eq!(dispatcher.regions(), before);
@@ -2545,6 +2584,13 @@ mod tests {
             .expect("legacy handler should register");
         let (_state, owned_handler) = ScriptedHandler::returning(&[0]);
         assert!(matches!(
+            handler_dispatcher.validate_owned_handler(
+                id(43),
+                &[MmioRegionRequest::new(address(0x3000), 0x100)],
+            ),
+            Err(MmioRegistrationError::ExistingHandler { region_id }) if region_id == id(43)
+        ));
+        assert!(matches!(
             handler_dispatcher.register_owned_handler(
                 &owner,
                 id(43),
@@ -2559,6 +2605,13 @@ mod tests {
             .insert_region(id(44), address(0x3000), 0x100)
             .expect("legacy region should register");
         let (_state, handler) = ScriptedHandler::returning(&[0]);
+        assert!(matches!(
+            region_dispatcher.validate_owned_handler(
+                id(44),
+                &[MmioRegionRequest::new(address(0x5000), 0x100)],
+            ),
+            Err(MmioRegistrationError::ExistingRegionId { region_id }) if region_id == id(44)
+        ));
         assert!(matches!(
             region_dispatcher.register_owned_handler(
                 &owner,

--- a/crates/runtime/src/pci.rs
+++ b/crates/runtime/src/pci.rs
@@ -233,10 +233,6 @@ impl PciBarAllocator {
         if size < PCI_BAR_MINIMUM_SIZE || !size.is_power_of_two() {
             return Err(PciBarAllocationError::InvalidSize { size });
         }
-        let next_generation = self
-            .next_generation
-            .checked_add(1)
-            .ok_or(PciBarAllocationError::GenerationExhausted)?;
 
         let mut selected = None;
         for range in self.free.iter().copied() {
@@ -256,7 +252,65 @@ impl PciBarAllocator {
         let Some((selected_free, allocation)) = selected else {
             return Err(PciBarAllocationError::Exhausted { size });
         };
+        let next_free = self.plan_reservation(selected_free, allocation)?;
+        self.commit_reservation(allocation, next_free)
+    }
 
+    /// Validate whether one exact BAR range can be reserved without changing
+    /// allocator state.
+    pub fn validate_exact_reservation(
+        &self,
+        allocation: GuestMemoryRange,
+    ) -> Result<(), PciBarAllocationError> {
+        let selected_free = self.validate_exact_range(allocation)?;
+        self.plan_reservation(selected_free, allocation)?;
+        Ok(())
+    }
+
+    /// Reserve one caller-supplied exact BAR range.
+    pub fn reserve_exact(
+        &mut self,
+        allocation: GuestMemoryRange,
+    ) -> Result<PciBarLease, PciBarAllocationError> {
+        let selected_free = self.validate_exact_range(allocation)?;
+        let next_free = self.plan_reservation(selected_free, allocation)?;
+        self.commit_reservation(allocation, next_free)
+    }
+
+    fn validate_exact_range(
+        &self,
+        allocation: GuestMemoryRange,
+    ) -> Result<GuestMemoryRange, PciBarAllocationError> {
+        let size = allocation.size();
+        if size < PCI_BAR_MINIMUM_SIZE || !size.is_power_of_two() {
+            return Err(PciBarAllocationError::InvalidSize { size });
+        }
+        if allocation.validate_alignment(size).is_err() {
+            return Err(PciBarAllocationError::UnalignedExactRange);
+        }
+        if allocation.start() < self.capacity.start()
+            || self.capacity.end_exclusive() < allocation.end_exclusive()
+        {
+            return Err(PciBarAllocationError::ExactRangeOutsideCapacity);
+        }
+        self.free
+            .iter()
+            .copied()
+            .find(|range| {
+                range.start() <= allocation.start()
+                    && allocation.end_exclusive() <= range.end_exclusive()
+            })
+            .ok_or(PciBarAllocationError::ExactRangeOccupied)
+    }
+
+    fn plan_reservation(
+        &self,
+        selected_free: GuestMemoryRange,
+        allocation: GuestMemoryRange,
+    ) -> Result<Vec<GuestMemoryRange>, PciBarAllocationError> {
+        self.next_generation
+            .checked_add(1)
+            .ok_or(PciBarAllocationError::GenerationExhausted)?;
         let mut next_free = Vec::new();
         next_free
             .try_reserve_exact(self.free.len().saturating_add(1))
@@ -280,7 +334,18 @@ impl PciBarAllocator {
             }
         }
         next_free.sort_by_key(|range| range.start());
+        Ok(next_free)
+    }
 
+    fn commit_reservation(
+        &mut self,
+        allocation: GuestMemoryRange,
+        next_free: Vec<GuestMemoryRange>,
+    ) -> Result<PciBarLease, PciBarAllocationError> {
+        let next_generation = self
+            .next_generation
+            .checked_add(1)
+            .ok_or(PciBarAllocationError::GenerationExhausted)?;
         let generation = self.next_generation;
         self.free = next_free;
         let replaced = self.allocations.insert(
@@ -344,6 +409,9 @@ pub enum PciBarAllocationError {
     InvalidSize { size: u64 },
     AddressOverflow,
     Exhausted { size: u64 },
+    UnalignedExactRange,
+    ExactRangeOutsideCapacity,
+    ExactRangeOccupied,
     GenerationExhausted,
     MetadataAllocation,
     InvalidRange { source: GuestMemoryError },
@@ -368,6 +436,13 @@ impl fmt::Display for PciBarAllocationError {
             Self::Exhausted { size } => {
                 write!(f, "PCI BAR address space cannot fit {size} bytes")
             }
+            Self::UnalignedExactRange => {
+                f.write_str("exact PCI BAR range is not aligned to its size")
+            }
+            Self::ExactRangeOutsideCapacity => {
+                f.write_str("exact PCI BAR range is outside allocator capacity")
+            }
+            Self::ExactRangeOccupied => f.write_str("exact PCI BAR range is already occupied"),
             Self::GenerationExhausted => f.write_str("PCI BAR lease generation is exhausted"),
             Self::MetadataAllocation => f.write_str("PCI BAR allocator metadata allocation failed"),
             Self::InvalidRange { source } => write!(f, "invalid PCI BAR range: {source}"),
@@ -382,6 +457,9 @@ impl std::error::Error for PciBarAllocationError {
             Self::InvalidSize { .. }
             | Self::AddressOverflow
             | Self::Exhausted { .. }
+            | Self::UnalignedExactRange
+            | Self::ExactRangeOutsideCapacity
+            | Self::ExactRangeOccupied
             | Self::GenerationExhausted
             | Self::MetadataAllocation => None,
         }
@@ -710,7 +788,7 @@ impl PciType0Configuration {
         self.install_bar_range(index, lease.range(), lease.address_space(), prefetchable)
     }
 
-    fn install_bar_range(
+    pub(crate) fn install_bar_range(
         &mut self,
         index: u8,
         range: GuestMemoryRange,
@@ -937,6 +1015,68 @@ impl PciType0Configuration {
             writable_bytes,
             bar_probes,
         })
+    }
+
+    /// Apply only the guest-owned portion of one checked type-0 profile.
+    ///
+    /// The target profile supplies every immutable field and writable mask.
+    /// A rejected value leaves this configuration unchanged.
+    pub(crate) fn apply_guest_state(
+        &mut self,
+        profile: &PciType0SnapshotProfile,
+        guest_state: &PciType0GuestState,
+    ) -> Result<(), PciType0SnapshotError> {
+        let expected = self.snapshot_guest_state(profile)?;
+        if expected.writable_bytes.len() != guest_state.writable_bytes.len()
+            || expected.bar_probes.len() != guest_state.bar_probes.len()
+        {
+            return Err(PciType0SnapshotError::ProfileMismatch);
+        }
+        for (expected, supplied) in expected
+            .writable_bytes
+            .iter()
+            .zip(&guest_state.writable_bytes)
+        {
+            if expected.offset != supplied.offset
+                || expected.writable_mask != supplied.writable_mask
+                || supplied.value & !supplied.writable_mask != 0
+            {
+                return Err(PciType0SnapshotError::ProfileMismatch);
+            }
+        }
+        for (expected, supplied) in expected.bar_probes.iter().zip(&guest_state.bar_probes) {
+            if expected.index != supplied.index {
+                return Err(PciType0SnapshotError::ProfileMismatch);
+            }
+        }
+
+        let mut candidate = self.clone();
+        for writable in &guest_state.writable_bytes {
+            let byte_offset = usize::from(writable.offset);
+            let register_index = byte_offset / PCI_CONFIG_REGISTER_SIZE;
+            let byte_index = byte_offset % PCI_CONFIG_REGISTER_SIZE;
+            let shift = u32::try_from(byte_index * 8)
+                .map_err(|_| PciType0SnapshotError::ProfileMismatch)?;
+            let mask = u32::from(writable.writable_mask) << shift;
+            let value = u32::from(writable.value) << shift;
+            let register = candidate
+                .registers
+                .get_mut(register_index)
+                .ok_or(PciType0SnapshotError::ProfileMismatch)?;
+            *register = (*register & !mask) | (value & mask);
+        }
+        for probe in &guest_state.bar_probes {
+            let bar = candidate
+                .bars
+                .get_mut(&probe.index)
+                .ok_or(PciType0SnapshotError::ProfileMismatch)?;
+            bar.probe_pending = probe.pending;
+        }
+        if candidate.snapshot_guest_state(profile)? != *guest_state {
+            return Err(PciType0SnapshotError::ProfileMismatch);
+        }
+        *self = candidate;
+        Ok(())
     }
 
     fn configuration_byte(&self, offset: usize) -> u8 {
@@ -1220,19 +1360,7 @@ impl PciSegment {
         sbdf: PciSbdf,
         function: impl PciConfigFunction + 'static,
     ) -> Result<PciFunctionLease, PciSegmentError> {
-        if sbdf.segment() != PCI_SEGMENT_ZERO
-            || sbdf.bus() != PCI_BUS_ZERO
-            || sbdf.function() != PCI_FUNCTION_ZERO
-            || !(PCI_FIRST_ENDPOINT_DEVICE..=PCI_LAST_ENDPOINT_DEVICE).contains(&sbdf.device())
-        {
-            return Err(PciSegmentError::UnsupportedIdentity { sbdf });
-        }
-        if self.functions.contains_key(&sbdf.device())
-            || self.suspended_functions.contains_key(&sbdf.device())
-            || self.records.contains_key(&sbdf.device())
-        {
-            return Err(PciSegmentError::DuplicateIdentity { sbdf });
-        }
+        self.validate_function_at(sbdf)?;
         let next_generation = self
             .next_generation
             .checked_add(1)
@@ -1250,6 +1378,33 @@ impl PciSegment {
             generation,
             sbdf,
         })
+    }
+
+    /// Validate whether one exact function identity can be published without
+    /// changing segment state.
+    pub fn validate_function_at(&self, sbdf: PciSbdf) -> Result<(), PciSegmentError> {
+        Self::validate_function_identity(sbdf)?;
+        if self.functions.contains_key(&sbdf.device())
+            || self.suspended_functions.contains_key(&sbdf.device())
+            || self.records.contains_key(&sbdf.device())
+        {
+            return Err(PciSegmentError::DuplicateIdentity { sbdf });
+        }
+        self.next_generation
+            .checked_add(1)
+            .map(|_| ())
+            .ok_or(PciSegmentError::GenerationExhausted)
+    }
+
+    pub(crate) fn validate_function_identity(sbdf: PciSbdf) -> Result<(), PciSegmentError> {
+        if sbdf.segment() != PCI_SEGMENT_ZERO
+            || sbdf.bus() != PCI_BUS_ZERO
+            || sbdf.function() != PCI_FUNCTION_ZERO
+            || !(PCI_FIRST_ENDPOINT_DEVICE..=PCI_LAST_ENDPOINT_DEVICE).contains(&sbdf.device())
+        {
+            return Err(PciSegmentError::UnsupportedIdentity { sbdf });
+        }
+        Ok(())
     }
 
     pub fn remove_function(
@@ -1756,6 +1911,92 @@ mod tests {
     }
 
     #[test]
+    fn bar_allocator_reserves_exact_ranges_and_reuses_them_after_release() {
+        let capacity = range(0x1000, 0x8000);
+        let mut allocator = PciBarAllocator::new(PciBarAddressSpace::Memory64, capacity);
+        let middle_range = range(0x4000, 0x1000);
+
+        allocator
+            .validate_exact_reservation(middle_range)
+            .expect("aligned free exact BAR should preflight");
+        assert_eq!(allocator.available_ranges(), &[capacity]);
+        let middle = allocator
+            .reserve_exact(middle_range)
+            .expect("middle exact BAR should reserve");
+        assert_eq!(middle.range(), middle_range);
+        assert_eq!(
+            allocator.available_ranges(),
+            &[range(0x1000, 0x3000), range(0x5000, 0x4000)]
+        );
+
+        let beginning = allocator
+            .reserve_exact(range(0x1000, 0x1000))
+            .expect("beginning exact BAR should reserve");
+        let end = allocator
+            .reserve_exact(range(0x8000, 0x1000))
+            .expect("end exact BAR should reserve");
+        allocator
+            .release(&middle)
+            .expect("middle exact BAR should release");
+        let reused = allocator
+            .reserve_exact(middle_range)
+            .expect("released middle exact BAR should be reusable");
+
+        for lease in [&beginning, &end, &reused] {
+            allocator
+                .release(lease)
+                .expect("exact BAR lease should release");
+        }
+        assert_eq!(allocator.available_ranges(), &[capacity]);
+    }
+
+    #[test]
+    fn exact_bar_rejections_are_deterministic_and_mutation_free() {
+        let capacity = range(0x2000, 0x4000);
+        let mut allocator = PciBarAllocator::new(PciBarAddressSpace::Memory64, capacity);
+        let incumbent = allocator
+            .reserve_exact(range(0x3000, 0x1000))
+            .expect("incumbent exact BAR should reserve");
+        let before = allocator.available_ranges().to_vec();
+
+        for (candidate, expected) in [
+            (
+                range(0x2000, 0x18),
+                PciBarAllocationError::InvalidSize { size: 0x18 },
+            ),
+            (
+                range(0x2800, 0x1000),
+                PciBarAllocationError::UnalignedExactRange,
+            ),
+            (
+                range(0x1000, 0x1000),
+                PciBarAllocationError::ExactRangeOutsideCapacity,
+            ),
+            (
+                range(0x6000, 0x1000),
+                PciBarAllocationError::ExactRangeOutsideCapacity,
+            ),
+            (incumbent.range(), PciBarAllocationError::ExactRangeOccupied),
+        ] {
+            assert_eq!(
+                allocator.validate_exact_reservation(candidate),
+                Err(expected.clone())
+            );
+            assert!(matches!(
+                allocator.reserve_exact(candidate),
+                Err(source) if source == expected
+            ));
+            assert_eq!(allocator.available_ranges(), before);
+            assert_eq!(allocator.allocations.len(), 1);
+        }
+
+        allocator
+            .release(&incumbent)
+            .expect("incumbent exact BAR should remain releasable");
+        assert_eq!(allocator.available_ranges(), &[capacity]);
+    }
+
+    #[test]
     fn bar_allocator_exhaustively_reuses_fragmented_small_ranges() {
         for start_offset in 0..16 {
             for size in [16, 32, 64] {
@@ -2140,6 +2381,77 @@ mod tests {
     }
 
     #[test]
+    fn type0_guest_state_application_is_exact_and_failure_atomic() {
+        let (mut configuration, profile) = snapshot_configuration_pair();
+        let mut profile = profile;
+        configuration.set_writable_configuration_byte(4, 0x0f);
+        profile
+            .configuration
+            .set_writable_configuration_byte(4, 0x0f);
+        let original = configuration.clone();
+        let mut desired = configuration
+            .snapshot_guest_state(&profile)
+            .expect("test profile should capture");
+        for (index, byte) in desired.writable_bytes.iter_mut().enumerate() {
+            byte.value = u8::try_from(index + 1).unwrap_or(u8::MAX) & byte.writable_mask;
+        }
+        for probe in &mut desired.bar_probes {
+            probe.pending = true;
+        }
+
+        configuration
+            .apply_guest_state(&profile, &desired)
+            .expect("checked guest state should apply");
+        assert_eq!(
+            configuration
+                .snapshot_guest_state(&profile)
+                .expect("applied guest state should recapture"),
+            desired
+        );
+        assert_eq!(
+            read_config_u32(&mut configuration, 0),
+            read_config_u32(&mut original.clone(), 0),
+            "immutable identity must remain host-derived"
+        );
+
+        let applied = configuration.clone();
+        let mut malformed = Vec::new();
+        let mut missing = desired.clone();
+        missing.writable_bytes.pop();
+        malformed.push(missing);
+        let mut duplicate = desired.clone();
+        duplicate.writable_bytes.push(desired.writable_bytes[0]);
+        malformed.push(duplicate);
+        let mut wrong_mask = desired.clone();
+        wrong_mask.writable_bytes[0].writable_mask ^= 1;
+        malformed.push(wrong_mask);
+        let mut outside_mask = desired.clone();
+        outside_mask.writable_bytes[0].value |= !outside_mask.writable_bytes[0].writable_mask;
+        malformed.push(outside_mask);
+        let mut wrong_offset = desired.clone();
+        wrong_offset.writable_bytes[0].offset =
+            wrong_offset.writable_bytes[0].offset.saturating_add(1);
+        malformed.push(wrong_offset);
+        let mut missing_probe = desired.clone();
+        missing_probe.bar_probes.pop();
+        malformed.push(missing_probe);
+        let mut extra_probe = desired.clone();
+        extra_probe.bar_probes.push(desired.bar_probes[0]);
+        malformed.push(extra_probe);
+        let mut wrong_probe = desired.clone();
+        wrong_probe.bar_probes[0].index = u8::MAX;
+        malformed.push(wrong_probe);
+
+        for state in malformed {
+            assert_eq!(
+                configuration.apply_guest_state(&profile, &state),
+                Err(PciType0SnapshotError::ProfileMismatch)
+            );
+            assert_eq!(configuration, applied);
+        }
+    }
+
+    #[test]
     fn type0_snapshot_view_rejects_every_private_profile_class() {
         let (configuration, profile) = snapshot_configuration_pair();
         let mut mismatches = Vec::new();
@@ -2285,6 +2597,10 @@ mod tests {
             u32::MAX
         );
         assert!(matches!(
+            segment.validate_function_at(sbdf),
+            Err(PciSegmentError::DuplicateIdentity { sbdf: duplicate }) if duplicate == sbdf
+        ));
+        assert!(matches!(
             segment.add_function_at(sbdf, endpoint(0x1af4, 0x10ff)),
             Err(PciSegmentError::DuplicateIdentity { sbdf: duplicate }) if duplicate == sbdf
         ));
@@ -2326,15 +2642,24 @@ mod tests {
         let mut first = PciSegment::new();
         let mut second = PciSegment::new();
         let sbdf = PciSbdf::new(0, 0, 1, 0).expect("test PCI SBDF should be valid");
+        assert!(first.validate_function_at(sbdf).is_ok());
         let lease = first
             .add_function_at(sbdf, endpoint(0x1af4, 0x10ff))
             .expect("test endpoint should insert");
 
         assert!(matches!(
+            first.validate_function_at(sbdf),
+            Err(PciSegmentError::DuplicateIdentity { sbdf: duplicate }) if duplicate == sbdf
+        ));
+        assert!(matches!(
             first.add_function_at(sbdf, endpoint(0x1af4, 0x10ff)),
             Err(PciSegmentError::DuplicateIdentity { sbdf: duplicate }) if duplicate == sbdf
         ));
         let unsupported = PciSbdf::new(1, 0, 2, 0).expect("test PCI SBDF should be valid");
+        assert!(matches!(
+            first.validate_function_at(unsupported),
+            Err(PciSegmentError::UnsupportedIdentity { sbdf: actual }) if actual == unsupported
+        ));
         assert!(matches!(
             first.add_function_at(unsupported, endpoint(0x1af4, 0x10ff)),
             Err(PciSegmentError::UnsupportedIdentity { sbdf: actual }) if actual == unsupported

--- a/crates/runtime/src/virtio_pci.rs
+++ b/crates/runtime/src/virtio_pci.rs
@@ -23,21 +23,26 @@ use crate::pci::{
     PciBarAddressSpace, PciBarAllocationError, PciBarAllocator, PciBarConfigurationError,
     PciBarLease, PciBarPrefetchable, PciBarReleaseError, PciCapabilityError, PciCapabilityId,
     PciClassCode, PciConfigAccessError, PciConfigFunction, PciFunctionLease,
-    PciFunctionReleaseError, PciSegmentError, PciSegmentLockError, PciType0Configuration,
-    PciType0GuestState, PciType0SnapshotError, PciType0SnapshotProfile, SharedPciSegment,
+    PciFunctionReleaseError, PciSbdf, PciSegment, PciSegmentError, PciSegmentLockError,
+    PciType0Configuration, PciType0GuestState, PciType0SnapshotError, PciType0SnapshotProfile,
+    SharedPciSegment,
 };
 use crate::virtio::{
     VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DRIVER, VIRTIO_DEVICE_STATUS_DRIVER_OK,
     VIRTIO_DEVICE_STATUS_FAILED, VIRTIO_DEVICE_STATUS_FEATURES_OK, VIRTIO_DEVICE_STATUS_INIT,
-    VirtioDeviceActivation, VirtioDeviceActivationHandler, VirtioDeviceConfigAccess,
-    VirtioDeviceConfigError, VirtioDeviceConfigHandler, VirtioDeviceCore, VirtioDeviceResetError,
-    VirtioDeviceResetOutcome, VirtioDeviceType, VirtioDeviceTypeError, VirtioDeviceWorkGuard,
-    VirtioInterruptIntent, VirtioQueueError, VirtioQueueNotificationError,
+    VIRTIO_MMIO_VERSION_1_FEATURE, VirtioDeviceActivation, VirtioDeviceActivationHandler,
+    VirtioDeviceConfigAccess, VirtioDeviceConfigError, VirtioDeviceConfigHandler, VirtioDeviceCore,
+    VirtioDeviceResetError, VirtioDeviceResetOutcome, VirtioDeviceType, VirtioDeviceTypeError,
+    VirtioDeviceWorkGuard, VirtioInterruptIntent, VirtioQueueError, VirtioQueueNotificationError,
     VirtioQueueNotificationState, VirtioQueues,
 };
 use crate::virtio_mmio::{
     VirtioMmioDeviceRegisters, VirtioMmioQueueRegisterError, VirtioMmioRegister,
     VirtioMmioRegisterStateError,
+};
+use crate::virtio_queue::{
+    VIRTQUEUE_AVAILABLE_RING_ALIGNMENT, VIRTQUEUE_DESCRIPTOR_ALIGNMENT,
+    VIRTQUEUE_USED_RING_ALIGNMENT,
 };
 
 pub const VIRTIO_PCI_VENDOR_ID: u16 = 0x1af4;
@@ -241,28 +246,8 @@ impl VirtioPciTransportState {
         }
         let device_type = VirtioDeviceType::new(self.device.device_id())
             .map_err(VirtioPciConfigurationSnapshotError::DeviceType)?;
-        let (class_code, subclass) = pci_class(device_type);
-        let device_id = device_type.modern_pci_device_id();
-        let mut profile = PciType0SnapshotProfile::new(
-            VIRTIO_PCI_VENDOR_ID,
-            device_id,
-            VIRTIO_PCI_REVISION_ID,
-            class_code,
-            subclass,
-            0,
-            VIRTIO_PCI_VENDOR_ID,
-            device_id,
-        );
-        profile
-            .install_bar(
-                VIRTIO_PCI_CAPABILITY_BAR_INDEX,
-                bar_range,
-                PciBarAddressSpace::Memory64,
-                PciBarPrefetchable::No,
-            )
-            .map_err(VirtioPciConfigurationSnapshotError::Bar)?;
-        let (pci_cfg_cap_offset, msix_cap_offset) =
-            add_virtio_pci_snapshot_capabilities(&mut profile, self.msix.vector_count())?;
+        let (profile, pci_cfg_cap_offset, msix_cap_offset) =
+            build_pci_snapshot_profile(device_type, bar_range, self.msix.vector_count())?;
         if self.pci_cfg_cap_offset != pci_cfg_cap_offset || self.msix_cap_offset != msix_cap_offset
         {
             return Err(VirtioPciConfigurationSnapshotError::CapabilityOffset);
@@ -271,6 +256,39 @@ impl VirtioPciTransportState {
             .snapshot_guest_state(&profile)
             .map_err(VirtioPciConfigurationSnapshotError::Configuration)
     }
+}
+
+fn build_pci_snapshot_profile(
+    device_type: VirtioDeviceType,
+    bar_range: GuestMemoryRange,
+    vector_count: usize,
+) -> Result<(PciType0SnapshotProfile, u16, u16), VirtioPciConfigurationSnapshotError> {
+    if bar_range.size() != VIRTIO_PCI_CAPABILITY_BAR_SIZE {
+        return Err(VirtioPciConfigurationSnapshotError::BarSize);
+    }
+    let (class_code, subclass) = pci_class(device_type);
+    let device_id = device_type.modern_pci_device_id();
+    let mut profile = PciType0SnapshotProfile::new(
+        VIRTIO_PCI_VENDOR_ID,
+        device_id,
+        VIRTIO_PCI_REVISION_ID,
+        class_code,
+        subclass,
+        0,
+        VIRTIO_PCI_VENDOR_ID,
+        device_id,
+    );
+    profile
+        .install_bar(
+            VIRTIO_PCI_CAPABILITY_BAR_INDEX,
+            bar_range,
+            PciBarAddressSpace::Memory64,
+            PciBarPrefetchable::No,
+        )
+        .map_err(VirtioPciConfigurationSnapshotError::Bar)?;
+    let (pci_cfg_cap_offset, msix_cap_offset) =
+        add_virtio_pci_snapshot_capabilities(&mut profile, vector_count)?;
+    Ok((profile, pci_cfg_cap_offset, msix_cap_offset))
 }
 
 pub(crate) enum VirtioPciConfigurationSnapshotError {
@@ -372,6 +390,14 @@ pub struct VirtioPciEndpoint<C, A> {
     inner: Arc<VirtioPciEndpointInner<C, A>>,
 }
 
+/// One fully validated retained endpoint awaiting exact resource publication.
+pub struct PreparedVirtioPciEndpoint<C, A> {
+    endpoint: VirtioPciEndpoint<C, A>,
+    sbdf: PciSbdf,
+    bar_range: GuestMemoryRange,
+    region_id: MmioRegionId,
+}
+
 /// One admitted device-work transaction for a modern virtio-pci endpoint.
 ///
 /// Teardown closes admission and waits for every retained transaction before
@@ -422,6 +448,14 @@ struct VirtioPciEndpointState<C, A> {
 impl<C, A> fmt::Debug for VirtioPciEndpoint<C, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("VirtioPciEndpoint")
+            .field("state", &"<redacted>")
+            .finish_non_exhaustive()
+    }
+}
+
+impl<C, A> fmt::Debug for PreparedVirtioPciEndpoint<C, A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PreparedVirtioPciEndpoint")
             .field("state", &"<redacted>")
             .finish_non_exhaustive()
     }
@@ -498,18 +532,6 @@ impl<C: VirtioDeviceConfigHandler, A: VirtioDeviceActivationHandler> VirtioPciEn
                 },
             });
         }
-        if capability_bar.range().size() != VIRTIO_PCI_CAPABILITY_BAR_SIZE {
-            return Err(VirtioPciEndpointError::CapabilityBarSize {
-                expected: VIRTIO_PCI_CAPABILITY_BAR_SIZE,
-                actual: capability_bar.range().size(),
-            });
-        }
-        if capability_bar.address_space() != PciBarAddressSpace::Memory64 {
-            return Err(VirtioPciEndpointError::CapabilityBarAddressSpace {
-                actual: capability_bar.address_space(),
-            });
-        }
-
         let notifications = VirtioQueueNotificationState::new(queue_count)
             .map_err(|source| VirtioPciEndpointError::QueueNotificationInitialization { source })?;
         let device = VirtioMmioDeviceRegisters::with_vendor_id_and_config_generation(
@@ -527,27 +549,12 @@ impl<C: VirtioDeviceConfigHandler, A: VirtioDeviceActivationHandler> VirtioPciEn
             requires_device_config_write_status,
         );
 
-        let (class_code, subclass) = pci_class(identity.device_type);
-        let device_id = identity.device_type.modern_pci_device_id();
-        let mut configuration = PciType0Configuration::new(
-            VIRTIO_PCI_VENDOR_ID,
-            device_id,
-            VIRTIO_PCI_REVISION_ID,
-            class_code,
-            subclass,
-            0,
-            VIRTIO_PCI_VENDOR_ID,
-            device_id,
-        );
-        configuration
-            .install_bar(
-                VIRTIO_PCI_CAPABILITY_BAR_INDEX,
-                capability_bar,
-                PciBarPrefetchable::No,
-            )
-            .map_err(|source| VirtioPciEndpointError::BarConfiguration { source })?;
-        let (pci_cfg_cap_offset, msix_cap_offset) =
-            add_virtio_pci_capabilities(&mut configuration, vector_count)?;
+        let (configuration, pci_cfg_cap_offset, msix_cap_offset) = build_pci_configuration(
+            identity,
+            capability_bar.range(),
+            capability_bar.address_space(),
+            vector_count,
+        )?;
 
         Ok(Self {
             inner: Arc::new(VirtioPciEndpointInner {
@@ -868,6 +875,468 @@ impl<C: VirtioDeviceConfigHandler, A: VirtioDeviceActivationHandler> VirtioPciEn
     }
 }
 
+impl<C: VirtioDeviceConfigHandler, A: VirtioDeviceActivationHandler>
+    PreparedVirtioPciEndpoint<C, A>
+{
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        identity: VirtioPciIdentity,
+        queue_max_sizes: &[u16],
+        device_config: C,
+        activation: A,
+        activation_is_active: bool,
+        requires_device_config_write_status: bool,
+        retained: &VirtioPciTransportState,
+        sbdf: PciSbdf,
+        bar_range: GuestMemoryRange,
+        region_id: MmioRegionId,
+        messages: GuestMessageInterruptRegistry,
+    ) -> Result<Self, VirtioPciEndpointError> {
+        validate_retained_transport_state(
+            retained,
+            identity,
+            queue_max_sizes,
+            activation_is_active,
+            requires_device_config_write_status,
+            sbdf,
+            bar_range,
+            &messages,
+        )?;
+
+        let guest_state = retained
+            .checked_configuration_guest_state(bar_range)
+            .map_err(|_| retained_error(VirtioPciRetainedStateError::Configuration))?;
+        let (profile, profile_pci_cfg_offset, profile_msix_offset) = build_pci_snapshot_profile(
+            identity.device_type,
+            bar_range,
+            retained.msix.vector_count(),
+        )
+        .map_err(|_| retained_error(VirtioPciRetainedStateError::Configuration))?;
+        let (mut configuration, pci_cfg_cap_offset, msix_cap_offset) = build_pci_configuration(
+            identity,
+            bar_range,
+            PciBarAddressSpace::Memory64,
+            retained.msix.vector_count(),
+        )?;
+        if profile_pci_cfg_offset != pci_cfg_cap_offset
+            || profile_msix_offset != msix_cap_offset
+            || retained.pci_cfg_cap_offset != pci_cfg_cap_offset
+            || retained.msix_cap_offset != msix_cap_offset
+        {
+            return Err(retained_error(VirtioPciRetainedStateError::Configuration));
+        }
+        configuration
+            .apply_guest_state(&profile, &guest_state)
+            .map_err(|_| retained_error(VirtioPciRetainedStateError::Configuration))?;
+
+        let mut core = VirtioDeviceCore::from_parts(
+            retained.device,
+            retained.queues.clone(),
+            retained.queue_notifications.clone(),
+            device_config,
+            activation,
+            requires_device_config_write_status,
+        );
+        core.device_activated = retained.device_activated;
+        core.interrupt_intents = retained.interrupt_intents.clone();
+
+        let endpoint = VirtioPciEndpoint {
+            inner: Arc::new(VirtioPciEndpointInner {
+                state: Mutex::new(VirtioPciEndpointState {
+                    phase: VirtioPciEndpointPhase::Active,
+                    configuration,
+                    pci_cfg_cap_offset,
+                    msix_cap_offset,
+                    pci_cfg_bar: retained.pci_cfg_bar,
+                    pci_cfg_offset: retained.pci_cfg_offset,
+                    pci_cfg_length: retained.pci_cfg_length,
+                    device_feature_select: retained.device_feature_select,
+                    driver_feature_select: retained.driver_feature_select,
+                    queue_select: retained.queue_select,
+                    core,
+                    msix: retained.msix.clone(),
+                }),
+                messages,
+            }),
+        };
+        if endpoint.transport_state()? != *retained {
+            return Err(retained_error(VirtioPciRetainedStateError::Recapture));
+        }
+        Ok(Self {
+            endpoint,
+            sbdf,
+            bar_range,
+            region_id,
+        })
+    }
+
+    pub const fn sbdf(&self) -> PciSbdf {
+        self.sbdf
+    }
+
+    pub const fn bar_range(&self) -> GuestMemoryRange {
+        self.bar_range
+    }
+
+    pub const fn region_id(&self) -> MmioRegionId {
+        self.region_id
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_retained_transport_state(
+    retained: &VirtioPciTransportState,
+    identity: VirtioPciIdentity,
+    queue_max_sizes: &[u16],
+    activation_is_active: bool,
+    requires_device_config_write_status: bool,
+    sbdf: PciSbdf,
+    bar_range: GuestMemoryRange,
+    messages: &GuestMessageInterruptRegistry,
+) -> Result<(), VirtioPciEndpointError> {
+    if retained.phase != VirtioPciEndpointPhase::Active {
+        return Err(retained_error(VirtioPciRetainedStateError::Phase));
+    }
+    PciSegment::validate_function_identity(sbdf)
+        .map_err(|_| retained_error(VirtioPciRetainedStateError::Sbdf))?;
+    let expected_features = identity.device_features | VIRTIO_MMIO_VERSION_1_FEATURE;
+    if retained.device.device_id() != identity.device_type.raw_value()
+        || retained.device.vendor_id() != 0
+        || retained.device.config_generation() != identity.config_generation
+    {
+        return Err(retained_error(VirtioPciRetainedStateError::DeviceIdentity));
+    }
+    if retained.device.device_features() != expected_features
+        || retained.device.driver_features() & !expected_features != 0
+        || retained.device.device_features_select() > 1
+        || retained.device.driver_features_select() > 1
+        || (retained.device.status() & VIRTIO_DEVICE_STATUS_DRIVER == 0
+            && retained.device.driver_features() != 0)
+        || (retained.device.status() & VIRTIO_DEVICE_STATUS_FEATURES_OK != 0
+            && retained.device.driver_features() & VIRTIO_MMIO_VERSION_1_FEATURE == 0)
+    {
+        return Err(retained_error(VirtioPciRetainedStateError::Features));
+    }
+    if !retained_status_is_healthy(retained.device.status()) {
+        return Err(retained_error(VirtioPciRetainedStateError::Status));
+    }
+    let status_is_active = retained.device.status() == VIRTIO_DRIVER_READY_STATUS;
+    if retained.device_activated != status_is_active
+        || retained.device_activated != activation_is_active
+    {
+        return Err(retained_error(VirtioPciRetainedStateError::Activation));
+    }
+    if retained.requires_device_config_write_status != requires_device_config_write_status {
+        return Err(retained_error(
+            VirtioPciRetainedStateError::DeviceConfigPolicy,
+        ));
+    }
+    if bar_range.size() != VIRTIO_PCI_CAPABILITY_BAR_SIZE
+        || bar_range
+            .validate_alignment(VIRTIO_PCI_CAPABILITY_BAR_SIZE)
+            .is_err()
+    {
+        return Err(retained_error(VirtioPciRetainedStateError::Bar));
+    }
+
+    validate_retained_queues(retained, queue_max_sizes)?;
+    validate_retained_notifications(retained)?;
+    validate_retained_interrupt_intents(retained)?;
+    validate_retained_msix(retained, messages)?;
+    validate_retained_configuration_relationships(retained)?;
+    retained
+        .checked_configuration_guest_state(bar_range)
+        .map_err(|_| retained_error(VirtioPciRetainedStateError::Configuration))?;
+    Ok(())
+}
+
+fn validate_retained_queues(
+    retained: &VirtioPciTransportState,
+    queue_max_sizes: &[u16],
+) -> Result<(), VirtioPciEndpointError> {
+    let queue_count = retained.queues.queue_count();
+    if queue_count == 0
+        || queue_count != queue_max_sizes.len()
+        || usize::try_from(retained.queues.queue_select())
+            .ok()
+            .is_none_or(|selector| selector >= queue_count)
+    {
+        return Err(retained_error(VirtioPciRetainedStateError::Queue));
+    }
+    let range_capacity = queue_count
+        .checked_mul(3)
+        .ok_or_else(|| retained_error(VirtioPciRetainedStateError::Queue))?;
+    let mut ranges = Vec::new();
+    ranges
+        .try_reserve_exact(range_capacity)
+        .map_err(|_| retained_error(VirtioPciRetainedStateError::Queue))?;
+    for (index, expected_max_size) in queue_max_sizes.iter().copied().enumerate() {
+        let queue = retained
+            .queues
+            .queue(
+                u32::try_from(index)
+                    .map_err(|_| retained_error(VirtioPciRetainedStateError::Queue))?,
+            )
+            .map_err(|_| retained_error(VirtioPciRetainedStateError::Queue))?;
+        if queue.max_size() != expected_max_size
+            || expected_max_size == 0
+            || !expected_max_size.is_power_of_two()
+            || (queue.size() != 0
+                && (!queue.size().is_power_of_two() || queue.size() > expected_max_size))
+            || (queue.ready() && queue.size() == 0)
+            || (retained.device_activated && !queue.ready())
+            || !queue
+                .descriptor_table()
+                .raw_value()
+                .is_multiple_of(VIRTQUEUE_DESCRIPTOR_ALIGNMENT)
+            || !queue
+                .driver_ring()
+                .raw_value()
+                .is_multiple_of(VIRTQUEUE_AVAILABLE_RING_ALIGNMENT)
+            || !queue
+                .device_ring()
+                .raw_value()
+                .is_multiple_of(VIRTQUEUE_USED_RING_ALIGNMENT)
+        {
+            return Err(retained_error(VirtioPciRetainedStateError::Queue));
+        }
+        if retained.device.status() & VIRTIO_DEVICE_STATUS_FEATURES_OK == 0
+            && (queue.size() != 0
+                || queue.ready()
+                || queue.descriptor_table().raw_value() != 0
+                || queue.driver_ring().raw_value() != 0
+                || queue.device_ring().raw_value() != 0)
+        {
+            return Err(retained_error(VirtioPciRetainedStateError::Queue));
+        }
+        if queue.size() != 0 {
+            ranges.extend_from_slice(&retained_queue_ranges(*queue)?);
+        }
+    }
+    for (first_index, first) in ranges.iter().copied().enumerate() {
+        for second in ranges.iter().copied().skip(first_index + 1) {
+            if first.overlaps(second) {
+                return Err(retained_error(VirtioPciRetainedStateError::Queue));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn retained_queue_ranges(
+    queue: crate::virtio::VirtioQueueState,
+) -> Result<[GuestMemoryRange; 3], VirtioPciEndpointError> {
+    let size = u64::from(queue.size());
+    let descriptor_size = size
+        .checked_mul(16)
+        .ok_or_else(|| retained_error(VirtioPciRetainedStateError::Queue))?;
+    let available_size = size
+        .checked_mul(2)
+        .and_then(|size| size.checked_add(6))
+        .ok_or_else(|| retained_error(VirtioPciRetainedStateError::Queue))?;
+    let used_size = size
+        .checked_mul(8)
+        .and_then(|size| size.checked_add(6))
+        .ok_or_else(|| retained_error(VirtioPciRetainedStateError::Queue))?;
+    Ok([
+        GuestMemoryRange::new(queue.descriptor_table(), descriptor_size)
+            .map_err(|_| retained_error(VirtioPciRetainedStateError::Queue))?,
+        GuestMemoryRange::new(queue.driver_ring(), available_size)
+            .map_err(|_| retained_error(VirtioPciRetainedStateError::Queue))?,
+        GuestMemoryRange::new(queue.device_ring(), used_size)
+            .map_err(|_| retained_error(VirtioPciRetainedStateError::Queue))?,
+    ])
+}
+
+fn validate_retained_notifications(
+    retained: &VirtioPciTransportState,
+) -> Result<(), VirtioPciEndpointError> {
+    if retained.queue_notifications.queue_count() != retained.queues.queue_count()
+        || (!retained.device_activated
+            && retained
+                .queue_notifications
+                .has_pending_queue_notifications())
+    {
+        Err(retained_error(VirtioPciRetainedStateError::Notification))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_retained_interrupt_intents(
+    retained: &VirtioPciTransportState,
+) -> Result<(), VirtioPciEndpointError> {
+    for (index, intent) in retained.interrupt_intents.iter().enumerate() {
+        if retained
+            .interrupt_intents
+            .iter()
+            .take(index)
+            .any(|previous| previous == intent)
+            || matches!(
+                intent,
+                VirtioInterruptIntent::Queue { queue_index }
+                    if usize::from(*queue_index) >= retained.queues.queue_count()
+            )
+        {
+            return Err(retained_error(VirtioPciRetainedStateError::InterruptIntent));
+        }
+    }
+    Ok(())
+}
+
+fn validate_retained_msix(
+    retained: &VirtioPciTransportState,
+    messages: &GuestMessageInterruptRegistry,
+) -> Result<(), VirtioPciEndpointError> {
+    let queue_count = retained.queues.queue_count();
+    let vector_count = queue_count
+        .checked_add(1)
+        .ok_or(VirtioPciEndpointError::VectorCountOverflow)?;
+    if vector_count > VIRTIO_PCI_MAX_MSIX_VECTORS
+        || retained.msix.entries.len() != vector_count
+        || retained.msix.pending.len() != vector_count.div_ceil(MSIX_BITS_PER_PBA_WORD)
+        || retained.msix.queue_vectors.len() != queue_count
+        || !valid_retained_vector(retained.msix.config_vector, vector_count)
+        || retained
+            .msix
+            .queue_vectors
+            .iter()
+            .copied()
+            .any(|vector| !valid_retained_vector(vector, vector_count))
+        || retained
+            .msix
+            .entries
+            .iter()
+            .any(|entry| entry.vector_control & !1 != 0)
+    {
+        return Err(retained_error(VirtioPciRetainedStateError::Msix));
+    }
+    if let Some(last) = retained.msix.pending.last().copied() {
+        let used_bits = vector_count % MSIX_BITS_PER_PBA_WORD;
+        if used_bits != 0 && last & !((1_u64 << used_bits) - 1) != 0 {
+            return Err(retained_error(VirtioPciRetainedStateError::Msix));
+        }
+    }
+    if messages.route_count() < vector_count {
+        return Err(VirtioPciEndpointError::MessageRouteCount {
+            expected: vector_count,
+            actual: messages.route_count(),
+        });
+    }
+    let phase = messages
+        .phase()
+        .map_err(|source| VirtioPciEndpointError::MessageRegistry { source })?;
+    if phase != GuestMessageInterruptRegistryPhase::Active {
+        return Err(VirtioPciEndpointError::MessageRegistry {
+            source: GuestMessageInterruptRegistryError::NotActive { phase },
+        });
+    }
+
+    let mut referenced = vec![false; vector_count];
+    if retained.msix.config_vector != VIRTIO_PCI_NO_VECTOR {
+        *referenced
+            .get_mut(usize::from(retained.msix.config_vector))
+            .ok_or_else(|| retained_error(VirtioPciRetainedStateError::Msix))? = true;
+    }
+    for vector in retained.msix.queue_vectors.iter().copied() {
+        if vector != VIRTIO_PCI_NO_VECTOR {
+            *referenced
+                .get_mut(usize::from(vector))
+                .ok_or_else(|| retained_error(VirtioPciRetainedStateError::Msix))? = true;
+        }
+    }
+    for (index, (entry, referenced)) in retained
+        .msix
+        .entries
+        .iter()
+        .copied()
+        .zip(referenced.iter().copied())
+        .enumerate()
+    {
+        let pending = retained
+            .msix
+            .pending
+            .get(index / MSIX_BITS_PER_PBA_WORD)
+            .is_some_and(|word| word & (1_u64 << (index % MSIX_BITS_PER_PBA_WORD)) != 0);
+        if !entry.is_masked() && (referenced || pending) {
+            messages
+                .validate_message(entry.message())
+                .map_err(|source| VirtioPciEndpointError::MessageRegistry { source })?;
+        }
+    }
+    Ok(())
+}
+
+fn valid_retained_vector(vector: u16, vector_count: usize) -> bool {
+    vector == VIRTIO_PCI_NO_VECTOR || usize::from(vector) < vector_count
+}
+
+fn validate_retained_configuration_relationships(
+    retained: &VirtioPciTransportState,
+) -> Result<(), VirtioPciEndpointError> {
+    let bar = read_retained_configuration::<1>(
+        &retained.configuration,
+        retained_configuration_offset(retained.pci_cfg_cap_offset, 4)?,
+    )?;
+    let offset = read_retained_configuration::<4>(
+        &retained.configuration,
+        retained_configuration_offset(retained.pci_cfg_cap_offset, 8)?,
+    )?;
+    let length = read_retained_configuration::<4>(
+        &retained.configuration,
+        retained_configuration_offset(retained.pci_cfg_cap_offset, 12)?,
+    )?;
+    if bar[0] != retained.pci_cfg_bar
+        || u32::from_le_bytes(offset) != retained.pci_cfg_offset
+        || u32::from_le_bytes(length) != retained.pci_cfg_length
+    {
+        return Err(retained_error(VirtioPciRetainedStateError::Configuration));
+    }
+    let control = read_retained_configuration::<2>(
+        &retained.configuration,
+        retained_configuration_offset(retained.msix_cap_offset, 2)?,
+    )?;
+    let control = u16::from_le_bytes(control);
+    if (control & MSIX_ENABLE != 0) != retained.msix.enabled
+        || (control & MSIX_FUNCTION_MASK != 0) != retained.msix.function_masked
+    {
+        return Err(retained_error(VirtioPciRetainedStateError::Msix));
+    }
+    Ok(())
+}
+
+fn read_retained_configuration<const N: usize>(
+    configuration: &PciType0Configuration,
+    offset: u16,
+) -> Result<[u8; N], VirtioPciEndpointError> {
+    let mut configuration = configuration.clone();
+    let mut bytes = [0_u8; N];
+    configuration
+        .read_config(offset, &mut bytes)
+        .map_err(|_| retained_error(VirtioPciRetainedStateError::Configuration))?;
+    Ok(bytes)
+}
+
+fn retained_configuration_offset(base: u16, relative: u16) -> Result<u16, VirtioPciEndpointError> {
+    base.checked_add(relative)
+        .ok_or_else(|| retained_error(VirtioPciRetainedStateError::Configuration))
+}
+
+const fn retained_status_is_healthy(status: u32) -> bool {
+    status == VIRTIO_DEVICE_STATUS_INIT
+        || status == VIRTIO_DEVICE_STATUS_ACKNOWLEDGE
+        || status == VIRTIO_DEVICE_STATUS_ACKNOWLEDGE | VIRTIO_DEVICE_STATUS_DRIVER
+        || status
+            == VIRTIO_DEVICE_STATUS_ACKNOWLEDGE
+                | VIRTIO_DEVICE_STATUS_DRIVER
+                | VIRTIO_DEVICE_STATUS_FEATURES_OK
+        || status == VIRTIO_DRIVER_READY_STATUS
+}
+
+const fn retained_error(kind: VirtioPciRetainedStateError) -> VirtioPciEndpointError {
+    VirtioPciEndpointError::RetainedState { kind }
+}
+
 fn clone_transport_state<C, A>(state: &VirtioPciEndpointState<C, A>) -> VirtioPciTransportState {
     VirtioPciTransportState {
         phase: state.phase,
@@ -1067,6 +1536,48 @@ impl<C, A> VirtioPciEndpointInner<C, A> {
         }
         Ok(())
     }
+}
+
+fn build_pci_configuration(
+    identity: VirtioPciIdentity,
+    capability_bar: GuestMemoryRange,
+    address_space: PciBarAddressSpace,
+    vector_count: usize,
+) -> Result<(PciType0Configuration, u16, u16), VirtioPciEndpointError> {
+    if capability_bar.size() != VIRTIO_PCI_CAPABILITY_BAR_SIZE {
+        return Err(VirtioPciEndpointError::CapabilityBarSize {
+            expected: VIRTIO_PCI_CAPABILITY_BAR_SIZE,
+            actual: capability_bar.size(),
+        });
+    }
+    if address_space != PciBarAddressSpace::Memory64 {
+        return Err(VirtioPciEndpointError::CapabilityBarAddressSpace {
+            actual: address_space,
+        });
+    }
+    let (class_code, subclass) = pci_class(identity.device_type);
+    let device_id = identity.device_type.modern_pci_device_id();
+    let mut configuration = PciType0Configuration::new(
+        VIRTIO_PCI_VENDOR_ID,
+        device_id,
+        VIRTIO_PCI_REVISION_ID,
+        class_code,
+        subclass,
+        0,
+        VIRTIO_PCI_VENDOR_ID,
+        device_id,
+    );
+    configuration
+        .install_bar_range(
+            VIRTIO_PCI_CAPABILITY_BAR_INDEX,
+            capability_bar,
+            address_space,
+            PciBarPrefetchable::No,
+        )
+        .map_err(|source| VirtioPciEndpointError::BarConfiguration { source })?;
+    let (pci_cfg_cap_offset, msix_cap_offset) =
+        add_virtio_pci_capabilities(&mut configuration, vector_count)?;
+    Ok((configuration, pci_cfg_cap_offset, msix_cap_offset))
 }
 
 fn pci_class(device_type: VirtioDeviceType) -> (PciClassCode, u8) {
@@ -2292,6 +2803,214 @@ where
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RetainedPublicationStage {
+    Preflight,
+    Bar,
+    Function,
+    Mmio,
+}
+
+impl<C, A> PreparedVirtioPciEndpoint<C, A>
+where
+    C: VirtioDeviceConfigHandler + 'static,
+    A: VirtioDeviceActivationHandler + 'static,
+{
+    pub fn publish<I>(
+        self,
+        bar_allocator: &mut PciBarAllocator,
+        segment: SharedPciSegment,
+        dispatcher: &mut MmioDispatcher,
+        interrupts: I,
+    ) -> Result<PublishedVirtioPciEndpoint<C, A, I>, VirtioPciPublicationError>
+    where
+        I: GuestMessageInterruptResources,
+    {
+        self.publish_with_hook(bar_allocator, segment, dispatcher, interrupts, |_| Ok(()))
+    }
+
+    fn publish_with_hook<I>(
+        self,
+        bar_allocator: &mut PciBarAllocator,
+        segment: SharedPciSegment,
+        dispatcher: &mut MmioDispatcher,
+        mut interrupts: I,
+        mut hook: impl FnMut(RetainedPublicationStage) -> Result<(), VirtioPciPublicationError>,
+    ) -> Result<PublishedVirtioPciEndpoint<C, A, I>, VirtioPciPublicationError>
+    where
+        I: GuestMessageInterruptResources,
+    {
+        let resource_registry = interrupts.registry();
+        if !self
+            .endpoint
+            .inner
+            .messages
+            .is_same_registry(&resource_registry)
+        {
+            let primary = VirtioPciPublicationError::InterruptRegistryMismatch;
+            let mut cleanup = String::new();
+            if let Err(source) = interrupts.release() {
+                append_cleanup(&mut cleanup, "interrupt resources", &source);
+            }
+            return Err(publication_rollback(primary, cleanup));
+        }
+        let retained = self
+            .endpoint
+            .transport_state()
+            .map_err(|source| VirtioPciPublicationError::Endpoint { source })?;
+        if let Err(source) = validate_retained_msix(&retained, &resource_registry) {
+            let primary = VirtioPciPublicationError::Endpoint { source };
+            let cleanup = cleanup_prepared_endpoint(&self.endpoint, &mut interrupts);
+            return Err(publication_rollback(primary, cleanup));
+        }
+        if bar_allocator.address_space() != PciBarAddressSpace::Memory64 {
+            let primary = VirtioPciPublicationError::Endpoint {
+                source: VirtioPciEndpointError::CapabilityBarAddressSpace {
+                    actual: bar_allocator.address_space(),
+                },
+            };
+            let cleanup = cleanup_prepared_endpoint(&self.endpoint, &mut interrupts);
+            return Err(publication_rollback(primary, cleanup));
+        }
+        if let Err(source) = bar_allocator.validate_exact_reservation(self.bar_range) {
+            let primary = VirtioPciPublicationError::BarAllocation { source };
+            let cleanup = cleanup_prepared_endpoint(&self.endpoint, &mut interrupts);
+            return Err(publication_rollback(primary, cleanup));
+        }
+        match segment.with_segment(|segment| segment.validate_function_at(self.sbdf)) {
+            Ok(Ok(())) => {}
+            Ok(Err(source)) => {
+                let primary = VirtioPciPublicationError::SegmentAdd { source };
+                let cleanup = cleanup_prepared_endpoint(&self.endpoint, &mut interrupts);
+                return Err(publication_rollback(primary, cleanup));
+            }
+            Err(source) => {
+                let primary = VirtioPciPublicationError::SegmentLock { source };
+                let cleanup = cleanup_prepared_endpoint(&self.endpoint, &mut interrupts);
+                return Err(publication_rollback(primary, cleanup));
+            }
+        }
+        let regions = [MmioRegionRequest::new(
+            self.bar_range.start(),
+            self.bar_range.size(),
+        )];
+        if let Err(source) = dispatcher.validate_owned_handler(self.region_id, &regions) {
+            let primary = VirtioPciPublicationError::MmioRegistration { source };
+            let cleanup = cleanup_prepared_endpoint(&self.endpoint, &mut interrupts);
+            return Err(publication_rollback(primary, cleanup));
+        }
+        if let Err(primary) = hook(RetainedPublicationStage::Preflight) {
+            let cleanup = cleanup_prepared_endpoint(&self.endpoint, &mut interrupts);
+            return Err(publication_rollback(primary, cleanup));
+        }
+
+        let bar_lease = match bar_allocator.reserve_exact(self.bar_range) {
+            Ok(lease) => lease,
+            Err(source) => {
+                let primary = VirtioPciPublicationError::BarAllocation { source };
+                let cleanup = cleanup_prepared_endpoint(&self.endpoint, &mut interrupts);
+                return Err(publication_rollback(primary, cleanup));
+            }
+        };
+        if let Err(primary) = hook(RetainedPublicationStage::Bar) {
+            let cleanup = cleanup_retained_bar_and_endpoint(
+                &self.endpoint,
+                &mut interrupts,
+                bar_allocator,
+                &bar_lease,
+            );
+            return Err(publication_rollback(primary, cleanup));
+        }
+
+        let function_lease = match segment.with_segment(|segment| {
+            segment.add_function_at(self.sbdf, self.endpoint.config_function())
+        }) {
+            Ok(Ok(lease)) => lease,
+            Ok(Err(source)) => {
+                let primary = VirtioPciPublicationError::SegmentAdd { source };
+                let cleanup = cleanup_retained_bar_and_endpoint(
+                    &self.endpoint,
+                    &mut interrupts,
+                    bar_allocator,
+                    &bar_lease,
+                );
+                return Err(publication_rollback(primary, cleanup));
+            }
+            Err(source) => {
+                let primary = VirtioPciPublicationError::SegmentLock { source };
+                let cleanup = cleanup_retained_bar_and_endpoint(
+                    &self.endpoint,
+                    &mut interrupts,
+                    bar_allocator,
+                    &bar_lease,
+                );
+                return Err(publication_rollback(primary, cleanup));
+            }
+        };
+        if let Err(primary) = hook(RetainedPublicationStage::Function) {
+            let cleanup = cleanup_retained_function(
+                &self.endpoint,
+                &mut interrupts,
+                bar_allocator,
+                &bar_lease,
+                &segment,
+                &function_lease,
+            );
+            return Err(publication_rollback(primary, cleanup));
+        }
+
+        let owner = MmioRegistrationOwner::new();
+        let mmio_lease = match dispatcher.register_owned_handler(
+            &owner,
+            self.region_id,
+            &regions,
+            self.endpoint.bar_handler(),
+        ) {
+            Ok(lease) => lease,
+            Err(source) => {
+                let primary = VirtioPciPublicationError::MmioRegistration { source };
+                let cleanup = cleanup_retained_function(
+                    &self.endpoint,
+                    &mut interrupts,
+                    bar_allocator,
+                    &bar_lease,
+                    &segment,
+                    &function_lease,
+                );
+                return Err(publication_rollback(primary, cleanup));
+            }
+        };
+        if let Err(primary) = hook(RetainedPublicationStage::Mmio) {
+            let cleanup = cleanup_retained_mmio(
+                &self.endpoint,
+                &mut interrupts,
+                bar_allocator,
+                &bar_lease,
+                &segment,
+                &function_lease,
+                dispatcher,
+                &owner,
+                &mmio_lease,
+            );
+            return Err(publication_rollback(primary, cleanup));
+        }
+
+        Ok(PublishedVirtioPciEndpoint {
+            endpoint: self.endpoint,
+            segment,
+            owner,
+            mmio_lease: Some(mmio_lease),
+            mmio_published: true,
+            function_lease: Some(function_lease),
+            function_published: true,
+            bar_lease: Some(bar_lease),
+            interrupts,
+            teardown_prepared: false,
+            released: false,
+        })
+    }
+}
+
 /// Published endpoint resources retained until ordered teardown completes.
 pub struct PublishedVirtioPciEndpoint<C, A, I> {
     endpoint: VirtioPciEndpoint<C, A>,
@@ -2677,6 +3396,117 @@ where
     cleanup
 }
 
+fn cleanup_prepared_endpoint<C, A, I>(
+    endpoint: &VirtioPciEndpoint<C, A>,
+    interrupts: &mut I,
+) -> String
+where
+    C: VirtioDeviceConfigHandler,
+    A: VirtioDeviceActivationHandler,
+    I: GuestMessageInterruptResources,
+{
+    let mut cleanup = String::new();
+    if let Err(source) = endpoint.release() {
+        append_cleanup(&mut cleanup, "endpoint", &source);
+    }
+    if let Err(source) = interrupts.release() {
+        append_cleanup(&mut cleanup, "interrupt resources", &source);
+    }
+    cleanup
+}
+
+fn cleanup_retained_bar_and_endpoint<C, A, I>(
+    endpoint: &VirtioPciEndpoint<C, A>,
+    interrupts: &mut I,
+    bar_allocator: &mut PciBarAllocator,
+    bar_lease: &PciBarLease,
+) -> String
+where
+    C: VirtioDeviceConfigHandler,
+    A: VirtioDeviceActivationHandler,
+    I: GuestMessageInterruptResources,
+{
+    let mut cleanup = String::new();
+    if let Err(source) = bar_allocator.release(bar_lease) {
+        append_cleanup(&mut cleanup, "BAR", &source);
+    }
+    if let Err(source) = endpoint.release() {
+        append_cleanup(&mut cleanup, "endpoint", &source);
+    }
+    if let Err(source) = interrupts.release() {
+        append_cleanup(&mut cleanup, "interrupt resources", &source);
+    }
+    cleanup
+}
+
+fn cleanup_retained_function<C, A, I>(
+    endpoint: &VirtioPciEndpoint<C, A>,
+    interrupts: &mut I,
+    bar_allocator: &mut PciBarAllocator,
+    bar_lease: &PciBarLease,
+    segment: &SharedPciSegment,
+    function_lease: &PciFunctionLease,
+) -> String
+where
+    C: VirtioDeviceConfigHandler,
+    A: VirtioDeviceActivationHandler,
+    I: GuestMessageInterruptResources,
+{
+    let mut cleanup = String::new();
+    match segment.with_segment(|segment| segment.remove_function(function_lease)) {
+        Ok(Ok(())) => {}
+        Ok(Err(source)) => append_cleanup(&mut cleanup, "PCI function", &source),
+        Err(source) => append_cleanup(&mut cleanup, "PCI segment lock", &source),
+    }
+    let remainder =
+        cleanup_retained_bar_and_endpoint(endpoint, interrupts, bar_allocator, bar_lease);
+    if !remainder.is_empty() {
+        if !cleanup.is_empty() {
+            cleanup.push_str("; ");
+        }
+        cleanup.push_str(&remainder);
+    }
+    cleanup
+}
+
+#[allow(clippy::too_many_arguments)]
+fn cleanup_retained_mmio<C, A, I>(
+    endpoint: &VirtioPciEndpoint<C, A>,
+    interrupts: &mut I,
+    bar_allocator: &mut PciBarAllocator,
+    bar_lease: &PciBarLease,
+    segment: &SharedPciSegment,
+    function_lease: &PciFunctionLease,
+    dispatcher: &mut MmioDispatcher,
+    owner: &MmioRegistrationOwner,
+    mmio_lease: &MmioRegistrationLease,
+) -> String
+where
+    C: VirtioDeviceConfigHandler,
+    A: VirtioDeviceActivationHandler,
+    I: GuestMessageInterruptResources,
+{
+    let mut cleanup = String::new();
+    if let Err(source) = dispatcher.release_owned_handler(owner, mmio_lease) {
+        append_cleanup(&mut cleanup, "MMIO registration", &source);
+    }
+    let remainder = cleanup_retained_function(
+        endpoint,
+        interrupts,
+        bar_allocator,
+        bar_lease,
+        segment,
+        function_lease,
+    );
+    if !remainder.is_empty() {
+        if !cleanup.is_empty() {
+            cleanup.push_str("; ");
+        }
+        cleanup.push_str(&remainder);
+    }
+    cleanup
+}
+
 fn append_cleanup(cleanup: &mut String, stage: &str, source: &impl fmt::Display) {
     if !cleanup.is_empty() {
         cleanup.push_str("; ");
@@ -2702,6 +3532,11 @@ fn publication_rollback(
 #[derive(Debug)]
 pub enum VirtioPciPublicationError {
     TeardownNotPrepared,
+    InterruptRegistryMismatch,
+    #[cfg(test)]
+    InjectedFailure {
+        stage: &'static str,
+    },
     BarAllocation {
         source: PciBarAllocationError,
     },
@@ -2742,6 +3577,16 @@ impl fmt::Display for VirtioPciPublicationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::TeardownNotPrepared => f.write_str("virtio-pci teardown was not prepared"),
+            Self::InterruptRegistryMismatch => {
+                f.write_str("virtio-pci interrupt resources do not own the prepared registry")
+            }
+            #[cfg(test)]
+            Self::InjectedFailure { stage } => {
+                write!(
+                    f,
+                    "injected retained virtio-pci publication failure after {stage}"
+                )
+            }
             Self::BarAllocation { source } => {
                 write!(f, "failed to allocate virtio-pci BAR: {source}")
             }
@@ -2780,7 +3625,9 @@ impl fmt::Display for VirtioPciPublicationError {
 impl std::error::Error for VirtioPciPublicationError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::TeardownNotPrepared => None,
+            Self::TeardownNotPrepared | Self::InterruptRegistryMismatch => None,
+            #[cfg(test)]
+            Self::InjectedFailure { .. } => None,
             Self::BarAllocation { source } => Some(source),
             Self::Endpoint { source } => Some(source),
             Self::SegmentLock { source } => Some(source),
@@ -2880,6 +3727,27 @@ pub enum VirtioPciEndpointError {
     DeviceRegisters {
         source: VirtioMmioRegisterStateError,
     },
+    RetainedState {
+        kind: VirtioPciRetainedStateError,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VirtioPciRetainedStateError {
+    Phase,
+    DeviceIdentity,
+    Features,
+    Status,
+    Activation,
+    DeviceConfigPolicy,
+    Queue,
+    Notification,
+    InterruptIntent,
+    Sbdf,
+    Bar,
+    Configuration,
+    Msix,
+    Recapture,
 }
 
 impl fmt::Display for VirtioPciEndpointError {
@@ -2968,7 +3836,32 @@ impl fmt::Display for VirtioPciEndpointError {
             Self::DeviceRegisters { source } => {
                 write!(f, "virtio-pci device register update failed: {source}")
             }
+            Self::RetainedState { kind } => {
+                write!(f, "retained virtio-pci {kind} state is invalid")
+            }
         }
+    }
+}
+
+impl fmt::Display for VirtioPciRetainedStateError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Self::Phase => "phase",
+            Self::DeviceIdentity => "device identity",
+            Self::Features => "feature",
+            Self::Status => "device status",
+            Self::Activation => "activation",
+            Self::DeviceConfigPolicy => "device-config policy",
+            Self::Queue => "queue",
+            Self::Notification => "notification",
+            Self::InterruptIntent => "interrupt-intent",
+            Self::Sbdf => "SBDF",
+            Self::Bar => "BAR",
+            Self::Configuration => "PCI configuration",
+            Self::Msix => "MSI-X",
+            Self::Recapture => "recapture",
+        };
+        formatter.write_str(name)
     }
 }
 
@@ -2999,6 +3892,7 @@ impl std::error::Error for VirtioPciEndpointError {
             Self::Queue { source } => Some(source),
             Self::QueueNotification { source } => Some(source),
             Self::DeviceRegisters { source } => Some(source),
+            Self::RetainedState { .. } => None,
             Self::VectorCountOverflow
             | Self::TooManyVectors { .. }
             | Self::MessageRouteCount { .. }
@@ -3125,6 +4019,22 @@ mod tests {
         _allocator: PciBarAllocator,
         messages: Vec<GuestMessage>,
         signals: Vec<Arc<Mutex<Vec<GuestMessage>>>>,
+    }
+
+    struct RetainedTransportFixture {
+        state: VirtioPciTransportState,
+        identity: VirtioPciIdentity,
+        bar_range: GuestMemoryRange,
+        sbdf: PciSbdf,
+        region_id: MmioRegionId,
+        messages: Vec<GuestMessage>,
+    }
+
+    struct CountingResourcesFixture {
+        registry: GuestMessageInterruptRegistry,
+        resources: CountingInterruptResources,
+        signals: Vec<Arc<Mutex<Vec<GuestMessage>>>>,
+        releases: Arc<Mutex<usize>>,
     }
 
     #[derive(Debug, Default)]
@@ -3445,6 +4355,249 @@ mod tests {
         RegistryGuestMessageInterruptResources::new(
             GuestMessageInterruptRegistry::new(routes)
                 .expect("test publication registry should validate"),
+        )
+    }
+
+    fn registry_for_messages(
+        messages: &[GuestMessage],
+    ) -> (
+        GuestMessageInterruptRegistry,
+        Vec<Arc<Mutex<Vec<GuestMessage>>>>,
+    ) {
+        let mut signals = Vec::with_capacity(messages.len());
+        let routes = messages
+            .iter()
+            .copied()
+            .map(|message| {
+                let recording = Arc::new(Mutex::new(Vec::new()));
+                signals.push(Arc::clone(&recording));
+                let route: Arc<dyn GuestMessageInterrupt> = Arc::new(RecordingRoute {
+                    message,
+                    signals: recording,
+                });
+                route
+            })
+            .collect();
+        (
+            GuestMessageInterruptRegistry::new(routes)
+                .expect("retained test message registry should validate"),
+            signals,
+        )
+    }
+
+    fn counting_resources_for_messages(messages: &[GuestMessage]) -> CountingResourcesFixture {
+        let (registry, signals) = registry_for_messages(messages);
+        let releases = Arc::new(Mutex::new(0));
+        CountingResourcesFixture {
+            registry: registry.clone(),
+            resources: CountingInterruptResources {
+                registry,
+                releases: Arc::clone(&releases),
+            },
+            signals,
+            releases,
+        }
+    }
+
+    fn retained_transport_fixture() -> RetainedTransportFixture {
+        let identity = VirtioPciIdentity::new(VirtioDeviceType::new(4).unwrap(), 0b0101);
+        let fixture = fixture_for_identity(&[8], 4, 0b0101);
+        let bus = bar_bus(&fixture);
+        let base = fixture.bar.range().start();
+        let mut bar = fixture.endpoint.bar_handler();
+
+        bar_write(&mut bar, &bus, base, VIRTIO_PCI_COMMON_DEVICE_STATUS, &[1]).unwrap();
+        bar_write(&mut bar, &bus, base, VIRTIO_PCI_COMMON_DEVICE_STATUS, &[3]).unwrap();
+        bar_write(
+            &mut bar,
+            &bus,
+            base,
+            VIRTIO_PCI_COMMON_DRIVER_FEATURE_SELECT,
+            &0_u32.to_le_bytes(),
+        )
+        .unwrap();
+        bar_write(
+            &mut bar,
+            &bus,
+            base,
+            VIRTIO_PCI_COMMON_DRIVER_FEATURE,
+            &0b0101_u32.to_le_bytes(),
+        )
+        .unwrap();
+        bar_write(
+            &mut bar,
+            &bus,
+            base,
+            VIRTIO_PCI_COMMON_DRIVER_FEATURE_SELECT,
+            &1_u32.to_le_bytes(),
+        )
+        .unwrap();
+        bar_write(
+            &mut bar,
+            &bus,
+            base,
+            VIRTIO_PCI_COMMON_DRIVER_FEATURE,
+            &1_u32.to_le_bytes(),
+        )
+        .unwrap();
+        bar_write(&mut bar, &bus, base, VIRTIO_PCI_COMMON_DEVICE_STATUS, &[11]).unwrap();
+        bar_write(
+            &mut bar,
+            &bus,
+            base,
+            VIRTIO_PCI_COMMON_QUEUE_SELECT,
+            &0_u16.to_le_bytes(),
+        )
+        .unwrap();
+        bar_write(
+            &mut bar,
+            &bus,
+            base,
+            VIRTIO_PCI_COMMON_QUEUE_SIZE,
+            &8_u16.to_le_bytes(),
+        )
+        .unwrap();
+        bar_write(
+            &mut bar,
+            &bus,
+            base,
+            VIRTIO_PCI_COMMON_QUEUE_DESC_LO,
+            &0x1000_u32.to_le_bytes(),
+        )
+        .unwrap();
+        bar_write(
+            &mut bar,
+            &bus,
+            base,
+            VIRTIO_PCI_COMMON_QUEUE_AVAIL_LO,
+            &0x2000_u32.to_le_bytes(),
+        )
+        .unwrap();
+        bar_write(
+            &mut bar,
+            &bus,
+            base,
+            VIRTIO_PCI_COMMON_QUEUE_USED_LO,
+            &0x3000_u32.to_le_bytes(),
+        )
+        .unwrap();
+        bar_write(
+            &mut bar,
+            &bus,
+            base,
+            VIRTIO_PCI_COMMON_QUEUE_ENABLE,
+            &1_u16.to_le_bytes(),
+        )
+        .unwrap();
+        for (vector, message) in fixture.messages.iter().copied().enumerate() {
+            let entry_offset = VIRTIO_PCI_MSIX_TABLE_OFFSET
+                + u64::try_from(vector).expect("test vector should fit") * MSIX_TABLE_ENTRY_SIZE;
+            bar_write(
+                &mut bar,
+                &bus,
+                base,
+                entry_offset,
+                &message.address().to_le_bytes(),
+            )
+            .unwrap();
+            bar_write(
+                &mut bar,
+                &bus,
+                base,
+                entry_offset + 8,
+                &u64::from(message.data()).to_le_bytes(),
+            )
+            .unwrap();
+        }
+        bar_write(
+            &mut bar,
+            &bus,
+            base,
+            VIRTIO_PCI_COMMON_MSIX_CONFIG,
+            &0_u16.to_le_bytes(),
+        )
+        .unwrap();
+        bar_write(
+            &mut bar,
+            &bus,
+            base,
+            VIRTIO_PCI_COMMON_QUEUE_MSIX_VECTOR,
+            &1_u16.to_le_bytes(),
+        )
+        .unwrap();
+        bar_write(&mut bar, &bus, base, VIRTIO_PCI_COMMON_DEVICE_STATUS, &[15]).unwrap();
+        bar_write(
+            &mut bar,
+            &bus,
+            base,
+            VIRTIO_PCI_NOTIFICATION_OFFSET,
+            &0_u16.to_le_bytes(),
+        )
+        .unwrap();
+        bar_write(
+            &mut bar,
+            &bus,
+            base,
+            VIRTIO_PCI_COMMON_DEVICE_FEATURE_SELECT,
+            &0xfeed_beef_u32.to_le_bytes(),
+        )
+        .unwrap();
+        bar_write(
+            &mut bar,
+            &bus,
+            base,
+            VIRTIO_PCI_COMMON_DRIVER_FEATURE_SELECT,
+            &0xdead_beef_u32.to_le_bytes(),
+        )
+        .unwrap();
+        {
+            let work = fixture.endpoint.admit_device_work().unwrap();
+            work.with_core_mut(|core| {
+                core.record_interrupt_intent(VirtioInterruptIntent::Configuration);
+            })
+            .unwrap();
+        }
+        let mut config = fixture.endpoint.config_function();
+        config_write(&mut config, 4, &[0x07]);
+        config_write(&mut config, 0x10, &[u8::MAX; 4]);
+
+        assert!(
+            fixture
+                .signals
+                .iter()
+                .all(|signals| signals.lock().unwrap().is_empty()),
+            "capturing retained state must not signal an interrupt"
+        );
+        RetainedTransportFixture {
+            state: fixture.endpoint.transport_state().unwrap(),
+            identity,
+            bar_range: fixture.bar.range(),
+            sbdf: PciSbdf::new(0, 0, 7, 0).unwrap(),
+            region_id: MmioRegionId::new(107),
+            messages: fixture.messages.clone(),
+        }
+    }
+
+    fn prepare_retained_endpoint(
+        fixture: &RetainedTransportFixture,
+        state: &VirtioPciTransportState,
+        messages: GuestMessageInterruptRegistry,
+    ) -> Result<
+        PreparedVirtioPciEndpoint<UnsupportedVirtioDeviceConfig, NoopVirtioDeviceActivation>,
+        VirtioPciEndpointError,
+    > {
+        PreparedVirtioPciEndpoint::new(
+            fixture.identity,
+            &[8],
+            UnsupportedVirtioDeviceConfig,
+            NoopVirtioDeviceActivation,
+            state.is_device_activated(),
+            false,
+            state,
+            fixture.sbdf,
+            fixture.bar_range,
+            fixture.region_id,
+            messages,
         )
     }
 
@@ -4794,6 +5947,594 @@ mod tests {
             .drain_interrupt_intents()
             .expect("drained intents should not repeat");
         assert_eq!(fixture.signals[0].lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn retained_endpoint_restores_exact_state_and_publication_leases() {
+        let fixture = retained_transport_fixture();
+        let CountingResourcesFixture {
+            registry,
+            resources,
+            signals,
+            releases,
+        } = counting_resources_for_messages(&fixture.messages);
+        let prepared = prepare_retained_endpoint(&fixture, &fixture.state, registry)
+            .expect("valid retained endpoint should prepare");
+        assert_eq!(prepared.sbdf(), fixture.sbdf);
+        assert_eq!(prepared.bar_range(), fixture.bar_range);
+        assert_eq!(prepared.region_id(), fixture.region_id);
+
+        let mut allocator = PciBarAllocator::new(PciBarAddressSpace::Memory64, fixture.bar_range);
+        let segment = SharedPciSegment::new(crate::pci::PciSegment::new());
+        let mut dispatcher = MmioDispatcher::new();
+        let mut published = prepared
+            .publish(&mut allocator, segment.clone(), &mut dispatcher, resources)
+            .expect("exact retained endpoint publication should succeed");
+
+        assert_eq!(published.sbdf(), Some(fixture.sbdf));
+        assert_eq!(published.bar_range(), Some(fixture.bar_range));
+        assert_eq!(
+            published.endpoint().transport_state().unwrap(),
+            fixture.state
+        );
+        assert!(matches!(
+            allocator.validate_exact_reservation(fixture.bar_range),
+            Err(PciBarAllocationError::ExactRangeOccupied)
+        ));
+        assert!(matches!(
+            segment
+                .with_segment(|segment| segment.validate_function_at(fixture.sbdf))
+                .unwrap(),
+            Err(PciSegmentError::DuplicateIdentity { sbdf }) if sbdf == fixture.sbdf
+        ));
+        assert!(dispatcher.lookup(fixture.bar_range.start(), 1).is_ok());
+        assert!(
+            signals
+                .iter()
+                .all(|signals| signals.lock().unwrap().is_empty()),
+            "retained route validation and publication must not signal"
+        );
+
+        published
+            .prepare_teardown(&mut dispatcher)
+            .expect("retained teardown should prepare");
+        assert_eq!(
+            published.endpoint().phase().unwrap(),
+            VirtioPciEndpointPhase::Quiescing
+        );
+        published
+            .rollback_prepared_teardown(&mut dispatcher)
+            .expect("retained teardown should roll back");
+        assert_eq!(
+            published.endpoint().transport_state().unwrap(),
+            fixture.state
+        );
+
+        published
+            .teardown(&mut dispatcher, &mut allocator)
+            .expect("retained endpoint should tear down");
+        assert_eq!(*releases.lock().unwrap(), 1);
+        assert!(dispatcher.regions().is_empty());
+        assert_eq!(
+            segment
+                .with_segment(|segment| segment.function_count())
+                .unwrap(),
+            1
+        );
+        let reused = allocator
+            .reserve_exact(fixture.bar_range)
+            .expect("exact retained BAR should be immediately reusable");
+        allocator.release(&reused).unwrap();
+    }
+
+    #[test]
+    fn retained_endpoint_rejects_every_hostile_state_family_before_publication() {
+        let fixture = retained_transport_fixture();
+        let assert_kind = |state: VirtioPciTransportState, expected| {
+            let (registry, signals) = registry_for_messages(&fixture.messages);
+            let observer = registry.clone();
+            let error = match prepare_retained_endpoint(&fixture, &state, registry) {
+                Ok(_) => panic!("hostile retained state should be rejected"),
+                Err(error) => error,
+            };
+            assert!(matches!(
+                error,
+                VirtioPciEndpointError::RetainedState { kind } if kind == expected
+            ));
+            assert_eq!(
+                observer.phase().unwrap(),
+                GuestMessageInterruptRegistryPhase::Active
+            );
+            assert!(
+                signals
+                    .iter()
+                    .all(|signals| signals.lock().unwrap().is_empty())
+            );
+        };
+
+        let mut state = fixture.state.clone();
+        state.phase = VirtioPciEndpointPhase::Quiescing;
+        assert_kind(state, VirtioPciRetainedStateError::Phase);
+
+        let mut state = fixture.state.clone();
+        let device = state.device;
+        state.device = VirtioMmioDeviceRegisters::with_vendor_id_and_config_generation(
+            5,
+            device.vendor_id(),
+            device.device_features(),
+            device.config_generation(),
+        )
+        .with_runtime_state(
+            [
+                device.device_features_select(),
+                device.driver_features_select(),
+            ],
+            device.driver_features(),
+            device.status(),
+        );
+        assert_kind(state, VirtioPciRetainedStateError::DeviceIdentity);
+
+        let mut state = fixture.state.clone();
+        let device = state.device;
+        state.device = VirtioMmioDeviceRegisters::with_vendor_id_and_config_generation(
+            device.device_id(),
+            device.vendor_id(),
+            device.device_features(),
+            device.config_generation(),
+        )
+        .with_runtime_state([2, 0], device.driver_features(), device.status());
+        assert_kind(state, VirtioPciRetainedStateError::Features);
+
+        let mut state = fixture.state.clone();
+        let device = state.device;
+        state.device = VirtioMmioDeviceRegisters::with_vendor_id_and_config_generation(
+            device.device_id(),
+            device.vendor_id(),
+            device.device_features(),
+            device.config_generation(),
+        )
+        .with_runtime_state([0, 0], 0, 0x20);
+        assert_kind(state, VirtioPciRetainedStateError::Status);
+
+        let mut state = fixture.state.clone();
+        state.device_activated = false;
+        assert_kind(state, VirtioPciRetainedStateError::Activation);
+
+        let mut state = fixture.state.clone();
+        state.requires_device_config_write_status = true;
+        assert_kind(state, VirtioPciRetainedStateError::DeviceConfigPolicy);
+
+        let mut state = fixture.state.clone();
+        state.queues = VirtioQueues::new(&[16]).unwrap();
+        assert_kind(state, VirtioPciRetainedStateError::Queue);
+
+        let mut state = fixture.state.clone();
+        state.queue_notifications = VirtioQueueNotificationState::new(2).unwrap();
+        assert_kind(state, VirtioPciRetainedStateError::Notification);
+
+        let mut state = fixture.state.clone();
+        state
+            .interrupt_intents
+            .push(VirtioInterruptIntent::Configuration);
+        assert_kind(state, VirtioPciRetainedStateError::InterruptIntent);
+
+        let mut state = fixture.state.clone();
+        state.pci_cfg_cap_offset += 1;
+        assert_kind(state, VirtioPciRetainedStateError::Configuration);
+
+        let mut state = fixture.state.clone();
+        state.msix.entries.pop();
+        assert_kind(state, VirtioPciRetainedStateError::Msix);
+
+        let invalid_sbdf = PciSbdf::new(0, 1, 7, 0).unwrap();
+        let (registry, signals) = registry_for_messages(&fixture.messages);
+        let observer = registry.clone();
+        let error = match PreparedVirtioPciEndpoint::new(
+            fixture.identity,
+            &[8],
+            UnsupportedVirtioDeviceConfig,
+            NoopVirtioDeviceActivation,
+            true,
+            false,
+            &fixture.state,
+            invalid_sbdf,
+            fixture.bar_range,
+            fixture.region_id,
+            registry,
+        ) {
+            Ok(_) => panic!("invalid retained SBDF should reject"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            VirtioPciEndpointError::RetainedState {
+                kind: VirtioPciRetainedStateError::Sbdf
+            }
+        ));
+        assert_eq!(
+            observer.phase().unwrap(),
+            GuestMessageInterruptRegistryPhase::Active
+        );
+        assert!(
+            signals
+                .iter()
+                .all(|signals| signals.lock().unwrap().is_empty())
+        );
+
+        let invalid_bar = GuestMemoryRange::new(
+            fixture.bar_range.start(),
+            VIRTIO_PCI_CAPABILITY_BAR_SIZE / 2,
+        )
+        .unwrap();
+        let (registry, signals) = registry_for_messages(&fixture.messages);
+        let observer = registry.clone();
+        let error = match PreparedVirtioPciEndpoint::new(
+            fixture.identity,
+            &[8],
+            UnsupportedVirtioDeviceConfig,
+            NoopVirtioDeviceActivation,
+            true,
+            false,
+            &fixture.state,
+            fixture.sbdf,
+            invalid_bar,
+            fixture.region_id,
+            registry,
+        ) {
+            Ok(_) => panic!("invalid retained BAR should reject"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            VirtioPciEndpointError::RetainedState {
+                kind: VirtioPciRetainedStateError::Bar
+            }
+        ));
+        assert_eq!(
+            observer.phase().unwrap(),
+            GuestMessageInterruptRegistryPhase::Active
+        );
+        assert!(
+            signals
+                .iter()
+                .all(|signals| signals.lock().unwrap().is_empty())
+        );
+    }
+
+    #[test]
+    fn retained_endpoint_validates_exact_routes_without_signaling() {
+        let fixture = retained_transport_fixture();
+        let unknown_messages = [
+            GuestMessage::new(0x0800_0080, 190),
+            GuestMessage::new(0x0800_0080, 191),
+        ];
+        let (unknown_registry, unknown_signals) = registry_for_messages(&unknown_messages);
+        let unknown = match prepare_retained_endpoint(&fixture, &fixture.state, unknown_registry) {
+            Ok(_) => panic!("unknown retained route should reject"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            unknown,
+            VirtioPciEndpointError::MessageRegistry {
+                source: GuestMessageInterruptRegistryError::UnknownMessage
+            }
+        ));
+        assert!(
+            unknown_signals
+                .iter()
+                .all(|signals| signals.lock().unwrap().is_empty())
+        );
+
+        let duplicate_signals = [
+            Arc::new(Mutex::new(Vec::new())),
+            Arc::new(Mutex::new(Vec::new())),
+        ];
+        let duplicate_routes = duplicate_signals
+            .iter()
+            .map(|signals| {
+                let route: Arc<dyn GuestMessageInterrupt> = Arc::new(RecordingRoute {
+                    message: fixture.messages[0],
+                    signals: Arc::clone(signals),
+                });
+                route
+            })
+            .collect();
+        let ambiguous_registry = GuestMessageInterruptRegistry::new(duplicate_routes).unwrap();
+        let ambiguous =
+            match prepare_retained_endpoint(&fixture, &fixture.state, ambiguous_registry) {
+                Ok(_) => panic!("ambiguous retained route should reject"),
+                Err(error) => error,
+            };
+        assert!(matches!(
+            ambiguous,
+            VirtioPciEndpointError::MessageRegistry {
+                source: GuestMessageInterruptRegistryError::AmbiguousMessage
+            }
+        ));
+        assert!(
+            duplicate_signals
+                .iter()
+                .all(|signals| signals.lock().unwrap().is_empty())
+        );
+    }
+
+    #[test]
+    fn retained_publication_rejects_interrupt_registry_owner_mismatch() {
+        let fixture = retained_transport_fixture();
+        let (prepared_registry, _) = registry_for_messages(&fixture.messages);
+        let prepared_observer = prepared_registry.clone();
+        let prepared =
+            prepare_retained_endpoint(&fixture, &fixture.state, prepared_registry).unwrap();
+        let CountingResourcesFixture {
+            registry: resource_registry,
+            resources,
+            signals: _,
+            releases,
+        } = counting_resources_for_messages(&fixture.messages);
+        let resource_observer = resource_registry.clone();
+        let mut allocator = PciBarAllocator::new(PciBarAddressSpace::Memory64, fixture.bar_range);
+        let segment = SharedPciSegment::new(crate::pci::PciSegment::new());
+        let mut dispatcher = MmioDispatcher::new();
+
+        let error = prepared
+            .publish(&mut allocator, segment.clone(), &mut dispatcher, resources)
+            .expect_err("foreign interrupt resources must reject publication");
+        assert!(matches!(
+            error,
+            VirtioPciPublicationError::InterruptRegistryMismatch
+        ));
+        assert_eq!(*releases.lock().unwrap(), 1);
+        assert_eq!(
+            resource_observer.phase().unwrap(),
+            GuestMessageInterruptRegistryPhase::Released
+        );
+        assert_eq!(
+            prepared_observer.phase().unwrap(),
+            GuestMessageInterruptRegistryPhase::Active
+        );
+        assert_eq!(allocator.available_ranges(), &[fixture.bar_range]);
+        assert_eq!(
+            segment
+                .with_segment(|segment| segment.function_count())
+                .unwrap(),
+            1
+        );
+        assert!(dispatcher.regions().is_empty());
+        prepared_observer.release().unwrap();
+    }
+
+    #[test]
+    fn retained_publication_preflights_all_exact_resource_conflicts() {
+        let fixture = retained_transport_fixture();
+
+        {
+            let CountingResourcesFixture {
+                registry,
+                resources,
+                signals: _,
+                releases,
+            } = counting_resources_for_messages(&fixture.messages);
+            let prepared = prepare_retained_endpoint(&fixture, &fixture.state, registry).unwrap();
+            let mut allocator =
+                PciBarAllocator::new(PciBarAddressSpace::Memory64, fixture.bar_range);
+            let incumbent = allocator.reserve_exact(fixture.bar_range).unwrap();
+            let segment = SharedPciSegment::new(crate::pci::PciSegment::new());
+            let mut dispatcher = MmioDispatcher::new();
+            let error = prepared
+                .publish(&mut allocator, segment.clone(), &mut dispatcher, resources)
+                .expect_err("occupied exact BAR should reject");
+            assert!(matches!(
+                error,
+                VirtioPciPublicationError::BarAllocation {
+                    source: PciBarAllocationError::ExactRangeOccupied
+                }
+            ));
+            assert_eq!(*releases.lock().unwrap(), 1);
+            assert_eq!(
+                segment
+                    .with_segment(|segment| segment.function_count())
+                    .unwrap(),
+                1
+            );
+            assert!(dispatcher.regions().is_empty());
+            allocator
+                .release(&incumbent)
+                .expect("incumbent BAR lease must survive preflight");
+        }
+
+        {
+            let CountingResourcesFixture {
+                registry,
+                resources,
+                signals: _,
+                releases,
+            } = counting_resources_for_messages(&fixture.messages);
+            let prepared = prepare_retained_endpoint(&fixture, &fixture.state, registry).unwrap();
+            let mut allocator =
+                PciBarAllocator::new(PciBarAddressSpace::Memory64, fixture.bar_range);
+            let segment = SharedPciSegment::new(crate::pci::PciSegment::new());
+            let incumbent = segment
+                .with_segment(|segment| {
+                    segment.add_function_at(
+                        fixture.sbdf,
+                        PciType0Configuration::new(
+                            0x1af4,
+                            0x1044,
+                            1,
+                            PciClassCode::Unclassified,
+                            0,
+                            0,
+                            0x1af4,
+                            0x1044,
+                        ),
+                    )
+                })
+                .unwrap()
+                .unwrap();
+            let mut dispatcher = MmioDispatcher::new();
+            let error = prepared
+                .publish(&mut allocator, segment.clone(), &mut dispatcher, resources)
+                .expect_err("occupied exact SBDF should reject");
+            assert!(matches!(
+                error,
+                VirtioPciPublicationError::SegmentAdd {
+                    source: PciSegmentError::DuplicateIdentity { sbdf }
+                } if sbdf == fixture.sbdf
+            ));
+            assert_eq!(*releases.lock().unwrap(), 1);
+            assert_eq!(allocator.available_ranges(), &[fixture.bar_range]);
+            assert_eq!(
+                segment
+                    .with_segment(|segment| segment.function_count())
+                    .unwrap(),
+                2
+            );
+            assert!(dispatcher.regions().is_empty());
+            segment
+                .with_segment(|segment| segment.remove_function(&incumbent))
+                .unwrap()
+                .expect("incumbent function lease must survive preflight");
+        }
+
+        {
+            let CountingResourcesFixture {
+                registry,
+                resources,
+                signals: _,
+                releases,
+            } = counting_resources_for_messages(&fixture.messages);
+            let prepared = prepare_retained_endpoint(&fixture, &fixture.state, registry).unwrap();
+            let mut allocator =
+                PciBarAllocator::new(PciBarAddressSpace::Memory64, fixture.bar_range);
+            let segment = SharedPciSegment::new(crate::pci::PciSegment::new());
+            let mut dispatcher = MmioDispatcher::new();
+            let incumbent_id = MmioRegionId::new(1007);
+            dispatcher
+                .insert_region(
+                    incumbent_id,
+                    fixture.bar_range.start(),
+                    fixture.bar_range.size(),
+                )
+                .unwrap();
+            let error = prepared
+                .publish(&mut allocator, segment.clone(), &mut dispatcher, resources)
+                .expect_err("occupied exact MMIO range should reject");
+            assert!(matches!(
+                error,
+                VirtioPciPublicationError::MmioRegistration {
+                    source: MmioRegistrationError::Region { .. }
+                }
+            ));
+            assert_eq!(*releases.lock().unwrap(), 1);
+            assert_eq!(allocator.available_ranges(), &[fixture.bar_range]);
+            assert_eq!(
+                segment
+                    .with_segment(|segment| segment.function_count())
+                    .unwrap(),
+                1
+            );
+            assert_eq!(dispatcher.regions().len(), 1);
+            assert_eq!(dispatcher.regions()[0].id(), incumbent_id);
+        }
+    }
+
+    #[test]
+    fn retained_publication_rolls_back_each_commit_stage_and_retries_exactly() {
+        let fixture = retained_transport_fixture();
+        for (stage, name) in [
+            (RetainedPublicationStage::Preflight, "preflight"),
+            (RetainedPublicationStage::Bar, "BAR"),
+            (RetainedPublicationStage::Function, "function"),
+            (RetainedPublicationStage::Mmio, "MMIO"),
+        ] {
+            let CountingResourcesFixture {
+                registry,
+                resources,
+                signals,
+                releases,
+            } = counting_resources_for_messages(&fixture.messages);
+            let prepared = prepare_retained_endpoint(&fixture, &fixture.state, registry).unwrap();
+            let mut allocator =
+                PciBarAllocator::new(PciBarAddressSpace::Memory64, fixture.bar_range);
+            let segment = SharedPciSegment::new(crate::pci::PciSegment::new());
+            let mut dispatcher = MmioDispatcher::new();
+
+            let error = prepared
+                .publish_with_hook(
+                    &mut allocator,
+                    segment.clone(),
+                    &mut dispatcher,
+                    resources,
+                    |current| {
+                        if current == stage {
+                            Err(VirtioPciPublicationError::InjectedFailure { stage: name })
+                        } else {
+                            Ok(())
+                        }
+                    },
+                )
+                .expect_err("injected publication failure should be returned");
+            assert!(matches!(
+                error,
+                VirtioPciPublicationError::InjectedFailure { stage: actual } if actual == name
+            ));
+            assert_eq!(*releases.lock().unwrap(), 1, "{name}");
+            assert!(
+                signals
+                    .iter()
+                    .all(|signals| signals.lock().unwrap().is_empty()),
+                "{name}"
+            );
+            assert_eq!(allocator.available_ranges(), &[fixture.bar_range], "{name}");
+            assert_eq!(
+                segment
+                    .with_segment(|segment| segment.function_count())
+                    .unwrap(),
+                1,
+                "{name}"
+            );
+            assert!(dispatcher.regions().is_empty(), "{name}");
+
+            let probe = allocator
+                .reserve_exact(fixture.bar_range)
+                .expect("rolled-back exact BAR should be reusable");
+            allocator.release(&probe).unwrap();
+
+            let CountingResourcesFixture {
+                registry,
+                resources,
+                signals: retry_signals,
+                releases: retry_releases,
+            } = counting_resources_for_messages(&fixture.messages);
+            let prepared = prepare_retained_endpoint(&fixture, &fixture.state, registry).unwrap();
+            let mut published = prepared
+                .publish(&mut allocator, segment.clone(), &mut dispatcher, resources)
+                .expect("the identical retained plan should retry successfully");
+            assert_eq!(
+                published.endpoint().transport_state().unwrap(),
+                fixture.state,
+                "{name}"
+            );
+            assert!(
+                retry_signals
+                    .iter()
+                    .all(|signals| signals.lock().unwrap().is_empty()),
+                "{name}"
+            );
+            published
+                .teardown(&mut dispatcher, &mut allocator)
+                .expect("retried retained endpoint should tear down");
+            assert_eq!(*retry_releases.lock().unwrap(), 1, "{name}");
+            assert_eq!(allocator.available_ranges(), &[fixture.bar_range], "{name}");
+            assert_eq!(
+                segment
+                    .with_segment(|segment| segment.function_count())
+                    .unwrap(),
+                1,
+                "{name}"
+            );
+            assert!(dispatcher.regions().is_empty(), "{name}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- rebuild published virtio-pci endpoints from complete retained transport state while deriving immutable host configuration locally
- reserve exact PCI BAR, SBDF, MMIO, interrupt-route, and HVF MSI resources with side-effect-free preflight and reverse-order rollback
- reject hostile or inconsistent retained state without signaling routes or disturbing incumbent owners, and prove exact recapture plus teardown/reuse

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented Apple-target Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

## Scope

This restores the retained virtio-pci endpoint publication boundary only. Public snapshot orchestration, process restoration, and additional device-family work remain in parent #1531 follow-ups.

Closes #1584
Parent: #1531