### PR TITLE
feat: prepare pathless pmem snapshot restore bundles

### DIFF
--- a/crates/bangbang/src/snapshot_restore_resources.rs
+++ b/crates/bangbang/src/snapshot_restore_resources.rs
@@ -4818,6 +4818,22 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct TestPrivateStorageDestination {
+        bundle: Option<PreparedSnapshotV2StorageBundle>,
+        destroyed: Rc<Cell<bool>>,
+    }
+
+    impl TestPrivateStorageDestination {
+        fn destroy(mut self) -> Result<(), SnapshotV2StorageCleanupError> {
+            self.destroyed.set(true);
+            match self.bundle.take() {
+                Some(bundle) => bundle.abort(),
+                None => Ok(()),
+            }
+        }
+    }
+
     fn requested() -> RequestedSnapshotRestoreResources {
         RequestedSnapshotRestoreResources::try_from_native_v2_device_graph(&fixture_graph(
             SnapshotV2DeviceTransportKind::Mmio,
@@ -6138,6 +6154,106 @@ mod tests {
         let diagnostics = format!("{construction:?} {controller:?}");
         assert!(!diagnostics.contains(block.path().to_string_lossy().as_ref()));
         assert!(!diagnostics.contains(pmem.path().to_string_lossy().as_ref()));
+    }
+
+    #[test]
+    fn profile_3_completion_failure_destroys_destination_and_is_terminal() {
+        let block_path = unique_short_path();
+        let pmem_path = unique_pmem_short_path();
+        let template = storage_fixture_graph(&block_path, &pmem_path);
+        let block = TempRoot::new_sized_at(
+            block_path,
+            template.block_records()[0].block().backing_bytes(),
+        );
+        let pmem =
+            TempRoot::new_sized_at(pmem_path, template.pmem_records()[0].pmem().file_bytes());
+        let graph = storage_fixture_graph(block.path(), pmem.path());
+        let memory = storage_restore_memory(&graph);
+        let mut prepared =
+            RequestedSnapshotRestoreResources::prepare_native_v2_storage_restore_bundle(
+                graph,
+                &memory,
+                Instant::now(),
+                None,
+                || false,
+            )
+            .expect("profile-3 completion fixture should prepare");
+        prepared
+            .completion
+            .take()
+            .expect("direct completion should exist")
+            .abort()
+            .expect("direct completion should abort before injection");
+
+        let root = TempRoot::new("storage-completion", b"root");
+        let fixture = contained_restore_authority_for_test(root.path(), false);
+        let root_owner = contained_requested_root()
+            .prepare(Some(fixture.authority()), || false)
+            .expect("contained root should prepare")
+            .into_root()
+            .expect("contained root should take exactly");
+        let (backing, completion) = root_owner.into_parts();
+        drop(backing);
+        let PreparedSnapshotRootRestoreCompletion {
+            lease,
+            contained_transaction,
+        } = completion;
+        let PreparedSnapshotRootBackingLease {
+            selector: _,
+            claim,
+            consumed: _,
+        } = lease;
+        prepared.completion = Some(PreparedSnapshotDriveRestoreCompletion {
+            claims: claim.into_iter().collect(),
+            contained_transaction,
+        });
+
+        let destroyed = Rc::new(Cell::new(false));
+        let destination = prepared
+            .construct_destination({
+                let destroyed = Rc::clone(&destroyed);
+                move |bundle| {
+                    Ok::<_, std::convert::Infallible>(Box::new(TestPrivateStorageDestination {
+                        bundle: Some(bundle),
+                        destroyed,
+                    }))
+                }
+            })
+            .expect("private profile-3 destination should construct");
+        fixture.invalidate_generation();
+        let error = destination
+            .commit(
+                |destination| {
+                    Ok::<_, (Box<TestPrivateStorageDestination>, std::convert::Infallible)>((
+                        destination,
+                        (),
+                    ))
+                },
+                |destination| (*destination).destroy(),
+            )
+            .expect_err("stale contained completion should fail");
+        assert!(destroyed.get());
+        assert!(error.is_terminal());
+        assert!(matches!(
+            error,
+            PreparedSnapshotV2StorageDestinationCommitError::Completion {
+                destination_cleanup: None,
+                ..
+            }
+        ));
+
+        let retry_graph = storage_fixture_graph(block.path(), pmem.path());
+        let retry_memory = storage_restore_memory(&retry_graph);
+        RequestedSnapshotRestoreResources::prepare_native_v2_storage_restore_bundle(
+            retry_graph,
+            &retry_memory,
+            Instant::now(),
+            None,
+            || false,
+        )
+        .expect("terminal completion failure should still release runtime owners")
+        .abort()
+        .expect("retried profile-3 bundle should abort cleanly");
     }
 
     #[test]

--- a/crates/bangbang/src/snapshot_restore_resources.rs
+++ b/crates/bangbang/src/snapshot_restore_resources.rs
@@ -22,7 +22,10 @@ use bangbang_runtime::snapshot_device_v2_5::{
     SnapshotV2MultiBlockCleanupError, SnapshotV2MultiBlockDeviceGraph,
     SnapshotV2MultiBlockRestorePlan, SnapshotV2MultiBlockRestorePlanError,
 };
-use bangbang_runtime::snapshot_device_v2_6::SnapshotV2StorageDeviceGraph;
+use bangbang_runtime::snapshot_device_v2_6::{
+    PreparedSnapshotV2StorageBundle, SnapshotV2StorageBundleError, SnapshotV2StorageCleanupError,
+    SnapshotV2StorageDeviceGraph, SnapshotV2StorageRestorePlan, SnapshotV2StorageRestorePlanError,
+};
 use bangbang_runtime::snapshot_restore::{
     PreparedSnapshotRestoreBindings, SnapshotRestoreBindingAllocationError,
     SnapshotRestoreBindingRejectionReason, SnapshotRestoreBindings, SnapshotRestoreManifest,
@@ -2285,6 +2288,16 @@ impl Drop for PreparedSnapshotDriveRestoreCompletion {
     }
 }
 
+fn abort_drive_completion_outcome(
+    completion: PreparedSnapshotDriveRestoreCompletion,
+) -> SnapshotRestoreAbortOutcome {
+    if completion.abort().is_err() {
+        SnapshotRestoreAbortOutcome::terminal(true)
+    } else {
+        SnapshotRestoreAbortOutcome::retryable()
+    }
+}
+
 impl fmt::Debug for PreparedSnapshotDriveRestoreCompletion {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
@@ -2639,6 +2652,398 @@ impl std::error::Error for PreparedSnapshotV2MultiBlockRestoreAbortError {
     }
 }
 
+/// Process-owned composition of one pathless profile-3 storage bundle and
+/// its aggregate provisional backing authority.
+pub(crate) struct PreparedSnapshotV2StorageRestoreBundle {
+    bundle: Option<PreparedSnapshotV2StorageBundle>,
+    completion: Option<PreparedSnapshotDriveRestoreCompletion>,
+}
+
+impl PreparedSnapshotV2StorageRestoreBundle {
+    pub(crate) const fn bundle(&self) -> Option<&PreparedSnapshotV2StorageBundle> {
+        self.bundle.as_ref()
+    }
+
+    pub(crate) fn construct_destination<D, E>(
+        mut self,
+        construct: impl FnOnce(PreparedSnapshotV2StorageBundle) -> Result<D, E>,
+    ) -> Result<
+        PreparedSnapshotV2StorageDestination<D>,
+        PreparedSnapshotV2StorageDestinationConstructionError<E>,
+    > {
+        let Some(bundle) = self.bundle.take() else {
+            return Err(
+                PreparedSnapshotV2StorageDestinationConstructionError::InvalidState {
+                    bundle_cleanup: None,
+                },
+            );
+        };
+        let Some(completion) = self.completion.take() else {
+            return Err(
+                PreparedSnapshotV2StorageDestinationConstructionError::InvalidState {
+                    bundle_cleanup: bundle.abort().err(),
+                },
+            );
+        };
+        match construct(bundle) {
+            Ok(destination) => Ok(PreparedSnapshotV2StorageDestination {
+                destination: Some(destination),
+                completion: Some(completion),
+            }),
+            Err(source) => Err(
+                PreparedSnapshotV2StorageDestinationConstructionError::Construction {
+                    source,
+                    completion_abort: completion.abort().err(),
+                },
+            ),
+        }
+    }
+
+    pub(crate) fn abort(mut self) -> Result<(), PreparedSnapshotV2StorageRestoreAbortError> {
+        let bundle = self.bundle.take().and_then(|bundle| bundle.abort().err());
+        let completion = self
+            .completion
+            .take()
+            .and_then(|completion| completion.abort().err());
+        if bundle.is_some() || completion.is_some() {
+            Err(PreparedSnapshotV2StorageRestoreAbortError { bundle, completion })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for PreparedSnapshotV2StorageRestoreBundle {
+    fn drop(&mut self) {
+        if let Some(bundle) = self.bundle.take() {
+            let _ = bundle.abort();
+        }
+        if let Some(completion) = self.completion.take() {
+            let _ = completion.abort();
+        }
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2StorageRestoreBundle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2StorageRestoreBundle")
+            .field(
+                "block_count",
+                &self
+                    .bundle
+                    .as_ref()
+                    .and_then(PreparedSnapshotV2StorageBundle::block_bundle)
+                    .map_or(0, |bundle| bundle.records().len()),
+            )
+            .field(
+                "pmem_count",
+                &self
+                    .bundle
+                    .as_ref()
+                    .map_or(0, |bundle| bundle.pmem_records().len()),
+            )
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// One complete private profile-3 destination whose backing authority remains
+/// provisional until its controller projection is also ready.
+pub(crate) struct PreparedSnapshotV2StorageDestination<D> {
+    destination: Option<D>,
+    completion: Option<PreparedSnapshotDriveRestoreCompletion>,
+}
+
+impl<D> PreparedSnapshotV2StorageDestination<D> {
+    pub(crate) fn commit<C, E, T>(
+        mut self,
+        prepare_controller: impl FnOnce(D) -> Result<(D, C), (D, E)>,
+        destroy_destination: impl FnOnce(D) -> Result<(), T>,
+    ) -> Result<(D, C), PreparedSnapshotV2StorageDestinationCommitError<E, T>> {
+        let destination = self
+            .destination
+            .take()
+            .ok_or(PreparedSnapshotV2StorageDestinationCommitError::InvalidState)?;
+        let completion = self
+            .completion
+            .take()
+            .ok_or(PreparedSnapshotV2StorageDestinationCommitError::InvalidState)?;
+        let (destination, controller) = match prepare_controller(destination) {
+            Ok(prepared) => prepared,
+            Err((destination, source)) => {
+                let destination_cleanup = destroy_destination(destination).err();
+                let completion_abort = completion.abort().err();
+                return Err(
+                    PreparedSnapshotV2StorageDestinationCommitError::Controller {
+                        source,
+                        destination_cleanup,
+                        completion_abort,
+                    },
+                );
+            }
+        };
+        match completion.commit() {
+            Ok(()) => Ok((destination, controller)),
+            Err(source) => {
+                let destination_cleanup = destroy_destination(destination).err();
+                Err(
+                    PreparedSnapshotV2StorageDestinationCommitError::Completion {
+                        source,
+                        destination_cleanup,
+                    },
+                )
+            }
+        }
+    }
+}
+
+impl<D> fmt::Debug for PreparedSnapshotV2StorageDestination<D> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2StorageDestination")
+            .field("state", &"<private-provisional>")
+            .finish()
+    }
+}
+
+pub(crate) enum PreparedSnapshotV2StorageDestinationConstructionError<E> {
+    InvalidState {
+        bundle_cleanup: Option<SnapshotV2StorageCleanupError>,
+    },
+    Construction {
+        source: E,
+        completion_abort: Option<PreparedSnapshotDriveRestoreCompletionError>,
+    },
+}
+
+impl<E> PreparedSnapshotV2StorageDestinationConstructionError<E> {
+    pub(crate) const fn is_terminal(&self) -> bool {
+        match self {
+            Self::InvalidState { .. }
+            | Self::Construction {
+                completion_abort: Some(_),
+                ..
+            } => true,
+            Self::Construction {
+                completion_abort: None,
+                ..
+            } => false,
+        }
+    }
+}
+
+impl<E> fmt::Debug for PreparedSnapshotV2StorageDestinationConstructionError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::InvalidState { .. } => "invalid-state",
+            Self::Construction { .. } => "construction",
+        };
+        formatter
+            .debug_struct("PreparedSnapshotV2StorageDestinationConstructionError")
+            .field("kind", &kind)
+            .field("terminal", &self.is_terminal())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl<E> fmt::Display for PreparedSnapshotV2StorageDestinationConstructionError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidState { .. } => {
+                "snapshot storage destination construction state is invalid"
+            }
+            Self::Construction { .. } => "snapshot storage destination construction failed",
+        })
+    }
+}
+
+impl<E> std::error::Error for PreparedSnapshotV2StorageDestinationConstructionError<E>
+where
+    E: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidState { bundle_cleanup } => bundle_cleanup
+                .as_ref()
+                .map(|source| source as &(dyn std::error::Error + 'static)),
+            Self::Construction { source, .. } => Some(source),
+        }
+    }
+}
+
+pub(crate) enum PreparedSnapshotV2StorageDestinationCommitError<E, T> {
+    InvalidState,
+    Controller {
+        source: E,
+        destination_cleanup: Option<T>,
+        completion_abort: Option<PreparedSnapshotDriveRestoreCompletionError>,
+    },
+    Completion {
+        source: PreparedSnapshotDriveRestoreCompletionError,
+        destination_cleanup: Option<T>,
+    },
+}
+
+impl<E, T> PreparedSnapshotV2StorageDestinationCommitError<E, T> {
+    pub(crate) const fn is_terminal(&self) -> bool {
+        match self {
+            Self::InvalidState => true,
+            Self::Controller {
+                destination_cleanup,
+                completion_abort,
+                ..
+            } => destination_cleanup.is_some() || completion_abort.is_some(),
+            Self::Completion {
+                destination_cleanup,
+                ..
+            } => {
+                let _cleanup_failed = destination_cleanup.is_some();
+                true
+            }
+        }
+    }
+}
+
+impl<E, T> fmt::Debug for PreparedSnapshotV2StorageDestinationCommitError<E, T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::InvalidState => "invalid-state",
+            Self::Controller { .. } => "controller",
+            Self::Completion { .. } => "completion",
+        };
+        formatter
+            .debug_struct("PreparedSnapshotV2StorageDestinationCommitError")
+            .field("kind", &kind)
+            .field("terminal", &self.is_terminal())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl<E, T> fmt::Display for PreparedSnapshotV2StorageDestinationCommitError<E, T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidState => "snapshot storage destination commit state is invalid",
+            Self::Controller { .. } => {
+                "snapshot storage controller preparation failed before completion"
+            }
+            Self::Completion { .. } => {
+                "snapshot storage backing completion failed after destination construction"
+            }
+        })
+    }
+}
+
+impl<E, T> std::error::Error for PreparedSnapshotV2StorageDestinationCommitError<E, T>
+where
+    E: std::error::Error + 'static,
+    T: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Controller { source, .. } => Some(source),
+            Self::Completion { source, .. } => Some(source),
+            Self::InvalidState => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct PreparedSnapshotV2StorageRestoreAbortError {
+    bundle: Option<SnapshotV2StorageCleanupError>,
+    completion: Option<PreparedSnapshotDriveRestoreCompletionError>,
+}
+
+impl fmt::Display for PreparedSnapshotV2StorageRestoreAbortError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("snapshot storage restore bundle cleanup failed")
+    }
+}
+
+impl std::error::Error for PreparedSnapshotV2StorageRestoreAbortError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.bundle
+            .as_ref()
+            .map(|source| source as &(dyn std::error::Error + 'static))
+            .or_else(|| {
+                self.completion
+                    .as_ref()
+                    .map(|source| source as &(dyn std::error::Error + 'static))
+            })
+    }
+}
+
+pub(crate) enum SnapshotV2StorageRestoreBundleError {
+    Resources(SnapshotRestoreResourceError),
+    Plan(SnapshotV2StorageRestorePlanError),
+    Bundle {
+        source: SnapshotV2StorageBundleError,
+        completion_abort: Option<PreparedSnapshotDriveRestoreCompletionError>,
+    },
+}
+
+impl SnapshotV2StorageRestoreBundleError {
+    pub(crate) const fn disposition(&self) -> SnapshotRestoreResourceDisposition {
+        match self {
+            Self::Resources(source) => source.disposition(),
+            Self::Plan(
+                SnapshotV2StorageRestorePlanError::Allocation
+                | SnapshotV2StorageRestorePlanError::Block(
+                    SnapshotV2MultiBlockRestorePlanError::Allocation,
+                ),
+            ) => SnapshotRestoreResourceDisposition::Retryable,
+            Self::Plan(_) => SnapshotRestoreResourceDisposition::Terminal,
+            Self::Bundle {
+                completion_abort: Some(_),
+                ..
+            } => SnapshotRestoreResourceDisposition::Terminal,
+            Self::Bundle {
+                source,
+                completion_abort: None,
+            } if source.is_retryable() => SnapshotRestoreResourceDisposition::Retryable,
+            Self::Bundle { .. } => SnapshotRestoreResourceDisposition::Terminal,
+        }
+    }
+}
+
+impl fmt::Debug for SnapshotV2StorageRestoreBundleError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::Resources(_) => "Resources",
+            Self::Plan(_) => "Plan",
+            Self::Bundle { .. } => "Bundle",
+        };
+        formatter
+            .debug_struct("SnapshotV2StorageRestoreBundleError")
+            .field("kind", &kind)
+            .field("disposition", &self.disposition())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotV2StorageRestoreBundleError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "snapshot storage restore bundle preparation failed ({:?})",
+            self.disposition()
+        )
+    }
+}
+
+impl std::error::Error for SnapshotV2StorageRestoreBundleError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Resources(source) => Some(source),
+            Self::Plan(source) => Some(source),
+            Self::Bundle { source, .. } => Some(source),
+        }
+    }
+}
+
 pub(crate) enum SnapshotV2MultiBlockRestoreBundleError {
     Resources(SnapshotRestoreResourceError),
     Plan(SnapshotV2MultiBlockRestorePlanError),
@@ -2871,6 +3276,156 @@ impl RequestedSnapshotRestoreResources {
         }
     }
 
+    /// Dormant profile-3 pathless bundle producer. It performs pure loaded-
+    /// memory planning before opening or taking one backing and retains the
+    /// aggregate completion without publishing transport, controller, or VM
+    /// state.
+    pub(crate) fn prepare_native_v2_storage_restore_bundle<F>(
+        graph: SnapshotV2StorageDeviceGraph,
+        memory: &GuestMemory,
+        now: Instant,
+        authority: Option<&ContainedSnapshotRestoreAuthority>,
+        cancelled: F,
+    ) -> Result<PreparedSnapshotV2StorageRestoreBundle, SnapshotV2StorageRestoreBundleError>
+    where
+        F: Fn() -> bool,
+    {
+        let _bundle = PreparedSnapshotV2StorageRestoreBundle::bundle;
+        let _construct = |prepared: PreparedSnapshotV2StorageRestoreBundle| {
+            prepared.construct_destination(Ok::<_, std::convert::Infallible>)
+        };
+        let _commit = |destination: PreparedSnapshotV2StorageDestination<()>| {
+            destination.commit(
+                |destination| Ok::<_, ((), std::convert::Infallible)>((destination, ())),
+                |_| Ok::<_, std::convert::Infallible>(()),
+            )
+        };
+        let _abort = PreparedSnapshotV2StorageRestoreBundle::abort;
+        Self::prepare_native_v2_storage_restore_bundle_with(
+            graph,
+            memory,
+            now,
+            authority,
+            cancelled,
+            |plan, blocks, pmems, cancelled| plan.prepare_backings(blocks, pmems, cancelled),
+        )
+    }
+
+    fn prepare_native_v2_storage_restore_bundle_with<F, B>(
+        graph: SnapshotV2StorageDeviceGraph,
+        memory: &GuestMemory,
+        now: Instant,
+        authority: Option<&ContainedSnapshotRestoreAuthority>,
+        cancelled: F,
+        build_bundle: B,
+    ) -> Result<PreparedSnapshotV2StorageRestoreBundle, SnapshotV2StorageRestoreBundleError>
+    where
+        F: Fn() -> bool,
+        B: FnOnce(
+            SnapshotV2StorageRestorePlan,
+            Vec<BlockFileBacking>,
+            Vec<PmemFileBacking>,
+            &F,
+        ) -> Result<PreparedSnapshotV2StorageBundle, SnapshotV2StorageBundleError>,
+    {
+        let mut expected_keys = Vec::new();
+        expected_keys
+            .try_reserve_exact(graph.record_count())
+            .map_err(|_| {
+                SnapshotV2StorageRestoreBundleError::Plan(
+                    SnapshotV2StorageRestorePlanError::Allocation,
+                )
+            })?;
+        expected_keys.extend(
+            graph
+                .block_records()
+                .iter()
+                .map(|record| (record.key(), SnapshotRestoreResourceClass::BlockBacking))
+                .chain(
+                    graph
+                        .pmem_records()
+                        .iter()
+                        .map(|record| (record.key(), SnapshotRestoreResourceClass::PmemBacking)),
+                ),
+        );
+        let requested =
+            RequestedSnapshotStorageRestoreResources::try_from_native_v2_storage_device_graph(
+                &graph,
+            )
+            .map_err(SnapshotV2StorageRestoreBundleError::Resources)?;
+        let plan = SnapshotV2StorageRestorePlan::prepare(graph, memory, now)
+            .map_err(SnapshotV2StorageRestoreBundleError::Plan)?;
+        let batch = requested
+            .prepare(authority, &cancelled)
+            .and_then(PreparedSnapshotStorageRestoreResources::into_storage_batch)
+            .map_err(SnapshotV2StorageRestoreBundleError::Resources)?;
+        let (blocks, pmems, completion) = batch.into_parts();
+        let mut block_backings = Vec::new();
+        let mut pmem_backings = Vec::new();
+        if block_backings.try_reserve_exact(blocks.len()).is_err()
+            || pmem_backings.try_reserve_exact(pmems.len()).is_err()
+        {
+            drop(blocks);
+            drop(pmems);
+            let outcome = abort_drive_completion_outcome(completion);
+            return Err(SnapshotV2StorageRestoreBundleError::Resources(
+                SnapshotRestoreResourceError::retryable(
+                    SnapshotRestoreResourceStage::Finish,
+                    SnapshotRestoreResourceErrorKind::InvalidStorageSet,
+                )
+                .with_abort_outcome(outcome),
+            ));
+        }
+
+        let mut expected = expected_keys.iter();
+        let mut valid = true;
+        for owner in blocks {
+            let (key, backing) = owner.into_parts();
+            valid &= expected.next().is_some_and(|(device_key, resource_class)| {
+                key.device_key() == *device_key
+                    && key.resource_class() == *resource_class
+                    && *resource_class == SnapshotRestoreResourceClass::BlockBacking
+            });
+            block_backings.push(backing);
+        }
+        for owner in pmems {
+            let (key, backing) = owner.into_parts();
+            valid &= expected.next().is_some_and(|(device_key, resource_class)| {
+                key.device_key() == *device_key
+                    && key.resource_class() == *resource_class
+                    && *resource_class == SnapshotRestoreResourceClass::PmemBacking
+            });
+            pmem_backings.push(backing);
+        }
+        valid &= expected.next().is_none();
+        if !valid {
+            drop(block_backings);
+            drop(pmem_backings);
+            let outcome = abort_drive_completion_outcome(completion);
+            return Err(SnapshotV2StorageRestoreBundleError::Resources(
+                SnapshotRestoreResourceError::terminal(
+                    SnapshotRestoreResourceStage::Finish,
+                    SnapshotRestoreResourceErrorKind::InvalidStorageSet,
+                )
+                .with_abort_outcome(outcome),
+            ));
+        }
+
+        match build_bundle(plan, block_backings, pmem_backings, &cancelled) {
+            Ok(bundle) => Ok(PreparedSnapshotV2StorageRestoreBundle {
+                bundle: Some(bundle),
+                completion: Some(completion),
+            }),
+            Err(source) => {
+                let completion_abort = completion.abort().err();
+                Err(SnapshotV2StorageRestoreBundleError::Bundle {
+                    source,
+                    completion_abort,
+                })
+            }
+        }
+    }
+
     /// Typed profile-2 resource producer retained for focused handoff tests.
     ///
     /// Public activation consumes the composed restore-bundle variant above.
@@ -2924,6 +3479,8 @@ impl RequestedSnapshotRestoreResources {
         let _profile_2_bundle_producer =
             Self::prepare_native_v2_multi_block_restore_bundle::<fn() -> bool>;
         let _profile_3_producer = Self::prepare_native_v2_storage_device_graph::<fn() -> bool>;
+        let _profile_3_bundle_producer =
+            Self::prepare_native_v2_storage_restore_bundle::<fn() -> bool>;
         Self::try_from_native_v2_device_graph_and_vsock(graph, None)
     }
 
@@ -4049,6 +4606,75 @@ mod tests {
                     GuestAddress::new(queue.device_ring().raw_value() + 2),
                 )
                 .expect("profile-2 used cursor should write");
+        }
+        memory
+    }
+
+    fn storage_restore_memory(graph: &SnapshotV2StorageDeviceGraph) -> GuestMemory {
+        let layout = GuestMemoryLayout::new(vec![
+            GuestMemoryRange::new(GuestAddress::new(0), 0x80_0000)
+                .expect("profile-3 restore memory range should validate"),
+        ])
+        .expect("profile-3 restore memory layout should validate");
+        let mut memory =
+            GuestMemory::allocate(&layout).expect("profile-3 restore memory should allocate");
+        for record in graph.block_records() {
+            let Some(cursor) = record.block().continuation().active_queue() else {
+                continue;
+            };
+            let queue = record
+                .virtio()
+                .queues()
+                .first()
+                .expect("profile-3 block queue should exist");
+            let available_index = if record.block().continuation().retry()
+                == bangbang_runtime::storage_capture::StorageRetryState::None
+            {
+                cursor.next_available()
+            } else {
+                cursor.next_available().wrapping_add(1)
+            };
+            memory
+                .write_slice(
+                    &available_index.to_le_bytes(),
+                    GuestAddress::new(queue.driver_ring().raw_value() + 2),
+                )
+                .expect("profile-3 block available cursor should write");
+            memory
+                .write_slice(
+                    &cursor.next_used().to_le_bytes(),
+                    GuestAddress::new(queue.device_ring().raw_value() + 2),
+                )
+                .expect("profile-3 block used cursor should write");
+        }
+        for record in graph.pmem_records() {
+            let Some(cursor) = record.pmem().active_queue() else {
+                continue;
+            };
+            let queue = record
+                .virtio()
+                .queues()
+                .first()
+                .expect("profile-3 pmem queue should exist");
+            let available_index = if record.pmem().retry()
+                == bangbang_runtime::storage_capture::StorageRetryState::None
+            {
+                cursor.next_available()
+            } else {
+                cursor.next_available().wrapping_add(1)
+            };
+            memory
+                .write_slice(
+                    &available_index.to_le_bytes(),
+                    GuestAddress::new(queue.driver_ring().raw_value() + 2),
+                )
+                .expect("profile-3 pmem available cursor should write");
+            memory
+                .write_slice(
+                    &cursor.next_used().to_le_bytes(),
+                    GuestAddress::new(queue.device_ring().raw_value() + 2),
+                )
+                .expect("profile-3 pmem used cursor should write");
         }
         memory
     }
@@ -5385,6 +6011,306 @@ mod tests {
             block_reference.as_path(),
             pmem_reference.as_path(),
         ] {
+            assert!(!diagnostics.contains(private.to_string_lossy().as_ref()));
+        }
+    }
+
+    #[test]
+    fn profile_3_process_bundle_retains_runtime_owners_until_explicit_commit() {
+        let block_path = unique_short_path();
+        let pmem_path = unique_pmem_short_path();
+        let template = storage_fixture_graph(&block_path, &pmem_path);
+        let block = TempRoot::new_sized_at(
+            block_path,
+            template.block_records()[0].block().backing_bytes(),
+        );
+        let pmem =
+            TempRoot::new_sized_at(pmem_path, template.pmem_records()[0].pmem().file_bytes());
+        let graph = storage_fixture_graph(block.path(), pmem.path());
+        let expected_root = graph.root_key();
+        let memory = storage_restore_memory(&graph);
+        let prepared = RequestedSnapshotRestoreResources::prepare_native_v2_storage_restore_bundle(
+            graph,
+            &memory,
+            Instant::now(),
+            None,
+            || false,
+        )
+        .expect("profile-3 process bundle should prepare");
+        let retained = prepared
+            .bundle()
+            .expect("profile-3 process owner should retain its bundle");
+        assert_eq!(retained.root_key(), expected_root);
+        assert_eq!(
+            retained
+                .block_bundle()
+                .expect("mixed storage should retain block owners")
+                .records()
+                .len(),
+            1
+        );
+        assert_eq!(retained.pmem_records().len(), 1);
+        assert_eq!(retained.pmem_configs().as_slice().len(), 1);
+        assert_eq!(
+            retained.pmem_records()[0].prepared_device().guest_range(),
+            template.pmem_records()[0].pmem().guest_range()
+        );
+        let diagnostics = format!("{prepared:?}");
+        assert!(!diagnostics.contains(block.path().to_string_lossy().as_ref()));
+        assert!(!diagnostics.contains(pmem.path().to_string_lossy().as_ref()));
+
+        let destination = prepared
+            .construct_destination(|bundle| Ok::<_, std::convert::Infallible>(Box::new(bundle)))
+            .expect("private profile-3 destination should construct");
+        let (bundle, ()) = destination
+            .commit(
+                |bundle| {
+                    Ok::<
+                        _,
+                        (
+                            Box<PreparedSnapshotV2StorageBundle>,
+                            std::convert::Infallible,
+                        ),
+                    >((bundle, ()))
+                },
+                |_| Ok::<_, std::convert::Infallible>(()),
+            )
+            .expect("profile-3 completion should commit after controller preparation");
+        (*bundle)
+            .abort()
+            .expect("committed detached profile-3 owners should abort cleanly");
+    }
+
+    #[test]
+    fn profile_3_destination_failures_and_drop_preserve_clean_retry() {
+        let block_path = unique_short_path();
+        let pmem_path = unique_pmem_short_path();
+        let template = storage_fixture_graph(&block_path, &pmem_path);
+        let block = TempRoot::new_sized_at(
+            block_path,
+            template.block_records()[0].block().backing_bytes(),
+        );
+        let pmem =
+            TempRoot::new_sized_at(pmem_path, template.pmem_records()[0].pmem().file_bytes());
+        let prepare = || {
+            let graph = storage_fixture_graph(block.path(), pmem.path());
+            let memory = storage_restore_memory(&graph);
+            RequestedSnapshotRestoreResources::prepare_native_v2_storage_restore_bundle(
+                graph,
+                &memory,
+                Instant::now(),
+                None,
+                || false,
+            )
+            .expect("profile-3 failure fixture should prepare")
+        };
+
+        let construction = prepare()
+            .construct_destination(|bundle| {
+                drop(bundle);
+                Err::<(), _>(io::Error::other(
+                    "scripted destination construction failure",
+                ))
+            })
+            .expect_err("destination construction failure should abort completion");
+        assert!(!construction.is_terminal());
+
+        let destination = prepare()
+            .construct_destination(|bundle| Ok::<_, std::convert::Infallible>(Box::new(bundle)))
+            .expect("controller failure destination should construct");
+        let controller = destination
+            .commit(
+                |destination| {
+                    Err::<(Box<PreparedSnapshotV2StorageBundle>, ()), _>((
+                        destination,
+                        io::Error::other("scripted controller preparation failure"),
+                    ))
+                },
+                |destination| (*destination).abort(),
+            )
+            .expect_err("controller failure should destroy the destination and abort completion");
+        assert!(!controller.is_terminal());
+
+        drop(prepare());
+        prepare()
+            .abort()
+            .expect("construction, controller, and drop failures should leave a clean retry");
+        let diagnostics = format!("{construction:?} {controller:?}");
+        assert!(!diagnostics.contains(block.path().to_string_lossy().as_ref()));
+        assert!(!diagnostics.contains(pmem.path().to_string_lossy().as_ref()));
+    }
+
+    #[test]
+    fn profile_3_plan_failure_precedes_backing_access_and_bundle_failure_aborts_completion() {
+        let missing_block = unique_short_path();
+        let missing_pmem = unique_pmem_short_path();
+        let graph = storage_fixture_graph(&missing_block, &missing_pmem);
+        let tiny_layout = GuestMemoryLayout::new(vec![
+            GuestMemoryRange::new(GuestAddress::new(0), 0x4000)
+                .expect("tiny restore range should validate"),
+        ])
+        .expect("tiny restore layout should validate");
+        let tiny_memory =
+            GuestMemory::allocate(&tiny_layout).expect("tiny restore memory should allocate");
+        let error = RequestedSnapshotRestoreResources::prepare_native_v2_storage_restore_bundle(
+            graph,
+            &tiny_memory,
+            Instant::now(),
+            None,
+            || false,
+        )
+        .expect_err("loaded-memory failure must precede missing backing access");
+        assert!(matches!(
+            error,
+            SnapshotV2StorageRestoreBundleError::Plan(_)
+        ));
+        assert_eq!(
+            error.disposition(),
+            SnapshotRestoreResourceDisposition::Terminal
+        );
+
+        let block_path = unique_short_path();
+        let pmem_path = unique_pmem_short_path();
+        let template = storage_fixture_graph(&block_path, &pmem_path);
+        let block = TempRoot::new_sized_at(
+            block_path,
+            template.block_records()[0].block().backing_bytes(),
+        );
+        let pmem =
+            TempRoot::new_sized_at(pmem_path, template.pmem_records()[0].pmem().file_bytes());
+        let graph = storage_fixture_graph(block.path(), pmem.path());
+        let memory = storage_restore_memory(&graph);
+        let error =
+            RequestedSnapshotRestoreResources::prepare_native_v2_storage_restore_bundle_with(
+                graph,
+                &memory,
+                Instant::now(),
+                None,
+                || false,
+                |plan, blocks, pmems, _| {
+                    drop(blocks);
+                    plan.prepare_backings(Vec::new(), pmems, || false)
+                },
+            )
+            .expect_err("wrong runtime cardinality should abort aggregate completion");
+        assert!(matches!(
+            error,
+            SnapshotV2StorageRestoreBundleError::Bundle { .. }
+        ));
+        assert_eq!(
+            error.disposition(),
+            SnapshotRestoreResourceDisposition::Terminal
+        );
+
+        let retry_graph = storage_fixture_graph(block.path(), pmem.path());
+        let retry_memory = storage_restore_memory(&retry_graph);
+        RequestedSnapshotRestoreResources::prepare_native_v2_storage_restore_bundle(
+            retry_graph,
+            &retry_memory,
+            Instant::now(),
+            None,
+            || false,
+        )
+        .expect("bundle failure should leave direct backings reusable")
+        .abort()
+        .expect("retried profile-3 bundle should abort cleanly");
+    }
+
+    #[test]
+    fn profile_3_runtime_cancellation_and_contained_abort_release_all_authority() {
+        let block_path = unique_short_path();
+        let pmem_path = unique_pmem_short_path();
+        let template = storage_fixture_graph(&block_path, &pmem_path);
+        let block = TempRoot::new_sized_at(
+            block_path,
+            template.block_records()[0].block().backing_bytes(),
+        );
+        let pmem =
+            TempRoot::new_sized_at(pmem_path, template.pmem_records()[0].pmem().file_bytes());
+        let graph = storage_fixture_graph(block.path(), pmem.path());
+        let memory = storage_restore_memory(&graph);
+        let cancellation =
+            RequestedSnapshotRestoreResources::prepare_native_v2_storage_restore_bundle_with(
+                graph,
+                &memory,
+                Instant::now(),
+                None,
+                || false,
+                |plan, blocks, pmems, _| plan.prepare_backings(blocks, pmems, || true),
+            )
+            .expect_err("runtime cancellation should unwind the complete direct batch");
+        assert!(matches!(
+            cancellation,
+            SnapshotV2StorageRestoreBundleError::Bundle { .. }
+        ));
+        assert_eq!(
+            cancellation.disposition(),
+            SnapshotRestoreResourceDisposition::Retryable
+        );
+
+        let block_reference = PathBuf::from("bangbang-grant:blk");
+        let pmem_reference = PathBuf::from("bangbang-grant:pm");
+        let base = storage_fixture_graph(&block_reference, pmem.path());
+        let captured_pmem = &base.pmem_records()[0];
+        let pmem_config = bangbang_runtime::snapshot_device_v2_6::SnapshotV2PmemConfig::try_new(
+            captured_pmem.config().pmem_id(),
+            captured_pmem.config().is_root(),
+            captured_pmem.config().is_read_only(),
+            captured_pmem.config().rate_limiter(),
+            pmem_reference.to_string_lossy(),
+        )
+        .expect("contained pmem configuration should validate");
+        let pmem_record =
+            bangbang_runtime::snapshot_device_v2_6::SnapshotV2PmemDeviceRecord::try_new(
+                captured_pmem.key().instance(),
+                pmem_config,
+                captured_pmem.pmem().clone(),
+                captured_pmem.virtio().clone(),
+                captured_pmem.transport().clone(),
+            )
+            .expect("contained pmem record should validate");
+        let graph = SnapshotV2StorageDeviceGraph::try_from_parts(
+            base.root_key(),
+            base.transport_kind(),
+            base.block_records().to_vec(),
+            vec![pmem_record],
+        )
+        .expect("contained storage graph should validate");
+        let block_access = grant_access(graph.block_records()[0].config().is_read_only());
+        let pmem_access = grant_access(graph.pmem_records()[0].config().is_read_only());
+        let fixture = contained_restore_authority_with_grants_for_test(
+            snapshot_storage_grant_authority_for_test(&[
+                (
+                    "blk",
+                    ResourceRole::DriveBacking,
+                    block_access,
+                    block.path(),
+                ),
+                ("pm", ResourceRole::PmemBacking, pmem_access, pmem.path()),
+            ]),
+            false,
+        );
+        let memory = storage_restore_memory(&graph);
+        let prepared = RequestedSnapshotRestoreResources::prepare_native_v2_storage_restore_bundle(
+            graph,
+            &memory,
+            Instant::now(),
+            Some(fixture.authority()),
+            || false,
+        )
+        .expect("contained profile-3 process bundle should prepare");
+        prepared
+            .abort()
+            .expect("contained profile-3 abort should release runtime then authority");
+        assert_storage_grants_reusable(
+            &fixture,
+            &block_reference,
+            block_access,
+            &pmem_reference,
+            pmem_access,
+        );
+        let diagnostics = format!("{cancellation:?}");
+        for private in [block.path(), pmem.path()] {
             assert!(!diagnostics.contains(private.to_string_lossy().as_ref()));
         }
     }

--- a/crates/runtime/src/pmem.rs
+++ b/crates/runtime/src/pmem.rs
@@ -25,7 +25,9 @@ use crate::mmio::{
     MmioAccessBytes, MmioAccessBytesError, MmioBusError, MmioDispatchError, MmioDispatcher,
     MmioHandlerError, MmioRegion, MmioRegionId,
 };
-use crate::token_bucket::{PersistedTokenBucketState, TokenBucket, TokenBucketConfig};
+use crate::token_bucket::{
+    PersistedTokenBucketState, PersistedTokenBucketStateError, TokenBucket, TokenBucketConfig,
+};
 use crate::virtio::VirtioInterruptIntent;
 use crate::virtio_mmio::{
     VIRTIO_MMIO_DEVICE_WINDOW_SIZE, VirtioMmioDeviceActivation, VirtioMmioDeviceActivationError,
@@ -481,6 +483,82 @@ impl VirtioPmemQueue {
         Ok(Self { available, used })
     }
 
+    pub(crate) fn from_snapshot_state(
+        queue: &VirtioMmioQueueState,
+        state: VirtioPmemQueueState,
+    ) -> Result<Self, VirtioPmemQueueSnapshotError> {
+        if !queue.ready() {
+            return Err(VirtioPmemQueueSnapshotError::QueueNotReady);
+        }
+
+        let available = VirtqueueAvailableRing::with_next_avail(
+            queue.descriptor_table(),
+            queue.driver_ring(),
+            queue.size(),
+            state.next_available(),
+        )
+        .map_err(|_| VirtioPmemQueueSnapshotError::AvailableRingInvalid)?;
+        let used =
+            VirtqueueUsedRing::with_next_used(queue.device_ring(), queue.size(), state.next_used())
+                .map_err(|_| VirtioPmemQueueSnapshotError::UsedRingInvalid)?;
+
+        Ok(Self { available, used })
+    }
+
+    pub(crate) fn validate_snapshot_state(
+        &self,
+        memory: &GuestMemory,
+        has_retry: bool,
+    ) -> Result<(), VirtioPmemQueueSnapshotError> {
+        self.available
+            .validate_mapped(memory)
+            .map_err(|_| VirtioPmemQueueSnapshotError::AvailableRingInvalid)?;
+        self.used
+            .validate_mapped(memory)
+            .map_err(|_| VirtioPmemQueueSnapshotError::UsedRingInvalid)?;
+
+        let descriptor_range = self
+            .available
+            .descriptor_table_range()
+            .map_err(|_| VirtioPmemQueueSnapshotError::QueueRangeInvalid)?;
+        let available_range = self
+            .available
+            .available_ring_range()
+            .map_err(|_| VirtioPmemQueueSnapshotError::QueueRangeInvalid)?;
+        let used_range = self
+            .used
+            .used_ring_range()
+            .map_err(|_| VirtioPmemQueueSnapshotError::QueueRangeInvalid)?;
+        if descriptor_range.overlaps(available_range)
+            || descriptor_range.overlaps(used_range)
+            || available_range.overlaps(used_range)
+        {
+            return Err(VirtioPmemQueueSnapshotError::QueueRangesOverlap);
+        }
+
+        let used_index = self
+            .used
+            .used_index(memory)
+            .map_err(|_| VirtioPmemQueueSnapshotError::UsedRingInvalid)?;
+        if used_index != self.used.next_used() {
+            return Err(VirtioPmemQueueSnapshotError::UsedCursorMismatch);
+        }
+
+        let available_index = self
+            .available
+            .available_index(memory)
+            .map_err(|_| VirtioPmemQueueSnapshotError::AvailableRingInvalid)?;
+        let pending = available_index.wrapping_sub(self.available.next_avail());
+        if pending > self.available.queue_size() {
+            return Err(VirtioPmemQueueSnapshotError::AvailableCursorOutOfBounds);
+        }
+        if has_retry && pending == 0 {
+            return Err(VirtioPmemQueueSnapshotError::RetryWithoutPendingDescriptor);
+        }
+
+        Ok(())
+    }
+
     pub const fn available_ring(&self) -> &VirtqueueAvailableRing {
         &self.available
     }
@@ -601,6 +679,39 @@ impl std::error::Error for VirtioPmemQueueBuildError {
         }
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VirtioPmemQueueSnapshotError {
+    QueueNotReady,
+    AvailableRingInvalid,
+    UsedRingInvalid,
+    QueueRangeInvalid,
+    QueueRangesOverlap,
+    UsedCursorMismatch,
+    AvailableCursorOutOfBounds,
+    RetryWithoutPendingDescriptor,
+}
+
+impl fmt::Display for VirtioPmemQueueSnapshotError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::QueueNotReady => "snapshot virtio-pmem queue is not ready",
+            Self::AvailableRingInvalid => "snapshot virtio-pmem available ring is invalid",
+            Self::UsedRingInvalid => "snapshot virtio-pmem used ring is invalid",
+            Self::QueueRangeInvalid => "snapshot virtio-pmem queue range is invalid",
+            Self::QueueRangesOverlap => "snapshot virtio-pmem queue ranges overlap",
+            Self::UsedCursorMismatch => "snapshot virtio-pmem used cursor is inconsistent",
+            Self::AvailableCursorOutOfBounds => {
+                "snapshot virtio-pmem available cursor is out of bounds"
+            }
+            Self::RetryWithoutPendingDescriptor => {
+                "snapshot virtio-pmem retry has no pending descriptor"
+            }
+        })
+    }
+}
+
+impl std::error::Error for VirtioPmemQueueSnapshotError {}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct VirtioPmemQueueDispatch {
@@ -845,6 +956,35 @@ impl VirtioPmemRateLimiter {
         }
     }
 
+    fn from_persisted_state_at(
+        config: Option<PmemRateLimiterConfig>,
+        state: VirtioPmemRateLimiterState,
+        now: Instant,
+    ) -> Result<Option<Self>, VirtioPmemRateLimiterStateError> {
+        let bandwidth = restore_pmem_bucket_state(
+            config.and_then(PmemRateLimiterConfig::bandwidth),
+            state.bandwidth(),
+            now,
+            VirtioPmemRateLimiterStateError::MissingBandwidth,
+            VirtioPmemRateLimiterStateError::UnexpectedBandwidth,
+            VirtioPmemRateLimiterStateError::InvalidBandwidth,
+        )?;
+        let ops = restore_pmem_bucket_state(
+            config.and_then(PmemRateLimiterConfig::ops),
+            state.ops(),
+            now,
+            VirtioPmemRateLimiterStateError::MissingOps,
+            VirtioPmemRateLimiterStateError::UnexpectedOps,
+            VirtioPmemRateLimiterStateError::InvalidOps,
+        )?;
+
+        if bandwidth.is_none() && ops.is_none() {
+            Ok(None)
+        } else {
+            Ok(Some(Self { bandwidth, ops }))
+        }
+    }
+
     fn reduce_at(&mut self, bytes: u64, now: Instant) -> VirtioPmemRateLimiterReduction {
         let ops_snapshot = self.ops.as_ref().map(TokenBucket::snapshot);
 
@@ -877,16 +1017,30 @@ pub struct VirtioPmemTokenBucketState {
 }
 
 impl VirtioPmemTokenBucketState {
+    pub const fn new(
+        config: PmemTokenBucketConfig,
+        budget: u64,
+        remaining_burst: u64,
+        age_nanos: u64,
+    ) -> Self {
+        Self {
+            config,
+            budget,
+            remaining_burst,
+            age_nanos,
+        }
+    }
+
     const fn from_persisted(
         config: PmemTokenBucketConfig,
         state: PersistedTokenBucketState,
     ) -> Self {
-        Self {
+        Self::new(
             config,
-            budget: state.budget(),
-            remaining_burst: state.one_time_burst(),
-            age_nanos: state.age_nanos(),
-        }
+            state.budget(),
+            state.one_time_burst(),
+            state.age_nanos(),
+        )
     }
 
     pub const fn config(self) -> PmemTokenBucketConfig {
@@ -903,6 +1057,15 @@ impl VirtioPmemTokenBucketState {
 
     pub const fn age_nanos(self) -> u64 {
         self.age_nanos
+    }
+
+    const fn into_persisted(self) -> PersistedTokenBucketState {
+        PersistedTokenBucketState::new(
+            self.config.token_bucket_config(),
+            self.budget,
+            self.remaining_burst,
+            self.age_nanos,
+        )
     }
 }
 
@@ -922,12 +1085,23 @@ pub struct VirtioPmemRateLimiterState {
 }
 
 impl VirtioPmemRateLimiterState {
+    pub const fn new(
+        bandwidth: Option<VirtioPmemTokenBucketState>,
+        ops: Option<VirtioPmemTokenBucketState>,
+    ) -> Self {
+        Self { bandwidth, ops }
+    }
+
     pub const fn bandwidth(self) -> Option<VirtioPmemTokenBucketState> {
         self.bandwidth
     }
 
     pub const fn ops(self) -> Option<VirtioPmemTokenBucketState> {
         self.ops
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.bandwidth.is_none() && self.ops.is_none()
     }
 }
 
@@ -937,6 +1111,53 @@ impl fmt::Debug for VirtioPmemRateLimiterState {
             .debug_struct("VirtioPmemRateLimiterState")
             .field("state", &"<redacted>")
             .finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VirtioPmemRateLimiterStateError {
+    MissingBandwidth,
+    UnexpectedBandwidth,
+    InvalidBandwidth,
+    MissingOps,
+    UnexpectedOps,
+    InvalidOps,
+}
+
+impl fmt::Display for VirtioPmemRateLimiterStateError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::MissingBandwidth => "snapshot pmem bandwidth bucket is missing",
+            Self::UnexpectedBandwidth => "snapshot pmem bandwidth bucket is unexpected",
+            Self::InvalidBandwidth => "snapshot pmem bandwidth bucket is invalid",
+            Self::MissingOps => "snapshot pmem ops bucket is missing",
+            Self::UnexpectedOps => "snapshot pmem ops bucket is unexpected",
+            Self::InvalidOps => "snapshot pmem ops bucket is invalid",
+        })
+    }
+}
+
+impl std::error::Error for VirtioPmemRateLimiterStateError {}
+
+fn restore_pmem_bucket_state(
+    config: Option<PmemTokenBucketConfig>,
+    state: Option<VirtioPmemTokenBucketState>,
+    now: Instant,
+    missing: VirtioPmemRateLimiterStateError,
+    unexpected: VirtioPmemRateLimiterStateError,
+    invalid: VirtioPmemRateLimiterStateError,
+) -> Result<Option<TokenBucket>, VirtioPmemRateLimiterStateError> {
+    match (config, state) {
+        (Some(config), Some(state)) if config.is_enabled() && state.config() == config => {
+            TokenBucket::from_persisted_state_at(state.into_persisted(), now)
+                .map(Some)
+                .map_err(|_: PersistedTokenBucketStateError| invalid)
+        }
+        (Some(config), None) if config.is_enabled() => Err(missing),
+        (Some(config), Some(_)) if !config.is_enabled() => Err(unexpected),
+        (Some(_), None) | (None, None) => Ok(None),
+        (None, Some(_)) => Err(unexpected),
+        (Some(_), Some(_)) => Err(invalid),
     }
 }
 
@@ -1086,6 +1307,38 @@ impl VirtioPmemDevice {
                 .and_then(|rate_limiter| VirtioPmemRateLimiter::new_at(rate_limiter, now)),
             pending_rate_limited_queue: false,
         }
+    }
+
+    pub(crate) fn from_snapshot_state_at(
+        file_len: u64,
+        active_queue: Option<VirtioPmemQueue>,
+        rate_limiter_config: Option<PmemRateLimiterConfig>,
+        rate_limiter_state: VirtioPmemRateLimiterState,
+        pending_rate_limited_queue: bool,
+        now: Instant,
+    ) -> Result<Self, VirtioPmemDeviceSnapshotError> {
+        if file_len == 0
+            || (pending_rate_limited_queue
+                && (active_queue.is_none() || rate_limiter_state.is_empty()))
+        {
+            return Err(VirtioPmemDeviceSnapshotError::InvalidState);
+        }
+        let rate_limiter = VirtioPmemRateLimiter::from_persisted_state_at(
+            rate_limiter_config,
+            rate_limiter_state,
+            now,
+        )
+        .map_err(VirtioPmemDeviceSnapshotError::RateLimiter)?;
+        if pending_rate_limited_queue && rate_limiter.is_none() {
+            return Err(VirtioPmemDeviceSnapshotError::InvalidState);
+        }
+
+        Ok(Self {
+            active_queue,
+            file_len,
+            rate_limiter,
+            pending_rate_limited_queue,
+        })
     }
 
     pub fn is_activated(&self) -> bool {
@@ -1293,6 +1546,30 @@ impl VirtioPmemDevice {
     pub fn reset(&mut self) {
         self.active_queue = None;
         self.pending_rate_limited_queue = false;
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VirtioPmemDeviceSnapshotError {
+    InvalidState,
+    RateLimiter(VirtioPmemRateLimiterStateError),
+}
+
+impl fmt::Display for VirtioPmemDeviceSnapshotError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidState => "snapshot virtio-pmem device state is invalid",
+            Self::RateLimiter(_) => "snapshot virtio-pmem rate limiter is invalid",
+        })
+    }
+}
+
+impl std::error::Error for VirtioPmemDeviceSnapshotError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::RateLimiter(source) => Some(source),
+            Self::InvalidState => None,
+        }
     }
 }
 
@@ -2071,6 +2348,10 @@ impl PmemConfigs {
 
     pub fn as_slice(&self) -> &[PmemConfig] {
         &self.configs
+    }
+
+    pub(crate) fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.configs.try_reserve_exact(additional)
     }
 
     pub fn insert(&mut self, input: PmemConfigInput) -> Result<(), PmemConfigError> {
@@ -3083,6 +3364,38 @@ pub enum PmemBackingMappingError {
     },
 }
 
+impl PmemBackingMappingError {
+    /// Returns whether a failed mapping also failed to release a temporary
+    /// reservation that was still owned by the constructor.
+    pub const fn cleanup_failed(&self) -> bool {
+        matches!(
+            self,
+            Self::MapFileOverReservation {
+                cleanup_source: Some(_),
+                ..
+            } | Self::FileMappingReturnedNull {
+                cleanup_source: Some(_),
+                ..
+            } | Self::FixedMappingMoved {
+                cleanup_source: Some(_),
+            }
+        )
+    }
+
+    /// Returns whether this is an ordinary clean host mapping failure.
+    pub const fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::MapFile { .. }
+                | Self::ReserveAlignedMapping { .. }
+                | Self::MapFileOverReservation {
+                    cleanup_source: None,
+                    ..
+                }
+        )
+    }
+}
+
 impl fmt::Display for PmemBackingMappingError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -3368,6 +3681,26 @@ impl PmemBackingMapper for SystemPmemBackingMapper {
     }
 }
 
+pub(crate) struct PreparedSnapshotPmemDeviceParts {
+    pub(crate) id: String,
+    pub(crate) is_read_only: bool,
+    pub(crate) rate_limiter: Option<PmemRateLimiterConfig>,
+    pub(crate) expected_file_len: u64,
+    pub(crate) expected_mapped_len: u64,
+    pub(crate) guest_range: GuestMemoryRange,
+    pub(crate) config_space: VirtioPmemConfigSpace,
+    pub(crate) backing: PmemFileBacking,
+}
+
+impl fmt::Debug for PreparedSnapshotPmemDeviceParts {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotPmemDeviceParts")
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
 #[derive(Debug)]
 pub struct PreparedPmemDevice {
     id: String,
@@ -3379,6 +3712,67 @@ pub struct PreparedPmemDevice {
 }
 
 impl PreparedPmemDevice {
+    pub(crate) fn from_snapshot_parts(
+        parts: PreparedSnapshotPmemDeviceParts,
+    ) -> Result<Self, PreparedSnapshotPmemDeviceError> {
+        Self::from_snapshot_parts_with_mapper(parts, &mut SystemPmemBackingMapper)
+    }
+
+    fn from_snapshot_parts_with_mapper(
+        parts: PreparedSnapshotPmemDeviceParts,
+        mapper: &mut impl PmemBackingMapper,
+    ) -> Result<Self, PreparedSnapshotPmemDeviceError> {
+        let PreparedSnapshotPmemDeviceParts {
+            id,
+            is_read_only,
+            rate_limiter,
+            expected_file_len,
+            expected_mapped_len,
+            guest_range,
+            config_space,
+            backing,
+        } = parts;
+        if id.is_empty() {
+            return Err(PreparedSnapshotPmemDeviceError::Configuration);
+        }
+        if backing.is_read_only() != is_read_only {
+            return Err(PreparedSnapshotPmemDeviceError::BackingMode);
+        }
+        if backing.len() != expected_file_len
+            || aligned_pmem_mapping_len(expected_file_len) != Some(expected_mapped_len)
+            || guest_range.size() != expected_mapped_len
+        {
+            return Err(PreparedSnapshotPmemDeviceError::Geometry);
+        }
+        let expected_config_space =
+            VirtioPmemConfigSpace::new(guest_range.start().raw_value(), guest_range.size());
+        if guest_range
+            .validate_alignment(VIRTIO_PMEM_ALIGNMENT)
+            .is_err()
+            || config_space != expected_config_space
+        {
+            return Err(PreparedSnapshotPmemDeviceError::Range);
+        }
+        let mapping = mapper
+            .map(&backing)
+            .map_err(PreparedSnapshotPmemDeviceError::Mapping)?;
+        if mapping.file_len() != expected_file_len
+            || mapping.mapped_len() != expected_mapped_len
+            || mapping.is_read_only() != is_read_only
+        {
+            return Err(PreparedSnapshotPmemDeviceError::Geometry);
+        }
+
+        Ok(Self {
+            id,
+            backing,
+            mapping,
+            guest_range,
+            config_space,
+            rate_limiter,
+        })
+    }
+
     /// Prepares one runtime pmem device from an already-opened backing and the
     /// owner thread's current reserved guest ranges.
     pub fn from_config_with_backing_and_reserved_ranges(
@@ -3528,6 +3922,64 @@ impl PreparedPmemDevice {
             self.config_space,
             self.rate_limiter,
         )
+    }
+}
+
+pub enum PreparedSnapshotPmemDeviceError {
+    Configuration,
+    BackingMode,
+    Geometry,
+    Range,
+    Mapping(PmemBackingMappingError),
+}
+
+impl PreparedSnapshotPmemDeviceError {
+    /// Returns whether mapping failure also left temporary cleanup uncertain.
+    pub const fn cleanup_failed(&self) -> bool {
+        matches!(self, Self::Mapping(source) if source.cleanup_failed())
+    }
+
+    /// Returns whether the failed snapshot owner construction may be retried.
+    pub const fn is_retryable(&self) -> bool {
+        matches!(self, Self::Mapping(source) if source.is_retryable())
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotPmemDeviceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::Configuration => "Configuration",
+            Self::BackingMode => "BackingMode",
+            Self::Geometry => "Geometry",
+            Self::Range => "Range",
+            Self::Mapping(_) => "Mapping",
+        };
+        formatter
+            .debug_struct("PreparedSnapshotPmemDeviceError")
+            .field("kind", &kind)
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for PreparedSnapshotPmemDeviceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Configuration => "snapshot pmem configuration is invalid",
+            Self::BackingMode => "snapshot pmem backing access mode is invalid",
+            Self::Geometry => "snapshot pmem backing geometry is invalid",
+            Self::Range => "snapshot pmem guest range is invalid",
+            Self::Mapping(_) => "snapshot pmem backing mapping failed",
+        })
+    }
+}
+
+impl std::error::Error for PreparedSnapshotPmemDeviceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Mapping(source) => Some(source),
+            Self::Configuration | Self::BackingMode | Self::Geometry | Self::Range => None,
+        }
     }
 }
 
@@ -5067,6 +5519,21 @@ mod tests {
         VirtioPmemQueue::new(available, used)
     }
 
+    fn pmem_mmio_queue_state(
+        descriptor_table: GuestAddress,
+        available_ring: GuestAddress,
+        used_ring: GuestAddress,
+    ) -> VirtioMmioQueueState {
+        VirtioMmioQueueState::from_parts(
+            TEST_QUEUE_SIZE,
+            TEST_QUEUE_SIZE,
+            true,
+            descriptor_table,
+            available_ring,
+            used_ring,
+        )
+    }
+
     fn write_pmem_flush_chain(memory: &mut GuestMemory) {
         write_pmem_flush_chain_at(memory, 0, 1, TEST_PMEM_REQUEST_ADDR, TEST_PMEM_STATUS_ADDR);
         write_available_heads(memory, &[0]);
@@ -5283,6 +5750,112 @@ mod tests {
         assert_eq!(dispatch.processed_requests(), 0);
         assert!(!dispatch.needs_queue_interrupt());
         assert_eq!(read_used_index(&memory), 0);
+    }
+
+    #[test]
+    fn snapshot_queue_restores_exact_cursors_and_validates_loaded_indices() {
+        let mut memory = request_memory();
+        write_guest_u16(&mut memory, available_ring_idx_address(), 6);
+        write_guest_u16(&mut memory, used_ring_idx_address(), 4);
+        let state = VirtioPmemQueueState::new(5, 4);
+        let queue = VirtioPmemQueue::from_snapshot_state(
+            &pmem_mmio_queue_state(TEST_DESCRIPTOR_TABLE, TEST_AVAILABLE_RING, TEST_USED_RING),
+            state,
+        )
+        .expect("saved pmem queue should rebuild");
+
+        queue
+            .validate_snapshot_state(&memory, true)
+            .expect("saved queue indices should match loaded memory");
+        assert_eq!(queue.snapshot_state(), state);
+
+        write_guest_u16(&mut memory, used_ring_idx_address(), 3);
+        assert_eq!(
+            queue.validate_snapshot_state(&memory, true),
+            Err(VirtioPmemQueueSnapshotError::UsedCursorMismatch)
+        );
+    }
+
+    #[test]
+    fn snapshot_queue_rejects_overlap_cursor_overflow_and_retry_without_work() {
+        let mut memory = request_memory();
+        write_guest_u16(&mut memory, available_ring_idx_address(), 5);
+        write_guest_u16(&mut memory, used_ring_idx_address(), 4);
+        let queue = VirtioPmemQueue::from_snapshot_state(
+            &pmem_mmio_queue_state(TEST_DESCRIPTOR_TABLE, TEST_AVAILABLE_RING, TEST_USED_RING),
+            VirtioPmemQueueState::new(5, 4),
+        )
+        .expect("saved pmem queue should rebuild");
+        assert_eq!(
+            queue.validate_snapshot_state(&memory, true),
+            Err(VirtioPmemQueueSnapshotError::RetryWithoutPendingDescriptor)
+        );
+
+        write_guest_u16(
+            &mut memory,
+            available_ring_idx_address(),
+            TEST_QUEUE_SIZE + 6,
+        );
+        assert_eq!(
+            queue.validate_snapshot_state(&memory, false),
+            Err(VirtioPmemQueueSnapshotError::AvailableCursorOutOfBounds)
+        );
+
+        let overlapping = VirtioPmemQueue::from_snapshot_state(
+            &pmem_mmio_queue_state(TEST_DESCRIPTOR_TABLE, TEST_DESCRIPTOR_TABLE, TEST_USED_RING),
+            VirtioPmemQueueState::new(0, 0),
+        )
+        .expect("aligned overlapping queue addresses should rebuild");
+        assert_eq!(
+            overlapping.validate_snapshot_state(&memory, false),
+            Err(VirtioPmemQueueSnapshotError::QueueRangesOverlap)
+        );
+    }
+
+    #[test]
+    fn snapshot_device_restores_limiter_budget_burst_and_age_at_fixed_clock() {
+        let now = Instant::now();
+        let bandwidth = PmemTokenBucketConfig::new(100, Some(20), 100);
+        let ops = PmemTokenBucketConfig::new(8, None, 200);
+        let config = PmemRateLimiterConfig::new(Some(bandwidth), Some(ops));
+        let state = VirtioPmemRateLimiterState::new(
+            Some(VirtioPmemTokenBucketState::new(bandwidth, 75, 11, 10_000)),
+            Some(VirtioPmemTokenBucketState::new(ops, 6, 0, 20_000)),
+        );
+        let device = VirtioPmemDevice::from_snapshot_state_at(
+            VIRTIO_PMEM_ALIGNMENT,
+            None,
+            Some(config),
+            state,
+            false,
+            now,
+        )
+        .expect("saved limiter should restore");
+        let captured = device
+            .capture_state_at(
+                VirtioPmemConfigSpace::new(TEST_PMEM_START, VIRTIO_PMEM_ALIGNMENT),
+                VIRTIO_PMEM_ALIGNMENT,
+                Some(config),
+                now,
+            )
+            .expect("restored limiter should recapture");
+
+        assert_eq!(captured.rate_limiter(), state);
+        let invalid = VirtioPmemRateLimiterState::new(
+            Some(VirtioPmemTokenBucketState::new(bandwidth, 101, 11, 10_000)),
+            Some(VirtioPmemTokenBucketState::new(ops, 6, 0, 20_000)),
+        );
+        assert!(matches!(
+            VirtioPmemDevice::from_snapshot_state_at(
+                VIRTIO_PMEM_ALIGNMENT,
+                None,
+                Some(config),
+                invalid,
+                false,
+                now,
+            ),
+            Err(VirtioPmemDeviceSnapshotError::RateLimiter(_))
+        ));
     }
 
     #[test]
@@ -6727,6 +7300,98 @@ mod tests {
         );
         assert!(!mapping.is_read_only());
         assert_eq!(&bytes, b"pmem");
+    }
+
+    #[test]
+    fn snapshot_mapping_error_retryability_requires_complete_temporary_cleanup() {
+        let clean = PmemBackingMappingError::MapFile {
+            len: 4096,
+            source: io::Error::from_raw_os_error(libc::ENOMEM),
+        };
+        assert!(clean.is_retryable());
+        assert!(!clean.cleanup_failed());
+
+        let uncertain = PmemBackingMappingError::MapFileOverReservation {
+            file_len: 4096,
+            mapped_len: usize::try_from(VIRTIO_PMEM_ALIGNMENT)
+                .expect("pmem alignment should fit usize"),
+            source: io::Error::from_raw_os_error(libc::ENOMEM),
+            cleanup_source: Some(io::Error::from_raw_os_error(libc::EIO)),
+        };
+        assert!(!uncertain.is_retryable());
+        assert!(uncertain.cleanup_failed());
+        let prepared = PreparedSnapshotPmemDeviceError::Mapping(uncertain);
+        assert!(!prepared.is_retryable());
+        assert!(prepared.cleanup_failed());
+    }
+
+    #[test]
+    fn snapshot_mapping_recreates_a_zeroed_private_tail_after_prior_tail_writes() {
+        let first = temp_file("snapshot-first-tail-pmem.img", b"old!");
+        let first_mapping = map_backing(first.as_path(), false);
+        let tail_offset =
+            usize::try_from(first_mapping.file_len()).expect("file length should fit usize");
+
+        // SAFETY: the retained mapping extends through `mapped_len`, and the
+        // selected byte is the first byte of its anonymous private tail.
+        unsafe {
+            first_mapping
+                .host_address()
+                .as_ptr()
+                .cast::<u8>()
+                .add(tail_offset)
+                .write(0x7f);
+        }
+        drop(first_mapping);
+
+        let second = temp_file("snapshot-second-tail-pmem.img", b"next");
+        let second_mapping = map_backing(second.as_path(), false);
+        // SAFETY: the second mapping independently owns the same bounded tail
+        // offset after its four-byte file prefix.
+        let first_tail_byte = unsafe {
+            second_mapping
+                .host_address()
+                .as_ptr()
+                .cast::<u8>()
+                .add(tail_offset)
+                .read()
+        };
+        assert_eq!(first_tail_byte, 0);
+    }
+
+    #[test]
+    fn snapshot_prepared_device_retains_the_recorded_range_without_allocation() {
+        let file = temp_file("snapshot-exact-range-pmem.img", b"pmem");
+        let backing = open_backing(file.as_path(), false).expect("pmem backing should open");
+        let drop_count = Arc::new(AtomicUsize::new(0));
+        let mut mapper = ScriptedPmemBackingMapper::new(Arc::clone(&drop_count), usize::MAX);
+        let range = guest_range(
+            TEST_PMEM_START + VIRTIO_PMEM_ALIGNMENT * 4,
+            VIRTIO_PMEM_ALIGNMENT,
+        );
+        let prepared = PreparedPmemDevice::from_snapshot_parts_with_mapper(
+            PreparedSnapshotPmemDeviceParts {
+                id: "pmem0".to_string(),
+                is_read_only: false,
+                rate_limiter: None,
+                expected_file_len: 4,
+                expected_mapped_len: VIRTIO_PMEM_ALIGNMENT,
+                guest_range: range,
+                config_space: VirtioPmemConfigSpace::new(range.start().raw_value(), range.size()),
+                backing,
+            },
+            &mut mapper,
+        )
+        .expect("snapshot pmem owner should retain its exact range");
+
+        assert_eq!(prepared.guest_range(), range);
+        assert_eq!(
+            prepared.config_space(),
+            VirtioPmemConfigSpace::new(range.start().raw_value(), range.size())
+        );
+        assert_eq!(mapper.calls, 1);
+        drop(prepared);
+        assert_eq!(drop_count.load(Ordering::Relaxed), 1);
     }
 
     #[test]

--- a/crates/runtime/src/snapshot_device_v2_6.rs
+++ b/crates/runtime/src/snapshot_device_v2_6.rs
@@ -33,6 +33,14 @@ use crate::storage_capture::{StorageDeviceOrigin, StorageRetryState};
 
 mod capture;
 mod codec;
+mod restore;
+
+pub use restore::{
+    PreparedSnapshotV2PmemRecord, PreparedSnapshotV2PmemRecordParts,
+    PreparedSnapshotV2StorageBundle, PreparedSnapshotV2StorageBundleParts,
+    SnapshotV2StorageBundleError, SnapshotV2StorageCleanupError, SnapshotV2StorageRestorePlan,
+    SnapshotV2StorageRestorePlanError,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/runtime/src/snapshot_device_v2_6/restore.rs
+++ b/crates/runtime/src/snapshot_device_v2_6/restore.rs
@@ -1,0 +1,1014 @@
+//! Pathless destination planning for the native-v2 profile-3 storage graph.
+
+use std::fmt;
+use std::time::{Duration, Instant};
+
+use super::*;
+
+use crate::block::async_executor::BlockAsyncRuntimeError;
+use crate::block::{BlockFileBacking, DriveConfigs};
+use crate::memory::{GuestMemory, GuestMemoryRange};
+use crate::pmem::{
+    PmemConfigInput, PmemConfigs, PmemFileBacking, PreparedPmemDevice,
+    PreparedSnapshotPmemDeviceError, PreparedSnapshotPmemDeviceParts, VirtioPmemDevice,
+    VirtioPmemRateLimiterState, VirtioPmemTokenBucketState,
+};
+use crate::snapshot_device_v2_5::{
+    PreparedSnapshotV2MultiBlockBundle, SnapshotV2MultiBlockBundleError,
+    SnapshotV2MultiBlockCleanupError, SnapshotV2MultiBlockDeviceGraph,
+    SnapshotV2MultiBlockRestorePlan, SnapshotV2MultiBlockRestorePlanError,
+};
+use crate::virtio_mmio::VirtioMmioQueueState;
+
+/// Complete pure destination proof for one detached profile-3 graph.
+pub struct SnapshotV2StorageRestorePlan {
+    root_key: Option<SnapshotV2DeviceKey>,
+    transport_kind: SnapshotV2DeviceTransportKind,
+    block: Option<SnapshotV2StorageBlockRestorePlan>,
+    pmem_configs: PmemConfigs,
+    pmem_records: Vec<SnapshotV2PmemRecordPlan>,
+}
+
+struct SnapshotV2StorageBlockRestorePlan {
+    configs: DriveConfigs,
+    plan: SnapshotV2MultiBlockRestorePlan,
+}
+
+struct SnapshotV2PmemRecordPlan {
+    key: SnapshotV2DeviceKey,
+    pmem_id: String,
+    is_root: bool,
+    is_read_only: bool,
+    rate_limiter: Option<PmemRateLimiterConfig>,
+    expected_file_len: u64,
+    expected_mapped_len: u64,
+    guest_range: GuestMemoryRange,
+    config_space: VirtioPmemConfigSpace,
+    queue_ranges: Option<[GuestMemoryRange; 3]>,
+    retry: StorageRetryState,
+    retry_deadline: Option<Instant>,
+    virtio: SnapshotV2VirtioState,
+    transport: SnapshotV2DeviceTransport,
+    device: VirtioPmemDevice,
+}
+
+impl SnapshotV2StorageRestorePlan {
+    /// Proves every record and queue against already-loaded guest memory.
+    ///
+    /// This phase does not open, map, or otherwise resolve a backing selector.
+    pub fn prepare(
+        graph: SnapshotV2StorageDeviceGraph,
+        memory: &GuestMemory,
+        now: Instant,
+    ) -> Result<Self, SnapshotV2StorageRestorePlanError> {
+        Self::prepare_with_reserve(graph, memory, now, &mut SystemRestoreReserve)
+    }
+
+    fn prepare_with_reserve(
+        graph: SnapshotV2StorageDeviceGraph,
+        memory: &GuestMemory,
+        now: Instant,
+        reserve: &mut impl StorageRestoreReserve,
+    ) -> Result<Self, SnapshotV2StorageRestorePlanError> {
+        validate_graph(&graph).map_err(|_| SnapshotV2StorageRestorePlanError::InvalidGraph)?;
+        let SnapshotV2StorageDeviceGraph {
+            root_key,
+            transport_kind,
+            block_records,
+            pmem_records,
+        } = graph;
+
+        let block = if block_records.is_empty() {
+            None
+        } else {
+            let block_root = root_key.filter(|root| {
+                block_records
+                    .first()
+                    .is_some_and(|record| record.key() == *root)
+            });
+            let block_graph = SnapshotV2MultiBlockDeviceGraph::try_from_parts(
+                block_root,
+                transport_kind,
+                block_records,
+            )
+            .map_err(|_| SnapshotV2StorageRestorePlanError::InvalidGraph)?;
+            let configs = block_graph
+                .project_drive_configs()
+                .map_err(|_| SnapshotV2StorageRestorePlanError::Configuration)?;
+            let plan = SnapshotV2MultiBlockRestorePlan::prepare(block_graph, memory, now)
+                .map_err(SnapshotV2StorageRestorePlanError::Block)?;
+            Some(SnapshotV2StorageBlockRestorePlan { configs, plan })
+        };
+
+        let mut pmem_configs = PmemConfigs::new();
+        reserve
+            .reserve_pmem_configs(&mut pmem_configs, pmem_records.len())
+            .map_err(|_| SnapshotV2StorageRestorePlanError::Allocation)?;
+        let mut planned = Vec::new();
+        reserve
+            .reserve_vec(&mut planned, pmem_records.len())
+            .map_err(|_| SnapshotV2StorageRestorePlanError::Allocation)?;
+
+        for record in pmem_records {
+            let SnapshotV2PmemDeviceRecord {
+                key,
+                config,
+                pmem,
+                virtio,
+                transport,
+            } = record;
+            let SnapshotV2PmemConfig {
+                pmem_id,
+                is_root,
+                is_read_only,
+                rate_limiter,
+                selector,
+            } = config;
+            let SnapshotV2PmemState {
+                file_bytes,
+                mapped_bytes,
+                guest_range,
+                config_space,
+                active_queue,
+                limiter,
+                pending_rate_limited_queue,
+                retry,
+            } = pmem;
+
+            if memory
+                .regions()
+                .iter()
+                .any(|region| region.range().overlaps(guest_range))
+            {
+                return Err(SnapshotV2StorageRestorePlanError::PmemRange);
+            }
+
+            let queue_state = *virtio
+                .queues()
+                .first()
+                .ok_or(SnapshotV2StorageRestorePlanError::InvalidGraph)?;
+            let queue_ranges = queue_ranges(&queue_state)
+                .map_err(|_| SnapshotV2StorageRestorePlanError::InvalidGraph)?;
+            if queue_ranges.is_some_and(|ranges| {
+                ranges
+                    .into_iter()
+                    .any(|range| !range_is_wholly_contained(memory, range))
+            }) {
+                return Err(SnapshotV2StorageRestorePlanError::QueueMemory);
+            }
+            let active_queue = active_queue
+                .map(|cursor| {
+                    let queue = VirtioMmioQueueState::from_parts(
+                        queue_state.max_size(),
+                        queue_state.size(),
+                        queue_state.ready(),
+                        queue_state.descriptor_table(),
+                        queue_state.driver_ring(),
+                        queue_state.device_ring(),
+                    );
+                    let queue =
+                        crate::pmem::VirtioPmemQueue::from_snapshot_state(&queue, cursor)
+                            .map_err(|_| SnapshotV2StorageRestorePlanError::QueueContinuation)?;
+                    queue
+                        .validate_snapshot_state(memory, retry != StorageRetryState::None)
+                        .map_err(|_| SnapshotV2StorageRestorePlanError::QueueContinuation)?;
+                    Ok(queue)
+                })
+                .transpose()?;
+            let limiter_state = persisted_pmem_limiter_state(rate_limiter, limiter)?;
+            let device = VirtioPmemDevice::from_snapshot_state_at(
+                file_bytes,
+                active_queue,
+                rate_limiter,
+                limiter_state,
+                pending_rate_limited_queue,
+                now,
+            )
+            .map_err(|_| SnapshotV2StorageRestorePlanError::RateLimiter)?;
+
+            let mut input = PmemConfigInput::new(pmem_id.clone(), selector.clone())
+                .with_root_device(is_root)
+                .with_read_only(is_read_only);
+            if let Some(rate_limiter) = rate_limiter {
+                input = input.with_rate_limiter(rate_limiter);
+            }
+            pmem_configs
+                .insert(input)
+                .map_err(|_| SnapshotV2StorageRestorePlanError::Configuration)?;
+            let projected = pmem_configs
+                .as_slice()
+                .last()
+                .ok_or(SnapshotV2StorageRestorePlanError::Configuration)?;
+            if projected.id() != pmem_id
+                || projected.path_on_host() != selector
+                || projected.root_device() != is_root
+                || projected.read_only() != is_read_only
+                || projected.rate_limiter() != rate_limiter
+            {
+                return Err(SnapshotV2StorageRestorePlanError::Configuration);
+            }
+
+            planned.push(SnapshotV2PmemRecordPlan {
+                key,
+                pmem_id,
+                is_root,
+                is_read_only,
+                rate_limiter,
+                expected_file_len: file_bytes,
+                expected_mapped_len: mapped_bytes,
+                guest_range,
+                config_space,
+                queue_ranges,
+                retry,
+                retry_deadline: restored_retry_deadline_at(retry, now),
+                virtio,
+                transport,
+                device,
+            });
+        }
+
+        if pmem_configs.as_slice().len() != planned.len() {
+            return Err(SnapshotV2StorageRestorePlanError::Configuration);
+        }
+
+        Ok(Self {
+            root_key,
+            transport_kind,
+            block,
+            pmem_configs,
+            pmem_records: planned,
+        })
+    }
+
+    /// Returns the optional cross-storage root key.
+    pub const fn root_key(&self) -> Option<SnapshotV2DeviceKey> {
+        self.root_key
+    }
+
+    /// Returns the graph-wide retained transport kind.
+    pub const fn transport_kind(&self) -> SnapshotV2DeviceTransportKind {
+        self.transport_kind
+    }
+
+    /// Returns the number of canonical block records.
+    pub fn block_len(&self) -> usize {
+        self.block.as_ref().map_or(0, |block| block.plan.len())
+    }
+
+    /// Returns the number of canonical pmem records.
+    pub fn pmem_len(&self) -> usize {
+        self.pmem_records.len()
+    }
+
+    /// Returns the pure ordered pmem controller projection.
+    pub const fn pmem_configs(&self) -> &PmemConfigs {
+        &self.pmem_configs
+    }
+
+    /// Adopts complete canonical backing vectors into one unpublished bundle.
+    ///
+    /// Cancellation is checked before block construction, before every pmem
+    /// mapping, and after the complete bundle is built.
+    pub fn prepare_backings(
+        self,
+        block_backings: Vec<BlockFileBacking>,
+        pmem_backings: Vec<PmemFileBacking>,
+        cancelled: impl Fn() -> bool,
+    ) -> Result<PreparedSnapshotV2StorageBundle, SnapshotV2StorageBundleError> {
+        self.prepare_backings_with(
+            block_backings,
+            pmem_backings,
+            cancelled,
+            &mut SystemRestoreReserve,
+            PreparedPmemDevice::from_snapshot_parts,
+        )
+    }
+
+    fn prepare_backings_with(
+        self,
+        block_backings: Vec<BlockFileBacking>,
+        pmem_backings: Vec<PmemFileBacking>,
+        cancelled: impl Fn() -> bool,
+        reserve: &mut impl StorageRestoreReserve,
+        mut prepare_pmem: impl FnMut(
+            PreparedSnapshotPmemDeviceParts,
+        )
+            -> Result<PreparedPmemDevice, PreparedSnapshotPmemDeviceError>,
+    ) -> Result<PreparedSnapshotV2StorageBundle, SnapshotV2StorageBundleError> {
+        let expected_block_count = self.block_len();
+        if block_backings.len() != expected_block_count
+            || pmem_backings.len() != self.pmem_records.len()
+        {
+            return Err(SnapshotV2StorageBundleError::new(
+                SnapshotV2StorageBundleErrorKind::BackingCount,
+                None,
+            ));
+        }
+        for (record, backing) in self.pmem_records.iter().zip(&pmem_backings) {
+            if backing.is_read_only() != record.is_read_only {
+                return Err(SnapshotV2StorageBundleError::new(
+                    SnapshotV2StorageBundleErrorKind::PmemBackingMode,
+                    None,
+                ));
+            }
+            if backing.len() != record.expected_file_len
+                || aligned_pmem_mapping_len(backing.len()) != Some(record.expected_mapped_len)
+                || record.guest_range.size() != record.expected_mapped_len
+            {
+                return Err(SnapshotV2StorageBundleError::new(
+                    SnapshotV2StorageBundleErrorKind::PmemBackingGeometry,
+                    None,
+                ));
+            }
+        }
+
+        let mut prepared_pmem = Vec::new();
+        reserve
+            .reserve_vec(&mut prepared_pmem, self.pmem_records.len())
+            .map_err(|_| {
+                SnapshotV2StorageBundleError::new(
+                    SnapshotV2StorageBundleErrorKind::Allocation,
+                    None,
+                )
+            })?;
+
+        if cancelled() {
+            return Err(SnapshotV2StorageBundleError::new(
+                SnapshotV2StorageBundleErrorKind::Cancelled,
+                None,
+            ));
+        }
+        let block = match self.block {
+            Some(block) => Some(
+                block
+                    .plan
+                    .prepare_backings(block.configs, block_backings)
+                    .map_err(|source| {
+                        SnapshotV2StorageBundleError::new(
+                            SnapshotV2StorageBundleErrorKind::Block(source),
+                            None,
+                        )
+                    })?,
+            ),
+            None => {
+                debug_assert!(block_backings.is_empty());
+                None
+            }
+        };
+
+        for (record, backing) in self.pmem_records.into_iter().zip(pmem_backings) {
+            if cancelled() {
+                release_pmem_records(&mut prepared_pmem);
+                let cleanup = abort_block_bundle(block).err();
+                return Err(SnapshotV2StorageBundleError::new(
+                    SnapshotV2StorageBundleErrorKind::Cancelled,
+                    cleanup,
+                ));
+            }
+            let SnapshotV2PmemRecordPlan {
+                key,
+                pmem_id,
+                is_root,
+                is_read_only,
+                rate_limiter,
+                expected_file_len,
+                expected_mapped_len,
+                guest_range,
+                config_space,
+                queue_ranges,
+                retry,
+                retry_deadline,
+                virtio,
+                transport,
+                device,
+            } = record;
+            let prepared_device = match prepare_pmem(PreparedSnapshotPmemDeviceParts {
+                id: pmem_id,
+                is_read_only,
+                rate_limiter,
+                expected_file_len,
+                expected_mapped_len,
+                guest_range,
+                config_space,
+                backing,
+            }) {
+                Ok(prepared) => prepared,
+                Err(source) => {
+                    release_pmem_records(&mut prepared_pmem);
+                    let cleanup = abort_block_bundle(block).err();
+                    return Err(SnapshotV2StorageBundleError::new(
+                        SnapshotV2StorageBundleErrorKind::Pmem(source),
+                        cleanup,
+                    ));
+                }
+            };
+            prepared_pmem.push(PreparedSnapshotV2PmemRecord {
+                key,
+                is_root,
+                queue_ranges,
+                retry,
+                retry_deadline,
+                virtio,
+                transport,
+                prepared_device,
+                device,
+            });
+        }
+
+        if cancelled() {
+            release_pmem_records(&mut prepared_pmem);
+            let cleanup = abort_block_bundle(block).err();
+            return Err(SnapshotV2StorageBundleError::new(
+                SnapshotV2StorageBundleErrorKind::Cancelled,
+                cleanup,
+            ));
+        }
+
+        Ok(PreparedSnapshotV2StorageBundle {
+            root_key: self.root_key,
+            transport_kind: self.transport_kind,
+            block,
+            pmem_configs: self.pmem_configs,
+            pmem_records: prepared_pmem,
+        })
+    }
+}
+
+impl fmt::Debug for SnapshotV2StorageRestorePlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2StorageRestorePlan")
+            .field("block_count", &self.block_len())
+            .field("pmem_count", &self.pmem_len())
+            .field("transport", &self.transport_kind)
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// One exact unpublished profile-3 pmem owner.
+pub struct PreparedSnapshotV2PmemRecord {
+    key: SnapshotV2DeviceKey,
+    is_root: bool,
+    queue_ranges: Option<[GuestMemoryRange; 3]>,
+    retry: StorageRetryState,
+    retry_deadline: Option<Instant>,
+    virtio: SnapshotV2VirtioState,
+    transport: SnapshotV2DeviceTransport,
+    prepared_device: PreparedPmemDevice,
+    device: VirtioPmemDevice,
+}
+
+/// Consumed exact pmem owner metadata and detached runtime owners.
+pub type PreparedSnapshotV2PmemRecordParts = (
+    SnapshotV2DeviceKey,
+    bool,
+    Option<[GuestMemoryRange; 3]>,
+    StorageRetryState,
+    Option<Instant>,
+    SnapshotV2VirtioState,
+    SnapshotV2DeviceTransport,
+    PreparedPmemDevice,
+    VirtioPmemDevice,
+);
+
+impl PreparedSnapshotV2PmemRecord {
+    pub const fn key(&self) -> SnapshotV2DeviceKey {
+        self.key
+    }
+
+    pub fn pmem_id(&self) -> &str {
+        self.prepared_device.id()
+    }
+
+    pub const fn is_root_device(&self) -> bool {
+        self.is_root
+    }
+
+    pub const fn queue_ranges(&self) -> Option<[GuestMemoryRange; 3]> {
+        self.queue_ranges
+    }
+
+    pub const fn retry(&self) -> StorageRetryState {
+        self.retry
+    }
+
+    pub const fn retry_deadline(&self) -> Option<Instant> {
+        self.retry_deadline
+    }
+
+    pub const fn virtio(&self) -> &SnapshotV2VirtioState {
+        &self.virtio
+    }
+
+    pub const fn transport(&self) -> &SnapshotV2DeviceTransport {
+        &self.transport
+    }
+
+    pub const fn prepared_device(&self) -> &PreparedPmemDevice {
+        &self.prepared_device
+    }
+
+    pub const fn device(&self) -> &VirtioPmemDevice {
+        &self.device
+    }
+
+    /// Consumes the complete detached pmem owner.
+    pub fn into_parts(self) -> PreparedSnapshotV2PmemRecordParts {
+        (
+            self.key,
+            self.is_root,
+            self.queue_ranges,
+            self.retry,
+            self.retry_deadline,
+            self.virtio,
+            self.transport,
+            self.prepared_device,
+            self.device,
+        )
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2PmemRecord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2PmemRecord")
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Canonical move-only pathless profile-3 block-and-pmem vector.
+pub struct PreparedSnapshotV2StorageBundle {
+    root_key: Option<SnapshotV2DeviceKey>,
+    transport_kind: SnapshotV2DeviceTransportKind,
+    block: Option<PreparedSnapshotV2MultiBlockBundle>,
+    pmem_configs: PmemConfigs,
+    pmem_records: Vec<PreparedSnapshotV2PmemRecord>,
+}
+
+/// Consumed detached storage bundle parts for later transport reconstruction.
+pub type PreparedSnapshotV2StorageBundleParts = (
+    Option<SnapshotV2DeviceKey>,
+    SnapshotV2DeviceTransportKind,
+    Option<PreparedSnapshotV2MultiBlockBundle>,
+    PmemConfigs,
+    Vec<PreparedSnapshotV2PmemRecord>,
+);
+
+impl PreparedSnapshotV2StorageBundle {
+    pub const fn root_key(&self) -> Option<SnapshotV2DeviceKey> {
+        self.root_key
+    }
+
+    pub const fn transport_kind(&self) -> SnapshotV2DeviceTransportKind {
+        self.transport_kind
+    }
+
+    pub const fn block_bundle(&self) -> Option<&PreparedSnapshotV2MultiBlockBundle> {
+        self.block.as_ref()
+    }
+
+    pub const fn pmem_configs(&self) -> &PmemConfigs {
+        &self.pmem_configs
+    }
+
+    pub fn pmem_records(&self) -> &[PreparedSnapshotV2PmemRecord] {
+        &self.pmem_records
+    }
+
+    /// Transfers every detached storage owner to the transport layer.
+    pub fn into_parts(mut self) -> PreparedSnapshotV2StorageBundleParts {
+        (
+            self.root_key,
+            self.transport_kind,
+            self.block.take(),
+            std::mem::take(&mut self.pmem_configs),
+            std::mem::take(&mut self.pmem_records),
+        )
+    }
+
+    /// Explicitly releases pmem owners in reverse, followed by block Async
+    /// generations in reverse.
+    pub fn abort(mut self) -> Result<(), SnapshotV2StorageCleanupError> {
+        release_pmem_records(&mut self.pmem_records);
+        self.block
+            .take()
+            .map_or(Ok(()), PreparedSnapshotV2MultiBlockBundle::abort)
+            .map_err(SnapshotV2StorageCleanupError::new)
+    }
+}
+
+impl Drop for PreparedSnapshotV2StorageBundle {
+    fn drop(&mut self) {
+        release_pmem_records(&mut self.pmem_records);
+        if let Some(block) = self.block.take() {
+            let _ = block.abort();
+        }
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2StorageBundle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2StorageBundle")
+            .field(
+                "block_count",
+                &self.block.as_ref().map_or(0, |block| block.records().len()),
+            )
+            .field("pmem_count", &self.pmem_records.len())
+            .field("transport", &self.transport_kind)
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Failure while proving a profile-3 graph against loaded destination state.
+#[derive(Debug)]
+pub enum SnapshotV2StorageRestorePlanError {
+    InvalidGraph,
+    Configuration,
+    Allocation,
+    QueueMemory,
+    QueueContinuation,
+    RateLimiter,
+    PmemRange,
+    Block(SnapshotV2MultiBlockRestorePlanError),
+}
+
+impl fmt::Display for SnapshotV2StorageRestorePlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidGraph => "native-v2 storage graph is invalid",
+            Self::Configuration => "native-v2 storage configuration is invalid",
+            Self::Allocation => "native-v2 storage restore plan allocation failed",
+            Self::QueueMemory => "native-v2 storage queue memory is invalid",
+            Self::QueueContinuation => "native-v2 storage queue continuation is invalid",
+            Self::RateLimiter => "native-v2 storage rate limiter is invalid",
+            Self::PmemRange => "native-v2 storage pmem range overlaps loaded memory",
+            Self::Block(_) => "native-v2 storage block restore plan is invalid",
+        })
+    }
+}
+
+impl std::error::Error for SnapshotV2StorageRestorePlanError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Block(source) => Some(source),
+            Self::InvalidGraph
+            | Self::Configuration
+            | Self::Allocation
+            | Self::QueueMemory
+            | Self::QueueContinuation
+            | Self::RateLimiter
+            | Self::PmemRange => None,
+        }
+    }
+}
+
+enum SnapshotV2StorageBundleErrorKind {
+    BackingCount,
+    PmemBackingMode,
+    PmemBackingGeometry,
+    Allocation,
+    Cancelled,
+    Block(SnapshotV2MultiBlockBundleError),
+    Pmem(PreparedSnapshotPmemDeviceError),
+}
+
+/// Failure while adopting one complete profile-3 backing batch.
+pub struct SnapshotV2StorageBundleError {
+    kind: SnapshotV2StorageBundleErrorKind,
+    cleanup: Option<SnapshotV2MultiBlockCleanupError>,
+}
+
+impl SnapshotV2StorageBundleError {
+    fn new(
+        kind: SnapshotV2StorageBundleErrorKind,
+        cleanup: Option<SnapshotV2MultiBlockCleanupError>,
+    ) -> Self {
+        Self { kind, cleanup }
+    }
+
+    pub const fn cleanup_failed(&self) -> bool {
+        self.cleanup.is_some()
+            || matches!(
+                &self.kind,
+                SnapshotV2StorageBundleErrorKind::Pmem(source) if source.cleanup_failed()
+            )
+    }
+
+    /// Returns whether a clean retry may be attempted.
+    pub const fn is_retryable(&self) -> bool {
+        if self.cleanup_failed() {
+            return false;
+        }
+        match &self.kind {
+            SnapshotV2StorageBundleErrorKind::Allocation
+            | SnapshotV2StorageBundleErrorKind::Cancelled => true,
+            SnapshotV2StorageBundleErrorKind::Pmem(source) => source.is_retryable(),
+            SnapshotV2StorageBundleErrorKind::Block(
+                SnapshotV2MultiBlockBundleError::Allocation
+                | SnapshotV2MultiBlockBundleError::AsyncBinding {
+                    source:
+                        BlockAsyncRuntimeError::MetadataAllocation
+                        | BlockAsyncRuntimeError::BuildExecutor(_)
+                        | BlockAsyncRuntimeError::DriveBuild(_),
+                    cleanup: None,
+                },
+            ) => true,
+            SnapshotV2StorageBundleErrorKind::BackingCount
+            | SnapshotV2StorageBundleErrorKind::PmemBackingMode
+            | SnapshotV2StorageBundleErrorKind::PmemBackingGeometry
+            | SnapshotV2StorageBundleErrorKind::Block(_) => false,
+        }
+    }
+
+    pub const fn is_cancelled(&self) -> bool {
+        matches!(self.kind, SnapshotV2StorageBundleErrorKind::Cancelled)
+    }
+}
+
+impl fmt::Debug for SnapshotV2StorageBundleError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self.kind {
+            SnapshotV2StorageBundleErrorKind::BackingCount => "BackingCount",
+            SnapshotV2StorageBundleErrorKind::PmemBackingMode => "PmemBackingMode",
+            SnapshotV2StorageBundleErrorKind::PmemBackingGeometry => "PmemBackingGeometry",
+            SnapshotV2StorageBundleErrorKind::Allocation => "Allocation",
+            SnapshotV2StorageBundleErrorKind::Cancelled => "Cancelled",
+            SnapshotV2StorageBundleErrorKind::Block(_) => "Block",
+            SnapshotV2StorageBundleErrorKind::Pmem(_) => "Pmem",
+        };
+        formatter
+            .debug_struct("SnapshotV2StorageBundleError")
+            .field("kind", &kind)
+            .field("retryable", &self.is_retryable())
+            .field("cleanup_failed", &self.cleanup_failed())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotV2StorageBundleError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self.kind {
+            SnapshotV2StorageBundleErrorKind::BackingCount => {
+                "snapshot storage backing count is inconsistent"
+            }
+            SnapshotV2StorageBundleErrorKind::PmemBackingMode => {
+                "snapshot storage pmem backing access mode is inconsistent"
+            }
+            SnapshotV2StorageBundleErrorKind::PmemBackingGeometry => {
+                "snapshot storage pmem backing geometry is inconsistent"
+            }
+            SnapshotV2StorageBundleErrorKind::Allocation => {
+                "snapshot storage bundle allocation failed"
+            }
+            SnapshotV2StorageBundleErrorKind::Cancelled => {
+                "snapshot storage bundle construction was cancelled"
+            }
+            SnapshotV2StorageBundleErrorKind::Block(_) => {
+                "snapshot storage block bundle construction failed"
+            }
+            SnapshotV2StorageBundleErrorKind::Pmem(_) => {
+                "snapshot storage pmem bundle construction failed"
+            }
+        })?;
+        if self.cleanup_failed() {
+            formatter.write_str("; cleanup also failed")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for SnapshotV2StorageBundleError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.kind {
+            SnapshotV2StorageBundleErrorKind::Block(source) => Some(source),
+            SnapshotV2StorageBundleErrorKind::Pmem(source) => Some(source),
+            SnapshotV2StorageBundleErrorKind::BackingCount
+            | SnapshotV2StorageBundleErrorKind::PmemBackingMode
+            | SnapshotV2StorageBundleErrorKind::PmemBackingGeometry
+            | SnapshotV2StorageBundleErrorKind::Allocation
+            | SnapshotV2StorageBundleErrorKind::Cancelled => self
+                .cleanup
+                .as_ref()
+                .map(|source| source as &(dyn std::error::Error + 'static)),
+        }
+    }
+}
+
+/// Failure while explicitly releasing a prepared pathless storage bundle.
+pub struct SnapshotV2StorageCleanupError {
+    source: SnapshotV2MultiBlockCleanupError,
+}
+
+impl SnapshotV2StorageCleanupError {
+    const fn new(source: SnapshotV2MultiBlockCleanupError) -> Self {
+        Self { source }
+    }
+}
+
+impl fmt::Debug for SnapshotV2StorageCleanupError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2StorageCleanupError")
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotV2StorageCleanupError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("snapshot storage block Async cleanup failed")
+    }
+}
+
+impl std::error::Error for SnapshotV2StorageCleanupError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+trait StorageRestoreReserve {
+    fn reserve_vec<T>(&mut self, values: &mut Vec<T>, additional: usize) -> Result<(), ()>;
+
+    fn reserve_pmem_configs(
+        &mut self,
+        configs: &mut PmemConfigs,
+        additional: usize,
+    ) -> Result<(), ()>;
+}
+
+struct SystemRestoreReserve;
+
+impl StorageRestoreReserve for SystemRestoreReserve {
+    fn reserve_vec<T>(&mut self, values: &mut Vec<T>, additional: usize) -> Result<(), ()> {
+        values.try_reserve_exact(additional).map_err(|_| ())
+    }
+
+    fn reserve_pmem_configs(
+        &mut self,
+        configs: &mut PmemConfigs,
+        additional: usize,
+    ) -> Result<(), ()> {
+        configs.try_reserve_exact(additional).map_err(|_| ())
+    }
+}
+
+#[cfg(test)]
+struct FailingStorageRestoreReserve {
+    calls: usize,
+    fail_at: usize,
+}
+
+#[cfg(test)]
+impl FailingStorageRestoreReserve {
+    const fn new(fail_at: usize) -> Self {
+        Self { calls: 0, fail_at }
+    }
+
+    fn should_fail(&mut self) -> bool {
+        let call = self.calls;
+        self.calls = self.calls.saturating_add(1);
+        call == self.fail_at
+    }
+}
+
+#[cfg(test)]
+impl StorageRestoreReserve for FailingStorageRestoreReserve {
+    fn reserve_vec<T>(&mut self, values: &mut Vec<T>, additional: usize) -> Result<(), ()> {
+        if self.should_fail() {
+            Err(())
+        } else {
+            values.try_reserve_exact(additional).map_err(|_| ())
+        }
+    }
+
+    fn reserve_pmem_configs(
+        &mut self,
+        configs: &mut PmemConfigs,
+        additional: usize,
+    ) -> Result<(), ()> {
+        if self.should_fail() {
+            Err(())
+        } else {
+            configs.try_reserve_exact(additional).map_err(|_| ())
+        }
+    }
+}
+
+#[cfg(test)]
+pub(super) fn prepare_with_failing_reserve_for_test(
+    graph: SnapshotV2StorageDeviceGraph,
+    memory: &GuestMemory,
+    now: Instant,
+    fail_at: usize,
+) -> Result<SnapshotV2StorageRestorePlan, SnapshotV2StorageRestorePlanError> {
+    SnapshotV2StorageRestorePlan::prepare_with_reserve(
+        graph,
+        memory,
+        now,
+        &mut FailingStorageRestoreReserve::new(fail_at),
+    )
+}
+
+#[cfg(test)]
+pub(super) fn prepare_backings_with_failing_reserve_for_test(
+    plan: SnapshotV2StorageRestorePlan,
+    block_backings: Vec<BlockFileBacking>,
+    pmem_backings: Vec<PmemFileBacking>,
+    fail_at: usize,
+) -> Result<PreparedSnapshotV2StorageBundle, SnapshotV2StorageBundleError> {
+    plan.prepare_backings_with(
+        block_backings,
+        pmem_backings,
+        || false,
+        &mut FailingStorageRestoreReserve::new(fail_at),
+        PreparedPmemDevice::from_snapshot_parts,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn prepare_backings_with_pmem_fault_for_test(
+    plan: SnapshotV2StorageRestorePlan,
+    block_backings: Vec<BlockFileBacking>,
+    pmem_backings: Vec<PmemFileBacking>,
+    fail_at: usize,
+) -> Result<PreparedSnapshotV2StorageBundle, SnapshotV2StorageBundleError> {
+    let mut pmem_calls = 0_usize;
+    plan.prepare_backings_with(
+        block_backings,
+        pmem_backings,
+        || false,
+        &mut SystemRestoreReserve,
+        |parts| {
+            let call = pmem_calls;
+            pmem_calls = pmem_calls.saturating_add(1);
+            if call == fail_at {
+                Err(PreparedSnapshotPmemDeviceError::Configuration)
+            } else {
+                PreparedPmemDevice::from_snapshot_parts(parts)
+            }
+        },
+    )
+}
+
+fn release_pmem_records(records: &mut Vec<PreparedSnapshotV2PmemRecord>) {
+    while records.pop().is_some() {}
+}
+
+fn abort_block_bundle(
+    block: Option<PreparedSnapshotV2MultiBlockBundle>,
+) -> Result<(), SnapshotV2MultiBlockCleanupError> {
+    block.map_or(Ok(()), PreparedSnapshotV2MultiBlockBundle::abort)
+}
+
+fn range_is_wholly_contained(memory: &GuestMemory, range: GuestMemoryRange) -> bool {
+    memory.regions().iter().any(|region| {
+        let region = region.range();
+        region.start().raw_value() <= range.start().raw_value()
+            && range.end_exclusive().raw_value() <= region.end_exclusive().raw_value()
+    })
+}
+
+fn restored_retry_deadline_at(retry: StorageRetryState, now: Instant) -> Option<Instant> {
+    match retry {
+        StorageRetryState::None => None,
+        StorageRetryState::Immediate => Some(now),
+        StorageRetryState::After { remaining_nanos } => Some(
+            now.checked_add(Duration::from_nanos(remaining_nanos))
+                .unwrap_or(now),
+        ),
+    }
+}
+
+fn persisted_pmem_limiter_state(
+    config: Option<PmemRateLimiterConfig>,
+    state: SnapshotV2PmemLimiterState,
+) -> Result<VirtioPmemRateLimiterState, SnapshotV2StorageRestorePlanError> {
+    Ok(VirtioPmemRateLimiterState::new(
+        persisted_pmem_bucket_state(
+            config.and_then(PmemRateLimiterConfig::bandwidth),
+            state.bandwidth(),
+        )?,
+        persisted_pmem_bucket_state(config.and_then(PmemRateLimiterConfig::ops), state.ops())?,
+    ))
+}
+
+fn persisted_pmem_bucket_state(
+    config: Option<PmemTokenBucketConfig>,
+    state: Option<SnapshotV2PmemBucketState>,
+) -> Result<Option<VirtioPmemTokenBucketState>, SnapshotV2StorageRestorePlanError> {
+    match (config, state) {
+        (Some(config), Some(state)) => Ok(Some(VirtioPmemTokenBucketState::new(
+            config,
+            state.budget(),
+            state.remaining_burst(),
+            state.age_nanos(),
+        ))),
+        (None, None) => Ok(None),
+        _ => Err(SnapshotV2StorageRestorePlanError::InvalidGraph),
+    }
+}

--- a/crates/runtime/src/snapshot_device_v2_6/tests.rs
+++ b/crates/runtime/src/snapshot_device_v2_6/tests.rs
@@ -1,8 +1,13 @@
+use std::fs::{self, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
 use super::codec;
 use super::*;
 
 use crate::interrupt::GuestInterruptLine;
-use crate::memory::{GuestAddress, GuestMemoryRange};
+use crate::memory::{GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange};
 use crate::mmio::{MmioRegion, MmioRegionId};
 use crate::pci::PciSbdf;
 use crate::pmem::{PmemRateLimiterConfig, PmemTokenBucketConfig};
@@ -49,6 +54,39 @@ const HEALTHY_DRIVER_OK: u32 = VIRTIO_DEVICE_STATUS_ACKNOWLEDGE
     | VIRTIO_DEVICE_STATUS_DRIVER
     | VIRTIO_DEVICE_STATUS_FEATURES_OK
     | VIRTIO_DEVICE_STATUS_DRIVER_OK;
+static NEXT_RESTORE_TEMP_FILE: AtomicU64 = AtomicU64::new(0);
+
+struct RestoreTempBacking {
+    path: PathBuf,
+}
+
+impl RestoreTempBacking {
+    fn new(name: &str, len: u64) -> Self {
+        let sequence = NEXT_RESTORE_TEMP_FILE.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "bangbang-profile-3-restore-{name}-{}-{sequence}",
+            std::process::id()
+        ));
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .expect("restore backing should create");
+        file.set_len(len).expect("restore backing should resize");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for RestoreTempBacking {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
 
 fn decode_hex(hex: &str) -> Vec<u8> {
     let hex = hex.trim();
@@ -272,6 +310,390 @@ fn encoded(graph: &SnapshotV2StorageDeviceGraph) -> Vec<u8> {
     graph
         .encode(NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION)
         .expect("fixture graph should encode")
+}
+
+fn restore_memory_for(graph: &SnapshotV2StorageDeviceGraph) -> GuestMemory {
+    let layout = GuestMemoryLayout::new(vec![
+        GuestMemoryRange::new(GuestAddress::new(0), 0x80_0000)
+            .expect("restore memory range should validate"),
+    ])
+    .expect("restore memory layout should validate");
+    let mut memory = GuestMemory::allocate(&layout).expect("restore memory should allocate");
+    for record in graph.block_records() {
+        let Some(cursor) = record.block().continuation().active_queue() else {
+            continue;
+        };
+        let queue = record
+            .virtio()
+            .queues()
+            .first()
+            .expect("block queue should exist");
+        let available_index = if record.block().continuation().retry() == StorageRetryState::None {
+            cursor.next_available()
+        } else {
+            cursor.next_available().wrapping_add(1)
+        };
+        memory
+            .write_slice(
+                &available_index.to_le_bytes(),
+                GuestAddress::new(queue.driver_ring().raw_value() + 2),
+            )
+            .expect("block available index should write");
+        memory
+            .write_slice(
+                &cursor.next_used().to_le_bytes(),
+                GuestAddress::new(queue.device_ring().raw_value() + 2),
+            )
+            .expect("block used index should write");
+    }
+    for record in graph.pmem_records() {
+        let Some(cursor) = record.pmem().active_queue() else {
+            continue;
+        };
+        let queue = record
+            .virtio()
+            .queues()
+            .first()
+            .expect("pmem queue should exist");
+        let available_index = if record.pmem().retry() == StorageRetryState::None {
+            cursor.next_available()
+        } else {
+            cursor.next_available().wrapping_add(1)
+        };
+        memory
+            .write_slice(
+                &available_index.to_le_bytes(),
+                GuestAddress::new(queue.driver_ring().raw_value() + 2),
+            )
+            .expect("pmem available index should write");
+        memory
+            .write_slice(
+                &cursor.next_used().to_le_bytes(),
+                GuestAddress::new(queue.device_ring().raw_value() + 2),
+            )
+            .expect("pmem used index should write");
+    }
+    memory
+}
+
+fn restore_backings(
+    graph: &SnapshotV2StorageDeviceGraph,
+) -> (
+    Vec<RestoreTempBacking>,
+    Vec<crate::block::BlockFileBacking>,
+    Vec<crate::pmem::PmemFileBacking>,
+) {
+    let mut files = Vec::new();
+    let mut blocks = Vec::new();
+    let mut pmems = Vec::new();
+    for (index, record) in graph.block_records().iter().enumerate() {
+        let file =
+            RestoreTempBacking::new(&format!("block-{index}"), record.block().backing_bytes());
+        let backing = crate::block::BlockFileBacking::open_snapshot(
+            file.path(),
+            record.config().is_read_only(),
+        )
+        .expect("block restore backing should open")
+        .0;
+        files.push(file);
+        blocks.push(backing);
+    }
+    for (index, record) in graph.pmem_records().iter().enumerate() {
+        let file = RestoreTempBacking::new(&format!("pmem-{index}"), record.pmem().file_bytes());
+        let host_file = OpenOptions::new()
+            .read(true)
+            .write(!record.config().is_read_only())
+            .open(file.path())
+            .expect("pmem restore file should open");
+        let backing =
+            crate::pmem::PmemFileBacking::from_file(host_file, record.config().is_read_only())
+                .expect("pmem restore backing should validate");
+        files.push(file);
+        pmems.push(backing);
+    }
+    (files, blocks, pmems)
+}
+
+#[test]
+fn restore_plan_prepares_all_root_transport_and_class_combinations() {
+    for (transport, blocks, pmems, root) in [
+        (
+            SnapshotV2DeviceTransportKind::Mmio,
+            1,
+            0,
+            Some(DEVICE_KIND_BLOCK),
+        ),
+        (SnapshotV2DeviceTransportKind::Pci, 1, 0, None),
+        (
+            SnapshotV2DeviceTransportKind::Mmio,
+            0,
+            1,
+            Some(DEVICE_KIND_PMEM),
+        ),
+        (SnapshotV2DeviceTransportKind::Pci, 0, 1, None),
+        (
+            SnapshotV2DeviceTransportKind::Mmio,
+            1,
+            1,
+            Some(DEVICE_KIND_BLOCK),
+        ),
+        (
+            SnapshotV2DeviceTransportKind::Pci,
+            1,
+            1,
+            Some(DEVICE_KIND_PMEM),
+        ),
+    ] {
+        let graph = fixture_graph(transport, blocks, pmems, root);
+        let memory = restore_memory_for(&graph);
+        let expected_root = graph.root_key();
+        let (_files, block_backings, pmem_backings) = restore_backings(&graph);
+        let plan = SnapshotV2StorageRestorePlan::prepare(graph, &memory, Instant::now())
+            .expect("profile-3 restore plan should validate");
+
+        assert_eq!(plan.root_key(), expected_root);
+        assert_eq!(plan.transport_kind(), transport);
+        assert_eq!(plan.block_len(), blocks);
+        assert_eq!(plan.pmem_len(), pmems);
+        assert_eq!(plan.pmem_configs().as_slice().len(), pmems);
+        let bundle = plan
+            .prepare_backings(block_backings, pmem_backings, || false)
+            .expect("profile-3 restore bundle should prepare");
+        assert_eq!(
+            bundle
+                .block_bundle()
+                .map_or(0, |block| block.records().len()),
+            blocks
+        );
+        assert_eq!(bundle.pmem_records().len(), pmems);
+        bundle
+            .abort()
+            .expect("profile-3 restore bundle should cleanly abort");
+    }
+}
+
+#[test]
+fn pmem_restore_bundle_retains_exact_range_queue_limiter_retry_and_value_state() {
+    let graph = fixture_graph(
+        SnapshotV2DeviceTransportKind::Mmio,
+        0,
+        1,
+        Some(DEVICE_KIND_PMEM),
+    );
+    let expected = graph.clone();
+    let memory = restore_memory_for(&graph);
+    let now = Instant::now();
+    let (_files, blocks, pmems) = restore_backings(&graph);
+    let bundle = SnapshotV2StorageRestorePlan::prepare(graph, &memory, now)
+        .expect("pmem restore plan should prepare")
+        .prepare_backings(blocks, pmems, || false)
+        .expect("pmem restore bundle should prepare");
+
+    assert_eq!(bundle.root_key(), expected.root_key());
+    assert_eq!(bundle.transport_kind(), SnapshotV2DeviceTransportKind::Mmio);
+    assert!(bundle.block_bundle().is_none());
+    assert_eq!(bundle.pmem_configs().as_slice().len(), 1);
+    let prepared = &bundle.pmem_records()[0];
+    let expected_record = &expected.pmem_records()[0];
+    assert_eq!(prepared.key(), expected_record.key());
+    assert!(prepared.is_root_device());
+    assert_eq!(
+        prepared.prepared_device().guest_range(),
+        expected_record.pmem().guest_range()
+    );
+    assert_eq!(
+        prepared.prepared_device().config_space(),
+        expected_record.pmem().config_space()
+    );
+    assert_eq!(
+        prepared
+            .device()
+            .active_queue()
+            .map(crate::pmem::VirtioPmemQueue::snapshot_state),
+        expected_record.pmem().active_queue()
+    );
+    assert!(prepared.device().has_pending_rate_limited_queue());
+    assert_eq!(prepared.retry(), expected_record.pmem().retry());
+    assert_eq!(
+        prepared.retry_deadline(),
+        Some(now + Duration::from_nanos(99))
+    );
+    assert_eq!(prepared.virtio(), expected_record.virtio());
+    assert_eq!(prepared.transport(), expected_record.transport());
+
+    let recaptured = prepared
+        .device()
+        .capture_state_at(
+            prepared.prepared_device().config_space(),
+            expected_record.pmem().file_bytes(),
+            expected_record.config().rate_limiter(),
+            now,
+        )
+        .expect("restored pmem semantics should recapture");
+    assert_eq!(
+        recaptured.active_queue(),
+        expected_record.pmem().active_queue()
+    );
+    assert_eq!(
+        recaptured.pending_rate_limited_queue(),
+        expected_record.pmem().pending_rate_limited_queue()
+    );
+    assert_eq!(
+        recaptured.rate_limiter().bandwidth().map(|bucket| (
+            bucket.budget(),
+            bucket.remaining_burst(),
+            bucket.age_nanos(),
+        )),
+        expected_record.pmem().limiter().bandwidth().map(|bucket| (
+            bucket.budget(),
+            bucket.remaining_burst(),
+            bucket.age_nanos(),
+        ))
+    );
+    assert_eq!(
+        format!("{bundle:?}"),
+        "PreparedSnapshotV2StorageBundle { block_count: 0, pmem_count: 1, transport: Mmio, state: \"<redacted>\" }"
+    );
+    bundle
+        .abort()
+        .expect("pmem-only cleanup should be infallible");
+}
+
+#[test]
+fn mixed_pmem_root_restore_keeps_the_block_subgraph_rootless() {
+    let graph = fixture_graph(
+        SnapshotV2DeviceTransportKind::Pci,
+        1,
+        1,
+        Some(DEVICE_KIND_PMEM),
+    );
+    let memory = restore_memory_for(&graph);
+    let now = Instant::now();
+    let (_files, blocks, pmems) = restore_backings(&graph);
+    let bundle = SnapshotV2StorageRestorePlan::prepare(graph, &memory, now)
+        .expect("mixed restore plan should prepare")
+        .prepare_backings(blocks, pmems, || false)
+        .expect("mixed restore bundle should prepare");
+
+    let block = bundle
+        .block_bundle()
+        .expect("mixed bundle should retain its block sub-bundle");
+    assert_eq!(block.records().len(), 1);
+    assert!(!block.records()[0].is_root_device());
+    assert_eq!(bundle.pmem_records().len(), 1);
+    assert!(bundle.pmem_records()[0].is_root_device());
+    bundle.abort().expect("mixed bundle should cleanly abort");
+}
+
+#[test]
+fn restore_plan_rejects_loaded_ram_overlap_and_stale_queue_indices() {
+    let mut overlapping = fixture_graph(
+        SnapshotV2DeviceTransportKind::Mmio,
+        0,
+        1,
+        Some(DEVICE_KIND_PMEM),
+    );
+    let range = GuestMemoryRange::new(GuestAddress::new(0x40_0000), VIRTIO_PMEM_ALIGNMENT * 2)
+        .expect("overlapping pmem range should validate");
+    overlapping.pmem_records[0].pmem.guest_range = range;
+    overlapping.pmem_records[0].pmem.config_space =
+        VirtioPmemConfigSpace::new(range.start().raw_value(), range.size());
+    let memory = restore_memory_for(&overlapping);
+    assert!(matches!(
+        SnapshotV2StorageRestorePlan::prepare(overlapping, &memory, Instant::now()),
+        Err(SnapshotV2StorageRestorePlanError::PmemRange)
+    ));
+
+    let graph = fixture_graph(
+        SnapshotV2DeviceTransportKind::Mmio,
+        0,
+        1,
+        Some(DEVICE_KIND_PMEM),
+    );
+    let mut memory = restore_memory_for(&graph);
+    let used_ring = graph.pmem_records()[0].virtio().queues()[0].device_ring();
+    memory
+        .write_slice(
+            &0_u16.to_le_bytes(),
+            GuestAddress::new(used_ring.raw_value() + 2),
+        )
+        .expect("stale used index should write");
+    assert!(matches!(
+        SnapshotV2StorageRestorePlan::prepare(graph, &memory, Instant::now()),
+        Err(SnapshotV2StorageRestorePlanError::QueueContinuation)
+    ));
+}
+
+#[test]
+fn restore_plan_and_bundle_allocation_faults_precede_owner_construction() {
+    let graph = fixture_graph(
+        SnapshotV2DeviceTransportKind::Mmio,
+        0,
+        1,
+        Some(DEVICE_KIND_PMEM),
+    );
+    let memory = restore_memory_for(&graph);
+    for fail_at in 0..2 {
+        assert!(matches!(
+            super::restore::prepare_with_failing_reserve_for_test(
+                graph.clone(),
+                &memory,
+                Instant::now(),
+                fail_at,
+            ),
+            Err(SnapshotV2StorageRestorePlanError::Allocation)
+        ));
+    }
+
+    let (_files, blocks, pmems) = restore_backings(&graph);
+    let plan = SnapshotV2StorageRestorePlan::prepare(graph, &memory, Instant::now())
+        .expect("allocation bundle plan should prepare");
+    let error =
+        super::restore::prepare_backings_with_failing_reserve_for_test(plan, blocks, pmems, 0)
+            .expect_err("bundle reserve failure should precede mapping");
+    assert!(error.is_retryable());
+    assert!(!error.cleanup_failed());
+}
+
+#[test]
+fn later_pmem_construction_fault_releases_the_prepared_prefix_and_allows_retry() {
+    let graph = fixture_graph(
+        SnapshotV2DeviceTransportKind::Mmio,
+        0,
+        2,
+        Some(DEVICE_KIND_PMEM),
+    );
+    let expected = graph.clone();
+    let memory = restore_memory_for(&graph);
+    let (_files, blocks, pmems) = restore_backings(&graph);
+    let plan = SnapshotV2StorageRestorePlan::prepare(graph, &memory, Instant::now())
+        .expect("pmem fault plan should prepare");
+    let error = super::restore::prepare_backings_with_pmem_fault_for_test(plan, blocks, pmems, 1)
+        .expect_err("second pmem construction should fail after the first mapping");
+    assert!(!error.is_retryable());
+    assert!(!error.cleanup_failed());
+
+    let (_retry_files, blocks, pmems) = restore_backings(&expected);
+    let retry = SnapshotV2StorageRestorePlan::prepare(expected, &memory, Instant::now())
+        .expect("pmem retry plan should prepare")
+        .prepare_backings(blocks, pmems, || false)
+        .expect("pmem backings should remain reusable after prefix cleanup");
+    assert_eq!(retry.pmem_records().len(), 2);
+    assert!(
+        retry.pmem_records()[0]
+            .prepared_device()
+            .backing()
+            .is_read_only()
+    );
+    assert!(
+        !retry.pmem_records()[1]
+            .prepared_device()
+            .backing()
+            .is_read_only()
+    );
+    retry
+        .abort()
+        .expect("pmem retry bundle should abort cleanly");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add a pure exact-2.6 storage restore plan that proves the complete block+pmem graph, loaded-memory exclusion, queue continuation, limiter state, retry timing, and controller projections before resource acquisition
- rebuild pathless pmem owners from already-opened backings with the recorded guest range, queue cursors, limiter clock, config space, and exact file-prefix/fresh-private-tail mapping policy
- compose detached block and pmem owners with aggregate direct or contained backing authority through explicit construct, commit, abort, drop, cancellation, and failure rollback paths

## Scope exclusions

- does not activate exact-2.6 through public snapshot load routing
- does not publish HVF mappings, MMIO/PCI transports, controllers, notifier routes, metrics leases, or retry schedulers
- does not change exact-2.6 codec bytes or exact-2.5 restore behavior

## Validation

- `cargo test -p bangbang-runtime --lib --all-features --locked snapshot_`
- `cargo test -p bangbang-runtime --lib --all-features --locked snapshot_device_v2_6::tests::`
- `cargo test -p bangbang --all-features --locked profile_3_`
- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `CARGO_BUILD_JOBS=1 cargo check --workspace --all-targets --all-features --locked`
- `CARGO_BUILD_JOBS=1 cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `CARGO_BUILD_JOBS=1 cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `CARGO_BUILD_JOBS=1 cargo test -p bangbang-hvf --lib --all-features --locked`
- `CARGO_BUILD_JOBS=1 cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" CARGO_BUILD_JOBS=1 cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
- `git diff --check`

Closes #1630

Parent context: #1534
