### PR TITLE
feat: reconstruct native-v2 MMIO and PCI root owners

### DIFF
--- a/crates/bangbang/src/contained_session.rs
+++ b/crates/bangbang/src/contained_session.rs
@@ -2925,8 +2925,9 @@ mod platform {
     #[cfg(test)]
     pub(crate) use tests::{
         TestDirectory as TestVhostDirectory, empty_grant_authority_for_vhost_test,
-        file_grant_authority_for_test, snapshot_file_grant_authority_for_test,
-        vhost_directory_authority_for_test, vsock_directory_authority_for_test,
+        file_grant_authority_for_test, root_file_grant_authority_for_test,
+        snapshot_file_grant_authority_for_test, vhost_directory_authority_for_test,
+        vsock_directory_authority_for_test,
     };
 
     #[cfg(test)]
@@ -3232,6 +3233,49 @@ mod platform {
                 .registry
         }
 
+        fn root_file_registry(root_path: &Path) -> GrantRegistry {
+            let session = SessionId::from_bytes([35; 32]);
+            let batch = BatchId::from_bytes([36; 16]);
+            let mut staged = StagedGrantBatch::new(session);
+            staged
+                .accept(received(
+                    session,
+                    batch,
+                    0,
+                    GrantRecord::Begin {
+                        grant_count: 1,
+                        record_count: 3,
+                        bookmark_bytes: 0,
+                    },
+                    None,
+                ))
+                .expect("root grant begin should stage");
+            let (record, descriptor) = file_record(
+                "drive-ro",
+                ResourceRole::DriveBacking,
+                GrantAccess::ReadOnly,
+                root_path,
+            );
+            staged
+                .accept(received(session, batch, 1, record, Some(descriptor)))
+                .expect("root descriptor should stage");
+            staged
+                .accept(received(
+                    session,
+                    batch,
+                    2,
+                    GrantRecord::Commit {
+                        grant_count: 1,
+                        record_count: 3,
+                        bookmark_bytes: 0,
+                    },
+                    None,
+                ))
+                .expect("root grant commit should validate")
+                .expect("root grant commit should return a registry")
+                .registry
+        }
+
         fn directory_registry(id: &str, role: ResourceRole) -> (GrantRegistry, TestDirectory) {
             let directory = TestDirectory::new();
             let bookmark = create_implicit_bookmark(directory.path(), true)
@@ -3334,6 +3378,11 @@ mod platform {
 
         pub(crate) fn file_grant_authority_for_test() -> GrantAuthority {
             let mut registry = file_registry();
+            GrantAuthority::new(registry.take_file_registry())
+        }
+
+        pub(crate) fn root_file_grant_authority_for_test(root_path: &Path) -> GrantAuthority {
+            let mut registry = root_file_registry(root_path);
             GrantAuthority::new(registry.take_file_registry())
         }
 
@@ -4547,6 +4596,6 @@ pub(crate) use platform::{
 #[cfg(all(test, target_os = "macos"))]
 pub(crate) use platform::{
     TestVhostDirectory, empty_grant_authority_for_vhost_test, file_grant_authority_for_test,
-    snapshot_file_grant_authority_for_test, vhost_directory_authority_for_test,
-    vsock_directory_authority_for_test,
+    root_file_grant_authority_for_test, snapshot_file_grant_authority_for_test,
+    vhost_directory_authority_for_test, vsock_directory_authority_for_test,
 };

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -43,9 +43,9 @@ use bangbang_hvf::{
     HvfSnapshotV1RestoreError, HvfSnapshotV1State, HvfSnapshotV2BootState, HvfSnapshotV2BuildError,
     HvfSnapshotV2DecodeError, HvfSnapshotV2DefaultProcessShell, HvfSnapshotV2EncodeError,
     HvfSnapshotV2NativePath, HvfSnapshotV2PlatformRestoreError, HvfSnapshotV2PlatformState,
-    HvfSnapshotV2RootProcessConfig, HvfSnapshotV2RootResourcePlan, HvfSnapshotV2State,
-    HvfVcpuRunControl, HvfVcpuRunCoordinatorError, HvfVcpuRunStepOutcome, OwnedHvfArm64BootSession,
-    PrepareHvfSnapshotV1LoadError, PrepareHvfSnapshotV2RootPlanError,
+    HvfSnapshotV2RootProcessConfig, HvfSnapshotV2RootResourcePlan, HvfSnapshotV2RootRestoreError,
+    HvfSnapshotV2State, HvfVcpuRunControl, HvfVcpuRunCoordinatorError, HvfVcpuRunStepOutcome,
+    OwnedHvfArm64BootSession, PrepareHvfSnapshotV1LoadError, PrepareHvfSnapshotV2RootPlanError,
     PreparedHvfArm64BootPciNetworkRemoval, PreparedHvfSnapshotV1Load, PreparedHvfSnapshotV1State,
     RestoredHvfSnapshotV2Platform, decode_hvf_snapshot_v2_platform_state,
     decode_hvf_snapshot_v2_state, encode_hvf_snapshot_v2_platform_state,
@@ -61,10 +61,10 @@ use bangbang_runtime::balloon::{
 #[cfg(target_os = "macos")]
 use bangbang_runtime::block::SnapshotBlockFileBackingError;
 use bangbang_runtime::block::{
-    BlockFileBacking, BlockMmioLayout, DriveBackendConfig, DriveConfig, DriveConfigInput,
-    DriveIoEngine, DriveLiveUpdateMode, DriveRateLimiterConfig, DriveRuntimeMutationError,
-    DriveUpdateError, DriveUpdateInput, PreparedBlockDevice, PreparedVhostUserBlockFrontend,
-    RuntimeBlockDeviceResource,
+    BlockFileBacking, BlockMmioLayout, DriveBackendConfig, DriveConfig, DriveConfigError,
+    DriveConfigInput, DriveIoEngine, DriveLiveUpdateMode, DriveRateLimiterConfig,
+    DriveRuntimeMutationError, DriveUpdateError, DriveUpdateInput, PreparedBlockDevice,
+    PreparedVhostUserBlockFrontend, RuntimeBlockDeviceResource,
 };
 use bangbang_runtime::boot::{BootSourceConfigError, BootSourceConfigInput, BootSourceFiles};
 use bangbang_runtime::boot_timer::BootTimerMmioLayout;
@@ -1198,6 +1198,7 @@ pub(crate) enum NativeV2SnapshotLoadError {
     CandidateMismatch,
     Decode(HvfSnapshotV2DecodeError),
     RootPlan(PrepareHvfSnapshotV2RootPlanError),
+    RootConfiguration(DriveConfigError),
     #[cfg(target_os = "macos")]
     RootBacking(SnapshotRootBackingLeaseError),
     RootBundle(SnapshotV2RootBackingError),
@@ -1205,6 +1206,7 @@ pub(crate) enum NativeV2SnapshotLoadError {
     Allocation(TryReserveError),
     ProcessPreparation(BackendError),
     Restore(HvfSnapshotV2PlatformRestoreError),
+    RootRestore(HvfSnapshotV2RootRestoreError),
     RunReady {
         source: HvfVcpuRunCoordinatorError,
         cleanup: Option<BackendError>,
@@ -1213,6 +1215,7 @@ pub(crate) enum NativeV2SnapshotLoadError {
         source: BackendError,
         cleanup: Option<BackendError>,
     },
+    ControllerCommit(BackendError),
     Resume(BackendError),
 }
 
@@ -1227,8 +1230,10 @@ impl NativeV2SnapshotLoadError {
             | Self::AfterResourceAdoption { .. }
             | Self::RunReady { .. }
             | Self::WorkerStart { .. }
+            | Self::ControllerCommit(_)
             | Self::Resume(_) => true,
             Self::Restore(source) => source.is_committed() || !source.cleanup_failures().is_empty(),
+            Self::RootRestore(source) => source.is_terminal(),
             Self::Preflight(_)
             | Self::Resource(_)
             | Self::Artifact(_)
@@ -1238,6 +1243,7 @@ impl NativeV2SnapshotLoadError {
             | Self::CandidateMismatch
             | Self::Decode(_)
             | Self::RootPlan(_)
+            | Self::RootConfiguration(_)
             | Self::RootBundle(_)
             | Self::BootMetadata(_)
             | Self::Allocation(_)
@@ -1287,6 +1293,12 @@ impl fmt::Display for NativeV2SnapshotLoadError {
                     "native-v2 root plan preparation failed: {source}"
                 )
             }
+            Self::RootConfiguration(source) => {
+                write!(
+                    formatter,
+                    "native-v2 root controller configuration failed: {source}"
+                )
+            }
             #[cfg(target_os = "macos")]
             Self::RootBacking(source) => {
                 write!(
@@ -1316,6 +1328,9 @@ impl fmt::Display for NativeV2SnapshotLoadError {
                 )
             }
             Self::Restore(source) => write!(formatter, "native-v2 HVF restore failed: {source}"),
+            Self::RootRestore(source) => {
+                write!(formatter, "native-v2 root-owner restore failed: {source}")
+            }
             Self::RunReady { cleanup, .. } => {
                 formatter.write_str("native-v2 run coordinator preparation failed")?;
                 if cleanup.is_some() {
@@ -1334,6 +1349,12 @@ impl fmt::Display for NativeV2SnapshotLoadError {
                     formatter.write_str("; platform cleanup also failed")?;
                 }
                 Ok(())
+            }
+            Self::ControllerCommit(source) => {
+                write!(
+                    formatter,
+                    "native-v2 controller commit checkpoint failed: {source}"
+                )
             }
             Self::Resume(source) => {
                 write!(
@@ -1356,6 +1377,7 @@ impl std::error::Error for NativeV2SnapshotLoadError {
             Self::CandidateFormat(source) => Some(source),
             Self::Decode(source) => Some(source),
             Self::RootPlan(source) => Some(source),
+            Self::RootConfiguration(source) => Some(source),
             #[cfg(target_os = "macos")]
             Self::RootBacking(source) => Some(source),
             Self::RootBundle(source) => Some(source),
@@ -1363,8 +1385,10 @@ impl std::error::Error for NativeV2SnapshotLoadError {
             Self::Allocation(source) => Some(source),
             Self::ProcessPreparation(source) => Some(source),
             Self::Restore(source) => Some(source),
+            Self::RootRestore(source) => Some(source),
             Self::RunReady { source, .. } => Some(source),
             Self::WorkerStart { source, .. } => Some(source),
+            Self::ControllerCommit(source) => Some(source),
             Self::Resume(source) => Some(source),
             Self::ProcessTerminal | Self::UnexpectedFamily(_) | Self::CandidateMismatch => None,
         }
@@ -5965,8 +5989,6 @@ impl ProcessVmm<HvfInstanceStartExecutor> {
             state.platform().machine().machine(),
             input.track_dirty_pages(),
         );
-        let controller_commit =
-            SnapshotV2ControllerCommit::new(machine, boot_source_config, input.resume_vm());
         let mut guest_ranges = Vec::new();
         guest_ranges
             .try_reserve_exact(memory.regions().len())
@@ -5980,6 +6002,17 @@ impl ProcessVmm<HvfInstanceStartExecutor> {
         );
         let prepared = prepare_hvf_snapshot_v2_root_plan(state, memory, process, Instant::now())
             .map_err(NativeV2SnapshotLoadError::RootPlan)?;
+        let drive_config = prepared
+            .root()
+            .drive_config()
+            .map_err(NativeV2SnapshotLoadError::RootConfiguration)?;
+        let controller_commit = SnapshotV2ControllerCommit::try_new_with_root(
+            machine,
+            boot_source_config,
+            drive_config,
+            input.resume_vm(),
+        )
+        .map_err(NativeV2SnapshotLoadError::Allocation)?;
 
         let rate_limiter = SerialConfig::default().rate_limiter();
         let serial_output = if self.starter.process_serial_stdio {
@@ -6020,6 +6053,50 @@ impl ProcessVmm<HvfInstanceStartExecutor> {
             guest_ranges,
             virtual_timer_intid,
         })
+    }
+
+    #[cfg(target_os = "macos")]
+    fn restore_native_v2_root_candidate_once(
+        &mut self,
+        input: &SnapshotLoadInput,
+        candidate: NativeV2SnapshotCandidateState,
+        memory: GuestMemory,
+    ) -> Result<bool, NativeV2SnapshotLoadError> {
+        self.restore_native_v2_root_candidate_once_with_controller_hook(
+            input,
+            candidate,
+            memory,
+            || Ok(()),
+        )
+    }
+
+    #[cfg(target_os = "macos")]
+    fn restore_native_v2_root_candidate_once_with_controller_hook(
+        &mut self,
+        input: &SnapshotLoadInput,
+        candidate: NativeV2SnapshotCandidateState,
+        memory: GuestMemory,
+        before_controller_commit: impl FnOnce() -> Result<(), BackendError>,
+    ) -> Result<bool, NativeV2SnapshotLoadError> {
+        let prepared = self.prepare_native_v2_root_candidate_load(input, candidate, memory)?;
+        let restored = self.starter.load_prepared_snapshot_v2_root_process(
+            &self.controller,
+            self.vmnet_authority,
+            prepared,
+        )?;
+        let (session, controller_commit, root_lease, serial_output) = restored.into_parts();
+        if let Err(source) = before_controller_commit() {
+            // Dropping the still-unpublished paused supervisor stops its
+            // worker and tears down the complete root/platform owner. The
+            // provisional backing claim is released when `root_lease` drops.
+            drop(session);
+            return Err(NativeV2SnapshotLoadError::ControllerCommit(source));
+        }
+        self.starter.active_serial_output = Some(serial_output);
+        self.started_session = Some(session);
+        let resume_requested = self.controller.commit_snapshot_v2_load(controller_commit);
+        root_lease.commit();
+        Ok(resume_requested)
     }
 
     fn capture_native_v2_root_candidate(
@@ -6078,6 +6155,15 @@ const _: fn(
     GuestMemory,
 ) -> Result<PreparedHvfSnapshotV2RootProcessLoad, NativeV2SnapshotLoadError> =
     ProcessVmm::<HvfInstanceStartExecutor>::prepare_native_v2_root_candidate_load;
+
+#[cfg(target_os = "macos")]
+const _: fn(
+    &mut ProcessVmm<HvfInstanceStartExecutor>,
+    &SnapshotLoadInput,
+    NativeV2SnapshotCandidateState,
+    GuestMemory,
+) -> Result<bool, NativeV2SnapshotLoadError> =
+    ProcessVmm::<HvfInstanceStartExecutor>::restore_native_v2_root_candidate_once;
 
 // Keep the pre-dispatch native-v1 load seam type-checked for focused legacy
 // compatibility tests; public loads use the one-open family dispatcher.
@@ -6292,7 +6378,7 @@ fn snapshot_destination_machine_config(
 #[cfg(target_os = "macos")]
 #[allow(
     dead_code,
-    reason = "exact-2.4 root restore stays dormant until endpoint reconstruction lands"
+    reason = "exact-2.4 root restore stays dormant until public activation lands"
 )]
 struct PreparedHvfSnapshotV2RootProcessLoad {
     platform: HvfSnapshotV2PlatformState,
@@ -6320,7 +6406,7 @@ impl fmt::Debug for PreparedHvfSnapshotV2RootProcessLoad {
 #[cfg(target_os = "macos")]
 #[allow(
     dead_code,
-    reason = "exact-2.4 root restore stays dormant until endpoint reconstruction lands"
+    reason = "exact-2.4 root restore stays dormant until public activation lands"
 )]
 impl PreparedHvfSnapshotV2RootProcessLoad {
     fn into_parts(self) -> PreparedHvfSnapshotV2RootProcessLoadParts {
@@ -6341,7 +6427,7 @@ impl PreparedHvfSnapshotV2RootProcessLoad {
 #[cfg(target_os = "macos")]
 #[allow(
     dead_code,
-    reason = "exact-2.4 root restore stays dormant until endpoint reconstruction lands"
+    reason = "exact-2.4 root restore stays dormant until public activation lands"
 )]
 struct PreparedHvfSnapshotV2RootProcessLoadParts {
     platform: HvfSnapshotV2PlatformState,
@@ -6353,6 +6439,43 @@ struct PreparedHvfSnapshotV2RootProcessLoadParts {
     serial_output: SharedSerialOutput,
     guest_ranges: Vec<GuestMemoryRange>,
     virtual_timer_intid: u32,
+}
+
+#[cfg(target_os = "macos")]
+struct SnapshotV2RootLoadSuccess {
+    session: HvfProcessSession,
+    controller_commit: SnapshotV2ControllerCommit,
+    root_lease: PreparedSnapshotRootBackingLease,
+    serial_output: SharedSerialOutput,
+}
+
+#[cfg(target_os = "macos")]
+impl SnapshotV2RootLoadSuccess {
+    fn into_parts(
+        self,
+    ) -> (
+        HvfProcessSession,
+        SnapshotV2ControllerCommit,
+        PreparedSnapshotRootBackingLease,
+        SharedSerialOutput,
+    ) {
+        (
+            self.session,
+            self.controller_commit,
+            self.root_lease,
+            self.serial_output,
+        )
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl fmt::Debug for SnapshotV2RootLoadSuccess {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2RootLoadSuccess")
+            .field("state", &"<redacted>")
+            .finish()
+    }
 }
 
 #[allow(
@@ -6392,6 +6515,78 @@ fn native_v2_boot_source_config(
     reason = "native-v2 process restore is target-gated and exercised by signed integration coverage"
 )]
 impl HvfInstanceStartExecutor {
+    #[cfg(target_os = "macos")]
+    fn load_prepared_snapshot_v2_root_process(
+        &mut self,
+        controller: &VmmController,
+        vmnet_authority: ProcessVmnetAuthority,
+        prepared: PreparedHvfSnapshotV2RootProcessLoad,
+    ) -> Result<SnapshotV2RootLoadSuccess, NativeV2SnapshotLoadError> {
+        let PreparedHvfSnapshotV2RootProcessLoadParts {
+            platform,
+            memory,
+            root,
+            resources,
+            root_lease,
+            controller_commit,
+            serial_output,
+            guest_ranges: _guest_ranges,
+            virtual_timer_intid: _virtual_timer_intid,
+        } = prepared.into_parts();
+        let (packet_io, mmds_metrics) =
+            ProcessNetworkPacketIoProvider::from_controller(controller, vmnet_authority).map_err(
+                |source| {
+                    NativeV2SnapshotLoadError::ProcessPreparation(BackendError::Hypervisor(
+                        format!("failed to build native-v2 network packet I/O provider: {source}"),
+                    ))
+                },
+            )?;
+        let process_shell = HvfSnapshotV2DefaultProcessShell::new(serial_output.clone());
+        let mut session = OwnedHvfArm64BootSession::restore_snapshot_v2_root(
+            platform,
+            memory,
+            process_shell,
+            root,
+            resources,
+        )
+        .map_err(NativeV2SnapshotLoadError::RootRestore)?;
+        if let Err(source) = session.resume_after_snapshot_v2_capture() {
+            let cleanup = session
+                .shutdown()
+                .err()
+                .map(|source| BackendError::Hypervisor(source.to_string()));
+            return Err(NativeV2SnapshotLoadError::RunReady { source, cleanup });
+        }
+        let process_session = ProcessHvfBootSession::new_with_vmnet_authority(
+            session,
+            packet_io,
+            mmds_metrics,
+            vmnet_authority,
+        );
+        let supervisor = match HvfBootRunLoopSupervisor::start_paused(
+            process_session,
+            default_hvf_boot_run_loop_step_limit(),
+        ) {
+            Ok(supervisor) => supervisor,
+            Err(error) => {
+                let (source, mut failed_session) = error.into_parts();
+                let cleanup = failed_session
+                    .session
+                    .shutdown()
+                    .err()
+                    .map(|source| BackendError::Hypervisor(source.to_string()));
+                return Err(NativeV2SnapshotLoadError::WorkerStart { source, cleanup });
+            }
+        };
+
+        Ok(SnapshotV2RootLoadSuccess {
+            session: HvfProcessSession::Boot(supervisor),
+            controller_commit,
+            root_lease,
+            serial_output,
+        })
+    }
+
     fn prepare_snapshot_v2_process_load(
         &self,
         input: &SnapshotLoadInput,
@@ -14659,8 +14854,8 @@ mod tests {
     };
     #[cfg(target_os = "macos")]
     use bangbang_runtime::snapshot_artifact::{
-        NativeSnapshotArtifactFamily, SnapshotArtifactOutput, SnapshotCommitDurability,
-        load_native_snapshot_artifacts, load_snapshot_artifacts,
+        NativeSnapshotArtifactFamily, NativeV2SnapshotCandidateState, SnapshotArtifactOutput,
+        SnapshotCommitDurability, load_native_snapshot_artifacts, load_snapshot_artifacts,
     };
     #[cfg(target_os = "macos")]
     use bangbang_runtime::snapshot_commit::SnapshotCommitKind;
@@ -14671,7 +14866,8 @@ mod tests {
     };
     use bangbang_runtime::snapshot_format_v2::{
         NATIVE_V2_DEVICE_GRAPH_COMPONENT_KEY, NATIVE_V2_MEMORY_COMPONENT_KEY, SnapshotV2Component,
-        SnapshotV2ComponentDisposition, encode_snapshot_v2_state_with_compatibility_version,
+        SnapshotV2ComponentDisposition, decode_snapshot_v2_state_with_compatibility_version,
+        encode_snapshot_v2_state_with_compatibility_version,
     };
     use bangbang_runtime::snapshot_memory::{SnapshotMemoryBinding, write_snapshot_memory_image};
     use bangbang_runtime::snapshot_memory_v2::{
@@ -14700,8 +14896,8 @@ mod tests {
     #[cfg(target_os = "macos")]
     use crate::contained_session::{
         TestVhostDirectory, VhostUserBrokerAuthority, empty_grant_authority_for_vhost_test,
-        file_grant_authority_for_test, snapshot_file_grant_authority_for_test,
-        vhost_directory_authority_for_test,
+        file_grant_authority_for_test, root_file_grant_authority_for_test,
+        snapshot_file_grant_authority_for_test, vhost_directory_authority_for_test,
     };
 
     use crate::host_network::virtio_vmnet::VmnetVirtioNetworkPacketIoStopError;
@@ -14758,7 +14954,7 @@ mod tests {
     };
     #[cfg(target_os = "macos")]
     use super::{
-        DirectRootSelectorPolicy, GrantAccess, PreparedSnapshotRootBackingLease,
+        DirectRootSelectorPolicy, GrantAccess, HvfProcessSession, PreparedSnapshotRootBackingLease,
         SnapshotRootBackingLeaseError,
     };
 
@@ -27238,6 +27434,198 @@ mod tests {
             fs::read(first_paths.memory()).expect("contained replacement memory should remain"),
             b"replacement memory"
         );
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[test]
+    #[ignore = "requires the signed native_v2_process integration group"]
+    fn signed_native_v2_root_process_commits_complete_mmio_and_pci_owners_atomically() {
+        const ARM64_IMAGE_HEADER_SIZE: usize = 64;
+        const ARM64_IMAGE_SIZE_OFFSET: usize = 16;
+        const ARM64_IMAGE_MAGIC_OFFSET: usize = 56;
+        const ARM64_IMAGE_MAGIC: u32 = 0x644d_5241;
+        const ARM64_BRANCH_TO_SELF: u32 = 0x1400_0000;
+        const ROOT_REFERENCE: &str = "bangbang-grant:drive-ro";
+
+        let mut image = vec![0_u8; ARM64_IMAGE_HEADER_SIZE];
+        image[..4].copy_from_slice(&ARM64_BRANCH_TO_SELF.to_le_bytes());
+        image[ARM64_IMAGE_SIZE_OFFSET..ARM64_IMAGE_SIZE_OFFSET + 8]
+            .copy_from_slice(&(ARM64_IMAGE_HEADER_SIZE as u64).to_le_bytes());
+        image[ARM64_IMAGE_MAGIC_OFFSET..ARM64_IMAGE_MAGIC_OFFSET + 4]
+            .copy_from_slice(&ARM64_IMAGE_MAGIC.to_le_bytes());
+        let kernel = TempFilePath::create_with_bytes("signed-native-v2-root-kernel", &image);
+
+        for (case, pci_enabled) in [("mmio", false), ("pci", true)] {
+            let root = TempFilePath::create_with_bytes(
+                &format!("signed-native-v2-{case}-root"),
+                &vec![0_u8; 1024 * 1024],
+            );
+            let mut source = ProcessVmm::with_starter(
+                format!("native-v2-{case}-source"),
+                "0.1.0",
+                "bangbang",
+                HvfInstanceStartExecutor::default(),
+            )
+            .with_grant_authority(Some(root_file_grant_authority_for_test(root.path())));
+            source.pci_enabled = pci_enabled;
+            source.starter.pci_enabled = pci_enabled;
+            source
+                .handle_action(VmmAction::PutMachineConfig(MachineConfigInput::new(2, 16)))
+                .expect("root source machine should configure");
+            source
+                .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+                    kernel.path(),
+                )))
+                .expect("root source boot metadata should configure");
+            source
+                .handle_action(VmmAction::PutDrive(
+                    DriveConfigInput::new("rootfs", "rootfs", ROOT_REFERENCE, true)
+                        .with_is_read_only(true)
+                        .with_io_engine(DriveIoEngine::Sync)
+                        .with_partuuid("1111-2222"),
+                ))
+                .expect("root source drive should configure");
+            source
+                .handle_action(VmmAction::InstanceStart)
+                .expect("root source should start");
+            source
+                .handle_action(VmmAction::Pause)
+                .expect("root source should pause");
+
+            let events = Arc::new(Mutex::new(Vec::new()));
+            let (output, memory_bytes) = SharedSnapshotMemoryOutput::new(events);
+            let candidate = source
+                .capture_native_v2_root_candidate(
+                    Box::new(output),
+                    NativeV2SnapshotCaptureCancellation::default(),
+                )
+                .unwrap_or_else(|error| panic!("{case} root candidate should capture: {error}"));
+            let candidate_bytes = candidate.bytes().to_vec();
+            let expected_graph = candidate.device_graph().clone();
+            let memory_image = TempFilePath::create_with_bytes(
+                &format!("signed-native-v2-{case}-memory"),
+                memory_bytes
+                    .lock()
+                    .expect("captured root memory should lock")
+                    .get_ref(),
+            );
+            drop(source);
+
+            let load_memory = || {
+                let structural = decode_snapshot_v2_state_with_compatibility_version(
+                    &candidate_bytes,
+                    NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                )
+                .expect("root candidate state should decode");
+                bangbang_runtime::snapshot_memory_v2::load_snapshot_v2_memory_path(
+                    &structural,
+                    memory_image.path(),
+                )
+                .expect("root candidate memory should load")
+            };
+            let input = SnapshotLoadInput::new(
+                "private-native-v2-root.state",
+                SnapshotMemoryBackend::new(memory_image.path(), SnapshotMemoryBackendType::File),
+            );
+
+            if !pci_enabled {
+                let failed_authority = root_file_grant_authority_for_test(root.path());
+                let failed_observer = failed_authority.clone();
+                let mut failed = ProcessVmm::with_starter(
+                    "native-v2-mmio-controller-checkpoint",
+                    "0.1.0",
+                    "bangbang",
+                    HvfInstanceStartExecutor::default(),
+                )
+                .with_grant_authority(Some(failed_authority));
+                let error = failed
+                    .restore_native_v2_root_candidate_once_with_controller_hook(
+                        &input,
+                        NativeV2SnapshotCandidateState::from_device_graph_v2_4(
+                            candidate_bytes.clone(),
+                        )
+                        .expect("checkpoint candidate should validate"),
+                        load_memory(),
+                        || {
+                            Err(BackendError::InvalidState(
+                                "injected pre-controller checkpoint",
+                            ))
+                        },
+                    )
+                    .expect_err("controller checkpoint should fail before publication");
+                assert!(matches!(
+                    &error,
+                    NativeV2SnapshotLoadError::ControllerCommit(_)
+                ));
+                assert!(error.is_terminal());
+                assert!(!failed.has_started_session());
+                assert!(failed.starter.active_serial_output.is_none());
+                assert_eq!(failed.instance_info().state, InstanceState::NotStarted);
+                assert!(failed.drive_configs().is_empty());
+                let restored_claim = failed_observer
+                    .prepare_drive_backing_claim(Path::new(ROOT_REFERENCE), GrantAccess::ReadOnly)
+                    .expect("failed controller checkpoint should restore the root grant")
+                    .expect("restored root grant should be claimable");
+                drop(restored_claim);
+                drop(failed);
+            }
+
+            let authority = root_file_grant_authority_for_test(root.path());
+            let observer = authority.clone();
+            let mut destination = ProcessVmm::with_starter(
+                format!("native-v2-{case}-destination"),
+                "0.1.0",
+                "bangbang",
+                HvfInstanceStartExecutor::default(),
+            )
+            .with_grant_authority(Some(authority));
+            destination.pci_enabled = pci_enabled;
+            destination.starter.pci_enabled = pci_enabled;
+            assert!(
+                !destination
+                    .restore_native_v2_root_candidate_once(
+                        &input,
+                        NativeV2SnapshotCandidateState::from_device_graph_v2_4(
+                            candidate_bytes.clone(),
+                        )
+                        .expect("destination candidate should validate"),
+                        load_memory(),
+                    )
+                    .unwrap_or_else(|error| panic!("{case} root destination should load: {error}"))
+            );
+            assert_eq!(destination.instance_info().state, InstanceState::Paused);
+            assert!(destination.starter.active_serial_output.is_some());
+            assert_eq!(destination.drive_configs().len(), 1);
+            assert_eq!(destination.drive_configs()[0].drive_id(), "rootfs");
+            assert_eq!(
+                destination.drive_configs()[0].path_on_host(),
+                Some(Path::new(ROOT_REFERENCE))
+            );
+            assert!(matches!(
+                destination.started_session.as_ref(),
+                Some(HvfProcessSession::Boot(_))
+            ));
+            assert!(
+                observer
+                    .prepare_drive_backing_claim(Path::new(ROOT_REFERENCE), GrantAccess::ReadOnly,)
+                    .is_err(),
+                "successful controller publication must consume the root claim"
+            );
+
+            let recapture_events = Arc::new(Mutex::new(Vec::new()));
+            let (recapture_output, _recapture_bytes) =
+                SharedSnapshotMemoryOutput::new(recapture_events);
+            let recaptured = destination
+                .capture_native_v2_root_candidate(
+                    Box::new(recapture_output),
+                    NativeV2SnapshotCaptureCancellation::default(),
+                )
+                .unwrap_or_else(|error| {
+                    panic!("{case} root destination should recapture: {error}")
+                });
+            assert_eq!(recaptured.device_graph(), &expected_graph);
+            assert_eq!(destination.instance_info().state, InstanceState::Paused);
+        }
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -187,7 +187,9 @@ pub use startup::{
     HvfArm64BootVsockCaptureStage, HvfArm64BootVsockCaptureState,
     HvfArm64BootVsockNotificationDispatch, HvfArm64BootVsockNotificationDispatchError,
     HvfArm64BootVsockNotificationDispatches, HvfArm64BootVsockTransportState,
-    OwnedHvfArm64BootSession, PreparedHvfArm64BootPciNetworkRemoval, RestoredHvfArm64BootSession,
+    HvfSnapshotV2RootRestoreCleanupFailure, HvfSnapshotV2RootRestoreError,
+    HvfSnapshotV2RootRestoreFailure, HvfSnapshotV2RootRestoreStage, OwnedHvfArm64BootSession,
+    PreparedHvfArm64BootPciNetworkRemoval, RestoredHvfArm64BootSession,
 };
 pub use topology::{
     HvfVcpuTopology, HvfVcpuTopologyAllocation, HvfVcpuTopologyCreateStage, HvfVcpuTopologyError,

--- a/crates/hvf/src/snapshot_v2_platform.rs
+++ b/crates/hvf/src/snapshot_v2_platform.rs
@@ -340,6 +340,15 @@ impl fmt::Debug for HvfSnapshotV2DefaultProcessShell {
     }
 }
 
+enum HvfSnapshotV2ProcessShellRestore {
+    DeviceFree(HvfSnapshotV2DefaultProcessShell),
+    Root {
+        shell: HvfSnapshotV2DefaultProcessShell,
+        resources: HvfSnapshotV2RootResourcePlan,
+        partuuid: Option<String>,
+    },
+}
+
 /// Ordered reconstruction stage for the unpublished native-v2 platform.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum HvfSnapshotV2PlatformRestoreStage {
@@ -842,49 +851,72 @@ impl std::error::Error for HvfSnapshotV2PlatformShutdownError {
 /// actions, and path-based loading. The vCPU session is declared before the
 /// backend so owners are dropped before VM memory.
 pub struct RestoredHvfSnapshotV2Platform {
-    runner: HvfArm64BootVcpuSession<'static>,
-    backend: HvfBackend,
-    memory_binding: SnapshotV2MemoryBinding,
-    machine: HvfSnapshotV2MachineState,
-    compatibility: HvfSnapshotV1CompatibilityState,
-    rtc_device: Arm64BootRtcDevice,
-    serial_device: Option<Arm64BootSerialDevice>,
-    vmgenid_device: Arm64BootVmGenIdDevice,
-    vmclock_device: Arm64BootVmClockDevice,
-    pvtime_layout: Arm64PvTimeLayout,
+    parts: Option<RestoredHvfSnapshotV2PlatformParts>,
+}
+
+/// Crate-private consuming handoff into the complete product owner.
+pub(crate) struct RestoredHvfSnapshotV2PlatformParts {
+    pub(crate) runner: HvfArm64BootVcpuSession<'static>,
+    pub(crate) backend: HvfBackend,
+    pub(crate) mmio_dispatcher: Arc<Mutex<MmioDispatcher>>,
+    pub(crate) memory_binding: SnapshotV2MemoryBinding,
+    pub(crate) machine: HvfSnapshotV2MachineState,
+    pub(crate) compatibility: HvfSnapshotV1CompatibilityState,
+    pub(crate) rtc_device: Arm64BootRtcDevice,
+    pub(crate) serial_device: Option<Arm64BootSerialDevice>,
+    pub(crate) vmgenid_device: Arm64BootVmGenIdDevice,
+    pub(crate) vmclock_device: Arm64BootVmClockDevice,
+    pub(crate) pvtime_layout: Arm64PvTimeLayout,
 }
 
 impl RestoredHvfSnapshotV2Platform {
+    fn parts(&self) -> &RestoredHvfSnapshotV2PlatformParts {
+        match self.parts.as_ref() {
+            Some(parts) => parts,
+            None => std::process::abort(),
+        }
+    }
+
+    fn parts_mut(&mut self) -> &mut RestoredHvfSnapshotV2PlatformParts {
+        match self.parts.as_mut() {
+            Some(parts) => parts,
+            None => std::process::abort(),
+        }
+    }
+
     /// Return the complete destination vCPU count.
     pub fn vcpu_count(&self) -> usize {
-        self.runner.member_count()
+        self.parts().runner.member_count()
     }
 
     /// Return owner-thread-verified canonical MPIDRs.
     pub fn vcpu_mpidrs(&self) -> &[u64] {
-        self.runner.mpidrs()
+        self.parts().runner.mpidrs()
     }
 
     /// Return the retained exact memory-image binding.
-    pub const fn memory_binding(&self) -> &SnapshotV2MemoryBinding {
-        &self.memory_binding
+    pub fn memory_binding(&self) -> &SnapshotV2MemoryBinding {
+        &self.parts().memory_binding
     }
 
     /// Return retained logical machine, boot, FDT, and CPU-template facts.
-    pub const fn machine(&self) -> &HvfSnapshotV2MachineState {
-        &self.machine
+    pub fn machine(&self) -> &HvfSnapshotV2MachineState {
+        &self.parts().machine
     }
 
     /// Return the destination-validated common compatibility facts.
-    pub const fn compatibility(&self) -> &HvfSnapshotV1CompatibilityState {
-        &self.compatibility
+    pub fn compatibility(&self) -> &HvfSnapshotV1CompatibilityState {
+        &self.parts().compatibility
     }
 
     /// Borrow the fresh process UART output when this owner was reconstructed
     /// through the closed process shell.
     #[doc(hidden)]
     pub fn serial_output(&self) -> Option<&SharedSerialOutput> {
-        self.serial_device.as_ref().map(|device| &device.output)
+        self.parts()
+            .serial_device
+            .as_ref()
+            .map(|device| &device.output)
     }
 
     /// Reobserve the complete paused lifecycle graph.
@@ -894,7 +926,7 @@ impl RestoredHvfSnapshotV2Platform {
         crate::paused_topology::HvfArm64StablePausedTopologyState,
         HvfArm64StablePausedTopologyCaptureError,
     > {
-        self.runner.capture_stable_paused_topology()
+        self.parts_mut().runner.capture_stable_paused_topology()
     }
 
     /// Recapture the complete reconstructed platform while it remains paused.
@@ -906,23 +938,25 @@ impl RestoredHvfSnapshotV2Platform {
         &mut self,
         memory_writer: &mut W,
     ) -> Result<HvfSnapshotV2PlatformState, HvfArm64BootSnapshotV2CaptureError> {
-        let (stable, captures, pvtime_capture) =
-            self.runner
-                .capture_arm64_snapshot_v2_topology()
-                .map_err(|source| HvfArm64BootSnapshotV2CaptureError::Topology { source })?;
-        let memory = self
+        let parts = self.parts_mut();
+        let (stable, captures, pvtime_capture) = parts
+            .runner
+            .capture_arm64_snapshot_v2_topology()
+            .map_err(|source| HvfArm64BootSnapshotV2CaptureError::Topology { source })?;
+        let memory = parts
             .backend
             .mapped_guest_memory()
             .map_err(|source| HvfArm64BootSnapshotV2CaptureError::GuestMemory { source })?;
-        verify_capture_fdt_identity(memory, &self.machine)?;
+        verify_capture_fdt_identity(memory, &parts.machine)?;
         if captures.len() != stable.members().len() {
             return Err(HvfArm64BootSnapshotV2CaptureError::CompatibilityMismatch {
                 index: captures.len(),
             });
         }
 
-        let expected_identification = self.compatibility.identification();
-        let expected_optional_identification = self.compatibility.optional_sve_sme_identification();
+        let expected_identification = parts.compatibility.identification();
+        let expected_optional_identification =
+            parts.compatibility.optional_sve_sme_identification();
         let mut vcpus = Vec::new();
         vcpus
             .try_reserve_exact(captures.len())
@@ -978,21 +1012,21 @@ impl RestoredHvfSnapshotV2Platform {
         }
         let global_gic =
             global_gic.ok_or(HvfArm64BootSnapshotV2CaptureError::GlobalGicShape { index: 0 })?;
-        let global = HvfSnapshotV2GlobalState::try_new(self.compatibility.clone(), global_gic)
+        let global = HvfSnapshotV2GlobalState::try_new(parts.compatibility.clone(), global_gic)
             .map_err(|source| HvfArm64BootSnapshotV2CaptureError::Build {
                 stage: HvfArm64BootSnapshotV2CaptureStage::GlobalGic,
                 source,
             })?;
         let rtc_layout = RtcMmioLayout::new(
-            self.rtc_device.region.range().start(),
-            self.rtc_device.region.id(),
+            parts.rtc_device.region.range().start(),
+            parts.rtc_device.region.id(),
         );
         let time = capture_hvf_snapshot_v2_time_state(
             memory,
             rtc_layout,
-            &self.vmgenid_device,
-            &self.vmclock_device,
-            Some(&self.pvtime_layout),
+            &parts.vmgenid_device,
+            &parts.vmclock_device,
+            Some(&parts.pvtime_layout),
             &pvtime_capture,
         )
         .map_err(|source| HvfArm64BootSnapshotV2CaptureError::Time { source })?;
@@ -1000,7 +1034,7 @@ impl RestoredHvfSnapshotV2Platform {
             .map_err(|source| HvfArm64BootSnapshotV2CaptureError::MemoryImage { source })?;
         HvfSnapshotV2PlatformState::try_new(
             memory_binding,
-            self.machine.clone(),
+            parts.machine.clone(),
             global,
             stable,
             vcpus,
@@ -1015,13 +1049,13 @@ impl RestoredHvfSnapshotV2Platform {
     /// Begin execution only after the fully restored platform was published.
     #[doc(hidden)]
     pub fn resume(&mut self) -> Result<(), HvfVcpuRunCoordinatorError> {
-        self.runner.resume()
+        self.parts_mut().runner.resume()
     }
 
     /// Return the post-publication topology control capability.
     #[doc(hidden)]
     pub fn control(&self) -> HvfVcpuRunControl {
-        self.runner.control()
+        self.parts().runner.control()
     }
 
     /// Run one post-publication boot-session step.
@@ -1030,19 +1064,35 @@ impl RestoredHvfSnapshotV2Platform {
         &mut self,
         entry_is_valid: impl FnMut(u64) -> bool,
     ) -> Result<HvfVcpuRunStepOutcome, HvfArm64BootVcpuError> {
-        self.runner.run_step(entry_is_valid)
+        self.parts_mut().runner.run_step(entry_is_valid)
     }
 
     /// Set the last stepped member's PPI pending bit.
     #[doc(hidden)]
     pub fn set_last_step_ppi_pending(&self, intid: u32) -> Result<(), HvfArm64BootVcpuError> {
-        self.runner.set_last_step_ppi_pending(intid)
+        self.parts().runner.set_last_step_ppi_pending(intid)
     }
 
     /// Borrow already-authorized destination guest memory.
     #[doc(hidden)]
     pub fn guest_memory(&self) -> Result<&GuestMemory, HvfGuestMemoryMappingError> {
-        self.backend.mapped_guest_memory_for_public_access()
+        self.parts().backend.mapped_guest_memory_for_public_access()
+    }
+
+    pub(crate) fn backend(&self) -> &HvfBackend {
+        &self.parts().backend
+    }
+
+    pub(crate) fn mmio_dispatcher(&self) -> &Arc<Mutex<MmioDispatcher>> {
+        &self.parts().mmio_dispatcher
+    }
+
+    /// Transfers the complete unpublished platform into a root-bearing owner.
+    pub(crate) fn into_parts(mut self) -> RestoredHvfSnapshotV2PlatformParts {
+        match self.parts.take() {
+            Some(parts) => parts,
+            None => std::process::abort(),
+        }
     }
 
     /// Shut down vCPU owners before unmapping memory and destroying the VM.
@@ -1054,10 +1104,14 @@ impl RestoredHvfSnapshotV2Platform {
                 HvfSnapshotV2PlatformCleanupStage::Backend,
             ]
         );
-        self.runner
+        let Some(parts) = self.parts.as_mut() else {
+            return Ok(());
+        };
+        parts
+            .runner
             .shutdown()
             .map_err(HvfSnapshotV2PlatformShutdownError::Vcpu)?;
-        <HvfBackend as VmBackend>::destroy_vm(&mut self.backend)
+        <HvfBackend as VmBackend>::destroy_vm(&mut parts.backend)
             .map_err(HvfSnapshotV2PlatformShutdownError::Backend)
     }
 }
@@ -1143,13 +1197,35 @@ pub fn restore_hvf_snapshot_v2_process_platform(
     memory: GuestMemory,
     shell: HvfSnapshotV2DefaultProcessShell,
 ) -> Result<RestoredHvfSnapshotV2Platform, HvfSnapshotV2PlatformRestoreError> {
-    restore_hvf_snapshot_v2_platform_with_shell(state, memory, Some(shell))
+    restore_hvf_snapshot_v2_platform_with_shell(
+        state,
+        memory,
+        Some(HvfSnapshotV2ProcessShellRestore::DeviceFree(shell)),
+    )
+}
+
+pub(crate) fn restore_hvf_snapshot_v2_root_process_platform(
+    state: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    shell: HvfSnapshotV2DefaultProcessShell,
+    resources: HvfSnapshotV2RootResourcePlan,
+    partuuid: Option<String>,
+) -> Result<RestoredHvfSnapshotV2Platform, HvfSnapshotV2PlatformRestoreError> {
+    restore_hvf_snapshot_v2_platform_with_shell(
+        state,
+        memory,
+        Some(HvfSnapshotV2ProcessShellRestore::Root {
+            shell,
+            resources,
+            partuuid,
+        }),
+    )
 }
 
 fn restore_hvf_snapshot_v2_platform_with_shell(
     state: HvfSnapshotV2PlatformState,
     memory: GuestMemory,
-    process_shell: Option<HvfSnapshotV2DefaultProcessShell>,
+    process_shell: Option<HvfSnapshotV2ProcessShellRestore>,
 ) -> Result<RestoredHvfSnapshotV2Platform, HvfSnapshotV2PlatformRestoreError> {
     debug_assert!(cleanup_sequence(RestoreOwnership::Empty).is_empty());
     let mut cleanup = Vec::new();
@@ -1555,7 +1631,7 @@ fn restore_hvf_snapshot_v2_platform_with_shell(
     let runner = match HvfArm64BootVcpuSession::from_stable_paused_topology(
         raw_topology,
         &stable,
-        dispatcher,
+        Arc::clone(&dispatcher),
         stable.virtual_timer_intid(),
     ) {
         Ok(runner) => runner,
@@ -1571,16 +1647,19 @@ fn restore_hvf_snapshot_v2_platform_with_shell(
     };
 
     Ok(RestoredHvfSnapshotV2Platform {
-        runner,
-        backend,
-        memory_binding,
-        machine,
-        compatibility,
-        rtc_device,
-        serial_device,
-        vmgenid_device,
-        vmclock_device,
-        pvtime_layout,
+        parts: Some(RestoredHvfSnapshotV2PlatformParts {
+            runner,
+            backend,
+            mmio_dispatcher: dispatcher,
+            memory_binding,
+            machine,
+            compatibility,
+            rtc_device,
+            serial_device,
+            vmgenid_device,
+            vmclock_device,
+            pvtime_layout,
+        }),
     })
 }
 
@@ -1977,7 +2056,18 @@ fn pci_msix_routes_match_gic(
     else {
         return false;
     };
-    state.entries().iter().all(|entry| {
+    state.entries().iter().enumerate().all(|(index, entry)| {
+        let Ok(vector) = u16::try_from(index) else {
+            return false;
+        };
+        let referenced = state.config_vector() == vector || state.queue_vectors().contains(&vector);
+        let pending = state
+            .pending_words()
+            .get(index / u64::BITS as usize)
+            .is_some_and(|word| word & (1_u64 << (index % u64::BITS as usize)) != 0);
+        if entry.vector_control() & 1 != 0 || (!referenced && !pending) {
+            return true;
+        }
         let address = (u64::from(entry.message_address_high()) << 32)
             | u64::from(entry.message_address_low());
         address == expected_address
@@ -1987,19 +2077,18 @@ fn pci_msix_routes_match_gic(
 }
 
 fn prepare_process_shell(
-    shell: Option<HvfSnapshotV2DefaultProcessShell>,
+    shell: Option<HvfSnapshotV2ProcessShellRestore>,
     state: &HvfSnapshotV2PlatformState,
     fdt_bytes: &[u8],
 ) -> Result<(MmioDispatcher, Option<Arm64BootSerialDevice>), HvfSnapshotV2PlatformRestoreFailure> {
     let mut dispatcher = MmioDispatcher::new();
-    let Some(shell) = shell else {
+    let Some(shell_restore) = shell else {
         return Ok((dispatcher, None));
     };
 
     let gic = state.global().compatibility().gic_metadata();
-    if gic.msi.is_some()
-        || state.time().rtc_layout()
-            != RtcMmioLayout::new(PROCESS_RTC_MMIO_BASE, PROCESS_RTC_MMIO_REGION_ID)
+    if state.time().rtc_layout()
+        != RtcMmioLayout::new(PROCESS_RTC_MMIO_BASE, PROCESS_RTC_MMIO_REGION_ID)
     {
         return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellFdt {
             mismatch: HvfSnapshotV2ProcessFdtMismatch::Profile,
@@ -2007,6 +2096,44 @@ fn prepare_process_shell(
     }
     let mut allocator = HvfGicInterruptLineAllocator::from_metadata(&gic)
         .map_err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterrupt)?;
+    let (shell, root) = match shell_restore {
+        HvfSnapshotV2ProcessShellRestore::DeviceFree(shell) => {
+            if gic.msi.is_some() {
+                return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellFdt {
+                    mismatch: HvfSnapshotV2ProcessFdtMismatch::Profile,
+                });
+            }
+            (shell, None)
+        }
+        HvfSnapshotV2ProcessShellRestore::Root {
+            shell,
+            resources,
+            partuuid,
+        } => {
+            match resources.transport() {
+                HvfSnapshotV2RootTransportPlan::Mmio { interrupt_line, .. } => {
+                    if gic.msi.is_some()
+                        || allocator
+                            .allocate()
+                            .map_err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterrupt)?
+                            != interrupt_line
+                    {
+                        return Err(
+                            HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterruptIdentity,
+                        );
+                    }
+                }
+                HvfSnapshotV2RootTransportPlan::Pci { msi, .. } => {
+                    if gic.msi != Some(msi) {
+                        return Err(
+                            HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterruptIdentity,
+                        );
+                    }
+                }
+            }
+            (shell, Some((partuuid, resources.transport())))
+        }
+    };
     let serial_interrupt = allocator
         .allocate()
         .map_err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterrupt)?;
@@ -2021,8 +2148,14 @@ fn prepare_process_shell(
     {
         return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterruptIdentity);
     }
-    validate_default_process_fdt(fdt_bytes, state, serial_interrupt)
-        .map_err(|mismatch| HvfSnapshotV2PlatformRestoreFailure::ProcessShellFdt { mismatch })?;
+    validate_process_fdt(
+        fdt_bytes,
+        state,
+        serial_interrupt,
+        root.as_ref()
+            .map(|(partuuid, transport)| (partuuid.as_deref(), *transport)),
+    )
+    .map_err(|mismatch| HvfSnapshotV2PlatformRestoreFailure::ProcessShellFdt { mismatch })?;
 
     let serial = register_arm64_boot_serial_mmio(
         &mut dispatcher,
@@ -2037,6 +2170,7 @@ fn prepare_process_shell(
     Ok((dispatcher, Some(serial)))
 }
 
+#[cfg(test)]
 fn validate_default_process_fdt(
     bytes: &[u8],
     state: &HvfSnapshotV2PlatformState,
@@ -2051,11 +2185,14 @@ fn validate_root_process_fdt(
     root: &SnapshotV2RootRestorePlan,
     resources: HvfSnapshotV2RootResourcePlan,
 ) -> Result<(), HvfSnapshotV2ProcessFdtMismatch> {
+    if root.transport().kind() != resources.transport().kind() {
+        return Err(HvfSnapshotV2ProcessFdtMismatch::Root);
+    }
     validate_process_fdt(
         bytes,
         state,
         resources.serial_interrupt,
-        Some((root, resources.transport)),
+        Some((root.partuuid(), resources.transport)),
     )
 }
 
@@ -2063,7 +2200,7 @@ fn validate_process_fdt(
     bytes: &[u8],
     state: &HvfSnapshotV2PlatformState,
     serial_interrupt: GuestInterruptLine,
-    root: Option<(&SnapshotV2RootRestorePlan, HvfSnapshotV2RootTransportPlan)>,
+    root: Option<(Option<&str>, HvfSnapshotV2RootTransportPlan)>,
 ) -> Result<(), HvfSnapshotV2ProcessFdtMismatch> {
     let tree = DeviceTree::load(bytes).map_err(|_| HvfSnapshotV2ProcessFdtMismatch::Parse)?;
     let time = state.time();
@@ -2167,10 +2304,10 @@ fn validate_process_fdt(
         return Err(HvfSnapshotV2ProcessFdtMismatch::Boot);
     };
     let expected_boot_args = match root {
-        Some((root, transport)) => canonical_process_root_block_command_line(
+        Some((partuuid, transport)) => canonical_process_root_block_command_line(
             state.machine().boot().boot_arguments(),
             matches!(transport, HvfSnapshotV2RootTransportPlan::Pci { .. }),
-            root.partuuid(),
+            partuuid,
             true,
         )
         .map_err(|_| HvfSnapshotV2ProcessFdtMismatch::Boot)?,
@@ -2347,19 +2484,16 @@ fn validate_process_fdt(
 fn validate_process_root_nodes(
     root_node: &Node,
     intc: &Node,
-    root: Option<(&SnapshotV2RootRestorePlan, HvfSnapshotV2RootTransportPlan)>,
+    root: Option<(Option<&str>, HvfSnapshotV2RootTransportPlan)>,
 ) -> Result<(), HvfSnapshotV2ProcessFdtMismatch> {
-    let Some((root, resources)) = root else {
+    let Some((_partuuid, resources)) = root else {
         return Ok(());
     };
-    match (root.transport(), resources) {
-        (
-            SnapshotV2DeviceTransport::Mmio(graph),
-            HvfSnapshotV2RootTransportPlan::Mmio {
-                region,
-                interrupt_line,
-            },
-        ) => {
+    match resources {
+        HvfSnapshotV2RootTransportPlan::Mmio {
+            region,
+            interrupt_line,
+        } => {
             let node = child_matching(root_node, |node| {
                 node_name_has_number(
                     &node.name,
@@ -2373,9 +2507,7 @@ fn validate_process_root_nodes(
                 .raw_value()
                 .checked_sub(32)
                 .ok_or(HvfSnapshotV2ProcessFdtMismatch::Root)?;
-            if graph.region() != region
-                || graph.interrupt_line() != interrupt_line
-                || !node.children.is_empty()
+            if !node.children.is_empty()
                 || !node
                     .prop_str("compatible")
                     .is_ok_and(|compatible| compatible == "virtio,mmio")
@@ -2394,18 +2526,13 @@ fn validate_process_root_nodes(
             }
             Ok(())
         }
-        (
-            SnapshotV2DeviceTransport::Pci(graph),
-            HvfSnapshotV2RootTransportPlan::Pci {
-                sbdf,
-                bar_region_id,
-                bar_range,
-                msi,
-            },
-        ) => {
-            if graph.sbdf() != sbdf
-                || graph.bar_range() != bar_range
-                || pci_root_restore_bar_region_id().ok() != Some(bar_region_id)
+        HvfSnapshotV2RootTransportPlan::Pci {
+            sbdf: _,
+            bar_region_id,
+            bar_range: _,
+            msi,
+        } => {
+            if pci_root_restore_bar_region_id().ok() != Some(bar_region_id)
                 || !validate_process_pci_host(root_node)
                 || !validate_process_gic_msi(intc, msi)
             {
@@ -2413,7 +2540,6 @@ fn validate_process_root_nodes(
             }
             Ok(())
         }
-        _ => Err(HvfSnapshotV2ProcessFdtMismatch::Root),
     }
 }
 
@@ -3940,6 +4066,38 @@ mod tests {
                 .to_string()
                 .contains("after destination identity committed")
         );
+    }
+
+    #[test]
+    fn root_restore_is_terminal_when_nested_platform_cleanup_is_incomplete() {
+        let clean = crate::startup::HvfSnapshotV2RootRestoreError::platform(
+            HvfSnapshotV2PlatformRestoreError::new(
+                HvfSnapshotV2PlatformRestoreStage::Memory,
+                HvfSnapshotV2PlatformRestoreFailure::MemoryTopology,
+                Vec::new(),
+            ),
+        );
+        assert!(!clean.is_committed());
+        assert!(!clean.has_incomplete_cleanup());
+        assert!(!clean.is_terminal());
+
+        let incomplete = crate::startup::HvfSnapshotV2RootRestoreError::platform(
+            HvfSnapshotV2PlatformRestoreError::new(
+                HvfSnapshotV2PlatformRestoreStage::Memory,
+                HvfSnapshotV2PlatformRestoreFailure::MemoryTopology,
+                vec![HvfSnapshotV2PlatformCleanupFailure {
+                    stage: HvfSnapshotV2PlatformCleanupStage::Backend,
+                    source: Box::new(Injected),
+                }],
+            ),
+        );
+        assert!(!incomplete.is_committed());
+        assert!(
+            incomplete.cleanup_failures().is_empty(),
+            "nested platform cleanup stays attached to its platform failure"
+        );
+        assert!(incomplete.has_incomplete_cleanup());
+        assert!(incomplete.is_terminal());
     }
 
     #[test]

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -22,11 +22,12 @@ use bangbang_runtime::balloon::{
 };
 use bangbang_runtime::block::async_executor::{BlockAsyncRuntimeError, SharedBlockAsyncRuntime};
 use bangbang_runtime::block::{
-    BlockFileBacking, BlockMmioLayout, DriveConfig, DriveIoEngine, DriveLiveUpdateMode,
-    DriveRateLimiterConfig, DriveRuntimeMutationError, DriveUpdateError, PreparedBlockDevice,
-    RuntimeBlockDeviceResource, VIRTIO_BLOCK_DEVICE_ID, VIRTIO_BLOCK_QUEUE_SIZES,
-    VhostUserBlockConfigSignalError, VirtioBlockBackendKind, VirtioBlockConfigSpace,
-    VirtioBlockDevice, VirtioBlockDeviceNotificationError, VirtioBlockLiveUpdateError,
+    BlockFileBacking, BlockMmioDeviceRegistration, BlockMmioLayout, DriveConfig, DriveIoEngine,
+    DriveLiveUpdateMode, DriveRateLimiterConfig, DriveRuntimeMutationError, DriveUpdateError,
+    PreparedBlockDevice, RuntimeBlockDeviceResource, VIRTIO_BLOCK_DEVICE_ID,
+    VIRTIO_BLOCK_QUEUE_SIZES, VhostUserBlockConfigSignalError, VirtioBlockBackendKind,
+    VirtioBlockConfigSpace, VirtioBlockDevice, VirtioBlockDeviceNotificationError,
+    VirtioBlockLiveUpdateError,
 };
 use bangbang_runtime::boot::BootSourceFiles;
 use bangbang_runtime::boot_timer::{
@@ -38,12 +39,16 @@ use bangbang_runtime::entropy::{
     VirtioRngEntropySourceError, VirtioRngMmioCaptureState, VirtioRngOsEntropySource,
     VirtioRngPciCaptureError, VirtioRngPciCaptureState, VirtioRngRetryCaptureState,
 };
-use bangbang_runtime::fdt::{Arm64FdtCacheHierarchy, Arm64FdtError};
+use bangbang_runtime::fdt::{
+    Arm64FdtCacheHierarchy, Arm64FdtError, Arm64FdtGuestMemoryWrite, Arm64FdtRegion,
+    Arm64FdtVirtioMmioDevice,
+};
 use bangbang_runtime::interrupt::{
     DeviceInterruptKind, DeviceInterruptTriggerError, GuestInterruptLine, InterruptSink,
 };
 use bangbang_runtime::memory::{
-    GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryBacking, GuestMemoryRange,
+    GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryBacking, GuestMemoryLayout,
+    GuestMemoryRange,
 };
 use bangbang_runtime::memory_hotplug::{
     MemoryHotplugConfig, MemoryHotplugSizeUpdate, MemoryHotplugStatus, MemoryHotplugStatusError,
@@ -53,12 +58,15 @@ use bangbang_runtime::memory_hotplug::{
 };
 use bangbang_runtime::message_interrupt::GuestMessageInterruptResources;
 use bangbang_runtime::metrics::{
-    BlockDeviceMetricsLease, NetworkInterfaceMetricsLease, PmemDeviceMetricsLease,
-    SharedBalloonDeviceMetrics, SharedBlockDeviceMetricsRegistry, SharedEntropyDeviceMetrics,
-    SharedMemoryHotplugDeviceMetrics, SharedNetworkInterfaceMetricsRegistry,
-    SharedPmemDeviceMetricsRegistry, SharedRtcDeviceMetrics, SharedVsockDeviceMetrics,
+    BlockDeviceMetricsLease, BlockDeviceMetricsRegistryError, NetworkInterfaceMetricsLease,
+    PmemDeviceMetricsLease, SharedBalloonDeviceMetrics, SharedBlockDeviceMetricsRegistry,
+    SharedEntropyDeviceMetrics, SharedMemoryHotplugDeviceMetrics,
+    SharedNetworkInterfaceMetricsRegistry, SharedPmemDeviceMetricsRegistry, SharedRtcDeviceMetrics,
+    SharedVsockDeviceMetrics,
 };
-use bangbang_runtime::mmio::{MmioDispatcher, MmioHandlerError, MmioRegion, MmioRegionId};
+use bangbang_runtime::mmio::{
+    MmioBusError, MmioDispatchError, MmioDispatcher, MmioHandlerError, MmioRegion, MmioRegionId,
+};
 use bangbang_runtime::network::{
     NetworkDeviceProfile, NetworkInterfaceConfig, NetworkInterfaceUpdate,
     NetworkInterfaceUpdateError, NetworkMmioLayout, NetworkRuntimeMutationError,
@@ -88,19 +96,23 @@ use bangbang_runtime::serial::{
 use bangbang_runtime::snapshot_device::{
     SnapshotV1BlockRetryState, SnapshotV1DeviceState, SnapshotV1PlatformDeviceMetadata,
 };
-use bangbang_runtime::snapshot_device_v2::NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION;
+use bangbang_runtime::snapshot_device_v2::{
+    NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, PreparedSnapshotV2PciRoot,
+    PreparedSnapshotV2RootBlock, PreparedSnapshotV2RootTransport,
+    SnapshotV2RootTransportRestoreError,
+};
 use bangbang_runtime::snapshot_format::SnapshotFormatVersion;
 use bangbang_runtime::snapshot_format_v2::NATIVE_V2_SNAPSHOT_VERSION;
 use bangbang_runtime::snapshot_memory_v2::{
-    SnapshotV2MemoryIoStage, SnapshotV2MemoryWriteError,
+    SnapshotV2MemoryBinding, SnapshotV2MemoryIoStage, SnapshotV2MemoryWriteError,
     write_snapshot_v2_memory_image_with_compatibility_version_and_cancel,
 };
 use bangbang_runtime::startup::{
     ARM64_BOOT_VMGENID_SIZE, Arm64BootBalloonNotificationDispatch,
     Arm64BootBalloonNotificationDispatchError, Arm64BootBalloonNotificationDispatches,
-    Arm64BootBlockNotificationDispatch, Arm64BootBlockNotificationDispatchError,
-    Arm64BootBlockNotificationDispatches, Arm64BootBlockWakeupFdsError,
-    Arm64BootEntropyCaptureError,
+    Arm64BootBlockDevice, Arm64BootBlockNotificationDispatch,
+    Arm64BootBlockNotificationDispatchError, Arm64BootBlockNotificationDispatches,
+    Arm64BootBlockWakeupFdsError, Arm64BootEntropyCaptureError,
     Arm64BootEntropyDeviceConfig as RuntimeArm64BootEntropyDeviceConfig,
     Arm64BootEntropyNotificationDispatch, Arm64BootEntropyNotificationDispatchError,
     Arm64BootEntropyNotificationDispatches, Arm64BootEntropySourceProvider,
@@ -112,8 +124,8 @@ use bangbang_runtime::startup::{
     Arm64BootNetworkNotificationDispatches, Arm64BootNetworkPacketIoProvider,
     Arm64BootPciValidationConfig, Arm64BootPciValidationResources, Arm64BootPmemFlushProvider,
     Arm64BootPmemNotificationDispatch, Arm64BootPmemNotificationDispatchError,
-    Arm64BootPmemNotificationDispatches, Arm64BootResourceConfig, Arm64BootResourceError,
-    Arm64BootResourceParts, Arm64BootResources,
+    Arm64BootPmemNotificationDispatches, Arm64BootPvTimeState, Arm64BootResourceConfig,
+    Arm64BootResourceError, Arm64BootResourceParts, Arm64BootResources,
     Arm64BootRtcDeviceConfig as RuntimeArm64BootRtcDeviceConfig, Arm64BootRuntimeResources,
     Arm64BootSerialCaptureError, Arm64BootSerialDeviceConfig as RuntimeArm64BootSerialDeviceConfig,
     Arm64BootSerialRuntimeError, Arm64BootVmClockDevice, Arm64BootVmGenIdDevice,
@@ -127,8 +139,8 @@ use bangbang_runtime::startup::{
     capture_memory_hotplug_state_for_device, capture_network_state_for_device_at,
     capture_ready_serial_state_for_device, capture_vsock_state_for_device,
     inject_serial_receive_bytes_for_device, memory_hotplug_status_for_device,
-    pending_serial_interrupt_intent_for_device, prepare_vsock_transport_reset_for_device,
-    record_serial_host_input_error_for_device,
+    pending_serial_interrupt_intent_for_device, prepare_restored_pci_validation,
+    prepare_vsock_transport_reset_for_device, record_serial_host_input_error_for_device,
     refresh_vhost_user_block_config_for_devices_with_signal, replace_arm64_boot_vmgenid,
     serial_receive_capacity_for_device, take_serial_input_ready_intent_for_device,
     take_serial_interrupt_intent_for_device, update_live_block_device_for_devices_with_opened,
@@ -200,6 +212,12 @@ use crate::snapshot_v2::{
     HvfSnapshotV2BootState, HvfSnapshotV2BuildError, HvfSnapshotV2FdtState,
     HvfSnapshotV2GlobalState, HvfSnapshotV2MachineState, HvfSnapshotV2PlatformState,
     HvfSnapshotV2PvTimeVcpuState, HvfSnapshotV2TimeState, HvfSnapshotV2VcpuState,
+};
+use crate::snapshot_v2_platform::{
+    HvfSnapshotV2DefaultProcessShell, HvfSnapshotV2PlatformRestoreError,
+    HvfSnapshotV2PlatformShutdownError, HvfSnapshotV2RootResourcePlan,
+    HvfSnapshotV2RootTransportPlan, RestoredHvfSnapshotV2Platform,
+    restore_hvf_snapshot_v2_root_process_platform,
 };
 use crate::topology::{HvfVcpuTopologyError, prepare_ordered_mpidrs};
 use crate::vcpu::{
@@ -3235,6 +3253,8 @@ pub struct OwnedHvfArm64BootSession {
     backend: HvfBackend,
     mmio_dispatcher: Arc<Mutex<MmioDispatcher>>,
     runtime_resources: Arm64BootRuntimeResources,
+    restored_snapshot_v2_memory_binding: Option<SnapshotV2MemoryBinding>,
+    restored_snapshot_v2_machine: Option<HvfSnapshotV2MachineState>,
     cpu_template_application: Option<crate::cpu_template::HvfArm64CpuTemplateApplicationState>,
     pci_validation_endpoint: Option<HvfArm64BootPciValidationEndpoint>,
     pci_data_devices: Option<HvfArm64BootPciDataDevices>,
@@ -3340,6 +3360,260 @@ impl fmt::Debug for RestoredHvfArm64BootSession {
             .field("profile", &"native-v1")
             .field("resources", &"<redacted>")
             .finish()
+    }
+}
+
+/// Stage at which complete native-v2 root-owner reconstruction stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfSnapshotV2RootRestoreStage {
+    Transport,
+    Platform,
+    MemoryLayout,
+    Metrics,
+    MmioRegion,
+    MmioHandler,
+    PciHost,
+    PciRoutes,
+    PciEndpoint,
+    RetryScheduler,
+}
+
+/// Primary failure from complete native-v2 root-owner reconstruction.
+pub enum HvfSnapshotV2RootRestoreFailure {
+    Transport(SnapshotV2RootTransportRestoreError),
+    Platform(Box<HvfSnapshotV2PlatformRestoreError>),
+    Allocation,
+    MemoryLayout,
+    Metrics(BlockDeviceMetricsRegistryError),
+    DispatcherUnavailable,
+    MmioRegion(MmioBusError),
+    MmioHandler(MmioDispatchError),
+    PciHost(Arm64BootResourceError),
+    PciData(HvfArm64BootPciDataError),
+    PciEndpoint(SnapshotV2RootTransportRestoreError),
+    PciPublication(VirtioPciPublicationError),
+    RetryScheduler(io::ErrorKind),
+    ResourcePlan,
+}
+
+impl fmt::Debug for HvfSnapshotV2RootRestoreFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::Transport(_) => "transport",
+            Self::Platform(_) => "platform",
+            Self::Allocation => "allocation",
+            Self::MemoryLayout => "memory-layout",
+            Self::Metrics(_) => "metrics",
+            Self::DispatcherUnavailable => "dispatcher",
+            Self::MmioRegion(_) => "mmio-region",
+            Self::MmioHandler(_) => "mmio-handler",
+            Self::PciHost(_) => "pci-host",
+            Self::PciData(_) => "pci-data",
+            Self::PciEndpoint(_) => "pci-endpoint",
+            Self::PciPublication(_) => "pci-publication",
+            Self::RetryScheduler(_) => "retry-scheduler",
+            Self::ResourcePlan => "resource-plan",
+        };
+        formatter
+            .debug_struct("HvfSnapshotV2RootRestoreFailure")
+            .field("kind", &kind)
+            .field("source", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2RootRestoreFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Transport(_) => formatter.write_str("root transport reconstruction failed"),
+            Self::Platform(_) => formatter.write_str("HVF platform reconstruction failed"),
+            Self::Allocation => formatter.write_str("root owner allocation failed"),
+            Self::MemoryLayout => formatter.write_str("restored memory layout is invalid"),
+            Self::Metrics(_) => formatter.write_str("root metrics ownership failed"),
+            Self::DispatcherUnavailable => {
+                formatter.write_str("root MMIO dispatcher is unavailable")
+            }
+            Self::MmioRegion(_) => formatter.write_str("root MMIO region publication failed"),
+            Self::MmioHandler(_) => formatter.write_str("root MMIO handler publication failed"),
+            Self::PciHost(_) => formatter.write_str("PCI host reconstruction failed"),
+            Self::PciData(_) => formatter.write_str("PCI owner reconstruction failed"),
+            Self::PciEndpoint(_) => formatter.write_str("PCI endpoint reconstruction failed"),
+            Self::PciPublication(_) => formatter.write_str("PCI endpoint publication failed"),
+            Self::RetryScheduler(kind) => {
+                write!(formatter, "block retry scheduler startup failed: {kind:?}")
+            }
+            Self::ResourcePlan => formatter.write_str("retained root resource plan diverged"),
+        }
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2RootRestoreFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Transport(source) => Some(source),
+            Self::Platform(source) => Some(source.as_ref()),
+            Self::Metrics(source) => Some(source),
+            Self::MmioRegion(source) => Some(source),
+            Self::MmioHandler(source) => Some(source),
+            Self::PciHost(source) => Some(source),
+            Self::PciData(source) => Some(source),
+            Self::PciEndpoint(source) => Some(source),
+            Self::PciPublication(source) => Some(source),
+            Self::Allocation
+            | Self::MemoryLayout
+            | Self::DispatcherUnavailable
+            | Self::RetryScheduler(_)
+            | Self::ResourcePlan => None,
+        }
+    }
+}
+
+/// Cleanup failure retained after a root-owner reconstruction error.
+pub enum HvfSnapshotV2RootRestoreCleanupFailure {
+    Pci(HvfArm64BootPciDataError),
+    Platform(HvfSnapshotV2PlatformShutdownError),
+}
+
+impl fmt::Debug for HvfSnapshotV2RootRestoreCleanupFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::Pci(_) => "pci",
+            Self::Platform(_) => "platform",
+        };
+        formatter
+            .debug_struct("HvfSnapshotV2RootRestoreCleanupFailure")
+            .field("kind", &kind)
+            .field("source", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2RootRestoreCleanupFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Pci(_) => formatter.write_str("PCI root cleanup failed"),
+            Self::Platform(_) => formatter.write_str("HVF platform cleanup failed"),
+        }
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2RootRestoreCleanupFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Pci(source) => Some(source),
+            Self::Platform(source) => Some(source),
+        }
+    }
+}
+
+/// Redacted complete-owner failure with publication and cleanup disposition.
+pub struct HvfSnapshotV2RootRestoreError {
+    stage: HvfSnapshotV2RootRestoreStage,
+    failure: Box<HvfSnapshotV2RootRestoreFailure>,
+    committed: bool,
+    cleanup: Vec<HvfSnapshotV2RootRestoreCleanupFailure>,
+}
+
+impl fmt::Debug for HvfSnapshotV2RootRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2RootRestoreError")
+            .field("stage", &self.stage)
+            .field("committed", &self.committed)
+            .field("failure", &"<redacted>")
+            .field("cleanup_count", &self.cleanup.len())
+            .finish()
+    }
+}
+
+impl HvfSnapshotV2RootRestoreError {
+    fn preflight(
+        stage: HvfSnapshotV2RootRestoreStage,
+        failure: HvfSnapshotV2RootRestoreFailure,
+    ) -> Self {
+        Self {
+            stage,
+            failure: Box::new(failure),
+            committed: false,
+            cleanup: Vec::new(),
+        }
+    }
+
+    pub(crate) fn platform(source: HvfSnapshotV2PlatformRestoreError) -> Self {
+        let committed = source.is_committed();
+        Self {
+            stage: HvfSnapshotV2RootRestoreStage::Platform,
+            failure: Box::new(HvfSnapshotV2RootRestoreFailure::Platform(Box::new(source))),
+            committed,
+            cleanup: Vec::new(),
+        }
+    }
+
+    fn after_platform(
+        stage: HvfSnapshotV2RootRestoreStage,
+        failure: HvfSnapshotV2RootRestoreFailure,
+        cleanup: Vec<HvfSnapshotV2RootRestoreCleanupFailure>,
+    ) -> Self {
+        Self {
+            stage,
+            failure: Box::new(failure),
+            committed: true,
+            cleanup,
+        }
+    }
+
+    pub const fn stage(&self) -> HvfSnapshotV2RootRestoreStage {
+        self.stage
+    }
+
+    /// Returns whether platform identity publication makes retry ambiguous.
+    pub const fn is_committed(&self) -> bool {
+        self.committed
+    }
+
+    /// Returns ordered cleanup failures, if cleanup was incomplete.
+    pub fn cleanup_failures(&self) -> &[HvfSnapshotV2RootRestoreCleanupFailure] {
+        &self.cleanup
+    }
+
+    /// Returns whether this transaction or its nested platform transaction
+    /// retained evidence that reverse cleanup did not complete.
+    pub fn has_incomplete_cleanup(&self) -> bool {
+        !self.cleanup.is_empty()
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2RootRestoreFailure::Platform(source)
+                    if !source.cleanup_failures().is_empty()
+            )
+    }
+
+    /// Returns whether retrying this destination would be ambiguous or unsafe.
+    pub fn is_terminal(&self) -> bool {
+        self.is_committed() || self.has_incomplete_cleanup()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2RootRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "native-v2 root owner reconstruction failed at {:?}: {}",
+            self.stage, self.failure
+        )?;
+        if !self.cleanup.is_empty() {
+            write!(
+                formatter,
+                "; {} cleanup failure(s) retained",
+                self.cleanup.len()
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2RootRestoreError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.failure.as_ref())
     }
 }
 
@@ -7312,10 +7586,12 @@ impl HvfArm64BootSnapshotV2CaptureOwner<'_, '_> {
             .map_err(|source| HvfArm64BootSnapshotV2CaptureError::GuestMemory { source })?;
         let boot = input.into_boot();
 
-        let boot_origin = self
+        let fdt_write = self
             .runtime_resources
             .boot_origin
             .as_ref()
+            .map(|origin| origin.fdt)
+            .or(self.runtime_resources.retained_fdt)
             .ok_or(HvfArm64BootSnapshotV2CaptureError::MissingBootOrigin)?;
         let rtc = self
             .runtime_resources
@@ -7324,21 +7600,18 @@ impl HvfArm64BootSnapshotV2CaptureOwner<'_, '_> {
             .ok_or(HvfArm64BootSnapshotV2CaptureError::MissingRtc)?;
         let mut fdt_bytes = Vec::new();
         fdt_bytes
-            .try_reserve_exact(boot_origin.fdt.size)
+            .try_reserve_exact(fdt_write.size)
             .map_err(|_| HvfArm64BootSnapshotV2CaptureError::FdtAllocation)?;
-        fdt_bytes.resize(boot_origin.fdt.size, 0);
+        fdt_bytes.resize(fdt_write.size, 0);
         memory
-            .read_slice(&mut fdt_bytes, boot_origin.fdt.address)
+            .read_slice(&mut fdt_bytes, fdt_write.address)
             .map_err(|source| HvfArm64BootSnapshotV2CaptureError::FdtRead { source })?;
-        let fdt = HvfSnapshotV2FdtState::try_new(
-            boot_origin.fdt.address,
-            boot_origin.fdt.size,
-            crc64(0, &fdt_bytes),
-        )
-        .map_err(|source| HvfArm64BootSnapshotV2CaptureError::Build {
-            stage: HvfArm64BootSnapshotV2CaptureStage::Machine,
-            source,
-        })?;
+        let fdt =
+            HvfSnapshotV2FdtState::try_new(fdt_write.address, fdt_write.size, crc64(0, &fdt_bytes))
+                .map_err(|source| HvfArm64BootSnapshotV2CaptureError::Build {
+                    stage: HvfArm64BootSnapshotV2CaptureStage::Machine,
+                    source,
+                })?;
 
         let primary = captures
             .first()
@@ -10114,6 +10387,265 @@ impl Drop for HvfArm64BootSession<'_> {
     }
 }
 
+fn validate_snapshot_v2_root_resource_plan(
+    transport: &PreparedSnapshotV2RootTransport,
+    resources: HvfSnapshotV2RootResourcePlan,
+) -> Result<(), HvfSnapshotV2RootRestoreError> {
+    let matches = match (transport, resources.transport()) {
+        (
+            PreparedSnapshotV2RootTransport::Mmio(root),
+            HvfSnapshotV2RootTransportPlan::Mmio {
+                region,
+                interrupt_line,
+            },
+        ) => root.region() == region && root.interrupt_line() == interrupt_line,
+        (
+            PreparedSnapshotV2RootTransport::Pci(root),
+            HvfSnapshotV2RootTransportPlan::Pci {
+                sbdf, bar_range, ..
+            },
+        ) => root.sbdf() == sbdf && root.bar_range() == bar_range,
+        _ => false,
+    };
+    if matches {
+        Ok(())
+    } else {
+        Err(HvfSnapshotV2RootRestoreError::preflight(
+            HvfSnapshotV2RootRestoreStage::Transport,
+            HvfSnapshotV2RootRestoreFailure::ResourcePlan,
+        ))
+    }
+}
+
+fn snapshot_v2_root_identity(
+    transport: &PreparedSnapshotV2RootTransport,
+) -> (&str, StorageRetryState) {
+    match transport {
+        PreparedSnapshotV2RootTransport::Mmio(root) => (root.drive_id(), root.retry()),
+        PreparedSnapshotV2RootTransport::Pci(root) => (root.drive_id(), root.retry()),
+    }
+}
+
+fn snapshot_v2_root_retry_deadline(retry: StorageRetryState) -> Option<Instant> {
+    match retry {
+        StorageRetryState::None => None,
+        StorageRetryState::Immediate => Some(Instant::now()),
+        StorageRetryState::After { remaining_nanos } => {
+            let now = Instant::now();
+            Some(
+                now.checked_add(Duration::from_nanos(remaining_nanos))
+                    .unwrap_or(now),
+            )
+        }
+    }
+}
+
+fn install_snapshot_v2_mmio_root(
+    platform: &RestoredHvfSnapshotV2Platform,
+    root: bangbang_runtime::snapshot_device_v2::PreparedSnapshotV2MmioRoot,
+) -> Result<Arm64BootBlockDevice, HvfSnapshotV2RootRestoreFailure> {
+    let (drive_id, _partuuid, _retry, region, interrupt_line, handler) = root.into_parts();
+    let mut dispatcher = platform
+        .mmio_dispatcher()
+        .lock()
+        .map_err(|_| HvfSnapshotV2RootRestoreFailure::DispatcherUnavailable)?;
+    let installed = dispatcher
+        .insert_region(region.id(), region.range().start(), region.range().size())
+        .map_err(HvfSnapshotV2RootRestoreFailure::MmioRegion)?;
+    dispatcher
+        .register_handler(installed.id(), handler)
+        .map_err(HvfSnapshotV2RootRestoreFailure::MmioHandler)?;
+    Ok(Arm64BootBlockDevice {
+        registration: BlockMmioDeviceRegistration::from_restored(0, drive_id, installed),
+        fdt_device: Arm64FdtVirtioMmioDevice {
+            region: Arm64FdtRegion {
+                base: installed.range().start().raw_value(),
+                size: installed.range().size(),
+            },
+            interrupt_line,
+        },
+    })
+}
+
+fn prepare_snapshot_v2_pci_root_owner(
+    platform: &RestoredHvfSnapshotV2Platform,
+    root: PreparedSnapshotV2PciRoot,
+    resources: HvfSnapshotV2RootResourcePlan,
+    layout: &GuestMemoryLayout,
+    block_device_metrics: &SharedBlockDeviceMetricsRegistry,
+    retry_deadline: Option<Instant>,
+    pci_data_devices: &mut Option<HvfArm64BootPciDataDevices>,
+) -> Result<(), HvfSnapshotV2RootRestoreFailure> {
+    let HvfSnapshotV2RootTransportPlan::Pci {
+        bar_region_id, msi, ..
+    } = resources.transport()
+    else {
+        return Err(HvfSnapshotV2RootRestoreFailure::ResourcePlan);
+    };
+
+    let validation = {
+        let mut dispatcher = platform
+            .mmio_dispatcher()
+            .lock()
+            .map_err(|_| HvfSnapshotV2RootRestoreFailure::DispatcherUnavailable)?;
+        prepare_restored_pci_validation(&mut dispatcher)
+            .map_err(HvfSnapshotV2RootRestoreFailure::PciHost)?
+    };
+    let available_slots = validation
+        .segment()
+        .with_segment(|segment| segment.available_endpoint_slots())
+        .map_err(|source| {
+            HvfSnapshotV2RootRestoreFailure::PciData(HvfArm64BootPciDataError::new(format!(
+                "failed to inspect restored PCI endpoint capacity: {source}"
+            )))
+        })?;
+    if available_slots < PCI_ENDPOINT_SLOT_COUNT {
+        return Err(HvfSnapshotV2RootRestoreFailure::PciData(
+            HvfArm64BootPciDataError::new(
+                "restored PCI segment cannot retain complete endpoint headroom",
+            ),
+        ));
+    }
+    if pci_data_available_bar_count(validation.bar_allocator())
+        .map_err(HvfSnapshotV2RootRestoreFailure::PciData)?
+        < PCI_ENDPOINT_SLOT_COUNT
+    {
+        return Err(HvfSnapshotV2RootRestoreFailure::PciData(
+            HvfArm64BootPciDataError::new(
+                "restored PCI BAR allocator cannot retain complete endpoint headroom",
+            ),
+        ));
+    }
+    let bar_plan = pci_data_bar_plan(validation.bar_allocator(), PCI_ENDPOINT_SLOT_COUNT)
+        .map_err(HvfSnapshotV2RootRestoreFailure::PciData)?;
+    {
+        let dispatcher = platform
+            .mmio_dispatcher()
+            .lock()
+            .map_err(|_| HvfSnapshotV2RootRestoreFailure::DispatcherUnavailable)?;
+        preflight_pci_data_dispatcher(&dispatcher, &bar_plan)
+            .map_err(HvfSnapshotV2RootRestoreFailure::PciData)?;
+    }
+
+    let mut pmem_static_reserved_ranges = Vec::new();
+    pmem_static_reserved_ranges
+        .try_reserve_exact(layout.ranges().len())
+        .map_err(|_| HvfSnapshotV2RootRestoreFailure::Allocation)?;
+    pmem_static_reserved_ranges.extend(layout.ranges().iter().copied());
+    let mut block = Vec::new();
+    block
+        .try_reserve_exact(PCI_ENDPOINT_SLOT_COUNT)
+        .map_err(|_| HvfSnapshotV2RootRestoreFailure::Allocation)?;
+    let mut network = Vec::new();
+    network
+        .try_reserve_exact(PCI_ENDPOINT_SLOT_COUNT)
+        .map_err(|_| HvfSnapshotV2RootRestoreFailure::Allocation)?;
+    let mut pmem = Vec::new();
+    pmem.try_reserve_exact(PCI_ENDPOINT_SLOT_COUNT)
+        .map_err(|_| HvfSnapshotV2RootRestoreFailure::Allocation)?;
+
+    let route_count = usize::try_from(msi.interrupt_range.count)
+        .map_err(|_| HvfSnapshotV2RootRestoreFailure::Allocation)?;
+    let mut exact_intids = Vec::new();
+    exact_intids
+        .try_reserve_exact(route_count)
+        .map_err(|_| HvfSnapshotV2RootRestoreFailure::Allocation)?;
+    for offset in 0..msi.interrupt_range.count {
+        exact_intids.push(
+            msi.interrupt_range
+                .base
+                .checked_add(offset)
+                .ok_or(HvfSnapshotV2RootRestoreFailure::ResourcePlan)?,
+        );
+    }
+    let signaler = platform.backend().gic_msi_signaler().ok_or_else(|| {
+        HvfSnapshotV2RootRestoreFailure::PciData(HvfArm64BootPciDataError::new(
+            "restored PCI root requires a GICv2m MSI signaler",
+        ))
+    })?;
+    let msi_interrupts = HvfGicMsiDeviceInterruptResources::allocate_exact(signaler, &exact_intids)
+        .map_err(|source| {
+            HvfSnapshotV2RootRestoreFailure::PciData(HvfArm64BootPciDataError::new(format!(
+                "failed to allocate exact restored PCI routes: {source}"
+            )))
+        })?;
+
+    *pci_data_devices = Some(HvfArm64BootPciDataDevices {
+        validation,
+        dispatcher: Arc::clone(platform.mmio_dispatcher()),
+        msi_interrupts: Some(msi_interrupts),
+        balloon: None,
+        block,
+        network,
+        pmem,
+        vsock: None,
+        entropy: None,
+        memory_hotplug: None,
+        pmem_static_reserved_ranges,
+        runtime_hotplug: true,
+    });
+    let Some(manager) = pci_data_devices.as_mut() else {
+        return Err(HvfSnapshotV2RootRestoreFailure::ResourcePlan);
+    };
+
+    let interrupts = manager
+        .shared_msi_registry()
+        .map_err(HvfSnapshotV2RootRestoreFailure::PciData)?;
+    let endpoint = root
+        .prepare_endpoint(bar_region_id, interrupts.registry())
+        .map_err(HvfSnapshotV2RootRestoreFailure::PciEndpoint)?;
+    let (drive_id, _partuuid, _retry, origin, endpoint) = endpoint.into_parts();
+    let metrics_lease = block_device_metrics
+        .claim_drive_lease(&drive_id)
+        .map_err(HvfSnapshotV2RootRestoreFailure::Metrics)?;
+    let segment = manager.validation.segment().clone();
+    let published = {
+        let mut dispatcher = manager
+            .dispatcher
+            .lock()
+            .map_err(|_| HvfSnapshotV2RootRestoreFailure::DispatcherUnavailable)?;
+        endpoint
+            .publish(
+                manager.validation.bar_allocator_mut(),
+                segment,
+                &mut dispatcher,
+                interrupts,
+            )
+            .map_err(HvfSnapshotV2RootRestoreFailure::PciPublication)?
+    };
+    manager.block.push(HvfArm64BootPciBlockDevice {
+        drive_id,
+        is_root_device: true,
+        origin,
+        published,
+        queue_deliveries: 0,
+        retry_deadline,
+        _metrics_lease: Some(metrics_lease),
+    });
+    Ok(())
+}
+
+fn failed_snapshot_v2_root_after_platform(
+    mut platform: RestoredHvfSnapshotV2Platform,
+    stage: HvfSnapshotV2RootRestoreStage,
+    failure: HvfSnapshotV2RootRestoreFailure,
+    pci_data_devices: &mut Option<HvfArm64BootPciDataDevices>,
+) -> HvfSnapshotV2RootRestoreError {
+    let mut cleanup = Vec::with_capacity(2);
+    if let Some(devices) = pci_data_devices.as_mut() {
+        match devices.teardown() {
+            Ok(()) => {
+                pci_data_devices.take();
+            }
+            Err(source) => cleanup.push(HvfSnapshotV2RootRestoreCleanupFailure::Pci(source)),
+        }
+    }
+    if let Err(source) = platform.shutdown() {
+        cleanup.push(HvfSnapshotV2RootRestoreCleanupFailure::Platform(source));
+    }
+    HvfSnapshotV2RootRestoreError::after_platform(stage, failure, cleanup)
+}
+
 fn failed_snapshot_v1_restore(
     stage: HvfSnapshotV1RestoreStage,
     failure: HvfSnapshotV1RestoreFailure,
@@ -10203,6 +10735,8 @@ impl OwnedHvfArm64BootSession {
             backend,
             mmio_dispatcher: prepared.mmio_dispatcher,
             runtime_resources: prepared.runtime_resources,
+            restored_snapshot_v2_memory_binding: None,
+            restored_snapshot_v2_machine: None,
             cpu_template_application: prepared.cpu_template_application,
             pci_validation_endpoint: prepared.pci_validation_endpoint,
             pci_data_devices: prepared.pci_data_devices,
@@ -10250,6 +10784,261 @@ impl OwnedHvfArm64BootSession {
     /// Restores cancellation semantics when paused-worker publication fails.
     pub fn abort_snapshot_v1_page_source_commit(&mut self) {
         self.backend.cancel_lazy_page_source_on_drop();
+    }
+
+    /// Reconstructs one exact native-v2 root-bearing destination and transfers
+    /// it directly from the unpublished platform transaction into the complete
+    /// product boot-session owner.
+    #[doc(hidden)]
+    pub fn restore_snapshot_v2_root(
+        state: HvfSnapshotV2PlatformState,
+        memory: GuestMemory,
+        process_shell: HvfSnapshotV2DefaultProcessShell,
+        root: PreparedSnapshotV2RootBlock,
+        resources: HvfSnapshotV2RootResourcePlan,
+    ) -> Result<Self, HvfSnapshotV2RootRestoreError> {
+        let mut ranges = Vec::new();
+        ranges
+            .try_reserve_exact(memory.regions().len())
+            .map_err(|_| {
+                HvfSnapshotV2RootRestoreError::preflight(
+                    HvfSnapshotV2RootRestoreStage::MemoryLayout,
+                    HvfSnapshotV2RootRestoreFailure::Allocation,
+                )
+            })?;
+        ranges.extend(memory.regions().iter().map(|region| region.range()));
+        let layout = GuestMemoryLayout::new(ranges).map_err(|_| {
+            HvfSnapshotV2RootRestoreError::preflight(
+                HvfSnapshotV2RootRestoreStage::MemoryLayout,
+                HvfSnapshotV2RootRestoreFailure::MemoryLayout,
+            )
+        })?;
+        let source_fdt = state.machine().fdt();
+        let retained_fdt = Arm64FdtGuestMemoryWrite {
+            address: source_fdt.address(),
+            size: usize::try_from(source_fdt.size()).map_err(|_| {
+                HvfSnapshotV2RootRestoreError::preflight(
+                    HvfSnapshotV2RootRestoreStage::MemoryLayout,
+                    HvfSnapshotV2RootRestoreFailure::Allocation,
+                )
+            })?,
+        };
+        let transport = root.prepare_transport().map_err(|source| {
+            HvfSnapshotV2RootRestoreError::preflight(
+                HvfSnapshotV2RootRestoreStage::Transport,
+                HvfSnapshotV2RootRestoreFailure::Transport(source),
+            )
+        })?;
+        validate_snapshot_v2_root_resource_plan(&transport, resources)?;
+        let (drive_id, retry) = snapshot_v2_root_identity(&transport);
+        let partuuid = match &transport {
+            PreparedSnapshotV2RootTransport::Mmio(root) => root.partuuid(),
+            PreparedSnapshotV2RootTransport::Pci(root) => root.partuuid(),
+        }
+        .map(str::to_owned);
+        let metrics_capacity = match &transport {
+            PreparedSnapshotV2RootTransport::Mmio(_) => 1,
+            PreparedSnapshotV2RootTransport::Pci(_) => PCI_ENDPOINT_SLOT_COUNT,
+        };
+        let block_device_metrics = SharedBlockDeviceMetricsRegistry::from_drive_ids_with_capacity(
+            [drive_id],
+            metrics_capacity,
+        )
+        .map_err(|source| {
+            HvfSnapshotV2RootRestoreError::preflight(
+                HvfSnapshotV2RootRestoreStage::Metrics,
+                HvfSnapshotV2RootRestoreFailure::Metrics(source),
+            )
+        })?;
+        let mut block_devices = Vec::new();
+        let mut block_interrupt_lines = Vec::new();
+        if matches!(&transport, PreparedSnapshotV2RootTransport::Mmio(_)) {
+            block_devices.try_reserve_exact(1).map_err(|_| {
+                HvfSnapshotV2RootRestoreError::preflight(
+                    HvfSnapshotV2RootRestoreStage::Transport,
+                    HvfSnapshotV2RootRestoreFailure::Allocation,
+                )
+            })?;
+            block_interrupt_lines.try_reserve_exact(1).map_err(|_| {
+                HvfSnapshotV2RootRestoreError::preflight(
+                    HvfSnapshotV2RootRestoreStage::Transport,
+                    HvfSnapshotV2RootRestoreFailure::Allocation,
+                )
+            })?;
+        }
+
+        let platform = restore_hvf_snapshot_v2_root_process_platform(
+            state,
+            memory,
+            process_shell,
+            resources,
+            partuuid,
+        )
+        .map_err(HvfSnapshotV2RootRestoreError::platform)?;
+        let retry_deadline = snapshot_v2_root_retry_deadline(retry);
+        let mut pci_data_devices = None;
+        match transport {
+            PreparedSnapshotV2RootTransport::Mmio(root) => {
+                let interrupt_line = root.interrupt_line();
+                let device = match install_snapshot_v2_mmio_root(&platform, root) {
+                    Ok(device) => device,
+                    Err(failure) => {
+                        let stage = match &failure {
+                            HvfSnapshotV2RootRestoreFailure::MmioRegion(_) => {
+                                HvfSnapshotV2RootRestoreStage::MmioRegion
+                            }
+                            _ => HvfSnapshotV2RootRestoreStage::MmioHandler,
+                        };
+                        return Err(failed_snapshot_v2_root_after_platform(
+                            platform,
+                            stage,
+                            failure,
+                            &mut pci_data_devices,
+                        ));
+                    }
+                };
+                block_devices.push(device);
+                block_interrupt_lines.push(interrupt_line);
+            }
+            PreparedSnapshotV2RootTransport::Pci(root) => {
+                if let Err(failure) = prepare_snapshot_v2_pci_root_owner(
+                    &platform,
+                    root,
+                    resources,
+                    &layout,
+                    &block_device_metrics,
+                    retry_deadline,
+                    &mut pci_data_devices,
+                ) {
+                    let stage = match &failure {
+                        HvfSnapshotV2RootRestoreFailure::PciHost(_) => {
+                            HvfSnapshotV2RootRestoreStage::PciHost
+                        }
+                        HvfSnapshotV2RootRestoreFailure::PciEndpoint(_)
+                        | HvfSnapshotV2RootRestoreFailure::PciPublication(_) => {
+                            HvfSnapshotV2RootRestoreStage::PciEndpoint
+                        }
+                        _ => HvfSnapshotV2RootRestoreStage::PciRoutes,
+                    };
+                    return Err(failed_snapshot_v2_root_after_platform(
+                        platform,
+                        stage,
+                        failure,
+                        &mut pci_data_devices,
+                    ));
+                }
+            }
+        }
+
+        let block_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        let vcpu_control = platform.control();
+        let block_retry_wakeup_scheduler =
+            match HvfArm64BootLimiterRetryWakeupScheduler::start_with_cancellation(
+                BLOCK_RETRY_WAKEUP_SCHEDULER_THREAD_NAME,
+                block_retry_wakeup.clone(),
+                move || vcpu_control.request_wakeup(),
+            ) {
+                Ok(scheduler) => scheduler,
+                Err(source) => {
+                    return Err(failed_snapshot_v2_root_after_platform(
+                        platform,
+                        HvfSnapshotV2RootRestoreStage::RetryScheduler,
+                        HvfSnapshotV2RootRestoreFailure::RetryScheduler(source.kind()),
+                        &mut pci_data_devices,
+                    ));
+                }
+            };
+        block_retry_wakeup_scheduler.schedule_deadline(retry_deadline);
+
+        let parts = platform.into_parts();
+        let machine_config = parts.machine.machine();
+        let cpu_template_application = parts.machine.cpu_template().cloned();
+        let cache_source = crate::vcpu_config::HvfArm64VcpuCacheFdtSource::new(
+            parts.compatibility.identification().id_aa64mmfr2_el1(),
+            parts.compatibility.cache_manifest(),
+        );
+        let gic = parts.compatibility.gic_metadata();
+        let serial_interrupt_line = parts
+            .serial_device
+            .as_ref()
+            .map(|device| device.fdt_device.interrupt_line);
+        let vmgenid_interrupt_line = parts.vmgenid_device.fdt_device.interrupt_line;
+        let vmclock_interrupt_line = parts.vmclock_device.fdt_device.interrupt_line;
+        let runtime_resources = Arm64BootRuntimeResources {
+            machine_config,
+            layout,
+            boot_origin: None,
+            retained_fdt: Some(retained_fdt),
+            rtc_device: Some(parts.rtc_device),
+            serial_device: parts.serial_device,
+            vmgenid_device: parts.vmgenid_device,
+            vmclock_device: parts.vmclock_device,
+            pvtime_state: Arm64BootPvTimeState::restored(parts.pvtime_layout),
+            block_devices,
+            block_async_runtime: SharedBlockAsyncRuntime::new(),
+            pci_block_devices: Vec::new(),
+            pmem_devices: Vec::new(),
+            pmem_mmio_devices: Vec::new(),
+            network_devices: Vec::new(),
+            pci_network_devices: Vec::new(),
+            vsock_device: None,
+            pci_vsock_device: None,
+            balloon_device: None,
+            pci_balloon_device: None,
+            memory_hotplug_device: None,
+            pci_memory_hotplug_device: None,
+            entropy_device: None,
+            pci_entropy_device: None,
+            pci_validation: None,
+        };
+        let pmem_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        let network_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        let entropy_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+
+        Ok(Self {
+            runner: parts.runner,
+            backend: parts.backend,
+            mmio_dispatcher: parts.mmio_dispatcher,
+            runtime_resources,
+            restored_snapshot_v2_memory_binding: Some(parts.memory_binding),
+            restored_snapshot_v2_machine: Some(parts.machine),
+            cpu_template_application,
+            pci_validation_endpoint: None,
+            pci_data_devices,
+            cache_source,
+            cache_hierarchy: None,
+            control_wakeup: HvfArm64BootRunLoopControlWakeupToken::default(),
+            run_loop_wakeup: HvfArm64BootRunLoopWakeupToken::default(),
+            block_retry_wakeup,
+            block_retry_wakeup_scheduler,
+            pmem_retry_wakeup,
+            pmem_retry_wakeup_scheduler: HvfArm64BootLimiterRetryWakeupScheduler::inactive(),
+            network_retry_wakeup,
+            network_retry_wakeup_scheduler: HvfArm64BootLimiterRetryWakeupScheduler::inactive(),
+            entropy_retry_wakeup,
+            entropy_retry_wakeup_scheduler: HvfArm64BootLimiterRetryWakeupScheduler::inactive(),
+            entropy_source: VirtioRngOsEntropySource::new(),
+            block_device_metrics,
+            pmem_device_metrics: SharedPmemDeviceMetricsRegistry::default(),
+            balloon_device_metrics: SharedBalloonDeviceMetrics::default(),
+            memory_hotplug_device_metrics: None,
+            network_interface_metrics: SharedNetworkInterfaceMetricsRegistry::default(),
+            vsock_device_metrics: SharedVsockDeviceMetrics::default(),
+            entropy_device_metrics: SharedEntropyDeviceMetrics::default(),
+            gic,
+            block_interrupt_lines,
+            pmem_interrupt_lines: Vec::new(),
+            network_interrupt_lines: Vec::new(),
+            vsock_interrupt_line: None,
+            balloon_interrupt_line: None,
+            entropy_interrupt_line: None,
+            memory_hotplug_interrupt_line: None,
+            serial_interrupt_line,
+            serial_input: None,
+            vmgenid_interrupt_line,
+            vmclock_interrupt_line,
+            boot_registers: None,
+        })
     }
 
     /// Construct and completely restore one never-run native-v1 destination.
@@ -10546,6 +11335,8 @@ impl OwnedHvfArm64BootSession {
             backend,
             mmio_dispatcher,
             runtime_resources,
+            restored_snapshot_v2_memory_binding: None,
+            restored_snapshot_v2_machine: None,
             cpu_template_application: None,
             pci_validation_endpoint: None,
             pci_data_devices: None,
@@ -11019,6 +11810,20 @@ impl OwnedHvfArm64BootSession {
         &self,
     ) -> Option<&crate::cpu_template::HvfArm64CpuTemplateApplicationState> {
         self.cpu_template_application.as_ref()
+    }
+
+    /// Returns the source memory binding retained by a native-v2 restored
+    /// owner until the next complete recapture replaces it.
+    #[doc(hidden)]
+    pub const fn restored_snapshot_v2_memory_binding(&self) -> Option<&SnapshotV2MemoryBinding> {
+        self.restored_snapshot_v2_memory_binding.as_ref()
+    }
+
+    /// Returns the inert source machine component retained by a native-v2
+    /// restored owner.
+    #[doc(hidden)]
+    pub const fn restored_snapshot_v2_machine(&self) -> Option<&HvfSnapshotV2MachineState> {
+        self.restored_snapshot_v2_machine.as_ref()
     }
 
     /// Publish and capture topology-ordered PVTime values after a pause barrier.
@@ -30152,6 +30957,47 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn native_v2_root_restore_errors_preserve_terminality_and_redact_sources() {
+        let retryable = super::HvfSnapshotV2RootRestoreError::preflight(
+            super::HvfSnapshotV2RootRestoreStage::Transport,
+            super::HvfSnapshotV2RootRestoreFailure::ResourcePlan,
+        );
+        assert!(!retryable.is_committed());
+        assert!(!retryable.has_incomplete_cleanup());
+        assert!(!retryable.is_terminal());
+
+        let committed = super::HvfSnapshotV2RootRestoreError::after_platform(
+            super::HvfSnapshotV2RootRestoreStage::MmioHandler,
+            super::HvfSnapshotV2RootRestoreFailure::ResourcePlan,
+            Vec::new(),
+        );
+        assert!(committed.is_committed());
+        assert!(committed.is_terminal());
+
+        let incomplete = super::HvfSnapshotV2RootRestoreError {
+            stage: super::HvfSnapshotV2RootRestoreStage::PciEndpoint,
+            failure: Box::new(super::HvfSnapshotV2RootRestoreFailure::PciData(
+                super::HvfArm64BootPciDataError::new("secret-primary/path"),
+            )),
+            committed: false,
+            cleanup: vec![super::HvfSnapshotV2RootRestoreCleanupFailure::Pci(
+                super::HvfArm64BootPciDataError::new("secret-cleanup/path"),
+            )],
+        };
+        assert!(!incomplete.is_committed());
+        assert!(incomplete.has_incomplete_cleanup());
+        assert!(incomplete.is_terminal());
+        let debug = format!("{incomplete:?}");
+        let cleanup_debug = format!("{:?}", incomplete.cleanup_failures());
+        assert!(debug.contains("<redacted>"));
+        assert!(cleanup_debug.contains("<redacted>"));
+        for diagnostics in [debug, incomplete.to_string(), cleanup_debug] {
+            assert!(!diagnostics.contains("secret-primary"));
+            assert!(!diagnostics.contains("secret-cleanup"));
+        }
     }
 
     #[test]

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -10417,27 +10417,14 @@ fn validate_snapshot_v2_root_resource_plan(
     }
 }
 
-fn snapshot_v2_root_identity(
+fn snapshot_v2_root_identity_and_retry_deadline(
     transport: &PreparedSnapshotV2RootTransport,
-) -> (&str, StorageRetryState) {
-    match transport {
-        PreparedSnapshotV2RootTransport::Mmio(root) => (root.drive_id(), root.retry()),
-        PreparedSnapshotV2RootTransport::Pci(root) => (root.drive_id(), root.retry()),
-    }
-}
-
-fn snapshot_v2_root_retry_deadline(retry: StorageRetryState) -> Option<Instant> {
-    match retry {
-        StorageRetryState::None => None,
-        StorageRetryState::Immediate => Some(Instant::now()),
-        StorageRetryState::After { remaining_nanos } => {
-            let now = Instant::now();
-            Some(
-                now.checked_add(Duration::from_nanos(remaining_nanos))
-                    .unwrap_or(now),
-            )
-        }
-    }
+) -> (&str, Option<Instant>) {
+    let drive_id = match transport {
+        PreparedSnapshotV2RootTransport::Mmio(root) => root.drive_id(),
+        PreparedSnapshotV2RootTransport::Pci(root) => root.drive_id(),
+    };
+    (drive_id, transport.retry_deadline())
 }
 
 fn install_snapshot_v2_mmio_root(
@@ -10830,7 +10817,7 @@ impl OwnedHvfArm64BootSession {
             )
         })?;
         validate_snapshot_v2_root_resource_plan(&transport, resources)?;
-        let (drive_id, retry) = snapshot_v2_root_identity(&transport);
+        let (drive_id, retry_deadline) = snapshot_v2_root_identity_and_retry_deadline(&transport);
         let partuuid = match &transport {
             PreparedSnapshotV2RootTransport::Mmio(root) => root.partuuid(),
             PreparedSnapshotV2RootTransport::Pci(root) => root.partuuid(),
@@ -10875,7 +10862,6 @@ impl OwnedHvfArm64BootSession {
             partuuid,
         )
         .map_err(HvfSnapshotV2RootRestoreError::platform)?;
-        let retry_deadline = snapshot_v2_root_retry_deadline(retry);
         let mut pci_data_devices = None;
         match transport {
             PreparedSnapshotV2RootTransport::Mmio(root) => {

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -7205,11 +7205,20 @@ fn capture_ready_storage_traverses_signed_mmio_and_pci_owners() {
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 #[test]
 fn native_v2_root_graph_converts_signed_mmio_and_pci_owners_canonically() {
+    use std::fs::{File, OpenOptions};
     use std::time::Instant;
 
-    use bangbang_hvf::{HvfArm64BootSessionConfig, OwnedHvfArm64BootSession};
+    use bangbang_hvf::{
+        HvfArm64BootSerialDeviceConfig, HvfArm64BootSessionConfig,
+        HvfArm64BootSnapshotV2CaptureInput, HvfSnapshotV2BootState,
+        HvfSnapshotV2DefaultProcessShell, HvfSnapshotV2NativePath, HvfSnapshotV2RootProcessConfig,
+        HvfSnapshotV2State, OwnedHvfArm64BootSession, decode_hvf_snapshot_v2_state,
+        encode_hvf_snapshot_v2_state, prepare_hvf_snapshot_v2_root_plan,
+    };
     use bangbang_runtime::VmmAction;
-    use bangbang_runtime::block::{BlockMmioLayout, DriveConfigInput, DriveIoEngine};
+    use bangbang_runtime::block::{
+        BlockFileBacking, BlockMmioLayout, DriveConfigInput, DriveIoEngine,
+    };
     use bangbang_runtime::boot::BootSourceConfigInput;
     use bangbang_runtime::memory::{GuestAddress, GuestMemoryRange};
     use bangbang_runtime::mmio::MmioRegionId;
@@ -7219,10 +7228,14 @@ fn native_v2_root_graph_converts_signed_mmio_and_pci_owners_canonically() {
         PCI_SEGMENT_ZERO, PciSbdf,
     };
     use bangbang_runtime::pmem::PmemMmioLayout;
+    use bangbang_runtime::rtc::RtcMmioLayout;
+    use bangbang_runtime::serial::{SharedSerialOutput, SharedSerialOutputBuffer};
     use bangbang_runtime::snapshot_device_v2::{
         NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2DeviceGraph,
         SnapshotV2DeviceTransport, SnapshotV2DeviceTransportKind,
     };
+    use bangbang_runtime::snapshot_format_v2::decode_snapshot_v2_state_with_compatibility_version;
+    use bangbang_runtime::snapshot_memory_v2::load_snapshot_v2_memory_file;
     use bangbang_runtime::storage_capture::{CaptureReadyStorageConfigs, StorageDeviceOrigin};
     use bangbang_runtime::virtio_pci::VIRTIO_PCI_CAPABILITY_BAR_SIZE;
     use bangbang_runtime::vsock::VsockMmioLayout;
@@ -7264,13 +7277,19 @@ fn native_v2_root_graph_converts_signed_mmio_and_pci_owners_canonically() {
 
         let block_layout =
             BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1));
+        let source_serial = SharedSerialOutputBuffer::default();
         let mut session_config = HvfArm64BootSessionConfig::new(
             block_layout,
             PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500)),
             NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000)),
             VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
-            test_rtc_mmio_layout(),
-        );
+            RtcMmioLayout::new(GuestAddress::new(0x4000_1000), MmioRegionId::new(10)),
+        )
+        .with_serial_device(HvfArm64BootSerialDeviceConfig::new(
+            MmioRegionId::new(20),
+            GuestAddress::new(0x4000_2000),
+            SharedSerialOutput::from(source_serial),
+        ));
         if pci_enabled {
             session_config = session_config.with_pci_enabled();
         }
@@ -7391,10 +7410,125 @@ fn native_v2_root_graph_converts_signed_mmio_and_pci_owners_canonically() {
         assert!(!diagnostics.contains(&path_text(root.path())));
         assert!(!diagnostics.contains("candidate-rootfs"));
 
+        session
+            .pause_for_snapshot_v2_capture()
+            .unwrap_or_else(|error| panic!("{case} source should pause: {error}"));
+        let boot = HvfSnapshotV2BootState::try_new(
+            HvfSnapshotV2NativePath::try_new(kernel.path().as_os_str())
+                .unwrap_or_else(|error| panic!("{case} kernel path should validate: {error}")),
+            None,
+            None,
+        )
+        .unwrap_or_else(|error| panic!("{case} boot metadata should validate: {error}"));
+        let capture_input = HvfArm64BootSnapshotV2CaptureInput::new(boot);
+        let memory_artifact = TempFile::new_len(&format!("{case}-root-owner-memory"), 0)
+            .unwrap_or_else(|error| panic!("{case} memory artifact should create: {error}"));
+        let mut memory_writer = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(memory_artifact.path())
+            .unwrap_or_else(|error| panic!("{case} memory artifact should open: {error}"));
+        let source_platform = session
+            .capture_snapshot_v2_device_graph_platform_with_cancel(
+                capture_input.clone(),
+                &mut memory_writer,
+                |_| false,
+            )
+            .unwrap_or_else(|error| panic!("{case} exact platform should capture: {error}"));
+        let source_state =
+            HvfSnapshotV2State::try_new(source_platform.clone(), first_graph.clone())
+                .unwrap_or_else(|error| panic!("{case} complete state should validate: {error}"));
+        let encoded = encode_hvf_snapshot_v2_state(&source_state)
+            .unwrap_or_else(|error| panic!("{case} complete state should encode: {error}"));
+        let structural = decode_snapshot_v2_state_with_compatibility_version(
+            &encoded,
+            NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+        )
+        .unwrap_or_else(|error| panic!("{case} complete state should decode: {error}"));
+        let decoded = decode_hvf_snapshot_v2_state(&structural)
+            .unwrap_or_else(|error| panic!("{case} typed state should decode: {error}"));
+        drop(memory_writer);
         drop(guard);
         session
             .shutdown()
             .unwrap_or_else(|error| panic!("{case} signed session should shut down: {error}"));
+
+        let restored_memory = load_snapshot_v2_memory_file(
+            &structural,
+            File::open(memory_artifact.path())
+                .unwrap_or_else(|error| panic!("{case} memory artifact should reopen: {error}")),
+        )
+        .unwrap_or_else(|error| panic!("{case} memory should load: {error}"));
+        let process = HvfSnapshotV2RootProcessConfig::new(block_layout, pci_enabled);
+        let prepared =
+            prepare_hvf_snapshot_v2_root_plan(decoded, restored_memory, process, Instant::now())
+                .unwrap_or_else(|error| panic!("{case} root plan should prepare: {error}"));
+        let (platform, memory, root_plan, resources) = prepared.into_parts();
+        let (backing, _identity) = BlockFileBacking::open_snapshot_read_only(root.path())
+            .unwrap_or_else(|error| panic!("{case} root backing should reopen: {error}"));
+        let prepared_root = root_plan
+            .prepare_backing(backing)
+            .unwrap_or_else(|error| panic!("{case} root backing should validate: {error}"));
+        let restored_serial = SharedSerialOutputBuffer::default();
+        let shell =
+            HvfSnapshotV2DefaultProcessShell::new(SharedSerialOutput::from(restored_serial));
+        let mut restored = OwnedHvfArm64BootSession::restore_snapshot_v2_root(
+            platform,
+            memory,
+            shell,
+            prepared_root,
+            resources,
+        )
+        .unwrap_or_else(|error| panic!("{case} complete root owner should restore: {error:?}"));
+        assert_eq!(restored.uses_pci_data_devices(), pci_enabled);
+        assert!(restored.restored_snapshot_v2_memory_binding().is_some());
+        assert_eq!(
+            restored.restored_snapshot_v2_machine(),
+            Some(source_platform.machine())
+        );
+        let restored_topology = restored
+            .capture_stable_paused_vcpu_topology()
+            .unwrap_or_else(|error| panic!("{case} paused topology should recapture: {error}"));
+        assert_eq!(restored_topology, *source_platform.topology());
+
+        let restored_guard = restored
+            .quiesce_limiter_retry_wakeups()
+            .unwrap_or_else(|error| {
+                panic!("{case} restored retry publishers should quiesce: {error}")
+            });
+        let restored_storage = restored
+            .capture_ready_storage_state_at(&configs, &restored_guard, Instant::now())
+            .unwrap_or_else(|error| panic!("{case} restored root should recapture: {error}"));
+        let [restored_root] = restored_storage.block_devices() else {
+            panic!("{case} restored owner should retain exactly one root");
+        };
+        let restored_graph = SnapshotV2DeviceGraph::from_capture_ready_root(
+            NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            restored_root,
+        )
+        .unwrap_or_else(|error| panic!("{case} restored graph should convert: {error}"));
+        assert_eq!(restored_graph, first_graph);
+
+        let recaptured_memory = TempFile::new_len(&format!("{case}-root-owner-recapture"), 0)
+            .unwrap_or_else(|error| panic!("{case} recapture artifact should create: {error}"));
+        let mut recaptured_writer = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(recaptured_memory.path())
+            .unwrap_or_else(|error| panic!("{case} recapture artifact should open: {error}"));
+        let recaptured_platform = restored
+            .capture_snapshot_v2_device_graph_platform_with_cancel(
+                capture_input,
+                &mut recaptured_writer,
+                |_| false,
+            )
+            .unwrap_or_else(|error| panic!("{case} restored platform should recapture: {error}"));
+        assert_native_v2_platform_recapture_equivalent(&source_platform, &recaptured_platform);
+
+        drop(restored_guard);
+        restored
+            .shutdown()
+            .unwrap_or_else(|error| panic!("{case} restored owner should shut down: {error}"));
     }
 }
 

--- a/crates/runtime/src/block.rs
+++ b/crates/runtime/src/block.rs
@@ -2681,20 +2681,28 @@ impl VirtioBlockRuntimeState {
             rate_limiter,
             input.has_retry,
         );
-        let activation_is_active = device.is_activated();
-        let mut handler = VirtioMmioRegisterHandler::with_device_config_and_activation(
-            VIRTIO_BLOCK_DEVICE_ID,
-            input.config_space.available_features(),
-            &VIRTIO_BLOCK_QUEUE_SIZES,
-            input.config_space,
-            device,
-        )
-        .map_err(|_| VirtioBlockRuntimeStateError::HandlerBuild)?;
-        handler
-            .restore_transport_state(&self.transport, activation_is_active)
-            .map_err(|_| VirtioBlockRuntimeStateError::Transport)?;
-        Ok(handler)
+        restore_prepared_block_mmio_handler(input.config_space, device, &self.transport)
     }
+}
+
+pub(crate) fn restore_prepared_block_mmio_handler(
+    config_space: VirtioBlockConfigSpace,
+    device: VirtioBlockDevice,
+    transport: &VirtioMmioTransportState,
+) -> Result<VirtioBlockMmioHandler, VirtioBlockRuntimeStateError> {
+    let activation_is_active = device.is_activated();
+    let mut handler = VirtioMmioRegisterHandler::with_device_config_and_activation(
+        VIRTIO_BLOCK_DEVICE_ID,
+        config_space.available_features(),
+        &VIRTIO_BLOCK_QUEUE_SIZES,
+        config_space,
+        device,
+    )
+    .map_err(|_| VirtioBlockRuntimeStateError::HandlerBuild)?;
+    handler
+        .restore_transport_state(transport, activation_is_active)
+        .map_err(|_| VirtioBlockRuntimeStateError::Transport)?;
+    Ok(handler)
 }
 
 impl fmt::Debug for VirtioBlockRuntimeState {
@@ -7413,7 +7421,10 @@ pub struct BlockMmioDeviceRegistration {
 }
 
 impl BlockMmioDeviceRegistration {
-    pub(crate) fn from_restored(index: usize, drive_id: String, region: MmioRegion) -> Self {
+    /// Reconstructs registration metadata for an already installed retained
+    /// MMIO handler.
+    #[doc(hidden)]
+    pub fn from_restored(index: usize, drive_id: String, region: MmioRegion) -> Self {
         Self {
             index,
             drive_id,

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -3495,6 +3495,32 @@ mod tests {
     }
 
     #[test]
+    fn private_native_v2_root_controller_commit_publishes_one_exact_drive() {
+        let mut controller = VmmController::new("demo-1", "0.1.0", "bangbang");
+        let machine = MachineConfigInput::new(2, 256)
+            .validate()
+            .expect("restored machine fixture should validate");
+        let boot = BootSourceConfigInput::new("/inert/source/kernel")
+            .with_boot_args("console=ttyS0")
+            .validate()
+            .expect("inert boot metadata should validate");
+        let root = DriveConfigInput::new("rootfs", "rootfs", "root-selector", true)
+            .with_is_read_only(true)
+            .with_io_engine(DriveIoEngine::Sync)
+            .with_partuuid("1111-2222")
+            .validate()
+            .expect("restored root configuration should validate");
+        let commit =
+            SnapshotV2ControllerCommit::try_new_with_root(machine, boot, root.clone(), false)
+                .expect("root controller state should preallocate");
+        assert!(!format!("{commit:?}").contains("root-selector"));
+
+        assert!(!controller.commit_snapshot_v2_load(commit));
+        assert_eq!(controller.instance_info().state, InstanceState::Paused);
+        assert_eq!(controller.drive_configs(), &[root]);
+    }
+
+    #[test]
     fn controller_native_v1_create_profile_is_fail_closed() {
         let input = snapshot_create_input(SnapshotType::Full);
         let mut supported = supported_snapshot_controller();

--- a/crates/runtime/src/pci.rs
+++ b/crates/runtime/src/pci.rs
@@ -641,6 +641,16 @@ pub(crate) struct PciType0GuestState {
 }
 
 impl PciType0GuestState {
+    pub(crate) fn from_parts(
+        writable_bytes: Vec<PciType0WritableByte>,
+        bar_probes: Vec<PciType0BarProbeState>,
+    ) -> Self {
+        Self {
+            writable_bytes,
+            bar_probes,
+        }
+    }
+
     pub(crate) fn writable_bytes(&self) -> &[PciType0WritableByte] {
         &self.writable_bytes
     }
@@ -678,6 +688,14 @@ impl PciType0WritableByte {
     pub(crate) const fn writable_mask(self) -> u8 {
         self.writable_mask
     }
+
+    pub(crate) fn with_value(mut self, value: u8) -> Result<Self, PciType0SnapshotError> {
+        if value & !self.writable_mask != 0 {
+            return Err(PciType0SnapshotError::ProfileMismatch);
+        }
+        self.value = value;
+        Ok(self)
+    }
 }
 
 impl fmt::Debug for PciType0WritableByte {
@@ -699,6 +717,11 @@ impl PciType0BarProbeState {
 
     pub(crate) const fn pending(self) -> bool {
         self.pending
+    }
+
+    pub(crate) const fn with_pending(mut self, pending: bool) -> Self {
+        self.pending = pending;
+        self
     }
 }
 

--- a/crates/runtime/src/snapshot.rs
+++ b/crates/runtime/src/snapshot.rs
@@ -83,6 +83,23 @@ impl SnapshotV2ControllerCommit {
         }
     }
 
+    /// Retains one already-validated exact-2.4 root configuration for atomic
+    /// publication with the reconstructed complete owner.
+    pub fn try_new_with_root(
+        machine_config: MachineConfig,
+        boot_source_config: BootSourceConfig,
+        drive_config: DriveConfig,
+        resume_requested: bool,
+    ) -> Result<Self, TryReserveError> {
+        Ok(Self {
+            machine_config,
+            boot_source_config,
+            drive_configs: DriveConfigs::from_validated_single(drive_config)?,
+            serial_config: SerialConfig::default(),
+            resume_requested,
+        })
+    }
+
     pub const fn resume_requested(&self) -> bool {
         self.resume_requested
     }

--- a/crates/runtime/src/snapshot_device_v2.rs
+++ b/crates/runtime/src/snapshot_device_v2.rs
@@ -5,16 +5,19 @@ use std::mem::size_of;
 use std::time::Instant;
 
 use crate::block::{
-    BlockCaptureIoEngine, BlockFileBacking, DriveCacheType, DriveConfig, DriveIoEngine,
-    DriveRateLimiterConfig, DriveTokenBucketConfig, VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE,
-    VIRTIO_BLOCK_DEVICE_ID, VIRTIO_BLOCK_ID_BYTES, VIRTIO_BLOCK_QUEUE_SIZE,
-    VIRTIO_BLOCK_SECTOR_SHIFT, VIRTIO_RING_FEATURE_EVENT_IDX, VIRTIO_RING_FEATURE_INDIRECT_DESC,
-    VirtioBlockConfigSpace, VirtioBlockDevice, VirtioBlockDeviceId, VirtioBlockQueue,
-    VirtioBlockRateLimiter, VirtioBlockRateLimiterState, VirtioBlockTokenBucketState,
+    BlockCaptureIoEngine, BlockFileBacking, DriveCacheType, DriveConfig, DriveConfigError,
+    DriveConfigInput, DriveIoEngine, DriveRateLimiterConfig, DriveTokenBucketConfig,
+    VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE, VIRTIO_BLOCK_DEVICE_ID, VIRTIO_BLOCK_ID_BYTES,
+    VIRTIO_BLOCK_QUEUE_SIZE, VIRTIO_BLOCK_QUEUE_SIZES, VIRTIO_BLOCK_SECTOR_SHIFT,
+    VIRTIO_RING_FEATURE_EVENT_IDX, VIRTIO_RING_FEATURE_INDIRECT_DESC, VirtioBlockConfigSpace,
+    VirtioBlockDevice, VirtioBlockDeviceId, VirtioBlockMmioHandler, VirtioBlockQueue,
+    VirtioBlockRateLimiter, VirtioBlockRateLimiterState, VirtioBlockRuntimeStateError,
+    VirtioBlockTokenBucketState, restore_prepared_block_mmio_handler,
 };
-use crate::interrupt::{DeviceInterruptKind, GuestInterruptLine};
+use crate::interrupt::{DeviceInterruptKind, DeviceInterruptStatus, GuestInterruptLine};
 use crate::memory::{GuestAddress, GuestMemory, GuestMemoryRange};
-use crate::mmio::MmioRegion;
+use crate::message_interrupt::GuestMessageInterruptRegistry;
+use crate::mmio::{MmioRegion, MmioRegionId};
 use crate::pci::{
     PCI_BAR64_SIZE, PCI_BAR64_START, PCI_BUS_ZERO, PCI_FIRST_ENDPOINT_DEVICE, PCI_FUNCTION_ZERO,
     PCI_LAST_ENDPOINT_DEVICE, PCI_SEGMENT_ZERO, PciBarAddressSpace, PciBarPrefetchable, PciSbdf,
@@ -27,15 +30,17 @@ use crate::storage_capture::{
 use crate::virtio::{
     VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DEVICE_NEEDS_RESET,
     VIRTIO_DEVICE_STATUS_DRIVER, VIRTIO_DEVICE_STATUS_DRIVER_OK, VIRTIO_DEVICE_STATUS_FAILED,
-    VIRTIO_DEVICE_STATUS_FEATURES_OK, VIRTIO_DEVICE_STATUS_INIT, VirtioInterruptIntent,
+    VIRTIO_DEVICE_STATUS_FEATURES_OK, VIRTIO_DEVICE_STATUS_INIT, VirtioDeviceType,
+    VirtioDeviceTypeError, VirtioInterruptIntent,
 };
 use crate::virtio_mmio::{
     VIRTIO_MMIO_DEVICE_WINDOW_SIZE, VIRTIO_MMIO_VENDOR_ID, VIRTIO_MMIO_VERSION_1_FEATURE,
     VirtioMmioDeviceRegisters, VirtioMmioQueueState, VirtioMmioTransportState,
 };
 use crate::virtio_pci::{
-    VIRTIO_PCI_CAPABILITY_BAR_INDEX, VIRTIO_PCI_CAPABILITY_BAR_SIZE, VIRTIO_PCI_MAX_MSIX_VECTORS,
-    VIRTIO_PCI_NO_VECTOR, VirtioPciEndpointPhase, VirtioPciMsixState, VirtioPciTransportState,
+    PreparedVirtioPciEndpoint, VIRTIO_PCI_CAPABILITY_BAR_INDEX, VIRTIO_PCI_CAPABILITY_BAR_SIZE,
+    VIRTIO_PCI_MAX_MSIX_VECTORS, VIRTIO_PCI_NO_VECTOR, VirtioPciEndpointError,
+    VirtioPciEndpointPhase, VirtioPciIdentity, VirtioPciMsixState, VirtioPciTransportState,
 };
 
 /// Exact outer native-v2 version understood by the first device-graph codec.
@@ -852,6 +857,7 @@ pub struct SnapshotV2RootRestorePlan {
     drive_id: String,
     partuuid: Option<String>,
     cache_type: DriveCacheType,
+    rate_limiter_config: Option<DriveRateLimiterConfig>,
     capacity_sectors: u64,
     device_id: VirtioBlockDeviceId,
     queue_ranges: Option<[GuestMemoryRange; 3]>,
@@ -941,9 +947,10 @@ impl SnapshotV2RootRestorePlan {
             })
             .transpose()?;
 
-        let limiter = persisted_limiter_state(rate_limiter, limiter)?;
+        let rate_limiter_config = rate_limiter;
+        let limiter = persisted_limiter_state(rate_limiter_config, limiter)?;
         let rate_limiter =
-            VirtioBlockRateLimiter::from_persisted_state_at(rate_limiter, limiter, now)
+            VirtioBlockRateLimiter::from_persisted_state_at(rate_limiter_config, limiter, now)
                 .map_err(|_| SnapshotV2RootRestorePlanError::RateLimiter)?;
 
         Ok(Self {
@@ -951,6 +958,7 @@ impl SnapshotV2RootRestorePlan {
             drive_id,
             partuuid,
             cache_type,
+            rate_limiter_config,
             capacity_sectors,
             device_id,
             queue_ranges,
@@ -965,6 +973,27 @@ impl SnapshotV2RootRestorePlan {
     /// Returns the inert, untrusted backing selector.
     pub fn selector(&self) -> &str {
         &self.selector
+    }
+
+    /// Reconstructs the validated public controller projection before backing
+    /// authority consumes the inert selector.
+    pub fn drive_config(&self) -> Result<DriveConfig, DriveConfigError> {
+        let mut input = DriveConfigInput::new(
+            self.drive_id.clone(),
+            self.drive_id.clone(),
+            self.selector.clone(),
+            true,
+        )
+        .with_is_read_only(true)
+        .with_cache_type(self.cache_type)
+        .with_io_engine(DriveIoEngine::Sync);
+        if let Some(partuuid) = &self.partuuid {
+            input = input.with_partuuid(partuuid.clone());
+        }
+        if let Some(rate_limiter) = self.rate_limiter_config {
+            input = input.with_rate_limiter(rate_limiter);
+        }
+        input.validate()
     }
 
     /// Returns the stable public drive identifier.
@@ -1076,9 +1105,359 @@ impl PreparedSnapshotV2RootBlock {
     ) {
         (self.config_space, self.device, self.continuation)
     }
+
+    /// Reconstructs the retained transport without publishing any live bus,
+    /// interrupt, BAR, or function resource.
+    pub fn prepare_transport(
+        self,
+    ) -> Result<PreparedSnapshotV2RootTransport, SnapshotV2RootTransportRestoreError> {
+        let (config_space, device, continuation) = self.into_parts();
+        let SnapshotV2RootContinuation {
+            drive_id,
+            partuuid,
+            retry,
+            virtio,
+            transport,
+        } = continuation;
+        match transport {
+            SnapshotV2DeviceTransport::Mmio(mmio) => {
+                let retained = restore_mmio_transport_state(&virtio, &mmio)?;
+                let handler = restore_prepared_block_mmio_handler(config_space, device, &retained)
+                    .map_err(SnapshotV2RootTransportRestoreError::Mmio)?;
+                Ok(PreparedSnapshotV2RootTransport::Mmio(
+                    PreparedSnapshotV2MmioRoot {
+                        drive_id,
+                        partuuid,
+                        retry,
+                        region: mmio.region(),
+                        interrupt_line: mmio.interrupt_line(),
+                        handler,
+                    },
+                ))
+            }
+            SnapshotV2DeviceTransport::Pci(pci) => {
+                let device_type = VirtioDeviceType::new(VIRTIO_BLOCK_DEVICE_ID)
+                    .map_err(SnapshotV2RootTransportRestoreError::DeviceType)?;
+                let identity = VirtioPciIdentity::new(device_type, virtio.available_features())
+                    .with_config_generation(virtio.config_generation());
+                let retained =
+                    VirtioPciTransportState::from_snapshot_v2_parts(identity, &virtio, &pci, false)
+                        .map_err(SnapshotV2RootTransportRestoreError::Pci)?;
+                Ok(PreparedSnapshotV2RootTransport::Pci(
+                    PreparedSnapshotV2PciRoot {
+                        drive_id,
+                        partuuid,
+                        retry,
+                        origin: pci.origin(),
+                        sbdf: pci.sbdf(),
+                        bar_range: pci.bar_range(),
+                        config_space,
+                        device,
+                        identity,
+                        retained,
+                    },
+                ))
+            }
+        }
+    }
 }
 
 redacted_debug!(PreparedSnapshotV2RootBlock, "PreparedSnapshotV2RootBlock");
+
+/// One fully reconstructed, still-unpublished exact root transport.
+pub enum PreparedSnapshotV2RootTransport {
+    /// Checked virtio-mmio handler with exact placement and SPI metadata.
+    Mmio(PreparedSnapshotV2MmioRoot),
+    /// Checked retained virtio-pci state awaiting live route publication.
+    Pci(PreparedSnapshotV2PciRoot),
+}
+
+impl PreparedSnapshotV2RootTransport {
+    /// Returns the selected transport kind.
+    pub const fn kind(&self) -> SnapshotV2DeviceTransportKind {
+        match self {
+            Self::Mmio(_) => SnapshotV2DeviceTransportKind::Mmio,
+            Self::Pci(_) => SnapshotV2DeviceTransportKind::Pci,
+        }
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2RootTransport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2RootTransport")
+            .field("kind", &self.kind())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Exact unpublished MMIO root handler and owner metadata.
+pub struct PreparedSnapshotV2MmioRoot {
+    drive_id: String,
+    partuuid: Option<String>,
+    retry: StorageRetryState,
+    region: MmioRegion,
+    interrupt_line: GuestInterruptLine,
+    handler: VirtioBlockMmioHandler,
+}
+
+impl PreparedSnapshotV2MmioRoot {
+    /// Returns the stable drive identifier.
+    pub fn drive_id(&self) -> &str {
+        &self.drive_id
+    }
+
+    /// Returns the optional root partition identifier.
+    pub fn partuuid(&self) -> Option<&str> {
+        self.partuuid.as_deref()
+    }
+
+    /// Returns the retained retry disposition.
+    pub const fn retry(&self) -> StorageRetryState {
+        self.retry
+    }
+
+    /// Returns the exact MMIO placement.
+    pub const fn region(&self) -> MmioRegion {
+        self.region
+    }
+
+    /// Returns the exact guest interrupt line.
+    pub const fn interrupt_line(&self) -> GuestInterruptLine {
+        self.interrupt_line
+    }
+
+    /// Consumes the unpublished handler and metadata.
+    pub fn into_parts(
+        self,
+    ) -> (
+        String,
+        Option<String>,
+        StorageRetryState,
+        MmioRegion,
+        GuestInterruptLine,
+        VirtioBlockMmioHandler,
+    ) {
+        (
+            self.drive_id,
+            self.partuuid,
+            self.retry,
+            self.region,
+            self.interrupt_line,
+            self.handler,
+        )
+    }
+}
+
+redacted_debug!(PreparedSnapshotV2MmioRoot, "PreparedSnapshotV2MmioRoot");
+
+/// Exact unpublished PCI root state awaiting destination-owned resources.
+pub struct PreparedSnapshotV2PciRoot {
+    drive_id: String,
+    partuuid: Option<String>,
+    retry: StorageRetryState,
+    origin: StorageDeviceOrigin,
+    sbdf: PciSbdf,
+    bar_range: GuestMemoryRange,
+    config_space: VirtioBlockConfigSpace,
+    device: VirtioBlockDevice,
+    identity: VirtioPciIdentity,
+    retained: VirtioPciTransportState,
+}
+
+impl PreparedSnapshotV2PciRoot {
+    /// Returns the stable drive identifier.
+    pub fn drive_id(&self) -> &str {
+        &self.drive_id
+    }
+
+    /// Returns the optional root partition identifier.
+    pub fn partuuid(&self) -> Option<&str> {
+        self.partuuid.as_deref()
+    }
+
+    /// Returns the retained retry disposition.
+    pub const fn retry(&self) -> StorageRetryState {
+        self.retry
+    }
+
+    /// Returns the retained startup/runtime origin.
+    pub const fn origin(&self) -> StorageDeviceOrigin {
+        self.origin
+    }
+
+    /// Returns the exact PCI function identity.
+    pub const fn sbdf(&self) -> PciSbdf {
+        self.sbdf
+    }
+
+    /// Returns the exact capability BAR range.
+    pub const fn bar_range(&self) -> GuestMemoryRange {
+        self.bar_range
+    }
+
+    /// Completes checked endpoint preparation against one live route registry.
+    pub fn prepare_endpoint(
+        self,
+        region_id: MmioRegionId,
+        messages: GuestMessageInterruptRegistry,
+    ) -> Result<PreparedSnapshotV2PciRootEndpoint, SnapshotV2RootTransportRestoreError> {
+        let endpoint = PreparedVirtioPciEndpoint::new(
+            self.identity,
+            &VIRTIO_BLOCK_QUEUE_SIZES,
+            self.config_space,
+            self.device,
+            self.retained.is_device_activated(),
+            false,
+            &self.retained,
+            self.sbdf,
+            self.bar_range,
+            region_id,
+            messages,
+        )
+        .map_err(SnapshotV2RootTransportRestoreError::Pci)?;
+        Ok(PreparedSnapshotV2PciRootEndpoint {
+            drive_id: self.drive_id,
+            partuuid: self.partuuid,
+            retry: self.retry,
+            origin: self.origin,
+            endpoint,
+        })
+    }
+}
+
+redacted_debug!(PreparedSnapshotV2PciRoot, "PreparedSnapshotV2PciRoot");
+
+/// Checked root endpoint plus process-visible owner metadata.
+pub struct PreparedSnapshotV2PciRootEndpoint {
+    drive_id: String,
+    partuuid: Option<String>,
+    retry: StorageRetryState,
+    origin: StorageDeviceOrigin,
+    endpoint: PreparedVirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice>,
+}
+
+impl PreparedSnapshotV2PciRootEndpoint {
+    /// Consumes the endpoint and owner metadata.
+    pub fn into_parts(
+        self,
+    ) -> (
+        String,
+        Option<String>,
+        StorageRetryState,
+        StorageDeviceOrigin,
+        PreparedVirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice>,
+    ) {
+        (
+            self.drive_id,
+            self.partuuid,
+            self.retry,
+            self.origin,
+            self.endpoint,
+        )
+    }
+}
+
+redacted_debug!(
+    PreparedSnapshotV2PciRootEndpoint,
+    "PreparedSnapshotV2PciRootEndpoint"
+);
+
+/// Failure while converting exact stable root state into a runtime transport.
+#[derive(Debug)]
+pub enum SnapshotV2RootTransportRestoreError {
+    /// Allocation failed while rebuilding bounded transport state.
+    Allocation,
+    /// The fixed virtio-block device identity could not be represented.
+    DeviceType(VirtioDeviceTypeError),
+    /// The checked MMIO handler rejected retained state.
+    Mmio(VirtioBlockRuntimeStateError),
+    /// The checked PCI retained-state path rejected retained state.
+    Pci(VirtioPciEndpointError),
+}
+
+impl fmt::Display for SnapshotV2RootTransportRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Allocation => formatter.write_str("native-v2 root transport allocation failed"),
+            Self::DeviceType(_) => {
+                formatter.write_str("native-v2 root transport device identity is invalid")
+            }
+            Self::Mmio(_) => formatter.write_str("native-v2 MMIO root reconstruction failed"),
+            Self::Pci(_) => formatter.write_str("native-v2 PCI root reconstruction failed"),
+        }
+    }
+}
+
+impl std::error::Error for SnapshotV2RootTransportRestoreError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::DeviceType(source) => Some(source),
+            Self::Mmio(source) => Some(source),
+            Self::Pci(source) => Some(source),
+            Self::Allocation => None,
+        }
+    }
+}
+
+fn restore_mmio_transport_state(
+    common: &SnapshotV2VirtioState,
+    mmio: &SnapshotV2MmioDeviceState,
+) -> Result<VirtioMmioTransportState, SnapshotV2RootTransportRestoreError> {
+    let device = VirtioMmioDeviceRegisters::with_vendor_id_and_config_generation(
+        VIRTIO_BLOCK_DEVICE_ID,
+        VIRTIO_MMIO_VENDOR_ID,
+        common.available_features(),
+        common.config_generation(),
+    )
+    .with_runtime_state(
+        [mmio.device_feature_select(), mmio.driver_feature_select()],
+        common.driver_features(),
+        common.status(),
+    );
+    let mut queues = Vec::new();
+    queues
+        .try_reserve_exact(common.queues().len())
+        .map_err(|_| SnapshotV2RootTransportRestoreError::Allocation)?;
+    for queue in common.queues() {
+        queues.push(VirtioMmioQueueState::from_parts(
+            queue.max_size(),
+            queue.size(),
+            queue.ready(),
+            queue.descriptor_table(),
+            queue.driver_ring(),
+            queue.device_ring(),
+        ));
+    }
+    let mut pending_notifications = Vec::new();
+    pending_notifications
+        .try_reserve_exact(common.queues().len())
+        .map_err(|_| SnapshotV2RootTransportRestoreError::Allocation)?;
+    pending_notifications.resize(common.queues().len(), false);
+    for queue_index in common.pending_notifications().iter().copied() {
+        let pending = pending_notifications
+            .get_mut(usize::from(queue_index))
+            .ok_or(SnapshotV2RootTransportRestoreError::Allocation)?;
+        *pending = true;
+    }
+    let mut interrupt_status = DeviceInterruptStatus::empty();
+    for intent in common.interrupt_intents() {
+        interrupt_status.insert(match intent {
+            SnapshotV2InterruptIntent::Queue { .. } => DeviceInterruptKind::Queue,
+            SnapshotV2InterruptIntent::Configuration => DeviceInterruptKind::Config,
+        });
+    }
+    Ok(VirtioMmioTransportState::from_parts(
+        device,
+        mmio.queue_select(),
+        queues,
+        pending_notifications,
+        interrupt_status,
+        common.is_activated(),
+        true,
+    ))
+}
 
 /// Pathless value state needed to reconstruct the root transport owner.
 #[derive(Clone, PartialEq, Eq)]

--- a/crates/runtime/src/snapshot_device_v2.rs
+++ b/crates/runtime/src/snapshot_device_v2.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 use std::mem::size_of;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::block::{
     BlockCaptureIoEngine, BlockFileBacking, DriveCacheType, DriveConfig, DriveConfigError,
@@ -864,6 +864,7 @@ pub struct SnapshotV2RootRestorePlan {
     active_queue: Option<VirtioBlockQueue>,
     rate_limiter: Option<VirtioBlockRateLimiter>,
     retry: StorageRetryState,
+    retry_deadline: Option<Instant>,
     virtio: SnapshotV2VirtioState,
     transport: SnapshotV2DeviceTransport,
 }
@@ -952,6 +953,7 @@ impl SnapshotV2RootRestorePlan {
         let rate_limiter =
             VirtioBlockRateLimiter::from_persisted_state_at(rate_limiter_config, limiter, now)
                 .map_err(|_| SnapshotV2RootRestorePlanError::RateLimiter)?;
+        let retry_deadline = restored_retry_deadline_at(retry, now);
 
         Ok(Self {
             selector,
@@ -965,6 +967,7 @@ impl SnapshotV2RootRestorePlan {
             active_queue,
             rate_limiter,
             retry,
+            retry_deadline,
             virtio,
             transport,
         })
@@ -1059,6 +1062,7 @@ impl SnapshotV2RootRestorePlan {
         Ok(PreparedSnapshotV2RootBlock {
             config_space,
             device,
+            retry_deadline: self.retry_deadline,
             continuation: SnapshotV2RootContinuation {
                 drive_id: self.drive_id,
                 partuuid: self.partuuid,
@@ -1076,6 +1080,7 @@ redacted_debug!(SnapshotV2RootRestorePlan, "SnapshotV2RootRestorePlan");
 pub struct PreparedSnapshotV2RootBlock {
     config_space: VirtioBlockConfigSpace,
     device: VirtioBlockDevice,
+    retry_deadline: Option<Instant>,
     continuation: SnapshotV2RootContinuation,
 }
 
@@ -1095,15 +1100,28 @@ impl PreparedSnapshotV2RootBlock {
         &self.continuation
     }
 
-    /// Separates the prepared device from its value-only continuation.
+    /// Returns the absolute destination retry deadline computed from the
+    /// restore plan's monotonic-time baseline.
+    pub const fn retry_deadline(&self) -> Option<Instant> {
+        self.retry_deadline
+    }
+
+    /// Separates the prepared device, retry deadline, and value-only
+    /// continuation.
     pub fn into_parts(
         self,
     ) -> (
         VirtioBlockConfigSpace,
         VirtioBlockDevice,
+        Option<Instant>,
         SnapshotV2RootContinuation,
     ) {
-        (self.config_space, self.device, self.continuation)
+        (
+            self.config_space,
+            self.device,
+            self.retry_deadline,
+            self.continuation,
+        )
     }
 
     /// Reconstructs the retained transport without publishing any live bus,
@@ -1111,7 +1129,7 @@ impl PreparedSnapshotV2RootBlock {
     pub fn prepare_transport(
         self,
     ) -> Result<PreparedSnapshotV2RootTransport, SnapshotV2RootTransportRestoreError> {
-        let (config_space, device, continuation) = self.into_parts();
+        let (config_space, device, retry_deadline, continuation) = self.into_parts();
         let SnapshotV2RootContinuation {
             drive_id,
             partuuid,
@@ -1129,6 +1147,7 @@ impl PreparedSnapshotV2RootBlock {
                         drive_id,
                         partuuid,
                         retry,
+                        retry_deadline,
                         region: mmio.region(),
                         interrupt_line: mmio.interrupt_line(),
                         handler,
@@ -1148,6 +1167,7 @@ impl PreparedSnapshotV2RootBlock {
                         drive_id,
                         partuuid,
                         retry,
+                        retry_deadline,
                         origin: pci.origin(),
                         sbdf: pci.sbdf(),
                         bar_range: pci.bar_range(),
@@ -1180,6 +1200,15 @@ impl PreparedSnapshotV2RootTransport {
             Self::Pci(_) => SnapshotV2DeviceTransportKind::Pci,
         }
     }
+
+    /// Returns the absolute destination retry deadline computed from the
+    /// restore plan's monotonic-time baseline.
+    pub const fn retry_deadline(&self) -> Option<Instant> {
+        match self {
+            Self::Mmio(root) => root.retry_deadline,
+            Self::Pci(root) => root.retry_deadline,
+        }
+    }
 }
 
 impl fmt::Debug for PreparedSnapshotV2RootTransport {
@@ -1197,6 +1226,7 @@ pub struct PreparedSnapshotV2MmioRoot {
     drive_id: String,
     partuuid: Option<String>,
     retry: StorageRetryState,
+    retry_deadline: Option<Instant>,
     region: MmioRegion,
     interrupt_line: GuestInterruptLine,
     handler: VirtioBlockMmioHandler,
@@ -1257,6 +1287,7 @@ pub struct PreparedSnapshotV2PciRoot {
     drive_id: String,
     partuuid: Option<String>,
     retry: StorageRetryState,
+    retry_deadline: Option<Instant>,
     origin: StorageDeviceOrigin,
     sbdf: PciSbdf,
     bar_range: GuestMemoryRange,
@@ -2561,6 +2592,17 @@ fn range_is_wholly_contained(memory: &GuestMemory, range: GuestMemoryRange) -> b
 
 const fn feature_enabled(features: u64, feature: u32) -> bool {
     features & (1_u64 << feature) != 0
+}
+
+fn restored_retry_deadline_at(retry: StorageRetryState, now: Instant) -> Option<Instant> {
+    match retry {
+        StorageRetryState::None => None,
+        StorageRetryState::Immediate => Some(now),
+        StorageRetryState::After { remaining_nanos } => Some(
+            now.checked_add(Duration::from_nanos(remaining_nanos))
+                .unwrap_or(now),
+        ),
+    }
 }
 
 fn persisted_limiter_state(

--- a/crates/runtime/src/snapshot_device_v2/tests.rs
+++ b/crates/runtime/src/snapshot_device_v2/tests.rs
@@ -1194,6 +1194,17 @@ fn root_restore_plan_prepares_pathless_mmio_and_pci_backings() {
         assert_eq!(plan.partuuid(), Some("1111-2222"));
         assert_eq!(plan.capacity_sectors(), 2048);
         assert!(!format!("{plan:?}").contains(plan.selector()));
+        let drive = plan
+            .drive_config()
+            .expect("validated root graph should reconstruct controller state");
+        assert_eq!(drive.drive_id(), "rootfs");
+        assert_eq!(drive.path_on_host(), Some(Path::new("root-selector")));
+        assert!(drive.is_root_device());
+        assert_eq!(drive.is_read_only(), Some(true));
+        assert_eq!(drive.partuuid(), Some("1111-2222"));
+        assert_eq!(drive.cache_type(), DriveCacheType::Writeback);
+        assert_eq!(drive.io_engine(), Some(DriveIoEngine::Sync));
+        assert_eq!(drive.rate_limiter(), fixture_config().rate_limiter());
 
         let file = TempFile::new("restore-root.img", 2048 << VIRTIO_BLOCK_SECTOR_SHIFT);
         let (backing, _) = BlockFileBacking::open_snapshot_read_only(file.path())
@@ -1219,6 +1230,69 @@ fn root_restore_plan_prepares_pathless_mmio_and_pci_backings() {
             }
         );
         assert!(!format!("{prepared:?}").contains("root-selector"));
+    }
+}
+
+#[test]
+fn prepared_root_transport_recaptures_exact_mmio_and_pci_state() {
+    for graph in [mmio_graph(), pci_graph()] {
+        let expected_virtio = graph.record.virtio.clone();
+        let expected_transport = graph.record.transport.clone();
+        let memory = contiguous_root_restore_memory();
+        let plan = SnapshotV2RootRestorePlan::prepare(graph, &memory, Instant::now())
+            .expect("root restore graph should prepare");
+        let file = TempFile::new(
+            "restore-root-transport.img",
+            2048 << VIRTIO_BLOCK_SECTOR_SHIFT,
+        );
+        let (backing, _) = BlockFileBacking::open_snapshot_read_only(file.path())
+            .expect("restore root backing should open");
+        let transport = plan
+            .prepare_backing(backing)
+            .expect("restore root backing should prepare")
+            .prepare_transport()
+            .expect("root transport should prepare");
+
+        match (transport, expected_transport) {
+            (
+                PreparedSnapshotV2RootTransport::Mmio(prepared),
+                SnapshotV2DeviceTransport::Mmio(expected),
+            ) => {
+                let (_, _, _, region, interrupt_line, handler) = prepared.into_parts();
+                let retained = handler.transport_state();
+                assert_eq!(
+                    capture_mmio_common(&retained, expected_virtio.available_features())
+                        .expect("restored MMIO common state should recapture"),
+                    expected_virtio
+                );
+                assert_eq!(
+                    capture_mmio_transport(region, interrupt_line, &retained)
+                        .expect("restored MMIO transport should recapture"),
+                    expected
+                );
+            }
+            (
+                PreparedSnapshotV2RootTransport::Pci(prepared),
+                SnapshotV2DeviceTransport::Pci(expected),
+            ) => {
+                assert_eq!(
+                    capture_pci_common(&prepared.retained, expected_virtio.available_features())
+                        .expect("restored PCI common state should recapture"),
+                    expected_virtio
+                );
+                assert_eq!(
+                    capture_pci_transport(
+                        prepared.origin,
+                        prepared.sbdf,
+                        prepared.bar_range,
+                        &prepared.retained,
+                    )
+                    .expect("restored PCI transport should recapture"),
+                    expected
+                );
+            }
+            _ => panic!("prepared root transport kind changed"),
+        }
     }
 }
 

--- a/crates/runtime/src/snapshot_device_v2/tests.rs
+++ b/crates/runtime/src/snapshot_device_v2/tests.rs
@@ -1187,7 +1187,8 @@ fn contiguous_root_restore_memory() -> GuestMemory {
 fn root_restore_plan_prepares_pathless_mmio_and_pci_backings() {
     for graph in [mmio_graph(), pci_graph()] {
         let memory = contiguous_root_restore_memory();
-        let plan = SnapshotV2RootRestorePlan::prepare(graph, &memory, Instant::now())
+        let now = Instant::now();
+        let plan = SnapshotV2RootRestorePlan::prepare(graph, &memory, now)
             .expect("root restore graph should prepare");
         assert_eq!(plan.selector(), "root-selector");
         assert_eq!(plan.drive_id(), "rootfs");
@@ -1228,6 +1229,10 @@ fn root_restore_plan_prepares_pathless_mmio_and_pci_backings() {
             StorageRetryState::After {
                 remaining_nanos: 99
             }
+        );
+        assert_eq!(
+            prepared.retry_deadline(),
+            now.checked_add(std::time::Duration::from_nanos(99))
         );
         assert!(!format!("{prepared:?}").contains("root-selector"));
     }

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -330,6 +330,15 @@ impl Arm64BootPvTimeState {
         }
     }
 
+    /// Rebuild the already-advertised retained-memory PVTime owner.
+    #[doc(hidden)]
+    pub fn restored(layout: Arm64PvTimeLayout) -> Self {
+        Self {
+            layout: Some(layout),
+            advertised: true,
+        }
+    }
+
     /// Return the topology-ordered hidden record layout, when boot initialized it.
     pub const fn layout(&self) -> Option<&Arm64PvTimeLayout> {
         self.layout.as_ref()
@@ -644,6 +653,10 @@ pub struct Arm64BootRuntimeResources {
     pub machine_config: MachineConfig,
     pub layout: GuestMemoryLayout,
     pub boot_origin: Option<Arm64BootOriginMetadata>,
+    /// Retained FDT placement for a restored owner that must not recreate boot
+    /// payload ownership or rewrite guest memory.
+    #[doc(hidden)]
+    pub retained_fdt: Option<Arm64FdtGuestMemoryWrite>,
     pub rtc_device: Option<Arm64BootRtcDevice>,
     pub serial_device: Option<Arm64BootSerialDevice>,
     pub vmgenid_device: Arm64BootVmGenIdDevice,
@@ -1515,6 +1528,7 @@ pub fn install_snapshot_v1_runtime_with_memory_owner<MemoryOwner>(
         machine_config,
         layout,
         boot_origin: None,
+        retained_fdt: None,
         rtc_device: Some(rtc_device),
         serial_device: Some(serial_device),
         vmgenid_device,
@@ -5617,6 +5631,7 @@ impl Arm64BootResources {
                     loaded_boot_source: self.loaded_boot_source,
                     fdt: self.fdt,
                 }),
+                retained_fdt: None,
                 rtc_device: self.rtc_device,
                 serial_device: self.serial_device,
                 vmgenid_device: self.vmgenid_device,
@@ -5696,6 +5711,19 @@ fn prepare_pci_validation(
         },
         Arm64FdtPciHost::from_address_plan(plan),
     ))
+}
+
+/// Installs the retained all-virtio PCI host resources without producing or
+/// rewriting FDT metadata.
+#[doc(hidden)]
+pub fn prepare_restored_pci_validation(
+    dispatcher: &mut MmioDispatcher,
+) -> Result<Arm64BootPciValidationResources, Arm64BootResourceError> {
+    prepare_pci_validation(
+        dispatcher,
+        Arm64BootPciValidationConfig::all_virtio_devices(),
+    )
+    .map(|(resources, _fdt)| resources)
 }
 
 fn memory_size_bytes(config: MachineConfig) -> Result<u64, Arm64BootResourceError> {

--- a/crates/runtime/src/virtio_mmio.rs
+++ b/crates/runtime/src/virtio_mmio.rs
@@ -532,6 +532,13 @@ impl VirtioMmioQueueRegisters {
         })
     }
 
+    pub(crate) fn from_parts(queue_select: u32, queues: Vec<VirtioMmioQueueState>) -> Self {
+        Self {
+            queue_select,
+            queues,
+        }
+    }
+
     pub const fn queue_select(&self) -> u32 {
         self.queue_select
     }
@@ -974,6 +981,12 @@ impl VirtioMmioQueueNotificationRegisters {
         Ok(Self {
             pending_notifications: vec![false; queue_count],
         })
+    }
+
+    pub(crate) fn from_parts(pending_notifications: Vec<bool>) -> Self {
+        Self {
+            pending_notifications,
+        }
     }
 
     pub fn queue_count(&self) -> usize {

--- a/crates/runtime/src/virtio_pci.rs
+++ b/crates/runtime/src/virtio_pci.rs
@@ -27,6 +27,9 @@ use crate::pci::{
     PciType0Configuration, PciType0GuestState, PciType0SnapshotError, PciType0SnapshotProfile,
     SharedPciSegment,
 };
+use crate::snapshot_device_v2::{
+    SnapshotV2InterruptIntent, SnapshotV2PciDeviceState, SnapshotV2VirtioState,
+};
 use crate::virtio::{
     VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DRIVER, VIRTIO_DEVICE_STATUS_DRIVER_OK,
     VIRTIO_DEVICE_STATUS_FAILED, VIRTIO_DEVICE_STATUS_FEATURES_OK, VIRTIO_DEVICE_STATUS_INIT,
@@ -165,6 +168,211 @@ pub struct VirtioPciTransportState {
 }
 
 impl VirtioPciTransportState {
+    pub(crate) fn from_snapshot_v2_parts(
+        identity: VirtioPciIdentity,
+        common: &SnapshotV2VirtioState,
+        pci: &SnapshotV2PciDeviceState,
+        requires_device_config_write_status: bool,
+    ) -> Result<Self, VirtioPciEndpointError> {
+        let vector_count = pci.msix().entries().len();
+        let (profile, profile_pci_cfg_offset, profile_msix_offset) =
+            build_pci_snapshot_profile(identity.device_type, pci.bar_range(), vector_count)
+                .map_err(|_| retained_error(VirtioPciRetainedStateError::Configuration))?;
+        let (mut configuration, pci_cfg_cap_offset, msix_cap_offset) = build_pci_configuration(
+            identity,
+            pci.bar_range(),
+            pci.bar_address_space(),
+            vector_count,
+        )?;
+        if profile_pci_cfg_offset != pci_cfg_cap_offset || profile_msix_offset != msix_cap_offset {
+            return Err(retained_error(VirtioPciRetainedStateError::Configuration));
+        }
+
+        let expected = configuration
+            .snapshot_guest_state(&profile)
+            .map_err(|_| retained_error(VirtioPciRetainedStateError::Configuration))?;
+        let selector_bar_offset = pci_cfg_cap_offset
+            .checked_add(4)
+            .ok_or_else(|| retained_error(VirtioPciRetainedStateError::Configuration))?;
+        let selector_offset_start = pci_cfg_cap_offset
+            .checked_add(8)
+            .ok_or_else(|| retained_error(VirtioPciRetainedStateError::Configuration))?;
+        let selector_length_start = pci_cfg_cap_offset
+            .checked_add(12)
+            .ok_or_else(|| retained_error(VirtioPciRetainedStateError::Configuration))?;
+        let data_start = pci_cfg_cap_offset
+            .checked_add(16)
+            .ok_or_else(|| retained_error(VirtioPciRetainedStateError::Configuration))?;
+        let data_end = data_start
+            .checked_add(4)
+            .ok_or_else(|| retained_error(VirtioPciRetainedStateError::Configuration))?;
+        let msix_control_high = msix_cap_offset
+            .checked_add(3)
+            .ok_or_else(|| retained_error(VirtioPciRetainedStateError::Configuration))?;
+        let selector_offset = pci.pci_cfg_offset().to_le_bytes();
+        let selector_length = pci.pci_cfg_length().to_le_bytes();
+
+        let mut writable_bytes = Vec::new();
+        writable_bytes
+            .try_reserve_exact(expected.writable_bytes().len())
+            .map_err(|_| retained_error(VirtioPciRetainedStateError::Configuration))?;
+        for writable in expected.writable_bytes().iter().copied() {
+            let offset = writable.offset();
+            let value = if offset == selector_bar_offset {
+                pci.pci_cfg_bar()
+            } else if (selector_offset_start..selector_length_start).contains(&offset) {
+                selector_offset
+                    .get(usize::from(offset - selector_offset_start))
+                    .copied()
+                    .ok_or_else(|| retained_error(VirtioPciRetainedStateError::Configuration))?
+            } else if (selector_length_start..data_start).contains(&offset) {
+                selector_length
+                    .get(usize::from(offset - selector_length_start))
+                    .copied()
+                    .ok_or_else(|| retained_error(VirtioPciRetainedStateError::Configuration))?
+            } else if (data_start..data_end).contains(&offset) {
+                writable.value()
+            } else if offset == msix_control_high {
+                (u8::from(pci.msix().enabled()) << 7)
+                    | (u8::from(pci.msix().function_masked()) << 6)
+            } else {
+                pci.writable_bytes()
+                    .iter()
+                    .copied()
+                    .find(|candidate| candidate.offset() == offset)
+                    .map(|candidate| candidate.value())
+                    .ok_or_else(|| retained_error(VirtioPciRetainedStateError::Configuration))?
+            };
+            writable_bytes.push(
+                writable
+                    .with_value(value)
+                    .map_err(|_| retained_error(VirtioPciRetainedStateError::Configuration))?,
+            );
+        }
+
+        let mut bar_probes = Vec::new();
+        bar_probes
+            .try_reserve_exact(expected.bar_probes().len())
+            .map_err(|_| retained_error(VirtioPciRetainedStateError::Configuration))?;
+        for probe in expected.bar_probes().iter().copied() {
+            let pending = pci
+                .bar_probes()
+                .iter()
+                .copied()
+                .find(|candidate| candidate.index() == probe.index())
+                .map(|candidate| candidate.pending())
+                .ok_or_else(|| retained_error(VirtioPciRetainedStateError::Configuration))?;
+            bar_probes.push(probe.with_pending(pending));
+        }
+        let guest_state = PciType0GuestState::from_parts(writable_bytes, bar_probes);
+        configuration
+            .apply_guest_state(&profile, &guest_state)
+            .map_err(|_| retained_error(VirtioPciRetainedStateError::Configuration))?;
+
+        let device = VirtioMmioDeviceRegisters::with_vendor_id_and_config_generation(
+            identity.device_type.raw_value(),
+            0,
+            common.available_features(),
+            common.config_generation(),
+        )
+        .with_runtime_state(
+            [pci.device_feature_select(), pci.driver_feature_select()],
+            common.driver_features(),
+            common.status(),
+        );
+        let mut queue_states = Vec::new();
+        queue_states
+            .try_reserve_exact(common.queues().len())
+            .map_err(|_| retained_error(VirtioPciRetainedStateError::Queue))?;
+        for queue in common.queues() {
+            queue_states.push(crate::virtio::VirtioQueueState::from_parts(
+                queue.max_size(),
+                queue.size(),
+                queue.ready(),
+                queue.descriptor_table(),
+                queue.driver_ring(),
+                queue.device_ring(),
+            ));
+        }
+        let queues = VirtioQueues::from_parts(u32::from(pci.queue_select()), queue_states);
+        let mut pending_notifications = Vec::new();
+        pending_notifications
+            .try_reserve_exact(common.queues().len())
+            .map_err(|_| retained_error(VirtioPciRetainedStateError::Notification))?;
+        pending_notifications.resize(common.queues().len(), false);
+        for queue_index in common.pending_notifications().iter().copied() {
+            let pending = pending_notifications
+                .get_mut(usize::from(queue_index))
+                .ok_or_else(|| retained_error(VirtioPciRetainedStateError::Notification))?;
+            *pending = true;
+        }
+        let queue_notifications = VirtioQueueNotificationState::from_parts(pending_notifications);
+        let mut interrupt_intents = Vec::new();
+        interrupt_intents
+            .try_reserve_exact(common.interrupt_intents().len())
+            .map_err(|_| retained_error(VirtioPciRetainedStateError::InterruptIntent))?;
+        for intent in common.interrupt_intents() {
+            interrupt_intents.push(match *intent {
+                SnapshotV2InterruptIntent::Queue { queue_index } => {
+                    VirtioInterruptIntent::Queue { queue_index }
+                }
+                SnapshotV2InterruptIntent::Configuration => VirtioInterruptIntent::Configuration,
+            });
+        }
+        let mut msix_entries = Vec::new();
+        msix_entries
+            .try_reserve_exact(pci.msix().entries().len())
+            .map_err(|_| retained_error(VirtioPciRetainedStateError::Msix))?;
+        for entry in pci.msix().entries() {
+            msix_entries.push(VirtioPciMsixTableEntry::from_parts(
+                entry.message_address_low(),
+                entry.message_address_high(),
+                entry.message_data(),
+                entry.vector_control(),
+            ));
+        }
+        let mut pending_words = Vec::new();
+        pending_words
+            .try_reserve_exact(pci.msix().pending_words().len())
+            .map_err(|_| retained_error(VirtioPciRetainedStateError::Msix))?;
+        pending_words.extend_from_slice(pci.msix().pending_words());
+        let mut queue_vectors = Vec::new();
+        queue_vectors
+            .try_reserve_exact(pci.msix().queue_vectors().len())
+            .map_err(|_| retained_error(VirtioPciRetainedStateError::Msix))?;
+        queue_vectors.extend_from_slice(pci.msix().queue_vectors());
+        let msix = VirtioPciMsixState::from_parts(
+            msix_entries,
+            pending_words,
+            pci.msix().enabled(),
+            pci.msix().function_masked(),
+            pci.msix().config_vector(),
+            queue_vectors,
+            pci.msix().pending_transition_observed(),
+        );
+
+        let retained = Self {
+            phase: pci.phase(),
+            configuration,
+            pci_cfg_cap_offset,
+            msix_cap_offset,
+            pci_cfg_bar: pci.pci_cfg_bar(),
+            pci_cfg_offset: pci.pci_cfg_offset(),
+            pci_cfg_length: pci.pci_cfg_length(),
+            device_feature_select: pci.device_feature_select(),
+            driver_feature_select: pci.driver_feature_select(),
+            queue_select: pci.queue_select(),
+            device,
+            queues,
+            queue_notifications,
+            device_activated: common.is_activated(),
+            requires_device_config_write_status,
+            interrupt_intents,
+            msix,
+        };
+        Ok(retained)
+    }
+
     pub const fn phase(&self) -> VirtioPciEndpointPhase {
         self.phase
     }
@@ -1734,6 +1942,20 @@ impl Default for VirtioPciMsixTableEntry {
 }
 
 impl VirtioPciMsixTableEntry {
+    pub(crate) const fn from_parts(
+        message_address_low: u32,
+        message_address_high: u32,
+        message_data: u32,
+        vector_control: u32,
+    ) -> Self {
+        Self {
+            message_address_low,
+            message_address_high,
+            message_data,
+            vector_control,
+        }
+    }
+
     pub const fn message_address_low(self) -> u32 {
         self.message_address_low
     }
@@ -1792,6 +2014,27 @@ impl VirtioPciMsixState {
             config_vector: VIRTIO_PCI_NO_VECTOR,
             queue_vectors: vec![VIRTIO_PCI_NO_VECTOR; queue_count],
             pending_transition_observed: false,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn from_parts(
+        entries: Vec<VirtioPciMsixTableEntry>,
+        pending: Vec<u64>,
+        enabled: bool,
+        function_masked: bool,
+        config_vector: u16,
+        queue_vectors: Vec<u16>,
+        pending_transition_observed: bool,
+    ) -> Self {
+        Self {
+            entries,
+            pending,
+            enabled,
+            function_masked,
+            config_vector,
+            queue_vectors,
+            pending_transition_observed,
         }
     }
 

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -513,7 +513,8 @@ done
 if contains native_v2_process "${selected_tests[@]}"; then
   for signed_snapshot_test in \
     vmm::tests::signed_native_v1_public_dispatch_restores_frozen_file_pair \
-    vmm::tests::signed_native_v2_process_publishes_recaptures_and_resumes_private_pair; do
+    vmm::tests::signed_native_v2_process_publishes_recaptures_and_resumes_private_pair \
+    vmm::tests::signed_native_v2_root_process_commits_complete_mmio_and_pci_owners_atomically; do
     if [[ "${#test_args[@]}" -eq 0 ]]; then
       "$native_v2_process_bin" \
         --test-threads=1 \


### PR DESCRIPTION
## Summary

- reconstruct exact native-v2 2.4 root block state into checked MMIO or retained virtio-pci owners inside the unpublished HVF restore transaction
- assemble the canonical paused `OwnedHvfArm64BootSession` with exact platform/FDT state, product PCI headroom, routes, metrics, retry scheduling, and reverse-cleanup evidence
- preallocate the singleton root controller projection and publish session, controller state, serial output, and contained backing claim only at the final infallible commit boundary
- add stable MMIO/PCI recapture coverage and signed process-level atomicity coverage for successful commit and an injected controller checkpoint

## Scope exclusions

- public native-v2 2.4 admission, create/load dispatch, advertised version, guest continuation, docs, and final inventory remain disabled for #1589
- no optional devices or post-publication root attachment are added

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo test -p bangbang-runtime --lib --all-features --locked snapshot_device_v2::tests::root_restore_plan_prepares_pathless_mmio_and_pci_backings`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
- `scripts/run-integration-tests.sh --test native_v2_process` after the final ownership-cleanup and retry-deadline refinements

Closes #1588
