### PR TITLE
feat: capture durable pmem snapshot state

### DIFF
--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -85,9 +85,10 @@ use bangbang_runtime::pci::{
     PciClassCode, PciSbdf, PciType0Configuration,
 };
 use bangbang_runtime::pmem::{
-    PmemConfig, PmemFileBacking, PmemMmioLayout, PmemRuntimeMutationError, PmemUpdate,
-    PmemUpdateError, PreparedPmemDevice, VIRTIO_PMEM_DEVICE_ID, VIRTIO_PMEM_QUEUE_SIZES,
-    VirtioPmemConfigSpace, VirtioPmemDevice, VirtioPmemFlushStatus,
+    PmemConfig, PmemFileBacking, PmemMmioLayout, PmemRuntimeMutationError,
+    PmemSnapshotPersistenceBinding, PmemUpdate, PmemUpdateError, PreparedPmemDevice,
+    VIRTIO_PMEM_DEVICE_ID, VIRTIO_PMEM_QUEUE_SIZES, VirtioPmemConfigSpace, VirtioPmemDevice,
+    VirtioPmemFlushStatus,
 };
 use bangbang_runtime::pvtime::{
     ARM64_PVTIME_STOLEN_TIME_OFFSET, ARM64_PVTIME_STRUCTURE_SIZE, Arm64PvTimeLayout,
@@ -113,6 +114,9 @@ use bangbang_runtime::snapshot_device_v2_5::{
     PreparedSnapshotV2MultiBlockPciRecord, SnapshotV2MultiBlockCleanupError,
     SnapshotV2MultiBlockDeviceGraph, SnapshotV2MultiBlockMmioTransportError,
     SnapshotV2MultiBlockPciTransportError,
+};
+use bangbang_runtime::snapshot_device_v2_6::{
+    NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2StorageDeviceGraph,
 };
 use bangbang_runtime::snapshot_format::SnapshotFormatVersion;
 use bangbang_runtime::snapshot_format_v2::NATIVE_V2_LEGACY_PLATFORM_VERSION;
@@ -5827,11 +5831,13 @@ enum CaptureReadyPmemOwner {
 enum CaptureReadyStorageMode {
     Diagnostic,
     SnapshotV2MultiBlock,
+    SnapshotV2Storage,
 }
 
 enum CaptureReadyStorageResult {
     Diagnostic(CaptureReadyStorageState),
     SnapshotV2MultiBlock(SnapshotV2MultiBlockDeviceGraph),
+    SnapshotV2Storage(SnapshotV2StorageDeviceGraph),
 }
 
 impl fmt::Debug for CaptureReadyStorageResult {
@@ -5839,6 +5845,7 @@ impl fmt::Debug for CaptureReadyStorageResult {
         let kind = match self {
             Self::Diagnostic(_) => "Diagnostic",
             Self::SnapshotV2MultiBlock(_) => "SnapshotV2MultiBlock",
+            Self::SnapshotV2Storage(_) => "SnapshotV2Storage",
         };
         formatter
             .debug_struct("CaptureReadyStorageResult")
@@ -7552,7 +7559,8 @@ fn capture_ready_storage_state_at_with_cancel(
         is_cancelled,
     )? {
         CaptureReadyStorageResult::Diagnostic(state) => Ok(state),
-        CaptureReadyStorageResult::SnapshotV2MultiBlock(_) => {
+        CaptureReadyStorageResult::SnapshotV2MultiBlock(_)
+        | CaptureReadyStorageResult::SnapshotV2Storage(_) => {
             Err(HvfArm64BootStorageCaptureError::new(
                 HvfArm64BootStorageCaptureErrorKind::InventoryMismatch,
                 false,
@@ -7592,10 +7600,54 @@ fn capture_snapshot_v2_multi_block_device_graph_at_with_cancel(
         is_cancelled,
     )? {
         CaptureReadyStorageResult::SnapshotV2MultiBlock(graph) => Ok(graph),
-        CaptureReadyStorageResult::Diagnostic(_) => Err(HvfArm64BootStorageCaptureError::new(
-            HvfArm64BootStorageCaptureErrorKind::InventoryMismatch,
-            false,
-        )),
+        CaptureReadyStorageResult::Diagnostic(_)
+        | CaptureReadyStorageResult::SnapshotV2Storage(_) => {
+            Err(HvfArm64BootStorageCaptureError::new(
+                HvfArm64BootStorageCaptureErrorKind::InventoryMismatch,
+                false,
+            ))
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn capture_snapshot_v2_storage_device_graph_at_with_cancel(
+    backend: &mut HvfBackend,
+    mmio_dispatcher: &Arc<Mutex<MmioDispatcher>>,
+    runtime_resources: &Arm64BootRuntimeResources,
+    pci_data_devices: &mut Option<HvfArm64BootPciDataDevices>,
+    block_device_metrics: &SharedBlockDeviceMetricsRegistry,
+    gic: &HvfGicMetadata,
+    block_retry_wakeup_scheduler: &HvfArm64BootLimiterRetryWakeupScheduler,
+    pmem_retry_wakeup_scheduler: &HvfArm64BootLimiterRetryWakeupScheduler,
+    configs: &CaptureReadyStorageConfigs,
+    guard: &HvfArm64BootLimiterRetryWakeupQuiescenceGuard,
+    now: Instant,
+    is_cancelled: impl FnMut(HvfArm64BootStorageCaptureStage) -> bool,
+) -> Result<SnapshotV2StorageDeviceGraph, HvfArm64BootStorageCaptureError> {
+    match capture_ready_storage_transaction_at_with_cancel(
+        backend,
+        mmio_dispatcher,
+        runtime_resources,
+        pci_data_devices,
+        block_device_metrics,
+        gic,
+        block_retry_wakeup_scheduler,
+        pmem_retry_wakeup_scheduler,
+        configs,
+        guard,
+        now,
+        CaptureReadyStorageMode::SnapshotV2Storage,
+        is_cancelled,
+    )? {
+        CaptureReadyStorageResult::SnapshotV2Storage(graph) => Ok(graph),
+        CaptureReadyStorageResult::Diagnostic(_)
+        | CaptureReadyStorageResult::SnapshotV2MultiBlock(_) => {
+            Err(HvfArm64BootStorageCaptureError::new(
+                HvfArm64BootStorageCaptureErrorKind::InventoryMismatch,
+                false,
+            ))
+        }
     }
 }
 
@@ -7694,19 +7746,31 @@ fn capture_ready_storage_transaction_at_with_cancel(
         }
     }
 
-    if mode == CaptureReadyStorageMode::SnapshotV2MultiBlock
-        && (!configs.pmem().is_empty()
-            || !runtime_resources.pmem_devices.is_empty()
-            || !runtime_resources.pmem_mmio_devices.is_empty()
-            || pci_data_devices
-                .as_ref()
-                .is_some_and(|devices| !devices.pmem.is_empty())
-            || SnapshotV2MultiBlockDeviceGraph::preflight_capture_configs(
-                NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+    let profile_preflight_failed = match mode {
+        CaptureReadyStorageMode::Diagnostic => false,
+        CaptureReadyStorageMode::SnapshotV2MultiBlock => {
+            !configs.pmem().is_empty()
+                || !runtime_resources.pmem_devices.is_empty()
+                || !runtime_resources.pmem_mmio_devices.is_empty()
+                || pci_data_devices
+                    .as_ref()
+                    .is_some_and(|devices| !devices.pmem.is_empty())
+                || SnapshotV2MultiBlockDeviceGraph::preflight_capture_configs(
+                    NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                    configs.drives(),
+                )
+                .is_err()
+        }
+        CaptureReadyStorageMode::SnapshotV2Storage => {
+            SnapshotV2StorageDeviceGraph::preflight_capture_configs(
+                NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
                 configs.drives(),
+                configs.pmem(),
             )
-            .is_err())
-    {
+            .is_err()
+        }
+    };
+    if profile_preflight_failed {
         return Err(HvfArm64BootStorageCaptureError::new(
             HvfArm64BootStorageCaptureErrorKind::ProfilePreflight,
             false,
@@ -7745,10 +7809,19 @@ fn capture_ready_storage_transaction_at_with_cancel(
     async_owners
         .try_reserve_exact(configs.drives().len())
         .map_err(allocation_error)?;
-    let mut persistence_bindings: Vec<VirtioBlockSnapshotPersistenceBinding> = Vec::new();
-    if mode == CaptureReadyStorageMode::SnapshotV2MultiBlock {
-        persistence_bindings
+    let mut block_persistence_bindings: Vec<VirtioBlockSnapshotPersistenceBinding> = Vec::new();
+    if matches!(
+        mode,
+        CaptureReadyStorageMode::SnapshotV2MultiBlock | CaptureReadyStorageMode::SnapshotV2Storage
+    ) {
+        block_persistence_bindings
             .try_reserve_exact(configs.drives().len())
+            .map_err(allocation_error)?;
+    }
+    let mut pmem_persistence_bindings: Vec<PmemSnapshotPersistenceBinding> = Vec::new();
+    if mode == CaptureReadyStorageMode::SnapshotV2Storage {
+        pmem_persistence_bindings
+            .try_reserve_exact(configs.pmem().len())
             .map_err(allocation_error)?;
     }
     let mut mmio_block_interrupts = Vec::new();
@@ -7799,7 +7872,11 @@ fn capture_ready_storage_transaction_at_with_cancel(
                             false,
                         )
                     })?;
-                if device.is_root_device != config.is_root_device() {
+                if device.is_root_device != config.is_root_device()
+                    || (mode != CaptureReadyStorageMode::Diagnostic
+                        && config.is_root_device()
+                        && device.origin != StorageDeviceOrigin::Startup)
+                {
                     return Err(HvfArm64BootStorageCaptureError::new(
                         HvfArm64BootStorageCaptureErrorKind::InventoryMismatch,
                         false,
@@ -7818,29 +7895,6 @@ fn capture_ready_storage_transaction_at_with_cancel(
             }
         };
         block_owners.push(owner);
-    }
-
-    if mode == CaptureReadyStorageMode::SnapshotV2MultiBlock {
-        let uniform_transport = block_owners.first().is_some_and(|first| {
-            block_owners.iter().all(|owner| {
-                matches!(
-                    (first, owner),
-                    (
-                        CaptureReadyBlockOwner::Mmio { .. },
-                        CaptureReadyBlockOwner::Mmio { .. }
-                    ) | (
-                        CaptureReadyBlockOwner::Pci { .. },
-                        CaptureReadyBlockOwner::Pci { .. }
-                    )
-                )
-            })
-        });
-        if !uniform_transport {
-            return Err(HvfArm64BootStorageCaptureError::new(
-                HvfArm64BootStorageCaptureErrorKind::ProfilePreflight,
-                false,
-            ));
-        }
     }
 
     for config in configs.pmem() {
@@ -7871,6 +7925,15 @@ fn capture_ready_storage_transaction_at_with_cancel(
                             false,
                         )
                     })?;
+                if mode == CaptureReadyStorageMode::SnapshotV2Storage
+                    && config.root_device()
+                    && device.origin != StorageDeviceOrigin::Startup
+                {
+                    return Err(HvfArm64BootStorageCaptureError::new(
+                        HvfArm64BootStorageCaptureErrorKind::ProfilePreflight,
+                        false,
+                    ));
+                }
                 CaptureReadyPmemOwner::Pci {
                     index,
                     retry: storage_retry_state_at(device.retry_deadline, now)?,
@@ -7886,13 +7949,57 @@ fn capture_ready_storage_transaction_at_with_cancel(
         pmem_owners.push(owner);
     }
 
+    if mode != CaptureReadyStorageMode::Diagnostic {
+        let first_is_mmio = block_owners
+            .first()
+            .map(|owner| matches!(owner, CaptureReadyBlockOwner::Mmio { .. }))
+            .or_else(|| {
+                pmem_owners
+                    .first()
+                    .map(|owner| matches!(owner, CaptureReadyPmemOwner::Mmio { .. }))
+            });
+        let uniform_transport = first_is_mmio.is_some_and(|expected_mmio| {
+            block_owners
+                .iter()
+                .all(|owner| matches!(owner, CaptureReadyBlockOwner::Mmio { .. }) == expected_mmio)
+                && pmem_owners.iter().all(|owner| {
+                    matches!(owner, CaptureReadyPmemOwner::Mmio { .. }) == expected_mmio
+                })
+        });
+        if !uniform_transport {
+            return Err(HvfArm64BootStorageCaptureError::new(
+                HvfArm64BootStorageCaptureErrorKind::ProfilePreflight,
+                false,
+            ));
+        }
+    }
+
+    if mode == CaptureReadyStorageMode::SnapshotV2Storage {
+        for config in configs.pmem() {
+            pmem_persistence_bindings.push(
+                runtime_resources
+                    .capture_ready_pmem_snapshot_persistence_binding(config)
+                    .map_err(|_| {
+                        HvfArm64BootStorageCaptureError::new(
+                            HvfArm64BootStorageCaptureErrorKind::ProfilePreflight,
+                            false,
+                        )
+                    })?,
+            );
+        }
+    }
+
     for (config_index, (config, owner)) in configs
         .drives()
         .iter()
         .zip(block_owners.iter().copied())
         .enumerate()
     {
-        let binding = if mode == CaptureReadyStorageMode::SnapshotV2MultiBlock {
+        let binding = if matches!(
+            mode,
+            CaptureReadyStorageMode::SnapshotV2MultiBlock
+                | CaptureReadyStorageMode::SnapshotV2Storage
+        ) {
             let persistence = match owner {
                 CaptureReadyBlockOwner::Mmio { .. } => runtime_resources
                     .capture_ready_mmio_block_snapshot_persistence_binding(
@@ -7931,7 +8038,7 @@ fn capture_ready_storage_transaction_at_with_cancel(
                 ));
             }
             let binding = persistence.async_binding();
-            persistence_bindings.push(persistence);
+            block_persistence_bindings.push(persistence);
             binding
         } else {
             match owner {
@@ -8022,7 +8129,8 @@ fn capture_ready_storage_transaction_at_with_cancel(
             CaptureReadyStorageMode::Diagnostic => runtime_resources
                 .block_async_runtime
                 .quiesce_generation(generation, memory),
-            CaptureReadyStorageMode::SnapshotV2MultiBlock => runtime_resources
+            CaptureReadyStorageMode::SnapshotV2MultiBlock
+            | CaptureReadyStorageMode::SnapshotV2Storage => runtime_resources
                 .block_async_runtime
                 .drain_stopped_generation(generation, memory),
         };
@@ -8046,7 +8154,10 @@ fn capture_ready_storage_transaction_at_with_cancel(
         }
     }
 
-    if mode == CaptureReadyStorageMode::SnapshotV2MultiBlock {
+    if matches!(
+        mode,
+        CaptureReadyStorageMode::SnapshotV2MultiBlock | CaptureReadyStorageMode::SnapshotV2Storage
+    ) {
         if primary.is_none() && is_cancelled(HvfArm64BootStorageCaptureStage::Persist) {
             retain_storage_capture_error(
                 &mut primary,
@@ -8056,7 +8167,7 @@ fn capture_ready_storage_transaction_at_with_cancel(
                 ),
             );
         }
-        if primary.is_none() && persistence_bindings.len() != configs.drives().len() {
+        if primary.is_none() && block_persistence_bindings.len() != configs.drives().len() {
             retain_storage_capture_error(
                 &mut primary,
                 HvfArm64BootStorageCaptureError::new(
@@ -8070,7 +8181,7 @@ fn capture_ready_storage_transaction_at_with_cancel(
                 .drives()
                 .iter()
                 .zip(block_owners.iter().copied())
-                .zip(persistence_bindings.iter())
+                .zip(block_persistence_bindings.iter())
             {
                 if !persistence.is_read_only() {
                     let persisted = match owner {
@@ -8117,6 +8228,42 @@ fn capture_ready_storage_transaction_at_with_cancel(
                         );
                         break;
                     }
+                }
+                if is_cancelled(HvfArm64BootStorageCaptureStage::Persist) {
+                    retain_storage_capture_error(
+                        &mut primary,
+                        HvfArm64BootStorageCaptureError::new(
+                            HvfArm64BootStorageCaptureErrorKind::Cancelled,
+                            false,
+                        ),
+                    );
+                    break;
+                }
+            }
+        }
+        if mode == CaptureReadyStorageMode::SnapshotV2Storage
+            && primary.is_none()
+            && pmem_persistence_bindings.len() != configs.pmem().len()
+        {
+            retain_storage_capture_error(
+                &mut primary,
+                HvfArm64BootStorageCaptureError::new(
+                    HvfArm64BootStorageCaptureErrorKind::ProfilePreflight,
+                    false,
+                ),
+            );
+        }
+        if mode == CaptureReadyStorageMode::SnapshotV2Storage && primary.is_none() {
+            for persistence in &pmem_persistence_bindings {
+                if !persistence.is_read_only() && persistence.persist().is_err() {
+                    retain_storage_capture_error(
+                        &mut primary,
+                        HvfArm64BootStorageCaptureError::new(
+                            HvfArm64BootStorageCaptureErrorKind::Persistence,
+                            false,
+                        ),
+                    );
+                    break;
                 }
                 if is_cancelled(HvfArm64BootStorageCaptureStage::Persist) {
                     retain_storage_capture_error(
@@ -8443,6 +8590,46 @@ fn capture_ready_storage_transaction_at_with_cancel(
                     }
                 }
             }
+            CaptureReadyStorageMode::SnapshotV2Storage => {
+                if is_cancelled(HvfArm64BootStorageCaptureStage::ComposeGraph) {
+                    retain_storage_capture_error(
+                        &mut primary,
+                        HvfArm64BootStorageCaptureError::new(
+                            HvfArm64BootStorageCaptureErrorKind::Cancelled,
+                            false,
+                        ),
+                    );
+                }
+                if primary.is_none() {
+                    match SnapshotV2StorageDeviceGraph::from_capture_ready_storage(
+                        NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                        &block_states,
+                        &pmem_states,
+                    ) {
+                        Ok(graph) => {
+                            if is_cancelled(HvfArm64BootStorageCaptureStage::ComposeGraph) {
+                                retain_storage_capture_error(
+                                    &mut primary,
+                                    HvfArm64BootStorageCaptureError::new(
+                                        HvfArm64BootStorageCaptureErrorKind::Cancelled,
+                                        false,
+                                    ),
+                                );
+                            } else {
+                                captured =
+                                    Some(CaptureReadyStorageResult::SnapshotV2Storage(graph));
+                            }
+                        }
+                        Err(_) => retain_storage_capture_error(
+                            &mut primary,
+                            HvfArm64BootStorageCaptureError::new(
+                                HvfArm64BootStorageCaptureErrorKind::GraphComposition,
+                                false,
+                            ),
+                        ),
+                    }
+                }
+            }
         }
     }
 
@@ -8704,6 +8891,7 @@ impl HvfArm64BootSnapshotV2CaptureOwner<'_, '_> {
             version == NATIVE_V2_LEGACY_PLATFORM_VERSION
                 || version == NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION
                 || version == NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION
+                || version == NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION
         );
         let (stable, captures, pvtime_capture) =
             self.runner
@@ -8738,6 +8926,7 @@ impl HvfArm64BootSnapshotV2CaptureOwner<'_, '_> {
         let fdt_checksum = crc64(0, &fdt_bytes);
         let fdt = if version == NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION
             || version == NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION
+            || version == NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION
         {
             HvfSnapshotV2FdtState::try_new_product_process_profile(
                 fdt_write.address,
@@ -9719,6 +9908,41 @@ impl HvfArm64BootSession<'_> {
         )
     }
 
+    /// Produces only a detached, durable profile-3 storage graph.
+    #[doc(hidden)]
+    pub fn capture_snapshot_v2_storage_device_graph_at(
+        &mut self,
+        configs: &CaptureReadyStorageConfigs,
+        guard: &HvfArm64BootLimiterRetryWakeupQuiescenceGuard,
+        now: Instant,
+    ) -> Result<SnapshotV2StorageDeviceGraph, HvfArm64BootStorageCaptureError> {
+        self.capture_snapshot_v2_storage_device_graph_at_with_cancel(configs, guard, now, |_| false)
+    }
+
+    #[doc(hidden)]
+    pub fn capture_snapshot_v2_storage_device_graph_at_with_cancel(
+        &mut self,
+        configs: &CaptureReadyStorageConfigs,
+        guard: &HvfArm64BootLimiterRetryWakeupQuiescenceGuard,
+        now: Instant,
+        is_cancelled: impl FnMut(HvfArm64BootStorageCaptureStage) -> bool,
+    ) -> Result<SnapshotV2StorageDeviceGraph, HvfArm64BootStorageCaptureError> {
+        capture_snapshot_v2_storage_device_graph_at_with_cancel(
+            self.backend,
+            &self.mmio_dispatcher,
+            &self.runtime_resources,
+            &mut self.pci_data_devices,
+            &self.block_device_metrics,
+            &self.gic,
+            &self.block_retry_wakeup_scheduler,
+            &self.pmem_retry_wakeup_scheduler,
+            configs,
+            guard,
+            now,
+            is_cancelled,
+        )
+    }
+
     pub fn capture_snapshot_v1_device_state_at(
         &self,
         drive_config: &DriveConfig,
@@ -10056,6 +10280,33 @@ impl HvfArm64BootSession<'_> {
             input,
             memory_writer,
             NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            is_cancelled,
+        )
+    }
+
+    /// Captures the exact native-v2 2.6 profile-3 platform.
+    #[doc(hidden)]
+    pub fn capture_snapshot_v2_storage_platform_with_cancel<
+        W: std::io::Write + std::io::Seek,
+        C: FnMut(SnapshotV2MemoryIoStage) -> bool,
+    >(
+        &mut self,
+        input: HvfArm64BootSnapshotV2CaptureInput,
+        memory_writer: &mut W,
+        is_cancelled: C,
+    ) -> Result<HvfSnapshotV2PlatformState, HvfArm64BootSnapshotV2CaptureError> {
+        HvfArm64BootSnapshotV2CaptureOwner {
+            runner: &mut self.runner,
+            backend: self.backend,
+            runtime_resources: &self.runtime_resources,
+            cpu_template_application: self.cpu_template_application.as_ref(),
+            cache_source: self.cache_source,
+            gic: self.gic,
+        }
+        .capture_with_compatibility_version_and_cancel(
+            input,
+            memory_writer,
+            NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
             is_cancelled,
         )
     }
@@ -14246,6 +14497,41 @@ impl OwnedHvfArm64BootSession {
         )
     }
 
+    /// Produces only a detached, durable profile-3 storage graph.
+    #[doc(hidden)]
+    pub fn capture_snapshot_v2_storage_device_graph_at(
+        &mut self,
+        configs: &CaptureReadyStorageConfigs,
+        guard: &HvfArm64BootLimiterRetryWakeupQuiescenceGuard,
+        now: Instant,
+    ) -> Result<SnapshotV2StorageDeviceGraph, HvfArm64BootStorageCaptureError> {
+        self.capture_snapshot_v2_storage_device_graph_at_with_cancel(configs, guard, now, |_| false)
+    }
+
+    #[doc(hidden)]
+    pub fn capture_snapshot_v2_storage_device_graph_at_with_cancel(
+        &mut self,
+        configs: &CaptureReadyStorageConfigs,
+        guard: &HvfArm64BootLimiterRetryWakeupQuiescenceGuard,
+        now: Instant,
+        is_cancelled: impl FnMut(HvfArm64BootStorageCaptureStage) -> bool,
+    ) -> Result<SnapshotV2StorageDeviceGraph, HvfArm64BootStorageCaptureError> {
+        capture_snapshot_v2_storage_device_graph_at_with_cancel(
+            &mut self.backend,
+            &self.mmio_dispatcher,
+            &self.runtime_resources,
+            &mut self.pci_data_devices,
+            &self.block_device_metrics,
+            &self.gic,
+            &self.block_retry_wakeup_scheduler,
+            &self.pmem_retry_wakeup_scheduler,
+            configs,
+            guard,
+            now,
+            is_cancelled,
+        )
+    }
+
     pub fn capture_snapshot_v1_device_state_at(
         &self,
         drive_config: &DriveConfig,
@@ -14620,6 +14906,33 @@ impl OwnedHvfArm64BootSession {
             input,
             memory_writer,
             NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            is_cancelled,
+        )
+    }
+
+    /// Captures the exact native-v2 2.6 profile-3 platform.
+    #[doc(hidden)]
+    pub fn capture_snapshot_v2_storage_platform_with_cancel<
+        W: std::io::Write + std::io::Seek,
+        C: FnMut(SnapshotV2MemoryIoStage) -> bool,
+    >(
+        &mut self,
+        input: HvfArm64BootSnapshotV2CaptureInput,
+        memory_writer: &mut W,
+        is_cancelled: C,
+    ) -> Result<HvfSnapshotV2PlatformState, HvfArm64BootSnapshotV2CaptureError> {
+        HvfArm64BootSnapshotV2CaptureOwner {
+            runner: &mut self.runner,
+            backend: &self.backend,
+            runtime_resources: &self.runtime_resources,
+            cpu_template_application: self.cpu_template_application.as_ref(),
+            cache_source: self.cache_source,
+            gic: self.gic,
+        }
+        .capture_with_compatibility_version_and_cancel(
+            input,
+            memory_writer,
+            NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
             is_cancelled,
         )
     }

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -6895,10 +6895,14 @@ fn prepares_internal_hvf_arm64_boot_session() {
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 #[test]
 fn capture_ready_storage_traverses_signed_mmio_and_pci_owners() {
+    use std::fs::OpenOptions;
     use std::time::Instant;
 
     use bangbang_hvf::{
-        HvfArm64BootSessionConfig, HvfArm64BootStorageCaptureErrorKind, OwnedHvfArm64BootSession,
+        HvfArm64BootSessionConfig, HvfArm64BootSnapshotV2CaptureInput,
+        HvfArm64BootStorageCaptureErrorKind, HvfArm64BootStorageCaptureStage,
+        HvfSnapshotV2BootState, HvfSnapshotV2NativePath, HvfSnapshotV2StorageState,
+        OwnedHvfArm64BootSession,
     };
     use bangbang_runtime::VmmAction;
     use bangbang_runtime::block::{
@@ -6911,6 +6915,12 @@ fn capture_ready_storage_traverses_signed_mmio_and_pci_owners() {
     use bangbang_runtime::network::NetworkMmioLayout;
     use bangbang_runtime::pmem::{
         PmemConfig, PmemConfigInput, PmemFileBacking, PmemMmioLayout, VIRTIO_PMEM_ALIGNMENT,
+    };
+    use bangbang_runtime::snapshot_device_v2::{
+        SnapshotV2DeviceTransport, SnapshotV2DeviceTransportKind,
+    };
+    use bangbang_runtime::snapshot_device_v2_6::{
+        NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2StorageDeviceGraph,
     };
     use bangbang_runtime::storage_capture::{
         CaptureReadyStorageConfigs, StorageDeviceOrigin, StorageTransportState,
@@ -6930,6 +6940,9 @@ fn capture_ready_storage_traverses_signed_mmio_and_pci_owners() {
         .expect("MMIO Async backing should create");
     let mmio_pmem = TempFile::new_len("capture-ready-mmio-pmem", VIRTIO_PMEM_ALIGNMENT)
         .expect("MMIO pmem backing should create");
+    let mmio_read_only_pmem =
+        TempFile::new_len("capture-ready-mmio-read-only-pmem", VIRTIO_PMEM_ALIGNMENT)
+            .expect("read-only MMIO pmem backing should create");
     let mut mmio_controller = bangbang_runtime::VmmController::new("test", "0.1.0", "bangbang");
     mmio_controller
         .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
@@ -6957,6 +6970,12 @@ fn capture_ready_storage_traverses_signed_mmio_and_pci_owners() {
             path_text(mmio_pmem.path()),
         )))
         .expect("MMIO pmem should configure");
+    mmio_controller
+        .handle_action(VmmAction::PutPmem(
+            PmemConfigInput::new("pmem_ro", path_text(mmio_read_only_pmem.path()))
+                .with_read_only(true),
+        ))
+        .expect("read-only MMIO pmem should configure");
     let mmio_session_config = HvfArm64BootSessionConfig::new(
         BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1)),
         PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500)),
@@ -6981,6 +7000,198 @@ fn capture_ready_storage_traverses_signed_mmio_and_pci_owners() {
         HvfArm64BootStorageCaptureErrorKind::ProfilePreflight
     );
     assert!(!profile_error.terminal());
+
+    let mmio_pmem_mapping = mmio_session.runtime_resources().pmem_devices[0].mapping();
+    // SAFETY: the retained prepared mapping is writable, and this one-byte
+    // write stays inside its exact file-backed prefix.
+    unsafe {
+        mmio_pmem_mapping
+            .host_address()
+            .as_ptr()
+            .cast::<u8>()
+            .write(0x5a);
+    }
+    for cancelled_stage in [
+        HvfArm64BootStorageCaptureStage::Inventory,
+        HvfArm64BootStorageCaptureStage::StopAsync,
+        HvfArm64BootStorageCaptureStage::DrainAsync,
+        HvfArm64BootStorageCaptureStage::Persist,
+        HvfArm64BootStorageCaptureStage::PublishAsync,
+        HvfArm64BootStorageCaptureStage::Capture,
+        HvfArm64BootStorageCaptureStage::ComposeGraph,
+    ] {
+        let error = mmio_session
+            .capture_snapshot_v2_storage_device_graph_at_with_cancel(
+                &mmio_configs,
+                &mmio_guard,
+                Instant::now(),
+                |stage| stage == cancelled_stage,
+            )
+            .expect_err("profile-3 cancellation must not return a graph");
+        assert_eq!(error.kind(), HvfArm64BootStorageCaptureErrorKind::Cancelled);
+        assert!(!error.cleanup_failed());
+        assert!(!error.terminal());
+    }
+    let mut persistence_visits = 0_u8;
+    let between_devices_error = mmio_session
+        .capture_snapshot_v2_storage_device_graph_at_with_cancel(
+            &mmio_configs,
+            &mmio_guard,
+            Instant::now(),
+            |stage| {
+                if stage == HvfArm64BootStorageCaptureStage::Persist {
+                    persistence_visits += 1;
+                    persistence_visits == 4
+                } else {
+                    false
+                }
+            },
+        )
+        .expect_err("cancellation between pmem owners must not return a graph");
+    assert_eq!(
+        between_devices_error.kind(),
+        HvfArm64BootStorageCaptureErrorKind::Cancelled
+    );
+    assert_eq!(
+        persistence_visits, 4,
+        "cancellation should occur after both block owners and the first pmem owner"
+    );
+    assert!(!between_devices_error.cleanup_failed());
+    assert!(!between_devices_error.terminal());
+    let mut mmio_stages = Vec::new();
+    let mmio_graph = mmio_session
+        .capture_snapshot_v2_storage_device_graph_at_with_cancel(
+            &mmio_configs,
+            &mmio_guard,
+            Instant::now(),
+            |stage| {
+                mmio_stages.push(stage);
+                false
+            },
+        )
+        .expect("signed MMIO profile-3 storage graph should capture");
+    let last_drain = mmio_stages
+        .iter()
+        .rposition(|stage| *stage == HvfArm64BootStorageCaptureStage::DrainAsync)
+        .expect("profile-3 capture should observe Async drain");
+    let first_persist = mmio_stages
+        .iter()
+        .position(|stage| *stage == HvfArm64BootStorageCaptureStage::Persist)
+        .expect("profile-3 capture should observe persistence");
+    let first_publication = mmio_stages
+        .iter()
+        .position(|stage| *stage == HvfArm64BootStorageCaptureStage::PublishAsync)
+        .expect("profile-3 capture should observe completion publication");
+    let first_capture = mmio_stages
+        .iter()
+        .position(|stage| *stage == HvfArm64BootStorageCaptureStage::Capture)
+        .expect("profile-3 capture should observe live capture");
+    let first_composition = mmio_stages
+        .iter()
+        .position(|stage| *stage == HvfArm64BootStorageCaptureStage::ComposeGraph)
+        .expect("profile-3 capture should observe graph composition");
+    assert!(last_drain < first_persist);
+    assert!(first_persist < first_publication);
+    assert!(first_publication < first_capture);
+    assert!(first_capture < first_composition);
+    assert_eq!(
+        std::fs::read(mmio_pmem.path())
+            .expect("persisted MMIO pmem backing should read")
+            .first()
+            .copied(),
+        Some(0x5a)
+    );
+    assert_eq!(
+        mmio_graph.transport_kind(),
+        SnapshotV2DeviceTransportKind::Mmio
+    );
+    assert_eq!(mmio_graph.block_records().len(), 2);
+    assert_eq!(mmio_graph.pmem_records().len(), 2);
+    assert_eq!(
+        mmio_graph.root_key(),
+        Some(mmio_graph.block_records()[0].key())
+    );
+    assert_eq!(mmio_graph.pmem_records()[0].config().pmem_id(), "pmem0");
+    assert_eq!(
+        mmio_graph.pmem_records()[0].pmem().file_bytes(),
+        VIRTIO_PMEM_ALIGNMENT
+    );
+    assert!(mmio_graph.pmem_records()[1].config().is_read_only());
+    assert_eq!(
+        std::fs::read(mmio_read_only_pmem.path())
+            .expect("read-only MMIO pmem backing should read")
+            .first()
+            .copied(),
+        Some(0)
+    );
+    assert!(matches!(
+        mmio_graph.pmem_records()[0].transport(),
+        SnapshotV2DeviceTransport::Mmio(_)
+    ));
+    let mmio_graph_bytes = mmio_graph
+        .encode(NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION)
+        .expect("captured MMIO profile-3 graph should encode");
+    assert_eq!(
+        SnapshotV2StorageDeviceGraph::decode(
+            NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            &mmio_graph_bytes,
+        )
+        .expect("captured MMIO profile-3 graph should decode"),
+        mmio_graph
+    );
+    assert_eq!(
+        mmio_session
+            .capture_snapshot_v2_storage_device_graph_at(
+                &mmio_configs,
+                &mmio_guard,
+                Instant::now(),
+            )
+            .expect("MMIO profile-3 capture should repeat"),
+        mmio_graph
+    );
+    mmio_session
+        .pause_for_snapshot_v2_capture()
+        .expect("MMIO profile-3 source should pause");
+    let mmio_boot = HvfSnapshotV2BootState::try_new(
+        HvfSnapshotV2NativePath::try_new(mmio_kernel.path().as_os_str())
+            .expect("MMIO profile-3 kernel path should validate"),
+        None,
+        None,
+    )
+    .expect("MMIO profile-3 boot metadata should validate");
+    let mmio_memory = TempFile::new_len("capture-ready-mmio-profile-3-memory", 0)
+        .expect("MMIO profile-3 memory artifact should create");
+    let mut mmio_memory_writer = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(mmio_memory.path())
+        .expect("MMIO profile-3 memory artifact should open");
+    let mmio_platform = mmio_session
+        .capture_snapshot_v2_storage_platform_with_cancel(
+            HvfArm64BootSnapshotV2CaptureInput::new(mmio_boot),
+            &mut mmio_memory_writer,
+            |_| false,
+        )
+        .expect("MMIO exact 2.6 platform should capture");
+    assert_eq!(
+        mmio_platform.memory().version(),
+        NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION
+    );
+    assert_eq!(
+        mmio_memory_writer
+            .metadata()
+            .expect("MMIO profile-3 memory metadata should read")
+            .len(),
+        mmio_platform.memory().file_length()
+    );
+    let mmio_complete = HvfSnapshotV2StorageState::try_new(mmio_platform, mmio_graph.clone())
+        .expect("MMIO exact 2.6 platform and storage graph should compose");
+    assert_eq!(mmio_complete.device_graph(), &mmio_graph);
+    drop(mmio_memory_writer);
+    mmio_session
+        .resume_after_snapshot_v2_capture()
+        .expect("MMIO profile-3 source should resume after capture");
+
     let mmio_first = mmio_session
         .capture_ready_storage_state_at(&mmio_configs, &mmio_guard, Instant::now())
         .expect("signed MMIO storage should become capture-ready");
@@ -6989,7 +7200,7 @@ fn capture_ready_storage_traverses_signed_mmio_and_pci_owners() {
         .expect("MMIO Async admission should reopen for a second capture");
 
     assert_eq!(mmio_first.block_devices().len(), 2);
-    assert_eq!(mmio_first.pmem_devices().len(), 1);
+    assert_eq!(mmio_first.pmem_devices().len(), 2);
     for (captured, configured) in mmio_first
         .block_devices()
         .iter()
@@ -7045,6 +7256,7 @@ fn capture_ready_storage_traverses_signed_mmio_and_pci_owners() {
         path_text(mmio_root.path()),
         path_text(mmio_async.path()),
         path_text(mmio_pmem.path()),
+        path_text(mmio_read_only_pmem.path()),
     ] {
         assert!(!mmio_debug.contains(&private_path));
     }
@@ -7134,6 +7346,73 @@ fn capture_ready_storage_traverses_signed_mmio_and_pci_owners() {
     let pci_guard = pci_session
         .quiesce_limiter_retry_wakeups()
         .expect("PCI retry publishers should quiesce");
+    for (index, byte) in [0x61_u8, 0x62].into_iter().enumerate() {
+        let mapping = pci_session.runtime_resources().pmem_devices[index].mapping();
+        // SAFETY: both retained prepared mappings are writable, and each
+        // one-byte write stays inside its exact file-backed prefix.
+        unsafe {
+            mapping.host_address().as_ptr().cast::<u8>().write(byte);
+        }
+    }
+    let pci_graph = pci_session
+        .capture_snapshot_v2_storage_device_graph_at(&pci_configs, &pci_guard, Instant::now())
+        .expect("signed startup/runtime PCI profile-3 graph should capture");
+    assert_eq!(
+        pci_graph.transport_kind(),
+        SnapshotV2DeviceTransportKind::Pci
+    );
+    assert_eq!(pci_graph.block_records().len(), 2);
+    assert_eq!(pci_graph.pmem_records().len(), 2);
+    assert_eq!(
+        pci_graph.root_key(),
+        Some(pci_graph.block_records()[0].key())
+    );
+    assert_eq!(
+        pci_graph
+            .pmem_records()
+            .iter()
+            .map(|record| match record.transport() {
+                SnapshotV2DeviceTransport::Pci(state) => state.origin(),
+                SnapshotV2DeviceTransport::Mmio(_) => {
+                    panic!("PCI pmem graph record must not use MMIO")
+                }
+            })
+            .collect::<Vec<_>>(),
+        vec![StorageDeviceOrigin::Startup, StorageDeviceOrigin::Runtime]
+    );
+    assert!(!pci_graph.pmem_records()[1].config().is_root());
+    assert_eq!(
+        std::fs::read(pci_startup_pmem.path())
+            .expect("persisted startup PCI pmem should read")
+            .first()
+            .copied(),
+        Some(0x61)
+    );
+    assert_eq!(
+        std::fs::read(pci_dynamic_pmem.path())
+            .expect("persisted runtime PCI pmem should read")
+            .first()
+            .copied(),
+        Some(0x62)
+    );
+    let pci_graph_bytes = pci_graph
+        .encode(NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION)
+        .expect("captured PCI profile-3 graph should encode");
+    assert_eq!(
+        SnapshotV2StorageDeviceGraph::decode(
+            NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            &pci_graph_bytes,
+        )
+        .expect("captured PCI profile-3 graph should decode"),
+        pci_graph
+    );
+    assert_eq!(
+        pci_session
+            .capture_snapshot_v2_storage_device_graph_at(&pci_configs, &pci_guard, Instant::now(),)
+            .expect("PCI profile-3 capture should repeat"),
+        pci_graph
+    );
+
     let pci_first = pci_session
         .capture_ready_storage_state_at(&pci_configs, &pci_guard, Instant::now())
         .expect("signed startup/runtime PCI storage should become capture-ready");

--- a/crates/runtime/src/pmem.rs
+++ b/crates/runtime/src/pmem.rs
@@ -2250,6 +2250,18 @@ impl PmemFileBackingIdentity {
         self.mode
     }
 
+    pub const fn is_regular_file(self) -> bool {
+        #[cfg(unix)]
+        {
+            self.mode & libc::S_IFMT as u32 == libc::S_IFREG as u32
+        }
+
+        #[cfg(not(unix))]
+        {
+            false
+        }
+    }
+
     pub const fn modified_seconds(self) -> i64 {
         self.modified_seconds
     }
@@ -2721,6 +2733,106 @@ impl std::error::Error for PmemBackingFlushError {
     }
 }
 
+/// Retained authoritative mapping lease for one snapshot persistence phase.
+#[derive(Clone)]
+pub struct PmemSnapshotPersistenceBinding {
+    mapping: PmemBackingMapping,
+}
+
+impl PmemSnapshotPersistenceBinding {
+    pub fn is_read_only(&self) -> bool {
+        self.mapping.is_read_only()
+    }
+
+    pub fn file_len(&self) -> u64 {
+        self.mapping.file_len()
+    }
+
+    pub fn mapped_len(&self) -> u64 {
+        self.mapping.mapped_len()
+    }
+
+    pub fn same_mapping(&self, identity: &PmemBackingMappingIdentity) -> bool {
+        Arc::ptr_eq(&self.mapping.inner, &identity.mapping.inner)
+    }
+
+    /// Synchronizes the exact writable file-backed prefix retained by this lease.
+    pub fn persist(&self) -> Result<(), PmemSnapshotPersistenceError> {
+        if self.is_read_only() {
+            return Err(PmemSnapshotPersistenceError::ReadOnly);
+        }
+        self.mapping
+            .flush()
+            .map_err(|source| PmemSnapshotPersistenceError::Flush { source })
+    }
+}
+
+impl fmt::Debug for PmemSnapshotPersistenceBinding {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PmemSnapshotPersistenceBinding")
+            .field("is_read_only", &self.is_read_only())
+            .field("file_len", &self.file_len())
+            .field("mapped_len", &self.mapped_len())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Value-redacted failure while validating or persisting one live pmem owner.
+pub enum PmemSnapshotPersistenceError {
+    ConfigurationMismatch,
+    UnsupportedBacking,
+    Identity {
+        source: PmemFileBackingIdentityError,
+    },
+    ReadOnly,
+    Flush {
+        source: PmemBackingFlushError,
+    },
+}
+
+impl fmt::Debug for PmemSnapshotPersistenceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::ConfigurationMismatch => "ConfigurationMismatch",
+            Self::UnsupportedBacking => "UnsupportedBacking",
+            Self::Identity { .. } => "Identity",
+            Self::ReadOnly => "ReadOnly",
+            Self::Flush { .. } => "Flush",
+        };
+        formatter
+            .debug_struct("PmemSnapshotPersistenceError")
+            .field("kind", &kind)
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for PmemSnapshotPersistenceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::ConfigurationMismatch => {
+                "live pmem owner does not match its snapshot configuration"
+            }
+            Self::UnsupportedBacking => "live pmem snapshot backing is unsupported",
+            Self::Identity { .. } => "failed to validate live pmem snapshot backing identity",
+            Self::ReadOnly => "read-only pmem snapshot backing cannot be persisted",
+            Self::Flush { .. } => "failed to persist live pmem snapshot backing",
+        })
+    }
+}
+
+impl std::error::Error for PmemSnapshotPersistenceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Identity { source } => Some(source),
+            Self::Flush { source } => Some(source),
+            Self::ConfigurationMismatch | Self::UnsupportedBacking | Self::ReadOnly => None,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum PmemBackingMappingError {
     MappedLengthOverflow {
@@ -3154,6 +3266,45 @@ impl PreparedPmemDevice {
 
     pub const fn rate_limiter(&self) -> Option<PmemRateLimiterConfig> {
         self.rate_limiter
+    }
+
+    /// Validates and retains the authoritative mapping before snapshot mutation.
+    pub fn snapshot_persistence_binding(
+        &self,
+        config: &PmemConfig,
+    ) -> Result<PmemSnapshotPersistenceBinding, PmemSnapshotPersistenceError> {
+        let identity = self
+            .backing
+            .capture_identity()
+            .map_err(|source| PmemSnapshotPersistenceError::Identity { source })?;
+        if !identity.is_regular_file() || identity.is_empty() {
+            return Err(PmemSnapshotPersistenceError::UnsupportedBacking);
+        }
+        let expected_mapped = align_pmem_mapping_len(self.backing.len())
+            .map_err(|_| PmemSnapshotPersistenceError::ConfigurationMismatch)?;
+        let expected_config_space = VirtioPmemConfigSpace::new(
+            self.guest_range.start().raw_value(),
+            self.guest_range.size(),
+        );
+        if self.id != config.id()
+            || self.backing.is_read_only() != config.read_only()
+            || self.mapping.is_read_only() != config.read_only()
+            || identity.len() != self.backing.len()
+            || self.mapping.file_len() != self.backing.len()
+            || self.mapping.mapped_len() != expected_mapped
+            || self.mapping.mapped_len() != self.guest_range.size()
+            || self
+                .guest_range
+                .validate_alignment(VIRTIO_PMEM_ALIGNMENT)
+                .is_err()
+            || self.config_space != expected_config_space
+            || self.rate_limiter != config.rate_limiter()
+        {
+            return Err(PmemSnapshotPersistenceError::ConfigurationMismatch);
+        }
+        Ok(PmemSnapshotPersistenceBinding {
+            mapping: self.mapping.clone(),
+        })
     }
 
     pub fn into_parts(
@@ -6498,6 +6649,139 @@ mod tests {
 
         assert!(rendered.contains("failed to synchronize pmem backing mapping"));
         assert!(!rendered.contains("0x"));
+        assert!(err.source().is_some());
+    }
+
+    #[test]
+    fn snapshot_persistence_binding_flushes_only_the_exact_writable_prefix() {
+        let file = temp_file("snapshot-binding-writable-secret.img", b"pmem");
+        let config = config_for_path(file.as_path(), false);
+        let backing = PmemFileBacking::open(&config).expect("pmem backing should open");
+        let drop_count = Arc::new(AtomicUsize::new(0));
+        let flush_calls = Arc::new(Mutex::new(Vec::new()));
+        let mapping = PmemBackingMapping::test_mapping_with_flush(
+            4,
+            VIRTIO_PMEM_ALIGNMENT,
+            false,
+            Arc::clone(&drop_count),
+            Some(Arc::clone(&flush_calls)),
+            None,
+        );
+        let mapping_identity = mapping.capture_identity();
+        let range = guest_range(TEST_PMEM_START, VIRTIO_PMEM_ALIGNMENT);
+        let prepared = PreparedPmemDevice {
+            id: config.id().to_string(),
+            backing,
+            mapping,
+            guest_range: range,
+            config_space: VirtioPmemConfigSpace::new(range.start().raw_value(), range.size()),
+            rate_limiter: config.rate_limiter(),
+        };
+
+        let binding = prepared
+            .snapshot_persistence_binding(&config)
+            .expect("writable pmem binding should validate");
+        assert!(!binding.is_read_only());
+        assert_eq!(binding.file_len(), 4);
+        assert_eq!(binding.mapped_len(), VIRTIO_PMEM_ALIGNMENT);
+        assert!(binding.same_mapping(&mapping_identity));
+        binding
+            .persist()
+            .expect("writable pmem prefix should synchronize");
+
+        let calls = flush_calls
+            .lock()
+            .expect("pmem flush call recorder should not be poisoned");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].len, 4);
+        assert_eq!(calls[0].flags, libc::MS_SYNC);
+        drop(calls);
+        drop(prepared);
+        assert_eq!(drop_count.load(Ordering::Relaxed), 0);
+        drop(binding);
+        drop(mapping_identity);
+        assert_eq!(drop_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn snapshot_persistence_binding_rejects_read_only_flush_without_calling_msync() {
+        let file = temp_file("snapshot-binding-read-only-secret.img", b"pmem");
+        let config = config_for_path(file.as_path(), true);
+        let backing = PmemFileBacking::open(&config).expect("pmem backing should open");
+        let flush_calls = Arc::new(Mutex::new(Vec::new()));
+        let mapping = PmemBackingMapping::test_mapping_with_flush(
+            4,
+            VIRTIO_PMEM_ALIGNMENT,
+            true,
+            Arc::new(AtomicUsize::new(0)),
+            Some(Arc::clone(&flush_calls)),
+            None,
+        );
+        let range = guest_range(TEST_PMEM_START, VIRTIO_PMEM_ALIGNMENT);
+        let prepared = PreparedPmemDevice {
+            id: config.id().to_string(),
+            backing,
+            mapping,
+            guest_range: range,
+            config_space: VirtioPmemConfigSpace::new(range.start().raw_value(), range.size()),
+            rate_limiter: config.rate_limiter(),
+        };
+
+        let binding = prepared
+            .snapshot_persistence_binding(&config)
+            .expect("read-only pmem binding should validate");
+        assert!(binding.is_read_only());
+        let err = binding
+            .persist()
+            .expect_err("read-only persistence should be rejected");
+        assert!(matches!(err, PmemSnapshotPersistenceError::ReadOnly));
+        assert!(
+            flush_calls
+                .lock()
+                .expect("pmem flush call recorder should not be poisoned")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn snapshot_persistence_binding_reports_mismatch_and_flush_failure_without_secrets() {
+        let file = temp_file("snapshot-binding-failure-secret.img", b"pmem");
+        let config = config_for_path(file.as_path(), false);
+        let backing = PmemFileBacking::open(&config).expect("pmem backing should open");
+        let mapping = PmemBackingMapping::test_mapping_with_flush(
+            4,
+            VIRTIO_PMEM_ALIGNMENT,
+            false,
+            Arc::new(AtomicUsize::new(0)),
+            None,
+            Some(libc::EIO),
+        );
+        let range = guest_range(TEST_PMEM_START, VIRTIO_PMEM_ALIGNMENT);
+        let prepared = PreparedPmemDevice {
+            id: config.id().to_string(),
+            backing,
+            mapping,
+            guest_range: range,
+            config_space: VirtioPmemConfigSpace::new(range.start().raw_value(), range.size()),
+            rate_limiter: config.rate_limiter(),
+        };
+        let mismatched = config_for_path(file.as_path(), true);
+        assert!(matches!(
+            prepared.snapshot_persistence_binding(&mismatched),
+            Err(PmemSnapshotPersistenceError::ConfigurationMismatch)
+        ));
+
+        let binding = prepared
+            .snapshot_persistence_binding(&config)
+            .expect("matching pmem binding should validate");
+        let err = binding
+            .persist()
+            .expect_err("scripted pmem persistence should fail");
+        assert!(matches!(err, PmemSnapshotPersistenceError::Flush { .. }));
+        for rendered in [err.to_string(), format!("{err:?}")] {
+            assert!(!rendered.contains("snapshot-binding-failure-secret"));
+            assert!(!rendered.contains("0x"));
+        }
         assert!(err.source().is_some());
     }
 

--- a/crates/runtime/src/snapshot_device_v2.rs
+++ b/crates/runtime/src/snapshot_device_v2.rs
@@ -2124,6 +2124,14 @@ pub(crate) fn capture_mmio_common(
     state: &VirtioMmioTransportState,
     expected_features: u64,
 ) -> Result<SnapshotV2VirtioState, SnapshotV2DeviceGraphCaptureError> {
+    capture_mmio_common_for_device(state, VIRTIO_BLOCK_DEVICE_ID, expected_features)
+}
+
+pub(crate) fn capture_mmio_common_for_device(
+    state: &VirtioMmioTransportState,
+    expected_device_id: u32,
+    expected_features: u64,
+) -> Result<SnapshotV2VirtioState, SnapshotV2DeviceGraphCaptureError> {
     if !state.requires_device_config_write_status() {
         return Err(SnapshotV2DeviceGraphCaptureError::InvalidMmioState);
     }
@@ -2149,12 +2157,21 @@ pub(crate) fn capture_mmio_common(
         state.pending_notifications(),
         state.is_device_activated(),
         intents,
+        expected_device_id,
         expected_features,
     )
 }
 
 pub(crate) fn capture_pci_common(
     state: &VirtioPciTransportState,
+    expected_features: u64,
+) -> Result<SnapshotV2VirtioState, SnapshotV2DeviceGraphCaptureError> {
+    capture_pci_common_for_device(state, VIRTIO_BLOCK_DEVICE_ID, expected_features)
+}
+
+pub(crate) fn capture_pci_common_for_device(
+    state: &VirtioPciTransportState,
+    expected_device_id: u32,
     expected_features: u64,
 ) -> Result<SnapshotV2VirtioState, SnapshotV2DeviceGraphCaptureError> {
     if state.requires_device_config_write_status() {
@@ -2217,6 +2234,7 @@ pub(crate) fn capture_pci_common(
         pending,
         state.is_device_activated(),
         intents,
+        expected_device_id,
         expected_features,
     )
 }
@@ -2227,6 +2245,7 @@ fn capture_common_state(
     pending_notifications: &[bool],
     activated: bool,
     intents: Vec<SnapshotV2InterruptIntent>,
+    expected_device_id: u32,
     expected_features: u64,
 ) -> Result<SnapshotV2VirtioState, SnapshotV2DeviceGraphCaptureError> {
     if queues.len() != 1 || pending_notifications.len() != 1 || intents.len() > 2 {
@@ -2257,6 +2276,7 @@ fn capture_common_state(
         pending,
         activated,
         intents,
+        expected_device_id,
         expected_features,
     )
 }
@@ -2267,12 +2287,13 @@ fn capture_common_state_from_owned_queues(
     pending_notifications: Vec<u16>,
     activated: bool,
     intents: Vec<SnapshotV2InterruptIntent>,
+    expected_device_id: u32,
     expected_features: u64,
 ) -> Result<SnapshotV2VirtioState, SnapshotV2DeviceGraphCaptureError> {
     if queues.len() != 1 || pending_notifications.len() > 1 || intents.len() > 2 {
         return Err(SnapshotV2DeviceGraphCaptureError::InvalidVirtioState);
     }
-    if registers.device_id() != VIRTIO_BLOCK_DEVICE_ID
+    if registers.device_id() != expected_device_id
         || registers.vendor_id() != VIRTIO_MMIO_VENDOR_ID
         || registers.device_features() != expected_features
     {

--- a/crates/runtime/src/snapshot_device_v2_5.rs
+++ b/crates/runtime/src/snapshot_device_v2_5.rs
@@ -40,6 +40,8 @@ mod capture;
 pub(crate) mod codec;
 mod restore;
 
+pub(crate) use capture::{capture_multi_block_record, preflight_capture_config_refs};
+
 pub use restore::{
     PreparedSnapshotV2MultiBlockBundle, PreparedSnapshotV2MultiBlockMmioBundle,
     PreparedSnapshotV2MultiBlockMmioRecord, PreparedSnapshotV2MultiBlockPciBundle,

--- a/crates/runtime/src/snapshot_device_v2_5/capture.rs
+++ b/crates/runtime/src/snapshot_device_v2_5/capture.rs
@@ -50,39 +50,7 @@ fn capture_multi_block_graph(
         .map_err(|_| SnapshotV2MultiBlockDeviceGraphCaptureError::Allocation)?;
     let mut transport_kind = None;
     for (index, state) in states.iter().enumerate() {
-        let config = capture_multi_block_config(state)?;
-        let block = capture_multi_block_state(state, &config)?;
-        let expected_features = VirtioBlockConfigSpace::new(
-            block.backing_bytes,
-            config.is_read_only,
-            config.cache_type,
-        )
-        .available_features();
-        let (record_transport_kind, virtio, transport) = match state.transport() {
-            StorageTransportState::Mmio(mmio) => (
-                SnapshotV2DeviceTransportKind::Mmio,
-                capture_mmio_common(mmio.transport(), expected_features)
-                    .map_err(map_capture_error)?,
-                SnapshotV2DeviceTransport::Mmio(
-                    capture_mmio_transport(mmio.region(), mmio.interrupt_line(), mmio.transport())
-                        .map_err(map_capture_error)?,
-                ),
-            ),
-            StorageTransportState::Pci(pci) => (
-                SnapshotV2DeviceTransportKind::Pci,
-                capture_pci_common(pci.transport(), expected_features)
-                    .map_err(map_capture_error)?,
-                SnapshotV2DeviceTransport::Pci(
-                    capture_pci_transport_parts(
-                        pci.origin(),
-                        pci.sbdf(),
-                        pci.bar_range(),
-                        pci.transport(),
-                    )
-                    .map_err(map_capture_error)?,
-                ),
-            ),
-        };
+        let (record_transport_kind, record) = capture_multi_block_record(index, state)?;
         match transport_kind {
             None => transport_kind = Some(record_transport_kind),
             Some(expected) if expected == record_transport_kind => {}
@@ -90,15 +58,7 @@ fn capture_multi_block_graph(
                 return Err(SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedInventory);
             }
         }
-        let instance = u32::try_from(index)
-            .map_err(|_| SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedInventory)?;
-        records.push(SnapshotV2MultiBlockDeviceRecord {
-            key: SnapshotV2DeviceKey::block(instance),
-            config,
-            block,
-            virtio,
-            transport,
-        });
+        records.push(record);
     }
 
     let root_key = records
@@ -113,6 +73,58 @@ fn capture_multi_block_graph(
     .map_err(|_| SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidGraph)
 }
 
+pub(crate) fn capture_multi_block_record(
+    index: usize,
+    state: &CaptureReadyBlockDeviceState,
+) -> Result<
+    (
+        SnapshotV2DeviceTransportKind,
+        SnapshotV2MultiBlockDeviceRecord,
+    ),
+    SnapshotV2MultiBlockDeviceGraphCaptureError,
+> {
+    let config = capture_multi_block_config(state)?;
+    let block = capture_multi_block_state(state, &config)?;
+    let expected_features =
+        VirtioBlockConfigSpace::new(block.backing_bytes, config.is_read_only, config.cache_type)
+            .available_features();
+    let (transport_kind, virtio, transport) = match state.transport() {
+        StorageTransportState::Mmio(mmio) => (
+            SnapshotV2DeviceTransportKind::Mmio,
+            capture_mmio_common(mmio.transport(), expected_features).map_err(map_capture_error)?,
+            SnapshotV2DeviceTransport::Mmio(
+                capture_mmio_transport(mmio.region(), mmio.interrupt_line(), mmio.transport())
+                    .map_err(map_capture_error)?,
+            ),
+        ),
+        StorageTransportState::Pci(pci) => (
+            SnapshotV2DeviceTransportKind::Pci,
+            capture_pci_common(pci.transport(), expected_features).map_err(map_capture_error)?,
+            SnapshotV2DeviceTransport::Pci(
+                capture_pci_transport_parts(
+                    pci.origin(),
+                    pci.sbdf(),
+                    pci.bar_range(),
+                    pci.transport(),
+                )
+                .map_err(map_capture_error)?,
+            ),
+        ),
+    };
+    let instance = u32::try_from(index)
+        .map_err(|_| SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedInventory)?;
+    Ok((
+        transport_kind,
+        SnapshotV2MultiBlockDeviceRecord {
+            key: SnapshotV2DeviceKey::block(instance),
+            config,
+            block,
+            virtio,
+            transport,
+        },
+    ))
+}
+
 fn preflight_capture_configs(
     compatibility_version: SnapshotFormatVersion,
     configs: &[crate::block::DriveConfig],
@@ -124,7 +136,7 @@ fn preflight_capture_configs(
     preflight_capture_config_refs(compatibility_version, &refs)
 }
 
-fn preflight_capture_config_refs(
+pub(crate) fn preflight_capture_config_refs(
     compatibility_version: SnapshotFormatVersion,
     configs: &[&crate::block::DriveConfig],
 ) -> Result<(), SnapshotV2MultiBlockDeviceGraphCaptureError> {

--- a/crates/runtime/src/snapshot_device_v2_6.rs
+++ b/crates/runtime/src/snapshot_device_v2_6.rs
@@ -31,6 +31,7 @@ use crate::snapshot_restore::{
 };
 use crate::storage_capture::{StorageDeviceOrigin, StorageRetryState};
 
+mod capture;
 mod codec;
 
 #[cfg(test)]
@@ -540,6 +541,59 @@ impl fmt::Display for SnapshotV2StorageDeviceGraphBuildError {
 }
 
 impl std::error::Error for SnapshotV2StorageDeviceGraphBuildError {}
+
+/// Failure while converting one complete live storage inventory into profile 3.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2StorageDeviceGraphCaptureError {
+    /// The supplied compatibility context is not exact 2.6.
+    UnsupportedVersion,
+    /// The combined inventory is empty, too large, or transport-mixed.
+    UnsupportedInventory,
+    /// A block or pmem configuration lies outside profile 3.
+    UnsupportedConfiguration,
+    /// Bounded live string metadata is invalid.
+    InvalidString,
+    /// Repeated block-local facts disagree.
+    InconsistentBlockState,
+    /// Repeated pmem-local facts disagree.
+    InconsistentPmemState,
+    /// Common virtio continuation is invalid.
+    InvalidVirtioState,
+    /// MMIO placement or selectors are invalid.
+    InvalidMmioState,
+    /// PCI placement, configuration, or MSI-X state is invalid.
+    InvalidPciState,
+    /// The complete config-ordered graph violates profile 3.
+    InvalidGraph,
+    /// A bounded artifact allocation failed.
+    Allocation,
+}
+
+impl fmt::Display for SnapshotV2StorageDeviceGraphCaptureError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::UnsupportedVersion => {
+                "native-v2 storage graph compatibility version is unsupported"
+            }
+            Self::UnsupportedInventory => {
+                "live storage inventory is outside the native-v2 storage profile"
+            }
+            Self::UnsupportedConfiguration => {
+                "live storage configuration is outside the native-v2 storage profile"
+            }
+            Self::InvalidString => "live storage string metadata is invalid",
+            Self::InconsistentBlockState => "live block continuation state is inconsistent",
+            Self::InconsistentPmemState => "live pmem continuation state is inconsistent",
+            Self::InvalidVirtioState => "live common virtio state is invalid",
+            Self::InvalidMmioState => "live virtio-mmio state is invalid",
+            Self::InvalidPciState => "live virtio-pci state is invalid",
+            Self::InvalidGraph => "captured native-v2 storage graph is invalid",
+            Self::Allocation => "failed to allocate a native-v2 storage graph",
+        })
+    }
+}
+
+impl std::error::Error for SnapshotV2StorageDeviceGraphCaptureError {}
 
 /// Failure while encoding one validated profile-3 graph.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/runtime/src/snapshot_device_v2_6/capture.rs
+++ b/crates/runtime/src/snapshot_device_v2_6/capture.rs
@@ -1,0 +1,849 @@
+//! Live-state conversion boundary for the pure profile-3 artifact model.
+
+use super::*;
+
+use crate::block::DriveConfig;
+use crate::pmem::{
+    PmemConfig, PmemRateLimiterConfig, PmemTokenBucketConfig, VIRTIO_PMEM_DEVICE_ID,
+    VirtioPmemRateLimiterState, VirtioPmemTokenBucketState,
+};
+use crate::snapshot_device_v2::{
+    SnapshotV2DeviceGraphCaptureError, capture_mmio_common_for_device, capture_mmio_transport,
+    capture_pci_common_for_device, capture_pci_transport_parts,
+};
+use crate::snapshot_device_v2_5::{
+    NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+    SnapshotV2MultiBlockDeviceGraphCaptureError, capture_multi_block_record,
+    preflight_capture_config_refs,
+};
+use crate::storage_capture::{
+    CaptureReadyBlockDeviceState, CaptureReadyPmemDeviceState, StorageTransportState,
+};
+
+impl SnapshotV2StorageDeviceGraph {
+    /// Validates profile-3 public configuration before live source mutation.
+    pub fn preflight_capture_configs(
+        compatibility_version: SnapshotFormatVersion,
+        drive_configs: &[DriveConfig],
+        pmem_configs: &[PmemConfig],
+    ) -> Result<(), SnapshotV2StorageDeviceGraphCaptureError> {
+        let mut drive_refs = Vec::new();
+        drive_refs
+            .try_reserve_exact(drive_configs.len())
+            .map_err(|_| SnapshotV2StorageDeviceGraphCaptureError::Allocation)?;
+        drive_refs.extend(drive_configs.iter());
+        let mut pmem_refs = Vec::new();
+        pmem_refs
+            .try_reserve_exact(pmem_configs.len())
+            .map_err(|_| SnapshotV2StorageDeviceGraphCaptureError::Allocation)?;
+        pmem_refs.extend(pmem_configs.iter());
+        preflight_capture_config_refs_2_6(compatibility_version, &drive_refs, &pmem_refs)
+    }
+
+    /// Converts one complete config-ordered live storage inventory into profile 3.
+    pub fn from_capture_ready_storage(
+        compatibility_version: SnapshotFormatVersion,
+        block_states: &[CaptureReadyBlockDeviceState],
+        pmem_states: &[CaptureReadyPmemDeviceState],
+    ) -> Result<Self, SnapshotV2StorageDeviceGraphCaptureError> {
+        capture_storage_graph(compatibility_version, block_states, pmem_states)
+    }
+}
+
+fn capture_storage_graph(
+    compatibility_version: SnapshotFormatVersion,
+    block_states: &[CaptureReadyBlockDeviceState],
+    pmem_states: &[CaptureReadyPmemDeviceState],
+) -> Result<SnapshotV2StorageDeviceGraph, SnapshotV2StorageDeviceGraphCaptureError> {
+    let mut drive_refs = Vec::new();
+    drive_refs
+        .try_reserve_exact(block_states.len())
+        .map_err(|_| SnapshotV2StorageDeviceGraphCaptureError::Allocation)?;
+    drive_refs.extend(
+        block_states
+            .iter()
+            .map(CaptureReadyBlockDeviceState::config),
+    );
+    let mut pmem_refs = Vec::new();
+    pmem_refs
+        .try_reserve_exact(pmem_states.len())
+        .map_err(|_| SnapshotV2StorageDeviceGraphCaptureError::Allocation)?;
+    pmem_refs.extend(pmem_states.iter().map(CaptureReadyPmemDeviceState::config));
+    preflight_capture_config_refs_2_6(compatibility_version, &drive_refs, &pmem_refs)?;
+
+    let mut block_records = Vec::new();
+    block_records
+        .try_reserve_exact(block_states.len())
+        .map_err(|_| SnapshotV2StorageDeviceGraphCaptureError::Allocation)?;
+    let mut pmem_records = Vec::new();
+    pmem_records
+        .try_reserve_exact(pmem_states.len())
+        .map_err(|_| SnapshotV2StorageDeviceGraphCaptureError::Allocation)?;
+    let mut transport_kind = None;
+
+    for (index, state) in block_states.iter().enumerate() {
+        let (record_transport, record) =
+            capture_multi_block_record(index, state).map_err(map_block_capture_error)?;
+        merge_transport_kind(&mut transport_kind, record_transport)?;
+        block_records.push(record);
+    }
+    for (index, state) in pmem_states.iter().enumerate() {
+        let (record_transport, record) = capture_pmem_record(index, state)?;
+        merge_transport_kind(&mut transport_kind, record_transport)?;
+        pmem_records.push(record);
+    }
+
+    let root_key = block_records
+        .first()
+        .filter(|record| record.is_root())
+        .map(|record| record.key())
+        .or_else(|| {
+            pmem_records
+                .first()
+                .filter(|record| record.is_root())
+                .map(SnapshotV2PmemDeviceRecord::key)
+        });
+    SnapshotV2StorageDeviceGraph::try_from_parts(
+        root_key,
+        transport_kind.ok_or(SnapshotV2StorageDeviceGraphCaptureError::UnsupportedInventory)?,
+        block_records,
+        pmem_records,
+    )
+    .map_err(|_| SnapshotV2StorageDeviceGraphCaptureError::InvalidGraph)
+}
+
+fn preflight_capture_config_refs_2_6(
+    compatibility_version: SnapshotFormatVersion,
+    drive_configs: &[&DriveConfig],
+    pmem_configs: &[&PmemConfig],
+) -> Result<(), SnapshotV2StorageDeviceGraphCaptureError> {
+    if compatibility_version != NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION {
+        return Err(SnapshotV2StorageDeviceGraphCaptureError::UnsupportedVersion);
+    }
+    let record_count = drive_configs
+        .len()
+        .checked_add(pmem_configs.len())
+        .ok_or(SnapshotV2StorageDeviceGraphCaptureError::UnsupportedInventory)?;
+    if record_count == 0 || record_count > usize::from(NATIVE_V2_STORAGE_DEVICE_GRAPH_MAX_RECORDS) {
+        return Err(SnapshotV2StorageDeviceGraphCaptureError::UnsupportedInventory);
+    }
+    if !drive_configs.is_empty() {
+        preflight_capture_config_refs(
+            NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            drive_configs,
+        )
+        .map_err(map_block_capture_error)?;
+    }
+
+    for (index, config) in pmem_configs.iter().copied().enumerate() {
+        validate_capture_string(
+            config.id(),
+            NATIVE_V2_STORAGE_DEVICE_GRAPH_MAX_PMEM_ID_BYTES,
+        )?;
+        if !config
+            .id()
+            .chars()
+            .all(|character| character == '_' || character.is_alphanumeric())
+        {
+            return Err(SnapshotV2StorageDeviceGraphCaptureError::InvalidString);
+        }
+        validate_capture_string(
+            config.path_on_host(),
+            NATIVE_V2_STORAGE_DEVICE_GRAPH_MAX_SELECTOR_BYTES,
+        )?;
+        if config.root_device() && index != 0 {
+            return Err(SnapshotV2StorageDeviceGraphCaptureError::InvalidGraph);
+        }
+        if pmem_configs
+            .iter()
+            .copied()
+            .take(index)
+            .any(|candidate| candidate.id() == config.id())
+        {
+            return Err(SnapshotV2StorageDeviceGraphCaptureError::InvalidGraph);
+        }
+        validate_pmem_limiter_config(config.rate_limiter())?;
+    }
+
+    let block_root_count = drive_configs
+        .iter()
+        .filter(|config| config.is_root_device())
+        .count();
+    let pmem_root_count = pmem_configs
+        .iter()
+        .filter(|config| config.root_device())
+        .count();
+    if block_root_count + pmem_root_count > 1 {
+        return Err(SnapshotV2StorageDeviceGraphCaptureError::InvalidGraph);
+    }
+
+    for (index, config) in drive_configs.iter().copied().enumerate() {
+        let selector = config
+            .path_on_host()
+            .and_then(|path| path.to_str())
+            .ok_or(SnapshotV2StorageDeviceGraphCaptureError::InvalidString)?;
+        if drive_configs
+            .iter()
+            .copied()
+            .skip(index + 1)
+            .any(|candidate| {
+                candidate.path_on_host().and_then(|path| path.to_str()) == Some(selector)
+            })
+            || pmem_configs
+                .iter()
+                .copied()
+                .any(|candidate| candidate.path_on_host() == selector)
+        {
+            return Err(SnapshotV2StorageDeviceGraphCaptureError::InvalidGraph);
+        }
+    }
+    for (index, config) in pmem_configs.iter().copied().enumerate() {
+        if pmem_configs
+            .iter()
+            .copied()
+            .skip(index + 1)
+            .any(|candidate| candidate.path_on_host() == config.path_on_host())
+        {
+            return Err(SnapshotV2StorageDeviceGraphCaptureError::InvalidGraph);
+        }
+    }
+    Ok(())
+}
+
+fn capture_pmem_record(
+    index: usize,
+    state: &CaptureReadyPmemDeviceState,
+) -> Result<
+    (SnapshotV2DeviceTransportKind, SnapshotV2PmemDeviceRecord),
+    SnapshotV2StorageDeviceGraphCaptureError,
+> {
+    let config = capture_pmem_config(state.config())?;
+    let pmem = capture_pmem_state(state, &config)?;
+    let expected_features = pmem.config_space.available_features();
+    let (transport_kind, virtio, transport) = match state.transport() {
+        StorageTransportState::Mmio(mmio) => (
+            SnapshotV2DeviceTransportKind::Mmio,
+            capture_mmio_common_for_device(
+                mmio.transport(),
+                VIRTIO_PMEM_DEVICE_ID,
+                expected_features,
+            )
+            .map_err(map_common_capture_error)?,
+            SnapshotV2DeviceTransport::Mmio(
+                capture_mmio_transport(mmio.region(), mmio.interrupt_line(), mmio.transport())
+                    .map_err(map_common_capture_error)?,
+            ),
+        ),
+        StorageTransportState::Pci(pci) => (
+            SnapshotV2DeviceTransportKind::Pci,
+            capture_pci_common_for_device(
+                pci.transport(),
+                VIRTIO_PMEM_DEVICE_ID,
+                expected_features,
+            )
+            .map_err(map_common_capture_error)?,
+            SnapshotV2DeviceTransport::Pci(
+                capture_pci_transport_parts(
+                    pci.origin(),
+                    pci.sbdf(),
+                    pci.bar_range(),
+                    pci.transport(),
+                )
+                .map_err(map_common_capture_error)?,
+            ),
+        ),
+    };
+    let instance = u32::try_from(index)
+        .map_err(|_| SnapshotV2StorageDeviceGraphCaptureError::UnsupportedInventory)?;
+    Ok((
+        transport_kind,
+        SnapshotV2PmemDeviceRecord {
+            key: SnapshotV2DeviceKey::pmem(instance),
+            config,
+            pmem,
+            virtio,
+            transport,
+        },
+    ))
+}
+
+fn capture_pmem_config(
+    config: &PmemConfig,
+) -> Result<SnapshotV2PmemConfig, SnapshotV2StorageDeviceGraphCaptureError> {
+    validate_capture_string(
+        config.id(),
+        NATIVE_V2_STORAGE_DEVICE_GRAPH_MAX_PMEM_ID_BYTES,
+    )?;
+    if !config
+        .id()
+        .chars()
+        .all(|character| character == '_' || character.is_alphanumeric())
+    {
+        return Err(SnapshotV2StorageDeviceGraphCaptureError::InvalidString);
+    }
+    validate_capture_string(
+        config.path_on_host(),
+        NATIVE_V2_STORAGE_DEVICE_GRAPH_MAX_SELECTOR_BYTES,
+    )?;
+    validate_pmem_limiter_config(config.rate_limiter())?;
+    Ok(SnapshotV2PmemConfig {
+        pmem_id: clone_capture_string(
+            config.id(),
+            NATIVE_V2_STORAGE_DEVICE_GRAPH_MAX_PMEM_ID_BYTES,
+        )?,
+        is_root: config.root_device(),
+        is_read_only: config.read_only(),
+        rate_limiter: config.rate_limiter(),
+        selector: clone_capture_string(
+            config.path_on_host(),
+            NATIVE_V2_STORAGE_DEVICE_GRAPH_MAX_SELECTOR_BYTES,
+        )?,
+    })
+}
+
+fn capture_pmem_state(
+    state: &CaptureReadyPmemDeviceState,
+    config: &SnapshotV2PmemConfig,
+) -> Result<SnapshotV2PmemState, SnapshotV2StorageDeviceGraphCaptureError> {
+    let backing = state.backing();
+    let mapping = state.mapping();
+    let device = state.device();
+    let guest_range = state.guest_range();
+    let expected_mapped = align_pmem_length(backing.len())
+        .ok_or(SnapshotV2StorageDeviceGraphCaptureError::InconsistentPmemState)?;
+    let expected_config_space =
+        VirtioPmemConfigSpace::new(guest_range.start().raw_value(), guest_range.size());
+    if !backing.is_regular_file()
+        || backing.is_empty()
+        || mapping.file_len() != backing.len()
+        || mapping.mapped_len() != expected_mapped
+        || mapping.mapped_len() != guest_range.size()
+        || mapping.is_read_only() != config.is_read_only
+        || device.file_len() != backing.len()
+        || device.config_space() != expected_config_space
+    {
+        return Err(SnapshotV2StorageDeviceGraphCaptureError::InconsistentPmemState);
+    }
+    let limiter = capture_pmem_limiter_state(config.rate_limiter, device.rate_limiter())?;
+    let pmem = SnapshotV2PmemState {
+        file_bytes: backing.len(),
+        mapped_bytes: mapping.mapped_len(),
+        guest_range,
+        config_space: device.config_space(),
+        active_queue: device.active_queue(),
+        limiter,
+        pending_rate_limited_queue: device.pending_rate_limited_queue(),
+        retry: state.retry(),
+    };
+    validate_pmem_state_local(&pmem)
+        .and_then(|()| validate_pmem_limiter_relationship(config.rate_limiter, pmem.limiter))
+        .map_err(|_| SnapshotV2StorageDeviceGraphCaptureError::InconsistentPmemState)?;
+    Ok(pmem)
+}
+
+fn capture_pmem_limiter_state(
+    config: Option<PmemRateLimiterConfig>,
+    state: VirtioPmemRateLimiterState,
+) -> Result<SnapshotV2PmemLimiterState, SnapshotV2StorageDeviceGraphCaptureError> {
+    Ok(SnapshotV2PmemLimiterState::new(
+        capture_pmem_bucket_state(
+            config.and_then(PmemRateLimiterConfig::bandwidth),
+            state.bandwidth(),
+        )?,
+        capture_pmem_bucket_state(config.and_then(PmemRateLimiterConfig::ops), state.ops())?,
+    ))
+}
+
+fn capture_pmem_bucket_state(
+    config: Option<PmemTokenBucketConfig>,
+    state: Option<VirtioPmemTokenBucketState>,
+) -> Result<Option<SnapshotV2PmemBucketState>, SnapshotV2StorageDeviceGraphCaptureError> {
+    match (config, state) {
+        (Some(config), Some(state))
+            if pmem_token_bucket_is_enabled(config)
+                && state.config() == config
+                && state.budget() <= config.size()
+                && state.remaining_burst() <= config.one_time_burst().unwrap_or(0) =>
+        {
+            Ok(Some(SnapshotV2PmemBucketState::new(
+                state.budget(),
+                state.remaining_burst(),
+                state.age_nanos(),
+            )))
+        }
+        (None, None) => Ok(None),
+        _ => Err(SnapshotV2StorageDeviceGraphCaptureError::InconsistentPmemState),
+    }
+}
+
+fn validate_pmem_limiter_config(
+    config: Option<PmemRateLimiterConfig>,
+) -> Result<(), SnapshotV2StorageDeviceGraphCaptureError> {
+    let Some(config) = config else {
+        return Ok(());
+    };
+    if !config.is_configured()
+        || [config.bandwidth(), config.ops()]
+            .into_iter()
+            .flatten()
+            .any(|bucket| !pmem_token_bucket_is_enabled(bucket))
+    {
+        return Err(SnapshotV2StorageDeviceGraphCaptureError::UnsupportedConfiguration);
+    }
+    Ok(())
+}
+
+fn merge_transport_kind(
+    expected: &mut Option<SnapshotV2DeviceTransportKind>,
+    candidate: SnapshotV2DeviceTransportKind,
+) -> Result<(), SnapshotV2StorageDeviceGraphCaptureError> {
+    match expected {
+        None => *expected = Some(candidate),
+        Some(current) if *current == candidate => {}
+        Some(_) => return Err(SnapshotV2StorageDeviceGraphCaptureError::UnsupportedInventory),
+    }
+    Ok(())
+}
+
+fn clone_capture_string(
+    value: &str,
+    maximum: usize,
+) -> Result<String, SnapshotV2StorageDeviceGraphCaptureError> {
+    validate_capture_string(value, maximum)?;
+    let mut owned = String::new();
+    owned
+        .try_reserve_exact(value.len())
+        .map_err(|_| SnapshotV2StorageDeviceGraphCaptureError::Allocation)?;
+    owned.push_str(value);
+    Ok(owned)
+}
+
+fn validate_capture_string(
+    value: &str,
+    maximum: usize,
+) -> Result<(), SnapshotV2StorageDeviceGraphCaptureError> {
+    if value.is_empty() || value.len() > maximum {
+        Err(SnapshotV2StorageDeviceGraphCaptureError::InvalidString)
+    } else {
+        Ok(())
+    }
+}
+
+const fn map_block_capture_error(
+    error: SnapshotV2MultiBlockDeviceGraphCaptureError,
+) -> SnapshotV2StorageDeviceGraphCaptureError {
+    match error {
+        SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedVersion => {
+            SnapshotV2StorageDeviceGraphCaptureError::UnsupportedVersion
+        }
+        SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedInventory => {
+            SnapshotV2StorageDeviceGraphCaptureError::UnsupportedInventory
+        }
+        SnapshotV2MultiBlockDeviceGraphCaptureError::UnsupportedConfiguration => {
+            SnapshotV2StorageDeviceGraphCaptureError::UnsupportedConfiguration
+        }
+        SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidString => {
+            SnapshotV2StorageDeviceGraphCaptureError::InvalidString
+        }
+        SnapshotV2MultiBlockDeviceGraphCaptureError::InconsistentBlockState => {
+            SnapshotV2StorageDeviceGraphCaptureError::InconsistentBlockState
+        }
+        SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidVirtioState => {
+            SnapshotV2StorageDeviceGraphCaptureError::InvalidVirtioState
+        }
+        SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidMmioState => {
+            SnapshotV2StorageDeviceGraphCaptureError::InvalidMmioState
+        }
+        SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidPciState => {
+            SnapshotV2StorageDeviceGraphCaptureError::InvalidPciState
+        }
+        SnapshotV2MultiBlockDeviceGraphCaptureError::InvalidGraph => {
+            SnapshotV2StorageDeviceGraphCaptureError::InvalidGraph
+        }
+        SnapshotV2MultiBlockDeviceGraphCaptureError::Allocation => {
+            SnapshotV2StorageDeviceGraphCaptureError::Allocation
+        }
+    }
+}
+
+const fn map_common_capture_error(
+    error: SnapshotV2DeviceGraphCaptureError,
+) -> SnapshotV2StorageDeviceGraphCaptureError {
+    match error {
+        SnapshotV2DeviceGraphCaptureError::UnsupportedVersion => {
+            SnapshotV2StorageDeviceGraphCaptureError::UnsupportedVersion
+        }
+        SnapshotV2DeviceGraphCaptureError::UnsupportedConfiguration => {
+            SnapshotV2StorageDeviceGraphCaptureError::UnsupportedConfiguration
+        }
+        SnapshotV2DeviceGraphCaptureError::InvalidString => {
+            SnapshotV2StorageDeviceGraphCaptureError::InvalidString
+        }
+        SnapshotV2DeviceGraphCaptureError::InconsistentBlockState => {
+            SnapshotV2StorageDeviceGraphCaptureError::InconsistentPmemState
+        }
+        SnapshotV2DeviceGraphCaptureError::InvalidVirtioState => {
+            SnapshotV2StorageDeviceGraphCaptureError::InvalidVirtioState
+        }
+        SnapshotV2DeviceGraphCaptureError::InvalidMmioState => {
+            SnapshotV2StorageDeviceGraphCaptureError::InvalidMmioState
+        }
+        SnapshotV2DeviceGraphCaptureError::InvalidPciState => {
+            SnapshotV2StorageDeviceGraphCaptureError::InvalidPciState
+        }
+        SnapshotV2DeviceGraphCaptureError::Allocation => {
+            SnapshotV2StorageDeviceGraphCaptureError::Allocation
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs::{self, OpenOptions};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Instant;
+
+    use crate::block::{
+        DriveCacheType, DriveConfigInput, DriveIoEngine, PreparedBlockDevice,
+        VIRTIO_BLOCK_DEVICE_ID, VIRTIO_BLOCK_QUEUE_SIZES,
+    };
+    use crate::interrupt::GuestInterruptLine;
+    use crate::memory::{GuestAddress, GuestMemoryRange};
+    use crate::mmio::{MmioRegion, MmioRegionId};
+    use crate::pmem::{
+        PmemConfigInput, PmemFileBacking, PreparedPmemDevice, VIRTIO_PMEM_ALIGNMENT,
+        VIRTIO_PMEM_QUEUE_SIZES, VirtioPmemDevice,
+    };
+    use crate::storage_capture::{StorageMmioTransportState, StorageRetryState};
+    use crate::virtio_mmio::{VIRTIO_MMIO_DEVICE_WINDOW_SIZE, VirtioMmioRegisterHandler};
+
+    static NEXT_TEMP_FILE: AtomicU64 = AtomicU64::new(0);
+
+    struct TempFile {
+        path: PathBuf,
+    }
+
+    impl TempFile {
+        fn new(name: &str, len: u64) -> Self {
+            let sequence = NEXT_TEMP_FILE.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "bangbang-snapshot-v2-6-capture-{name}-{}-{sequence}",
+                std::process::id(),
+            ));
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create_new(true)
+                .open(&path)
+                .expect("capture backing should create");
+            file.set_len(len).expect("capture backing should resize");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempFile {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+
+    fn block_config(path: &Path, is_root: bool) -> DriveConfig {
+        DriveConfigInput::new("rootfs", "rootfs", path, is_root)
+            .with_is_read_only(false)
+            .with_cache_type(DriveCacheType::Unsafe)
+            .with_io_engine(DriveIoEngine::Sync)
+            .validate()
+            .expect("profile-3 block config should validate")
+    }
+
+    fn pmem_config(
+        id: &str,
+        path: &Path,
+        is_root: bool,
+        is_read_only: bool,
+        rate_limiter: Option<PmemRateLimiterConfig>,
+    ) -> PmemConfig {
+        let mut input = PmemConfigInput::new(id, path.to_string_lossy().into_owned())
+            .with_root_device(is_root)
+            .with_read_only(is_read_only);
+        if let Some(rate_limiter) = rate_limiter {
+            input = input.with_rate_limiter(rate_limiter);
+        }
+        PmemConfig::try_from(input).expect("profile-3 pmem config should validate")
+    }
+
+    fn mmio_region(index: u32) -> MmioRegion {
+        MmioRegion::new(
+            MmioRegionId::new(u64::from(index) + 1),
+            GuestAddress::new(0xd000_0000 + u64::from(index) * VIRTIO_MMIO_DEVICE_WINDOW_SIZE),
+            VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+        )
+        .expect("profile-3 MMIO region should validate")
+    }
+
+    fn capture_mmio_block(config: &DriveConfig, index: u32) -> CaptureReadyBlockDeviceState {
+        let prepared = PreparedBlockDevice::from_config_with_backing(config, None)
+            .expect("profile-3 block should prepare");
+        let (_, _, config_space, device) = prepared.into_parts();
+        let handler = VirtioMmioRegisterHandler::with_device_config_and_activation(
+            VIRTIO_BLOCK_DEVICE_ID,
+            config_space.available_features(),
+            &VIRTIO_BLOCK_QUEUE_SIZES,
+            config_space,
+            device,
+        )
+        .expect("profile-3 block MMIO handler should build");
+        let captured = handler
+            .capture_block_device_state_at(config, Instant::now())
+            .expect("profile-3 block state should capture");
+        CaptureReadyBlockDeviceState::new(
+            config.clone(),
+            StorageTransportState::Mmio(StorageMmioTransportState::new(
+                mmio_region(index),
+                GuestInterruptLine::new(index + 32)
+                    .expect("profile-3 block interrupt should validate"),
+                handler.transport_state(),
+            )),
+            StorageRetryState::None,
+            captured,
+        )
+    }
+
+    fn capture_mmio_pmem(config: &PmemConfig, index: u32) -> CaptureReadyPmemDeviceState {
+        let prepared = PreparedPmemDevice::from_config_with_backing_and_reserved_ranges(
+            config,
+            PmemFileBacking::open(config).expect("profile-3 pmem backing should open"),
+            &[],
+        )
+        .expect("profile-3 pmem should prepare");
+        let (_, backing, mapping, guest_range, config_space, rate_limiter) = prepared.into_parts();
+        let handler = VirtioMmioRegisterHandler::with_device_config_and_activation(
+            VIRTIO_PMEM_DEVICE_ID,
+            config_space.available_features(),
+            &VIRTIO_PMEM_QUEUE_SIZES,
+            config_space,
+            VirtioPmemDevice::with_rate_limiter(mapping.file_len(), rate_limiter),
+        )
+        .expect("profile-3 pmem MMIO handler should build");
+        let captured = handler
+            .capture_pmem_device_state_at(mapping.file_len(), rate_limiter, Instant::now())
+            .expect("profile-3 pmem state should capture");
+        CaptureReadyPmemDeviceState::new(
+            config.clone(),
+            guest_range,
+            backing
+                .capture_identity()
+                .expect("profile-3 pmem identity should capture"),
+            mapping.capture_identity(),
+            StorageTransportState::Mmio(StorageMmioTransportState::new(
+                mmio_region(index),
+                GuestInterruptLine::new(index + 32)
+                    .expect("profile-3 pmem interrupt should validate"),
+                handler.transport_state(),
+            )),
+            StorageRetryState::None,
+            captured,
+        )
+    }
+
+    fn limiter_config() -> PmemRateLimiterConfig {
+        PmemRateLimiterConfig::new(
+            Some(PmemTokenBucketConfig::new(1_000_000, Some(4096), 10)),
+            Some(PmemTokenBucketConfig::new(1_000, None, 20)),
+        )
+    }
+
+    #[test]
+    fn live_mixed_mmio_inventory_converts_to_exact_profile_3() {
+        let block_file = TempFile::new("mixed-root.img", 4096);
+        let pmem_file = TempFile::new("mixed-pmem.img", VIRTIO_PMEM_ALIGNMENT + 513);
+        let block = block_config(block_file.path(), true);
+        let pmem = pmem_config(
+            "pmem_0",
+            pmem_file.path(),
+            false,
+            false,
+            Some(limiter_config()),
+        );
+        let block_state = capture_mmio_block(&block, 0);
+        let pmem_state = capture_mmio_pmem(&pmem, 1);
+
+        SnapshotV2StorageDeviceGraph::preflight_capture_configs(
+            NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            std::slice::from_ref(&block),
+            std::slice::from_ref(&pmem),
+        )
+        .expect("mixed profile-3 config should preflight");
+        let graph = SnapshotV2StorageDeviceGraph::from_capture_ready_storage(
+            NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            &[block_state],
+            &[pmem_state],
+        )
+        .expect("mixed live inventory should convert");
+
+        assert_eq!(graph.root_key(), Some(SnapshotV2DeviceKey::block(0)));
+        assert_eq!(graph.transport_kind(), SnapshotV2DeviceTransportKind::Mmio);
+        assert_eq!(graph.block_records().len(), 1);
+        assert_eq!(graph.pmem_records().len(), 1);
+        let record = &graph.pmem_records()[0];
+        assert_eq!(record.config().pmem_id(), "pmem_0");
+        assert!(!record.config().is_read_only());
+        assert_eq!(record.pmem().file_bytes(), VIRTIO_PMEM_ALIGNMENT + 513);
+        assert_eq!(record.pmem().mapped_bytes(), VIRTIO_PMEM_ALIGNMENT * 2);
+        assert_eq!(
+            record.pmem().guest_range().size(),
+            record.pmem().mapped_bytes()
+        );
+        assert_eq!(
+            record.pmem().config_space().size(),
+            record.pmem().mapped_bytes()
+        );
+        assert!(record.pmem().limiter().bandwidth().is_some());
+        assert!(record.pmem().limiter().ops().is_some());
+        assert_eq!(record.pmem().retry(), StorageRetryState::None);
+        assert!(matches!(
+            record.transport(),
+            SnapshotV2DeviceTransport::Mmio(_)
+        ));
+
+        let bytes = graph
+            .encode(NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION)
+            .expect("captured profile-3 graph should encode");
+        assert_eq!(
+            SnapshotV2StorageDeviceGraph::decode(
+                NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                &bytes,
+            )
+            .expect("captured profile-3 graph should decode"),
+            graph
+        );
+    }
+
+    #[test]
+    fn live_read_only_pmem_root_converts_without_blocks() {
+        let file = TempFile::new("pmem-root.img", 4097);
+        let config = pmem_config("pmem_root", file.path(), true, true, None);
+        let state = capture_mmio_pmem(&config, 0);
+
+        let graph = SnapshotV2StorageDeviceGraph::from_capture_ready_storage(
+            NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            &[],
+            &[state],
+        )
+        .expect("pmem-only live inventory should convert");
+
+        assert_eq!(graph.root_key(), Some(SnapshotV2DeviceKey::pmem(0)));
+        assert!(graph.block_records().is_empty());
+        assert_eq!(graph.pmem_records().len(), 1);
+        assert!(graph.pmem_records()[0].config().is_read_only());
+        assert_eq!(graph.pmem_records()[0].pmem().file_bytes(), 4097);
+        assert_eq!(
+            graph.pmem_records()[0].pmem().mapped_bytes(),
+            VIRTIO_PMEM_ALIGNMENT
+        );
+    }
+
+    #[test]
+    fn profile_3_preflight_rejects_wrong_version_empty_cross_roots_and_selectors() {
+        assert_eq!(
+            SnapshotV2StorageDeviceGraph::preflight_capture_configs(
+                NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                &[],
+                &[],
+            ),
+            Err(SnapshotV2StorageDeviceGraphCaptureError::UnsupportedVersion)
+        );
+        assert_eq!(
+            SnapshotV2StorageDeviceGraph::preflight_capture_configs(
+                NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                &[],
+                &[],
+            ),
+            Err(SnapshotV2StorageDeviceGraphCaptureError::UnsupportedInventory)
+        );
+
+        let block_file = TempFile::new("preflight-block.img", 4096);
+        let pmem_file = TempFile::new("preflight-pmem.img", 4096);
+        let block_root = block_config(block_file.path(), true);
+        let pmem_root = pmem_config("pmem_root", pmem_file.path(), true, false, None);
+        assert_eq!(
+            SnapshotV2StorageDeviceGraph::preflight_capture_configs(
+                NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                &[block_root],
+                &[pmem_root],
+            ),
+            Err(SnapshotV2StorageDeviceGraphCaptureError::InvalidGraph)
+        );
+
+        let block = block_config(block_file.path(), false);
+        let same_selector = pmem_config("pmem_data", block_file.path(), false, false, None);
+        assert_eq!(
+            SnapshotV2StorageDeviceGraph::preflight_capture_configs(
+                NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                &[block],
+                &[same_selector],
+            ),
+            Err(SnapshotV2StorageDeviceGraphCaptureError::InvalidGraph)
+        );
+
+        let first = pmem_config("pmem_first", block_file.path(), false, false, None);
+        let late_root = pmem_config("pmem_root", pmem_file.path(), true, false, None);
+        assert_eq!(
+            SnapshotV2StorageDeviceGraph::preflight_capture_configs(
+                NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                &[],
+                &[first, late_root],
+            ),
+            Err(SnapshotV2StorageDeviceGraphCaptureError::InvalidGraph)
+        );
+    }
+
+    #[test]
+    fn profile_3_conversion_rejects_mapping_access_mismatch() {
+        let file = TempFile::new("mapping-access.img", 4096);
+        let writable = pmem_config("pmem_0", file.path(), false, false, None);
+        let state = capture_mmio_pmem(&writable, 0);
+        let read_only = pmem_config("pmem_0", file.path(), false, true, None);
+        let mismatched = CaptureReadyPmemDeviceState::new(
+            read_only,
+            state.guest_range(),
+            state.backing(),
+            state.mapping().clone(),
+            state.transport().clone(),
+            state.retry(),
+            state.device().clone(),
+        );
+
+        assert_eq!(
+            SnapshotV2StorageDeviceGraph::from_capture_ready_storage(
+                NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                &[],
+                &[mismatched],
+            ),
+            Err(SnapshotV2StorageDeviceGraphCaptureError::InconsistentPmemState)
+        );
+    }
+
+    #[test]
+    fn pmem_guest_range_is_aligned_for_capture_fixture() {
+        let file = TempFile::new("range-alignment.img", 4096);
+        let config = pmem_config("pmem_0", file.path(), false, false, None);
+        let state = capture_mmio_pmem(&config, 0);
+        let range = state.guest_range();
+
+        assert_eq!(range.start().raw_value() % VIRTIO_PMEM_ALIGNMENT, 0);
+        assert_eq!(range.size(), VIRTIO_PMEM_ALIGNMENT);
+        assert_eq!(
+            GuestMemoryRange::new(range.start(), range.size())
+                .expect("captured range should remain valid"),
+            range
+        );
+    }
+}

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -83,9 +83,10 @@ use crate::pci::{
 };
 use crate::pmem::{
     PmemConfig, PmemFileBacking, PmemMmioDeviceRegistration, PmemMmioLayout,
-    PmemMmioRegistrationError, PmemUpdate, PmemUpdateError, PreparedPmemDevice,
-    PreparedPmemDeviceError, PreparedPmemDevices, VirtioPmemDeviceNotificationDispatch,
-    VirtioPmemDeviceNotificationError, VirtioPmemFlushStatus, VirtioPmemMmioHandler,
+    PmemMmioRegistrationError, PmemSnapshotPersistenceBinding, PmemUpdate, PmemUpdateError,
+    PreparedPmemDevice, PreparedPmemDeviceError, PreparedPmemDevices,
+    VirtioPmemDeviceNotificationDispatch, VirtioPmemDeviceNotificationError, VirtioPmemFlushStatus,
+    VirtioPmemMmioHandler,
 };
 use crate::pvtime::{
     Arm64PvTimeLayout, Arm64PvTimeLayoutError, initialize_arm64_pvtime_records_with,
@@ -3130,6 +3131,7 @@ pub enum Arm64BootStorageCaptureError {
     PmemMetadata,
     PmemHandler,
     PmemBacking,
+    PmemPersistencePreflight,
     PmemCapture,
 }
 
@@ -3147,6 +3149,7 @@ impl fmt::Debug for Arm64BootStorageCaptureError {
             Self::PmemMetadata => "PmemMetadata",
             Self::PmemHandler => "PmemHandler",
             Self::PmemBacking => "PmemBacking",
+            Self::PmemPersistencePreflight => "PmemPersistencePreflight",
             Self::PmemCapture => "PmemCapture",
         };
         formatter
@@ -3171,6 +3174,7 @@ impl Arm64BootStorageCaptureError {
             | Self::PmemMetadata
             | Self::PmemHandler
             | Self::PmemBacking
+            | Self::PmemPersistencePreflight
             | Self::PmemCapture => None,
         }
     }
@@ -3198,6 +3202,9 @@ impl fmt::Display for Arm64BootStorageCaptureError {
             Self::PmemMetadata => formatter.write_str("live MMIO pmem metadata is inconsistent"),
             Self::PmemHandler => formatter.write_str("live MMIO pmem handler is unavailable"),
             Self::PmemBacking => formatter.write_str("live pmem backing identity is unavailable"),
+            Self::PmemPersistencePreflight => {
+                formatter.write_str("live pmem persistence preflight failed")
+            }
             Self::PmemCapture => formatter.write_str("live MMIO pmem capture failed"),
         }
     }
@@ -3441,6 +3448,15 @@ impl Arm64BootRuntimeResources {
             retry,
             captured,
         ))
+    }
+
+    pub fn capture_ready_pmem_snapshot_persistence_binding(
+        &self,
+        config: &PmemConfig,
+    ) -> Result<PmemSnapshotPersistenceBinding, Arm64BootStorageCaptureError> {
+        unique_prepared_pmem_device(&self.pmem_devices, config.id())?
+            .snapshot_persistence_binding(config)
+            .map_err(|_| Arm64BootStorageCaptureError::PmemPersistencePreflight)
     }
 
     pub fn capture_snapshot_v1_device_state_at(


### PR DESCRIPTION
## Summary

- add allocation-aware exact native-v2 2.6 conversion from complete live block and pmem inventories, preserving canonical MMIO/PCI transport, startup/runtime origin, root selection, device continuation, limiter/retry state, and exact backing geometry
- retain authoritative pmem mapping leases and synchronously persist only each writable file-backed prefix with `MS_SYNC` before completion publication and graph composition
- extend the existing HVF storage transaction with a hidden profile-3 mode, including full preflight, deterministic block-then-pmem persistence, cancellation, reverse cleanup, and exact-2.6 platform composition
- cover writable durability, read-only skipping, between-device cancellation, MMIO/PCI owners, runtime-added pmem, round trips, and hidden platform version agreement in runtime and signed HVF tests

## Scope exclusions

- public native-v2 create, load, version reporting, and pmem rejection remain exact 2.5
- profile-3 external restore resources, pathless reconstruction, MMIO/PCI restoration, activation, and final certification remain later children of #1534

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

Closes #1628

Parent: #1534
