### PR TITLE
feat: reconstruct multi-block MMIO snapshot owners

### DIFF
--- a/crates/bangbang/src/snapshot_restore_resources.rs
+++ b/crates/bangbang/src/snapshot_restore_resources.rs
@@ -1653,20 +1653,39 @@ impl PreparedSnapshotV2MultiBlockRestoreBundle {
         self.bundle.as_ref()
     }
 
-    pub(crate) fn commit(
+    pub(crate) fn construct_destination<D, E>(
         mut self,
-    ) -> Result<PreparedSnapshotV2MultiBlockBundle, PreparedSnapshotV2MultiBlockRestoreCommitError>
-    {
-        let completion = self
-            .completion
-            .take()
-            .ok_or(PreparedSnapshotV2MultiBlockRestoreCommitError::InvalidState)?;
-        completion
-            .commit()
-            .map_err(PreparedSnapshotV2MultiBlockRestoreCommitError::Completion)?;
-        self.bundle
-            .take()
-            .ok_or(PreparedSnapshotV2MultiBlockRestoreCommitError::InvalidState)
+        construct: impl FnOnce(PreparedSnapshotV2MultiBlockBundle) -> Result<D, E>,
+    ) -> Result<
+        PreparedSnapshotV2MultiBlockDestination<D>,
+        PreparedSnapshotV2MultiBlockDestinationConstructionError<E>,
+    > {
+        let Some(bundle) = self.bundle.take() else {
+            return Err(
+                PreparedSnapshotV2MultiBlockDestinationConstructionError::InvalidState {
+                    bundle_cleanup: None,
+                },
+            );
+        };
+        let Some(completion) = self.completion.take() else {
+            return Err(
+                PreparedSnapshotV2MultiBlockDestinationConstructionError::InvalidState {
+                    bundle_cleanup: bundle.abort().err(),
+                },
+            );
+        };
+        match construct(bundle) {
+            Ok(destination) => Ok(PreparedSnapshotV2MultiBlockDestination {
+                destination: Some(destination),
+                completion: Some(completion),
+            }),
+            Err(source) => Err(
+                PreparedSnapshotV2MultiBlockDestinationConstructionError::Construction {
+                    source,
+                    completion_abort: completion.abort().err(),
+                },
+            ),
+        }
     }
 
     pub(crate) fn abort(mut self) -> Result<(), PreparedSnapshotV2MultiBlockRestoreAbortError> {
@@ -1710,25 +1729,203 @@ impl fmt::Debug for PreparedSnapshotV2MultiBlockRestoreBundle {
     }
 }
 
-#[derive(Debug)]
-pub(crate) enum PreparedSnapshotV2MultiBlockRestoreCommitError {
-    InvalidState,
-    Completion(PreparedSnapshotDriveRestoreCompletionError),
+/// One complete private destination whose backing authority remains
+/// provisional until the controller projection is also ready.
+pub(crate) struct PreparedSnapshotV2MultiBlockDestination<D> {
+    destination: Option<D>,
+    completion: Option<PreparedSnapshotDriveRestoreCompletion>,
 }
 
-impl fmt::Display for PreparedSnapshotV2MultiBlockRestoreCommitError {
+impl<D> PreparedSnapshotV2MultiBlockDestination<D> {
+    pub(crate) fn commit<C, E, T>(
+        mut self,
+        prepare_controller: impl FnOnce(D) -> Result<(D, C), (D, E)>,
+        destroy_destination: impl FnOnce(D) -> Result<(), T>,
+    ) -> Result<(D, C), PreparedSnapshotV2MultiBlockDestinationCommitError<E, T>> {
+        let destination = self
+            .destination
+            .take()
+            .ok_or(PreparedSnapshotV2MultiBlockDestinationCommitError::InvalidState)?;
+        let completion = self
+            .completion
+            .take()
+            .ok_or(PreparedSnapshotV2MultiBlockDestinationCommitError::InvalidState)?;
+        let (destination, controller) = match prepare_controller(destination) {
+            Ok(prepared) => prepared,
+            Err((destination, source)) => {
+                let destination_cleanup = destroy_destination(destination).err();
+                let completion_abort = completion.abort().err();
+                return Err(
+                    PreparedSnapshotV2MultiBlockDestinationCommitError::Controller {
+                        source,
+                        destination_cleanup,
+                        completion_abort,
+                    },
+                );
+            }
+        };
+        match completion.commit() {
+            Ok(()) => Ok((destination, controller)),
+            Err(source) => {
+                let destination_cleanup = destroy_destination(destination).err();
+                Err(
+                    PreparedSnapshotV2MultiBlockDestinationCommitError::Completion {
+                        source,
+                        destination_cleanup,
+                    },
+                )
+            }
+        }
+    }
+}
+
+impl<D> fmt::Debug for PreparedSnapshotV2MultiBlockDestination<D> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2MultiBlockDestination")
+            .field("state", &"<private-provisional>")
+            .finish()
+    }
+}
+
+pub(crate) enum PreparedSnapshotV2MultiBlockDestinationConstructionError<E> {
+    InvalidState {
+        bundle_cleanup: Option<SnapshotV2MultiBlockCleanupError>,
+    },
+    Construction {
+        source: E,
+        completion_abort: Option<PreparedSnapshotDriveRestoreCompletionError>,
+    },
+}
+
+impl<E> PreparedSnapshotV2MultiBlockDestinationConstructionError<E> {
+    pub(crate) const fn is_terminal(&self) -> bool {
+        match self {
+            Self::InvalidState { .. }
+            | Self::Construction {
+                completion_abort: Some(_),
+                ..
+            } => true,
+            Self::Construction {
+                completion_abort: None,
+                ..
+            } => false,
+        }
+    }
+}
+
+impl<E> fmt::Debug for PreparedSnapshotV2MultiBlockDestinationConstructionError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::InvalidState { .. } => "invalid-state",
+            Self::Construction { .. } => "construction",
+        };
+        formatter
+            .debug_struct("PreparedSnapshotV2MultiBlockDestinationConstructionError")
+            .field("kind", &kind)
+            .field("terminal", &self.is_terminal())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl<E> fmt::Display for PreparedSnapshotV2MultiBlockDestinationConstructionError<E> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(match self {
-            Self::InvalidState => "snapshot multi-block restore commit state is invalid",
-            Self::Completion(_) => "snapshot multi-block restore completion commit failed",
+            Self::InvalidState { .. } => {
+                "snapshot multi-block destination construction state is invalid"
+            }
+            Self::Construction { .. } => "snapshot multi-block destination construction failed",
         })
     }
 }
 
-impl std::error::Error for PreparedSnapshotV2MultiBlockRestoreCommitError {
+impl<E> std::error::Error for PreparedSnapshotV2MultiBlockDestinationConstructionError<E>
+where
+    E: std::error::Error + 'static,
+{
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::Completion(source) => Some(source),
+            Self::InvalidState { bundle_cleanup } => bundle_cleanup
+                .as_ref()
+                .map(|source| source as &(dyn std::error::Error + 'static)),
+            Self::Construction { source, .. } => Some(source),
+        }
+    }
+}
+
+pub(crate) enum PreparedSnapshotV2MultiBlockDestinationCommitError<E, T> {
+    InvalidState,
+    Controller {
+        source: E,
+        destination_cleanup: Option<T>,
+        completion_abort: Option<PreparedSnapshotDriveRestoreCompletionError>,
+    },
+    Completion {
+        source: PreparedSnapshotDriveRestoreCompletionError,
+        destination_cleanup: Option<T>,
+    },
+}
+
+impl<E, T> PreparedSnapshotV2MultiBlockDestinationCommitError<E, T> {
+    pub(crate) const fn is_terminal(&self) -> bool {
+        match self {
+            Self::InvalidState => true,
+            Self::Controller {
+                destination_cleanup,
+                completion_abort,
+                ..
+            } => destination_cleanup.is_some() || completion_abort.is_some(),
+            Self::Completion {
+                destination_cleanup,
+                ..
+            } => {
+                let _cleanup_failed = destination_cleanup.is_some();
+                true
+            }
+        }
+    }
+}
+
+impl<E, T> fmt::Debug for PreparedSnapshotV2MultiBlockDestinationCommitError<E, T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::InvalidState => "invalid-state",
+            Self::Controller { .. } => "controller",
+            Self::Completion { .. } => "completion",
+        };
+        formatter
+            .debug_struct("PreparedSnapshotV2MultiBlockDestinationCommitError")
+            .field("kind", &kind)
+            .field("terminal", &self.is_terminal())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl<E, T> fmt::Display for PreparedSnapshotV2MultiBlockDestinationCommitError<E, T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidState => "snapshot multi-block destination commit state is invalid",
+            Self::Controller { .. } => {
+                "snapshot multi-block controller preparation failed before completion"
+            }
+            Self::Completion { .. } => {
+                "snapshot multi-block backing completion failed after destination construction"
+            }
+        })
+    }
+}
+
+impl<E, T> std::error::Error for PreparedSnapshotV2MultiBlockDestinationCommitError<E, T>
+where
+    E: std::error::Error + 'static,
+    T: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Controller { source, .. } => Some(source),
+            Self::Completion { source, .. } => Some(source),
             Self::InvalidState => None,
         }
     }
@@ -1927,7 +2124,15 @@ impl RequestedSnapshotRestoreResources {
         // Keep the complete dormant ownership contract type-checked before
         // later profile-2 activation consumes it.
         let _bundle = PreparedSnapshotV2MultiBlockRestoreBundle::bundle;
-        let _commit = PreparedSnapshotV2MultiBlockRestoreBundle::commit;
+        let _construct = |prepared: PreparedSnapshotV2MultiBlockRestoreBundle| {
+            prepared.construct_destination(Ok::<_, std::convert::Infallible>)
+        };
+        let _commit = |destination: PreparedSnapshotV2MultiBlockDestination<()>| {
+            destination.commit(
+                |destination| Ok::<_, ((), std::convert::Infallible)>((destination, ())),
+                |_| Ok::<_, std::convert::Infallible>(()),
+            )
+        };
         let _abort = PreparedSnapshotV2MultiBlockRestoreBundle::abort;
         Self::prepare_native_v2_multi_block_restore_bundle_with(
             graph,
@@ -2843,7 +3048,8 @@ mod tests {
     use std::cell::{Cell, RefCell};
     use std::env;
     use std::fs::{self, OpenOptions};
-    use std::io::Write;
+    use std::io::{self, Write};
+    use std::rc::Rc;
     use std::sync::atomic::{AtomicU64, Ordering};
 
     use bangbang_runtime::block::DriveConfigInput;
@@ -3025,6 +3231,60 @@ mod tests {
                 .expect("profile-2 used cursor should write");
         }
         memory
+    }
+
+    fn direct_profile_2_process_bundle() -> (
+        PreparedSnapshotV2MultiBlockRestoreBundle,
+        TempRoot,
+        TempRoot,
+    ) {
+        let template = multi_fixture_graph(None, None);
+        let first_path = unique_short_path();
+        let second_path = unique_short_path();
+        let first = TempRoot::new_at(
+            first_path,
+            &vec![
+                0x61;
+                usize::try_from(template.records()[0].block().backing_bytes())
+                    .expect("fixture length should fit")
+            ],
+        );
+        let second = TempRoot::new_at(
+            second_path,
+            &vec![
+                0x62;
+                usize::try_from(template.records()[1].block().backing_bytes())
+                    .expect("fixture length should fit")
+            ],
+        );
+        let graph = multi_fixture_graph(Some(first.path()), Some(second.path()));
+        let memory = multi_restore_memory(&graph);
+        let prepared =
+            RequestedSnapshotRestoreResources::prepare_native_v2_multi_block_restore_bundle(
+                graph,
+                &memory,
+                Instant::now(),
+                None,
+                || false,
+            )
+            .expect("direct profile-2 process bundle should prepare");
+        (prepared, first, second)
+    }
+
+    #[derive(Debug)]
+    struct TestPrivateMultiBlockDestination {
+        bundle: Option<PreparedSnapshotV2MultiBlockBundle>,
+        destroyed: Rc<Cell<bool>>,
+    }
+
+    impl TestPrivateMultiBlockDestination {
+        fn destroy(mut self) -> Result<(), SnapshotV2MultiBlockCleanupError> {
+            self.destroyed.set(true);
+            match self.bundle.take() {
+                Some(bundle) => bundle.abort(),
+                None => Ok(()),
+            }
+        }
     }
 
     fn requested() -> RequestedSnapshotRestoreResources {
@@ -3509,13 +3769,187 @@ mod tests {
             assert!(!diagnostics.contains(private.as_ref()));
         }
 
-        let bundle = prepared
-            .commit()
+        let destination = prepared
+            .construct_destination(Ok::<_, std::convert::Infallible>)
+            .expect("private destination should construct before completion");
+        let (bundle, ()) = destination
+            .commit(
+                |bundle| {
+                    Ok::<_, (PreparedSnapshotV2MultiBlockBundle, std::convert::Infallible)>((
+                        bundle,
+                        (),
+                    ))
+                },
+                PreparedSnapshotV2MultiBlockBundle::abort,
+            )
             .expect("direct aggregate completion should commit");
         assert_eq!(bundle.drive_configs(), &expected_configs);
         bundle
             .abort()
             .expect("fresh Async generation should release cleanly");
+    }
+
+    #[test]
+    fn profile_2_destination_construction_failure_aborts_completion_and_runtime() {
+        let (prepared, _first, _second) = direct_profile_2_process_bundle();
+        let runtime = prepared
+            .bundle()
+            .and_then(PreparedSnapshotV2MultiBlockBundle::async_runtime)
+            .expect("mixed fixture should own one runtime")
+            .clone();
+        let error = prepared
+            .construct_destination(|bundle| {
+                bundle
+                    .abort()
+                    .expect("injected construction should release the runtime");
+                Err::<(), _>(io::Error::other("injected destination construction"))
+            })
+            .expect_err("injected destination construction should fail");
+        assert!(!error.is_terminal());
+        assert!(matches!(
+            error,
+            PreparedSnapshotV2MultiBlockDestinationConstructionError::Construction {
+                completion_abort: None,
+                ..
+            }
+        ));
+        assert_eq!(runtime.generation_count().expect("runtime should lock"), 0);
+    }
+
+    #[test]
+    fn profile_2_invalid_destination_state_is_terminal() {
+        let invalid = PreparedSnapshotV2MultiBlockRestoreBundle {
+            bundle: None,
+            completion: None,
+        };
+        let error = invalid
+            .construct_destination(Ok::<_, std::convert::Infallible>)
+            .expect_err("consumed destination state must fail");
+        assert!(error.is_terminal());
+        assert!(matches!(
+            error,
+            PreparedSnapshotV2MultiBlockDestinationConstructionError::InvalidState {
+                bundle_cleanup: None
+            }
+        ));
+    }
+
+    #[test]
+    fn profile_2_controller_failure_destroys_destination_before_completion_abort() {
+        let (prepared, _first, _second) = direct_profile_2_process_bundle();
+        let runtime = prepared
+            .bundle()
+            .and_then(PreparedSnapshotV2MultiBlockBundle::async_runtime)
+            .expect("mixed fixture should own one runtime")
+            .clone();
+        let destroyed = Rc::new(Cell::new(false));
+        let destination = prepared
+            .construct_destination({
+                let destroyed = Rc::clone(&destroyed);
+                move |bundle| {
+                    Ok::<_, std::convert::Infallible>(TestPrivateMultiBlockDestination {
+                        bundle: Some(bundle),
+                        destroyed,
+                    })
+                }
+            })
+            .expect("private destination should construct");
+        let error = destination
+            .commit(
+                |destination| {
+                    Err::<(TestPrivateMultiBlockDestination, ()), _>((
+                        destination,
+                        io::Error::other("injected controller preparation"),
+                    ))
+                },
+                TestPrivateMultiBlockDestination::destroy,
+            )
+            .expect_err("injected controller preparation should fail");
+        assert!(destroyed.get());
+        assert!(!error.is_terminal());
+        assert!(matches!(
+            error,
+            PreparedSnapshotV2MultiBlockDestinationCommitError::Controller {
+                destination_cleanup: None,
+                completion_abort: None,
+                ..
+            }
+        ));
+        assert_eq!(runtime.generation_count().expect("runtime should lock"), 0);
+    }
+
+    #[test]
+    fn profile_2_completion_failure_destroys_destination_and_is_terminal() {
+        let (mut prepared, _first, _second) = direct_profile_2_process_bundle();
+        prepared
+            .completion
+            .take()
+            .expect("direct completion should exist")
+            .abort()
+            .expect("direct completion should abort before injection");
+
+        let root = TempRoot::new("multi-completion", b"root");
+        let fixture = contained_restore_authority_for_test(root.path(), false);
+        let root_owner = contained_requested_root()
+            .prepare(Some(fixture.authority()), || false)
+            .expect("contained root should prepare")
+            .into_root()
+            .expect("contained root should take exactly");
+        let (backing, completion) = root_owner.into_parts();
+        drop(backing);
+        let PreparedSnapshotRootRestoreCompletion {
+            lease,
+            contained_transaction,
+        } = completion;
+        let PreparedSnapshotRootBackingLease {
+            selector: _,
+            claim,
+            consumed: _,
+        } = lease;
+        prepared.completion = Some(PreparedSnapshotDriveRestoreCompletion {
+            claims: claim.into_iter().collect(),
+            contained_transaction,
+        });
+
+        let runtime = prepared
+            .bundle()
+            .and_then(PreparedSnapshotV2MultiBlockBundle::async_runtime)
+            .expect("mixed fixture should own one runtime")
+            .clone();
+        let destroyed = Rc::new(Cell::new(false));
+        let destination = prepared
+            .construct_destination({
+                let destroyed = Rc::clone(&destroyed);
+                move |bundle| {
+                    Ok::<_, std::convert::Infallible>(TestPrivateMultiBlockDestination {
+                        bundle: Some(bundle),
+                        destroyed,
+                    })
+                }
+            })
+            .expect("private destination should construct");
+        fixture.invalidate_generation();
+        let error = destination
+            .commit(
+                |destination| {
+                    Ok::<_, (TestPrivateMultiBlockDestination, std::convert::Infallible)>((
+                        destination,
+                        (),
+                    ))
+                },
+                TestPrivateMultiBlockDestination::destroy,
+            )
+            .expect_err("stale contained completion should fail");
+        assert!(destroyed.get());
+        assert!(error.is_terminal());
+        assert!(matches!(
+            error,
+            PreparedSnapshotV2MultiBlockDestinationCommitError::Completion {
+                destination_cleanup: None,
+                ..
+            }
+        ));
+        assert_eq!(runtime.generation_count().expect("runtime should lock"), 0);
     }
 
     #[test]

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -30,16 +30,18 @@ use bangbang_hvf::{
     HvfArm64BootPciNetworkDeviceUpdater, HvfArm64BootPciPmemDeviceUpdater,
     HvfArm64BootRunLoopControl, HvfArm64BootRunLoopError, HvfArm64BootRunLoopOutcome,
     HvfArm64BootRunLoopStopToken, HvfArm64BootSerialCaptureError, HvfArm64BootSerialDeviceConfig,
-    HvfArm64BootSessionConfig, HvfArm64BootSnapshotV1CaptureStage,
-    HvfArm64BootSnapshotV1DeviceCaptureError, HvfArm64BootSnapshotV1StateCaptureError,
-    HvfArm64BootSnapshotV2CaptureError, HvfArm64BootSnapshotV2CaptureInput,
-    HvfArm64BootStorageCaptureError, HvfArm64BootStorageCaptureErrorKind,
-    HvfArm64BootStorageCaptureStage, HvfArm64BootTimerDeviceConfig, HvfArm64BootVcpuError,
-    HvfArm64BootVsockCaptureDisposition, HvfArm64BootVsockCaptureError,
-    HvfArm64BootVsockCaptureStage, HvfArm64BootVsockCaptureState, HvfBackend, HvfSnapshotV1Bundle,
-    HvfSnapshotV1BundleError, HvfSnapshotV1RestoreCleanup, HvfSnapshotV1RestoreDisposition,
-    HvfSnapshotV1RestoreError, HvfSnapshotV1State, HvfSnapshotV2BootState, HvfSnapshotV2BuildError,
-    HvfSnapshotV2DecodeError, HvfSnapshotV2DefaultProcessShell, HvfSnapshotV2EncodeError,
+    HvfArm64BootSessionConfig, HvfArm64BootSessionShutdownError,
+    HvfArm64BootSnapshotV1CaptureStage, HvfArm64BootSnapshotV1DeviceCaptureError,
+    HvfArm64BootSnapshotV1StateCaptureError, HvfArm64BootSnapshotV2CaptureError,
+    HvfArm64BootSnapshotV2CaptureInput, HvfArm64BootStorageCaptureError,
+    HvfArm64BootStorageCaptureErrorKind, HvfArm64BootStorageCaptureStage,
+    HvfArm64BootTimerDeviceConfig, HvfArm64BootVcpuError, HvfArm64BootVsockCaptureDisposition,
+    HvfArm64BootVsockCaptureError, HvfArm64BootVsockCaptureStage, HvfArm64BootVsockCaptureState,
+    HvfBackend, HvfSnapshotV1Bundle, HvfSnapshotV1BundleError, HvfSnapshotV1RestoreCleanup,
+    HvfSnapshotV1RestoreDisposition, HvfSnapshotV1RestoreError, HvfSnapshotV1State,
+    HvfSnapshotV2BootState, HvfSnapshotV2BuildError, HvfSnapshotV2DecodeError,
+    HvfSnapshotV2DefaultProcessShell, HvfSnapshotV2EncodeError,
+    HvfSnapshotV2MultiBlockMmioRestoreError, HvfSnapshotV2MultiBlockPlatformPlan,
     HvfSnapshotV2NativePath, HvfSnapshotV2PlatformRestoreError, HvfSnapshotV2PlatformState,
     HvfSnapshotV2RootProcessConfig, HvfSnapshotV2RootResourcePlan, HvfSnapshotV2RootRestoreError,
     HvfSnapshotV2State, HvfVcpuRunControl, HvfVcpuRunCoordinatorError, HvfVcpuRunStepOutcome,
@@ -57,7 +59,7 @@ use bangbang_runtime::balloon::{
 };
 use bangbang_runtime::block::{
     BlockFileBacking, BlockMmioLayout, DriveBackendConfig, DriveConfig, DriveConfigError,
-    DriveConfigInput, DriveIoEngine, DriveLiveUpdateMode, DriveRateLimiterConfig,
+    DriveConfigInput, DriveConfigs, DriveIoEngine, DriveLiveUpdateMode, DriveRateLimiterConfig,
     DriveRuntimeMutationError, DriveUpdateError, DriveUpdateInput, PreparedBlockDevice,
     PreparedVhostUserBlockFrontend, RuntimeBlockDeviceResource,
 };
@@ -200,7 +202,9 @@ use crate::host_network::vmnet::{
 #[cfg(target_os = "macos")]
 use crate::snapshot_restore_resources::{
     PreparedSnapshotRootBackingLease, PreparedSnapshotRootRestoreCompletion,
-    PreparedSnapshotRootRestoreCompletionError, RequestedSnapshotRestoreResources,
+    PreparedSnapshotRootRestoreCompletionError, PreparedSnapshotV2MultiBlockDestinationCommitError,
+    PreparedSnapshotV2MultiBlockDestinationConstructionError,
+    PreparedSnapshotV2MultiBlockRestoreBundle, RequestedSnapshotRestoreResources,
     SnapshotRestoreResourceDisposition, SnapshotRestoreResourceError,
     SnapshotRootBackingLeaseError, SnapshotRootSelectorPolicy,
 };
@@ -6653,6 +6657,211 @@ fn native_v2_boot_source_config(
         input = input.with_boot_args(arguments);
     }
     input.validate()
+}
+
+#[cfg(target_os = "macos")]
+struct PreparedHvfSnapshotV2MultiBlockMmioDestination {
+    session: Box<OwnedHvfArm64BootSession>,
+    drive_configs: Option<DriveConfigs>,
+}
+
+#[cfg(target_os = "macos")]
+impl PreparedHvfSnapshotV2MultiBlockMmioDestination {
+    fn prepare_controller(
+        mut self,
+        machine: bangbang_runtime::machine::MachineConfig,
+        boot: bangbang_runtime::boot::BootSourceConfig,
+        resume_requested: bool,
+    ) -> Result<
+        (Self, SnapshotV2ControllerCommit),
+        (Self, PreparedHvfSnapshotV2MultiBlockControllerError),
+    > {
+        let Some(drive_configs) = self.drive_configs.take() else {
+            return Err((
+                self,
+                PreparedHvfSnapshotV2MultiBlockControllerError::MissingDriveConfigs,
+            ));
+        };
+        let controller = SnapshotV2ControllerCommit::with_drive_configs(
+            machine,
+            boot,
+            drive_configs,
+            resume_requested,
+        );
+        Ok((self, controller))
+    }
+
+    fn shutdown(mut self) -> Result<(), HvfArm64BootSessionShutdownError> {
+        self.session.shutdown()
+    }
+
+    fn into_session(self) -> OwnedHvfArm64BootSession {
+        debug_assert!(self.drive_configs.is_none());
+        *self.session
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl fmt::Debug for PreparedHvfSnapshotV2MultiBlockMmioDestination {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedHvfSnapshotV2MultiBlockMmioDestination")
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PreparedHvfSnapshotV2MultiBlockControllerError {
+    MissingDriveConfigs,
+}
+
+#[cfg(target_os = "macos")]
+impl fmt::Display for PreparedHvfSnapshotV2MultiBlockControllerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("profile-2 controller projection is unavailable")
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl std::error::Error for PreparedHvfSnapshotV2MultiBlockControllerError {}
+
+#[cfg(target_os = "macos")]
+enum PrepareHvfSnapshotV2MultiBlockMmioDestinationError {
+    Construction(
+        PreparedSnapshotV2MultiBlockDestinationConstructionError<
+            HvfSnapshotV2MultiBlockMmioRestoreError,
+        >,
+    ),
+    Commit(
+        PreparedSnapshotV2MultiBlockDestinationCommitError<
+            PreparedHvfSnapshotV2MultiBlockControllerError,
+            HvfArm64BootSessionShutdownError,
+        >,
+    ),
+}
+
+#[cfg(target_os = "macos")]
+impl PrepareHvfSnapshotV2MultiBlockMmioDestinationError {
+    fn is_terminal(&self) -> bool {
+        match self {
+            Self::Construction(source) => {
+                source.is_terminal()
+                    || matches!(
+                        source,
+                        PreparedSnapshotV2MultiBlockDestinationConstructionError::Construction {
+                            source,
+                            ..
+                        } if source.is_terminal()
+                    )
+            }
+            Self::Commit(source) => source.is_terminal(),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl fmt::Debug for PrepareHvfSnapshotV2MultiBlockMmioDestinationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let stage = match self {
+            Self::Construction(_) => "construction",
+            Self::Commit(_) => "completion",
+        };
+        formatter
+            .debug_struct("PrepareHvfSnapshotV2MultiBlockMmioDestinationError")
+            .field("stage", &stage)
+            .field("terminal", &self.is_terminal())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl fmt::Display for PrepareHvfSnapshotV2MultiBlockMmioDestinationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "profile-2 MMIO destination transaction failed ({})",
+            if self.is_terminal() {
+                "terminal"
+            } else {
+                "retryable"
+            }
+        )
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl std::error::Error for PrepareHvfSnapshotV2MultiBlockMmioDestinationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Construction(source) => Some(source),
+            Self::Commit(source) => Some(source),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+struct PrepareHvfSnapshotV2MultiBlockMmioDestinationInput {
+    platform: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    process_shell: HvfSnapshotV2DefaultProcessShell,
+    bundle: PreparedSnapshotV2MultiBlockRestoreBundle,
+    plan: HvfSnapshotV2MultiBlockPlatformPlan,
+    machine: bangbang_runtime::machine::MachineConfig,
+    boot: bangbang_runtime::boot::BootSourceConfig,
+    resume_requested: bool,
+}
+
+/// Dormant profile-2 process transaction. Public native-v2 dispatch remains
+/// exact 2.4 until the activation slice consumes this boundary.
+#[cfg(target_os = "macos")]
+#[allow(
+    dead_code,
+    reason = "profile-2 public native-v2 activation is owned by the dependent delivery slice"
+)]
+fn prepare_hvf_native_v2_multi_block_mmio_destination(
+    input: PrepareHvfSnapshotV2MultiBlockMmioDestinationInput,
+) -> Result<
+    (OwnedHvfArm64BootSession, SnapshotV2ControllerCommit),
+    PrepareHvfSnapshotV2MultiBlockMmioDestinationError,
+> {
+    let PrepareHvfSnapshotV2MultiBlockMmioDestinationInput {
+        platform,
+        memory,
+        process_shell,
+        bundle,
+        plan,
+        machine,
+        boot,
+        resume_requested,
+    } = input;
+    let destination = bundle
+        .construct_destination(|bundle| {
+            OwnedHvfArm64BootSession::restore_snapshot_v2_multi_block_mmio(
+                platform,
+                memory,
+                process_shell,
+                bundle,
+                plan,
+            )
+            .map(|owners| {
+                let (session, drive_configs) = owners.into_parts();
+                PreparedHvfSnapshotV2MultiBlockMmioDestination {
+                    session: Box::new(session),
+                    drive_configs: Some(drive_configs),
+                }
+            })
+        })
+        .map_err(PrepareHvfSnapshotV2MultiBlockMmioDestinationError::Construction)?;
+    let (destination, controller) = destination
+        .commit(
+            |destination| destination.prepare_controller(machine, boot, resume_requested),
+            PreparedHvfSnapshotV2MultiBlockMmioDestination::shutdown,
+        )
+        .map_err(PrepareHvfSnapshotV2MultiBlockMmioDestinationError::Commit)?;
+    Ok((destination.into_session(), controller))
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -195,9 +195,12 @@ pub use startup::{
     HvfArm64BootVsockCaptureStage, HvfArm64BootVsockCaptureState,
     HvfArm64BootVsockNotificationDispatch, HvfArm64BootVsockNotificationDispatchError,
     HvfArm64BootVsockNotificationDispatches, HvfArm64BootVsockTransportState,
+    HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure, HvfSnapshotV2MultiBlockMmioRestoreError,
+    HvfSnapshotV2MultiBlockMmioRestoreFailure, HvfSnapshotV2MultiBlockMmioRestoreStage,
     HvfSnapshotV2RootRestoreCleanupFailure, HvfSnapshotV2RootRestoreError,
     HvfSnapshotV2RootRestoreFailure, HvfSnapshotV2RootRestoreStage, OwnedHvfArm64BootSession,
     PreparedHvfArm64BootPciNetworkRemoval, RestoredHvfArm64BootSession,
+    RestoredHvfSnapshotV2MultiBlockMmioOwners,
 };
 pub use topology::{
     HvfVcpuTopology, HvfVcpuTopologyAllocation, HvfVcpuTopologyCreateStage, HvfVcpuTopologyError,

--- a/crates/hvf/src/snapshot_v2_multi_block_platform.rs
+++ b/crates/hvf/src/snapshot_v2_multi_block_platform.rs
@@ -317,6 +317,18 @@ pub struct HvfSnapshotV2MultiBlockPlatformPlan {
     vmclock_interrupt: GuestInterruptLine,
 }
 
+pub(crate) struct HvfSnapshotV2MultiBlockPlatformPlanParts {
+    pub(crate) root_key: Option<SnapshotV2DeviceKey>,
+    pub(crate) command_line: String,
+    pub(crate) metrics_ids: Vec<String>,
+    pub(crate) retries: Vec<HvfSnapshotV2MultiBlockRetryPlan>,
+    pub(crate) earliest_retry_index: Option<usize>,
+    pub(crate) transport: HvfSnapshotV2MultiBlockTransportPlan,
+    pub(crate) serial_interrupt: GuestInterruptLine,
+    pub(crate) vmgenid_interrupt: GuestInterruptLine,
+    pub(crate) vmclock_interrupt: GuestInterruptLine,
+}
+
 impl HvfSnapshotV2MultiBlockPlatformPlan {
     /// Returns the optional root graph key.
     pub const fn root_key(&self) -> Option<SnapshotV2DeviceKey> {
@@ -362,6 +374,20 @@ impl HvfSnapshotV2MultiBlockPlatformPlan {
     /// Returns the canonical VMClock SPI.
     pub const fn vmclock_interrupt(&self) -> GuestInterruptLine {
         self.vmclock_interrupt
+    }
+
+    pub(crate) fn into_parts(self) -> HvfSnapshotV2MultiBlockPlatformPlanParts {
+        HvfSnapshotV2MultiBlockPlatformPlanParts {
+            root_key: self.root_key,
+            command_line: self.command_line,
+            metrics_ids: self.metrics_ids,
+            retries: self.retries,
+            earliest_retry_index: self.earliest_retry_index,
+            transport: self.transport,
+            serial_interrupt: self.serial_interrupt,
+            vmgenid_interrupt: self.vmgenid_interrupt,
+            vmclock_interrupt: self.vmclock_interrupt,
+        }
     }
 }
 
@@ -994,7 +1020,7 @@ impl PlatformPlanReserve for SystemPlatformPlanReserve {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::fs::{self, OpenOptions};
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -1352,6 +1378,21 @@ mod tests {
             crate::snapshot_v2_platform::tests::mmio_root_plan_fixture();
         drop(root);
         rebuild_product_platform(platform, record_count, None, true)
+    }
+
+    pub(crate) fn mmio_fdt_plan_fixture() -> (
+        HvfSnapshotV2PlatformState,
+        HvfSnapshotV2MultiBlockPlatformPlan,
+    ) {
+        let fixture = bundle_from_graph(fixture_graph(SnapshotV2DeviceTransportKind::Mmio, false));
+        let platform = product_mmio_platform(fixture.bundle.records().len());
+        let plan = prepare_hvf_snapshot_v2_multi_block_platform_plan(
+            &platform,
+            &fixture.bundle,
+            mmio_process(),
+        )
+        .expect("multi-block MMIO FDT plan should validate");
+        (platform, plan)
     }
 
     fn product_pci_platform() -> HvfSnapshotV2PlatformState {

--- a/crates/hvf/src/snapshot_v2_platform.rs
+++ b/crates/hvf/src/snapshot_v2_platform.rs
@@ -67,6 +67,7 @@ use crate::snapshot_v2::{
     HvfSnapshotV2GlobalState, HvfSnapshotV2MachineState, HvfSnapshotV2PlatformState,
     HvfSnapshotV2State, HvfSnapshotV2TimeState, HvfSnapshotV2VcpuState,
 };
+use crate::snapshot_v2_multi_block_platform::HvfSnapshotV2MultiBlockMmioRecordPlan;
 use crate::startup::{
     HvfArm64BootSnapshotV2CaptureError, HvfArm64BootSnapshotV2CaptureStage,
     HvfArm64BootVmClockRestoreError, HvfArm64BootVmGenIdRestoreError,
@@ -347,12 +348,36 @@ impl fmt::Debug for HvfSnapshotV2DefaultProcessShell {
     }
 }
 
-enum HvfSnapshotV2ProcessShellRestore {
+pub(crate) struct HvfSnapshotV2MultiBlockMmioShellPlan<'a> {
+    pub(crate) command_line: &'a str,
+    pub(crate) records: &'a [HvfSnapshotV2MultiBlockMmioRecordPlan],
+    pub(crate) serial_interrupt: GuestInterruptLine,
+    pub(crate) vmgenid_interrupt: GuestInterruptLine,
+    pub(crate) vmclock_interrupt: GuestInterruptLine,
+}
+
+enum HvfSnapshotV2ProcessShellRestore<'a> {
     DeviceFree(HvfSnapshotV2DefaultProcessShell),
     Root {
         shell: HvfSnapshotV2DefaultProcessShell,
         resources: HvfSnapshotV2RootResourcePlan,
         partuuid: Option<String>,
+    },
+    MultiBlockMmio {
+        shell: HvfSnapshotV2DefaultProcessShell,
+        plan: HvfSnapshotV2MultiBlockMmioShellPlan<'a>,
+    },
+}
+
+enum HvfSnapshotV2ProcessBlockFdtPlan<'a> {
+    None,
+    Root {
+        partuuid: Option<String>,
+        transport: HvfSnapshotV2RootTransportPlan,
+    },
+    MultiBlockMmio {
+        command_line: &'a str,
+        records: &'a [HvfSnapshotV2MultiBlockMmioRecordPlan],
     },
 }
 
@@ -831,6 +856,11 @@ pub enum HvfSnapshotV2PlatformShutdownError {
     Vcpu(HvfVcpuRunCoordinatorError),
     /// Guest-memory teardown or VM destruction failed.
     Backend(BackendError),
+    /// Both independent reverse-cleanup operations failed.
+    VcpuAndBackend {
+        vcpu: HvfVcpuRunCoordinatorError,
+        backend: BackendError,
+    },
 }
 
 impl fmt::Display for HvfSnapshotV2PlatformShutdownError {
@@ -838,6 +868,10 @@ impl fmt::Display for HvfSnapshotV2PlatformShutdownError {
         match self {
             Self::Vcpu(_) => f.write_str("native-v2 vCPU topology shutdown failed"),
             Self::Backend(_) => f.write_str("native-v2 backend shutdown failed"),
+            Self::VcpuAndBackend { vcpu, backend } => {
+                let _sources = (vcpu, backend);
+                f.write_str("native-v2 vCPU and backend shutdown both failed")
+            }
         }
     }
 }
@@ -847,6 +881,7 @@ impl std::error::Error for HvfSnapshotV2PlatformShutdownError {
         match self {
             Self::Vcpu(source) => Some(source),
             Self::Backend(source) => Some(source),
+            Self::VcpuAndBackend { vcpu, .. } => Some(vcpu),
         }
     }
 }
@@ -1090,6 +1125,12 @@ impl RestoredHvfSnapshotV2Platform {
         self.parts().backend.mapped_guest_memory_for_public_access()
     }
 
+    pub(crate) fn guest_memory_mut(
+        &mut self,
+    ) -> Result<&mut GuestMemory, HvfGuestMemoryMappingError> {
+        self.parts_mut().backend.mapped_guest_memory_mut()
+    }
+
     pub(crate) fn backend(&self) -> &HvfBackend {
         &self.parts().backend
     }
@@ -1118,12 +1159,16 @@ impl RestoredHvfSnapshotV2Platform {
         let Some(parts) = self.parts.as_mut() else {
             return Ok(());
         };
-        parts
-            .runner
-            .shutdown()
-            .map_err(HvfSnapshotV2PlatformShutdownError::Vcpu)?;
-        <HvfBackend as VmBackend>::destroy_vm(&mut parts.backend)
-            .map_err(HvfSnapshotV2PlatformShutdownError::Backend)
+        let vcpu = parts.runner.shutdown().err();
+        let backend = <HvfBackend as VmBackend>::destroy_vm(&mut parts.backend).err();
+        match (vcpu, backend) {
+            (None, None) => Ok(()),
+            (Some(source), None) => Err(HvfSnapshotV2PlatformShutdownError::Vcpu(source)),
+            (None, Some(source)) => Err(HvfSnapshotV2PlatformShutdownError::Backend(source)),
+            (Some(vcpu), Some(backend)) => {
+                Err(HvfSnapshotV2PlatformShutdownError::VcpuAndBackend { vcpu, backend })
+            }
+        }
     }
 }
 
@@ -1237,10 +1282,23 @@ pub(crate) fn restore_hvf_snapshot_v2_root_process_platform(
     )
 }
 
+pub(crate) fn restore_hvf_snapshot_v2_multi_block_mmio_process_platform(
+    state: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    shell: HvfSnapshotV2DefaultProcessShell,
+    plan: HvfSnapshotV2MultiBlockMmioShellPlan<'_>,
+) -> Result<RestoredHvfSnapshotV2Platform, HvfSnapshotV2PlatformRestoreError> {
+    restore_hvf_snapshot_v2_platform_with_shell(
+        state,
+        memory,
+        Some(HvfSnapshotV2ProcessShellRestore::MultiBlockMmio { shell, plan }),
+    )
+}
+
 fn restore_hvf_snapshot_v2_platform_with_shell(
     state: HvfSnapshotV2PlatformState,
     memory: GuestMemory,
-    process_shell: Option<HvfSnapshotV2ProcessShellRestore>,
+    process_shell: Option<HvfSnapshotV2ProcessShellRestore<'_>>,
 ) -> Result<RestoredHvfSnapshotV2Platform, HvfSnapshotV2PlatformRestoreError> {
     debug_assert!(cleanup_sequence(RestoreOwnership::Empty).is_empty());
     let mut cleanup = Vec::new();
@@ -2092,7 +2150,7 @@ pub(crate) fn pci_msix_routes_match_gic(
 }
 
 fn prepare_process_shell(
-    shell: Option<HvfSnapshotV2ProcessShellRestore>,
+    shell: Option<HvfSnapshotV2ProcessShellRestore<'_>>,
     state: &HvfSnapshotV2PlatformState,
     fdt_bytes: &[u8],
 ) -> Result<(MmioDispatcher, Option<Arm64BootSerialDevice>), HvfSnapshotV2PlatformRestoreFailure> {
@@ -2111,44 +2169,91 @@ fn prepare_process_shell(
     }
     let mut allocator = HvfGicInterruptLineAllocator::from_metadata(&gic)
         .map_err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterrupt)?;
-    let (shell, root, product_process_profile) = match shell_restore {
-        HvfSnapshotV2ProcessShellRestore::DeviceFree(shell) => {
-            if gic.msi.is_some() {
-                return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellFdt {
-                    mismatch: HvfSnapshotV2ProcessFdtMismatch::Profile,
-                });
+    let (shell, block_plan, product_process_profile, validate_detailed, planned_interrupts) =
+        match shell_restore {
+            HvfSnapshotV2ProcessShellRestore::DeviceFree(shell) => {
+                if gic.msi.is_some() {
+                    return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellFdt {
+                        mismatch: HvfSnapshotV2ProcessFdtMismatch::Profile,
+                    });
+                }
+                (
+                    shell,
+                    HvfSnapshotV2ProcessBlockFdtPlan::None,
+                    false,
+                    true,
+                    None,
+                )
             }
-            (shell, None, false)
-        }
-        HvfSnapshotV2ProcessShellRestore::Root {
-            shell,
-            resources,
-            partuuid,
-        } => {
-            match resources.transport() {
-                HvfSnapshotV2RootTransportPlan::Mmio { interrupt_line, .. } => {
-                    if gic.msi.is_some()
-                        || allocator
-                            .allocate()
-                            .map_err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterrupt)?
-                            != interrupt_line
+            HvfSnapshotV2ProcessShellRestore::Root {
+                shell,
+                resources,
+                partuuid,
+            } => {
+                match resources.transport() {
+                    HvfSnapshotV2RootTransportPlan::Mmio { interrupt_line, .. } => {
+                        if gic.msi.is_some()
+                            || allocator.allocate().map_err(
+                                HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterrupt,
+                            )? != interrupt_line
+                        {
+                            return Err(
+                                HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterruptIdentity,
+                            );
+                        }
+                    }
+                    HvfSnapshotV2RootTransportPlan::Pci { msi, .. } => {
+                        if gic.msi != Some(msi) {
+                            return Err(
+                                HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterruptIdentity,
+                            );
+                        }
+                    }
+                }
+                (
+                    shell,
+                    HvfSnapshotV2ProcessBlockFdtPlan::Root {
+                        partuuid,
+                        transport: resources.transport(),
+                    },
+                    true,
+                    false,
+                    None,
+                )
+            }
+            HvfSnapshotV2ProcessShellRestore::MultiBlockMmio { shell, plan } => {
+                if gic.msi.is_some() || plan.records.is_empty() {
+                    return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellFdt {
+                        mismatch: HvfSnapshotV2ProcessFdtMismatch::Profile,
+                    });
+                }
+                for record in plan.records {
+                    if allocator
+                        .allocate()
+                        .map_err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterrupt)?
+                        != record.interrupt_line()
                     {
                         return Err(
                             HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterruptIdentity,
                         );
                     }
                 }
-                HvfSnapshotV2RootTransportPlan::Pci { msi, .. } => {
-                    if gic.msi != Some(msi) {
-                        return Err(
-                            HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterruptIdentity,
-                        );
-                    }
-                }
+                (
+                    shell,
+                    HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockMmio {
+                        command_line: plan.command_line,
+                        records: plan.records,
+                    },
+                    true,
+                    true,
+                    Some((
+                        plan.serial_interrupt,
+                        plan.vmgenid_interrupt,
+                        plan.vmclock_interrupt,
+                    )),
+                )
             }
-            (shell, Some((partuuid, resources.transport())), true)
-        }
-    };
+        };
     let serial_interrupt = allocator
         .allocate()
         .map_err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterrupt)?;
@@ -2158,26 +2263,22 @@ fn prepare_process_shell(
     let vmclock_interrupt = allocator
         .allocate()
         .map_err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterrupt)?;
-    if state.time().vmgenid().interrupt_line() != vmgenid_interrupt
+    if planned_interrupts.is_some_and(|expected| {
+        expected != (serial_interrupt, vmgenid_interrupt, vmclock_interrupt)
+    }) || state.time().vmgenid().interrupt_line() != vmgenid_interrupt
         || state.time().vmclock().interrupt_line() != vmclock_interrupt
     {
         return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterruptIdentity);
     }
-    if product_process_profile {
-        if !state.machine().fdt().is_product_process_profile() {
-            return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellFdt {
-                mismatch: HvfSnapshotV2ProcessFdtMismatch::Profile,
-            });
-        }
-    } else {
-        validate_process_fdt(
-            fdt_bytes,
-            state,
-            serial_interrupt,
-            root.as_ref()
-                .map(|(partuuid, transport)| (partuuid.as_deref(), *transport)),
-        )
-        .map_err(|mismatch| HvfSnapshotV2PlatformRestoreFailure::ProcessShellFdt { mismatch })?;
+    if product_process_profile && !state.machine().fdt().is_product_process_profile() {
+        return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellFdt {
+            mismatch: HvfSnapshotV2ProcessFdtMismatch::Profile,
+        });
+    }
+    if validate_detailed {
+        validate_process_fdt(fdt_bytes, state, serial_interrupt, &block_plan).map_err(
+            |mismatch| HvfSnapshotV2PlatformRestoreFailure::ProcessShellFdt { mismatch },
+        )?;
     }
 
     let serial = register_arm64_boot_serial_mmio(
@@ -2199,7 +2300,12 @@ fn validate_default_process_fdt(
     state: &HvfSnapshotV2PlatformState,
     serial_interrupt: GuestInterruptLine,
 ) -> Result<(), HvfSnapshotV2ProcessFdtMismatch> {
-    validate_process_fdt(bytes, state, serial_interrupt, None)
+    validate_process_fdt(
+        bytes,
+        state,
+        serial_interrupt,
+        &HvfSnapshotV2ProcessBlockFdtPlan::None,
+    )
 }
 
 #[cfg(test)]
@@ -2216,7 +2322,10 @@ fn validate_root_process_fdt(
         bytes,
         state,
         resources.serial_interrupt,
-        Some((root.partuuid(), resources.transport)),
+        &HvfSnapshotV2ProcessBlockFdtPlan::Root {
+            partuuid: root.partuuid().map(str::to_owned),
+            transport: resources.transport,
+        },
     )
 }
 
@@ -2248,7 +2357,7 @@ fn validate_process_fdt(
     bytes: &[u8],
     state: &HvfSnapshotV2PlatformState,
     serial_interrupt: GuestInterruptLine,
-    root: Option<(Option<&str>, HvfSnapshotV2RootTransportPlan)>,
+    block: &HvfSnapshotV2ProcessBlockFdtPlan<'_>,
 ) -> Result<(), HvfSnapshotV2ProcessFdtMismatch> {
     let tree = DeviceTree::load(bytes).map_err(|_| HvfSnapshotV2ProcessFdtMismatch::Parse)?;
     let time = state.time();
@@ -2259,7 +2368,12 @@ fn validate_process_fdt(
         |name: &str| node_name_has_number(name, "rtc@", 16, PROCESS_RTC_MMIO_BASE.raw_value());
     let vmclock_name =
         |name: &str| node_name_has_number(name, "ptp@", 10, time.vmclock().fdt_region().base);
-    if tree.root.children.len() != 11 + usize::from(root.is_some())
+    let block_child_count = match block {
+        HvfSnapshotV2ProcessBlockFdtPlan::None => 0,
+        HvfSnapshotV2ProcessBlockFdtPlan::Root { .. } => 1,
+        HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockMmio { records, .. } => records.len(),
+    };
+    if tree.root.children.len() != 11 + block_child_count
         || [
             "cpus",
             "memory@ram",
@@ -2351,20 +2465,34 @@ fn validate_process_fdt(
     let Some(chosen) = child_named(&tree.root, "chosen") else {
         return Err(HvfSnapshotV2ProcessFdtMismatch::Boot);
     };
-    let expected_boot_args = match root {
-        Some((partuuid, transport)) => canonical_process_root_block_command_line(
-            state.machine().boot().boot_arguments(),
-            matches!(transport, HvfSnapshotV2RootTransportPlan::Pci { .. }),
+    let boot_arguments_match = match block {
+        HvfSnapshotV2ProcessBlockFdtPlan::Root {
             partuuid,
-            true,
-        )
-        .map_err(|_| HvfSnapshotV2ProcessFdtMismatch::Boot)?,
-        None => expected_process_boot_arguments(state.machine().boot().boot_arguments())
-            .ok_or(HvfSnapshotV2ProcessFdtMismatch::Boot)?,
+            transport,
+        } => {
+            let expected = canonical_process_root_block_command_line(
+                state.machine().boot().boot_arguments(),
+                matches!(transport, HvfSnapshotV2RootTransportPlan::Pci { .. }),
+                partuuid.as_deref(),
+                true,
+            )
+            .map_err(|_| HvfSnapshotV2ProcessFdtMismatch::Boot)?;
+            chosen
+                .prop_str("bootargs")
+                .is_ok_and(|arguments| arguments == expected.as_str())
+        }
+        HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockMmio { command_line, .. } => chosen
+            .prop_str("bootargs")
+            .is_ok_and(|arguments| arguments == *command_line),
+        HvfSnapshotV2ProcessBlockFdtPlan::None => {
+            let expected = expected_process_boot_arguments(state.machine().boot().boot_arguments())
+                .ok_or(HvfSnapshotV2ProcessFdtMismatch::Boot)?;
+            chosen
+                .prop_str("bootargs")
+                .is_ok_and(|arguments| arguments == expected.as_str())
+        }
     };
-    if !chosen
-        .prop_str("bootargs")
-        .is_ok_and(|arguments| arguments == expected_boot_args.as_str())
+    if !boot_arguments_match
         || chosen.has_prop("linux,initrd-start") != state.machine().boot().initrd_path().is_some()
         || chosen.has_prop("linux,initrd-end") != state.machine().boot().initrd_path().is_some()
     {
@@ -2375,8 +2503,11 @@ fn validate_process_fdt(
         return Err(HvfSnapshotV2ProcessFdtMismatch::Gic);
     };
     let expected_gic_children = usize::from(matches!(
-        root,
-        Some((_, HvfSnapshotV2RootTransportPlan::Pci { .. }))
+        block,
+        HvfSnapshotV2ProcessBlockFdtPlan::Root {
+            transport: HvfSnapshotV2RootTransportPlan::Pci { .. },
+            ..
+        }
     ));
     if intc.children.len() != expected_gic_children
         || !intc
@@ -2526,54 +2657,33 @@ fn validate_process_fdt(
         return Err(HvfSnapshotV2ProcessFdtMismatch::VmClock);
     }
 
-    validate_process_root_nodes(&tree.root, intc, root)
+    validate_process_block_nodes(&tree.root, intc, block)
 }
 
-fn validate_process_root_nodes(
+fn validate_process_block_nodes(
     root_node: &Node,
     intc: &Node,
-    root: Option<(Option<&str>, HvfSnapshotV2RootTransportPlan)>,
+    block: &HvfSnapshotV2ProcessBlockFdtPlan<'_>,
 ) -> Result<(), HvfSnapshotV2ProcessFdtMismatch> {
-    let Some((_partuuid, resources)) = root else {
-        return Ok(());
+    let resources = match block {
+        HvfSnapshotV2ProcessBlockFdtPlan::None => return Ok(()),
+        HvfSnapshotV2ProcessBlockFdtPlan::Root { transport, .. } => *transport,
+        HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockMmio { records, .. } => {
+            for record in *records {
+                validate_process_mmio_block_node(
+                    root_node,
+                    record.region(),
+                    record.interrupt_line(),
+                )?;
+            }
+            return Ok(());
+        }
     };
     match resources {
         HvfSnapshotV2RootTransportPlan::Mmio {
             region,
             interrupt_line,
-        } => {
-            let node = child_matching(root_node, |node| {
-                node_name_has_number(
-                    &node.name,
-                    "virtio_mmio@",
-                    16,
-                    region.range().start().raw_value(),
-                )
-            })
-            .ok_or(HvfSnapshotV2ProcessFdtMismatch::Root)?;
-            let interrupt_cell = interrupt_line
-                .raw_value()
-                .checked_sub(32)
-                .ok_or(HvfSnapshotV2ProcessFdtMismatch::Root)?;
-            if !node.children.is_empty()
-                || !node
-                    .prop_str("compatible")
-                    .is_ok_and(|compatible| compatible == "virtio,mmio")
-                || !property_u64_cells_equal(
-                    node,
-                    "reg",
-                    &[region.range().start().raw_value(), region.range().size()],
-                )
-                || !property_u32_cells_equal(node, "interrupts", &[0, interrupt_cell, 1])
-                || !node
-                    .prop_u32("interrupt-parent")
-                    .is_ok_and(|phandle| phandle == 1)
-                || !property_is_null(node, "dma-coherent")
-            {
-                return Err(HvfSnapshotV2ProcessFdtMismatch::Root);
-            }
-            Ok(())
-        }
+        } => validate_process_mmio_block_node(root_node, region, interrupt_line),
         HvfSnapshotV2RootTransportPlan::Pci {
             sbdf: _,
             bar_region_id,
@@ -2589,6 +2699,44 @@ fn validate_process_root_nodes(
             Ok(())
         }
     }
+}
+
+fn validate_process_mmio_block_node(
+    root_node: &Node,
+    region: MmioRegion,
+    interrupt_line: GuestInterruptLine,
+) -> Result<(), HvfSnapshotV2ProcessFdtMismatch> {
+    let node = child_matching(root_node, |node| {
+        node_name_has_number(
+            &node.name,
+            "virtio_mmio@",
+            16,
+            region.range().start().raw_value(),
+        )
+    })
+    .ok_or(HvfSnapshotV2ProcessFdtMismatch::Root)?;
+    let interrupt_cell = interrupt_line
+        .raw_value()
+        .checked_sub(32)
+        .ok_or(HvfSnapshotV2ProcessFdtMismatch::Root)?;
+    if !node.children.is_empty()
+        || !node
+            .prop_str("compatible")
+            .is_ok_and(|compatible| compatible == "virtio,mmio")
+        || !property_u64_cells_equal(
+            node,
+            "reg",
+            &[region.range().start().raw_value(), region.range().size()],
+        )
+        || !property_u32_cells_equal(node, "interrupts", &[0, interrupt_cell, 1])
+        || !node
+            .prop_u32("interrupt-parent")
+            .is_ok_and(|phandle| phandle == 1)
+        || !property_is_null(node, "dma-coherent")
+    {
+        return Err(HvfSnapshotV2ProcessFdtMismatch::Root);
+    }
+    Ok(())
 }
 
 fn validate_process_gic_msi(intc: &Node, msi: crate::gic::HvfGicMsiMetadata) -> bool {
@@ -3731,6 +3879,170 @@ pub(crate) mod tests {
         assert_eq!(
             validate_root_process_fdt(&with_optional, &platform, &root, resources),
             Err(HvfSnapshotV2ProcessFdtMismatch::RootInventory)
+        );
+    }
+
+    #[test]
+    fn multi_block_mmio_fdt_requires_exact_unique_node_set_and_command_line() {
+        let (platform, plan) =
+            crate::snapshot_v2_multi_block_platform::tests::mmio_fdt_plan_fixture();
+        let records = plan
+            .transport()
+            .mmio_records()
+            .expect("fixture plan should use MMIO");
+        let devices = records
+            .iter()
+            .map(|record| record.fdt_device())
+            .collect::<Vec<_>>();
+        assert_eq!(devices.len(), 2);
+        let shell = (
+            bangbang_runtime::fdt::Arm64FdtSerialDevice {
+                region: bangbang_runtime::fdt::Arm64FdtRegion {
+                    base: PROCESS_SERIAL_MMIO_BASE.raw_value(),
+                    size: SERIAL_MMIO_DEVICE_WINDOW_SIZE,
+                },
+                interrupt_line: plan.serial_interrupt(),
+            },
+            bangbang_runtime::fdt::Arm64FdtRtcDevice {
+                region: bangbang_runtime::fdt::Arm64FdtRegion {
+                    base: PROCESS_RTC_MMIO_BASE.raw_value(),
+                    size: RTC_MMIO_DEVICE_WINDOW_SIZE,
+                },
+            },
+            bangbang_runtime::fdt::Arm64FdtVmGenIdDevice {
+                region: platform.time().vmgenid().fdt_region(),
+                interrupt_line: plan.vmgenid_interrupt(),
+            },
+            bangbang_runtime::fdt::Arm64FdtVmClockDevice {
+                region: platform.time().vmclock().fdt_region(),
+                interrupt_line: plan.vmclock_interrupt(),
+            },
+        );
+        let block = HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockMmio {
+            command_line: plan.command_line(),
+            records,
+        };
+        let valid = build_process_fdt_fixture_with_profile(
+            &platform,
+            shell,
+            &devices,
+            plan.command_line(),
+            None,
+        );
+        assert_eq!(
+            validate_process_fdt(&valid, &platform, plan.serial_interrupt(), &block),
+            Ok(())
+        );
+
+        let mut reversed = devices.clone();
+        reversed.reverse();
+        let reordered = build_process_fdt_fixture_with_profile(
+            &platform,
+            shell,
+            &reversed,
+            plan.command_line(),
+            None,
+        );
+        assert_eq!(
+            validate_process_fdt(&reordered, &platform, plan.serial_interrupt(), &block),
+            Ok(())
+        );
+
+        let mut missing = devices.clone();
+        missing.pop();
+        let missing = build_process_fdt_fixture_with_profile(
+            &platform,
+            shell,
+            &missing,
+            plan.command_line(),
+            None,
+        );
+        assert_eq!(
+            validate_process_fdt(&missing, &platform, plan.serial_interrupt(), &block),
+            Err(HvfSnapshotV2ProcessFdtMismatch::RootInventory)
+        );
+
+        let mut extra = devices.clone();
+        let mut extra_device = extra
+            .last()
+            .copied()
+            .expect("fixture should have a last device");
+        extra_device.region.base = extra_device
+            .region
+            .base
+            .checked_add(VIRTIO_MMIO_DEVICE_WINDOW_SIZE)
+            .expect("extra device address should fit");
+        extra_device.interrupt_line =
+            GuestInterruptLine::new(extra_device.interrupt_line.raw_value().saturating_add(1))
+                .expect("extra device interrupt should validate");
+        extra.push(extra_device);
+        let extra = build_process_fdt_fixture_with_profile(
+            &platform,
+            shell,
+            &extra,
+            plan.command_line(),
+            None,
+        );
+        assert_eq!(
+            validate_process_fdt(&extra, &platform, plan.serial_interrupt(), &block),
+            Err(HvfSnapshotV2ProcessFdtMismatch::RootInventory)
+        );
+
+        let mut unexpected = devices.clone();
+        let last = unexpected
+            .last_mut()
+            .expect("fixture should have a last device");
+        last.region.base = last
+            .region
+            .base
+            .checked_add(VIRTIO_MMIO_DEVICE_WINDOW_SIZE)
+            .expect("unexpected device address should fit");
+        let unexpected = build_process_fdt_fixture_with_profile(
+            &platform,
+            shell,
+            &unexpected,
+            plan.command_line(),
+            None,
+        );
+        assert_eq!(
+            validate_process_fdt(&unexpected, &platform, plan.serial_interrupt(), &block),
+            Err(HvfSnapshotV2ProcessFdtMismatch::Root)
+        );
+
+        let mut wrong_interrupt = devices.clone();
+        let second = wrong_interrupt
+            .last_mut()
+            .expect("fixture should have a second device");
+        second.interrupt_line =
+            GuestInterruptLine::new(second.interrupt_line.raw_value().saturating_add(1))
+                .expect("mutated interrupt should validate");
+        let wrong_interrupt = build_process_fdt_fixture_with_profile(
+            &platform,
+            shell,
+            &wrong_interrupt,
+            plan.command_line(),
+            None,
+        );
+        assert_eq!(
+            validate_process_fdt(&wrong_interrupt, &platform, plan.serial_interrupt(), &block),
+            Err(HvfSnapshotV2ProcessFdtMismatch::Root)
+        );
+
+        let wrong_command_line = build_process_fdt_fixture_with_profile(
+            &platform,
+            shell,
+            &devices,
+            "console=ttyS0 pci=off",
+            None,
+        );
+        assert_eq!(
+            validate_process_fdt(
+                &wrong_command_line,
+                &platform,
+                plan.serial_interrupt(),
+                &block
+            ),
+            Err(HvfSnapshotV2ProcessFdtMismatch::Boot)
         );
     }
 

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -22,9 +22,9 @@ use bangbang_runtime::balloon::{
 };
 use bangbang_runtime::block::async_executor::{BlockAsyncRuntimeError, SharedBlockAsyncRuntime};
 use bangbang_runtime::block::{
-    BlockFileBacking, BlockMmioDeviceRegistration, BlockMmioLayout, DriveConfig, DriveIoEngine,
-    DriveLiveUpdateMode, DriveRateLimiterConfig, DriveRuntimeMutationError, DriveUpdateError,
-    PreparedBlockDevice, RuntimeBlockDeviceResource, VIRTIO_BLOCK_DEVICE_ID,
+    BlockFileBacking, BlockMmioDeviceRegistration, BlockMmioLayout, DriveConfig, DriveConfigs,
+    DriveIoEngine, DriveLiveUpdateMode, DriveRateLimiterConfig, DriveRuntimeMutationError,
+    DriveUpdateError, PreparedBlockDevice, RuntimeBlockDeviceResource, VIRTIO_BLOCK_DEVICE_ID,
     VIRTIO_BLOCK_QUEUE_SIZES, VhostUserBlockConfigSignalError, VirtioBlockBackendKind,
     VirtioBlockConfigSpace, VirtioBlockDevice, VirtioBlockDeviceNotificationError,
     VirtioBlockLiveUpdateError, VirtioBlockSnapshotPersistenceBinding,
@@ -66,6 +66,8 @@ use bangbang_runtime::metrics::{
 };
 use bangbang_runtime::mmio::{
     MmioBusError, MmioDispatchError, MmioDispatcher, MmioHandlerError, MmioRegion, MmioRegionId,
+    MmioRegionRequest, MmioRegistrationError, MmioRegistrationLease, MmioRegistrationOwner,
+    MmioRegistrationReleaseError,
 };
 use bangbang_runtime::network::{
     NetworkDeviceProfile, NetworkInterfaceConfig, NetworkInterfaceUpdate,
@@ -102,7 +104,10 @@ use bangbang_runtime::snapshot_device_v2::{
     SnapshotV2RootTransportRestoreError,
 };
 use bangbang_runtime::snapshot_device_v2_5::{
-    NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2MultiBlockDeviceGraph,
+    NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION, PreparedSnapshotV2MultiBlockBundle,
+    PreparedSnapshotV2MultiBlockMmioBundle, PreparedSnapshotV2MultiBlockMmioRecord,
+    SnapshotV2MultiBlockCleanupError, SnapshotV2MultiBlockDeviceGraph,
+    SnapshotV2MultiBlockMmioTransportError,
 };
 use bangbang_runtime::snapshot_format::SnapshotFormatVersion;
 use bangbang_runtime::snapshot_format_v2::NATIVE_V2_LEGACY_PLATFORM_VERSION;
@@ -216,10 +221,15 @@ use crate::snapshot_v2::{
     HvfSnapshotV2GlobalState, HvfSnapshotV2MachineState, HvfSnapshotV2PlatformState,
     HvfSnapshotV2PvTimeVcpuState, HvfSnapshotV2TimeState, HvfSnapshotV2VcpuState,
 };
+use crate::snapshot_v2_multi_block_platform::{
+    HvfSnapshotV2MultiBlockPlatformPlan, HvfSnapshotV2MultiBlockPlatformPlanParts,
+    HvfSnapshotV2MultiBlockTransportPlan,
+};
 use crate::snapshot_v2_platform::{
-    HvfSnapshotV2DefaultProcessShell, HvfSnapshotV2PlatformRestoreError,
-    HvfSnapshotV2PlatformShutdownError, HvfSnapshotV2RootResourcePlan,
-    HvfSnapshotV2RootTransportPlan, RestoredHvfSnapshotV2Platform,
+    HvfSnapshotV2DefaultProcessShell, HvfSnapshotV2MultiBlockMmioShellPlan,
+    HvfSnapshotV2PlatformRestoreError, HvfSnapshotV2PlatformShutdownError,
+    HvfSnapshotV2RootResourcePlan, HvfSnapshotV2RootTransportPlan, RestoredHvfSnapshotV2Platform,
+    restore_hvf_snapshot_v2_multi_block_mmio_process_platform,
     restore_hvf_snapshot_v2_root_process_platform,
 };
 use crate::topology::{HvfVcpuTopologyError, prepare_ordered_mpidrs};
@@ -3259,6 +3269,7 @@ pub struct OwnedHvfArm64BootSession {
     backend: HvfBackend,
     mmio_dispatcher: Arc<Mutex<MmioDispatcher>>,
     runtime_resources: Arm64BootRuntimeResources,
+    _restored_snapshot_v2_mmio_registrations: Option<HvfSnapshotV2MultiBlockMmioRegistrations>,
     restored_snapshot_v2_memory_binding: Option<SnapshotV2MemoryBinding>,
     restored_snapshot_v2_machine: Option<HvfSnapshotV2MachineState>,
     cpu_template_application: Option<crate::cpu_template::HvfArm64CpuTemplateApplicationState>,
@@ -3366,6 +3377,312 @@ impl fmt::Debug for RestoredHvfArm64BootSession {
             .field("profile", &"native-v1")
             .field("resources", &"<redacted>")
             .finish()
+    }
+}
+
+#[derive(Debug)]
+struct HvfSnapshotV2MultiBlockMmioRegistrations {
+    _owner: MmioRegistrationOwner,
+    _leases: Vec<MmioRegistrationLease>,
+}
+
+/// One complete, still-unpublished profile-2 MMIO destination and controller
+/// projection.
+pub struct RestoredHvfSnapshotV2MultiBlockMmioOwners {
+    session: OwnedHvfArm64BootSession,
+    drive_configs: DriveConfigs,
+}
+
+impl RestoredHvfSnapshotV2MultiBlockMmioOwners {
+    pub const fn session(&self) -> &OwnedHvfArm64BootSession {
+        &self.session
+    }
+
+    pub const fn drive_configs(&self) -> &DriveConfigs {
+        &self.drive_configs
+    }
+
+    pub fn into_parts(self) -> (OwnedHvfArm64BootSession, DriveConfigs) {
+        (self.session, self.drive_configs)
+    }
+}
+
+impl fmt::Debug for RestoredHvfSnapshotV2MultiBlockMmioOwners {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RestoredHvfSnapshotV2MultiBlockMmioOwners")
+            .field("record_count", &self.drive_configs.as_slice().len())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Stage at which complete profile-2 MMIO owner reconstruction stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfSnapshotV2MultiBlockMmioRestoreStage {
+    MemoryLayout,
+    Transport,
+    ResourcePlan,
+    Metrics,
+    Platform,
+    Registration { index: usize },
+    RetryScheduler,
+}
+
+/// Primary failure from complete profile-2 MMIO owner reconstruction.
+pub enum HvfSnapshotV2MultiBlockMmioRestoreFailure {
+    Allocation,
+    MemoryLayout,
+    Transport(SnapshotV2MultiBlockMmioTransportError),
+    ResourcePlan,
+    Metrics(BlockDeviceMetricsRegistryError),
+    Platform(Box<HvfSnapshotV2PlatformRestoreError>),
+    DispatcherUnavailable,
+    Registration(MmioRegistrationError),
+    RetryScheduler(io::ErrorKind),
+}
+
+impl fmt::Debug for HvfSnapshotV2MultiBlockMmioRestoreFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::Allocation => "allocation",
+            Self::MemoryLayout => "memory-layout",
+            Self::Transport(_) => "transport",
+            Self::ResourcePlan => "resource-plan",
+            Self::Metrics(_) => "metrics",
+            Self::Platform(_) => "platform",
+            Self::DispatcherUnavailable => "dispatcher",
+            Self::Registration(_) => "registration",
+            Self::RetryScheduler(_) => "retry-scheduler",
+        };
+        formatter
+            .debug_struct("HvfSnapshotV2MultiBlockMmioRestoreFailure")
+            .field("kind", &kind)
+            .field("source", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2MultiBlockMmioRestoreFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Allocation => "profile-2 MMIO owner allocation failed",
+            Self::MemoryLayout => "restored memory layout is invalid",
+            Self::Transport(_) => "profile-2 MMIO transport reconstruction failed",
+            Self::ResourcePlan => "profile-2 MMIO resource plan diverged",
+            Self::Metrics(_) => "profile-2 MMIO metrics ownership failed",
+            Self::Platform(_) => "HVF platform reconstruction failed",
+            Self::DispatcherUnavailable => "profile-2 MMIO dispatcher is unavailable",
+            Self::Registration(_) => "profile-2 MMIO registration failed",
+            Self::RetryScheduler(kind) => {
+                return write!(formatter, "block retry scheduler startup failed: {kind:?}");
+            }
+        })
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2MultiBlockMmioRestoreFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Transport(source) => Some(source),
+            Self::Metrics(source) => Some(source),
+            Self::Platform(source) => Some(source.as_ref()),
+            Self::Registration(source) => Some(source),
+            Self::Allocation
+            | Self::MemoryLayout
+            | Self::ResourcePlan
+            | Self::DispatcherUnavailable
+            | Self::RetryScheduler(_) => None,
+        }
+    }
+}
+
+/// Cleanup uncertainty retained after profile-2 MMIO reconstruction failed.
+pub enum HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure {
+    PreparedBundle(SnapshotV2MultiBlockCleanupError),
+    RetryScheduler,
+    AsyncGuestMemory(HvfGuestMemoryMappingError),
+    Async(BlockAsyncRuntimeError),
+    DispatcherUnavailable,
+    Registration {
+        index: usize,
+        source: MmioRegistrationReleaseError,
+    },
+    Platform(HvfSnapshotV2PlatformShutdownError),
+}
+
+impl fmt::Debug for HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::PreparedBundle(_) => "prepared-bundle",
+            Self::RetryScheduler => "retry-scheduler",
+            Self::AsyncGuestMemory(_) => "async-guest-memory",
+            Self::Async(_) => "async-runtime",
+            Self::DispatcherUnavailable => "dispatcher",
+            Self::Registration { .. } => "registration",
+            Self::Platform(_) => "platform",
+        };
+        formatter
+            .debug_struct("HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure")
+            .field("kind", &kind)
+            .field("source", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::PreparedBundle(_) => "prepared Async bundle cleanup failed",
+            Self::RetryScheduler => "retry scheduler cleanup failed",
+            Self::AsyncGuestMemory(_) => "Async cleanup could not borrow guest memory",
+            Self::Async(_) => "Async runtime cleanup failed",
+            Self::DispatcherUnavailable => "MMIO dispatcher cleanup was unavailable",
+            Self::Registration { .. } => "owned MMIO registration cleanup failed",
+            Self::Platform(_) => "HVF platform cleanup failed",
+        })
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::PreparedBundle(source) => Some(source),
+            Self::AsyncGuestMemory(source) => Some(source),
+            Self::Async(source) => Some(source),
+            Self::Registration { source, .. } => Some(source),
+            Self::Platform(source) => Some(source),
+            Self::RetryScheduler | Self::DispatcherUnavailable => None,
+        }
+    }
+}
+
+/// Redacted profile-2 MMIO owner failure with ordered cleanup evidence.
+pub struct HvfSnapshotV2MultiBlockMmioRestoreError {
+    stage: HvfSnapshotV2MultiBlockMmioRestoreStage,
+    failure: Box<HvfSnapshotV2MultiBlockMmioRestoreFailure>,
+    cleanup: Vec<HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure>,
+}
+
+impl HvfSnapshotV2MultiBlockMmioRestoreError {
+    fn preflight(
+        stage: HvfSnapshotV2MultiBlockMmioRestoreStage,
+        failure: HvfSnapshotV2MultiBlockMmioRestoreFailure,
+    ) -> Self {
+        Self {
+            stage,
+            failure: Box::new(failure),
+            cleanup: Vec::new(),
+        }
+    }
+
+    fn with_prepared_bundle_abort(
+        stage: HvfSnapshotV2MultiBlockMmioRestoreStage,
+        failure: HvfSnapshotV2MultiBlockMmioRestoreFailure,
+        bundle: PreparedSnapshotV2MultiBlockMmioBundle,
+    ) -> Self {
+        let cleanup = bundle
+            .abort()
+            .err()
+            .map(HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure::PreparedBundle)
+            .into_iter()
+            .collect();
+        Self {
+            stage,
+            failure: Box::new(failure),
+            cleanup,
+        }
+    }
+
+    fn platform(
+        source: HvfSnapshotV2PlatformRestoreError,
+        bundle: PreparedSnapshotV2MultiBlockMmioBundle,
+    ) -> Self {
+        Self::with_prepared_bundle_abort(
+            HvfSnapshotV2MultiBlockMmioRestoreStage::Platform,
+            HvfSnapshotV2MultiBlockMmioRestoreFailure::Platform(Box::new(source)),
+            bundle,
+        )
+    }
+
+    fn after_platform(
+        stage: HvfSnapshotV2MultiBlockMmioRestoreStage,
+        failure: HvfSnapshotV2MultiBlockMmioRestoreFailure,
+        cleanup: Vec<HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure>,
+    ) -> Self {
+        Self {
+            stage,
+            failure: Box::new(failure),
+            cleanup,
+        }
+    }
+
+    pub const fn stage(&self) -> HvfSnapshotV2MultiBlockMmioRestoreStage {
+        self.stage
+    }
+
+    pub fn cleanup_failures(&self) -> &[HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure] {
+        &self.cleanup
+    }
+
+    pub fn has_incomplete_cleanup(&self) -> bool {
+        !self.cleanup.is_empty()
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MultiBlockMmioRestoreFailure::Transport(source)
+                    if source.cleanup_failed()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MultiBlockMmioRestoreFailure::Platform(source)
+                    if !source.cleanup_failures().is_empty()
+            )
+    }
+
+    /// Returns whether retry safety cannot be proven.
+    pub fn is_terminal(&self) -> bool {
+        self.has_incomplete_cleanup()
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MultiBlockMmioRestoreFailure::Platform(source)
+                    if source.is_committed()
+            )
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2MultiBlockMmioRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2MultiBlockMmioRestoreError")
+            .field("stage", &self.stage)
+            .field("failure", &"<redacted>")
+            .field("cleanup_count", &self.cleanup.len())
+            .field("terminal", &self.is_terminal())
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2MultiBlockMmioRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "profile-2 MMIO owner reconstruction failed at {:?}: {}",
+            self.stage, self.failure
+        )?;
+        if !self.cleanup.is_empty() {
+            write!(
+                formatter,
+                "; {} cleanup failure(s) retained",
+                self.cleanup.len()
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2MultiBlockMmioRestoreError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.failure.as_ref())
     }
 }
 
@@ -11029,6 +11346,159 @@ fn failed_snapshot_v2_root_after_platform(
     HvfSnapshotV2RootRestoreError::after_platform(stage, failure, cleanup)
 }
 
+fn validate_snapshot_v2_multi_block_mmio_resource_plan(
+    bundle: &PreparedSnapshotV2MultiBlockMmioBundle,
+    plan: &HvfSnapshotV2MultiBlockPlatformPlanParts,
+) -> bool {
+    let records = bundle.records();
+    let configs = bundle.drive_configs().as_slice();
+    let Some(planned_records) = plan.transport.mmio_records() else {
+        return false;
+    };
+    if records.is_empty()
+        || records.len() != configs.len()
+        || records.len() != planned_records.len()
+        || records.len() != plan.metrics_ids.len()
+        || records.len() != plan.retries.len()
+    {
+        return false;
+    }
+
+    let mut root_key = None;
+    for (index, ((((record, config), planned), retry), metrics_id)) in records
+        .iter()
+        .zip(configs)
+        .zip(planned_records)
+        .zip(&plan.retries)
+        .zip(&plan.metrics_ids)
+        .enumerate()
+    {
+        let async_binding_matches = match config.io_engine() {
+            Some(DriveIoEngine::Sync) => record.async_generation().is_none(),
+            Some(DriveIoEngine::Async) => record.async_generation().is_some(),
+            None => false,
+        };
+        if record.key() != planned.key()
+            || record.key() != retry.key()
+            || record.drive_id() != config.drive_id()
+            || record.drive_id() != metrics_id
+            || record.is_root_device() != config.is_root_device()
+            || record.region() != planned.region()
+            || record.interrupt_line() != planned.interrupt_line()
+            || record.retry() != retry.retry()
+            || record.retry_deadline().is_some()
+                == matches!(record.retry(), StorageRetryState::None)
+            || !async_binding_matches
+            || (record.is_root_device() && index != 0)
+        {
+            return false;
+        }
+        if record.is_root_device() && root_key.replace(record.key()).is_some() {
+            return false;
+        }
+    }
+
+    let earliest_retry_index = records
+        .iter()
+        .enumerate()
+        .filter_map(|(index, record)| {
+            snapshot_v2_multi_block_retry_rank(record.retry()).map(|rank| (rank, index))
+        })
+        .min_by_key(|(rank, _)| *rank)
+        .map(|(_, index)| index);
+    root_key == plan.root_key && earliest_retry_index == plan.earliest_retry_index
+}
+
+const fn snapshot_v2_multi_block_retry_rank(retry: StorageRetryState) -> Option<(u8, u64)> {
+    match retry {
+        StorageRetryState::None => None,
+        StorageRetryState::Immediate => Some((0, 0)),
+        StorageRetryState::After { remaining_nanos } => Some((1, remaining_nanos)),
+    }
+}
+
+struct HvfSnapshotV2MultiBlockMmioCleanup<'a> {
+    scheduler: &'a mut Option<HvfArm64BootLimiterRetryWakeupScheduler>,
+    async_runtime: Option<&'a SharedBlockAsyncRuntime>,
+    registration_owner: &'a MmioRegistrationOwner,
+    registration_leases: &'a [MmioRegistrationLease],
+    failures: Vec<HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure>,
+}
+
+fn failed_snapshot_v2_multi_block_mmio_after_platform(
+    mut platform: RestoredHvfSnapshotV2Platform,
+    stage: HvfSnapshotV2MultiBlockMmioRestoreStage,
+    failure: HvfSnapshotV2MultiBlockMmioRestoreFailure,
+    cleanup: HvfSnapshotV2MultiBlockMmioCleanup<'_>,
+) -> HvfSnapshotV2MultiBlockMmioRestoreError {
+    let HvfSnapshotV2MultiBlockMmioCleanup {
+        scheduler,
+        async_runtime,
+        registration_owner,
+        registration_leases,
+        failures: mut cleanup,
+    } = cleanup;
+    if scheduler
+        .as_mut()
+        .is_some_and(|scheduler| scheduler.stop_with_result().is_err())
+    {
+        cleanup.push(HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure::RetryScheduler);
+    }
+    drop(scheduler.take());
+
+    if let Some(runtime) = async_runtime {
+        let needs_memory = match runtime.shutdown_if_idle() {
+            Ok(idle) => !idle,
+            Err(source) => {
+                cleanup.push(HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure::Async(
+                    source,
+                ));
+                true
+            }
+        };
+        if needs_memory {
+            match platform.guest_memory_mut() {
+                Ok(memory) => {
+                    if let Err(source) = runtime.shutdown(memory) {
+                        cleanup.push(HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure::Async(
+                            source,
+                        ));
+                    }
+                }
+                Err(source) => cleanup.push(
+                    HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure::AsyncGuestMemory(source),
+                ),
+            }
+        }
+    }
+
+    match platform.mmio_dispatcher().lock() {
+        Ok(mut dispatcher) => {
+            for (index, lease) in registration_leases.iter().enumerate().rev() {
+                if let Err(source) = dispatcher.release_owned_handler(registration_owner, lease) {
+                    cleanup.push(
+                        HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure::Registration {
+                            index,
+                            source,
+                        },
+                    );
+                }
+            }
+        }
+        Err(_) => {
+            cleanup.push(HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure::DispatcherUnavailable)
+        }
+    }
+
+    if let Err(source) = platform.shutdown() {
+        cleanup.push(HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure::Platform(
+            source,
+        ));
+    }
+
+    HvfSnapshotV2MultiBlockMmioRestoreError::after_platform(stage, failure, cleanup)
+}
+
 fn failed_snapshot_v1_restore(
     stage: HvfSnapshotV1RestoreStage,
     failure: HvfSnapshotV1RestoreFailure,
@@ -11118,6 +11588,7 @@ impl OwnedHvfArm64BootSession {
             backend,
             mmio_dispatcher: prepared.mmio_dispatcher,
             runtime_resources: prepared.runtime_resources,
+            _restored_snapshot_v2_mmio_registrations: None,
             restored_snapshot_v2_memory_binding: None,
             restored_snapshot_v2_machine: None,
             cpu_template_application: prepared.cpu_template_application,
@@ -11382,6 +11853,7 @@ impl OwnedHvfArm64BootSession {
             backend: parts.backend,
             mmio_dispatcher: parts.mmio_dispatcher,
             runtime_resources,
+            _restored_snapshot_v2_mmio_registrations: None,
             restored_snapshot_v2_memory_binding: Some(parts.memory_binding),
             restored_snapshot_v2_machine: Some(parts.machine),
             cpu_template_application,
@@ -11420,6 +11892,377 @@ impl OwnedHvfArm64BootSession {
             vmgenid_interrupt_line,
             vmclock_interrupt_line,
             boot_registers: None,
+        })
+    }
+
+    /// Reconstructs one exact profile-2 MMIO vector without publishing a
+    /// process session or controller.
+    #[doc(hidden)]
+    pub fn restore_snapshot_v2_multi_block_mmio(
+        state: HvfSnapshotV2PlatformState,
+        memory: GuestMemory,
+        process_shell: HvfSnapshotV2DefaultProcessShell,
+        bundle: PreparedSnapshotV2MultiBlockBundle,
+        plan: HvfSnapshotV2MultiBlockPlatformPlan,
+    ) -> Result<RestoredHvfSnapshotV2MultiBlockMmioOwners, HvfSnapshotV2MultiBlockMmioRestoreError>
+    {
+        let mut ranges = Vec::new();
+        ranges
+            .try_reserve_exact(memory.regions().len())
+            .map_err(|_| {
+                HvfSnapshotV2MultiBlockMmioRestoreError::preflight(
+                    HvfSnapshotV2MultiBlockMmioRestoreStage::MemoryLayout,
+                    HvfSnapshotV2MultiBlockMmioRestoreFailure::Allocation,
+                )
+            })?;
+        ranges.extend(memory.regions().iter().map(|region| region.range()));
+        let layout = GuestMemoryLayout::new(ranges).map_err(|_| {
+            HvfSnapshotV2MultiBlockMmioRestoreError::preflight(
+                HvfSnapshotV2MultiBlockMmioRestoreStage::MemoryLayout,
+                HvfSnapshotV2MultiBlockMmioRestoreFailure::MemoryLayout,
+            )
+        })?;
+        let source_fdt = state.machine().fdt();
+        let retained_fdt = Arm64FdtGuestMemoryWrite {
+            address: source_fdt.address(),
+            size: usize::try_from(source_fdt.size()).map_err(|_| {
+                HvfSnapshotV2MultiBlockMmioRestoreError::preflight(
+                    HvfSnapshotV2MultiBlockMmioRestoreStage::MemoryLayout,
+                    HvfSnapshotV2MultiBlockMmioRestoreFailure::Allocation,
+                )
+            })?,
+        };
+        let prepared = bundle.prepare_mmio_transport().map_err(|source| {
+            HvfSnapshotV2MultiBlockMmioRestoreError::preflight(
+                HvfSnapshotV2MultiBlockMmioRestoreStage::Transport,
+                HvfSnapshotV2MultiBlockMmioRestoreFailure::Transport(source),
+            )
+        })?;
+        let plan = plan.into_parts();
+        if !validate_snapshot_v2_multi_block_mmio_resource_plan(&prepared, &plan) {
+            return Err(
+                HvfSnapshotV2MultiBlockMmioRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2MultiBlockMmioRestoreStage::ResourcePlan,
+                    HvfSnapshotV2MultiBlockMmioRestoreFailure::ResourcePlan,
+                    prepared,
+                ),
+            );
+        }
+
+        let HvfSnapshotV2MultiBlockPlatformPlanParts {
+            root_key: _,
+            command_line,
+            metrics_ids,
+            retries: _,
+            earliest_retry_index: _,
+            transport,
+            serial_interrupt,
+            vmgenid_interrupt,
+            vmclock_interrupt,
+        } = plan;
+        let HvfSnapshotV2MultiBlockTransportPlan::Mmio(planned_records) = transport else {
+            return Err(
+                HvfSnapshotV2MultiBlockMmioRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2MultiBlockMmioRestoreStage::ResourcePlan,
+                    HvfSnapshotV2MultiBlockMmioRestoreFailure::ResourcePlan,
+                    prepared,
+                ),
+            );
+        };
+        let record_count = prepared.records().len();
+        let earliest_retry_deadline = prepared
+            .records()
+            .iter()
+            .filter_map(PreparedSnapshotV2MultiBlockMmioRecord::retry_deadline)
+            .min();
+        let block_device_metrics =
+            match SharedBlockDeviceMetricsRegistry::from_owned_drive_ids_with_capacity(
+                metrics_ids,
+                record_count,
+            ) {
+                Ok(metrics) => metrics,
+                Err(source) => {
+                    return Err(
+                        HvfSnapshotV2MultiBlockMmioRestoreError::with_prepared_bundle_abort(
+                            HvfSnapshotV2MultiBlockMmioRestoreStage::Metrics,
+                            HvfSnapshotV2MultiBlockMmioRestoreFailure::Metrics(source),
+                            prepared,
+                        ),
+                    );
+                }
+            };
+        let mut block_devices = Vec::new();
+        if block_devices.try_reserve_exact(record_count).is_err() {
+            return Err(
+                HvfSnapshotV2MultiBlockMmioRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2MultiBlockMmioRestoreStage::ResourcePlan,
+                    HvfSnapshotV2MultiBlockMmioRestoreFailure::Allocation,
+                    prepared,
+                ),
+            );
+        }
+        let mut block_interrupt_lines = Vec::new();
+        if block_interrupt_lines
+            .try_reserve_exact(record_count)
+            .is_err()
+        {
+            return Err(
+                HvfSnapshotV2MultiBlockMmioRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2MultiBlockMmioRestoreStage::ResourcePlan,
+                    HvfSnapshotV2MultiBlockMmioRestoreFailure::Allocation,
+                    prepared,
+                ),
+            );
+        }
+        let mut registration_leases = Vec::new();
+        if registration_leases.try_reserve_exact(record_count).is_err() {
+            return Err(
+                HvfSnapshotV2MultiBlockMmioRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2MultiBlockMmioRestoreStage::ResourcePlan,
+                    HvfSnapshotV2MultiBlockMmioRestoreFailure::Allocation,
+                    prepared,
+                ),
+            );
+        }
+        let mut cleanup = Vec::new();
+        if cleanup
+            .try_reserve_exact(record_count.saturating_add(5))
+            .is_err()
+        {
+            return Err(
+                HvfSnapshotV2MultiBlockMmioRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2MultiBlockMmioRestoreStage::ResourcePlan,
+                    HvfSnapshotV2MultiBlockMmioRestoreFailure::Allocation,
+                    prepared,
+                ),
+            );
+        }
+
+        let shell_plan = HvfSnapshotV2MultiBlockMmioShellPlan {
+            command_line: &command_line,
+            records: &planned_records,
+            serial_interrupt,
+            vmgenid_interrupt,
+            vmclock_interrupt,
+        };
+        let platform = match restore_hvf_snapshot_v2_multi_block_mmio_process_platform(
+            state,
+            memory,
+            process_shell,
+            shell_plan,
+        ) {
+            Ok(platform) => platform,
+            Err(source) => {
+                return Err(HvfSnapshotV2MultiBlockMmioRestoreError::platform(
+                    source, prepared,
+                ));
+            }
+        };
+        let (drive_configs, records, async_runtime, async_generations) = prepared.into_parts();
+        debug_assert_eq!(
+            async_generations.len(),
+            records
+                .iter()
+                .filter(|record| record.async_generation().is_some())
+                .count()
+        );
+        drop(async_generations);
+
+        let registration_owner = MmioRegistrationOwner::new();
+        let install_result = (|| {
+            for (index, (record, planned)) in records.into_iter().zip(planned_records).enumerate() {
+                let (
+                    _key,
+                    drive_id,
+                    _is_root_device,
+                    _retry,
+                    _retry_deadline,
+                    region,
+                    interrupt_line,
+                    _async_generation,
+                    handler,
+                ) = record.into_parts();
+                let request = [MmioRegionRequest::new(
+                    region.range().start(),
+                    region.range().size(),
+                )];
+                let lease = {
+                    let mut dispatcher = platform.mmio_dispatcher().lock().map_err(|_| {
+                        (
+                            HvfSnapshotV2MultiBlockMmioRestoreStage::Registration { index },
+                            HvfSnapshotV2MultiBlockMmioRestoreFailure::DispatcherUnavailable,
+                        )
+                    })?;
+                    dispatcher
+                        .register_owned_handler(&registration_owner, region.id(), &request, handler)
+                        .map_err(|source| {
+                            (
+                                HvfSnapshotV2MultiBlockMmioRestoreStage::Registration { index },
+                                HvfSnapshotV2MultiBlockMmioRestoreFailure::Registration(source),
+                            )
+                        })?
+                };
+                registration_leases.push(lease);
+                if registration_leases.last().is_none_or(|lease| {
+                    lease.region_id() != region.id() || lease.regions() != [region]
+                }) {
+                    return Err((
+                        HvfSnapshotV2MultiBlockMmioRestoreStage::Registration { index },
+                        HvfSnapshotV2MultiBlockMmioRestoreFailure::ResourcePlan,
+                    ));
+                }
+                block_devices.push(Arm64BootBlockDevice {
+                    registration: BlockMmioDeviceRegistration::from_restored(
+                        index, drive_id, region,
+                    ),
+                    fdt_device: planned.fdt_device(),
+                });
+                block_interrupt_lines.push(interrupt_line);
+            }
+            Ok(())
+        })();
+        let mut block_retry_wakeup_scheduler = None;
+        if let Err((stage, failure)) = install_result {
+            return Err(failed_snapshot_v2_multi_block_mmio_after_platform(
+                platform,
+                stage,
+                failure,
+                HvfSnapshotV2MultiBlockMmioCleanup {
+                    scheduler: &mut block_retry_wakeup_scheduler,
+                    async_runtime: async_runtime.as_ref(),
+                    registration_owner: &registration_owner,
+                    registration_leases: &registration_leases,
+                    failures: cleanup,
+                },
+            ));
+        }
+
+        let block_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        let vcpu_control = platform.control();
+        block_retry_wakeup_scheduler =
+            match HvfArm64BootLimiterRetryWakeupScheduler::start_with_cancellation(
+                BLOCK_RETRY_WAKEUP_SCHEDULER_THREAD_NAME,
+                block_retry_wakeup.clone(),
+                move || vcpu_control.request_wakeup(),
+            ) {
+                Ok(scheduler) => Some(scheduler),
+                Err(source) => {
+                    return Err(failed_snapshot_v2_multi_block_mmio_after_platform(
+                        platform,
+                        HvfSnapshotV2MultiBlockMmioRestoreStage::RetryScheduler,
+                        HvfSnapshotV2MultiBlockMmioRestoreFailure::RetryScheduler(source.kind()),
+                        HvfSnapshotV2MultiBlockMmioCleanup {
+                            scheduler: &mut block_retry_wakeup_scheduler,
+                            async_runtime: async_runtime.as_ref(),
+                            registration_owner: &registration_owner,
+                            registration_leases: &registration_leases,
+                            failures: cleanup,
+                        },
+                    ));
+                }
+            };
+        let Some(block_retry_wakeup_scheduler) = block_retry_wakeup_scheduler.take() else {
+            std::process::abort();
+        };
+        block_retry_wakeup_scheduler.schedule_deadline(earliest_retry_deadline);
+
+        let parts = platform.into_parts();
+        let machine_config = parts.machine.machine();
+        let cpu_template_application = parts.machine.cpu_template().cloned();
+        let cache_source = crate::vcpu_config::HvfArm64VcpuCacheFdtSource::new(
+            parts.compatibility.identification().id_aa64mmfr2_el1(),
+            parts.compatibility.cache_manifest(),
+        );
+        let gic = parts.compatibility.gic_metadata();
+        let serial_interrupt_line = parts
+            .serial_device
+            .as_ref()
+            .map(|device| device.fdt_device.interrupt_line);
+        let vmgenid_interrupt_line = parts.vmgenid_device.fdt_device.interrupt_line;
+        let vmclock_interrupt_line = parts.vmclock_device.fdt_device.interrupt_line;
+        let runtime_resources = Arm64BootRuntimeResources {
+            machine_config,
+            layout,
+            boot_origin: None,
+            retained_fdt: Some(retained_fdt),
+            rtc_device: Some(parts.rtc_device),
+            serial_device: parts.serial_device,
+            vmgenid_device: parts.vmgenid_device,
+            vmclock_device: parts.vmclock_device,
+            pvtime_state: Arm64BootPvTimeState::restored(parts.pvtime_layout),
+            block_devices,
+            block_async_runtime: async_runtime.unwrap_or_default(),
+            pci_block_devices: Vec::new(),
+            pmem_devices: Vec::new(),
+            pmem_mmio_devices: Vec::new(),
+            network_devices: Vec::new(),
+            pci_network_devices: Vec::new(),
+            vsock_device: None,
+            pci_vsock_device: None,
+            balloon_device: None,
+            pci_balloon_device: None,
+            memory_hotplug_device: None,
+            pci_memory_hotplug_device: None,
+            entropy_device: None,
+            pci_entropy_device: None,
+            pci_validation: None,
+        };
+        let pmem_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        let network_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        let entropy_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        let session = Self {
+            runner: parts.runner,
+            backend: parts.backend,
+            mmio_dispatcher: parts.mmio_dispatcher,
+            runtime_resources,
+            _restored_snapshot_v2_mmio_registrations: Some(
+                HvfSnapshotV2MultiBlockMmioRegistrations {
+                    _owner: registration_owner,
+                    _leases: registration_leases,
+                },
+            ),
+            restored_snapshot_v2_memory_binding: Some(parts.memory_binding),
+            restored_snapshot_v2_machine: Some(parts.machine),
+            cpu_template_application,
+            pci_validation_endpoint: None,
+            pci_data_devices: None,
+            cache_source,
+            cache_hierarchy: None,
+            control_wakeup: HvfArm64BootRunLoopControlWakeupToken::default(),
+            run_loop_wakeup: HvfArm64BootRunLoopWakeupToken::default(),
+            block_retry_wakeup,
+            block_retry_wakeup_scheduler,
+            pmem_retry_wakeup,
+            pmem_retry_wakeup_scheduler: HvfArm64BootLimiterRetryWakeupScheduler::inactive(),
+            network_retry_wakeup,
+            network_retry_wakeup_scheduler: HvfArm64BootLimiterRetryWakeupScheduler::inactive(),
+            entropy_retry_wakeup,
+            entropy_retry_wakeup_scheduler: HvfArm64BootLimiterRetryWakeupScheduler::inactive(),
+            entropy_source: VirtioRngOsEntropySource::new(),
+            block_device_metrics,
+            pmem_device_metrics: SharedPmemDeviceMetricsRegistry::default(),
+            balloon_device_metrics: SharedBalloonDeviceMetrics::default(),
+            memory_hotplug_device_metrics: None,
+            network_interface_metrics: SharedNetworkInterfaceMetricsRegistry::default(),
+            vsock_device_metrics: SharedVsockDeviceMetrics::default(),
+            entropy_device_metrics: SharedEntropyDeviceMetrics::default(),
+            gic,
+            block_interrupt_lines,
+            pmem_interrupt_lines: Vec::new(),
+            network_interrupt_lines: Vec::new(),
+            vsock_interrupt_line: None,
+            balloon_interrupt_line: None,
+            entropy_interrupt_line: None,
+            memory_hotplug_interrupt_line: None,
+            serial_interrupt_line,
+            serial_input: None,
+            vmgenid_interrupt_line,
+            vmclock_interrupt_line,
+            boot_registers: None,
+        };
+        Ok(RestoredHvfSnapshotV2MultiBlockMmioOwners {
+            session,
+            drive_configs,
         })
     }
 
@@ -11717,6 +12560,7 @@ impl OwnedHvfArm64BootSession {
             backend,
             mmio_dispatcher,
             runtime_resources,
+            _restored_snapshot_v2_mmio_registrations: None,
             restored_snapshot_v2_memory_binding: None,
             restored_snapshot_v2_machine: None,
             cpu_template_application: None,
@@ -31416,6 +32260,47 @@ mod tests {
         assert!(cleanup_debug.contains("<redacted>"));
         for diagnostics in [debug, incomplete.to_string(), cleanup_debug] {
             assert!(!diagnostics.contains("secret-primary"));
+            assert!(!diagnostics.contains("secret-cleanup"));
+        }
+    }
+
+    #[test]
+    fn native_v2_multi_block_mmio_errors_preserve_terminality_and_redact_cleanup() {
+        let retryable = super::HvfSnapshotV2MultiBlockMmioRestoreError::preflight(
+            super::HvfSnapshotV2MultiBlockMmioRestoreStage::ResourcePlan,
+            super::HvfSnapshotV2MultiBlockMmioRestoreFailure::ResourcePlan,
+        );
+        assert!(!retryable.has_incomplete_cleanup());
+        assert!(!retryable.is_terminal());
+
+        let clean_rollback = super::HvfSnapshotV2MultiBlockMmioRestoreError::after_platform(
+            super::HvfSnapshotV2MultiBlockMmioRestoreStage::Registration { index: 1 },
+            super::HvfSnapshotV2MultiBlockMmioRestoreFailure::ResourcePlan,
+            Vec::new(),
+        );
+        assert!(!clean_rollback.has_incomplete_cleanup());
+        assert!(!clean_rollback.is_terminal());
+
+        let incomplete = super::HvfSnapshotV2MultiBlockMmioRestoreError::after_platform(
+            super::HvfSnapshotV2MultiBlockMmioRestoreStage::RetryScheduler,
+            super::HvfSnapshotV2MultiBlockMmioRestoreFailure::RetryScheduler(
+                io::ErrorKind::PermissionDenied,
+            ),
+            vec![
+                super::HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure::Platform(
+                    crate::snapshot_v2_platform::HvfSnapshotV2PlatformShutdownError::Backend(
+                        super::BackendError::Hypervisor("secret-cleanup/path".to_string()),
+                    ),
+                ),
+            ],
+        );
+        assert!(incomplete.has_incomplete_cleanup());
+        assert!(incomplete.is_terminal());
+        let debug = format!("{incomplete:?}");
+        let cleanup_debug = format!("{:?}", incomplete.cleanup_failures());
+        assert!(debug.contains("<redacted>"));
+        assert!(cleanup_debug.contains("<redacted>"));
+        for diagnostics in [debug, incomplete.to_string(), cleanup_debug] {
             assert!(!diagnostics.contains("secret-cleanup"));
         }
     }

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -7473,6 +7473,1137 @@ fn native_v2_multi_block_graph_is_durable_and_recoverable_for_mmio_and_pci() {
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const NATIVE_V2_MULTI_BLOCK_QUEUE_SIZE: u16 = 8;
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[derive(Clone, Copy)]
+struct NativeV2MultiBlockQueueFixture {
+    base: bangbang_runtime::memory::GuestAddress,
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+impl NativeV2MultiBlockQueueFixture {
+    const fn new(base: u64) -> Self {
+        Self {
+            base: bangbang_runtime::memory::GuestAddress::new(base),
+        }
+    }
+
+    fn address(self, offset: u64) -> bangbang_runtime::memory::GuestAddress {
+        self.base
+            .checked_add(offset)
+            .expect("native-v2 multi-block fixture address should fit")
+    }
+
+    fn descriptor_table(self) -> bangbang_runtime::memory::GuestAddress {
+        self.address(0)
+    }
+
+    fn available_ring(self) -> bangbang_runtime::memory::GuestAddress {
+        self.address(0x1000)
+    }
+
+    fn used_ring(self) -> bangbang_runtime::memory::GuestAddress {
+        self.address(0x2000)
+    }
+
+    fn write_header(self) -> bangbang_runtime::memory::GuestAddress {
+        self.address(0x3000)
+    }
+
+    fn write_data(self) -> bangbang_runtime::memory::GuestAddress {
+        self.address(0x4000)
+    }
+
+    fn write_status(self) -> bangbang_runtime::memory::GuestAddress {
+        self.address(0x5000)
+    }
+
+    fn flush_header(self) -> bangbang_runtime::memory::GuestAddress {
+        self.address(0x6000)
+    }
+
+    fn flush_status(self) -> bangbang_runtime::memory::GuestAddress {
+        self.address(0x7000)
+    }
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const NATIVE_V2_MULTI_BLOCK_SYNC_QUEUE: NativeV2MultiBlockQueueFixture =
+    NativeV2MultiBlockQueueFixture::new(0x8060_0000);
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const NATIVE_V2_MULTI_BLOCK_ASYNC_QUEUE: NativeV2MultiBlockQueueFixture =
+    NativeV2MultiBlockQueueFixture::new(0x8070_0000);
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn write_native_v2_multi_block_mmio(
+    dispatcher: &mut bangbang_runtime::mmio::MmioDispatcher,
+    address: bangbang_runtime::memory::GuestAddress,
+    data: &[u8],
+) {
+    use bangbang_runtime::mmio::{MmioAccessBytes, MmioDispatchOutcome, MmioOperation};
+
+    let access = dispatcher
+        .lookup(
+            address,
+            u64::try_from(data.len()).expect("multi-block MMIO write length should fit u64"),
+        )
+        .expect("multi-block MMIO write should resolve");
+    let outcome = dispatcher
+        .dispatch(
+            MmioOperation::write(
+                access,
+                MmioAccessBytes::new(data).expect("multi-block MMIO bytes should validate"),
+            )
+            .expect("multi-block MMIO write should validate"),
+        )
+        .expect("multi-block MMIO write should dispatch");
+    assert!(matches!(outcome, MmioDispatchOutcome::Write));
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn read_native_v2_multi_block_mmio_u32(
+    dispatcher: &mut bangbang_runtime::mmio::MmioDispatcher,
+    address: bangbang_runtime::memory::GuestAddress,
+) -> u32 {
+    use bangbang_runtime::mmio::{MmioDispatchOutcome, MmioOperation};
+
+    let access = dispatcher
+        .lookup(address, 4)
+        .expect("multi-block MMIO read should resolve");
+    let outcome = dispatcher
+        .dispatch(MmioOperation::read(access).expect("multi-block MMIO read should validate"))
+        .expect("multi-block MMIO read should dispatch");
+    let data = match outcome {
+        MmioDispatchOutcome::Read { data } => Some(data),
+        MmioDispatchOutcome::Write => None,
+    };
+    let data = data.expect("multi-block MMIO read should return data");
+    u32::from_le_bytes(
+        data.as_slice()
+            .try_into()
+            .expect("multi-block MMIO u32 should contain four bytes"),
+    )
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn write_native_v2_multi_block_descriptor(
+    memory: &mut bangbang_runtime::memory::GuestMemory,
+    fixture: NativeV2MultiBlockQueueFixture,
+    index: u16,
+    address: bangbang_runtime::memory::GuestAddress,
+    len: u32,
+    flags: u16,
+    next: u16,
+) {
+    use bangbang_runtime::virtio_queue::VIRTQUEUE_DESCRIPTOR_SIZE;
+
+    let descriptor = fixture
+        .descriptor_table()
+        .checked_add(
+            u64::from(index)
+                * u64::try_from(VIRTQUEUE_DESCRIPTOR_SIZE)
+                    .expect("virtqueue descriptor size should fit u64"),
+        )
+        .expect("multi-block descriptor address should fit");
+    memory
+        .write_slice(&address.raw_value().to_le_bytes(), descriptor)
+        .expect("multi-block descriptor address should write");
+    memory
+        .write_slice(
+            &len.to_le_bytes(),
+            descriptor
+                .checked_add(8)
+                .expect("multi-block descriptor length address should fit"),
+        )
+        .expect("multi-block descriptor length should write");
+    memory
+        .write_slice(
+            &flags.to_le_bytes(),
+            descriptor
+                .checked_add(12)
+                .expect("multi-block descriptor flags address should fit"),
+        )
+        .expect("multi-block descriptor flags should write");
+    memory
+        .write_slice(
+            &next.to_le_bytes(),
+            descriptor
+                .checked_add(14)
+                .expect("multi-block descriptor next address should fit"),
+        )
+        .expect("multi-block descriptor next index should write");
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn write_native_v2_multi_block_request_header(
+    memory: &mut bangbang_runtime::memory::GuestMemory,
+    address: bangbang_runtime::memory::GuestAddress,
+    request_type: u32,
+) {
+    memory
+        .write_slice(&request_type.to_le_bytes(), address)
+        .expect("multi-block request type should write");
+    memory
+        .write_slice(
+            &0_u32.to_le_bytes(),
+            address
+                .checked_add(4)
+                .expect("multi-block reserved header address should fit"),
+        )
+        .expect("multi-block reserved header should write");
+    memory
+        .write_slice(
+            &0_u64.to_le_bytes(),
+            address
+                .checked_add(8)
+                .expect("multi-block sector header address should fit"),
+        )
+        .expect("multi-block request sector should write");
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn initialize_native_v2_multi_block_queue(
+    memory: &mut bangbang_runtime::memory::GuestMemory,
+    fixture: NativeV2MultiBlockQueueFixture,
+) {
+    memory
+        .write_slice(&[0; 4], fixture.available_ring())
+        .expect("multi-block available ring should initialize");
+    memory
+        .write_slice(&[0; 4], fixture.used_ring())
+        .expect("multi-block used ring should initialize");
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn submit_native_v2_multi_block_write_and_flush(
+    memory: &mut bangbang_runtime::memory::GuestMemory,
+    fixture: NativeV2MultiBlockQueueFixture,
+    payload_byte: u8,
+) {
+    use bangbang_runtime::block::{
+        VIRTIO_BLOCK_REQUEST_HEADER_SIZE, VIRTIO_BLOCK_REQUEST_TYPE_FLUSH,
+        VIRTIO_BLOCK_REQUEST_TYPE_OUT, VIRTIO_BLOCK_SECTOR_SIZE, VIRTIO_BLOCK_STATUS_SIZE,
+    };
+    use bangbang_runtime::virtio_queue::{VIRTQUEUE_DESC_F_NEXT, VIRTQUEUE_DESC_F_WRITE};
+
+    write_native_v2_multi_block_request_header(
+        memory,
+        fixture.write_header(),
+        VIRTIO_BLOCK_REQUEST_TYPE_OUT,
+    );
+    write_native_v2_multi_block_request_header(
+        memory,
+        fixture.flush_header(),
+        VIRTIO_BLOCK_REQUEST_TYPE_FLUSH,
+    );
+    memory
+        .write_slice(
+            &[payload_byte; VIRTIO_BLOCK_SECTOR_SIZE as usize],
+            fixture.write_data(),
+        )
+        .expect("multi-block write payload should write");
+    memory
+        .write_slice(&[u8::MAX], fixture.write_status())
+        .expect("multi-block write status should initialize");
+    memory
+        .write_slice(&[u8::MAX], fixture.flush_status())
+        .expect("multi-block flush status should initialize");
+
+    write_native_v2_multi_block_descriptor(
+        memory,
+        fixture,
+        0,
+        fixture.write_header(),
+        VIRTIO_BLOCK_REQUEST_HEADER_SIZE,
+        VIRTQUEUE_DESC_F_NEXT,
+        1,
+    );
+    write_native_v2_multi_block_descriptor(
+        memory,
+        fixture,
+        1,
+        fixture.write_data(),
+        u32::try_from(VIRTIO_BLOCK_SECTOR_SIZE).expect("block sector size should fit u32"),
+        VIRTQUEUE_DESC_F_NEXT,
+        2,
+    );
+    write_native_v2_multi_block_descriptor(
+        memory,
+        fixture,
+        2,
+        fixture.write_status(),
+        VIRTIO_BLOCK_STATUS_SIZE,
+        VIRTQUEUE_DESC_F_WRITE,
+        0,
+    );
+    write_native_v2_multi_block_descriptor(
+        memory,
+        fixture,
+        3,
+        fixture.flush_header(),
+        VIRTIO_BLOCK_REQUEST_HEADER_SIZE,
+        VIRTQUEUE_DESC_F_NEXT,
+        4,
+    );
+    write_native_v2_multi_block_descriptor(
+        memory,
+        fixture,
+        4,
+        fixture.flush_status(),
+        VIRTIO_BLOCK_STATUS_SIZE,
+        VIRTQUEUE_DESC_F_WRITE,
+        0,
+    );
+
+    memory
+        .write_slice(
+            &0_u16.to_le_bytes(),
+            fixture
+                .available_ring()
+                .checked_add(4)
+                .expect("first multi-block available head address should fit"),
+        )
+        .expect("first multi-block available head should write");
+    memory
+        .write_slice(
+            &3_u16.to_le_bytes(),
+            fixture
+                .available_ring()
+                .checked_add(6)
+                .expect("second multi-block available head address should fit"),
+        )
+        .expect("second multi-block available head should write");
+    memory
+        .write_slice(
+            &2_u16.to_le_bytes(),
+            fixture
+                .available_ring()
+                .checked_add(2)
+                .expect("multi-block available index address should fit"),
+        )
+        .expect("multi-block available index should write");
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn activate_native_v2_multi_block_queue(
+    session: &bangbang_hvf::OwnedHvfArm64BootSession,
+    transport_base: bangbang_runtime::memory::GuestAddress,
+    fixture: NativeV2MultiBlockQueueFixture,
+) {
+    use bangbang_runtime::virtio_mmio::{
+        VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DRIVER,
+        VIRTIO_DEVICE_STATUS_DRIVER_OK, VIRTIO_DEVICE_STATUS_FEATURES_OK, VirtioMmioRegister,
+    };
+
+    let dispatcher = session.mmio_dispatcher();
+    let mut dispatcher = dispatcher
+        .lock()
+        .expect("multi-block MMIO dispatcher should not be poisoned");
+    let write = |dispatcher: &mut bangbang_runtime::mmio::MmioDispatcher,
+                 register: VirtioMmioRegister,
+                 value: u32| {
+        write_native_v2_multi_block_mmio(
+            dispatcher,
+            transport_base
+                .checked_add(register.offset())
+                .expect("multi-block register address should fit"),
+            &value.to_le_bytes(),
+        );
+    };
+    let features_ok = VIRTIO_DEVICE_STATUS_ACKNOWLEDGE
+        | VIRTIO_DEVICE_STATUS_DRIVER
+        | VIRTIO_DEVICE_STATUS_FEATURES_OK;
+    for status in [
+        VIRTIO_DEVICE_STATUS_ACKNOWLEDGE,
+        VIRTIO_DEVICE_STATUS_ACKNOWLEDGE | VIRTIO_DEVICE_STATUS_DRIVER,
+    ] {
+        write(&mut dispatcher, VirtioMmioRegister::Status, status);
+    }
+    write(&mut dispatcher, VirtioMmioRegister::DriverFeaturesSel, 1);
+    write(&mut dispatcher, VirtioMmioRegister::DriverFeatures, 1);
+    write(&mut dispatcher, VirtioMmioRegister::Status, features_ok);
+    write(&mut dispatcher, VirtioMmioRegister::QueueSel, 0);
+    write(
+        &mut dispatcher,
+        VirtioMmioRegister::QueueNum,
+        u32::from(NATIVE_V2_MULTI_BLOCK_QUEUE_SIZE),
+    );
+    write(
+        &mut dispatcher,
+        VirtioMmioRegister::QueueDescLow,
+        u32::try_from(fixture.descriptor_table().raw_value())
+            .expect("multi-block descriptor address should fit u32"),
+    );
+    write(
+        &mut dispatcher,
+        VirtioMmioRegister::QueueDriverLow,
+        u32::try_from(fixture.available_ring().raw_value())
+            .expect("multi-block available ring should fit u32"),
+    );
+    write(
+        &mut dispatcher,
+        VirtioMmioRegister::QueueDeviceLow,
+        u32::try_from(fixture.used_ring().raw_value())
+            .expect("multi-block used ring should fit u32"),
+    );
+    write(&mut dispatcher, VirtioMmioRegister::QueueReady, 1);
+    write(
+        &mut dispatcher,
+        VirtioMmioRegister::Status,
+        features_ok | VIRTIO_DEVICE_STATUS_DRIVER_OK,
+    );
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn notify_native_v2_multi_block_queue(
+    session: &bangbang_hvf::OwnedHvfArm64BootSession,
+    transport_base: bangbang_runtime::memory::GuestAddress,
+) {
+    use bangbang_runtime::virtio_mmio::VirtioMmioRegister;
+
+    let dispatcher = session.mmio_dispatcher();
+    let mut dispatcher = dispatcher
+        .lock()
+        .expect("multi-block MMIO dispatcher should not be poisoned");
+    write_native_v2_multi_block_mmio(
+        &mut dispatcher,
+        transport_base
+            .checked_add(VirtioMmioRegister::QueueNotify.offset())
+            .expect("multi-block queue-notify address should fit"),
+        &0_u32.to_le_bytes(),
+    );
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn native_v2_multi_block_interrupt_status(
+    session: &bangbang_hvf::OwnedHvfArm64BootSession,
+    transport_base: bangbang_runtime::memory::GuestAddress,
+) -> u32 {
+    use bangbang_runtime::virtio_mmio::VirtioMmioRegister;
+
+    let dispatcher = session.mmio_dispatcher();
+    let mut dispatcher = dispatcher
+        .lock()
+        .expect("multi-block MMIO dispatcher should not be poisoned");
+    read_native_v2_multi_block_mmio_u32(
+        &mut dispatcher,
+        transport_base
+            .checked_add(VirtioMmioRegister::InterruptStatus.offset())
+            .expect("multi-block interrupt-status address should fit"),
+    )
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn read_native_v2_multi_block_guest_u16(
+    memory: &bangbang_runtime::memory::GuestMemory,
+    address: bangbang_runtime::memory::GuestAddress,
+) -> u16 {
+    let mut bytes = [0_u8; 2];
+    memory
+        .read_slice(&mut bytes, address)
+        .expect("multi-block guest u16 should read");
+    u16::from_le_bytes(bytes)
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn read_native_v2_multi_block_guest_u8(
+    memory: &bangbang_runtime::memory::GuestMemory,
+    address: bangbang_runtime::memory::GuestAddress,
+) -> u8 {
+    let mut byte = [0_u8; 1];
+    memory
+        .read_slice(&mut byte, address)
+        .expect("multi-block guest u8 should read");
+    byte.first()
+        .copied()
+        .expect("multi-block guest u8 should contain one byte")
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn native_v2_multi_block_used_index(
+    session: &bangbang_hvf::OwnedHvfArm64BootSession,
+    fixture: NativeV2MultiBlockQueueFixture,
+) -> u16 {
+    read_native_v2_multi_block_guest_u16(
+        session
+            .guest_memory()
+            .expect("multi-block guest memory should remain mapped"),
+        fixture
+            .used_ring()
+            .checked_add(2)
+            .expect("multi-block used index address should fit"),
+    )
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn wait_for_native_v2_multi_block_async_completion(
+    session: &bangbang_hvf::OwnedHvfArm64BootSession,
+) {
+    let completion_fd = session
+        .runtime_resources()
+        .block_async_completion_fd()
+        .expect("multi-block Async completion descriptor should inspect")
+        .expect("multi-block Async runtime should expose a completion descriptor");
+    let mut readiness = libc::pollfd {
+        fd: completion_fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    // SAFETY: One initialized pollfd is writable for the bounded wait.
+    let ready = unsafe { libc::poll(&raw mut readiness, 1, 5_000) };
+    assert_eq!(
+        ready, 1,
+        "multi-block Async request should complete before the deadline"
+    );
+    assert_ne!(
+        readiness.revents & libc::POLLIN,
+        0,
+        "multi-block Async completion descriptor should become readable"
+    );
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn native_v2_multi_block_dispatch_signaled(
+    dispatches: &bangbang_hvf::HvfArm64BootBlockNotificationDispatches,
+    drive_id: &str,
+) -> bool {
+    dispatches.as_slice().iter().any(|dispatch| {
+        dispatch.dispatch().device().registration.drive_id() == drive_id
+            && dispatch.queue_interrupt_signaled()
+    })
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
+    use std::fs::OpenOptions;
+    use std::time::Instant;
+
+    use bangbang_hvf::{
+        HvfArm64BootSerialDeviceConfig, HvfArm64BootSessionConfig,
+        HvfArm64BootSnapshotV2CaptureInput, HvfSnapshotV2BootState,
+        HvfSnapshotV2DefaultProcessShell, HvfSnapshotV2MultiBlockProcessConfig,
+        HvfSnapshotV2NativePath, HvfVcpuRunStepOutcome, OwnedHvfArm64BootSession,
+        prepare_hvf_snapshot_v2_multi_block_platform_plan,
+    };
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::block::{
+        BlockFileBacking, BlockMmioLayout, DriveCacheType, DriveConfigInput, DriveIoEngine,
+    };
+    use bangbang_runtime::boot::BootSourceConfigInput;
+    use bangbang_runtime::machine::MachineConfigInput;
+    use bangbang_runtime::memory::{GuestAddress, GuestMemory, GuestMemoryLayout};
+    use bangbang_runtime::mmio::MmioRegionId;
+    use bangbang_runtime::network::NetworkMmioLayout;
+    use bangbang_runtime::pmem::PmemMmioLayout;
+    use bangbang_runtime::serial::{SharedSerialOutput, SharedSerialOutputBuffer};
+    use bangbang_runtime::snapshot_device_v2::SnapshotV2DeviceTransport;
+    use bangbang_runtime::snapshot_device_v2_5::SnapshotV2MultiBlockRestorePlan;
+    use bangbang_runtime::storage_capture::CaptureReadyStorageConfigs;
+    use bangbang_runtime::vsock::VsockMmioLayout;
+
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let image = arm64_image().expect("test arm64 image should build");
+
+    for (case, rooted) in [
+        ("native-v2-multi-block-mmio-rooted-owner", true),
+        ("native-v2-multi-block-mmio-rootless-owner", false),
+    ] {
+        let kernel = TempFile::new(&format!("{case}-kernel"), &image)
+            .unwrap_or_else(|error| panic!("{case} kernel should create: {error}"));
+        let first = TempFile::new_len(&format!("{case}-sync"), 4096)
+            .unwrap_or_else(|error| panic!("{case} Sync backing should create: {error}"));
+        let second = TempFile::new_len(&format!("{case}-async"), 4096)
+            .unwrap_or_else(|error| panic!("{case} Async backing should create: {error}"));
+        let mut controller = bangbang_runtime::VmmController::new(case, "0.1.0", "bangbang");
+        controller
+            .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+                kernel.path(),
+            )))
+            .unwrap_or_else(|error| panic!("{case} boot source should configure: {error}"));
+        controller
+            .handle_action(VmmAction::PutMachineConfig(MachineConfigInput::new(1, 16)))
+            .unwrap_or_else(|error| panic!("{case} machine should configure: {error}"));
+        controller
+            .handle_action(VmmAction::PutDrive(
+                DriveConfigInput::new("sync", "sync", first.path(), rooted)
+                    .with_is_read_only(false)
+                    .with_cache_type(DriveCacheType::Unsafe)
+                    .with_io_engine(DriveIoEngine::Sync),
+            ))
+            .unwrap_or_else(|error| panic!("{case} Sync drive should configure: {error}"));
+        controller
+            .handle_action(VmmAction::PutDrive(
+                DriveConfigInput::new("async", "async", second.path(), false)
+                    .with_is_read_only(false)
+                    .with_cache_type(DriveCacheType::Writeback)
+                    .with_io_engine(DriveIoEngine::Async),
+            ))
+            .unwrap_or_else(|error| panic!("{case} Async drive should configure: {error}"));
+
+        let block_layout =
+            BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1));
+        let source_serial = SharedSerialOutputBuffer::default();
+        let session_config = HvfArm64BootSessionConfig::new(
+            block_layout,
+            PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500)),
+            NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000)),
+            VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
+            bangbang_runtime::rtc::RtcMmioLayout::new(
+                GuestAddress::new(0x4000_1000),
+                MmioRegionId::new(10),
+            ),
+        )
+        .with_serial_device(HvfArm64BootSerialDeviceConfig::new(
+            MmioRegionId::new(20),
+            GuestAddress::new(0x4000_2000),
+            SharedSerialOutput::from(source_serial),
+        ));
+        let mut source = OwnedHvfArm64BootSession::new(&controller, session_config)
+            .unwrap_or_else(|error| panic!("{case} source should prepare: {error}"));
+
+        let source_entry = GuestAddress::new(
+            source
+                .capture_arm64_general_register_state()
+                .unwrap_or_else(|error| panic!("{case} source registers should capture: {error}"))
+                .pc(),
+        );
+        let guest_code = [
+            0xd503_4fdf, // msr daifset, #0xf (synthetic guest has no exception vectors)
+            0xd282_4685, // mov x5, #0x1234
+            0xd2a8_0001, // mov x1, #0x40000000
+            0xf284_00e1, // movk x1, #0x2007
+            0xd280_0b42, // mov x2, #0x5a
+            0x3900_0022, // strb w2, [x1]
+            0xd2b0_8000, // mov x0, #0x84000000 (PSCI_VERSION)
+            0xd400_0002, // hvc #0
+            0xd28a_cf06, // mov x6, #0x5678
+            0xd2b0_8000, // mov x0, #0x84000000 (PSCI_VERSION)
+            0xd400_0002, // hvc #0
+        ]
+        .into_iter()
+        .flat_map(u32::to_le_bytes)
+        .collect::<Vec<_>>();
+        source
+            .guest_memory_mut()
+            .unwrap_or_else(|error| panic!("{case} source memory should map: {error}"))
+            .write_slice(&guest_code, source_entry)
+            .unwrap_or_else(|error| panic!("{case} guest continuation should write: {error}"));
+        assert!(matches!(
+            source.run_once_and_handle_mmio(),
+            Ok(HvfVcpuRunStepOutcome::Mmio { .. })
+        ));
+        assert!(matches!(
+            source.run_once_and_handle_mmio(),
+            Ok(HvfVcpuRunStepOutcome::Hvc {
+                function_id: 0x8400_0000,
+                return_value: 0x0001_0000,
+                ..
+            })
+        ));
+        assert_eq!(
+            source
+                .capture_arm64_general_register_state()
+                .unwrap_or_else(|error| {
+                    panic!("{case} masked source registers should capture: {error}")
+                })
+                .cpsr()
+                & 0xc0,
+            0xc0,
+            "{case} synthetic source guest should mask IRQ and FIQ"
+        );
+
+        let source_configs =
+            CaptureReadyStorageConfigs::new(controller.drive_configs().to_vec(), Vec::new());
+        let source_guard = source
+            .quiesce_limiter_retry_wakeups()
+            .unwrap_or_else(|error| panic!("{case} retry publishers should quiesce: {error}"));
+        let graph = source
+            .capture_snapshot_v2_multi_block_device_graph_at(
+                &source_configs,
+                &source_guard,
+                Instant::now(),
+            )
+            .unwrap_or_else(|error| panic!("{case} graph should capture: {error}"));
+        assert_eq!(graph.records().len(), 2);
+        assert_eq!(graph.root_key().is_some(), rooted);
+        source
+            .pause_for_snapshot_v2_capture()
+            .unwrap_or_else(|error| panic!("{case} source should pause: {error}"));
+        let boot = HvfSnapshotV2BootState::try_new(
+            HvfSnapshotV2NativePath::try_new(kernel.path().as_os_str())
+                .unwrap_or_else(|error| panic!("{case} kernel path should validate: {error}")),
+            None,
+            None,
+        )
+        .unwrap_or_else(|error| panic!("{case} boot metadata should validate: {error}"));
+        let capture_input = HvfArm64BootSnapshotV2CaptureInput::new(boot);
+        let memory_artifact = TempFile::new_len(&format!("{case}-memory"), 0)
+            .unwrap_or_else(|error| panic!("{case} memory artifact should create: {error}"));
+        let mut memory_writer = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(memory_artifact.path())
+            .unwrap_or_else(|error| panic!("{case} memory artifact should open: {error}"));
+        let source_platform = source
+            .capture_snapshot_v2_device_graph_platform_with_cancel(
+                capture_input.clone(),
+                &mut memory_writer,
+                |_| false,
+            )
+            .unwrap_or_else(|error| panic!("{case} platform should capture: {error}"));
+
+        let layout = GuestMemoryLayout::new(source.runtime_resources().layout.ranges().to_vec())
+            .unwrap_or_else(|error| panic!("{case} destination layout should validate: {error}"));
+        let mut restored_memory = GuestMemory::allocate(&layout)
+            .unwrap_or_else(|error| panic!("{case} destination memory should allocate: {error}"));
+        let source_memory = source
+            .guest_memory()
+            .unwrap_or_else(|error| panic!("{case} source memory should remain mapped: {error}"));
+        let mut page = vec![0_u8; 64 * 1024];
+        for range in layout.ranges() {
+            let mut copied = 0_u64;
+            while copied < range.size() {
+                let remaining = range.size() - copied;
+                let count = usize::try_from(
+                    remaining.min(u64::try_from(page.len()).expect("page length should fit")),
+                )
+                .expect("copy count should fit");
+                let address = range
+                    .start()
+                    .checked_add(copied)
+                    .expect("copy address should fit");
+                source_memory
+                    .read_slice(&mut page[..count], address)
+                    .unwrap_or_else(|error| panic!("{case} source page should read: {error}"));
+                restored_memory
+                    .write_slice(&page[..count], address)
+                    .unwrap_or_else(|error| {
+                        panic!("{case} destination page should write: {error}")
+                    });
+                copied += u64::try_from(count).expect("copy count should fit u64");
+            }
+        }
+        drop(memory_writer);
+        drop(source_guard);
+        source
+            .shutdown()
+            .unwrap_or_else(|error| panic!("{case} source should shut down: {error}"));
+
+        let drive_configs = graph
+            .project_drive_configs()
+            .unwrap_or_else(|error| panic!("{case} configs should project: {error}"));
+        let backings = graph
+            .records()
+            .iter()
+            .map(|record| {
+                BlockFileBacking::open_snapshot(
+                    std::path::Path::new(record.config().selector()),
+                    record.config().is_read_only(),
+                )
+                .map(|(backing, _identity)| backing)
+                .unwrap_or_else(|error| panic!("{case} backing should reopen: {error}"))
+            })
+            .collect::<Vec<_>>();
+        let now = Instant::now();
+        let bundle = SnapshotV2MultiBlockRestorePlan::prepare(graph.clone(), &restored_memory, now)
+            .unwrap_or_else(|error| panic!("{case} restore plan should prepare: {error}"))
+            .prepare_backings(drive_configs.clone(), backings)
+            .unwrap_or_else(|error| panic!("{case} backing vector should prepare: {error}"));
+        let platform_plan = prepare_hvf_snapshot_v2_multi_block_platform_plan(
+            &source_platform,
+            &bundle,
+            HvfSnapshotV2MultiBlockProcessConfig::new(block_layout, false),
+        )
+        .unwrap_or_else(|error| panic!("{case} platform plan should prepare: {error}"));
+        let restored_serial = SharedSerialOutputBuffer::default();
+        let shell =
+            HvfSnapshotV2DefaultProcessShell::new(SharedSerialOutput::from(restored_serial));
+        let owners = OwnedHvfArm64BootSession::restore_snapshot_v2_multi_block_mmio(
+            source_platform.clone(),
+            restored_memory,
+            shell,
+            bundle,
+            platform_plan,
+        )
+        .unwrap_or_else(|error| panic!("{case} owner vector should restore: {error:?}"));
+        assert_eq!(owners.drive_configs(), &drive_configs);
+        let (mut restored, restored_drive_configs) = owners.into_parts();
+        assert_eq!(
+            restored
+                .capture_arm64_general_register_state()
+                .unwrap_or_else(|error| {
+                    panic!("{case} masked restored registers should capture: {error}")
+                })
+                .cpsr()
+                & 0xc0,
+            0xc0,
+            "{case} restored synthetic guest should retain IRQ and FIQ masks"
+        );
+        assert_eq!(restored.runtime_resources().block_devices.len(), 2);
+        for ((device, record), config) in restored
+            .runtime_resources()
+            .block_devices
+            .iter()
+            .zip(graph.records())
+            .zip(restored_drive_configs.as_slice())
+        {
+            let SnapshotV2DeviceTransport::Mmio(mmio) = record.transport() else {
+                panic!("{case} record should retain MMIO transport");
+            };
+            assert_eq!(
+                device.registration.index(),
+                record.key().instance() as usize
+            );
+            assert_eq!(device.registration.drive_id(), config.drive_id());
+            assert_eq!(device.registration.region(), mmio.region());
+            assert_eq!(device.fdt_device.interrupt_line, mmio.interrupt_line());
+        }
+
+        let metrics = restored.shared_block_device_metrics();
+        for config in restored_drive_configs.as_slice() {
+            assert!(
+                metrics
+                    .per_drive(config.drive_id())
+                    .expect("restored per-drive metrics entry should exist")
+                    .snapshot()
+                    .is_empty()
+            );
+        }
+        assert_eq!(
+            metrics
+                .per_drive(restored_drive_configs.as_slice()[0].drive_id())
+                .expect("first metrics entry should exist")
+                .snapshot()
+                .update_count(),
+            0
+        );
+
+        {
+            let dispatcher = restored.mmio_dispatcher();
+            let mut dispatcher = dispatcher
+                .lock()
+                .expect("restored MMIO dispatcher should lock");
+            for config in restored_drive_configs.as_slice() {
+                let binding = restored
+                    .runtime_resources()
+                    .capture_ready_mmio_block_async_binding(&mut dispatcher, config.drive_id())
+                    .unwrap_or_else(|error| {
+                        panic!("{case} Async identity should inspect: {error}")
+                    });
+                match config.io_engine() {
+                    Some(DriveIoEngine::Sync) => assert!(binding.is_none()),
+                    Some(DriveIoEngine::Async) => {
+                        let (runtime, _generation) =
+                            binding.expect("Async record should retain one generation");
+                        assert!(
+                            runtime.same_runtime(&restored.runtime_resources().block_async_runtime)
+                        );
+                    }
+                    None => panic!("{case} restored local drive should have an I/O engine"),
+                }
+                let persistence = restored
+                    .runtime_resources()
+                    .capture_ready_mmio_block_snapshot_persistence_binding(&mut dispatcher, config)
+                    .unwrap_or_else(|error| {
+                        panic!(
+                            "{case} {} persistence binding should validate: {error}",
+                            config.drive_id()
+                        )
+                    });
+                assert!(!persistence.is_read_only());
+                assert_eq!(Some(persistence.io_engine()), config.io_engine());
+            }
+        }
+
+        let restored_configs =
+            CaptureReadyStorageConfigs::new(restored_drive_configs.as_slice().to_vec(), Vec::new());
+        let restored_guard = restored
+            .quiesce_limiter_retry_wakeups()
+            .unwrap_or_else(|error| {
+                panic!("{case} restored retry publishers should quiesce: {error}")
+            });
+        let recaptured_graph = restored
+            .capture_snapshot_v2_multi_block_device_graph_at(
+                &restored_configs,
+                &restored_guard,
+                now,
+            )
+            .unwrap_or_else(|error| panic!("{case} restored graph should recapture: {error}"));
+        assert_eq!(recaptured_graph, graph);
+        let recaptured_memory = TempFile::new_len(&format!("{case}-recapture"), 0)
+            .unwrap_or_else(|error| panic!("{case} recapture artifact should create: {error}"));
+        let mut recaptured_writer = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(recaptured_memory.path())
+            .unwrap_or_else(|error| panic!("{case} recapture artifact should open: {error}"));
+        let recaptured_platform = restored
+            .capture_snapshot_v2_device_graph_platform_with_cancel(
+                capture_input,
+                &mut recaptured_writer,
+                |_| false,
+            )
+            .unwrap_or_else(|error| panic!("{case} platform should recapture: {error}"));
+        assert_native_v2_platform_recapture_equivalent(&source_platform, &recaptured_platform);
+        drop(restored_guard);
+
+        let mut transport_bases = graph.records().iter().map(|record| {
+            let SnapshotV2DeviceTransport::Mmio(mmio) = record.transport() else {
+                panic!("{case} restored test record should use MMIO");
+            };
+            mmio.region().range().start()
+        });
+        let sync_transport_base = transport_bases
+            .next()
+            .expect("Sync transport base should exist");
+        let async_transport_base = transport_bases
+            .next()
+            .expect("Async transport base should exist");
+        assert!(
+            transport_bases.next().is_none(),
+            "{case} should restore exactly two block transports"
+        );
+        {
+            let memory = restored
+                .guest_memory_mut()
+                .unwrap_or_else(|error| panic!("{case} restored memory should map: {error}"));
+            initialize_native_v2_multi_block_queue(memory, NATIVE_V2_MULTI_BLOCK_SYNC_QUEUE);
+            initialize_native_v2_multi_block_queue(memory, NATIVE_V2_MULTI_BLOCK_ASYNC_QUEUE);
+        }
+        activate_native_v2_multi_block_queue(
+            &restored,
+            sync_transport_base,
+            NATIVE_V2_MULTI_BLOCK_SYNC_QUEUE,
+        );
+        activate_native_v2_multi_block_queue(
+            &restored,
+            async_transport_base,
+            NATIVE_V2_MULTI_BLOCK_ASYNC_QUEUE,
+        );
+
+        {
+            let memory = restored
+                .guest_memory_mut()
+                .unwrap_or_else(|error| panic!("{case} restored memory should map: {error}"));
+            submit_native_v2_multi_block_write_and_flush(
+                memory,
+                NATIVE_V2_MULTI_BLOCK_SYNC_QUEUE,
+                0x5a,
+            );
+        }
+        notify_native_v2_multi_block_queue(&restored, sync_transport_base);
+        let sync_dispatches = restored
+            .dispatch_block_queue_notifications_and_signal_interrupts()
+            .unwrap_or_else(|error| panic!("{case} Sync requests should dispatch: {error}"));
+        assert_eq!(sync_dispatches.len(), 2);
+        assert!(native_v2_multi_block_dispatch_signaled(
+            &sync_dispatches,
+            restored_drive_configs.as_slice()[0].drive_id(),
+        ));
+        assert!(!native_v2_multi_block_dispatch_signaled(
+            &sync_dispatches,
+            restored_drive_configs.as_slice()[1].drive_id(),
+        ));
+        assert_eq!(
+            native_v2_multi_block_used_index(&restored, NATIVE_V2_MULTI_BLOCK_SYNC_QUEUE),
+            2
+        );
+        {
+            let memory = restored
+                .guest_memory()
+                .unwrap_or_else(|error| panic!("{case} restored memory should map: {error}"));
+            assert_eq!(
+                read_native_v2_multi_block_guest_u8(
+                    memory,
+                    NATIVE_V2_MULTI_BLOCK_SYNC_QUEUE.write_status(),
+                ),
+                bangbang_runtime::block::VIRTIO_BLOCK_STATUS_OK
+            );
+            assert_eq!(
+                read_native_v2_multi_block_guest_u8(
+                    memory,
+                    NATIVE_V2_MULTI_BLOCK_SYNC_QUEUE.flush_status(),
+                ),
+                bangbang_runtime::block::VIRTIO_BLOCK_STATUS_OK
+            );
+        }
+
+        {
+            let memory = restored
+                .guest_memory_mut()
+                .unwrap_or_else(|error| panic!("{case} restored memory should map: {error}"));
+            submit_native_v2_multi_block_write_and_flush(
+                memory,
+                NATIVE_V2_MULTI_BLOCK_ASYNC_QUEUE,
+                0xa5,
+            );
+        }
+        notify_native_v2_multi_block_queue(&restored, async_transport_base);
+        let mut async_interrupt_signaled = false;
+        let initial_async_dispatches = restored
+            .dispatch_block_queue_notifications_and_signal_interrupts()
+            .unwrap_or_else(|error| panic!("{case} Async requests should schedule: {error}"));
+        async_interrupt_signaled |= native_v2_multi_block_dispatch_signaled(
+            &initial_async_dispatches,
+            restored_drive_configs.as_slice()[1].drive_id(),
+        );
+        for _ in 0..8 {
+            if native_v2_multi_block_used_index(&restored, NATIVE_V2_MULTI_BLOCK_ASYNC_QUEUE) == 2 {
+                break;
+            }
+            wait_for_native_v2_multi_block_async_completion(&restored);
+            let dispatches = restored
+                .dispatch_block_queue_notifications_and_signal_interrupts()
+                .unwrap_or_else(|error| panic!("{case} Async completion should dispatch: {error}"));
+            async_interrupt_signaled |= native_v2_multi_block_dispatch_signaled(
+                &dispatches,
+                restored_drive_configs.as_slice()[1].drive_id(),
+            );
+        }
+        assert_eq!(
+            native_v2_multi_block_used_index(&restored, NATIVE_V2_MULTI_BLOCK_ASYNC_QUEUE),
+            2,
+            "{case} Async write and flush should both publish"
+        );
+        assert!(
+            async_interrupt_signaled,
+            "{case} Async completion should signal its queue interrupt"
+        );
+        {
+            let memory = restored
+                .guest_memory()
+                .unwrap_or_else(|error| panic!("{case} restored memory should map: {error}"));
+            assert_eq!(
+                read_native_v2_multi_block_guest_u8(
+                    memory,
+                    NATIVE_V2_MULTI_BLOCK_ASYNC_QUEUE.write_status(),
+                ),
+                bangbang_runtime::block::VIRTIO_BLOCK_STATUS_OK
+            );
+            assert_eq!(
+                read_native_v2_multi_block_guest_u8(
+                    memory,
+                    NATIVE_V2_MULTI_BLOCK_ASYNC_QUEUE.flush_status(),
+                ),
+                bangbang_runtime::block::VIRTIO_BLOCK_STATUS_OK
+            );
+        }
+
+        let queue_interrupt = bangbang_runtime::interrupt::DeviceInterruptKind::Queue
+            .status()
+            .bits();
+        assert_eq!(
+            native_v2_multi_block_interrupt_status(&restored, sync_transport_base)
+                & queue_interrupt,
+            queue_interrupt
+        );
+        assert_eq!(
+            native_v2_multi_block_interrupt_status(&restored, async_transport_base)
+                & queue_interrupt,
+            queue_interrupt
+        );
+
+        for (config, expected_byte) in restored_drive_configs.as_slice().iter().zip([0x5a, 0xa5]) {
+            let snapshot = metrics
+                .per_drive(config.drive_id())
+                .expect("restored per-drive metrics entry should exist")
+                .snapshot();
+            assert_eq!(snapshot.write_count(), 1);
+            assert_eq!(
+                snapshot.write_bytes(),
+                bangbang_runtime::block::VIRTIO_BLOCK_SECTOR_SIZE
+            );
+            assert_eq!(snapshot.flush_count(), 1);
+            let backing = std::fs::read(
+                config
+                    .path_on_host()
+                    .expect("restored local backing path should exist"),
+            )
+            .unwrap_or_else(|error| panic!("{case} backing should read: {error}"));
+            assert_eq!(
+                backing
+                    .get(..bangbang_runtime::block::VIRTIO_BLOCK_SECTOR_SIZE as usize)
+                    .expect("restored backing should contain one sector"),
+                &[expected_byte; bangbang_runtime::block::VIRTIO_BLOCK_SECTOR_SIZE as usize]
+            );
+        }
+
+        let post_io_guard = restored
+            .quiesce_limiter_retry_wakeups()
+            .unwrap_or_else(|error| {
+                panic!("{case} post-I/O retry publishers should quiesce: {error}")
+            });
+        let post_io_now = Instant::now();
+        let post_io_graph = restored
+            .capture_snapshot_v2_multi_block_device_graph_at(
+                &restored_configs,
+                &post_io_guard,
+                post_io_now,
+            )
+            .unwrap_or_else(|error| panic!("{case} post-I/O graph should capture: {error}"));
+        let continued_post_io_graph = restored
+            .capture_snapshot_v2_multi_block_device_graph_at(
+                &restored_configs,
+                &post_io_guard,
+                post_io_now,
+            )
+            .unwrap_or_else(|error| {
+                panic!("{case} continued post-I/O graph should capture: {error}")
+            });
+        assert_ne!(post_io_graph, graph);
+        assert_eq!(continued_post_io_graph, post_io_graph);
+        for record in post_io_graph.records() {
+            assert!(record.virtio().is_activated());
+            assert!(
+                record
+                    .virtio()
+                    .queues()
+                    .first()
+                    .expect("restored block queue should exist")
+                    .ready()
+            );
+            let queue = record
+                .block()
+                .continuation()
+                .active_queue()
+                .expect("restored block queue cursor should capture");
+            assert_eq!(queue.next_available(), 2);
+            assert_eq!(queue.next_used(), 2);
+        }
+        drop(post_io_guard);
+
+        let resumed_step = restored.run_once_and_handle_mmio();
+        assert!(
+            matches!(
+                &resumed_step,
+                Ok(HvfVcpuRunStepOutcome::Hvc {
+                    function_id: 0x8400_0000,
+                    return_value: 0x0001_0000,
+                    ..
+                })
+            ),
+            "{case} should resume to the second HVC after block I/O: {resumed_step:?}"
+        );
+        assert_eq!(
+            restored
+                .capture_arm64_general_register_state()
+                .unwrap_or_else(|error| {
+                    panic!("{case} restored registers should capture: {error}")
+                })
+                .general_purpose_register(6),
+            Some(0x5678)
+        );
+        restored
+            .shutdown()
+            .unwrap_or_else(|error| panic!("{case} restored owner should shut down: {error}"));
+    }
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 #[test]
 fn native_v2_root_graph_converts_signed_mmio_and_pci_owners_canonically() {
     use std::fs::{File, OpenOptions};

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -2099,6 +2099,55 @@ impl SharedBlockDeviceMetricsRegistry {
         })
     }
 
+    /// Builds a bounded registry by consuming already-validated owned IDs.
+    ///
+    /// This avoids allocating a second string vector while an unpublished
+    /// restore transaction is acquiring its complete metrics owner.
+    #[doc(hidden)]
+    pub fn from_owned_drive_ids_with_capacity(
+        drive_ids: Vec<String>,
+        capacity: usize,
+    ) -> Result<Self, BlockDeviceMetricsRegistryError> {
+        if drive_ids.len() > capacity {
+            return Err(BlockDeviceMetricsRegistryError::Capacity);
+        }
+        let mut entries = Vec::new();
+        entries
+            .try_reserve_exact(capacity)
+            .map_err(|_| BlockDeviceMetricsRegistryError::Capacity)?;
+        let mut reservations = Vec::new();
+        reservations
+            .try_reserve_exact(capacity)
+            .map_err(|_| BlockDeviceMetricsRegistryError::Capacity)?;
+        for drive_id in drive_ids {
+            if entries
+                .iter()
+                .any(|entry: &BlockDeviceMetricsRegistryEntry| entry.drive_id == drive_id)
+            {
+                return Err(BlockDeviceMetricsRegistryError::DuplicateDrive);
+            }
+            let generation = u64::try_from(entries.len())
+                .map_err(|_| BlockDeviceMetricsRegistryError::GenerationExhausted)?;
+            entries.push(BlockDeviceMetricsRegistryEntry {
+                generation,
+                drive_id,
+                metrics: SharedBlockDeviceMetrics::default(),
+                lease_claimed: false,
+            });
+        }
+        let next_generation = u64::try_from(entries.len())
+            .map_err(|_| BlockDeviceMetricsRegistryError::GenerationExhausted)?;
+        Ok(Self {
+            aggregate: SharedBlockDeviceMetrics::default(),
+            per_drive: Arc::new(Mutex::new(BlockDeviceMetricsRegistryState {
+                entries,
+                reservations,
+                next_generation,
+                capacity,
+            })),
+        })
+    }
+
     pub fn prepare_drive(
         &self,
         drive_id: impl Into<String>,

--- a/crates/runtime/src/snapshot.rs
+++ b/crates/runtime/src/snapshot.rs
@@ -100,6 +100,24 @@ impl SnapshotV2ControllerCommit {
         })
     }
 
+    /// Retains an already-validated complete drive vector without rebuilding
+    /// or cloning its authority projection.
+    #[doc(hidden)]
+    pub fn with_drive_configs(
+        machine_config: MachineConfig,
+        boot_source_config: BootSourceConfig,
+        drive_configs: DriveConfigs,
+        resume_requested: bool,
+    ) -> Self {
+        Self {
+            machine_config,
+            boot_source_config,
+            drive_configs,
+            serial_config: SerialConfig::default(),
+            resume_requested,
+        }
+    }
+
     pub const fn resume_requested(&self) -> bool {
         self.resume_requested
     }

--- a/crates/runtime/src/snapshot_device_v2.rs
+++ b/crates/runtime/src/snapshot_device_v2.rs
@@ -1637,7 +1637,7 @@ impl std::error::Error for SnapshotV2RootTransportRestoreError {
     }
 }
 
-fn restore_mmio_transport_state(
+pub(crate) fn restore_mmio_transport_state(
     common: &SnapshotV2VirtioState,
     mmio: &SnapshotV2MmioDeviceState,
 ) -> Result<VirtioMmioTransportState, SnapshotV2RootTransportRestoreError> {

--- a/crates/runtime/src/snapshot_device_v2_5.rs
+++ b/crates/runtime/src/snapshot_device_v2_5.rs
@@ -41,10 +41,11 @@ mod codec;
 mod restore;
 
 pub use restore::{
-    PreparedSnapshotV2MultiBlockBundle, PreparedSnapshotV2MultiBlockRecord,
+    PreparedSnapshotV2MultiBlockBundle, PreparedSnapshotV2MultiBlockMmioBundle,
+    PreparedSnapshotV2MultiBlockMmioRecord, PreparedSnapshotV2MultiBlockRecord,
     SnapshotV2MultiBlockBundleError, SnapshotV2MultiBlockCleanupError,
-    SnapshotV2MultiBlockRestorePlan, SnapshotV2MultiBlockRestorePlanError,
-    SnapshotV2MultiBlockRetryProjection,
+    SnapshotV2MultiBlockMmioTransportError, SnapshotV2MultiBlockRestorePlan,
+    SnapshotV2MultiBlockRestorePlanError, SnapshotV2MultiBlockRetryProjection,
 };
 
 #[cfg(test)]

--- a/crates/runtime/src/snapshot_device_v2_5/restore.rs
+++ b/crates/runtime/src/snapshot_device_v2_5/restore.rs
@@ -11,11 +11,15 @@ use crate::block::async_executor::{
 use crate::block::{
     PreparedBlockDevice, PreparedSnapshotBlockDeviceError, PreparedSnapshotBlockDeviceParts,
     VIRTIO_RING_FEATURE_EVENT_IDX, VIRTIO_RING_FEATURE_INDIRECT_DESC, VirtioBlockConfigSpace,
-    VirtioBlockQueue, VirtioBlockRateLimiter, VirtioBlockRateLimiterState,
-    VirtioBlockTokenBucketState,
+    VirtioBlockMmioHandler, VirtioBlockQueue, VirtioBlockRateLimiter, VirtioBlockRateLimiterState,
+    VirtioBlockTokenBucketState, restore_prepared_block_mmio_handler,
 };
+use crate::interrupt::GuestInterruptLine;
 use crate::memory::GuestMemory;
-use crate::snapshot_device_v2::SnapshotV2BlockBucketState;
+use crate::mmio::MmioRegion;
+use crate::snapshot_device_v2::{
+    SnapshotV2BlockBucketState, SnapshotV2RootTransportRestoreError, restore_mmio_transport_state,
+};
 use crate::virtio_mmio::VirtioMmioQueueState;
 
 /// Complete pure destination proof for one detached profile-2 graph.
@@ -443,6 +447,235 @@ impl fmt::Debug for PreparedSnapshotV2MultiBlockRecord {
     }
 }
 
+/// One exact profile-2 MMIO handler prepared before live bus construction.
+pub struct PreparedSnapshotV2MultiBlockMmioRecord {
+    key: SnapshotV2DeviceKey,
+    drive_id: String,
+    is_root_device: bool,
+    retry: StorageRetryState,
+    retry_deadline: Option<Instant>,
+    region: MmioRegion,
+    interrupt_line: GuestInterruptLine,
+    async_generation: Option<BlockAsyncDriveGeneration>,
+    handler: VirtioBlockMmioHandler,
+}
+
+impl PreparedSnapshotV2MultiBlockMmioRecord {
+    pub const fn key(&self) -> SnapshotV2DeviceKey {
+        self.key
+    }
+
+    pub fn drive_id(&self) -> &str {
+        &self.drive_id
+    }
+
+    pub const fn is_root_device(&self) -> bool {
+        self.is_root_device
+    }
+
+    pub const fn retry(&self) -> StorageRetryState {
+        self.retry
+    }
+
+    pub const fn retry_deadline(&self) -> Option<Instant> {
+        self.retry_deadline
+    }
+
+    pub const fn region(&self) -> MmioRegion {
+        self.region
+    }
+
+    pub const fn interrupt_line(&self) -> GuestInterruptLine {
+        self.interrupt_line
+    }
+
+    pub const fn async_generation(&self) -> Option<BlockAsyncDriveGeneration> {
+        self.async_generation
+    }
+
+    /// Consumes the still-unpublished exact handler and its owner metadata.
+    pub fn into_parts(
+        self,
+    ) -> (
+        SnapshotV2DeviceKey,
+        String,
+        bool,
+        StorageRetryState,
+        Option<Instant>,
+        MmioRegion,
+        GuestInterruptLine,
+        Option<BlockAsyncDriveGeneration>,
+        VirtioBlockMmioHandler,
+    ) {
+        (
+            self.key,
+            self.drive_id,
+            self.is_root_device,
+            self.retry,
+            self.retry_deadline,
+            self.region,
+            self.interrupt_line,
+            self.async_generation,
+            self.handler,
+        )
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2MultiBlockMmioRecord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2MultiBlockMmioRecord")
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Move-only exact profile-2 MMIO vector awaiting one private dispatcher.
+pub struct PreparedSnapshotV2MultiBlockMmioBundle {
+    drive_configs: DriveConfigs,
+    records: Vec<PreparedSnapshotV2MultiBlockMmioRecord>,
+    async_runtime: Option<SharedBlockAsyncRuntime>,
+    async_generations: Vec<BlockAsyncDriveGeneration>,
+}
+
+impl PreparedSnapshotV2MultiBlockMmioBundle {
+    pub const fn drive_configs(&self) -> &DriveConfigs {
+        &self.drive_configs
+    }
+
+    pub fn records(&self) -> &[PreparedSnapshotV2MultiBlockMmioRecord] {
+        &self.records
+    }
+
+    pub const fn async_runtime(&self) -> Option<&SharedBlockAsyncRuntime> {
+        self.async_runtime.as_ref()
+    }
+
+    /// Transfers every exact handler, generation owner, and controller value.
+    pub fn into_parts(
+        mut self,
+    ) -> (
+        DriveConfigs,
+        Vec<PreparedSnapshotV2MultiBlockMmioRecord>,
+        Option<SharedBlockAsyncRuntime>,
+        Vec<BlockAsyncDriveGeneration>,
+    ) {
+        (
+            std::mem::take(&mut self.drive_configs),
+            std::mem::take(&mut self.records),
+            self.async_runtime.take(),
+            std::mem::take(&mut self.async_generations),
+        )
+    }
+
+    /// Explicitly releases every transferred fresh Async generation.
+    pub fn abort(mut self) -> Result<(), SnapshotV2MultiBlockCleanupError> {
+        let result =
+            cleanup_async_generations(self.async_runtime.as_ref(), &self.async_generations);
+        self.async_generations.clear();
+        self.async_runtime = None;
+        result
+    }
+}
+
+impl Drop for PreparedSnapshotV2MultiBlockMmioBundle {
+    fn drop(&mut self) {
+        let _ = cleanup_async_generations(self.async_runtime.as_ref(), &self.async_generations);
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2MultiBlockMmioBundle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2MultiBlockMmioBundle")
+            .field("record_count", &self.records.len())
+            .field("has_async_runtime", &self.async_runtime.is_some())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+enum SnapshotV2MultiBlockMmioTransportErrorKind {
+    TransportPolicy,
+    Allocation,
+    AsyncBinding,
+    Transport(SnapshotV2RootTransportRestoreError),
+}
+
+/// Redacted failure while consuming profile-2 devices into exact MMIO handlers.
+pub struct SnapshotV2MultiBlockMmioTransportError {
+    kind: SnapshotV2MultiBlockMmioTransportErrorKind,
+    cleanup: Option<SnapshotV2MultiBlockCleanupError>,
+}
+
+impl SnapshotV2MultiBlockMmioTransportError {
+    fn new(
+        kind: SnapshotV2MultiBlockMmioTransportErrorKind,
+        cleanup: Option<SnapshotV2MultiBlockCleanupError>,
+    ) -> Self {
+        Self { kind, cleanup }
+    }
+
+    pub const fn cleanup_failed(&self) -> bool {
+        self.cleanup.is_some()
+    }
+}
+
+impl fmt::Debug for SnapshotV2MultiBlockMmioTransportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self.kind {
+            SnapshotV2MultiBlockMmioTransportErrorKind::TransportPolicy => "transport-policy",
+            SnapshotV2MultiBlockMmioTransportErrorKind::Allocation => "allocation",
+            SnapshotV2MultiBlockMmioTransportErrorKind::AsyncBinding => "async-binding",
+            SnapshotV2MultiBlockMmioTransportErrorKind::Transport(_) => "transport",
+        };
+        formatter
+            .debug_struct("SnapshotV2MultiBlockMmioTransportError")
+            .field("kind", &kind)
+            .field("cleanup_failed", &self.cleanup_failed())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotV2MultiBlockMmioTransportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self.kind {
+            SnapshotV2MultiBlockMmioTransportErrorKind::TransportPolicy => {
+                "snapshot multi-block MMIO transport policy is invalid"
+            }
+            SnapshotV2MultiBlockMmioTransportErrorKind::Allocation => {
+                "snapshot multi-block MMIO transport allocation failed"
+            }
+            SnapshotV2MultiBlockMmioTransportErrorKind::AsyncBinding => {
+                "snapshot multi-block MMIO Async ownership is invalid"
+            }
+            SnapshotV2MultiBlockMmioTransportErrorKind::Transport(_) => {
+                "snapshot multi-block MMIO handler reconstruction failed"
+            }
+        })?;
+        if self.cleanup_failed() {
+            formatter.write_str("; Async cleanup also failed")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for SnapshotV2MultiBlockMmioTransportError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.kind {
+            SnapshotV2MultiBlockMmioTransportErrorKind::Transport(source) => Some(source),
+            SnapshotV2MultiBlockMmioTransportErrorKind::TransportPolicy
+            | SnapshotV2MultiBlockMmioTransportErrorKind::Allocation
+            | SnapshotV2MultiBlockMmioTransportErrorKind::AsyncBinding => self
+                .cleanup
+                .as_ref()
+                .map(|source| source as &(dyn std::error::Error + 'static)),
+        }
+    }
+}
+
 /// Host-time projection of one record retry disposition.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct SnapshotV2MultiBlockRetryProjection {
@@ -511,6 +744,112 @@ impl PreparedSnapshotV2MultiBlockBundle {
 
     pub fn retry_projection(&self) -> &[SnapshotV2MultiBlockRetryProjection] {
         &self.retry_projection
+    }
+
+    /// Reconstructs the complete exact MMIO vector without publishing a bus.
+    pub fn prepare_mmio_transport(
+        mut self,
+    ) -> Result<PreparedSnapshotV2MultiBlockMmioBundle, SnapshotV2MultiBlockMmioTransportError>
+    {
+        let mut async_generations = Vec::new();
+        if async_generations
+            .try_reserve_exact(self.records.len())
+            .is_err()
+        {
+            return Err(
+                self.mmio_transport_error(SnapshotV2MultiBlockMmioTransportErrorKind::Allocation)
+            );
+        }
+        if !validate_mmio_async_ownership(
+            &self.records,
+            self.async_runtime.as_ref(),
+            &mut async_generations,
+        ) {
+            return Err(
+                self.mmio_transport_error(SnapshotV2MultiBlockMmioTransportErrorKind::AsyncBinding)
+            );
+        }
+        if self
+            .records
+            .iter()
+            .any(|record| !matches!(record.transport, SnapshotV2DeviceTransport::Mmio(_)))
+        {
+            return Err(self.mmio_transport_error(
+                SnapshotV2MultiBlockMmioTransportErrorKind::TransportPolicy,
+            ));
+        }
+
+        let mut prepared = Vec::new();
+        if prepared.try_reserve_exact(self.records.len()).is_err() {
+            return Err(
+                self.mmio_transport_error(SnapshotV2MultiBlockMmioTransportErrorKind::Allocation)
+            );
+        }
+
+        let drive_configs = std::mem::take(&mut self.drive_configs);
+        let records = std::mem::take(&mut self.records);
+        let async_runtime = self.async_runtime.take();
+        self.retry_projection.clear();
+        let result = (|| {
+            for record in records {
+                let PreparedSnapshotV2MultiBlockRecord {
+                    key,
+                    queue_ranges: _,
+                    retry,
+                    retry_deadline,
+                    virtio,
+                    transport,
+                    async_generation,
+                    device,
+                } = record;
+                let SnapshotV2DeviceTransport::Mmio(mmio) = transport else {
+                    return Err(SnapshotV2MultiBlockMmioTransportErrorKind::TransportPolicy);
+                };
+                let retained = restore_mmio_transport_state(&virtio, &mmio)
+                    .map_err(SnapshotV2MultiBlockMmioTransportErrorKind::Transport)?;
+                let (drive_id, is_root_device, config_space, device) = device.into_parts();
+                let handler = restore_prepared_block_mmio_handler(config_space, device, &retained)
+                    .map_err(|source| {
+                        SnapshotV2MultiBlockMmioTransportErrorKind::Transport(
+                            SnapshotV2RootTransportRestoreError::Mmio(source),
+                        )
+                    })?;
+                prepared.push(PreparedSnapshotV2MultiBlockMmioRecord {
+                    key,
+                    drive_id,
+                    is_root_device,
+                    retry,
+                    retry_deadline,
+                    region: mmio.region(),
+                    interrupt_line: mmio.interrupt_line(),
+                    async_generation,
+                    handler,
+                });
+            }
+            Ok(())
+        })();
+        match result {
+            Ok(()) => Ok(PreparedSnapshotV2MultiBlockMmioBundle {
+                drive_configs,
+                records: prepared,
+                async_runtime,
+                async_generations,
+            }),
+            Err(kind) => {
+                drop(prepared);
+                let cleanup =
+                    cleanup_async_generations(async_runtime.as_ref(), &async_generations).err();
+                Err(SnapshotV2MultiBlockMmioTransportError::new(kind, cleanup))
+            }
+        }
+    }
+
+    fn mmio_transport_error(
+        self,
+        kind: SnapshotV2MultiBlockMmioTransportErrorKind,
+    ) -> SnapshotV2MultiBlockMmioTransportError {
+        let cleanup = self.abort().err();
+        SnapshotV2MultiBlockMmioTransportError::new(kind, cleanup)
     }
 
     /// Explicitly releases every fresh Async generation in reverse order.
@@ -682,6 +1021,49 @@ fn async_binding_failure(
     }
 }
 
+fn validate_mmio_async_ownership(
+    records: &[PreparedSnapshotV2MultiBlockRecord],
+    runtime: Option<&SharedBlockAsyncRuntime>,
+    generations: &mut Vec<BlockAsyncDriveGeneration>,
+) -> bool {
+    for record in records {
+        match (
+            record.device.device().io_engine(),
+            record.async_generation,
+            record.device.device().async_binding(),
+            runtime,
+        ) {
+            (Some(DriveIoEngine::Sync), None, None, _) => {}
+            (
+                Some(DriveIoEngine::Async),
+                Some(generation),
+                Some((bound_runtime, bound_generation)),
+                Some(runtime),
+            ) if generation == bound_generation
+                && runtime.same_runtime(&bound_runtime)
+                && !generations.contains(&generation)
+                && runtime
+                    .pressure_pending(generation)
+                    .is_ok_and(|pending| !pending)
+                && runtime
+                    .pop_completion(generation)
+                    .is_ok_and(|completion| completion.is_none()) =>
+            {
+                generations.push(generation);
+            }
+            _ => return false,
+        }
+    }
+    match runtime {
+        Some(runtime) => {
+            !generations.is_empty()
+                && runtime.generation_count().ok() == Some(generations.len())
+                && runtime.outstanding_tasks().ok() == Some(0)
+        }
+        None => generations.is_empty(),
+    }
+}
+
 fn cleanup_async_bundle(
     records: &mut [PreparedSnapshotV2MultiBlockRecord],
     runtime: Option<&SharedBlockAsyncRuntime>,
@@ -692,9 +1074,57 @@ fn cleanup_async_bundle(
     let mut first = None;
     let mut additional_failures = 0_usize;
     for record in records.iter_mut().rev() {
-        let Some(generation) = record.async_generation.take() else {
+        let generation = record
+            .device
+            .device()
+            .async_binding()
+            .and_then(|(bound_runtime, generation)| {
+                runtime.same_runtime(&bound_runtime).then_some(generation)
+            })
+            .or_else(|| record.async_generation.take());
+        record.async_generation = None;
+        let Some(generation) = generation else {
             continue;
         };
+        if let Err(source) = runtime.discard_generation_without_guest_memory(generation) {
+            if first.is_none() {
+                first = Some(source);
+            } else {
+                additional_failures = additional_failures.saturating_add(1);
+            }
+        }
+    }
+    let shutdown = match runtime.shutdown_if_idle() {
+        Ok(true) => None,
+        Ok(false) => Some(BlockAsyncRuntimeError::ExecutorInvariant),
+        Err(source) => Some(source),
+    };
+    if let Some(source) = shutdown {
+        if first.is_none() {
+            first = Some(source);
+        } else {
+            additional_failures = additional_failures.saturating_add(1);
+        }
+    }
+    match first {
+        Some(source) => Err(SnapshotV2MultiBlockCleanupError {
+            source,
+            additional_failures,
+        }),
+        None => Ok(()),
+    }
+}
+
+fn cleanup_async_generations(
+    runtime: Option<&SharedBlockAsyncRuntime>,
+    generations: &[BlockAsyncDriveGeneration],
+) -> Result<(), SnapshotV2MultiBlockCleanupError> {
+    let Some(runtime) = runtime else {
+        return Ok(());
+    };
+    let mut first = None;
+    let mut additional_failures = 0_usize;
+    for generation in generations.iter().rev().copied() {
         if let Err(source) = runtime.discard_generation_without_guest_memory(generation) {
             if first.is_none() {
                 first = Some(source);
@@ -1099,6 +1529,145 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn consuming_mmio_handoff_preserves_exact_transport_and_async_identity() {
+        let graph = crate::snapshot_device_v2_5::tests::fixture_graph(
+            SnapshotV2DeviceTransportKind::Mmio,
+            true,
+        );
+        let expected = graph.clone();
+        let memory = memory_for(&graph);
+        let now = Instant::now();
+        let configs = graph
+            .project_drive_configs()
+            .expect("fixture configs should project");
+        let (_files, backings) = open_backings(&graph);
+        let bundle = SnapshotV2MultiBlockRestorePlan::prepare(graph, &memory, now)
+            .expect("fixture graph should prepare")
+            .prepare_backings(configs.clone(), backings)
+            .expect("fixture backings should prepare");
+        let expected_runtime = bundle
+            .async_runtime()
+            .expect("mixed fixture should own one runtime")
+            .clone();
+
+        let mmio = bundle
+            .prepare_mmio_transport()
+            .expect("exact MMIO vector should reconstruct");
+        assert_eq!(mmio.drive_configs(), &configs);
+        assert_eq!(mmio.records().len(), expected.records().len());
+        assert!(
+            mmio.async_runtime()
+                .is_some_and(|runtime| runtime.same_runtime(&expected_runtime))
+        );
+        let (returned_configs, records, runtime, generations) = mmio.into_parts();
+        assert_eq!(returned_configs, configs);
+        assert_eq!(generations.len(), 1);
+        for (record, expected) in records.into_iter().zip(expected.records()) {
+            let SnapshotV2DeviceTransport::Mmio(expected_mmio) = expected.transport() else {
+                panic!("fixture transport should be MMIO");
+            };
+            let expected_transport = restore_mmio_transport_state(expected.virtio(), expected_mmio)
+                .expect("retained transport should restore");
+            let (
+                key,
+                drive_id,
+                is_root,
+                retry,
+                retry_deadline,
+                region,
+                interrupt_line,
+                generation,
+                handler,
+            ) = record.into_parts();
+            assert_eq!(key, expected.key());
+            assert_eq!(drive_id, expected.config().drive_id());
+            assert_eq!(is_root, expected.is_root());
+            assert_eq!(retry, expected.block().continuation().retry());
+            assert_eq!(retry_deadline.is_some(), retry != StorageRetryState::None);
+            assert_eq!(region, expected_mmio.region());
+            assert_eq!(interrupt_line, expected_mmio.interrupt_line());
+            assert_eq!(handler.transport_state(), expected_transport);
+            match expected.config().io_engine() {
+                DriveIoEngine::Sync => {
+                    assert_eq!(generation, None);
+                    assert!(handler.block_async_binding().is_none());
+                }
+                DriveIoEngine::Async => {
+                    let generation = generation.expect("Async generation should transfer");
+                    let (handler_runtime, handler_generation) = handler
+                        .block_async_binding()
+                        .expect("Async handler should retain its binding");
+                    assert_eq!(handler_generation, generation);
+                    assert!(handler_runtime.same_runtime(&expected_runtime));
+                }
+            }
+        }
+        cleanup_async_generations(runtime.as_ref(), &generations)
+            .expect("transferred Async runtime should cleanly release");
+        assert_eq!(
+            expected_runtime
+                .generation_count()
+                .expect("runtime should remain observable"),
+            0
+        );
+    }
+
+    #[test]
+    fn consuming_mmio_handoff_rejects_foreign_transport_and_invalid_generation_set() {
+        let pci_graph = crate::snapshot_device_v2_5::tests::fixture_graph(
+            SnapshotV2DeviceTransportKind::Pci,
+            true,
+        );
+        let memory = memory_for(&pci_graph);
+        let configs = pci_graph
+            .project_drive_configs()
+            .expect("fixture configs should project");
+        let (_files, backings) = open_backings(&pci_graph);
+        let bundle = SnapshotV2MultiBlockRestorePlan::prepare(pci_graph, &memory, Instant::now())
+            .expect("PCI graph should prepare")
+            .prepare_backings(configs, backings)
+            .expect("PCI bundle should prepare");
+        let runtime = bundle
+            .async_runtime()
+            .expect("mixed fixture should own one runtime")
+            .clone();
+        let error = bundle
+            .prepare_mmio_transport()
+            .expect_err("PCI vector must not enter the MMIO handoff");
+        assert!(!error.cleanup_failed());
+        assert_eq!(runtime.generation_count().expect("runtime should lock"), 0);
+
+        let graph = crate::snapshot_device_v2_5::tests::fixture_graph(
+            SnapshotV2DeviceTransportKind::Mmio,
+            true,
+        );
+        let memory = memory_for(&graph);
+        let configs = graph
+            .project_drive_configs()
+            .expect("fixture configs should project");
+        let (_files, backings) = open_backings(&graph);
+        let mut bundle = SnapshotV2MultiBlockRestorePlan::prepare(graph, &memory, Instant::now())
+            .expect("MMIO graph should prepare")
+            .prepare_backings(configs, backings)
+            .expect("MMIO bundle should prepare");
+        let runtime = bundle
+            .async_runtime()
+            .expect("mixed fixture should own one runtime")
+            .clone();
+        let async_record = bundle
+            .records
+            .iter_mut()
+            .find(|record| record.async_generation.is_some())
+            .expect("fixture should contain one Async record");
+        async_record.async_generation = None;
+        let error = bundle
+            .prepare_mmio_transport()
+            .expect_err("missing generation ownership must be rejected");
+        assert!(!error.cleanup_failed());
+        assert_eq!(runtime.generation_count().expect("runtime should lock"), 0);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1614

## Summary

- consume the checked profile-2 bundle into an exact ordered virtio-mmio handler vector while preserving the shared Async runtime and generation identities
- validate the complete MMIO FDT/SPI/resource plan before VM construction, then retain metrics, retry scheduling, owned registration leases, and exact runtime resources in one unpublished HVF session
- keep aggregate backing completion provisional through destination/controller construction and preserve terminal cleanup evidence
- add hardware-free transaction coverage plus signed rooted/rootless mixed Sync/Async write, flush, interrupt, metrics, recapture, resume, and shutdown evidence

## Scope exclusions

- no PCI reconstruction; that remains #1615
- no public profile-2 activation or artifact/version-ceiling change; that remains #1616
- native-v2 writer, reader, API/CLI, and public create/load behavior stay exact 2.4

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented `aarch64-apple-darwin` integration-target Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh` without `--allow-unsupported` on Apple Silicon