### PR TITLE
feat: make contained restore batches failure-atomic

### DIFF
--- a/crates/bangbang/Cargo.toml
+++ b/crates/bangbang/Cargo.toml
@@ -23,6 +23,7 @@ signal-hook = "0.3"
 signal-hook-registry = "1"
 
 [dev-dependencies]
+bangbang-session = { path = "../session", features = ["test-support"] }
 crc64 = "2.0.0"
 plist = "1"
 

--- a/crates/bangbang/src/anchored_socket.rs
+++ b/crates/bangbang/src/anchored_socket.rs
@@ -522,10 +522,13 @@ fn bind_inner(
             .as_ref()
             .ok_or(AnchoredSocketError::Invalid)
             .and_then(SocketBrokerClaim::endpoint)
-            .and_then(prepare_connector_endpoint);
+            .and_then(|endpoint| {
+                prepare_connector_endpoint(endpoint)?;
+                wait_for_broker(endpoint, libc::POLLOUT, AnchoredSocketError::Cancelled)
+            });
         if let Err(error) = prepared {
             cleanup_published_claim_checked(&namespace, &claim, &record)?;
-            return Err(error);
+            return Err(pre_activation_broker_error(error));
         }
     }
     if cancelled() {
@@ -567,6 +570,14 @@ fn bind_inner(
         },
         connector,
     })
+}
+
+const fn pre_activation_broker_error(error: AnchoredSocketError) -> AnchoredSocketError {
+    if matches!(error, AnchoredSocketError::Cancelled) {
+        AnchoredSocketError::Cancelled
+    } else {
+        AnchoredSocketError::Broker
+    }
 }
 
 fn spawn_binder(
@@ -648,6 +659,7 @@ fn spawn_connector(
     endpoint: SocketBrokerEndpoint,
 ) -> Result<AnchoredVsockConnector, AnchoredSocketError> {
     prepare_connector_endpoint(&endpoint)?;
+    wait_for_broker(&endpoint, libc::POLLOUT, AnchoredSocketError::Broker)?;
     let activate = SocketBrokerMessage::Activate {
         session: endpoint.session,
         sequence: 1,
@@ -655,6 +667,7 @@ fn spawn_connector(
     };
     send_socket_broker_message(&endpoint.socket, &activate, None)
         .map_err(|_| AnchoredSocketError::Binder)?;
+    wait_for_broker(&endpoint, libc::POLLIN, AnchoredSocketError::Broker)?;
     let response =
         receive_socket_broker_message(&endpoint.socket).map_err(|_| AnchoredSocketError::Binder)?;
     verify_peer_pid(endpoint.socket.as_raw_fd(), endpoint.launcher_pid)
@@ -668,13 +681,97 @@ fn spawn_connector(
     ) {
         return Err(AnchoredSocketError::Invalid);
     }
+    let SocketBrokerEndpoint {
+        socket,
+        session,
+        launcher_pid,
+        wakeup: _,
+    } = endpoint;
     Ok(AnchoredVsockConnector {
-        socket: endpoint.socket,
-        session: endpoint.session,
-        launcher_pid: endpoint.launcher_pid,
+        socket,
+        session,
+        launcher_pid,
         next_sequence: 2,
         healthy: true,
     })
+}
+
+fn wait_for_broker(
+    endpoint: &SocketBrokerEndpoint,
+    broker_events: libc::c_short,
+    wakeup_error: AnchoredSocketError,
+) -> Result<(), AnchoredSocketError> {
+    let mut descriptors = [
+        libc::pollfd {
+            fd: endpoint.socket.as_raw_fd(),
+            events: broker_events,
+            revents: 0,
+        },
+        libc::pollfd {
+            fd: endpoint
+                .wakeup
+                .as_ref()
+                .map_or(-1, |wakeup| wakeup.as_raw_fd()),
+            events: libc::POLLIN,
+            revents: 0,
+        },
+    ];
+    let descriptor_count = if endpoint.wakeup.is_some() {
+        descriptors.len()
+    } else {
+        descriptors.len() - 1
+    };
+    let timeout =
+        i32::try_from(BINDER_TIMEOUT.as_millis()).map_err(|_| AnchoredSocketError::Invalid)?;
+    loop {
+        // SAFETY: The initialized poll array remains writable for the call.
+        let result = unsafe {
+            libc::poll(
+                descriptors.as_mut_ptr(),
+                descriptor_count as libc::nfds_t,
+                timeout,
+            )
+        };
+        if result < 0 {
+            if io::Error::last_os_error().kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(AnchoredSocketError::Broker);
+        }
+        if result == 0 {
+            return Err(AnchoredSocketError::Broker);
+        }
+        let invalid = libc::POLLERR | libc::POLLHUP | libc::POLLNVAL;
+        if endpoint.wakeup.is_some() && descriptors[1].revents & (libc::POLLIN | invalid) != 0 {
+            return Err(wakeup_error);
+        }
+        if descriptors[0].revents & invalid != 0 {
+            return Err(AnchoredSocketError::Broker);
+        }
+        if descriptors[0].revents & broker_events != 0 {
+            if broker_events & libc::POLLIN != 0 {
+                let mut byte = 0_u8;
+                // SAFETY: The byte is writable and MSG_PEEK preserves the
+                // complete authenticated broker datagram for its decoder.
+                let peeked = unsafe {
+                    libc::recv(
+                        endpoint.socket.as_raw_fd(),
+                        (&raw mut byte).cast(),
+                        1,
+                        libc::MSG_PEEK | libc::MSG_DONTWAIT,
+                    )
+                };
+                if peeked <= 0 {
+                    if peeked < 0 && io::Error::last_os_error().kind() == io::ErrorKind::Interrupted
+                    {
+                        continue;
+                    }
+                    return Err(AnchoredSocketError::Broker);
+                }
+            }
+            return Ok(());
+        }
+    }
 }
 
 fn prepare_connector_endpoint(endpoint: &SocketBrokerEndpoint) -> Result<(), AnchoredSocketError> {
@@ -1716,6 +1813,11 @@ fn cvt_spawn(result: libc::c_int) -> Result<(), AnchoredSocketError> {
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Read as _, Write as _};
+    use std::rc::Rc;
+
+    use bangbang_session::SessionId;
+
     use super::*;
 
     #[test]
@@ -1770,5 +1872,95 @@ mod tests {
             helper_exit_registration_recovery(&invalid, None),
             HelperExitRegistrationRecovery::Error(io::ErrorKind::InvalidInput)
         );
+    }
+
+    #[test]
+    fn broker_wait_observes_broker_and_wakeup_without_consuming_either() {
+        let (worker, launcher) = UnixDatagram::pair().expect("broker pair should create");
+        let (wakeup_reader, mut wakeup_writer) =
+            UnixStream::pair().expect("wakeup pair should create");
+        // SAFETY: Both endpoints belong to this test process.
+        let pid = unsafe { libc::getpid() };
+        let endpoint = SocketBrokerEndpoint {
+            socket: worker,
+            session: SessionId::from_bytes([71; 32]),
+            launcher_pid: pid,
+            wakeup: Some(Rc::new(wakeup_reader)),
+        };
+
+        launcher
+            .send(b"ready")
+            .expect("launcher readiness should send");
+        wait_for_broker(&endpoint, libc::POLLIN, AnchoredSocketError::Broker)
+            .expect("broker readiness should wake poll");
+        let mut broker_bytes = [0_u8; 5];
+        endpoint
+            .socket
+            .recv(&mut broker_bytes)
+            .expect("broker wait must not consume broker data");
+        assert_eq!(&broker_bytes, b"ready");
+
+        wakeup_writer
+            .write_all(&[1])
+            .expect("worker shutdown should signal");
+        assert_eq!(
+            wait_for_broker(&endpoint, libc::POLLIN, AnchoredSocketError::Cancelled),
+            Err(AnchoredSocketError::Cancelled)
+        );
+        assert_eq!(
+            wait_for_broker(&endpoint, libc::POLLIN, AnchoredSocketError::Broker),
+            Err(AnchoredSocketError::Broker)
+        );
+        let mut observed_wakeup = endpoint
+            .wakeup
+            .as_ref()
+            .expect("endpoint should retain wakeup")
+            .try_clone()
+            .expect("wakeup should clone");
+        let mut wakeup_byte = [0_u8; 1];
+        observed_wakeup
+            .read_exact(&mut wakeup_byte)
+            .expect("broker wait must leave shutdown evidence for the outer loop");
+        assert_eq!(wakeup_byte, [1]);
+    }
+
+    #[test]
+    fn launcher_death_interrupts_broker_wait_independently() {
+        let (worker, launcher) = UnixDatagram::pair().expect("broker pair should create");
+        // SAFETY: Both endpoints belong to this test process.
+        let pid = unsafe { libc::getpid() };
+        let endpoint = SocketBrokerEndpoint {
+            socket: worker,
+            session: SessionId::from_bytes([72; 32]),
+            launcher_pid: pid,
+            wakeup: None,
+        };
+        launcher
+            .shutdown(std::net::Shutdown::Both)
+            .expect("launcher endpoint should shut down");
+        drop(launcher);
+        assert_eq!(
+            wait_for_broker(&endpoint, libc::POLLIN, AnchoredSocketError::Broker),
+            Err(AnchoredSocketError::Broker)
+        );
+    }
+
+    #[test]
+    fn only_pre_activation_wakeup_cancellation_remains_retryable() {
+        assert_eq!(
+            pre_activation_broker_error(AnchoredSocketError::Cancelled),
+            AnchoredSocketError::Cancelled
+        );
+        for error in [
+            AnchoredSocketError::Binder,
+            AnchoredSocketError::Broker,
+            AnchoredSocketError::Invalid,
+            AnchoredSocketError::Io(io::ErrorKind::Other),
+        ] {
+            assert_eq!(
+                pre_activation_broker_error(error),
+                AnchoredSocketError::Broker
+            );
+        }
     }
 }

--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -2970,7 +2970,7 @@ mod tests {
             let ProcessSnapshotV2RootLoadRequest {
                 controller: _,
                 vmnet_authority: _,
-                grant_authority: _,
+                contained_restore_authority: _,
                 pci_enabled: _,
                 input,
                 candidate: _,

--- a/crates/bangbang/src/contained_session.rs
+++ b/crates/bangbang/src/contained_session.rs
@@ -297,6 +297,7 @@ mod platform {
     use std::collections::{HashMap, HashSet};
     use std::env;
     use std::ffi::OsStr;
+    use std::fmt;
     use std::fs::File;
     use std::io::{self, Read, Write};
     use std::mem::MaybeUninit;
@@ -409,6 +410,211 @@ mod platform {
                 *current = state;
             }
             Ok(())
+        }
+    }
+
+    /// Redacted reason a contained restore transaction could not proceed.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) enum ContainedSnapshotRestoreErrorKind {
+        Busy,
+        Cancelled,
+        Inactive,
+        InvalidRequest,
+        Authority,
+        Provenance,
+        Cleanup,
+    }
+
+    /// Process-only contained restore transaction failure.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) struct ContainedSnapshotRestoreError {
+        kind: ContainedSnapshotRestoreErrorKind,
+        cleanup_failed: bool,
+    }
+
+    impl ContainedSnapshotRestoreError {
+        const fn new(kind: ContainedSnapshotRestoreErrorKind) -> Self {
+            Self {
+                kind,
+                cleanup_failed: false,
+            }
+        }
+
+        const fn with_cleanup_failure(mut self) -> Self {
+            self.cleanup_failed = true;
+            self
+        }
+
+        pub(crate) const fn kind(&self) -> ContainedSnapshotRestoreErrorKind {
+            self.kind
+        }
+
+        pub(crate) const fn cleanup_failed(&self) -> bool {
+            self.cleanup_failed
+        }
+
+        pub(crate) const fn is_terminal(&self) -> bool {
+            matches!(
+                self.kind(),
+                ContainedSnapshotRestoreErrorKind::Inactive
+                    | ContainedSnapshotRestoreErrorKind::Provenance
+                    | ContainedSnapshotRestoreErrorKind::Cleanup
+            ) || self.cleanup_failed
+        }
+
+        pub(crate) const fn invalid_request() -> Self {
+            Self::new(ContainedSnapshotRestoreErrorKind::InvalidRequest)
+        }
+    }
+
+    impl fmt::Display for ContainedSnapshotRestoreError {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("contained snapshot restore transaction failed")
+        }
+    }
+
+    impl std::error::Error for ContainedSnapshotRestoreError {}
+
+    struct ContainedSnapshotRestoreGenerationState {
+        session: SessionId,
+        next_generation: u64,
+        active_generation: Option<u64>,
+        active: bool,
+    }
+
+    /// Sendable lifecycle revocation facet for process-only restore generations.
+    #[derive(Clone)]
+    struct ContainedSnapshotRestoreGenerationAuthority {
+        state: Arc<Mutex<ContainedSnapshotRestoreGenerationState>>,
+    }
+
+    impl ContainedSnapshotRestoreGenerationAuthority {
+        fn new(session: SessionId) -> Self {
+            Self {
+                state: Arc::new(Mutex::new(ContainedSnapshotRestoreGenerationState {
+                    session,
+                    next_generation: 0,
+                    active_generation: None,
+                    active: true,
+                })),
+            }
+        }
+
+        fn begin(
+            &self,
+            expected_session: SessionId,
+        ) -> Result<ContainedSnapshotRestoreTransaction, ContainedSnapshotRestoreError> {
+            let mut state = self.state.lock().map_err(|_| {
+                ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Inactive)
+            })?;
+            if !state.active || state.session != expected_session {
+                return Err(ContainedSnapshotRestoreError::new(
+                    ContainedSnapshotRestoreErrorKind::Inactive,
+                ));
+            }
+            if state.active_generation.is_some() {
+                return Err(ContainedSnapshotRestoreError::new(
+                    ContainedSnapshotRestoreErrorKind::Busy,
+                ));
+            }
+            let generation = state.next_generation.checked_add(1).ok_or_else(|| {
+                state.active = false;
+                ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Inactive)
+            })?;
+            state.next_generation = generation;
+            state.active_generation = Some(generation);
+            Ok(ContainedSnapshotRestoreTransaction {
+                authority: self.clone(),
+                session: expected_session,
+                generation,
+                finished: false,
+            })
+        }
+
+        fn invalidate(&self) {
+            let mut state = match self.state.lock() {
+                Ok(state) => state,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            state.active = false;
+            state.active_generation = None;
+        }
+    }
+
+    /// Move-only witness for one active contained restore generation.
+    pub(crate) struct ContainedSnapshotRestoreTransaction {
+        authority: ContainedSnapshotRestoreGenerationAuthority,
+        session: SessionId,
+        generation: u64,
+        finished: bool,
+    }
+
+    impl ContainedSnapshotRestoreTransaction {
+        pub(crate) fn check(&self) -> Result<(), ContainedSnapshotRestoreError> {
+            let state = self.authority.state.lock().map_err(|_| {
+                ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Inactive)
+            })?;
+            if !state.active
+                || state.session != self.session
+                || state.active_generation != Some(self.generation)
+            {
+                return Err(ContainedSnapshotRestoreError::new(
+                    ContainedSnapshotRestoreErrorKind::Inactive,
+                ));
+            }
+            Ok(())
+        }
+
+        fn finish_inner(&mut self) -> Result<(), ContainedSnapshotRestoreError> {
+            let mut state = self.authority.state.lock().map_err(|_| {
+                ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Cleanup)
+            })?;
+            if !state.active
+                || state.session != self.session
+                || state.active_generation != Some(self.generation)
+            {
+                self.finished = true;
+                return Err(ContainedSnapshotRestoreError::new(
+                    ContainedSnapshotRestoreErrorKind::Inactive,
+                ));
+            }
+            state.active_generation = None;
+            self.finished = true;
+            Ok(())
+        }
+
+        pub(crate) fn commit(mut self) -> Result<(), ContainedSnapshotRestoreError> {
+            self.finish_inner()
+        }
+
+        pub(crate) fn abort(mut self) -> Result<(), ContainedSnapshotRestoreError> {
+            self.finish_inner()
+        }
+    }
+
+    impl fmt::Debug for ContainedSnapshotRestoreTransaction {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter
+                .debug_struct("ContainedSnapshotRestoreTransaction")
+                .field("identity", &"<redacted>")
+                .field("active", &self.check().is_ok())
+                .finish()
+        }
+    }
+
+    impl Drop for ContainedSnapshotRestoreTransaction {
+        fn drop(&mut self) {
+            if self.finished {
+                return;
+            }
+            let mut state = match self.authority.state.lock() {
+                Ok(state) => state,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            if state.session == self.session && state.active_generation == Some(self.generation) {
+                state.active_generation = None;
+            }
+            self.finished = true;
         }
     }
 
@@ -686,6 +892,40 @@ mod platform {
         }
     }
 
+    struct SnapshotRestoreDriveClaimBuffers {
+        identities: Vec<ObjectIdentity>,
+        duplicates: Vec<GrantedFile>,
+        originals: Vec<GrantedFile>,
+        claims: Vec<PreparedDriveBackingClaim>,
+    }
+
+    impl SnapshotRestoreDriveClaimBuffers {
+        fn try_new(count: usize) -> Result<Self, ContainedSnapshotRestoreError> {
+            let mut identities = Vec::new();
+            let mut duplicates = Vec::new();
+            let mut originals = Vec::new();
+            let mut claims = Vec::new();
+            identities.try_reserve_exact(count).map_err(|_| {
+                ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Authority)
+            })?;
+            duplicates.try_reserve_exact(count).map_err(|_| {
+                ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Authority)
+            })?;
+            originals.try_reserve_exact(count).map_err(|_| {
+                ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Authority)
+            })?;
+            claims.try_reserve_exact(count).map_err(|_| {
+                ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Authority)
+            })?;
+            Ok(Self {
+                identities,
+                duplicates,
+                originals,
+                claims,
+            })
+        }
+    }
+
     impl std::fmt::Debug for GrantAuthority {
         fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             formatter
@@ -864,6 +1104,76 @@ mod platform {
                 })
         }
 
+        fn inspect_snapshot_restore_files(
+            &self,
+            requests: &[(GrantId, ResourceRole, GrantAccess, GrantObjectKind)],
+            identities: &mut Vec<ObjectIdentity>,
+        ) -> Result<(), ContainedSnapshotRestoreError> {
+            let registry = self.registry.lock().map_err(|_| {
+                ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Inactive)
+            })?;
+            registry
+                .as_ref()
+                .ok_or_else(|| {
+                    ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Inactive)
+                })?
+                .inspect_exact_files_into(requests, identities)
+                .map_err(|_| {
+                    ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Authority)
+                })
+        }
+
+        fn prepare_snapshot_restore_drive_claims(
+            &self,
+            requests: Vec<(GrantId, ResourceRole, GrantAccess, GrantObjectKind)>,
+            mut buffers: SnapshotRestoreDriveClaimBuffers,
+        ) -> Result<Vec<PreparedDriveBackingClaim>, ContainedSnapshotRestoreError> {
+            if requests
+                .iter()
+                .any(|(_, role, _, _)| *role != ResourceRole::DriveBacking)
+            {
+                return Err(ContainedSnapshotRestoreError::new(
+                    ContainedSnapshotRestoreErrorKind::InvalidRequest,
+                ));
+            }
+            {
+                let mut locked = self.registry.lock().map_err(|_| {
+                    ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Inactive)
+                })?;
+                let registry = locked.as_mut().ok_or_else(|| {
+                    ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Inactive)
+                })?;
+                registry
+                    .duplicate_exact_files_into(&requests, &mut buffers.duplicates)
+                    .map_err(|_| {
+                        ContainedSnapshotRestoreError::new(
+                            ContainedSnapshotRestoreErrorKind::Authority,
+                        )
+                    })?;
+                registry
+                    .take_exact_files_into(&requests, &mut buffers.originals)
+                    .map_err(|_| {
+                        ContainedSnapshotRestoreError::new(
+                            ContainedSnapshotRestoreErrorKind::Authority,
+                        )
+                    })?;
+            }
+            for (((id, _, _, _), original), duplicate) in requests
+                .into_iter()
+                .zip(buffers.originals)
+                .zip(buffers.duplicates)
+            {
+                buffers.claims.push(PreparedDriveBackingClaim {
+                    registry: Arc::clone(&self.registry),
+                    block_control: self.block_control.clone(),
+                    id,
+                    original: Some(original),
+                    duplicate: Some(duplicate),
+                });
+            }
+            Ok(buffers.claims)
+        }
+
         pub(crate) fn take_exact_files(
             &self,
             requests: &[(GrantId, ResourceRole, GrantAccess)],
@@ -965,23 +1275,30 @@ mod platform {
                 child: self.child.clone(),
             }
         }
+
+        fn restore(&mut self) -> Result<(), GrantClaimError> {
+            let Some(directory) = self.directory.take() else {
+                return Ok(());
+            };
+            let mut registry = self
+                .authority
+                .registry
+                .try_borrow_mut()
+                .map_err(|_| GrantClaimError)?;
+            let registry = registry.as_mut().ok_or(GrantClaimError)?;
+            registry
+                .restore_scoped_directory(self.grant_id.clone(), directory)
+                .map_err(|_| GrantClaimError)
+        }
+
+        pub(crate) fn abort(mut self) -> Result<(), GrantClaimError> {
+            self.restore()
+        }
     }
 
     impl Drop for PreparedSocketDirectoryClaim {
         fn drop(&mut self) {
-            let Some(directory) = self.directory.take() else {
-                return;
-            };
-            let Ok(mut registry) = self.authority.registry.try_borrow_mut() else {
-                abort_vhost_user_claim_invariant();
-            };
-            let Some(registry) = registry.as_mut() else {
-                abort_vhost_user_claim_invariant();
-            };
-            if registry
-                .restore_scoped_directory(self.grant_id.clone(), directory)
-                .is_err()
-            {
+            if self.restore().is_err() {
                 abort_vhost_user_claim_invariant();
             }
         }
@@ -1251,6 +1568,34 @@ mod platform {
         retained_vhost: Rc<RefCell<HashMap<GrantId, Rc<GrantedDirectory>>>>,
     }
 
+    struct SnapshotRestoreDirectoryClaimBuffers {
+        identities: Vec<ObjectIdentity>,
+        directories: Vec<GrantedDirectory>,
+        claims: Vec<PreparedSocketDirectoryClaim>,
+    }
+
+    impl SnapshotRestoreDirectoryClaimBuffers {
+        fn try_new(count: usize) -> Result<Self, ContainedSnapshotRestoreError> {
+            let mut identities = Vec::new();
+            let mut directories = Vec::new();
+            let mut claims = Vec::new();
+            identities.try_reserve_exact(count).map_err(|_| {
+                ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Authority)
+            })?;
+            directories.try_reserve_exact(count).map_err(|_| {
+                ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Authority)
+            })?;
+            claims.try_reserve_exact(count).map_err(|_| {
+                ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Authority)
+            })?;
+            Ok(Self {
+                identities,
+                directories,
+                claims,
+            })
+        }
+    }
+
     impl std::fmt::Debug for DirectoryGrantAuthority {
         fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             formatter
@@ -1380,6 +1725,67 @@ mod platform {
             }))
         }
 
+        fn inspect_snapshot_restore_directories(
+            &self,
+            requests: &[(GrantId, ResourceRole, GrantAccess)],
+            identities: &mut Vec<ObjectIdentity>,
+        ) -> Result<(), ContainedSnapshotRestoreError> {
+            let registry = self.registry.try_borrow().map_err(|_| {
+                ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Inactive)
+            })?;
+            registry
+                .as_ref()
+                .ok_or_else(|| {
+                    ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Inactive)
+                })?
+                .inspect_exact_directories_into(requests, identities)
+                .map_err(|_| {
+                    ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Authority)
+                })
+        }
+
+        fn prepare_snapshot_restore_directory_claims(
+            &self,
+            requests: Vec<(GrantId, ResourceRole, GrantAccess)>,
+            children: Vec<SocketChild>,
+            mut buffers: SnapshotRestoreDirectoryClaimBuffers,
+        ) -> Result<Vec<PreparedSocketDirectoryClaim>, ContainedSnapshotRestoreError> {
+            if requests.len() != children.len() {
+                return Err(ContainedSnapshotRestoreError::new(
+                    ContainedSnapshotRestoreErrorKind::InvalidRequest,
+                ));
+            }
+            {
+                let mut locked = self.registry.try_borrow_mut().map_err(|_| {
+                    ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Inactive)
+                })?;
+                locked
+                    .as_mut()
+                    .ok_or_else(|| {
+                        ContainedSnapshotRestoreError::new(
+                            ContainedSnapshotRestoreErrorKind::Inactive,
+                        )
+                    })?
+                    .take_exact_directories_into(&requests, &mut buffers.directories)
+                    .map_err(|_| {
+                        ContainedSnapshotRestoreError::new(
+                            ContainedSnapshotRestoreErrorKind::Authority,
+                        )
+                    })?;
+            }
+            for (((grant_id, _, _), directory), child) in
+                requests.into_iter().zip(buffers.directories).zip(children)
+            {
+                buffers.claims.push(PreparedSocketDirectoryClaim {
+                    authority: self.clone(),
+                    directory: Some(directory),
+                    grant_id,
+                    child,
+                });
+            }
+            Ok(buffers.claims)
+        }
+
         pub(crate) fn claim_snapshot_outputs(
             &self,
             state_reference: &Path,
@@ -1485,6 +1891,7 @@ mod platform {
         pub(crate) socket: UnixDatagram,
         pub(crate) session: SessionId,
         pub(crate) launcher_pid: libc::pid_t,
+        pub(crate) wakeup: Option<Rc<UnixStream>>,
     }
 
     /// One launcher broker endpoint reserved until its activation boundary.
@@ -1529,6 +1936,33 @@ mod platform {
             }
             self.endpoint.take().ok_or(GrantClaimError)
         }
+
+        fn with_restore_wakeup(mut self, wakeup: Rc<UnixStream>) -> Self {
+            if let Some(endpoint) = self.endpoint.as_mut() {
+                endpoint.wakeup = Some(wakeup);
+            }
+            self
+        }
+
+        fn restore(&mut self) -> Result<(), GrantClaimError> {
+            let Some(endpoint) = self.endpoint.take() else {
+                return Ok(());
+            };
+            let mut state = self
+                .authority
+                .state
+                .try_borrow_mut()
+                .map_err(|_| GrantClaimError)?;
+            if !state.active || state.endpoint.is_some() {
+                return Err(GrantClaimError);
+            }
+            state.endpoint = Some(endpoint);
+            Ok(())
+        }
+
+        pub(crate) fn abort(mut self) -> Result<(), GrantClaimError> {
+            self.restore()
+        }
     }
 
     impl Drop for PreparedSocketBrokerEndpoint {
@@ -1561,6 +1995,7 @@ mod platform {
                 .field("socket", &"<owned>")
                 .field("session", &"<redacted>")
                 .field("launcher_pid", &"<redacted>")
+                .field("wakeup", &self.wakeup.as_ref().map(|_| "<borrowed>"))
                 .finish()
         }
     }
@@ -1588,6 +2023,7 @@ mod platform {
                         socket,
                         session,
                         launcher_pid,
+                        wakeup: None,
                     }),
                     active: true,
                 })),
@@ -1600,6 +2036,27 @@ mod platform {
                 return Err(GrantClaimError);
             }
             state.endpoint.take().ok_or(GrantClaimError)
+        }
+
+        fn validates_snapshot_restore_session(
+            &self,
+            session: SessionId,
+        ) -> Result<(), ContainedSnapshotRestoreError> {
+            let state = self.state.try_borrow().map_err(|_| {
+                ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Inactive)
+            })?;
+            if state.active
+                && state
+                    .endpoint
+                    .as_ref()
+                    .is_some_and(|endpoint| endpoint.session == session)
+            {
+                Ok(())
+            } else {
+                Err(ContainedSnapshotRestoreError::new(
+                    ContainedSnapshotRestoreErrorKind::Provenance,
+                ))
+            }
         }
 
         pub(crate) fn prepare_endpoint(
@@ -1623,6 +2080,386 @@ mod platform {
                 state.endpoint.take();
             }
         }
+    }
+
+    /// Exact contained facets bound to one authenticated restore session.
+    pub(crate) struct ContainedSnapshotRestoreAuthority {
+        session: SessionId,
+        generations: ContainedSnapshotRestoreGenerationAuthority,
+        grants: GrantAuthority,
+        directories: DirectoryGrantAuthority,
+        broker: SocketBrokerAuthority,
+        namespace: Rc<WorkerSocketNamespace>,
+        wakeup: Rc<UnixStream>,
+    }
+
+    impl fmt::Debug for ContainedSnapshotRestoreAuthority {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter
+                .debug_struct("ContainedSnapshotRestoreAuthority")
+                .field("identity", &"<redacted>")
+                .field("facets", &"<bound>")
+                .finish()
+        }
+    }
+
+    impl ContainedSnapshotRestoreAuthority {
+        pub(crate) fn prepare(
+            &self,
+            root_reference: &Path,
+            vsock_reference: Option<&Path>,
+            cancelled: &impl Fn() -> bool,
+        ) -> Result<ReservedContainedSnapshotRestoreResources, ContainedSnapshotRestoreError>
+        {
+            let root_id = grant_reference_id(root_reference)
+                .map_err(|_| {
+                    ContainedSnapshotRestoreError::new(
+                        ContainedSnapshotRestoreErrorKind::InvalidRequest,
+                    )
+                })?
+                .ok_or_else(|| {
+                    ContainedSnapshotRestoreError::new(
+                        ContainedSnapshotRestoreErrorKind::InvalidRequest,
+                    )
+                })?;
+            let mut file_requests = Vec::new();
+            file_requests.try_reserve_exact(1).map_err(|_| {
+                ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Authority)
+            })?;
+            file_requests.push((
+                root_id,
+                ResourceRole::DriveBacking,
+                GrantAccess::ReadOnly,
+                GrantObjectKind::RegularFile,
+            ));
+
+            let mut directory_requests = Vec::new();
+            let mut children = Vec::new();
+            directory_requests
+                .try_reserve_exact(usize::from(vsock_reference.is_some()))
+                .map_err(|_| {
+                    ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Authority)
+                })?;
+            children
+                .try_reserve_exact(usize::from(vsock_reference.is_some()))
+                .map_err(|_| {
+                    ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Authority)
+                })?;
+            if let Some(reference) = vsock_reference {
+                let (id, child) = socket_directory_reference(reference)
+                    .map_err(|_| {
+                        ContainedSnapshotRestoreError::new(
+                            ContainedSnapshotRestoreErrorKind::InvalidRequest,
+                        )
+                    })?
+                    .ok_or_else(|| {
+                        ContainedSnapshotRestoreError::new(
+                            ContainedSnapshotRestoreErrorKind::InvalidRequest,
+                        )
+                    })?;
+                directory_requests.push((
+                    id,
+                    ResourceRole::VsockSocketDirectory,
+                    GrantAccess::CreateChildren,
+                ));
+                children.push(child);
+            }
+
+            let mut drive_buffers = SnapshotRestoreDriveClaimBuffers::try_new(file_requests.len())?;
+            let mut directory_buffers =
+                SnapshotRestoreDirectoryClaimBuffers::try_new(directory_requests.len())?;
+            let mut identities = HashSet::new();
+            identities
+                .try_reserve(file_requests.len().saturating_add(directory_requests.len()))
+                .map_err(|_| {
+                    ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Authority)
+                })?;
+            if cancelled() {
+                return Err(ContainedSnapshotRestoreError::new(
+                    ContainedSnapshotRestoreErrorKind::Cancelled,
+                ));
+            }
+            let transaction = self.generations.begin(self.session)?;
+            check_contained_restore_progress(&transaction, cancelled)?;
+            self.grants
+                .inspect_snapshot_restore_files(&file_requests, &mut drive_buffers.identities)?;
+            check_contained_restore_progress(&transaction, cancelled)?;
+            self.directories.inspect_snapshot_restore_directories(
+                &directory_requests,
+                &mut directory_buffers.identities,
+            )?;
+            check_contained_restore_progress(&transaction, cancelled)?;
+            if drive_buffers
+                .identities
+                .iter()
+                .copied()
+                .chain(directory_buffers.identities.iter().copied())
+                .any(|identity| !identities.insert(identity))
+            {
+                return Err(ContainedSnapshotRestoreError::new(
+                    ContainedSnapshotRestoreErrorKind::InvalidRequest,
+                ));
+            }
+            if !directory_buffers.identities.is_empty()
+                && directory_buffers
+                    .identities
+                    .iter()
+                    .any(|identity| identity.device != self.namespace.identity().device)
+            {
+                return Err(ContainedSnapshotRestoreError::new(
+                    ContainedSnapshotRestoreErrorKind::Authority,
+                ));
+            }
+            if vsock_reference.is_some() {
+                self.broker
+                    .validates_snapshot_restore_session(self.session)?;
+            }
+            check_contained_restore_progress(&transaction, cancelled)?;
+
+            let drive_claims = self
+                .grants
+                .prepare_snapshot_restore_drive_claims(file_requests, drive_buffers)?;
+            if let Err(source) = check_contained_restore_progress(&transaction, cancelled) {
+                return Err(if abort_drive_claims(drive_claims).is_err() {
+                    source.with_cleanup_failure()
+                } else {
+                    source
+                });
+            }
+            let directory_claims = match self.directories.prepare_snapshot_restore_directory_claims(
+                directory_requests,
+                children,
+                directory_buffers,
+            ) {
+                Ok(claims) => claims,
+                Err(source) => {
+                    return Err(if abort_drive_claims(drive_claims).is_err() {
+                        source.with_cleanup_failure()
+                    } else {
+                        source
+                    });
+                }
+            };
+            if let Err(source) = check_contained_restore_progress(&transaction, cancelled) {
+                let cleanup_failed = abort_directory_claims(directory_claims).is_err()
+                    | abort_drive_claims(drive_claims).is_err();
+                return Err(if cleanup_failed {
+                    source.with_cleanup_failure()
+                } else {
+                    source
+                });
+            }
+            let broker = if vsock_reference.is_some() {
+                match self.broker.prepare_endpoint() {
+                    Ok(broker) => Some(broker.with_restore_wakeup(Rc::clone(&self.wakeup))),
+                    Err(_) => {
+                        let cleanup_failed = abort_directory_claims(directory_claims).is_err()
+                            | abort_drive_claims(drive_claims).is_err();
+                        let source = ContainedSnapshotRestoreError::new(
+                            ContainedSnapshotRestoreErrorKind::Authority,
+                        );
+                        return Err(if cleanup_failed {
+                            source.with_cleanup_failure()
+                        } else {
+                            source
+                        });
+                    }
+                }
+            } else {
+                None
+            };
+            if let Err(source) = check_contained_restore_progress(&transaction, cancelled) {
+                let cleanup_failed = abort_prepared_broker(broker).is_err()
+                    | abort_directory_claims(directory_claims).is_err()
+                    | abort_drive_claims(drive_claims).is_err();
+                return Err(if cleanup_failed {
+                    source.with_cleanup_failure()
+                } else {
+                    source
+                });
+            }
+            let namespace = if vsock_reference.is_some() {
+                match self.namespace.try_clone() {
+                    Ok(namespace) => Some(namespace),
+                    Err(_) => {
+                        let cleanup_failed = abort_prepared_broker(broker).is_err()
+                            | abort_directory_claims(directory_claims).is_err()
+                            | abort_drive_claims(drive_claims).is_err();
+                        let source = ContainedSnapshotRestoreError::new(
+                            ContainedSnapshotRestoreErrorKind::Authority,
+                        );
+                        return Err(if cleanup_failed {
+                            source.with_cleanup_failure()
+                        } else {
+                            source
+                        });
+                    }
+                }
+            } else {
+                None
+            };
+            if let Err(source) = check_contained_restore_progress(&transaction, cancelled) {
+                let cleanup_failed = abort_prepared_broker(broker).is_err()
+                    | abort_directory_claims(directory_claims).is_err()
+                    | abort_drive_claims(drive_claims).is_err();
+                return Err(if cleanup_failed {
+                    source.with_cleanup_failure()
+                } else {
+                    source
+                });
+            }
+            Ok(ReservedContainedSnapshotRestoreResources {
+                transaction: Some(transaction),
+                drive_claims,
+                directory_claims,
+                broker,
+                namespace,
+                expects_vsock: vsock_reference.is_some(),
+            })
+        }
+    }
+
+    fn check_contained_restore_progress(
+        transaction: &ContainedSnapshotRestoreTransaction,
+        cancelled: &impl Fn() -> bool,
+    ) -> Result<(), ContainedSnapshotRestoreError> {
+        transaction.check()?;
+        if cancelled() {
+            Err(ContainedSnapshotRestoreError::new(
+                ContainedSnapshotRestoreErrorKind::Cancelled,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Preflighted and failure-atomically reserved contained restore facets.
+    pub(crate) struct ReservedContainedSnapshotRestoreResources {
+        // Declaration order preserves reverse restoration during conservative
+        // drop: borrowed namespace, broker, directory, file, then generation.
+        namespace: Option<WorkerSocketNamespace>,
+        broker: Option<PreparedSocketBrokerEndpoint>,
+        directory_claims: Vec<PreparedSocketDirectoryClaim>,
+        drive_claims: Vec<PreparedDriveBackingClaim>,
+        transaction: Option<ContainedSnapshotRestoreTransaction>,
+        expects_vsock: bool,
+    }
+
+    type PreparedContainedVsockRestoreFacets = (
+        PreparedSocketDirectoryClaim,
+        PreparedSocketBrokerEndpoint,
+        WorkerSocketNamespace,
+    );
+
+    type ContainedSnapshotRestoreReservationParts = (
+        PreparedDriveBackingClaim,
+        Option<PreparedContainedVsockRestoreFacets>,
+        ContainedSnapshotRestoreTransaction,
+    );
+
+    impl ReservedContainedSnapshotRestoreResources {
+        pub(crate) fn into_parts(
+            mut self,
+        ) -> Result<ContainedSnapshotRestoreReservationParts, ContainedSnapshotRestoreError>
+        {
+            let valid = self.drive_claims.len() == 1
+                && if self.expects_vsock {
+                    self.directory_claims.len() == 1
+                        && self.broker.is_some()
+                        && self.namespace.is_some()
+                } else {
+                    self.directory_claims.is_empty()
+                        && self.broker.is_none()
+                        && self.namespace.is_none()
+                }
+                && self.transaction.is_some();
+            if !valid {
+                let source = ContainedSnapshotRestoreError::new(
+                    ContainedSnapshotRestoreErrorKind::InvalidRequest,
+                );
+                return Err(if self.abort().is_err() {
+                    source.with_cleanup_failure()
+                } else {
+                    source
+                });
+            }
+            let Some(root) = self.drive_claims.pop() else {
+                abort_vhost_user_claim_invariant();
+            };
+            let vsock = if self.expects_vsock {
+                let Some(directory) = self.directory_claims.pop() else {
+                    abort_vhost_user_claim_invariant();
+                };
+                let Some(broker) = self.broker.take() else {
+                    abort_vhost_user_claim_invariant();
+                };
+                let Some(namespace) = self.namespace.take() else {
+                    abort_vhost_user_claim_invariant();
+                };
+                Some((directory, broker, namespace))
+            } else {
+                None
+            };
+            let Some(transaction) = self.transaction.take() else {
+                abort_vhost_user_claim_invariant();
+            };
+            Ok((root, vsock, transaction))
+        }
+
+        pub(crate) fn abort(mut self) -> Result<(), ContainedSnapshotRestoreError> {
+            drop(self.namespace.take());
+            let cleanup_failed = abort_prepared_broker(self.broker.take()).is_err()
+                | abort_directory_claims(std::mem::take(&mut self.directory_claims)).is_err()
+                | abort_drive_claims(std::mem::take(&mut self.drive_claims)).is_err();
+            let generation_failed = self
+                .transaction
+                .take()
+                .is_some_and(|transaction| transaction.abort().is_err());
+            if cleanup_failed | generation_failed {
+                Err(
+                    ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Cleanup)
+                        .with_cleanup_failure(),
+                )
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    impl fmt::Debug for ReservedContainedSnapshotRestoreResources {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter
+                .debug_struct("ReservedContainedSnapshotRestoreResources")
+                .field("identity", &"<redacted>")
+                .field("file_count", &self.drive_claims.len())
+                .field("directory_count", &self.directory_claims.len())
+                .field("broker", &self.broker.as_ref().map(|_| "<reserved>"))
+                .finish()
+        }
+    }
+
+    fn abort_drive_claims(claims: Vec<PreparedDriveBackingClaim>) -> Result<(), GrantClaimError> {
+        let mut failed = false;
+        for claim in claims.into_iter().rev() {
+            failed |= claim.abort().is_err();
+        }
+        if failed { Err(GrantClaimError) } else { Ok(()) }
+    }
+
+    fn abort_directory_claims(
+        claims: Vec<PreparedSocketDirectoryClaim>,
+    ) -> Result<(), GrantClaimError> {
+        let mut failed = false;
+        for claim in claims.into_iter().rev() {
+            failed |= claim.abort().is_err();
+        }
+        if failed { Err(GrantClaimError) } else { Ok(()) }
+    }
+
+    fn abort_prepared_broker(
+        broker: Option<PreparedSocketBrokerEndpoint>,
+    ) -> Result<(), GrantClaimError> {
+        broker.map_or(Ok(()), PreparedSocketBrokerEndpoint::abort)
     }
 
     struct BlockControlBrokerState {
@@ -2223,7 +3060,9 @@ mod platform {
         directory_grants: DirectoryGrantAuthority,
         socket_broker: SocketBrokerAuthority,
         vhost_user_broker: VhostUserBrokerAuthority,
-        socket_namespace: WorkerSocketNamespace,
+        socket_namespace: Rc<WorkerSocketNamespace>,
+        restore_generations: ContainedSnapshotRestoreGenerationAuthority,
+        restore_wakeup: Option<Rc<UnixStream>>,
         policy: WorkerPolicy,
         started: bool,
         closed: bool,
@@ -2306,9 +3145,11 @@ mod platform {
             let namespace = WorkerNamespace::create(session).map_err(|_| ContainedSessionError)?;
             namespace.enter().map_err(|_| ContainedSessionError)?;
             let identity = namespace.identity();
-            let socket_namespace = namespace
-                .socket_namespace()
-                .map_err(|_| ContainedSessionError)?;
+            let socket_namespace = Rc::new(
+                namespace
+                    .socket_namespace()
+                    .map_err(|_| ContainedSessionError)?,
+            );
             let prepared = lifecycle
                 .prepared(identity.device, identity.inode)
                 .map_err(|_| ContainedSessionError)?;
@@ -2390,6 +3231,7 @@ mod platform {
             let socket_broker = SocketBrokerAuthority::new(broker_socket, session, parent);
             let vhost_user_broker =
                 VhostUserBrokerAuthority::new(vhost_broker_socket, session, parent);
+            let restore_generations = ContainedSnapshotRestoreGenerationAuthority::new(session);
             let lifecycle = Arc::new(Mutex::new(lifecycle));
             let namespace = Arc::new(Mutex::new(Some(namespace)));
             let (wakeup_reader, mut wakeup_writer) =
@@ -2409,6 +3251,7 @@ mod platform {
                         grants: file_grants.clone(),
                         pager_grants: pager_grants.clone(),
                         vhost_user_broker: vhost_user_broker.clone(),
+                        restore_generations: restore_generations.clone(),
                     },
                     reader_wakeup,
                 )?)
@@ -2432,6 +3275,8 @@ mod platform {
                 socket_broker,
                 vhost_user_broker,
                 socket_namespace,
+                restore_generations,
+                restore_wakeup: None,
                 policy,
                 started,
                 closed: false,
@@ -2441,10 +3286,11 @@ mod platform {
         pub(crate) fn take_wakeup_pair(
             &mut self,
         ) -> Result<(UnixStream, UnixStream), ContainedSessionError> {
-            Ok((
-                self.wakeup_reader.take().ok_or(ContainedSessionError)?,
-                self.wakeup_writer.take().ok_or(ContainedSessionError)?,
-            ))
+            let reader = self.wakeup_reader.take().ok_or(ContainedSessionError)?;
+            let restore_wakeup = reader.try_clone().map_err(|_| ContainedSessionError)?;
+            let writer = self.wakeup_writer.take().ok_or(ContainedSessionError)?;
+            self.restore_wakeup = Some(Rc::new(restore_wakeup));
+            Ok((reader, writer))
         }
 
         pub(crate) fn shutdown_requested(&self) -> Result<bool, ContainedSessionError> {
@@ -2486,6 +3332,35 @@ mod platform {
 
         pub(crate) fn socket_broker_authority(&self) -> Option<SocketBrokerAuthority> {
             self.started.then(|| self.socket_broker.clone())
+        }
+
+        pub(crate) fn snapshot_restore_authority(
+            &self,
+        ) -> Result<Option<ContainedSnapshotRestoreAuthority>, ContainedSessionError> {
+            if !self.started {
+                return Ok(None);
+            }
+            let session = self
+                .lifecycle
+                .lock()
+                .map_err(|_| ContainedSessionError)?
+                .session()
+                .filter(|session| !session.is_pre_session())
+                .ok_or(ContainedSessionError)?;
+            let wakeup = self
+                .restore_wakeup
+                .as_ref()
+                .map(Rc::clone)
+                .ok_or(ContainedSessionError)?;
+            Ok(Some(ContainedSnapshotRestoreAuthority {
+                session,
+                generations: self.restore_generations.clone(),
+                grants: self.grants.clone(),
+                directories: self.directory_grants.clone(),
+                broker: self.socket_broker.clone(),
+                namespace: Rc::clone(&self.socket_namespace),
+                wakeup,
+            }))
         }
 
         pub(crate) fn vhost_user_broker_authority(&self) -> Option<VhostUserBrokerAuthority> {
@@ -2599,6 +3474,7 @@ mod platform {
             self.directory_grants.invalidate();
             self.socket_broker.invalidate();
             self.vhost_user_broker.invalidate();
+            self.restore_generations.invalidate();
             let _ = self.stream.shutdown(std::net::Shutdown::Both);
             if let Some(reader) = self.reader.take() {
                 let _ = reader.join();
@@ -2833,6 +3709,7 @@ mod platform {
         grants: GrantAuthority,
         pager_grants: PagerGrantAuthority,
         vhost_user_broker: VhostUserBrokerAuthority,
+        restore_generations: ContainedSnapshotRestoreGenerationAuthority,
     }
 
     fn spawn_reader(
@@ -2852,6 +3729,7 @@ mod platform {
                     authorities.grants.invalidate();
                     authorities.pager_grants.invalidate();
                     authorities.vhost_user_broker.invalidate();
+                    authorities.restore_generations.invalidate();
                     if state == ControlState::Disconnected {
                         cleanup_namespace(&namespace);
                     }
@@ -2960,19 +3838,22 @@ mod platform {
 
     #[cfg(test)]
     pub(crate) use tests::{
-        TestDirectory as TestVhostDirectory, empty_grant_authority_for_vhost_test,
-        file_grant_authority_for_test, root_file_grant_authority_for_test,
-        snapshot_file_grant_authority_for_test, snapshot_root_file_grant_authority_for_test,
-        vhost_directory_authority_for_test, vsock_directory_authority_for_test,
+        TestContainedRestoreAuthority, TestDirectory as TestVhostDirectory,
+        contained_restore_authority_for_test, contained_restore_authority_with_grants_for_test,
+        empty_grant_authority_for_vhost_test, file_grant_authority_for_test,
+        root_file_grant_authority_for_test, snapshot_file_grant_authority_for_test,
+        snapshot_root_file_grant_authority_for_test, vhost_directory_authority_for_test,
+        vsock_directory_authority_for_test,
     };
 
     #[cfg(test)]
     mod tests {
+        use std::cell::Cell;
         use std::fs::{self, OpenOptions};
         use std::io::{self, Read as _};
         use std::mem::MaybeUninit;
         use std::os::fd::{AsRawFd, OwnedFd};
-        use std::os::unix::fs::OpenOptionsExt;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
         use std::os::unix::net::{UnixDatagram, UnixStream};
         use std::path::{Path, PathBuf};
         use std::rc::Rc;
@@ -2986,8 +3867,11 @@ mod platform {
             receive_block_control_message, send_block_control_message,
         };
         use bangbang_session::macos::bookmark::create_implicit_bookmark;
-        use bangbang_session::macos::grant_registry::{GrantRegistry, StagedGrantBatch};
+        use bangbang_session::macos::grant_registry::{
+            DirectoryGrantRegistry, GrantRegistry, StagedGrantBatch,
+        };
         use bangbang_session::macos::grant_transport::ReceivedGrant;
+        use bangbang_session::macos::runtime::WorkerSocketNamespace;
         use bangbang_session::macos::vhost_user_broker::{
             VhostUserBrokerMessage, receive_vhost_user_broker_message,
             send_vhost_user_broker_message,
@@ -3030,6 +3914,525 @@ mod platform {
             fn drop(&mut self) {
                 fs::remove_dir_all(&self.0).expect("test directory should clean up");
             }
+        }
+
+        pub(crate) struct TestContainedRestoreAuthority {
+            authority: super::ContainedSnapshotRestoreAuthority,
+            grants: GrantAuthority,
+            directories: DirectoryGrantAuthority,
+            broker: SocketBrokerAuthority,
+            _namespace_directory: TestDirectory,
+            _launcher: UnixDatagram,
+            _wakeup_writer: UnixStream,
+            _vsock_directory: Option<TestDirectory>,
+        }
+
+        impl TestContainedRestoreAuthority {
+            pub(crate) const fn authority(&self) -> &super::ContainedSnapshotRestoreAuthority {
+                &self.authority
+            }
+
+            pub(crate) const fn grants(&self) -> &GrantAuthority {
+                &self.grants
+            }
+
+            pub(crate) const fn directories(&self) -> &DirectoryGrantAuthority {
+                &self.directories
+            }
+
+            pub(crate) fn invalidate_generation(&self) {
+                self.authority.generations.invalidate();
+            }
+
+            pub(crate) fn invalidate_broker(&self) {
+                self.broker.invalidate();
+            }
+
+            pub(crate) fn assert_authorities_available(&self, with_vsock: bool) {
+                assert_contained_restore_authorities_available(self, with_vsock);
+            }
+
+            pub(crate) fn into_authority(self) -> super::ContainedSnapshotRestoreAuthority {
+                self.authority
+            }
+        }
+
+        fn next_restore_session() -> SessionId {
+            let sequence = NEXT_TEST_DIRECTORY.fetch_add(1, Ordering::Relaxed);
+            let mut bytes = [0_u8; 32];
+            bytes[..8].copy_from_slice(&sequence.to_le_bytes());
+            bytes[8..12].copy_from_slice(&std::process::id().to_le_bytes());
+            bytes[31] = 0xa5;
+            SessionId::from_bytes(bytes)
+        }
+
+        pub(crate) fn contained_restore_authority_for_test(
+            root_path: &Path,
+            with_vsock: bool,
+        ) -> TestContainedRestoreAuthority {
+            contained_restore_authority_with_grants_for_test(
+                root_file_grant_authority_for_test(root_path),
+                with_vsock,
+            )
+        }
+
+        pub(crate) fn contained_restore_authority_with_grants_for_test(
+            grants: GrantAuthority,
+            with_vsock: bool,
+        ) -> TestContainedRestoreAuthority {
+            let session = next_restore_session();
+            let (directories, vsock_directory) = if with_vsock {
+                let (authority, directory) = vsock_directory_authority_for_test();
+                (authority, Some(directory))
+            } else {
+                (
+                    DirectoryGrantAuthority::new(DirectoryGrantRegistry::default()),
+                    None,
+                )
+            };
+            let (worker, launcher) = UnixDatagram::pair().expect("broker pair should create");
+            // SAFETY: Both broker endpoints belong to this test process.
+            let broker = SocketBrokerAuthority::new(worker, session, unsafe { libc::getpid() });
+            let namespace_directory = TestDirectory::new();
+            fs::set_permissions(
+                namespace_directory.path(),
+                fs::Permissions::from_mode(0o700),
+            )
+            .expect("test namespace permissions should restrict");
+            let socket_namespace = Rc::new(
+                WorkerSocketNamespace::from_directory_for_test(namespace_directory.path())
+                    .expect("test socket namespace should anchor"),
+            );
+            let (wakeup_reader, wakeup_writer) =
+                UnixStream::pair().expect("test wakeup pair should create");
+            let authority = super::ContainedSnapshotRestoreAuthority {
+                session,
+                generations: super::ContainedSnapshotRestoreGenerationAuthority::new(session),
+                grants: grants.clone(),
+                directories: directories.clone(),
+                broker: broker.clone(),
+                namespace: socket_namespace,
+                wakeup: Rc::new(wakeup_reader),
+            };
+            TestContainedRestoreAuthority {
+                authority,
+                grants,
+                directories,
+                broker,
+                _namespace_directory: namespace_directory,
+                _launcher: launcher,
+                _wakeup_writer: wakeup_writer,
+                _vsock_directory: vsock_directory,
+            }
+        }
+
+        fn assert_contained_restore_authorities_available(
+            fixture: &TestContainedRestoreAuthority,
+            with_vsock: bool,
+        ) {
+            let root = fixture
+                .grants
+                .prepare_drive_backing_claim(
+                    Path::new("bangbang-grant:drive-ro"),
+                    GrantAccess::ReadOnly,
+                )
+                .expect("root authority should remain valid")
+                .expect("root reference should remain contained");
+            root.abort().expect("root authority should restore");
+            if with_vsock {
+                let directory = fixture
+                    .directories
+                    .prepare_socket_directory(
+                        Path::new("bangbang-grant:vsock-directory/restored.sock"),
+                        ResourceRole::VsockSocketDirectory,
+                    )
+                    .expect("directory authority should remain valid")
+                    .expect("directory reference should remain contained");
+                directory
+                    .abort()
+                    .expect("directory authority should restore");
+            }
+            let broker = fixture
+                .broker
+                .prepare_endpoint()
+                .expect("broker authority should remain valid");
+            broker.abort().expect("broker authority should restore");
+        }
+
+        #[test]
+        fn contained_restore_generation_rejects_overlap_and_releases_after_reverse_abort() {
+            let root_directory = TestDirectory::new();
+            let root_path = root_directory.path().join("root.img");
+            fs::write(&root_path, b"root").expect("root fixture should write");
+            let fixture = contained_restore_authority_for_test(&root_path, false);
+            let reserved = fixture
+                .authority
+                .prepare(Path::new("bangbang-grant:drive-ro"), None, &|| false)
+                .expect("first root-only transaction should reserve");
+            let overlap = fixture
+                .authority
+                .prepare(Path::new("bangbang-grant:drive-ro"), None, &|| false)
+                .expect_err("overlapping transaction must fail before inspection");
+            assert_eq!(
+                overlap.kind(),
+                super::ContainedSnapshotRestoreErrorKind::Busy
+            );
+            assert!(!overlap.is_terminal());
+            assert!(!overlap.cleanup_failed());
+
+            let diagnostic = format!("{:?} {overlap}", fixture.authority);
+            assert!(!diagnostic.contains("drive-ro"));
+            assert!(!diagnostic.contains(root_path.to_string_lossy().as_ref()));
+            let (root, vsock, transaction) = reserved
+                .into_parts()
+                .expect("exact root-only reservation should split");
+            assert!(vsock.is_none());
+            let first_generation = transaction.generation;
+            let stale = super::ContainedSnapshotRestoreTransaction {
+                authority: transaction.authority.clone(),
+                session: transaction.session,
+                generation: transaction.generation,
+                finished: false,
+            };
+            transaction
+                .check()
+                .expect("current transaction witness should remain active");
+            root.abort()
+                .expect("root owner should restore before generation release");
+            transaction
+                .abort()
+                .expect("active generation should release after owners");
+            assert_contained_restore_authorities_available(&fixture, false);
+
+            let second = fixture
+                .authority
+                .prepare(Path::new("bangbang-grant:drive-ro"), None, &|| false)
+                .expect("released generation and root should be reusable");
+            let (root, vsock, transaction) = second
+                .into_parts()
+                .expect("second root-only reservation should split");
+            assert!(vsock.is_none());
+            assert!(transaction.generation > first_generation);
+            assert_eq!(
+                stale
+                    .check()
+                    .expect_err("old generation must remain stale")
+                    .kind(),
+                super::ContainedSnapshotRestoreErrorKind::Inactive
+            );
+            drop(stale);
+            transaction
+                .check()
+                .expect("dropping a stale witness must not clear the current generation");
+            root.abort()
+                .expect("second root owner should reverse cleanly");
+            transaction
+                .abort()
+                .expect("second generation should reverse cleanly");
+        }
+
+        #[test]
+        fn contained_restore_generation_poison_and_overflow_fail_terminal_before_authority_use() {
+            let poisoned_root = TestDirectory::new();
+            let poisoned_root_path = poisoned_root.path().join("root.img");
+            fs::write(&poisoned_root_path, b"root").expect("root fixture should write");
+            let poisoned = contained_restore_authority_for_test(&poisoned_root_path, false);
+            let generations = poisoned.authority.generations.clone();
+            let result = std::thread::spawn(move || {
+                let _state = generations
+                    .state
+                    .lock()
+                    .expect("generation state should initially lock");
+                panic!("injected generation poison");
+            })
+            .join();
+            assert!(result.is_err(), "generation poison helper should panic");
+            let error = poisoned
+                .authority
+                .prepare(Path::new("bangbang-grant:drive-ro"), None, &|| false)
+                .expect_err("poisoned generation state must reject before inspection");
+            assert_eq!(
+                error.kind(),
+                super::ContainedSnapshotRestoreErrorKind::Inactive
+            );
+            assert!(error.is_terminal());
+            assert_contained_restore_authorities_available(&poisoned, false);
+
+            let overflow_root = TestDirectory::new();
+            let overflow_root_path = overflow_root.path().join("root.img");
+            fs::write(&overflow_root_path, b"root").expect("root fixture should write");
+            let overflow = contained_restore_authority_for_test(&overflow_root_path, false);
+            overflow
+                .authority
+                .generations
+                .state
+                .lock()
+                .expect("generation state should lock")
+                .next_generation = u64::MAX;
+            let error = overflow
+                .authority
+                .prepare(Path::new("bangbang-grant:drive-ro"), None, &|| false)
+                .expect_err("generation overflow must reject before inspection");
+            assert_eq!(
+                error.kind(),
+                super::ContainedSnapshotRestoreErrorKind::Inactive
+            );
+            assert!(error.is_terminal());
+            assert_contained_restore_authorities_available(&overflow, false);
+        }
+
+        #[test]
+        fn contained_restore_cancellation_restores_every_reserved_phase() {
+            let root_directory = TestDirectory::new();
+            let root_path = root_directory.path().join("root.img");
+            fs::write(&root_path, b"root").expect("root fixture should write");
+            let fixture = contained_restore_authority_for_test(&root_path, true);
+            for cancellation_check in 1..=9 {
+                let checks = Cell::new(0);
+                let error = fixture
+                    .authority
+                    .prepare(
+                        Path::new("bangbang-grant:drive-ro"),
+                        Some(Path::new("bangbang-grant:vsock-directory/restored.sock")),
+                        &|| {
+                            let next = checks.get() + 1;
+                            checks.set(next);
+                            next == cancellation_check
+                        },
+                    )
+                    .expect_err("injected phase cancellation should fail");
+                assert_eq!(
+                    error.kind(),
+                    super::ContainedSnapshotRestoreErrorKind::Cancelled
+                );
+                assert!(!error.is_terminal());
+                assert!(!error.cleanup_failed());
+                assert_contained_restore_authorities_available(&fixture, true);
+            }
+
+            fixture
+                .authority
+                .prepare(
+                    Path::new("bangbang-grant:drive-ro"),
+                    Some(Path::new("bangbang-grant:vsock-directory/restored.sock")),
+                    &|| false,
+                )
+                .expect("uncancelled complete batch should reserve")
+                .abort()
+                .expect("uncancelled batch should reverse cleanly");
+        }
+
+        #[test]
+        fn contained_restore_preflight_rejects_reference_and_authority_substitution_without_use() {
+            let root_directory = TestDirectory::new();
+            let root_path = root_directory.path().join("root.img");
+            fs::write(&root_path, b"root").expect("root fixture should write");
+            let fixture = contained_restore_authority_for_test(&root_path, true);
+            for (root, vsock, expected_kind) in [
+                (
+                    Path::new("/tmp/ordinary-root.img"),
+                    None,
+                    super::ContainedSnapshotRestoreErrorKind::InvalidRequest,
+                ),
+                (
+                    Path::new("bangbang-grant:missing"),
+                    None,
+                    super::ContainedSnapshotRestoreErrorKind::Authority,
+                ),
+                (
+                    Path::new("bangbang-grant:drive-ro"),
+                    Some(Path::new("/tmp/ordinary-vsock.sock")),
+                    super::ContainedSnapshotRestoreErrorKind::InvalidRequest,
+                ),
+                (
+                    Path::new("bangbang-grant:drive-ro"),
+                    Some(Path::new("bangbang-grant:missing/restored.sock")),
+                    super::ContainedSnapshotRestoreErrorKind::Authority,
+                ),
+            ] {
+                let error = fixture
+                    .authority
+                    .prepare(root, vsock, &|| false)
+                    .expect_err("substituted contained authority must fail preflight");
+                assert_eq!(error.kind(), expected_kind);
+                assert!(!error.cleanup_failed());
+                let diagnostic = format!("{error:?} {error}");
+                assert!(!diagnostic.contains("drive-ro"));
+                assert!(!diagnostic.contains("missing"));
+                assert!(!diagnostic.contains("ordinary"));
+                assert_contained_restore_authorities_available(&fixture, true);
+            }
+
+            let mixed_files = file_grant_authority_for_test();
+            let mixed =
+                contained_restore_authority_with_grants_for_test(mixed_files.clone(), false);
+            for reference in [
+                Path::new("bangbang-grant:kernel"),
+                Path::new("bangbang-grant:drive-rw"),
+            ] {
+                let error = mixed
+                    .authority
+                    .prepare(reference, None, &|| false)
+                    .expect_err("wrong role or access must fail exact file preflight");
+                assert_eq!(
+                    error.kind(),
+                    super::ContainedSnapshotRestoreErrorKind::Authority
+                );
+                assert!(!error.cleanup_failed());
+            }
+            let kernel = mixed_files
+                .prepare_file_claim(
+                    Path::new("bangbang-grant:kernel"),
+                    ResourceRole::KernelImage,
+                    GrantAccess::ReadOnly,
+                )
+                .expect("failed preflight must retain substituted kernel")
+                .expect("kernel reference should remain contained");
+            drop(kernel);
+            let drive = mixed_files
+                .prepare_drive_backing_claim(
+                    Path::new("bangbang-grant:drive-rw"),
+                    GrantAccess::ReadWrite,
+                )
+                .expect("failed preflight must retain wrong-access drive")
+                .expect("drive reference should remain contained");
+            drive
+                .abort()
+                .expect("wrong-access drive should restore after observation");
+
+            let consumed_root = TestDirectory::new();
+            let consumed_root_path = consumed_root.path().join("root.img");
+            fs::write(&consumed_root_path, b"root").expect("root fixture should write");
+            let consumed = contained_restore_authority_for_test(&consumed_root_path, false);
+            consumed
+                .grants
+                .prepare_drive_backing_claim(
+                    Path::new("bangbang-grant:drive-ro"),
+                    GrantAccess::ReadOnly,
+                )
+                .expect("root claim should validate")
+                .expect("root reference should remain contained")
+                .commit();
+            let error = consumed
+                .authority
+                .prepare(Path::new("bangbang-grant:drive-ro"), None, &|| false)
+                .expect_err("already-consumed root must fail exact preflight");
+            assert_eq!(
+                error.kind(),
+                super::ContainedSnapshotRestoreErrorKind::Authority
+            );
+            assert!(!error.cleanup_failed());
+        }
+
+        #[test]
+        fn contained_restore_worker_and_launcher_invalidation_are_independently_terminal() {
+            let worker_root = TestDirectory::new();
+            let worker_root_path = worker_root.path().join("root.img");
+            fs::write(&worker_root_path, b"root").expect("root fixture should write");
+            let worker = contained_restore_authority_for_test(&worker_root_path, false);
+            let reserved = worker
+                .authority
+                .prepare(Path::new("bangbang-grant:drive-ro"), None, &|| false)
+                .expect("worker fixture should reserve");
+            worker.authority.generations.invalidate();
+            let error = reserved
+                .abort()
+                .expect_err("invalidated worker generation must be terminal");
+            assert_eq!(
+                error.kind(),
+                super::ContainedSnapshotRestoreErrorKind::Cleanup
+            );
+            assert!(error.is_terminal());
+            assert!(error.cleanup_failed());
+            let inactive = worker
+                .authority
+                .prepare(Path::new("bangbang-grant:drive-ro"), None, &|| false)
+                .expect_err("invalidated worker must reject later generations");
+            assert_eq!(
+                inactive.kind(),
+                super::ContainedSnapshotRestoreErrorKind::Inactive
+            );
+            assert!(inactive.is_terminal());
+            assert_contained_restore_authorities_available(&worker, false);
+
+            let launcher_root = TestDirectory::new();
+            let launcher_root_path = launcher_root.path().join("root.img");
+            fs::write(&launcher_root_path, b"root").expect("root fixture should write");
+            let launcher = contained_restore_authority_for_test(&launcher_root_path, true);
+            let reserved = launcher
+                .authority
+                .prepare(
+                    Path::new("bangbang-grant:drive-ro"),
+                    Some(Path::new("bangbang-grant:vsock-directory/restored.sock")),
+                    &|| false,
+                )
+                .expect("launcher fixture should reserve");
+            launcher.broker.invalidate();
+            let error = reserved
+                .abort()
+                .expect_err("invalidated launcher broker must report incomplete cleanup");
+            assert_eq!(
+                error.kind(),
+                super::ContainedSnapshotRestoreErrorKind::Cleanup
+            );
+            assert!(error.is_terminal());
+            assert!(error.cleanup_failed());
+            let root = launcher
+                .grants
+                .prepare_drive_backing_claim(
+                    Path::new("bangbang-grant:drive-ro"),
+                    GrantAccess::ReadOnly,
+                )
+                .expect("launcher death should still restore root")
+                .expect("root should remain contained");
+            root.abort().expect("restored root should abort");
+            let directory = launcher
+                .directories
+                .prepare_socket_directory(
+                    Path::new("bangbang-grant:vsock-directory/restored.sock"),
+                    ResourceRole::VsockSocketDirectory,
+                )
+                .expect("launcher death should still restore directory")
+                .expect("directory should remain contained");
+            directory.abort().expect("restored directory should abort");
+            assert!(launcher.broker.prepare_endpoint().is_err());
+        }
+
+        #[test]
+        fn contained_restore_rejects_cross_session_broker_before_reservation() {
+            let first_root = TestDirectory::new();
+            let first_root_path = first_root.path().join("root.img");
+            fs::write(&first_root_path, b"root").expect("root fixture should write");
+            let first = contained_restore_authority_for_test(&first_root_path, true);
+            let second_root = TestDirectory::new();
+            let second_root_path = second_root.path().join("root.img");
+            fs::write(&second_root_path, b"root").expect("root fixture should write");
+            let second = contained_restore_authority_for_test(&second_root_path, true);
+            let mixed = super::ContainedSnapshotRestoreAuthority {
+                session: first.authority.session,
+                generations: first.authority.generations.clone(),
+                grants: first.grants.clone(),
+                directories: first.directories.clone(),
+                broker: second.broker.clone(),
+                namespace: Rc::clone(&first.authority.namespace),
+                wakeup: Rc::clone(&first.authority.wakeup),
+            };
+
+            let error = mixed
+                .prepare(
+                    Path::new("bangbang-grant:drive-ro"),
+                    Some(Path::new("bangbang-grant:vsock-directory/restored.sock")),
+                    &|| false,
+                )
+                .expect_err("cross-session broker must fail during read-only preflight");
+            assert_eq!(
+                error.kind(),
+                super::ContainedSnapshotRestoreErrorKind::Provenance
+            );
+            assert!(error.is_terminal());
+            assert!(!error.cleanup_failed());
+            assert_contained_restore_authorities_available(&first, true);
+            assert_contained_restore_authorities_available(&second, true);
         }
 
         #[test]
@@ -4722,13 +6125,16 @@ pub(crate) use platform::{
 };
 #[cfg(target_os = "macos")]
 pub(crate) use platform::{
-    ClaimedVhostUserSocket, PreparedSocketBrokerEndpoint, PreparedVhostUserSocketClaim,
-    SnapshotStagingRecordTracker, SocketBrokerAuthority, SocketBrokerEndpoint,
-    VhostUserBrokerAuthority,
+    ClaimedVhostUserSocket, ContainedSnapshotRestoreAuthority, ContainedSnapshotRestoreError,
+    ContainedSnapshotRestoreTransaction, PreparedSocketBrokerEndpoint,
+    PreparedVhostUserSocketClaim, SnapshotStagingRecordTracker, SocketBrokerAuthority,
+    SocketBrokerEndpoint, VhostUserBrokerAuthority,
 };
 #[cfg(all(test, target_os = "macos"))]
 pub(crate) use platform::{
-    TestVhostDirectory, empty_grant_authority_for_vhost_test, file_grant_authority_for_test,
+    ContainedSnapshotRestoreErrorKind, TestContainedRestoreAuthority, TestVhostDirectory,
+    contained_restore_authority_for_test, contained_restore_authority_with_grants_for_test,
+    empty_grant_authority_for_vhost_test, file_grant_authority_for_test,
     root_file_grant_authority_for_test, snapshot_file_grant_authority_for_test,
     snapshot_root_file_grant_authority_for_test, vhost_directory_authority_for_test,
     vsock_directory_authority_for_test,

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -215,6 +215,13 @@ fn run(contained: &mut Option<ContainedSession>) -> Result<(), ProcessError> {
                 .transpose()
                 .map_err(|_| ProcessError::ContainedSession)?
                 .flatten();
+            #[cfg(target_os = "macos")]
+            let contained_restore_authority = contained
+                .as_ref()
+                .map(ContainedSession::snapshot_restore_authority)
+                .transpose()
+                .map_err(|_| ProcessError::ContainedSession)?
+                .flatten();
             preallocate_fdtable().map_err(ProcessError::FdTablePreallocation)?;
             if contained_shutdown_requested(contained)? {
                 return Ok(());
@@ -267,7 +274,8 @@ fn run(contained: &mut Option<ContainedSession>) -> Result<(), ProcessError> {
                     socket_broker_authority,
                     vhost_user_broker_authority,
                     socket_namespace,
-                );
+                )
+                .with_contained_restore_authority(contained_restore_authority);
             #[cfg(not(target_os = "macos"))]
             let mut vmm = vmm;
             apply_startup_metrics_config(&mut vmm, metrics_config)?;

--- a/crates/bangbang/src/snapshot_restore_resources.rs
+++ b/crates/bangbang/src/snapshot_restore_resources.rs
@@ -14,12 +14,16 @@ use bangbang_runtime::snapshot_restore::{
     SnapshotRestoreResourceKey, SnapshotRestoreTakeError,
 };
 use bangbang_session::GrantAccess;
+#[cfg(test)]
 use bangbang_session::macos::runtime::WorkerSocketNamespace;
 
 use crate::contained_session::{
-    DirectoryGrantAuthority, GrantAuthority, GrantClaimError, PreparedDriveBackingClaim,
-    SocketBrokerAuthority, grant_reference_id,
+    ContainedSnapshotRestoreAuthority, ContainedSnapshotRestoreError,
+    ContainedSnapshotRestoreTransaction, GrantAuthority, GrantClaimError,
+    PreparedDriveBackingClaim, grant_reference_id,
 };
+#[cfg(test)]
+use crate::contained_session::{DirectoryGrantAuthority, SocketBrokerAuthority};
 use crate::vsock_restore::{
     LocallyPreparedVsockRestoreResource, PreparedVsockRestoreResource,
     RequestedVsockRestoreResource, ReservedVsockRestoreResource, VsockRestoreDisposition,
@@ -37,6 +41,7 @@ pub(crate) enum SnapshotRestoreResourceStage {
     Manifest,
     BindingAllocation,
     Cancellation,
+    ContainedReservation,
     RootPreparation,
     VsockPreparation,
     Binding,
@@ -48,6 +53,7 @@ pub(crate) enum SnapshotRestoreResourceStage {
 pub(crate) enum SnapshotRestoreResourceErrorKind {
     Manifest(SnapshotRestoreManifestError),
     BindingAllocation(SnapshotRestoreBindingAllocationError),
+    Contained(ContainedSnapshotRestoreError),
     RootBacking(SnapshotRootBackingLeaseError),
     Vsock(VsockRestoreError),
     Binding(SnapshotRestoreBindingRejectionReason),
@@ -67,6 +73,10 @@ impl fmt::Debug for SnapshotRestoreResourceErrorKind {
                 .finish(),
             Self::BindingAllocation(source) => formatter
                 .debug_tuple("SnapshotRestoreResourceErrorKind::BindingAllocation")
+                .field(source)
+                .finish(),
+            Self::Contained(source) => formatter
+                .debug_tuple("SnapshotRestoreResourceErrorKind::Contained")
                 .field(source)
                 .finish(),
             Self::RootBacking(source) => formatter
@@ -106,6 +116,7 @@ impl fmt::Display for SnapshotRestoreResourceErrorKind {
         match self {
             Self::Manifest(source) => source.fmt(formatter),
             Self::BindingAllocation(source) => source.fmt(formatter),
+            Self::Contained(source) => source.fmt(formatter),
             Self::RootBacking(source) => source.fmt(formatter),
             Self::Vsock(source) => source.fmt(formatter),
             Self::Binding(reason) => reason.fmt(formatter),
@@ -204,6 +215,7 @@ impl std::error::Error for SnapshotRestoreResourceError {
         match &self.kind {
             SnapshotRestoreResourceErrorKind::Manifest(source) => Some(source),
             SnapshotRestoreResourceErrorKind::BindingAllocation(source) => Some(source),
+            SnapshotRestoreResourceErrorKind::Contained(source) => Some(source),
             SnapshotRestoreResourceErrorKind::RootBacking(source) => Some(source),
             SnapshotRestoreResourceErrorKind::Vsock(source) => Some(source),
             SnapshotRestoreResourceErrorKind::Take(source) => Some(source),
@@ -264,6 +276,19 @@ fn snapshot_vsock_error(source: VsockRestoreError) -> SnapshotRestoreResourceErr
     }
 }
 
+fn snapshot_contained_error(source: ContainedSnapshotRestoreError) -> SnapshotRestoreResourceError {
+    SnapshotRestoreResourceError {
+        stage: SnapshotRestoreResourceStage::ContainedReservation,
+        kind: SnapshotRestoreResourceErrorKind::Contained(source),
+        disposition: if source.is_terminal() {
+            SnapshotRestoreResourceDisposition::Terminal
+        } else {
+            SnapshotRestoreResourceDisposition::Retryable
+        },
+        cleanup_failed: source.cleanup_failed(),
+    }
+}
+
 fn vsock_abort_outcome(
     result: Result<VsockRestoreDisposition, VsockRestoreError>,
 ) -> SnapshotRestoreAbortOutcome {
@@ -319,6 +344,14 @@ impl PreparedSnapshotRootBackingLease {
             claim,
             consumed: false,
         })
+    }
+
+    fn from_prepared_claim(selector: PathBuf, claim: PreparedDriveBackingClaim) -> Self {
+        Self {
+            selector: Some(selector),
+            claim: Some(claim),
+            consumed: false,
+        }
     }
 
     pub(crate) fn take_snapshot_read_only_file(&mut self) -> Result<Option<File>, GrantClaimError> {
@@ -412,15 +445,50 @@ impl std::error::Error for SnapshotRootBackingLeaseError {
 
 pub(crate) struct PreparedSnapshotRootRestoreCompletion {
     lease: PreparedSnapshotRootBackingLease,
+    contained_transaction: Option<ContainedSnapshotRestoreTransaction>,
 }
 
 impl PreparedSnapshotRootRestoreCompletion {
-    pub(crate) fn commit(self) {
-        self.lease.commit();
+    pub(crate) fn commit(self) -> Result<(), PreparedSnapshotRootRestoreCompletionError> {
+        let Self {
+            lease,
+            contained_transaction,
+        } = self;
+        lease.commit();
+        match contained_transaction {
+            Some(transaction) => {
+                transaction
+                    .commit()
+                    .map_err(|source| PreparedSnapshotRootRestoreCompletionError {
+                        grant: None,
+                        contained: Some(source),
+                    })
+            }
+            None => Ok(()),
+        }
     }
 
-    pub(crate) fn abort(self) -> Result<(), GrantClaimError> {
-        self.lease.abort()
+    pub(crate) fn abort(self) -> Result<(), PreparedSnapshotRootRestoreCompletionError> {
+        let Self {
+            lease,
+            contained_transaction,
+        } = self;
+        let grant = lease.abort().err();
+        let contained = contained_transaction.and_then(|transaction| transaction.abort().err());
+        if grant.is_some() || contained.is_some() {
+            Err(PreparedSnapshotRootRestoreCompletionError { grant, contained })
+        } else {
+            Ok(())
+        }
+    }
+
+    fn with_contained_transaction(
+        mut self,
+        transaction: ContainedSnapshotRestoreTransaction,
+    ) -> Self {
+        debug_assert!(self.contained_transaction.is_none());
+        self.contained_transaction = Some(transaction);
+        self
     }
 }
 
@@ -430,6 +498,31 @@ impl fmt::Debug for PreparedSnapshotRootRestoreCompletion {
             .debug_struct("PreparedSnapshotRootRestoreCompletion")
             .field("state", &"<provisional>")
             .finish()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct PreparedSnapshotRootRestoreCompletionError {
+    grant: Option<GrantClaimError>,
+    contained: Option<ContainedSnapshotRestoreError>,
+}
+
+impl fmt::Display for PreparedSnapshotRootRestoreCompletionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("snapshot root completion authority failed")
+    }
+}
+
+impl std::error::Error for PreparedSnapshotRootRestoreCompletionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.contained
+            .as_ref()
+            .map(|source| source as &(dyn std::error::Error + 'static))
+            .or_else(|| {
+                self.grant
+                    .as_ref()
+                    .map(|source| source as &(dyn std::error::Error + 'static))
+            })
     }
 }
 
@@ -445,7 +538,11 @@ impl ReservedSnapshotRootRestoreResource {
         let lease = PreparedSnapshotRootBackingLease::prepare(
             selector,
             authority,
-            SnapshotRootSelectorPolicy::RequireGrantWhenContained,
+            if authority.is_some() {
+                SnapshotRootSelectorPolicy::RequireGrantWhenContained
+            } else {
+                SnapshotRootSelectorPolicy::RejectGrantReference
+            },
         )
         .map_err(|source| {
             let kind = SnapshotRestoreResourceErrorKind::RootBacking(
@@ -466,6 +563,12 @@ impl ReservedSnapshotRootRestoreResource {
         Ok(Self { lease })
     }
 
+    fn from_prepared_claim(selector: PathBuf, claim: PreparedDriveBackingClaim) -> Self {
+        Self {
+            lease: PreparedSnapshotRootBackingLease::from_prepared_claim(selector, claim),
+        }
+    }
+
     fn prepare_local(
         mut self,
     ) -> Result<
@@ -478,7 +581,10 @@ impl ReservedSnapshotRootRestoreResource {
         match self.lease.open_snapshot_read_only() {
             Ok(backing) => Ok(PreparedSnapshotRootRestoreResource {
                 backing,
-                completion: PreparedSnapshotRootRestoreCompletion { lease: self.lease },
+                completion: PreparedSnapshotRootRestoreCompletion {
+                    lease: self.lease,
+                    contained_transaction: None,
+                },
             }),
             Err(source) => Err(Box::new((source, self))),
         }
@@ -527,7 +633,15 @@ impl PreparedSnapshotRootRestoreResource {
         (self.backing, self.completion)
     }
 
-    fn abort(self) -> Result<(), GrantClaimError> {
+    fn with_contained_transaction(
+        mut self,
+        transaction: ContainedSnapshotRestoreTransaction,
+    ) -> Self {
+        self.completion = self.completion.with_contained_transaction(transaction);
+        self
+    }
+
+    fn abort(self) -> Result<(), PreparedSnapshotRootRestoreCompletionError> {
         let Self {
             backing,
             completion,
@@ -644,6 +758,18 @@ enum SnapshotRestorePreparationStep {
     Completion,
     VsockAbort,
     RootAbort,
+}
+
+enum SnapshotRestoreReservationSource<'a> {
+    Direct,
+    Contained(&'a ContainedSnapshotRestoreAuthority),
+    #[cfg(test)]
+    Independent {
+        root: Option<&'a GrantAuthority>,
+        directory: Option<&'a DirectoryGrantAuthority>,
+        broker: Option<&'a SocketBrokerAuthority>,
+        namespace: Option<&'a WorkerSocketNamespace>,
+    },
 }
 
 impl RequestedSnapshotRestoreResources {
@@ -768,13 +894,29 @@ impl RequestedSnapshotRestoreResources {
 
     pub(crate) fn prepare_root(
         self,
-        authority: Option<&GrantAuthority>,
+        authority: Option<&ContainedSnapshotRestoreAuthority>,
         cancelled: impl Fn() -> bool,
     ) -> Result<PreparedSnapshotRestoreResources, SnapshotRestoreResourceError> {
-        self.prepare(authority, None, None, None, cancelled)
+        self.prepare(authority, cancelled)
     }
 
     pub(crate) fn prepare(
+        self,
+        authority: Option<&ContainedSnapshotRestoreAuthority>,
+        cancelled: impl Fn() -> bool,
+    ) -> Result<PreparedSnapshotRestoreResources, SnapshotRestoreResourceError> {
+        self.prepare_from_source_with_observer(
+            match authority {
+                Some(authority) => SnapshotRestoreReservationSource::Contained(authority),
+                None => SnapshotRestoreReservationSource::Direct,
+            },
+            cancelled,
+            |_| {},
+        )
+    }
+
+    #[cfg(test)]
+    fn prepare_with_independent(
         self,
         root_authority: Option<&GrantAuthority>,
         directory_authority: Option<&DirectoryGrantAuthority>,
@@ -782,7 +924,7 @@ impl RequestedSnapshotRestoreResources {
         namespace: Option<&WorkerSocketNamespace>,
         cancelled: impl Fn() -> bool,
     ) -> Result<PreparedSnapshotRestoreResources, SnapshotRestoreResourceError> {
-        self.prepare_with_observer(
+        self.prepare_with_independent_observer(
             root_authority,
             directory_authority,
             broker_authority,
@@ -792,12 +934,31 @@ impl RequestedSnapshotRestoreResources {
         )
     }
 
-    fn prepare_with_observer(
+    #[cfg(test)]
+    fn prepare_with_independent_observer(
         self,
         root_authority: Option<&GrantAuthority>,
         directory_authority: Option<&DirectoryGrantAuthority>,
         broker_authority: Option<&SocketBrokerAuthority>,
         namespace: Option<&WorkerSocketNamespace>,
+        cancelled: impl Fn() -> bool,
+        observe: impl FnMut(SnapshotRestorePreparationStep),
+    ) -> Result<PreparedSnapshotRestoreResources, SnapshotRestoreResourceError> {
+        self.prepare_from_source_with_observer(
+            SnapshotRestoreReservationSource::Independent {
+                root: root_authority,
+                directory: directory_authority,
+                broker: broker_authority,
+                namespace,
+            },
+            cancelled,
+            observe,
+        )
+    }
+
+    fn prepare_from_source_with_observer(
+        self,
+        source: SnapshotRestoreReservationSource<'_>,
         cancelled: impl Fn() -> bool,
         mut observe: impl FnMut(SnapshotRestorePreparationStep),
     ) -> Result<PreparedSnapshotRestoreResources, SnapshotRestoreResourceError> {
@@ -815,34 +976,124 @@ impl RequestedSnapshotRestoreResources {
         }
 
         observe(SnapshotRestorePreparationStep::RootReservation);
-        let root_reserved =
-            match ReservedSnapshotRootRestoreResource::reserve(&root_selector, root_authority) {
-                Ok(reserved) => reserved,
-                Err(source) => {
-                    let outcome = abort_resources(bindings.into_values());
-                    return Err(source.with_abort_outcome(outcome));
+        let (root_reserved, vsock_reserved, contained_transaction) = match source {
+            SnapshotRestoreReservationSource::Direct => {
+                let root_reserved =
+                    match ReservedSnapshotRootRestoreResource::reserve(&root_selector, None) {
+                        Ok(reserved) => reserved,
+                        Err(source) => {
+                            let outcome = abort_resources(bindings.into_values());
+                            return Err(source.with_abort_outcome(outcome));
+                        }
+                    };
+                let vsock_reserved = match vsock_request {
+                    Some(request) => {
+                        observe(SnapshotRestorePreparationStep::VsockReservation);
+                        match request.reserve(None, None, None, &cancelled) {
+                            Ok(reserved) => Some(reserved),
+                            Err(source) => {
+                                let outcome = root_reserved
+                                    .abort()
+                                    .merge(abort_resources(bindings.into_values()));
+                                return Err(
+                                    snapshot_vsock_error(source).with_abort_outcome(outcome)
+                                );
+                            }
+                        }
+                    }
+                    None => None,
+                };
+                (root_reserved, vsock_reserved, None)
+            }
+            SnapshotRestoreReservationSource::Contained(authority) => {
+                if vsock_request.is_some() {
+                    observe(SnapshotRestorePreparationStep::VsockReservation);
                 }
-            };
-        let vsock_reserved = match vsock_request {
-            Some(request) => {
-                observe(SnapshotRestorePreparationStep::VsockReservation);
-                match request.reserve(directory_authority, broker_authority, namespace, &cancelled)
-                {
-                    Ok(reserved) => Some(reserved),
-                    Err(source) => {
+                let reserved = authority
+                    .prepare(
+                        &root_selector,
+                        vsock_request
+                            .as_ref()
+                            .map(RequestedVsockRestoreResource::destination_reference),
+                        &cancelled,
+                    )
+                    .map_err(snapshot_contained_error)?;
+                let (root_claim, vsock_facets, transaction) =
+                    reserved.into_parts().map_err(snapshot_contained_error)?;
+                let root_reserved = ReservedSnapshotRootRestoreResource::from_prepared_claim(
+                    root_selector,
+                    root_claim,
+                );
+                let vsock_reserved = match (vsock_request, vsock_facets) {
+                    (Some(request), Some((claim, broker, namespace))) => {
+                        Some(request.reserve_contained(claim, broker, namespace))
+                    }
+                    (None, None) => None,
+                    (Some(_), None) => {
                         let outcome = root_reserved
                             .abort()
-                            .merge(abort_resources(bindings.into_values()));
-                        return Err(snapshot_vsock_error(source).with_abort_outcome(outcome));
+                            .merge(abort_contained_transaction(Some(transaction)));
+                        let error = ContainedSnapshotRestoreError::invalid_request();
+                        return Err(snapshot_contained_error(error).with_abort_outcome(outcome));
                     }
-                }
+                    (None, Some((directory, broker, namespace))) => {
+                        drop(namespace);
+                        let owner_cleanup_failed =
+                            broker.abort().is_err() | directory.abort().is_err();
+                        let owner_outcome = if owner_cleanup_failed {
+                            SnapshotRestoreAbortOutcome::terminal(true)
+                        } else {
+                            SnapshotRestoreAbortOutcome::retryable()
+                        };
+                        let outcome = owner_outcome
+                            .merge(root_reserved.abort())
+                            .merge(abort_contained_transaction(Some(transaction)));
+                        let error = ContainedSnapshotRestoreError::invalid_request();
+                        return Err(snapshot_contained_error(error).with_abort_outcome(outcome));
+                    }
+                };
+                (root_reserved, vsock_reserved, Some(transaction))
             }
-            None => None,
+            #[cfg(test)]
+            SnapshotRestoreReservationSource::Independent {
+                root,
+                directory,
+                broker,
+                namespace,
+            } => {
+                let root_reserved =
+                    match ReservedSnapshotRootRestoreResource::reserve(&root_selector, root) {
+                        Ok(reserved) => reserved,
+                        Err(source) => {
+                            let outcome = abort_resources(bindings.into_values());
+                            return Err(source.with_abort_outcome(outcome));
+                        }
+                    };
+                let vsock_reserved = match vsock_request {
+                    Some(request) => {
+                        observe(SnapshotRestorePreparationStep::VsockReservation);
+                        match request.reserve(directory, broker, namespace, &cancelled) {
+                            Ok(reserved) => Some(reserved),
+                            Err(source) => {
+                                let outcome = root_reserved
+                                    .abort()
+                                    .merge(abort_resources(bindings.into_values()));
+                                return Err(
+                                    snapshot_vsock_error(source).with_abort_outcome(outcome)
+                                );
+                            }
+                        }
+                    }
+                    None => None,
+                };
+                (root_reserved, vsock_reserved, None)
+            }
         };
         if cancelled() {
             let outcome = abort_reserved_vsock(vsock_reserved)
                 .merge(root_reserved.abort())
-                .merge(abort_resources(bindings.into_values()));
+                .merge(abort_resources(bindings.into_values()))
+                .merge(abort_contained_transaction(contained_transaction));
             return Err(cancelled_batch_error().with_abort_outcome(outcome));
         }
 
@@ -853,7 +1104,8 @@ impl RequestedSnapshotRestoreResources {
                 let (source, root_reserved) = *failure;
                 let outcome = abort_reserved_vsock(vsock_reserved)
                     .merge(root_reserved.abort())
-                    .merge(abort_resources(bindings.into_values()));
+                    .merge(abort_resources(bindings.into_values()))
+                    .merge(abort_contained_transaction(contained_transaction));
                 return Err(SnapshotRestoreResourceError::retryable(
                     SnapshotRestoreResourceStage::RootPreparation,
                     SnapshotRestoreResourceErrorKind::RootBacking(source),
@@ -868,7 +1120,8 @@ impl RequestedSnapshotRestoreResources {
                     Ok(local) => Some(local),
                     Err(source) => {
                         let outcome = prepared_root_abort_outcome(root)
-                            .merge(abort_resources(bindings.into_values()));
+                            .merge(abort_resources(bindings.into_values()))
+                            .merge(abort_contained_transaction(contained_transaction));
                         return Err(snapshot_vsock_error(source).with_abort_outcome(outcome));
                     }
                 }
@@ -878,7 +1131,8 @@ impl RequestedSnapshotRestoreResources {
         if cancelled() {
             let outcome = abort_local_vsock(vsock_local)
                 .merge(prepared_root_abort_outcome(root))
-                .merge(abort_resources(bindings.into_values()));
+                .merge(abort_resources(bindings.into_values()))
+                .merge(abort_contained_transaction(contained_transaction));
             return Err(cancelled_batch_error().with_abort_outcome(outcome));
         }
         let vsock = match vsock_local {
@@ -888,7 +1142,8 @@ impl RequestedSnapshotRestoreResources {
                     Ok(vsock) => Some(vsock),
                     Err(source) => {
                         let outcome = prepared_root_abort_outcome(root)
-                            .merge(abort_resources(bindings.into_values()));
+                            .merge(abort_resources(bindings.into_values()))
+                            .merge(abort_contained_transaction(contained_transaction));
                         return Err(snapshot_vsock_error(source).with_abort_outcome(outcome));
                     }
                 }
@@ -908,7 +1163,8 @@ impl RequestedSnapshotRestoreResources {
                     observe(SnapshotRestorePreparationStep::RootAbort);
                     rejection.into_value().abort()
                 })
-                .merge(abort_resources(bindings.into_values()));
+                .merge(abort_resources(bindings.into_values()))
+                .merge(abort_contained_transaction(contained_transaction));
             return Err(SnapshotRestoreResourceError::terminal(
                 SnapshotRestoreResourceStage::Binding,
                 SnapshotRestoreResourceErrorKind::Binding(reason),
@@ -923,7 +1179,8 @@ impl RequestedSnapshotRestoreResources {
                 let outcome = rejection
                     .into_value()
                     .abort()
-                    .merge(abort_resources(bindings.into_values()));
+                    .merge(abort_resources(bindings.into_values()))
+                    .merge(abort_contained_transaction(contained_transaction));
                 return Err(SnapshotRestoreResourceError::terminal(
                     SnapshotRestoreResourceStage::Binding,
                     SnapshotRestoreResourceErrorKind::Binding(reason),
@@ -937,7 +1194,8 @@ impl RequestedSnapshotRestoreResources {
             Ok(bindings) => bindings,
             Err(incomplete) => {
                 let missing_count = incomplete.missing_count();
-                let outcome = abort_resources(incomplete.into_bindings().into_values());
+                let outcome = abort_resources(incomplete.into_bindings().into_values())
+                    .merge(abort_contained_transaction(contained_transaction));
                 return Err(SnapshotRestoreResourceError::terminal(
                     SnapshotRestoreResourceStage::Completion,
                     SnapshotRestoreResourceErrorKind::Incomplete { missing_count },
@@ -949,6 +1207,7 @@ impl RequestedSnapshotRestoreResources {
             root_key,
             vsock_key,
             bindings,
+            contained_transaction,
         };
         if cancelled() {
             let outcome = prepared.abort();
@@ -1034,6 +1293,7 @@ impl RequestedSnapshotRestoreResources {
             root_key: self.root_key,
             vsock_key: self.vsock_key,
             bindings,
+            contained_transaction: None,
         };
         if cancelled() {
             let outcome = prepared.abort();
@@ -1060,6 +1320,7 @@ impl RequestedSnapshotRestoreResources {
             root_key: self.root_key,
             vsock_key: self.vsock_key,
             bindings,
+            contained_transaction: None,
         })
     }
 }
@@ -1084,10 +1345,7 @@ fn abort_reserved_vsock(
     reserved: Option<ReservedVsockRestoreResource>,
 ) -> SnapshotRestoreAbortOutcome {
     match reserved {
-        Some(reserved) => match reserved.abort() {
-            VsockRestoreDisposition::Retryable => SnapshotRestoreAbortOutcome::retryable(),
-            VsockRestoreDisposition::Terminal => SnapshotRestoreAbortOutcome::terminal(false),
-        },
+        Some(reserved) => vsock_abort_outcome(reserved.abort()),
         None => SnapshotRestoreAbortOutcome::retryable(),
     }
 }
@@ -1097,6 +1355,18 @@ fn abort_local_vsock(
 ) -> SnapshotRestoreAbortOutcome {
     match local {
         Some(local) => vsock_abort_outcome(local.abort()),
+        None => SnapshotRestoreAbortOutcome::retryable(),
+    }
+}
+
+fn abort_contained_transaction(
+    transaction: Option<ContainedSnapshotRestoreTransaction>,
+) -> SnapshotRestoreAbortOutcome {
+    match transaction {
+        Some(transaction) => match transaction.abort() {
+            Ok(()) => SnapshotRestoreAbortOutcome::retryable(),
+            Err(_) => SnapshotRestoreAbortOutcome::terminal(true),
+        },
         None => SnapshotRestoreAbortOutcome::retryable(),
     }
 }
@@ -1133,6 +1403,7 @@ pub(crate) struct PreparedSnapshotRestoreResources {
     root_key: SnapshotRestoreResourceKey,
     vsock_key: Option<SnapshotRestoreResourceKey>,
     bindings: PreparedSnapshotRestoreBindings<PreparedSnapshotRestoreResource>,
+    contained_transaction: Option<ContainedSnapshotRestoreTransaction>,
 }
 
 impl PreparedSnapshotRestoreResources {
@@ -1180,12 +1451,35 @@ impl PreparedSnapshotRestoreResources {
         }
     }
 
+    fn abort_bindings_and_take_transaction(
+        self,
+    ) -> (
+        SnapshotRestoreAbortOutcome,
+        Option<ContainedSnapshotRestoreTransaction>,
+    ) {
+        (
+            abort_resources(self.bindings.into_values()),
+            self.contained_transaction,
+        )
+    }
+
+    #[cfg(test)]
     fn finish(self) -> Result<(), SnapshotRestoreResourceError> {
-        match self.bindings.finish() {
-            Ok(()) => Ok(()),
+        let Self {
+            root_key: _,
+            vsock_key: _,
+            bindings,
+            contained_transaction,
+        } = self;
+        match bindings.finish() {
+            Ok(()) => match contained_transaction {
+                Some(transaction) => transaction.abort().map_err(snapshot_contained_error),
+                None => Ok(()),
+            },
             Err(unconsumed) => {
                 let unconsumed_count = unconsumed.unconsumed_count();
-                let outcome = abort_resources(unconsumed.into_bindings().into_values());
+                let outcome = abort_resources(unconsumed.into_bindings().into_values())
+                    .merge(abort_contained_transaction(contained_transaction));
                 Err(SnapshotRestoreResourceError::terminal(
                     SnapshotRestoreResourceStage::Finish,
                     SnapshotRestoreResourceErrorKind::Unconsumed { unconsumed_count },
@@ -1216,17 +1510,39 @@ impl PreparedSnapshotRestoreResources {
             Some(key) => match self.take_vsock(&key) {
                 Ok(vsock) => Some(vsock),
                 Err(source) => {
-                    let outcome = self.abort().merge(prepared_root_abort_outcome(root));
+                    let (outcome, transaction) = self.abort_bindings_and_take_transaction();
+                    let outcome = outcome
+                        .merge(prepared_root_abort_outcome(root))
+                        .merge(abort_contained_transaction(transaction));
                     return Err(source.with_abort_outcome(outcome));
                 }
             },
             None => None,
         };
-        if let Err(source) = self.finish() {
-            let outcome =
-                prepared_vsock_abort_outcome(vsock).merge(prepared_root_abort_outcome(root));
-            return Err(source.with_abort_outcome(outcome));
-        }
+        let Self {
+            root_key: _,
+            vsock_key: _,
+            bindings,
+            contained_transaction,
+        } = self;
+        let root = match bindings.finish() {
+            Ok(()) => match contained_transaction {
+                Some(transaction) => root.with_contained_transaction(transaction),
+                None => root,
+            },
+            Err(unconsumed) => {
+                let unconsumed_count = unconsumed.unconsumed_count();
+                let outcome = abort_resources(unconsumed.into_bindings().into_values())
+                    .merge(prepared_vsock_abort_outcome(vsock))
+                    .merge(prepared_root_abort_outcome(root))
+                    .merge(abort_contained_transaction(contained_transaction));
+                return Err(SnapshotRestoreResourceError::terminal(
+                    SnapshotRestoreResourceStage::Finish,
+                    SnapshotRestoreResourceErrorKind::Unconsumed { unconsumed_count },
+                )
+                .with_abort_outcome(outcome));
+            }
+        };
         Ok((root, vsock))
     }
 
@@ -1255,6 +1571,7 @@ impl PreparedSnapshotRestoreResources {
 
     fn abort(self) -> SnapshotRestoreAbortOutcome {
         abort_resources(self.bindings.into_values())
+            .merge(abort_contained_transaction(self.contained_transaction))
     }
 }
 
@@ -1264,6 +1581,10 @@ impl fmt::Debug for PreparedSnapshotRestoreResources {
             .debug_struct("PreparedSnapshotRestoreResources")
             .field("resource_count", &self.bindings.manifest().len())
             .field("remaining_count", &self.bindings.remaining_count())
+            .field(
+                "contained_transaction",
+                &self.contained_transaction.as_ref().map(|_| "<provisional>"),
+            )
             .field("values", &"<redacted>")
             .finish()
     }
@@ -1305,7 +1626,9 @@ mod tests {
     use bangbang_session::ResourceRole;
 
     use crate::contained_session::{
-        GrantAuthority, root_file_grant_authority_for_test, vsock_directory_authority_for_test,
+        ContainedSnapshotRestoreErrorKind, GrantAuthority, TestContainedRestoreAuthority,
+        contained_restore_authority_for_test, root_file_grant_authority_for_test,
+        vsock_directory_authority_for_test,
     };
 
     use super::*;
@@ -1378,6 +1701,23 @@ mod tests {
             SnapshotV2DeviceTransportKind::Mmio,
         ))
         .expect("fixture request should build")
+    }
+
+    fn contained_requested_root() -> RequestedSnapshotRestoreResources {
+        let graph = fixture_graph(SnapshotV2DeviceTransportKind::Mmio);
+        let key = SnapshotRestoreResourceKey::new(
+            graph.root_key(),
+            SnapshotRestorePublicId::try_from(graph.record().config().drive_id())
+                .expect("fixture root ID should validate"),
+            SnapshotRestoreResourceClass::BlockBacking,
+        );
+        RequestedSnapshotRestoreResources::try_from_exact_requests(vec![
+            RequestedSnapshotRestoreResource::Root {
+                key,
+                selector: PathBuf::from(ROOT_REFERENCE),
+            },
+        ])
+        .expect("contained root request should validate")
     }
 
     fn socket_path(name: &str) -> PathBuf {
@@ -1455,6 +1795,162 @@ mod tests {
             .expect("observed restored claim should return to authority");
     }
 
+    fn assert_coherent_root_claim_restored(fixture: &TestContainedRestoreAuthority) {
+        assert_root_claim_restored(fixture.grants());
+    }
+
+    #[test]
+    fn coherent_contained_generation_moves_from_bindings_to_root_completion() {
+        let root = TempRoot::new("coherent-contained", b"root");
+        let fixture = contained_restore_authority_for_test(root.path(), false);
+        let prepared = contained_requested_root()
+            .prepare(Some(fixture.authority()), || false)
+            .expect("coherent contained batch should prepare");
+        let overlap = fixture
+            .authority()
+            .prepare(Path::new(ROOT_REFERENCE), None, &|| false)
+            .expect_err("completed bindings must retain their generation");
+        assert_eq!(overlap.kind(), ContainedSnapshotRestoreErrorKind::Busy);
+
+        let root_owner = prepared
+            .into_root()
+            .expect("exact take and finish should produce the root owner");
+        let overlap = fixture
+            .authority()
+            .prepare(Path::new(ROOT_REFERENCE), None, &|| false)
+            .expect_err("root owner completion must retain its generation");
+        assert_eq!(overlap.kind(), ContainedSnapshotRestoreErrorKind::Busy);
+        let (backing, completion) = root_owner.into_parts();
+        drop(backing);
+        completion
+            .abort()
+            .expect("root and generation should abort in order");
+        assert_coherent_root_claim_restored(&fixture);
+
+        let committed = contained_requested_root()
+            .prepare(Some(fixture.authority()), || false)
+            .expect("released transaction should prepare again")
+            .into_root()
+            .expect("committed transaction should take exactly");
+        let (backing, completion) = committed.into_parts();
+        drop(backing);
+        completion
+            .commit()
+            .expect("final completion boundary should clear the generation");
+        assert!(
+            fixture
+                .grants()
+                .prepare_drive_backing_claim(Path::new(ROOT_REFERENCE), GrantAccess::ReadOnly)
+                .is_err(),
+            "committed root authority must remain consumed"
+        );
+        let consumed = fixture
+            .authority()
+            .prepare(Path::new(ROOT_REFERENCE), None, &|| false)
+            .expect_err("consumed root must fail complete-set preflight");
+        assert_eq!(
+            consumed.kind(),
+            ContainedSnapshotRestoreErrorKind::Authority
+        );
+    }
+
+    #[test]
+    fn coherent_contained_abort_restores_root_before_stale_generation_failure() {
+        let root = TempRoot::new("coherent-stale", b"root");
+        let fixture = contained_restore_authority_for_test(root.path(), false);
+        let root_owner = contained_requested_root()
+            .prepare(Some(fixture.authority()), || false)
+            .expect("coherent contained batch should prepare")
+            .into_root()
+            .expect("coherent root should take exactly");
+        let (backing, completion) = root_owner.into_parts();
+        drop(backing);
+        fixture.invalidate_generation();
+        let error = completion
+            .abort()
+            .expect_err("stale generation must not be converted into success");
+        let diagnostic = format!("{error:?} {error}");
+        assert!(!diagnostic.contains(ROOT_REFERENCE));
+        assert!(!diagnostic.contains(root.path().to_string_lossy().as_ref()));
+        assert_coherent_root_claim_restored(&fixture);
+    }
+
+    #[test]
+    fn coherent_contained_vsock_facets_abort_before_publication_on_cancellation() {
+        let root = TempRoot::new("coherent-vsock-cancel", b"root");
+        let fixture = contained_restore_authority_for_test(root.path(), true);
+        let contained_vsock = selector(Path::new("bangbang-grant:vsock-directory/restored.sock"));
+        let (request, _, _) =
+            composed_request(Path::new(ROOT_REFERENCE), &contained_vsock, None, false);
+        let checks = Cell::new(0);
+        let error = request
+            .prepare(Some(fixture.authority()), || {
+                let next = checks.get() + 1;
+                checks.set(next);
+                next > 10
+            })
+            .expect_err("cancellation after coherent reservation should reverse every facet");
+        assert_eq!(error.stage, SnapshotRestoreResourceStage::Cancellation);
+        assert_eq!(
+            error.disposition,
+            SnapshotRestoreResourceDisposition::Retryable
+        );
+        assert!(!error.cleanup_failed);
+        fixture.assert_authorities_available(true);
+    }
+
+    #[test]
+    fn coherent_contained_vsock_abort_reports_broker_restoration_failure() {
+        let root = TempRoot::new("coherent-vsock-broker-loss", b"root");
+        let fixture = contained_restore_authority_for_test(root.path(), true);
+        let contained_vsock = selector(Path::new("bangbang-grant:vsock-directory/restored.sock"));
+        let (request, _, _) =
+            composed_request(Path::new(ROOT_REFERENCE), &contained_vsock, None, false);
+        let checks = Cell::new(0);
+        let error = request
+            .prepare(Some(fixture.authority()), || {
+                let next = checks.get() + 1;
+                checks.set(next);
+                if next == 11 {
+                    fixture.invalidate_broker();
+                    true
+                } else {
+                    false
+                }
+            })
+            .expect_err("broker invalidation during outer cancellation must be terminal");
+        assert_eq!(error.stage, SnapshotRestoreResourceStage::Cancellation);
+        assert_eq!(
+            error.disposition,
+            SnapshotRestoreResourceDisposition::Terminal
+        );
+        assert!(error.cleanup_failed);
+        assert_coherent_root_claim_restored(&fixture);
+        let directory = fixture
+            .directories()
+            .prepare_socket_directory(
+                Path::new("bangbang-grant:vsock-directory/restored.sock"),
+                bangbang_session::ResourceRole::VsockSocketDirectory,
+            )
+            .expect("directory restoration should still be attempted")
+            .expect("directory reference should remain contained");
+        directory
+            .abort()
+            .expect("restored directory should remain reusable");
+    }
+
+    #[test]
+    fn direct_batch_rejects_reserved_root_reference_without_path_fallback() {
+        let error = contained_requested_root()
+            .prepare(None, || false)
+            .expect_err("direct mode must reject reserved grant grammar");
+        assert_eq!(error.stage, SnapshotRestoreResourceStage::RootPreparation);
+        assert!(matches!(
+            error.kind,
+            SnapshotRestoreResourceErrorKind::RootBacking(SnapshotRootBackingLeaseError::Grant(_))
+        ));
+    }
+
     #[test]
     fn current_graphs_build_one_exact_host_free_root_request() {
         for transport in [
@@ -1527,7 +2023,7 @@ mod tests {
 
             let events = RefCell::new(Vec::new());
             let prepared = request
-                .prepare_with_observer(
+                .prepare_with_independent_observer(
                     None,
                     None,
                     None,
@@ -1602,7 +2098,7 @@ mod tests {
             true,
         );
         let (root_owner, vsock) = request
-            .prepare(None, None, None, None, || false)
+            .prepare(None, || false)
             .expect("composed owners should prepare before construction")
             .into_root_and_optional_vsock()
             .expect("exact owners should be taken before construction");
@@ -1638,7 +2134,7 @@ mod tests {
         let (request, _, _) = composed_request(Path::new(ROOT_REFERENCE), &captured, None, false);
         let events = RefCell::new(Vec::new());
         let error = request
-            .prepare_with_observer(
+            .prepare_with_independent_observer(
                 Some(&authority),
                 None,
                 None,
@@ -1680,7 +2176,7 @@ mod tests {
         let (request, _, _) = composed_request(Path::new(ROOT_REFERENCE), &captured, None, true);
         let events = RefCell::new(Vec::new());
         let error = request
-            .prepare_with_observer(
+            .prepare_with_independent_observer(
                 Some(&root_authority),
                 Some(&directory_authority),
                 None,
@@ -1826,7 +2322,7 @@ mod tests {
         );
         let events = RefCell::new(Vec::new());
         let error = request
-            .prepare_with_observer(
+            .prepare_with_independent_observer(
                 Some(&authority),
                 None,
                 None,
@@ -1893,7 +2389,7 @@ mod tests {
         let (request, root_key, vsock_key) =
             composed_request(Path::new(ROOT_REFERENCE), &captured, None, false);
         let mut prepared = request
-            .prepare(Some(&authority), None, None, None, || false)
+            .prepare_with_independent(Some(&authority), None, None, None, || false)
             .expect("composed batch should prepare");
         let vsock = prepared
             .take_vsock(&vsock_key)
@@ -1925,7 +2421,7 @@ mod tests {
         let (request, _, _) =
             composed_request(Path::new(ROOT_REFERENCE), &second_captured, None, false);
         let unconsumed = request
-            .prepare(Some(&second_authority), None, None, None, || false)
+            .prepare_with_independent(Some(&second_authority), None, None, None, || false)
             .expect("second composed batch should prepare")
             .finish()
             .expect_err("finish must reject both unconsumed owners");
@@ -2090,7 +2586,9 @@ mod tests {
             contained_root(&committed_authority).expect("committed root should prepare");
         let (backing, completion) = committed.into_parts();
         drop(backing);
-        completion.commit();
+        completion
+            .commit()
+            .expect("contained completion should commit its exact claim");
         assert!(
             committed_observer
                 .prepare_drive_backing_claim(Path::new(ROOT_REFERENCE), GrantAccess::ReadOnly,)

--- a/crates/bangbang/src/snapshot_restore_resources.rs
+++ b/crates/bangbang/src/snapshot_restore_resources.rs
@@ -27,7 +27,7 @@ use crate::contained_session::{DirectoryGrantAuthority, SocketBrokerAuthority};
 use crate::vsock_restore::{
     LocallyPreparedVsockRestoreResource, PreparedVsockRestoreResource,
     RequestedVsockRestoreResource, ReservedVsockRestoreResource, VsockRestoreDisposition,
-    VsockRestoreError,
+    VsockRestoreError, VsockRestoreStage,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -272,7 +272,7 @@ fn snapshot_vsock_error(source: VsockRestoreError) -> SnapshotRestoreResourceErr
         stage: SnapshotRestoreResourceStage::VsockPreparation,
         kind: SnapshotRestoreResourceErrorKind::Vsock(source),
         disposition,
-        cleanup_failed: false,
+        cleanup_failed: source.stage() == VsockRestoreStage::Cleanup,
     }
 }
 
@@ -1920,6 +1920,46 @@ mod tests {
             })
             .expect_err("broker invalidation during outer cancellation must be terminal");
         assert_eq!(error.stage, SnapshotRestoreResourceStage::Cancellation);
+        assert_eq!(
+            error.disposition,
+            SnapshotRestoreResourceDisposition::Terminal
+        );
+        assert!(error.cleanup_failed);
+        assert_coherent_root_claim_restored(&fixture);
+        let directory = fixture
+            .directories()
+            .prepare_socket_directory(
+                Path::new("bangbang-grant:vsock-directory/restored.sock"),
+                bangbang_session::ResourceRole::VsockSocketDirectory,
+            )
+            .expect("directory restoration should still be attempted")
+            .expect("directory reference should remain contained");
+        directory
+            .abort()
+            .expect("restored directory should remain reusable");
+    }
+
+    #[test]
+    fn coherent_contained_local_cancellation_preserves_cleanup_failure_evidence() {
+        let root = TempRoot::new("coherent-vsock-local-broker-loss", b"root");
+        let fixture = contained_restore_authority_for_test(root.path(), true);
+        let contained_vsock = selector(Path::new("bangbang-grant:vsock-directory/restored.sock"));
+        let (request, _, _) =
+            composed_request(Path::new(ROOT_REFERENCE), &contained_vsock, None, false);
+        let checks = Cell::new(0);
+        let error = request
+            .prepare(Some(fixture.authority()), || {
+                let next = checks.get() + 1;
+                checks.set(next);
+                if next == 12 {
+                    fixture.invalidate_broker();
+                    true
+                } else {
+                    false
+                }
+            })
+            .expect_err("local cancellation must preserve broker cleanup failure evidence");
+        assert_eq!(error.stage, SnapshotRestoreResourceStage::VsockPreparation);
         assert_eq!(
             error.disposition,
             SnapshotRestoreResourceDisposition::Terminal

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -171,6 +171,8 @@ use bangbang_session::{GrantAccess, GrantId, ResourceRole, SessionId, VmnetAutho
 #[cfg(target_os = "macos")]
 use crate::anchored_socket::{AnchoredSocketGuard, bind as bind_anchored_socket};
 #[cfg(target_os = "macos")]
+use crate::contained_session::ContainedSnapshotRestoreAuthority;
+#[cfg(target_os = "macos")]
 use crate::contained_session::{
     ClaimedSocketDirectory, ClaimedVhostUserSocket, DirectoryGrantAuthority, PagerGrantAuthority,
     PreparedVhostUserSocketClaim, SnapshotStagingRecordTracker, SocketBrokerAuthority,
@@ -198,8 +200,9 @@ use crate::host_network::vmnet::{
 #[cfg(target_os = "macos")]
 use crate::snapshot_restore_resources::{
     PreparedSnapshotRootBackingLease, PreparedSnapshotRootRestoreCompletion,
-    RequestedSnapshotRestoreResources, SnapshotRestoreResourceDisposition,
-    SnapshotRestoreResourceError, SnapshotRootBackingLeaseError, SnapshotRootSelectorPolicy,
+    PreparedSnapshotRootRestoreCompletionError, RequestedSnapshotRestoreResources,
+    SnapshotRestoreResourceDisposition, SnapshotRestoreResourceError,
+    SnapshotRootBackingLeaseError, SnapshotRootSelectorPolicy,
 };
 #[cfg(target_os = "macos")]
 use crate::vsock_restore::{
@@ -312,7 +315,8 @@ impl NativeV2SnapshotPublicationRequest {
 pub(crate) struct ProcessSnapshotV2RootLoadRequest<'a> {
     pub(crate) controller: &'a VmmController,
     pub(crate) vmnet_authority: ProcessVmnetAuthority,
-    pub(crate) grant_authority: Option<&'a GrantAuthority>,
+    #[cfg(target_os = "macos")]
+    pub(crate) contained_restore_authority: Option<&'a ContainedSnapshotRestoreAuthority>,
     pub(crate) pci_enabled: bool,
     pub(crate) input: &'a SnapshotLoadInput,
     pub(crate) candidate: NativeV2SnapshotCandidateState,
@@ -487,7 +491,8 @@ pub(crate) trait InstanceStartExecutor {
     fn commit_prepared_snapshot_v2_root_load(
         &mut self,
         _completion: ProcessSnapshotV2RootLoadCompletion,
-    ) {
+    ) -> Result<(), ProcessSnapshotV2RootLoadCompletionError> {
+        Ok(())
     }
 
     fn metrics_diagnostics(&self) -> MetricsDiagnostics {
@@ -1281,6 +1286,38 @@ pub(crate) struct ProcessSnapshotV2RootLoadCompletionResources {
     serial_output: SharedSerialOutput,
 }
 
+#[derive(Debug)]
+pub(crate) struct ProcessSnapshotV2RootLoadCompletionError {
+    #[cfg(target_os = "macos")]
+    source: PreparedSnapshotRootRestoreCompletionError,
+}
+
+impl fmt::Display for ProcessSnapshotV2RootLoadCompletionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("native-v2 root-load completion failed")
+    }
+}
+
+impl std::error::Error for ProcessSnapshotV2RootLoadCompletionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        #[cfg(target_os = "macos")]
+        {
+            Some(&self.source)
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            None
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl From<PreparedSnapshotRootRestoreCompletionError> for ProcessSnapshotV2RootLoadCompletionError {
+    fn from(source: PreparedSnapshotRootRestoreCompletionError) -> Self {
+        Self { source }
+    }
+}
+
 #[cfg(all(not(test), target_os = "macos"))]
 impl ProcessSnapshotV2RootLoadCompletion {
     const fn new(
@@ -1293,13 +1330,13 @@ impl ProcessSnapshotV2RootLoadCompletion {
         }
     }
 
-    fn abort(self) -> Result<(), GrantClaimError> {
+    fn abort(self) -> Result<(), ProcessSnapshotV2RootLoadCompletionError> {
         let Self {
             root_completion,
             serial_output,
         } = self;
         drop(serial_output);
-        root_completion.abort()
+        root_completion.abort().map_err(Into::into)
     }
 }
 
@@ -1315,7 +1352,7 @@ impl ProcessSnapshotV2RootLoadCompletion {
         }))
     }
 
-    fn abort(self) -> Result<(), GrantClaimError> {
+    fn abort(self) -> Result<(), ProcessSnapshotV2RootLoadCompletionError> {
         match self {
             Self::Prepared(resources) => {
                 let ProcessSnapshotV2RootLoadCompletionResources {
@@ -1323,7 +1360,7 @@ impl ProcessSnapshotV2RootLoadCompletion {
                     serial_output,
                 } = *resources;
                 drop(serial_output);
-                root_completion.abort()
+                root_completion.abort().map_err(Into::into)
             }
             Self::Empty => Ok(()),
         }
@@ -1385,8 +1422,9 @@ pub(crate) enum NativeV2SnapshotLoadError {
     #[cfg(target_os = "macos")]
     RootResourceCleanup {
         source: Box<NativeV2SnapshotLoadError>,
-        cleanup: GrantClaimError,
+        cleanup: ProcessSnapshotV2RootLoadCompletionError,
     },
+    RootResourceCommit(ProcessSnapshotV2RootLoadCompletionError),
     Artifact(SnapshotArtifactLoadError),
     ArtifactState(NativeSnapshotArtifactStateError),
     UnexpectedFamily(NativeSnapshotArtifactFamily),
@@ -1430,6 +1468,7 @@ impl NativeV2SnapshotLoadError {
             | Self::Resume(_) => true,
             #[cfg(target_os = "macos")]
             Self::RootResourceCleanup { .. } => true,
+            Self::RootResourceCommit(_) => true,
             Self::Restore(source) => source.is_committed() || !source.cleanup_failures().is_empty(),
             Self::RootRestore(source) => source.is_terminal(),
             Self::Preflight(_)
@@ -1489,6 +1528,9 @@ impl fmt::Display for NativeV2SnapshotLoadError {
                     formatter,
                     "native-v2 load failed and root authority cleanup was incomplete: {source}"
                 )
+            }
+            Self::RootResourceCommit(_) => {
+                formatter.write_str("native-v2 root authority commit failed")
             }
             Self::Artifact(source) => write!(formatter, "native-v2 artifact load failed: {source}"),
             Self::ArtifactState(source) => {
@@ -1599,6 +1641,7 @@ impl std::error::Error for NativeV2SnapshotLoadError {
             Self::AfterResourceAdoption { source } => Some(source.as_ref()),
             #[cfg(target_os = "macos")]
             Self::RootResourceCleanup { source, .. } => Some(source.as_ref()),
+            Self::RootResourceCommit(source) => Some(source),
             Self::Artifact(source) => Some(source),
             Self::ArtifactState(source) => Some(source),
             Self::State(source) => Some(source),
@@ -1635,7 +1678,7 @@ fn native_v2_error_after_root_resource_abort(
         Ok(()) => source,
         Err(cleanup) => NativeV2SnapshotLoadError::RootResourceCleanup {
             source: Box::new(source),
-            cleanup,
+            cleanup: cleanup.into(),
         },
     }
 }
@@ -2995,6 +3038,8 @@ where
     #[cfg(target_os = "macos")]
     socket_namespace: Option<WorkerSocketNamespace>,
     #[cfg(target_os = "macos")]
+    contained_restore_authority: Option<ContainedSnapshotRestoreAuthority>,
+    #[cfg(target_os = "macos")]
     vsock_grant_state: VsockGrantState,
 }
 
@@ -3101,6 +3146,8 @@ where
             #[cfg(target_os = "macos")]
             socket_namespace: None,
             #[cfg(target_os = "macos")]
+            contained_restore_authority: None,
+            #[cfg(target_os = "macos")]
             vsock_grant_state: VsockGrantState::PathBased,
         }
     }
@@ -3157,6 +3204,15 @@ where
         self.socket_broker_authority = broker;
         self.vhost_user_broker_authority = vhost_user_broker;
         self.socket_namespace = namespace;
+        self
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(crate) fn with_contained_restore_authority(
+        mut self,
+        authority: Option<ContainedSnapshotRestoreAuthority>,
+    ) -> Self {
+        self.contained_restore_authority = authority;
         self
     }
 
@@ -5219,7 +5275,8 @@ where
                 .load_prepared_snapshot_v2_root(ProcessSnapshotV2RootLoadRequest {
                     controller: &self.controller,
                     vmnet_authority: self.vmnet_authority,
-                    grant_authority: self.grant_authority.as_ref(),
+                    #[cfg(target_os = "macos")]
+                    contained_restore_authority: self.contained_restore_authority.as_ref(),
                     pci_enabled: self.pci_enabled,
                     input,
                     candidate,
@@ -5253,7 +5310,8 @@ where
             self.started_session = Some(session);
             let resume_requested = self.controller.commit_snapshot_v2_load(controller_commit);
             self.starter
-                .commit_prepared_snapshot_v2_root_load(completion);
+                .commit_prepared_snapshot_v2_root_load(completion)
+                .map_err(NativeV2SnapshotLoadError::RootResourceCommit)?;
             Ok(resume_requested)
         } else {
             let restored = self
@@ -6128,7 +6186,7 @@ impl ProcessVmm<HvfInstanceStartExecutor> {
         }
         prepare_hvf_native_v2_root_candidate_load(
             &self.starter,
-            self.grant_authority.as_ref(),
+            self.contained_restore_authority.as_ref(),
             self.pci_enabled,
             input,
             candidate,
@@ -6188,7 +6246,10 @@ impl ProcessVmm<HvfInstanceStartExecutor> {
         self.starter.active_serial_output = Some(serial_output);
         self.started_session = Some(session);
         let resume_requested = self.controller.commit_snapshot_v2_load(controller_commit);
-        root_completion.commit();
+        root_completion
+            .commit()
+            .map_err(ProcessSnapshotV2RootLoadCompletionError::from)
+            .map_err(NativeV2SnapshotLoadError::RootResourceCommit)?;
         Ok(resume_requested)
     }
 
@@ -6597,7 +6658,7 @@ fn native_v2_boot_source_config(
 #[cfg(target_os = "macos")]
 fn prepare_hvf_native_v2_root_candidate_load(
     starter: &HvfInstanceStartExecutor,
-    grant_authority: Option<&GrantAuthority>,
+    contained_restore_authority: Option<&ContainedSnapshotRestoreAuthority>,
     pci_enabled: bool,
     input: &SnapshotLoadInput,
     candidate: NativeV2SnapshotCandidateState,
@@ -6663,7 +6724,7 @@ fn prepare_hvf_native_v2_root_candidate_load(
     };
 
     let prepared_resources = requested_resources
-        .prepare_root(grant_authority, || cancellation.is_cancelled())
+        .prepare_root(contained_restore_authority, || cancellation.is_cancelled())
         .map_err(NativeV2SnapshotLoadError::RestoreResources)?;
     let root_resource = prepared_resources
         .into_root()
@@ -7329,7 +7390,7 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
         let ProcessSnapshotV2RootLoadRequest {
             controller,
             vmnet_authority,
-            grant_authority,
+            contained_restore_authority,
             pci_enabled,
             input,
             candidate,
@@ -7340,7 +7401,7 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
             .map_err(NativeV2SnapshotLoadError::Preflight)?;
         let prepared = prepare_hvf_native_v2_root_candidate_load(
             self,
-            grant_authority,
+            contained_restore_authority,
             pci_enabled,
             input,
             candidate,
@@ -7361,7 +7422,7 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
     fn commit_prepared_snapshot_v2_root_load(
         &mut self,
         completion: ProcessSnapshotV2RootLoadCompletion,
-    ) {
+    ) -> Result<(), ProcessSnapshotV2RootLoadCompletionError> {
         #[cfg(not(test))]
         {
             let ProcessSnapshotV2RootLoadCompletion {
@@ -7369,7 +7430,9 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
                 serial_output,
             } = completion;
             self.active_serial_output = Some(serial_output);
-            root_completion.commit();
+            root_completion
+                .commit()
+                .map_err(ProcessSnapshotV2RootLoadCompletionError::from)?;
         }
         #[cfg(test)]
         match completion {
@@ -7379,12 +7442,15 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
                     serial_output,
                 } = *resources;
                 self.active_serial_output = Some(serial_output);
-                root_completion.commit();
+                root_completion
+                    .commit()
+                    .map_err(ProcessSnapshotV2RootLoadCompletionError::from)?;
             }
             ProcessSnapshotV2RootLoadCompletion::Empty => {
                 debug_assert!(false, "HVF root-load completion must own both resources");
             }
         }
+        Ok(())
     }
 
     fn metrics_diagnostics(&self) -> MetricsDiagnostics {
@@ -15189,7 +15255,8 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     use crate::contained_session::{
-        TestVhostDirectory, VhostUserBrokerAuthority, empty_grant_authority_for_vhost_test,
+        TestVhostDirectory, VhostUserBrokerAuthority, contained_restore_authority_for_test,
+        contained_restore_authority_with_grants_for_test, empty_grant_authority_for_vhost_test,
         file_grant_authority_for_test, root_file_grant_authority_for_test,
         snapshot_file_grant_authority_for_test, snapshot_root_file_grant_authority_for_test,
         vhost_directory_authority_for_test,
@@ -17075,7 +17142,7 @@ mod tests {
             let ProcessSnapshotV2RootLoadRequest {
                 controller,
                 vmnet_authority,
-                grant_authority: _,
+                contained_restore_authority: _,
                 pci_enabled,
                 input,
                 candidate,
@@ -27774,13 +27841,16 @@ mod tests {
             first_paths.state(),
             SnapshotMemoryBackend::new(first_paths.memory(), SnapshotMemoryBackendType::File),
         );
+        let paused_restore = contained_restore_authority_for_test(root.path(), false);
+        let paused_grants = paused_restore.grants().clone();
         let mut paused_destination = ProcessVmm::with_starter(
             "native-v2-paused-destination",
             "0.1.0",
             "bangbang",
             HvfInstanceStartExecutor::default(),
         )
-        .with_grant_authority(Some(root_file_grant_authority_for_test(root.path())));
+        .with_grant_authority(Some(paused_grants))
+        .with_contained_restore_authority(Some(paused_restore.into_authority()));
         assert_eq!(
             paused_destination.handle_action(VmmAction::LoadSnapshot(paused_load)),
             Ok(VmmData::Empty)
@@ -27813,6 +27883,8 @@ mod tests {
             first_paths.memory(),
             root.path(),
         );
+        let resumed_restore =
+            contained_restore_authority_with_grants_for_test(authority.clone(), false);
         let replacement_state = first_paths
             .state()
             .with_file_name("contained-replacement.state");
@@ -27839,7 +27911,8 @@ mod tests {
             "bangbang",
             HvfInstanceStartExecutor::default(),
         )
-        .with_grant_authority(Some(authority));
+        .with_grant_authority(Some(authority))
+        .with_contained_restore_authority(Some(resumed_restore.into_authority()));
         assert_eq!(
             resumed_destination.handle_action(VmmAction::LoadSnapshot(resumed_load)),
             Ok(VmmData::Empty)
@@ -27957,13 +28030,18 @@ mod tests {
             if !pci_enabled {
                 let failed_authority = root_file_grant_authority_for_test(root.path());
                 let failed_observer = failed_authority.clone();
+                let failed_restore = contained_restore_authority_with_grants_for_test(
+                    failed_authority.clone(),
+                    false,
+                );
                 let mut failed = ProcessVmm::with_starter(
                     "native-v2-mmio-controller-checkpoint",
                     "0.1.0",
                     "bangbang",
                     HvfInstanceStartExecutor::default(),
                 )
-                .with_grant_authority(Some(failed_authority));
+                .with_grant_authority(Some(failed_authority))
+                .with_contained_restore_authority(Some(failed_restore.into_authority()));
                 let error = failed
                     .restore_native_v2_root_candidate_once_with_controller_hook(
                         &input,
@@ -28025,13 +28103,16 @@ mod tests {
 
             let authority = root_file_grant_authority_for_test(root.path());
             let observer = authority.clone();
+            let restore =
+                contained_restore_authority_with_grants_for_test(authority.clone(), false);
             let mut destination = ProcessVmm::with_starter(
                 format!("native-v2-{case}-destination"),
                 "0.1.0",
                 "bangbang",
                 HvfInstanceStartExecutor::default(),
             )
-            .with_grant_authority(Some(authority));
+            .with_grant_authority(Some(authority))
+            .with_contained_restore_authority(Some(restore.into_authority()));
             destination.pci_enabled = pci_enabled;
             destination.starter.pci_enabled = pci_enabled;
             assert!(

--- a/crates/bangbang/src/vsock_restore.rs
+++ b/crates/bangbang/src/vsock_restore.rs
@@ -17,7 +17,7 @@ use bangbang_session::macos::runtime::WorkerSocketNamespace;
 use crate::anchored_socket::{AnchoredSocketError, AnchoredSocketGuard, bind_prepared_vsock};
 use crate::contained_session::{
     DirectoryGrantAuthority, PreparedSocketBrokerEndpoint, PreparedSocketDirectoryClaim,
-    SocketBrokerAuthority,
+    SocketBrokerAuthority, socket_directory_reference,
 };
 
 /// Whether the same process may safely retry a failed restore preparation.
@@ -326,6 +326,10 @@ impl RequestedVsockRestoreResource {
         self.overridden
     }
 
+    pub(crate) fn destination_reference(&self) -> &std::path::Path {
+        self.selectors.destination().path()
+    }
+
     /// Reserves every contained authority without publishing an endpoint.
     pub(crate) fn reserve(
         self,
@@ -338,6 +342,12 @@ impl RequestedVsockRestoreResource {
             return Err(cancelled_error());
         }
         if directory_authority.is_none() && broker_authority.is_none() && namespace.is_none() {
+            if socket_directory_reference(self.destination_reference())
+                .map_err(|_| contained_authority_error())?
+                .is_some()
+            {
+                return Err(contained_authority_error());
+            }
             return Ok(ReservedVsockRestoreResource::Direct(self.selectors));
         }
 
@@ -380,6 +390,21 @@ impl RequestedVsockRestoreResource {
             },
         )))
     }
+
+    /// Accepts only the coherent facets reserved by a contained restore batch.
+    pub(crate) fn reserve_contained(
+        self,
+        claim: PreparedSocketDirectoryClaim,
+        broker: PreparedSocketBrokerEndpoint,
+        namespace: WorkerSocketNamespace,
+    ) -> ReservedVsockRestoreResource {
+        ReservedVsockRestoreResource::Contained(Box::new(ReservedContainedVsockRestoreResource {
+            selectors: self.selectors,
+            claim,
+            broker,
+            namespace,
+        }))
+    }
 }
 
 impl fmt::Debug for RequestedVsockRestoreResource {
@@ -407,10 +432,33 @@ fn contained_authority_error() -> VsockRestoreError {
 }
 
 pub(crate) struct ReservedContainedVsockRestoreResource {
-    selectors: SnapshotVsockSelectors,
-    claim: PreparedSocketDirectoryClaim,
-    broker: PreparedSocketBrokerEndpoint,
+    // Declaration order preserves reverse restoration during conservative
+    // drop; explicit abort additionally reports incomplete restoration.
     namespace: WorkerSocketNamespace,
+    broker: PreparedSocketBrokerEndpoint,
+    claim: PreparedSocketDirectoryClaim,
+    selectors: SnapshotVsockSelectors,
+}
+
+impl ReservedContainedVsockRestoreResource {
+    fn abort(self) -> Result<(), VsockRestoreError> {
+        let Self {
+            selectors: _,
+            claim,
+            broker,
+            namespace,
+        } = self;
+        drop(namespace);
+        let cleanup_failed = broker.abort().is_err() | claim.abort().is_err();
+        if cleanup_failed {
+            Err(VsockRestoreError::terminal(
+                VsockRestoreStage::Cleanup,
+                VsockRestoreErrorKind::Grant,
+            ))
+        } else {
+            Ok(())
+        }
+    }
 }
 
 /// One vsock request after reversible authority reservation.
@@ -454,7 +502,7 @@ impl ReservedVsockRestoreResource {
             }
             Self::Contained(contained) => {
                 if cancelled() {
-                    drop(contained);
+                    contained.abort()?;
                     return Err(cancelled_error());
                 }
                 Ok(LocallyPreparedVsockRestoreResource::Contained(*contained))
@@ -462,9 +510,14 @@ impl ReservedVsockRestoreResource {
         }
     }
 
-    pub(crate) fn abort(self) -> VsockRestoreDisposition {
-        drop(self);
-        VsockRestoreDisposition::Retryable
+    pub(crate) fn abort(self) -> Result<VsockRestoreDisposition, VsockRestoreError> {
+        match self {
+            Self::Direct(_) => Ok(VsockRestoreDisposition::Retryable),
+            Self::Contained(contained) => {
+                contained.abort()?;
+                Ok(VsockRestoreDisposition::Retryable)
+            }
+        }
     }
 }
 
@@ -500,7 +553,7 @@ impl LocallyPreparedVsockRestoreResource {
             Self::Direct(prepared) => Ok(prepared),
             Self::Contained(contained) => {
                 if cancelled() {
-                    drop(contained);
+                    contained.abort()?;
                     return Err(cancelled_error());
                 }
                 let ReservedContainedVsockRestoreResource {
@@ -553,7 +606,7 @@ impl LocallyPreparedVsockRestoreResource {
         match self {
             Self::Direct(prepared) => prepared.abort(),
             Self::Contained(contained) => {
-                drop(contained);
+                contained.abort()?;
                 Ok(VsockRestoreDisposition::Retryable)
             }
         }

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 repository.workspace = true
 
+[features]
+test-support = []
+
 [dependencies]
 getrandom = "0.3"
 libc = "0.2"

--- a/crates/session/src/macos/grant_registry.rs
+++ b/crates/session/src/macos/grant_registry.rs
@@ -231,6 +231,62 @@ impl FileGrantRegistry {
         duplicate_files(&self.entries, requests)
     }
 
+    /// Validates exact file grants without duplicating or adopting descriptors.
+    ///
+    /// The returned identities preserve request order and permit a caller to
+    /// reject aliases across independently owned authority classes.
+    pub fn inspect_exact_files(
+        &self,
+        requests: &[(GrantId, ResourceRole, GrantAccess, GrantObjectKind)],
+    ) -> Result<Vec<ObjectIdentity>, GrantRegistryError> {
+        inspect_exact_files(&self.entries, requests)
+    }
+
+    /// Validates exact file grants into caller-preallocated identity storage.
+    ///
+    /// This variant performs no allocation, duplication, or adoption.
+    pub fn inspect_exact_files_into(
+        &self,
+        requests: &[(GrantId, ResourceRole, GrantAccess, GrantObjectKind)],
+        identities: &mut Vec<ObjectIdentity>,
+    ) -> Result<(), GrantRegistryError> {
+        inspect_exact_files_into(&self.entries, requests, identities)
+    }
+
+    /// Duplicates exact file grants after complete in-memory validation.
+    pub fn duplicate_exact_files(
+        &self,
+        requests: &[(GrantId, ResourceRole, GrantAccess, GrantObjectKind)],
+    ) -> Result<Vec<GrantedFile>, GrantRegistryError> {
+        duplicate_exact_files(&self.entries, requests)
+    }
+
+    /// Duplicates exact file grants into caller-preallocated owner storage.
+    pub fn duplicate_exact_files_into(
+        &self,
+        requests: &[(GrantId, ResourceRole, GrantAccess, GrantObjectKind)],
+        files: &mut Vec<GrantedFile>,
+    ) -> Result<(), GrantRegistryError> {
+        duplicate_exact_files_into(&self.entries, requests, files)
+    }
+
+    /// Atomically adopts exact file grants after complete validation.
+    pub fn take_exact_files(
+        &mut self,
+        requests: &[(GrantId, ResourceRole, GrantAccess, GrantObjectKind)],
+    ) -> Result<Vec<GrantedFile>, GrantRegistryError> {
+        take_exact_files(&mut self.entries, requests)
+    }
+
+    /// Atomically adopts exact file grants into caller-preallocated storage.
+    pub fn take_exact_files_into(
+        &mut self,
+        requests: &[(GrantId, ResourceRole, GrantAccess, GrantObjectKind)],
+        files: &mut Vec<GrantedFile>,
+    ) -> Result<(), GrantRegistryError> {
+        take_exact_files_into(&mut self.entries, requests, files)
+    }
+
     /// Duplicates one exact drive backing without adopting the original.
     pub fn duplicate_drive_backing(
         &self,
@@ -383,6 +439,45 @@ impl DirectoryGrantRegistry {
         take_scoped_directories(&mut self.entries, requests)
     }
 
+    /// Validates exact directory grants without adopting active scopes.
+    ///
+    /// The returned identities preserve request order and permit a caller to
+    /// reject aliases across independently owned authority classes.
+    pub fn inspect_exact_directories(
+        &self,
+        requests: &[(GrantId, ResourceRole, GrantAccess)],
+    ) -> Result<Vec<ObjectIdentity>, GrantRegistryError> {
+        inspect_exact_directories(&self.entries, requests)
+    }
+
+    /// Validates exact directory grants into caller-preallocated identity storage.
+    ///
+    /// This variant performs no allocation or scope adoption.
+    pub fn inspect_exact_directories_into(
+        &self,
+        requests: &[(GrantId, ResourceRole, GrantAccess)],
+        identities: &mut Vec<ObjectIdentity>,
+    ) -> Result<(), GrantRegistryError> {
+        inspect_exact_directories_into(&self.entries, requests, identities)
+    }
+
+    /// Atomically adopts exact directory grants after complete validation.
+    pub fn take_exact_directories(
+        &mut self,
+        requests: &[(GrantId, ResourceRole, GrantAccess)],
+    ) -> Result<Vec<GrantedDirectory>, GrantRegistryError> {
+        take_exact_directories(&mut self.entries, requests)
+    }
+
+    /// Atomically adopts exact directories into caller-preallocated storage.
+    pub fn take_exact_directories_into(
+        &mut self,
+        requests: &[(GrantId, ResourceRole, GrantAccess)],
+        directories: &mut Vec<GrantedDirectory>,
+    ) -> Result<(), GrantRegistryError> {
+        take_exact_directories_into(&mut self.entries, requests, directories)
+    }
+
     /// Returns one reserved directory grant after an aborted owner transaction.
     pub fn restore_scoped_directory(
         &mut self,
@@ -415,6 +510,108 @@ fn take_scoped_directory(
         return Err(GrantRegistryError);
     }
     entries.remove(id).ok_or(GrantRegistryError)
+}
+
+fn inspect_exact_directories(
+    entries: &HashMap<GrantId, GrantedDirectory>,
+    requests: &[(GrantId, ResourceRole, GrantAccess)],
+) -> Result<Vec<ObjectIdentity>, GrantRegistryError> {
+    let mut inspected = Vec::new();
+    inspected
+        .try_reserve_exact(requests.len())
+        .map_err(|_| GrantRegistryError)?;
+    inspect_exact_directories_into(entries, requests, &mut inspected)?;
+    Ok(inspected)
+}
+
+fn validate_exact_directories(
+    entries: &HashMap<GrantId, GrantedDirectory>,
+    requests: &[(GrantId, ResourceRole, GrantAccess)],
+) -> Result<(), GrantRegistryError> {
+    for (index, (id, role, access)) in requests.iter().enumerate() {
+        let directory = entries.get(id).ok_or(GrantRegistryError)?;
+        let prior = requests.get(..index).ok_or(GrantRegistryError)?;
+        if !matches_exact_directory(directory, *role, *access)
+            || prior.iter().any(|(prior_id, _, _)| prior_id == id)
+            || prior.iter().any(|(prior_id, _, _)| {
+                entries
+                    .get(prior_id)
+                    .is_some_and(|prior| prior.identity == directory.identity)
+            })
+        {
+            return Err(GrantRegistryError);
+        }
+    }
+    Ok(())
+}
+
+fn inspect_exact_directories_into(
+    entries: &HashMap<GrantId, GrantedDirectory>,
+    requests: &[(GrantId, ResourceRole, GrantAccess)],
+    inspected: &mut Vec<ObjectIdentity>,
+) -> Result<(), GrantRegistryError> {
+    if !inspected.is_empty() || inspected.capacity() < requests.len() {
+        return Err(GrantRegistryError);
+    }
+    validate_exact_directories(entries, requests)?;
+    inspected.extend(
+        requests
+            .iter()
+            .filter_map(|(id, _, _)| entries.get(id).map(|directory| directory.identity)),
+    );
+    if inspected.len() != requests.len() {
+        inspected.clear();
+        return Err(GrantRegistryError);
+    }
+    Ok(())
+}
+
+fn take_exact_directories(
+    entries: &mut HashMap<GrantId, GrantedDirectory>,
+    requests: &[(GrantId, ResourceRole, GrantAccess)],
+) -> Result<Vec<GrantedDirectory>, GrantRegistryError> {
+    let mut directories = Vec::new();
+    directories
+        .try_reserve_exact(requests.len())
+        .map_err(|_| GrantRegistryError)?;
+    take_exact_directories_into(entries, requests, &mut directories)?;
+    Ok(directories)
+}
+
+fn take_exact_directories_into(
+    entries: &mut HashMap<GrantId, GrantedDirectory>,
+    requests: &[(GrantId, ResourceRole, GrantAccess)],
+    directories: &mut Vec<GrantedDirectory>,
+) -> Result<(), GrantRegistryError> {
+    if !directories.is_empty() || directories.capacity() < requests.len() {
+        return Err(GrantRegistryError);
+    }
+    validate_exact_directories(entries, requests)?;
+    for (id, _, _) in requests {
+        let Some(directory) = entries.remove(id) else {
+            for (restored_id, restored_directory) in requests.iter().zip(directories.drain(..)).map(
+                |((restored_id, _, _), restored_directory)| {
+                    (restored_id.clone(), restored_directory)
+                },
+            ) {
+                entries.insert(restored_id, restored_directory);
+            }
+            return Err(GrantRegistryError);
+        };
+        directories.push(directory);
+    }
+    Ok(())
+}
+
+fn matches_exact_directory(
+    directory: &GrantedDirectory,
+    role: ResourceRole,
+    access: GrantAccess,
+) -> bool {
+    directory.role == role
+        && directory.access == access
+        && role.is_scoped_directory()
+        && role.permits(access)
 }
 
 fn take_scoped_directories(
@@ -569,6 +766,153 @@ fn duplicate_files(
         files.push(duplicate_file(file)?);
     }
     Ok(files)
+}
+
+fn inspect_exact_files(
+    entries: &HashMap<GrantId, GrantedFile>,
+    requests: &[(GrantId, ResourceRole, GrantAccess, GrantObjectKind)],
+) -> Result<Vec<ObjectIdentity>, GrantRegistryError> {
+    let mut inspected = Vec::new();
+    inspected
+        .try_reserve_exact(requests.len())
+        .map_err(|_| GrantRegistryError)?;
+    inspect_exact_files_into(entries, requests, &mut inspected)?;
+    Ok(inspected)
+}
+
+fn validate_exact_files(
+    entries: &HashMap<GrantId, GrantedFile>,
+    requests: &[(GrantId, ResourceRole, GrantAccess, GrantObjectKind)],
+) -> Result<(), GrantRegistryError> {
+    for (index, (id, role, access, kind)) in requests.iter().enumerate() {
+        let file = entries.get(id).ok_or(GrantRegistryError)?;
+        let prior = requests.get(..index).ok_or(GrantRegistryError)?;
+        if !matches_exact_file(file, *role, *access, *kind)
+            || prior.iter().any(|(prior_id, _, _, _)| prior_id == id)
+            || prior.iter().any(|(prior_id, _, _, _)| {
+                entries
+                    .get(prior_id)
+                    .is_some_and(|prior| prior.identity == file.identity)
+            })
+        {
+            return Err(GrantRegistryError);
+        }
+    }
+    Ok(())
+}
+
+fn inspect_exact_files_into(
+    entries: &HashMap<GrantId, GrantedFile>,
+    requests: &[(GrantId, ResourceRole, GrantAccess, GrantObjectKind)],
+    inspected: &mut Vec<ObjectIdentity>,
+) -> Result<(), GrantRegistryError> {
+    if !inspected.is_empty() || inspected.capacity() < requests.len() {
+        return Err(GrantRegistryError);
+    }
+    validate_exact_files(entries, requests)?;
+    inspected.extend(
+        requests
+            .iter()
+            .filter_map(|(id, _, _, _)| entries.get(id).map(|file| file.identity)),
+    );
+    if inspected.len() != requests.len() {
+        inspected.clear();
+        return Err(GrantRegistryError);
+    }
+    Ok(())
+}
+
+fn duplicate_exact_files(
+    entries: &HashMap<GrantId, GrantedFile>,
+    requests: &[(GrantId, ResourceRole, GrantAccess, GrantObjectKind)],
+) -> Result<Vec<GrantedFile>, GrantRegistryError> {
+    let mut files = Vec::new();
+    files
+        .try_reserve_exact(requests.len())
+        .map_err(|_| GrantRegistryError)?;
+    duplicate_exact_files_into(entries, requests, &mut files)?;
+    Ok(files)
+}
+
+fn duplicate_exact_files_into(
+    entries: &HashMap<GrantId, GrantedFile>,
+    requests: &[(GrantId, ResourceRole, GrantAccess, GrantObjectKind)],
+    files: &mut Vec<GrantedFile>,
+) -> Result<(), GrantRegistryError> {
+    if !files.is_empty() || files.capacity() < requests.len() {
+        return Err(GrantRegistryError);
+    }
+    validate_exact_files(entries, requests)?;
+    for (id, _, _, _) in requests {
+        let duplicate = entries
+            .get(id)
+            .ok_or(GrantRegistryError)
+            .and_then(duplicate_file);
+        match duplicate {
+            Ok(file) => files.push(file),
+            Err(source) => {
+                files.clear();
+                return Err(source);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn take_exact_files(
+    entries: &mut HashMap<GrantId, GrantedFile>,
+    requests: &[(GrantId, ResourceRole, GrantAccess, GrantObjectKind)],
+) -> Result<Vec<GrantedFile>, GrantRegistryError> {
+    let mut files = Vec::new();
+    files
+        .try_reserve_exact(requests.len())
+        .map_err(|_| GrantRegistryError)?;
+    take_exact_files_into(entries, requests, &mut files)?;
+    Ok(files)
+}
+
+fn take_exact_files_into(
+    entries: &mut HashMap<GrantId, GrantedFile>,
+    requests: &[(GrantId, ResourceRole, GrantAccess, GrantObjectKind)],
+    files: &mut Vec<GrantedFile>,
+) -> Result<(), GrantRegistryError> {
+    if !files.is_empty() || files.capacity() < requests.len() {
+        return Err(GrantRegistryError);
+    }
+    validate_exact_files(entries, requests)?;
+    for (id, _, _, _) in requests {
+        let Some(file) = entries.remove(id) else {
+            for (restored_id, restored_file) in requests
+                .iter()
+                .zip(files.drain(..))
+                .map(|((restored_id, _, _, _), restored_file)| (restored_id.clone(), restored_file))
+            {
+                entries.insert(restored_id, restored_file);
+            }
+            return Err(GrantRegistryError);
+        };
+        files.push(file);
+    }
+    Ok(())
+}
+
+fn matches_exact_file(
+    file: &GrantedFile,
+    role: ResourceRole,
+    access: GrantAccess,
+    kind: GrantObjectKind,
+) -> bool {
+    file.role == role
+        && file.access == access
+        && file.kind == kind
+        && role.permits(access)
+        && match kind {
+            GrantObjectKind::RegularFile => file.block_device.is_none(),
+            GrantObjectKind::BlockDevice => {
+                role == ResourceRole::DriveBacking && file.block_device.is_some()
+            }
+            GrantObjectKind::Directory | GrantObjectKind::ConnectedUnixStream => false,
+        }
 }
 
 fn matches_generic_file(file: &GrantedFile, role: ResourceRole, access: GrantAccess) -> bool {
@@ -2236,6 +2580,86 @@ mod tests {
         assert!(files.duplicate_files(&duplicate).is_err());
         assert_eq!(files.len(), 2);
 
+        let exact = [
+            (
+                kernel_id.clone(),
+                ResourceRole::KernelImage,
+                GrantAccess::ReadOnly,
+                GrantObjectKind::RegularFile,
+            ),
+            (
+                initrd_id.clone(),
+                ResourceRole::InitrdImage,
+                GrantAccess::ReadOnly,
+                GrantObjectKind::RegularFile,
+            ),
+        ];
+        let identities = files
+            .inspect_exact_files(&exact)
+            .expect("exact inspection should use retained metadata");
+        assert_eq!(
+            identities,
+            [
+                ObjectIdentity {
+                    device: normalized_device(kernel_stat.st_dev),
+                    inode: kernel_stat.st_ino,
+                },
+                ObjectIdentity {
+                    device: normalized_device(initrd_stat.st_dev),
+                    inode: initrd_stat.st_ino,
+                },
+            ]
+        );
+        assert_eq!(files.len(), 2);
+        for invalid in [
+            vec![(
+                kernel_id.clone(),
+                ResourceRole::KernelImage,
+                GrantAccess::WriteOnly,
+                GrantObjectKind::RegularFile,
+            )],
+            vec![(
+                kernel_id.clone(),
+                ResourceRole::KernelImage,
+                GrantAccess::ReadOnly,
+                GrantObjectKind::BlockDevice,
+            )],
+            vec![exact[0].clone(), exact[0].clone()],
+        ] {
+            assert!(files.inspect_exact_files(&invalid).is_err());
+            assert!(files.duplicate_exact_files(&invalid).is_err());
+            assert!(files.take_exact_files(&invalid).is_err());
+            assert_eq!(files.len(), 2);
+        }
+        let exact_duplicates = files
+            .duplicate_exact_files(&exact)
+            .expect("exact duplication should follow complete validation");
+        assert_eq!(exact_duplicates.len(), 2);
+        assert_eq!(files.len(), 2);
+        drop(exact_duplicates);
+        let initrd_identity = files
+            .entries
+            .get(&initrd_id)
+            .expect("initrd grant should remain")
+            .identity;
+        let kernel_identity = files
+            .entries
+            .get(&kernel_id)
+            .expect("kernel grant should remain")
+            .identity;
+        files
+            .entries
+            .get_mut(&initrd_id)
+            .expect("initrd grant should remain")
+            .identity = kernel_identity;
+        assert!(files.inspect_exact_files(&exact).is_err());
+        assert_eq!(files.len(), 2);
+        files
+            .entries
+            .get_mut(&initrd_id)
+            .expect("initrd grant should remain")
+            .identity = initrd_identity;
+
         let reserved = files
             .take_file(&kernel_id, ResourceRole::KernelImage, GrantAccess::ReadOnly)
             .expect("matching grant should reserve");
@@ -2257,18 +2681,7 @@ mod tests {
         );
 
         let adopted = files
-            .take_files(&[
-                (
-                    initrd_id.clone(),
-                    ResourceRole::InitrdImage,
-                    GrantAccess::ReadOnly,
-                ),
-                (
-                    kernel_id.clone(),
-                    ResourceRole::KernelImage,
-                    GrantAccess::ReadOnly,
-                ),
-            ])
+            .take_exact_files(&[exact[1].clone(), exact[0].clone()])
             .expect("matching reverse-order pair should adopt");
         assert_eq!(adopted.len(), 2);
         assert_eq!(adopted[0].role, ResourceRole::InitrdImage);
@@ -2325,6 +2738,39 @@ mod tests {
             ]),
         };
 
+        let exact = [
+            (
+                state_id.clone(),
+                ResourceRole::SnapshotOutputDirectory,
+                GrantAccess::CreateChildren,
+            ),
+            (
+                memory_id.clone(),
+                ResourceRole::SnapshotOutputDirectory,
+                GrantAccess::CreateChildren,
+            ),
+        ];
+        assert_eq!(
+            directories
+                .inspect_exact_directories(&exact)
+                .expect("exact directory inspection should remain read-only")
+                .len(),
+            2
+        );
+        assert_eq!(directories.len(), 2);
+        for invalid in [
+            vec![(
+                state_id.clone(),
+                ResourceRole::SnapshotOutputDirectory,
+                GrantAccess::ConnectChildren,
+            )],
+            vec![exact[0].clone(), exact[0].clone()],
+        ] {
+            assert!(directories.inspect_exact_directories(&invalid).is_err());
+            assert!(directories.take_exact_directories(&invalid).is_err());
+            assert_eq!(directories.len(), 2);
+        }
+
         assert!(
             directories
                 .take_scoped_directories(&[
@@ -2345,10 +2791,7 @@ mod tests {
         assert_eq!(directories.len(), 2);
 
         let adopted = directories
-            .take_scoped_directories(&[
-                (memory_id, ResourceRole::SnapshotOutputDirectory),
-                (state_id, ResourceRole::SnapshotOutputDirectory),
-            ])
+            .take_exact_directories(&[exact[1].clone(), exact[0].clone()])
             .expect("matching directories should adopt atomically");
         assert_eq!(adopted.len(), 2);
         assert!(directories.is_empty());

--- a/crates/session/src/macos/runtime.rs
+++ b/crates/session/src/macos/runtime.rs
@@ -248,6 +248,21 @@ impl fmt::Debug for WorkerSocketNamespace {
 }
 
 impl WorkerSocketNamespace {
+    /// Constructs an anchored namespace from a test-owned directory.
+    ///
+    /// This bypasses production session naming and locking and is available
+    /// only to repository test targets.
+    #[doc(hidden)]
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn from_directory_for_test(path: &Path) -> Result<Self, RuntimeError> {
+        let directory = open_directory(path)?;
+        let identity = validate_directory(directory.as_raw_fd())?;
+        Ok(Self {
+            directory,
+            identity,
+        })
+    }
+
     /// Duplicates the validated namespace anchor with close-on-exec ownership.
     pub fn try_clone(&self) -> Result<Self, RuntimeError> {
         Ok(Self {


### PR DESCRIPTION
## Summary

- add exact, read-only file and directory grant preflight plus failure-atomic batch reservation
- bind contained root/vsock restore owners to one redacted, session-scoped generation through final root completion
- interrupt broker activation with the existing process wakeup and explicitly merge reverse cleanup failures
- require the coherent contained authority bundle in production while keeping direct restore path-based
- cover hostile authority substitution, cancellation phases, overlap/stale/poison/overflow, broker loss, reuse, and redaction

## Scope

This changes no launcher/session protocol frame, grant grammar, public API, snapshot artifact, entitlement, or compatibility claim. Signed production certification and documentation reconciliation remain in #1601.

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five Apple-target integration-test Clippy commands from `AGENTS.md`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

Closes #1600
Parent: #1532
