### PR TITLE
feat: batch native-v2 root restore ownership

### DIFF
--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -2975,6 +2975,7 @@ mod tests {
                 input,
                 candidate: _,
                 memory: _,
+                cancellation: _,
             } = request;
             if !self.snapshot_operations_succeed {
                 return Err(NativeV2SnapshotLoadError::ProcessPreparation(

--- a/crates/bangbang/src/contained_session.rs
+++ b/crates/bangbang/src/contained_session.rs
@@ -599,6 +599,18 @@ mod platform {
     }
 
     impl PreparedDriveBackingClaim {
+        fn restore_original(&mut self) -> Result<(), GrantClaimError> {
+            if self.original.is_none() {
+                return Ok(());
+            }
+            let mut registry = self.registry.lock().map_err(|_| GrantClaimError)?;
+            let registry = registry.as_mut().ok_or(GrantClaimError)?;
+            let original = self.original.take().ok_or(GrantClaimError)?;
+            registry
+                .restore_drive_backing(self.id.clone(), original)
+                .map_err(|_| GrantClaimError)
+        }
+
         pub(crate) fn take_snapshot_read_only_file(&mut self) -> Result<File, GrantClaimError> {
             let duplicate = self.duplicate.take().ok_or(GrantClaimError)?;
             if duplicate.access() != GrantAccess::ReadOnly
@@ -651,6 +663,10 @@ mod platform {
 
         pub(crate) fn commit(mut self) {
             self.original.take();
+        }
+
+        pub(crate) fn abort(mut self) -> Result<(), GrantClaimError> {
+            self.restore_original()
         }
     }
 
@@ -884,6 +900,22 @@ mod platform {
                 Err(error) => error.into_inner(),
             };
             registry.take();
+        }
+
+        #[cfg(test)]
+        pub(crate) fn invalidate_for_test(&self) {
+            self.invalidate();
+        }
+
+        #[cfg(test)]
+        fn poison_for_test(&self) {
+            let registry = Arc::clone(&self.registry);
+            let result = std::thread::spawn(move || {
+                let _registry = registry.lock().expect("test authority should lock");
+                panic!("injected file authority poison");
+            })
+            .join();
+            assert!(result.is_err(), "test authority poison should panic");
         }
     }
 
@@ -3696,7 +3728,9 @@ mod platform {
                     .take_snapshot_read_only_file()
                     .expect("regular read-only root should remain a dedicated drive claim"),
             );
-            drop(snapshot_root);
+            snapshot_root
+                .abort()
+                .expect("explicit snapshot-root abort should restore authority");
             assert!(
                 authority
                     .prepare_drive_backing_claim(
@@ -3718,7 +3752,9 @@ mod platform {
                 .take_backing(false)
                 .expect("prepared claim should expose one backing");
             drop(duplicate);
-            drop(prepared);
+            prepared
+                .abort()
+                .expect("explicit writable-drive abort should restore authority");
             let restored = authority
                 .prepare_drive_backing_claim(
                     Path::new("bangbang-grant:drive-rw"),
@@ -3750,6 +3786,65 @@ mod platform {
                         GrantAccess::ReadWrite,
                     )
                     .is_err()
+            );
+
+            let mut inactive_registry = file_registry();
+            let inactive_authority = GrantAuthority::new(inactive_registry.take_file_registry());
+            let inactive = inactive_authority
+                .prepare_drive_backing_claim(
+                    Path::new("bangbang-grant:drive-ro"),
+                    GrantAccess::ReadOnly,
+                )
+                .expect("inactive-abort fixture should prepare")
+                .expect("inactive-abort fixture should reserve a grant");
+            inactive_authority.invalidate();
+            assert_eq!(inactive.abort(), Err(GrantClaimError));
+        }
+
+        #[test]
+        fn prepared_drive_claim_abort_reports_poison_and_restoration_collision() {
+            let mut poisoned_registry = file_registry();
+            let poisoned_authority = GrantAuthority::new(poisoned_registry.take_file_registry());
+            let poisoned = poisoned_authority
+                .prepare_drive_backing_claim(
+                    Path::new("bangbang-grant:drive-ro"),
+                    GrantAccess::ReadOnly,
+                )
+                .expect("poison fixture should prepare")
+                .expect("poison fixture should reserve a grant");
+            poisoned_authority.poison_for_test();
+            assert_eq!(poisoned.abort(), Err(GrantClaimError));
+
+            let mut collision_registry = file_registry();
+            let collision_authority = GrantAuthority::new(collision_registry.take_file_registry());
+            let mut collision = collision_authority
+                .prepare_drive_backing_claim(
+                    Path::new("bangbang-grant:drive-ro"),
+                    GrantAccess::ReadOnly,
+                )
+                .expect("collision fixture should prepare")
+                .expect("collision fixture should reserve a grant");
+            let replacement = collision
+                .duplicate
+                .take()
+                .expect("collision fixture should retain a duplicate");
+            collision_authority
+                .registry
+                .lock()
+                .expect("collision authority should lock")
+                .as_mut()
+                .expect("collision authority should remain active")
+                .restore_drive_backing(collision.id.clone(), replacement)
+                .expect("collision fixture should insert replacement");
+            assert_eq!(collision.abort(), Err(GrantClaimError));
+            assert!(
+                collision_authority
+                    .prepare_drive_backing_claim(
+                        Path::new("bangbang-grant:drive-ro"),
+                        GrantAccess::ReadOnly,
+                    )
+                    .expect("replacement grant should remain valid")
+                    .is_some()
             );
         }
 
@@ -4435,6 +4530,10 @@ mod platform {
         }
 
         pub(crate) fn commit(self) {}
+
+        pub(crate) fn abort(self) -> Result<(), GrantClaimError> {
+            Err(GrantClaimError)
+        }
     }
 
     #[derive(Debug, Clone)]

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -22,6 +22,8 @@ mod grant_integration_probe;
 #[cfg(target_os = "macos")]
 pub mod host_network;
 mod periodic_metrics;
+#[cfg(target_os = "macos")]
+mod snapshot_restore_resources;
 #[cfg(test)]
 mod test_support;
 #[cfg(test)]

--- a/crates/bangbang/src/snapshot_restore_resources.rs
+++ b/crates/bangbang/src/snapshot_restore_resources.rs
@@ -1,0 +1,1177 @@
+//! Process-owned destination resources for native-v2 snapshot restore.
+
+use std::fmt;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+use bangbang_runtime::block::{BlockFileBacking, SnapshotBlockFileBackingError};
+use bangbang_runtime::snapshot_device_v2::SnapshotV2DeviceGraph;
+use bangbang_runtime::snapshot_restore::{
+    PreparedSnapshotRestoreBindings, SnapshotRestoreBindingAllocationError,
+    SnapshotRestoreBindingRejectionReason, SnapshotRestoreBindings, SnapshotRestoreManifest,
+    SnapshotRestoreManifestError, SnapshotRestoreResourceClass, SnapshotRestoreResourceKey,
+    SnapshotRestoreTakeError,
+};
+use bangbang_session::GrantAccess;
+
+use crate::contained_session::{
+    GrantAuthority, GrantClaimError, PreparedDriveBackingClaim, grant_reference_id,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SnapshotRestoreResourceDisposition {
+    Retryable,
+    Terminal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SnapshotRestoreResourceStage {
+    Manifest,
+    BindingAllocation,
+    Cancellation,
+    RootPreparation,
+    Binding,
+    Completion,
+    Take,
+    Finish,
+}
+
+pub(crate) enum SnapshotRestoreResourceErrorKind {
+    Manifest(SnapshotRestoreManifestError),
+    BindingAllocation(SnapshotRestoreBindingAllocationError),
+    RootBacking(SnapshotRootBackingLeaseError),
+    Binding(SnapshotRestoreBindingRejectionReason),
+    Incomplete { missing_count: usize },
+    Take(SnapshotRestoreTakeError),
+    Unconsumed { unconsumed_count: usize },
+    OwnerClassMismatch,
+    Cancelled,
+}
+
+impl fmt::Debug for SnapshotRestoreResourceErrorKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Manifest(source) => formatter
+                .debug_tuple("SnapshotRestoreResourceErrorKind::Manifest")
+                .field(source)
+                .finish(),
+            Self::BindingAllocation(source) => formatter
+                .debug_tuple("SnapshotRestoreResourceErrorKind::BindingAllocation")
+                .field(source)
+                .finish(),
+            Self::RootBacking(source) => formatter
+                .debug_tuple("SnapshotRestoreResourceErrorKind::RootBacking")
+                .field(source)
+                .finish(),
+            Self::Binding(reason) => formatter
+                .debug_tuple("SnapshotRestoreResourceErrorKind::Binding")
+                .field(reason)
+                .finish(),
+            Self::Incomplete { missing_count } => formatter
+                .debug_struct("SnapshotRestoreResourceErrorKind::Incomplete")
+                .field("missing_count", missing_count)
+                .finish(),
+            Self::Take(source) => formatter
+                .debug_tuple("SnapshotRestoreResourceErrorKind::Take")
+                .field(source)
+                .finish(),
+            Self::Unconsumed { unconsumed_count } => formatter
+                .debug_struct("SnapshotRestoreResourceErrorKind::Unconsumed")
+                .field("unconsumed_count", unconsumed_count)
+                .finish(),
+            Self::OwnerClassMismatch => {
+                formatter.write_str("SnapshotRestoreResourceErrorKind::OwnerClassMismatch")
+            }
+            Self::Cancelled => formatter.write_str("SnapshotRestoreResourceErrorKind::Cancelled"),
+        }
+    }
+}
+
+impl fmt::Display for SnapshotRestoreResourceErrorKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Manifest(source) => source.fmt(formatter),
+            Self::BindingAllocation(source) => source.fmt(formatter),
+            Self::RootBacking(source) => source.fmt(formatter),
+            Self::Binding(reason) => reason.fmt(formatter),
+            Self::Incomplete { .. } => {
+                formatter.write_str("snapshot restore resource set is incomplete")
+            }
+            Self::Take(source) => source.fmt(formatter),
+            Self::Unconsumed { .. } => {
+                formatter.write_str("snapshot restore resource set is unconsumed")
+            }
+            Self::OwnerClassMismatch => {
+                formatter.write_str("snapshot restore owner has the wrong resource class")
+            }
+            Self::Cancelled => {
+                formatter.write_str("snapshot restore resource preparation cancelled")
+            }
+        }
+    }
+}
+
+pub(crate) struct SnapshotRestoreResourceError {
+    stage: SnapshotRestoreResourceStage,
+    kind: SnapshotRestoreResourceErrorKind,
+    disposition: SnapshotRestoreResourceDisposition,
+    cleanup_failed: bool,
+}
+
+impl SnapshotRestoreResourceError {
+    fn retryable(
+        stage: SnapshotRestoreResourceStage,
+        kind: SnapshotRestoreResourceErrorKind,
+    ) -> Self {
+        Self {
+            stage,
+            kind,
+            disposition: SnapshotRestoreResourceDisposition::Retryable,
+            cleanup_failed: false,
+        }
+    }
+
+    fn terminal(
+        stage: SnapshotRestoreResourceStage,
+        kind: SnapshotRestoreResourceErrorKind,
+    ) -> Self {
+        Self {
+            stage,
+            kind,
+            disposition: SnapshotRestoreResourceDisposition::Terminal,
+            cleanup_failed: false,
+        }
+    }
+
+    fn with_cleanup_failed(mut self, cleanup_failed: bool) -> Self {
+        if cleanup_failed {
+            self.disposition = SnapshotRestoreResourceDisposition::Terminal;
+            self.cleanup_failed = true;
+        }
+        self
+    }
+
+    pub(crate) const fn disposition(&self) -> SnapshotRestoreResourceDisposition {
+        self.disposition
+    }
+}
+
+impl fmt::Debug for SnapshotRestoreResourceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotRestoreResourceError")
+            .field("stage", &self.stage)
+            .field("kind", &self.kind)
+            .field("disposition", &self.disposition)
+            .field("cleanup_failed", &self.cleanup_failed)
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotRestoreResourceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "snapshot restore resources failed at {:?}: {} ({:?})",
+            self.stage, self.kind, self.disposition
+        )?;
+        if self.cleanup_failed {
+            formatter.write_str("; resource cleanup also failed")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for SnapshotRestoreResourceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.kind {
+            SnapshotRestoreResourceErrorKind::Manifest(source) => Some(source),
+            SnapshotRestoreResourceErrorKind::BindingAllocation(source) => Some(source),
+            SnapshotRestoreResourceErrorKind::RootBacking(source) => Some(source),
+            SnapshotRestoreResourceErrorKind::Take(source) => Some(source),
+            SnapshotRestoreResourceErrorKind::Binding(_)
+            | SnapshotRestoreResourceErrorKind::Incomplete { .. }
+            | SnapshotRestoreResourceErrorKind::Unconsumed { .. }
+            | SnapshotRestoreResourceErrorKind::OwnerClassMismatch
+            | SnapshotRestoreResourceErrorKind::Cancelled => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SnapshotRootSelectorPolicy {
+    TreatAsPath,
+    RejectGrantReference,
+    RequireGrantWhenContained,
+}
+
+pub(crate) struct PreparedSnapshotRootBackingLease {
+    selector: Option<PathBuf>,
+    claim: Option<PreparedDriveBackingClaim>,
+    consumed: bool,
+}
+
+impl PreparedSnapshotRootBackingLease {
+    pub(crate) fn prepare(
+        selector: &Path,
+        authority: Option<&GrantAuthority>,
+        selector_policy: SnapshotRootSelectorPolicy,
+    ) -> Result<Self, GrantClaimError> {
+        let claim = match authority {
+            Some(authority) => {
+                match authority.prepare_drive_backing_claim(selector, GrantAccess::ReadOnly)? {
+                    Some(claim) => Some(claim),
+                    None if selector_policy
+                        == SnapshotRootSelectorPolicy::RequireGrantWhenContained =>
+                    {
+                        return Err(GrantClaimError);
+                    }
+                    None => None,
+                }
+            }
+            None => {
+                if selector_policy == SnapshotRootSelectorPolicy::RejectGrantReference
+                    && grant_reference_id(selector)?.is_some()
+                {
+                    return Err(GrantClaimError);
+                }
+                None
+            }
+        };
+        Ok(Self {
+            selector: Some(selector.to_path_buf()),
+            claim,
+            consumed: false,
+        })
+    }
+
+    pub(crate) fn take_snapshot_read_only_file(&mut self) -> Result<Option<File>, GrantClaimError> {
+        let (_selector, file) = self.consume_inner()?;
+        Ok(file)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn consume(&mut self) -> Result<(PathBuf, Option<File>), GrantClaimError> {
+        self.consume_inner()
+    }
+
+    fn consume_inner(&mut self) -> Result<(PathBuf, Option<File>), GrantClaimError> {
+        if self.consumed {
+            return Err(GrantClaimError);
+        }
+        self.consumed = true;
+        let selector = self.selector.take().ok_or(GrantClaimError)?;
+        let file = self
+            .claim
+            .as_mut()
+            .map(PreparedDriveBackingClaim::take_snapshot_read_only_file)
+            .transpose()?;
+        Ok((selector, file))
+    }
+
+    pub(crate) fn open_snapshot_read_only(
+        &mut self,
+    ) -> Result<BlockFileBacking, SnapshotRootBackingLeaseError> {
+        let (selector, file) = self
+            .consume_inner()
+            .map_err(SnapshotRootBackingLeaseError::Grant)?;
+        match file {
+            Some(file) => BlockFileBacking::from_snapshot_read_only_file(file)
+                .map(|(backing, _identity)| backing)
+                .map_err(SnapshotRootBackingLeaseError::Backing),
+            None => BlockFileBacking::open_snapshot_read_only(&selector)
+                .map(|(backing, _identity)| backing)
+                .map_err(SnapshotRootBackingLeaseError::Backing),
+        }
+    }
+
+    pub(crate) fn commit(self) {
+        if let Some(claim) = self.claim {
+            claim.commit();
+        }
+    }
+
+    pub(crate) fn abort(self) -> Result<(), GrantClaimError> {
+        match self.claim {
+            Some(claim) => claim.abort(),
+            None => Ok(()),
+        }
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotRootBackingLease {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotRootBackingLease")
+            .field("selector", &self.selector.as_ref().map(|_| "<redacted>"))
+            .field("claim", &self.claim.as_ref().map(|_| "<provisional>"))
+            .field("consumed", &self.consumed)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum SnapshotRootBackingLeaseError {
+    Grant(GrantClaimError),
+    Backing(SnapshotBlockFileBackingError),
+}
+
+impl fmt::Display for SnapshotRootBackingLeaseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Grant(_) => formatter.write_str("snapshot root authority validation failed"),
+            Self::Backing(_) => formatter.write_str("snapshot root backing validation failed"),
+        }
+    }
+}
+
+impl std::error::Error for SnapshotRootBackingLeaseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Grant(source) => Some(source),
+            Self::Backing(source) => Some(source),
+        }
+    }
+}
+
+pub(crate) struct PreparedSnapshotRootRestoreCompletion {
+    lease: PreparedSnapshotRootBackingLease,
+}
+
+impl PreparedSnapshotRootRestoreCompletion {
+    pub(crate) fn commit(self) {
+        self.lease.commit();
+    }
+
+    pub(crate) fn abort(self) -> Result<(), GrantClaimError> {
+        self.lease.abort()
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotRootRestoreCompletion {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotRootRestoreCompletion")
+            .field("state", &"<provisional>")
+            .finish()
+    }
+}
+
+pub(crate) struct PreparedSnapshotRootRestoreResource {
+    backing: BlockFileBacking,
+    completion: PreparedSnapshotRootRestoreCompletion,
+}
+
+impl PreparedSnapshotRootRestoreResource {
+    fn prepare(
+        selector: &Path,
+        authority: Option<&GrantAuthority>,
+    ) -> Result<Self, SnapshotRestoreResourceError> {
+        let mut lease = PreparedSnapshotRootBackingLease::prepare(
+            selector,
+            authority,
+            SnapshotRootSelectorPolicy::RequireGrantWhenContained,
+        )
+        .map_err(|source| {
+            let kind = SnapshotRestoreResourceErrorKind::RootBacking(
+                SnapshotRootBackingLeaseError::Grant(source),
+            );
+            if authority.is_some_and(|authority| !authority.is_active()) {
+                SnapshotRestoreResourceError::terminal(
+                    SnapshotRestoreResourceStage::RootPreparation,
+                    kind,
+                )
+            } else {
+                SnapshotRestoreResourceError::retryable(
+                    SnapshotRestoreResourceStage::RootPreparation,
+                    kind,
+                )
+            }
+        })?;
+        let backing = match lease.open_snapshot_read_only() {
+            Ok(backing) => backing,
+            Err(source) => {
+                let cleanup_failed = lease.abort().is_err();
+                return Err(SnapshotRestoreResourceError::retryable(
+                    SnapshotRestoreResourceStage::RootPreparation,
+                    SnapshotRestoreResourceErrorKind::RootBacking(source),
+                )
+                .with_cleanup_failed(cleanup_failed));
+            }
+        };
+        Ok(Self {
+            backing,
+            completion: PreparedSnapshotRootRestoreCompletion { lease },
+        })
+    }
+
+    pub(crate) fn into_parts(self) -> (BlockFileBacking, PreparedSnapshotRootRestoreCompletion) {
+        (self.backing, self.completion)
+    }
+
+    fn abort(self) -> Result<(), GrantClaimError> {
+        let Self {
+            backing,
+            completion,
+        } = self;
+        drop(backing);
+        completion.abort()
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotRootRestoreResource {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotRootRestoreResource")
+            .field("backing", &"<owned>")
+            .field("completion", &"<provisional>")
+            .finish()
+    }
+}
+
+enum PreparedSnapshotRestoreResource {
+    Root(PreparedSnapshotRootRestoreResource),
+}
+
+impl PreparedSnapshotRestoreResource {
+    const fn resource_class(&self) -> SnapshotRestoreResourceClass {
+        match self {
+            Self::Root(_) => SnapshotRestoreResourceClass::BlockBacking,
+        }
+    }
+
+    fn abort(self) -> Result<(), GrantClaimError> {
+        match self {
+            Self::Root(root) => root.abort(),
+        }
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotRestoreResource {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotRestoreResource")
+            .field("class", &self.resource_class())
+            .field("value", &"<owned>")
+            .finish()
+    }
+}
+
+pub(crate) struct RequestedSnapshotRestoreResources {
+    root_key: SnapshotRestoreResourceKey,
+    root_selector: PathBuf,
+    bindings: SnapshotRestoreBindings<PreparedSnapshotRestoreResource>,
+}
+
+impl RequestedSnapshotRestoreResources {
+    pub(crate) fn try_from_native_v2_device_graph(
+        graph: &SnapshotV2DeviceGraph,
+    ) -> Result<Self, SnapshotRestoreResourceError> {
+        let manifest = SnapshotRestoreManifest::try_from_native_v2_device_graph(graph, Vec::new())
+            .map_err(|source| {
+                SnapshotRestoreResourceError::retryable(
+                    SnapshotRestoreResourceStage::Manifest,
+                    SnapshotRestoreResourceErrorKind::Manifest(source),
+                )
+            })?;
+        let root_key = manifest.resources().first().cloned().ok_or_else(|| {
+            SnapshotRestoreResourceError::terminal(
+                SnapshotRestoreResourceStage::Manifest,
+                SnapshotRestoreResourceErrorKind::OwnerClassMismatch,
+            )
+        })?;
+        if manifest.len() != 1
+            || root_key.resource_class() != SnapshotRestoreResourceClass::BlockBacking
+        {
+            return Err(SnapshotRestoreResourceError::terminal(
+                SnapshotRestoreResourceStage::Manifest,
+                SnapshotRestoreResourceErrorKind::OwnerClassMismatch,
+            ));
+        }
+        let bindings = manifest.try_into_bindings().map_err(|source| {
+            SnapshotRestoreResourceError::retryable(
+                SnapshotRestoreResourceStage::BindingAllocation,
+                SnapshotRestoreResourceErrorKind::BindingAllocation(source),
+            )
+        })?;
+        Ok(Self {
+            root_key,
+            root_selector: PathBuf::from(graph.record().config().selector()),
+            bindings,
+        })
+    }
+
+    pub(crate) fn prepare_root(
+        self,
+        authority: Option<&GrantAuthority>,
+        cancelled: impl Fn() -> bool,
+    ) -> Result<PreparedSnapshotRestoreResources, SnapshotRestoreResourceError> {
+        self.prepare_root_with(cancelled, |selector| {
+            PreparedSnapshotRootRestoreResource::prepare(selector, authority)
+        })
+    }
+
+    fn prepare_root_with(
+        self,
+        cancelled: impl Fn() -> bool,
+        provider: impl FnOnce(
+            &Path,
+        ) -> Result<
+            PreparedSnapshotRootRestoreResource,
+            SnapshotRestoreResourceError,
+        >,
+    ) -> Result<PreparedSnapshotRestoreResources, SnapshotRestoreResourceError> {
+        let root_key = self.root_key.clone();
+        self.prepare_root_with_key(root_key, cancelled, provider)
+    }
+
+    fn prepare_root_with_key(
+        mut self,
+        root_key: SnapshotRestoreResourceKey,
+        cancelled: impl Fn() -> bool,
+        provider: impl FnOnce(
+            &Path,
+        ) -> Result<
+            PreparedSnapshotRootRestoreResource,
+            SnapshotRestoreResourceError,
+        >,
+    ) -> Result<PreparedSnapshotRestoreResources, SnapshotRestoreResourceError> {
+        if cancelled() {
+            let cleanup_failed = abort_resources(self.bindings.into_values());
+            return Err(SnapshotRestoreResourceError::retryable(
+                SnapshotRestoreResourceStage::Cancellation,
+                SnapshotRestoreResourceErrorKind::Cancelled,
+            )
+            .with_cleanup_failed(cleanup_failed));
+        }
+        let root = match provider(&self.root_selector) {
+            Ok(root) => root,
+            Err(source) => {
+                let cleanup_failed = abort_resources(self.bindings.into_values());
+                return Err(source.with_cleanup_failed(cleanup_failed));
+            }
+        };
+        let owner = PreparedSnapshotRestoreResource::Root(root);
+        if owner.resource_class() != root_key.resource_class() {
+            let mut cleanup_failed = owner.abort().is_err();
+            cleanup_failed |= abort_resources(self.bindings.into_values());
+            return Err(SnapshotRestoreResourceError::terminal(
+                SnapshotRestoreResourceStage::Binding,
+                SnapshotRestoreResourceErrorKind::OwnerClassMismatch,
+            )
+            .with_cleanup_failed(cleanup_failed));
+        }
+        if let Err(rejection) = self.bindings.bind(&root_key, owner) {
+            let reason = rejection.reason();
+            let mut cleanup_failed = rejection.into_value().abort().is_err();
+            cleanup_failed |= abort_resources(self.bindings.into_values());
+            return Err(SnapshotRestoreResourceError::terminal(
+                SnapshotRestoreResourceStage::Binding,
+                SnapshotRestoreResourceErrorKind::Binding(reason),
+            )
+            .with_cleanup_failed(cleanup_failed));
+        }
+        let prepared = self.complete()?;
+        if cancelled() {
+            let cleanup_failed = prepared.abort();
+            return Err(SnapshotRestoreResourceError::retryable(
+                SnapshotRestoreResourceStage::Cancellation,
+                SnapshotRestoreResourceErrorKind::Cancelled,
+            )
+            .with_cleanup_failed(cleanup_failed));
+        }
+        Ok(prepared)
+    }
+
+    fn complete(self) -> Result<PreparedSnapshotRestoreResources, SnapshotRestoreResourceError> {
+        let bindings = match self.bindings.complete() {
+            Ok(bindings) => bindings,
+            Err(incomplete) => {
+                let missing_count = incomplete.missing_count();
+                let cleanup_failed = abort_resources(incomplete.into_bindings().into_values());
+                return Err(SnapshotRestoreResourceError::terminal(
+                    SnapshotRestoreResourceStage::Completion,
+                    SnapshotRestoreResourceErrorKind::Incomplete { missing_count },
+                )
+                .with_cleanup_failed(cleanup_failed));
+            }
+        };
+        Ok(PreparedSnapshotRestoreResources {
+            root_key: self.root_key,
+            bindings,
+        })
+    }
+}
+
+impl fmt::Debug for RequestedSnapshotRestoreResources {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RequestedSnapshotRestoreResources")
+            .field("resource_count", &self.bindings.manifest().len())
+            .field("values", &"<redacted>")
+            .finish()
+    }
+}
+
+pub(crate) struct PreparedSnapshotRestoreResources {
+    root_key: SnapshotRestoreResourceKey,
+    bindings: PreparedSnapshotRestoreBindings<PreparedSnapshotRestoreResource>,
+}
+
+impl PreparedSnapshotRestoreResources {
+    fn take_root(
+        &mut self,
+        key: &SnapshotRestoreResourceKey,
+    ) -> Result<PreparedSnapshotRootRestoreResource, SnapshotRestoreResourceError> {
+        let owner = self.bindings.take(key).map_err(|source| {
+            SnapshotRestoreResourceError::terminal(
+                SnapshotRestoreResourceStage::Take,
+                SnapshotRestoreResourceErrorKind::Take(source),
+            )
+        })?;
+        match owner {
+            PreparedSnapshotRestoreResource::Root(root) => Ok(root),
+        }
+    }
+
+    fn finish(self) -> Result<(), SnapshotRestoreResourceError> {
+        match self.bindings.finish() {
+            Ok(()) => Ok(()),
+            Err(unconsumed) => {
+                let unconsumed_count = unconsumed.unconsumed_count();
+                let cleanup_failed = abort_resources(unconsumed.into_bindings().into_values());
+                Err(SnapshotRestoreResourceError::terminal(
+                    SnapshotRestoreResourceStage::Finish,
+                    SnapshotRestoreResourceErrorKind::Unconsumed { unconsumed_count },
+                )
+                .with_cleanup_failed(cleanup_failed))
+            }
+        }
+    }
+
+    fn consume_root_with<T>(
+        mut self,
+        consumer: impl FnOnce(PreparedSnapshotRootRestoreResource) -> T,
+    ) -> Result<T, SnapshotRestoreResourceError> {
+        let key = self.root_key.clone();
+        let root = match self.take_root(&key) {
+            Ok(root) => root,
+            Err(source) => {
+                let cleanup_failed = self.abort();
+                return Err(source.with_cleanup_failed(cleanup_failed));
+            }
+        };
+        if let Err(source) = self.finish() {
+            let cleanup_failed = root.abort().is_err();
+            return Err(source.with_cleanup_failed(cleanup_failed));
+        }
+        Ok(consumer(root))
+    }
+
+    pub(crate) fn into_root(
+        self,
+    ) -> Result<PreparedSnapshotRootRestoreResource, SnapshotRestoreResourceError> {
+        self.consume_root_with(|root| root)
+    }
+
+    fn abort(self) -> bool {
+        abort_resources(self.bindings.into_values())
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotRestoreResources {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotRestoreResources")
+            .field("resource_count", &self.bindings.manifest().len())
+            .field("remaining_count", &self.bindings.remaining_count())
+            .field("values", &"<redacted>")
+            .finish()
+    }
+}
+
+fn abort_resources(
+    resources: impl DoubleEndedIterator<Item = PreparedSnapshotRestoreResource>,
+) -> bool {
+    let mut failed = false;
+    for resource in resources.rev() {
+        failed |= resource.abort().is_err();
+    }
+    failed
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::{Cell, RefCell};
+    use std::env;
+    use std::fs::{self, OpenOptions};
+    use std::io::Write;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use bangbang_runtime::snapshot_device_v2::{
+        NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2DeviceTransportKind,
+    };
+    use bangbang_runtime::snapshot_restore::{
+        SnapshotRestoreBindingRejectionReason, SnapshotRestorePublicId,
+    };
+
+    use crate::contained_session::{GrantAuthority, root_file_grant_authority_for_test};
+
+    use super::*;
+
+    const ROOT_REFERENCE: &str = "bangbang-grant:drive-ro";
+
+    static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
+
+    struct TempRoot {
+        path: PathBuf,
+    }
+
+    impl TempRoot {
+        fn new(name: &str, bytes: &[u8]) -> Self {
+            let path = unique_path(name);
+            let mut file = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)
+                .expect("temporary root should be created once");
+            file.write_all(bytes)
+                .expect("temporary root bytes should write");
+            file.sync_all().expect("temporary root should synchronize");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempRoot {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+
+    fn unique_path(name: &str) -> PathBuf {
+        let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+        env::temp_dir().join(format!(
+            "bangbang-snapshot-restore-{name}-{}-{id}",
+            std::process::id()
+        ))
+    }
+
+    fn fixture_graph(transport: SnapshotV2DeviceTransportKind) -> SnapshotV2DeviceGraph {
+        let fixture = match transport {
+            SnapshotV2DeviceTransportKind::Mmio => {
+                include_str!("../../runtime/src/snapshot_device_v2/fixtures/mmio.hex")
+            }
+            SnapshotV2DeviceTransportKind::Pci => {
+                include_str!("../../runtime/src/snapshot_device_v2/fixtures/pci.hex")
+            }
+        };
+        let bytes = fixture
+            .trim()
+            .as_bytes()
+            .chunks_exact(2)
+            .map(|pair| {
+                let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
+                u8::from_str_radix(pair, 16).expect("fixture hex should decode")
+            })
+            .collect::<Vec<_>>();
+        SnapshotV2DeviceGraph::decode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, &bytes)
+            .expect("fixture graph should decode")
+    }
+
+    fn requested() -> RequestedSnapshotRestoreResources {
+        RequestedSnapshotRestoreResources::try_from_native_v2_device_graph(&fixture_graph(
+            SnapshotV2DeviceTransportKind::Mmio,
+        ))
+        .expect("fixture request should build")
+    }
+
+    fn contained_root(
+        authority: &GrantAuthority,
+    ) -> Result<PreparedSnapshotRootRestoreResource, SnapshotRestoreResourceError> {
+        PreparedSnapshotRootRestoreResource::prepare(Path::new(ROOT_REFERENCE), Some(authority))
+    }
+
+    fn assert_root_claim_restored(authority: &GrantAuthority) {
+        let claim = authority
+            .prepare_drive_backing_claim(Path::new(ROOT_REFERENCE), GrantAccess::ReadOnly)
+            .expect("restored root authority should remain usable")
+            .expect("restored root claim should be present");
+        claim
+            .abort()
+            .expect("observed restored claim should return to authority");
+    }
+
+    #[test]
+    fn current_graphs_build_one_exact_host_free_root_request() {
+        for transport in [
+            SnapshotV2DeviceTransportKind::Mmio,
+            SnapshotV2DeviceTransportKind::Pci,
+        ] {
+            let graph = fixture_graph(transport);
+            let request =
+                RequestedSnapshotRestoreResources::try_from_native_v2_device_graph(&graph)
+                    .expect("current graph should produce a request");
+
+            assert_eq!(request.root_key.device_key(), graph.root_key());
+            assert_eq!(
+                request.root_key.public_id().as_str(),
+                graph.record().config().drive_id()
+            );
+            assert_eq!(
+                request.root_key.resource_class(),
+                SnapshotRestoreResourceClass::BlockBacking
+            );
+            assert_eq!(request.bindings.manifest().len(), 1);
+            assert_eq!(request.bindings.missing_count(), 1);
+            assert_eq!(
+                request.root_selector,
+                PathBuf::from(graph.record().config().selector())
+            );
+
+            let diagnostics = format!("{request:?} {:?}", request.root_key);
+            assert!(!diagnostics.contains(graph.record().config().drive_id()));
+            assert!(!diagnostics.contains(graph.record().config().selector()));
+        }
+    }
+
+    #[test]
+    fn complete_and_finish_gate_host_access_before_construction() {
+        let root = TempRoot::new("ordering", b"root");
+        let events = RefCell::new(vec!["logical-request"]);
+        let request = requested();
+        let prepared = request
+            .prepare_root_with(
+                || false,
+                |selector| {
+                    assert_eq!(selector, Path::new("root-selector"));
+                    events.borrow_mut().push("host-prepare");
+                    PreparedSnapshotRootRestoreResource::prepare(root.path(), None)
+                },
+            )
+            .expect("root batch should prepare");
+        events.borrow_mut().push("complete-batch");
+
+        let resource = prepared
+            .consume_root_with(|resource| {
+                events.borrow_mut().push("construction");
+                resource
+            })
+            .expect("exact take and finish should precede construction");
+        assert_eq!(
+            events.into_inner(),
+            [
+                "logical-request",
+                "host-prepare",
+                "complete-batch",
+                "construction",
+            ]
+        );
+        resource
+            .abort()
+            .expect("direct completion should abort infallibly");
+    }
+
+    #[test]
+    fn cancellation_brackets_host_preparation_and_reports_cleanup_evidence() {
+        let host_called = Cell::new(false);
+        let error = requested()
+            .prepare_root_with(
+                || true,
+                |_| {
+                    host_called.set(true);
+                    panic!("cancelled request must not invoke its provider");
+                },
+            )
+            .expect_err("pre-provider cancellation should stop preparation");
+        assert!(!host_called.get());
+        assert_eq!(error.stage, SnapshotRestoreResourceStage::Cancellation);
+        assert!(matches!(
+            error.kind,
+            SnapshotRestoreResourceErrorKind::Cancelled
+        ));
+        assert_eq!(
+            error.disposition,
+            SnapshotRestoreResourceDisposition::Retryable
+        );
+        assert!(!error.cleanup_failed);
+
+        let root = TempRoot::new("cancel-after-prepare", b"root");
+        let authority = root_file_grant_authority_for_test(root.path());
+        let checks = Cell::new(0);
+        let error = requested()
+            .prepare_root_with(
+                || {
+                    checks.set(checks.get() + 1);
+                    checks.get() == 2
+                },
+                |_| contained_root(&authority),
+            )
+            .expect_err("post-provider cancellation should abort the complete batch");
+        assert_eq!(checks.get(), 2);
+        assert_eq!(error.stage, SnapshotRestoreResourceStage::Cancellation);
+        assert!(matches!(
+            error.kind,
+            SnapshotRestoreResourceErrorKind::Cancelled
+        ));
+        assert_eq!(
+            error.disposition,
+            SnapshotRestoreResourceDisposition::Retryable
+        );
+        assert!(!error.cleanup_failed);
+        assert_root_claim_restored(&authority);
+
+        let poisoned_root = TempRoot::new("cancel-cleanup-failure", b"root");
+        let poisoned_authority = root_file_grant_authority_for_test(poisoned_root.path());
+        let checks = Cell::new(0);
+        let error = requested()
+            .prepare_root_with(
+                || {
+                    checks.set(checks.get() + 1);
+                    if checks.get() == 2 {
+                        poisoned_authority.invalidate_for_test();
+                        true
+                    } else {
+                        false
+                    }
+                },
+                |_| contained_root(&poisoned_authority),
+            )
+            .expect_err("inactive cleanup authority should fail closed");
+        assert_eq!(error.stage, SnapshotRestoreResourceStage::Cancellation);
+        assert_eq!(
+            error.disposition,
+            SnapshotRestoreResourceDisposition::Terminal
+        );
+        assert!(error.cleanup_failed);
+    }
+
+    #[test]
+    fn direct_and_contained_resources_share_one_pathless_shape() {
+        let root = TempRoot::new("direct-contained-shape", b"root-shape");
+        let direct = PreparedSnapshotRootRestoreResource::prepare(root.path(), None)
+            .expect("direct root should prepare");
+        let (direct_backing, direct_completion) = direct.into_parts();
+        assert!(direct_backing.kind().is_regular_file());
+        assert!(direct_backing.is_read_only());
+        assert_eq!(direct_backing.len(), 10);
+        drop(direct_backing);
+        direct_completion
+            .abort()
+            .expect("direct completion should abort infallibly");
+
+        let authority = root_file_grant_authority_for_test(root.path());
+        let observer = authority.clone();
+        let contained = contained_root(&authority).expect("contained root should prepare");
+        let diagnostics = format!("{contained:?}");
+        assert!(!diagnostics.contains(ROOT_REFERENCE));
+        assert!(!diagnostics.contains(&root.path().display().to_string()));
+        let (contained_backing, contained_completion) = contained.into_parts();
+        assert!(contained_backing.kind().is_regular_file());
+        assert!(contained_backing.is_read_only());
+        assert_eq!(contained_backing.len(), 10);
+        drop(contained_backing);
+        contained_completion
+            .abort()
+            .expect("contained completion should restore its exact claim");
+        assert_root_claim_restored(&observer);
+
+        let committed_authority = root_file_grant_authority_for_test(root.path());
+        let committed_observer = committed_authority.clone();
+        let committed =
+            contained_root(&committed_authority).expect("committed root should prepare");
+        let (backing, completion) = committed.into_parts();
+        drop(backing);
+        completion.commit();
+        assert!(
+            committed_observer
+                .prepare_drive_backing_claim(Path::new(ROOT_REFERENCE), GrantAccess::ReadOnly,)
+                .is_err(),
+            "commit should consume the contained claim exactly once"
+        );
+    }
+
+    #[test]
+    fn contained_root_rejects_ambient_paths_without_fallback() {
+        let root = TempRoot::new("contained-no-fallback", b"root");
+        let authority = root_file_grant_authority_for_test(root.path());
+        let error = PreparedSnapshotRootRestoreResource::prepare(
+            Path::new("/private/ambient-root"),
+            Some(&authority),
+        )
+        .expect_err("contained root must require an exact grant reference");
+        assert_eq!(
+            error.disposition,
+            SnapshotRestoreResourceDisposition::Retryable
+        );
+        assert_eq!(error.stage, SnapshotRestoreResourceStage::RootPreparation);
+        assert!(matches!(
+            error.kind,
+            SnapshotRestoreResourceErrorKind::RootBacking(SnapshotRootBackingLeaseError::Grant(_))
+        ));
+        assert_root_claim_restored(&authority);
+    }
+
+    #[test]
+    fn hostile_binding_and_consumption_states_abort_every_root_owner() {
+        let root = TempRoot::new("hostile-bindings", b"root");
+
+        let missing = requested()
+            .complete()
+            .expect_err("unbound request should remain incomplete");
+        assert_eq!(missing.stage, SnapshotRestoreResourceStage::Completion);
+        assert!(matches!(
+            missing.kind,
+            SnapshotRestoreResourceErrorKind::Incomplete { missing_count: 1 }
+        ));
+
+        let extra_authority = root_file_grant_authority_for_test(root.path());
+        let extra_request = requested();
+        let extra_key = SnapshotRestoreResourceKey::new(
+            extra_request.root_key.device_key(),
+            SnapshotRestorePublicId::try_from("other-root").expect("extra ID should validate"),
+            SnapshotRestoreResourceClass::BlockBacking,
+        );
+        let extra = extra_request
+            .prepare_root_with_key(extra_key, || false, |_| contained_root(&extra_authority))
+            .expect_err("swapped public identity should be extra");
+        assert_eq!(extra.stage, SnapshotRestoreResourceStage::Binding);
+        assert!(matches!(
+            extra.kind,
+            SnapshotRestoreResourceErrorKind::Binding(
+                SnapshotRestoreBindingRejectionReason::ExtraBinding
+            )
+        ));
+        assert_root_claim_restored(&extra_authority);
+
+        let wrong_class_authority = root_file_grant_authority_for_test(root.path());
+        let wrong_class_request = requested();
+        let wrong_class_key = SnapshotRestoreResourceKey::new(
+            wrong_class_request.root_key.device_key(),
+            wrong_class_request.root_key.public_id().clone(),
+            SnapshotRestoreResourceClass::VsockEndpoint,
+        );
+        let wrong_class = wrong_class_request
+            .prepare_root_with_key(
+                wrong_class_key,
+                || false,
+                |_| contained_root(&wrong_class_authority),
+            )
+            .expect_err("root owner under a vsock key should fail");
+        assert_eq!(wrong_class.stage, SnapshotRestoreResourceStage::Binding);
+        assert!(matches!(
+            wrong_class.kind,
+            SnapshotRestoreResourceErrorKind::OwnerClassMismatch
+        ));
+        assert_root_claim_restored(&wrong_class_authority);
+
+        let first_authority = root_file_grant_authority_for_test(root.path());
+        let second_authority = root_file_grant_authority_for_test(root.path());
+        let mut duplicate_request = requested();
+        let duplicate_key = duplicate_request.root_key.clone();
+        duplicate_request
+            .bindings
+            .bind(
+                &duplicate_key,
+                PreparedSnapshotRestoreResource::Root(
+                    contained_root(&first_authority).expect("first duplicate owner should prepare"),
+                ),
+            )
+            .expect("first exact owner should bind");
+        let duplicate = duplicate_request
+            .prepare_root_with_key(
+                duplicate_key,
+                || false,
+                |_| contained_root(&second_authority),
+            )
+            .expect_err("second exact owner should be duplicate");
+        assert_eq!(duplicate.stage, SnapshotRestoreResourceStage::Binding);
+        assert!(matches!(
+            duplicate.kind,
+            SnapshotRestoreResourceErrorKind::Binding(
+                SnapshotRestoreBindingRejectionReason::DuplicateBinding
+            )
+        ));
+        assert_root_claim_restored(&first_authority);
+        assert_root_claim_restored(&second_authority);
+
+        let swapped_take_authority = root_file_grant_authority_for_test(root.path());
+        let mut swapped_take = requested()
+            .prepare_root_with(|| false, |_| contained_root(&swapped_take_authority))
+            .expect("swapped-take batch should prepare");
+        swapped_take.root_key = SnapshotRestoreResourceKey::new(
+            swapped_take.root_key.device_key(),
+            SnapshotRestorePublicId::try_from("swapped-root")
+                .expect("swapped take ID should validate"),
+            SnapshotRestoreResourceClass::BlockBacking,
+        );
+        let construction_called = Cell::new(false);
+        let error = swapped_take
+            .consume_root_with(|_| {
+                construction_called.set(true);
+            })
+            .expect_err("swapped exact take should fail before construction");
+        assert!(!construction_called.get());
+        assert_eq!(error.stage, SnapshotRestoreResourceStage::Take);
+        assert!(matches!(
+            error.kind,
+            SnapshotRestoreResourceErrorKind::Take(SnapshotRestoreTakeError::UnknownResource)
+        ));
+        assert_root_claim_restored(&swapped_take_authority);
+
+        let repeated_authority = root_file_grant_authority_for_test(root.path());
+        let mut repeated = requested()
+            .prepare_root_with(|| false, |_| contained_root(&repeated_authority))
+            .expect("repeated-take batch should prepare");
+        let repeated_key = repeated.root_key.clone();
+        let repeated_root = repeated
+            .take_root(&repeated_key)
+            .expect("first exact take should succeed");
+        let error = repeated
+            .take_root(&repeated_key)
+            .expect_err("second exact take should fail");
+        assert_eq!(error.stage, SnapshotRestoreResourceStage::Take);
+        assert!(matches!(
+            error.kind,
+            SnapshotRestoreResourceErrorKind::Take(SnapshotRestoreTakeError::AlreadyTaken)
+        ));
+        repeated
+            .finish()
+            .expect("taken singleton should leave no unconsumed owner");
+        repeated_root
+            .abort()
+            .expect("taken owner should still abort explicitly");
+        assert_root_claim_restored(&repeated_authority);
+
+        let unconsumed_authority = root_file_grant_authority_for_test(root.path());
+        let unconsumed = requested()
+            .prepare_root_with(|| false, |_| contained_root(&unconsumed_authority))
+            .expect("unconsumed batch should prepare")
+            .finish()
+            .expect_err("finish should reject an unconsumed root");
+        assert_eq!(unconsumed.stage, SnapshotRestoreResourceStage::Finish);
+        assert!(matches!(
+            unconsumed.kind,
+            SnapshotRestoreResourceErrorKind::Unconsumed {
+                unconsumed_count: 1
+            }
+        ));
+        assert_root_claim_restored(&unconsumed_authority);
+    }
+
+    #[test]
+    fn provider_and_batch_diagnostics_redact_private_values() {
+        let private_path = unique_path("private-selector-do-not-render");
+        let error = PreparedSnapshotRootRestoreResource::prepare(&private_path, None)
+            .expect_err("missing private selector should fail");
+        let diagnostics = format!("{error:?} {error} {:?}", requested());
+        assert!(!diagnostics.contains(&private_path.display().to_string()));
+        assert!(!diagnostics.contains("private-selector-do-not-render"));
+        assert!(!diagnostics.contains(ROOT_REFERENCE));
+        assert!(!diagnostics.contains("root-selector"));
+        assert!(!diagnostics.contains("rootfs"));
+    }
+}

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -11,8 +11,6 @@ use std::os::unix::ffi::OsStringExt;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
-#[cfg(target_os = "macos")]
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, mpsc};
 use std::thread::{self, JoinHandle};
@@ -57,8 +55,6 @@ use bangbang_runtime::balloon::{
     BalloonHintingStatus, BalloonHintingStatusError, BalloonStats, BalloonStatsError,
     BalloonStatsUpdateInput, BalloonUpdateError, BalloonUpdateInput,
 };
-#[cfg(target_os = "macos")]
-use bangbang_runtime::block::SnapshotBlockFileBackingError;
 use bangbang_runtime::block::{
     BlockFileBacking, BlockMmioLayout, DriveBackendConfig, DriveConfig, DriveConfigError,
     DriveConfigInput, DriveIoEngine, DriveLiveUpdateMode, DriveRateLimiterConfig,
@@ -200,6 +196,12 @@ use crate::host_network::vmnet::{
     VmnetInterfaceStartDisposition, VmnetInterfaceStartError, VmnetMode, VmnetPacketIoBackend,
 };
 #[cfg(target_os = "macos")]
+use crate::snapshot_restore_resources::{
+    PreparedSnapshotRootBackingLease, PreparedSnapshotRootRestoreCompletion,
+    RequestedSnapshotRestoreResources, SnapshotRestoreResourceDisposition,
+    SnapshotRestoreResourceError, SnapshotRootBackingLeaseError, SnapshotRootSelectorPolicy,
+};
+#[cfg(target_os = "macos")]
 use crate::vsock_restore::{
     PreparedVsockRestoreResource, VsockRestoreDisposition, VsockRestoreError,
     prepare_vsock_restore_resource,
@@ -315,28 +317,7 @@ pub(crate) struct ProcessSnapshotV2RootLoadRequest<'a> {
     pub(crate) input: &'a SnapshotLoadInput,
     pub(crate) candidate: NativeV2SnapshotCandidateState,
     pub(crate) memory: GuestMemory,
-}
-
-impl<'a> ProcessSnapshotV2RootLoadRequest<'a> {
-    const fn new(
-        controller: &'a VmmController,
-        vmnet_authority: ProcessVmnetAuthority,
-        grant_authority: Option<&'a GrantAuthority>,
-        pci_enabled: bool,
-        input: &'a SnapshotLoadInput,
-        candidate: NativeV2SnapshotCandidateState,
-        memory: GuestMemory,
-    ) -> Self {
-        Self {
-            controller,
-            vmnet_authority,
-            grant_authority,
-            pci_enabled,
-            input,
-            candidate,
-            memory,
-        }
-    }
+    pub(crate) cancellation: NativeV2SnapshotCaptureCancellation,
 }
 
 pub(crate) trait InstanceStartExecutor {
@@ -1279,40 +1260,80 @@ impl<S> fmt::Debug for ProcessSnapshotV2RootLoadSuccess<S> {
     }
 }
 
+#[cfg(not(test))]
 pub(crate) struct ProcessSnapshotV2RootLoadCompletion {
     #[cfg(target_os = "macos")]
-    root_lease: Option<PreparedSnapshotRootBackingLease>,
+    root_completion: PreparedSnapshotRootRestoreCompletion,
     #[cfg(target_os = "macos")]
-    serial_output: Option<SharedSerialOutput>,
+    serial_output: SharedSerialOutput,
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(test)]
+pub(crate) enum ProcessSnapshotV2RootLoadCompletion {
+    #[cfg(target_os = "macos")]
+    Prepared(Box<ProcessSnapshotV2RootLoadCompletionResources>),
+    Empty,
+}
+
+#[cfg(all(test, target_os = "macos"))]
+pub(crate) struct ProcessSnapshotV2RootLoadCompletionResources {
+    root_completion: PreparedSnapshotRootRestoreCompletion,
+    serial_output: SharedSerialOutput,
+}
+
+#[cfg(all(not(test), target_os = "macos"))]
 impl ProcessSnapshotV2RootLoadCompletion {
     const fn new(
-        root_lease: PreparedSnapshotRootBackingLease,
+        root_completion: PreparedSnapshotRootRestoreCompletion,
         serial_output: SharedSerialOutput,
     ) -> Self {
         Self {
-            root_lease: Some(root_lease),
-            serial_output: Some(serial_output),
+            root_completion,
+            serial_output,
         }
     }
 
-    #[cfg(test)]
+    fn abort(self) -> Result<(), GrantClaimError> {
+        let Self {
+            root_completion,
+            serial_output,
+        } = self;
+        drop(serial_output);
+        root_completion.abort()
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+impl ProcessSnapshotV2RootLoadCompletion {
+    fn new(
+        root_completion: PreparedSnapshotRootRestoreCompletion,
+        serial_output: SharedSerialOutput,
+    ) -> Self {
+        Self::Prepared(Box::new(ProcessSnapshotV2RootLoadCompletionResources {
+            root_completion,
+            serial_output,
+        }))
+    }
+
+    fn abort(self) -> Result<(), GrantClaimError> {
+        match self {
+            Self::Prepared(resources) => {
+                let ProcessSnapshotV2RootLoadCompletionResources {
+                    root_completion,
+                    serial_output,
+                } = *resources;
+                drop(serial_output);
+                root_completion.abort()
+            }
+            Self::Empty => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+impl ProcessSnapshotV2RootLoadCompletion {
     pub(crate) const fn empty_for_test() -> Self {
-        Self {
-            root_lease: None,
-            serial_output: None,
-        }
-    }
-
-    fn into_parts(
-        self,
-    ) -> (
-        Option<PreparedSnapshotRootBackingLease>,
-        Option<SharedSerialOutput>,
-    ) {
-        (self.root_lease, self.serial_output)
+        Self::Empty
     }
 }
 
@@ -1325,6 +1346,27 @@ impl fmt::Debug for ProcessSnapshotV2RootLoadCompletion {
     }
 }
 
+fn native_v2_error_after_process_root_completion_abort(
+    source: NativeV2SnapshotLoadError,
+    completion: ProcessSnapshotV2RootLoadCompletion,
+) -> NativeV2SnapshotLoadError {
+    #[cfg(target_os = "macos")]
+    {
+        match completion.abort() {
+            Ok(()) => source,
+            Err(cleanup) => NativeV2SnapshotLoadError::RootResourceCleanup {
+                source: Box::new(source),
+                cleanup,
+            },
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = completion;
+        source
+    }
+}
+
 #[allow(
     dead_code,
     reason = "native-v2 process restore is target-gated and exercised by signed integration coverage"
@@ -1333,9 +1375,17 @@ impl fmt::Debug for ProcessSnapshotV2RootLoadCompletion {
 pub(crate) enum NativeV2SnapshotLoadError {
     Preflight(VmmActionError),
     ProcessTerminal,
+    Cancelled,
     Resource(GrantClaimError),
+    #[cfg(target_os = "macos")]
+    RestoreResources(SnapshotRestoreResourceError),
     AfterResourceAdoption {
         source: Box<NativeV2SnapshotLoadError>,
+    },
+    #[cfg(target_os = "macos")]
+    RootResourceCleanup {
+        source: Box<NativeV2SnapshotLoadError>,
+        cleanup: GrantClaimError,
     },
     Artifact(SnapshotArtifactLoadError),
     ArtifactState(NativeSnapshotArtifactStateError),
@@ -1377,12 +1427,14 @@ impl NativeV2SnapshotLoadError {
             | Self::AfterResourceAdoption { .. }
             | Self::RunReady { .. }
             | Self::WorkerStart { .. }
-            | Self::ControllerCommit(_)
             | Self::Resume(_) => true,
+            #[cfg(target_os = "macos")]
+            Self::RootResourceCleanup { .. } => true,
             Self::Restore(source) => source.is_committed() || !source.cleanup_failures().is_empty(),
             Self::RootRestore(source) => source.is_terminal(),
             Self::Preflight(_)
             | Self::Resource(_)
+            | Self::Cancelled
             | Self::Artifact(_)
             | Self::ArtifactState(_)
             | Self::UnexpectedFamily(_)
@@ -1395,9 +1447,14 @@ impl NativeV2SnapshotLoadError {
             | Self::RootBundle(_)
             | Self::BootMetadata(_)
             | Self::Allocation(_)
-            | Self::ProcessPreparation(_) => false,
+            | Self::ProcessPreparation(_)
+            | Self::ControllerCommit(_) => false,
             #[cfg(target_os = "macos")]
             Self::RootBacking(_) => false,
+            #[cfg(target_os = "macos")]
+            Self::RestoreResources(source) => {
+                source.disposition() == SnapshotRestoreResourceDisposition::Terminal
+            }
         }
     }
 }
@@ -1409,13 +1466,28 @@ impl fmt::Display for NativeV2SnapshotLoadError {
                 write!(formatter, "native-v2 load preflight failed: {source}")
             }
             Self::ProcessTerminal => formatter.write_str("native-v2 load process is terminal"),
+            Self::Cancelled => formatter.write_str("native-v2 load was cancelled"),
             Self::Resource(source) => {
                 write!(formatter, "native-v2 resource adoption failed: {source}")
+            }
+            #[cfg(target_os = "macos")]
+            Self::RestoreResources(source) => {
+                write!(
+                    formatter,
+                    "native-v2 restore resource preparation failed: {source}"
+                )
             }
             Self::AfterResourceAdoption { source } => {
                 write!(
                     formatter,
                     "native-v2 load failed after resource adoption: {source}"
+                )
+            }
+            #[cfg(target_os = "macos")]
+            Self::RootResourceCleanup { source, .. } => {
+                write!(
+                    formatter,
+                    "native-v2 load failed and root authority cleanup was incomplete: {source}"
                 )
             }
             Self::Artifact(source) => write!(formatter, "native-v2 artifact load failed: {source}"),
@@ -1522,7 +1594,11 @@ impl std::error::Error for NativeV2SnapshotLoadError {
         match self {
             Self::Preflight(source) => Some(source),
             Self::Resource(source) => Some(source),
+            #[cfg(target_os = "macos")]
+            Self::RestoreResources(source) => Some(source),
             Self::AfterResourceAdoption { source } => Some(source.as_ref()),
+            #[cfg(target_os = "macos")]
+            Self::RootResourceCleanup { source, .. } => Some(source.as_ref()),
             Self::Artifact(source) => Some(source),
             Self::ArtifactState(source) => Some(source),
             Self::State(source) => Some(source),
@@ -1542,8 +1618,25 @@ impl std::error::Error for NativeV2SnapshotLoadError {
             Self::WorkerStart { source, .. } => Some(source),
             Self::ControllerCommit(source) => Some(source),
             Self::Resume(source) => Some(source),
-            Self::ProcessTerminal | Self::UnexpectedFamily(_) | Self::CandidateMismatch => None,
+            Self::ProcessTerminal
+            | Self::Cancelled
+            | Self::UnexpectedFamily(_)
+            | Self::CandidateMismatch => None,
         }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn native_v2_error_after_root_resource_abort(
+    source: NativeV2SnapshotLoadError,
+    completion: PreparedSnapshotRootRestoreCompletion,
+) -> NativeV2SnapshotLoadError {
+    match completion.abort() {
+        Ok(()) => source,
+        Err(cleanup) => NativeV2SnapshotLoadError::RootResourceCleanup {
+            source: Box::new(source),
+            cleanup,
+        },
     }
 }
 
@@ -1750,137 +1843,6 @@ impl fmt::Debug for PreparedNativeSnapshotLoad {
             .field("state", &"<redacted>")
             .field("authority", &"<redacted>")
             .finish()
-    }
-}
-
-#[cfg(target_os = "macos")]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SnapshotRootSelectorPolicy {
-    TreatAsPath,
-    RejectGrantReference,
-    RequireGrantWhenContained,
-}
-
-#[cfg(target_os = "macos")]
-struct PreparedSnapshotRootBackingLease {
-    selector: Option<PathBuf>,
-    claim: Option<PreparedDriveBackingClaim>,
-    consumed: bool,
-}
-
-#[cfg(target_os = "macos")]
-impl PreparedSnapshotRootBackingLease {
-    fn prepare(
-        selector: &Path,
-        authority: Option<&GrantAuthority>,
-        selector_policy: SnapshotRootSelectorPolicy,
-    ) -> Result<Self, GrantClaimError> {
-        let claim = match authority {
-            Some(authority) => {
-                match authority.prepare_drive_backing_claim(selector, GrantAccess::ReadOnly)? {
-                    Some(claim) => Some(claim),
-                    None if selector_policy
-                        == SnapshotRootSelectorPolicy::RequireGrantWhenContained =>
-                    {
-                        return Err(GrantClaimError);
-                    }
-                    None => None,
-                }
-            }
-            None => {
-                if selector_policy == SnapshotRootSelectorPolicy::RejectGrantReference
-                    && grant_reference_id(selector)?.is_some()
-                {
-                    return Err(GrantClaimError);
-                }
-                None
-            }
-        };
-        Ok(Self {
-            selector: Some(selector.to_path_buf()),
-            claim,
-            consumed: false,
-        })
-    }
-
-    fn take_snapshot_read_only_file(&mut self) -> Result<Option<File>, GrantClaimError> {
-        let (_selector, file) = self.consume()?;
-        Ok(file)
-    }
-
-    fn consume(&mut self) -> Result<(PathBuf, Option<File>), GrantClaimError> {
-        if self.consumed {
-            return Err(GrantClaimError);
-        }
-        self.consumed = true;
-        let selector = self.selector.take().ok_or(GrantClaimError)?;
-        let file = self
-            .claim
-            .as_mut()
-            .map(PreparedDriveBackingClaim::take_snapshot_read_only_file)
-            .transpose()?;
-        Ok((selector, file))
-    }
-
-    fn open_snapshot_read_only(
-        &mut self,
-    ) -> Result<BlockFileBacking, SnapshotRootBackingLeaseError> {
-        let (selector, file) = self
-            .consume()
-            .map_err(SnapshotRootBackingLeaseError::Grant)?;
-        match file {
-            Some(file) => BlockFileBacking::from_snapshot_read_only_file(file)
-                .map(|(backing, _identity)| backing)
-                .map_err(SnapshotRootBackingLeaseError::Backing),
-            None => BlockFileBacking::open_snapshot_read_only(&selector)
-                .map(|(backing, _identity)| backing)
-                .map_err(SnapshotRootBackingLeaseError::Backing),
-        }
-    }
-
-    fn commit(self) {
-        if let Some(claim) = self.claim {
-            claim.commit();
-        }
-    }
-}
-
-#[cfg(target_os = "macos")]
-impl fmt::Debug for PreparedSnapshotRootBackingLease {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("PreparedSnapshotRootBackingLease")
-            .field("selector", &self.selector.as_ref().map(|_| "<redacted>"))
-            .field("claim", &self.claim.as_ref().map(|_| "<provisional>"))
-            .field("consumed", &self.consumed)
-            .finish()
-    }
-}
-
-#[cfg(target_os = "macos")]
-#[derive(Debug)]
-pub(crate) enum SnapshotRootBackingLeaseError {
-    Grant(GrantClaimError),
-    Backing(SnapshotBlockFileBackingError),
-}
-
-#[cfg(target_os = "macos")]
-impl fmt::Display for SnapshotRootBackingLeaseError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Grant(_) => formatter.write_str("snapshot root authority validation failed"),
-            Self::Backing(_) => formatter.write_str("snapshot root backing validation failed"),
-        }
-    }
-}
-
-#[cfg(target_os = "macos")]
-impl std::error::Error for SnapshotRootBackingLeaseError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Grant(source) => Some(source),
-            Self::Backing(source) => Some(source),
-        }
     }
 }
 
@@ -5185,6 +5147,9 @@ where
             self.starter
                 .preflight_snapshot_v2_root_process(self.pci_enabled)
                 .map_err(NativeV2SnapshotLoadError::Preflight)?;
+            if !self.snapshot_capture_cancellation.begin_operation() {
+                return Err(NativeV2SnapshotLoadError::Cancelled);
+            }
         } else {
             self.starter
                 .preflight_snapshot_v2_process()
@@ -5251,15 +5216,16 @@ where
                 })?;
             let restored = self
                 .starter
-                .load_prepared_snapshot_v2_root(ProcessSnapshotV2RootLoadRequest::new(
-                    &self.controller,
-                    self.vmnet_authority,
-                    self.grant_authority.as_ref(),
-                    self.pci_enabled,
+                .load_prepared_snapshot_v2_root(ProcessSnapshotV2RootLoadRequest {
+                    controller: &self.controller,
+                    vmnet_authority: self.vmnet_authority,
+                    grant_authority: self.grant_authority.as_ref(),
+                    pci_enabled: self.pci_enabled,
                     input,
                     candidate,
                     memory,
-                ))
+                    cancellation: self.snapshot_capture_cancellation.clone(),
+                })
                 .map_err(|source| {
                     if resource_adopted {
                         NativeV2SnapshotLoadError::AfterResourceAdoption {
@@ -5270,6 +5236,20 @@ where
                     }
                 })?;
             let (session, controller_commit, completion) = restored.into_parts();
+            if !self.snapshot_capture_cancellation.try_seal_commit() {
+                drop(session);
+                let source = native_v2_error_after_process_root_completion_abort(
+                    NativeV2SnapshotLoadError::Cancelled,
+                    completion,
+                );
+                return Err(if resource_adopted {
+                    NativeV2SnapshotLoadError::AfterResourceAdoption {
+                        source: Box::new(source),
+                    }
+                } else {
+                    source
+                });
+            }
             self.started_session = Some(session);
             let resume_requested = self.controller.commit_snapshot_v2_load(controller_commit);
             self.starter
@@ -6143,6 +6123,9 @@ impl ProcessVmm<HvfInstanceStartExecutor> {
         self.starter
             .preflight_snapshot_v2_root_process(self.pci_enabled)
             .map_err(NativeV2SnapshotLoadError::Preflight)?;
+        if !self.snapshot_capture_cancellation.begin_operation() {
+            return Err(NativeV2SnapshotLoadError::Cancelled);
+        }
         prepare_hvf_native_v2_root_candidate_load(
             &self.starter,
             self.grant_authority.as_ref(),
@@ -6150,6 +6133,7 @@ impl ProcessVmm<HvfInstanceStartExecutor> {
             input,
             candidate,
             memory,
+            self.snapshot_capture_cancellation.clone(),
         )
     }
 
@@ -6182,18 +6166,29 @@ impl ProcessVmm<HvfInstanceStartExecutor> {
             self.vmnet_authority,
             prepared,
         )?;
-        let (session, controller_commit, root_lease, serial_output) = restored.into_parts();
+        let (session, controller_commit, root_completion, serial_output) = restored.into_parts();
         if let Err(source) = before_controller_commit() {
-            // Dropping the still-unpublished paused supervisor stops its
-            // worker and tears down the complete root/platform owner. The
-            // provisional backing claim is released when `root_lease` drops.
             drop(session);
-            return Err(NativeV2SnapshotLoadError::ControllerCommit(source));
+            drop(serial_output);
+            drop(controller_commit);
+            return Err(native_v2_error_after_root_resource_abort(
+                NativeV2SnapshotLoadError::ControllerCommit(source),
+                root_completion,
+            ));
+        }
+        if !self.snapshot_capture_cancellation.try_seal_commit() {
+            drop(session);
+            drop(serial_output);
+            drop(controller_commit);
+            return Err(native_v2_error_after_root_resource_abort(
+                NativeV2SnapshotLoadError::Cancelled,
+                root_completion,
+            ));
         }
         self.starter.active_serial_output = Some(serial_output);
         self.started_session = Some(session);
         let resume_requested = self.controller.commit_snapshot_v2_load(controller_commit);
-        root_lease.commit();
+        root_completion.commit();
         Ok(resume_requested)
     }
 
@@ -6479,11 +6474,12 @@ struct PreparedHvfSnapshotV2RootProcessLoad {
     memory: GuestMemory,
     root: PreparedSnapshotV2RootBlock,
     resources: HvfSnapshotV2RootResourcePlan,
-    root_lease: PreparedSnapshotRootBackingLease,
+    root_completion: PreparedSnapshotRootRestoreCompletion,
     controller_commit: SnapshotV2ControllerCommit,
     serial_output: SharedSerialOutput,
     guest_ranges: Vec<GuestMemoryRange>,
     virtual_timer_intid: u32,
+    cancellation: NativeV2SnapshotCaptureCancellation,
 }
 
 #[cfg(target_os = "macos")]
@@ -6505,11 +6501,12 @@ impl PreparedHvfSnapshotV2RootProcessLoad {
             memory: self.memory,
             root: self.root,
             resources: self.resources,
-            root_lease: self.root_lease,
+            root_completion: self.root_completion,
             controller_commit: self.controller_commit,
             serial_output: self.serial_output,
             guest_ranges: self.guest_ranges,
             virtual_timer_intid: self.virtual_timer_intid,
+            cancellation: self.cancellation,
         }
     }
 }
@@ -6520,18 +6517,19 @@ struct PreparedHvfSnapshotV2RootProcessLoadParts {
     memory: GuestMemory,
     root: PreparedSnapshotV2RootBlock,
     resources: HvfSnapshotV2RootResourcePlan,
-    root_lease: PreparedSnapshotRootBackingLease,
+    root_completion: PreparedSnapshotRootRestoreCompletion,
     controller_commit: SnapshotV2ControllerCommit,
     serial_output: SharedSerialOutput,
     guest_ranges: Vec<GuestMemoryRange>,
     virtual_timer_intid: u32,
+    cancellation: NativeV2SnapshotCaptureCancellation,
 }
 
 #[cfg(target_os = "macos")]
 struct SnapshotV2RootLoadSuccess {
     session: HvfProcessSession,
     controller_commit: SnapshotV2ControllerCommit,
-    root_lease: PreparedSnapshotRootBackingLease,
+    root_completion: PreparedSnapshotRootRestoreCompletion,
     serial_output: SharedSerialOutput,
 }
 
@@ -6542,13 +6540,13 @@ impl SnapshotV2RootLoadSuccess {
     ) -> (
         HvfProcessSession,
         SnapshotV2ControllerCommit,
-        PreparedSnapshotRootBackingLease,
+        PreparedSnapshotRootRestoreCompletion,
         SharedSerialOutput,
     ) {
         (
             self.session,
             self.controller_commit,
-            self.root_lease,
+            self.root_completion,
             self.serial_output,
         )
     }
@@ -6604,6 +6602,7 @@ fn prepare_hvf_native_v2_root_candidate_load(
     input: &SnapshotLoadInput,
     candidate: NativeV2SnapshotCandidateState,
     memory: GuestMemory,
+    cancellation: NativeV2SnapshotCaptureCancellation,
 ) -> Result<PreparedHvfSnapshotV2RootProcessLoad, NativeV2SnapshotLoadError> {
     let (bytes, binding, graph) = candidate.into_parts();
     let structural = decode_snapshot_v2_state_with_compatibility_version(
@@ -6616,6 +6615,9 @@ fn prepare_hvf_native_v2_root_candidate_load(
     if state.platform().memory() != &binding || state.device_graph() != &graph {
         return Err(NativeV2SnapshotLoadError::CandidateMismatch);
     }
+    let requested_resources =
+        RequestedSnapshotRestoreResources::try_from_native_v2_device_graph(&graph)
+            .map_err(NativeV2SnapshotLoadError::RestoreResources)?;
 
     let boot_source_config = native_v2_boot_source_config(state.platform().machine().boot())
         .map_err(NativeV2SnapshotLoadError::BootMetadata)?;
@@ -6660,32 +6662,39 @@ fn prepare_hvf_native_v2_root_candidate_load(
         SharedSerialOutput::with_rate_limiter(starter.serial_output.clone(), rate_limiter)
     };
 
-    let mut root_lease = PreparedSnapshotRootBackingLease::prepare(
-        Path::new(prepared.selector()),
-        grant_authority,
-        SnapshotRootSelectorPolicy::RequireGrantWhenContained,
-    )
-    .map_err(|source| {
-        NativeV2SnapshotLoadError::RootBacking(SnapshotRootBackingLeaseError::Grant(source))
-    })?;
+    let prepared_resources = requested_resources
+        .prepare_root(grant_authority, || cancellation.is_cancelled())
+        .map_err(NativeV2SnapshotLoadError::RestoreResources)?;
+    let root_resource = prepared_resources
+        .into_root()
+        .map_err(NativeV2SnapshotLoadError::RestoreResources)?;
+    let (backing, root_completion) = root_resource.into_parts();
     let (platform, memory, root, resources) = prepared.into_parts();
-    let backing = root_lease
-        .open_snapshot_read_only()
-        .map_err(NativeV2SnapshotLoadError::RootBacking)?;
-    let root = root
-        .prepare_backing(backing)
-        .map_err(NativeV2SnapshotLoadError::RootBundle)?;
+    let root = match root.prepare_backing(backing) {
+        Ok(root) => root,
+        Err(source) => {
+            drop(platform);
+            drop(memory);
+            drop(controller_commit);
+            drop(serial_output);
+            return Err(native_v2_error_after_root_resource_abort(
+                NativeV2SnapshotLoadError::RootBundle(source),
+                root_completion,
+            ));
+        }
+    };
 
     Ok(PreparedHvfSnapshotV2RootProcessLoad {
         platform,
         memory,
         root,
         resources,
-        root_lease,
+        root_completion,
         controller_commit,
         serial_output,
         guest_ranges,
         virtual_timer_intid,
+        cancellation,
     })
 }
 
@@ -6706,35 +6715,66 @@ impl HvfInstanceStartExecutor {
             memory,
             root,
             resources,
-            root_lease,
+            root_completion,
             controller_commit,
             serial_output,
             guest_ranges: _guest_ranges,
             virtual_timer_intid: _virtual_timer_intid,
+            cancellation,
         } = prepared.into_parts();
         let (packet_io, mmds_metrics) =
-            ProcessNetworkPacketIoProvider::from_controller(controller, vmnet_authority).map_err(
-                |source| {
-                    NativeV2SnapshotLoadError::ProcessPreparation(BackendError::Hypervisor(
-                        format!("failed to build native-v2 network packet I/O provider: {source}"),
-                    ))
-                },
-            )?;
+            match ProcessNetworkPacketIoProvider::from_controller(controller, vmnet_authority) {
+                Ok(prepared) => prepared,
+                Err(source) => {
+                    drop(root);
+                    drop(platform);
+                    drop(memory);
+                    drop(controller_commit);
+                    drop(serial_output);
+                    return Err(native_v2_error_after_root_resource_abort(
+                        NativeV2SnapshotLoadError::ProcessPreparation(BackendError::Hypervisor(
+                            format!(
+                                "failed to build native-v2 network packet I/O provider: {source}"
+                            ),
+                        )),
+                        root_completion,
+                    ));
+                }
+            };
         let process_shell = HvfSnapshotV2DefaultProcessShell::new(serial_output.clone());
-        let mut session = OwnedHvfArm64BootSession::restore_snapshot_v2_root(
+        let mut session = match OwnedHvfArm64BootSession::restore_snapshot_v2_root(
             platform,
             memory,
             process_shell,
             root,
             resources,
-        )
-        .map_err(NativeV2SnapshotLoadError::RootRestore)?;
+        ) {
+            Ok(session) => session,
+            Err(source) => {
+                drop(packet_io);
+                drop(mmds_metrics);
+                drop(controller_commit);
+                drop(serial_output);
+                return Err(native_v2_error_after_root_resource_abort(
+                    NativeV2SnapshotLoadError::RootRestore(source),
+                    root_completion,
+                ));
+            }
+        };
         if let Err(source) = session.resume_after_snapshot_v2_capture() {
             let cleanup = session
                 .shutdown()
                 .err()
                 .map(|source| BackendError::Hypervisor(source.to_string()));
-            return Err(NativeV2SnapshotLoadError::RunReady { source, cleanup });
+            drop(session);
+            drop(packet_io);
+            drop(mmds_metrics);
+            drop(controller_commit);
+            drop(serial_output);
+            return Err(native_v2_error_after_root_resource_abort(
+                NativeV2SnapshotLoadError::RunReady { source, cleanup },
+                root_completion,
+            ));
         }
         let process_session = ProcessHvfBootSession::new_with_vmnet_authority(
             session,
@@ -6754,14 +6794,29 @@ impl HvfInstanceStartExecutor {
                     .shutdown()
                     .err()
                     .map(|source| BackendError::Hypervisor(source.to_string()));
-                return Err(NativeV2SnapshotLoadError::WorkerStart { source, cleanup });
+                drop(failed_session);
+                drop(controller_commit);
+                drop(serial_output);
+                return Err(native_v2_error_after_root_resource_abort(
+                    NativeV2SnapshotLoadError::WorkerStart { source, cleanup },
+                    root_completion,
+                ));
             }
         };
+        if cancellation.is_cancelled() {
+            drop(supervisor);
+            drop(controller_commit);
+            drop(serial_output);
+            return Err(native_v2_error_after_root_resource_abort(
+                NativeV2SnapshotLoadError::Cancelled,
+                root_completion,
+            ));
+        }
 
         Ok(SnapshotV2RootLoadSuccess {
             session: HvfProcessSession::Boot(supervisor),
             controller_commit,
-            root_lease,
+            root_completion,
             serial_output,
         })
     }
@@ -7279,6 +7334,7 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
             input,
             candidate,
             memory,
+            cancellation,
         } = request;
         self.preflight_snapshot_v2_root_process(pci_enabled)
             .map_err(NativeV2SnapshotLoadError::Preflight)?;
@@ -7289,14 +7345,15 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
             input,
             candidate,
             memory,
+            cancellation,
         )?;
         let restored =
             self.load_prepared_snapshot_v2_root_process(controller, vmnet_authority, prepared)?;
-        let (session, controller_commit, root_lease, serial_output) = restored.into_parts();
+        let (session, controller_commit, root_completion, serial_output) = restored.into_parts();
         Ok(ProcessSnapshotV2RootLoadSuccess::new(
             session,
             controller_commit,
-            ProcessSnapshotV2RootLoadCompletion::new(root_lease, serial_output),
+            ProcessSnapshotV2RootLoadCompletion::new(root_completion, serial_output),
         ))
     }
 
@@ -7305,13 +7362,29 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
         &mut self,
         completion: ProcessSnapshotV2RootLoadCompletion,
     ) {
-        let (root_lease, serial_output) = completion.into_parts();
-        let (Some(root_lease), Some(serial_output)) = (root_lease, serial_output) else {
-            debug_assert!(false, "HVF root-load completion must own both resources");
-            return;
-        };
-        self.active_serial_output = Some(serial_output);
-        root_lease.commit();
+        #[cfg(not(test))]
+        {
+            let ProcessSnapshotV2RootLoadCompletion {
+                root_completion,
+                serial_output,
+            } = completion;
+            self.active_serial_output = Some(serial_output);
+            root_completion.commit();
+        }
+        #[cfg(test)]
+        match completion {
+            ProcessSnapshotV2RootLoadCompletion::Prepared(resources) => {
+                let ProcessSnapshotV2RootLoadCompletionResources {
+                    root_completion,
+                    serial_output,
+                } = *resources;
+                self.active_serial_output = Some(serial_output);
+                root_completion.commit();
+            }
+            ProcessSnapshotV2RootLoadCompletion::Empty => {
+                debug_assert!(false, "HVF root-load completion must own both resources");
+            }
+        }
     }
 
     fn metrics_diagnostics(&self) -> MetricsDiagnostics {
@@ -15629,12 +15702,16 @@ mod tests {
         assert!(backing.kind().is_regular_file());
         assert!(backing.is_read_only());
         drop(backing);
-        drop(cancelled);
+        cancelled
+            .abort()
+            .expect("cancelled lease should explicitly restore its claim");
         let restored = observer
             .prepare_drive_backing_claim(Path::new(ROOT), GrantAccess::ReadOnly)
             .expect("cancelled lease should restore exact grant")
             .expect("restored grant should reserve again");
-        drop(restored);
+        restored
+            .abort()
+            .expect("observed restored claim should return to authority");
 
         let authority = file_grant_authority_for_test();
         let observer = authority.clone();
@@ -17003,6 +17080,7 @@ mod tests {
                 input,
                 candidate,
                 memory: _,
+                cancellation: _,
             } = request;
             let expected_transport = if pci_enabled {
                 SnapshotV2DeviceTransportKind::Pci
@@ -27905,7 +27983,7 @@ mod tests {
                     &error,
                     NativeV2SnapshotLoadError::ControllerCommit(_)
                 ));
-                assert!(error.is_terminal());
+                assert!(!error.is_terminal());
                 assert!(!failed.has_started_session());
                 assert!(failed.starter.active_serial_output.is_none());
                 assert_eq!(failed.instance_info().state, InstanceState::NotStarted);
@@ -27914,7 +27992,34 @@ mod tests {
                     .prepare_drive_backing_claim(Path::new(ROOT_REFERENCE), GrantAccess::ReadOnly)
                     .expect("failed controller checkpoint should restore the root grant")
                     .expect("restored root grant should be claimable");
-                drop(restored_claim);
+                restored_claim
+                    .abort()
+                    .expect("observed checkpoint claim should restore for the retry");
+                assert!(
+                    !failed
+                        .restore_native_v2_root_candidate_once(
+                            &input,
+                            NativeV2SnapshotCandidateState::from_device_graph_v2_4(
+                                candidate_bytes.clone(),
+                            )
+                            .expect("checkpoint retry candidate should validate"),
+                            load_memory(),
+                        )
+                        .expect("clean controller checkpoint should remain retryable")
+                );
+                assert_eq!(failed.instance_info().state, InstanceState::Paused);
+                assert!(failed.has_started_session());
+                assert!(failed.starter.active_serial_output.is_some());
+                assert_eq!(failed.drive_configs().len(), 1);
+                assert!(
+                    failed_observer
+                        .prepare_drive_backing_claim(
+                            Path::new(ROOT_REFERENCE),
+                            GrantAccess::ReadOnly,
+                        )
+                        .is_err(),
+                    "successful retry must consume the restored root claim"
+                );
                 drop(failed);
             }
 


### PR DESCRIPTION
## Summary

- derive the exact native-v2 2.4 root restore manifest before direct path access or contained grant reservation
- prepare, bind, complete, exact-take, and finish a process-owned pathless root resource batch before HVF construction
- keep root authority provisional through unpublished construction and controller checkpoints, with explicit abort evidence for retryable versus terminal failures
- make clean controller-checkpoint rollback retryable and prove same-process retry consumes the restored claim exactly once
- add hostile batch-state, ordering, cancellation, cleanup, redaction, MMIO/PCI, direct, and contained coverage

## Scope

This PR implements the root/file owner only. It does not add root-plus-vsock composition, cross-authority session hardening, launcher protocol changes, artifact codec changes, or public profile expansion.

Closes #1598

Parent: #1532

Program context: #1490

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test native_v2_process`
- `scripts/run-integration-tests.sh`
