### PR TITLE
feat: prepare native-v2 root restore resources

### DIFF
--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -1578,6 +1578,13 @@ impl fmt::Debug for PreparedNativeSnapshotLoad {
 }
 
 #[cfg(target_os = "macos")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DirectRootSelectorPolicy {
+    TreatAsPath,
+    RejectGrantReference,
+}
+
+#[cfg(target_os = "macos")]
 struct PreparedSnapshotRootBackingLease {
     selector: Option<PathBuf>,
     claim: Option<PreparedDriveBackingClaim>,
@@ -1589,13 +1596,16 @@ impl PreparedSnapshotRootBackingLease {
     fn prepare(
         selector: &Path,
         authority: Option<&GrantAuthority>,
+        direct_policy: DirectRootSelectorPolicy,
     ) -> Result<Self, GrantClaimError> {
         let claim = match authority {
             Some(authority) => {
                 authority.prepare_drive_backing_claim(selector, GrantAccess::ReadOnly)?
             }
             None => {
-                if grant_reference_id(selector)?.is_some() {
+                if direct_policy == DirectRootSelectorPolicy::RejectGrantReference
+                    && grant_reference_id(selector)?.is_some()
+                {
                     return Err(GrantClaimError);
                 }
                 None
@@ -4801,6 +4811,7 @@ where
         let mut root_lease = PreparedSnapshotRootBackingLease::prepare(
             state.root_backing_path(),
             self.grant_authority.as_ref(),
+            DirectRootSelectorPolicy::TreatAsPath,
         )
         .map_err(NativeV1SnapshotLoadError::Resource)?;
         let root = root_lease
@@ -4888,6 +4899,7 @@ where
         let mut root_lease = PreparedSnapshotRootBackingLease::prepare(
             state.root_backing_path(),
             self.grant_authority.as_ref(),
+            DirectRootSelectorPolicy::RejectGrantReference,
         )
         .map_err(NativeV1SnapshotLoadError::Resource)?;
         let root = root_lease
@@ -5174,9 +5186,12 @@ where
         .map_err(NativeV1SnapshotLoadError::Artifact)?;
         let state = PreparedHvfSnapshotV1State::from_prepared_state(state)
             .map_err(NativeV1SnapshotLoadError::Prepare)?;
-        let mut root_lease =
-            PreparedSnapshotRootBackingLease::prepare(state.root_backing_path(), Some(authority))
-                .map_err(NativeV1SnapshotLoadError::Resource)?;
+        let mut root_lease = PreparedSnapshotRootBackingLease::prepare(
+            state.root_backing_path(),
+            Some(authority),
+            DirectRootSelectorPolicy::TreatAsPath,
+        )
+        .map_err(NativeV1SnapshotLoadError::Resource)?;
         let root = root_lease
             .take_snapshot_read_only_file()
             .map_err(NativeV1SnapshotLoadError::Resource)?;
@@ -5272,6 +5287,7 @@ where
         let mut root_lease = PreparedSnapshotRootBackingLease::prepare(
             state.root_backing_path(),
             self.grant_authority.as_ref(),
+            DirectRootSelectorPolicy::RejectGrantReference,
         )
         .map_err(NativeV1SnapshotLoadError::Resource)?;
         let root = root_lease
@@ -5980,6 +5996,7 @@ impl ProcessVmm<HvfInstanceStartExecutor> {
         let mut root_lease = PreparedSnapshotRootBackingLease::prepare(
             Path::new(prepared.selector()),
             self.grant_authority.as_ref(),
+            DirectRootSelectorPolicy::TreatAsPath,
         )
         .map_err(|source| {
             NativeV2SnapshotLoadError::RootBacking(SnapshotRootBackingLeaseError::Grant(source))
@@ -5997,7 +6014,7 @@ impl ProcessVmm<HvfInstanceStartExecutor> {
             memory,
             root,
             resources,
-            root_lease: Some(root_lease),
+            root_lease,
             controller_commit,
             serial_output,
             guest_ranges,
@@ -6282,7 +6299,7 @@ struct PreparedHvfSnapshotV2RootProcessLoad {
     memory: GuestMemory,
     root: PreparedSnapshotV2RootBlock,
     resources: HvfSnapshotV2RootResourcePlan,
-    root_lease: Option<PreparedSnapshotRootBackingLease>,
+    root_lease: PreparedSnapshotRootBackingLease,
     controller_commit: SnapshotV2ControllerCommit,
     serial_output: SharedSerialOutput,
     guest_ranges: Vec<GuestMemoryRange>,
@@ -6306,11 +6323,36 @@ impl fmt::Debug for PreparedHvfSnapshotV2RootProcessLoad {
     reason = "exact-2.4 root restore stays dormant until endpoint reconstruction lands"
 )]
 impl PreparedHvfSnapshotV2RootProcessLoad {
-    fn commit_root_claim(&mut self) {
-        if let Some(lease) = self.root_lease.take() {
-            lease.commit();
+    fn into_parts(self) -> PreparedHvfSnapshotV2RootProcessLoadParts {
+        PreparedHvfSnapshotV2RootProcessLoadParts {
+            platform: self.platform,
+            memory: self.memory,
+            root: self.root,
+            resources: self.resources,
+            root_lease: self.root_lease,
+            controller_commit: self.controller_commit,
+            serial_output: self.serial_output,
+            guest_ranges: self.guest_ranges,
+            virtual_timer_intid: self.virtual_timer_intid,
         }
     }
+}
+
+#[cfg(target_os = "macos")]
+#[allow(
+    dead_code,
+    reason = "exact-2.4 root restore stays dormant until endpoint reconstruction lands"
+)]
+struct PreparedHvfSnapshotV2RootProcessLoadParts {
+    platform: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    root: PreparedSnapshotV2RootBlock,
+    resources: HvfSnapshotV2RootResourcePlan,
+    root_lease: PreparedSnapshotRootBackingLease,
+    controller_commit: SnapshotV2ControllerCommit,
+    serial_output: SharedSerialOutput,
+    guest_ranges: Vec<GuestMemoryRange>,
+    virtual_timer_intid: u32,
 }
 
 #[allow(
@@ -14715,7 +14757,10 @@ mod tests {
         snapshot_destination_machine_config, vsock_capture_error_from_boot_run_loop_command,
     };
     #[cfg(target_os = "macos")]
-    use super::{GrantAccess, PreparedSnapshotRootBackingLease, SnapshotRootBackingLeaseError};
+    use super::{
+        DirectRootSelectorPolicy, GrantAccess, PreparedSnapshotRootBackingLease,
+        SnapshotRootBackingLeaseError,
+    };
 
     static NEXT_TEMP_FILE_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -15075,8 +15120,12 @@ mod tests {
     #[test]
     fn root_backing_lease_direct_path_is_read_only_redacted_and_single_use() {
         let root = TempFilePath::create_with_bytes("root-lease-direct", b"root");
-        let mut lease = PreparedSnapshotRootBackingLease::prepare(root.path(), None)
-            .expect("direct root lease should prepare");
+        let mut lease = PreparedSnapshotRootBackingLease::prepare(
+            root.path(),
+            None,
+            DirectRootSelectorPolicy::TreatAsPath,
+        )
+        .expect("direct root lease should prepare");
         assert!(!format!("{lease:?}").contains(&root.path().display().to_string()));
         let backing = lease
             .open_snapshot_read_only()
@@ -15093,16 +15142,32 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn root_backing_lease_has_no_grant_fallback_and_rejects_wrong_access() {
+    fn root_backing_lease_preserves_direct_grant_shaped_paths_without_contained_fallback() {
+        let mut direct = PreparedSnapshotRootBackingLease::prepare(
+            Path::new("bangbang-grant:missing"),
+            None,
+            DirectRootSelectorPolicy::TreatAsPath,
+        )
+        .expect("direct mode should retain grant-shaped bytes as a pathname");
+        let (selector, file) = direct
+            .consume()
+            .expect("direct grant-shaped pathname should consume");
+        assert_eq!(selector, PathBuf::from("bangbang-grant:missing"));
+        assert!(file.is_none());
         assert!(
-            PreparedSnapshotRootBackingLease::prepare(Path::new("bangbang-grant:missing"), None,)
-                .is_err()
+            PreparedSnapshotRootBackingLease::prepare(
+                Path::new("bangbang-grant:missing"),
+                None,
+                DirectRootSelectorPolicy::RejectGrantReference,
+            )
+            .is_err()
         );
         let authority = file_grant_authority_for_test();
         assert!(
             PreparedSnapshotRootBackingLease::prepare(
                 Path::new("bangbang-grant:missing"),
                 Some(&authority),
+                DirectRootSelectorPolicy::TreatAsPath,
             )
             .is_err()
         );
@@ -15110,6 +15175,7 @@ mod tests {
             PreparedSnapshotRootBackingLease::prepare(
                 Path::new("bangbang-grant:drive-rw"),
                 Some(&authority),
+                DirectRootSelectorPolicy::TreatAsPath,
             )
             .is_err()
         );
@@ -15122,9 +15188,12 @@ mod tests {
 
         let authority = file_grant_authority_for_test();
         let observer = authority.clone();
-        let mut cancelled =
-            PreparedSnapshotRootBackingLease::prepare(Path::new(ROOT), Some(&authority))
-                .expect("contained root lease should prepare");
+        let mut cancelled = PreparedSnapshotRootBackingLease::prepare(
+            Path::new(ROOT),
+            Some(&authority),
+            DirectRootSelectorPolicy::TreatAsPath,
+        )
+        .expect("contained root lease should prepare");
         let backing = cancelled
             .open_snapshot_read_only()
             .expect("contained root backing should adopt");
@@ -15140,9 +15209,12 @@ mod tests {
 
         let authority = file_grant_authority_for_test();
         let observer = authority.clone();
-        let mut committed =
-            PreparedSnapshotRootBackingLease::prepare(Path::new(ROOT), Some(&authority))
-                .expect("contained root lease should prepare");
+        let mut committed = PreparedSnapshotRootBackingLease::prepare(
+            Path::new(ROOT),
+            Some(&authority),
+            DirectRootSelectorPolicy::TreatAsPath,
+        )
+        .expect("contained root lease should prepare");
         drop(
             committed
                 .open_snapshot_read_only()

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -11,6 +11,8 @@ use std::os::unix::ffi::OsStringExt;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
+#[cfg(target_os = "macos")]
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, mpsc};
 use std::thread::{self, JoinHandle};
@@ -41,11 +43,14 @@ use bangbang_hvf::{
     HvfSnapshotV1RestoreError, HvfSnapshotV1State, HvfSnapshotV2BootState, HvfSnapshotV2BuildError,
     HvfSnapshotV2DecodeError, HvfSnapshotV2DefaultProcessShell, HvfSnapshotV2EncodeError,
     HvfSnapshotV2NativePath, HvfSnapshotV2PlatformRestoreError, HvfSnapshotV2PlatformState,
-    HvfSnapshotV2State, HvfVcpuRunControl, HvfVcpuRunCoordinatorError, HvfVcpuRunStepOutcome,
-    OwnedHvfArm64BootSession, PrepareHvfSnapshotV1LoadError, PreparedHvfArm64BootPciNetworkRemoval,
-    PreparedHvfSnapshotV1Load, PreparedHvfSnapshotV1State, RestoredHvfSnapshotV2Platform,
-    decode_hvf_snapshot_v2_platform_state, encode_hvf_snapshot_v2_platform_state,
-    encode_hvf_snapshot_v2_state, restore_hvf_snapshot_v2_process_platform,
+    HvfSnapshotV2RootProcessConfig, HvfSnapshotV2RootResourcePlan, HvfSnapshotV2State,
+    HvfVcpuRunControl, HvfVcpuRunCoordinatorError, HvfVcpuRunStepOutcome, OwnedHvfArm64BootSession,
+    PrepareHvfSnapshotV1LoadError, PrepareHvfSnapshotV2RootPlanError,
+    PreparedHvfArm64BootPciNetworkRemoval, PreparedHvfSnapshotV1Load, PreparedHvfSnapshotV1State,
+    RestoredHvfSnapshotV2Platform, decode_hvf_snapshot_v2_platform_state,
+    decode_hvf_snapshot_v2_state, encode_hvf_snapshot_v2_platform_state,
+    encode_hvf_snapshot_v2_state, prepare_hvf_snapshot_v2_root_plan,
+    restore_hvf_snapshot_v2_process_platform,
 };
 use bangbang_runtime::balloon::BalloonMmioLayout;
 use bangbang_runtime::balloon::{
@@ -53,6 +58,8 @@ use bangbang_runtime::balloon::{
     BalloonHintingStatus, BalloonHintingStatusError, BalloonStats, BalloonStatsError,
     BalloonStatsUpdateInput, BalloonUpdateError, BalloonUpdateInput,
 };
+#[cfg(target_os = "macos")]
+use bangbang_runtime::block::SnapshotBlockFileBackingError;
 use bangbang_runtime::block::{
     BlockFileBacking, BlockMmioLayout, DriveBackendConfig, DriveConfig, DriveConfigInput,
     DriveIoEngine, DriveLiveUpdateMode, DriveRateLimiterConfig, DriveRuntimeMutationError,
@@ -130,11 +137,15 @@ use bangbang_runtime::snapshot_artifact::{
 use bangbang_runtime::snapshot_commit::{SnapshotCommitKind, SnapshotCommitRecord};
 use bangbang_runtime::snapshot_device::SnapshotV1DeviceState;
 use bangbang_runtime::snapshot_device_v2::{
-    NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2DeviceGraph,
-    SnapshotV2DeviceGraphCaptureError, SnapshotV2DeviceTransportKind,
+    NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, PreparedSnapshotV2RootBlock,
+    SnapshotV2DeviceGraph, SnapshotV2DeviceGraphCaptureError, SnapshotV2DeviceTransportKind,
+    SnapshotV2RootBackingError,
 };
 use bangbang_runtime::snapshot_format::{
     NativeSnapshotFormatError, NativeSnapshotState, decode_native_snapshot_state,
+};
+use bangbang_runtime::snapshot_format_v2::{
+    SnapshotV2DecodeError, decode_snapshot_v2_state_with_compatibility_version,
 };
 use bangbang_runtime::snapshot_memory::{
     SnapshotMemoryIoStage, SnapshotMemoryWriteError, write_snapshot_memory_image_with_cancel,
@@ -1183,7 +1194,13 @@ pub(crate) enum NativeV2SnapshotLoadError {
     Artifact(SnapshotArtifactLoadError),
     UnexpectedFamily(NativeSnapshotArtifactFamily),
     State(NativeSnapshotFormatError),
+    CandidateFormat(SnapshotV2DecodeError),
+    CandidateMismatch,
     Decode(HvfSnapshotV2DecodeError),
+    RootPlan(PrepareHvfSnapshotV2RootPlanError),
+    #[cfg(target_os = "macos")]
+    RootBacking(SnapshotRootBackingLeaseError),
+    RootBundle(SnapshotV2RootBackingError),
     BootMetadata(BootSourceConfigError),
     Allocation(TryReserveError),
     ProcessPreparation(BackendError),
@@ -1217,10 +1234,16 @@ impl NativeV2SnapshotLoadError {
             | Self::Artifact(_)
             | Self::UnexpectedFamily(_)
             | Self::State(_)
+            | Self::CandidateFormat(_)
+            | Self::CandidateMismatch
             | Self::Decode(_)
+            | Self::RootPlan(_)
+            | Self::RootBundle(_)
             | Self::BootMetadata(_)
             | Self::Allocation(_)
             | Self::ProcessPreparation(_) => false,
+            #[cfg(target_os = "macos")]
+            Self::RootBacking(_) => false,
         }
     }
 }
@@ -1249,8 +1272,33 @@ impl fmt::Display for NativeV2SnapshotLoadError {
                 )
             }
             Self::State(source) => write!(formatter, "native-v2 state decode failed: {source}"),
+            Self::CandidateFormat(source) => {
+                write!(formatter, "native-v2 candidate decode failed: {source}")
+            }
+            Self::CandidateMismatch => {
+                formatter.write_str("native-v2 candidate components are inconsistent")
+            }
             Self::Decode(source) => {
                 write!(formatter, "native-v2 platform decode failed: {source}")
+            }
+            Self::RootPlan(source) => {
+                write!(
+                    formatter,
+                    "native-v2 root plan preparation failed: {source}"
+                )
+            }
+            #[cfg(target_os = "macos")]
+            Self::RootBacking(source) => {
+                write!(
+                    formatter,
+                    "native-v2 root backing adoption failed: {source}"
+                )
+            }
+            Self::RootBundle(source) => {
+                write!(
+                    formatter,
+                    "native-v2 root bundle preparation failed: {source}"
+                )
             }
             Self::BootMetadata(source) => {
                 write!(
@@ -1305,7 +1353,12 @@ impl std::error::Error for NativeV2SnapshotLoadError {
             Self::AfterResourceAdoption { source } => Some(source.as_ref()),
             Self::Artifact(source) => Some(source),
             Self::State(source) => Some(source),
+            Self::CandidateFormat(source) => Some(source),
             Self::Decode(source) => Some(source),
+            Self::RootPlan(source) => Some(source),
+            #[cfg(target_os = "macos")]
+            Self::RootBacking(source) => Some(source),
+            Self::RootBundle(source) => Some(source),
             Self::BootMetadata(source) => Some(source),
             Self::Allocation(source) => Some(source),
             Self::ProcessPreparation(source) => Some(source),
@@ -1313,7 +1366,7 @@ impl std::error::Error for NativeV2SnapshotLoadError {
             Self::RunReady { source, .. } => Some(source),
             Self::WorkerStart { source, .. } => Some(source),
             Self::Resume(source) => Some(source),
-            Self::ProcessTerminal | Self::UnexpectedFamily(_) => None,
+            Self::ProcessTerminal | Self::UnexpectedFamily(_) | Self::CandidateMismatch => None,
         }
     }
 }
@@ -1521,6 +1574,118 @@ impl fmt::Debug for PreparedNativeSnapshotLoad {
             .field("state", &"<redacted>")
             .field("authority", &"<redacted>")
             .finish()
+    }
+}
+
+#[cfg(target_os = "macos")]
+struct PreparedSnapshotRootBackingLease {
+    selector: Option<PathBuf>,
+    claim: Option<PreparedDriveBackingClaim>,
+    consumed: bool,
+}
+
+#[cfg(target_os = "macos")]
+impl PreparedSnapshotRootBackingLease {
+    fn prepare(
+        selector: &Path,
+        authority: Option<&GrantAuthority>,
+    ) -> Result<Self, GrantClaimError> {
+        let claim = match authority {
+            Some(authority) => {
+                authority.prepare_drive_backing_claim(selector, GrantAccess::ReadOnly)?
+            }
+            None => {
+                if grant_reference_id(selector)?.is_some() {
+                    return Err(GrantClaimError);
+                }
+                None
+            }
+        };
+        Ok(Self {
+            selector: Some(selector.to_path_buf()),
+            claim,
+            consumed: false,
+        })
+    }
+
+    fn take_snapshot_read_only_file(&mut self) -> Result<Option<File>, GrantClaimError> {
+        let (_selector, file) = self.consume()?;
+        Ok(file)
+    }
+
+    fn consume(&mut self) -> Result<(PathBuf, Option<File>), GrantClaimError> {
+        if self.consumed {
+            return Err(GrantClaimError);
+        }
+        self.consumed = true;
+        let selector = self.selector.take().ok_or(GrantClaimError)?;
+        let file = self
+            .claim
+            .as_mut()
+            .map(PreparedDriveBackingClaim::take_snapshot_read_only_file)
+            .transpose()?;
+        Ok((selector, file))
+    }
+
+    fn open_snapshot_read_only(
+        &mut self,
+    ) -> Result<BlockFileBacking, SnapshotRootBackingLeaseError> {
+        let (selector, file) = self
+            .consume()
+            .map_err(SnapshotRootBackingLeaseError::Grant)?;
+        match file {
+            Some(file) => BlockFileBacking::from_snapshot_read_only_file(file)
+                .map(|(backing, _identity)| backing)
+                .map_err(SnapshotRootBackingLeaseError::Backing),
+            None => BlockFileBacking::open_snapshot_read_only(&selector)
+                .map(|(backing, _identity)| backing)
+                .map_err(SnapshotRootBackingLeaseError::Backing),
+        }
+    }
+
+    fn commit(self) {
+        if let Some(claim) = self.claim {
+            claim.commit();
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl fmt::Debug for PreparedSnapshotRootBackingLease {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotRootBackingLease")
+            .field("selector", &self.selector.as_ref().map(|_| "<redacted>"))
+            .field("claim", &self.claim.as_ref().map(|_| "<provisional>"))
+            .field("consumed", &self.consumed)
+            .finish()
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Debug)]
+pub(crate) enum SnapshotRootBackingLeaseError {
+    Grant(GrantClaimError),
+    Backing(SnapshotBlockFileBackingError),
+}
+
+#[cfg(target_os = "macos")]
+impl fmt::Display for SnapshotRootBackingLeaseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Grant(_) => formatter.write_str("snapshot root authority validation failed"),
+            Self::Backing(_) => formatter.write_str("snapshot root backing validation failed"),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl std::error::Error for SnapshotRootBackingLeaseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Grant(source) => Some(source),
+            Self::Backing(source) => Some(source),
+        }
     }
 }
 
@@ -4633,20 +4798,13 @@ where
         let state = state.into_v1().map_err(NativeV1SnapshotLoadError::State)?;
         let state = PreparedHvfSnapshotV1State::from_prepared_state(state)
             .map_err(NativeV1SnapshotLoadError::Prepare)?;
-        let mut root_claim = self
-            .grant_authority
-            .as_ref()
-            .map(|authority| {
-                authority
-                    .prepare_drive_backing_claim(state.root_backing_path(), GrantAccess::ReadOnly)
-            })
-            .transpose()
-            .map_err(NativeV1SnapshotLoadError::Resource)?
-            .flatten();
-        let root = root_claim
-            .as_mut()
-            .map(PreparedDriveBackingClaim::take_snapshot_read_only_file)
-            .transpose()
+        let mut root_lease = PreparedSnapshotRootBackingLease::prepare(
+            state.root_backing_path(),
+            self.grant_authority.as_ref(),
+        )
+        .map_err(NativeV1SnapshotLoadError::Resource)?;
+        let root = root_lease
+            .take_snapshot_read_only_file()
             .map_err(NativeV1SnapshotLoadError::Resource)?;
 
         let mut files = self
@@ -4675,9 +4833,7 @@ where
         let prepared = prepared
             .finish(root, Instant::now())
             .map_err(NativeV1SnapshotLoadError::Prepare)?;
-        if let Some(claim) = root_claim {
-            claim.commit();
-        }
+        root_lease.commit();
         Ok(prepared)
     }
 
@@ -4729,24 +4885,13 @@ where
             .map_err(NativeV1SnapshotLoadError::Prepare)?
             .prepare_lazy()
             .map_err(NativeV1SnapshotLoadError::Prepare)?;
-        let mut root_claim = match &self.grant_authority {
-            Some(authority) => authority
-                .prepare_drive_backing_claim(state.root_backing_path(), GrantAccess::ReadOnly)
-                .map_err(NativeV1SnapshotLoadError::Resource)?,
-            None => {
-                if grant_reference_id(state.root_backing_path())
-                    .map_err(NativeV1SnapshotLoadError::Resource)?
-                    .is_some()
-                {
-                    return Err(NativeV1SnapshotLoadError::Resource(GrantClaimError));
-                }
-                None
-            }
-        };
-        let root = root_claim
-            .as_mut()
-            .map(PreparedDriveBackingClaim::take_snapshot_read_only_file)
-            .transpose()
+        let mut root_lease = PreparedSnapshotRootBackingLease::prepare(
+            state.root_backing_path(),
+            self.grant_authority.as_ref(),
+        )
+        .map_err(NativeV1SnapshotLoadError::Resource)?;
+        let root = root_lease
+            .take_snapshot_read_only_file()
             .map_err(NativeV1SnapshotLoadError::Resource)?;
         let state = state
             .prepare_root_backing(root)
@@ -4773,9 +4918,7 @@ where
         if let Some(claim) = state_claim {
             claim.commit();
         }
-        if let Some(claim) = root_claim {
-            claim.commit();
-        }
+        root_lease.commit();
         Ok(prepared)
     }
 
@@ -5031,13 +5174,11 @@ where
         .map_err(NativeV1SnapshotLoadError::Artifact)?;
         let state = PreparedHvfSnapshotV1State::from_prepared_state(state)
             .map_err(NativeV1SnapshotLoadError::Prepare)?;
-        let mut root_claim = authority
-            .prepare_drive_backing_claim(state.root_backing_path(), GrantAccess::ReadOnly)
-            .map_err(NativeV1SnapshotLoadError::Resource)?;
-        let root = root_claim
-            .as_mut()
-            .map(PreparedDriveBackingClaim::take_snapshot_read_only_file)
-            .transpose()
+        let mut root_lease =
+            PreparedSnapshotRootBackingLease::prepare(state.root_backing_path(), Some(authority))
+                .map_err(NativeV1SnapshotLoadError::Resource)?;
+        let root = root_lease
+            .take_snapshot_read_only_file()
             .map_err(NativeV1SnapshotLoadError::Resource)?;
 
         let mut requests = Vec::with_capacity(2);
@@ -5081,9 +5222,7 @@ where
         let prepared = prepared
             .finish(root, Instant::now())
             .map_err(NativeV1SnapshotLoadError::Prepare)?;
-        if let Some(claim) = root_claim {
-            claim.commit();
-        }
+        root_lease.commit();
         Ok(Some(prepared))
     }
 
@@ -5130,24 +5269,13 @@ where
             .prepare_lazy()
             .map_err(NativeV1SnapshotLoadError::Prepare)?;
 
-        let mut root_claim = match &self.grant_authority {
-            Some(authority) => authority
-                .prepare_drive_backing_claim(state.root_backing_path(), GrantAccess::ReadOnly)
-                .map_err(NativeV1SnapshotLoadError::Resource)?,
-            None => {
-                if grant_reference_id(state.root_backing_path())
-                    .map_err(NativeV1SnapshotLoadError::Resource)?
-                    .is_some()
-                {
-                    return Err(NativeV1SnapshotLoadError::Resource(GrantClaimError));
-                }
-                None
-            }
-        };
-        let root = root_claim
-            .as_mut()
-            .map(PreparedDriveBackingClaim::take_snapshot_read_only_file)
-            .transpose()
+        let mut root_lease = PreparedSnapshotRootBackingLease::prepare(
+            state.root_backing_path(),
+            self.grant_authority.as_ref(),
+        )
+        .map_err(NativeV1SnapshotLoadError::Resource)?;
+        let root = root_lease
+            .take_snapshot_read_only_file()
             .map_err(NativeV1SnapshotLoadError::Resource)?;
         let state = state
             .prepare_root_backing(root)
@@ -5174,9 +5302,7 @@ where
         if let Some(claim) = state_claim {
             claim.commit();
         }
-        if let Some(claim) = root_claim {
-            claim.commit();
-        }
+        root_lease.commit();
         Ok(prepared)
     }
 
@@ -5783,6 +5909,102 @@ impl ProcessVmm<HvfInstanceStartExecutor> {
         })
     }
 
+    #[cfg(target_os = "macos")]
+    fn prepare_native_v2_root_candidate_load(
+        &self,
+        input: &SnapshotLoadInput,
+        candidate: NativeV2SnapshotCandidateState,
+        memory: GuestMemory,
+    ) -> Result<PreparedHvfSnapshotV2RootProcessLoad, NativeV2SnapshotLoadError> {
+        if self.terminal_snapshot_load_failure || self.terminal_instance_start_failure {
+            return Err(NativeV2SnapshotLoadError::ProcessTerminal);
+        }
+        self.controller
+            .preflight_load_snapshot_v2(input)
+            .map_err(NativeV2SnapshotLoadError::Preflight)?;
+        self.starter
+            .preflight_snapshot_v2_root_process()
+            .map_err(NativeV2SnapshotLoadError::Preflight)?;
+        if self.starter.pci_enabled != self.pci_enabled {
+            return Err(NativeV2SnapshotLoadError::Preflight(
+                VmmActionError::SnapshotUnsupported,
+            ));
+        }
+
+        let (bytes, binding, graph) = candidate.into_parts();
+        let structural = decode_snapshot_v2_state_with_compatibility_version(
+            &bytes,
+            NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+        )
+        .map_err(NativeV2SnapshotLoadError::CandidateFormat)?;
+        let state =
+            decode_hvf_snapshot_v2_state(&structural).map_err(NativeV2SnapshotLoadError::Decode)?;
+        if state.platform().memory() != &binding || state.device_graph() != &graph {
+            return Err(NativeV2SnapshotLoadError::CandidateMismatch);
+        }
+
+        let boot_source_config = native_v2_boot_source_config(state.platform().machine().boot())
+            .map_err(NativeV2SnapshotLoadError::BootMetadata)?;
+        let machine = snapshot_destination_machine_config(
+            state.platform().machine().machine(),
+            input.track_dirty_pages(),
+        );
+        let controller_commit =
+            SnapshotV2ControllerCommit::new(machine, boot_source_config, input.resume_vm());
+        let mut guest_ranges = Vec::new();
+        guest_ranges
+            .try_reserve_exact(memory.regions().len())
+            .map_err(NativeV2SnapshotLoadError::Allocation)?;
+        guest_ranges.extend(memory.regions().iter().map(|region| region.range()));
+        let virtual_timer_intid = state.platform().topology().virtual_timer_intid();
+
+        let process = HvfSnapshotV2RootProcessConfig::new(
+            BlockMmioLayout::new(DEFAULT_BLOCK_MMIO_BASE, DEFAULT_BLOCK_MMIO_REGION_ID),
+            self.pci_enabled,
+        );
+        let prepared = prepare_hvf_snapshot_v2_root_plan(state, memory, process, Instant::now())
+            .map_err(NativeV2SnapshotLoadError::RootPlan)?;
+
+        let rate_limiter = SerialConfig::default().rate_limiter();
+        let serial_output = if self.starter.process_serial_stdio {
+            let output = SerialStdio::output_from_process_standard_stream().map_err(|source| {
+                NativeV2SnapshotLoadError::ProcessPreparation(BackendError::Hypervisor(format!(
+                    "failed to initialize native-v2 serial standard output: {source}"
+                )))
+            })?;
+            SharedSerialOutput::with_rate_limiter(output, rate_limiter)
+        } else {
+            SharedSerialOutput::with_rate_limiter(self.starter.serial_output.clone(), rate_limiter)
+        };
+
+        let mut root_lease = PreparedSnapshotRootBackingLease::prepare(
+            Path::new(prepared.selector()),
+            self.grant_authority.as_ref(),
+        )
+        .map_err(|source| {
+            NativeV2SnapshotLoadError::RootBacking(SnapshotRootBackingLeaseError::Grant(source))
+        })?;
+        let (platform, memory, root, resources) = prepared.into_parts();
+        let backing = root_lease
+            .open_snapshot_read_only()
+            .map_err(NativeV2SnapshotLoadError::RootBacking)?;
+        let root = root
+            .prepare_backing(backing)
+            .map_err(NativeV2SnapshotLoadError::RootBundle)?;
+
+        Ok(PreparedHvfSnapshotV2RootProcessLoad {
+            platform,
+            memory,
+            root,
+            resources,
+            root_lease: Some(root_lease),
+            controller_commit,
+            serial_output,
+            guest_ranges,
+            virtual_timer_intid,
+        })
+    }
+
     fn capture_native_v2_root_candidate(
         &mut self,
         output: BoxedNativeV2SnapshotMemoryOutput,
@@ -5830,6 +6052,15 @@ const _: fn(
     NativeV2SnapshotCaptureCancellation,
 ) -> Result<NativeV2SnapshotCandidateState, NativeV2RootCandidateProcessError> =
     ProcessVmm::<HvfInstanceStartExecutor>::capture_native_v2_root_candidate;
+
+#[cfg(target_os = "macos")]
+const _: fn(
+    &ProcessVmm<HvfInstanceStartExecutor>,
+    &SnapshotLoadInput,
+    NativeV2SnapshotCandidateState,
+    GuestMemory,
+) -> Result<PreparedHvfSnapshotV2RootProcessLoad, NativeV2SnapshotLoadError> =
+    ProcessVmm::<HvfInstanceStartExecutor>::prepare_native_v2_root_candidate_load;
 
 // Keep the pre-dispatch native-v1 load seam type-checked for focused legacy
 // compatibility tests; public loads use the one-open family dispatcher.
@@ -5951,6 +6182,15 @@ impl HvfInstanceStartExecutor {
         default_hvf_boot_session_config(SharedSerialOutput::from(self.serial_output.clone()))
     }
 
+    #[cfg(target_os = "macos")]
+    fn preflight_snapshot_v2_root_process(&self) -> Result<(), VmmActionError> {
+        if self.boot_timer_enabled {
+            Err(VmmActionError::SnapshotUnsupported)
+        } else {
+            Ok(())
+        }
+    }
+
     fn serial_output_for_controller(
         &self,
         controller: &VmmController,
@@ -6030,6 +6270,47 @@ fn snapshot_destination_machine_config(
     track_dirty_pages: bool,
 ) -> bangbang_runtime::machine::MachineConfig {
     source.with_track_dirty_pages(track_dirty_pages)
+}
+
+#[cfg(target_os = "macos")]
+#[allow(
+    dead_code,
+    reason = "exact-2.4 root restore stays dormant until endpoint reconstruction lands"
+)]
+struct PreparedHvfSnapshotV2RootProcessLoad {
+    platform: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    root: PreparedSnapshotV2RootBlock,
+    resources: HvfSnapshotV2RootResourcePlan,
+    root_lease: Option<PreparedSnapshotRootBackingLease>,
+    controller_commit: SnapshotV2ControllerCommit,
+    serial_output: SharedSerialOutput,
+    guest_ranges: Vec<GuestMemoryRange>,
+    virtual_timer_intid: u32,
+}
+
+#[cfg(target_os = "macos")]
+impl fmt::Debug for PreparedHvfSnapshotV2RootProcessLoad {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedHvfSnapshotV2RootProcessLoad")
+            .field("transport", &self.resources.transport().kind())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[allow(
+    dead_code,
+    reason = "exact-2.4 root restore stays dormant until endpoint reconstruction lands"
+)]
+impl PreparedHvfSnapshotV2RootProcessLoad {
+    fn commit_root_claim(&mut self) {
+        if let Some(lease) = self.root_lease.take() {
+            lease.commit();
+        }
+    }
 }
 
 #[allow(
@@ -14433,6 +14714,8 @@ mod tests {
         native_v2_platform_capture_is_terminal, require_native_v1_composite_record,
         snapshot_destination_machine_config, vsock_capture_error_from_boot_run_loop_command,
     };
+    #[cfg(target_os = "macos")]
+    use super::{GrantAccess, PreparedSnapshotRootBackingLease, SnapshotRootBackingLeaseError};
 
     static NEXT_TEMP_FILE_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -14786,6 +15069,91 @@ mod tests {
         fn drop(&mut self) {
             let _ = remove_file(&self.path);
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn root_backing_lease_direct_path_is_read_only_redacted_and_single_use() {
+        let root = TempFilePath::create_with_bytes("root-lease-direct", b"root");
+        let mut lease = PreparedSnapshotRootBackingLease::prepare(root.path(), None)
+            .expect("direct root lease should prepare");
+        assert!(!format!("{lease:?}").contains(&root.path().display().to_string()));
+        let backing = lease
+            .open_snapshot_read_only()
+            .expect("direct root backing should open");
+        assert!(backing.kind().is_regular_file());
+        assert!(backing.is_read_only());
+        assert_eq!(backing.len(), 4);
+        assert!(matches!(
+            lease.open_snapshot_read_only(),
+            Err(SnapshotRootBackingLeaseError::Grant(_))
+        ));
+        lease.commit();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn root_backing_lease_has_no_grant_fallback_and_rejects_wrong_access() {
+        assert!(
+            PreparedSnapshotRootBackingLease::prepare(Path::new("bangbang-grant:missing"), None,)
+                .is_err()
+        );
+        let authority = file_grant_authority_for_test();
+        assert!(
+            PreparedSnapshotRootBackingLease::prepare(
+                Path::new("bangbang-grant:missing"),
+                Some(&authority),
+            )
+            .is_err()
+        );
+        assert!(
+            PreparedSnapshotRootBackingLease::prepare(
+                Path::new("bangbang-grant:drive-rw"),
+                Some(&authority),
+            )
+            .is_err()
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn root_backing_lease_abort_restores_and_commit_consumes_exact_grant() {
+        const ROOT: &str = "bangbang-grant:drive-ro";
+
+        let authority = file_grant_authority_for_test();
+        let observer = authority.clone();
+        let mut cancelled =
+            PreparedSnapshotRootBackingLease::prepare(Path::new(ROOT), Some(&authority))
+                .expect("contained root lease should prepare");
+        let backing = cancelled
+            .open_snapshot_read_only()
+            .expect("contained root backing should adopt");
+        assert!(backing.kind().is_regular_file());
+        assert!(backing.is_read_only());
+        drop(backing);
+        drop(cancelled);
+        let restored = observer
+            .prepare_drive_backing_claim(Path::new(ROOT), GrantAccess::ReadOnly)
+            .expect("cancelled lease should restore exact grant")
+            .expect("restored grant should reserve again");
+        drop(restored);
+
+        let authority = file_grant_authority_for_test();
+        let observer = authority.clone();
+        let mut committed =
+            PreparedSnapshotRootBackingLease::prepare(Path::new(ROOT), Some(&authority))
+                .expect("contained root lease should prepare");
+        drop(
+            committed
+                .open_snapshot_read_only()
+                .expect("contained root backing should adopt"),
+        );
+        committed.commit();
+        assert!(
+            observer
+                .prepare_drive_backing_claim(Path::new(ROOT), GrantAccess::ReadOnly)
+                .is_err()
+        );
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -147,8 +147,10 @@ pub use snapshot_v2_platform::{
     HvfSnapshotV2PlatformCleanupStage, HvfSnapshotV2PlatformRestoreError,
     HvfSnapshotV2PlatformRestoreFailure, HvfSnapshotV2PlatformRestoreStage,
     HvfSnapshotV2PlatformShutdownError, HvfSnapshotV2ProcessFdtMismatch,
-    RestoredHvfSnapshotV2Platform, restore_hvf_snapshot_v2_platform,
-    restore_hvf_snapshot_v2_process_platform,
+    HvfSnapshotV2RootProcessConfig, HvfSnapshotV2RootResourcePlan, HvfSnapshotV2RootTransportPlan,
+    PrepareHvfSnapshotV2RootPlanError, PreparedHvfSnapshotV2RootPlan,
+    RestoredHvfSnapshotV2Platform, prepare_hvf_snapshot_v2_root_plan,
+    restore_hvf_snapshot_v2_platform, restore_hvf_snapshot_v2_process_platform,
 };
 pub use startup::{
     HvfArm64BootBalloonCaptureError, HvfArm64BootBalloonCaptureState,

--- a/crates/hvf/src/snapshot_v2/tests.rs
+++ b/crates/hvf/src/snapshot_v2/tests.rs
@@ -18,9 +18,9 @@ use super::*;
 use crate::snapshot_bundle::tests::fixture as native_v1_fixture;
 
 const FIXTURE_MEMORY_MIB: u64 = 4;
-const MMIO_GRAPH_FIXTURE_HEX: &str =
+pub(crate) const MMIO_GRAPH_FIXTURE_HEX: &str =
     include_str!("../../../runtime/src/snapshot_device_v2/fixtures/mmio.hex");
-const PCI_GRAPH_FIXTURE_HEX: &str =
+pub(crate) const PCI_GRAPH_FIXTURE_HEX: &str =
     include_str!("../../../runtime/src/snapshot_device_v2/fixtures/pci.hex");
 const DETERMINISTIC_MEMORY_IMAGE_ID: [u8; 16] = *b"v2.4-fixture-id!";
 const COMPLETE_STATE_FINGERPRINTS: [(usize, u64); 2] = [
@@ -283,7 +283,7 @@ fn encoded_fixture(with_sme: bool) -> Vec<u8> {
         .expect("fixture platform should encode")
 }
 
-fn fixture_bytes(hex: &str) -> Vec<u8> {
+pub(crate) fn fixture_bytes(hex: &str) -> Vec<u8> {
     let hex = hex.trim();
     assert!(hex.len().is_multiple_of(2));
     hex.as_bytes()
@@ -295,7 +295,7 @@ fn fixture_bytes(hex: &str) -> Vec<u8> {
         .collect()
 }
 
-fn deterministic_minor_four_platform_fixture() -> HvfSnapshotV2PlatformState {
+pub(crate) fn deterministic_minor_four_platform_fixture() -> HvfSnapshotV2PlatformState {
     let mut platform = platform_fixture(false);
     let mut binding = platform
         .memory()
@@ -337,7 +337,7 @@ fn deterministic_minor_four_platform_fixture() -> HvfSnapshotV2PlatformState {
     platform
 }
 
-fn complete_state_fixture(graph_hex: &str) -> HvfSnapshotV2State {
+pub(crate) fn complete_state_fixture(graph_hex: &str) -> HvfSnapshotV2State {
     let graph = SnapshotV2DeviceGraph::decode(
         NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
         &fixture_bytes(graph_hex),

--- a/crates/hvf/src/snapshot_v2_platform.rs
+++ b/crates/hvf/src/snapshot_v2_platform.rs
@@ -4,19 +4,32 @@ use std::fmt;
 use std::io::{Seek, Write};
 use std::num::NonZeroU32;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use device_tree::{DeviceTree, Node};
 
+use bangbang_runtime::block::BlockMmioLayout;
+use bangbang_runtime::boot::canonical_process_root_block_command_line;
+use bangbang_runtime::fdt::ARM64_GICV2M_MSI_SET_SPI_NSR_OFFSET;
+use bangbang_runtime::interrupt::GuestInterruptLine;
 use bangbang_runtime::memory::{
     GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryRange, aarch64,
 };
-use bangbang_runtime::mmio::{MmioDispatcher, MmioRegionId};
+use bangbang_runtime::mmio::{MmioDispatcher, MmioRegion, MmioRegionId};
+use bangbang_runtime::pci::{
+    Arm64PciAddressPlan, PCI_BUS_ZERO, PCI_FIRST_ENDPOINT_DEVICE, PCI_FUNCTION_ZERO,
+    PCI_SEGMENT_ZERO, PciBarAddressSpace, PciBarPrefetchable, PciSbdf,
+};
 use bangbang_runtime::pvtime::{
     ARM64_PVTIME_STOLEN_TIME_OFFSET, ARM64_PVTIME_STRUCTURE_SIZE, Arm64PvTimeLayout,
     Arm64PvTimeStAbi,
 };
 use bangbang_runtime::rtc::{RTC_MMIO_DEVICE_WINDOW_SIZE, RtcMmioLayout};
 use bangbang_runtime::serial::{SERIAL_MMIO_DEVICE_WINDOW_SIZE, SharedSerialOutput};
+use bangbang_runtime::snapshot_device_v2::{
+    SnapshotV2DeviceTransport, SnapshotV2DeviceTransportKind, SnapshotV2RootRestorePlan,
+    SnapshotV2RootRestorePlanError,
+};
 use bangbang_runtime::snapshot_memory_v2::{
     SnapshotV2MemoryBinding, write_snapshot_v2_memory_image,
 };
@@ -25,6 +38,10 @@ use bangbang_runtime::startup::{
     Arm64BootVmClockDevice, Arm64BootVmGenIdDevice, PrepareArm64SnapshotTimeIdentityError,
     prepare_arm64_snapshot_time_identity, register_arm64_boot_rtc_mmio,
     register_arm64_boot_serial_mmio, replace_arm64_boot_vmgenid,
+};
+use bangbang_runtime::virtio_mmio::VIRTIO_MMIO_DEVICE_WINDOW_SIZE;
+use bangbang_runtime::virtio_pci::{
+    VIRTIO_PCI_CAPABILITY_BAR_INDEX, VIRTIO_PCI_CAPABILITY_BAR_SIZE,
 };
 use bangbang_runtime::{BackendError, VmBackend};
 use crc64::crc64;
@@ -47,13 +64,13 @@ use crate::session_vcpu::{
 use crate::snapshot_bundle::HvfSnapshotV1CompatibilityState;
 use crate::snapshot_v2::{
     HvfSnapshotV2GlobalState, HvfSnapshotV2MachineState, HvfSnapshotV2PlatformState,
-    HvfSnapshotV2TimeState, HvfSnapshotV2VcpuState,
+    HvfSnapshotV2State, HvfSnapshotV2TimeState, HvfSnapshotV2VcpuState,
 };
 use crate::startup::{
     HvfArm64BootSnapshotV2CaptureError, HvfArm64BootSnapshotV2CaptureStage,
     HvfArm64BootVmClockRestoreError, HvfArm64BootVmGenIdRestoreError,
-    capture_hvf_snapshot_v2_time_state, replace_vmgenid_and_signal_with,
-    update_vmclock_and_signal_with,
+    capture_hvf_snapshot_v2_time_state, pci_root_restore_gic_msi_configuration,
+    replace_vmgenid_and_signal_with, update_vmclock_and_signal_with,
 };
 use crate::topology::{HvfVcpuTopology, HvfVcpuTopologyError};
 use crate::vcpu::HvfArm64VcpuIdentificationRegisterState;
@@ -63,6 +80,243 @@ const PROCESS_SERIAL_MMIO_BASE: GuestAddress = GuestAddress::new(0x4000_2000);
 const PROCESS_SERIAL_MMIO_REGION_ID: MmioRegionId = MmioRegionId::new(20);
 const PROCESS_RTC_MMIO_BASE: GuestAddress = GuestAddress::new(0x4000_1000);
 const PROCESS_RTC_MMIO_REGION_ID: MmioRegionId = MmioRegionId::new(10);
+const PROCESS_PCI_ROOT_BAR_REGION_ID: MmioRegionId = MmioRegionId::new(4100);
+
+/// Destination process policy needed to verify the exact root allocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HvfSnapshotV2RootProcessConfig {
+    block_mmio_layout: BlockMmioLayout,
+    pci_enabled: bool,
+}
+
+impl HvfSnapshotV2RootProcessConfig {
+    /// Creates one closed process-policy input without optional-device overrides.
+    pub const fn new(block_mmio_layout: BlockMmioLayout, pci_enabled: bool) -> Self {
+        Self {
+            block_mmio_layout,
+            pci_enabled,
+        }
+    }
+
+    /// Returns the configured root MMIO allocation sequence.
+    pub const fn block_mmio_layout(self) -> BlockMmioLayout {
+        self.block_mmio_layout
+    }
+
+    /// Returns whether the process selected the all-virtio PCI profile.
+    pub const fn pci_enabled(self) -> bool {
+        self.pci_enabled
+    }
+}
+
+/// Exact product allocation selected for the root transport.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum HvfSnapshotV2RootTransportPlan {
+    /// First virtio-mmio block window and SPI in startup order.
+    Mmio {
+        /// Exact dispatcher region.
+        region: MmioRegion,
+        /// Exact GIC SPI line.
+        interrupt_line: GuestInterruptLine,
+    },
+    /// First modern PCI endpoint and capability BAR.
+    Pci {
+        /// Exact bus/function identity.
+        sbdf: PciSbdf,
+        /// Destination dispatcher identity for the BAR owner.
+        bar_region_id: MmioRegionId,
+        /// Exact capability BAR range.
+        bar_range: GuestMemoryRange,
+        /// Retained GICv2m frame and route range.
+        msi: crate::gic::HvfGicMsiMetadata,
+    },
+}
+
+impl HvfSnapshotV2RootTransportPlan {
+    /// Returns the selected transport profile.
+    pub const fn kind(self) -> SnapshotV2DeviceTransportKind {
+        match self {
+            Self::Mmio { .. } => SnapshotV2DeviceTransportKind::Mmio,
+            Self::Pci { .. } => SnapshotV2DeviceTransportKind::Pci,
+        }
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2RootTransportPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2RootTransportPlan")
+            .field("kind", &self.kind())
+            .field("resources", &REDACTED)
+            .finish()
+    }
+}
+
+/// Deterministic root, UART, VMGenID, and VMClock destination plan.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct HvfSnapshotV2RootResourcePlan {
+    transport: HvfSnapshotV2RootTransportPlan,
+    serial_interrupt: GuestInterruptLine,
+    vmgenid_interrupt: GuestInterruptLine,
+    vmclock_interrupt: GuestInterruptLine,
+}
+
+impl HvfSnapshotV2RootResourcePlan {
+    /// Returns the exact root transport allocation.
+    pub const fn transport(self) -> HvfSnapshotV2RootTransportPlan {
+        self.transport
+    }
+
+    /// Returns the canonical process UART interrupt.
+    pub const fn serial_interrupt(self) -> GuestInterruptLine {
+        self.serial_interrupt
+    }
+
+    /// Returns the canonical VMGenID interrupt.
+    pub const fn vmgenid_interrupt(self) -> GuestInterruptLine {
+        self.vmgenid_interrupt
+    }
+
+    /// Returns the canonical VMClock interrupt.
+    pub const fn vmclock_interrupt(self) -> GuestInterruptLine {
+        self.vmclock_interrupt
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2RootResourcePlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2RootResourcePlan")
+            .field("transport", &self.transport.kind())
+            .field("resources", &REDACTED)
+            .finish()
+    }
+}
+
+/// Fully validated, pre-HVF root preparation with owned loaded memory.
+pub struct PreparedHvfSnapshotV2RootPlan {
+    platform: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    root: SnapshotV2RootRestorePlan,
+    resources: HvfSnapshotV2RootResourcePlan,
+}
+
+impl PreparedHvfSnapshotV2RootPlan {
+    /// Returns the inert root selector for the destination authority layer.
+    pub fn selector(&self) -> &str {
+        self.root.selector()
+    }
+
+    /// Returns the path-shaped-data-free product allocation.
+    pub const fn resources(&self) -> HvfSnapshotV2RootResourcePlan {
+        self.resources
+    }
+
+    /// Returns the validated runtime root plan.
+    pub const fn root(&self) -> &SnapshotV2RootRestorePlan {
+        &self.root
+    }
+
+    /// Consumes the proof into still-unpublished platform resources.
+    pub fn into_parts(
+        self,
+    ) -> (
+        HvfSnapshotV2PlatformState,
+        GuestMemory,
+        SnapshotV2RootRestorePlan,
+        HvfSnapshotV2RootResourcePlan,
+    ) {
+        (self.platform, self.memory, self.root, self.resources)
+    }
+}
+
+impl fmt::Debug for PreparedHvfSnapshotV2RootPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedHvfSnapshotV2RootPlan")
+            .field("transport", &self.resources.transport.kind())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Redacted rejection from the pre-HVF root preparation boundary.
+pub enum PrepareHvfSnapshotV2RootPlanError {
+    /// Loaded memory does not exactly match the artifact binding.
+    MemoryTopology,
+    /// FDT bytes cannot be read or do not match their retained checksum.
+    Fdt(Box<HvfSnapshotV2PlatformRestoreFailure>),
+    /// Device-graph continuation does not agree with loaded memory.
+    Root(SnapshotV2RootRestorePlanError),
+    /// Process transport selection disagrees with the root graph.
+    TransportPolicy,
+    /// Retained placement is not the exact fresh product allocation.
+    ResourcePlan,
+    /// The retained GIC cannot supply the deterministic SPI sequence.
+    Interrupt(HvfInterruptLineAllocationError),
+    /// The retained FDT is not the exact root-bearing product shell.
+    ProcessFdt {
+        /// Value-free mismatch category.
+        mismatch: HvfSnapshotV2ProcessFdtMismatch,
+    },
+    /// Portable time/identity memory failed preflight.
+    TimeIdentity(Box<HvfSnapshotV2PlatformRestoreFailure>),
+}
+
+impl fmt::Debug for PrepareHvfSnapshotV2RootPlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let category = match self {
+            Self::MemoryTopology => "memory topology",
+            Self::Fdt(_) => "FDT identity",
+            Self::Root(_) => "root continuation",
+            Self::TransportPolicy => "transport policy",
+            Self::ResourcePlan => "resource plan",
+            Self::Interrupt(_) => "interrupt plan",
+            Self::ProcessFdt { .. } => "process FDT",
+            Self::TimeIdentity(_) => "time identity",
+        };
+        let mismatch = match self {
+            Self::ProcessFdt { mismatch } => Some(mismatch),
+            _ => None,
+        };
+        formatter
+            .debug_struct("PrepareHvfSnapshotV2RootPlanError")
+            .field("category", &category)
+            .field("mismatch", &mismatch)
+            .field("source", &REDACTED)
+            .finish()
+    }
+}
+
+impl fmt::Display for PrepareHvfSnapshotV2RootPlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let category = match self {
+            Self::MemoryTopology => "memory topology",
+            Self::Fdt(_) => "FDT identity",
+            Self::Root(_) => "root continuation",
+            Self::TransportPolicy => "transport policy",
+            Self::ResourcePlan => "resource plan",
+            Self::Interrupt(_) => "interrupt plan",
+            Self::ProcessFdt { .. } => "process FDT",
+            Self::TimeIdentity(_) => "time identity",
+        };
+        write!(formatter, "native-v2 root preparation {category} failed")
+    }
+}
+
+impl std::error::Error for PrepareHvfSnapshotV2RootPlanError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Fdt(source) | Self::TimeIdentity(source) => Some(source.as_ref()),
+            Self::Root(source) => Some(source),
+            Self::Interrupt(source) => Some(source),
+            Self::MemoryTopology
+            | Self::TransportPolicy
+            | Self::ResourcePlan
+            | Self::ProcessFdt { .. } => None,
+        }
+    }
+}
 
 /// Closed fresh-output shell accepted by native-v2 process reconstruction.
 pub struct HvfSnapshotV2DefaultProcessShell {
@@ -181,6 +435,10 @@ pub enum HvfSnapshotV2ProcessFdtMismatch {
     VmGenId,
     /// The retained FDT VM clock description does not match the admitted state.
     VmClock,
+    /// Root selection or the virtio-mmio node is inconsistent.
+    Root,
+    /// The PCI host or GICv2m child is inconsistent.
+    Pci,
 }
 
 impl fmt::Display for HvfSnapshotV2ProcessFdtMismatch {
@@ -198,6 +456,8 @@ impl fmt::Display for HvfSnapshotV2ProcessFdtMismatch {
             Self::Serial => "serial",
             Self::VmGenId => "VMGenID",
             Self::VmClock => "VMClock",
+            Self::Root => "root",
+            Self::Pci => "PCI",
         })
     }
 }
@@ -815,6 +1075,51 @@ impl Drop for RestoredHvfSnapshotV2Platform {
     fn drop(&mut self) {
         let _ = self.shutdown();
     }
+}
+
+/// Proves an exact 2.4 root graph and product shell before backing or HVF access.
+///
+/// This boundary constructs no backend, VM, dispatcher, transport endpoint, or
+/// scheduler. The returned owner still contains the inert selector solely so
+/// the destination authority layer can resolve one read-only backing.
+pub fn prepare_hvf_snapshot_v2_root_plan(
+    state: HvfSnapshotV2State,
+    memory: GuestMemory,
+    process: HvfSnapshotV2RootProcessConfig,
+    now: Instant,
+) -> Result<PreparedHvfSnapshotV2RootPlan, PrepareHvfSnapshotV2RootPlanError> {
+    let (platform, graph) = state.into_parts();
+    if !memory_matches_binding(&memory, platform.memory()) {
+        return Err(PrepareHvfSnapshotV2RootPlanError::MemoryTopology);
+    }
+    let fdt = verified_fdt_bytes(&memory, platform.machine())
+        .map_err(|source| PrepareHvfSnapshotV2RootPlanError::Fdt(Box::new(source)))?;
+    let root = SnapshotV2RootRestorePlan::prepare(graph, &memory, now)
+        .map_err(PrepareHvfSnapshotV2RootPlanError::Root)?;
+    let resources = prepare_root_resource_plan(&platform, &root, process)?;
+    validate_root_process_fdt(&fdt, &platform, &root, resources)
+        .map_err(|mismatch| PrepareHvfSnapshotV2RootPlanError::ProcessFdt { mismatch })?;
+
+    prepare_arm64_snapshot_time_identity(
+        &memory,
+        platform.time().vmgenid(),
+        platform.time().vmclock(),
+        platform.time().vmclock_abi(),
+    )
+    .map_err(|source| {
+        PrepareHvfSnapshotV2RootPlanError::TimeIdentity(Box::new(
+            HvfSnapshotV2PlatformRestoreFailure::TimePreparation(source),
+        ))
+    })?;
+    verify_snapshot_v2_pvtime_memory(&memory, platform.time())
+        .map_err(|source| PrepareHvfSnapshotV2RootPlanError::TimeIdentity(Box::new(source)))?;
+
+    Ok(PreparedHvfSnapshotV2RootPlan {
+        platform,
+        memory,
+        root,
+        resources,
+    })
 }
 
 /// Reconstruct one unpublished, initially paused native-v2 HVF platform.
@@ -1513,6 +1818,172 @@ fn memory_matches_binding(memory: &GuestMemory, binding: &SnapshotV2MemoryBindin
             .all(|(region, extent)| region.range() == extent.range())
 }
 
+fn prepare_root_resource_plan(
+    state: &HvfSnapshotV2PlatformState,
+    root: &SnapshotV2RootRestorePlan,
+    process: HvfSnapshotV2RootProcessConfig,
+) -> Result<HvfSnapshotV2RootResourcePlan, PrepareHvfSnapshotV2RootPlanError> {
+    let expected_kind = if process.pci_enabled {
+        SnapshotV2DeviceTransportKind::Pci
+    } else {
+        SnapshotV2DeviceTransportKind::Mmio
+    };
+    if root.transport_kind() != expected_kind
+        || state.time().rtc_layout()
+            != RtcMmioLayout::new(PROCESS_RTC_MMIO_BASE, PROCESS_RTC_MMIO_REGION_ID)
+    {
+        return Err(PrepareHvfSnapshotV2RootPlanError::TransportPolicy);
+    }
+    if root_queue_ranges_conflict_with_platform(state, root) {
+        return Err(PrepareHvfSnapshotV2RootPlanError::ResourcePlan);
+    }
+
+    let gic = state.global().compatibility().gic_metadata();
+    let mut allocator = HvfGicInterruptLineAllocator::from_metadata(&gic)
+        .map_err(PrepareHvfSnapshotV2RootPlanError::Interrupt)?;
+    let transport = match root.transport() {
+        SnapshotV2DeviceTransport::Mmio(mmio) => {
+            if gic.msi.is_some() {
+                return Err(PrepareHvfSnapshotV2RootPlanError::ResourcePlan);
+            }
+            let expected_region = MmioRegion::new(
+                process.block_mmio_layout.base_region_id(),
+                process.block_mmio_layout.base_address(),
+                VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+            )
+            .map_err(|_| PrepareHvfSnapshotV2RootPlanError::ResourcePlan)?;
+            let expected_interrupt = allocator
+                .allocate()
+                .map_err(PrepareHvfSnapshotV2RootPlanError::Interrupt)?;
+            if mmio.region() != expected_region || mmio.interrupt_line() != expected_interrupt {
+                return Err(PrepareHvfSnapshotV2RootPlanError::ResourcePlan);
+            }
+            HvfSnapshotV2RootTransportPlan::Mmio {
+                region: expected_region,
+                interrupt_line: expected_interrupt,
+            }
+        }
+        SnapshotV2DeviceTransport::Pci(pci) => {
+            let Some(msi) = gic.msi else {
+                return Err(PrepareHvfSnapshotV2RootPlanError::ResourcePlan);
+            };
+            let expected_msi = pci_root_restore_gic_msi_configuration()
+                .map_err(|_| PrepareHvfSnapshotV2RootPlanError::ResourcePlan)?;
+            if msi.interrupt_range.count != expected_msi.interrupt_count().get() {
+                return Err(PrepareHvfSnapshotV2RootPlanError::ResourcePlan);
+            }
+            let expected_sbdf = PciSbdf::new(
+                PCI_SEGMENT_ZERO,
+                PCI_BUS_ZERO,
+                PCI_FIRST_ENDPOINT_DEVICE,
+                PCI_FUNCTION_ZERO,
+            )
+            .map_err(|_| PrepareHvfSnapshotV2RootPlanError::ResourcePlan)?;
+            let address_plan = Arm64PciAddressPlan::firecracker_v1_16()
+                .map_err(|_| PrepareHvfSnapshotV2RootPlanError::ResourcePlan)?;
+            let expected_bar =
+                GuestMemoryRange::new(address_plan.bar64().start(), VIRTIO_PCI_CAPABILITY_BAR_SIZE)
+                    .map_err(|_| PrepareHvfSnapshotV2RootPlanError::ResourcePlan)?;
+            if pci.sbdf() != expected_sbdf
+                || pci.bar_index() != VIRTIO_PCI_CAPABILITY_BAR_INDEX
+                || pci.bar_address_space() != PciBarAddressSpace::Memory64
+                || pci.bar_prefetchable() != PciBarPrefetchable::No
+                || pci.bar_range() != expected_bar
+                || !pci_msix_routes_match_gic(pci.msix(), msi)
+            {
+                return Err(PrepareHvfSnapshotV2RootPlanError::ResourcePlan);
+            }
+            HvfSnapshotV2RootTransportPlan::Pci {
+                sbdf: expected_sbdf,
+                bar_region_id: PROCESS_PCI_ROOT_BAR_REGION_ID,
+                bar_range: expected_bar,
+                msi,
+            }
+        }
+    };
+
+    let serial_interrupt = allocator
+        .allocate()
+        .map_err(PrepareHvfSnapshotV2RootPlanError::Interrupt)?;
+    let vmgenid_interrupt = allocator
+        .allocate()
+        .map_err(PrepareHvfSnapshotV2RootPlanError::Interrupt)?;
+    let vmclock_interrupt = allocator
+        .allocate()
+        .map_err(PrepareHvfSnapshotV2RootPlanError::Interrupt)?;
+    if state.time().vmgenid().interrupt_line() != vmgenid_interrupt
+        || state.time().vmclock().interrupt_line() != vmclock_interrupt
+    {
+        return Err(PrepareHvfSnapshotV2RootPlanError::ResourcePlan);
+    }
+
+    Ok(HvfSnapshotV2RootResourcePlan {
+        transport,
+        serial_interrupt,
+        vmgenid_interrupt,
+        vmclock_interrupt,
+    })
+}
+
+fn root_queue_ranges_conflict_with_platform(
+    state: &HvfSnapshotV2PlatformState,
+    root: &SnapshotV2RootRestorePlan,
+) -> bool {
+    let Some(queue_ranges) = root.queue_ranges() else {
+        return false;
+    };
+    let fdt = state.machine().fdt();
+    let Ok(fdt_range) = GuestMemoryRange::new(fdt.address(), u64::from(fdt.size())) else {
+        return true;
+    };
+    if queue_ranges.iter().any(|queue| {
+        [
+            fdt_range,
+            state.time().vmgenid().range(),
+            state.time().vmclock().range(),
+        ]
+        .into_iter()
+        .any(|reserved| queue.overlaps(reserved))
+    }) {
+        return true;
+    }
+    let Ok(pvtime_size) = u64::try_from(ARM64_PVTIME_STRUCTURE_SIZE) else {
+        return true;
+    };
+    state.time().pvtime_vcpus().iter().any(|record| {
+        GuestMemoryRange::new(record.record_ipa(), pvtime_size).map_or(true, |reserved| {
+            queue_ranges.iter().any(|queue| queue.overlaps(reserved))
+        })
+    })
+}
+
+fn pci_msix_routes_match_gic(
+    state: &bangbang_runtime::snapshot_device_v2::SnapshotV2PciMsixState,
+    msi: crate::gic::HvfGicMsiMetadata,
+) -> bool {
+    let Some(expected_address) = msi
+        .region
+        .base
+        .checked_add(ARM64_GICV2M_MSI_SET_SPI_NSR_OFFSET)
+    else {
+        return false;
+    };
+    let Some(interrupt_end) = msi
+        .interrupt_range
+        .base
+        .checked_add(msi.interrupt_range.count)
+    else {
+        return false;
+    };
+    state.entries().iter().all(|entry| {
+        let address = (u64::from(entry.message_address_high()) << 32)
+            | u64::from(entry.message_address_low());
+        address == expected_address
+            && entry.message_data() >= msi.interrupt_range.base
+            && entry.message_data() < interrupt_end
+    })
+}
+
 fn prepare_process_shell(
     shell: Option<HvfSnapshotV2DefaultProcessShell>,
     state: &HvfSnapshotV2PlatformState,
@@ -1567,7 +2038,30 @@ fn prepare_process_shell(
 fn validate_default_process_fdt(
     bytes: &[u8],
     state: &HvfSnapshotV2PlatformState,
-    serial_interrupt: bangbang_runtime::interrupt::GuestInterruptLine,
+    serial_interrupt: GuestInterruptLine,
+) -> Result<(), HvfSnapshotV2ProcessFdtMismatch> {
+    validate_process_fdt(bytes, state, serial_interrupt, None)
+}
+
+fn validate_root_process_fdt(
+    bytes: &[u8],
+    state: &HvfSnapshotV2PlatformState,
+    root: &SnapshotV2RootRestorePlan,
+    resources: HvfSnapshotV2RootResourcePlan,
+) -> Result<(), HvfSnapshotV2ProcessFdtMismatch> {
+    validate_process_fdt(
+        bytes,
+        state,
+        resources.serial_interrupt,
+        Some((root, resources.transport)),
+    )
+}
+
+fn validate_process_fdt(
+    bytes: &[u8],
+    state: &HvfSnapshotV2PlatformState,
+    serial_interrupt: GuestInterruptLine,
+    root: Option<(&SnapshotV2RootRestorePlan, HvfSnapshotV2RootTransportPlan)>,
 ) -> Result<(), HvfSnapshotV2ProcessFdtMismatch> {
     let tree = DeviceTree::load(bytes).map_err(|_| HvfSnapshotV2ProcessFdtMismatch::Parse)?;
     let time = state.time();
@@ -1578,7 +2072,7 @@ fn validate_default_process_fdt(
         |name: &str| node_name_has_number(name, "rtc@", 16, PROCESS_RTC_MMIO_BASE.raw_value());
     let vmclock_name =
         |name: &str| node_name_has_number(name, "ptp@", 10, time.vmclock().fdt_region().base);
-    if tree.root.children.len() != 11
+    if tree.root.children.len() != 11 + usize::from(root.is_some())
         || [
             "cpus",
             "memory@ram",
@@ -1670,10 +2164,16 @@ fn validate_default_process_fdt(
     let Some(chosen) = child_named(&tree.root, "chosen") else {
         return Err(HvfSnapshotV2ProcessFdtMismatch::Boot);
     };
-    let Some(expected_boot_args) =
-        expected_process_boot_arguments(state.machine().boot().boot_arguments())
-    else {
-        return Err(HvfSnapshotV2ProcessFdtMismatch::Boot);
+    let expected_boot_args = match root {
+        Some((root, transport)) => canonical_process_root_block_command_line(
+            state.machine().boot().boot_arguments(),
+            matches!(transport, HvfSnapshotV2RootTransportPlan::Pci { .. }),
+            root.partuuid(),
+            true,
+        )
+        .map_err(|_| HvfSnapshotV2ProcessFdtMismatch::Boot)?,
+        None => expected_process_boot_arguments(state.machine().boot().boot_arguments())
+            .ok_or(HvfSnapshotV2ProcessFdtMismatch::Boot)?,
     };
     if !chosen
         .prop_str("bootargs")
@@ -1687,7 +2187,11 @@ fn validate_default_process_fdt(
     let Some(intc) = child_named(&tree.root, "intc") else {
         return Err(HvfSnapshotV2ProcessFdtMismatch::Gic);
     };
-    if !intc.children.is_empty()
+    let expected_gic_children = usize::from(matches!(
+        root,
+        Some((_, HvfSnapshotV2RootTransportPlan::Pci { .. }))
+    ));
+    if intc.children.len() != expected_gic_children
         || !intc
             .prop_str("compatible")
             .is_ok_and(|compatible| compatible == "arm,gic-v3")
@@ -1818,11 +2322,11 @@ fn validate_default_process_fdt(
     else {
         return Err(HvfSnapshotV2ProcessFdtMismatch::VmClock);
     };
-    if vmclock.children.is_empty()
-        && vmclock
+    if !vmclock.children.is_empty()
+        || !vmclock
             .prop_str("compatible")
             .is_ok_and(|compatible| compatible == "amazon,vmclock")
-        && property_u64_cells_equal(
+        || !property_u64_cells_equal(
             vmclock,
             "reg",
             &[
@@ -1830,12 +2334,169 @@ fn validate_default_process_fdt(
                 vmclock_metadata.fdt_region().size,
             ],
         )
-        && property_u32_cells_equal(vmclock, "interrupts", &[0, vmclock_interrupt_cell, 1])
+        || !property_u32_cells_equal(vmclock, "interrupts", &[0, vmclock_interrupt_cell, 1])
     {
-        Ok(())
-    } else {
-        Err(HvfSnapshotV2ProcessFdtMismatch::VmClock)
+        return Err(HvfSnapshotV2ProcessFdtMismatch::VmClock);
     }
+
+    validate_process_root_nodes(&tree.root, intc, root)
+}
+
+fn validate_process_root_nodes(
+    root_node: &Node,
+    intc: &Node,
+    root: Option<(&SnapshotV2RootRestorePlan, HvfSnapshotV2RootTransportPlan)>,
+) -> Result<(), HvfSnapshotV2ProcessFdtMismatch> {
+    let Some((root, resources)) = root else {
+        return Ok(());
+    };
+    match (root.transport(), resources) {
+        (
+            SnapshotV2DeviceTransport::Mmio(graph),
+            HvfSnapshotV2RootTransportPlan::Mmio {
+                region,
+                interrupt_line,
+            },
+        ) => {
+            let node = child_matching(root_node, |node| {
+                node_name_has_number(
+                    &node.name,
+                    "virtio_mmio@",
+                    16,
+                    region.range().start().raw_value(),
+                )
+            })
+            .ok_or(HvfSnapshotV2ProcessFdtMismatch::Root)?;
+            let interrupt_cell = interrupt_line
+                .raw_value()
+                .checked_sub(32)
+                .ok_or(HvfSnapshotV2ProcessFdtMismatch::Root)?;
+            if graph.region() != region
+                || graph.interrupt_line() != interrupt_line
+                || !node.children.is_empty()
+                || !node
+                    .prop_str("compatible")
+                    .is_ok_and(|compatible| compatible == "virtio,mmio")
+                || !property_u64_cells_equal(
+                    node,
+                    "reg",
+                    &[region.range().start().raw_value(), region.range().size()],
+                )
+                || !property_u32_cells_equal(node, "interrupts", &[0, interrupt_cell, 1])
+                || !node
+                    .prop_u32("interrupt-parent")
+                    .is_ok_and(|phandle| phandle == 1)
+                || !property_is_null(node, "dma-coherent")
+            {
+                return Err(HvfSnapshotV2ProcessFdtMismatch::Root);
+            }
+            Ok(())
+        }
+        (
+            SnapshotV2DeviceTransport::Pci(graph),
+            HvfSnapshotV2RootTransportPlan::Pci {
+                sbdf,
+                bar_region_id,
+                bar_range,
+                msi,
+            },
+        ) => {
+            if graph.sbdf() != sbdf
+                || graph.bar_range() != bar_range
+                || bar_region_id != PROCESS_PCI_ROOT_BAR_REGION_ID
+                || !validate_process_pci_host(root_node)
+                || !validate_process_gic_msi(intc, msi)
+            {
+                return Err(HvfSnapshotV2ProcessFdtMismatch::Pci);
+            }
+            Ok(())
+        }
+        _ => Err(HvfSnapshotV2ProcessFdtMismatch::Root),
+    }
+}
+
+fn validate_process_gic_msi(intc: &Node, msi: crate::gic::HvfGicMsiMetadata) -> bool {
+    let Some(frame) = child_matching(intc, |node| {
+        node_name_has_number(&node.name, "v2m@", 16, msi.region.base)
+    }) else {
+        return false;
+    };
+    frame.children.is_empty()
+        && frame
+            .prop_str("compatible")
+            .is_ok_and(|compatible| compatible == "arm,gic-v2m-frame")
+        && property_is_null(frame, "msi-controller")
+        && frame.prop_u32("phandle").is_ok_and(|phandle| phandle == 3)
+        && property_u64_cells_equal(frame, "reg", &[msi.region.base, msi.region.size])
+}
+
+fn validate_process_pci_host(root: &Node) -> bool {
+    let Ok(plan) = Arm64PciAddressPlan::firecracker_v1_16() else {
+        return false;
+    };
+    let Some(node) = child_matching(root, |node| {
+        node_name_has_number(&node.name, "pci@", 16, plan.ecam().start().raw_value())
+    }) else {
+        return false;
+    };
+    let ranges = [
+        0x0200_0000,
+        high_u32(plan.bar32().start().raw_value()),
+        low_u32(plan.bar32().start().raw_value()),
+        high_u32(plan.bar32().start().raw_value()),
+        low_u32(plan.bar32().start().raw_value()),
+        high_u32(plan.bar32().size()),
+        low_u32(plan.bar32().size()),
+        0x0300_0000,
+        high_u32(plan.bar64().start().raw_value()),
+        low_u32(plan.bar64().start().raw_value()),
+        high_u32(plan.bar64().start().raw_value()),
+        low_u32(plan.bar64().start().raw_value()),
+        high_u32(plan.bar64().size()),
+        low_u32(plan.bar64().size()),
+    ];
+    node.children.is_empty()
+        && node
+            .prop_str("compatible")
+            .is_ok_and(|compatible| compatible == "pci-host-ecam-generic")
+        && node
+            .prop_str("device_type")
+            .is_ok_and(|device_type| device_type == "pci")
+        && property_u32_cells_equal(node, "ranges", &ranges)
+        && property_u32_cells_equal(node, "bus-range", &[0, 0])
+        && node
+            .prop_u32("linux,pci-domain")
+            .is_ok_and(|domain| domain == 0)
+        && node
+            .prop_u32("#address-cells")
+            .is_ok_and(|cells| cells == 3)
+        && node.prop_u32("#size-cells").is_ok_and(|cells| cells == 2)
+        && property_u64_cells_equal(
+            node,
+            "reg",
+            &[plan.ecam().start().raw_value(), plan.ecam().size()],
+        )
+        && node
+            .prop_u32("#interrupt-cells")
+            .is_ok_and(|cells| cells == 1)
+        && property_is_null(node, "interrupt-map")
+        && property_is_null(node, "interrupt-map-mask")
+        && property_is_null(node, "dma-coherent")
+        && node
+            .prop_u32("msi-parent")
+            .is_ok_and(|phandle| phandle == 3)
+}
+
+fn property_is_null(node: &Node, name: &str) -> bool {
+    node.prop_raw(name).is_some_and(Vec::is_empty)
+}
+
+const fn high_u32(value: u64) -> u32 {
+    (value >> 32) as u32
+}
+
+const fn low_u32(value: u64) -> u32 {
+    value as u32
 }
 
 fn child_named<'a>(node: &'a Node, name: &str) -> Option<&'a Node> {
@@ -2123,6 +2784,346 @@ fn restore_protocol_stages(vcpu_count: usize) -> Vec<HvfSnapshotV2PlatformRestor
 mod tests {
     use super::*;
 
+    fn root_restore_memory() -> GuestMemory {
+        let layout = bangbang_runtime::memory::GuestMemoryLayout::new(vec![
+            GuestMemoryRange::new(GuestAddress::new(0), 0x4_0000)
+                .expect("root restore memory range should validate"),
+        ])
+        .expect("root restore memory layout should validate");
+        let mut memory =
+            GuestMemory::allocate(&layout).expect("root restore memory should allocate");
+        memory
+            .write_slice(&8_u16.to_le_bytes(), GuestAddress::new(0x2_0002))
+            .expect("root available cursor should write");
+        memory
+            .write_slice(&6_u16.to_le_bytes(), GuestAddress::new(0x3_0002))
+            .expect("root used cursor should write");
+        memory
+    }
+
+    fn readdress_root_graph(
+        graph: bangbang_runtime::snapshot_device_v2::SnapshotV2DeviceGraph,
+        descriptor_table: GuestAddress,
+        driver_ring: GuestAddress,
+        device_ring: GuestAddress,
+    ) -> bangbang_runtime::snapshot_device_v2::SnapshotV2DeviceGraph {
+        let queue = graph.record().virtio().queues()[0];
+        let mut bytes = graph
+            .encode(
+                bangbang_runtime::snapshot_device_v2::NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            )
+            .expect("root graph should encode");
+        let mut old = Vec::with_capacity(24);
+        for address in [
+            queue.descriptor_table(),
+            queue.driver_ring(),
+            queue.device_ring(),
+        ] {
+            old.extend_from_slice(&address.raw_value().to_le_bytes());
+        }
+        let offsets = bytes
+            .windows(old.len())
+            .enumerate()
+            .filter_map(|(offset, window)| (window == old).then_some(offset))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            offsets.len(),
+            1,
+            "ordered queue addresses should occur exactly once"
+        );
+        let offset = offsets[0];
+        let mut replacement = Vec::with_capacity(24);
+        for address in [descriptor_table, driver_ring, device_ring] {
+            replacement.extend_from_slice(&address.raw_value().to_le_bytes());
+        }
+        bytes[offset..offset + replacement.len()].copy_from_slice(&replacement);
+        bangbang_runtime::snapshot_device_v2::SnapshotV2DeviceGraph::decode(
+            bangbang_runtime::snapshot_device_v2::NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            &bytes,
+        )
+        .expect("readdressed root graph should decode")
+    }
+
+    fn root_restore_memory_for_platform(
+        platform: &HvfSnapshotV2PlatformState,
+        driver_ring: GuestAddress,
+        device_ring: GuestAddress,
+    ) -> GuestMemory {
+        let layout = bangbang_runtime::memory::GuestMemoryLayout::new(
+            platform
+                .memory()
+                .extents()
+                .iter()
+                .map(|extent| extent.range())
+                .collect(),
+        )
+        .expect("platform restore memory layout should validate");
+        let mut memory =
+            GuestMemory::allocate(&layout).expect("platform restore memory should allocate");
+        memory
+            .write_slice(
+                &8_u16.to_le_bytes(),
+                driver_ring
+                    .checked_add(2)
+                    .expect("available cursor address should fit"),
+            )
+            .expect("available cursor should write");
+        memory
+            .write_slice(
+                &6_u16.to_le_bytes(),
+                device_ring
+                    .checked_add(2)
+                    .expect("used cursor address should fit"),
+            )
+            .expect("used cursor should write");
+        memory
+    }
+
+    fn coherent_mmio_root_plan_fixture(
+        include_root_in_fdt: bool,
+    ) -> (
+        HvfSnapshotV2State,
+        GuestMemory,
+        HvfSnapshotV2RootProcessConfig,
+    ) {
+        let state = crate::snapshot_v2::tests::complete_state_fixture(
+            crate::snapshot_v2::tests::MMIO_GRAPH_FIXTURE_HEX,
+        );
+        let (platform, graph) = state.into_parts();
+        let platform = without_initrd(platform);
+        let descriptor_table = GuestAddress::new(aarch64::DRAM_MEM_START + 0x30_0000);
+        let driver_ring = GuestAddress::new(aarch64::DRAM_MEM_START + 0x34_0000);
+        let device_ring = GuestAddress::new(aarch64::DRAM_MEM_START + 0x38_0000);
+        let graph = readdress_root_graph(graph, descriptor_table, driver_ring, device_ring);
+        let mut memory = root_restore_memory_for_platform(&platform, driver_ring, device_ring);
+        let root = SnapshotV2RootRestorePlan::prepare(graph.clone(), &memory, Instant::now())
+            .expect("coherent MMIO root graph should prepare");
+        let SnapshotV2DeviceTransport::Mmio(mmio) = root.transport() else {
+            panic!("fixture root should use MMIO");
+        };
+        let process = HvfSnapshotV2RootProcessConfig::new(
+            BlockMmioLayout::new(mmio.region().range().start(), mmio.region().id()),
+            false,
+        );
+        let resources = prepare_root_resource_plan(&platform, &root, process)
+            .expect("coherent MMIO resources should prepare");
+
+        memory
+            .write_slice(
+                &platform.time().vmclock_abi().to_bytes(),
+                platform.time().vmclock().range().start(),
+            )
+            .expect("VMClock ABI should write");
+        for captured in platform.time().pvtime_vcpus() {
+            let mut bytes = Arm64PvTimeStAbi::initial().to_bytes();
+            bytes[ARM64_PVTIME_STOLEN_TIME_OFFSET..ARM64_PVTIME_STOLEN_TIME_OFFSET + 8]
+                .copy_from_slice(&captured.stolen_time_ns().to_le_bytes());
+            memory
+                .write_slice(&bytes, captured.record_ipa())
+                .expect("PVTime ABI should write");
+        }
+
+        let command_line = canonical_process_root_block_command_line(
+            platform.machine().boot().boot_arguments(),
+            false,
+            root.partuuid(),
+            true,
+        )
+        .expect("coherent MMIO root command line should normalize");
+        let HvfSnapshotV2RootTransportPlan::Mmio {
+            region,
+            interrupt_line,
+        } = resources.transport()
+        else {
+            panic!("coherent fixture resource plan should use MMIO");
+        };
+        let root_device = bangbang_runtime::fdt::Arm64FdtVirtioMmioDevice {
+            region: bangbang_runtime::fdt::Arm64FdtRegion {
+                base: region.range().start().raw_value(),
+                size: region.range().size(),
+            },
+            interrupt_line,
+        };
+        let root_devices = include_root_in_fdt
+            .then_some(root_device)
+            .into_iter()
+            .collect::<Vec<_>>();
+        let fdt = build_process_fdt_fixture_with_profile(
+            &platform,
+            root_shell_devices(&platform, resources),
+            &root_devices,
+            &command_line,
+            None,
+        );
+        let fdt_address = platform.machine().fdt().address();
+        memory
+            .write_slice(&fdt, fdt_address)
+            .expect("coherent process FDT should write");
+
+        let mut image = std::io::Cursor::new(Vec::new());
+        let binding =
+            bangbang_runtime::snapshot_memory_v2::write_snapshot_v2_memory_image_with_compatibility_version(
+                &memory,
+                &mut image,
+                bangbang_runtime::snapshot_device_v2::NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            )
+            .expect("coherent restore memory should encode");
+        let (_old_binding, machine, global, topology, vcpus, time) = platform.into_parts();
+        let fdt = crate::snapshot_v2::HvfSnapshotV2FdtState::try_new(
+            fdt_address,
+            fdt.len(),
+            crc64(0, &fdt),
+        )
+        .expect("coherent FDT identity should validate");
+        let machine = HvfSnapshotV2MachineState::try_new(
+            machine.machine(),
+            machine.boot().clone(),
+            fdt,
+            machine.cpu_template().cloned(),
+        )
+        .expect("coherent machine metadata should validate");
+        let platform =
+            HvfSnapshotV2PlatformState::try_new(binding, machine, global, topology, vcpus, time)
+                .expect("coherent platform should cross-validate");
+        let state = HvfSnapshotV2State::try_new(platform, graph)
+            .expect("coherent exact-2.4 state should cross-validate");
+        (state, memory, process)
+    }
+
+    fn without_initrd(platform: HvfSnapshotV2PlatformState) -> HvfSnapshotV2PlatformState {
+        let (memory, machine, global, topology, vcpus, time) = platform.into_parts();
+        let boot = crate::snapshot_v2::HvfSnapshotV2BootState::try_new(
+            machine.boot().kernel_path().clone(),
+            None,
+            machine.boot().boot_arguments(),
+        )
+        .expect("root fixture boot metadata should validate");
+        let machine = HvfSnapshotV2MachineState::try_new(
+            machine.machine(),
+            boot,
+            machine.fdt(),
+            machine.cpu_template().cloned(),
+        )
+        .expect("root fixture machine metadata should validate");
+        HvfSnapshotV2PlatformState::try_new(memory, machine, global, topology, vcpus, time)
+            .expect("root fixture platform should cross-validate")
+    }
+
+    fn mmio_root_plan_fixture() -> (
+        HvfSnapshotV2PlatformState,
+        SnapshotV2RootRestorePlan,
+        HvfSnapshotV2RootProcessConfig,
+    ) {
+        let state = crate::snapshot_v2::tests::complete_state_fixture(
+            crate::snapshot_v2::tests::MMIO_GRAPH_FIXTURE_HEX,
+        );
+        let (platform, graph) = state.into_parts();
+        let platform = without_initrd(platform);
+        let memory = root_restore_memory();
+        let root = SnapshotV2RootRestorePlan::prepare(graph, &memory, Instant::now())
+            .expect("MMIO root graph should prepare");
+        let SnapshotV2DeviceTransport::Mmio(mmio) = root.transport() else {
+            panic!("fixture root should use MMIO");
+        };
+        let process = HvfSnapshotV2RootProcessConfig::new(
+            BlockMmioLayout::new(mmio.region().range().start(), mmio.region().id()),
+            false,
+        );
+        (platform, root, process)
+    }
+
+    fn pci_root_plan_fixture() -> (
+        HvfSnapshotV2PlatformState,
+        SnapshotV2RootRestorePlan,
+        HvfSnapshotV2RootProcessConfig,
+    ) {
+        let state = crate::snapshot_v2::tests::complete_state_fixture(
+            crate::snapshot_v2::tests::PCI_GRAPH_FIXTURE_HEX,
+        );
+        let (platform, graph) = state.into_parts();
+        let SnapshotV2DeviceTransport::Pci(pci) = graph.record().transport() else {
+            panic!("fixture root should use PCI");
+        };
+        let message = pci.msix().entries()[0];
+        let message_address = (u64::from(message.message_address_high()) << 32)
+            | u64::from(message.message_address_low());
+        let msi_region_base = message_address
+            .checked_sub(ARM64_GICV2M_MSI_SET_SPI_NSR_OFFSET)
+            .expect("fixture MSI region base should fit");
+
+        let (memory, machine, global, topology, vcpus, time) = platform.into_parts();
+        let (compatibility, gic_device) = global.into_parts();
+        let expected_msi = pci_root_restore_gic_msi_configuration()
+            .expect("PCI root MSI demand should validate")
+            .interrupt_count()
+            .get();
+        let mut gic = compatibility.gic_metadata();
+        let legacy_count = 3;
+        let msi_base = gic
+            .spi_interrupt_range
+            .base
+            .checked_add(legacy_count)
+            .expect("fixture MSI interrupt base should fit");
+        gic.spi_interrupt_range.count = legacy_count;
+        gic.msi = Some(crate::gic::HvfGicMsiMetadata {
+            region: crate::gic::HvfGicRegion {
+                base: msi_region_base,
+                size: 0x1_0000,
+            },
+            interrupt_range: crate::gic::HvfGicInterruptRange {
+                base: msi_base,
+                count: expected_msi,
+            },
+        });
+        let compatibility = HvfSnapshotV1CompatibilityState::new(
+            compatibility.identification(),
+            compatibility.optional_sve_sme_identification(),
+            compatibility.cache_manifest(),
+            compatibility.primary_mpidr(),
+            gic,
+            compatibility.rtc_mmio_layout(),
+        );
+        let global = HvfSnapshotV2GlobalState::try_new(compatibility, gic_device)
+            .expect("PCI root global state should validate");
+
+        let mut allocator = HvfGicInterruptLineAllocator::from_metadata(&gic)
+            .expect("PCI root legacy interrupt allocator should validate");
+        let _serial = allocator
+            .allocate()
+            .expect("PCI root serial interrupt should allocate");
+        let vmgenid_interrupt = allocator
+            .allocate()
+            .expect("PCI root VMGenID interrupt should allocate");
+        let vmclock_interrupt = allocator
+            .allocate()
+            .expect("PCI root VMClock interrupt should allocate");
+        let (rtc, vmgenid, vmclock, vmclock_abi, pvtime) = time.into_parts();
+        let vmgenid = bangbang_runtime::snapshot_device::SnapshotV1PlatformDeviceMetadata::new(
+            vmgenid.range(),
+            vmgenid.fdt_region(),
+            vmgenid_interrupt,
+        );
+        let vmclock = bangbang_runtime::snapshot_device::SnapshotV1PlatformDeviceMetadata::new(
+            vmclock.range(),
+            vmclock.fdt_region(),
+            vmclock_interrupt,
+        );
+        let time = HvfSnapshotV2TimeState::try_new(rtc, vmgenid, vmclock, vmclock_abi, pvtime)
+            .expect("PCI root time metadata should validate");
+        let platform =
+            HvfSnapshotV2PlatformState::try_new(memory, machine, global, topology, vcpus, time)
+                .expect("PCI root platform should cross-validate");
+        let platform = without_initrd(platform);
+        let root =
+            SnapshotV2RootRestorePlan::prepare(graph, &root_restore_memory(), Instant::now())
+                .expect("PCI root graph should prepare");
+        let process = HvfSnapshotV2RootProcessConfig::new(
+            BlockMmioLayout::new(GuestAddress::new(0xd000_0000), MmioRegionId::new(9)),
+            true,
+        );
+        (platform, root, process)
+    }
+
     fn process_platform_fixture() -> HvfSnapshotV2PlatformState {
         let state = crate::snapshot_v2::tests::platform_fixture(false);
         let gic = state.global().compatibility().gic_metadata();
@@ -2216,6 +3217,40 @@ mod tests {
         )
     }
 
+    fn root_shell_devices(
+        state: &HvfSnapshotV2PlatformState,
+        resources: HvfSnapshotV2RootResourcePlan,
+    ) -> (
+        bangbang_runtime::fdt::Arm64FdtSerialDevice,
+        bangbang_runtime::fdt::Arm64FdtRtcDevice,
+        bangbang_runtime::fdt::Arm64FdtVmGenIdDevice,
+        bangbang_runtime::fdt::Arm64FdtVmClockDevice,
+    ) {
+        (
+            bangbang_runtime::fdt::Arm64FdtSerialDevice {
+                region: bangbang_runtime::fdt::Arm64FdtRegion {
+                    base: PROCESS_SERIAL_MMIO_BASE.raw_value(),
+                    size: SERIAL_MMIO_DEVICE_WINDOW_SIZE,
+                },
+                interrupt_line: resources.serial_interrupt(),
+            },
+            bangbang_runtime::fdt::Arm64FdtRtcDevice {
+                region: bangbang_runtime::fdt::Arm64FdtRegion {
+                    base: PROCESS_RTC_MMIO_BASE.raw_value(),
+                    size: RTC_MMIO_DEVICE_WINDOW_SIZE,
+                },
+            },
+            bangbang_runtime::fdt::Arm64FdtVmGenIdDevice {
+                region: state.time().vmgenid().fdt_region(),
+                interrupt_line: resources.vmgenid_interrupt(),
+            },
+            bangbang_runtime::fdt::Arm64FdtVmClockDevice {
+                region: state.time().vmclock().fdt_region(),
+                interrupt_line: resources.vmclock_interrupt(),
+            },
+        )
+    }
+
     fn build_process_fdt_fixture(
         state: &HvfSnapshotV2PlatformState,
         serial: bangbang_runtime::fdt::Arm64FdtSerialDevice,
@@ -2224,6 +3259,30 @@ mod tests {
         vmclock: bangbang_runtime::fdt::Arm64FdtVmClockDevice,
         optional_devices: &[bangbang_runtime::fdt::Arm64FdtVirtioMmioDevice],
     ) -> Vec<u8> {
+        let command_line = expected_process_boot_arguments(state.machine().boot().boot_arguments())
+            .expect("fixture command line should normalize");
+        build_process_fdt_fixture_with_profile(
+            state,
+            (serial, rtc, vmgenid, vmclock),
+            optional_devices,
+            &command_line,
+            None,
+        )
+    }
+
+    fn build_process_fdt_fixture_with_profile(
+        state: &HvfSnapshotV2PlatformState,
+        shell: (
+            bangbang_runtime::fdt::Arm64FdtSerialDevice,
+            bangbang_runtime::fdt::Arm64FdtRtcDevice,
+            bangbang_runtime::fdt::Arm64FdtVmGenIdDevice,
+            bangbang_runtime::fdt::Arm64FdtVmClockDevice,
+        ),
+        optional_devices: &[bangbang_runtime::fdt::Arm64FdtVirtioMmioDevice],
+        command_line: &str,
+        pci: Option<bangbang_runtime::fdt::Arm64FdtPciHost>,
+    ) -> Vec<u8> {
+        let (serial, rtc, vmgenid, vmclock) = shell;
         let ranges = state
             .memory()
             .extents()
@@ -2250,22 +3309,22 @@ mod tests {
             .iter()
             .map(|member| member.mpidr())
             .collect::<Vec<_>>();
-        let command_line = expected_process_boot_arguments(state.machine().boot().boot_arguments())
-            .expect("fixture command line should normalize");
-        let initrd =
-            state
-                .machine()
-                .boot()
-                .initrd_path()
-                .map(|_| bangbang_runtime::boot::LoadedInitrd {
-                    address: GuestAddress::new(aarch64::DRAM_MEM_START + 0x1_0000),
-                    size: 4096,
-                });
+        let initrd = state.machine().boot().initrd_path().map(|_| {
+            let address = state.memory().extents()[0]
+                .range()
+                .start()
+                .checked_add(aarch64::SYSTEM_MEM_SIZE + 0x1_0000)
+                .expect("fixture initrd address should fit");
+            bangbang_runtime::boot::LoadedInitrd {
+                address,
+                size: 4096,
+            }
+        });
         let gic = state.global().compatibility().gic_metadata();
-        bangbang_runtime::fdt::build_arm64_fdt(&bangbang_runtime::fdt::Arm64FdtConfig {
+        let config = bangbang_runtime::fdt::Arm64FdtConfig {
             layout: &layout,
             boot: bangbang_runtime::fdt::Arm64FdtBootInfo {
-                command_line: &command_line,
+                command_line,
                 initrd,
             },
             vcpu_mpidrs: &mpidrs,
@@ -2279,8 +3338,267 @@ mod tests {
             vmgenid_device: Some(vmgenid),
             vmclock_device: Some(vmclock),
             virtio_mmio_devices: optional_devices,
-        })
+        };
+        match pci {
+            Some(pci) => bangbang_runtime::fdt::build_arm64_fdt_with_pci(&config, pci),
+            None => bangbang_runtime::fdt::build_arm64_fdt(&config),
+        }
         .expect("fixture FDT should build")
+    }
+
+    #[test]
+    fn mmio_root_resource_plan_matches_fresh_product_order() {
+        let (platform, root, process) = mmio_root_plan_fixture();
+        let resources = prepare_root_resource_plan(&platform, &root, process)
+            .expect("MMIO root resources should match product order");
+        let SnapshotV2DeviceTransport::Mmio(graph) = root.transport() else {
+            panic!("fixture root should use MMIO");
+        };
+        assert_eq!(
+            resources.transport(),
+            HvfSnapshotV2RootTransportPlan::Mmio {
+                region: graph.region(),
+                interrupt_line: graph.interrupt_line(),
+            }
+        );
+        assert_eq!(
+            resources.vmgenid_interrupt(),
+            platform.time().vmgenid().interrupt_line()
+        );
+        assert_eq!(
+            resources.vmclock_interrupt(),
+            platform.time().vmclock().interrupt_line()
+        );
+
+        let wrong_policy = HvfSnapshotV2RootProcessConfig::new(process.block_mmio_layout(), true);
+        assert!(matches!(
+            prepare_root_resource_plan(&platform, &root, wrong_policy),
+            Err(PrepareHvfSnapshotV2RootPlanError::TransportPolicy)
+        ));
+        let wrong_layout = HvfSnapshotV2RootProcessConfig::new(
+            BlockMmioLayout::new(
+                process
+                    .block_mmio_layout()
+                    .base_address()
+                    .checked_add(VIRTIO_MMIO_DEVICE_WINDOW_SIZE)
+                    .expect("wrong layout base should fit"),
+                process.block_mmio_layout().base_region_id(),
+            ),
+            false,
+        );
+        assert!(matches!(
+            prepare_root_resource_plan(&platform, &root, wrong_layout),
+            Err(PrepareHvfSnapshotV2RootPlanError::ResourcePlan)
+        ));
+    }
+
+    #[test]
+    fn root_resource_plan_rejects_queue_platform_collision() {
+        let state = crate::snapshot_v2::tests::complete_state_fixture(
+            crate::snapshot_v2::tests::MMIO_GRAPH_FIXTURE_HEX,
+        );
+        let (platform, graph) = state.into_parts();
+        let descriptor_table = platform.time().vmgenid().range().start();
+        let driver_ring = GuestAddress::new(aarch64::DRAM_MEM_START + 0x28_0000);
+        let device_ring = GuestAddress::new(aarch64::DRAM_MEM_START + 0x30_0000);
+        let graph = readdress_root_graph(graph, descriptor_table, driver_ring, device_ring);
+        let memory = root_restore_memory_for_platform(&platform, driver_ring, device_ring);
+        let root = SnapshotV2RootRestorePlan::prepare(graph, &memory, Instant::now())
+            .expect("colliding graph should pass device-local memory checks");
+        let SnapshotV2DeviceTransport::Mmio(mmio) = root.transport() else {
+            panic!("fixture root should use MMIO");
+        };
+        let process = HvfSnapshotV2RootProcessConfig::new(
+            BlockMmioLayout::new(mmio.region().range().start(), mmio.region().id()),
+            false,
+        );
+
+        assert!(matches!(
+            prepare_root_resource_plan(&platform, &root, process),
+            Err(PrepareHvfSnapshotV2RootPlanError::ResourcePlan)
+        ));
+    }
+
+    #[test]
+    fn exact_root_preparation_accepts_one_coherent_pathless_mmio_plan() {
+        let (state, memory, process) = coherent_mmio_root_plan_fixture(true);
+        let prepared = prepare_hvf_snapshot_v2_root_plan(state, memory, process, Instant::now())
+            .expect("coherent exact-2.4 root plan should prepare");
+
+        assert_eq!(
+            prepared.resources().transport().kind(),
+            SnapshotV2DeviceTransportKind::Mmio
+        );
+        assert_eq!(prepared.root().drive_id(), "rootfs");
+        assert_eq!(prepared.selector(), "root-selector");
+        assert!(!format!("{prepared:?}").contains(prepared.selector()));
+    }
+
+    #[test]
+    fn exact_root_preparation_rejects_hostile_fdt_before_backing() {
+        let (state, memory, process) = coherent_mmio_root_plan_fixture(false);
+
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_root_plan(state, memory, process, Instant::now()),
+            Err(PrepareHvfSnapshotV2RootPlanError::ProcessFdt {
+                mismatch: HvfSnapshotV2ProcessFdtMismatch::RootInventory,
+            })
+        ));
+    }
+
+    #[test]
+    fn mmio_root_fdt_requires_exact_node_and_command_line() {
+        let (platform, root, process) = mmio_root_plan_fixture();
+        let resources = prepare_root_resource_plan(&platform, &root, process)
+            .expect("MMIO root resources should prepare");
+        let shell = root_shell_devices(&platform, resources);
+        let HvfSnapshotV2RootTransportPlan::Mmio {
+            region,
+            interrupt_line,
+        } = resources.transport()
+        else {
+            panic!("fixture resource plan should use MMIO");
+        };
+        let root_device = bangbang_runtime::fdt::Arm64FdtVirtioMmioDevice {
+            region: bangbang_runtime::fdt::Arm64FdtRegion {
+                base: region.range().start().raw_value(),
+                size: region.range().size(),
+            },
+            interrupt_line,
+        };
+        let command_line = canonical_process_root_block_command_line(
+            platform.machine().boot().boot_arguments(),
+            false,
+            root.partuuid(),
+            true,
+        )
+        .expect("MMIO root command line should normalize");
+        let valid = build_process_fdt_fixture_with_profile(
+            &platform,
+            shell,
+            &[root_device],
+            &command_line,
+            None,
+        );
+        assert_eq!(
+            validate_root_process_fdt(&valid, &platform, &root, resources),
+            Ok(())
+        );
+
+        let missing_root_command_line =
+            expected_process_boot_arguments(platform.machine().boot().boot_arguments())
+                .expect("device-free command line should normalize");
+        let missing_root = build_process_fdt_fixture_with_profile(
+            &platform,
+            shell,
+            &[root_device],
+            &missing_root_command_line,
+            None,
+        );
+        assert_eq!(
+            validate_root_process_fdt(&missing_root, &platform, &root, resources),
+            Err(HvfSnapshotV2ProcessFdtMismatch::Boot)
+        );
+
+        let optional = bangbang_runtime::fdt::Arm64FdtVirtioMmioDevice {
+            region: bangbang_runtime::fdt::Arm64FdtRegion {
+                base: region.range().end_exclusive().raw_value(),
+                size: region.range().size(),
+            },
+            interrupt_line: GuestInterruptLine::new(interrupt_line.raw_value() + 1)
+                .expect("optional interrupt should validate"),
+        };
+        let with_optional = build_process_fdt_fixture_with_profile(
+            &platform,
+            shell,
+            &[root_device, optional],
+            &command_line,
+            None,
+        );
+        assert_eq!(
+            validate_root_process_fdt(&with_optional, &platform, &root, resources),
+            Err(HvfSnapshotV2ProcessFdtMismatch::RootInventory)
+        );
+    }
+
+    #[test]
+    fn pci_root_resource_and_fdt_plans_match_first_product_slot() {
+        let (platform, root, process) = pci_root_plan_fixture();
+        let resources = prepare_root_resource_plan(&platform, &root, process)
+            .expect("PCI root resources should match product order");
+        let HvfSnapshotV2RootTransportPlan::Pci {
+            sbdf,
+            bar_region_id,
+            bar_range,
+            msi,
+        } = resources.transport()
+        else {
+            panic!("fixture resource plan should use PCI");
+        };
+        assert_eq!(
+            sbdf,
+            PciSbdf::new(
+                PCI_SEGMENT_ZERO,
+                PCI_BUS_ZERO,
+                PCI_FIRST_ENDPOINT_DEVICE,
+                PCI_FUNCTION_ZERO,
+            )
+            .expect("first endpoint identity should validate")
+        );
+        assert_eq!(bar_region_id, PROCESS_PCI_ROOT_BAR_REGION_ID);
+        assert_eq!(
+            bar_range,
+            GuestMemoryRange::new(
+                Arm64PciAddressPlan::firecracker_v1_16()
+                    .expect("PCI address plan should validate")
+                    .bar64()
+                    .start(),
+                VIRTIO_PCI_CAPABILITY_BAR_SIZE,
+            )
+            .expect("first PCI BAR should validate")
+        );
+        assert_eq!(
+            msi.interrupt_range.count,
+            pci_root_restore_gic_msi_configuration()
+                .expect("PCI MSI demand should validate")
+                .interrupt_count()
+                .get()
+        );
+
+        let command_line = canonical_process_root_block_command_line(
+            platform.machine().boot().boot_arguments(),
+            true,
+            root.partuuid(),
+            true,
+        )
+        .expect("PCI root command line should normalize");
+        let pci_host = bangbang_runtime::fdt::Arm64FdtPciHost::from_address_plan(
+            Arm64PciAddressPlan::firecracker_v1_16()
+                .expect("PCI host address plan should validate"),
+        );
+        let valid = build_process_fdt_fixture_with_profile(
+            &platform,
+            root_shell_devices(&platform, resources),
+            &[],
+            &command_line,
+            Some(pci_host),
+        );
+        assert_eq!(
+            validate_root_process_fdt(&valid, &platform, &root, resources),
+            Ok(())
+        );
+
+        let missing_host = build_process_fdt_fixture_with_profile(
+            &platform,
+            root_shell_devices(&platform, resources),
+            &[],
+            &command_line,
+            None,
+        );
+        assert_eq!(
+            validate_root_process_fdt(&missing_host, &platform, &root, resources),
+            Err(HvfSnapshotV2ProcessFdtMismatch::RootInventory)
+        );
     }
 
     #[test]

--- a/crates/hvf/src/snapshot_v2_platform.rs
+++ b/crates/hvf/src/snapshot_v2_platform.rs
@@ -69,8 +69,9 @@ use crate::snapshot_v2::{
 use crate::startup::{
     HvfArm64BootSnapshotV2CaptureError, HvfArm64BootSnapshotV2CaptureStage,
     HvfArm64BootVmClockRestoreError, HvfArm64BootVmGenIdRestoreError,
-    capture_hvf_snapshot_v2_time_state, pci_root_restore_gic_msi_configuration,
-    replace_vmgenid_and_signal_with, update_vmclock_and_signal_with,
+    capture_hvf_snapshot_v2_time_state, pci_root_restore_bar_region_id,
+    pci_root_restore_gic_msi_configuration, replace_vmgenid_and_signal_with,
+    update_vmclock_and_signal_with,
 };
 use crate::topology::{HvfVcpuTopology, HvfVcpuTopologyError};
 use crate::vcpu::HvfArm64VcpuIdentificationRegisterState;
@@ -80,7 +81,6 @@ const PROCESS_SERIAL_MMIO_BASE: GuestAddress = GuestAddress::new(0x4000_2000);
 const PROCESS_SERIAL_MMIO_REGION_ID: MmioRegionId = MmioRegionId::new(20);
 const PROCESS_RTC_MMIO_BASE: GuestAddress = GuestAddress::new(0x4000_1000);
 const PROCESS_RTC_MMIO_REGION_ID: MmioRegionId = MmioRegionId::new(10);
-const PROCESS_PCI_ROOT_BAR_REGION_ID: MmioRegionId = MmioRegionId::new(4100);
 
 /// Destination process policy needed to verify the exact root allocation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1884,6 +1884,8 @@ fn prepare_root_resource_plan(
             let expected_bar =
                 GuestMemoryRange::new(address_plan.bar64().start(), VIRTIO_PCI_CAPABILITY_BAR_SIZE)
                     .map_err(|_| PrepareHvfSnapshotV2RootPlanError::ResourcePlan)?;
+            let bar_region_id = pci_root_restore_bar_region_id()
+                .map_err(|_| PrepareHvfSnapshotV2RootPlanError::ResourcePlan)?;
             if pci.sbdf() != expected_sbdf
                 || pci.bar_index() != VIRTIO_PCI_CAPABILITY_BAR_INDEX
                 || pci.bar_address_space() != PciBarAddressSpace::Memory64
@@ -1895,7 +1897,7 @@ fn prepare_root_resource_plan(
             }
             HvfSnapshotV2RootTransportPlan::Pci {
                 sbdf: expected_sbdf,
-                bar_region_id: PROCESS_PCI_ROOT_BAR_REGION_ID,
+                bar_region_id,
                 bar_range: expected_bar,
                 msi,
             }
@@ -2403,7 +2405,7 @@ fn validate_process_root_nodes(
         ) => {
             if graph.sbdf() != sbdf
                 || graph.bar_range() != bar_range
-                || bar_region_id != PROCESS_PCI_ROOT_BAR_REGION_ID
+                || pci_root_restore_bar_region_id().ok() != Some(bar_region_id)
                 || !validate_process_pci_host(root_node)
                 || !validate_process_gic_msi(intc, msi)
             {
@@ -3545,7 +3547,10 @@ mod tests {
             )
             .expect("first endpoint identity should validate")
         );
-        assert_eq!(bar_region_id, PROCESS_PCI_ROOT_BAR_REGION_ID);
+        assert_eq!(
+            bar_region_id,
+            pci_root_restore_bar_region_id().expect("root BAR region id should validate")
+        );
         assert_eq!(
             bar_range,
             GuestMemoryRange::new(

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -18190,6 +18190,10 @@ pub(crate) fn pci_root_restore_gic_msi_configuration()
     pci_all_virtio_gic_msi_configuration_for_fixed_demand(fixed_demand)
 }
 
+pub(crate) fn pci_root_restore_bar_region_id() -> Result<MmioRegionId, HvfArm64BootPciDataError> {
+    pci_data_region_id(0)
+}
+
 fn pci_all_virtio_gic_msi_configuration_for_fixed_demand(
     fixed_demand: HvfArm64BootPciDataResourceDemand,
 ) -> Result<HvfGicMsiConfiguration, HvfArm64BootPciDataError> {

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -18175,6 +18175,24 @@ fn pci_all_virtio_gic_msi_configuration(
         config.entropy_device.is_some(),
         controller.memory_hotplug_config().is_some(),
     )?;
+    let configuration = pci_all_virtio_gic_msi_configuration_for_fixed_demand(fixed_demand)?;
+    debug_assert!(
+        usize::try_from(configuration.interrupt_count().get())
+            .ok()
+            .is_some_and(|routes| routes >= startup_demand.routes)
+    );
+    Ok(configuration)
+}
+
+pub(crate) fn pci_root_restore_gic_msi_configuration()
+-> Result<HvfGicMsiConfiguration, HvfArm64BootPciDataError> {
+    let fixed_demand = pci_all_virtio_resource_demand(0, 0, 0, None, false, false, false)?;
+    pci_all_virtio_gic_msi_configuration_for_fixed_demand(fixed_demand)
+}
+
+fn pci_all_virtio_gic_msi_configuration_for_fixed_demand(
+    fixed_demand: HvfArm64BootPciDataResourceDemand,
+) -> Result<HvfGicMsiConfiguration, HvfArm64BootPciDataError> {
     let dynamic_slots = PCI_ENDPOINT_SLOT_COUNT
         .checked_sub(fixed_demand.endpoints)
         .ok_or_else(|| {
@@ -18191,7 +18209,6 @@ fn pci_all_virtio_gic_msi_configuration(
         .ok_or_else(|| {
             HvfArm64BootPciDataError::new("PCI all-virtio hotplug route count overflowed")
         })?;
-    debug_assert!(routes >= startup_demand.routes);
     let routes = u32::try_from(routes.max(1)).map_err(|_| {
         HvfArm64BootPciDataError::new("PCI all-virtio MSI-X route count does not fit u32")
     })?;

--- a/crates/runtime/src/boot.rs
+++ b/crates/runtime/src/boot.rs
@@ -168,6 +168,37 @@ impl KernelCommandLine {
     }
 }
 
+/// Builds the canonical process command line for one read-only root block.
+///
+/// Transport policy is inserted before root selection while Linux init
+/// arguments, when present, remain after the canonical ` -- ` separator.
+pub fn canonical_process_root_block_command_line(
+    boot_args: Option<&str>,
+    pci_enabled: bool,
+    partuuid: Option<&str>,
+    read_only: bool,
+) -> Result<String, BootCommandLineError> {
+    let mut command_line = validate_command_line_text(boot_args)?;
+    if !pci_enabled {
+        command_line = command_line.with_appended_kernel_args(["pci=off"])?;
+    }
+    let (root, mode) = root_block_kernel_arguments(partuuid, read_only);
+    command_line = command_line.with_appended_kernel_args([root.as_str(), mode])?;
+    Ok(command_line.text)
+}
+
+/// Returns the canonical Linux root selector and access-mode arguments.
+pub fn root_block_kernel_arguments(
+    partuuid: Option<&str>,
+    read_only: bool,
+) -> (String, &'static str) {
+    let root = partuuid
+        .map(|partuuid| format!("root=PARTUUID={partuuid}"))
+        .unwrap_or_else(|| "root=/dev/vda".to_string());
+    let mode = if read_only { "ro" } else { "rw" };
+    (root, mode)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LoadedBootSource {
     pub command_line: KernelCommandLine,

--- a/crates/runtime/src/snapshot_artifact.rs
+++ b/crates/runtime/src/snapshot_artifact.rs
@@ -386,6 +386,11 @@ impl NativeV2SnapshotCandidateState {
     pub const fn device_graph(&self) -> &SnapshotV2DeviceGraph {
         &self.device_graph
     }
+
+    /// Consumes the closed candidate into its exact committed components.
+    pub fn into_parts(self) -> (Vec<u8>, SnapshotV2MemoryBinding, SnapshotV2DeviceGraph) {
+        (self.bytes, self.binding, self.device_graph)
+    }
 }
 
 impl fmt::Debug for NativeV2SnapshotCandidateState {

--- a/crates/runtime/src/snapshot_device_v2.rs
+++ b/crates/runtime/src/snapshot_device_v2.rs
@@ -2,15 +2,18 @@
 
 use std::fmt;
 use std::mem::size_of;
+use std::time::Instant;
 
 use crate::block::{
-    BlockCaptureIoEngine, DriveCacheType, DriveConfig, DriveIoEngine, DriveRateLimiterConfig,
-    DriveTokenBucketConfig, VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE, VIRTIO_BLOCK_DEVICE_ID,
-    VIRTIO_BLOCK_ID_BYTES, VIRTIO_BLOCK_QUEUE_SIZE, VIRTIO_BLOCK_SECTOR_SHIFT, VirtioBlockDeviceId,
-    VirtioBlockRateLimiterState, VirtioBlockTokenBucketState,
+    BlockCaptureIoEngine, BlockFileBacking, DriveCacheType, DriveConfig, DriveIoEngine,
+    DriveRateLimiterConfig, DriveTokenBucketConfig, VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE,
+    VIRTIO_BLOCK_DEVICE_ID, VIRTIO_BLOCK_ID_BYTES, VIRTIO_BLOCK_QUEUE_SIZE,
+    VIRTIO_BLOCK_SECTOR_SHIFT, VIRTIO_RING_FEATURE_EVENT_IDX, VIRTIO_RING_FEATURE_INDIRECT_DESC,
+    VirtioBlockConfigSpace, VirtioBlockDevice, VirtioBlockDeviceId, VirtioBlockQueue,
+    VirtioBlockRateLimiter, VirtioBlockRateLimiterState, VirtioBlockTokenBucketState,
 };
 use crate::interrupt::{DeviceInterruptKind, GuestInterruptLine};
-use crate::memory::{GuestAddress, GuestMemoryRange};
+use crate::memory::{GuestAddress, GuestMemory, GuestMemoryRange};
 use crate::mmio::MmioRegion;
 use crate::pci::{
     PCI_BAR64_SIZE, PCI_BAR64_START, PCI_BUS_ZERO, PCI_FIRST_ENDPOINT_DEVICE, PCI_FUNCTION_ZERO,
@@ -839,6 +842,334 @@ impl SnapshotV2DeviceGraph {
 }
 
 redacted_debug!(SnapshotV2DeviceGraph, "SnapshotV2DeviceGraph");
+
+/// Proof that one validated 2.4 root graph can continue against loaded memory.
+///
+/// The selector remains inert data until the destination authority layer
+/// resolves it. No path is retained after [`Self::prepare_backing`] succeeds.
+pub struct SnapshotV2RootRestorePlan {
+    selector: String,
+    drive_id: String,
+    partuuid: Option<String>,
+    cache_type: DriveCacheType,
+    capacity_sectors: u64,
+    device_id: VirtioBlockDeviceId,
+    queue_ranges: Option<[GuestMemoryRange; 3]>,
+    active_queue: Option<VirtioBlockQueue>,
+    rate_limiter: Option<VirtioBlockRateLimiter>,
+    retry: StorageRetryState,
+    virtio: SnapshotV2VirtioState,
+    transport: SnapshotV2DeviceTransport,
+}
+
+impl SnapshotV2RootRestorePlan {
+    /// Validates a complete graph against already-loaded guest memory.
+    ///
+    /// Queue geometry must be wholly contained by individual memory regions;
+    /// an otherwise readable range spanning adjacent regions is rejected.
+    /// Active queue cursors and limiter time state are also restored here so
+    /// all untrusted continuation data is rejected before backing access.
+    pub fn prepare(
+        graph: SnapshotV2DeviceGraph,
+        memory: &GuestMemory,
+        now: Instant,
+    ) -> Result<Self, SnapshotV2RootRestorePlanError> {
+        validate_graph(&graph).map_err(|_| SnapshotV2RootRestorePlanError::InvalidGraph)?;
+
+        let SnapshotV2DeviceGraph { record, .. } = graph;
+        let SnapshotV2DeviceRecord {
+            config,
+            block,
+            virtio,
+            transport,
+            ..
+        } = record;
+        let SnapshotV2RootBlockConfig {
+            drive_id,
+            partuuid,
+            cache_type,
+            rate_limiter,
+            selector,
+        } = config;
+        let SnapshotV2BlockState {
+            capacity_sectors,
+            device_id,
+            active_queue,
+            limiter,
+            retry,
+        } = block;
+        let queue_state = *virtio
+            .queues
+            .first()
+            .ok_or(SnapshotV2RootRestorePlanError::InvalidGraph)?;
+
+        let queue_ranges =
+            queue_ranges(&queue_state).map_err(|_| SnapshotV2RootRestorePlanError::InvalidGraph)?;
+        if let Some(ranges) = queue_ranges
+            && ranges
+                .into_iter()
+                .any(|range| !range_is_wholly_contained(memory, range))
+        {
+            return Err(SnapshotV2RootRestorePlanError::QueueMemory);
+        }
+
+        let active_queue = active_queue
+            .map(|cursor| {
+                let queue = VirtioMmioQueueState::from_parts(
+                    queue_state.max_size,
+                    queue_state.size,
+                    queue_state.ready,
+                    queue_state.descriptor_table,
+                    queue_state.driver_ring,
+                    queue_state.device_ring,
+                );
+                let event_idx_enabled =
+                    feature_enabled(virtio.driver_features, VIRTIO_RING_FEATURE_EVENT_IDX);
+                let indirect_descriptors_enabled =
+                    feature_enabled(virtio.driver_features, VIRTIO_RING_FEATURE_INDIRECT_DESC);
+                let queue = VirtioBlockQueue::from_snapshot_state(
+                    &queue,
+                    cursor,
+                    event_idx_enabled,
+                    indirect_descriptors_enabled,
+                )
+                .map_err(|_| SnapshotV2RootRestorePlanError::QueueContinuation)?;
+                queue
+                    .validate_snapshot_state(memory, retry != StorageRetryState::None)
+                    .map_err(|_| SnapshotV2RootRestorePlanError::QueueContinuation)?;
+                Ok(queue)
+            })
+            .transpose()?;
+
+        let limiter = persisted_limiter_state(rate_limiter, limiter)?;
+        let rate_limiter =
+            VirtioBlockRateLimiter::from_persisted_state_at(rate_limiter, limiter, now)
+                .map_err(|_| SnapshotV2RootRestorePlanError::RateLimiter)?;
+
+        Ok(Self {
+            selector,
+            drive_id,
+            partuuid,
+            cache_type,
+            capacity_sectors,
+            device_id,
+            queue_ranges,
+            active_queue,
+            rate_limiter,
+            retry,
+            virtio,
+            transport,
+        })
+    }
+
+    /// Returns the inert, untrusted backing selector.
+    pub fn selector(&self) -> &str {
+        &self.selector
+    }
+
+    /// Returns the stable public drive identifier.
+    pub fn drive_id(&self) -> &str {
+        &self.drive_id
+    }
+
+    /// Returns the optional root partition identifier.
+    pub fn partuuid(&self) -> Option<&str> {
+        self.partuuid.as_deref()
+    }
+
+    /// Returns the graph-selected transport kind.
+    pub const fn transport_kind(&self) -> SnapshotV2DeviceTransportKind {
+        self.transport.kind()
+    }
+
+    /// Returns the validated common virtio continuation.
+    pub const fn virtio(&self) -> &SnapshotV2VirtioState {
+        &self.virtio
+    }
+
+    /// Returns the validated transport continuation.
+    pub const fn transport(&self) -> &SnapshotV2DeviceTransport {
+        &self.transport
+    }
+
+    /// Returns the canonical guest-visible capacity.
+    pub const fn capacity_sectors(&self) -> u64 {
+        self.capacity_sectors
+    }
+
+    /// Returns the validated descriptor, available, and used ring ranges.
+    pub const fn queue_ranges(&self) -> Option<[GuestMemoryRange; 3]> {
+        self.queue_ranges
+    }
+
+    /// Binds one already-authorized backing and removes all path-shaped data.
+    pub fn prepare_backing(
+        self,
+        backing: BlockFileBacking,
+    ) -> Result<PreparedSnapshotV2RootBlock, SnapshotV2RootBackingError> {
+        if !backing.kind().is_regular_file() || !backing.is_read_only() {
+            return Err(SnapshotV2RootBackingError::UnsupportedBacking);
+        }
+        let config_space = VirtioBlockConfigSpace::from_backing(&backing, self.cache_type);
+        if config_space.config_len() != VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE
+            || config_space.capacity_sectors() != self.capacity_sectors
+            || !config_space.is_read_only()
+            || config_space.cache_type() != self.cache_type
+            || config_space.available_features() != self.virtio.available_features
+        {
+            return Err(SnapshotV2RootBackingError::GeometryMismatch);
+        }
+
+        let device = VirtioBlockDevice::from_snapshot_parts(
+            backing,
+            self.device_id,
+            self.active_queue,
+            self.rate_limiter,
+            self.retry != StorageRetryState::None,
+        );
+        Ok(PreparedSnapshotV2RootBlock {
+            config_space,
+            device,
+            continuation: SnapshotV2RootContinuation {
+                drive_id: self.drive_id,
+                partuuid: self.partuuid,
+                retry: self.retry,
+                virtio: self.virtio,
+                transport: self.transport,
+            },
+        })
+    }
+}
+
+redacted_debug!(SnapshotV2RootRestorePlan, "SnapshotV2RootRestorePlan");
+
+/// Pathless root-block owner prepared for later endpoint reconstruction.
+pub struct PreparedSnapshotV2RootBlock {
+    config_space: VirtioBlockConfigSpace,
+    device: VirtioBlockDevice,
+    continuation: SnapshotV2RootContinuation,
+}
+
+impl PreparedSnapshotV2RootBlock {
+    /// Returns the canonical block configuration space.
+    pub const fn config_space(&self) -> VirtioBlockConfigSpace {
+        self.config_space
+    }
+
+    /// Returns the prepared pathless block device.
+    pub const fn device(&self) -> &VirtioBlockDevice {
+        &self.device
+    }
+
+    /// Returns the remaining guest-visible continuation.
+    pub const fn continuation(&self) -> &SnapshotV2RootContinuation {
+        &self.continuation
+    }
+
+    /// Separates the prepared device from its value-only continuation.
+    pub fn into_parts(
+        self,
+    ) -> (
+        VirtioBlockConfigSpace,
+        VirtioBlockDevice,
+        SnapshotV2RootContinuation,
+    ) {
+        (self.config_space, self.device, self.continuation)
+    }
+}
+
+redacted_debug!(PreparedSnapshotV2RootBlock, "PreparedSnapshotV2RootBlock");
+
+/// Pathless value state needed to reconstruct the root transport owner.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SnapshotV2RootContinuation {
+    drive_id: String,
+    partuuid: Option<String>,
+    retry: StorageRetryState,
+    virtio: SnapshotV2VirtioState,
+    transport: SnapshotV2DeviceTransport,
+}
+
+impl SnapshotV2RootContinuation {
+    /// Returns the stable public drive identifier.
+    pub fn drive_id(&self) -> &str {
+        &self.drive_id
+    }
+
+    /// Returns the optional root partition identifier.
+    pub fn partuuid(&self) -> Option<&str> {
+        self.partuuid.as_deref()
+    }
+
+    /// Returns the retained retry disposition.
+    pub const fn retry(&self) -> StorageRetryState {
+        self.retry
+    }
+
+    /// Returns the common virtio continuation.
+    pub const fn virtio(&self) -> &SnapshotV2VirtioState {
+        &self.virtio
+    }
+
+    /// Returns the tagged transport continuation.
+    pub const fn transport(&self) -> &SnapshotV2DeviceTransport {
+        &self.transport
+    }
+}
+
+redacted_debug!(SnapshotV2RootContinuation, "SnapshotV2RootContinuation");
+
+/// Failure while proving a root graph against loaded destination state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2RootRestorePlanError {
+    /// The graph no longer satisfies the exact 2.4 singleton profile.
+    InvalidGraph,
+    /// A queue range is not wholly contained by one guest-memory region.
+    QueueMemory,
+    /// Active guest queue cursors or pending work are inconsistent.
+    QueueContinuation,
+    /// Persisted limiter state cannot be anchored at destination time.
+    RateLimiter,
+}
+
+impl fmt::Display for SnapshotV2RootRestorePlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidGraph => formatter.write_str("native-v2 root graph is invalid"),
+            Self::QueueMemory => formatter.write_str("native-v2 root queue memory is invalid"),
+            Self::QueueContinuation => {
+                formatter.write_str("native-v2 root queue continuation is invalid")
+            }
+            Self::RateLimiter => formatter.write_str("native-v2 root rate limiter is invalid"),
+        }
+    }
+}
+
+impl std::error::Error for SnapshotV2RootRestorePlanError {}
+
+/// Failure while binding an authorized backing to a validated root plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2RootBackingError {
+    /// Only regular, read-only backings are admitted.
+    UnsupportedBacking,
+    /// Guest-visible backing geometry or features differ from the graph.
+    GeometryMismatch,
+}
+
+impl fmt::Display for SnapshotV2RootBackingError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedBacking => {
+                formatter.write_str("native-v2 root backing is unsupported")
+            }
+            Self::GeometryMismatch => {
+                formatter.write_str("native-v2 root backing geometry is inconsistent")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SnapshotV2RootBackingError {}
 
 /// Failure while converting detached runtime state into an artifact graph.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1839,6 +2170,47 @@ fn queue_ranges(
     let used = GuestMemoryRange::new(queue.device_ring, used_size)
         .map_err(|_| GraphValidationError::Virtio)?;
     Ok(Some([descriptor, available, used]))
+}
+
+fn range_is_wholly_contained(memory: &GuestMemory, range: GuestMemoryRange) -> bool {
+    memory.regions().iter().any(|region| {
+        let region = region.range();
+        region.start().raw_value() <= range.start().raw_value()
+            && range.end_exclusive().raw_value() <= region.end_exclusive().raw_value()
+    })
+}
+
+const fn feature_enabled(features: u64, feature: u32) -> bool {
+    features & (1_u64 << feature) != 0
+}
+
+fn persisted_limiter_state(
+    config: Option<DriveRateLimiterConfig>,
+    state: SnapshotV2BlockLimiterState,
+) -> Result<VirtioBlockRateLimiterState, SnapshotV2RootRestorePlanError> {
+    Ok(VirtioBlockRateLimiterState::new(
+        persisted_bucket_state(
+            config.and_then(DriveRateLimiterConfig::bandwidth),
+            state.bandwidth,
+        )?,
+        persisted_bucket_state(config.and_then(DriveRateLimiterConfig::ops), state.ops)?,
+    ))
+}
+
+fn persisted_bucket_state(
+    config: Option<DriveTokenBucketConfig>,
+    state: Option<SnapshotV2BlockBucketState>,
+) -> Result<Option<VirtioBlockTokenBucketState>, SnapshotV2RootRestorePlanError> {
+    match (config, state) {
+        (Some(config), Some(state)) => Ok(Some(VirtioBlockTokenBucketState::new(
+            config,
+            state.budget,
+            state.remaining_burst,
+            state.age_nanos,
+        ))),
+        (None, None) => Ok(None),
+        _ => Err(SnapshotV2RootRestorePlanError::InvalidGraph),
+    }
 }
 
 fn validate_mmio_state(state: &SnapshotV2MmioDeviceState) -> Result<(), GraphValidationError> {

--- a/crates/runtime/src/snapshot_device_v2/tests.rs
+++ b/crates/runtime/src/snapshot_device_v2/tests.rs
@@ -10,6 +10,7 @@ use crate::block::{
     BlockFileBacking, DriveConfigInput, PreparedBlockDevice, VIRTIO_BLOCK_QUEUE_SIZES,
     VirtioBlockConfigSpace, VirtioBlockDevice,
 };
+use crate::memory::{GuestMemory, GuestMemoryLayout};
 use crate::message_interrupt::{
     GuestMessage, GuestMessageInterrupt, GuestMessageInterruptRegistry,
     GuestMessageInterruptSignalError,
@@ -1161,6 +1162,107 @@ impl Drop for TempFile {
     fn drop(&mut self) {
         let _ = fs::remove_file(&self.path);
     }
+}
+
+fn root_restore_memory(ranges: Vec<GuestMemoryRange>) -> GuestMemory {
+    let layout = GuestMemoryLayout::new(ranges).expect("restore memory layout should validate");
+    let mut memory = GuestMemory::allocate(&layout).expect("restore memory should allocate");
+    memory
+        .write_slice(&8_u16.to_le_bytes(), GuestAddress::new(0x2_0002))
+        .expect("available cursor should write");
+    memory
+        .write_slice(&6_u16.to_le_bytes(), GuestAddress::new(0x3_0002))
+        .expect("used cursor should write");
+    memory
+}
+
+fn contiguous_root_restore_memory() -> GuestMemory {
+    root_restore_memory(vec![
+        GuestMemoryRange::new(GuestAddress::new(0), 0x4_0000)
+            .expect("restore memory range should validate"),
+    ])
+}
+
+#[test]
+fn root_restore_plan_prepares_pathless_mmio_and_pci_backings() {
+    for graph in [mmio_graph(), pci_graph()] {
+        let memory = contiguous_root_restore_memory();
+        let plan = SnapshotV2RootRestorePlan::prepare(graph, &memory, Instant::now())
+            .expect("root restore graph should prepare");
+        assert_eq!(plan.selector(), "root-selector");
+        assert_eq!(plan.drive_id(), "rootfs");
+        assert_eq!(plan.partuuid(), Some("1111-2222"));
+        assert_eq!(plan.capacity_sectors(), 2048);
+        assert!(!format!("{plan:?}").contains(plan.selector()));
+
+        let file = TempFile::new("restore-root.img", 2048 << VIRTIO_BLOCK_SECTOR_SHIFT);
+        let (backing, _) = BlockFileBacking::open_snapshot_read_only(file.path())
+            .expect("restore root backing should open");
+        let prepared = plan
+            .prepare_backing(backing)
+            .expect("restore root backing should prepare");
+        assert_eq!(prepared.config_space().capacity_sectors(), 2048);
+        assert!(prepared.config_space().is_read_only());
+        assert_eq!(
+            prepared
+                .device()
+                .backing()
+                .expect("prepared device should retain file backing")
+                .len(),
+            2048 << VIRTIO_BLOCK_SECTOR_SHIFT
+        );
+        assert_eq!(prepared.continuation().drive_id(), "rootfs");
+        assert_eq!(
+            prepared.continuation().retry(),
+            StorageRetryState::After {
+                remaining_nanos: 99
+            }
+        );
+        assert!(!format!("{prepared:?}").contains("root-selector"));
+    }
+}
+
+#[test]
+fn root_restore_plan_rejects_cross_region_and_cursor_mismatches() {
+    let mut cross_region = mmio_graph();
+    cross_region.record.virtio.queues[0].descriptor_table = GuestAddress::new(0xf800);
+    validate_graph(&cross_region).expect("cross-region graph should be structurally valid");
+    let memory = root_restore_memory(vec![
+        GuestMemoryRange::new(GuestAddress::new(0), 0x1_0000)
+            .expect("first restore region should validate"),
+        GuestMemoryRange::new(GuestAddress::new(0x1_0000), 0x3_0000)
+            .expect("second restore region should validate"),
+    ]);
+    assert_eq!(
+        SnapshotV2RootRestorePlan::prepare(cross_region, &memory, Instant::now())
+            .expect_err("one queue range spanning regions must fail"),
+        SnapshotV2RootRestorePlanError::QueueMemory
+    );
+
+    let mut memory = contiguous_root_restore_memory();
+    memory
+        .write_slice(&7_u16.to_le_bytes(), GuestAddress::new(0x2_0002))
+        .expect("available cursor mismatch should write");
+    assert_eq!(
+        SnapshotV2RootRestorePlan::prepare(mmio_graph(), &memory, Instant::now())
+            .expect_err("retry without one pending descriptor must fail"),
+        SnapshotV2RootRestorePlanError::QueueContinuation
+    );
+}
+
+#[test]
+fn root_restore_plan_rejects_backing_geometry_after_pure_validation() {
+    let memory = contiguous_root_restore_memory();
+    let plan = SnapshotV2RootRestorePlan::prepare(mmio_graph(), &memory, Instant::now())
+        .expect("root restore graph should prepare");
+    let file = TempFile::new("restore-root-wrong-size.img", 4096);
+    let (backing, _) = BlockFileBacking::open_snapshot_read_only(file.path())
+        .expect("wrong-size restore root backing should open");
+    assert_eq!(
+        plan.prepare_backing(backing)
+            .expect_err("wrong backing geometry must fail"),
+        SnapshotV2RootBackingError::GeometryMismatch
+    );
 }
 
 fn root_config(path: &Path) -> DriveConfig {

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -30,7 +30,7 @@ use crate::block::{
 };
 use crate::boot::{
     BootCommandLineError, BootSource, BootSourceConfig, BootSourceFiles, BootSourceLoadError,
-    LoadedBootSource,
+    LoadedBootSource, root_block_kernel_arguments,
 };
 use crate::entropy::{
     EntropyConfig, EntropyMmioDeviceRegistration, EntropyMmioLayout, EntropyMmioRegistrationError,
@@ -5877,24 +5877,23 @@ fn append_root_device_command_line(
 
     let root = root_drive
         .map(|root_drive| {
-            let root_arg = root_drive
-                .partuuid()
-                .map(|partuuid| format!("root=PARTUUID={partuuid}"))
-                .unwrap_or_else(|| "root=/dev/vda".to_string());
             let read_only = root_drive.is_read_only().unwrap_or_else(|| {
                 vhost_user_frontends
                     .get(root_drive.drive_id())
                     .is_some_and(PreparedVhostUserBlockFrontend::is_read_only)
             });
-            (root_arg, read_only)
+            root_block_kernel_arguments(root_drive.partuuid(), read_only)
         })
         .or_else(|| {
-            root_pmem
-                .map(|(index, root_pmem)| (format!("root=/dev/pmem{index}"), root_pmem.read_only()))
+            root_pmem.map(|(index, root_pmem)| {
+                (
+                    format!("root=/dev/pmem{index}"),
+                    if root_pmem.read_only() { "ro" } else { "rw" },
+                )
+            })
         });
 
-    if let Some((root_arg, read_only)) = root {
-        let mode_arg = if read_only { "ro" } else { "rw" };
+    if let Some((root_arg, mode_arg)) = root {
         loaded_boot_source.command_line = loaded_boot_source
             .command_line
             .with_appended_kernel_args([root_arg.as_str(), mode_arg])


### PR DESCRIPTION
## Summary

- validate exact native-v2 2.4 root graph, queue memory, continuation state, retained FDT, command line, and deterministic MMIO/PCI product resources before backing access
- bind one regular read-only backing into a pathless block bundle through a shared direct/contained root lease with single consumption and provisional grant rollback
- migrate native-v1 eager and lazy root preparation to the shared narrow lease without changing its snapshot format or public dispatch
- add hostile memory/FDT/resource-plan coverage and direct/contained authority lifecycle tests

## Scope exclusions

- does not construct an HVF VM, dispatcher registration, PCI endpoint, live interrupt route, or retry scheduler
- does not expose the exact-2.4 restore path through the public API; the public native-v2 version remains 2.3
- does not add generalized resource manifests, overrides, writable roots, multiple drives, or optional devices

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

Closes #1587

Parent delivery context: #1531
