### PR TITLE
feat: reconstruct multi-block PCI snapshot owners

### DIFF
--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -41,11 +41,12 @@ use bangbang_hvf::{
     HvfSnapshotV1RestoreDisposition, HvfSnapshotV1RestoreError, HvfSnapshotV1State,
     HvfSnapshotV2BootState, HvfSnapshotV2BuildError, HvfSnapshotV2DecodeError,
     HvfSnapshotV2DefaultProcessShell, HvfSnapshotV2EncodeError,
-    HvfSnapshotV2MultiBlockMmioRestoreError, HvfSnapshotV2MultiBlockPlatformPlan,
-    HvfSnapshotV2NativePath, HvfSnapshotV2PlatformRestoreError, HvfSnapshotV2PlatformState,
-    HvfSnapshotV2RootProcessConfig, HvfSnapshotV2RootResourcePlan, HvfSnapshotV2RootRestoreError,
-    HvfSnapshotV2State, HvfVcpuRunControl, HvfVcpuRunCoordinatorError, HvfVcpuRunStepOutcome,
-    OwnedHvfArm64BootSession, PrepareHvfSnapshotV1LoadError, PrepareHvfSnapshotV2RootPlanError,
+    HvfSnapshotV2MultiBlockMmioRestoreError, HvfSnapshotV2MultiBlockPciRestoreError,
+    HvfSnapshotV2MultiBlockPlatformPlan, HvfSnapshotV2NativePath,
+    HvfSnapshotV2PlatformRestoreError, HvfSnapshotV2PlatformState, HvfSnapshotV2RootProcessConfig,
+    HvfSnapshotV2RootResourcePlan, HvfSnapshotV2RootRestoreError, HvfSnapshotV2State,
+    HvfVcpuRunControl, HvfVcpuRunCoordinatorError, HvfVcpuRunStepOutcome, OwnedHvfArm64BootSession,
+    PrepareHvfSnapshotV1LoadError, PrepareHvfSnapshotV2RootPlanError,
     PreparedHvfArm64BootPciNetworkRemoval, PreparedHvfSnapshotV1Load, PreparedHvfSnapshotV1State,
     RestoredHvfSnapshotV2Platform, decode_hvf_snapshot_v2_platform_state,
     decode_hvf_snapshot_v2_state, encode_hvf_snapshot_v2_state, prepare_hvf_snapshot_v2_root_plan,
@@ -6660,13 +6661,13 @@ fn native_v2_boot_source_config(
 }
 
 #[cfg(target_os = "macos")]
-struct PreparedHvfSnapshotV2MultiBlockMmioDestination {
+struct PreparedHvfSnapshotV2MultiBlockDestination {
     session: Box<OwnedHvfArm64BootSession>,
     drive_configs: Option<DriveConfigs>,
 }
 
 #[cfg(target_os = "macos")]
-impl PreparedHvfSnapshotV2MultiBlockMmioDestination {
+impl PreparedHvfSnapshotV2MultiBlockDestination {
     fn prepare_controller(
         mut self,
         machine: bangbang_runtime::machine::MachineConfig,
@@ -6702,10 +6703,10 @@ impl PreparedHvfSnapshotV2MultiBlockMmioDestination {
 }
 
 #[cfg(target_os = "macos")]
-impl fmt::Debug for PreparedHvfSnapshotV2MultiBlockMmioDestination {
+impl fmt::Debug for PreparedHvfSnapshotV2MultiBlockDestination {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
-            .debug_struct("PreparedHvfSnapshotV2MultiBlockMmioDestination")
+            .debug_struct("PreparedHvfSnapshotV2MultiBlockDestination")
             .field("state", &"<redacted>")
             .finish()
     }
@@ -6728,12 +6729,27 @@ impl fmt::Display for PreparedHvfSnapshotV2MultiBlockControllerError {
 impl std::error::Error for PreparedHvfSnapshotV2MultiBlockControllerError {}
 
 #[cfg(target_os = "macos")]
-enum PrepareHvfSnapshotV2MultiBlockMmioDestinationError {
-    Construction(
-        PreparedSnapshotV2MultiBlockDestinationConstructionError<
-            HvfSnapshotV2MultiBlockMmioRestoreError,
-        >,
-    ),
+trait HvfSnapshotV2MultiBlockRestoreDisposition {
+    fn is_terminal(&self) -> bool;
+}
+
+#[cfg(target_os = "macos")]
+impl HvfSnapshotV2MultiBlockRestoreDisposition for HvfSnapshotV2MultiBlockMmioRestoreError {
+    fn is_terminal(&self) -> bool {
+        self.is_terminal()
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl HvfSnapshotV2MultiBlockRestoreDisposition for HvfSnapshotV2MultiBlockPciRestoreError {
+    fn is_terminal(&self) -> bool {
+        self.is_terminal()
+    }
+}
+
+#[cfg(target_os = "macos")]
+enum PrepareHvfSnapshotV2MultiBlockDestinationError<E> {
+    Construction(PreparedSnapshotV2MultiBlockDestinationConstructionError<E>),
     Commit(
         PreparedSnapshotV2MultiBlockDestinationCommitError<
             PreparedHvfSnapshotV2MultiBlockControllerError,
@@ -6743,7 +6759,10 @@ enum PrepareHvfSnapshotV2MultiBlockMmioDestinationError {
 }
 
 #[cfg(target_os = "macos")]
-impl PrepareHvfSnapshotV2MultiBlockMmioDestinationError {
+impl<E> PrepareHvfSnapshotV2MultiBlockDestinationError<E>
+where
+    E: HvfSnapshotV2MultiBlockRestoreDisposition,
+{
     fn is_terminal(&self) -> bool {
         match self {
             Self::Construction(source) => {
@@ -6762,14 +6781,17 @@ impl PrepareHvfSnapshotV2MultiBlockMmioDestinationError {
 }
 
 #[cfg(target_os = "macos")]
-impl fmt::Debug for PrepareHvfSnapshotV2MultiBlockMmioDestinationError {
+impl<E> fmt::Debug for PrepareHvfSnapshotV2MultiBlockDestinationError<E>
+where
+    E: HvfSnapshotV2MultiBlockRestoreDisposition,
+{
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         let stage = match self {
             Self::Construction(_) => "construction",
             Self::Commit(_) => "completion",
         };
         formatter
-            .debug_struct("PrepareHvfSnapshotV2MultiBlockMmioDestinationError")
+            .debug_struct("PrepareHvfSnapshotV2MultiBlockDestinationError")
             .field("stage", &stage)
             .field("terminal", &self.is_terminal())
             .field("state", &"<redacted>")
@@ -6778,11 +6800,14 @@ impl fmt::Debug for PrepareHvfSnapshotV2MultiBlockMmioDestinationError {
 }
 
 #[cfg(target_os = "macos")]
-impl fmt::Display for PrepareHvfSnapshotV2MultiBlockMmioDestinationError {
+impl<E> fmt::Display for PrepareHvfSnapshotV2MultiBlockDestinationError<E>
+where
+    E: HvfSnapshotV2MultiBlockRestoreDisposition,
+{
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             formatter,
-            "profile-2 MMIO destination transaction failed ({})",
+            "profile-2 destination transaction failed ({})",
             if self.is_terminal() {
                 "terminal"
             } else {
@@ -6793,7 +6818,10 @@ impl fmt::Display for PrepareHvfSnapshotV2MultiBlockMmioDestinationError {
 }
 
 #[cfg(target_os = "macos")]
-impl std::error::Error for PrepareHvfSnapshotV2MultiBlockMmioDestinationError {
+impl<E> std::error::Error for PrepareHvfSnapshotV2MultiBlockDestinationError<E>
+where
+    E: HvfSnapshotV2MultiBlockRestoreDisposition + std::error::Error + 'static,
+{
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Construction(source) => Some(source),
@@ -6825,7 +6853,7 @@ fn prepare_hvf_native_v2_multi_block_mmio_destination(
     input: PrepareHvfSnapshotV2MultiBlockMmioDestinationInput,
 ) -> Result<
     (OwnedHvfArm64BootSession, SnapshotV2ControllerCommit),
-    PrepareHvfSnapshotV2MultiBlockMmioDestinationError,
+    PrepareHvfSnapshotV2MultiBlockDestinationError<HvfSnapshotV2MultiBlockMmioRestoreError>,
 > {
     let PrepareHvfSnapshotV2MultiBlockMmioDestinationInput {
         platform,
@@ -6848,19 +6876,81 @@ fn prepare_hvf_native_v2_multi_block_mmio_destination(
             )
             .map(|owners| {
                 let (session, drive_configs) = owners.into_parts();
-                PreparedHvfSnapshotV2MultiBlockMmioDestination {
+                PreparedHvfSnapshotV2MultiBlockDestination {
                     session: Box::new(session),
                     drive_configs: Some(drive_configs),
                 }
             })
         })
-        .map_err(PrepareHvfSnapshotV2MultiBlockMmioDestinationError::Construction)?;
+        .map_err(PrepareHvfSnapshotV2MultiBlockDestinationError::Construction)?;
     let (destination, controller) = destination
         .commit(
             |destination| destination.prepare_controller(machine, boot, resume_requested),
-            PreparedHvfSnapshotV2MultiBlockMmioDestination::shutdown,
+            PreparedHvfSnapshotV2MultiBlockDestination::shutdown,
         )
-        .map_err(PrepareHvfSnapshotV2MultiBlockMmioDestinationError::Commit)?;
+        .map_err(PrepareHvfSnapshotV2MultiBlockDestinationError::Commit)?;
+    Ok((destination.into_session(), controller))
+}
+
+#[cfg(target_os = "macos")]
+struct PrepareHvfSnapshotV2MultiBlockPciDestinationInput {
+    platform: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    process_shell: HvfSnapshotV2DefaultProcessShell,
+    bundle: PreparedSnapshotV2MultiBlockRestoreBundle,
+    plan: HvfSnapshotV2MultiBlockPlatformPlan,
+    machine: bangbang_runtime::machine::MachineConfig,
+    boot: bangbang_runtime::boot::BootSourceConfig,
+    resume_requested: bool,
+}
+
+/// Dormant profile-2 PCI process transaction. Public native-v2 dispatch
+/// remains exact 2.4 until the activation slice consumes this boundary.
+#[cfg(target_os = "macos")]
+#[allow(
+    dead_code,
+    reason = "profile-2 public native-v2 activation is owned by the dependent delivery slice"
+)]
+fn prepare_hvf_native_v2_multi_block_pci_destination(
+    input: PrepareHvfSnapshotV2MultiBlockPciDestinationInput,
+) -> Result<
+    (OwnedHvfArm64BootSession, SnapshotV2ControllerCommit),
+    PrepareHvfSnapshotV2MultiBlockDestinationError<HvfSnapshotV2MultiBlockPciRestoreError>,
+> {
+    let PrepareHvfSnapshotV2MultiBlockPciDestinationInput {
+        platform,
+        memory,
+        process_shell,
+        bundle,
+        plan,
+        machine,
+        boot,
+        resume_requested,
+    } = input;
+    let destination = bundle
+        .construct_destination(|bundle| {
+            OwnedHvfArm64BootSession::restore_snapshot_v2_multi_block_pci(
+                platform,
+                memory,
+                process_shell,
+                bundle,
+                plan,
+            )
+            .map(|owners| {
+                let (session, drive_configs) = owners.into_parts();
+                PreparedHvfSnapshotV2MultiBlockDestination {
+                    session: Box::new(session),
+                    drive_configs: Some(drive_configs),
+                }
+            })
+        })
+        .map_err(PrepareHvfSnapshotV2MultiBlockDestinationError::Construction)?;
+    let (destination, controller) = destination
+        .commit(
+            |destination| destination.prepare_controller(machine, boot, resume_requested),
+            PreparedHvfSnapshotV2MultiBlockDestination::shutdown,
+        )
+        .map_err(PrepareHvfSnapshotV2MultiBlockDestinationError::Commit)?;
     Ok((destination.into_session(), controller))
 }
 

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -197,10 +197,12 @@ pub use startup::{
     HvfArm64BootVsockNotificationDispatches, HvfArm64BootVsockTransportState,
     HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure, HvfSnapshotV2MultiBlockMmioRestoreError,
     HvfSnapshotV2MultiBlockMmioRestoreFailure, HvfSnapshotV2MultiBlockMmioRestoreStage,
+    HvfSnapshotV2MultiBlockPciRestoreCleanupFailure, HvfSnapshotV2MultiBlockPciRestoreError,
+    HvfSnapshotV2MultiBlockPciRestoreFailure, HvfSnapshotV2MultiBlockPciRestoreStage,
     HvfSnapshotV2RootRestoreCleanupFailure, HvfSnapshotV2RootRestoreError,
     HvfSnapshotV2RootRestoreFailure, HvfSnapshotV2RootRestoreStage, OwnedHvfArm64BootSession,
     PreparedHvfArm64BootPciNetworkRemoval, RestoredHvfArm64BootSession,
-    RestoredHvfSnapshotV2MultiBlockMmioOwners,
+    RestoredHvfSnapshotV2MultiBlockMmioOwners, RestoredHvfSnapshotV2MultiBlockPciOwners,
 };
 pub use topology::{
     HvfVcpuTopology, HvfVcpuTopologyAllocation, HvfVcpuTopologyCreateStage, HvfVcpuTopologyError,

--- a/crates/hvf/src/snapshot_v2_multi_block_platform.rs
+++ b/crates/hvf/src/snapshot_v2_multi_block_platform.rs
@@ -1395,6 +1395,37 @@ pub(crate) mod tests {
         (platform, plan)
     }
 
+    pub(crate) fn pci_fdt_plan_fixture() -> (
+        HvfSnapshotV2PlatformState,
+        HvfSnapshotV2MultiBlockPlatformPlan,
+    ) {
+        let fixture = bundle_from_graph(fixture_graph(SnapshotV2DeviceTransportKind::Pci, false));
+        let platform = product_pci_platform();
+        let plan = prepare_hvf_snapshot_v2_multi_block_platform_plan(
+            &platform,
+            &fixture.bundle,
+            pci_process(),
+        )
+        .expect("multi-block PCI FDT plan should validate");
+        (platform, plan)
+    }
+
+    pub(crate) fn rooted_pci_bundle_and_fdt_plan_fixture() -> (
+        HvfSnapshotV2PlatformState,
+        PreparedSnapshotV2MultiBlockBundle,
+        HvfSnapshotV2MultiBlockPlatformPlan,
+    ) {
+        let fixture = bundle_from_graph(fixture_graph(SnapshotV2DeviceTransportKind::Pci, true));
+        let platform = product_pci_platform();
+        let plan = prepare_hvf_snapshot_v2_multi_block_platform_plan(
+            &platform,
+            &fixture.bundle,
+            pci_process(),
+        )
+        .expect("rooted multi-block PCI FDT plan should validate");
+        (platform, fixture.bundle, plan)
+    }
+
     fn product_pci_platform() -> HvfSnapshotV2PlatformState {
         let (platform, root, _process) =
             crate::snapshot_v2_platform::tests::pci_root_plan_fixture();

--- a/crates/hvf/src/snapshot_v2_platform.rs
+++ b/crates/hvf/src/snapshot_v2_platform.rs
@@ -67,7 +67,9 @@ use crate::snapshot_v2::{
     HvfSnapshotV2GlobalState, HvfSnapshotV2MachineState, HvfSnapshotV2PlatformState,
     HvfSnapshotV2State, HvfSnapshotV2TimeState, HvfSnapshotV2VcpuState,
 };
-use crate::snapshot_v2_multi_block_platform::HvfSnapshotV2MultiBlockMmioRecordPlan;
+use crate::snapshot_v2_multi_block_platform::{
+    HvfSnapshotV2MultiBlockMmioRecordPlan, HvfSnapshotV2MultiBlockPciPlan,
+};
 use crate::startup::{
     HvfArm64BootSnapshotV2CaptureError, HvfArm64BootSnapshotV2CaptureStage,
     HvfArm64BootVmClockRestoreError, HvfArm64BootVmGenIdRestoreError,
@@ -356,6 +358,14 @@ pub(crate) struct HvfSnapshotV2MultiBlockMmioShellPlan<'a> {
     pub(crate) vmclock_interrupt: GuestInterruptLine,
 }
 
+pub(crate) struct HvfSnapshotV2MultiBlockPciShellPlan<'a> {
+    pub(crate) command_line: &'a str,
+    pub(crate) pci: &'a HvfSnapshotV2MultiBlockPciPlan,
+    pub(crate) serial_interrupt: GuestInterruptLine,
+    pub(crate) vmgenid_interrupt: GuestInterruptLine,
+    pub(crate) vmclock_interrupt: GuestInterruptLine,
+}
+
 enum HvfSnapshotV2ProcessShellRestore<'a> {
     DeviceFree(HvfSnapshotV2DefaultProcessShell),
     Root {
@@ -366,6 +376,10 @@ enum HvfSnapshotV2ProcessShellRestore<'a> {
     MultiBlockMmio {
         shell: HvfSnapshotV2DefaultProcessShell,
         plan: HvfSnapshotV2MultiBlockMmioShellPlan<'a>,
+    },
+    MultiBlockPci {
+        shell: HvfSnapshotV2DefaultProcessShell,
+        plan: HvfSnapshotV2MultiBlockPciShellPlan<'a>,
     },
 }
 
@@ -378,6 +392,10 @@ enum HvfSnapshotV2ProcessBlockFdtPlan<'a> {
     MultiBlockMmio {
         command_line: &'a str,
         records: &'a [HvfSnapshotV2MultiBlockMmioRecordPlan],
+    },
+    MultiBlockPci {
+        command_line: &'a str,
+        pci: &'a HvfSnapshotV2MultiBlockPciPlan,
     },
 }
 
@@ -1292,6 +1310,19 @@ pub(crate) fn restore_hvf_snapshot_v2_multi_block_mmio_process_platform(
         state,
         memory,
         Some(HvfSnapshotV2ProcessShellRestore::MultiBlockMmio { shell, plan }),
+    )
+}
+
+pub(crate) fn restore_hvf_snapshot_v2_multi_block_pci_process_platform(
+    state: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    shell: HvfSnapshotV2DefaultProcessShell,
+    plan: HvfSnapshotV2MultiBlockPciShellPlan<'_>,
+) -> Result<RestoredHvfSnapshotV2Platform, HvfSnapshotV2PlatformRestoreError> {
+    restore_hvf_snapshot_v2_platform_with_shell(
+        state,
+        memory,
+        Some(HvfSnapshotV2ProcessShellRestore::MultiBlockPci { shell, plan }),
     )
 }
 
@@ -2253,6 +2284,30 @@ fn prepare_process_shell(
                     )),
                 )
             }
+            HvfSnapshotV2ProcessShellRestore::MultiBlockPci { shell, plan } => {
+                if plan.pci.records().is_empty()
+                    || plan.pci.route_demand() == 0
+                    || gic.msi != Some(plan.pci.msi())
+                {
+                    return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellFdt {
+                        mismatch: HvfSnapshotV2ProcessFdtMismatch::Profile,
+                    });
+                }
+                (
+                    shell,
+                    HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockPci {
+                        command_line: plan.command_line,
+                        pci: plan.pci,
+                    },
+                    true,
+                    true,
+                    Some((
+                        plan.serial_interrupt,
+                        plan.vmgenid_interrupt,
+                        plan.vmclock_interrupt,
+                    )),
+                )
+            }
         };
     let serial_interrupt = allocator
         .allocate()
@@ -2372,6 +2427,7 @@ fn validate_process_fdt(
         HvfSnapshotV2ProcessBlockFdtPlan::None => 0,
         HvfSnapshotV2ProcessBlockFdtPlan::Root { .. } => 1,
         HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockMmio { records, .. } => records.len(),
+        HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockPci { .. } => 1,
     };
     if tree.root.children.len() != 11 + block_child_count
         || [
@@ -2484,6 +2540,9 @@ fn validate_process_fdt(
         HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockMmio { command_line, .. } => chosen
             .prop_str("bootargs")
             .is_ok_and(|arguments| arguments == *command_line),
+        HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockPci { command_line, .. } => chosen
+            .prop_str("bootargs")
+            .is_ok_and(|arguments| arguments == *command_line),
         HvfSnapshotV2ProcessBlockFdtPlan::None => {
             let expected = expected_process_boot_arguments(state.machine().boot().boot_arguments())
                 .ok_or(HvfSnapshotV2ProcessFdtMismatch::Boot)?;
@@ -2507,7 +2566,7 @@ fn validate_process_fdt(
         HvfSnapshotV2ProcessBlockFdtPlan::Root {
             transport: HvfSnapshotV2RootTransportPlan::Pci { .. },
             ..
-        }
+        } | HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockPci { .. }
     ));
     if intc.children.len() != expected_gic_children
         || !intc
@@ -2675,6 +2734,18 @@ fn validate_process_block_nodes(
                     record.region(),
                     record.interrupt_line(),
                 )?;
+            }
+            return Ok(());
+        }
+        HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockPci { pci, .. } => {
+            let canonical_host = Arm64PciAddressPlan::firecracker_v1_16()
+                .map(bangbang_runtime::fdt::Arm64FdtPciHost::from_address_plan)
+                .ok();
+            if canonical_host != Some(pci.host())
+                || !validate_process_pci_host(root_node)
+                || !validate_process_gic_msi(intc, pci.msi())
+            {
+                return Err(HvfSnapshotV2ProcessFdtMismatch::Pci);
             }
             return Ok(());
         }
@@ -4034,6 +4105,81 @@ pub(crate) mod tests {
             &devices,
             "console=ttyS0 pci=off",
             None,
+        );
+        assert_eq!(
+            validate_process_fdt(
+                &wrong_command_line,
+                &platform,
+                plan.serial_interrupt(),
+                &block
+            ),
+            Err(HvfSnapshotV2ProcessFdtMismatch::Boot)
+        );
+    }
+
+    #[test]
+    fn multi_block_pci_fdt_requires_one_exact_host_msi_frame_and_command_line() {
+        let (platform, plan) =
+            crate::snapshot_v2_multi_block_platform::tests::pci_fdt_plan_fixture();
+        let pci = plan.transport().pci().expect("fixture plan should use PCI");
+        assert_eq!(pci.records().len(), 2);
+        let shell = (
+            bangbang_runtime::fdt::Arm64FdtSerialDevice {
+                region: bangbang_runtime::fdt::Arm64FdtRegion {
+                    base: PROCESS_SERIAL_MMIO_BASE.raw_value(),
+                    size: SERIAL_MMIO_DEVICE_WINDOW_SIZE,
+                },
+                interrupt_line: plan.serial_interrupt(),
+            },
+            bangbang_runtime::fdt::Arm64FdtRtcDevice {
+                region: bangbang_runtime::fdt::Arm64FdtRegion {
+                    base: PROCESS_RTC_MMIO_BASE.raw_value(),
+                    size: RTC_MMIO_DEVICE_WINDOW_SIZE,
+                },
+            },
+            bangbang_runtime::fdt::Arm64FdtVmGenIdDevice {
+                region: platform.time().vmgenid().fdt_region(),
+                interrupt_line: plan.vmgenid_interrupt(),
+            },
+            bangbang_runtime::fdt::Arm64FdtVmClockDevice {
+                region: platform.time().vmclock().fdt_region(),
+                interrupt_line: plan.vmclock_interrupt(),
+            },
+        );
+        let block = HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockPci {
+            command_line: plan.command_line(),
+            pci,
+        };
+        let valid = build_process_fdt_fixture_with_profile(
+            &platform,
+            shell,
+            &[],
+            plan.command_line(),
+            Some(pci.host()),
+        );
+        assert_eq!(
+            validate_process_fdt(&valid, &platform, plan.serial_interrupt(), &block),
+            Ok(())
+        );
+
+        let missing_host = build_process_fdt_fixture_with_profile(
+            &platform,
+            shell,
+            &[],
+            plan.command_line(),
+            None,
+        );
+        assert_eq!(
+            validate_process_fdt(&missing_host, &platform, plan.serial_interrupt(), &block),
+            Err(HvfSnapshotV2ProcessFdtMismatch::RootInventory)
+        );
+
+        let wrong_command_line = build_process_fdt_fixture_with_profile(
+            &platform,
+            shell,
+            &[],
+            "console=ttyS0 pci=off",
+            Some(pci.host()),
         );
         assert_eq!(
             validate_process_fdt(

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -29,7 +29,10 @@ use bangbang_runtime::block::{
     VirtioBlockConfigSpace, VirtioBlockDevice, VirtioBlockDeviceNotificationError,
     VirtioBlockLiveUpdateError, VirtioBlockSnapshotPersistenceBinding,
 };
-use bangbang_runtime::boot::BootSourceFiles;
+use bangbang_runtime::boot::{
+    BootSourceFiles, canonical_process_block_command_line,
+    canonical_process_root_block_command_line,
+};
 use bangbang_runtime::boot_timer::{
     BootTimerMmioLayout, BootTimerMmioRegistrationError, register_boot_timer_mmio,
 };
@@ -106,8 +109,10 @@ use bangbang_runtime::snapshot_device_v2::{
 use bangbang_runtime::snapshot_device_v2_5::{
     NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION, PreparedSnapshotV2MultiBlockBundle,
     PreparedSnapshotV2MultiBlockMmioBundle, PreparedSnapshotV2MultiBlockMmioRecord,
-    SnapshotV2MultiBlockCleanupError, SnapshotV2MultiBlockDeviceGraph,
-    SnapshotV2MultiBlockMmioTransportError,
+    PreparedSnapshotV2MultiBlockPciBundle, PreparedSnapshotV2MultiBlockPciEndpoint,
+    PreparedSnapshotV2MultiBlockPciRecord, SnapshotV2MultiBlockCleanupError,
+    SnapshotV2MultiBlockDeviceGraph, SnapshotV2MultiBlockMmioTransportError,
+    SnapshotV2MultiBlockPciTransportError,
 };
 use bangbang_runtime::snapshot_format::SnapshotFormatVersion;
 use bangbang_runtime::snapshot_format_v2::NATIVE_V2_LEGACY_PLATFORM_VERSION;
@@ -227,9 +232,11 @@ use crate::snapshot_v2_multi_block_platform::{
 };
 use crate::snapshot_v2_platform::{
     HvfSnapshotV2DefaultProcessShell, HvfSnapshotV2MultiBlockMmioShellPlan,
-    HvfSnapshotV2PlatformRestoreError, HvfSnapshotV2PlatformShutdownError,
-    HvfSnapshotV2RootResourcePlan, HvfSnapshotV2RootTransportPlan, RestoredHvfSnapshotV2Platform,
+    HvfSnapshotV2MultiBlockPciShellPlan, HvfSnapshotV2PlatformRestoreError,
+    HvfSnapshotV2PlatformShutdownError, HvfSnapshotV2RootResourcePlan,
+    HvfSnapshotV2RootTransportPlan, RestoredHvfSnapshotV2Platform,
     restore_hvf_snapshot_v2_multi_block_mmio_process_platform,
+    restore_hvf_snapshot_v2_multi_block_pci_process_platform,
     restore_hvf_snapshot_v2_root_process_platform,
 };
 use crate::topology::{HvfVcpuTopologyError, prepare_ordered_mpidrs};
@@ -2514,6 +2521,134 @@ impl HvfArm64BootPciDataDevices {
         }
         Ok(())
     }
+
+    /// Attempts every reversible manager cleanup boundary without
+    /// short-circuiting after an earlier endpoint failure.
+    fn teardown_exhaustive(&mut self, mut record_failure: impl FnMut(HvfArm64BootPciDataError)) {
+        let dispatcher = self.dispatcher.lock();
+        match dispatcher {
+            Ok(mut dispatcher) => {
+                if let Some(device) = self.memory_hotplug.as_mut() {
+                    match device
+                        .published
+                        .teardown(&mut dispatcher, self.validation.bar_allocator_mut())
+                    {
+                        Ok(()) => self.memory_hotplug = None,
+                        Err(source) => record_failure(pci_data_teardown_error(
+                            "memory-hotplug",
+                            "mem0",
+                            source,
+                        )),
+                    }
+                }
+                if let Some(device) = self.entropy.as_mut() {
+                    match device
+                        .published
+                        .teardown(&mut dispatcher, self.validation.bar_allocator_mut())
+                    {
+                        Ok(()) => self.entropy = None,
+                        Err(source) => {
+                            record_failure(pci_data_teardown_error("entropy", "entropy0", source));
+                        }
+                    }
+                }
+                if let Some(device) = self.vsock.as_mut() {
+                    match device
+                        .published
+                        .teardown(&mut dispatcher, self.validation.bar_allocator_mut())
+                    {
+                        Ok(()) => self.vsock = None,
+                        Err(source) => {
+                            record_failure(pci_data_teardown_error("vsock", "vsock0", source));
+                        }
+                    }
+                }
+                for index in (0..self.pmem.len()).rev() {
+                    let Some(device) = self.pmem.get_mut(index) else {
+                        record_failure(HvfArm64BootPciDataError::new(
+                            "PCI pmem cleanup inventory diverged",
+                        ));
+                        continue;
+                    };
+                    let result = device
+                        .published
+                        .teardown(&mut dispatcher, self.validation.bar_allocator_mut())
+                        .map_err(|source| pci_data_teardown_error("pmem", &device.pmem_id, source));
+                    match result {
+                        Ok(()) => {
+                            self.pmem.remove(index);
+                        }
+                        Err(source) => record_failure(source),
+                    }
+                }
+                for index in (0..self.network.len()).rev() {
+                    let Some(device) = self.network.get_mut(index) else {
+                        record_failure(HvfArm64BootPciDataError::new(
+                            "PCI network cleanup inventory diverged",
+                        ));
+                        continue;
+                    };
+                    let result = device
+                        .published
+                        .teardown(&mut dispatcher, self.validation.bar_allocator_mut())
+                        .map_err(|source| {
+                            pci_data_teardown_error("network", &device.iface_id, source)
+                        });
+                    match result {
+                        Ok(()) => {
+                            self.network.remove(index);
+                        }
+                        Err(source) => record_failure(source),
+                    }
+                }
+                for index in (0..self.block.len()).rev() {
+                    let Some(device) = self.block.get_mut(index) else {
+                        record_failure(HvfArm64BootPciDataError::new(
+                            "PCI block cleanup inventory diverged",
+                        ));
+                        continue;
+                    };
+                    let result = device
+                        .published
+                        .teardown(&mut dispatcher, self.validation.bar_allocator_mut())
+                        .map_err(|source| {
+                            pci_data_teardown_error("block", &device.drive_id, source)
+                        });
+                    match result {
+                        Ok(()) => {
+                            self.block.remove(index);
+                        }
+                        Err(source) => record_failure(source),
+                    }
+                }
+                if let Some(device) = self.balloon.as_mut() {
+                    match device
+                        .published
+                        .teardown(&mut dispatcher, self.validation.bar_allocator_mut())
+                    {
+                        Ok(()) => self.balloon = None,
+                        Err(source) => {
+                            record_failure(pci_data_teardown_error("balloon", "balloon0", source));
+                        }
+                    }
+                }
+            }
+            Err(_) => record_failure(HvfArm64BootPciDataError::new(
+                "PCI data-device MMIO dispatcher is unavailable",
+            )),
+        }
+        if let Some(interrupts) = self.msi_interrupts.as_mut() {
+            match interrupts.release() {
+                Ok(()) if interrupts.lease_count() == 0 => self.msi_interrupts = None,
+                Ok(()) => record_failure(HvfArm64BootPciDataError::new(
+                    "shared PCI data GICv2m routes remain owned after endpoint cleanup",
+                )),
+                Err(source) => record_failure(HvfArm64BootPciDataError::new(format!(
+                    "failed to release shared PCI data GICv2m routes: {source}"
+                ))),
+            }
+        }
+    }
 }
 
 /// Cloneable live-update handle for production PCI block endpoints.
@@ -3681,6 +3816,332 @@ impl fmt::Display for HvfSnapshotV2MultiBlockMmioRestoreError {
 }
 
 impl std::error::Error for HvfSnapshotV2MultiBlockMmioRestoreError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.failure.as_ref())
+    }
+}
+
+/// One complete, still-unpublished profile-2 PCI destination and controller
+/// projection.
+pub struct RestoredHvfSnapshotV2MultiBlockPciOwners {
+    session: OwnedHvfArm64BootSession,
+    drive_configs: DriveConfigs,
+}
+
+impl RestoredHvfSnapshotV2MultiBlockPciOwners {
+    pub const fn session(&self) -> &OwnedHvfArm64BootSession {
+        &self.session
+    }
+
+    pub const fn drive_configs(&self) -> &DriveConfigs {
+        &self.drive_configs
+    }
+
+    pub fn into_parts(self) -> (OwnedHvfArm64BootSession, DriveConfigs) {
+        (self.session, self.drive_configs)
+    }
+}
+
+impl fmt::Debug for RestoredHvfSnapshotV2MultiBlockPciOwners {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RestoredHvfSnapshotV2MultiBlockPciOwners")
+            .field("record_count", &self.drive_configs.as_slice().len())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Stage at which complete profile-2 PCI owner reconstruction stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfSnapshotV2MultiBlockPciRestoreStage {
+    MemoryLayout,
+    Transport,
+    ResourcePlan,
+    Metrics,
+    Platform,
+    PciHost,
+    PciRoutes,
+    EndpointPreparation { index: usize },
+    Publication { index: usize },
+    RetryScheduler,
+}
+
+/// Primary failure from complete profile-2 PCI owner reconstruction.
+pub enum HvfSnapshotV2MultiBlockPciRestoreFailure {
+    Allocation,
+    MemoryLayout,
+    Transport(SnapshotV2MultiBlockPciTransportError),
+    ResourcePlan,
+    Metrics(BlockDeviceMetricsRegistryError),
+    Platform(Box<HvfSnapshotV2PlatformRestoreError>),
+    DispatcherUnavailable,
+    PciHost(Arm64BootResourceError),
+    PciData(HvfArm64BootPciDataError),
+    PciRoutes(HvfGicMsiDeviceInterruptResourceError),
+    PciEndpoint(SnapshotV2RootTransportRestoreError),
+    PciPublication(VirtioPciPublicationError),
+    RetryScheduler(io::ErrorKind),
+}
+
+impl fmt::Debug for HvfSnapshotV2MultiBlockPciRestoreFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::Allocation => "allocation",
+            Self::MemoryLayout => "memory-layout",
+            Self::Transport(_) => "transport",
+            Self::ResourcePlan => "resource-plan",
+            Self::Metrics(_) => "metrics",
+            Self::Platform(_) => "platform",
+            Self::DispatcherUnavailable => "dispatcher",
+            Self::PciHost(_) => "pci-host",
+            Self::PciData(_) => "pci-data",
+            Self::PciRoutes(_) => "pci-routes",
+            Self::PciEndpoint(_) => "pci-endpoint",
+            Self::PciPublication(_) => "pci-publication",
+            Self::RetryScheduler(_) => "retry-scheduler",
+        };
+        formatter
+            .debug_struct("HvfSnapshotV2MultiBlockPciRestoreFailure")
+            .field("kind", &kind)
+            .field("source", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2MultiBlockPciRestoreFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Allocation => "profile-2 PCI owner allocation failed",
+            Self::MemoryLayout => "restored memory layout is invalid",
+            Self::Transport(_) => "profile-2 PCI transport reconstruction failed",
+            Self::ResourcePlan => "profile-2 PCI resource plan diverged",
+            Self::Metrics(_) => "profile-2 PCI metrics ownership failed",
+            Self::Platform(_) => "HVF platform reconstruction failed",
+            Self::DispatcherUnavailable => "profile-2 PCI dispatcher is unavailable",
+            Self::PciHost(_) => "profile-2 PCI host reconstruction failed",
+            Self::PciData(_) => "profile-2 PCI manager reconstruction failed",
+            Self::PciRoutes(_) => "profile-2 PCI route reconstruction failed",
+            Self::PciEndpoint(_) => "profile-2 PCI endpoint preparation failed",
+            Self::PciPublication(_) => "profile-2 PCI endpoint publication failed",
+            Self::RetryScheduler(kind) => {
+                return write!(formatter, "block retry scheduler startup failed: {kind:?}");
+            }
+        })
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2MultiBlockPciRestoreFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Transport(source) => Some(source),
+            Self::Metrics(source) => Some(source),
+            Self::Platform(source) => Some(source.as_ref()),
+            Self::PciHost(source) => Some(source),
+            Self::PciData(source) => Some(source),
+            Self::PciRoutes(HvfGicMsiDeviceInterruptResourceError::Rollback { .. })
+            | Self::PciPublication(VirtioPciPublicationError::Rollback { .. }) => None,
+            Self::PciRoutes(source) => Some(source),
+            Self::PciEndpoint(source) => Some(source),
+            Self::PciPublication(source) => Some(source),
+            Self::Allocation
+            | Self::MemoryLayout
+            | Self::ResourcePlan
+            | Self::DispatcherUnavailable
+            | Self::RetryScheduler(_) => None,
+        }
+    }
+}
+
+/// Cleanup uncertainty retained after profile-2 PCI reconstruction failed.
+pub enum HvfSnapshotV2MultiBlockPciRestoreCleanupFailure {
+    PreparedBundle(SnapshotV2MultiBlockCleanupError),
+    RetryScheduler,
+    AsyncGuestMemory(HvfGuestMemoryMappingError),
+    Async(BlockAsyncRuntimeError),
+    Pci(HvfArm64BootPciDataError),
+    Platform(HvfSnapshotV2PlatformShutdownError),
+}
+
+impl fmt::Debug for HvfSnapshotV2MultiBlockPciRestoreCleanupFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::PreparedBundle(_) => "prepared-bundle",
+            Self::RetryScheduler => "retry-scheduler",
+            Self::AsyncGuestMemory(_) => "async-guest-memory",
+            Self::Async(_) => "async-runtime",
+            Self::Pci(_) => "pci-owner",
+            Self::Platform(_) => "platform",
+        };
+        formatter
+            .debug_struct("HvfSnapshotV2MultiBlockPciRestoreCleanupFailure")
+            .field("kind", &kind)
+            .field("source", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2MultiBlockPciRestoreCleanupFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::PreparedBundle(_) => "prepared Async bundle cleanup failed",
+            Self::RetryScheduler => "retry scheduler cleanup failed",
+            Self::AsyncGuestMemory(_) => "Async cleanup could not borrow guest memory",
+            Self::Async(_) => "Async runtime cleanup failed",
+            Self::Pci(_) => "PCI owner cleanup failed",
+            Self::Platform(_) => "HVF platform cleanup failed",
+        })
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2MultiBlockPciRestoreCleanupFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::PreparedBundle(source) => Some(source),
+            Self::AsyncGuestMemory(source) => Some(source),
+            Self::Async(source) => Some(source),
+            Self::Pci(source) => Some(source),
+            Self::Platform(source) => Some(source),
+            Self::RetryScheduler => None,
+        }
+    }
+}
+
+/// Redacted profile-2 PCI owner failure with ordered cleanup evidence.
+pub struct HvfSnapshotV2MultiBlockPciRestoreError {
+    stage: HvfSnapshotV2MultiBlockPciRestoreStage,
+    failure: Box<HvfSnapshotV2MultiBlockPciRestoreFailure>,
+    cleanup: Vec<HvfSnapshotV2MultiBlockPciRestoreCleanupFailure>,
+}
+
+impl HvfSnapshotV2MultiBlockPciRestoreError {
+    fn preflight(
+        stage: HvfSnapshotV2MultiBlockPciRestoreStage,
+        failure: HvfSnapshotV2MultiBlockPciRestoreFailure,
+    ) -> Self {
+        Self {
+            stage,
+            failure: Box::new(failure),
+            cleanup: Vec::new(),
+        }
+    }
+
+    fn with_prepared_bundle_abort(
+        stage: HvfSnapshotV2MultiBlockPciRestoreStage,
+        failure: HvfSnapshotV2MultiBlockPciRestoreFailure,
+        bundle: PreparedSnapshotV2MultiBlockPciBundle,
+    ) -> Self {
+        let cleanup = bundle
+            .abort()
+            .err()
+            .map(HvfSnapshotV2MultiBlockPciRestoreCleanupFailure::PreparedBundle)
+            .into_iter()
+            .collect();
+        Self {
+            stage,
+            failure: Box::new(failure),
+            cleanup,
+        }
+    }
+
+    fn platform(
+        source: HvfSnapshotV2PlatformRestoreError,
+        bundle: PreparedSnapshotV2MultiBlockPciBundle,
+    ) -> Self {
+        Self::with_prepared_bundle_abort(
+            HvfSnapshotV2MultiBlockPciRestoreStage::Platform,
+            HvfSnapshotV2MultiBlockPciRestoreFailure::Platform(Box::new(source)),
+            bundle,
+        )
+    }
+
+    fn after_platform(
+        stage: HvfSnapshotV2MultiBlockPciRestoreStage,
+        failure: HvfSnapshotV2MultiBlockPciRestoreFailure,
+        cleanup: Vec<HvfSnapshotV2MultiBlockPciRestoreCleanupFailure>,
+    ) -> Self {
+        Self {
+            stage,
+            failure: Box::new(failure),
+            cleanup,
+        }
+    }
+
+    pub const fn stage(&self) -> HvfSnapshotV2MultiBlockPciRestoreStage {
+        self.stage
+    }
+
+    pub fn cleanup_failures(&self) -> &[HvfSnapshotV2MultiBlockPciRestoreCleanupFailure] {
+        &self.cleanup
+    }
+
+    pub fn has_incomplete_cleanup(&self) -> bool {
+        !self.cleanup.is_empty()
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MultiBlockPciRestoreFailure::Transport(source)
+                    if source.cleanup_failed()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MultiBlockPciRestoreFailure::Platform(source)
+                    if !source.cleanup_failures().is_empty()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MultiBlockPciRestoreFailure::PciRoutes(
+                    HvfGicMsiDeviceInterruptResourceError::Rollback { .. }
+                )
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MultiBlockPciRestoreFailure::PciPublication(
+                    VirtioPciPublicationError::Rollback { .. }
+                )
+            )
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        self.has_incomplete_cleanup()
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MultiBlockPciRestoreFailure::Platform(source)
+                    if source.is_committed()
+            )
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2MultiBlockPciRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2MultiBlockPciRestoreError")
+            .field("stage", &self.stage)
+            .field("failure", &"<redacted>")
+            .field("cleanup_count", &self.cleanup.len())
+            .field("terminal", &self.is_terminal())
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2MultiBlockPciRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "profile-2 PCI owner reconstruction failed at {:?}: {}",
+            self.stage, self.failure
+        )?;
+        if !self.cleanup.is_empty() {
+            write!(
+                formatter,
+                "; {} cleanup failure(s) retained",
+                self.cleanup.len()
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2MultiBlockPciRestoreError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(self.failure.as_ref())
     }
@@ -11409,6 +11870,111 @@ fn validate_snapshot_v2_multi_block_mmio_resource_plan(
     root_key == plan.root_key && earliest_retry_index == plan.earliest_retry_index
 }
 
+fn validate_snapshot_v2_multi_block_pci_resource_plan(
+    bundle: &PreparedSnapshotV2MultiBlockPciBundle,
+    plan: &HvfSnapshotV2MultiBlockPlatformPlanParts,
+    base_arguments: Option<&str>,
+) -> bool {
+    let records = bundle.records();
+    let configs = bundle.drive_configs().as_slice();
+    let Some(pci) = plan.transport.pci() else {
+        return false;
+    };
+    let planned_records = pci.records();
+    if records.is_empty()
+        || records.len() != configs.len()
+        || records.len() != planned_records.len()
+        || records.len() != plan.metrics_ids.len()
+        || records.len() != plan.retries.len()
+        || records.len() > PCI_ENDPOINT_SLOT_COUNT
+    {
+        return false;
+    }
+    let Some(expected_command_line) =
+        expected_snapshot_v2_multi_block_command_line(configs, base_arguments, true)
+    else {
+        return false;
+    };
+    if plan.command_line != expected_command_line {
+        return false;
+    }
+
+    let expected_route_count = VIRTIO_BLOCK_QUEUE_SIZES.len().checked_add(1);
+    let mut root_key = None;
+    let mut route_demand = 0_usize;
+    for (index, ((((record, config), planned), retry), metrics_id)) in records
+        .iter()
+        .zip(configs)
+        .zip(planned_records)
+        .zip(&plan.retries)
+        .zip(&plan.metrics_ids)
+        .enumerate()
+    {
+        let async_binding_matches = match config.io_engine() {
+            Some(DriveIoEngine::Sync) => record.async_generation().is_none(),
+            Some(DriveIoEngine::Async) => record.async_generation().is_some(),
+            None => false,
+        };
+        if record.key() != planned.key()
+            || record.key() != retry.key()
+            || record.drive_id() != config.drive_id()
+            || record.drive_id() != metrics_id
+            || record.is_root_device() != config.is_root_device()
+            || record.origin() != planned.origin()
+            || record.sbdf() != planned.sbdf()
+            || pci_data_region_id(index).ok() != Some(planned.bar_region_id())
+            || record.bar_range() != planned.bar_range()
+            || Some(planned.route_count()) != expected_route_count
+            || record.retry() != retry.retry()
+            || record.retry_deadline().is_some()
+                == matches!(record.retry(), StorageRetryState::None)
+            || !async_binding_matches
+            || (record.is_root_device() && index != 0)
+        {
+            return false;
+        }
+        let Some(updated_route_demand) = route_demand.checked_add(planned.route_count()) else {
+            return false;
+        };
+        route_demand = updated_route_demand;
+        if record.is_root_device() && root_key.replace(record.key()).is_some() {
+            return false;
+        }
+    }
+
+    let earliest_retry_index = records
+        .iter()
+        .enumerate()
+        .filter_map(|(index, record)| {
+            snapshot_v2_multi_block_retry_rank(record.retry()).map(|rank| (rank, index))
+        })
+        .min_by_key(|(rank, _)| *rank)
+        .map(|(_, index)| index);
+    root_key == plan.root_key
+        && earliest_retry_index == plan.earliest_retry_index
+        && route_demand == pci.route_demand()
+}
+
+fn expected_snapshot_v2_multi_block_command_line(
+    configs: &[DriveConfig],
+    base_arguments: Option<&str>,
+    pci_enabled: bool,
+) -> Option<String> {
+    let base_command_line =
+        canonical_process_block_command_line(base_arguments, pci_enabled).ok()?;
+    let root = configs.iter().find(|config| config.is_root_device());
+    match root {
+        Some(root) => canonical_process_root_block_command_line(
+            base_arguments,
+            pci_enabled,
+            root.partuuid(),
+            root.is_read_only()?,
+        )
+        .ok(),
+        None => Some(base_command_line),
+    }
+}
+
 const fn snapshot_v2_multi_block_retry_rank(retry: StorageRetryState) -> Option<(u8, u64)> {
     match retry {
         StorageRetryState::None => None,
@@ -11497,6 +12063,104 @@ fn failed_snapshot_v2_multi_block_mmio_after_platform(
     }
 
     HvfSnapshotV2MultiBlockMmioRestoreError::after_platform(stage, failure, cleanup)
+}
+
+struct PreparedHvfSnapshotV2MultiBlockPciPublication {
+    endpoint: PreparedSnapshotV2MultiBlockPciEndpoint,
+    interrupts: HvfGicMsiDeviceInterruptResources,
+    metrics_lease: BlockDeviceMetricsLease,
+}
+
+fn release_unpublished_snapshot_v2_multi_block_pci_interrupts<I: GuestMessageInterruptResources>(
+    index: usize,
+    interrupts: &mut I,
+    cleanup: &mut Vec<HvfSnapshotV2MultiBlockPciRestoreCleanupFailure>,
+) {
+    if let Err(source) = interrupts.release() {
+        cleanup.push(HvfSnapshotV2MultiBlockPciRestoreCleanupFailure::Pci(
+            HvfArm64BootPciDataError::new(format!(
+                "failed to release unpublished profile-2 PCI endpoint {index} routes: {source}"
+            )),
+        ));
+    }
+}
+
+fn release_unpublished_snapshot_v2_multi_block_pci_publications(
+    publications: &mut [Option<PreparedHvfSnapshotV2MultiBlockPciPublication>],
+    cleanup: &mut Vec<HvfSnapshotV2MultiBlockPciRestoreCleanupFailure>,
+) {
+    for (index, publication) in publications.iter_mut().enumerate().rev() {
+        let Some(publication) = publication.take() else {
+            continue;
+        };
+        let PreparedHvfSnapshotV2MultiBlockPciPublication {
+            endpoint,
+            mut interrupts,
+            metrics_lease,
+        } = publication;
+        drop(endpoint);
+        drop(metrics_lease);
+        release_unpublished_snapshot_v2_multi_block_pci_interrupts(index, &mut interrupts, cleanup);
+    }
+}
+
+fn failed_snapshot_v2_multi_block_pci_after_platform(
+    mut platform: RestoredHvfSnapshotV2Platform,
+    stage: HvfSnapshotV2MultiBlockPciRestoreStage,
+    failure: HvfSnapshotV2MultiBlockPciRestoreFailure,
+    scheduler: &mut Option<HvfArm64BootLimiterRetryWakeupScheduler>,
+    async_runtime: Option<&SharedBlockAsyncRuntime>,
+    pci_data_devices: &mut Option<HvfArm64BootPciDataDevices>,
+    mut cleanup: Vec<HvfSnapshotV2MultiBlockPciRestoreCleanupFailure>,
+) -> HvfSnapshotV2MultiBlockPciRestoreError {
+    if scheduler
+        .as_mut()
+        .is_some_and(|scheduler| scheduler.stop_with_result().is_err())
+    {
+        cleanup.push(HvfSnapshotV2MultiBlockPciRestoreCleanupFailure::RetryScheduler);
+    }
+    drop(scheduler.take());
+
+    if let Some(runtime) = async_runtime {
+        let needs_memory = match runtime.shutdown_if_idle() {
+            Ok(idle) => !idle,
+            Err(source) => {
+                cleanup.push(HvfSnapshotV2MultiBlockPciRestoreCleanupFailure::Async(
+                    source,
+                ));
+                true
+            }
+        };
+        if needs_memory {
+            match platform.guest_memory_mut() {
+                Ok(memory) => {
+                    if let Err(source) = runtime.shutdown(memory) {
+                        cleanup.push(HvfSnapshotV2MultiBlockPciRestoreCleanupFailure::Async(
+                            source,
+                        ));
+                    }
+                }
+                Err(source) => cleanup.push(
+                    HvfSnapshotV2MultiBlockPciRestoreCleanupFailure::AsyncGuestMemory(source),
+                ),
+            }
+        }
+    }
+
+    if let Some(manager) = pci_data_devices.as_mut() {
+        manager.teardown_exhaustive(|source| {
+            cleanup.push(HvfSnapshotV2MultiBlockPciRestoreCleanupFailure::Pci(source));
+        });
+    }
+    drop(pci_data_devices.take());
+
+    if let Err(source) = platform.shutdown() {
+        cleanup.push(HvfSnapshotV2MultiBlockPciRestoreCleanupFailure::Platform(
+            source,
+        ));
+    }
+
+    HvfSnapshotV2MultiBlockPciRestoreError::after_platform(stage, failure, cleanup)
 }
 
 fn failed_snapshot_v1_restore(
@@ -12261,6 +12925,731 @@ impl OwnedHvfArm64BootSession {
             boot_registers: None,
         };
         Ok(RestoredHvfSnapshotV2MultiBlockMmioOwners {
+            session,
+            drive_configs,
+        })
+    }
+
+    /// Reconstructs one exact profile-2 PCI vector inside a private canonical
+    /// manager without publishing a process session or controller.
+    #[doc(hidden)]
+    pub fn restore_snapshot_v2_multi_block_pci(
+        state: HvfSnapshotV2PlatformState,
+        memory: GuestMemory,
+        process_shell: HvfSnapshotV2DefaultProcessShell,
+        bundle: PreparedSnapshotV2MultiBlockBundle,
+        plan: HvfSnapshotV2MultiBlockPlatformPlan,
+    ) -> Result<RestoredHvfSnapshotV2MultiBlockPciOwners, HvfSnapshotV2MultiBlockPciRestoreError>
+    {
+        let mut ranges = Vec::new();
+        ranges
+            .try_reserve_exact(memory.regions().len())
+            .map_err(|_| {
+                HvfSnapshotV2MultiBlockPciRestoreError::preflight(
+                    HvfSnapshotV2MultiBlockPciRestoreStage::MemoryLayout,
+                    HvfSnapshotV2MultiBlockPciRestoreFailure::Allocation,
+                )
+            })?;
+        ranges.extend(memory.regions().iter().map(|region| region.range()));
+        let layout = GuestMemoryLayout::new(ranges).map_err(|_| {
+            HvfSnapshotV2MultiBlockPciRestoreError::preflight(
+                HvfSnapshotV2MultiBlockPciRestoreStage::MemoryLayout,
+                HvfSnapshotV2MultiBlockPciRestoreFailure::MemoryLayout,
+            )
+        })?;
+        let source_fdt = state.machine().fdt();
+        let retained_fdt = Arm64FdtGuestMemoryWrite {
+            address: source_fdt.address(),
+            size: usize::try_from(source_fdt.size()).map_err(|_| {
+                HvfSnapshotV2MultiBlockPciRestoreError::preflight(
+                    HvfSnapshotV2MultiBlockPciRestoreStage::MemoryLayout,
+                    HvfSnapshotV2MultiBlockPciRestoreFailure::Allocation,
+                )
+            })?,
+        };
+        let prepared = bundle.prepare_pci_transport().map_err(|source| {
+            HvfSnapshotV2MultiBlockPciRestoreError::preflight(
+                HvfSnapshotV2MultiBlockPciRestoreStage::Transport,
+                HvfSnapshotV2MultiBlockPciRestoreFailure::Transport(source),
+            )
+        })?;
+        let plan = plan.into_parts();
+        if !validate_snapshot_v2_multi_block_pci_resource_plan(
+            &prepared,
+            &plan,
+            state.machine().boot().boot_arguments(),
+        ) {
+            return Err(
+                HvfSnapshotV2MultiBlockPciRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2MultiBlockPciRestoreStage::ResourcePlan,
+                    HvfSnapshotV2MultiBlockPciRestoreFailure::ResourcePlan,
+                    prepared,
+                ),
+            );
+        }
+
+        let HvfSnapshotV2MultiBlockPlatformPlanParts {
+            root_key: _,
+            command_line,
+            metrics_ids,
+            retries: _,
+            earliest_retry_index: _,
+            transport,
+            serial_interrupt,
+            vmgenid_interrupt,
+            vmclock_interrupt,
+        } = plan;
+        let HvfSnapshotV2MultiBlockTransportPlan::Pci(pci_plan) = transport else {
+            return Err(
+                HvfSnapshotV2MultiBlockPciRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2MultiBlockPciRestoreStage::ResourcePlan,
+                    HvfSnapshotV2MultiBlockPciRestoreFailure::ResourcePlan,
+                    prepared,
+                ),
+            );
+        };
+        let record_count = prepared.records().len();
+        let earliest_retry_deadline = prepared
+            .records()
+            .iter()
+            .filter_map(PreparedSnapshotV2MultiBlockPciRecord::retry_deadline)
+            .min();
+        let block_device_metrics =
+            match SharedBlockDeviceMetricsRegistry::from_owned_drive_ids_with_capacity(
+                metrics_ids,
+                PCI_ENDPOINT_SLOT_COUNT,
+            ) {
+                Ok(metrics) => metrics,
+                Err(source) => {
+                    return Err(
+                        HvfSnapshotV2MultiBlockPciRestoreError::with_prepared_bundle_abort(
+                            HvfSnapshotV2MultiBlockPciRestoreStage::Metrics,
+                            HvfSnapshotV2MultiBlockPciRestoreFailure::Metrics(source),
+                            prepared,
+                        ),
+                    );
+                }
+            };
+
+        let mut pmem_static_reserved_ranges = Vec::new();
+        if pmem_static_reserved_ranges
+            .try_reserve_exact(layout.ranges().len())
+            .is_err()
+        {
+            return Err(
+                HvfSnapshotV2MultiBlockPciRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2MultiBlockPciRestoreStage::ResourcePlan,
+                    HvfSnapshotV2MultiBlockPciRestoreFailure::Allocation,
+                    prepared,
+                ),
+            );
+        }
+        pmem_static_reserved_ranges.extend(layout.ranges().iter().copied());
+        let mut block = Vec::new();
+        if block.try_reserve_exact(PCI_ENDPOINT_SLOT_COUNT).is_err() {
+            return Err(
+                HvfSnapshotV2MultiBlockPciRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2MultiBlockPciRestoreStage::ResourcePlan,
+                    HvfSnapshotV2MultiBlockPciRestoreFailure::Allocation,
+                    prepared,
+                ),
+            );
+        }
+        let mut network = Vec::new();
+        if network.try_reserve_exact(PCI_ENDPOINT_SLOT_COUNT).is_err() {
+            return Err(
+                HvfSnapshotV2MultiBlockPciRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2MultiBlockPciRestoreStage::ResourcePlan,
+                    HvfSnapshotV2MultiBlockPciRestoreFailure::Allocation,
+                    prepared,
+                ),
+            );
+        }
+        let mut pmem = Vec::new();
+        if pmem.try_reserve_exact(PCI_ENDPOINT_SLOT_COUNT).is_err() {
+            return Err(
+                HvfSnapshotV2MultiBlockPciRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2MultiBlockPciRestoreStage::ResourcePlan,
+                    HvfSnapshotV2MultiBlockPciRestoreFailure::Allocation,
+                    prepared,
+                ),
+            );
+        }
+        let mut prepared_publications = Vec::new();
+        if prepared_publications
+            .try_reserve_exact(record_count)
+            .is_err()
+        {
+            return Err(
+                HvfSnapshotV2MultiBlockPciRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2MultiBlockPciRestoreStage::ResourcePlan,
+                    HvfSnapshotV2MultiBlockPciRestoreFailure::Allocation,
+                    prepared,
+                ),
+            );
+        }
+        let route_count = match usize::try_from(pci_plan.msi().interrupt_range.count) {
+            Ok(route_count) => route_count,
+            Err(_) => {
+                return Err(
+                    HvfSnapshotV2MultiBlockPciRestoreError::with_prepared_bundle_abort(
+                        HvfSnapshotV2MultiBlockPciRestoreStage::ResourcePlan,
+                        HvfSnapshotV2MultiBlockPciRestoreFailure::Allocation,
+                        prepared,
+                    ),
+                );
+            }
+        };
+        let mut exact_intids = Vec::new();
+        if exact_intids.try_reserve_exact(route_count).is_err() {
+            return Err(
+                HvfSnapshotV2MultiBlockPciRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2MultiBlockPciRestoreStage::ResourcePlan,
+                    HvfSnapshotV2MultiBlockPciRestoreFailure::Allocation,
+                    prepared,
+                ),
+            );
+        }
+        for offset in 0..pci_plan.msi().interrupt_range.count {
+            let Some(intid) = pci_plan.msi().interrupt_range.base.checked_add(offset) else {
+                return Err(
+                    HvfSnapshotV2MultiBlockPciRestoreError::with_prepared_bundle_abort(
+                        HvfSnapshotV2MultiBlockPciRestoreStage::ResourcePlan,
+                        HvfSnapshotV2MultiBlockPciRestoreFailure::ResourcePlan,
+                        prepared,
+                    ),
+                );
+            };
+            exact_intids.push(intid);
+        }
+        let mut cleanup = Vec::new();
+        if cleanup
+            .try_reserve_exact(record_count.saturating_add(6))
+            .is_err()
+        {
+            return Err(
+                HvfSnapshotV2MultiBlockPciRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2MultiBlockPciRestoreStage::ResourcePlan,
+                    HvfSnapshotV2MultiBlockPciRestoreFailure::Allocation,
+                    prepared,
+                ),
+            );
+        }
+
+        let shell_plan = HvfSnapshotV2MultiBlockPciShellPlan {
+            command_line: &command_line,
+            pci: &pci_plan,
+            serial_interrupt,
+            vmgenid_interrupt,
+            vmclock_interrupt,
+        };
+        let platform = match restore_hvf_snapshot_v2_multi_block_pci_process_platform(
+            state,
+            memory,
+            process_shell,
+            shell_plan,
+        ) {
+            Ok(platform) => platform,
+            Err(source) => {
+                return Err(HvfSnapshotV2MultiBlockPciRestoreError::platform(
+                    source, prepared,
+                ));
+            }
+        };
+        let (drive_configs, records, async_runtime, async_generations) = prepared.into_parts();
+        debug_assert_eq!(
+            async_generations.len(),
+            records
+                .iter()
+                .filter(|record| record.async_generation().is_some())
+                .count()
+        );
+        drop(async_generations);
+
+        let mut block_retry_wakeup_scheduler = None;
+        let mut pci_data_devices = None;
+        let validation = {
+            let dispatcher_owner = Arc::clone(platform.mmio_dispatcher());
+            let mut dispatcher = match dispatcher_owner.lock() {
+                Ok(dispatcher) => dispatcher,
+                Err(_) => {
+                    return Err(failed_snapshot_v2_multi_block_pci_after_platform(
+                        platform,
+                        HvfSnapshotV2MultiBlockPciRestoreStage::PciHost,
+                        HvfSnapshotV2MultiBlockPciRestoreFailure::DispatcherUnavailable,
+                        &mut block_retry_wakeup_scheduler,
+                        async_runtime.as_ref(),
+                        &mut pci_data_devices,
+                        cleanup,
+                    ));
+                }
+            };
+            match prepare_restored_pci_validation(&mut dispatcher) {
+                Ok(validation) => validation,
+                Err(source) => {
+                    drop(dispatcher);
+                    return Err(failed_snapshot_v2_multi_block_pci_after_platform(
+                        platform,
+                        HvfSnapshotV2MultiBlockPciRestoreStage::PciHost,
+                        HvfSnapshotV2MultiBlockPciRestoreFailure::PciHost(source),
+                        &mut block_retry_wakeup_scheduler,
+                        async_runtime.as_ref(),
+                        &mut pci_data_devices,
+                        cleanup,
+                    ));
+                }
+            }
+        };
+        let available_slots = match validation
+            .segment()
+            .with_segment(|segment| segment.available_endpoint_slots())
+        {
+            Ok(available_slots) => available_slots,
+            Err(source) => {
+                return Err(failed_snapshot_v2_multi_block_pci_after_platform(
+                    platform,
+                    HvfSnapshotV2MultiBlockPciRestoreStage::PciHost,
+                    HvfSnapshotV2MultiBlockPciRestoreFailure::PciData(
+                        HvfArm64BootPciDataError::new(format!(
+                            "failed to inspect restored PCI endpoint capacity: {source}"
+                        )),
+                    ),
+                    &mut block_retry_wakeup_scheduler,
+                    async_runtime.as_ref(),
+                    &mut pci_data_devices,
+                    cleanup,
+                ));
+            }
+        };
+        if available_slots < PCI_ENDPOINT_SLOT_COUNT {
+            return Err(failed_snapshot_v2_multi_block_pci_after_platform(
+                platform,
+                HvfSnapshotV2MultiBlockPciRestoreStage::PciHost,
+                HvfSnapshotV2MultiBlockPciRestoreFailure::PciData(HvfArm64BootPciDataError::new(
+                    "restored PCI segment cannot retain complete endpoint headroom",
+                )),
+                &mut block_retry_wakeup_scheduler,
+                async_runtime.as_ref(),
+                &mut pci_data_devices,
+                cleanup,
+            ));
+        }
+        let available_bars = match pci_data_available_bar_count(validation.bar_allocator()) {
+            Ok(available_bars) => available_bars,
+            Err(source) => {
+                return Err(failed_snapshot_v2_multi_block_pci_after_platform(
+                    platform,
+                    HvfSnapshotV2MultiBlockPciRestoreStage::PciHost,
+                    HvfSnapshotV2MultiBlockPciRestoreFailure::PciData(source),
+                    &mut block_retry_wakeup_scheduler,
+                    async_runtime.as_ref(),
+                    &mut pci_data_devices,
+                    cleanup,
+                ));
+            }
+        };
+        if available_bars < PCI_ENDPOINT_SLOT_COUNT {
+            return Err(failed_snapshot_v2_multi_block_pci_after_platform(
+                platform,
+                HvfSnapshotV2MultiBlockPciRestoreStage::PciHost,
+                HvfSnapshotV2MultiBlockPciRestoreFailure::PciData(HvfArm64BootPciDataError::new(
+                    "restored PCI BAR allocator cannot retain complete endpoint headroom",
+                )),
+                &mut block_retry_wakeup_scheduler,
+                async_runtime.as_ref(),
+                &mut pci_data_devices,
+                cleanup,
+            ));
+        }
+        let bar_plan = match pci_data_bar_plan(validation.bar_allocator(), PCI_ENDPOINT_SLOT_COUNT)
+        {
+            Ok(bar_plan) => bar_plan,
+            Err(source) => {
+                return Err(failed_snapshot_v2_multi_block_pci_after_platform(
+                    platform,
+                    HvfSnapshotV2MultiBlockPciRestoreStage::PciHost,
+                    HvfSnapshotV2MultiBlockPciRestoreFailure::PciData(source),
+                    &mut block_retry_wakeup_scheduler,
+                    async_runtime.as_ref(),
+                    &mut pci_data_devices,
+                    cleanup,
+                ));
+            }
+        };
+        {
+            let dispatcher_owner = Arc::clone(platform.mmio_dispatcher());
+            let dispatcher = match dispatcher_owner.lock() {
+                Ok(dispatcher) => dispatcher,
+                Err(_) => {
+                    return Err(failed_snapshot_v2_multi_block_pci_after_platform(
+                        platform,
+                        HvfSnapshotV2MultiBlockPciRestoreStage::PciHost,
+                        HvfSnapshotV2MultiBlockPciRestoreFailure::DispatcherUnavailable,
+                        &mut block_retry_wakeup_scheduler,
+                        async_runtime.as_ref(),
+                        &mut pci_data_devices,
+                        cleanup,
+                    ));
+                }
+            };
+            if let Err(source) = preflight_pci_data_dispatcher(&dispatcher, &bar_plan) {
+                drop(dispatcher);
+                return Err(failed_snapshot_v2_multi_block_pci_after_platform(
+                    platform,
+                    HvfSnapshotV2MultiBlockPciRestoreStage::PciHost,
+                    HvfSnapshotV2MultiBlockPciRestoreFailure::PciData(source),
+                    &mut block_retry_wakeup_scheduler,
+                    async_runtime.as_ref(),
+                    &mut pci_data_devices,
+                    cleanup,
+                ));
+            }
+        }
+        let signaler = match platform.backend().gic_msi_signaler() {
+            Some(signaler) => signaler,
+            None => {
+                return Err(failed_snapshot_v2_multi_block_pci_after_platform(
+                    platform,
+                    HvfSnapshotV2MultiBlockPciRestoreStage::PciRoutes,
+                    HvfSnapshotV2MultiBlockPciRestoreFailure::PciData(
+                        HvfArm64BootPciDataError::new(
+                            "restored PCI vector requires a GICv2m MSI signaler",
+                        ),
+                    ),
+                    &mut block_retry_wakeup_scheduler,
+                    async_runtime.as_ref(),
+                    &mut pci_data_devices,
+                    cleanup,
+                ));
+            }
+        };
+        let msi_interrupts =
+            match HvfGicMsiDeviceInterruptResources::allocate_exact(signaler, &exact_intids) {
+                Ok(interrupts) => interrupts,
+                Err(source) => {
+                    return Err(failed_snapshot_v2_multi_block_pci_after_platform(
+                        platform,
+                        HvfSnapshotV2MultiBlockPciRestoreStage::PciRoutes,
+                        HvfSnapshotV2MultiBlockPciRestoreFailure::PciRoutes(source),
+                        &mut block_retry_wakeup_scheduler,
+                        async_runtime.as_ref(),
+                        &mut pci_data_devices,
+                        cleanup,
+                    ));
+                }
+            };
+        pci_data_devices = Some(HvfArm64BootPciDataDevices {
+            validation,
+            dispatcher: Arc::clone(platform.mmio_dispatcher()),
+            msi_interrupts: Some(msi_interrupts),
+            balloon: None,
+            block,
+            network,
+            pmem,
+            vsock: None,
+            entropy: None,
+            memory_hotplug: None,
+            pmem_static_reserved_ranges,
+            runtime_hotplug: true,
+        });
+
+        let preparation_result = (|| {
+            let manager = pci_data_devices.as_mut().ok_or((
+                HvfSnapshotV2MultiBlockPciRestoreStage::PciRoutes,
+                HvfSnapshotV2MultiBlockPciRestoreFailure::ResourcePlan,
+            ))?;
+            for (index, (record, planned)) in
+                records.into_iter().zip(pci_plan.records()).enumerate()
+            {
+                let mut interrupts = manager.shared_msi_registry().map_err(|source| {
+                    (
+                        HvfSnapshotV2MultiBlockPciRestoreStage::EndpointPreparation { index },
+                        HvfSnapshotV2MultiBlockPciRestoreFailure::PciData(source),
+                    )
+                })?;
+                let endpoint = match record
+                    .prepare_endpoint(planned.bar_region_id(), interrupts.registry())
+                {
+                    Ok(endpoint) => endpoint,
+                    Err(source) => {
+                        release_unpublished_snapshot_v2_multi_block_pci_interrupts(
+                            index,
+                            &mut interrupts,
+                            &mut cleanup,
+                        );
+                        return Err((
+                            HvfSnapshotV2MultiBlockPciRestoreStage::EndpointPreparation { index },
+                            HvfSnapshotV2MultiBlockPciRestoreFailure::PciEndpoint(source),
+                        ));
+                    }
+                };
+                let metrics_lease = match block_device_metrics
+                    .claim_drive_lease(endpoint.drive_id())
+                {
+                    Ok(metrics_lease) => metrics_lease,
+                    Err(source) => {
+                        drop(endpoint);
+                        release_unpublished_snapshot_v2_multi_block_pci_interrupts(
+                            index,
+                            &mut interrupts,
+                            &mut cleanup,
+                        );
+                        return Err((
+                            HvfSnapshotV2MultiBlockPciRestoreStage::EndpointPreparation { index },
+                            HvfSnapshotV2MultiBlockPciRestoreFailure::Metrics(source),
+                        ));
+                    }
+                };
+                prepared_publications.push(Some(PreparedHvfSnapshotV2MultiBlockPciPublication {
+                    endpoint,
+                    interrupts,
+                    metrics_lease,
+                }));
+            }
+            Ok(())
+        })();
+        if let Err((stage, failure)) = preparation_result {
+            release_unpublished_snapshot_v2_multi_block_pci_publications(
+                &mut prepared_publications,
+                &mut cleanup,
+            );
+            return Err(failed_snapshot_v2_multi_block_pci_after_platform(
+                platform,
+                stage,
+                failure,
+                &mut block_retry_wakeup_scheduler,
+                async_runtime.as_ref(),
+                &mut pci_data_devices,
+                cleanup,
+            ));
+        }
+
+        let block_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        let vcpu_control = platform.control();
+        block_retry_wakeup_scheduler =
+            match HvfArm64BootLimiterRetryWakeupScheduler::start_with_cancellation(
+                BLOCK_RETRY_WAKEUP_SCHEDULER_THREAD_NAME,
+                block_retry_wakeup.clone(),
+                move || vcpu_control.request_wakeup(),
+            ) {
+                Ok(scheduler) => Some(scheduler),
+                Err(source) => {
+                    release_unpublished_snapshot_v2_multi_block_pci_publications(
+                        &mut prepared_publications,
+                        &mut cleanup,
+                    );
+                    return Err(failed_snapshot_v2_multi_block_pci_after_platform(
+                        platform,
+                        HvfSnapshotV2MultiBlockPciRestoreStage::RetryScheduler,
+                        HvfSnapshotV2MultiBlockPciRestoreFailure::RetryScheduler(source.kind()),
+                        &mut block_retry_wakeup_scheduler,
+                        async_runtime.as_ref(),
+                        &mut pci_data_devices,
+                        cleanup,
+                    ));
+                }
+            };
+
+        let publication_result = (|| {
+            let manager = pci_data_devices.as_mut().ok_or((
+                HvfSnapshotV2MultiBlockPciRestoreStage::PciRoutes,
+                HvfSnapshotV2MultiBlockPciRestoreFailure::ResourcePlan,
+            ))?;
+            for index in 0..record_count {
+                let planned = pci_plan.records().get(index).ok_or((
+                    HvfSnapshotV2MultiBlockPciRestoreStage::Publication { index },
+                    HvfSnapshotV2MultiBlockPciRestoreFailure::ResourcePlan,
+                ))?;
+                let prepared = prepared_publications
+                    .get(index)
+                    .and_then(Option::as_ref)
+                    .ok_or((
+                        HvfSnapshotV2MultiBlockPciRestoreStage::Publication { index },
+                        HvfSnapshotV2MultiBlockPciRestoreFailure::ResourcePlan,
+                    ))?;
+                if prepared.endpoint.key() != planned.key() || manager.block.len() != index {
+                    return Err((
+                        HvfSnapshotV2MultiBlockPciRestoreStage::Publication { index },
+                        HvfSnapshotV2MultiBlockPciRestoreFailure::ResourcePlan,
+                    ));
+                }
+                let prepared = prepared_publications
+                    .get_mut(index)
+                    .and_then(Option::take)
+                    .ok_or((
+                        HvfSnapshotV2MultiBlockPciRestoreStage::Publication { index },
+                        HvfSnapshotV2MultiBlockPciRestoreFailure::ResourcePlan,
+                    ))?;
+                let PreparedHvfSnapshotV2MultiBlockPciPublication {
+                    endpoint,
+                    mut interrupts,
+                    metrics_lease,
+                } = prepared;
+                let (
+                    _key,
+                    drive_id,
+                    is_root_device,
+                    _retry,
+                    retry_deadline,
+                    origin,
+                    _async_generation,
+                    endpoint,
+                ) = endpoint.into_parts();
+                let segment = manager.validation.segment().clone();
+                let published = {
+                    let mut dispatcher = match manager.dispatcher.lock() {
+                        Ok(dispatcher) => dispatcher,
+                        Err(_) => {
+                            drop(endpoint);
+                            drop(metrics_lease);
+                            release_unpublished_snapshot_v2_multi_block_pci_interrupts(
+                                index,
+                                &mut interrupts,
+                                &mut cleanup,
+                            );
+                            return Err((
+                                HvfSnapshotV2MultiBlockPciRestoreStage::Publication { index },
+                                HvfSnapshotV2MultiBlockPciRestoreFailure::DispatcherUnavailable,
+                            ));
+                        }
+                    };
+                    endpoint
+                        .publish(
+                            manager.validation.bar_allocator_mut(),
+                            segment,
+                            &mut dispatcher,
+                            interrupts,
+                        )
+                        .map_err(|source| {
+                            (
+                                HvfSnapshotV2MultiBlockPciRestoreStage::Publication { index },
+                                HvfSnapshotV2MultiBlockPciRestoreFailure::PciPublication(source),
+                            )
+                        })?
+                };
+                manager.block.push(HvfArm64BootPciBlockDevice {
+                    drive_id,
+                    is_root_device,
+                    origin,
+                    published,
+                    queue_deliveries: 0,
+                    retry_deadline,
+                    _metrics_lease: Some(metrics_lease),
+                });
+            }
+            Ok(())
+        })();
+        if let Err((stage, failure)) = publication_result {
+            release_unpublished_snapshot_v2_multi_block_pci_publications(
+                &mut prepared_publications,
+                &mut cleanup,
+            );
+            return Err(failed_snapshot_v2_multi_block_pci_after_platform(
+                platform,
+                stage,
+                failure,
+                &mut block_retry_wakeup_scheduler,
+                async_runtime.as_ref(),
+                &mut pci_data_devices,
+                cleanup,
+            ));
+        }
+
+        let Some(block_retry_wakeup_scheduler) = block_retry_wakeup_scheduler.take() else {
+            std::process::abort();
+        };
+        block_retry_wakeup_scheduler.schedule_deadline(earliest_retry_deadline);
+
+        let parts = platform.into_parts();
+        let machine_config = parts.machine.machine();
+        let cpu_template_application = parts.machine.cpu_template().cloned();
+        let cache_source = crate::vcpu_config::HvfArm64VcpuCacheFdtSource::new(
+            parts.compatibility.identification().id_aa64mmfr2_el1(),
+            parts.compatibility.cache_manifest(),
+        );
+        let gic = parts.compatibility.gic_metadata();
+        let serial_interrupt_line = parts
+            .serial_device
+            .as_ref()
+            .map(|device| device.fdt_device.interrupt_line);
+        let vmgenid_interrupt_line = parts.vmgenid_device.fdt_device.interrupt_line;
+        let vmclock_interrupt_line = parts.vmclock_device.fdt_device.interrupt_line;
+        let runtime_resources = Arm64BootRuntimeResources {
+            machine_config,
+            layout,
+            boot_origin: None,
+            retained_fdt: Some(retained_fdt),
+            rtc_device: Some(parts.rtc_device),
+            serial_device: parts.serial_device,
+            vmgenid_device: parts.vmgenid_device,
+            vmclock_device: parts.vmclock_device,
+            pvtime_state: Arm64BootPvTimeState::restored(parts.pvtime_layout),
+            block_devices: Vec::new(),
+            block_async_runtime: async_runtime.unwrap_or_default(),
+            pci_block_devices: Vec::new(),
+            pmem_devices: Vec::new(),
+            pmem_mmio_devices: Vec::new(),
+            network_devices: Vec::new(),
+            pci_network_devices: Vec::new(),
+            vsock_device: None,
+            pci_vsock_device: None,
+            balloon_device: None,
+            pci_balloon_device: None,
+            memory_hotplug_device: None,
+            pci_memory_hotplug_device: None,
+            entropy_device: None,
+            pci_entropy_device: None,
+            pci_validation: None,
+        };
+        let pmem_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        let network_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        let entropy_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        let session = Self {
+            runner: parts.runner,
+            backend: parts.backend,
+            mmio_dispatcher: parts.mmio_dispatcher,
+            runtime_resources,
+            _restored_snapshot_v2_mmio_registrations: None,
+            restored_snapshot_v2_memory_binding: Some(parts.memory_binding),
+            restored_snapshot_v2_machine: Some(parts.machine),
+            cpu_template_application,
+            pci_validation_endpoint: None,
+            pci_data_devices,
+            cache_source,
+            cache_hierarchy: None,
+            control_wakeup: HvfArm64BootRunLoopControlWakeupToken::default(),
+            run_loop_wakeup: HvfArm64BootRunLoopWakeupToken::default(),
+            block_retry_wakeup,
+            block_retry_wakeup_scheduler,
+            pmem_retry_wakeup,
+            pmem_retry_wakeup_scheduler: HvfArm64BootLimiterRetryWakeupScheduler::inactive(),
+            network_retry_wakeup,
+            network_retry_wakeup_scheduler: HvfArm64BootLimiterRetryWakeupScheduler::inactive(),
+            entropy_retry_wakeup,
+            entropy_retry_wakeup_scheduler: HvfArm64BootLimiterRetryWakeupScheduler::inactive(),
+            entropy_source: VirtioRngOsEntropySource::new(),
+            block_device_metrics,
+            pmem_device_metrics: SharedPmemDeviceMetricsRegistry::default(),
+            balloon_device_metrics: SharedBalloonDeviceMetrics::default(),
+            memory_hotplug_device_metrics: None,
+            network_interface_metrics: SharedNetworkInterfaceMetricsRegistry::default(),
+            vsock_device_metrics: SharedVsockDeviceMetrics::default(),
+            entropy_device_metrics: SharedEntropyDeviceMetrics::default(),
+            gic,
+            block_interrupt_lines: Vec::new(),
+            pmem_interrupt_lines: Vec::new(),
+            network_interrupt_lines: Vec::new(),
+            vsock_interrupt_line: None,
+            balloon_interrupt_line: None,
+            entropy_interrupt_line: None,
+            memory_hotplug_interrupt_line: None,
+            serial_interrupt_line,
+            serial_input: None,
+            vmgenid_interrupt_line,
+            vmclock_interrupt_line,
+            boot_registers: None,
+        };
+        Ok(RestoredHvfSnapshotV2MultiBlockPciOwners {
             session,
             drive_configs,
         })
@@ -21297,6 +22686,103 @@ mod tests {
     const TEST_MEMORY_MIB: u64 = 8;
     const ARM64_IMAGE_HEADER_SIZE: usize = 64;
     const ARM64_IMAGE_TEXT_OFFSET_OFFSET: usize = 8;
+
+    #[derive(Debug)]
+    struct UnusedUnpublishedPciInterrupt;
+
+    impl bangbang_runtime::message_interrupt::GuestMessageInterrupt for UnusedUnpublishedPciInterrupt {
+        fn matches(&self, _message: bangbang_runtime::message_interrupt::GuestMessage) -> bool {
+            false
+        }
+
+        fn signal(
+            &self,
+            _message: bangbang_runtime::message_interrupt::GuestMessage,
+        ) -> Result<(), bangbang_runtime::message_interrupt::GuestMessageInterruptSignalError>
+        {
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingUnpublishedPciInterrupts {
+        registry: bangbang_runtime::message_interrupt::GuestMessageInterruptRegistry,
+        release_count: usize,
+    }
+
+    impl bangbang_runtime::message_interrupt::GuestMessageInterruptResources
+        for FailingUnpublishedPciInterrupts
+    {
+        fn registry(&self) -> bangbang_runtime::message_interrupt::GuestMessageInterruptRegistry {
+            self.registry.clone()
+        }
+
+        fn release(
+            &mut self,
+        ) -> Result<(), bangbang_runtime::message_interrupt::GuestMessageInterruptResourcesError>
+        {
+            self.release_count += 1;
+            Err(
+                bangbang_runtime::message_interrupt::GuestMessageInterruptResourcesError::new(
+                    "secret-unpublished-route-cleanup",
+                ),
+            )
+        }
+    }
+
+    #[test]
+    fn unpublished_multi_block_pci_route_release_failure_is_retained_and_redacted() {
+        let mut interrupts = FailingUnpublishedPciInterrupts {
+            registry: bangbang_runtime::message_interrupt::GuestMessageInterruptRegistry::new(
+                vec![Arc::new(UnusedUnpublishedPciInterrupt)],
+            )
+            .expect("single-route test registry should validate"),
+            release_count: 0,
+        };
+        let mut cleanup = Vec::new();
+
+        super::release_unpublished_snapshot_v2_multi_block_pci_interrupts(
+            7,
+            &mut interrupts,
+            &mut cleanup,
+        );
+
+        assert_eq!(interrupts.release_count, 1);
+        assert_eq!(cleanup.len(), 1);
+        assert!(!format!("{cleanup:?}").contains("secret-unpublished"));
+        assert!(!cleanup[0].to_string().contains("secret-unpublished"));
+    }
+
+    #[test]
+    fn multi_block_pci_resource_plan_rejects_mismatched_root_command_line() {
+        let (platform, bundle, plan) =
+            crate::snapshot_v2_multi_block_platform::tests::rooted_pci_bundle_and_fdt_plan_fixture(
+            );
+        let prepared = bundle
+            .prepare_pci_transport()
+            .expect("rooted PCI bundle should prepare");
+        let mut plan = plan.into_parts();
+        let base_arguments = platform.machine().boot().boot_arguments();
+
+        assert!(super::validate_snapshot_v2_multi_block_pci_resource_plan(
+            &prepared,
+            &plan,
+            base_arguments,
+        ));
+
+        plan.command_line = bangbang_runtime::boot::canonical_process_root_block_command_line(
+            base_arguments,
+            true,
+            Some("mismatched-partuuid"),
+            true,
+        )
+        .expect("mismatched root command line should still be syntactically valid");
+        assert!(!super::validate_snapshot_v2_multi_block_pci_resource_plan(
+            &prepared,
+            &plan,
+            base_arguments,
+        ));
+    }
 
     #[test]
     fn vsock_run_loop_wakeup_token_retains_each_pending_request() {
@@ -32302,6 +33788,91 @@ mod tests {
         assert!(cleanup_debug.contains("<redacted>"));
         for diagnostics in [debug, incomplete.to_string(), cleanup_debug] {
             assert!(!diagnostics.contains("secret-cleanup"));
+        }
+    }
+
+    #[test]
+    fn native_v2_multi_block_pci_errors_preserve_terminality_and_redact_cleanup() {
+        let retryable = super::HvfSnapshotV2MultiBlockPciRestoreError::preflight(
+            super::HvfSnapshotV2MultiBlockPciRestoreStage::ResourcePlan,
+            super::HvfSnapshotV2MultiBlockPciRestoreFailure::ResourcePlan,
+        );
+        assert!(!retryable.has_incomplete_cleanup());
+        assert!(!retryable.is_terminal());
+
+        let clean_rollback = super::HvfSnapshotV2MultiBlockPciRestoreError::after_platform(
+            super::HvfSnapshotV2MultiBlockPciRestoreStage::Publication { index: 1 },
+            super::HvfSnapshotV2MultiBlockPciRestoreFailure::ResourcePlan,
+            Vec::new(),
+        );
+        assert!(!clean_rollback.has_incomplete_cleanup());
+        assert!(!clean_rollback.is_terminal());
+
+        let publication_rollback = super::HvfSnapshotV2MultiBlockPciRestoreError::after_platform(
+            super::HvfSnapshotV2MultiBlockPciRestoreStage::Publication { index: 1 },
+            super::HvfSnapshotV2MultiBlockPciRestoreFailure::PciPublication(
+                super::VirtioPciPublicationError::Rollback {
+                    primary: "secret-primary/path".to_owned(),
+                    cleanup: "secret-publication-cleanup/path".to_owned(),
+                },
+            ),
+            Vec::new(),
+        );
+        assert!(publication_rollback.has_incomplete_cleanup());
+        assert!(publication_rollback.is_terminal());
+        assert!(!format!("{publication_rollback:?}").contains("secret-primary"));
+        assert!(
+            !publication_rollback
+                .to_string()
+                .contains("secret-publication-cleanup")
+        );
+        let publication_failure =
+            std::error::Error::source(&publication_rollback).expect("failure should be retained");
+        assert!(publication_failure.source().is_none());
+
+        let route_rollback = super::HvfSnapshotV2MultiBlockPciRestoreError::after_platform(
+            super::HvfSnapshotV2MultiBlockPciRestoreStage::PciRoutes,
+            super::HvfSnapshotV2MultiBlockPciRestoreFailure::PciRoutes(
+                super::HvfGicMsiDeviceInterruptResourceError::Rollback {
+                    primary: "secret-route-primary/path".to_owned(),
+                    cleanup: crate::gic::HvfGicMsiInterruptReleaseError::Stale,
+                },
+            ),
+            Vec::new(),
+        );
+        assert!(route_rollback.has_incomplete_cleanup());
+        assert!(route_rollback.is_terminal());
+        assert!(!format!("{route_rollback:?}").contains("secret-route-primary"));
+        assert!(!route_rollback.to_string().contains("secret-route-primary"));
+        let route_failure =
+            std::error::Error::source(&route_rollback).expect("failure should be retained");
+        assert!(route_failure.source().is_none());
+
+        let incomplete = super::HvfSnapshotV2MultiBlockPciRestoreError::after_platform(
+            super::HvfSnapshotV2MultiBlockPciRestoreStage::RetryScheduler,
+            super::HvfSnapshotV2MultiBlockPciRestoreFailure::RetryScheduler(
+                io::ErrorKind::PermissionDenied,
+            ),
+            vec![
+                super::HvfSnapshotV2MultiBlockPciRestoreCleanupFailure::Pci(
+                    super::HvfArm64BootPciDataError::new("secret-pci-cleanup/path"),
+                ),
+                super::HvfSnapshotV2MultiBlockPciRestoreCleanupFailure::Platform(
+                    crate::snapshot_v2_platform::HvfSnapshotV2PlatformShutdownError::Backend(
+                        super::BackendError::Hypervisor("secret-platform-cleanup/path".to_string()),
+                    ),
+                ),
+            ],
+        );
+        assert!(incomplete.has_incomplete_cleanup());
+        assert!(incomplete.is_terminal());
+        let debug = format!("{incomplete:?}");
+        let cleanup_debug = format!("{:?}", incomplete.cleanup_failures());
+        assert!(debug.contains("<redacted>"));
+        assert!(cleanup_debug.contains("<redacted>"));
+        for diagnostics in [debug, incomplete.to_string(), cleanup_debug] {
+            assert!(!diagnostics.contains("secret-pci"));
+            assert!(!diagnostics.contains("secret-platform"));
         }
     }
 

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -7876,6 +7876,140 @@ fn notify_native_v2_multi_block_queue(
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn activate_native_v2_multi_block_pci_queue(
+    session: &bangbang_hvf::OwnedHvfArm64BootSession,
+    bar_base: bangbang_runtime::memory::GuestAddress,
+    fixture: NativeV2MultiBlockQueueFixture,
+    message_address: u64,
+    message_data: u32,
+) {
+    use bangbang_runtime::virtio::{
+        VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DRIVER,
+        VIRTIO_DEVICE_STATUS_DRIVER_OK, VIRTIO_DEVICE_STATUS_FEATURES_OK,
+    };
+    use bangbang_runtime::virtio_pci::VIRTIO_PCI_MSIX_TABLE_OFFSET;
+
+    const DRIVER_FEATURE_SELECT: u64 = 0x08;
+    const DRIVER_FEATURE: u64 = 0x0c;
+    const DEVICE_STATUS: u64 = 0x14;
+    const QUEUE_SELECT: u64 = 0x16;
+    const QUEUE_SIZE: u64 = 0x18;
+    const QUEUE_MSIX_VECTOR: u64 = 0x1a;
+    const QUEUE_ENABLE: u64 = 0x1c;
+    const QUEUE_DESC_LOW: u64 = 0x20;
+    const QUEUE_AVAIL_LOW: u64 = 0x28;
+    const QUEUE_USED_LOW: u64 = 0x30;
+
+    let dispatcher = session.mmio_dispatcher();
+    let mut dispatcher = dispatcher
+        .lock()
+        .expect("multi-block PCI dispatcher should not be poisoned");
+    let write =
+        |dispatcher: &mut bangbang_runtime::mmio::MmioDispatcher, offset: u64, data: &[u8]| {
+            write_native_v2_multi_block_mmio(
+                dispatcher,
+                bar_base
+                    .checked_add(offset)
+                    .expect("multi-block PCI BAR address should fit"),
+                data,
+            );
+        };
+
+    write(
+        &mut dispatcher,
+        VIRTIO_PCI_MSIX_TABLE_OFFSET,
+        &message_address.to_le_bytes(),
+    );
+    write(
+        &mut dispatcher,
+        VIRTIO_PCI_MSIX_TABLE_OFFSET + 8,
+        &u64::from(message_data).to_le_bytes(),
+    );
+    for status in [
+        VIRTIO_DEVICE_STATUS_ACKNOWLEDGE,
+        VIRTIO_DEVICE_STATUS_ACKNOWLEDGE | VIRTIO_DEVICE_STATUS_DRIVER,
+    ] {
+        write(
+            &mut dispatcher,
+            DEVICE_STATUS,
+            &[u8::try_from(status).expect("virtio status should fit u8")],
+        );
+    }
+    write(&mut dispatcher, DRIVER_FEATURE_SELECT, &1_u32.to_le_bytes());
+    write(&mut dispatcher, DRIVER_FEATURE, &1_u32.to_le_bytes());
+    write(
+        &mut dispatcher,
+        DEVICE_STATUS,
+        &[u8::try_from(
+            VIRTIO_DEVICE_STATUS_ACKNOWLEDGE
+                | VIRTIO_DEVICE_STATUS_DRIVER
+                | VIRTIO_DEVICE_STATUS_FEATURES_OK,
+        )
+        .expect("virtio status should fit u8")],
+    );
+    write(&mut dispatcher, QUEUE_SELECT, &0_u16.to_le_bytes());
+    write(
+        &mut dispatcher,
+        QUEUE_SIZE,
+        &NATIVE_V2_MULTI_BLOCK_QUEUE_SIZE.to_le_bytes(),
+    );
+    write(&mut dispatcher, QUEUE_MSIX_VECTOR, &0_u16.to_le_bytes());
+    write(
+        &mut dispatcher,
+        QUEUE_DESC_LOW,
+        &u32::try_from(fixture.descriptor_table().raw_value())
+            .expect("multi-block descriptor address should fit u32")
+            .to_le_bytes(),
+    );
+    write(
+        &mut dispatcher,
+        QUEUE_AVAIL_LOW,
+        &u32::try_from(fixture.available_ring().raw_value())
+            .expect("multi-block available ring should fit u32")
+            .to_le_bytes(),
+    );
+    write(
+        &mut dispatcher,
+        QUEUE_USED_LOW,
+        &u32::try_from(fixture.used_ring().raw_value())
+            .expect("multi-block used ring should fit u32")
+            .to_le_bytes(),
+    );
+    write(&mut dispatcher, QUEUE_ENABLE, &1_u16.to_le_bytes());
+    write(
+        &mut dispatcher,
+        DEVICE_STATUS,
+        &[u8::try_from(
+            VIRTIO_DEVICE_STATUS_ACKNOWLEDGE
+                | VIRTIO_DEVICE_STATUS_DRIVER
+                | VIRTIO_DEVICE_STATUS_FEATURES_OK
+                | VIRTIO_DEVICE_STATUS_DRIVER_OK,
+        )
+        .expect("virtio status should fit u8")],
+    );
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn notify_native_v2_multi_block_pci_queue(
+    session: &bangbang_hvf::OwnedHvfArm64BootSession,
+    bar_base: bangbang_runtime::memory::GuestAddress,
+) {
+    use bangbang_runtime::virtio_pci::VIRTIO_PCI_NOTIFICATION_OFFSET;
+
+    let dispatcher = session.mmio_dispatcher();
+    let mut dispatcher = dispatcher
+        .lock()
+        .expect("multi-block PCI dispatcher should not be poisoned");
+    write_native_v2_multi_block_mmio(
+        &mut dispatcher,
+        bar_base
+            .checked_add(VIRTIO_PCI_NOTIFICATION_OFFSET)
+            .expect("multi-block PCI notification address should fit"),
+        &0_u16.to_le_bytes(),
+    );
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 fn native_v2_multi_block_interrupt_status(
     session: &bangbang_hvf::OwnedHvfArm64BootSession,
     transport_base: bangbang_runtime::memory::GuestAddress,
@@ -7976,7 +8110,7 @@ fn native_v2_multi_block_dispatch_signaled(
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 #[test]
-fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
+fn native_v2_multi_block_reconstructs_rooted_and_rootless_mmio_and_pci_owners() {
     use std::fs::OpenOptions;
     use std::time::Instant;
 
@@ -7990,6 +8124,7 @@ fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
     use bangbang_runtime::VmmAction;
     use bangbang_runtime::block::{
         BlockFileBacking, BlockMmioLayout, DriveCacheType, DriveConfigInput, DriveIoEngine,
+        PreparedBlockDevice,
     };
     use bangbang_runtime::boot::BootSourceConfigInput;
     use bangbang_runtime::machine::MachineConfigInput;
@@ -8000,7 +8135,7 @@ fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
     use bangbang_runtime::serial::{SharedSerialOutput, SharedSerialOutputBuffer};
     use bangbang_runtime::snapshot_device_v2::SnapshotV2DeviceTransport;
     use bangbang_runtime::snapshot_device_v2_5::SnapshotV2MultiBlockRestorePlan;
-    use bangbang_runtime::storage_capture::CaptureReadyStorageConfigs;
+    use bangbang_runtime::storage_capture::{CaptureReadyStorageConfigs, StorageDeviceOrigin};
     use bangbang_runtime::vsock::VsockMmioLayout;
 
     let _test_lock = HVF_LIFECYCLE_TEST_LOCK
@@ -8008,9 +8143,11 @@ fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
         .expect("HVF lifecycle test lock should not be poisoned");
     let image = arm64_image().expect("test arm64 image should build");
 
-    for (case, rooted) in [
-        ("native-v2-multi-block-mmio-rooted-owner", true),
-        ("native-v2-multi-block-mmio-rootless-owner", false),
+    for (case, rooted, pci_enabled) in [
+        ("native-v2-multi-block-mmio-rooted-owner", true, false),
+        ("native-v2-multi-block-mmio-rootless-owner", false, false),
+        ("native-v2-multi-block-pci-rooted-owner", true, true),
+        ("native-v2-multi-block-pci-rootless-owner", false, true),
     ] {
         let kernel = TempFile::new(&format!("{case}-kernel"), &image)
             .unwrap_or_else(|error| panic!("{case} kernel should create: {error}"));
@@ -8035,19 +8172,20 @@ fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
                     .with_io_engine(DriveIoEngine::Sync),
             ))
             .unwrap_or_else(|error| panic!("{case} Sync drive should configure: {error}"));
-        controller
-            .handle_action(VmmAction::PutDrive(
-                DriveConfigInput::new("async", "async", second.path(), false)
-                    .with_is_read_only(false)
-                    .with_cache_type(DriveCacheType::Writeback)
-                    .with_io_engine(DriveIoEngine::Async),
-            ))
-            .unwrap_or_else(|error| panic!("{case} Async drive should configure: {error}"));
+        let async_input = DriveConfigInput::new("async", "async", second.path(), false)
+            .with_is_read_only(false)
+            .with_cache_type(DriveCacheType::Writeback)
+            .with_io_engine(DriveIoEngine::Async);
+        if !pci_enabled {
+            controller
+                .handle_action(VmmAction::PutDrive(async_input.clone()))
+                .unwrap_or_else(|error| panic!("{case} Async drive should configure: {error}"));
+        }
 
         let block_layout =
             BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1));
         let source_serial = SharedSerialOutputBuffer::default();
-        let session_config = HvfArm64BootSessionConfig::new(
+        let mut session_config = HvfArm64BootSessionConfig::new(
             block_layout,
             PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500)),
             NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000)),
@@ -8062,8 +8200,30 @@ fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
             GuestAddress::new(0x4000_2000),
             SharedSerialOutput::from(source_serial),
         ));
+        if pci_enabled {
+            session_config = session_config.with_pci_enabled();
+        }
         let mut source = OwnedHvfArm64BootSession::new(&controller, session_config)
             .unwrap_or_else(|error| panic!("{case} source should prepare: {error}"));
+        if pci_enabled {
+            let async_config = async_input
+                .clone()
+                .validate()
+                .unwrap_or_else(|error| panic!("{case} Async config should validate: {error}"));
+            controller
+                .handle_action(VmmAction::PutDrive(async_input))
+                .unwrap_or_else(|error| panic!("{case} Async drive should configure: {error}"));
+            source
+                .insert_runtime_block_device(
+                    PreparedBlockDevice::from_config_with_backing(&async_config, None)
+                        .unwrap_or_else(|error| {
+                            panic!("{case} runtime Async drive should prepare: {error}")
+                        }),
+                )
+                .unwrap_or_else(|error| {
+                    panic!("{case} runtime Async drive should publish: {error}")
+                });
+        }
 
         let source_entry = GuestAddress::new(
             source
@@ -8130,6 +8290,13 @@ fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
             .unwrap_or_else(|error| panic!("{case} graph should capture: {error}"));
         assert_eq!(graph.records().len(), 2);
         assert_eq!(graph.root_key().is_some(), rooted);
+        if pci_enabled {
+            let SnapshotV2DeviceTransport::Pci(second_transport) = graph.records()[1].transport()
+            else {
+                panic!("{case} runtime record should use PCI");
+            };
+            assert_eq!(second_transport.origin(), StorageDeviceOrigin::Runtime);
+        }
         source
             .pause_for_snapshot_v2_capture()
             .unwrap_or_else(|error| panic!("{case} source should pause: {error}"));
@@ -8216,22 +8383,35 @@ fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
         let platform_plan = prepare_hvf_snapshot_v2_multi_block_platform_plan(
             &source_platform,
             &bundle,
-            HvfSnapshotV2MultiBlockProcessConfig::new(block_layout, false),
+            HvfSnapshotV2MultiBlockProcessConfig::new(block_layout, pci_enabled),
         )
         .unwrap_or_else(|error| panic!("{case} platform plan should prepare: {error}"));
         let restored_serial = SharedSerialOutputBuffer::default();
         let shell =
             HvfSnapshotV2DefaultProcessShell::new(SharedSerialOutput::from(restored_serial));
-        let owners = OwnedHvfArm64BootSession::restore_snapshot_v2_multi_block_mmio(
-            source_platform.clone(),
-            restored_memory,
-            shell,
-            bundle,
-            platform_plan,
-        )
-        .unwrap_or_else(|error| panic!("{case} owner vector should restore: {error:?}"));
-        assert_eq!(owners.drive_configs(), &drive_configs);
-        let (mut restored, restored_drive_configs) = owners.into_parts();
+        let (mut restored, restored_drive_configs) = if pci_enabled {
+            let owners = OwnedHvfArm64BootSession::restore_snapshot_v2_multi_block_pci(
+                source_platform.clone(),
+                restored_memory,
+                shell,
+                bundle,
+                platform_plan,
+            )
+            .unwrap_or_else(|error| panic!("{case} PCI owner vector should restore: {error:?}"));
+            assert_eq!(owners.drive_configs(), &drive_configs);
+            owners.into_parts()
+        } else {
+            let owners = OwnedHvfArm64BootSession::restore_snapshot_v2_multi_block_mmio(
+                source_platform.clone(),
+                restored_memory,
+                shell,
+                bundle,
+                platform_plan,
+            )
+            .unwrap_or_else(|error| panic!("{case} MMIO owner vector should restore: {error:?}"));
+            assert_eq!(owners.drive_configs(), &drive_configs);
+            owners.into_parts()
+        };
         assert_eq!(
             restored
                 .capture_arm64_general_register_state()
@@ -8243,24 +8423,57 @@ fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
             0xc0,
             "{case} restored synthetic guest should retain IRQ and FIQ masks"
         );
-        assert_eq!(restored.runtime_resources().block_devices.len(), 2);
-        for ((device, record), config) in restored
-            .runtime_resources()
-            .block_devices
-            .iter()
-            .zip(graph.records())
-            .zip(restored_drive_configs.as_slice())
-        {
-            let SnapshotV2DeviceTransport::Mmio(mmio) = record.transport() else {
-                panic!("{case} record should retain MMIO transport");
-            };
+        assert_eq!(restored.uses_pci_data_devices(), pci_enabled);
+        if pci_enabled {
+            assert!(restored.runtime_resources().block_devices.is_empty());
+            assert!(restored.runtime_resources().pci_block_devices.is_empty());
+            assert!(restored.block_interrupt_lines().is_empty());
+            let diagnostics = restored
+                .pci_data_device_diagnostics()
+                .expect("restored PCI manager should exist")
+                .unwrap_or_else(|error| panic!("{case} PCI diagnostics should inspect: {error}"));
+            assert_eq!(diagnostics.len(), 2);
+            for (diagnostics, config) in diagnostics.iter().zip(restored_drive_configs.as_slice()) {
+                assert_eq!(
+                    diagnostics.kind,
+                    bangbang_hvf::HvfArm64BootPciDataDeviceKind::Block
+                );
+                assert_eq!(diagnostics.id, config.drive_id());
+                assert_eq!(
+                    diagnostics.transport.phase,
+                    bangbang_runtime::virtio_pci::VirtioPciEndpointPhase::Active
+                );
+                assert!(!diagnostics.transport.device_activated);
+                assert_eq!(diagnostics.queue_deliveries, 0);
+            }
             assert_eq!(
-                device.registration.index(),
-                record.key().instance() as usize
+                restored
+                    .runtime_resources()
+                    .block_async_runtime
+                    .generation_count()
+                    .expect("restored PCI Async runtime should inspect"),
+                1
             );
-            assert_eq!(device.registration.drive_id(), config.drive_id());
-            assert_eq!(device.registration.region(), mmio.region());
-            assert_eq!(device.fdt_device.interrupt_line, mmio.interrupt_line());
+        } else {
+            assert_eq!(restored.runtime_resources().block_devices.len(), 2);
+            for ((device, record), config) in restored
+                .runtime_resources()
+                .block_devices
+                .iter()
+                .zip(graph.records())
+                .zip(restored_drive_configs.as_slice())
+            {
+                let SnapshotV2DeviceTransport::Mmio(mmio) = record.transport() else {
+                    panic!("{case} record should retain MMIO transport");
+                };
+                assert_eq!(
+                    device.registration.index(),
+                    record.key().instance() as usize
+                );
+                assert_eq!(device.registration.drive_id(), config.drive_id());
+                assert_eq!(device.registration.region(), mmio.region());
+                assert_eq!(device.fdt_device.interrupt_line, mmio.interrupt_line());
+            }
         }
 
         let metrics = restored.shared_block_device_metrics();
@@ -8282,7 +8495,7 @@ fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
             0
         );
 
-        {
+        if !pci_enabled {
             let dispatcher = restored.mmio_dispatcher();
             let mut dispatcher = dispatcher
                 .lock()
@@ -8351,12 +8564,16 @@ fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
         assert_native_v2_platform_recapture_equivalent(&source_platform, &recaptured_platform);
         drop(restored_guard);
 
-        let mut transport_bases = graph.records().iter().map(|record| {
-            let SnapshotV2DeviceTransport::Mmio(mmio) = record.transport() else {
-                panic!("{case} restored test record should use MMIO");
-            };
-            mmio.region().range().start()
-        });
+        let mut transport_bases = graph
+            .records()
+            .iter()
+            .map(|record| match record.transport() {
+                SnapshotV2DeviceTransport::Mmio(mmio) if !pci_enabled => {
+                    mmio.region().range().start()
+                }
+                SnapshotV2DeviceTransport::Pci(pci) if pci_enabled => pci.bar_range().start(),
+                _ => panic!("{case} restored test record should use the selected transport"),
+            });
         let sync_transport_base = transport_bases
             .next()
             .expect("Sync transport base should exist");
@@ -8374,16 +8591,45 @@ fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
             initialize_native_v2_multi_block_queue(memory, NATIVE_V2_MULTI_BLOCK_SYNC_QUEUE);
             initialize_native_v2_multi_block_queue(memory, NATIVE_V2_MULTI_BLOCK_ASYNC_QUEUE);
         }
-        activate_native_v2_multi_block_queue(
-            &restored,
-            sync_transport_base,
-            NATIVE_V2_MULTI_BLOCK_SYNC_QUEUE,
-        );
-        activate_native_v2_multi_block_queue(
-            &restored,
-            async_transport_base,
-            NATIVE_V2_MULTI_BLOCK_ASYNC_QUEUE,
-        );
+        if pci_enabled {
+            let msi = restored
+                .gic_metadata()
+                .msi
+                .expect("restored PCI GIC should retain MSI metadata");
+            let message_address = msi
+                .region
+                .base
+                .checked_add(bangbang_runtime::fdt::ARM64_GICV2M_MSI_SET_SPI_NSR_OFFSET)
+                .expect("GICv2m message address should fit");
+            activate_native_v2_multi_block_pci_queue(
+                &restored,
+                sync_transport_base,
+                NATIVE_V2_MULTI_BLOCK_SYNC_QUEUE,
+                message_address,
+                msi.interrupt_range.base,
+            );
+            activate_native_v2_multi_block_pci_queue(
+                &restored,
+                async_transport_base,
+                NATIVE_V2_MULTI_BLOCK_ASYNC_QUEUE,
+                message_address,
+                msi.interrupt_range
+                    .base
+                    .checked_add(1)
+                    .expect("second GICv2m INTID should fit"),
+            );
+        } else {
+            activate_native_v2_multi_block_queue(
+                &restored,
+                sync_transport_base,
+                NATIVE_V2_MULTI_BLOCK_SYNC_QUEUE,
+            );
+            activate_native_v2_multi_block_queue(
+                &restored,
+                async_transport_base,
+                NATIVE_V2_MULTI_BLOCK_ASYNC_QUEUE,
+            );
+        }
 
         {
             let memory = restored
@@ -8395,19 +8641,33 @@ fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
                 0x5a,
             );
         }
-        notify_native_v2_multi_block_queue(&restored, sync_transport_base);
+        if pci_enabled {
+            notify_native_v2_multi_block_pci_queue(&restored, sync_transport_base);
+        } else {
+            notify_native_v2_multi_block_queue(&restored, sync_transport_base);
+        }
         let sync_dispatches = restored
             .dispatch_block_queue_notifications_and_signal_interrupts()
             .unwrap_or_else(|error| panic!("{case} Sync requests should dispatch: {error}"));
-        assert_eq!(sync_dispatches.len(), 2);
-        assert!(native_v2_multi_block_dispatch_signaled(
-            &sync_dispatches,
-            restored_drive_configs.as_slice()[0].drive_id(),
-        ));
-        assert!(!native_v2_multi_block_dispatch_signaled(
-            &sync_dispatches,
-            restored_drive_configs.as_slice()[1].drive_id(),
-        ));
+        if pci_enabled {
+            assert!(sync_dispatches.is_empty());
+            let diagnostics = restored
+                .pci_data_device_diagnostics()
+                .expect("restored PCI manager should exist")
+                .unwrap_or_else(|error| panic!("{case} PCI diagnostics should inspect: {error}"));
+            assert_eq!(diagnostics[0].queue_deliveries, 1);
+            assert_eq!(diagnostics[1].queue_deliveries, 0);
+        } else {
+            assert_eq!(sync_dispatches.len(), 2);
+            assert!(native_v2_multi_block_dispatch_signaled(
+                &sync_dispatches,
+                restored_drive_configs.as_slice()[0].drive_id(),
+            ));
+            assert!(!native_v2_multi_block_dispatch_signaled(
+                &sync_dispatches,
+                restored_drive_configs.as_slice()[1].drive_id(),
+            ));
+        }
         assert_eq!(
             native_v2_multi_block_used_index(&restored, NATIVE_V2_MULTI_BLOCK_SYNC_QUEUE),
             2
@@ -8442,15 +8702,28 @@ fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
                 0xa5,
             );
         }
-        notify_native_v2_multi_block_queue(&restored, async_transport_base);
-        let mut async_interrupt_signaled = false;
+        if pci_enabled {
+            notify_native_v2_multi_block_pci_queue(&restored, async_transport_base);
+        } else {
+            notify_native_v2_multi_block_queue(&restored, async_transport_base);
+        }
         let initial_async_dispatches = restored
             .dispatch_block_queue_notifications_and_signal_interrupts()
             .unwrap_or_else(|error| panic!("{case} Async requests should schedule: {error}"));
-        async_interrupt_signaled |= native_v2_multi_block_dispatch_signaled(
-            &initial_async_dispatches,
-            restored_drive_configs.as_slice()[1].drive_id(),
-        );
+        let mut async_interrupt_signaled = if pci_enabled {
+            assert!(initial_async_dispatches.is_empty());
+            restored
+                .pci_data_device_diagnostics()
+                .expect("restored PCI manager should exist")
+                .unwrap_or_else(|error| panic!("{case} PCI diagnostics should inspect: {error}"))[1]
+                .queue_deliveries
+                > 0
+        } else {
+            native_v2_multi_block_dispatch_signaled(
+                &initial_async_dispatches,
+                restored_drive_configs.as_slice()[1].drive_id(),
+            )
+        };
         for _ in 0..8 {
             if native_v2_multi_block_used_index(&restored, NATIVE_V2_MULTI_BLOCK_ASYNC_QUEUE) == 2 {
                 break;
@@ -8459,10 +8732,22 @@ fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
             let dispatches = restored
                 .dispatch_block_queue_notifications_and_signal_interrupts()
                 .unwrap_or_else(|error| panic!("{case} Async completion should dispatch: {error}"));
-            async_interrupt_signaled |= native_v2_multi_block_dispatch_signaled(
-                &dispatches,
-                restored_drive_configs.as_slice()[1].drive_id(),
-            );
+            if pci_enabled {
+                assert!(dispatches.is_empty());
+                async_interrupt_signaled |= restored
+                    .pci_data_device_diagnostics()
+                    .expect("restored PCI manager should exist")
+                    .unwrap_or_else(|error| {
+                        panic!("{case} PCI diagnostics should inspect: {error}")
+                    })[1]
+                    .queue_deliveries
+                    > 0;
+            } else {
+                async_interrupt_signaled |= native_v2_multi_block_dispatch_signaled(
+                    &dispatches,
+                    restored_drive_configs.as_slice()[1].drive_id(),
+                );
+            }
         }
         assert_eq!(
             native_v2_multi_block_used_index(&restored, NATIVE_V2_MULTI_BLOCK_ASYNC_QUEUE),
@@ -8493,19 +8778,35 @@ fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
             );
         }
 
-        let queue_interrupt = bangbang_runtime::interrupt::DeviceInterruptKind::Queue
-            .status()
-            .bits();
-        assert_eq!(
-            native_v2_multi_block_interrupt_status(&restored, sync_transport_base)
-                & queue_interrupt,
-            queue_interrupt
-        );
-        assert_eq!(
-            native_v2_multi_block_interrupt_status(&restored, async_transport_base)
-                & queue_interrupt,
-            queue_interrupt
-        );
+        if pci_enabled {
+            let diagnostics = restored
+                .pci_data_device_diagnostics()
+                .expect("restored PCI manager should exist")
+                .unwrap_or_else(|error| panic!("{case} PCI diagnostics should inspect: {error}"));
+            for endpoint in diagnostics {
+                assert!(endpoint.transport.device_activated);
+                assert!(endpoint.transport.driver_ready);
+                assert!(endpoint.transport.msix_enabled);
+                assert_eq!(endpoint.transport.programmed_msix_entries, 1);
+                assert_eq!(endpoint.transport.unmasked_msix_entries, 1);
+                assert_eq!(endpoint.transport.queue_vectors, [Some(0)]);
+                assert!(endpoint.queue_deliveries > 0);
+            }
+        } else {
+            let queue_interrupt = bangbang_runtime::interrupt::DeviceInterruptKind::Queue
+                .status()
+                .bits();
+            assert_eq!(
+                native_v2_multi_block_interrupt_status(&restored, sync_transport_base)
+                    & queue_interrupt,
+                queue_interrupt
+            );
+            assert_eq!(
+                native_v2_multi_block_interrupt_status(&restored, async_transport_base)
+                    & queue_interrupt,
+                queue_interrupt
+            );
+        }
 
         for (config, expected_byte) in restored_drive_configs.as_slice().iter().zip([0x5a, 0xa5]) {
             let snapshot = metrics
@@ -8556,7 +8857,7 @@ fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
             });
         assert_ne!(post_io_graph, graph);
         assert_eq!(continued_post_io_graph, post_io_graph);
-        for record in post_io_graph.records() {
+        for (index, record) in post_io_graph.records().iter().enumerate() {
             assert!(record.virtio().is_activated());
             assert!(
                 record
@@ -8573,6 +8874,47 @@ fn native_v2_multi_block_mmio_reconstructs_rooted_and_rootless_owners() {
                 .expect("restored block queue cursor should capture");
             assert_eq!(queue.next_available(), 2);
             assert_eq!(queue.next_used(), 2);
+            if pci_enabled {
+                let SnapshotV2DeviceTransport::Pci(pci) = record.transport() else {
+                    panic!("{case} post-I/O record should retain PCI");
+                };
+                let SnapshotV2DeviceTransport::Pci(original) = graph.records()[index].transport()
+                else {
+                    panic!("{case} original record should retain PCI");
+                };
+                assert_eq!(pci.origin(), original.origin());
+                assert_eq!(pci.sbdf(), original.sbdf());
+                assert_eq!(pci.bar_range(), original.bar_range());
+                assert_eq!(pci.msix().queue_vectors(), [0]);
+                let entry = pci.msix().entries()[0];
+                let msi = restored
+                    .gic_metadata()
+                    .msi
+                    .expect("restored PCI GIC should retain MSI metadata");
+                let message_address = msi
+                    .region
+                    .base
+                    .checked_add(bangbang_runtime::fdt::ARM64_GICV2M_MSI_SET_SPI_NSR_OFFSET)
+                    .expect("GICv2m message address should fit");
+                assert_eq!(
+                    entry.message_address_low(),
+                    u32::try_from(message_address & u64::from(u32::MAX))
+                        .expect("GICv2m message low word should fit")
+                );
+                assert_eq!(
+                    entry.message_address_high(),
+                    u32::try_from(message_address >> 32)
+                        .expect("GICv2m message high word should fit")
+                );
+                assert_eq!(
+                    entry.message_data(),
+                    msi.interrupt_range
+                        .base
+                        .checked_add(u32::try_from(index).expect("record index should fit"))
+                        .expect("GICv2m message INTID should fit")
+                );
+                assert_eq!(entry.vector_control(), 0);
+            }
         }
         drop(post_io_guard);
 

--- a/crates/runtime/src/snapshot_device_v2_5.rs
+++ b/crates/runtime/src/snapshot_device_v2_5.rs
@@ -42,10 +42,13 @@ mod restore;
 
 pub use restore::{
     PreparedSnapshotV2MultiBlockBundle, PreparedSnapshotV2MultiBlockMmioBundle,
-    PreparedSnapshotV2MultiBlockMmioRecord, PreparedSnapshotV2MultiBlockRecord,
+    PreparedSnapshotV2MultiBlockMmioRecord, PreparedSnapshotV2MultiBlockPciBundle,
+    PreparedSnapshotV2MultiBlockPciEndpoint, PreparedSnapshotV2MultiBlockPciEndpointParts,
+    PreparedSnapshotV2MultiBlockPciRecord, PreparedSnapshotV2MultiBlockRecord,
     SnapshotV2MultiBlockBundleError, SnapshotV2MultiBlockCleanupError,
-    SnapshotV2MultiBlockMmioTransportError, SnapshotV2MultiBlockRestorePlan,
-    SnapshotV2MultiBlockRestorePlanError, SnapshotV2MultiBlockRetryProjection,
+    SnapshotV2MultiBlockMmioTransportError, SnapshotV2MultiBlockPciTransportError,
+    SnapshotV2MultiBlockRestorePlan, SnapshotV2MultiBlockRestorePlanError,
+    SnapshotV2MultiBlockRetryProjection,
 };
 
 #[cfg(test)]

--- a/crates/runtime/src/snapshot_device_v2_5/restore.rs
+++ b/crates/runtime/src/snapshot_device_v2_5/restore.rs
@@ -10,17 +10,22 @@ use crate::block::async_executor::{
 };
 use crate::block::{
     PreparedBlockDevice, PreparedSnapshotBlockDeviceError, PreparedSnapshotBlockDeviceParts,
-    VIRTIO_RING_FEATURE_EVENT_IDX, VIRTIO_RING_FEATURE_INDIRECT_DESC, VirtioBlockConfigSpace,
+    VIRTIO_BLOCK_DEVICE_ID, VIRTIO_BLOCK_QUEUE_SIZES, VIRTIO_RING_FEATURE_EVENT_IDX,
+    VIRTIO_RING_FEATURE_INDIRECT_DESC, VirtioBlockConfigSpace, VirtioBlockDevice,
     VirtioBlockMmioHandler, VirtioBlockQueue, VirtioBlockRateLimiter, VirtioBlockRateLimiterState,
     VirtioBlockTokenBucketState, restore_prepared_block_mmio_handler,
 };
 use crate::interrupt::GuestInterruptLine;
-use crate::memory::GuestMemory;
-use crate::mmio::MmioRegion;
+use crate::memory::{GuestMemory, GuestMemoryRange};
+use crate::message_interrupt::GuestMessageInterruptRegistry;
+use crate::mmio::{MmioRegion, MmioRegionId};
+use crate::pci::PciSbdf;
 use crate::snapshot_device_v2::{
     SnapshotV2BlockBucketState, SnapshotV2RootTransportRestoreError, restore_mmio_transport_state,
 };
+use crate::virtio::VirtioDeviceType;
 use crate::virtio_mmio::VirtioMmioQueueState;
+use crate::virtio_pci::{PreparedVirtioPciEndpoint, VirtioPciIdentity, VirtioPciTransportState};
 
 /// Complete pure destination proof for one detached profile-2 graph.
 pub struct SnapshotV2MultiBlockRestorePlan {
@@ -595,6 +600,229 @@ impl fmt::Debug for PreparedSnapshotV2MultiBlockMmioBundle {
     }
 }
 
+/// One exact detached profile-2 PCI block owner awaiting live route resources.
+pub struct PreparedSnapshotV2MultiBlockPciRecord {
+    key: SnapshotV2DeviceKey,
+    drive_id: String,
+    is_root_device: bool,
+    retry: StorageRetryState,
+    retry_deadline: Option<Instant>,
+    origin: StorageDeviceOrigin,
+    sbdf: PciSbdf,
+    bar_range: GuestMemoryRange,
+    async_generation: Option<BlockAsyncDriveGeneration>,
+    config_space: VirtioBlockConfigSpace,
+    device: VirtioBlockDevice,
+    identity: VirtioPciIdentity,
+    retained: VirtioPciTransportState,
+}
+
+impl PreparedSnapshotV2MultiBlockPciRecord {
+    pub const fn key(&self) -> SnapshotV2DeviceKey {
+        self.key
+    }
+
+    pub fn drive_id(&self) -> &str {
+        &self.drive_id
+    }
+
+    pub const fn is_root_device(&self) -> bool {
+        self.is_root_device
+    }
+
+    pub const fn retry(&self) -> StorageRetryState {
+        self.retry
+    }
+
+    pub const fn retry_deadline(&self) -> Option<Instant> {
+        self.retry_deadline
+    }
+
+    pub const fn origin(&self) -> StorageDeviceOrigin {
+        self.origin
+    }
+
+    pub const fn sbdf(&self) -> PciSbdf {
+        self.sbdf
+    }
+
+    pub const fn bar_range(&self) -> GuestMemoryRange {
+        self.bar_range
+    }
+
+    pub const fn async_generation(&self) -> Option<BlockAsyncDriveGeneration> {
+        self.async_generation
+    }
+
+    /// Completes retained endpoint preparation against the destination's live
+    /// shared message registry without publishing a BAR or PCI function.
+    pub fn prepare_endpoint(
+        self,
+        region_id: MmioRegionId,
+        messages: GuestMessageInterruptRegistry,
+    ) -> Result<PreparedSnapshotV2MultiBlockPciEndpoint, SnapshotV2RootTransportRestoreError> {
+        let endpoint = PreparedVirtioPciEndpoint::new(
+            self.identity,
+            &VIRTIO_BLOCK_QUEUE_SIZES,
+            self.config_space,
+            self.device,
+            self.retained.is_device_activated(),
+            false,
+            &self.retained,
+            self.sbdf,
+            self.bar_range,
+            region_id,
+            messages,
+        )
+        .map_err(SnapshotV2RootTransportRestoreError::Pci)?;
+        Ok(PreparedSnapshotV2MultiBlockPciEndpoint {
+            key: self.key,
+            drive_id: self.drive_id,
+            is_root_device: self.is_root_device,
+            retry: self.retry,
+            retry_deadline: self.retry_deadline,
+            origin: self.origin,
+            async_generation: self.async_generation,
+            endpoint,
+        })
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2MultiBlockPciRecord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2MultiBlockPciRecord")
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// One fully checked, still-unpublished profile-2 PCI endpoint and owner
+/// metadata.
+pub struct PreparedSnapshotV2MultiBlockPciEndpoint {
+    key: SnapshotV2DeviceKey,
+    drive_id: String,
+    is_root_device: bool,
+    retry: StorageRetryState,
+    retry_deadline: Option<Instant>,
+    origin: StorageDeviceOrigin,
+    async_generation: Option<BlockAsyncDriveGeneration>,
+    endpoint: PreparedVirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice>,
+}
+
+/// Consumed exact owner metadata and unpublished retained PCI endpoint.
+pub type PreparedSnapshotV2MultiBlockPciEndpointParts = (
+    SnapshotV2DeviceKey,
+    String,
+    bool,
+    StorageRetryState,
+    Option<Instant>,
+    StorageDeviceOrigin,
+    Option<BlockAsyncDriveGeneration>,
+    PreparedVirtioPciEndpoint<VirtioBlockConfigSpace, VirtioBlockDevice>,
+);
+
+impl PreparedSnapshotV2MultiBlockPciEndpoint {
+    /// Returns the canonical graph key before publication consumes the value.
+    pub const fn key(&self) -> SnapshotV2DeviceKey {
+        self.key
+    }
+
+    /// Returns the public drive identifier used to claim its metrics lease.
+    pub fn drive_id(&self) -> &str {
+        &self.drive_id
+    }
+
+    /// Consumes the endpoint and its exact manager metadata.
+    pub fn into_parts(self) -> PreparedSnapshotV2MultiBlockPciEndpointParts {
+        (
+            self.key,
+            self.drive_id,
+            self.is_root_device,
+            self.retry,
+            self.retry_deadline,
+            self.origin,
+            self.async_generation,
+            self.endpoint,
+        )
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2MultiBlockPciEndpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2MultiBlockPciEndpoint")
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Move-only exact profile-2 PCI vector awaiting one private manager.
+pub struct PreparedSnapshotV2MultiBlockPciBundle {
+    drive_configs: DriveConfigs,
+    records: Vec<PreparedSnapshotV2MultiBlockPciRecord>,
+    async_runtime: Option<SharedBlockAsyncRuntime>,
+    async_generations: Vec<BlockAsyncDriveGeneration>,
+}
+
+impl PreparedSnapshotV2MultiBlockPciBundle {
+    pub const fn drive_configs(&self) -> &DriveConfigs {
+        &self.drive_configs
+    }
+
+    pub fn records(&self) -> &[PreparedSnapshotV2MultiBlockPciRecord] {
+        &self.records
+    }
+
+    pub const fn async_runtime(&self) -> Option<&SharedBlockAsyncRuntime> {
+        self.async_runtime.as_ref()
+    }
+
+    /// Transfers every detached endpoint owner, generation and controller
+    /// value into the destination transaction.
+    pub fn into_parts(
+        mut self,
+    ) -> (
+        DriveConfigs,
+        Vec<PreparedSnapshotV2MultiBlockPciRecord>,
+        Option<SharedBlockAsyncRuntime>,
+        Vec<BlockAsyncDriveGeneration>,
+    ) {
+        (
+            std::mem::take(&mut self.drive_configs),
+            std::mem::take(&mut self.records),
+            self.async_runtime.take(),
+            std::mem::take(&mut self.async_generations),
+        )
+    }
+
+    /// Explicitly releases every transferred fresh Async generation.
+    pub fn abort(mut self) -> Result<(), SnapshotV2MultiBlockCleanupError> {
+        let result =
+            cleanup_async_generations(self.async_runtime.as_ref(), &self.async_generations);
+        self.async_generations.clear();
+        self.async_runtime = None;
+        result
+    }
+}
+
+impl Drop for PreparedSnapshotV2MultiBlockPciBundle {
+    fn drop(&mut self) {
+        let _ = cleanup_async_generations(self.async_runtime.as_ref(), &self.async_generations);
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2MultiBlockPciBundle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2MultiBlockPciBundle")
+            .field("record_count", &self.records.len())
+            .field("has_async_runtime", &self.async_runtime.is_some())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
 #[derive(Debug)]
 enum SnapshotV2MultiBlockMmioTransportErrorKind {
     TransportPolicy,
@@ -607,6 +835,88 @@ enum SnapshotV2MultiBlockMmioTransportErrorKind {
 pub struct SnapshotV2MultiBlockMmioTransportError {
     kind: SnapshotV2MultiBlockMmioTransportErrorKind,
     cleanup: Option<SnapshotV2MultiBlockCleanupError>,
+}
+
+#[derive(Debug)]
+enum SnapshotV2MultiBlockPciTransportErrorKind {
+    TransportPolicy,
+    Allocation,
+    AsyncBinding,
+    Transport(SnapshotV2RootTransportRestoreError),
+}
+
+/// Redacted failure while consuming profile-2 devices into detached exact PCI
+/// transports.
+pub struct SnapshotV2MultiBlockPciTransportError {
+    kind: SnapshotV2MultiBlockPciTransportErrorKind,
+    cleanup: Option<SnapshotV2MultiBlockCleanupError>,
+}
+
+impl SnapshotV2MultiBlockPciTransportError {
+    fn new(
+        kind: SnapshotV2MultiBlockPciTransportErrorKind,
+        cleanup: Option<SnapshotV2MultiBlockCleanupError>,
+    ) -> Self {
+        Self { kind, cleanup }
+    }
+
+    pub const fn cleanup_failed(&self) -> bool {
+        self.cleanup.is_some()
+    }
+}
+
+impl fmt::Debug for SnapshotV2MultiBlockPciTransportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self.kind {
+            SnapshotV2MultiBlockPciTransportErrorKind::TransportPolicy => "transport-policy",
+            SnapshotV2MultiBlockPciTransportErrorKind::Allocation => "allocation",
+            SnapshotV2MultiBlockPciTransportErrorKind::AsyncBinding => "async-binding",
+            SnapshotV2MultiBlockPciTransportErrorKind::Transport(_) => "transport",
+        };
+        formatter
+            .debug_struct("SnapshotV2MultiBlockPciTransportError")
+            .field("kind", &kind)
+            .field("cleanup_failed", &self.cleanup_failed())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotV2MultiBlockPciTransportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self.kind {
+            SnapshotV2MultiBlockPciTransportErrorKind::TransportPolicy => {
+                "snapshot multi-block PCI transport policy is invalid"
+            }
+            SnapshotV2MultiBlockPciTransportErrorKind::Allocation => {
+                "snapshot multi-block PCI transport allocation failed"
+            }
+            SnapshotV2MultiBlockPciTransportErrorKind::AsyncBinding => {
+                "snapshot multi-block PCI Async ownership is invalid"
+            }
+            SnapshotV2MultiBlockPciTransportErrorKind::Transport(_) => {
+                "snapshot multi-block PCI transport reconstruction failed"
+            }
+        })?;
+        if self.cleanup_failed() {
+            formatter.write_str("; Async cleanup also failed")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for SnapshotV2MultiBlockPciTransportError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.kind {
+            SnapshotV2MultiBlockPciTransportErrorKind::Transport(source) => Some(source),
+            SnapshotV2MultiBlockPciTransportErrorKind::TransportPolicy
+            | SnapshotV2MultiBlockPciTransportErrorKind::Allocation
+            | SnapshotV2MultiBlockPciTransportErrorKind::AsyncBinding => self
+                .cleanup
+                .as_ref()
+                .map(|source| source as &(dyn std::error::Error + 'static)),
+        }
+    }
 }
 
 impl SnapshotV2MultiBlockMmioTransportError {
@@ -760,7 +1070,7 @@ impl PreparedSnapshotV2MultiBlockBundle {
                 self.mmio_transport_error(SnapshotV2MultiBlockMmioTransportErrorKind::Allocation)
             );
         }
-        if !validate_mmio_async_ownership(
+        if !validate_async_ownership(
             &self.records,
             self.async_runtime.as_ref(),
             &mut async_generations,
@@ -844,12 +1154,128 @@ impl PreparedSnapshotV2MultiBlockBundle {
         }
     }
 
+    /// Reconstructs the complete detached exact PCI vector without publishing
+    /// a BAR, function, message route or dispatcher handler.
+    pub fn prepare_pci_transport(
+        mut self,
+    ) -> Result<PreparedSnapshotV2MultiBlockPciBundle, SnapshotV2MultiBlockPciTransportError> {
+        let mut async_generations = Vec::new();
+        if async_generations
+            .try_reserve_exact(self.records.len())
+            .is_err()
+        {
+            return Err(
+                self.pci_transport_error(SnapshotV2MultiBlockPciTransportErrorKind::Allocation)
+            );
+        }
+        if !validate_async_ownership(
+            &self.records,
+            self.async_runtime.as_ref(),
+            &mut async_generations,
+        ) {
+            return Err(
+                self.pci_transport_error(SnapshotV2MultiBlockPciTransportErrorKind::AsyncBinding)
+            );
+        }
+        if self
+            .records
+            .iter()
+            .any(|record| !matches!(record.transport, SnapshotV2DeviceTransport::Pci(_)))
+        {
+            return Err(self
+                .pci_transport_error(SnapshotV2MultiBlockPciTransportErrorKind::TransportPolicy));
+        }
+
+        let mut prepared = Vec::new();
+        if prepared.try_reserve_exact(self.records.len()).is_err() {
+            return Err(
+                self.pci_transport_error(SnapshotV2MultiBlockPciTransportErrorKind::Allocation)
+            );
+        }
+
+        let drive_configs = std::mem::take(&mut self.drive_configs);
+        let records = std::mem::take(&mut self.records);
+        let async_runtime = self.async_runtime.take();
+        self.retry_projection.clear();
+        let result = (|| {
+            for record in records {
+                let PreparedSnapshotV2MultiBlockRecord {
+                    key,
+                    queue_ranges: _,
+                    retry,
+                    retry_deadline,
+                    virtio,
+                    transport,
+                    async_generation,
+                    device,
+                } = record;
+                let SnapshotV2DeviceTransport::Pci(pci) = transport else {
+                    return Err(SnapshotV2MultiBlockPciTransportErrorKind::TransportPolicy);
+                };
+                let device_type =
+                    VirtioDeviceType::new(VIRTIO_BLOCK_DEVICE_ID).map_err(|source| {
+                        SnapshotV2MultiBlockPciTransportErrorKind::Transport(
+                            SnapshotV2RootTransportRestoreError::DeviceType(source),
+                        )
+                    })?;
+                let identity = VirtioPciIdentity::new(device_type, virtio.available_features())
+                    .with_config_generation(virtio.config_generation());
+                let retained =
+                    VirtioPciTransportState::from_snapshot_v2_parts(identity, &virtio, &pci, false)
+                        .map_err(|source| {
+                            SnapshotV2MultiBlockPciTransportErrorKind::Transport(
+                                SnapshotV2RootTransportRestoreError::Pci(source),
+                            )
+                        })?;
+                let (drive_id, is_root_device, config_space, device) = device.into_parts();
+                prepared.push(PreparedSnapshotV2MultiBlockPciRecord {
+                    key,
+                    drive_id,
+                    is_root_device,
+                    retry,
+                    retry_deadline,
+                    origin: pci.origin(),
+                    sbdf: pci.sbdf(),
+                    bar_range: pci.bar_range(),
+                    async_generation,
+                    config_space,
+                    device,
+                    identity,
+                    retained,
+                });
+            }
+            Ok(())
+        })();
+        match result {
+            Ok(()) => Ok(PreparedSnapshotV2MultiBlockPciBundle {
+                drive_configs,
+                records: prepared,
+                async_runtime,
+                async_generations,
+            }),
+            Err(kind) => {
+                drop(prepared);
+                let cleanup =
+                    cleanup_async_generations(async_runtime.as_ref(), &async_generations).err();
+                Err(SnapshotV2MultiBlockPciTransportError::new(kind, cleanup))
+            }
+        }
+    }
+
     fn mmio_transport_error(
         self,
         kind: SnapshotV2MultiBlockMmioTransportErrorKind,
     ) -> SnapshotV2MultiBlockMmioTransportError {
         let cleanup = self.abort().err();
         SnapshotV2MultiBlockMmioTransportError::new(kind, cleanup)
+    }
+
+    fn pci_transport_error(
+        self,
+        kind: SnapshotV2MultiBlockPciTransportErrorKind,
+    ) -> SnapshotV2MultiBlockPciTransportError {
+        let cleanup = self.abort().err();
+        SnapshotV2MultiBlockPciTransportError::new(kind, cleanup)
     }
 
     /// Explicitly releases every fresh Async generation in reverse order.
@@ -1021,7 +1447,7 @@ fn async_binding_failure(
     }
 }
 
-fn validate_mmio_async_ownership(
+fn validate_async_ownership(
     records: &[PreparedSnapshotV2MultiBlockRecord],
     runtime: Option<&SharedBlockAsyncRuntime>,
     generations: &mut Vec<BlockAsyncDriveGeneration>,
@@ -1613,6 +2039,198 @@ mod tests {
                 .expect("runtime should remain observable"),
             0
         );
+    }
+
+    #[test]
+    fn consuming_pci_handoff_preserves_exact_transport_and_async_identity() {
+        let graph = crate::snapshot_device_v2_5::tests::fixture_graph(
+            SnapshotV2DeviceTransportKind::Pci,
+            true,
+        );
+        let expected = graph.clone();
+        let memory = memory_for(&graph);
+        let now = Instant::now();
+        let configs = graph
+            .project_drive_configs()
+            .expect("fixture configs should project");
+        let (_files, backings) = open_backings(&graph);
+        let bundle = SnapshotV2MultiBlockRestorePlan::prepare(graph, &memory, now)
+            .expect("fixture graph should prepare")
+            .prepare_backings(configs.clone(), backings)
+            .expect("fixture backings should prepare");
+        let expected_runtime = bundle
+            .async_runtime()
+            .expect("mixed fixture should own one runtime")
+            .clone();
+
+        let pci = bundle
+            .prepare_pci_transport()
+            .expect("exact PCI vector should reconstruct");
+        assert_eq!(pci.drive_configs(), &configs);
+        assert_eq!(pci.records().len(), expected.records().len());
+        assert!(
+            pci.async_runtime()
+                .is_some_and(|runtime| runtime.same_runtime(&expected_runtime))
+        );
+        for (record, expected) in pci.records().iter().zip(expected.records()) {
+            let SnapshotV2DeviceTransport::Pci(expected_pci) = expected.transport() else {
+                panic!("fixture transport should be PCI");
+            };
+            let device_type = VirtioDeviceType::new(VIRTIO_BLOCK_DEVICE_ID)
+                .expect("block device type should validate");
+            let identity =
+                VirtioPciIdentity::new(device_type, expected.virtio().available_features())
+                    .with_config_generation(expected.virtio().config_generation());
+            let expected_transport = VirtioPciTransportState::from_snapshot_v2_parts(
+                identity,
+                expected.virtio(),
+                expected_pci,
+                false,
+            )
+            .expect("retained transport should restore");
+
+            assert_eq!(record.key(), expected.key());
+            assert_eq!(record.drive_id(), expected.config().drive_id());
+            assert_eq!(record.is_root_device(), expected.is_root());
+            assert_eq!(record.retry(), expected.block().continuation().retry());
+            assert_eq!(
+                record.retry_deadline().is_some(),
+                record.retry() != StorageRetryState::None
+            );
+            assert_eq!(record.origin(), expected_pci.origin());
+            assert_eq!(record.sbdf(), expected_pci.sbdf());
+            assert_eq!(record.bar_range(), expected_pci.bar_range());
+            assert_eq!(
+                record.config_space,
+                VirtioBlockConfigSpace::new(
+                    expected.block().backing_bytes(),
+                    expected.config().is_read_only(),
+                    expected.config().cache_type(),
+                )
+            );
+            assert_eq!(record.identity, identity);
+            assert_eq!(record.retained, expected_transport);
+            match expected.config().io_engine() {
+                DriveIoEngine::Sync => {
+                    assert_eq!(record.async_generation(), None);
+                    assert!(record.device.async_binding().is_none());
+                }
+                DriveIoEngine::Async => {
+                    let generation = record
+                        .async_generation()
+                        .expect("Async generation should transfer");
+                    let (record_runtime, record_generation) = record
+                        .device
+                        .async_binding()
+                        .expect("Async device should retain its binding");
+                    assert_eq!(record_generation, generation);
+                    assert!(record_runtime.same_runtime(&expected_runtime));
+                }
+            }
+        }
+        let (returned_configs, records, runtime, generations) = pci.into_parts();
+        assert_eq!(returned_configs, configs);
+        assert_eq!(records.len(), expected.records().len());
+        assert_eq!(generations.len(), 1);
+        drop(records);
+        cleanup_async_generations(runtime.as_ref(), &generations)
+            .expect("transferred Async runtime should cleanly release");
+        assert_eq!(
+            expected_runtime
+                .generation_count()
+                .expect("runtime should remain observable"),
+            0
+        );
+    }
+
+    #[test]
+    fn consuming_pci_handoff_preserves_rootless_sync_only_ownership() {
+        let fixture = crate::snapshot_device_v2_5::tests::fixture_graph(
+            SnapshotV2DeviceTransportKind::Pci,
+            false,
+        );
+        let graph = SnapshotV2MultiBlockDeviceGraph::try_from_parts(
+            None,
+            SnapshotV2DeviceTransportKind::Pci,
+            vec![fixture.records()[0].clone()],
+        )
+        .expect("one rootless Sync PCI record should remain graph-valid");
+        assert_eq!(graph.records()[0].config().io_engine(), DriveIoEngine::Sync);
+        let memory = memory_for(&graph);
+        let configs = graph
+            .project_drive_configs()
+            .expect("rootless Sync config should project");
+        let (_files, backings) = open_backings(&graph);
+        let bundle = SnapshotV2MultiBlockRestorePlan::prepare(graph, &memory, Instant::now())
+            .expect("rootless Sync graph should prepare")
+            .prepare_backings(configs.clone(), backings)
+            .expect("rootless Sync backing should prepare")
+            .prepare_pci_transport()
+            .expect("rootless Sync PCI handoff should prepare");
+
+        assert_eq!(bundle.drive_configs(), &configs);
+        assert!(bundle.async_runtime().is_none());
+        assert_eq!(bundle.records().len(), 1);
+        assert!(!bundle.records()[0].is_root_device());
+        assert_eq!(bundle.records()[0].async_generation(), None);
+        bundle
+            .abort()
+            .expect("rootless Sync handoff should cleanly abort");
+    }
+
+    #[test]
+    fn consuming_pci_handoff_rejects_foreign_transport_and_invalid_generation_set() {
+        let mmio_graph = crate::snapshot_device_v2_5::tests::fixture_graph(
+            SnapshotV2DeviceTransportKind::Mmio,
+            true,
+        );
+        let memory = memory_for(&mmio_graph);
+        let configs = mmio_graph
+            .project_drive_configs()
+            .expect("fixture configs should project");
+        let (_files, backings) = open_backings(&mmio_graph);
+        let bundle = SnapshotV2MultiBlockRestorePlan::prepare(mmio_graph, &memory, Instant::now())
+            .expect("MMIO graph should prepare")
+            .prepare_backings(configs, backings)
+            .expect("MMIO bundle should prepare");
+        let runtime = bundle
+            .async_runtime()
+            .expect("mixed fixture should own one runtime")
+            .clone();
+        let error = bundle
+            .prepare_pci_transport()
+            .expect_err("MMIO vector must not enter the PCI handoff");
+        assert!(!error.cleanup_failed());
+        assert_eq!(runtime.generation_count().expect("runtime should lock"), 0);
+
+        let graph = crate::snapshot_device_v2_5::tests::fixture_graph(
+            SnapshotV2DeviceTransportKind::Pci,
+            true,
+        );
+        let memory = memory_for(&graph);
+        let configs = graph
+            .project_drive_configs()
+            .expect("fixture configs should project");
+        let (_files, backings) = open_backings(&graph);
+        let mut bundle = SnapshotV2MultiBlockRestorePlan::prepare(graph, &memory, Instant::now())
+            .expect("PCI graph should prepare")
+            .prepare_backings(configs, backings)
+            .expect("PCI bundle should prepare");
+        let runtime = bundle
+            .async_runtime()
+            .expect("mixed fixture should own one runtime")
+            .clone();
+        let async_record = bundle
+            .records
+            .iter_mut()
+            .find(|record| record.async_generation.is_some())
+            .expect("fixture should contain one Async record");
+        async_record.async_generation = None;
+        let error = bundle
+            .prepare_pci_transport()
+            .expect_err("missing generation ownership must be rejected");
+        assert!(!error.cleanup_failed());
+        assert_eq!(runtime.generation_count().expect("runtime should lock"), 0);
     }
 
     #[test]

--- a/crates/runtime/src/virtio_pci.rs
+++ b/crates/runtime/src/virtio_pci.rs
@@ -3097,10 +3097,14 @@ where
             }
             return Err(publication_rollback(primary, cleanup));
         }
-        let retained = self
-            .endpoint
-            .transport_state()
-            .map_err(|source| VirtioPciPublicationError::Endpoint { source })?;
+        let retained = match self.endpoint.transport_state() {
+            Ok(retained) => retained,
+            Err(source) => {
+                let primary = VirtioPciPublicationError::Endpoint { source };
+                let cleanup = cleanup_prepared_endpoint(&self.endpoint, &mut interrupts);
+                return Err(publication_rollback(primary, cleanup));
+            }
+        };
         if let Err(source) = validate_retained_msix(&retained, &resource_registry) {
             let primary = VirtioPciPublicationError::Endpoint { source };
             let cleanup = cleanup_prepared_endpoint(&self.endpoint, &mut interrupts);
@@ -6544,6 +6548,35 @@ mod tests {
         );
         assert!(dispatcher.regions().is_empty());
         prepared_observer.release().unwrap();
+    }
+
+    #[test]
+    fn retained_publication_releases_interrupts_when_endpoint_state_is_poisoned() {
+        let fixture = retained_transport_fixture();
+        let CountingResourcesFixture {
+            registry,
+            resources,
+            signals: _,
+            releases,
+        } = counting_resources_for_messages(&fixture.messages);
+        let prepared = prepare_retained_endpoint(&fixture, &fixture.state, registry).unwrap();
+        let poison = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = prepared.endpoint.inner.state.lock().unwrap();
+            panic!("inject retained endpoint state poison");
+        }));
+        assert!(poison.is_err());
+        let mut allocator = PciBarAllocator::new(PciBarAddressSpace::Memory64, fixture.bar_range);
+        let segment = SharedPciSegment::new(crate::pci::PciSegment::new());
+        let mut dispatcher = MmioDispatcher::new();
+
+        let error = prepared
+            .publish(&mut allocator, segment, &mut dispatcher, resources)
+            .expect_err("poisoned retained endpoint must reject publication");
+
+        assert!(matches!(error, VirtioPciPublicationError::Rollback { .. }));
+        assert_eq!(*releases.lock().unwrap(), 1);
+        assert_eq!(allocator.available_ranges(), &[fixture.bar_range]);
+        assert!(dispatcher.regions().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reconstruct the complete native-v2 profile-2 block vector as exact detached
  virtio-pci endpoints while preserving graph order, root/data roles, captured
  origin, SBDF/BAR/config/MSI-X/queue state, retry deadlines, and the original
  shared Async runtime/generations
- validate the PCI bundle, controller projection, command line, canonical
  host/GICv2m FDT, full 31-slot headroom, metrics IDs, and route demand before
  ordered publication into one private canonical PCI manager
- make batch failure cleanup exhaustive and terminal on uncertainty, including
  unpublished route handles, published endpoints, shared MSI ownership, Async,
  scheduler, and platform teardown
- generalize the dormant profile-2 destination transaction for MMIO and PCI,
  and add rooted/rootless mixed Sync/Async signed I/O, flush, MSI-X, metrics,
  recapture, and resume coverage

## Scope exclusions

- public native-v2 create/load/resume dispatch and the writer/reader ceiling
  remain exact 2.4; profile-2 activation belongs to #1616
- this PR does not change the native-v2 outer artifact format or admit a 2.5
  production artifact

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented `aarch64-apple-darwin` Clippy targets with `-D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

Closes #1615

Parent delivery: #1533
