### PR TITLE
test: synchronize remaining-device final marker

### DIFF
--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -5347,6 +5347,7 @@ mod macos_arm64 {
                 "/actions",
                 r#"{"action_type":"FlushMetrics"}"#,
             );
+            let error = error.replace(path_text(&control_path), "<control-backing>");
             let metrics = file_tail_lossy(&metrics_path, 16 * 1024);
             let output = bangbang.force_stop_and_collect();
             panic!(
@@ -5358,6 +5359,27 @@ mod macos_arm64 {
         assert!(aggregate_stdout.contains(REMAINING_DEVICE_SERIAL_SUCCESS_MARKER));
         assert!(aggregate_stdout.contains("BANGBANG_REMAINING_DEVICE_PVTIME_STEAL="));
         assert!(!aggregate_stdout.contains(REMAINING_DEVICE_FAILURE_MARKER));
+        if let Err(error) = wait_for_file_markers_at(
+            &control_path,
+            &[(
+                REMAINING_DEVICE_FINAL_MARKER_OFFSET,
+                REMAINING_DEVICE_SUCCESS_MARKER.as_bytes(),
+                REMAINING_DEVICE_FAILURE_MARKER.as_bytes(),
+            )],
+            GUEST_EXECUTION_TIMEOUT,
+        ) {
+            let _ = http_put_json(
+                &socket_path,
+                "/actions",
+                r#"{"action_type":"FlushMetrics"}"#,
+            );
+            let metrics = file_tail_lossy(&metrics_path, 16 * 1024);
+            let output = bangbang.force_stop_and_collect();
+            panic!(
+                "{transport} remaining-device final control marker should become durable: {error}; status: {:?}\nmetrics:\n{metrics}\nstdout:\n{}\nstderr:\n{}",
+                output.status, output.stdout, output.stderr,
+            );
+        }
         assert_eq!(
             file_bytes_at(
                 &control_path,

--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -5347,7 +5347,6 @@ mod macos_arm64 {
                 "/actions",
                 r#"{"action_type":"FlushMetrics"}"#,
             );
-            let error = error.replace(path_text(&control_path), "<control-backing>");
             let metrics = file_tail_lossy(&metrics_path, 16 * 1024);
             let output = bangbang.force_stop_and_collect();
             panic!(
@@ -5373,6 +5372,7 @@ mod macos_arm64 {
                 "/actions",
                 r#"{"action_type":"FlushMetrics"}"#,
             );
+            let error = error.replace(path_text(&control_path), "<control-backing>");
             let metrics = file_tail_lossy(&metrics_path, 16 * 1024);
             let output = bangbang.force_stop_and_collect();
             panic!(

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2177,7 +2177,10 @@ exact five PCI virtio identities, and emits phase/failure markers for memory
 hotplug, time/identity discovery, entropy, balloon, and greater-than-FIFO serial
 input. Host tests use control-drive sectors and public API state as the source
 of progress; no entropy bytes, serial bytes, raw PVTime values, or paths appear
-in failure diagnostics.
+in failure diagnostics. The final guest stdout success line is progress rather
+than a durability boundary: the host then uses a bounded kqueue-backed wait for
+the exact sector-5 control marker written with `fsync`, followed by an
+independent exact-byte assertion.
 When the boot args include `bangbang.rtc-check=1`, the same init script checks
 that Linux exposes `/dev/rtc0` as a character device and finds PL031 RTC
 evidence in sysfs, procfs, or dmesg before writing


### PR DESCRIPTION
## Summary

- wait for the exact sector-5 remaining-device completion marker through the existing bounded kqueue helper before retaining the exact byte assertion
- collect redacted marker-wait, metrics, and process diagnostics on failure
- document stdout as progress and the fsync-completed control marker as the durability boundary

No production VMM behavior, guest fixture, cache version, API, snapshot format, capability disposition, or compatibility claim changes.

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five Apple-target integration Clippy commands from `AGENTS.md`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- exact signed MMIO and product-PCI remaining-device tests
- `scripts/run-integration-tests.sh` (82 HVF, 30 guest boot, 3 native snapshot, 82 sandbox HVF, 7 sandbox process, 64 production bundle, 68 signed executable tests)

Closes #1605
