### PR TITLE
feat: prepare keyed multi-block restore resources

### DIFF
--- a/crates/bangbang/src/contained_session.rs
+++ b/crates/bangbang/src/contained_session.rs
@@ -326,7 +326,8 @@ mod platform {
     use bangbang_session::macos::grant_registry::GrantedUnixStream;
     use bangbang_session::macos::grant_registry::{
         CommittedGrantBatch, ConnectedStreamGrantRegistry, DirectoryGrantRegistry,
-        FileGrantRegistry, GrantRegistry, GrantedDirectory, GrantedFile, StagedGrantBatch,
+        ExactRegularFileGrantObservation, FileGrantRegistry, GrantRegistry, GrantedDirectory,
+        GrantedFile, StagedGrantBatch,
     };
     use bangbang_session::macos::grant_transport::receive_grant;
     use bangbang_session::macos::runtime::{
@@ -430,6 +431,49 @@ mod platform {
     pub(crate) struct ContainedSnapshotRestoreError {
         kind: ContainedSnapshotRestoreErrorKind,
         cleanup_failed: bool,
+    }
+
+    /// One exact graph-ordered contained drive-backing request.
+    #[derive(Clone, Copy)]
+    pub(crate) struct ContainedSnapshotRestoreDriveRequest<'a> {
+        reference: &'a Path,
+        access: GrantAccess,
+        expected_len: Option<u64>,
+    }
+
+    impl<'a> ContainedSnapshotRestoreDriveRequest<'a> {
+        pub(crate) const fn new(
+            reference: &'a Path,
+            access: GrantAccess,
+            expected_len: Option<u64>,
+        ) -> Self {
+            Self {
+                reference,
+                access,
+                expected_len,
+            }
+        }
+
+        const fn reference(self) -> &'a Path {
+            self.reference
+        }
+
+        const fn access(self) -> GrantAccess {
+            self.access
+        }
+
+        const fn expected_len(self) -> Option<u64> {
+            self.expected_len
+        }
+    }
+
+    impl fmt::Debug for ContainedSnapshotRestoreDriveRequest<'_> {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter
+                .debug_struct("ContainedSnapshotRestoreDriveRequest")
+                .field("state", &"<redacted>")
+                .finish()
+        }
     }
 
     impl ContainedSnapshotRestoreError {
@@ -750,6 +794,7 @@ mod platform {
         id: GrantId,
         original: Option<GrantedFile>,
         duplicate: Option<GrantedFile>,
+        snapshot_observation: Option<ExactRegularFileGrantObservation>,
     }
 
     impl std::fmt::Debug for PreparedFileGrantClaim {
@@ -800,6 +845,10 @@ mod platform {
                 )
                 .field("original", &self.original.as_ref().map(|_| "<reserved>"))
                 .field("duplicate", &self.duplicate.as_ref().map(|_| "<owned>"))
+                .field(
+                    "snapshot_observation",
+                    &self.snapshot_observation.as_ref().map(|_| "<redacted>"),
+                )
                 .finish()
         }
     }
@@ -818,14 +867,46 @@ mod platform {
         }
 
         pub(crate) fn take_snapshot_read_only_file(&mut self) -> Result<File, GrantClaimError> {
+            self.take_snapshot_file(true).map(|(file, _)| file)
+        }
+
+        pub(crate) fn take_snapshot_file(
+            &mut self,
+            is_read_only: bool,
+        ) -> Result<(File, Option<ExactRegularFileGrantObservation>), GrantClaimError> {
             let duplicate = self.duplicate.take().ok_or(GrantClaimError)?;
-            if duplicate.access() != GrantAccess::ReadOnly
+            let expected_access = if is_read_only {
+                GrantAccess::ReadOnly
+            } else {
+                GrantAccess::ReadWrite
+            };
+            if duplicate.access() != expected_access
                 || duplicate.kind() != GrantObjectKind::RegularFile
                 || duplicate.block_device().is_some()
             {
                 return Err(GrantClaimError);
             }
-            Ok(File::from(duplicate.into_owned_fd()))
+            if self
+                .snapshot_observation
+                .is_some_and(|observation| observation.identity() != duplicate.identity())
+            {
+                return Err(GrantClaimError);
+            }
+            Ok((
+                File::from(duplicate.into_owned_fd()),
+                self.snapshot_observation.take(),
+            ))
+        }
+
+        pub(crate) fn take_snapshot_file_for(
+            &mut self,
+            reference: &Path,
+            is_read_only: bool,
+        ) -> Result<(File, Option<ExactRegularFileGrantObservation>), GrantClaimError> {
+            if grant_reference_id(reference)?.as_ref() != Some(&self.id) {
+                return Err(GrantClaimError);
+            }
+            self.take_snapshot_file(is_read_only)
         }
 
         pub(crate) fn take_backing(
@@ -893,7 +974,7 @@ mod platform {
     }
 
     struct SnapshotRestoreDriveClaimBuffers {
-        identities: Vec<ObjectIdentity>,
+        observations: Vec<ExactRegularFileGrantObservation>,
         duplicates: Vec<GrantedFile>,
         originals: Vec<GrantedFile>,
         claims: Vec<PreparedDriveBackingClaim>,
@@ -901,11 +982,11 @@ mod platform {
 
     impl SnapshotRestoreDriveClaimBuffers {
         fn try_new(count: usize) -> Result<Self, ContainedSnapshotRestoreError> {
-            let mut identities = Vec::new();
+            let mut observations = Vec::new();
             let mut duplicates = Vec::new();
             let mut originals = Vec::new();
             let mut claims = Vec::new();
-            identities.try_reserve_exact(count).map_err(|_| {
+            observations.try_reserve_exact(count).map_err(|_| {
                 ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Authority)
             })?;
             duplicates.try_reserve_exact(count).map_err(|_| {
@@ -918,7 +999,7 @@ mod platform {
                 ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Authority)
             })?;
             Ok(Self {
-                identities,
+                observations,
                 duplicates,
                 originals,
                 claims,
@@ -1039,6 +1120,7 @@ mod platform {
                 id,
                 original: Some(original),
                 duplicate: Some(duplicate),
+                snapshot_observation: None,
             }))
         }
 
@@ -1107,7 +1189,7 @@ mod platform {
         fn inspect_snapshot_restore_files(
             &self,
             requests: &[(GrantId, ResourceRole, GrantAccess, GrantObjectKind)],
-            identities: &mut Vec<ObjectIdentity>,
+            observations: &mut Vec<ExactRegularFileGrantObservation>,
         ) -> Result<(), ContainedSnapshotRestoreError> {
             let registry = self.registry.lock().map_err(|_| {
                 ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Inactive)
@@ -1117,7 +1199,7 @@ mod platform {
                 .ok_or_else(|| {
                     ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Inactive)
                 })?
-                .inspect_exact_files_into(requests, identities)
+                .inspect_exact_regular_files_into(requests, observations)
                 .map_err(|_| {
                     ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Authority)
                 })
@@ -1131,6 +1213,7 @@ mod platform {
             if requests
                 .iter()
                 .any(|(_, role, _, _)| *role != ResourceRole::DriveBacking)
+                || buffers.observations.len() != requests.len()
             {
                 return Err(ContainedSnapshotRestoreError::new(
                     ContainedSnapshotRestoreErrorKind::InvalidRequest,
@@ -1158,10 +1241,39 @@ mod platform {
                         )
                     })?;
             }
-            for (((id, _, _, _), original), duplicate) in requests
+            if buffers.duplicates.len() != requests.len()
+                || buffers.originals.len() != requests.len()
+            {
+                let mut failed = buffers.originals.len() != requests.len();
+                let mut locked = match self.registry.lock() {
+                    Ok(registry) => registry,
+                    Err(poisoned) => poisoned.into_inner(),
+                };
+                if let Some(registry) = locked.as_mut() {
+                    for ((id, _, _, _), original) in
+                        requests.iter().zip(buffers.originals.drain(..))
+                    {
+                        failed |= registry
+                            .restore_drive_backing(id.clone(), original)
+                            .is_err();
+                    }
+                } else {
+                    failed = true;
+                }
+                let source = ContainedSnapshotRestoreError::new(
+                    ContainedSnapshotRestoreErrorKind::Authority,
+                );
+                return Err(if failed {
+                    source.with_cleanup_failure()
+                } else {
+                    source
+                });
+            }
+            for ((((id, _, _, _), original), duplicate), observation) in requests
                 .into_iter()
                 .zip(buffers.originals)
                 .zip(buffers.duplicates)
+                .zip(buffers.observations)
             {
                 buffers.claims.push(PreparedDriveBackingClaim {
                     registry: Arc::clone(&self.registry),
@@ -1169,6 +1281,7 @@ mod platform {
                     id,
                     original: Some(original),
                     duplicate: Some(duplicate),
+                    snapshot_observation: Some(observation),
                 });
             }
             Ok(buffers.claims)
@@ -2111,27 +2224,57 @@ mod platform {
             cancelled: &impl Fn() -> bool,
         ) -> Result<ReservedContainedSnapshotRestoreResources, ContainedSnapshotRestoreError>
         {
-            let root_id = grant_reference_id(root_reference)
-                .map_err(|_| {
-                    ContainedSnapshotRestoreError::new(
-                        ContainedSnapshotRestoreErrorKind::InvalidRequest,
-                    )
-                })?
-                .ok_or_else(|| {
-                    ContainedSnapshotRestoreError::new(
-                        ContainedSnapshotRestoreErrorKind::InvalidRequest,
-                    )
-                })?;
+            let drives = [ContainedSnapshotRestoreDriveRequest::new(
+                root_reference,
+                GrantAccess::ReadOnly,
+                None,
+            )];
+            self.prepare_drives(&drives, vsock_reference, cancelled)
+        }
+
+        pub(crate) fn prepare_drives(
+            &self,
+            drives: &[ContainedSnapshotRestoreDriveRequest<'_>],
+            vsock_reference: Option<&Path>,
+            cancelled: &impl Fn() -> bool,
+        ) -> Result<ReservedContainedSnapshotRestoreResources, ContainedSnapshotRestoreError>
+        {
             let mut file_requests = Vec::new();
-            file_requests.try_reserve_exact(1).map_err(|_| {
+            file_requests.try_reserve_exact(drives.len()).map_err(|_| {
                 ContainedSnapshotRestoreError::new(ContainedSnapshotRestoreErrorKind::Authority)
             })?;
-            file_requests.push((
-                root_id,
-                ResourceRole::DriveBacking,
-                GrantAccess::ReadOnly,
-                GrantObjectKind::RegularFile,
-            ));
+            if drives.is_empty() {
+                return Err(ContainedSnapshotRestoreError::new(
+                    ContainedSnapshotRestoreErrorKind::InvalidRequest,
+                ));
+            }
+            for drive in drives {
+                let id = grant_reference_id(drive.reference())
+                    .map_err(|_| {
+                        ContainedSnapshotRestoreError::new(
+                            ContainedSnapshotRestoreErrorKind::InvalidRequest,
+                        )
+                    })?
+                    .ok_or_else(|| {
+                        ContainedSnapshotRestoreError::new(
+                            ContainedSnapshotRestoreErrorKind::InvalidRequest,
+                        )
+                    })?;
+                if !matches!(
+                    drive.access(),
+                    GrantAccess::ReadOnly | GrantAccess::ReadWrite
+                ) {
+                    return Err(ContainedSnapshotRestoreError::new(
+                        ContainedSnapshotRestoreErrorKind::InvalidRequest,
+                    ));
+                }
+                file_requests.push((
+                    id,
+                    ResourceRole::DriveBacking,
+                    drive.access(),
+                    GrantObjectKind::RegularFile,
+                ));
+            }
 
             let mut directory_requests = Vec::new();
             let mut children = Vec::new();
@@ -2182,17 +2325,32 @@ mod platform {
             let transaction = self.generations.begin(self.session)?;
             check_contained_restore_progress(&transaction, cancelled)?;
             self.grants
-                .inspect_snapshot_restore_files(&file_requests, &mut drive_buffers.identities)?;
+                .inspect_snapshot_restore_files(&file_requests, &mut drive_buffers.observations)?;
             check_contained_restore_progress(&transaction, cancelled)?;
+            if drive_buffers.observations.len() != drives.len()
+                || drive_buffers
+                    .observations
+                    .iter()
+                    .zip(drives)
+                    .any(|(observation, request)| {
+                        request
+                            .expected_len()
+                            .is_some_and(|expected| observation.len() != expected)
+                    })
+            {
+                return Err(ContainedSnapshotRestoreError::new(
+                    ContainedSnapshotRestoreErrorKind::InvalidRequest,
+                ));
+            }
             self.directories.inspect_snapshot_restore_directories(
                 &directory_requests,
                 &mut directory_buffers.identities,
             )?;
             check_contained_restore_progress(&transaction, cancelled)?;
             if drive_buffers
-                .identities
+                .observations
                 .iter()
-                .copied()
+                .map(|observation| observation.identity())
                 .chain(directory_buffers.identities.iter().copied())
                 .any(|identity| !identities.insert(identity))
             {
@@ -2314,6 +2472,7 @@ mod platform {
                 directory_claims,
                 broker,
                 namespace,
+                expected_drive_count: drives.len(),
                 expects_vsock: vsock_reference.is_some(),
             })
         }
@@ -2342,6 +2501,7 @@ mod platform {
         directory_claims: Vec<PreparedSocketDirectoryClaim>,
         drive_claims: Vec<PreparedDriveBackingClaim>,
         transaction: Option<ContainedSnapshotRestoreTransaction>,
+        expected_drive_count: usize,
         expects_vsock: bool,
     }
 
@@ -2352,6 +2512,12 @@ mod platform {
     );
 
     type ContainedSnapshotRestoreReservationParts = (
+        Vec<PreparedDriveBackingClaim>,
+        Option<PreparedContainedVsockRestoreFacets>,
+        ContainedSnapshotRestoreTransaction,
+    );
+
+    type ContainedSnapshotRestoreSingletonReservationParts = (
         PreparedDriveBackingClaim,
         Option<PreparedContainedVsockRestoreFacets>,
         ContainedSnapshotRestoreTransaction,
@@ -2359,10 +2525,37 @@ mod platform {
 
     impl ReservedContainedSnapshotRestoreResources {
         pub(crate) fn into_parts(
+            self,
+        ) -> Result<ContainedSnapshotRestoreSingletonReservationParts, ContainedSnapshotRestoreError>
+        {
+            let (mut drives, vsock, transaction) = self.into_drive_parts()?;
+            if drives.len() != 1 {
+                let source = ContainedSnapshotRestoreError::new(
+                    ContainedSnapshotRestoreErrorKind::InvalidRequest,
+                );
+                let cleanup_failed = vsock.is_some_and(|(directory, broker, namespace)| {
+                    drop(namespace);
+                    broker.abort().is_err() | directory.abort().is_err()
+                }) | abort_drive_claims(drives).is_err()
+                    | transaction.abort().is_err();
+                return Err(if cleanup_failed {
+                    source.with_cleanup_failure()
+                } else {
+                    source
+                });
+            }
+            let Some(drive) = drives.pop() else {
+                abort_vhost_user_claim_invariant();
+            };
+            Ok((drive, vsock, transaction))
+        }
+
+        pub(crate) fn into_drive_parts(
             mut self,
         ) -> Result<ContainedSnapshotRestoreReservationParts, ContainedSnapshotRestoreError>
         {
-            let valid = self.drive_claims.len() == 1
+            let valid = self.expected_drive_count != 0
+                && self.drive_claims.len() == self.expected_drive_count
                 && if self.expects_vsock {
                     self.directory_claims.len() == 1
                         && self.broker.is_some()
@@ -2383,9 +2576,7 @@ mod platform {
                     source
                 });
             }
-            let Some(root) = self.drive_claims.pop() else {
-                abort_vhost_user_claim_invariant();
-            };
+            let drives = std::mem::take(&mut self.drive_claims);
             let vsock = if self.expects_vsock {
                 let Some(directory) = self.directory_claims.pop() else {
                     abort_vhost_user_claim_invariant();
@@ -2403,7 +2594,7 @@ mod platform {
             let Some(transaction) = self.transaction.take() else {
                 abort_vhost_user_claim_invariant();
             };
-            Ok((root, vsock, transaction))
+            Ok((drives, vsock, transaction))
         }
 
         pub(crate) fn abort(mut self) -> Result<(), ContainedSnapshotRestoreError> {
@@ -3882,8 +4073,9 @@ mod platform {
         };
 
         use super::{
-            BlockControlBrokerAuthority, BlockControlResponse, DirectoryGrantAuthority,
-            GrantAuthority, GrantClaimError, SocketBrokerAuthority, VhostUserBrokerAuthority,
+            BlockControlBrokerAuthority, BlockControlResponse,
+            ContainedSnapshotRestoreDriveRequest, DirectoryGrantAuthority, GrantAuthority,
+            GrantClaimError, SocketBrokerAuthority, VhostUserBrokerAuthority,
             VhostUserBrokerConnectError, checked_observed_geometry, exact_resource_limit,
         };
 
@@ -4057,6 +4249,136 @@ mod platform {
                 .prepare_endpoint()
                 .expect("broker authority should remain valid");
             broker.abort().expect("broker authority should restore");
+        }
+
+        #[test]
+        fn contained_restore_preflights_mixed_drive_vectors_before_exact_take() {
+            let fixture = contained_restore_authority_with_grants_for_test(
+                file_grant_authority_for_test(),
+                false,
+            );
+            let read_only_len = fs::metadata(
+                Path::new(env!("CARGO_MANIFEST_DIR")).join("src/contained_session.rs"),
+            )
+            .expect("read-only fixture metadata should read")
+            .len();
+            let read_write_len =
+                fs::metadata(Path::new(env!("CARGO_MANIFEST_DIR")).join("src/vmm.rs"))
+                    .expect("read-write fixture metadata should read")
+                    .len();
+            let requests = [
+                ContainedSnapshotRestoreDriveRequest::new(
+                    Path::new("bangbang-grant:drive-ro"),
+                    GrantAccess::ReadOnly,
+                    Some(read_only_len),
+                ),
+                ContainedSnapshotRestoreDriveRequest::new(
+                    Path::new("bangbang-grant:drive-rw"),
+                    GrantAccess::ReadWrite,
+                    Some(read_write_len),
+                ),
+            ];
+            let reserved = fixture
+                .authority
+                .prepare_drives(&requests, None, &|| false)
+                .expect("mixed exact vector should reserve");
+            let (mut claims, vsock, transaction) = reserved
+                .into_drive_parts()
+                .expect("mixed exact vector should split");
+            assert_eq!(claims.len(), 2);
+            assert!(vsock.is_none());
+            let (read_only, read_only_observation) = claims[0]
+                .take_snapshot_file(true)
+                .expect("read-only claim should retain exact access");
+            let (read_write, read_write_observation) = claims[1]
+                .take_snapshot_file(false)
+                .expect("read-write claim should retain exact access");
+            assert_eq!(
+                read_only
+                    .metadata()
+                    .expect("read-only metadata should remain live")
+                    .len(),
+                read_only_len
+            );
+            assert_eq!(
+                read_write
+                    .metadata()
+                    .expect("read-write metadata should remain live")
+                    .len(),
+                read_write_len
+            );
+            assert_eq!(
+                read_only_observation
+                    .expect("read-only observation should be retained")
+                    .len(),
+                read_only_len
+            );
+            assert_eq!(
+                read_write_observation
+                    .expect("read-write observation should be retained")
+                    .len(),
+                read_write_len
+            );
+            drop((read_only, read_write));
+            for claim in claims.into_iter().rev() {
+                claim.abort().expect("claim should restore in reverse");
+            }
+            transaction
+                .abort()
+                .expect("contained generation should abort once");
+
+            let wrong_geometry = [
+                ContainedSnapshotRestoreDriveRequest::new(
+                    Path::new("bangbang-grant:drive-ro"),
+                    GrantAccess::ReadOnly,
+                    Some(read_only_len.saturating_add(1)),
+                ),
+                requests[1],
+            ];
+            let error = fixture
+                .authority
+                .prepare_drives(&wrong_geometry, None, &|| false)
+                .expect_err("wrong geometry must fail before exact take");
+            assert_eq!(
+                error.kind(),
+                super::ContainedSnapshotRestoreErrorKind::InvalidRequest
+            );
+            for (reference, access) in [
+                (Path::new("bangbang-grant:drive-ro"), GrantAccess::ReadOnly),
+                (Path::new("bangbang-grant:drive-rw"), GrantAccess::ReadWrite),
+            ] {
+                fixture
+                    .grants
+                    .prepare_drive_backing_claim(reference, access)
+                    .expect("failed geometry preflight should retain authority")
+                    .expect("reference should remain contained")
+                    .abort()
+                    .expect("retained claim should restore");
+            }
+
+            let reserved = fixture
+                .authority
+                .prepare_drives(&requests, None, &|| false)
+                .expect("exact vector should reserve again");
+            let (mut claims, vsock, transaction) = reserved
+                .into_drive_parts()
+                .expect("exact vector should split again");
+            assert!(vsock.is_none());
+            claims.swap(0, 1);
+            assert!(
+                claims[0]
+                    .take_snapshot_file_for(Path::new("bangbang-grant:drive-ro"), true)
+                    .is_err(),
+                "a reordered claim must not be adopted under another request"
+            );
+            for claim in claims.into_iter().rev() {
+                claim
+                    .abort()
+                    .expect("reordered claim rejection should preserve authority");
+            }
+            transaction
+                .abort()
+                .expect("reordered claim transaction should abort once");
         }
 
         #[test]
@@ -6127,7 +6449,8 @@ pub(crate) use platform::{
 };
 #[cfg(target_os = "macos")]
 pub(crate) use platform::{
-    ClaimedVhostUserSocket, ContainedSnapshotRestoreAuthority, ContainedSnapshotRestoreError,
+    ClaimedVhostUserSocket, ContainedSnapshotRestoreAuthority,
+    ContainedSnapshotRestoreDriveRequest, ContainedSnapshotRestoreError,
     ContainedSnapshotRestoreTransaction, PreparedSocketBrokerEndpoint,
     PreparedVhostUserSocketClaim, SnapshotStagingRecordTracker, SocketBrokerAuthority,
     SocketBrokerEndpoint, VhostUserBrokerAuthority,

--- a/crates/bangbang/src/snapshot_restore_resources.rs
+++ b/crates/bangbang/src/snapshot_restore_resources.rs
@@ -1,12 +1,16 @@
 //! Process-owned destination resources for native-v2 snapshot restore.
 
-use std::collections::TryReserveError;
+use std::collections::{HashSet, TryReserveError};
 use std::fmt;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 
-use bangbang_runtime::block::{BlockFileBacking, SnapshotBlockFileBackingError};
+use bangbang_runtime::block::{
+    BlockFileBacking, BlockFileBackingIdentity, DriveConfigs, SnapshotBlockFileBackingError,
+    SnapshotBlockFileBackingReservation,
+};
 use bangbang_runtime::snapshot_device_v2::SnapshotV2DeviceGraph;
+use bangbang_runtime::snapshot_device_v2_5::SnapshotV2MultiBlockDeviceGraph;
 use bangbang_runtime::snapshot_restore::{
     PreparedSnapshotRestoreBindings, SnapshotRestoreBindingAllocationError,
     SnapshotRestoreBindingRejectionReason, SnapshotRestoreBindings, SnapshotRestoreManifest,
@@ -14,13 +18,12 @@ use bangbang_runtime::snapshot_restore::{
     SnapshotRestoreResourceKey, SnapshotRestoreTakeError,
 };
 use bangbang_session::GrantAccess;
-#[cfg(test)]
 use bangbang_session::macos::runtime::WorkerSocketNamespace;
 
 use crate::contained_session::{
-    ContainedSnapshotRestoreAuthority, ContainedSnapshotRestoreError,
-    ContainedSnapshotRestoreTransaction, GrantAuthority, GrantClaimError,
-    PreparedDriveBackingClaim, grant_reference_id,
+    ContainedSnapshotRestoreAuthority, ContainedSnapshotRestoreDriveRequest,
+    ContainedSnapshotRestoreError, ContainedSnapshotRestoreTransaction, GrantAuthority,
+    GrantClaimError, PreparedDriveBackingClaim, grant_reference_id,
 };
 #[cfg(test)]
 use crate::contained_session::{DirectoryGrantAuthority, SocketBrokerAuthority};
@@ -42,6 +45,8 @@ pub(crate) enum SnapshotRestoreResourceStage {
     BindingAllocation,
     Cancellation,
     ContainedReservation,
+    DrivePreflight,
+    DrivePreparation,
     RootPreparation,
     VsockPreparation,
     Binding,
@@ -55,12 +60,15 @@ pub(crate) enum SnapshotRestoreResourceErrorKind {
     BindingAllocation(SnapshotRestoreBindingAllocationError),
     Contained(ContainedSnapshotRestoreError),
     RootBacking(SnapshotRootBackingLeaseError),
+    DriveBacking(SnapshotDriveBackingPreparationError),
     Vsock(VsockRestoreError),
     Binding(SnapshotRestoreBindingRejectionReason),
     Incomplete { missing_count: usize },
     Take(SnapshotRestoreTakeError),
     Unconsumed { unconsumed_count: usize },
     OwnerClassMismatch,
+    InvalidDriveSet,
+    DriveProjection,
     Cancelled,
 }
 
@@ -81,6 +89,10 @@ impl fmt::Debug for SnapshotRestoreResourceErrorKind {
                 .finish(),
             Self::RootBacking(source) => formatter
                 .debug_tuple("SnapshotRestoreResourceErrorKind::RootBacking")
+                .field(source)
+                .finish(),
+            Self::DriveBacking(source) => formatter
+                .debug_tuple("SnapshotRestoreResourceErrorKind::DriveBacking")
                 .field(source)
                 .finish(),
             Self::Vsock(source) => formatter
@@ -106,6 +118,12 @@ impl fmt::Debug for SnapshotRestoreResourceErrorKind {
             Self::OwnerClassMismatch => {
                 formatter.write_str("SnapshotRestoreResourceErrorKind::OwnerClassMismatch")
             }
+            Self::InvalidDriveSet => {
+                formatter.write_str("SnapshotRestoreResourceErrorKind::InvalidDriveSet")
+            }
+            Self::DriveProjection => {
+                formatter.write_str("SnapshotRestoreResourceErrorKind::DriveProjection")
+            }
             Self::Cancelled => formatter.write_str("SnapshotRestoreResourceErrorKind::Cancelled"),
         }
     }
@@ -118,6 +136,7 @@ impl fmt::Display for SnapshotRestoreResourceErrorKind {
             Self::BindingAllocation(source) => source.fmt(formatter),
             Self::Contained(source) => source.fmt(formatter),
             Self::RootBacking(source) => source.fmt(formatter),
+            Self::DriveBacking(source) => source.fmt(formatter),
             Self::Vsock(source) => source.fmt(formatter),
             Self::Binding(reason) => reason.fmt(formatter),
             Self::Incomplete { .. } => {
@@ -129,6 +148,12 @@ impl fmt::Display for SnapshotRestoreResourceErrorKind {
             }
             Self::OwnerClassMismatch => {
                 formatter.write_str("snapshot restore owner has the wrong resource class")
+            }
+            Self::InvalidDriveSet => {
+                formatter.write_str("snapshot restore drive resource set is invalid")
+            }
+            Self::DriveProjection => {
+                formatter.write_str("snapshot restore drive projection is invalid")
             }
             Self::Cancelled => {
                 formatter.write_str("snapshot restore resource preparation cancelled")
@@ -217,12 +242,15 @@ impl std::error::Error for SnapshotRestoreResourceError {
             SnapshotRestoreResourceErrorKind::BindingAllocation(source) => Some(source),
             SnapshotRestoreResourceErrorKind::Contained(source) => Some(source),
             SnapshotRestoreResourceErrorKind::RootBacking(source) => Some(source),
+            SnapshotRestoreResourceErrorKind::DriveBacking(source) => Some(source),
             SnapshotRestoreResourceErrorKind::Vsock(source) => Some(source),
             SnapshotRestoreResourceErrorKind::Take(source) => Some(source),
             SnapshotRestoreResourceErrorKind::Binding(_)
             | SnapshotRestoreResourceErrorKind::Incomplete { .. }
             | SnapshotRestoreResourceErrorKind::Unconsumed { .. }
             | SnapshotRestoreResourceErrorKind::OwnerClassMismatch
+            | SnapshotRestoreResourceErrorKind::InvalidDriveSet
+            | SnapshotRestoreResourceErrorKind::DriveProjection
             | SnapshotRestoreResourceErrorKind::Cancelled => None,
         }
     }
@@ -438,6 +466,34 @@ impl std::error::Error for SnapshotRootBackingLeaseError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Grant(source) => Some(source),
+            Self::Backing(source) => Some(source),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum SnapshotDriveBackingPreparationError {
+    Authority(GrantClaimError),
+    Backing(SnapshotBlockFileBackingError),
+}
+
+impl fmt::Display for SnapshotDriveBackingPreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Authority(_) => {
+                formatter.write_str("snapshot drive backing authority validation failed")
+            }
+            Self::Backing(_) => {
+                formatter.write_str("snapshot drive backing descriptor validation failed")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SnapshotDriveBackingPreparationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Authority(source) => Some(source),
             Self::Backing(source) => Some(source),
         }
     }
@@ -695,6 +751,889 @@ impl fmt::Debug for PreparedSnapshotRestoreResource {
     }
 }
 
+struct RequestedSnapshotDriveRestoreResource {
+    key: SnapshotRestoreResourceKey,
+    selector: PathBuf,
+    is_read_only: bool,
+    expected_len: u64,
+}
+
+impl fmt::Debug for RequestedSnapshotDriveRestoreResource {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RequestedSnapshotDriveRestoreResource")
+            .field("class", &SnapshotRestoreResourceClass::BlockBacking)
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+struct PreparedSnapshotDriveRestoreResource {
+    key: SnapshotRestoreResourceKey,
+    backing: BlockFileBacking,
+    claim: Option<PreparedDriveBackingClaim>,
+}
+
+impl PreparedSnapshotDriveRestoreResource {
+    fn abort(self) -> SnapshotRestoreAbortOutcome {
+        let Self {
+            key: _,
+            backing,
+            claim,
+        } = self;
+        drop(backing);
+        match claim {
+            Some(claim) => {
+                if claim.abort().is_err() {
+                    SnapshotRestoreAbortOutcome::terminal(true)
+                } else {
+                    SnapshotRestoreAbortOutcome::retryable()
+                }
+            }
+            None => SnapshotRestoreAbortOutcome::retryable(),
+        }
+    }
+}
+
+struct ReservedDirectSnapshotDriveRestoreResource {
+    key: SnapshotRestoreResourceKey,
+    reservation: SnapshotBlockFileBackingReservation,
+}
+
+impl fmt::Debug for PreparedSnapshotDriveRestoreResource {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotDriveRestoreResource")
+            .field("backing", &"<owned>")
+            .field("claim", &self.claim.as_ref().map(|_| "<provisional>"))
+            .finish()
+    }
+}
+
+/// Complete profile-2 block resource request before host authority is touched.
+pub(crate) struct RequestedSnapshotMultiDriveRestoreResources {
+    drives: Vec<RequestedSnapshotDriveRestoreResource>,
+    drive_keys: Vec<SnapshotRestoreResourceKey>,
+    drive_configs: DriveConfigs,
+    bindings: SnapshotRestoreBindings<PreparedSnapshotDriveRestoreResource>,
+}
+
+impl RequestedSnapshotMultiDriveRestoreResources {
+    pub(crate) fn try_from_native_v2_multi_block_device_graph(
+        graph: &SnapshotV2MultiBlockDeviceGraph,
+    ) -> Result<Self, SnapshotRestoreResourceError> {
+        let drive_configs = graph.project_drive_configs().map_err(|_| {
+            SnapshotRestoreResourceError::terminal(
+                SnapshotRestoreResourceStage::DrivePreflight,
+                SnapshotRestoreResourceErrorKind::DriveProjection,
+            )
+        })?;
+        let mut drives = Vec::new();
+        let mut drive_keys = Vec::new();
+        let mut resources = Vec::new();
+        drives
+            .try_reserve_exact(graph.records().len())
+            .map_err(manifest_allocation_error)?;
+        drive_keys
+            .try_reserve_exact(graph.records().len())
+            .map_err(manifest_allocation_error)?;
+        resources
+            .try_reserve_exact(graph.records().len())
+            .map_err(manifest_allocation_error)?;
+        for record in graph.records() {
+            let public_id = SnapshotRestorePublicId::try_from(record.config().drive_id()).map_err(
+                |source| {
+                    SnapshotRestoreResourceError::retryable(
+                        SnapshotRestoreResourceStage::Manifest,
+                        SnapshotRestoreResourceErrorKind::Manifest(
+                            SnapshotRestoreManifestError::PublicId { source },
+                        ),
+                    )
+                },
+            )?;
+            let key = SnapshotRestoreResourceKey::new(
+                record.key(),
+                public_id,
+                SnapshotRestoreResourceClass::BlockBacking,
+            );
+            drives.push(RequestedSnapshotDriveRestoreResource {
+                key: key.clone(),
+                selector: PathBuf::from(record.config().selector()),
+                is_read_only: record.config().is_read_only(),
+                expected_len: record.block().backing_bytes(),
+            });
+            drive_keys.push(key.clone());
+            resources.push(key);
+        }
+        let manifest =
+            SnapshotRestoreManifest::try_new(resources, Vec::new()).map_err(|source| {
+                SnapshotRestoreResourceError::retryable(
+                    SnapshotRestoreResourceStage::Manifest,
+                    SnapshotRestoreResourceErrorKind::Manifest(source),
+                )
+            })?;
+        if manifest.len() != drives.len()
+            || drives.is_empty()
+            || drive_configs.as_slice().len() != drives.len()
+            || drives
+                .iter()
+                .zip(graph.records())
+                .zip(drive_configs.as_slice())
+                .any(|((drive, record), config)| {
+                    drive.key.device_key() != record.key()
+                        || drive.key.public_id().as_str() != record.config().drive_id()
+                        || drive.selector != Path::new(record.config().selector())
+                        || drive.is_read_only != record.config().is_read_only()
+                        || drive.expected_len != record.block().backing_bytes()
+                        || config.drive_id() != record.config().drive_id()
+                })
+        {
+            return Err(SnapshotRestoreResourceError::terminal(
+                SnapshotRestoreResourceStage::DrivePreflight,
+                SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+            ));
+        }
+        let bindings = manifest.try_into_bindings().map_err(|source| {
+            SnapshotRestoreResourceError::retryable(
+                SnapshotRestoreResourceStage::BindingAllocation,
+                SnapshotRestoreResourceErrorKind::BindingAllocation(source),
+            )
+        })?;
+        Ok(Self {
+            drives,
+            drive_keys,
+            drive_configs,
+            bindings,
+        })
+    }
+
+    pub(crate) fn prepare(
+        self,
+        authority: Option<&ContainedSnapshotRestoreAuthority>,
+        cancelled: impl Fn() -> bool,
+    ) -> Result<PreparedSnapshotMultiDriveRestoreResources, SnapshotRestoreResourceError> {
+        let Self {
+            drives,
+            drive_keys,
+            drive_configs,
+            mut bindings,
+        } = self;
+        if cancelled() {
+            return Err(cancelled_batch_error());
+        }
+
+        let (prepared, contained_transaction) = match authority {
+            Some(authority) => {
+                let mut requests = Vec::new();
+                requests
+                    .try_reserve_exact(drives.len())
+                    .map_err(manifest_allocation_error)?;
+                for drive in &drives {
+                    requests.push(ContainedSnapshotRestoreDriveRequest::new(
+                        &drive.selector,
+                        if drive.is_read_only {
+                            GrantAccess::ReadOnly
+                        } else {
+                            GrantAccess::ReadWrite
+                        },
+                        Some(drive.expected_len),
+                    ));
+                }
+                let reserved = authority
+                    .prepare_drives(&requests, None, &cancelled)
+                    .map_err(snapshot_contained_error)?;
+                let (claims, vsock, transaction) = reserved
+                    .into_drive_parts()
+                    .map_err(snapshot_contained_error)?;
+                if vsock.is_some() || claims.len() != drives.len() {
+                    let outcome = abort_contained_vsock_facets(vsock)
+                        .merge(abort_prepared_drive_claims(claims))
+                        .merge(abort_contained_transaction(Some(transaction)));
+                    return Err(SnapshotRestoreResourceError::terminal(
+                        SnapshotRestoreResourceStage::DrivePreflight,
+                        SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+                    )
+                    .with_abort_outcome(outcome));
+                }
+                let prepared = match prepare_contained_drives(&drives, claims, &cancelled) {
+                    Ok(prepared) => prepared,
+                    Err(failure) => {
+                        let (source, resources, claims) = *failure;
+                        return Err(source.with_abort_outcome(
+                            abort_prepared_drive_claims(claims)
+                                .merge(abort_prepared_drive_resources(resources))
+                                .merge(abort_contained_transaction(Some(transaction))),
+                        ));
+                    }
+                };
+                (prepared, Some(transaction))
+            }
+            None => (prepare_direct_drives(&drives, &cancelled)?, None),
+        };
+
+        if cancelled() {
+            let outcome = abort_prepared_drive_resources(prepared)
+                .merge(abort_contained_transaction(contained_transaction));
+            return Err(cancelled_batch_error().with_abort_outcome(outcome));
+        }
+        if prepared.len() != drive_keys.len()
+            || prepared
+                .iter()
+                .zip(&drive_keys)
+                .any(|(owner, key)| owner.key != *key)
+        {
+            let outcome = abort_prepared_drive_resources(prepared)
+                .merge(abort_contained_transaction(contained_transaction));
+            return Err(SnapshotRestoreResourceError::terminal(
+                SnapshotRestoreResourceStage::Binding,
+                SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+            )
+            .with_abort_outcome(outcome));
+        }
+        let mut prepared = prepared.into_iter();
+        for key in &drive_keys {
+            let Some(owner) = prepared.next() else {
+                let outcome = abort_prepared_drive_resource_iter(prepared)
+                    .merge(abort_drive_bindings(bindings.into_values()))
+                    .merge(abort_contained_transaction(contained_transaction));
+                return Err(SnapshotRestoreResourceError::terminal(
+                    SnapshotRestoreResourceStage::Binding,
+                    SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+                )
+                .with_abort_outcome(outcome));
+            };
+            if owner.key != *key {
+                let outcome = abort_prepared_drive_resource_iter(prepared)
+                    .merge(owner.abort())
+                    .merge(abort_drive_bindings(bindings.into_values()))
+                    .merge(abort_contained_transaction(contained_transaction));
+                return Err(SnapshotRestoreResourceError::terminal(
+                    SnapshotRestoreResourceStage::Binding,
+                    SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+                )
+                .with_abort_outcome(outcome));
+            }
+            if let Err(rejection) = bindings.bind(key, owner) {
+                let reason = rejection.reason();
+                let outcome = abort_prepared_drive_resource_iter(prepared)
+                    .merge(rejection.into_value().abort())
+                    .merge(abort_drive_bindings(bindings.into_values()))
+                    .merge(abort_contained_transaction(contained_transaction));
+                return Err(SnapshotRestoreResourceError::terminal(
+                    SnapshotRestoreResourceStage::Binding,
+                    SnapshotRestoreResourceErrorKind::Binding(reason),
+                )
+                .with_abort_outcome(outcome));
+            }
+        }
+        if let Some(extra) = prepared.next() {
+            let outcome =
+                abort_prepared_drive_resource_iter(std::iter::once(extra).chain(prepared))
+                    .merge(abort_drive_bindings(bindings.into_values()))
+                    .merge(abort_contained_transaction(contained_transaction));
+            return Err(SnapshotRestoreResourceError::terminal(
+                SnapshotRestoreResourceStage::Binding,
+                SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+            )
+            .with_abort_outcome(outcome));
+        }
+        let bindings = match bindings.complete() {
+            Ok(bindings) => bindings,
+            Err(incomplete) => {
+                let missing_count = incomplete.missing_count();
+                let outcome = abort_drive_bindings(incomplete.into_bindings().into_values())
+                    .merge(abort_contained_transaction(contained_transaction));
+                return Err(SnapshotRestoreResourceError::terminal(
+                    SnapshotRestoreResourceStage::Completion,
+                    SnapshotRestoreResourceErrorKind::Incomplete { missing_count },
+                )
+                .with_abort_outcome(outcome));
+            }
+        };
+        let prepared = PreparedSnapshotMultiDriveRestoreResources {
+            drive_keys,
+            drive_configs,
+            bindings,
+            contained_transaction,
+        };
+        if cancelled() {
+            let outcome = prepared.abort();
+            return Err(cancelled_batch_error().with_abort_outcome(outcome));
+        }
+        Ok(prepared)
+    }
+}
+
+impl fmt::Debug for RequestedSnapshotMultiDriveRestoreResources {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RequestedSnapshotMultiDriveRestoreResources")
+            .field("resource_count", &self.drives.len())
+            .field("values", &"<redacted>")
+            .finish()
+    }
+}
+
+type ContainedDrivePreparationFailure = Box<(
+    SnapshotRestoreResourceError,
+    Vec<PreparedSnapshotDriveRestoreResource>,
+    Vec<PreparedDriveBackingClaim>,
+)>;
+
+fn prepare_direct_drives(
+    drives: &[RequestedSnapshotDriveRestoreResource],
+    cancelled: &impl Fn() -> bool,
+) -> Result<Vec<PreparedSnapshotDriveRestoreResource>, SnapshotRestoreResourceError> {
+    let mut reservations = Vec::new();
+    let mut identities = HashSet::new();
+    reservations
+        .try_reserve_exact(drives.len())
+        .map_err(manifest_allocation_error)?;
+    identities.try_reserve(drives.len()).map_err(|_| {
+        SnapshotRestoreResourceError::retryable(
+            SnapshotRestoreResourceStage::DrivePreflight,
+            SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+        )
+    })?;
+    for drive in drives {
+        if cancelled() {
+            return Err(cancelled_batch_error());
+        }
+        if grant_reference_id(&drive.selector)
+            .map_err(|source| {
+                SnapshotRestoreResourceError::retryable(
+                    SnapshotRestoreResourceStage::DrivePreflight,
+                    SnapshotRestoreResourceErrorKind::DriveBacking(
+                        SnapshotDriveBackingPreparationError::Authority(source),
+                    ),
+                )
+            })?
+            .is_some()
+        {
+            return Err(SnapshotRestoreResourceError::retryable(
+                SnapshotRestoreResourceStage::DrivePreflight,
+                SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+            ));
+        }
+        let reservation =
+            match SnapshotBlockFileBackingReservation::open(&drive.selector, drive.is_read_only) {
+                Ok(reservation) => reservation,
+                Err(source) => {
+                    return Err(SnapshotRestoreResourceError::retryable(
+                        SnapshotRestoreResourceStage::DrivePreparation,
+                        SnapshotRestoreResourceErrorKind::DriveBacking(
+                            SnapshotDriveBackingPreparationError::Backing(source),
+                        ),
+                    ));
+                }
+            };
+        let identity = reservation.identity();
+        if !snapshot_drive_reservation_matches(drive, &reservation)
+            || !identities.insert((identity.device(), identity.inode()))
+        {
+            return Err(SnapshotRestoreResourceError::retryable(
+                SnapshotRestoreResourceStage::DrivePreflight,
+                SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+            ));
+        }
+        reservations.push(ReservedDirectSnapshotDriveRestoreResource {
+            key: drive.key.clone(),
+            reservation,
+        });
+    }
+
+    if cancelled() {
+        return Err(cancelled_batch_error());
+    }
+    let mut prepared = Vec::new();
+    prepared
+        .try_reserve_exact(drives.len())
+        .map_err(manifest_allocation_error)?;
+    let mut reservations = reservations.into_iter();
+    for drive in drives {
+        if cancelled() {
+            return Err(cancelled_batch_error()
+                .with_abort_outcome(abort_prepared_drive_resources(prepared)));
+        }
+        let Some(reserved) = reservations.next() else {
+            return Err(SnapshotRestoreResourceError::terminal(
+                SnapshotRestoreResourceStage::DrivePreparation,
+                SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+            )
+            .with_abort_outcome(abort_prepared_drive_resources(prepared)));
+        };
+        if reserved.key != drive.key {
+            return Err(SnapshotRestoreResourceError::terminal(
+                SnapshotRestoreResourceStage::DrivePreparation,
+                SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+            )
+            .with_abort_outcome(abort_prepared_drive_resources(prepared)));
+        }
+        let (backing, identity) = match reserved.reservation.into_backing() {
+            Ok(parts) => parts,
+            Err(source) => {
+                return Err(SnapshotRestoreResourceError::retryable(
+                    SnapshotRestoreResourceStage::DrivePreparation,
+                    SnapshotRestoreResourceErrorKind::DriveBacking(
+                        SnapshotDriveBackingPreparationError::Backing(source),
+                    ),
+                )
+                .with_abort_outcome(abort_prepared_drive_resources(prepared)));
+            }
+        };
+        if !snapshot_drive_observation_matches(drive, &backing, identity) {
+            drop(backing);
+            return Err(SnapshotRestoreResourceError::retryable(
+                SnapshotRestoreResourceStage::DrivePreflight,
+                SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+            )
+            .with_abort_outcome(abort_prepared_drive_resources(prepared)));
+        }
+        prepared.push(PreparedSnapshotDriveRestoreResource {
+            key: drive.key.clone(),
+            backing,
+            claim: None,
+        });
+    }
+    if reservations.next().is_some() {
+        return Err(SnapshotRestoreResourceError::terminal(
+            SnapshotRestoreResourceStage::DrivePreparation,
+            SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+        )
+        .with_abort_outcome(abort_prepared_drive_resources(prepared)));
+    }
+    Ok(prepared)
+}
+
+fn prepare_contained_drives(
+    drives: &[RequestedSnapshotDriveRestoreResource],
+    mut claims: Vec<PreparedDriveBackingClaim>,
+    cancelled: &impl Fn() -> bool,
+) -> Result<Vec<PreparedSnapshotDriveRestoreResource>, ContainedDrivePreparationFailure> {
+    let mut prepared = Vec::new();
+    let mut identities = HashSet::new();
+    if prepared.try_reserve_exact(drives.len()).is_err()
+        || identities.try_reserve(drives.len()).is_err()
+    {
+        return Err(Box::new((
+            SnapshotRestoreResourceError::retryable(
+                SnapshotRestoreResourceStage::DrivePreflight,
+                SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+            ),
+            prepared,
+            claims,
+        )));
+    }
+    if claims.len() != drives.len() {
+        return Err(Box::new((
+            SnapshotRestoreResourceError::terminal(
+                SnapshotRestoreResourceStage::DrivePreflight,
+                SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+            ),
+            prepared,
+            claims,
+        )));
+    }
+    for drive in drives {
+        if cancelled() {
+            return Err(Box::new((cancelled_batch_error(), prepared, claims)));
+        }
+        let mut claim = claims.remove(0);
+        let (file, observation) =
+            match claim.take_snapshot_file_for(&drive.selector, drive.is_read_only) {
+                Ok(parts) => parts,
+                Err(source) => {
+                    claims.insert(0, claim);
+                    return Err(Box::new((
+                        SnapshotRestoreResourceError::retryable(
+                            SnapshotRestoreResourceStage::DrivePreparation,
+                            SnapshotRestoreResourceErrorKind::DriveBacking(
+                                SnapshotDriveBackingPreparationError::Authority(source),
+                            ),
+                        ),
+                        prepared,
+                        claims,
+                    )));
+                }
+            };
+        let (backing, identity) =
+            match BlockFileBacking::from_snapshot_file(file, drive.is_read_only) {
+                Ok(parts) => parts,
+                Err(source) => {
+                    claims.insert(0, claim);
+                    return Err(Box::new((
+                        SnapshotRestoreResourceError::retryable(
+                            SnapshotRestoreResourceStage::DrivePreparation,
+                            SnapshotRestoreResourceErrorKind::DriveBacking(
+                                SnapshotDriveBackingPreparationError::Backing(source),
+                            ),
+                        ),
+                        prepared,
+                        claims,
+                    )));
+                }
+            };
+        let observation_matches = observation.is_some_and(|observation| {
+            observation.identity().device == identity.device()
+                && observation.identity().inode == identity.inode()
+                && observation.len() == identity.len()
+        });
+        if !observation_matches
+            || !snapshot_drive_observation_matches(drive, &backing, identity)
+            || !identities.insert((identity.device(), identity.inode()))
+        {
+            drop(backing);
+            claims.insert(0, claim);
+            return Err(Box::new((
+                SnapshotRestoreResourceError::retryable(
+                    SnapshotRestoreResourceStage::DrivePreflight,
+                    SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+                ),
+                prepared,
+                claims,
+            )));
+        }
+        prepared.push(PreparedSnapshotDriveRestoreResource {
+            key: drive.key.clone(),
+            backing,
+            claim: Some(claim),
+        });
+    }
+    if !claims.is_empty() {
+        return Err(Box::new((
+            SnapshotRestoreResourceError::terminal(
+                SnapshotRestoreResourceStage::DrivePreflight,
+                SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+            ),
+            prepared,
+            claims,
+        )));
+    }
+    Ok(prepared)
+}
+
+fn snapshot_drive_reservation_matches(
+    drive: &RequestedSnapshotDriveRestoreResource,
+    reservation: &SnapshotBlockFileBackingReservation,
+) -> bool {
+    let identity = reservation.identity();
+    reservation.is_read_only() == drive.is_read_only
+        && identity.kind().is_regular_file()
+        && identity.len() == drive.expected_len
+}
+
+fn snapshot_drive_observation_matches(
+    drive: &RequestedSnapshotDriveRestoreResource,
+    backing: &BlockFileBacking,
+    identity: BlockFileBackingIdentity,
+) -> bool {
+    backing.kind().is_regular_file()
+        && backing.is_read_only() == drive.is_read_only
+        && backing.len() == drive.expected_len
+        && identity.kind().is_regular_file()
+        && identity.len() == drive.expected_len
+}
+
+fn abort_contained_vsock_facets(
+    facets: Option<(
+        crate::contained_session::PreparedSocketDirectoryClaim,
+        crate::contained_session::PreparedSocketBrokerEndpoint,
+        WorkerSocketNamespace,
+    )>,
+) -> SnapshotRestoreAbortOutcome {
+    match facets {
+        Some((directory, broker, namespace)) => {
+            drop(namespace);
+            if broker.abort().is_err() | directory.abort().is_err() {
+                SnapshotRestoreAbortOutcome::terminal(true)
+            } else {
+                SnapshotRestoreAbortOutcome::retryable()
+            }
+        }
+        None => SnapshotRestoreAbortOutcome::retryable(),
+    }
+}
+
+fn abort_prepared_drive_claims(
+    claims: Vec<PreparedDriveBackingClaim>,
+) -> SnapshotRestoreAbortOutcome {
+    let mut outcome = SnapshotRestoreAbortOutcome::retryable();
+    for claim in claims.into_iter().rev() {
+        if claim.abort().is_err() {
+            outcome = outcome.merge(SnapshotRestoreAbortOutcome::terminal(true));
+        }
+    }
+    outcome
+}
+
+fn abort_prepared_drive_resources(
+    resources: Vec<PreparedSnapshotDriveRestoreResource>,
+) -> SnapshotRestoreAbortOutcome {
+    abort_prepared_drive_resource_iter(resources.into_iter())
+}
+
+fn abort_prepared_drive_resource_iter(
+    resources: impl DoubleEndedIterator<Item = PreparedSnapshotDriveRestoreResource>,
+) -> SnapshotRestoreAbortOutcome {
+    let mut outcome = SnapshotRestoreAbortOutcome::retryable();
+    for resource in resources.rev() {
+        outcome = outcome.merge(resource.abort());
+    }
+    outcome
+}
+
+fn abort_drive_bindings(
+    resources: impl DoubleEndedIterator<Item = PreparedSnapshotDriveRestoreResource>,
+) -> SnapshotRestoreAbortOutcome {
+    let mut outcome = SnapshotRestoreAbortOutcome::retryable();
+    for resource in resources.rev() {
+        outcome = outcome.merge(resource.abort());
+    }
+    outcome
+}
+
+pub(crate) struct PreparedSnapshotMultiDriveRestoreResources {
+    drive_keys: Vec<SnapshotRestoreResourceKey>,
+    drive_configs: DriveConfigs,
+    bindings: PreparedSnapshotRestoreBindings<PreparedSnapshotDriveRestoreResource>,
+    contained_transaction: Option<ContainedSnapshotRestoreTransaction>,
+}
+
+impl PreparedSnapshotMultiDriveRestoreResources {
+    pub(crate) fn into_drive_batch(
+        mut self,
+    ) -> Result<PreparedSnapshotRestoreDriveBatch, SnapshotRestoreResourceError> {
+        let mut owners = Vec::new();
+        if owners.try_reserve_exact(self.drive_keys.len()).is_err() {
+            let outcome = self.abort();
+            return Err(SnapshotRestoreResourceError::retryable(
+                SnapshotRestoreResourceStage::Take,
+                SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+            )
+            .with_abort_outcome(outcome));
+        }
+        for key in &self.drive_keys {
+            match self.bindings.take(key) {
+                Ok(owner) if owner.key == *key => owners.push(owner),
+                Ok(owner) => {
+                    owners.push(owner);
+                    let outcome = self.abort_with_taken(owners);
+                    return Err(SnapshotRestoreResourceError::terminal(
+                        SnapshotRestoreResourceStage::Take,
+                        SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+                    )
+                    .with_abort_outcome(outcome));
+                }
+                Err(source) => {
+                    let outcome = self.abort_with_taken(owners);
+                    return Err(SnapshotRestoreResourceError::terminal(
+                        SnapshotRestoreResourceStage::Take,
+                        SnapshotRestoreResourceErrorKind::Take(source),
+                    )
+                    .with_abort_outcome(outcome));
+                }
+            }
+        }
+        let Self {
+            drive_keys: _,
+            drive_configs,
+            bindings,
+            contained_transaction,
+        } = self;
+        if let Err(unconsumed) = bindings.finish() {
+            let unconsumed_count = unconsumed.unconsumed_count();
+            let outcome = abort_drive_bindings(unconsumed.into_bindings().into_values())
+                .merge(abort_prepared_drive_resources(owners))
+                .merge(abort_contained_transaction(contained_transaction));
+            return Err(SnapshotRestoreResourceError::terminal(
+                SnapshotRestoreResourceStage::Finish,
+                SnapshotRestoreResourceErrorKind::Unconsumed { unconsumed_count },
+            )
+            .with_abort_outcome(outcome));
+        }
+        let mut backings = Vec::new();
+        let mut claims = Vec::new();
+        if backings.try_reserve_exact(owners.len()).is_err()
+            || claims.try_reserve_exact(owners.len()).is_err()
+        {
+            let outcome = abort_prepared_drive_resources(owners)
+                .merge(abort_contained_transaction(contained_transaction));
+            return Err(SnapshotRestoreResourceError::retryable(
+                SnapshotRestoreResourceStage::Finish,
+                SnapshotRestoreResourceErrorKind::InvalidDriveSet,
+            )
+            .with_abort_outcome(outcome));
+        }
+        for owner in owners {
+            let PreparedSnapshotDriveRestoreResource {
+                key: _,
+                backing,
+                claim,
+            } = owner;
+            backings.push(backing);
+            if let Some(claim) = claim {
+                claims.push(claim);
+            }
+        }
+        Ok(PreparedSnapshotRestoreDriveBatch {
+            drive_configs,
+            backings,
+            completion: PreparedSnapshotDriveRestoreCompletion {
+                claims,
+                contained_transaction,
+            },
+        })
+    }
+
+    fn abort(self) -> SnapshotRestoreAbortOutcome {
+        abort_drive_bindings(self.bindings.into_values())
+            .merge(abort_contained_transaction(self.contained_transaction))
+    }
+
+    fn abort_with_taken(
+        self,
+        taken: Vec<PreparedSnapshotDriveRestoreResource>,
+    ) -> SnapshotRestoreAbortOutcome {
+        abort_drive_bindings(self.bindings.into_values())
+            .merge(abort_prepared_drive_resources(taken))
+            .merge(abort_contained_transaction(self.contained_transaction))
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotMultiDriveRestoreResources {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotMultiDriveRestoreResources")
+            .field("resource_count", &self.drive_keys.len())
+            .field("remaining_count", &self.bindings.remaining_count())
+            .field("values", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Exact graph-ordered block resources ready for pathless device construction.
+pub(crate) struct PreparedSnapshotRestoreDriveBatch {
+    drive_configs: DriveConfigs,
+    backings: Vec<BlockFileBacking>,
+    completion: PreparedSnapshotDriveRestoreCompletion,
+}
+
+impl PreparedSnapshotRestoreDriveBatch {
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        DriveConfigs,
+        Vec<BlockFileBacking>,
+        PreparedSnapshotDriveRestoreCompletion,
+    ) {
+        (self.drive_configs, self.backings, self.completion)
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotRestoreDriveBatch {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotRestoreDriveBatch")
+            .field("drive_count", &self.backings.len())
+            .field("values", &"<redacted>")
+            .finish()
+    }
+}
+
+pub(crate) struct PreparedSnapshotDriveRestoreCompletion {
+    claims: Vec<PreparedDriveBackingClaim>,
+    contained_transaction: Option<ContainedSnapshotRestoreTransaction>,
+}
+
+impl PreparedSnapshotDriveRestoreCompletion {
+    pub(crate) fn commit(mut self) -> Result<(), PreparedSnapshotDriveRestoreCompletionError> {
+        let claims = std::mem::take(&mut self.claims);
+        let contained_transaction = self.contained_transaction.take();
+        for claim in claims {
+            claim.commit();
+        }
+        match contained_transaction {
+            Some(transaction) => {
+                transaction
+                    .commit()
+                    .map_err(|source| PreparedSnapshotDriveRestoreCompletionError {
+                        grant_failed: false,
+                        contained: Some(source),
+                    })
+            }
+            None => Ok(()),
+        }
+    }
+
+    pub(crate) fn abort(mut self) -> Result<(), PreparedSnapshotDriveRestoreCompletionError> {
+        let claims = std::mem::take(&mut self.claims);
+        let contained_transaction = self.contained_transaction.take();
+        let grant_failed = claims
+            .into_iter()
+            .rev()
+            .fold(false, |failed, claim| claim.abort().is_err() | failed);
+        let contained = contained_transaction.and_then(|transaction| transaction.abort().err());
+        if grant_failed || contained.is_some() {
+            Err(PreparedSnapshotDriveRestoreCompletionError {
+                grant_failed,
+                contained,
+            })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for PreparedSnapshotDriveRestoreCompletion {
+    fn drop(&mut self) {
+        for claim in std::mem::take(&mut self.claims).into_iter().rev() {
+            let _ = claim.abort();
+        }
+        if let Some(transaction) = self.contained_transaction.take() {
+            let _ = transaction.abort();
+        }
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotDriveRestoreCompletion {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotDriveRestoreCompletion")
+            .field("state", &"<provisional>")
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct PreparedSnapshotDriveRestoreCompletionError {
+    grant_failed: bool,
+    contained: Option<ContainedSnapshotRestoreError>,
+}
+
+impl PreparedSnapshotDriveRestoreCompletionError {
+    pub(crate) const fn disposition(&self) -> SnapshotRestoreResourceDisposition {
+        SnapshotRestoreResourceDisposition::Terminal
+    }
+}
+
+impl fmt::Display for PreparedSnapshotDriveRestoreCompletionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("snapshot drive batch completion authority failed")?;
+        if self.grant_failed {
+            formatter.write_str("; grant cleanup also failed")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for PreparedSnapshotDriveRestoreCompletionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.contained
+            .as_ref()
+            .map(|source| source as &(dyn std::error::Error + 'static))
+    }
+}
+
 pub(crate) enum RequestedSnapshotRestoreResource {
     Root {
         key: SnapshotRestoreResourceKey,
@@ -773,9 +1712,35 @@ enum SnapshotRestoreReservationSource<'a> {
 }
 
 impl RequestedSnapshotRestoreResources {
+    /// Dormant typed profile-2 resource producer. Public native-v2 dispatch
+    /// remains exact 2.4 until the later activation slice.
+    pub(crate) fn prepare_native_v2_multi_block_device_graph<F>(
+        graph: &SnapshotV2MultiBlockDeviceGraph,
+        authority: Option<&ContainedSnapshotRestoreAuthority>,
+        cancelled: F,
+    ) -> Result<PreparedSnapshotRestoreDriveBatch, SnapshotRestoreResourceError>
+    where
+        F: Fn() -> bool,
+    {
+        // Keep the complete dormant handoff contract type-checked before the
+        // dependent pathless-device slice consumes it.
+        let _batch_parts = PreparedSnapshotRestoreDriveBatch::into_parts;
+        let _commit = PreparedSnapshotDriveRestoreCompletion::commit;
+        let _abort = PreparedSnapshotDriveRestoreCompletion::abort;
+        let _completion_disposition = PreparedSnapshotDriveRestoreCompletionError::disposition;
+        RequestedSnapshotMultiDriveRestoreResources::try_from_native_v2_multi_block_device_graph(
+            graph,
+        )?
+        .prepare(authority, cancelled)?
+        .into_drive_batch()
+    }
+
     pub(crate) fn try_from_native_v2_device_graph(
         graph: &SnapshotV2DeviceGraph,
     ) -> Result<Self, SnapshotRestoreResourceError> {
+        // Keep the dormant typed producer linked without admitting profile 2
+        // to public dispatch.
+        let _profile_2_producer = Self::prepare_native_v2_multi_block_device_graph::<fn() -> bool>;
         Self::try_from_native_v2_device_graph_and_vsock(graph, None)
     }
 
@@ -1608,12 +2573,16 @@ mod tests {
     use std::io::Write;
     use std::sync::atomic::{AtomicU64, Ordering};
 
+    use bangbang_runtime::block::DriveConfigInput;
     use bangbang_runtime::memory::{
         GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange,
     };
     use bangbang_runtime::snapshot::SnapshotVsockOverride;
     use bangbang_runtime::snapshot_device_v2::{
         NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2DeviceTransportKind,
+    };
+    use bangbang_runtime::snapshot_device_v2_5::{
+        NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2MultiBlockDeviceGraph,
     };
     use bangbang_runtime::snapshot_restore::{
         SnapshotRestoreBindingRejectionReason, SnapshotRestorePublicId,
@@ -1627,7 +2596,8 @@ mod tests {
 
     use crate::contained_session::{
         ContainedSnapshotRestoreErrorKind, GrantAuthority, TestContainedRestoreAuthority,
-        contained_restore_authority_for_test, root_file_grant_authority_for_test,
+        contained_restore_authority_for_test, contained_restore_authority_with_grants_for_test,
+        file_grant_authority_for_test, root_file_grant_authority_for_test,
         vsock_directory_authority_for_test,
     };
 
@@ -1644,6 +2614,10 @@ mod tests {
     impl TempRoot {
         fn new(name: &str, bytes: &[u8]) -> Self {
             let path = unique_path(name);
+            Self::new_at(path, bytes)
+        }
+
+        fn new_at(path: PathBuf, bytes: &[u8]) -> Self {
             let mut file = OpenOptions::new()
                 .write(true)
                 .create_new(true)
@@ -1674,6 +2648,11 @@ mod tests {
         ))
     }
 
+    fn unique_short_path() -> PathBuf {
+        let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+        PathBuf::from(format!("/tmp/bb{id:011x}"))
+    }
+
     fn fixture_graph(transport: SnapshotV2DeviceTransportKind) -> SnapshotV2DeviceGraph {
         let fixture = match transport {
             SnapshotV2DeviceTransportKind::Mmio => {
@@ -1694,6 +2673,45 @@ mod tests {
             .collect::<Vec<_>>();
         SnapshotV2DeviceGraph::decode(NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, &bytes)
             .expect("fixture graph should decode")
+    }
+
+    fn multi_fixture_graph(
+        first_selector: Option<&Path>,
+        second_selector: Option<&Path>,
+    ) -> SnapshotV2MultiBlockDeviceGraph {
+        let fixture = include_str!("../../runtime/src/snapshot_device_v2_5/fixtures/root-mmio.hex");
+        let mut bytes = fixture
+            .trim()
+            .as_bytes()
+            .chunks_exact(2)
+            .map(|pair| {
+                let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
+                u8::from_str_radix(pair, 16).expect("fixture hex should decode")
+            })
+            .collect::<Vec<_>>();
+        for (captured, replacement) in [
+            (b"logical-selector-0".as_slice(), first_selector),
+            (b"logical-selector-1".as_slice(), second_selector),
+        ] {
+            let Some(replacement) = replacement else {
+                continue;
+            };
+            let replacement = replacement
+                .to_str()
+                .expect("test selector should be UTF-8")
+                .as_bytes();
+            assert_eq!(replacement.len(), captured.len());
+            let offset = bytes
+                .windows(captured.len())
+                .position(|window| window == captured)
+                .expect("fixture selector should exist");
+            bytes[offset..offset + captured.len()].copy_from_slice(replacement);
+        }
+        SnapshotV2MultiBlockDeviceGraph::decode(
+            NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            &bytes,
+        )
+        .expect("profile-2 fixture graph should decode")
     }
 
     fn requested() -> RequestedSnapshotRestoreResources {
@@ -2021,6 +3039,301 @@ mod tests {
             let diagnostics = format!("{request:?} {:?}", request.root_key);
             assert!(!diagnostics.contains(graph.record().config().drive_id()));
             assert!(!diagnostics.contains(graph.record().config().selector()));
+        }
+    }
+
+    #[test]
+    fn profile_2_derives_one_exact_request_and_config_per_record() {
+        let graph = multi_fixture_graph(None, None);
+        let request =
+            RequestedSnapshotMultiDriveRestoreResources::try_from_native_v2_multi_block_device_graph(
+                &graph,
+            )
+            .expect("profile-2 graph should produce an exact request");
+        assert_eq!(request.drives.len(), graph.records().len());
+        assert_eq!(request.drive_keys.len(), graph.records().len());
+        assert_eq!(
+            request.drive_configs.as_slice().len(),
+            graph.records().len()
+        );
+        assert_eq!(request.bindings.manifest().len(), graph.records().len());
+        for (((drive, key), config), record) in request
+            .drives
+            .iter()
+            .zip(&request.drive_keys)
+            .zip(request.drive_configs.as_slice())
+            .zip(graph.records())
+        {
+            assert_eq!(drive.key, *key);
+            assert_eq!(key.device_key(), record.key());
+            assert_eq!(key.public_id().as_str(), record.config().drive_id());
+            assert_eq!(
+                key.resource_class(),
+                SnapshotRestoreResourceClass::BlockBacking
+            );
+            assert_eq!(drive.selector, Path::new(record.config().selector()));
+            assert_eq!(drive.is_read_only, record.config().is_read_only());
+            assert_eq!(drive.expected_len, record.block().backing_bytes());
+            assert_eq!(config.drive_id(), record.config().drive_id());
+            assert_eq!(
+                config.path_on_host(),
+                Some(Path::new(record.config().selector()))
+            );
+        }
+        let diagnostics = format!("{request:?}");
+        for record in graph.records() {
+            assert!(!diagnostics.contains(record.config().drive_id()));
+            assert!(!diagnostics.contains(record.config().selector()));
+        }
+    }
+
+    #[test]
+    fn profile_2_direct_batch_preserves_mixed_access_order_and_completion() {
+        let template = multi_fixture_graph(None, None);
+        let first_path = unique_short_path();
+        let second_path = unique_short_path();
+        let first = TempRoot::new_at(
+            first_path.clone(),
+            &vec![
+                0x11;
+                usize::try_from(template.records()[0].block().backing_bytes())
+                    .expect("fixture length should fit")
+            ],
+        );
+        let second = TempRoot::new_at(
+            second_path.clone(),
+            &vec![
+                0x22;
+                usize::try_from(template.records()[1].block().backing_bytes())
+                    .expect("fixture length should fit")
+            ],
+        );
+        let graph = multi_fixture_graph(Some(first.path()), Some(second.path()));
+        let batch = RequestedSnapshotRestoreResources::prepare_native_v2_multi_block_device_graph(
+            &graph,
+            None,
+            || false,
+        )
+        .expect("mixed direct batch should prepare");
+        let (configs, backings, completion) = batch.into_parts();
+        assert_eq!(configs.as_slice().len(), 2);
+        assert_eq!(backings.len(), 2);
+        for (((config, backing), record), expected_path) in configs
+            .as_slice()
+            .iter()
+            .zip(&backings)
+            .zip(graph.records())
+            .zip([first.path(), second.path()])
+        {
+            assert_eq!(config.drive_id(), record.config().drive_id());
+            assert_eq!(config.path_on_host(), Some(expected_path));
+            assert_eq!(config.is_root_device(), record.is_root());
+            assert_eq!(config.is_read_only(), Some(record.config().is_read_only()));
+            assert_eq!(backing.is_read_only(), record.config().is_read_only());
+            assert_eq!(backing.len(), record.block().backing_bytes());
+        }
+        assert!(configs.as_slice()[0].is_root_device());
+        assert!(!configs.as_slice()[1].is_root_device());
+        completion
+            .commit()
+            .expect("direct batch completion should commit once");
+    }
+
+    #[test]
+    fn profile_2_contained_batch_has_no_path_fallback_and_aborts_as_one_vector() {
+        let graph = multi_fixture_graph(None, None);
+        let selectors = [
+            PathBuf::from("bangbang-grant:drive-ro"),
+            PathBuf::from("bangbang-grant:drive-rw"),
+        ];
+        let expected_lengths = [
+            fs::metadata(Path::new(env!("CARGO_MANIFEST_DIR")).join("src/contained_session.rs"))
+                .expect("read-only grant metadata should read")
+                .len(),
+            fs::metadata(Path::new(env!("CARGO_MANIFEST_DIR")).join("src/vmm.rs"))
+                .expect("read-write grant metadata should read")
+                .len(),
+        ];
+        let mut drives = Vec::new();
+        let mut drive_keys = Vec::new();
+        let mut resources = Vec::new();
+        let mut configs = DriveConfigs::new();
+        for ((record, selector), expected_len) in
+            graph.records().iter().zip(&selectors).zip(expected_lengths)
+        {
+            let public_id = SnapshotRestorePublicId::try_from(record.config().drive_id())
+                .expect("fixture public ID should validate");
+            let key = SnapshotRestoreResourceKey::new(
+                record.key(),
+                public_id,
+                SnapshotRestoreResourceClass::BlockBacking,
+            );
+            let mut input = DriveConfigInput::new(
+                record.config().drive_id(),
+                record.config().drive_id(),
+                selector,
+                record.is_root(),
+            )
+            .with_is_read_only(record.config().is_read_only())
+            .with_cache_type(record.config().cache_type())
+            .with_io_engine(record.config().io_engine());
+            if let Some(partuuid) = record.config().partuuid() {
+                input = input.with_partuuid(partuuid);
+            }
+            if let Some(rate_limiter) = record.config().rate_limiter() {
+                input = input.with_rate_limiter(rate_limiter);
+            }
+            configs
+                .insert(input)
+                .expect("contained projected config should validate");
+            drives.push(RequestedSnapshotDriveRestoreResource {
+                key: key.clone(),
+                selector: selector.clone(),
+                is_read_only: record.config().is_read_only(),
+                expected_len,
+            });
+            drive_keys.push(key.clone());
+            resources.push(key);
+        }
+        let manifest = SnapshotRestoreManifest::try_new(resources, Vec::new())
+            .expect("contained manifest should validate");
+        let bindings = manifest
+            .try_into_bindings()
+            .expect("contained bindings should allocate");
+        let request = RequestedSnapshotMultiDriveRestoreResources {
+            drives,
+            drive_keys,
+            drive_configs: configs,
+            bindings,
+        };
+        let fixture = contained_restore_authority_with_grants_for_test(
+            file_grant_authority_for_test(),
+            false,
+        );
+        let prepared = request
+            .prepare(Some(fixture.authority()), || false)
+            .expect("contained mixed vector should prepare");
+        let batch = prepared
+            .into_drive_batch()
+            .expect("contained bindings should become one batch");
+        let diagnostic = format!("{batch:?}");
+        for selector in &selectors {
+            assert!(!diagnostic.contains(selector.to_string_lossy().as_ref()));
+        }
+        let (configs, backings, completion) = batch.into_parts();
+        assert_eq!(configs.as_slice().len(), 2);
+        assert_eq!(backings.len(), 2);
+        for (((config, backing), selector), expected_len) in configs
+            .as_slice()
+            .iter()
+            .zip(&backings)
+            .zip(&selectors)
+            .zip(expected_lengths)
+        {
+            assert_eq!(config.path_on_host(), Some(selector.as_path()));
+            assert_eq!(backing.len(), expected_len);
+        }
+        assert!(backings[0].is_read_only());
+        assert!(!backings[1].is_read_only());
+        drop(backings);
+        completion
+            .abort()
+            .expect("contained claims and generation should abort once");
+        for (selector, access) in [
+            (&selectors[0], GrantAccess::ReadOnly),
+            (&selectors[1], GrantAccess::ReadWrite),
+        ] {
+            fixture
+                .grants()
+                .prepare_drive_backing_claim(selector, access)
+                .expect("batch abort should restore every grant")
+                .expect("selector should remain contained")
+                .abort()
+                .expect("restored grant should remain reusable");
+        }
+    }
+
+    #[test]
+    fn profile_2_direct_preflight_rejects_alias_geometry_grants_and_cancellation() {
+        let graph = multi_fixture_graph(None, None);
+        let shared = TempRoot::new("multi-alias", &[0x33; 4096]);
+        let requests = graph
+            .records()
+            .iter()
+            .map(|record| {
+                let public_id = SnapshotRestorePublicId::try_from(record.config().drive_id())
+                    .expect("fixture public ID should validate");
+                RequestedSnapshotDriveRestoreResource {
+                    key: SnapshotRestoreResourceKey::new(
+                        record.key(),
+                        public_id,
+                        SnapshotRestoreResourceClass::BlockBacking,
+                    ),
+                    selector: shared.path().to_path_buf(),
+                    is_read_only: record.config().is_read_only(),
+                    expected_len: 4096,
+                }
+            })
+            .collect::<Vec<_>>();
+        let alias = prepare_direct_drives(&requests, &|| false)
+            .expect_err("same descriptor identity must reject");
+        assert_eq!(alias.stage, SnapshotRestoreResourceStage::DrivePreflight);
+        assert!(matches!(
+            alias.kind,
+            SnapshotRestoreResourceErrorKind::InvalidDriveSet
+        ));
+
+        let first = TempRoot::new("multi-geometry-0", &[0x44; 4096]);
+        let second = TempRoot::new("multi-geometry-1", &[0x55; 8192]);
+        let mut distinct = requests;
+        distinct[0].selector = first.path().to_path_buf();
+        distinct[1].selector = second.path().to_path_buf();
+        distinct[1].expected_len = 8193;
+        let geometry = prepare_direct_drives(&distinct, &|| false)
+            .expect_err("wrong expected geometry must reject");
+        assert_eq!(geometry.stage, SnapshotRestoreResourceStage::DrivePreflight);
+
+        distinct[1].expected_len = 8192;
+        let calls = Cell::new(0_u8);
+        let changed = prepare_direct_drives(&distinct, &|| {
+            let next = calls.get().saturating_add(1);
+            calls.set(next);
+            if next == 3 {
+                fs::write(first.path(), [0x66; 4097])
+                    .expect("reserved direct fixture should change before adoption");
+            }
+            false
+        })
+        .expect_err("changed preflight observation must reject before binding");
+        assert_eq!(
+            changed.stage,
+            SnapshotRestoreResourceStage::DrivePreparation
+        );
+        fs::write(first.path(), [0x44; 4096])
+            .expect("changed direct fixture should reset for later checks");
+
+        distinct[0].selector = PathBuf::from(ROOT_REFERENCE);
+        let grant = prepare_direct_drives(&distinct, &|| false)
+            .expect_err("direct mode must not treat a grant reference as a path");
+        assert_eq!(grant.stage, SnapshotRestoreResourceStage::DrivePreflight);
+
+        distinct[0].selector = first.path().to_path_buf();
+        let calls = Cell::new(0_u8);
+        let cancelled = prepare_direct_drives(&distinct, &|| {
+            let next = calls.get().saturating_add(1);
+            calls.set(next);
+            next >= 2
+        })
+        .expect_err("mid-vector cancellation must unwind earlier reservations");
+        assert_eq!(cancelled.stage, SnapshotRestoreResourceStage::Cancellation);
+        let diagnostic = format!("{alias:?} {geometry:?} {changed:?} {grant:?} {cancelled:?}");
+        for private in [
+            shared.path(),
+            first.path(),
+            second.path(),
+            Path::new(ROOT_REFERENCE),
+        ] {
+            assert!(!diagnostic.contains(private.to_string_lossy().as_ref()));
         }
     }
 

--- a/crates/runtime/src/block.rs
+++ b/crates/runtime/src/block.rs
@@ -4616,6 +4616,141 @@ impl fmt::Display for SnapshotBlockFileBackingError {
 
 impl std::error::Error for SnapshotBlockFileBackingError {}
 
+/// Securely opened regular-file snapshot backing awaiting complete-set
+/// validation.
+///
+/// This value owns only the descriptor reservation. It does not construct a
+/// live block backing until [`Self::into_backing`] revalidates the captured
+/// descriptor observation.
+pub struct SnapshotBlockFileBackingReservation {
+    file: File,
+    identity: BlockFileBackingIdentity,
+    is_read_only: bool,
+}
+
+impl SnapshotBlockFileBackingReservation {
+    /// Opens and inspects one exact regular-file snapshot descriptor.
+    pub fn open(path: &Path, is_read_only: bool) -> Result<Self, SnapshotBlockFileBackingError> {
+        #[cfg(unix)]
+        {
+            let mut options = OpenOptions::new();
+            options.read(true);
+            if !is_read_only {
+                options.write(true);
+            }
+            options.custom_flags(libc::O_NONBLOCK | libc::O_NOFOLLOW | libc::O_CLOEXEC);
+            let file = options
+                .open(path)
+                .map_err(|_| SnapshotBlockFileBackingError::Open)?;
+            let metadata = file
+                .metadata()
+                .map_err(|_| SnapshotBlockFileBackingError::ReadMetadata)?;
+            if !metadata.file_type().is_file() {
+                return Err(SnapshotBlockFileBackingError::NonRegularFile);
+            }
+            validate_block_file_descriptor_status(
+                &file,
+                is_read_only,
+                DescriptorCloexecPolicy::SetIfMissing,
+            )
+            .map_err(|_| SnapshotBlockFileBackingError::InvalidMetadata)?;
+            let identity = snapshot_block_file_identity(
+                &metadata,
+                BlockFileBackingKind::REGULAR_FILE,
+                metadata.len(),
+            )?;
+            Ok(Self {
+                file,
+                identity,
+                is_read_only,
+            })
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = (path, is_read_only);
+            Err(SnapshotBlockFileBackingError::UnsupportedPlatform)
+        }
+    }
+
+    /// Returns the descriptor-derived pre-adoption observation.
+    pub const fn identity(&self) -> BlockFileBackingIdentity {
+        self.identity
+    }
+
+    /// Returns the captured descriptor access.
+    pub const fn is_read_only(&self) -> bool {
+        self.is_read_only
+    }
+
+    /// Revalidates and adopts the reserved descriptor as a block backing.
+    pub fn into_backing(
+        self,
+    ) -> Result<(BlockFileBacking, BlockFileBackingIdentity), SnapshotBlockFileBackingError> {
+        snapshot_block_file_backing_from_file(
+            self.file,
+            self.is_read_only,
+            BlockFileBackingOrigin::Path,
+            Some(self.identity),
+        )
+    }
+}
+
+impl fmt::Debug for SnapshotBlockFileBackingReservation {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotBlockFileBackingReservation")
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+fn snapshot_block_file_backing_from_file(
+    file: File,
+    is_read_only: bool,
+    origin: BlockFileBackingOrigin,
+    expected_identity: Option<BlockFileBackingIdentity>,
+) -> Result<(BlockFileBacking, BlockFileBackingIdentity), SnapshotBlockFileBackingError> {
+    #[cfg(unix)]
+    {
+        let descriptor_status = validate_block_file_descriptor_status(
+            &file,
+            is_read_only,
+            DescriptorCloexecPolicy::SetIfMissing,
+        )
+        .map_err(|_| SnapshotBlockFileBackingError::InvalidMetadata)?;
+        let metadata = file
+            .metadata()
+            .map_err(|_| SnapshotBlockFileBackingError::ReadMetadata)?;
+        if !metadata.file_type().is_file() {
+            return Err(SnapshotBlockFileBackingError::NonRegularFile);
+        }
+        let kind = BlockFileBackingKind::REGULAR_FILE;
+        let identity = snapshot_block_file_identity(&metadata, kind, metadata.len())?;
+        if expected_identity.is_some_and(|expected| expected != identity) {
+            return Err(SnapshotBlockFileBackingError::InvalidMetadata);
+        }
+        let backing = BlockFileBacking {
+            file,
+            len: metadata.len(),
+            kind,
+            descriptor_identity: block_file_descriptor_identity(&metadata, kind),
+            descriptor_status,
+            block_control: None,
+            device_id: virtio_block_device_id_from_metadata(&metadata),
+            is_read_only,
+            origin,
+        };
+        Ok((backing, identity))
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (file, is_read_only, origin, expected_identity);
+        Err(SnapshotBlockFileBackingError::UnsupportedPlatform)
+    }
+}
+
 impl BlockFileBacking {
     pub fn open(config: &DriveConfig) -> Result<Self, BlockFileBackingError> {
         let DriveBackendConfig::File {
@@ -4712,94 +4847,43 @@ impl BlockFileBacking {
         })
     }
 
+    /// Opens one exact regular-file snapshot backing with the captured access.
+    ///
+    /// Snapshot restore never follows a final symlink and always requires a
+    /// close-on-exec descriptor. The returned identity is descriptor-derived
+    /// and may be retained transiently for complete-set validation.
+    pub fn open_snapshot(
+        path: &Path,
+        is_read_only: bool,
+    ) -> Result<(Self, BlockFileBackingIdentity), SnapshotBlockFileBackingError> {
+        SnapshotBlockFileBackingReservation::open(path, is_read_only)?.into_backing()
+    }
+
+    /// Compatibility wrapper for the exact read-only profile-1 restore path.
     pub fn open_snapshot_read_only(
         path: &Path,
     ) -> Result<(Self, BlockFileBackingIdentity), SnapshotBlockFileBackingError> {
-        #[cfg(unix)]
-        {
-            let mut options = OpenOptions::new();
-            options
-                .read(true)
-                .custom_flags(libc::O_NONBLOCK | libc::O_NOFOLLOW | libc::O_CLOEXEC);
-            let file = options
-                .open(path)
-                .map_err(|_| SnapshotBlockFileBackingError::Open)?;
-            let metadata = file
-                .metadata()
-                .map_err(|_| SnapshotBlockFileBackingError::ReadMetadata)?;
-            if !metadata.file_type().is_file() {
-                return Err(SnapshotBlockFileBackingError::NonRegularFile);
-            }
-            let descriptor_status = validate_block_file_descriptor_status(
-                &file,
-                true,
-                DescriptorCloexecPolicy::SetIfMissing,
-            )
-            .map_err(|_| SnapshotBlockFileBackingError::InvalidMetadata)?;
-            let kind = BlockFileBackingKind::REGULAR_FILE;
-            let descriptor_identity = block_file_descriptor_identity(&metadata, kind);
-            let identity = snapshot_block_file_identity(&metadata, kind, metadata.len())?;
-            let backing = Self {
-                file,
-                len: metadata.len(),
-                kind,
-                descriptor_identity,
-                descriptor_status,
-                block_control: None,
-                device_id: virtio_block_device_id_from_metadata(&metadata),
-                is_read_only: true,
-                origin: BlockFileBackingOrigin::Path,
-            };
-            Ok((backing, identity))
-        }
-
-        #[cfg(not(unix))]
-        {
-            let _ = path;
-            Err(SnapshotBlockFileBackingError::UnsupportedPlatform)
-        }
+        Self::open_snapshot(path, true)
     }
 
-    /// Adopts an already-opened exact read-only snapshot backing.
+    /// Adopts an already-opened exact regular-file snapshot backing.
+    pub fn from_snapshot_file(
+        file: File,
+        is_read_only: bool,
+    ) -> Result<(Self, BlockFileBackingIdentity), SnapshotBlockFileBackingError> {
+        snapshot_block_file_backing_from_file(
+            file,
+            is_read_only,
+            BlockFileBackingOrigin::SuppliedFile,
+            None,
+        )
+    }
+
+    /// Compatibility wrapper for the exact read-only profile-1 restore path.
     pub fn from_snapshot_read_only_file(
         file: File,
     ) -> Result<(Self, BlockFileBackingIdentity), SnapshotBlockFileBackingError> {
-        #[cfg(unix)]
-        {
-            let descriptor_status = validate_block_file_descriptor_status(
-                &file,
-                true,
-                DescriptorCloexecPolicy::SetIfMissing,
-            )
-            .map_err(|_| SnapshotBlockFileBackingError::InvalidMetadata)?;
-            let metadata = file
-                .metadata()
-                .map_err(|_| SnapshotBlockFileBackingError::ReadMetadata)?;
-            if !metadata.file_type().is_file() {
-                return Err(SnapshotBlockFileBackingError::NonRegularFile);
-            }
-            let kind = BlockFileBackingKind::REGULAR_FILE;
-            let descriptor_identity = block_file_descriptor_identity(&metadata, kind);
-            let identity = snapshot_block_file_identity(&metadata, kind, metadata.len())?;
-            let backing = Self {
-                file,
-                len: metadata.len(),
-                kind,
-                descriptor_identity,
-                descriptor_status,
-                block_control: None,
-                device_id: virtio_block_device_id_from_metadata(&metadata),
-                is_read_only: true,
-                origin: BlockFileBackingOrigin::SuppliedFile,
-            };
-            Ok((backing, identity))
-        }
-
-        #[cfg(not(unix))]
-        {
-            let _ = file;
-            Err(SnapshotBlockFileBackingError::UnsupportedPlatform)
-        }
+        Self::from_snapshot_file(file, true)
     }
 
     pub fn snapshot_identity(
@@ -8827,18 +8911,18 @@ mod tests {
         PreparedBlockDeviceError, PreparedBlockDevices, PreparedVhostUserBlockFrontend,
         PreparedVhostUserBlockFrontendError, PreparedVhostUserBlockMemoryError,
         RuntimeBlockDeviceResource, SnapshotBlockFileBackingError,
-        VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE, VIRTIO_BLOCK_CONFIG_SIZE, VIRTIO_BLOCK_DEVICE_ID,
-        VIRTIO_BLOCK_FEATURE_FLUSH, VIRTIO_BLOCK_FEATURE_READ_ONLY, VIRTIO_BLOCK_ID_BYTES,
-        VIRTIO_BLOCK_QUEUE_COUNT, VIRTIO_BLOCK_QUEUE_SIZE, VIRTIO_BLOCK_QUEUE_SIZES,
-        VIRTIO_BLOCK_REQUEST_HEADER_SIZE, VIRTIO_BLOCK_REQUEST_TYPE_FLUSH,
-        VIRTIO_BLOCK_REQUEST_TYPE_GET_ID, VIRTIO_BLOCK_REQUEST_TYPE_IN,
-        VIRTIO_BLOCK_REQUEST_TYPE_OUT, VIRTIO_BLOCK_SECTOR_SHIFT, VIRTIO_BLOCK_SECTOR_SIZE,
-        VIRTIO_BLOCK_STATUS_IOERR, VIRTIO_BLOCK_STATUS_OK, VIRTIO_BLOCK_STATUS_SIZE,
-        VIRTIO_BLOCK_STATUS_UNSUPPORTED, VIRTIO_FEATURE_VERSION_1, VIRTIO_RING_FEATURE_EVENT_IDX,
-        VIRTIO_RING_FEATURE_INDIRECT_DESC, VhostUserBlockConfigRefreshError,
-        VhostUserBlockConfigSignalError, VhostUserBlockMemoryRegion,
-        VhostUserBlockNotificationError, VhostUserBlockState, VirtioBlockBackend,
-        VirtioBlockBackendKind, VirtioBlockConfigSpace, VirtioBlockDevice,
+        SnapshotBlockFileBackingReservation, VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE,
+        VIRTIO_BLOCK_CONFIG_SIZE, VIRTIO_BLOCK_DEVICE_ID, VIRTIO_BLOCK_FEATURE_FLUSH,
+        VIRTIO_BLOCK_FEATURE_READ_ONLY, VIRTIO_BLOCK_ID_BYTES, VIRTIO_BLOCK_QUEUE_COUNT,
+        VIRTIO_BLOCK_QUEUE_SIZE, VIRTIO_BLOCK_QUEUE_SIZES, VIRTIO_BLOCK_REQUEST_HEADER_SIZE,
+        VIRTIO_BLOCK_REQUEST_TYPE_FLUSH, VIRTIO_BLOCK_REQUEST_TYPE_GET_ID,
+        VIRTIO_BLOCK_REQUEST_TYPE_IN, VIRTIO_BLOCK_REQUEST_TYPE_OUT, VIRTIO_BLOCK_SECTOR_SHIFT,
+        VIRTIO_BLOCK_SECTOR_SIZE, VIRTIO_BLOCK_STATUS_IOERR, VIRTIO_BLOCK_STATUS_OK,
+        VIRTIO_BLOCK_STATUS_SIZE, VIRTIO_BLOCK_STATUS_UNSUPPORTED, VIRTIO_FEATURE_VERSION_1,
+        VIRTIO_RING_FEATURE_EVENT_IDX, VIRTIO_RING_FEATURE_INDIRECT_DESC,
+        VhostUserBlockConfigRefreshError, VhostUserBlockConfigSignalError,
+        VhostUserBlockMemoryRegion, VhostUserBlockNotificationError, VhostUserBlockState,
+        VirtioBlockBackend, VirtioBlockBackendKind, VirtioBlockConfigSpace, VirtioBlockDevice,
         VirtioBlockDeviceActivationError, VirtioBlockDeviceCaptureError, VirtioBlockDeviceId,
         VirtioBlockDeviceNotificationError, VirtioBlockLiveUpdateError, VirtioBlockQueue,
         VirtioBlockQueueBuildError, VirtioBlockQueueDispatch, VirtioBlockQueueDispatchError,
@@ -17364,6 +17448,35 @@ mod tests {
                 .expect("opened descriptor identity should read"),
             identity
         );
+        let writable_file = temp_file("snapshot-backing-rw.img", &[0x11; 512]);
+        let (writable, writable_identity) =
+            BlockFileBacking::open_snapshot(writable_file.as_path(), false)
+                .expect("writable snapshot backing should open");
+        assert!(!writable.is_read_only());
+        assert_eq!(writable_identity.len(), 512);
+        writable
+            .write_at(0, &[0x22])
+            .expect("captured writable access should permit writes");
+        let read_only_file =
+            File::open(writable_file.as_path()).expect("read-only supplied backing should open");
+        assert_eq!(
+            BlockFileBacking::from_snapshot_file(read_only_file, false)
+                .expect_err("supplied access mismatch should reject"),
+            SnapshotBlockFileBackingError::InvalidMetadata
+        );
+        let changed_file = temp_file("snapshot-backing-changed.img", &[0x44; 512]);
+        let reservation = SnapshotBlockFileBackingReservation::open(changed_file.as_path(), true)
+            .expect("snapshot reservation should open");
+        assert_eq!(reservation.identity().len(), 512);
+        assert!(reservation.is_read_only());
+        fs::write(changed_file.as_path(), [0x55; 1024])
+            .expect("reserved backing fixture should change");
+        assert_eq!(
+            reservation
+                .into_backing()
+                .expect_err("changed reservation must reject before adoption"),
+            SnapshotBlockFileBackingError::InvalidMetadata
+        );
         let supplied_file = File::open(file.as_path()).expect("supplied backing should open");
         let moved = file.as_path().with_extension("opened");
         fs::rename(file.as_path(), &moved).expect("opened backing should move");
@@ -17383,6 +17496,11 @@ mod tests {
         assert_eq!(
             BlockFileBacking::open_snapshot_read_only(link.as_path())
                 .expect_err("snapshot backing symlink should reject"),
+            SnapshotBlockFileBackingError::Open
+        );
+        assert_eq!(
+            BlockFileBacking::open_snapshot(link.as_path(), false)
+                .expect_err("writable snapshot symlink should reject"),
             SnapshotBlockFileBackingError::Open
         );
         for unsupported in [directory.as_path(), fifo.as_path(), socket.as_path()] {

--- a/crates/runtime/src/snapshot_device_v2_5.rs
+++ b/crates/runtime/src/snapshot_device_v2_5.rs
@@ -3,8 +3,9 @@
 use std::fmt;
 
 use crate::block::{
-    DriveCacheType, DriveIoEngine, DriveRateLimiterConfig, DriveTokenBucketConfig,
-    VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE, VIRTIO_BLOCK_QUEUE_SIZE, VirtioBlockConfigSpace,
+    DriveCacheType, DriveConfigInput, DriveConfigs, DriveIoEngine, DriveRateLimiterConfig,
+    DriveTokenBucketConfig, VIRTIO_BLOCK_CONFIG_CAPACITY_SIZE, VIRTIO_BLOCK_QUEUE_SIZE,
+    VirtioBlockConfigSpace,
 };
 use crate::memory::{GuestMemoryError, GuestMemoryRange};
 use crate::pci::{
@@ -301,6 +302,55 @@ impl SnapshotV2MultiBlockDeviceGraph {
         &self.records
     }
 
+    /// Builds the exact controller projection without mutating a live
+    /// controller or consuming any restore authority.
+    pub fn project_drive_configs(
+        &self,
+    ) -> Result<DriveConfigs, SnapshotV2MultiBlockDriveConfigsError> {
+        let mut configs = DriveConfigs::new();
+        for record in &self.records {
+            let config = record.config();
+            let mut input = DriveConfigInput::new(
+                config.drive_id(),
+                config.drive_id(),
+                config.selector(),
+                config.is_root(),
+            )
+            .with_is_read_only(config.is_read_only())
+            .with_cache_type(config.cache_type())
+            .with_io_engine(config.io_engine());
+            if let Some(partuuid) = config.partuuid() {
+                input = input.with_partuuid(partuuid);
+            }
+            if let Some(rate_limiter) = config.rate_limiter() {
+                input = input.with_rate_limiter(rate_limiter);
+            }
+            configs
+                .insert(input)
+                .map_err(|_| SnapshotV2MultiBlockDriveConfigsError)?;
+        }
+        if configs.as_slice().len() != self.records.len()
+            || configs
+                .as_slice()
+                .iter()
+                .zip(&self.records)
+                .any(|(config, record)| {
+                    config.drive_id() != record.config().drive_id()
+                        || config.is_root_device() != record.is_root()
+                        || config.is_read_only() != Some(record.config().is_read_only())
+                        || config.partuuid() != record.config().partuuid()
+                        || config.cache_type() != record.config().cache_type()
+                        || config.io_engine() != Some(record.config().io_engine())
+                        || config.rate_limiter() != record.config().rate_limiter()
+                        || config.path_on_host().and_then(|path| path.to_str())
+                            != Some(record.config().selector())
+                })
+        {
+            return Err(SnapshotV2MultiBlockDriveConfigsError);
+        }
+        Ok(configs)
+    }
+
     /// Consumes a trusted record vector only after complete graph validation.
     pub(crate) fn try_from_parts(
         root_key: Option<SnapshotV2DeviceKey>,
@@ -333,6 +383,19 @@ impl SnapshotV2MultiBlockDeviceGraph {
         codec::decode(compatibility_version, bytes)
     }
 }
+
+/// Failure while projecting a validated profile-2 graph into controller
+/// configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotV2MultiBlockDriveConfigsError;
+
+impl fmt::Display for SnapshotV2MultiBlockDriveConfigsError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("native-v2 multi-block drive projection is invalid")
+    }
+}
+
+impl std::error::Error for SnapshotV2MultiBlockDriveConfigsError {}
 
 impl fmt::Debug for SnapshotV2MultiBlockDeviceGraph {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/runtime/src/snapshot_device_v2_5/tests.rs
+++ b/crates/runtime/src/snapshot_device_v2_5/tests.rs
@@ -1,6 +1,8 @@
 use super::codec::{self, ReservePolicy};
 use super::*;
 
+use std::path::Path;
+
 use crate::block::{VIRTIO_BLOCK_ID_BYTES, VirtioBlockDeviceId, VirtioBlockQueueState};
 use crate::interrupt::GuestInterruptLine;
 use crate::memory::GuestAddress;
@@ -430,6 +432,49 @@ fn fixture_matrix_covers_required_semantic_variants() {
             .continuation()
             .active_queue()
             .is_none()
+    );
+}
+
+#[test]
+fn drive_config_projection_is_complete_ordered_and_all_or_nothing() {
+    for with_root in [false, true] {
+        let graph = fixture_graph(SnapshotV2DeviceTransportKind::Mmio, with_root);
+        let configs = graph
+            .project_drive_configs()
+            .expect("validated graph should project");
+        assert_eq!(configs.as_slice().len(), graph.records().len());
+        assert_eq!(configs.has_root_device(), with_root);
+        for (config, record) in configs.as_slice().iter().zip(graph.records()) {
+            let expected = record.config();
+            assert_eq!(config.drive_id(), expected.drive_id());
+            assert_eq!(config.path_on_host(), Some(Path::new(expected.selector())));
+            assert_eq!(config.is_root_device(), expected.is_root());
+            assert_eq!(config.is_read_only(), Some(expected.is_read_only()));
+            assert_eq!(config.partuuid(), expected.partuuid());
+            assert_eq!(config.cache_type(), expected.cache_type());
+            assert_eq!(config.io_engine(), Some(expected.io_engine()));
+            assert_eq!(config.rate_limiter(), expected.rate_limiter());
+        }
+    }
+
+    let maximum = boundary_graph(
+        usize::from(NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_MAX_RECORDS),
+        true,
+    );
+    let configs = maximum
+        .project_drive_configs()
+        .expect("maximum graph should project");
+    assert_eq!(
+        configs.as_slice().len(),
+        usize::from(NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_MAX_RECORDS)
+    );
+    assert!(configs.as_slice()[0].is_root_device());
+    assert!(
+        configs
+            .as_slice()
+            .iter()
+            .skip(1)
+            .all(|config| !config.is_root_device())
     );
 }
 

--- a/crates/session/src/macos/grant_registry.rs
+++ b/crates/session/src/macos/grant_registry.rs
@@ -36,6 +36,39 @@ impl From<BookmarkError> for GrantRegistryError {
     }
 }
 
+/// Redacted live observation of one exact regular-file grant.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ExactRegularFileGrantObservation {
+    identity: ObjectIdentity,
+    len: u64,
+}
+
+impl ExactRegularFileGrantObservation {
+    /// Returns the descriptor-derived identity for alias checks.
+    #[must_use]
+    pub const fn identity(self) -> ObjectIdentity {
+        self.identity
+    }
+
+    /// Returns the exact descriptor byte length.
+    #[must_use]
+    pub const fn len(self) -> u64 {
+        self.len
+    }
+
+    /// Returns whether the observed file is empty.
+    #[must_use]
+    pub const fn is_empty(self) -> bool {
+        self.len == 0
+    }
+}
+
+impl fmt::Debug for ExactRegularFileGrantObservation {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ExactRegularFileGrantObservation(<redacted>)")
+    }
+}
+
 /// Atomically committed grant batch and acknowledgment values.
 #[derive(Debug)]
 pub struct CommittedGrantBatch {
@@ -251,6 +284,21 @@ impl FileGrantRegistry {
         identities: &mut Vec<ObjectIdentity>,
     ) -> Result<(), GrantRegistryError> {
         inspect_exact_files_into(&self.entries, requests, identities)
+    }
+
+    /// Live-inspects exact regular-file grants into caller-preallocated
+    /// observation storage.
+    ///
+    /// Unlike the generic stored-fact inspection, this operation revalidates
+    /// every live descriptor's close-on-exec flag, access, kind, identity,
+    /// status flags, and byte length before any descriptor is duplicated or
+    /// adopted.
+    pub fn inspect_exact_regular_files_into(
+        &self,
+        requests: &[(GrantId, ResourceRole, GrantAccess, GrantObjectKind)],
+        observations: &mut Vec<ExactRegularFileGrantObservation>,
+    ) -> Result<(), GrantRegistryError> {
+        inspect_exact_regular_files_into(&self.entries, requests, observations)
     }
 
     /// Duplicates exact file grants after complete in-memory validation.
@@ -817,6 +865,61 @@ fn inspect_exact_files_into(
     );
     if inspected.len() != requests.len() {
         inspected.clear();
+        return Err(GrantRegistryError);
+    }
+    Ok(())
+}
+
+fn inspect_exact_regular_files_into(
+    entries: &HashMap<GrantId, GrantedFile>,
+    requests: &[(GrantId, ResourceRole, GrantAccess, GrantObjectKind)],
+    observations: &mut Vec<ExactRegularFileGrantObservation>,
+) -> Result<(), GrantRegistryError> {
+    if !observations.is_empty()
+        || observations.capacity() < requests.len()
+        || requests
+            .iter()
+            .any(|(_, _, _, kind)| *kind != GrantObjectKind::RegularFile)
+    {
+        return Err(GrantRegistryError);
+    }
+    validate_exact_files(entries, requests)?;
+    for (id, _, _, _) in requests {
+        let file = entries.get(id).ok_or(GrantRegistryError)?;
+        if validate_descriptor(
+            file.descriptor.as_raw_fd(),
+            file.kind,
+            file.access,
+            file.identity,
+            Some(file.status_flags),
+            file.block_device,
+        )
+        .is_err()
+        {
+            observations.clear();
+            return Err(GrantRegistryError);
+        }
+        let stat = match descriptor_stat(file.descriptor.as_raw_fd()) {
+            Ok(stat) => stat,
+            Err(source) => {
+                observations.clear();
+                return Err(source);
+            }
+        };
+        let len = match u64::try_from(stat.st_size) {
+            Ok(len) => len,
+            Err(_) => {
+                observations.clear();
+                return Err(GrantRegistryError);
+            }
+        };
+        observations.push(ExactRegularFileGrantObservation {
+            identity: file.identity,
+            len,
+        });
+    }
+    if observations.len() != requests.len() {
+        observations.clear();
         return Err(GrantRegistryError);
     }
     Ok(())
@@ -2610,6 +2713,52 @@ mod tests {
                 },
             ]
         );
+        let mut observations = Vec::with_capacity(exact.len());
+        files
+            .inspect_exact_regular_files_into(&exact, &mut observations)
+            .expect("live exact inspection should preserve request order");
+        assert_eq!(observations.len(), 2);
+        assert_eq!(observations[0].identity(), identities[0]);
+        assert_eq!(observations[1].identity(), identities[1]);
+        assert_eq!(
+            observations[0].len(),
+            u64::try_from(kernel_stat.st_size).expect("kernel fixture length should fit")
+        );
+        assert_eq!(
+            observations[1].len(),
+            u64::try_from(initrd_stat.st_size).expect("initrd fixture length should fit")
+        );
+        let kernel_descriptor = files
+            .entries
+            .get(&kernel_id)
+            .expect("kernel grant should remain")
+            .descriptor
+            .as_raw_fd();
+        // SAFETY: F_GETFL and F_SETFL inspect and update the live test
+        // descriptor while the registry continues to own it.
+        let kernel_flags = unsafe { libc::fcntl(kernel_descriptor, libc::F_GETFL) };
+        assert!(kernel_flags >= 0);
+        // SAFETY: The descriptor remains live and O_NONBLOCK is a mutable
+        // status flag.
+        let set_nonblocking = unsafe {
+            libc::fcntl(
+                kernel_descriptor,
+                libc::F_SETFL,
+                kernel_flags | libc::O_NONBLOCK,
+            )
+        };
+        assert!(set_nonblocking >= 0);
+        let mut changed = Vec::with_capacity(exact.len());
+        assert!(
+            files
+                .inspect_exact_regular_files_into(&exact, &mut changed)
+                .is_err()
+        );
+        assert!(changed.is_empty());
+        // SAFETY: Restore the original status flags on the same live test
+        // descriptor before subsequent registry assertions.
+        let restore_flags = unsafe { libc::fcntl(kernel_descriptor, libc::F_SETFL, kernel_flags) };
+        assert!(restore_flags >= 0);
         assert_eq!(files.len(), 2);
         for invalid in [
             vec![(
@@ -2627,6 +2776,13 @@ mod tests {
             vec![exact[0].clone(), exact[0].clone()],
         ] {
             assert!(files.inspect_exact_files(&invalid).is_err());
+            let mut observations = Vec::with_capacity(invalid.len());
+            assert!(
+                files
+                    .inspect_exact_regular_files_into(&invalid, &mut observations)
+                    .is_err()
+            );
+            assert!(observations.is_empty());
             assert!(files.duplicate_exact_files(&invalid).is_err());
             assert!(files.take_exact_files(&invalid).is_err());
             assert_eq!(files.len(), 2);
@@ -2653,6 +2809,13 @@ mod tests {
             .expect("initrd grant should remain")
             .identity = kernel_identity;
         assert!(files.inspect_exact_files(&exact).is_err());
+        let mut observations = Vec::with_capacity(exact.len());
+        assert!(
+            files
+                .inspect_exact_regular_files_into(&exact, &mut observations)
+                .is_err()
+        );
+        assert!(observations.is_empty());
         assert_eq!(files.len(), 2);
         files
             .entries


### PR DESCRIPTION
## Summary

- derive one keyed restore-manifest owner and exact `DriveConfigs` projection per validated native-v2 profile-2 block record
- stage complete direct or contained mixed RO/RW descriptor vectors before backing adoption, with no-follow direct opens and no contained pathname fallback
- return exact-order backings plus one aggregate commit/reverse-abort completion while preserving frozen native-v2 2.4 dispatch

## Scope exclusions

- does not construct virtio block devices or mutate a controller, VM, bus, BAR, interrupt, metrics, or Async executor
- does not activate public native-v2 2.5 support
- remains regular-file-only; block-special and vhost-user restore are outside this slice

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented Apple-target integration Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

Closes #1611
Parent: #1533
