### PR TITLE
feat: capture durable multi-block snapshot state

### DIFF
--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -27,7 +27,7 @@ use bangbang_runtime::block::{
     PreparedBlockDevice, RuntimeBlockDeviceResource, VIRTIO_BLOCK_DEVICE_ID,
     VIRTIO_BLOCK_QUEUE_SIZES, VhostUserBlockConfigSignalError, VirtioBlockBackendKind,
     VirtioBlockConfigSpace, VirtioBlockDevice, VirtioBlockDeviceNotificationError,
-    VirtioBlockLiveUpdateError,
+    VirtioBlockLiveUpdateError, VirtioBlockSnapshotPersistenceBinding,
 };
 use bangbang_runtime::boot::BootSourceFiles;
 use bangbang_runtime::boot_timer::{
@@ -100,6 +100,9 @@ use bangbang_runtime::snapshot_device_v2::{
     NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, PreparedSnapshotV2PciRoot,
     PreparedSnapshotV2RootBlock, PreparedSnapshotV2RootTransport,
     SnapshotV2RootTransportRestoreError,
+};
+use bangbang_runtime::snapshot_device_v2_5::{
+    NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2MultiBlockDeviceGraph,
 };
 use bangbang_runtime::snapshot_format::SnapshotFormatVersion;
 use bangbang_runtime::snapshot_format_v2::NATIVE_V2_LEGACY_PLATFORM_VERSION;
@@ -4011,8 +4014,10 @@ pub enum HvfArm64BootStorageCaptureStage {
     Inventory,
     StopAsync,
     DrainAsync,
+    Persist,
     PublishAsync,
     Capture,
+    ComposeGraph,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4026,13 +4031,16 @@ pub enum HvfArm64BootStorageCaptureErrorKind {
     Allocation,
     InventoryMismatch,
     VhostUserUnsupported,
+    ProfilePreflight,
     AsyncPreparation,
     AsyncDrain,
+    Persistence,
     AsyncResume,
     CompletionPublication,
     BlockCapture,
     PmemCapture,
     PciPlacement,
+    GraphComposition,
     Cancelled,
 }
 
@@ -4121,11 +4129,17 @@ impl fmt::Display for HvfArm64BootStorageCaptureError {
             HvfArm64BootStorageCaptureErrorKind::VhostUserUnsupported => {
                 formatter.write_str("vhost-user block capture is unsupported")
             }
+            HvfArm64BootStorageCaptureErrorKind::ProfilePreflight => {
+                formatter.write_str("multi-block snapshot profile preflight failed")
+            }
             HvfArm64BootStorageCaptureErrorKind::AsyncPreparation => {
                 formatter.write_str("Async storage capture preparation failed")
             }
             HvfArm64BootStorageCaptureErrorKind::AsyncDrain => {
                 formatter.write_str("Async storage capture drain failed")
+            }
+            HvfArm64BootStorageCaptureErrorKind::Persistence => {
+                formatter.write_str("snapshot block backing persistence failed")
             }
             HvfArm64BootStorageCaptureErrorKind::AsyncResume => {
                 formatter.write_str("Async storage capture resume failed")
@@ -4141,6 +4155,9 @@ impl fmt::Display for HvfArm64BootStorageCaptureError {
             }
             HvfArm64BootStorageCaptureErrorKind::PciPlacement => {
                 formatter.write_str("live PCI storage placement is unavailable")
+            }
+            HvfArm64BootStorageCaptureErrorKind::GraphComposition => {
+                formatter.write_str("multi-block snapshot graph composition failed")
             }
             HvfArm64BootStorageCaptureErrorKind::Cancelled => {
                 formatter.write_str("storage capture was cancelled")
@@ -5026,6 +5043,31 @@ enum CaptureReadyPmemOwner {
         index: usize,
         retry: StorageRetryState,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CaptureReadyStorageMode {
+    Diagnostic,
+    SnapshotV2MultiBlock,
+}
+
+enum CaptureReadyStorageResult {
+    Diagnostic(CaptureReadyStorageState),
+    SnapshotV2MultiBlock(SnapshotV2MultiBlockDeviceGraph),
+}
+
+impl fmt::Debug for CaptureReadyStorageResult {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::Diagnostic(_) => "Diagnostic",
+            Self::SnapshotV2MultiBlock(_) => "SnapshotV2MultiBlock",
+        };
+        formatter
+            .debug_struct("CaptureReadyStorageResult")
+            .field("kind", &kind)
+            .field("state", &"<redacted>")
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -6714,8 +6756,87 @@ fn capture_ready_storage_state_at_with_cancel(
     configs: &CaptureReadyStorageConfigs,
     guard: &HvfArm64BootLimiterRetryWakeupQuiescenceGuard,
     now: Instant,
-    mut is_cancelled: impl FnMut(HvfArm64BootStorageCaptureStage) -> bool,
+    is_cancelled: impl FnMut(HvfArm64BootStorageCaptureStage) -> bool,
 ) -> Result<CaptureReadyStorageState, HvfArm64BootStorageCaptureError> {
+    match capture_ready_storage_transaction_at_with_cancel(
+        backend,
+        mmio_dispatcher,
+        runtime_resources,
+        pci_data_devices,
+        block_device_metrics,
+        gic,
+        block_retry_wakeup_scheduler,
+        pmem_retry_wakeup_scheduler,
+        configs,
+        guard,
+        now,
+        CaptureReadyStorageMode::Diagnostic,
+        is_cancelled,
+    )? {
+        CaptureReadyStorageResult::Diagnostic(state) => Ok(state),
+        CaptureReadyStorageResult::SnapshotV2MultiBlock(_) => {
+            Err(HvfArm64BootStorageCaptureError::new(
+                HvfArm64BootStorageCaptureErrorKind::InventoryMismatch,
+                false,
+            ))
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn capture_snapshot_v2_multi_block_device_graph_at_with_cancel(
+    backend: &mut HvfBackend,
+    mmio_dispatcher: &Arc<Mutex<MmioDispatcher>>,
+    runtime_resources: &Arm64BootRuntimeResources,
+    pci_data_devices: &mut Option<HvfArm64BootPciDataDevices>,
+    block_device_metrics: &SharedBlockDeviceMetricsRegistry,
+    gic: &HvfGicMetadata,
+    block_retry_wakeup_scheduler: &HvfArm64BootLimiterRetryWakeupScheduler,
+    pmem_retry_wakeup_scheduler: &HvfArm64BootLimiterRetryWakeupScheduler,
+    configs: &CaptureReadyStorageConfigs,
+    guard: &HvfArm64BootLimiterRetryWakeupQuiescenceGuard,
+    now: Instant,
+    is_cancelled: impl FnMut(HvfArm64BootStorageCaptureStage) -> bool,
+) -> Result<SnapshotV2MultiBlockDeviceGraph, HvfArm64BootStorageCaptureError> {
+    match capture_ready_storage_transaction_at_with_cancel(
+        backend,
+        mmio_dispatcher,
+        runtime_resources,
+        pci_data_devices,
+        block_device_metrics,
+        gic,
+        block_retry_wakeup_scheduler,
+        pmem_retry_wakeup_scheduler,
+        configs,
+        guard,
+        now,
+        CaptureReadyStorageMode::SnapshotV2MultiBlock,
+        is_cancelled,
+    )? {
+        CaptureReadyStorageResult::SnapshotV2MultiBlock(graph) => Ok(graph),
+        CaptureReadyStorageResult::Diagnostic(_) => Err(HvfArm64BootStorageCaptureError::new(
+            HvfArm64BootStorageCaptureErrorKind::InventoryMismatch,
+            false,
+        )),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn capture_ready_storage_transaction_at_with_cancel(
+    backend: &mut HvfBackend,
+    mmio_dispatcher: &Arc<Mutex<MmioDispatcher>>,
+    runtime_resources: &Arm64BootRuntimeResources,
+    pci_data_devices: &mut Option<HvfArm64BootPciDataDevices>,
+    block_device_metrics: &SharedBlockDeviceMetricsRegistry,
+    gic: &HvfGicMetadata,
+    block_retry_wakeup_scheduler: &HvfArm64BootLimiterRetryWakeupScheduler,
+    pmem_retry_wakeup_scheduler: &HvfArm64BootLimiterRetryWakeupScheduler,
+    configs: &CaptureReadyStorageConfigs,
+    guard: &HvfArm64BootLimiterRetryWakeupQuiescenceGuard,
+    now: Instant,
+    mode: CaptureReadyStorageMode,
+    mut is_cancelled: impl FnMut(HvfArm64BootStorageCaptureStage) -> bool,
+) -> Result<CaptureReadyStorageResult, HvfArm64BootStorageCaptureError> {
     if !Arc::ptr_eq(&guard.block.shared, &block_retry_wakeup_scheduler.shared)
         || !Arc::ptr_eq(&guard.pmem.shared, &pmem_retry_wakeup_scheduler.shared)
     {
@@ -6795,6 +6916,25 @@ fn capture_ready_storage_state_at_with_cancel(
         }
     }
 
+    if mode == CaptureReadyStorageMode::SnapshotV2MultiBlock
+        && (!configs.pmem().is_empty()
+            || !runtime_resources.pmem_devices.is_empty()
+            || !runtime_resources.pmem_mmio_devices.is_empty()
+            || pci_data_devices
+                .as_ref()
+                .is_some_and(|devices| !devices.pmem.is_empty())
+            || SnapshotV2MultiBlockDeviceGraph::preflight_capture_configs(
+                NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                configs.drives(),
+            )
+            .is_err())
+    {
+        return Err(HvfArm64BootStorageCaptureError::new(
+            HvfArm64BootStorageCaptureErrorKind::ProfilePreflight,
+            false,
+        ));
+    }
+
     let pci_block_count = pci_data_devices
         .as_ref()
         .map_or(0, |devices| devices.block.len());
@@ -6827,6 +6967,12 @@ fn capture_ready_storage_state_at_with_cancel(
     async_owners
         .try_reserve_exact(configs.drives().len())
         .map_err(allocation_error)?;
+    let mut persistence_bindings: Vec<VirtioBlockSnapshotPersistenceBinding> = Vec::new();
+    if mode == CaptureReadyStorageMode::SnapshotV2MultiBlock {
+        persistence_bindings
+            .try_reserve_exact(configs.drives().len())
+            .map_err(allocation_error)?;
+    }
     let mut mmio_block_interrupts = Vec::new();
     mmio_block_interrupts
         .try_reserve_exact(configs.drives().len())
@@ -6896,6 +7042,29 @@ fn capture_ready_storage_state_at_with_cancel(
         block_owners.push(owner);
     }
 
+    if mode == CaptureReadyStorageMode::SnapshotV2MultiBlock {
+        let uniform_transport = block_owners.first().is_some_and(|first| {
+            block_owners.iter().all(|owner| {
+                matches!(
+                    (first, owner),
+                    (
+                        CaptureReadyBlockOwner::Mmio { .. },
+                        CaptureReadyBlockOwner::Mmio { .. }
+                    ) | (
+                        CaptureReadyBlockOwner::Pci { .. },
+                        CaptureReadyBlockOwner::Pci { .. }
+                    )
+                )
+            })
+        });
+        if !uniform_transport {
+            return Err(HvfArm64BootStorageCaptureError::new(
+                HvfArm64BootStorageCaptureErrorKind::ProfilePreflight,
+                false,
+            ));
+        }
+    }
+
     for config in configs.pmem() {
         let mut mmio_matches = runtime_resources
             .pmem_mmio_devices
@@ -6945,36 +7114,79 @@ fn capture_ready_storage_state_at_with_cancel(
         .zip(block_owners.iter().copied())
         .enumerate()
     {
-        let binding = match owner {
-            CaptureReadyBlockOwner::Mmio { .. } => runtime_resources
-                .capture_ready_mmio_block_async_binding(
-                    &mut mmio_dispatcher_guard,
-                    config.drive_id(),
-                )
-                .map_err(|_| {
-                    HvfArm64BootStorageCaptureError::new(
-                        HvfArm64BootStorageCaptureErrorKind::AsyncPreparation,
-                        false,
+        let binding = if mode == CaptureReadyStorageMode::SnapshotV2MultiBlock {
+            let persistence = match owner {
+                CaptureReadyBlockOwner::Mmio { .. } => runtime_resources
+                    .capture_ready_mmio_block_snapshot_persistence_binding(
+                        &mut mmio_dispatcher_guard,
+                        config,
                     )
-                })?,
-            CaptureReadyBlockOwner::Pci { index, .. } => pci_data_devices
-                .as_ref()
-                .and_then(|devices| devices.block.get(index))
-                .ok_or_else(|| {
-                    HvfArm64BootStorageCaptureError::new(
-                        HvfArm64BootStorageCaptureErrorKind::InventoryMismatch,
-                        false,
+                    .map_err(|_| {
+                        HvfArm64BootStorageCaptureError::new(
+                            HvfArm64BootStorageCaptureErrorKind::ProfilePreflight,
+                            false,
+                        )
+                    })?,
+                CaptureReadyBlockOwner::Pci { index, .. } => pci_data_devices
+                    .as_ref()
+                    .and_then(|devices| devices.block.get(index))
+                    .ok_or_else(|| {
+                        HvfArm64BootStorageCaptureError::new(
+                            HvfArm64BootStorageCaptureErrorKind::InventoryMismatch,
+                            false,
+                        )
+                    })?
+                    .published
+                    .endpoint()
+                    .block_snapshot_persistence_binding(config)
+                    .map_err(|_| {
+                        HvfArm64BootStorageCaptureError::new(
+                            HvfArm64BootStorageCaptureErrorKind::ProfilePreflight,
+                            false,
+                        )
+                    })?,
+            };
+            if Some(persistence.io_engine()) != config.io_engine() {
+                return Err(HvfArm64BootStorageCaptureError::new(
+                    HvfArm64BootStorageCaptureErrorKind::ProfilePreflight,
+                    false,
+                ));
+            }
+            let binding = persistence.async_binding();
+            persistence_bindings.push(persistence);
+            binding
+        } else {
+            match owner {
+                CaptureReadyBlockOwner::Mmio { .. } => runtime_resources
+                    .capture_ready_mmio_block_async_binding(
+                        &mut mmio_dispatcher_guard,
+                        config.drive_id(),
                     )
-                })?
-                .published
-                .endpoint()
-                .block_async_binding()
-                .map_err(|_| {
-                    HvfArm64BootStorageCaptureError::new(
-                        HvfArm64BootStorageCaptureErrorKind::AsyncPreparation,
-                        false,
-                    )
-                })?,
+                    .map_err(|_| {
+                        HvfArm64BootStorageCaptureError::new(
+                            HvfArm64BootStorageCaptureErrorKind::AsyncPreparation,
+                            false,
+                        )
+                    })?,
+                CaptureReadyBlockOwner::Pci { index, .. } => pci_data_devices
+                    .as_ref()
+                    .and_then(|devices| devices.block.get(index))
+                    .ok_or_else(|| {
+                        HvfArm64BootStorageCaptureError::new(
+                            HvfArm64BootStorageCaptureErrorKind::InventoryMismatch,
+                            false,
+                        )
+                    })?
+                    .published
+                    .endpoint()
+                    .block_async_binding()
+                    .map_err(|_| {
+                        HvfArm64BootStorageCaptureError::new(
+                            HvfArm64BootStorageCaptureErrorKind::AsyncPreparation,
+                            false,
+                        )
+                    })?,
+            }
         };
         match (config.io_engine(), binding) {
             (Some(DriveIoEngine::Sync), None) => {}
@@ -7028,11 +7240,15 @@ fn capture_ready_storage_state_at_with_cancel(
 
     let mut primary = None;
     for generation in generations.iter().copied() {
-        if runtime_resources
-            .block_async_runtime
-            .quiesce_generation(generation, memory)
-            .is_err()
-        {
+        let drained = match mode {
+            CaptureReadyStorageMode::Diagnostic => runtime_resources
+                .block_async_runtime
+                .quiesce_generation(generation, memory),
+            CaptureReadyStorageMode::SnapshotV2MultiBlock => runtime_resources
+                .block_async_runtime
+                .drain_stopped_generation(generation, memory),
+        };
+        if drained.is_err() {
             retain_storage_capture_error(
                 &mut primary,
                 HvfArm64BootStorageCaptureError::new(
@@ -7049,6 +7265,92 @@ fn capture_ready_storage_state_at_with_cancel(
                     false,
                 ),
             );
+        }
+    }
+
+    if mode == CaptureReadyStorageMode::SnapshotV2MultiBlock {
+        if primary.is_none() && is_cancelled(HvfArm64BootStorageCaptureStage::Persist) {
+            retain_storage_capture_error(
+                &mut primary,
+                HvfArm64BootStorageCaptureError::new(
+                    HvfArm64BootStorageCaptureErrorKind::Cancelled,
+                    false,
+                ),
+            );
+        }
+        if primary.is_none() && persistence_bindings.len() != configs.drives().len() {
+            retain_storage_capture_error(
+                &mut primary,
+                HvfArm64BootStorageCaptureError::new(
+                    HvfArm64BootStorageCaptureErrorKind::ProfilePreflight,
+                    false,
+                ),
+            );
+        }
+        if primary.is_none() {
+            for ((config, owner), persistence) in configs
+                .drives()
+                .iter()
+                .zip(block_owners.iter().copied())
+                .zip(persistence_bindings.iter())
+            {
+                if !persistence.is_read_only() {
+                    let persisted = match owner {
+                        CaptureReadyBlockOwner::Mmio { .. } => runtime_resources
+                            .persist_capture_ready_mmio_block_snapshot_backing(
+                                &mut mmio_dispatcher_guard,
+                                config,
+                            )
+                            .map_err(|_| {
+                                HvfArm64BootStorageCaptureError::new(
+                                    HvfArm64BootStorageCaptureErrorKind::Persistence,
+                                    false,
+                                )
+                            }),
+                        CaptureReadyBlockOwner::Pci { index, .. } => pci_data_devices
+                            .as_ref()
+                            .and_then(|devices| devices.block.get(index))
+                            .ok_or_else(|| {
+                                HvfArm64BootStorageCaptureError::new(
+                                    HvfArm64BootStorageCaptureErrorKind::InventoryMismatch,
+                                    false,
+                                )
+                            })
+                            .and_then(|device| {
+                                device
+                                    .published
+                                    .endpoint()
+                                    .persist_block_snapshot_backing(config)
+                                    .map_err(|_| {
+                                        HvfArm64BootStorageCaptureError::new(
+                                            HvfArm64BootStorageCaptureErrorKind::Persistence,
+                                            false,
+                                        )
+                                    })
+                            }),
+                    };
+                    if persisted.is_err() {
+                        retain_storage_capture_error(
+                            &mut primary,
+                            HvfArm64BootStorageCaptureError::new(
+                                HvfArm64BootStorageCaptureErrorKind::Persistence,
+                                false,
+                            ),
+                        );
+                        break;
+                    }
+                }
+                if is_cancelled(HvfArm64BootStorageCaptureStage::Persist) {
+                    retain_storage_capture_error(
+                        &mut primary,
+                        HvfArm64BootStorageCaptureError::new(
+                            HvfArm64BootStorageCaptureErrorKind::Cancelled,
+                            false,
+                        ),
+                    );
+                    break;
+                }
+            }
         }
     }
 
@@ -7313,12 +7615,57 @@ fn capture_ready_storage_state_at_with_cancel(
         }
     }
     if primary.is_none() {
-        captured = Some(CaptureReadyStorageState::new(
-            block_states,
-            pmem_states,
-            shared_block_retry,
-            shared_pmem_retry,
-        ));
+        match mode {
+            CaptureReadyStorageMode::Diagnostic => {
+                captured = Some(CaptureReadyStorageResult::Diagnostic(
+                    CaptureReadyStorageState::new(
+                        block_states,
+                        pmem_states,
+                        shared_block_retry,
+                        shared_pmem_retry,
+                    ),
+                ));
+            }
+            CaptureReadyStorageMode::SnapshotV2MultiBlock => {
+                if is_cancelled(HvfArm64BootStorageCaptureStage::ComposeGraph) {
+                    retain_storage_capture_error(
+                        &mut primary,
+                        HvfArm64BootStorageCaptureError::new(
+                            HvfArm64BootStorageCaptureErrorKind::Cancelled,
+                            false,
+                        ),
+                    );
+                }
+                if primary.is_none() {
+                    match SnapshotV2MultiBlockDeviceGraph::from_capture_ready_blocks(
+                        NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                        &block_states,
+                    ) {
+                        Ok(graph) => {
+                            if is_cancelled(HvfArm64BootStorageCaptureStage::ComposeGraph) {
+                                retain_storage_capture_error(
+                                    &mut primary,
+                                    HvfArm64BootStorageCaptureError::new(
+                                        HvfArm64BootStorageCaptureErrorKind::Cancelled,
+                                        false,
+                                    ),
+                                );
+                            } else {
+                                captured =
+                                    Some(CaptureReadyStorageResult::SnapshotV2MultiBlock(graph));
+                            }
+                        }
+                        Err(_) => retain_storage_capture_error(
+                            &mut primary,
+                            HvfArm64BootStorageCaptureError::new(
+                                HvfArm64BootStorageCaptureErrorKind::GraphComposition,
+                                false,
+                            ),
+                        ),
+                    }
+                }
+            }
+        }
     }
 
     let mut cleanup_failed = false;
@@ -8538,6 +8885,44 @@ impl HvfArm64BootSession<'_> {
         is_cancelled: impl FnMut(HvfArm64BootStorageCaptureStage) -> bool,
     ) -> Result<CaptureReadyStorageState, HvfArm64BootStorageCaptureError> {
         capture_ready_storage_state_at_with_cancel(
+            self.backend,
+            &self.mmio_dispatcher,
+            &self.runtime_resources,
+            &mut self.pci_data_devices,
+            &self.block_device_metrics,
+            &self.gic,
+            &self.block_retry_wakeup_scheduler,
+            &self.pmem_retry_wakeup_scheduler,
+            configs,
+            guard,
+            now,
+            is_cancelled,
+        )
+    }
+
+    /// Produces only a detached, durable profile-2 block graph.
+    pub fn capture_snapshot_v2_multi_block_device_graph_at(
+        &mut self,
+        configs: &CaptureReadyStorageConfigs,
+        guard: &HvfArm64BootLimiterRetryWakeupQuiescenceGuard,
+        now: Instant,
+    ) -> Result<SnapshotV2MultiBlockDeviceGraph, HvfArm64BootStorageCaptureError> {
+        self.capture_snapshot_v2_multi_block_device_graph_at_with_cancel(
+            configs,
+            guard,
+            now,
+            |_| false,
+        )
+    }
+
+    pub fn capture_snapshot_v2_multi_block_device_graph_at_with_cancel(
+        &mut self,
+        configs: &CaptureReadyStorageConfigs,
+        guard: &HvfArm64BootLimiterRetryWakeupQuiescenceGuard,
+        now: Instant,
+        is_cancelled: impl FnMut(HvfArm64BootStorageCaptureStage) -> bool,
+    ) -> Result<SnapshotV2MultiBlockDeviceGraph, HvfArm64BootStorageCaptureError> {
+        capture_snapshot_v2_multi_block_device_graph_at_with_cancel(
             self.backend,
             &self.mmio_dispatcher,
             &self.runtime_resources,
@@ -11545,6 +11930,44 @@ impl OwnedHvfArm64BootSession {
         is_cancelled: impl FnMut(HvfArm64BootStorageCaptureStage) -> bool,
     ) -> Result<CaptureReadyStorageState, HvfArm64BootStorageCaptureError> {
         capture_ready_storage_state_at_with_cancel(
+            &mut self.backend,
+            &self.mmio_dispatcher,
+            &self.runtime_resources,
+            &mut self.pci_data_devices,
+            &self.block_device_metrics,
+            &self.gic,
+            &self.block_retry_wakeup_scheduler,
+            &self.pmem_retry_wakeup_scheduler,
+            configs,
+            guard,
+            now,
+            is_cancelled,
+        )
+    }
+
+    /// Produces only a detached, durable profile-2 block graph.
+    pub fn capture_snapshot_v2_multi_block_device_graph_at(
+        &mut self,
+        configs: &CaptureReadyStorageConfigs,
+        guard: &HvfArm64BootLimiterRetryWakeupQuiescenceGuard,
+        now: Instant,
+    ) -> Result<SnapshotV2MultiBlockDeviceGraph, HvfArm64BootStorageCaptureError> {
+        self.capture_snapshot_v2_multi_block_device_graph_at_with_cancel(
+            configs,
+            guard,
+            now,
+            |_| false,
+        )
+    }
+
+    pub fn capture_snapshot_v2_multi_block_device_graph_at_with_cancel(
+        &mut self,
+        configs: &CaptureReadyStorageConfigs,
+        guard: &HvfArm64BootLimiterRetryWakeupQuiescenceGuard,
+        now: Instant,
+        is_cancelled: impl FnMut(HvfArm64BootStorageCaptureStage) -> bool,
+    ) -> Result<SnapshotV2MultiBlockDeviceGraph, HvfArm64BootStorageCaptureError> {
+        capture_snapshot_v2_multi_block_device_graph_at_with_cancel(
             &mut self.backend,
             &self.mmio_dispatcher,
             &self.runtime_resources,

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -1657,7 +1657,9 @@ fn temporary_virtual_block_traverses_async_flush_and_capture_ready_owner() {
     use std::time::Instant;
 
     use crate::macos_virtual_block::{MacosVirtualBlock, MacosVirtualBlockAccess};
-    use bangbang_hvf::{HvfArm64BootSessionConfig, OwnedHvfArm64BootSession};
+    use bangbang_hvf::{
+        HvfArm64BootSessionConfig, HvfArm64BootStorageCaptureErrorKind, OwnedHvfArm64BootSession,
+    };
     use bangbang_runtime::VmmAction;
     use bangbang_runtime::block::async_executor::{
         BlockAsyncApplyOutcome, BlockAsyncCompletionDisposition, BlockAsyncDrive,
@@ -1841,6 +1843,14 @@ fn temporary_virtual_block_traverses_async_flush_and_capture_ready_owner() {
     let retry_guard = session
         .quiesce_limiter_retry_wakeups()
         .expect("block capture retry publishers should quiesce");
+    let profile_error = session
+        .capture_snapshot_v2_multi_block_device_graph_at(&configs, &retry_guard, Instant::now())
+        .expect_err("block-special backing must fail profile preflight");
+    assert_eq!(
+        profile_error.kind(),
+        HvfArm64BootStorageCaptureErrorKind::ProfilePreflight
+    );
+    assert!(!profile_error.terminal());
     let first = session
         .capture_ready_storage_state_at(&configs, &retry_guard, Instant::now())
         .expect("real block drive should become capture-ready");
@@ -6887,7 +6897,9 @@ fn prepares_internal_hvf_arm64_boot_session() {
 fn capture_ready_storage_traverses_signed_mmio_and_pci_owners() {
     use std::time::Instant;
 
-    use bangbang_hvf::{HvfArm64BootSessionConfig, OwnedHvfArm64BootSession};
+    use bangbang_hvf::{
+        HvfArm64BootSessionConfig, HvfArm64BootStorageCaptureErrorKind, OwnedHvfArm64BootSession,
+    };
     use bangbang_runtime::VmmAction;
     use bangbang_runtime::block::{
         BlockCaptureIoEngine, BlockMmioLayout, DriveCacheType, DriveConfigInput, DriveIoEngine,
@@ -6961,6 +6973,14 @@ fn capture_ready_storage_traverses_signed_mmio_and_pci_owners() {
     let mmio_guard = mmio_session
         .quiesce_limiter_retry_wakeups()
         .expect("MMIO retry publishers should quiesce");
+    let profile_error = mmio_session
+        .capture_snapshot_v2_multi_block_device_graph_at(&mmio_configs, &mmio_guard, Instant::now())
+        .expect_err("pmem inventory must fail multi-block profile preflight");
+    assert_eq!(
+        profile_error.kind(),
+        HvfArm64BootStorageCaptureErrorKind::ProfilePreflight
+    );
+    assert!(!profile_error.terminal());
     let mmio_first = mmio_session
         .capture_ready_storage_state_at(&mmio_configs, &mmio_guard, Instant::now())
         .expect("signed MMIO storage should become capture-ready");
@@ -7200,6 +7220,256 @@ fn capture_ready_storage_traverses_signed_mmio_and_pci_owners() {
     pci_session
         .shutdown()
         .expect("signed PCI storage session should shut down");
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn native_v2_multi_block_graph_is_durable_and_recoverable_for_mmio_and_pci() {
+    use std::time::Instant;
+
+    use bangbang_hvf::{
+        HvfArm64BootSessionConfig, HvfArm64BootStorageCaptureErrorKind,
+        HvfArm64BootStorageCaptureStage, OwnedHvfArm64BootSession,
+    };
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::block::{
+        BlockMmioLayout, DriveCacheType, DriveConfigInput, DriveIoEngine, PreparedBlockDevice,
+    };
+    use bangbang_runtime::boot::BootSourceConfigInput;
+    use bangbang_runtime::memory::GuestAddress;
+    use bangbang_runtime::mmio::MmioRegionId;
+    use bangbang_runtime::network::NetworkMmioLayout;
+    use bangbang_runtime::pmem::PmemMmioLayout;
+    use bangbang_runtime::snapshot_device_v2::{
+        SnapshotV2DeviceTransport, SnapshotV2DeviceTransportKind,
+    };
+    use bangbang_runtime::snapshot_device_v2_5::{
+        NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2MultiBlockDeviceGraph,
+    };
+    use bangbang_runtime::storage_capture::{CaptureReadyStorageConfigs, StorageDeviceOrigin};
+    use bangbang_runtime::vsock::VsockMmioLayout;
+
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let image = arm64_image().expect("test arm64 image should build");
+
+    for (case, pci_enabled, expected_transport) in [
+        (
+            "native-v2-multi-block-mmio",
+            false,
+            SnapshotV2DeviceTransportKind::Mmio,
+        ),
+        (
+            "native-v2-multi-block-pci",
+            true,
+            SnapshotV2DeviceTransportKind::Pci,
+        ),
+    ] {
+        let kernel = TempFile::new(&format!("{case}-kernel"), &image)
+            .unwrap_or_else(|error| panic!("{case} kernel should create: {error}"));
+        let root = TempFile::new_len(&format!("{case}-root"), 4096)
+            .unwrap_or_else(|error| panic!("{case} root should create: {error}"));
+        let sync = TempFile::new_len(&format!("{case}-sync"), 8193)
+            .unwrap_or_else(|error| panic!("{case} Sync backing should create: {error}"));
+        let asynchronous = TempFile::new_len(&format!("{case}-async"), 12_288)
+            .unwrap_or_else(|error| panic!("{case} Async backing should create: {error}"));
+        let mut controller = bangbang_runtime::VmmController::new(case, "0.1.0", "bangbang");
+        controller
+            .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+                kernel.path(),
+            )))
+            .unwrap_or_else(|error| panic!("{case} boot source should configure: {error}"));
+        controller
+            .handle_action(VmmAction::PutDrive(
+                DriveConfigInput::new("rootfs", "rootfs", root.path(), true)
+                    .with_is_read_only(true)
+                    .with_cache_type(DriveCacheType::Writeback)
+                    .with_io_engine(DriveIoEngine::Sync),
+            ))
+            .unwrap_or_else(|error| panic!("{case} root should configure: {error}"));
+        controller
+            .handle_action(VmmAction::PutDrive(
+                DriveConfigInput::new("data_sync", "data_sync", sync.path(), false)
+                    .with_is_read_only(false)
+                    .with_cache_type(DriveCacheType::Unsafe)
+                    .with_io_engine(DriveIoEngine::Sync),
+            ))
+            .unwrap_or_else(|error| panic!("{case} Sync data should configure: {error}"));
+        if !pci_enabled {
+            controller
+                .handle_action(VmmAction::PutDrive(
+                    DriveConfigInput::new("data_async", "data_async", asynchronous.path(), false)
+                        .with_is_read_only(false)
+                        .with_cache_type(DriveCacheType::Writeback)
+                        .with_io_engine(DriveIoEngine::Async),
+                ))
+                .unwrap_or_else(|error| panic!("{case} Async data should configure: {error}"));
+        }
+
+        let mut session_config = HvfArm64BootSessionConfig::new(
+            BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1)),
+            PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500)),
+            NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000)),
+            VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
+            test_rtc_mmio_layout(),
+        );
+        if pci_enabled {
+            session_config = session_config.with_pci_enabled();
+        }
+        let mut session = OwnedHvfArm64BootSession::new(&controller, session_config)
+            .unwrap_or_else(|error| panic!("{case} signed session should prepare: {error}"));
+
+        if pci_enabled {
+            let input =
+                DriveConfigInput::new("data_async", "data_async", asynchronous.path(), false)
+                    .with_is_read_only(false)
+                    .with_cache_type(DriveCacheType::Writeback)
+                    .with_io_engine(DriveIoEngine::Async);
+            let config = input.clone().validate().unwrap_or_else(|error| {
+                panic!("{case} runtime Async config should validate: {error}")
+            });
+            controller
+                .handle_action(VmmAction::PutDrive(input))
+                .unwrap_or_else(|error| {
+                    panic!("{case} runtime Async config should publish: {error}")
+                });
+            session
+                .insert_runtime_block_device(
+                    PreparedBlockDevice::from_config_with_backing(&config, None).unwrap_or_else(
+                        |error| panic!("{case} runtime Async device should prepare: {error}"),
+                    ),
+                )
+                .unwrap_or_else(|error| {
+                    panic!("{case} runtime Async device should insert: {error}")
+                });
+        }
+
+        let configs =
+            CaptureReadyStorageConfigs::new(controller.drive_configs().to_vec(), Vec::new());
+        let guard = session
+            .quiesce_limiter_retry_wakeups()
+            .unwrap_or_else(|error| panic!("{case} retry publishers should quiesce: {error}"));
+
+        for cancelled_stage in [
+            HvfArm64BootStorageCaptureStage::Persist,
+            HvfArm64BootStorageCaptureStage::ComposeGraph,
+        ] {
+            let result = session.capture_snapshot_v2_multi_block_device_graph_at_with_cancel(
+                &configs,
+                &guard,
+                Instant::now(),
+                |stage| stage == cancelled_stage,
+            );
+            let error = match result {
+                Ok(_) => panic!("{case} cancellation at {cancelled_stage:?} returned a graph"),
+                Err(error) => error,
+            };
+            assert_eq!(error.kind(), HvfArm64BootStorageCaptureErrorKind::Cancelled);
+            assert!(!error.cleanup_failed());
+            assert!(!error.terminal());
+        }
+
+        let mut observed_stages = Vec::new();
+        let first = session
+            .capture_snapshot_v2_multi_block_device_graph_at_with_cancel(
+                &configs,
+                &guard,
+                Instant::now(),
+                |stage| {
+                    observed_stages.push(stage);
+                    false
+                },
+            )
+            .unwrap_or_else(|error| panic!("{case} first graph should capture: {error}"));
+        let last_drain = observed_stages
+            .iter()
+            .rposition(|stage| *stage == HvfArm64BootStorageCaptureStage::DrainAsync)
+            .expect("profile capture should observe an Async drain boundary");
+        let first_persist = observed_stages
+            .iter()
+            .position(|stage| *stage == HvfArm64BootStorageCaptureStage::Persist)
+            .expect("profile capture should observe a persistence boundary");
+        let first_publication = observed_stages
+            .iter()
+            .position(|stage| *stage == HvfArm64BootStorageCaptureStage::PublishAsync)
+            .expect("profile capture should observe a publication boundary");
+        let first_capture = observed_stages
+            .iter()
+            .position(|stage| *stage == HvfArm64BootStorageCaptureStage::Capture)
+            .expect("profile capture should observe a live-state capture boundary");
+        let first_composition = observed_stages
+            .iter()
+            .position(|stage| *stage == HvfArm64BootStorageCaptureStage::ComposeGraph)
+            .expect("profile capture should observe a graph-composition boundary");
+        assert!(last_drain < first_persist);
+        assert!(first_persist < first_publication);
+        assert!(first_publication < first_capture);
+        assert!(first_capture < first_composition);
+        let second = session
+            .capture_snapshot_v2_multi_block_device_graph_at(&configs, &guard, Instant::now())
+            .unwrap_or_else(|error| panic!("{case} second graph should capture: {error}"));
+        assert_eq!(first, second);
+        assert_eq!(first.transport_kind(), expected_transport);
+        assert_eq!(first.records().len(), 3);
+        assert_eq!(first.root_key(), Some(first.records()[0].key()));
+        assert_eq!(first.records()[0].config().drive_id(), "rootfs");
+        assert!(first.records()[0].config().is_read_only());
+        assert_eq!(first.records()[0].config().io_engine(), DriveIoEngine::Sync);
+        assert_eq!(first.records()[1].config().drive_id(), "data_sync");
+        assert!(!first.records()[1].config().is_read_only());
+        assert_eq!(first.records()[1].config().io_engine(), DriveIoEngine::Sync);
+        assert_eq!(
+            first.records()[1].config().cache_type(),
+            DriveCacheType::Unsafe
+        );
+        assert_eq!(first.records()[1].block().backing_bytes(), 8193);
+        assert_eq!(first.records()[2].config().drive_id(), "data_async");
+        assert_eq!(
+            first.records()[2].config().io_engine(),
+            DriveIoEngine::Async
+        );
+        assert_eq!(
+            first.records()[2].config().cache_type(),
+            DriveCacheType::Writeback
+        );
+        match first.records()[2].transport() {
+            SnapshotV2DeviceTransport::Mmio(_) => assert!(!pci_enabled),
+            SnapshotV2DeviceTransport::Pci(state) => {
+                assert!(pci_enabled);
+                assert_eq!(state.origin(), StorageDeviceOrigin::Runtime);
+            }
+        }
+
+        let bytes = first
+            .encode(NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION)
+            .unwrap_or_else(|error| panic!("{case} graph should encode: {error}"));
+        let decoded = SnapshotV2MultiBlockDeviceGraph::decode(
+            NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            &bytes,
+        )
+        .unwrap_or_else(|error| panic!("{case} graph should decode: {error}"));
+        assert_eq!(decoded, first);
+        assert_eq!(
+            decoded
+                .encode(NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION)
+                .unwrap_or_else(|error| panic!("{case} decoded graph should re-encode: {error}")),
+            bytes
+        );
+        let diagnostics = format!("{first:?} {:?}", first.records());
+        for private in [
+            path_text(root.path()),
+            path_text(sync.path()),
+            path_text(asynchronous.path()),
+        ] {
+            assert!(!diagnostics.contains(&private));
+        }
+
+        drop(guard);
+        session
+            .shutdown()
+            .unwrap_or_else(|error| panic!("{case} session should shut down: {error}"));
+    }
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/crates/runtime/src/block.rs
+++ b/crates/runtime/src/block.rs
@@ -2497,6 +2497,107 @@ pub enum BlockCaptureIoEngine {
     Async(BlockAsyncGenerationCaptureState),
 }
 
+/// Validated live regular-file binding for one snapshot persistence phase.
+#[derive(Clone)]
+pub struct VirtioBlockSnapshotPersistenceBinding {
+    is_read_only: bool,
+    io_engine: DriveIoEngine,
+    async_binding: Option<(SharedBlockAsyncRuntime, BlockAsyncDriveGeneration)>,
+}
+
+impl VirtioBlockSnapshotPersistenceBinding {
+    pub const fn is_read_only(&self) -> bool {
+        self.is_read_only
+    }
+
+    pub const fn io_engine(&self) -> DriveIoEngine {
+        self.io_engine
+    }
+
+    pub fn async_binding(&self) -> Option<(SharedBlockAsyncRuntime, BlockAsyncDriveGeneration)> {
+        self.async_binding.clone()
+    }
+}
+
+impl fmt::Debug for VirtioBlockSnapshotPersistenceBinding {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("VirtioBlockSnapshotPersistenceBinding")
+            .field("is_read_only", &self.is_read_only)
+            .field("io_engine", &self.io_engine)
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Value-redacted failure while validating or persisting one live block owner.
+pub enum VirtioBlockSnapshotPersistenceError {
+    UnsupportedBackend,
+    UnsupportedBacking,
+    ConfigurationMismatch,
+    ReadOnly,
+    Identity {
+        source: SnapshotBlockFileBackingError,
+    },
+    Backing {
+        source: BlockFileBackingError,
+    },
+    Async {
+        source: BlockAsyncRuntimeError,
+    },
+}
+
+impl fmt::Debug for VirtioBlockSnapshotPersistenceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::UnsupportedBackend => "UnsupportedBackend",
+            Self::UnsupportedBacking => "UnsupportedBacking",
+            Self::ConfigurationMismatch => "ConfigurationMismatch",
+            Self::ReadOnly => "ReadOnly",
+            Self::Identity { .. } => "Identity",
+            Self::Backing { .. } => "Backing",
+            Self::Async { .. } => "Async",
+        };
+        formatter
+            .debug_struct("VirtioBlockSnapshotPersistenceError")
+            .field("kind", &kind)
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for VirtioBlockSnapshotPersistenceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::UnsupportedBackend => "snapshot persistence requires a local block backing",
+            Self::UnsupportedBacking => {
+                "snapshot persistence requires a regular-file block backing"
+            }
+            Self::ConfigurationMismatch => {
+                "snapshot persistence binding does not match block configuration"
+            }
+            Self::ReadOnly => "snapshot persistence cannot write a read-only block backing",
+            Self::Identity { .. } => "snapshot block backing identity validation failed",
+            Self::Backing { .. } => "snapshot block backing persistence failed",
+            Self::Async { .. } => "snapshot Async block persistence failed",
+        })
+    }
+}
+
+impl std::error::Error for VirtioBlockSnapshotPersistenceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Identity { source } => Some(source),
+            Self::Backing { source } => Some(source),
+            Self::Async { source } => Some(source),
+            Self::UnsupportedBackend
+            | Self::UnsupportedBacking
+            | Self::ConfigurationMismatch
+            | Self::ReadOnly => None,
+        }
+    }
+}
+
 /// Detached, value-redacted block state retained for later persistence.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct VirtioBlockDeviceCaptureState {
@@ -2602,6 +2703,44 @@ impl std::error::Error for VirtioBlockPciCaptureError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Device(source) => Some(source),
+            Self::Endpoint(source) => Some(source),
+        }
+    }
+}
+
+/// Value-redacted failure while validating or persisting a PCI block owner.
+pub enum VirtioBlockPciSnapshotPersistenceError {
+    Persistence(VirtioBlockSnapshotPersistenceError),
+    Endpoint(VirtioPciEndpointError),
+}
+
+impl fmt::Debug for VirtioBlockPciSnapshotPersistenceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::Persistence(_) => "Persistence",
+            Self::Endpoint(_) => "Endpoint",
+        };
+        formatter
+            .debug_struct("VirtioBlockPciSnapshotPersistenceError")
+            .field("kind", &kind)
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for VirtioBlockPciSnapshotPersistenceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Persistence(_) => formatter.write_str("PCI block persistence failed"),
+            Self::Endpoint(_) => formatter.write_str("PCI block endpoint access failed"),
+        }
+    }
+}
+
+impl std::error::Error for VirtioBlockPciSnapshotPersistenceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Persistence(source) => Some(source),
             Self::Endpoint(source) => Some(source),
         }
     }
@@ -5923,6 +6062,79 @@ impl VirtioBlockDevice {
         }
     }
 
+    /// Validates one live regular-file owner before snapshot source mutation.
+    pub fn snapshot_persistence_binding(
+        &self,
+        config_space: VirtioBlockConfigSpace,
+        config: &DriveConfig,
+    ) -> Result<VirtioBlockSnapshotPersistenceBinding, VirtioBlockSnapshotPersistenceError> {
+        let VirtioBlockBackend::File {
+            backing, io_engine, ..
+        } = &self.backend
+        else {
+            return Err(VirtioBlockSnapshotPersistenceError::UnsupportedBackend);
+        };
+        if config.is_vhost_user()
+            || !backing.snapshot_device_id_is_compatible(config.drive_id(), self.device_id)
+            || config.is_read_only() != Some(backing.is_read_only())
+            || config_space != VirtioBlockConfigSpace::from_backing(backing, config.cache_type())
+        {
+            return Err(VirtioBlockSnapshotPersistenceError::ConfigurationMismatch);
+        }
+        let identity = backing
+            .snapshot_identity()
+            .map_err(|source| VirtioBlockSnapshotPersistenceError::Identity { source })?;
+        if !identity.kind().is_regular_file() {
+            return Err(VirtioBlockSnapshotPersistenceError::UnsupportedBacking);
+        }
+        let (io_engine, async_binding) = match io_engine {
+            VirtioBlockFileIoEngine::Sync if config.io_engine() == Some(DriveIoEngine::Sync) => {
+                (DriveIoEngine::Sync, None)
+            }
+            VirtioBlockFileIoEngine::Async {
+                runtime,
+                generation,
+                cache_type,
+                terminal: false,
+            } if config.io_engine() == Some(DriveIoEngine::Async)
+                && *cache_type == config.cache_type() =>
+            {
+                (DriveIoEngine::Async, Some((runtime.clone(), *generation)))
+            }
+            VirtioBlockFileIoEngine::Sync | VirtioBlockFileIoEngine::Async { .. } => {
+                return Err(VirtioBlockSnapshotPersistenceError::ConfigurationMismatch);
+            }
+        };
+        Ok(VirtioBlockSnapshotPersistenceBinding {
+            is_read_only: backing.is_read_only(),
+            io_engine,
+            async_binding,
+        })
+    }
+
+    /// Persists one exact writable regular-file owner after all Async drains.
+    pub fn persist_snapshot_backing(
+        &self,
+        config_space: VirtioBlockConfigSpace,
+        config: &DriveConfig,
+    ) -> Result<(), VirtioBlockSnapshotPersistenceError> {
+        let binding = self.snapshot_persistence_binding(config_space, config)?;
+        if binding.is_read_only() {
+            return Err(VirtioBlockSnapshotPersistenceError::ReadOnly);
+        }
+        if let Some((runtime, generation)) = binding.async_binding() {
+            return runtime
+                .persist_drained_generation(generation)
+                .map_err(|source| VirtioBlockSnapshotPersistenceError::Async { source });
+        }
+        let VirtioBlockBackend::File { backing, .. } = &self.backend else {
+            return Err(VirtioBlockSnapshotPersistenceError::UnsupportedBackend);
+        };
+        backing
+            .flush()
+            .map_err(|source| VirtioBlockSnapshotPersistenceError::Backing { source })
+    }
+
     /// Captures a regular-file device after any Async generation is drained.
     pub fn capture_state_at(
         &self,
@@ -7797,6 +8009,22 @@ impl VirtioBlockMmioHandler {
         self.activation_handler().backend_kind()
     }
 
+    pub fn block_snapshot_persistence_binding(
+        &self,
+        config: &DriveConfig,
+    ) -> Result<VirtioBlockSnapshotPersistenceBinding, VirtioBlockSnapshotPersistenceError> {
+        self.activation_handler()
+            .snapshot_persistence_binding(*self.device_config_handler(), config)
+    }
+
+    pub fn persist_block_snapshot_backing(
+        &self,
+        config: &DriveConfig,
+    ) -> Result<(), VirtioBlockSnapshotPersistenceError> {
+        self.activation_handler()
+            .persist_snapshot_backing(*self.device_config_handler(), config)
+    }
+
     pub fn block_async_binding(
         &self,
     ) -> Option<(SharedBlockAsyncRuntime, BlockAsyncDriveGeneration)> {
@@ -7817,6 +8045,36 @@ impl VirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice> {
     pub fn block_backend_kind(&self) -> Result<VirtioBlockBackendKind, VirtioPciEndpointError> {
         let work = self.admit_device_work()?;
         work.with_core_mut(|core| core.activation.backend_kind())
+    }
+
+    pub fn block_snapshot_persistence_binding(
+        &self,
+        config: &DriveConfig,
+    ) -> Result<VirtioBlockSnapshotPersistenceBinding, VirtioBlockPciSnapshotPersistenceError> {
+        let work = self
+            .admit_device_work()
+            .map_err(VirtioBlockPciSnapshotPersistenceError::Endpoint)?;
+        work.with_core_mut(|core| {
+            core.activation
+                .snapshot_persistence_binding(core.device_config, config)
+        })
+        .map_err(VirtioBlockPciSnapshotPersistenceError::Endpoint)?
+        .map_err(VirtioBlockPciSnapshotPersistenceError::Persistence)
+    }
+
+    pub fn persist_block_snapshot_backing(
+        &self,
+        config: &DriveConfig,
+    ) -> Result<(), VirtioBlockPciSnapshotPersistenceError> {
+        let work = self
+            .admit_device_work()
+            .map_err(VirtioBlockPciSnapshotPersistenceError::Endpoint)?;
+        work.with_core_mut(|core| {
+            core.activation
+                .persist_snapshot_backing(core.device_config, config)
+        })
+        .map_err(VirtioBlockPciSnapshotPersistenceError::Endpoint)?
+        .map_err(VirtioBlockPciSnapshotPersistenceError::Persistence)
     }
 
     pub fn block_async_binding(
@@ -8586,7 +8844,8 @@ mod tests {
         VirtioBlockQueueBuildError, VirtioBlockQueueDispatch, VirtioBlockQueueDispatchError,
         VirtioBlockQueueSnapshotError, VirtioBlockRateLimiter, VirtioBlockRequest,
         VirtioBlockRequestCompletion, VirtioBlockRequestError, VirtioBlockRequestExecutionError,
-        VirtioBlockRequestExecutionOutcome, VirtioBlockRequestType, normalize_completion_status,
+        VirtioBlockRequestExecutionOutcome, VirtioBlockRequestType,
+        VirtioBlockSnapshotPersistenceError, normalize_completion_status,
     };
 
     static NEXT_TEMP_PATH_ID: AtomicUsize = AtomicUsize::new(0);
@@ -11344,6 +11603,116 @@ mod tests {
             runtime
                 .shutdown_if_idle()
                 .expect("idle Async runtime should stop")
+        );
+    }
+
+    #[test]
+    fn snapshot_persistence_binding_revalidates_sync_async_and_read_only_owners() {
+        let sync_file = temp_file("snapshot-persist-sync.img", &[0; 512]);
+        let sync_config = DriveConfigInput::new("sync", "sync", sync_file.as_path(), false)
+            .with_cache_type(DriveCacheType::Unsafe)
+            .with_io_engine(DriveIoEngine::Sync)
+            .validate()
+            .expect("snapshot Sync config should validate");
+        let sync = PreparedBlockDevice::from_config_with_backing(&sync_config, None)
+            .expect("snapshot Sync device should prepare");
+        let sync_binding = sync
+            .device()
+            .snapshot_persistence_binding(sync.config_space(), &sync_config)
+            .expect("writable Sync owner should preflight");
+        assert!(!sync_binding.is_read_only());
+        assert_eq!(sync_binding.io_engine(), DriveIoEngine::Sync);
+        assert!(sync_binding.async_binding().is_none());
+        sync.device()
+            .backing()
+            .expect("Sync device should retain its backing")
+            .write_at(0, b"durable")
+            .expect("Sync backing should accept test bytes");
+        sync.device()
+            .persist_snapshot_backing(sync.config_space(), &sync_config)
+            .expect("writable Sync owner should persist");
+        assert_eq!(
+            &fs::read(sync_file.as_path()).expect("persisted Sync backing should reopen")[..7],
+            b"durable"
+        );
+
+        let read_only_file = temp_file("snapshot-persist-read-only.img", &[0; 512]);
+        let read_only_config =
+            DriveConfigInput::new("readonly", "readonly", read_only_file.as_path(), false)
+                .with_is_read_only(true)
+                .with_io_engine(DriveIoEngine::Sync)
+                .validate()
+                .expect("snapshot read-only config should validate");
+        let read_only = PreparedBlockDevice::from_config_with_backing(&read_only_config, None)
+            .expect("snapshot read-only device should prepare");
+        assert!(
+            read_only
+                .device()
+                .snapshot_persistence_binding(read_only.config_space(), &read_only_config)
+                .expect("read-only owner should preflight")
+                .is_read_only()
+        );
+        assert!(matches!(
+            read_only
+                .device()
+                .persist_snapshot_backing(read_only.config_space(), &read_only_config),
+            Err(VirtioBlockSnapshotPersistenceError::ReadOnly)
+        ));
+
+        let async_file = temp_file("snapshot-persist-async.img", &[0; 512]);
+        let async_config = DriveConfigInput::new("async", "async", async_file.as_path(), false)
+            .with_cache_type(DriveCacheType::Writeback)
+            .with_io_engine(DriveIoEngine::Async)
+            .validate()
+            .expect("snapshot Async config should validate");
+        let mut asynchronous = PreparedBlockDevice::from_config_with_backing(&async_config, None)
+            .expect("snapshot Async device should prepare");
+        let runtime = SharedBlockAsyncRuntime::new();
+        let generation = asynchronous
+            .bind_async_runtime(runtime.clone())
+            .expect("snapshot Async runtime should bind")
+            .expect("snapshot Async config should own a generation");
+        let async_binding = asynchronous
+            .device()
+            .snapshot_persistence_binding(asynchronous.config_space(), &async_config)
+            .expect("snapshot Async owner should preflight");
+        assert_eq!(async_binding.io_engine(), DriveIoEngine::Async);
+        assert_eq!(
+            async_binding
+                .async_binding()
+                .expect("snapshot Async binding should exist")
+                .1,
+            generation
+        );
+        assert!(matches!(
+            asynchronous
+                .device()
+                .persist_snapshot_backing(asynchronous.config_space(), &async_config),
+            Err(VirtioBlockSnapshotPersistenceError::Async {
+                source: BlockAsyncRuntimeError::AdmissionNotStopped
+            })
+        ));
+        let mut memory = request_memory();
+        runtime
+            .stop_generations(&[generation])
+            .expect("snapshot Async admission should stop");
+        runtime
+            .drain_stopped_generation(generation, &mut memory)
+            .expect("snapshot Async owner should drain without persistence");
+        asynchronous
+            .device()
+            .persist_snapshot_backing(asynchronous.config_space(), &async_config)
+            .expect("snapshot Async owner should persist through its exact generation");
+        runtime
+            .capture_quiesced_generation(generation)
+            .expect("persisted Async owner should remain capture-ready");
+        runtime
+            .unbind_quiesced(generation)
+            .expect("persisted Async owner should unbind");
+        assert!(
+            runtime
+                .shutdown_if_idle()
+                .expect("snapshot Async executor should stop")
         );
     }
 

--- a/crates/runtime/src/block/async_executor.rs
+++ b/crates/runtime/src/block/async_executor.rs
@@ -2892,6 +2892,32 @@ impl SharedBlockAsyncRuntime {
         self.lock()?.quiesce_generation(generation, memory)
     }
 
+    /// Drains one generation whose admission was stopped by an aggregate preflight.
+    ///
+    /// Unlike [`Self::quiesce_generation`], this does not inject a final
+    /// Writeback flush. Callers that require a whole-vector persistence phase
+    /// can therefore drain every selected generation before synchronizing any
+    /// backing.
+    pub fn drain_stopped_generation(
+        &self,
+        generation: BlockAsyncDriveGeneration,
+        memory: &mut GuestMemory,
+    ) -> Result<(), BlockAsyncRuntimeError> {
+        self.lock()?.drain_stopped_generation(generation, memory)
+    }
+
+    /// Persists the backing owned by one exact stopped and drained generation.
+    ///
+    /// Final guest completions may remain queued for later transport
+    /// publication. No operation is admitted and continuation counters remain
+    /// unchanged.
+    pub fn persist_drained_generation(
+        &self,
+        generation: BlockAsyncDriveGeneration,
+    ) -> Result<(), BlockAsyncRuntimeError> {
+        self.lock()?.persist_drained_generation(generation)
+    }
+
     /// Captures one stopped generation after host and guest completion queues drain.
     pub fn capture_quiesced_generation(
         &self,
@@ -3352,6 +3378,33 @@ impl BlockAsyncRuntime {
             .ok_or(BlockAsyncRuntimeError::UnknownGeneration)?
             .coordinator
             .stop_admission();
+        self.drain_generation(generation, memory, needs_final_flush)
+    }
+
+    fn drain_stopped_generation(
+        &mut self,
+        generation: BlockAsyncDriveGeneration,
+        memory: &mut GuestMemory,
+    ) -> Result<(), BlockAsyncRuntimeError> {
+        let index = self.drive_index(generation)?;
+        if self
+            .drives
+            .get(index)
+            .ok_or(BlockAsyncRuntimeError::UnknownGeneration)?
+            .coordinator
+            .is_accepting()
+        {
+            return Err(BlockAsyncRuntimeError::AdmissionNotStopped);
+        }
+        self.drain_generation(generation, memory, false)
+    }
+
+    fn drain_generation(
+        &mut self,
+        generation: BlockAsyncDriveGeneration,
+        memory: &mut GuestMemory,
+        needs_final_flush: bool,
+    ) -> Result<(), BlockAsyncRuntimeError> {
         let mut final_flush_started = false;
         loop {
             let mut made_progress = self.route_parked_completions(memory)?;
@@ -3406,6 +3459,35 @@ impl BlockAsyncRuntime {
         }
 
         self.reconcile_quiesced_notification(generation, memory)
+    }
+
+    fn persist_drained_generation(
+        &mut self,
+        generation: BlockAsyncDriveGeneration,
+    ) -> Result<(), BlockAsyncRuntimeError> {
+        let index = self.drive_index(generation)?;
+        let parked = self
+            .parked
+            .iter()
+            .filter(|completion| completion.key.operation.generation() == generation)
+            .count();
+        let drive = self
+            .drives
+            .get(index)
+            .ok_or(BlockAsyncRuntimeError::UnknownGeneration)?;
+        if drive.coordinator.is_accepting() {
+            return Err(BlockAsyncRuntimeError::AdmissionNotStopped);
+        }
+        if !drive.coordinator.is_drained() {
+            return Err(BlockAsyncRuntimeError::OutstandingOperations);
+        }
+        if parked != 0 {
+            return Err(BlockAsyncRuntimeError::ParkedCompletionInvariant);
+        }
+        let backing = Arc::clone(&drive.backing);
+        let host = Arc::clone(&self.host);
+        host.flush(&backing)
+            .map_err(|_| BlockAsyncRuntimeError::BackingPersistence { generation })
     }
 
     fn route_parked_completions(
@@ -4082,6 +4164,180 @@ mod tests {
             runtime
                 .shutdown_if_idle()
                 .expect("idle executor should stop")
+        );
+    }
+
+    #[test]
+    fn snapshot_drain_defers_writeback_persistence_until_the_explicit_barrier() {
+        let host = Arc::new(FlushHost {
+            flushes: AtomicUsize::new(0),
+            fail: false,
+        });
+        let runtime = SharedBlockAsyncRuntime::with_config_and_host(
+            test_config(1, 1, 1, 4, 4),
+            Arc::clone(&host) as Arc<dyn BlockAsyncHostIo>,
+        );
+        let (_temporary, backing) = temporary_backing(&[]);
+        let generation = runtime
+            .bind_drive(backing, DriveCacheType::Writeback)
+            .expect("snapshot drive should bind");
+        assert!(matches!(
+            runtime.drain_stopped_generation(generation, &mut guest_memory()),
+            Err(BlockAsyncRuntimeError::AdmissionNotStopped)
+        ));
+        assert!(matches!(
+            runtime.persist_drained_generation(generation),
+            Err(BlockAsyncRuntimeError::AdmissionNotStopped)
+        ));
+
+        runtime
+            .stop_generations(&[generation])
+            .expect("snapshot admission should stop");
+        let mut memory = guest_memory();
+        runtime
+            .drain_stopped_generation(generation, &mut memory)
+            .expect("snapshot drain should complete without an injected flush");
+        assert_eq!(host.flushes.load(Ordering::Acquire), 0);
+        let before_persistence = runtime
+            .capture_quiesced_generation(generation)
+            .expect("drained generation should capture before persistence");
+        runtime
+            .persist_drained_generation(generation)
+            .expect("explicit snapshot barrier should persist");
+        assert_eq!(host.flushes.load(Ordering::Acquire), 1);
+        let after_persistence = runtime
+            .capture_quiesced_generation(generation)
+            .expect("persisted generation should remain capture-ready");
+        assert_eq!(after_persistence, before_persistence);
+        runtime
+            .resume_quiesced_generation(generation)
+            .expect("persisted generation should reopen");
+
+        runtime
+            .stop_generations(&[generation])
+            .expect("reopened generation should stop");
+        runtime
+            .quiesce_generation(generation, &mut memory)
+            .expect("generic quiescence should retain its final Writeback flush");
+        assert_eq!(host.flushes.load(Ordering::Acquire), 2);
+        runtime
+            .unbind_quiesced(generation)
+            .expect("snapshot generation should unbind");
+        assert!(
+            runtime
+                .shutdown_if_idle()
+                .expect("idle snapshot executor should stop")
+        );
+    }
+
+    #[test]
+    fn snapshot_persistence_allows_an_unpublished_guest_flush_completion() {
+        let host = Arc::new(FlushHost {
+            flushes: AtomicUsize::new(0),
+            fail: false,
+        });
+        let runtime = SharedBlockAsyncRuntime::with_config_and_host(
+            test_config(1, 1, 1, 4, 4),
+            Arc::clone(&host) as Arc<dyn BlockAsyncHostIo>,
+        );
+        let (_temporary, backing) = temporary_backing(&[]);
+        let generation = runtime
+            .bind_drive(backing, DriveCacheType::Unsafe)
+            .expect("guest-flush snapshot drive should bind");
+        runtime
+            .admit_preflighted(generation, BlockAsyncOperation::flush(identity(97)))
+            .expect("guest flush should admit before the snapshot stop");
+        runtime
+            .stop_generations(&[generation])
+            .expect("guest-flush snapshot admission should stop");
+        let mut memory = guest_memory();
+        runtime
+            .drain_stopped_generation(generation, &mut memory)
+            .expect("already-admitted guest flush should drain as ordinary work");
+        assert_eq!(host.flushes.load(Ordering::Acquire), 1);
+        assert!(matches!(
+            runtime.capture_quiesced_generation(generation),
+            Err(BlockAsyncRuntimeError::OutstandingCompletions)
+        ));
+
+        runtime
+            .persist_drained_generation(generation)
+            .expect("snapshot barrier should tolerate the unpublished guest completion");
+        assert_eq!(host.flushes.load(Ordering::Acquire), 2);
+        let completion = runtime
+            .pop_completion(generation)
+            .expect("guest flush completion lookup should succeed")
+            .expect("guest flush completion should remain queued through persistence");
+        assert_eq!(completion.kind(), BlockAsyncOperationKind::Flush);
+        assert_eq!(completion.status(), BlockAsyncOperationStatus::Success);
+        runtime
+            .capture_quiesced_generation(generation)
+            .expect("published guest flush should leave a capture-ready generation");
+        runtime
+            .resume_quiesced_generation(generation)
+            .expect("guest-flush snapshot generation should reopen");
+
+        runtime
+            .stop_generations(&[generation])
+            .expect("guest-flush generation should stop for cleanup");
+        runtime
+            .drain_stopped_generation(generation, &mut memory)
+            .expect("guest-flush generation should drain for cleanup");
+        runtime
+            .unbind_quiesced(generation)
+            .expect("guest-flush generation should unbind");
+        assert!(
+            runtime
+                .shutdown_if_idle()
+                .expect("guest-flush executor should stop")
+        );
+    }
+
+    #[test]
+    fn snapshot_persistence_failure_is_typed_and_does_not_prevent_reopen() {
+        let host = Arc::new(FlushHost {
+            flushes: AtomicUsize::new(0),
+            fail: true,
+        });
+        let runtime = SharedBlockAsyncRuntime::with_config_and_host(
+            test_config(1, 1, 1, 4, 4),
+            Arc::clone(&host) as Arc<dyn BlockAsyncHostIo>,
+        );
+        let (_temporary, backing) = temporary_backing(&[]);
+        let generation = runtime
+            .bind_drive(backing, DriveCacheType::Unsafe)
+            .expect("failing snapshot drive should bind");
+        runtime
+            .stop_generations(&[generation])
+            .expect("failing snapshot admission should stop");
+        let mut memory = guest_memory();
+        runtime
+            .drain_stopped_generation(generation, &mut memory)
+            .expect("failing snapshot drive should drain before persistence");
+        assert!(matches!(
+            runtime.persist_drained_generation(generation),
+            Err(BlockAsyncRuntimeError::BackingPersistence {
+                generation: failed
+            }) if failed == generation
+        ));
+        assert_eq!(host.flushes.load(Ordering::Acquire), 1);
+        runtime
+            .resume_quiesced_generation(generation)
+            .expect("failed persistence should leave exact reverse recovery available");
+
+        runtime
+            .stop_generations(&[generation])
+            .expect("recovered generation should stop for cleanup");
+        runtime
+            .drain_stopped_generation(generation, &mut memory)
+            .expect("recovered generation should drain for cleanup");
+        runtime
+            .unbind_quiesced(generation)
+            .expect("recovered generation should unbind");
+        assert!(
+            runtime
+                .shutdown_if_idle()
+                .expect("idle failing executor should stop")
         );
     }
 

--- a/crates/runtime/src/snapshot_device_v2.rs
+++ b/crates/runtime/src/snapshot_device_v2.rs
@@ -2074,7 +2074,7 @@ fn capture_block_state(
     })
 }
 
-fn capture_limiter_state(
+pub(crate) fn capture_limiter_state(
     config: Option<DriveRateLimiterConfig>,
     state: VirtioBlockRateLimiterState,
 ) -> Result<SnapshotV2BlockLimiterState, ()> {
@@ -2112,7 +2112,7 @@ fn capture_bucket_state(
     }
 }
 
-fn capture_mmio_common(
+pub(crate) fn capture_mmio_common(
     state: &VirtioMmioTransportState,
     expected_features: u64,
 ) -> Result<SnapshotV2VirtioState, SnapshotV2DeviceGraphCaptureError> {
@@ -2145,7 +2145,7 @@ fn capture_mmio_common(
     )
 }
 
-fn capture_pci_common(
+pub(crate) fn capture_pci_common(
     state: &VirtioPciTransportState,
     expected_features: u64,
 ) -> Result<SnapshotV2VirtioState, SnapshotV2DeviceGraphCaptureError> {
@@ -2299,7 +2299,7 @@ fn capture_common_state_from_owned_queues(
     Ok(state)
 }
 
-fn capture_mmio_transport(
+pub(crate) fn capture_mmio_transport(
     region: MmioRegion,
     interrupt_line: GuestInterruptLine,
     state: &VirtioMmioTransportState,
@@ -2317,6 +2317,17 @@ fn capture_mmio_transport(
 }
 
 fn capture_pci_transport(
+    origin: StorageDeviceOrigin,
+    sbdf: PciSbdf,
+    bar_range: GuestMemoryRange,
+    state: &VirtioPciTransportState,
+) -> Result<SnapshotV2PciDeviceState, SnapshotV2DeviceGraphCaptureError> {
+    let pci = capture_pci_transport_parts(origin, sbdf, bar_range, state)?;
+    validate_pci_state(&pci).map_err(|_| SnapshotV2DeviceGraphCaptureError::InvalidPciState)?;
+    Ok(pci)
+}
+
+pub(crate) fn capture_pci_transport_parts(
     origin: StorageDeviceOrigin,
     sbdf: PciSbdf,
     bar_range: GuestMemoryRange,
@@ -2355,7 +2366,6 @@ fn capture_pci_transport(
         bar_probes,
         msix,
     };
-    validate_pci_state(&pci).map_err(|_| SnapshotV2DeviceGraphCaptureError::InvalidPciState)?;
     Ok(pci)
 }
 
@@ -2941,7 +2951,7 @@ fn validate_compatibility_version(version: SnapshotFormatVersion) -> Result<(), 
     }
 }
 
-fn expected_block_features(cache_type: DriveCacheType) -> u64 {
+pub(crate) fn expected_block_features(cache_type: DriveCacheType) -> u64 {
     crate::block::VirtioBlockConfigSpace::new(0, true, cache_type).available_features()
 }
 

--- a/crates/runtime/src/snapshot_device_v2_5.rs
+++ b/crates/runtime/src/snapshot_device_v2_5.rs
@@ -35,6 +35,7 @@ use crate::virtio_pci::{
     VIRTIO_PCI_NO_VECTOR, VirtioPciEndpointPhase,
 };
 
+mod capture;
 mod codec;
 
 #[cfg(test)]
@@ -358,6 +359,56 @@ impl fmt::Display for SnapshotV2MultiBlockDeviceGraphBuildError {
 }
 
 impl std::error::Error for SnapshotV2MultiBlockDeviceGraphBuildError {}
+
+/// Failure while converting live capture-ready blocks into profile 2.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2MultiBlockDeviceGraphCaptureError {
+    /// The supplied compatibility context is not exact 2.5.
+    UnsupportedVersion,
+    /// The selected block inventory is empty, too large, or transport-mixed.
+    UnsupportedInventory,
+    /// A drive lies outside the regular-file Sync/Async profile.
+    UnsupportedConfiguration,
+    /// A bounded string is empty, non-UTF-8, or too large.
+    InvalidString,
+    /// Repeated block-local facts disagree.
+    InconsistentBlockState,
+    /// Common virtio continuation is invalid.
+    InvalidVirtioState,
+    /// MMIO placement or selectors are invalid.
+    InvalidMmioState,
+    /// PCI placement, configuration, or MSI-X state is invalid.
+    InvalidPciState,
+    /// The complete config-ordered graph violates profile 2.
+    InvalidGraph,
+    /// A bounded artifact allocation failed.
+    Allocation,
+}
+
+impl fmt::Display for SnapshotV2MultiBlockDeviceGraphCaptureError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::UnsupportedVersion => {
+                "native-v2 multi-block graph compatibility version is unsupported"
+            }
+            Self::UnsupportedInventory => {
+                "live block inventory is outside the native-v2 multi-block profile"
+            }
+            Self::UnsupportedConfiguration => {
+                "live block configuration is outside the native-v2 multi-block profile"
+            }
+            Self::InvalidString => "live block string metadata is invalid",
+            Self::InconsistentBlockState => "live block continuation state is inconsistent",
+            Self::InvalidVirtioState => "live common virtio state is invalid",
+            Self::InvalidMmioState => "live virtio-mmio state is invalid",
+            Self::InvalidPciState => "live virtio-pci state is invalid",
+            Self::InvalidGraph => "captured native-v2 multi-block graph is invalid",
+            Self::Allocation => "failed to allocate a native-v2 multi-block graph",
+        })
+    }
+}
+
+impl std::error::Error for SnapshotV2MultiBlockDeviceGraphCaptureError {}
 
 /// Failure while encoding one validated profile-2 graph.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/runtime/src/snapshot_device_v2_5/capture.rs
+++ b/crates/runtime/src/snapshot_device_v2_5/capture.rs
@@ -1,0 +1,601 @@
+//! Live-state conversion boundary for the pure profile-2 artifact model.
+
+use super::*;
+
+use crate::block::{
+    BlockCaptureIoEngine, VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE, VIRTIO_BLOCK_SECTOR_SHIFT,
+};
+use crate::snapshot_device_v2::{
+    SnapshotV2DeviceGraphCaptureError, capture_limiter_state, capture_mmio_common,
+    capture_mmio_transport, capture_pci_common, capture_pci_transport_parts,
+};
+use crate::storage_capture::{CaptureReadyBlockDeviceState, StorageTransportState};
+
+impl SnapshotV2MultiBlockDeviceGraph {
+    /// Validates profile-2 public configuration before live source mutation.
+    pub fn preflight_capture_configs(
+        compatibility_version: SnapshotFormatVersion,
+        configs: &[crate::block::DriveConfig],
+    ) -> Result<(), SnapshotV2MultiBlockDeviceGraphCaptureError> {
+        preflight_capture_configs(compatibility_version, configs)
+    }
+
+    /// Converts one config-ordered live block vector into detached profile 2.
+    ///
+    /// Backing generation, host executor counters, and host file identity are
+    /// deliberately discarded. The resulting graph retains only the stable
+    /// semantic engine choice and exact guest-visible continuation.
+    pub fn from_capture_ready_blocks(
+        compatibility_version: SnapshotFormatVersion,
+        states: &[CaptureReadyBlockDeviceState],
+    ) -> Result<Self, SnapshotV2MultiBlockDeviceGraphCaptureError> {
+        capture_multi_block_graph(compatibility_version, states)
+    }
+}
+
+fn capture_multi_block_graph(
+    compatibility_version: SnapshotFormatVersion,
+    states: &[CaptureReadyBlockDeviceState],
+) -> Result<SnapshotV2MultiBlockDeviceGraph, SnapshotV2MultiBlockDeviceGraphCaptureError> {
+    let mut configs = Vec::new();
+    configs
+        .try_reserve_exact(states.len())
+        .map_err(|_| SnapshotV2MultiBlockDeviceGraphCaptureError::Allocation)?;
+    configs.extend(states.iter().map(CaptureReadyBlockDeviceState::config));
+    preflight_capture_config_refs(compatibility_version, &configs)?;
+
+    let mut records = Vec::new();
+    records
+        .try_reserve_exact(states.len())
+        .map_err(|_| SnapshotV2MultiBlockDeviceGraphCaptureError::Allocation)?;
+    let mut transport_kind = None;
+    for (index, state) in states.iter().enumerate() {
+        let config = capture_multi_block_config(state)?;
+        let block = capture_multi_block_state(state, &config)?;
+        let expected_features = VirtioBlockConfigSpace::new(
+            block.backing_bytes,
+            config.is_read_only,
+            config.cache_type,
+        )
+        .available_features();
+        let (record_transport_kind, virtio, transport) = match state.transport() {
+            StorageTransportState::Mmio(mmio) => (
+                SnapshotV2DeviceTransportKind::Mmio,
+                capture_mmio_common(mmio.transport(), expected_features)
+                    .map_err(map_capture_error)?,
+                SnapshotV2DeviceTransport::Mmio(
+                    capture_mmio_transport(mmio.region(), mmio.interrupt_line(), mmio.transport())
+                        .map_err(map_capture_error)?,
+                ),
+            ),
+            StorageTransportState::Pci(pci) => (
+                SnapshotV2DeviceTransportKind::Pci,
+                capture_pci_common(pci.transport(), expected_features)
+                    .map_err(map_capture_error)?,
+                SnapshotV2DeviceTransport::Pci(
+                    capture_pci_transport_parts(
+                        pci.origin(),
+                        pci.sbdf(),
+                        pci.bar_range(),
+                        pci.transport(),
+                    )
+                    .map_err(map_capture_error)?,
+                ),
+            ),
+        };
+        match transport_kind {
+            None => transport_kind = Some(record_transport_kind),
+            Some(expected) if expected == record_transport_kind => {}
+            Some(_) => {
+                return Err(SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedInventory);
+            }
+        }
+        let instance = u32::try_from(index)
+            .map_err(|_| SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedInventory)?;
+        records.push(SnapshotV2MultiBlockDeviceRecord {
+            key: SnapshotV2DeviceKey::block(instance),
+            config,
+            block,
+            virtio,
+            transport,
+        });
+    }
+
+    let root_key = records
+        .first()
+        .filter(|record| record.config.is_root)
+        .map(|record| record.key);
+    SnapshotV2MultiBlockDeviceGraph::try_from_parts(
+        root_key,
+        transport_kind.ok_or(SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedInventory)?,
+        records,
+    )
+    .map_err(|_| SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidGraph)
+}
+
+fn preflight_capture_configs(
+    compatibility_version: SnapshotFormatVersion,
+    configs: &[crate::block::DriveConfig],
+) -> Result<(), SnapshotV2MultiBlockDeviceGraphCaptureError> {
+    let mut refs = Vec::new();
+    refs.try_reserve_exact(configs.len())
+        .map_err(|_| SnapshotV2MultiBlockDeviceGraphCaptureError::Allocation)?;
+    refs.extend(configs.iter());
+    preflight_capture_config_refs(compatibility_version, &refs)
+}
+
+fn preflight_capture_config_refs(
+    compatibility_version: SnapshotFormatVersion,
+    configs: &[&crate::block::DriveConfig],
+) -> Result<(), SnapshotV2MultiBlockDeviceGraphCaptureError> {
+    if compatibility_version != NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION {
+        return Err(SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedVersion);
+    }
+    if configs.is_empty()
+        || configs.len() > usize::from(NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_MAX_RECORDS)
+    {
+        return Err(SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedInventory);
+    }
+    for (index, config) in configs.iter().copied().enumerate() {
+        if config.is_vhost_user()
+            || config.is_read_only().is_none()
+            || config.io_engine().is_none()
+            || (config.is_root_device() && index != 0)
+            || configs
+                .iter()
+                .copied()
+                .take(index)
+                .any(|candidate| candidate.drive_id() == config.drive_id())
+        {
+            return Err(SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidGraph);
+        }
+        validate_capture_string(
+            config.drive_id(),
+            NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_MAX_DRIVE_ID_BYTES,
+        )?;
+        if !config
+            .drive_id()
+            .chars()
+            .all(|character| character == '_' || character.is_alphanumeric())
+        {
+            return Err(SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidString);
+        }
+        if let Some(partuuid) = config.partuuid() {
+            validate_capture_string(
+                partuuid,
+                NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_MAX_PARTUUID_BYTES,
+            )?;
+        }
+        let selector = config
+            .path_on_host()
+            .and_then(|path| path.to_str())
+            .ok_or(SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidString)?;
+        validate_capture_string(
+            selector,
+            NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_MAX_SELECTOR_BYTES,
+        )?;
+        super::validate_limiter_config(config.rate_limiter())
+            .map_err(|_| SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedConfiguration)?;
+    }
+    Ok(())
+}
+
+fn capture_multi_block_config(
+    state: &CaptureReadyBlockDeviceState,
+) -> Result<SnapshotV2MultiBlockConfig, SnapshotV2MultiBlockDeviceGraphCaptureError> {
+    let config = state.config();
+    let (Some(is_read_only), Some(io_engine)) = (config.is_read_only(), config.io_engine()) else {
+        return Err(SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedConfiguration);
+    };
+    if config.is_vhost_user() {
+        return Err(SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedConfiguration);
+    }
+    let drive_id = clone_capture_string(
+        config.drive_id(),
+        NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_MAX_DRIVE_ID_BYTES,
+    )?;
+    if !drive_id
+        .chars()
+        .all(|character| character == '_' || character.is_alphanumeric())
+    {
+        return Err(SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidString);
+    }
+    let partuuid = config
+        .partuuid()
+        .map(|value| {
+            clone_capture_string(value, NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_MAX_PARTUUID_BYTES)
+        })
+        .transpose()?;
+    let selector = config
+        .path_on_host()
+        .and_then(|path| path.to_str())
+        .ok_or(SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidString)
+        .and_then(|value| {
+            clone_capture_string(value, NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_MAX_SELECTOR_BYTES)
+        })?;
+    super::validate_limiter_config(config.rate_limiter())
+        .map_err(|_| SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedConfiguration)?;
+
+    Ok(SnapshotV2MultiBlockConfig {
+        drive_id,
+        partuuid,
+        is_root: config.is_root_device(),
+        is_read_only,
+        cache_type: config.cache_type(),
+        io_engine,
+        rate_limiter: config.rate_limiter(),
+        selector,
+    })
+}
+
+fn capture_multi_block_state(
+    state: &CaptureReadyBlockDeviceState,
+    config: &SnapshotV2MultiBlockConfig,
+) -> Result<SnapshotV2MultiBlockState, SnapshotV2MultiBlockDeviceGraphCaptureError> {
+    let device = *state.device();
+    let backing = device.backing();
+    let expected_config_space =
+        VirtioBlockConfigSpace::new(backing.len(), config.is_read_only, config.cache_type);
+    if !backing.kind().is_regular_file()
+        || device.config_space() != expected_config_space
+        || device.config_space().config_len() != VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE
+        || device.config_space().capacity_sectors() != backing.len() >> VIRTIO_BLOCK_SECTOR_SHIFT
+    {
+        return Err(SnapshotV2MultiBlockDeviceGraphCaptureError::InconsistentBlockState);
+    }
+    match (config.io_engine, device.io_engine()) {
+        (DriveIoEngine::Sync, BlockCaptureIoEngine::Sync) => {}
+        (DriveIoEngine::Async, BlockCaptureIoEngine::Async(async_state))
+            if async_state.cache_type() == config.cache_type
+                && async_state.admission_stopped()
+                && async_state.owned_operations() == 0
+                && async_state.parked_host_completions() == 0
+                && async_state.final_completions() == 0 => {}
+        (DriveIoEngine::Sync | DriveIoEngine::Async, _) => {
+            return Err(SnapshotV2MultiBlockDeviceGraphCaptureError::InconsistentBlockState);
+        }
+    }
+
+    let limiter = capture_limiter_state(config.rate_limiter, device.rate_limiter())
+        .map_err(|_| SnapshotV2MultiBlockDeviceGraphCaptureError::InconsistentBlockState)?;
+    let active_queue = device.active_queue();
+    let retry = state.retry();
+    if (retry != StorageRetryState::None && (active_queue.is_none() || limiter.is_empty()))
+        || matches!(retry, StorageRetryState::After { remaining_nanos: 0 })
+        || (retry != StorageRetryState::None
+            && active_queue.is_some_and(|queue| queue.next_available() == queue.next_used()))
+    {
+        return Err(SnapshotV2MultiBlockDeviceGraphCaptureError::InconsistentBlockState);
+    }
+    Ok(SnapshotV2MultiBlockState {
+        backing_bytes: backing.len(),
+        continuation: SnapshotV2BlockState::from_parts(
+            expected_config_space.capacity_sectors(),
+            device.device_id(),
+            active_queue,
+            limiter,
+            retry,
+        ),
+    })
+}
+
+fn clone_capture_string(
+    value: &str,
+    maximum: usize,
+) -> Result<String, SnapshotV2MultiBlockDeviceGraphCaptureError> {
+    validate_capture_string(value, maximum)?;
+    let mut owned = String::new();
+    owned
+        .try_reserve_exact(value.len())
+        .map_err(|_| SnapshotV2MultiBlockDeviceGraphCaptureError::Allocation)?;
+    owned.push_str(value);
+    Ok(owned)
+}
+
+fn validate_capture_string(
+    value: &str,
+    maximum: usize,
+) -> Result<(), SnapshotV2MultiBlockDeviceGraphCaptureError> {
+    if value.is_empty() || value.len() > maximum {
+        Err(SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidString)
+    } else {
+        Ok(())
+    }
+}
+
+const fn map_capture_error(
+    error: SnapshotV2DeviceGraphCaptureError,
+) -> SnapshotV2MultiBlockDeviceGraphCaptureError {
+    match error {
+        SnapshotV2DeviceGraphCaptureError::UnsupportedVersion => {
+            SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedVersion
+        }
+        SnapshotV2DeviceGraphCaptureError::UnsupportedConfiguration => {
+            SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedConfiguration
+        }
+        SnapshotV2DeviceGraphCaptureError::InvalidString => {
+            SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidString
+        }
+        SnapshotV2DeviceGraphCaptureError::InconsistentBlockState => {
+            SnapshotV2MultiBlockDeviceGraphCaptureError::InconsistentBlockState
+        }
+        SnapshotV2DeviceGraphCaptureError::InvalidVirtioState => {
+            SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidVirtioState
+        }
+        SnapshotV2DeviceGraphCaptureError::InvalidMmioState => {
+            SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidMmioState
+        }
+        SnapshotV2DeviceGraphCaptureError::InvalidPciState => {
+            SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidPciState
+        }
+        SnapshotV2DeviceGraphCaptureError::Allocation => {
+            SnapshotV2MultiBlockDeviceGraphCaptureError::Allocation
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs::{self, OpenOptions};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Instant;
+
+    use crate::block::async_executor::{BlockAsyncDriveGeneration, SharedBlockAsyncRuntime};
+    use crate::block::{
+        DriveConfig, DriveConfigInput, PreparedBlockDevice, VIRTIO_BLOCK_DEVICE_ID,
+        VIRTIO_BLOCK_QUEUE_SIZES,
+    };
+    use crate::interrupt::GuestInterruptLine;
+    use crate::memory::{GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange};
+    use crate::mmio::{MmioRegion, MmioRegionId};
+    use crate::storage_capture::{StorageMmioTransportState, StorageRetryState};
+    use crate::virtio_mmio::{VIRTIO_MMIO_DEVICE_WINDOW_SIZE, VirtioMmioRegisterHandler};
+
+    static NEXT_TEMP_FILE: AtomicU64 = AtomicU64::new(0);
+
+    struct TempFile {
+        path: PathBuf,
+    }
+
+    impl TempFile {
+        fn new(name: &str, len: u64) -> Self {
+            let sequence = NEXT_TEMP_FILE.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "bangbang-snapshot-v2-5-capture-{name}-{}-{sequence}",
+                std::process::id(),
+            ));
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create_new(true)
+                .open(&path)
+                .expect("capture backing should create");
+            file.set_len(len).expect("capture backing should resize");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempFile {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+
+    fn config(
+        drive_id: &str,
+        path: &Path,
+        is_root: bool,
+        is_read_only: bool,
+        cache_type: DriveCacheType,
+        io_engine: DriveIoEngine,
+    ) -> DriveConfig {
+        DriveConfigInput::new(drive_id, drive_id, path, is_root)
+            .with_is_read_only(is_read_only)
+            .with_cache_type(cache_type)
+            .with_io_engine(io_engine)
+            .validate()
+            .expect("profile-2 capture config should validate")
+    }
+
+    fn guest_memory() -> GuestMemory {
+        let range = GuestMemoryRange::new(GuestAddress::new(0), 0x1_0000)
+            .expect("capture memory range should validate");
+        GuestMemory::allocate(
+            &GuestMemoryLayout::new(vec![range]).expect("capture memory layout should validate"),
+        )
+        .expect("capture guest memory should allocate")
+    }
+
+    fn capture_mmio(
+        config: &DriveConfig,
+        index: u32,
+        runtime: &SharedBlockAsyncRuntime,
+    ) -> (
+        CaptureReadyBlockDeviceState,
+        Option<BlockAsyncDriveGeneration>,
+    ) {
+        let mut prepared = PreparedBlockDevice::from_config_with_backing(config, None)
+            .expect("profile-2 block should prepare");
+        let generation = prepared
+            .bind_async_runtime(runtime.clone())
+            .expect("profile-2 Async binding should succeed");
+        let (_, _, config_space, device) = prepared.into_parts();
+        let handler = VirtioMmioRegisterHandler::with_device_config_and_activation(
+            VIRTIO_BLOCK_DEVICE_ID,
+            config_space.available_features(),
+            &VIRTIO_BLOCK_QUEUE_SIZES,
+            config_space,
+            device,
+        )
+        .expect("profile-2 MMIO handler should build");
+        if let Some(generation) = generation {
+            runtime
+                .stop_generations(&[generation])
+                .expect("profile-2 Async admission should stop");
+            runtime
+                .drain_stopped_generation(generation, &mut guest_memory())
+                .expect("profile-2 Async generation should drain");
+        }
+        let captured = handler
+            .capture_block_device_state_at(config, Instant::now())
+            .expect("profile-2 block state should capture");
+        let region = MmioRegion::new(
+            MmioRegionId::new(u64::from(index) + 1),
+            GuestAddress::new(0xd000_0000 + u64::from(index) * VIRTIO_MMIO_DEVICE_WINDOW_SIZE),
+            VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+        )
+        .expect("profile-2 MMIO region should validate");
+        (
+            CaptureReadyBlockDeviceState::new(
+                config.clone(),
+                StorageTransportState::Mmio(StorageMmioTransportState::new(
+                    region,
+                    GuestInterruptLine::new(index + 32)
+                        .expect("profile-2 interrupt should validate"),
+                    handler.transport_state(),
+                )),
+                StorageRetryState::None,
+                captured,
+            ),
+            generation,
+        )
+    }
+
+    #[test]
+    fn live_mmio_sync_and_async_vector_converts_to_semantic_profile() {
+        let root_file = TempFile::new("root.img", 4096);
+        let data_file = TempFile::new("data.img", 8193);
+        let root = config(
+            "rootfs",
+            root_file.path(),
+            true,
+            false,
+            DriveCacheType::Unsafe,
+            DriveIoEngine::Sync,
+        );
+        let data = config(
+            "data_1",
+            data_file.path(),
+            false,
+            false,
+            DriveCacheType::Writeback,
+            DriveIoEngine::Async,
+        );
+        let runtime = SharedBlockAsyncRuntime::new();
+        let (root_state, root_generation) = capture_mmio(&root, 0, &runtime);
+        assert_eq!(root_generation, None);
+        let (data_state, data_generation) = capture_mmio(&data, 1, &runtime);
+        let data_generation = data_generation.expect("Async drive should own a generation");
+
+        let graph = SnapshotV2MultiBlockDeviceGraph::from_capture_ready_blocks(
+            NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            &[root_state, data_state],
+        )
+        .expect("live config-ordered block vector should convert");
+        assert_eq!(graph.root_key(), Some(SnapshotV2DeviceKey::block(0)));
+        assert_eq!(graph.transport_kind(), SnapshotV2DeviceTransportKind::Mmio);
+        assert_eq!(graph.records().len(), 2);
+        assert_eq!(graph.records()[0].config().drive_id(), "rootfs");
+        assert!(!graph.records()[0].config().is_read_only());
+        assert_eq!(graph.records()[0].config().io_engine(), DriveIoEngine::Sync);
+        assert_eq!(graph.records()[0].block().backing_bytes(), 4096);
+        assert_eq!(graph.records()[1].config().drive_id(), "data_1");
+        assert_eq!(
+            graph.records()[1].config().io_engine(),
+            DriveIoEngine::Async
+        );
+        assert_eq!(graph.records()[1].block().backing_bytes(), 8193);
+        assert_eq!(
+            SnapshotV2MultiBlockDeviceGraph::decode(
+                NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                &graph
+                    .encode(NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION)
+                    .expect("converted graph should encode"),
+            )
+            .expect("converted graph should decode"),
+            graph
+        );
+
+        runtime
+            .unbind_quiesced(data_generation)
+            .expect("captured Async generation should unbind");
+        assert!(
+            runtime
+                .shutdown_if_idle()
+                .expect("capture runtime should stop")
+        );
+    }
+
+    #[test]
+    fn conversion_rejects_wrong_version_and_empty_inventory() {
+        assert_eq!(
+            SnapshotV2MultiBlockDeviceGraph::from_capture_ready_blocks(
+                SnapshotFormatVersion::new(2, 4, 0),
+                &[],
+            ),
+            Err(SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedVersion)
+        );
+        assert_eq!(
+            SnapshotV2MultiBlockDeviceGraph::from_capture_ready_blocks(
+                NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                &[],
+            ),
+            Err(SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedInventory)
+        );
+
+        let file = TempFile::new("preflight.img", 4096);
+        let rootless = config(
+            "data_0",
+            file.path(),
+            false,
+            true,
+            DriveCacheType::Unsafe,
+            DriveIoEngine::Sync,
+        );
+        assert_eq!(
+            SnapshotV2MultiBlockDeviceGraph::preflight_capture_configs(
+                NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                std::slice::from_ref(&rootless),
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            SnapshotV2MultiBlockDeviceGraph::preflight_capture_configs(
+                NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                &[rootless.clone(), rootless],
+            ),
+            Err(SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidGraph)
+        );
+
+        let late_root = config(
+            "rootfs",
+            file.path(),
+            true,
+            true,
+            DriveCacheType::Unsafe,
+            DriveIoEngine::Sync,
+        );
+        let first_data = config(
+            "data_1",
+            file.path(),
+            false,
+            true,
+            DriveCacheType::Unsafe,
+            DriveIoEngine::Sync,
+        );
+        assert_eq!(
+            SnapshotV2MultiBlockDeviceGraph::preflight_capture_configs(
+                NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                &[first_data, late_root],
+            ),
+            Err(SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidGraph)
+        );
+    }
+}

--- a/crates/runtime/src/snapshot_device_v2_5/tests.rs
+++ b/crates/runtime/src/snapshot_device_v2_5/tests.rs
@@ -1400,6 +1400,10 @@ fn diagnostics_and_source_ownership_are_value_redacted() {
     assert!(rendered.contains("<redacted>"));
 
     let model_source = include_str!("../snapshot_device_v2_5.rs");
+    let capture_source = include_str!("capture.rs")
+        .split("#[cfg(test)]")
+        .next()
+        .expect("capture source should have a production prefix");
     let codec_source = include_str!("codec.rs");
     for forbidden in [
         "CaptureReadyBlockDeviceState",
@@ -1411,5 +1415,20 @@ fn diagnostics_and_source_ownership_are_value_redacted() {
     ] {
         assert!(!model_source.contains(forbidden));
         assert!(!codec_source.contains(forbidden));
+    }
+    for forbidden in [
+        "async_state.generation()",
+        "next_operation_id()",
+        "next_sequence()",
+        "pressure_pending()",
+        "BlockFileBackingIdentity",
+        "SharedBlockAsyncRuntime",
+        "OwnedFd",
+        "RawFd",
+    ] {
+        assert!(
+            !capture_source.contains(forbidden),
+            "live conversion retained forbidden authority field {forbidden}",
+        );
     }
 }

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -27,6 +27,7 @@ use crate::block::{
     VirtioBlockConfigSpace, VirtioBlockDeviceNotificationDispatch,
     VirtioBlockDeviceNotificationError, VirtioBlockLiveUpdateError, VirtioBlockMmioHandler,
     VirtioBlockQueueDispatch, VirtioBlockQueueDispatchError, VirtioBlockRuntimeRestoreInput,
+    VirtioBlockSnapshotPersistenceBinding,
 };
 use crate::boot::{
     BootCommandLineError, BootSource, BootSourceConfig, BootSourceFiles, BootSourceLoadError,
@@ -3121,6 +3122,8 @@ pub enum Arm64BootStorageCaptureError {
     BlockInventory,
     BlockMetadata,
     BlockHandler,
+    BlockPersistencePreflight,
+    BlockPersistence,
     BlockCapture,
     BlockCompletion(VirtioBlockQueueDispatchError),
     PmemInventory,
@@ -3136,6 +3139,8 @@ impl fmt::Debug for Arm64BootStorageCaptureError {
             Self::BlockInventory => "BlockInventory",
             Self::BlockMetadata => "BlockMetadata",
             Self::BlockHandler => "BlockHandler",
+            Self::BlockPersistencePreflight => "BlockPersistencePreflight",
+            Self::BlockPersistence => "BlockPersistence",
             Self::BlockCapture => "BlockCapture",
             Self::BlockCompletion(_) => "BlockCompletion",
             Self::PmemInventory => "PmemInventory",
@@ -3159,6 +3164,8 @@ impl Arm64BootStorageCaptureError {
             Self::BlockInventory
             | Self::BlockMetadata
             | Self::BlockHandler
+            | Self::BlockPersistencePreflight
+            | Self::BlockPersistence
             | Self::BlockCapture
             | Self::PmemInventory
             | Self::PmemMetadata
@@ -3177,6 +3184,12 @@ impl fmt::Display for Arm64BootStorageCaptureError {
             }
             Self::BlockMetadata => formatter.write_str("live MMIO block metadata is inconsistent"),
             Self::BlockHandler => formatter.write_str("live MMIO block handler is unavailable"),
+            Self::BlockPersistencePreflight => {
+                formatter.write_str("live MMIO block persistence preflight failed")
+            }
+            Self::BlockPersistence => {
+                formatter.write_str("live MMIO block backing persistence failed")
+            }
             Self::BlockCapture => formatter.write_str("live MMIO block capture failed"),
             Self::BlockCompletion(_) => {
                 formatter.write_str("live MMIO block completion publication failed")
@@ -3298,6 +3311,37 @@ impl Arm64BootRuntimeResources {
             .handler_mut::<VirtioBlockMmioHandler>(device.registration.region_id())
             .map_err(|_| Arm64BootStorageCaptureError::BlockHandler)
             .map(|handler| handler.block_async_binding())
+    }
+
+    pub fn capture_ready_mmio_block_snapshot_persistence_binding(
+        &self,
+        mmio_dispatcher: &mut MmioDispatcher,
+        config: &DriveConfig,
+    ) -> Result<VirtioBlockSnapshotPersistenceBinding, Arm64BootStorageCaptureError> {
+        let device = unique_mmio_block_device(&self.block_devices, config.drive_id())?;
+        validate_mmio_storage_metadata(
+            device.registration.region(),
+            device.fdt_device,
+            Arm64BootStorageCaptureError::BlockMetadata,
+        )?;
+        mmio_dispatcher
+            .handler_mut::<VirtioBlockMmioHandler>(device.registration.region_id())
+            .map_err(|_| Arm64BootStorageCaptureError::BlockHandler)?
+            .block_snapshot_persistence_binding(config)
+            .map_err(|_| Arm64BootStorageCaptureError::BlockPersistencePreflight)
+    }
+
+    pub fn persist_capture_ready_mmio_block_snapshot_backing(
+        &self,
+        mmio_dispatcher: &mut MmioDispatcher,
+        config: &DriveConfig,
+    ) -> Result<(), Arm64BootStorageCaptureError> {
+        let device = unique_mmio_block_device(&self.block_devices, config.drive_id())?;
+        mmio_dispatcher
+            .handler_mut::<VirtioBlockMmioHandler>(device.registration.region_id())
+            .map_err(|_| Arm64BootStorageCaptureError::BlockHandler)?
+            .persist_block_snapshot_backing(config)
+            .map_err(|_| Arm64BootStorageCaptureError::BlockPersistence)
     }
 
     pub fn publish_capture_ready_mmio_block_completions(


### PR DESCRIPTION
## Summary

- add stopped-generation drain-only and exact writable Sync/Async backing persistence primitives so every selected generation drains before the configuration-order durability barrier
- compose live capture-ready regular-file blocks into the detached native-v2 2.5 profile-2 graph while dropping generations, counters, backing identity, and cleanup authority
- extend the HVF storage transaction with regular-file/no-pmem/uniform-transport preflight, persistence and graph-composition stages, complete completion publication, reverse recovery, and signed MMIO/PCI coverage
- preserve generic block-special/pmem diagnostics and every public exact-2.4 snapshot path

## Verification

- cargo fmt --all -- --check
- cargo run -p bangbang-firecracker-capability-audit --locked -- validate
- cargo check --workspace --all-targets --all-features --locked
- cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- all five documented aarch64-apple-darwin integration-target Clippy commands
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps --locked
- scripts/run-integration-tests.sh

Closes #1610