### PR TITLE
feat: reconstruct pmem snapshot owners over MMIO

### DIFF
--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -44,15 +44,16 @@ use bangbang_hvf::{
     HvfSnapshotV2MultiBlockPlatformPlan, HvfSnapshotV2MultiBlockProcessConfig,
     HvfSnapshotV2MultiBlockState, HvfSnapshotV2NativePath, HvfSnapshotV2PlatformRestoreError,
     HvfSnapshotV2PlatformState, HvfSnapshotV2RootProcessConfig, HvfSnapshotV2RootResourcePlan,
-    HvfSnapshotV2RootRestoreError, HvfSnapshotV2State, HvfVcpuRunControl,
-    HvfVcpuRunCoordinatorError, HvfVcpuRunStepOutcome, OwnedHvfArm64BootSession,
-    PrepareHvfSnapshotV1LoadError, PrepareHvfSnapshotV2MultiBlockPlatformPlanError,
-    PrepareHvfSnapshotV2RootPlanError, PreparedHvfArm64BootPciNetworkRemoval,
-    PreparedHvfSnapshotV1Load, PreparedHvfSnapshotV1State, RestoredHvfSnapshotV2Platform,
-    decode_hvf_snapshot_v2_multi_block_state, decode_hvf_snapshot_v2_platform_state,
-    decode_hvf_snapshot_v2_state, encode_hvf_snapshot_v2_multi_block_state,
-    encode_hvf_snapshot_v2_state, prepare_hvf_snapshot_v2_multi_block_platform_plan,
-    prepare_hvf_snapshot_v2_root_plan, restore_hvf_snapshot_v2_process_platform,
+    HvfSnapshotV2RootRestoreError, HvfSnapshotV2State, HvfSnapshotV2StorageMmioPlatformPlan,
+    HvfSnapshotV2StorageMmioRestoreError, HvfVcpuRunControl, HvfVcpuRunCoordinatorError,
+    HvfVcpuRunStepOutcome, OwnedHvfArm64BootSession, PrepareHvfSnapshotV1LoadError,
+    PrepareHvfSnapshotV2MultiBlockPlatformPlanError, PrepareHvfSnapshotV2RootPlanError,
+    PreparedHvfArm64BootPciNetworkRemoval, PreparedHvfSnapshotV1Load, PreparedHvfSnapshotV1State,
+    RestoredHvfSnapshotV2Platform, decode_hvf_snapshot_v2_multi_block_state,
+    decode_hvf_snapshot_v2_platform_state, decode_hvf_snapshot_v2_state,
+    encode_hvf_snapshot_v2_multi_block_state, encode_hvf_snapshot_v2_state,
+    prepare_hvf_snapshot_v2_multi_block_platform_plan, prepare_hvf_snapshot_v2_root_plan,
+    restore_hvf_snapshot_v2_process_platform,
 };
 use bangbang_runtime::balloon::BalloonMmioLayout;
 use bangbang_runtime::balloon::{
@@ -213,9 +214,10 @@ use crate::snapshot_restore_resources::{
     PreparedSnapshotRootBackingLease, PreparedSnapshotRootRestoreCompletion,
     PreparedSnapshotRootRestoreCompletionError, PreparedSnapshotV2MultiBlockDestinationCommitError,
     PreparedSnapshotV2MultiBlockDestinationConstructionError,
-    PreparedSnapshotV2MultiBlockRestoreBundle, RequestedSnapshotRestoreResources,
-    SnapshotRestoreResourceDisposition, SnapshotRestoreResourceError,
-    SnapshotRootBackingLeaseError, SnapshotRootSelectorPolicy,
+    PreparedSnapshotV2MultiBlockRestoreBundle, PreparedSnapshotV2StorageDestinationCommitError,
+    PreparedSnapshotV2StorageDestinationConstructionError, PreparedSnapshotV2StorageRestoreBundle,
+    RequestedSnapshotRestoreResources, SnapshotRestoreResourceDisposition,
+    SnapshotRestoreResourceError, SnapshotRootBackingLeaseError, SnapshotRootSelectorPolicy,
     SnapshotV2MultiBlockRestoreBundleError,
 };
 #[cfg(target_os = "macos")]
@@ -7224,26 +7226,33 @@ impl fmt::Display for PreparedHvfSnapshotV2MultiBlockControllerError {
 impl std::error::Error for PreparedHvfSnapshotV2MultiBlockControllerError {}
 
 #[cfg(target_os = "macos")]
-trait HvfSnapshotV2MultiBlockRestoreDisposition {
+trait HvfSnapshotV2RestoreDisposition {
     fn is_terminal(&self) -> bool;
 }
 
 #[cfg(target_os = "macos")]
-impl HvfSnapshotV2MultiBlockRestoreDisposition for HvfSnapshotV2MultiBlockMmioRestoreError {
+impl HvfSnapshotV2RestoreDisposition for HvfSnapshotV2MultiBlockMmioRestoreError {
     fn is_terminal(&self) -> bool {
         self.is_terminal()
     }
 }
 
 #[cfg(target_os = "macos")]
-impl HvfSnapshotV2MultiBlockRestoreDisposition for HvfSnapshotV2MultiBlockPciRestoreError {
+impl HvfSnapshotV2RestoreDisposition for HvfSnapshotV2MultiBlockPciRestoreError {
     fn is_terminal(&self) -> bool {
         self.is_terminal()
     }
 }
 
 #[cfg(target_os = "macos")]
-enum HvfSnapshotV2MultiBlockProcessConstructionError<E> {
+impl HvfSnapshotV2RestoreDisposition for HvfSnapshotV2StorageMmioRestoreError {
+    fn is_terminal(&self) -> bool {
+        self.is_terminal()
+    }
+}
+
+#[cfg(target_os = "macos")]
+enum HvfSnapshotV2ProcessConstructionError<E> {
     Restore(E),
     RunReady {
         source: HvfVcpuRunCoordinatorError,
@@ -7256,10 +7265,9 @@ enum HvfSnapshotV2MultiBlockProcessConstructionError<E> {
 }
 
 #[cfg(target_os = "macos")]
-impl<E> HvfSnapshotV2MultiBlockRestoreDisposition
-    for HvfSnapshotV2MultiBlockProcessConstructionError<E>
+impl<E> HvfSnapshotV2RestoreDisposition for HvfSnapshotV2ProcessConstructionError<E>
 where
-    E: HvfSnapshotV2MultiBlockRestoreDisposition,
+    E: HvfSnapshotV2RestoreDisposition,
 {
     fn is_terminal(&self) -> bool {
         match self {
@@ -7270,9 +7278,9 @@ where
 }
 
 #[cfg(target_os = "macos")]
-impl<E> fmt::Debug for HvfSnapshotV2MultiBlockProcessConstructionError<E>
+impl<E> fmt::Debug for HvfSnapshotV2ProcessConstructionError<E>
 where
-    E: HvfSnapshotV2MultiBlockRestoreDisposition,
+    E: HvfSnapshotV2RestoreDisposition,
 {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         let (stage, cleanup_failed) = match self {
@@ -7281,7 +7289,7 @@ where
             Self::WorkerStart { cleanup, .. } => ("worker-start", cleanup.is_some()),
         };
         formatter
-            .debug_struct("HvfSnapshotV2MultiBlockProcessConstructionError")
+            .debug_struct("HvfSnapshotV2ProcessConstructionError")
             .field("stage", &stage)
             .field("terminal", &self.is_terminal())
             .field("cleanup_failed", &cleanup_failed)
@@ -7291,19 +7299,19 @@ where
 }
 
 #[cfg(target_os = "macos")]
-impl<E> fmt::Display for HvfSnapshotV2MultiBlockProcessConstructionError<E>
+impl<E> fmt::Display for HvfSnapshotV2ProcessConstructionError<E>
 where
-    E: HvfSnapshotV2MultiBlockRestoreDisposition,
+    E: HvfSnapshotV2RestoreDisposition,
 {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         let (message, cleanup_failed) = match self {
-            Self::Restore(_) => ("profile-2 HVF owner restore failed", false),
+            Self::Restore(_) => ("native-v2 HVF owner restore failed", false),
             Self::RunReady { cleanup, .. } => (
-                "profile-2 run coordinator preparation failed",
+                "native-v2 run coordinator preparation failed",
                 cleanup.is_some(),
             ),
             Self::WorkerStart { cleanup, .. } => {
-                ("profile-2 paused worker startup failed", cleanup.is_some())
+                ("native-v2 paused worker startup failed", cleanup.is_some())
             }
         };
         formatter.write_str(message)?;
@@ -7315,9 +7323,9 @@ where
 }
 
 #[cfg(target_os = "macos")]
-impl<E> std::error::Error for HvfSnapshotV2MultiBlockProcessConstructionError<E>
+impl<E> std::error::Error for HvfSnapshotV2ProcessConstructionError<E>
 where
-    E: HvfSnapshotV2MultiBlockRestoreDisposition + std::error::Error + 'static,
+    E: HvfSnapshotV2RestoreDisposition + std::error::Error + 'static,
 {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
@@ -7342,7 +7350,7 @@ enum PrepareHvfSnapshotV2MultiBlockDestinationError<E> {
 #[cfg(target_os = "macos")]
 impl<E> PrepareHvfSnapshotV2MultiBlockDestinationError<E>
 where
-    E: HvfSnapshotV2MultiBlockRestoreDisposition,
+    E: HvfSnapshotV2RestoreDisposition,
 {
     fn is_terminal(&self) -> bool {
         match self {
@@ -7364,7 +7372,7 @@ where
 #[cfg(target_os = "macos")]
 impl<E> fmt::Debug for PrepareHvfSnapshotV2MultiBlockDestinationError<E>
 where
-    E: HvfSnapshotV2MultiBlockRestoreDisposition,
+    E: HvfSnapshotV2RestoreDisposition,
 {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         let stage = match self {
@@ -7383,7 +7391,7 @@ where
 #[cfg(target_os = "macos")]
 impl<E> fmt::Display for PrepareHvfSnapshotV2MultiBlockDestinationError<E>
 where
-    E: HvfSnapshotV2MultiBlockRestoreDisposition,
+    E: HvfSnapshotV2RestoreDisposition,
 {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -7401,7 +7409,7 @@ where
 #[cfg(target_os = "macos")]
 impl<E> std::error::Error for PrepareHvfSnapshotV2MultiBlockDestinationError<E>
 where
-    E: HvfSnapshotV2MultiBlockRestoreDisposition + std::error::Error + 'static,
+    E: HvfSnapshotV2RestoreDisposition + std::error::Error + 'static,
 {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
@@ -7439,7 +7447,7 @@ fn prepare_hvf_native_v2_multi_block_mmio_destination(
         SharedSerialOutput,
     ),
     PrepareHvfSnapshotV2MultiBlockDestinationError<
-        HvfSnapshotV2MultiBlockProcessConstructionError<HvfSnapshotV2MultiBlockMmioRestoreError>,
+        HvfSnapshotV2ProcessConstructionError<HvfSnapshotV2MultiBlockMmioRestoreError>,
     >,
 > {
     let PrepareHvfSnapshotV2MultiBlockMmioDestinationInput {
@@ -7466,17 +7474,14 @@ fn prepare_hvf_native_v2_multi_block_mmio_destination(
                 bundle,
                 plan,
             )
-            .map_err(HvfSnapshotV2MultiBlockProcessConstructionError::Restore)?;
+            .map_err(HvfSnapshotV2ProcessConstructionError::Restore)?;
             let (mut session, drive_configs) = owners.into_parts();
             if let Err(source) = session.resume_after_snapshot_v2_capture() {
                 let cleanup = session
                     .shutdown()
                     .err()
                     .map(|source| BackendError::Hypervisor(source.to_string()));
-                return Err(HvfSnapshotV2MultiBlockProcessConstructionError::RunReady {
-                    source,
-                    cleanup,
-                });
+                return Err(HvfSnapshotV2ProcessConstructionError::RunReady { source, cleanup });
             }
             let process_session = ProcessHvfBootSession::new_with_vmnet_authority(
                 session,
@@ -7496,12 +7501,10 @@ fn prepare_hvf_native_v2_multi_block_mmio_destination(
                         .shutdown()
                         .err()
                         .map(|source| BackendError::Hypervisor(source.to_string()));
-                    return Err(
-                        HvfSnapshotV2MultiBlockProcessConstructionError::WorkerStart {
-                            source,
-                            cleanup,
-                        },
-                    );
+                    return Err(HvfSnapshotV2ProcessConstructionError::WorkerStart {
+                        source,
+                        cleanup,
+                    });
                 }
             };
             Ok(PreparedHvfSnapshotV2MultiBlockDestination {
@@ -7525,6 +7528,321 @@ fn prepare_hvf_native_v2_multi_block_mmio_destination(
             PreparedHvfSnapshotV2MultiBlockDestination::shutdown,
         )
         .map_err(PrepareHvfSnapshotV2MultiBlockDestinationError::Commit)?;
+    let (session, serial_output) = destination.into_parts();
+    Ok((session, controller, serial_output))
+}
+
+#[cfg(target_os = "macos")]
+#[allow(
+    dead_code,
+    reason = "exact-2.6 process restore remains private until the public activation slice"
+)]
+struct PreparedHvfSnapshotV2StorageControllerProjection {
+    machine: bangbang_runtime::machine::MachineConfig,
+    boot: bangbang_runtime::boot::BootSourceConfig,
+    configs: CaptureReadyStorageConfigs,
+    resume_requested: bool,
+}
+
+#[cfg(target_os = "macos")]
+impl fmt::Debug for PreparedHvfSnapshotV2StorageControllerProjection {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedHvfSnapshotV2StorageControllerProjection")
+            .field("block_count", &self.configs.drives().len())
+            .field("pmem_count", &self.configs.pmem().len())
+            .field("resume_requested", &self.resume_requested)
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+#[cfg(target_os = "macos")]
+struct PreparedHvfSnapshotV2StorageDestination {
+    session: Box<HvfProcessSession>,
+    configs: Option<CaptureReadyStorageConfigs>,
+    serial_output: SharedSerialOutput,
+}
+
+#[cfg(target_os = "macos")]
+impl PreparedHvfSnapshotV2StorageDestination {
+    fn prepare_controller(
+        mut self,
+        machine: bangbang_runtime::machine::MachineConfig,
+        boot: bangbang_runtime::boot::BootSourceConfig,
+        resume_requested: bool,
+    ) -> Result<
+        (Self, PreparedHvfSnapshotV2StorageControllerProjection),
+        (Self, PreparedHvfSnapshotV2StorageControllerError),
+    > {
+        let Some(configs) = self.configs.take() else {
+            return Err((
+                self,
+                PreparedHvfSnapshotV2StorageControllerError::MissingConfigs,
+            ));
+        };
+        let projection = PreparedHvfSnapshotV2StorageControllerProjection {
+            machine,
+            boot,
+            configs,
+            resume_requested,
+        };
+        Ok((self, projection))
+    }
+
+    fn shutdown(mut self) -> Result<(), BackendError> {
+        let result = match self.session.as_mut() {
+            HvfProcessSession::Boot(supervisor) => supervisor
+                .run_command(|session| {
+                    session
+                        .session
+                        .shutdown()
+                        .map_err(|source| BackendError::Hypervisor(source.to_string()))
+                })
+                .map_err(lifecycle_error_from_boot_run_loop_command),
+            HvfProcessSession::SnapshotV2(_) => Err(BackendError::InvalidState(
+                "exact-2.6 storage destination has the wrong worker type",
+            )),
+        };
+        drop(self);
+        result
+    }
+
+    fn into_parts(self) -> (HvfProcessSession, SharedSerialOutput) {
+        let Self {
+            session,
+            configs,
+            serial_output,
+        } = self;
+        debug_assert!(configs.is_none());
+        (*session, serial_output)
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl fmt::Debug for PreparedHvfSnapshotV2StorageDestination {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedHvfSnapshotV2StorageDestination")
+            .field("state", &"<private-provisional>")
+            .finish()
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PreparedHvfSnapshotV2StorageControllerError {
+    MissingConfigs,
+    Cancelled,
+}
+
+#[cfg(target_os = "macos")]
+impl fmt::Display for PreparedHvfSnapshotV2StorageControllerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::MissingConfigs => "profile-3 controller projection is unavailable",
+            Self::Cancelled => "profile-3 destination commit was cancelled",
+        })
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl std::error::Error for PreparedHvfSnapshotV2StorageControllerError {}
+
+#[cfg(target_os = "macos")]
+enum PrepareHvfSnapshotV2StorageDestinationError {
+    Construction(
+        PreparedSnapshotV2StorageDestinationConstructionError<
+            HvfSnapshotV2ProcessConstructionError<HvfSnapshotV2StorageMmioRestoreError>,
+        >,
+    ),
+    Commit(
+        PreparedSnapshotV2StorageDestinationCommitError<
+            PreparedHvfSnapshotV2StorageControllerError,
+            BackendError,
+        >,
+    ),
+}
+
+#[cfg(target_os = "macos")]
+impl PrepareHvfSnapshotV2StorageDestinationError {
+    fn is_terminal(&self) -> bool {
+        match self {
+            Self::Construction(source) => {
+                source.is_terminal()
+                    || matches!(
+                        source,
+                        PreparedSnapshotV2StorageDestinationConstructionError::Construction {
+                            source,
+                            ..
+                        } if source.is_terminal()
+                    )
+            }
+            Self::Commit(source) => source.is_terminal(),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl fmt::Debug for PrepareHvfSnapshotV2StorageDestinationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let stage = match self {
+            Self::Construction(_) => "construction",
+            Self::Commit(_) => "completion",
+        };
+        formatter
+            .debug_struct("PrepareHvfSnapshotV2StorageDestinationError")
+            .field("stage", &stage)
+            .field("terminal", &self.is_terminal())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl fmt::Display for PrepareHvfSnapshotV2StorageDestinationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "profile-3 destination transaction failed ({})",
+            if self.is_terminal() {
+                "terminal"
+            } else {
+                "retryable"
+            }
+        )
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl std::error::Error for PrepareHvfSnapshotV2StorageDestinationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Construction(source) => Some(source),
+            Self::Commit(source) => Some(source),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[allow(
+    dead_code,
+    reason = "exact-2.6 process restore remains private until the public activation slice"
+)]
+struct PrepareHvfSnapshotV2StorageMmioDestinationInput {
+    platform: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    process_shell: HvfSnapshotV2DefaultProcessShell,
+    packet_io: ProcessNetworkPacketIoProvider,
+    mmds_metrics: Option<SharedMmdsMetrics>,
+    vmnet_authority: ProcessVmnetAuthority,
+    serial_output: SharedSerialOutput,
+    bundle: PreparedSnapshotV2StorageRestoreBundle,
+    plan: HvfSnapshotV2StorageMmioPlatformPlan,
+    machine: bangbang_runtime::machine::MachineConfig,
+    boot: bangbang_runtime::boot::BootSourceConfig,
+    resume_requested: bool,
+    cancellation: NativeV2SnapshotCaptureCancellation,
+}
+
+/// Builds one complete exact-2.6 MMIO worker behind the private Paused gate.
+///
+/// This deliberately returns a provisional block+pmem controller projection
+/// instead of mutating the public controller. The activation slice owns that
+/// final publication.
+#[cfg(target_os = "macos")]
+#[allow(
+    dead_code,
+    reason = "exact-2.6 process restore remains private until the public activation slice"
+)]
+fn prepare_hvf_native_v2_storage_mmio_destination(
+    input: PrepareHvfSnapshotV2StorageMmioDestinationInput,
+) -> Result<
+    (
+        HvfProcessSession,
+        PreparedHvfSnapshotV2StorageControllerProjection,
+        SharedSerialOutput,
+    ),
+    PrepareHvfSnapshotV2StorageDestinationError,
+> {
+    let PrepareHvfSnapshotV2StorageMmioDestinationInput {
+        platform,
+        memory,
+        process_shell,
+        packet_io,
+        mmds_metrics,
+        vmnet_authority,
+        serial_output,
+        bundle,
+        plan,
+        machine,
+        boot,
+        resume_requested,
+        cancellation,
+    } = input;
+    let destination = bundle
+        .construct_destination(|bundle| {
+            let owners = OwnedHvfArm64BootSession::restore_snapshot_v2_storage_mmio(
+                platform,
+                memory,
+                process_shell,
+                bundle,
+                plan,
+            )
+            .map_err(HvfSnapshotV2ProcessConstructionError::Restore)?;
+            let (mut session, configs) = owners.into_parts();
+            if let Err(source) = session.resume_after_snapshot_v2_capture() {
+                let cleanup = session
+                    .shutdown()
+                    .err()
+                    .map(|source| BackendError::Hypervisor(source.to_string()));
+                return Err(HvfSnapshotV2ProcessConstructionError::RunReady { source, cleanup });
+            }
+            let process_session = ProcessHvfBootSession::new_with_vmnet_authority(
+                session,
+                packet_io,
+                mmds_metrics,
+                vmnet_authority,
+            );
+            let supervisor = match HvfBootRunLoopSupervisor::start_paused(
+                process_session,
+                default_hvf_boot_run_loop_step_limit(),
+            ) {
+                Ok(supervisor) => supervisor,
+                Err(error) => {
+                    let (source, mut failed_session) = error.into_parts();
+                    let cleanup = failed_session
+                        .session
+                        .shutdown()
+                        .err()
+                        .map(|source| BackendError::Hypervisor(source.to_string()));
+                    return Err(HvfSnapshotV2ProcessConstructionError::WorkerStart {
+                        source,
+                        cleanup,
+                    });
+                }
+            };
+            Ok(PreparedHvfSnapshotV2StorageDestination {
+                session: Box::new(HvfProcessSession::Boot(supervisor)),
+                configs: Some(configs),
+                serial_output,
+            })
+        })
+        .map_err(PrepareHvfSnapshotV2StorageDestinationError::Construction)?;
+    let (destination, controller) = destination
+        .commit(
+            |destination| {
+                if !cancellation.try_seal_commit() {
+                    return Err((
+                        destination,
+                        PreparedHvfSnapshotV2StorageControllerError::Cancelled,
+                    ));
+                }
+                destination.prepare_controller(machine, boot, resume_requested)
+            },
+            PreparedHvfSnapshotV2StorageDestination::shutdown,
+        )
+        .map_err(PrepareHvfSnapshotV2StorageDestinationError::Commit)?;
     let (session, serial_output) = destination.into_parts();
     Ok((session, controller, serial_output))
 }
@@ -7557,7 +7875,7 @@ fn prepare_hvf_native_v2_multi_block_pci_destination(
         SharedSerialOutput,
     ),
     PrepareHvfSnapshotV2MultiBlockDestinationError<
-        HvfSnapshotV2MultiBlockProcessConstructionError<HvfSnapshotV2MultiBlockPciRestoreError>,
+        HvfSnapshotV2ProcessConstructionError<HvfSnapshotV2MultiBlockPciRestoreError>,
     >,
 > {
     let PrepareHvfSnapshotV2MultiBlockPciDestinationInput {
@@ -7584,17 +7902,14 @@ fn prepare_hvf_native_v2_multi_block_pci_destination(
                 bundle,
                 plan,
             )
-            .map_err(HvfSnapshotV2MultiBlockProcessConstructionError::Restore)?;
+            .map_err(HvfSnapshotV2ProcessConstructionError::Restore)?;
             let (mut session, drive_configs) = owners.into_parts();
             if let Err(source) = session.resume_after_snapshot_v2_capture() {
                 let cleanup = session
                     .shutdown()
                     .err()
                     .map(|source| BackendError::Hypervisor(source.to_string()));
-                return Err(HvfSnapshotV2MultiBlockProcessConstructionError::RunReady {
-                    source,
-                    cleanup,
-                });
+                return Err(HvfSnapshotV2ProcessConstructionError::RunReady { source, cleanup });
             }
             let process_session = ProcessHvfBootSession::new_with_vmnet_authority(
                 session,
@@ -7614,12 +7929,10 @@ fn prepare_hvf_native_v2_multi_block_pci_destination(
                         .shutdown()
                         .err()
                         .map(|source| BackendError::Hypervisor(source.to_string()));
-                    return Err(
-                        HvfSnapshotV2MultiBlockProcessConstructionError::WorkerStart {
-                            source,
-                            cleanup,
-                        },
-                    );
+                    return Err(HvfSnapshotV2ProcessConstructionError::WorkerStart {
+                        source,
+                        cleanup,
+                    });
                 }
             };
             Ok(PreparedHvfSnapshotV2MultiBlockDestination {
@@ -29858,6 +30171,267 @@ mod tests {
             assert_eq!(recaptured.device_graph(), &expected_graph);
             assert_eq!(destination.instance_info().state, InstanceState::Paused);
         }
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[test]
+    #[ignore = "requires the signed native_v2_process integration group"]
+    fn signed_native_v2_storage_destination_stays_private_and_paused_through_commit() {
+        use bangbang_runtime::pmem::VIRTIO_PMEM_ALIGNMENT;
+
+        const ARM64_IMAGE_HEADER_SIZE: usize = 64;
+        const ARM64_IMAGE_SIZE_OFFSET: usize = 16;
+        const ARM64_IMAGE_MAGIC_OFFSET: usize = 56;
+        const ARM64_IMAGE_MAGIC: u32 = 0x644d_5241;
+        const ARM64_BRANCH_TO_SELF: u32 = 0x1400_0000;
+
+        let mut image = vec![0_u8; ARM64_IMAGE_HEADER_SIZE];
+        image[..4].copy_from_slice(&ARM64_BRANCH_TO_SELF.to_le_bytes());
+        image[ARM64_IMAGE_SIZE_OFFSET..ARM64_IMAGE_SIZE_OFFSET + 8]
+            .copy_from_slice(&(ARM64_IMAGE_HEADER_SIZE as u64).to_le_bytes());
+        image[ARM64_IMAGE_MAGIC_OFFSET..ARM64_IMAGE_MAGIC_OFFSET + 4]
+            .copy_from_slice(&ARM64_IMAGE_MAGIC.to_le_bytes());
+        let kernel = TempFilePath::create_with_bytes("signed-native-v2-storage-kernel", &image);
+        let root = TempFilePath::create_with_bytes("signed-native-v2-storage-root", &[0_u8; 4096]);
+        let pmem = TempFilePath::create_with_bytes(
+            "signed-native-v2-storage-pmem",
+            &vec![
+                0_u8;
+                usize::try_from(VIRTIO_PMEM_ALIGNMENT).expect("pmem alignment should fit usize")
+            ],
+        );
+
+        let mut source_controller =
+            VmmController::new("native-v2-storage-source", "0.1.0", "bangbang");
+        source_controller
+            .handle_action(VmmAction::PutMachineConfig(MachineConfigInput::new(1, 16)))
+            .expect("storage source machine should configure");
+        source_controller
+            .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+                kernel.path(),
+            )))
+            .expect("storage source boot metadata should configure");
+        source_controller
+            .handle_action(VmmAction::PutDrive(
+                DriveConfigInput::new("rootfs", "rootfs", root.path(), true)
+                    .with_is_read_only(true)
+                    .with_io_engine(DriveIoEngine::Sync),
+            ))
+            .expect("storage source block root should configure");
+        source_controller
+            .handle_action(VmmAction::PutPmem(PmemConfigInput::new(
+                "pmem0",
+                pmem.path().to_string_lossy().into_owned(),
+            )))
+            .expect("storage source pmem should configure");
+
+        let source_serial = SharedSerialOutput::from(SharedSerialOutputBuffer::default());
+        let mut source_session = super::OwnedHvfArm64BootSession::new(
+            &source_controller,
+            default_hvf_boot_session_config(source_serial),
+        )
+        .expect("signed exact-2.6 source should prepare");
+        let expected_configs = CaptureReadyStorageConfigs::new(
+            source_controller.drive_configs().to_vec(),
+            source_controller.pmem_configs().to_vec(),
+        );
+        let capture_now = Instant::now();
+        let capture_guard = source_session
+            .quiesce_limiter_retry_wakeups()
+            .expect("storage source retry publishers should quiesce");
+        let graph = source_session
+            .capture_snapshot_v2_storage_device_graph_at(
+                &expected_configs,
+                &capture_guard,
+                capture_now,
+            )
+            .expect("signed exact-2.6 storage graph should capture");
+
+        let restored_layout =
+            GuestMemoryLayout::new(source_session.runtime_resources().layout.ranges().to_vec())
+                .expect("storage destination layout should validate");
+        let copy_source_memory = || {
+            let mut destination = GuestMemory::allocate(&restored_layout)
+                .expect("storage destination memory should allocate");
+            let source = source_session
+                .guest_memory()
+                .expect("storage source memory should remain mapped");
+            let mut buffer = vec![0_u8; 64 * 1024];
+            for range in restored_layout.ranges() {
+                let mut copied = 0_u64;
+                while copied < range.size() {
+                    let count = usize::try_from(
+                        (range.size() - copied).min(
+                            u64::try_from(buffer.len())
+                                .expect("storage copy buffer length should fit u64"),
+                        ),
+                    )
+                    .expect("storage memory copy length should fit usize");
+                    let address = range
+                        .start()
+                        .checked_add(copied)
+                        .expect("storage memory copy address should fit");
+                    source
+                        .read_slice(&mut buffer[..count], address)
+                        .expect("storage source memory should read");
+                    destination
+                        .write_slice(&buffer[..count], address)
+                        .expect("storage destination memory should write");
+                    copied += u64::try_from(count).expect("storage copy length should fit u64");
+                }
+            }
+            destination
+        };
+        let cancelled_memory = copy_source_memory();
+        let committed_memory = copy_source_memory();
+
+        source_session
+            .pause_for_snapshot_v2_capture()
+            .expect("storage source topology should pause");
+        let boot_state = HvfSnapshotV2BootState::try_new(
+            HvfSnapshotV2NativePath::try_new(kernel.path().as_os_str())
+                .expect("storage source kernel path should validate"),
+            None,
+            None,
+        )
+        .expect("storage source boot state should validate");
+        let mut memory_output = Cursor::new(Vec::new());
+        let platform = source_session
+            .capture_snapshot_v2_storage_platform_with_cancel(
+                HvfArm64BootSnapshotV2CaptureInput::new(boot_state),
+                &mut memory_output,
+                |_| false,
+            )
+            .expect("signed exact-2.6 storage platform should capture");
+        drop(capture_guard);
+        source_session
+            .shutdown()
+            .expect("storage source should shut down");
+
+        let machine = snapshot_destination_machine_config(platform.machine().machine(), false);
+        let boot = super::native_v2_boot_source_config(platform.machine().boot())
+            .expect("storage destination boot projection should validate");
+        let process = bangbang_hvf::HvfSnapshotV2StorageMmioProcessConfig::new(
+            BlockMmioLayout::new(DEFAULT_BLOCK_MMIO_BASE, DEFAULT_BLOCK_MMIO_REGION_ID),
+            PmemMmioLayout::new(DEFAULT_PMEM_MMIO_BASE, DEFAULT_PMEM_MMIO_REGION_ID),
+        );
+
+        let cancelled_bundle =
+            super::RequestedSnapshotRestoreResources::prepare_native_v2_storage_restore_bundle(
+                graph.clone(),
+                &cancelled_memory,
+                Instant::now(),
+                None,
+                || false,
+            )
+            .expect("cancelled storage bundle should prepare");
+        let cancelled_plan = bangbang_hvf::prepare_hvf_snapshot_v2_storage_mmio_platform_plan(
+            &platform,
+            cancelled_bundle
+                .bundle()
+                .expect("cancelled storage bundle owner should remain present"),
+            process,
+        )
+        .expect("cancelled storage platform plan should prepare");
+        let cancelled_serial = SharedSerialOutput::from(SharedSerialOutputBuffer::default());
+        let cancelled_shell =
+            super::HvfSnapshotV2DefaultProcessShell::new(cancelled_serial.clone());
+        let (cancelled_packet_io, cancelled_mmds_metrics) =
+            ProcessNetworkPacketIoProvider::from_controller(
+                &source_controller,
+                ProcessVmnetAuthority::Direct,
+            )
+            .expect("cancelled storage packet I/O should prepare");
+        let cancellation = NativeV2SnapshotCaptureCancellation::default();
+        cancellation.cancel();
+        let cancelled = super::prepare_hvf_native_v2_storage_mmio_destination(
+            super::PrepareHvfSnapshotV2StorageMmioDestinationInput {
+                platform: platform.clone(),
+                memory: cancelled_memory,
+                process_shell: cancelled_shell,
+                packet_io: cancelled_packet_io,
+                mmds_metrics: cancelled_mmds_metrics,
+                vmnet_authority: ProcessVmnetAuthority::Direct,
+                serial_output: cancelled_serial,
+                bundle: cancelled_bundle,
+                plan: cancelled_plan,
+                machine,
+                boot: boot.clone(),
+                resume_requested: false,
+                cancellation,
+            },
+        )
+        .expect_err("cancellation should prevent private storage commit");
+        assert!(!cancelled.is_terminal());
+        assert!(matches!(
+            cancelled,
+            super::PrepareHvfSnapshotV2StorageDestinationError::Commit(_)
+        ));
+
+        let committed_bundle =
+            super::RequestedSnapshotRestoreResources::prepare_native_v2_storage_restore_bundle(
+                graph,
+                &committed_memory,
+                Instant::now(),
+                None,
+                || false,
+            )
+            .expect("committed storage bundle should prepare after rollback");
+        let committed_plan = bangbang_hvf::prepare_hvf_snapshot_v2_storage_mmio_platform_plan(
+            &platform,
+            committed_bundle
+                .bundle()
+                .expect("committed storage bundle owner should remain present"),
+            process,
+        )
+        .expect("committed storage platform plan should prepare");
+        let committed_serial = SharedSerialOutput::from(SharedSerialOutputBuffer::default());
+        let committed_shell =
+            super::HvfSnapshotV2DefaultProcessShell::new(committed_serial.clone());
+        let (committed_packet_io, committed_mmds_metrics) =
+            ProcessNetworkPacketIoProvider::from_controller(
+                &source_controller,
+                ProcessVmnetAuthority::Direct,
+            )
+            .expect("committed storage packet I/O should prepare");
+        let (session, projection, returned_serial) =
+            super::prepare_hvf_native_v2_storage_mmio_destination(
+                super::PrepareHvfSnapshotV2StorageMmioDestinationInput {
+                    platform,
+                    memory: committed_memory,
+                    process_shell: committed_shell,
+                    packet_io: committed_packet_io,
+                    mmds_metrics: committed_mmds_metrics,
+                    vmnet_authority: ProcessVmnetAuthority::Direct,
+                    serial_output: committed_serial,
+                    bundle: committed_bundle,
+                    plan: committed_plan,
+                    machine,
+                    boot: boot.clone(),
+                    resume_requested: false,
+                    cancellation: NativeV2SnapshotCaptureCancellation::default(),
+                },
+            )
+            .unwrap_or_else(|error| {
+                panic!("private exact-2.6 storage destination should commit: {error:?}")
+            });
+        assert_eq!(projection.machine, machine);
+        assert_eq!(projection.boot, boot);
+        assert_eq!(projection.configs, expected_configs);
+        assert!(!projection.resume_requested);
+        assert_eq!(
+            returned_serial.metrics(),
+            bangbang_runtime::serial::SerialOutputMetrics::default()
+        );
+        match &session {
+            super::HvfProcessSession::Boot(supervisor) => {
+                assert_eq!(supervisor.status(), BootRunLoopWorkerStatus::Paused);
+            }
+            super::HvfProcessSession::SnapshotV2(_) => {
+                panic!("exact-2.6 storage handoff should use the boot supervisor");
+            }
+        }
+        drop(session);
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -27,6 +27,7 @@ mod snapshot_restore;
 mod snapshot_v2;
 mod snapshot_v2_multi_block_platform;
 mod snapshot_v2_platform;
+mod snapshot_v2_storage_platform;
 mod startup;
 mod topology;
 mod vcpu;
@@ -163,6 +164,12 @@ pub use snapshot_v2_platform::{
     RestoredHvfSnapshotV2Platform, prepare_hvf_snapshot_v2_root_plan,
     restore_hvf_snapshot_v2_platform, restore_hvf_snapshot_v2_process_platform,
 };
+pub use snapshot_v2_storage_platform::{
+    HvfSnapshotV2StorageMmioPlatformPlan, HvfSnapshotV2StorageMmioProcessConfig,
+    HvfSnapshotV2StorageMmioRecordPlan, HvfSnapshotV2StorageRetryPlan,
+    PrepareHvfSnapshotV2StorageMmioPlatformPlanError,
+    prepare_hvf_snapshot_v2_storage_mmio_platform_plan,
+};
 pub use startup::{
     HvfArm64BootBalloonCaptureError, HvfArm64BootBalloonCaptureState,
     HvfArm64BootBalloonDeviceConfig, HvfArm64BootBalloonTransportState,
@@ -203,9 +210,12 @@ pub use startup::{
     HvfSnapshotV2MultiBlockPciRestoreCleanupFailure, HvfSnapshotV2MultiBlockPciRestoreError,
     HvfSnapshotV2MultiBlockPciRestoreFailure, HvfSnapshotV2MultiBlockPciRestoreStage,
     HvfSnapshotV2RootRestoreCleanupFailure, HvfSnapshotV2RootRestoreError,
-    HvfSnapshotV2RootRestoreFailure, HvfSnapshotV2RootRestoreStage, OwnedHvfArm64BootSession,
-    PreparedHvfArm64BootPciNetworkRemoval, RestoredHvfArm64BootSession,
+    HvfSnapshotV2RootRestoreFailure, HvfSnapshotV2RootRestoreStage,
+    HvfSnapshotV2StorageMmioRestoreCleanupFailure, HvfSnapshotV2StorageMmioRestoreError,
+    HvfSnapshotV2StorageMmioRestoreFailure, HvfSnapshotV2StorageMmioRestoreStage,
+    OwnedHvfArm64BootSession, PreparedHvfArm64BootPciNetworkRemoval, RestoredHvfArm64BootSession,
     RestoredHvfSnapshotV2MultiBlockMmioOwners, RestoredHvfSnapshotV2MultiBlockPciOwners,
+    RestoredHvfSnapshotV2StorageMmioOwners,
 };
 pub use topology::{
     HvfVcpuTopology, HvfVcpuTopologyAllocation, HvfVcpuTopologyCreateStage, HvfVcpuTopologyError,

--- a/crates/hvf/src/snapshot_v2_multi_block_platform.rs
+++ b/crates/hvf/src/snapshot_v2_multi_block_platform.rs
@@ -1359,7 +1359,7 @@ pub(crate) mod tests {
         graph
     }
 
-    fn product_mmio_platform(record_count: usize) -> HvfSnapshotV2PlatformState {
+    pub(crate) fn product_mmio_platform(record_count: usize) -> HvfSnapshotV2PlatformState {
         let (platform, root, _process) =
             crate::snapshot_v2_platform::tests::mmio_root_plan_fixture();
         drop(root);
@@ -1419,7 +1419,7 @@ pub(crate) mod tests {
         rebuild_product_platform(platform, 0, None, false)
     }
 
-    fn rebuild_product_platform(
+    pub(crate) fn rebuild_product_platform(
         platform: HvfSnapshotV2PlatformState,
         mmio_record_count: usize,
         exact_spi_count: Option<u32>,

--- a/crates/hvf/src/snapshot_v2_platform.rs
+++ b/crates/hvf/src/snapshot_v2_platform.rs
@@ -70,6 +70,7 @@ use crate::snapshot_v2::{
 use crate::snapshot_v2_multi_block_platform::{
     HvfSnapshotV2MultiBlockMmioRecordPlan, HvfSnapshotV2MultiBlockPciPlan,
 };
+use crate::snapshot_v2_storage_platform::HvfSnapshotV2StorageMmioRecordPlan;
 use crate::startup::{
     HvfArm64BootSnapshotV2CaptureError, HvfArm64BootSnapshotV2CaptureStage,
     HvfArm64BootVmClockRestoreError, HvfArm64BootVmGenIdRestoreError,
@@ -366,6 +367,15 @@ pub(crate) struct HvfSnapshotV2MultiBlockPciShellPlan<'a> {
     pub(crate) vmclock_interrupt: GuestInterruptLine,
 }
 
+pub(crate) struct HvfSnapshotV2StorageMmioShellPlan<'a> {
+    pub(crate) command_line: &'a str,
+    pub(crate) block_records: &'a [HvfSnapshotV2StorageMmioRecordPlan],
+    pub(crate) pmem_records: &'a [HvfSnapshotV2StorageMmioRecordPlan],
+    pub(crate) serial_interrupt: GuestInterruptLine,
+    pub(crate) vmgenid_interrupt: GuestInterruptLine,
+    pub(crate) vmclock_interrupt: GuestInterruptLine,
+}
+
 enum HvfSnapshotV2ProcessShellRestore<'a> {
     DeviceFree(HvfSnapshotV2DefaultProcessShell),
     Root {
@@ -380,6 +390,10 @@ enum HvfSnapshotV2ProcessShellRestore<'a> {
     MultiBlockPci {
         shell: HvfSnapshotV2DefaultProcessShell,
         plan: HvfSnapshotV2MultiBlockPciShellPlan<'a>,
+    },
+    StorageMmio {
+        shell: HvfSnapshotV2DefaultProcessShell,
+        plan: HvfSnapshotV2StorageMmioShellPlan<'a>,
     },
 }
 
@@ -396,6 +410,11 @@ enum HvfSnapshotV2ProcessBlockFdtPlan<'a> {
     MultiBlockPci {
         command_line: &'a str,
         pci: &'a HvfSnapshotV2MultiBlockPciPlan,
+    },
+    StorageMmio {
+        command_line: &'a str,
+        block_records: &'a [HvfSnapshotV2StorageMmioRecordPlan],
+        pmem_records: &'a [HvfSnapshotV2StorageMmioRecordPlan],
     },
 }
 
@@ -1157,6 +1176,10 @@ impl RestoredHvfSnapshotV2Platform {
         &self.parts().backend
     }
 
+    pub(crate) fn backend_mut(&mut self) -> &mut HvfBackend {
+        &mut self.parts_mut().backend
+    }
+
     pub(crate) fn mmio_dispatcher(&self) -> &Arc<Mutex<MmioDispatcher>> {
         &self.parts().mmio_dispatcher
     }
@@ -1327,6 +1350,19 @@ pub(crate) fn restore_hvf_snapshot_v2_multi_block_pci_process_platform(
         state,
         memory,
         Some(HvfSnapshotV2ProcessShellRestore::MultiBlockPci { shell, plan }),
+    )
+}
+
+pub(crate) fn restore_hvf_snapshot_v2_storage_mmio_process_platform(
+    state: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    shell: HvfSnapshotV2DefaultProcessShell,
+    plan: HvfSnapshotV2StorageMmioShellPlan<'_>,
+) -> Result<RestoredHvfSnapshotV2Platform, HvfSnapshotV2PlatformRestoreError> {
+    restore_hvf_snapshot_v2_platform_with_shell(
+        state,
+        memory,
+        Some(HvfSnapshotV2ProcessShellRestore::StorageMmio { shell, plan }),
     )
 }
 
@@ -2316,6 +2352,39 @@ fn prepare_process_shell(
                     )),
                 )
             }
+            HvfSnapshotV2ProcessShellRestore::StorageMmio { shell, plan } => {
+                if gic.msi.is_some() || plan.block_records.len() + plan.pmem_records.len() == 0 {
+                    return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellFdt {
+                        mismatch: HvfSnapshotV2ProcessFdtMismatch::Profile,
+                    });
+                }
+                for record in plan.block_records.iter().chain(plan.pmem_records) {
+                    if allocator
+                        .allocate()
+                        .map_err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterrupt)?
+                        != record.interrupt_line()
+                    {
+                        return Err(
+                            HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterruptIdentity,
+                        );
+                    }
+                }
+                (
+                    shell,
+                    HvfSnapshotV2ProcessBlockFdtPlan::StorageMmio {
+                        command_line: plan.command_line,
+                        block_records: plan.block_records,
+                        pmem_records: plan.pmem_records,
+                    },
+                    true,
+                    false,
+                    Some((
+                        plan.serial_interrupt,
+                        plan.vmgenid_interrupt,
+                        plan.vmclock_interrupt,
+                    )),
+                )
+            }
         };
     let serial_interrupt = allocator
         .allocate()
@@ -2436,6 +2505,11 @@ fn validate_process_fdt(
         HvfSnapshotV2ProcessBlockFdtPlan::Root { .. } => 1,
         HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockMmio { records, .. } => records.len(),
         HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockPci { .. } => 1,
+        HvfSnapshotV2ProcessBlockFdtPlan::StorageMmio {
+            block_records,
+            pmem_records,
+            ..
+        } => block_records.len() + pmem_records.len(),
     };
     if tree.root.children.len() != 11 + block_child_count
         || [
@@ -2549,6 +2623,9 @@ fn validate_process_fdt(
             .prop_str("bootargs")
             .is_ok_and(|arguments| arguments == *command_line),
         HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockPci { command_line, .. } => chosen
+            .prop_str("bootargs")
+            .is_ok_and(|arguments| arguments == *command_line),
+        HvfSnapshotV2ProcessBlockFdtPlan::StorageMmio { command_line, .. } => chosen
             .prop_str("bootargs")
             .is_ok_and(|arguments| arguments == *command_line),
         HvfSnapshotV2ProcessBlockFdtPlan::None => {
@@ -2754,6 +2831,20 @@ fn validate_process_block_nodes(
                 || !validate_process_gic_msi(intc, pci.msi())
             {
                 return Err(HvfSnapshotV2ProcessFdtMismatch::Pci);
+            }
+            return Ok(());
+        }
+        HvfSnapshotV2ProcessBlockFdtPlan::StorageMmio {
+            block_records,
+            pmem_records,
+            ..
+        } => {
+            for record in block_records.iter().chain(*pmem_records) {
+                validate_process_mmio_block_node(
+                    root_node,
+                    record.region(),
+                    record.interrupt_line(),
+                )?;
             }
             return Ok(());
         }

--- a/crates/hvf/src/snapshot_v2_storage_platform.rs
+++ b/crates/hvf/src/snapshot_v2_storage_platform.rs
@@ -1,0 +1,1340 @@
+//! Host-free exact native-v2 2.6 storage platform planning.
+
+use std::fmt;
+use std::time::Instant;
+
+use bangbang_runtime::block::{BlockMmioLayout, BlockMmioRegistrationError};
+use bangbang_runtime::boot::{
+    BootCommandLineError, canonical_process_block_command_line,
+    canonical_process_root_block_command_line, canonical_process_root_pmem_command_line,
+};
+use bangbang_runtime::fdt::{Arm64FdtRegion, Arm64FdtVirtioMmioDevice};
+use bangbang_runtime::interrupt::GuestInterruptLine;
+use bangbang_runtime::memory::{GuestAddress, GuestMemoryRange};
+use bangbang_runtime::mmio::MmioRegion;
+use bangbang_runtime::pmem::{PmemMmioLayout, PmemMmioRegistrationError};
+use bangbang_runtime::pvtime::ARM64_PVTIME_STRUCTURE_SIZE;
+use bangbang_runtime::rtc::{RTC_MMIO_DEVICE_WINDOW_SIZE, RtcMmioLayout};
+use bangbang_runtime::serial::SERIAL_MMIO_DEVICE_WINDOW_SIZE;
+use bangbang_runtime::snapshot_device_v2::{
+    SnapshotV2DeviceKey, SnapshotV2DeviceTransport, SnapshotV2DeviceTransportKind,
+};
+use bangbang_runtime::snapshot_device_v2_6::{
+    NATIVE_V2_STORAGE_DEVICE_GRAPH_MAX_RECORDS, PreparedSnapshotV2StorageBundle,
+};
+use bangbang_runtime::storage_capture::StorageRetryState;
+
+use crate::gic::{HvfGicInterruptLineAllocator, HvfGicMetadata, HvfInterruptLineAllocationError};
+use crate::snapshot_v2::HvfSnapshotV2PlatformState;
+use crate::snapshot_v2_platform::{
+    PROCESS_RTC_MMIO_BASE, PROCESS_RTC_MMIO_REGION_ID, PROCESS_SERIAL_MMIO_BASE,
+    PROCESS_SERIAL_MMIO_REGION_ID,
+};
+
+const REDACTED: &str = "<redacted>";
+
+/// Destination MMIO policy for an exact profile-3 storage product.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct HvfSnapshotV2StorageMmioProcessConfig {
+    block_layout: BlockMmioLayout,
+    pmem_layout: PmemMmioLayout,
+}
+
+impl HvfSnapshotV2StorageMmioProcessConfig {
+    /// Creates one closed MMIO destination policy.
+    pub const fn new(block_layout: BlockMmioLayout, pmem_layout: PmemMmioLayout) -> Self {
+        Self {
+            block_layout,
+            pmem_layout,
+        }
+    }
+
+    pub const fn block_layout(self) -> BlockMmioLayout {
+        self.block_layout
+    }
+
+    pub const fn pmem_layout(self) -> PmemMmioLayout {
+        self.pmem_layout
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2StorageMmioProcessConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2StorageMmioProcessConfig")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// One canonical MMIO record and semantic FDT node.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct HvfSnapshotV2StorageMmioRecordPlan {
+    key: SnapshotV2DeviceKey,
+    region: MmioRegion,
+    interrupt_line: GuestInterruptLine,
+    fdt_device: Arm64FdtVirtioMmioDevice,
+}
+
+impl HvfSnapshotV2StorageMmioRecordPlan {
+    pub const fn key(self) -> SnapshotV2DeviceKey {
+        self.key
+    }
+
+    pub const fn region(self) -> MmioRegion {
+        self.region
+    }
+
+    pub const fn interrupt_line(self) -> GuestInterruptLine {
+        self.interrupt_line
+    }
+
+    pub const fn fdt_device(self) -> Arm64FdtVirtioMmioDevice {
+        self.fdt_device
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2StorageMmioRecordPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2StorageMmioRecordPlan")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Host-time projection of one exact storage retry owner.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct HvfSnapshotV2StorageRetryPlan {
+    key: SnapshotV2DeviceKey,
+    retry: StorageRetryState,
+    retry_deadline: Option<Instant>,
+}
+
+impl HvfSnapshotV2StorageRetryPlan {
+    pub const fn key(self) -> SnapshotV2DeviceKey {
+        self.key
+    }
+
+    pub const fn retry(self) -> StorageRetryState {
+        self.retry
+    }
+
+    pub const fn retry_deadline(self) -> Option<Instant> {
+        self.retry_deadline
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2StorageRetryPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2StorageRetryPlan")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Complete pre-HVF exact-2.6 MMIO storage proof.
+pub struct HvfSnapshotV2StorageMmioPlatformPlan {
+    root_key: Option<SnapshotV2DeviceKey>,
+    command_line: String,
+    block_metrics_ids: Vec<String>,
+    pmem_metrics_ids: Vec<String>,
+    block_retries: Vec<HvfSnapshotV2StorageRetryPlan>,
+    pmem_retries: Vec<HvfSnapshotV2StorageRetryPlan>,
+    block_records: Vec<HvfSnapshotV2StorageMmioRecordPlan>,
+    pmem_records: Vec<HvfSnapshotV2StorageMmioRecordPlan>,
+    serial_interrupt: GuestInterruptLine,
+    vmgenid_interrupt: GuestInterruptLine,
+    vmclock_interrupt: GuestInterruptLine,
+}
+
+pub(crate) struct HvfSnapshotV2StorageMmioPlatformPlanParts {
+    pub(crate) root_key: Option<SnapshotV2DeviceKey>,
+    pub(crate) command_line: String,
+    pub(crate) block_metrics_ids: Vec<String>,
+    pub(crate) pmem_metrics_ids: Vec<String>,
+    pub(crate) block_retries: Vec<HvfSnapshotV2StorageRetryPlan>,
+    pub(crate) pmem_retries: Vec<HvfSnapshotV2StorageRetryPlan>,
+    pub(crate) block_records: Vec<HvfSnapshotV2StorageMmioRecordPlan>,
+    pub(crate) pmem_records: Vec<HvfSnapshotV2StorageMmioRecordPlan>,
+    pub(crate) serial_interrupt: GuestInterruptLine,
+    pub(crate) vmgenid_interrupt: GuestInterruptLine,
+    pub(crate) vmclock_interrupt: GuestInterruptLine,
+}
+
+impl HvfSnapshotV2StorageMmioPlatformPlan {
+    pub const fn root_key(&self) -> Option<SnapshotV2DeviceKey> {
+        self.root_key
+    }
+
+    pub fn command_line(&self) -> &str {
+        &self.command_line
+    }
+
+    pub fn block_metrics_ids(&self) -> &[String] {
+        &self.block_metrics_ids
+    }
+
+    pub fn pmem_metrics_ids(&self) -> &[String] {
+        &self.pmem_metrics_ids
+    }
+
+    pub fn block_retries(&self) -> &[HvfSnapshotV2StorageRetryPlan] {
+        &self.block_retries
+    }
+
+    pub fn pmem_retries(&self) -> &[HvfSnapshotV2StorageRetryPlan] {
+        &self.pmem_retries
+    }
+
+    pub fn earliest_block_retry_deadline(&self) -> Option<Instant> {
+        self.block_retries
+            .iter()
+            .filter_map(|retry| retry.retry_deadline)
+            .min()
+    }
+
+    pub fn earliest_pmem_retry_deadline(&self) -> Option<Instant> {
+        self.pmem_retries
+            .iter()
+            .filter_map(|retry| retry.retry_deadline)
+            .min()
+    }
+
+    pub fn block_records(&self) -> &[HvfSnapshotV2StorageMmioRecordPlan] {
+        &self.block_records
+    }
+
+    pub fn pmem_records(&self) -> &[HvfSnapshotV2StorageMmioRecordPlan] {
+        &self.pmem_records
+    }
+
+    pub const fn serial_interrupt(&self) -> GuestInterruptLine {
+        self.serial_interrupt
+    }
+
+    pub const fn vmgenid_interrupt(&self) -> GuestInterruptLine {
+        self.vmgenid_interrupt
+    }
+
+    pub const fn vmclock_interrupt(&self) -> GuestInterruptLine {
+        self.vmclock_interrupt
+    }
+
+    pub(crate) fn into_parts(self) -> HvfSnapshotV2StorageMmioPlatformPlanParts {
+        HvfSnapshotV2StorageMmioPlatformPlanParts {
+            root_key: self.root_key,
+            command_line: self.command_line,
+            block_metrics_ids: self.block_metrics_ids,
+            pmem_metrics_ids: self.pmem_metrics_ids,
+            block_retries: self.block_retries,
+            pmem_retries: self.pmem_retries,
+            block_records: self.block_records,
+            pmem_records: self.pmem_records,
+            serial_interrupt: self.serial_interrupt,
+            vmgenid_interrupt: self.vmgenid_interrupt,
+            vmclock_interrupt: self.vmclock_interrupt,
+        }
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2StorageMmioPlatformPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2StorageMmioPlatformPlan")
+            .field("block_count", &self.block_records.len())
+            .field("pmem_count", &self.pmem_records.len())
+            .field("has_root", &self.root_key.is_some())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Redacted rejection from exact-2.6 host-free MMIO platform planning.
+pub enum PrepareHvfSnapshotV2StorageMmioPlatformPlanError {
+    PlatformProfile,
+    Cardinality,
+    Allocation,
+    RecordIdentity,
+    RootIdentity,
+    TransportPolicy,
+    CommandLine(BootCommandLineError),
+    QueuePlatformConflict,
+    PmemRangeConflict,
+    BlockMmioLayout(Box<BlockMmioRegistrationError>),
+    PmemMmioLayout(Box<PmemMmioRegistrationError>),
+    Interrupt(HvfInterruptLineAllocationError),
+    ResourcePlan,
+}
+
+impl fmt::Debug for PrepareHvfSnapshotV2StorageMmioPlatformPlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let category = match self {
+            Self::PlatformProfile => "platform-profile",
+            Self::Cardinality => "cardinality",
+            Self::Allocation => "allocation",
+            Self::RecordIdentity => "record-identity",
+            Self::RootIdentity => "root-identity",
+            Self::TransportPolicy => "transport-policy",
+            Self::CommandLine(_) => "command-line",
+            Self::QueuePlatformConflict => "queue-platform-conflict",
+            Self::PmemRangeConflict => "pmem-range-conflict",
+            Self::BlockMmioLayout(_) => "block-mmio-layout",
+            Self::PmemMmioLayout(_) => "pmem-mmio-layout",
+            Self::Interrupt(_) => "interrupt",
+            Self::ResourcePlan => "resource-plan",
+        };
+        formatter
+            .debug_struct("PrepareHvfSnapshotV2StorageMmioPlatformPlanError")
+            .field("category", &category)
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+impl fmt::Display for PrepareHvfSnapshotV2StorageMmioPlatformPlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::PlatformProfile => "native-v2 storage platform profile is not canonical",
+            Self::Cardinality => "native-v2 storage platform cardinality is inconsistent",
+            Self::Allocation => "native-v2 storage platform allocation failed",
+            Self::RecordIdentity => "native-v2 storage record identity is inconsistent",
+            Self::RootIdentity => "native-v2 storage root identity is inconsistent",
+            Self::TransportPolicy => "native-v2 storage MMIO transport policy is inconsistent",
+            Self::CommandLine(_) => "native-v2 storage process command line is invalid",
+            Self::QueuePlatformConflict => "native-v2 storage queue overlaps platform-owned memory",
+            Self::PmemRangeConflict => {
+                "native-v2 storage pmem mapping overlaps platform-owned resources"
+            }
+            Self::BlockMmioLayout(_) => "native-v2 storage block MMIO layout is invalid",
+            Self::PmemMmioLayout(_) => "native-v2 storage pmem MMIO layout is invalid",
+            Self::Interrupt(_) => "native-v2 storage interrupt demand is invalid",
+            Self::ResourcePlan => "native-v2 storage platform resources are inconsistent",
+        })
+    }
+}
+
+impl std::error::Error for PrepareHvfSnapshotV2StorageMmioPlatformPlanError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::CommandLine(source) => Some(source),
+            Self::BlockMmioLayout(source) => Some(source),
+            Self::PmemMmioLayout(source) => Some(source),
+            Self::Interrupt(source) => Some(source),
+            Self::PlatformProfile
+            | Self::Cardinality
+            | Self::Allocation
+            | Self::RecordIdentity
+            | Self::RootIdentity
+            | Self::TransportPolicy
+            | Self::QueuePlatformConflict
+            | Self::PmemRangeConflict
+            | Self::ResourcePlan => None,
+        }
+    }
+}
+
+enum StorageRoot<'a> {
+    Block {
+        partuuid: Option<&'a str>,
+        read_only: bool,
+    },
+    Pmem {
+        index: usize,
+        read_only: bool,
+    },
+}
+
+/// Proves a complete exact-2.6 block+pmem MMIO product before live HVF
+/// construction.
+pub fn prepare_hvf_snapshot_v2_storage_mmio_platform_plan(
+    platform: &HvfSnapshotV2PlatformState,
+    bundle: &PreparedSnapshotV2StorageBundle,
+    process: HvfSnapshotV2StorageMmioProcessConfig,
+) -> Result<HvfSnapshotV2StorageMmioPlatformPlan, PrepareHvfSnapshotV2StorageMmioPlatformPlanError>
+{
+    prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with(
+        platform,
+        bundle,
+        process,
+        &mut SystemStoragePlatformPlanReserve,
+    )
+}
+
+fn prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with(
+    platform: &HvfSnapshotV2PlatformState,
+    bundle: &PreparedSnapshotV2StorageBundle,
+    process: HvfSnapshotV2StorageMmioProcessConfig,
+    reserve: &mut impl StoragePlatformPlanReserve,
+) -> Result<HvfSnapshotV2StorageMmioPlatformPlan, PrepareHvfSnapshotV2StorageMmioPlatformPlanError>
+{
+    validate_platform_profile(platform)?;
+    if bundle.transport_kind() != SnapshotV2DeviceTransportKind::Mmio {
+        return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::TransportPolicy);
+    }
+
+    let block_records = bundle
+        .block_bundle()
+        .map_or(&[][..], |block| block.records());
+    let block_configs = bundle
+        .block_bundle()
+        .map_or(&[][..], |block| block.drive_configs().as_slice());
+    let block_retry_projection = bundle
+        .block_bundle()
+        .map_or(&[][..], |block| block.retry_projection());
+    let pmem_records = bundle.pmem_records();
+    let pmem_configs = bundle.pmem_configs().as_slice();
+    let record_count = block_records
+        .len()
+        .checked_add(pmem_records.len())
+        .ok_or(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::Cardinality)?;
+    if record_count == 0
+        || record_count > usize::from(NATIVE_V2_STORAGE_DEVICE_GRAPH_MAX_RECORDS)
+        || block_records.len() != block_configs.len()
+        || block_records.len() != block_retry_projection.len()
+        || pmem_records.len() != pmem_configs.len()
+    {
+        return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::Cardinality);
+    }
+
+    let mut block_metrics_ids = Vec::new();
+    let mut pmem_metrics_ids = Vec::new();
+    let mut block_retries = Vec::new();
+    let mut pmem_retries = Vec::new();
+    let mut planned_block = Vec::new();
+    let mut planned_pmem = Vec::new();
+    let mut planned_regions = Vec::new();
+    reserve.reserve(&mut block_metrics_ids, block_records.len())?;
+    reserve.reserve(&mut pmem_metrics_ids, pmem_records.len())?;
+    reserve.reserve(&mut block_retries, block_records.len())?;
+    reserve.reserve(&mut pmem_retries, pmem_records.len())?;
+    reserve.reserve(&mut planned_block, block_records.len())?;
+    reserve.reserve(&mut planned_pmem, pmem_records.len())?;
+    reserve.reserve(&mut planned_regions, record_count)?;
+
+    let mut root_key = None;
+    let mut root = None;
+    for (index, ((record, config), projected_retry)) in block_records
+        .iter()
+        .zip(block_configs)
+        .zip(block_retry_projection)
+        .enumerate()
+    {
+        let read_only = config
+            .is_read_only()
+            .ok_or(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::RecordIdentity)?;
+        if record.transport().kind() != SnapshotV2DeviceTransportKind::Mmio
+            || record.key() != projected_retry.key()
+            || record.retry() != projected_retry.retry()
+            || record.retry_deadline() != projected_retry.retry_deadline()
+            || record.drive_id() != config.drive_id()
+            || record.is_root_device() != config.is_root_device()
+            || record.config_space().is_read_only() != read_only
+            || record.device().device().io_engine() != config.io_engine()
+            || record.device().cache_type() != config.cache_type()
+            || config.is_vhost_user()
+            || block_metrics_ids
+                .iter()
+                .any(|candidate| candidate == config.drive_id())
+        {
+            return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::RecordIdentity);
+        }
+        if queue_ranges_conflict_with_platform(platform, record.queue_ranges())? {
+            return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::QueuePlatformConflict);
+        }
+        if config.is_root_device() {
+            if root_key.replace(record.key()).is_some() || root.is_some() {
+                return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::RootIdentity);
+            }
+            root = Some(StorageRoot::Block {
+                partuuid: config.partuuid(),
+                read_only,
+            });
+        }
+        block_metrics_ids.push(try_clone(config.drive_id())?);
+        block_retries.push(HvfSnapshotV2StorageRetryPlan {
+            key: record.key(),
+            retry: record.retry(),
+            retry_deadline: record.retry_deadline(),
+        });
+        let planned = plan_mmio_record(
+            platform,
+            record.key(),
+            record.transport(),
+            process.block_layout.region_at(index).map_err(|source| {
+                PrepareHvfSnapshotV2StorageMmioPlatformPlanError::BlockMmioLayout(Box::new(source))
+            })?,
+            &mut planned_regions,
+            None,
+        )?;
+        planned_block.push(planned);
+    }
+
+    let gic = platform.global().compatibility().gic_metadata();
+    if gic.msi.is_some() {
+        return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan);
+    }
+    let mut interrupt_allocator = HvfGicInterruptLineAllocator::from_metadata(&gic)
+        .map_err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::Interrupt)?;
+    for (record, planned) in block_records.iter().zip(&mut planned_block) {
+        let interrupt = interrupt_allocator
+            .allocate()
+            .map_err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::Interrupt)?;
+        validate_and_set_interrupt(record.transport(), interrupt, planned)?;
+    }
+
+    for (index, (record, config)) in pmem_records.iter().zip(pmem_configs).enumerate() {
+        let prepared = record.prepared_device();
+        let guest_range = prepared.guest_range();
+        if record.transport().kind() != SnapshotV2DeviceTransportKind::Mmio
+            || record.pmem_id() != config.id()
+            || record.is_root_device() != config.root_device()
+            || prepared.id() != config.id()
+            || prepared.backing().is_read_only() != config.read_only()
+            || prepared.mapping().is_read_only() != config.read_only()
+            || prepared.rate_limiter() != config.rate_limiter()
+            || prepared.config_space().available_features() != record.virtio().available_features()
+            || prepared.mapping().mapped_len() != guest_range.size()
+            || pmem_metrics_ids
+                .iter()
+                .any(|candidate| candidate == config.id())
+        {
+            return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::RecordIdentity);
+        }
+        if mapping_range_conflicts_with_platform(platform, guest_range, &gic)?
+            || planned_regions
+                .iter()
+                .any(|region: &MmioRegion| region.range().overlaps(guest_range))
+        {
+            return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::PmemRangeConflict);
+        }
+        if queue_ranges_conflict_with_platform(platform, record.queue_ranges())? {
+            return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::QueuePlatformConflict);
+        }
+        if config.root_device() {
+            if root_key.replace(record.key()).is_some() || root.is_some() {
+                return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::RootIdentity);
+            }
+            root = Some(StorageRoot::Pmem {
+                index,
+                read_only: config.read_only(),
+            });
+        }
+        pmem_metrics_ids.push(try_clone(config.id())?);
+        pmem_retries.push(HvfSnapshotV2StorageRetryPlan {
+            key: record.key(),
+            retry: record.retry(),
+            retry_deadline: record.retry_deadline(),
+        });
+        let region = process.pmem_layout.region_at(index).map_err(|source| {
+            PrepareHvfSnapshotV2StorageMmioPlatformPlanError::PmemMmioLayout(Box::new(source))
+        })?;
+        if region.range().overlaps(guest_range) {
+            return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::PmemRangeConflict);
+        }
+        let interrupt = interrupt_allocator
+            .allocate()
+            .map_err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::Interrupt)?;
+        let planned = plan_mmio_record(
+            platform,
+            record.key(),
+            record.transport(),
+            region,
+            &mut planned_regions,
+            Some(interrupt),
+        )?;
+        planned_pmem.push(planned);
+    }
+
+    if bundle.root_key() != root_key || bundle.root_key().is_some() != root.is_some() {
+        return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::RootIdentity);
+    }
+    for range in bundle
+        .pmem_records()
+        .iter()
+        .map(|record| record.prepared_device().guest_range())
+    {
+        if planned_regions
+            .iter()
+            .any(|region| region.range().overlaps(range))
+        {
+            return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::PmemRangeConflict);
+        }
+    }
+
+    let base_arguments = platform.machine().boot().boot_arguments();
+    let command_line = match root {
+        Some(StorageRoot::Block {
+            partuuid,
+            read_only,
+        }) => canonical_process_root_block_command_line(base_arguments, false, partuuid, read_only),
+        Some(StorageRoot::Pmem { index, read_only }) => {
+            canonical_process_root_pmem_command_line(base_arguments, false, index, read_only)
+        }
+        None => canonical_process_block_command_line(base_arguments, false),
+    }
+    .map_err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::CommandLine)?;
+
+    let serial_interrupt = interrupt_allocator
+        .allocate()
+        .map_err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::Interrupt)?;
+    let vmgenid_interrupt = interrupt_allocator
+        .allocate()
+        .map_err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::Interrupt)?;
+    let vmclock_interrupt = interrupt_allocator
+        .allocate()
+        .map_err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::Interrupt)?;
+    if platform.time().vmgenid().interrupt_line() != vmgenid_interrupt
+        || platform.time().vmclock().interrupt_line() != vmclock_interrupt
+    {
+        return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan);
+    }
+
+    Ok(HvfSnapshotV2StorageMmioPlatformPlan {
+        root_key,
+        command_line,
+        block_metrics_ids,
+        pmem_metrics_ids,
+        block_retries,
+        pmem_retries,
+        block_records: planned_block,
+        pmem_records: planned_pmem,
+        serial_interrupt,
+        vmgenid_interrupt,
+        vmclock_interrupt,
+    })
+}
+
+fn validate_platform_profile(
+    platform: &HvfSnapshotV2PlatformState,
+) -> Result<(), PrepareHvfSnapshotV2StorageMmioPlatformPlanError> {
+    if !platform.machine().fdt().is_product_process_profile()
+        || platform.time().rtc_layout()
+            != RtcMmioLayout::new(PROCESS_RTC_MMIO_BASE, PROCESS_RTC_MMIO_REGION_ID)
+    {
+        Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::PlatformProfile)
+    } else {
+        Ok(())
+    }
+}
+
+fn plan_mmio_record(
+    platform: &HvfSnapshotV2PlatformState,
+    key: SnapshotV2DeviceKey,
+    captured: &SnapshotV2DeviceTransport,
+    region: MmioRegion,
+    planned_regions: &mut Vec<MmioRegion>,
+    expected_interrupt: Option<GuestInterruptLine>,
+) -> Result<HvfSnapshotV2StorageMmioRecordPlan, PrepareHvfSnapshotV2StorageMmioPlatformPlanError> {
+    let SnapshotV2DeviceTransport::Mmio(captured) = captured else {
+        return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::TransportPolicy);
+    };
+    if captured.region() != region
+        || expected_interrupt.is_some_and(|line| captured.interrupt_line() != line)
+        || mmio_region_conflicts_with_platform(
+            platform,
+            region,
+            &platform.global().compatibility().gic_metadata(),
+        )?
+        || planned_regions
+            .iter()
+            .any(|planned| planned.id() == region.id() || planned.range().overlaps(region.range()))
+    {
+        return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan);
+    }
+    planned_regions.push(region);
+    let interrupt_line = captured.interrupt_line();
+    Ok(HvfSnapshotV2StorageMmioRecordPlan {
+        key,
+        region,
+        interrupt_line,
+        fdt_device: Arm64FdtVirtioMmioDevice {
+            region: Arm64FdtRegion {
+                base: region.range().start().raw_value(),
+                size: region.range().size(),
+            },
+            interrupt_line,
+        },
+    })
+}
+
+fn validate_and_set_interrupt(
+    captured: &SnapshotV2DeviceTransport,
+    interrupt: GuestInterruptLine,
+    planned: &mut HvfSnapshotV2StorageMmioRecordPlan,
+) -> Result<(), PrepareHvfSnapshotV2StorageMmioPlatformPlanError> {
+    let SnapshotV2DeviceTransport::Mmio(captured) = captured else {
+        return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::TransportPolicy);
+    };
+    if captured.interrupt_line() != interrupt {
+        return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan);
+    }
+    planned.interrupt_line = interrupt;
+    planned.fdt_device.interrupt_line = interrupt;
+    Ok(())
+}
+
+fn queue_ranges_conflict_with_platform(
+    platform: &HvfSnapshotV2PlatformState,
+    queue_ranges: Option<[GuestMemoryRange; 3]>,
+) -> Result<bool, PrepareHvfSnapshotV2StorageMmioPlatformPlanError> {
+    let Some(queue_ranges) = queue_ranges else {
+        return Ok(false);
+    };
+    let fdt = platform.machine().fdt();
+    let fdt_range = GuestMemoryRange::new(fdt.address(), u64::from(fdt.size()))
+        .map_err(|_| PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan)?;
+    let fixed = [
+        fdt_range,
+        platform.time().vmgenid().range(),
+        platform.time().vmclock().range(),
+    ];
+    if queue_ranges
+        .iter()
+        .any(|queue| fixed.into_iter().any(|reserved| queue.overlaps(reserved)))
+    {
+        return Ok(true);
+    }
+    let pvtime_size = u64::try_from(ARM64_PVTIME_STRUCTURE_SIZE)
+        .map_err(|_| PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan)?;
+    for record in platform.time().pvtime_vcpus() {
+        let range = GuestMemoryRange::new(record.record_ipa(), pvtime_size)
+            .map_err(|_| PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan)?;
+        if queue_ranges.iter().any(|queue| queue.overlaps(range)) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn mapping_range_conflicts_with_platform(
+    platform: &HvfSnapshotV2PlatformState,
+    range: GuestMemoryRange,
+    gic: &HvfGicMetadata,
+) -> Result<bool, PrepareHvfSnapshotV2StorageMmioPlatformPlanError> {
+    if platform
+        .memory()
+        .extents()
+        .iter()
+        .any(|extent| range.overlaps(extent.range()))
+    {
+        return Ok(true);
+    }
+    let fdt = platform.machine().fdt();
+    let fixed = [
+        GuestMemoryRange::new(fdt.address(), u64::from(fdt.size())),
+        Ok(platform.time().vmgenid().range()),
+        Ok(platform.time().vmclock().range()),
+        GuestMemoryRange::new(PROCESS_SERIAL_MMIO_BASE, SERIAL_MMIO_DEVICE_WINDOW_SIZE),
+        GuestMemoryRange::new(PROCESS_RTC_MMIO_BASE, RTC_MMIO_DEVICE_WINDOW_SIZE),
+        gic_region_range(gic.distributor),
+        gic_region_range(gic.redistributor.region),
+    ];
+    for fixed in fixed {
+        let fixed =
+            fixed.map_err(|_| PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan)?;
+        if range.overlaps(fixed) {
+            return Ok(true);
+        }
+    }
+    let pvtime_size = u64::try_from(ARM64_PVTIME_STRUCTURE_SIZE)
+        .map_err(|_| PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan)?;
+    for record in platform.time().pvtime_vcpus() {
+        let pvtime = GuestMemoryRange::new(record.record_ipa(), pvtime_size)
+            .map_err(|_| PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan)?;
+        if range.overlaps(pvtime) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn mmio_region_conflicts_with_platform(
+    platform: &HvfSnapshotV2PlatformState,
+    region: MmioRegion,
+    gic: &HvfGicMetadata,
+) -> Result<bool, PrepareHvfSnapshotV2StorageMmioPlatformPlanError> {
+    if matches!(
+        region.id(),
+        PROCESS_SERIAL_MMIO_REGION_ID | PROCESS_RTC_MMIO_REGION_ID
+    ) {
+        return Ok(true);
+    }
+    let range = region.range();
+    if platform
+        .memory()
+        .extents()
+        .iter()
+        .any(|extent| range.overlaps(extent.range()))
+    {
+        return Ok(true);
+    }
+    let fixed = [
+        GuestMemoryRange::new(PROCESS_SERIAL_MMIO_BASE, SERIAL_MMIO_DEVICE_WINDOW_SIZE),
+        GuestMemoryRange::new(PROCESS_RTC_MMIO_BASE, RTC_MMIO_DEVICE_WINDOW_SIZE),
+        gic_region_range(gic.distributor),
+        gic_region_range(gic.redistributor.region),
+    ];
+    for fixed in fixed {
+        let fixed =
+            fixed.map_err(|_| PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan)?;
+        if range.overlaps(fixed) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn gic_region_range(
+    region: crate::gic::HvfGicRegion,
+) -> Result<GuestMemoryRange, bangbang_runtime::memory::GuestMemoryError> {
+    GuestMemoryRange::new(GuestAddress::new(region.base), region.size)
+}
+
+fn try_clone(value: &str) -> Result<String, PrepareHvfSnapshotV2StorageMmioPlatformPlanError> {
+    let mut cloned = String::new();
+    cloned
+        .try_reserve_exact(value.len())
+        .map_err(|_| PrepareHvfSnapshotV2StorageMmioPlatformPlanError::Allocation)?;
+    cloned.push_str(value);
+    Ok(cloned)
+}
+
+trait StoragePlatformPlanReserve {
+    fn reserve<T>(
+        &mut self,
+        values: &mut Vec<T>,
+        additional: usize,
+    ) -> Result<(), PrepareHvfSnapshotV2StorageMmioPlatformPlanError>;
+}
+
+struct SystemStoragePlatformPlanReserve;
+
+impl StoragePlatformPlanReserve for SystemStoragePlatformPlanReserve {
+    fn reserve<T>(
+        &mut self,
+        values: &mut Vec<T>,
+        additional: usize,
+    ) -> Result<(), PrepareHvfSnapshotV2StorageMmioPlatformPlanError> {
+        values
+            .try_reserve_exact(additional)
+            .map_err(|_| PrepareHvfSnapshotV2StorageMmioPlatformPlanError::Allocation)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{self, OpenOptions};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Instant;
+
+    use bangbang_runtime::block::{BlockFileBacking, BlockMmioLayout};
+    use bangbang_runtime::memory::{GuestMemory, GuestMemoryLayout};
+    use bangbang_runtime::pmem::{PmemFileBacking, PmemMmioLayout};
+    use bangbang_runtime::snapshot_device_v2::{
+        SnapshotV2DeviceTransport, SnapshotV2DeviceTransportKind, SnapshotV2MmioDeviceState,
+    };
+    use bangbang_runtime::snapshot_device_v2_5::{
+        NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2MultiBlockDeviceGraph,
+    };
+    use bangbang_runtime::snapshot_device_v2_6::{
+        NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION, PreparedSnapshotV2StorageBundle,
+        SnapshotV2PmemDeviceRecord, SnapshotV2StorageDeviceGraph, SnapshotV2StorageRestorePlan,
+    };
+    use bangbang_runtime::storage_capture::StorageRetryState;
+    use bangbang_runtime::virtio_mmio::VIRTIO_MMIO_DEVICE_WINDOW_SIZE;
+
+    use super::*;
+
+    const BLOCK_ROOT_MMIO_HEX: &str =
+        include_str!("../../runtime/src/snapshot_device_v2_6/fixtures/block-root-mmio.hex");
+    const PMEM_ROOT_MMIO_HEX: &str =
+        include_str!("../../runtime/src/snapshot_device_v2_6/fixtures/pmem-root-mmio.hex");
+    const MIXED_BLOCK_ROOT_MMIO_HEX: &str =
+        include_str!("../../runtime/src/snapshot_device_v2_6/fixtures/mixed-block-root-mmio.hex");
+    const PMEM_ROOTLESS_PCI_HEX: &str =
+        include_str!("../../runtime/src/snapshot_device_v2_6/fixtures/pmem-rootless-pci.hex");
+    const PROFILE_2_ROOTLESS_MMIO_HEX: &str =
+        include_str!("../../runtime/src/snapshot_device_v2_5/fixtures/rootless-mmio.hex");
+
+    const BLOCK_MMIO_BASE: GuestAddress = GuestAddress::new(0xd000_0000);
+    const PMEM_MMIO_BASE: GuestAddress = GuestAddress::new(0xd100_0000);
+    const BLOCK_MMIO_REGION_ID: bangbang_runtime::mmio::MmioRegionId =
+        bangbang_runtime::mmio::MmioRegionId::new(100);
+    const PMEM_MMIO_REGION_ID: bangbang_runtime::mmio::MmioRegionId =
+        bangbang_runtime::mmio::MmioRegionId::new(200);
+
+    static NEXT_TEMP_FILE: AtomicU64 = AtomicU64::new(0);
+
+    struct TempBacking {
+        path: PathBuf,
+    }
+
+    impl TempBacking {
+        fn new(name: &str, len: u64) -> Self {
+            let sequence = NEXT_TEMP_FILE.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "bangbang-profile-3-platform-{name}-{}-{sequence}",
+                std::process::id()
+            ));
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create_new(true)
+                .open(&path)
+                .expect("storage platform backing should create");
+            file.set_len(len)
+                .expect("storage platform backing should resize");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempBacking {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum FixtureShape {
+        BlockRoot,
+        PmemRoot,
+        MixedBlockRoot,
+        BlockRootless,
+        PmemRootless,
+    }
+
+    struct StorageFixture {
+        platform: HvfSnapshotV2PlatformState,
+        bundle: PreparedSnapshotV2StorageBundle,
+        _files: Vec<TempBacking>,
+    }
+
+    fn fixture_bytes(hex: &str) -> Vec<u8> {
+        hex.trim()
+            .as_bytes()
+            .chunks_exact(2)
+            .map(|pair| {
+                u8::from_str_radix(
+                    std::str::from_utf8(pair).expect("fixture hex should be UTF-8"),
+                    16,
+                )
+                .expect("fixture hex should decode")
+            })
+            .collect()
+    }
+
+    fn storage_graph(hex: &str) -> SnapshotV2StorageDeviceGraph {
+        SnapshotV2StorageDeviceGraph::decode(
+            NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            &fixture_bytes(hex),
+        )
+        .expect("profile-3 fixture should decode")
+    }
+
+    fn rootless_blocks()
+    -> Vec<bangbang_runtime::snapshot_device_v2_5::SnapshotV2MultiBlockDeviceRecord> {
+        SnapshotV2MultiBlockDeviceGraph::decode(
+            NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            &fixture_bytes(PROFILE_2_ROOTLESS_MMIO_HEX),
+        )
+        .expect("rootless profile-2 fixture should decode")
+        .records()
+        .to_vec()
+    }
+
+    fn base_graph(shape: FixtureShape) -> SnapshotV2StorageDeviceGraph {
+        match shape {
+            FixtureShape::BlockRoot => storage_graph(BLOCK_ROOT_MMIO_HEX),
+            FixtureShape::PmemRoot => storage_graph(PMEM_ROOT_MMIO_HEX),
+            FixtureShape::MixedBlockRoot => storage_graph(MIXED_BLOCK_ROOT_MMIO_HEX),
+            FixtureShape::BlockRootless => SnapshotV2StorageDeviceGraph::try_from_parts(
+                None,
+                SnapshotV2DeviceTransportKind::Mmio,
+                rootless_blocks(),
+                Vec::new(),
+            )
+            .expect("rootless block graph should validate"),
+            FixtureShape::PmemRootless => {
+                let mixed = storage_graph(MIXED_BLOCK_ROOT_MMIO_HEX);
+                SnapshotV2StorageDeviceGraph::try_from_parts(
+                    None,
+                    SnapshotV2DeviceTransportKind::Mmio,
+                    Vec::new(),
+                    mixed.pmem_records().to_vec(),
+                )
+                .expect("rootless pmem graph should validate")
+            }
+        }
+    }
+
+    fn canonicalize_pmem_placement(
+        graph: SnapshotV2StorageDeviceGraph,
+        first_interrupt: u32,
+    ) -> SnapshotV2StorageDeviceGraph {
+        let root_key = graph.root_key();
+        let block_records = graph.block_records().to_vec();
+        for (index, record) in block_records.iter().enumerate() {
+            let SnapshotV2DeviceTransport::Mmio(mmio) = record.transport() else {
+                panic!("canonical storage fixture should use MMIO");
+            };
+            assert_eq!(
+                mmio.interrupt_line().raw_value(),
+                first_interrupt + u32::try_from(index).expect("block index should fit")
+            );
+        }
+        let block_count = block_records.len();
+        let layout = PmemMmioLayout::new(PMEM_MMIO_BASE, PMEM_MMIO_REGION_ID);
+        let pmem_records = graph
+            .pmem_records()
+            .iter()
+            .enumerate()
+            .map(|(index, record)| {
+                let SnapshotV2DeviceTransport::Mmio(captured) = record.transport() else {
+                    panic!("canonical storage fixture should use MMIO");
+                };
+                let region = layout
+                    .region_at(index)
+                    .expect("canonical pmem region should validate");
+                let interrupt = GuestInterruptLine::new(
+                    first_interrupt
+                        + u32::try_from(block_count + index)
+                            .expect("storage interrupt index should fit"),
+                )
+                .expect("canonical pmem interrupt should validate");
+                let transport =
+                    SnapshotV2DeviceTransport::Mmio(SnapshotV2MmioDeviceState::from_parts(
+                        captured.device_feature_select(),
+                        captured.driver_feature_select(),
+                        captured.queue_select(),
+                        region,
+                        interrupt,
+                    ));
+                SnapshotV2PmemDeviceRecord::try_new(
+                    record.key().instance(),
+                    record.config().clone(),
+                    record.pmem().clone(),
+                    record.virtio().clone(),
+                    transport,
+                )
+                .expect("canonical pmem record should validate")
+            })
+            .collect();
+        SnapshotV2StorageDeviceGraph::try_from_parts(
+            root_key,
+            SnapshotV2DeviceTransportKind::Mmio,
+            block_records,
+            pmem_records,
+        )
+        .expect("canonical storage graph should validate")
+    }
+
+    fn restore_memory(graph: &SnapshotV2StorageDeviceGraph) -> GuestMemory {
+        let layout = GuestMemoryLayout::new(vec![
+            GuestMemoryRange::new(GuestAddress::new(0), 0x80_0000)
+                .expect("storage restore memory range should validate"),
+        ])
+        .expect("storage restore memory layout should validate");
+        let mut memory = GuestMemory::allocate(&layout).expect("storage memory should allocate");
+        for record in graph.block_records() {
+            let Some(cursor) = record.block().continuation().active_queue() else {
+                continue;
+            };
+            let queue = &record.virtio().queues()[0];
+            let available = if record.block().continuation().retry() == StorageRetryState::None {
+                cursor.next_available()
+            } else {
+                cursor.next_available().wrapping_add(1)
+            };
+            memory
+                .write_slice(
+                    &available.to_le_bytes(),
+                    GuestAddress::new(queue.driver_ring().raw_value() + 2),
+                )
+                .expect("block available cursor should write");
+            memory
+                .write_slice(
+                    &cursor.next_used().to_le_bytes(),
+                    GuestAddress::new(queue.device_ring().raw_value() + 2),
+                )
+                .expect("block used cursor should write");
+        }
+        for record in graph.pmem_records() {
+            let Some(cursor) = record.pmem().active_queue() else {
+                continue;
+            };
+            let queue = &record.virtio().queues()[0];
+            let available = if record.pmem().retry() == StorageRetryState::None {
+                cursor.next_available()
+            } else {
+                cursor.next_available().wrapping_add(1)
+            };
+            memory
+                .write_slice(
+                    &available.to_le_bytes(),
+                    GuestAddress::new(queue.driver_ring().raw_value() + 2),
+                )
+                .expect("pmem available cursor should write");
+            memory
+                .write_slice(
+                    &cursor.next_used().to_le_bytes(),
+                    GuestAddress::new(queue.device_ring().raw_value() + 2),
+                )
+                .expect("pmem used cursor should write");
+        }
+        memory
+    }
+
+    fn bundle_from_graph(
+        graph: SnapshotV2StorageDeviceGraph,
+    ) -> (PreparedSnapshotV2StorageBundle, Vec<TempBacking>) {
+        let memory = restore_memory(&graph);
+        let mut files = Vec::new();
+        let mut block_backings = Vec::new();
+        let mut pmem_backings = Vec::new();
+        for (index, record) in graph.block_records().iter().enumerate() {
+            let file = TempBacking::new(&format!("block-{index}"), record.block().backing_bytes());
+            let backing =
+                BlockFileBacking::open_snapshot(file.path(), record.config().is_read_only())
+                    .expect("block backing should open")
+                    .0;
+            files.push(file);
+            block_backings.push(backing);
+        }
+        for (index, record) in graph.pmem_records().iter().enumerate() {
+            let file = TempBacking::new(&format!("pmem-{index}"), record.pmem().file_bytes());
+            let host_file = OpenOptions::new()
+                .read(true)
+                .write(!record.config().is_read_only())
+                .open(file.path())
+                .expect("pmem backing should open");
+            let backing = PmemFileBacking::from_file(host_file, record.config().is_read_only())
+                .expect("pmem backing should validate");
+            files.push(file);
+            pmem_backings.push(backing);
+        }
+        let bundle = SnapshotV2StorageRestorePlan::prepare(graph, &memory, Instant::now())
+            .expect("storage restore plan should prepare")
+            .prepare_backings(block_backings, pmem_backings, || false)
+            .expect("storage restore bundle should prepare");
+        (bundle, files)
+    }
+
+    fn fixture(shape: FixtureShape) -> StorageFixture {
+        let base = base_graph(shape);
+        let platform = crate::snapshot_v2_multi_block_platform::tests::product_mmio_platform(
+            base.record_count(),
+        );
+        let first_interrupt = platform
+            .global()
+            .compatibility()
+            .gic_metadata()
+            .spi_interrupt_range
+            .base;
+        let graph = canonicalize_pmem_placement(base, first_interrupt);
+        let (bundle, files) = bundle_from_graph(graph);
+        StorageFixture {
+            platform,
+            bundle,
+            _files: files,
+        }
+    }
+
+    const fn process_config() -> HvfSnapshotV2StorageMmioProcessConfig {
+        HvfSnapshotV2StorageMmioProcessConfig::new(
+            BlockMmioLayout::new(BLOCK_MMIO_BASE, BLOCK_MMIO_REGION_ID),
+            PmemMmioLayout::new(PMEM_MMIO_BASE, PMEM_MMIO_REGION_ID),
+        )
+    }
+
+    #[test]
+    fn shape_and_root_matrix_projects_one_ordered_mmio_product() {
+        for (shape, block_count, pmem_count, root_kind) in [
+            (FixtureShape::BlockRoot, 1, 0, Some("block")),
+            (FixtureShape::PmemRoot, 0, 1, Some("pmem")),
+            (FixtureShape::MixedBlockRoot, 1, 1, Some("block")),
+            (FixtureShape::BlockRootless, 2, 0, None),
+            (FixtureShape::PmemRootless, 0, 1, None),
+        ] {
+            let fixture = fixture(shape);
+            let plan = prepare_hvf_snapshot_v2_storage_mmio_platform_plan(
+                &fixture.platform,
+                &fixture.bundle,
+                process_config(),
+            )
+            .expect("storage platform matrix entry should plan");
+            assert_eq!(plan.block_records().len(), block_count);
+            assert_eq!(plan.pmem_records().len(), pmem_count);
+            assert_eq!(plan.block_metrics_ids().len(), block_count);
+            assert_eq!(plan.pmem_metrics_ids().len(), pmem_count);
+            assert_eq!(plan.block_retries().len(), block_count);
+            assert_eq!(plan.pmem_retries().len(), pmem_count);
+            assert_eq!(plan.root_key().is_some(), root_kind.is_some());
+            match root_kind {
+                Some("block") => {
+                    assert!(plan.command_line().contains("root=PARTUUID="));
+                    assert!(!plan.command_line().contains("root=/dev/pmem"));
+                }
+                Some("pmem") => assert!(plan.command_line().contains("root=/dev/pmem0")),
+                None => assert!(!plan.command_line().contains("root=")),
+                Some(other) => panic!("unexpected root kind {other}"),
+            }
+
+            let first_interrupt = fixture
+                .platform
+                .global()
+                .compatibility()
+                .gic_metadata()
+                .spi_interrupt_range
+                .base;
+            for (index, record) in plan
+                .block_records()
+                .iter()
+                .chain(plan.pmem_records())
+                .enumerate()
+            {
+                assert_eq!(
+                    record.interrupt_line().raw_value(),
+                    first_interrupt + u32::try_from(index).expect("record index should fit")
+                );
+                assert_eq!(record.fdt_device().interrupt_line, record.interrupt_line());
+            }
+            assert_eq!(
+                plan.serial_interrupt().raw_value(),
+                first_interrupt + u32::try_from(block_count + pmem_count).unwrap()
+            );
+            assert_eq!(
+                plan.vmgenid_interrupt().raw_value(),
+                plan.serial_interrupt().raw_value() + 1
+            );
+            assert_eq!(
+                plan.vmclock_interrupt().raw_value(),
+                plan.serial_interrupt().raw_value() + 2
+            );
+            let debug = format!("{plan:?}");
+            for secret in ["rootfs", "pmem_0", "PARTUUID", "root=/dev/pmem"] {
+                assert!(!debug.contains(secret));
+            }
+            fixture
+                .bundle
+                .abort()
+                .expect("planned storage bundle should abort cleanly");
+        }
+    }
+
+    #[test]
+    fn pci_is_explicitly_unavailable_at_the_mmio_platform_boundary() {
+        let graph = storage_graph(PMEM_ROOTLESS_PCI_HEX);
+        let (bundle, _files) = bundle_from_graph(graph);
+        let platform = crate::snapshot_v2_multi_block_platform::tests::product_mmio_platform(1);
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_storage_mmio_platform_plan(
+                &platform,
+                &bundle,
+                process_config(),
+            ),
+            Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::TransportPolicy)
+        ));
+        bundle
+            .abort()
+            .expect("rejected PCI bundle should abort cleanly");
+    }
+
+    #[test]
+    fn placement_interrupt_and_fixed_range_conflicts_fail_before_construction() {
+        let fixture = fixture(FixtureShape::MixedBlockRoot);
+        let shifted = HvfSnapshotV2StorageMmioProcessConfig::new(
+            BlockMmioLayout::new(
+                BLOCK_MMIO_BASE
+                    .checked_add(VIRTIO_MMIO_DEVICE_WINDOW_SIZE)
+                    .expect("shifted block base should fit"),
+                BLOCK_MMIO_REGION_ID,
+            ),
+            PmemMmioLayout::new(PMEM_MMIO_BASE, PMEM_MMIO_REGION_ID),
+        );
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_storage_mmio_platform_plan(
+                &fixture.platform,
+                &fixture.bundle,
+                shifted,
+            ),
+            Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan)
+        ));
+
+        let gic = fixture.platform.global().compatibility().gic_metadata();
+        let fdt = fixture.platform.machine().fdt();
+        let fdt_range = GuestMemoryRange::new(fdt.address(), u64::from(fdt.size()))
+            .expect("FDT range should validate");
+        assert!(
+            mapping_range_conflicts_with_platform(&fixture.platform, fdt_range, &gic)
+                .expect("mapping conflict should be checked")
+        );
+        assert!(
+            queue_ranges_conflict_with_platform(&fixture.platform, Some([fdt_range; 3]))
+                .expect("queue conflict should be checked")
+        );
+        let serial_region = MmioRegion::new(
+            bangbang_runtime::mmio::MmioRegionId::new(999),
+            PROCESS_SERIAL_MMIO_BASE,
+            VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+        )
+        .expect("serial conflict region should validate");
+        assert!(
+            mmio_region_conflicts_with_platform(&fixture.platform, serial_region, &gic)
+                .expect("MMIO conflict should be checked")
+        );
+        fixture
+            .bundle
+            .abort()
+            .expect("conflict fixture should abort cleanly");
+    }
+
+    struct FailingReserve {
+        calls: usize,
+        fail_at: usize,
+    }
+
+    impl StoragePlatformPlanReserve for FailingReserve {
+        fn reserve<T>(
+            &mut self,
+            values: &mut Vec<T>,
+            additional: usize,
+        ) -> Result<(), PrepareHvfSnapshotV2StorageMmioPlatformPlanError> {
+            let call = self.calls;
+            self.calls = self.calls.saturating_add(1);
+            if call == self.fail_at {
+                Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::Allocation)
+            } else {
+                values
+                    .try_reserve_exact(additional)
+                    .map_err(|_| PrepareHvfSnapshotV2StorageMmioPlatformPlanError::Allocation)
+            }
+        }
+    }
+
+    #[test]
+    fn every_platform_inventory_reservation_reports_explicit_allocation_failure() {
+        for fail_at in 0..7 {
+            let fixture = fixture(FixtureShape::MixedBlockRoot);
+            assert!(matches!(
+                prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with(
+                    &fixture.platform,
+                    &fixture.bundle,
+                    process_config(),
+                    &mut FailingReserve { calls: 0, fail_at },
+                ),
+                Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::Allocation)
+            ));
+            fixture
+                .bundle
+                .abort()
+                .expect("allocation fixture should abort cleanly");
+        }
+    }
+}

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -62,8 +62,8 @@ use bangbang_runtime::memory_hotplug::{
 use bangbang_runtime::message_interrupt::GuestMessageInterruptResources;
 use bangbang_runtime::metrics::{
     BlockDeviceMetricsLease, BlockDeviceMetricsRegistryError, NetworkInterfaceMetricsLease,
-    PmemDeviceMetricsLease, SharedBalloonDeviceMetrics, SharedBlockDeviceMetricsRegistry,
-    SharedEntropyDeviceMetrics, SharedMemoryHotplugDeviceMetrics,
+    PmemDeviceMetricsLease, PmemDeviceMetricsRegistryError, SharedBalloonDeviceMetrics,
+    SharedBlockDeviceMetricsRegistry, SharedEntropyDeviceMetrics, SharedMemoryHotplugDeviceMetrics,
     SharedNetworkInterfaceMetricsRegistry, SharedPmemDeviceMetricsRegistry, SharedRtcDeviceMetrics,
     SharedVsockDeviceMetrics,
 };
@@ -85,10 +85,10 @@ use bangbang_runtime::pci::{
     PciClassCode, PciSbdf, PciType0Configuration,
 };
 use bangbang_runtime::pmem::{
-    PmemConfig, PmemFileBacking, PmemMmioLayout, PmemRuntimeMutationError,
-    PmemSnapshotPersistenceBinding, PmemUpdate, PmemUpdateError, PreparedPmemDevice,
-    VIRTIO_PMEM_DEVICE_ID, VIRTIO_PMEM_QUEUE_SIZES, VirtioPmemConfigSpace, VirtioPmemDevice,
-    VirtioPmemFlushStatus,
+    PmemConfig, PmemFileBacking, PmemMmioDeviceRegistration, PmemMmioLayout,
+    PmemRuntimeMutationError, PmemSnapshotPersistenceBinding, PmemUpdate, PmemUpdateError,
+    PreparedPmemDevice, VIRTIO_PMEM_DEVICE_ID, VIRTIO_PMEM_QUEUE_SIZES, VirtioPmemConfigSpace,
+    VirtioPmemDevice, VirtioPmemFlushStatus,
 };
 use bangbang_runtime::pvtime::{
     ARM64_PVTIME_STOLEN_TIME_OFFSET, ARM64_PVTIME_STRUCTURE_SIZE, Arm64PvTimeLayout,
@@ -116,7 +116,9 @@ use bangbang_runtime::snapshot_device_v2_5::{
     SnapshotV2MultiBlockPciTransportError,
 };
 use bangbang_runtime::snapshot_device_v2_6::{
-    NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2StorageDeviceGraph,
+    NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION, PreparedSnapshotV2StorageBundle,
+    PreparedSnapshotV2StorageMmioBundle, SnapshotV2StorageCleanupError,
+    SnapshotV2StorageDeviceGraph, SnapshotV2StorageMmioTransportError,
 };
 use bangbang_runtime::snapshot_format::SnapshotFormatVersion;
 use bangbang_runtime::snapshot_format_v2::NATIVE_V2_LEGACY_PLATFORM_VERSION;
@@ -139,14 +141,14 @@ use bangbang_runtime::startup::{
     Arm64BootMemoryHotplugNotificationDispatches, Arm64BootNetworkInterface,
     Arm64BootNetworkNotificationDispatch, Arm64BootNetworkNotificationDispatchError,
     Arm64BootNetworkNotificationDispatches, Arm64BootNetworkPacketIoProvider,
-    Arm64BootPciValidationConfig, Arm64BootPciValidationResources, Arm64BootPmemFlushProvider,
-    Arm64BootPmemNotificationDispatch, Arm64BootPmemNotificationDispatchError,
-    Arm64BootPmemNotificationDispatches, Arm64BootPvTimeState, Arm64BootResourceConfig,
-    Arm64BootResourceError, Arm64BootResourceParts, Arm64BootResources,
-    Arm64BootRtcDeviceConfig as RuntimeArm64BootRtcDeviceConfig, Arm64BootRuntimeResources,
-    Arm64BootSerialCaptureError, Arm64BootSerialDeviceConfig as RuntimeArm64BootSerialDeviceConfig,
-    Arm64BootSerialRuntimeError, Arm64BootVmClockDevice, Arm64BootVmGenIdDevice,
-    Arm64BootVmGenIdReplacementError,
+    Arm64BootPciValidationConfig, Arm64BootPciValidationResources, Arm64BootPmemDevice,
+    Arm64BootPmemFlushProvider, Arm64BootPmemNotificationDispatch,
+    Arm64BootPmemNotificationDispatchError, Arm64BootPmemNotificationDispatches,
+    Arm64BootPvTimeState, Arm64BootResourceConfig, Arm64BootResourceError, Arm64BootResourceParts,
+    Arm64BootResources, Arm64BootRtcDeviceConfig as RuntimeArm64BootRtcDeviceConfig,
+    Arm64BootRuntimeResources, Arm64BootSerialCaptureError,
+    Arm64BootSerialDeviceConfig as RuntimeArm64BootSerialDeviceConfig, Arm64BootSerialRuntimeError,
+    Arm64BootVmClockDevice, Arm64BootVmGenIdDevice, Arm64BootVmGenIdReplacementError,
     Arm64BootVsockCaptureError as RuntimeArm64BootVsockCaptureError, Arm64BootVsockDevice,
     Arm64BootVsockNotificationDispatch, Arm64BootVsockNotificationDispatchError,
     Arm64BootVsockNotificationDispatches,
@@ -238,10 +240,14 @@ use crate::snapshot_v2_platform::{
     HvfSnapshotV2DefaultProcessShell, HvfSnapshotV2MultiBlockMmioShellPlan,
     HvfSnapshotV2MultiBlockPciShellPlan, HvfSnapshotV2PlatformRestoreError,
     HvfSnapshotV2PlatformShutdownError, HvfSnapshotV2RootResourcePlan,
-    HvfSnapshotV2RootTransportPlan, RestoredHvfSnapshotV2Platform,
-    restore_hvf_snapshot_v2_multi_block_mmio_process_platform,
+    HvfSnapshotV2RootTransportPlan, HvfSnapshotV2StorageMmioShellPlan,
+    RestoredHvfSnapshotV2Platform, restore_hvf_snapshot_v2_multi_block_mmio_process_platform,
     restore_hvf_snapshot_v2_multi_block_pci_process_platform,
     restore_hvf_snapshot_v2_root_process_platform,
+    restore_hvf_snapshot_v2_storage_mmio_process_platform,
+};
+use crate::snapshot_v2_storage_platform::{
+    HvfSnapshotV2StorageMmioPlatformPlan, HvfSnapshotV2StorageMmioPlatformPlanParts,
 };
 use crate::topology::{HvfVcpuTopologyError, prepare_ordered_mpidrs};
 use crate::vcpu::{
@@ -3408,7 +3414,7 @@ pub struct OwnedHvfArm64BootSession {
     backend: HvfBackend,
     mmio_dispatcher: Arc<Mutex<MmioDispatcher>>,
     runtime_resources: Arm64BootRuntimeResources,
-    _restored_snapshot_v2_mmio_registrations: Option<HvfSnapshotV2MultiBlockMmioRegistrations>,
+    restored_snapshot_v2_mmio_registrations: Option<HvfSnapshotV2MultiBlockMmioRegistrations>,
     restored_snapshot_v2_memory_binding: Option<SnapshotV2MemoryBinding>,
     restored_snapshot_v2_machine: Option<HvfSnapshotV2MachineState>,
     cpu_template_application: Option<crate::cpu_template::HvfArm64CpuTemplateApplicationState>,
@@ -3521,8 +3527,9 @@ impl fmt::Debug for RestoredHvfArm64BootSession {
 
 #[derive(Debug)]
 struct HvfSnapshotV2MultiBlockMmioRegistrations {
-    _owner: MmioRegistrationOwner,
-    _leases: Vec<MmioRegistrationLease>,
+    owner: MmioRegistrationOwner,
+    leases: Vec<MmioRegistrationLease>,
+    pmem_ranges: Vec<GuestMemoryRange>,
 }
 
 /// One complete, still-unpublished profile-2 MMIO destination and controller
@@ -3820,6 +3827,339 @@ impl fmt::Display for HvfSnapshotV2MultiBlockMmioRestoreError {
 }
 
 impl std::error::Error for HvfSnapshotV2MultiBlockMmioRestoreError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.failure.as_ref())
+    }
+}
+
+/// One complete, still-unpublished exact-2.6 MMIO storage destination and
+/// ordered controller projection.
+pub struct RestoredHvfSnapshotV2StorageMmioOwners {
+    session: OwnedHvfArm64BootSession,
+    configs: CaptureReadyStorageConfigs,
+}
+
+impl RestoredHvfSnapshotV2StorageMmioOwners {
+    pub const fn session(&self) -> &OwnedHvfArm64BootSession {
+        &self.session
+    }
+
+    pub const fn configs(&self) -> &CaptureReadyStorageConfigs {
+        &self.configs
+    }
+
+    pub fn into_parts(self) -> (OwnedHvfArm64BootSession, CaptureReadyStorageConfigs) {
+        (self.session, self.configs)
+    }
+}
+
+impl fmt::Debug for RestoredHvfSnapshotV2StorageMmioOwners {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RestoredHvfSnapshotV2StorageMmioOwners")
+            .field("block_count", &self.configs.drives().len())
+            .field("pmem_count", &self.configs.pmem().len())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Stage at which exact-2.6 block-and-pmem MMIO owner reconstruction stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfSnapshotV2StorageMmioRestoreStage {
+    MemoryLayout,
+    Transport,
+    ResourcePlan,
+    BlockMetrics,
+    PmemMetrics,
+    Platform,
+    Mapping { index: usize },
+    Registration { index: usize },
+    BlockRetryScheduler,
+    PmemRetryScheduler,
+}
+
+/// Primary failure from exact-2.6 block-and-pmem MMIO owner reconstruction.
+pub enum HvfSnapshotV2StorageMmioRestoreFailure {
+    Allocation,
+    MemoryLayout,
+    Transport(SnapshotV2StorageMmioTransportError),
+    ResourcePlan,
+    BlockMetrics(BlockDeviceMetricsRegistryError),
+    PmemMetrics(PmemDeviceMetricsRegistryError),
+    Platform(Box<HvfSnapshotV2PlatformRestoreError>),
+    Mapping(HvfGuestMemoryMappingError),
+    DispatcherUnavailable,
+    Registration(MmioRegistrationError),
+    InjectedPublication,
+    RetryScheduler(io::ErrorKind),
+}
+
+impl fmt::Debug for HvfSnapshotV2StorageMmioRestoreFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::Allocation => "allocation",
+            Self::MemoryLayout => "memory-layout",
+            Self::Transport(_) => "transport",
+            Self::ResourcePlan => "resource-plan",
+            Self::BlockMetrics(_) => "block-metrics",
+            Self::PmemMetrics(_) => "pmem-metrics",
+            Self::Platform(_) => "platform",
+            Self::Mapping(_) => "mapping",
+            Self::DispatcherUnavailable => "dispatcher",
+            Self::Registration(_) => "registration",
+            Self::InjectedPublication => "injected-publication",
+            Self::RetryScheduler(_) => "retry-scheduler",
+        };
+        formatter
+            .debug_struct("HvfSnapshotV2StorageMmioRestoreFailure")
+            .field("kind", &kind)
+            .field("source", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2StorageMmioRestoreFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Allocation => "exact-2.6 MMIO owner allocation failed",
+            Self::MemoryLayout => "restored memory layout is invalid",
+            Self::Transport(_) => "exact-2.6 MMIO transport reconstruction failed",
+            Self::ResourcePlan => "exact-2.6 MMIO resource plan diverged",
+            Self::BlockMetrics(_) => "exact-2.6 block metrics ownership failed",
+            Self::PmemMetrics(_) => "exact-2.6 pmem metrics ownership failed",
+            Self::Platform(_) => "HVF platform reconstruction failed",
+            Self::Mapping(_) => "exact-2.6 pmem mapping reconstruction failed",
+            Self::DispatcherUnavailable => "exact-2.6 MMIO dispatcher is unavailable",
+            Self::Registration(_) => "exact-2.6 MMIO registration failed",
+            Self::InjectedPublication => {
+                "exact-2.6 MMIO publication certification fault was injected"
+            }
+            Self::RetryScheduler(kind) => {
+                return write!(
+                    formatter,
+                    "storage retry scheduler startup failed: {kind:?}"
+                );
+            }
+        })
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2StorageMmioRestoreFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Transport(source) => Some(source),
+            Self::BlockMetrics(source) => Some(source),
+            Self::PmemMetrics(source) => Some(source),
+            Self::Platform(source) => Some(source.as_ref()),
+            Self::Mapping(source) => Some(source),
+            Self::Registration(source) => Some(source),
+            Self::Allocation
+            | Self::MemoryLayout
+            | Self::ResourcePlan
+            | Self::DispatcherUnavailable
+            | Self::InjectedPublication
+            | Self::RetryScheduler(_) => None,
+        }
+    }
+}
+
+/// Cleanup uncertainty retained after exact-2.6 MMIO reconstruction failed.
+pub enum HvfSnapshotV2StorageMmioRestoreCleanupFailure {
+    PreparedBundle(SnapshotV2StorageCleanupError),
+    BlockRetryScheduler,
+    PmemRetryScheduler,
+    AsyncGuestMemory(HvfGuestMemoryMappingError),
+    Async(BlockAsyncRuntimeError),
+    DispatcherUnavailable,
+    Registration {
+        index: usize,
+        source: MmioRegistrationReleaseError,
+    },
+    Mapping {
+        index: usize,
+        source: HvfGuestMemoryMappingError,
+    },
+    Platform(HvfSnapshotV2PlatformShutdownError),
+}
+
+impl fmt::Debug for HvfSnapshotV2StorageMmioRestoreCleanupFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::PreparedBundle(_) => "prepared-bundle",
+            Self::BlockRetryScheduler => "block-retry-scheduler",
+            Self::PmemRetryScheduler => "pmem-retry-scheduler",
+            Self::AsyncGuestMemory(_) => "async-guest-memory",
+            Self::Async(_) => "async-runtime",
+            Self::DispatcherUnavailable => "dispatcher",
+            Self::Registration { .. } => "registration",
+            Self::Mapping { .. } => "mapping",
+            Self::Platform(_) => "platform",
+        };
+        formatter
+            .debug_struct("HvfSnapshotV2StorageMmioRestoreCleanupFailure")
+            .field("kind", &kind)
+            .field("source", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2StorageMmioRestoreCleanupFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::PreparedBundle(_) => "prepared storage bundle cleanup failed",
+            Self::BlockRetryScheduler => "block retry scheduler cleanup failed",
+            Self::PmemRetryScheduler => "pmem retry scheduler cleanup failed",
+            Self::AsyncGuestMemory(_) => "Async cleanup could not borrow guest memory",
+            Self::Async(_) => "Async runtime cleanup failed",
+            Self::DispatcherUnavailable => "MMIO dispatcher cleanup was unavailable",
+            Self::Registration { .. } => "owned MMIO registration cleanup failed",
+            Self::Mapping { .. } => "pmem mapping cleanup failed",
+            Self::Platform(_) => "HVF platform cleanup failed",
+        })
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2StorageMmioRestoreCleanupFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::PreparedBundle(source) => Some(source),
+            Self::AsyncGuestMemory(source) => Some(source),
+            Self::Async(source) => Some(source),
+            Self::Registration { source, .. } => Some(source),
+            Self::Mapping { source, .. } => Some(source),
+            Self::Platform(source) => Some(source),
+            Self::BlockRetryScheduler | Self::PmemRetryScheduler | Self::DispatcherUnavailable => {
+                None
+            }
+        }
+    }
+}
+
+/// Redacted exact-2.6 MMIO owner failure with ordered cleanup evidence.
+pub struct HvfSnapshotV2StorageMmioRestoreError {
+    stage: HvfSnapshotV2StorageMmioRestoreStage,
+    failure: Box<HvfSnapshotV2StorageMmioRestoreFailure>,
+    cleanup: Vec<HvfSnapshotV2StorageMmioRestoreCleanupFailure>,
+}
+
+impl HvfSnapshotV2StorageMmioRestoreError {
+    fn preflight(
+        stage: HvfSnapshotV2StorageMmioRestoreStage,
+        failure: HvfSnapshotV2StorageMmioRestoreFailure,
+    ) -> Self {
+        Self {
+            stage,
+            failure: Box::new(failure),
+            cleanup: Vec::new(),
+        }
+    }
+
+    fn with_prepared_bundle_abort(
+        stage: HvfSnapshotV2StorageMmioRestoreStage,
+        failure: HvfSnapshotV2StorageMmioRestoreFailure,
+        bundle: PreparedSnapshotV2StorageMmioBundle,
+    ) -> Self {
+        let cleanup = bundle
+            .abort()
+            .err()
+            .map(HvfSnapshotV2StorageMmioRestoreCleanupFailure::PreparedBundle)
+            .into_iter()
+            .collect();
+        Self {
+            stage,
+            failure: Box::new(failure),
+            cleanup,
+        }
+    }
+
+    fn platform(
+        source: HvfSnapshotV2PlatformRestoreError,
+        bundle: PreparedSnapshotV2StorageMmioBundle,
+    ) -> Self {
+        Self::with_prepared_bundle_abort(
+            HvfSnapshotV2StorageMmioRestoreStage::Platform,
+            HvfSnapshotV2StorageMmioRestoreFailure::Platform(Box::new(source)),
+            bundle,
+        )
+    }
+
+    fn after_platform(
+        stage: HvfSnapshotV2StorageMmioRestoreStage,
+        failure: HvfSnapshotV2StorageMmioRestoreFailure,
+        cleanup: Vec<HvfSnapshotV2StorageMmioRestoreCleanupFailure>,
+    ) -> Self {
+        Self {
+            stage,
+            failure: Box::new(failure),
+            cleanup,
+        }
+    }
+
+    pub const fn stage(&self) -> HvfSnapshotV2StorageMmioRestoreStage {
+        self.stage
+    }
+
+    pub fn cleanup_failures(&self) -> &[HvfSnapshotV2StorageMmioRestoreCleanupFailure] {
+        &self.cleanup
+    }
+
+    pub fn has_incomplete_cleanup(&self) -> bool {
+        !self.cleanup.is_empty()
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2StorageMmioRestoreFailure::Transport(source)
+                    if source.cleanup_failed()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2StorageMmioRestoreFailure::Platform(source)
+                    if !source.cleanup_failures().is_empty()
+            )
+    }
+
+    /// Returns whether retry safety cannot be proven.
+    pub fn is_terminal(&self) -> bool {
+        self.has_incomplete_cleanup()
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2StorageMmioRestoreFailure::Platform(source)
+                    if source.is_committed()
+            )
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2StorageMmioRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2StorageMmioRestoreError")
+            .field("stage", &self.stage)
+            .field("failure", &"<redacted>")
+            .field("cleanup_count", &self.cleanup.len())
+            .field("terminal", &self.is_terminal())
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2StorageMmioRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "exact-2.6 MMIO owner reconstruction failed at {:?}: {}",
+            self.stage, self.failure
+        )?;
+        if !self.cleanup.is_empty() {
+            write!(
+                formatter,
+                "; {} cleanup failure(s) retained",
+                self.cleanup.len()
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2StorageMmioRestoreError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(self.failure.as_ref())
     }
@@ -12151,6 +12491,99 @@ fn validate_snapshot_v2_multi_block_mmio_resource_plan(
     root_key == plan.root_key && earliest_retry_index == plan.earliest_retry_index
 }
 
+fn validate_snapshot_v2_storage_mmio_resource_plan(
+    bundle: &PreparedSnapshotV2StorageMmioBundle,
+    plan: &HvfSnapshotV2StorageMmioPlatformPlanParts,
+) -> bool {
+    let block_records = bundle
+        .block_bundle()
+        .map_or(&[][..], PreparedSnapshotV2MultiBlockMmioBundle::records);
+    let block_configs = bundle
+        .block_bundle()
+        .map_or(&[][..], |block| block.drive_configs().as_slice());
+    let pmem_records = bundle.pmem_records();
+    let pmem_configs = bundle.pmem_configs().as_slice();
+    if block_records.len() != block_configs.len()
+        || block_records.len() != plan.block_records.len()
+        || block_records.len() != plan.block_metrics_ids.len()
+        || block_records.len() != plan.block_retries.len()
+        || pmem_records.len() != pmem_configs.len()
+        || pmem_records.len() != plan.pmem_records.len()
+        || pmem_records.len() != plan.pmem_metrics_ids.len()
+        || pmem_records.len() != plan.pmem_retries.len()
+        || block_records.len().saturating_add(pmem_records.len()) == 0
+    {
+        return false;
+    }
+
+    let mut root_key = None;
+    for (index, ((((record, config), planned), retry), metrics_id)) in block_records
+        .iter()
+        .zip(block_configs)
+        .zip(&plan.block_records)
+        .zip(&plan.block_retries)
+        .zip(&plan.block_metrics_ids)
+        .enumerate()
+    {
+        let async_binding_matches = match config.io_engine() {
+            Some(DriveIoEngine::Sync) => record.async_generation().is_none(),
+            Some(DriveIoEngine::Async) => record.async_generation().is_some(),
+            None => false,
+        };
+        if record.key() != planned.key()
+            || record.key() != retry.key()
+            || record.drive_id() != config.drive_id()
+            || record.drive_id() != metrics_id
+            || record.is_root_device() != config.is_root_device()
+            || record.region() != planned.region()
+            || record.interrupt_line() != planned.interrupt_line()
+            || record.retry() != retry.retry()
+            || record.retry_deadline() != retry.retry_deadline()
+            || record.retry_deadline().is_some()
+                == matches!(record.retry(), StorageRetryState::None)
+            || !async_binding_matches
+            || (record.is_root_device() && index != 0)
+        {
+            return false;
+        }
+        if record.is_root_device() && root_key.replace(record.key()).is_some() {
+            return false;
+        }
+    }
+
+    for ((((record, config), planned), retry), metrics_id) in pmem_records
+        .iter()
+        .zip(pmem_configs)
+        .zip(&plan.pmem_records)
+        .zip(&plan.pmem_retries)
+        .zip(&plan.pmem_metrics_ids)
+    {
+        let prepared = record.prepared_device();
+        if record.key() != planned.key()
+            || record.key() != retry.key()
+            || record.pmem_id() != config.id()
+            || record.pmem_id() != metrics_id
+            || record.is_root_device() != config.root_device()
+            || record.region() != planned.region()
+            || record.interrupt_line() != planned.interrupt_line()
+            || record.retry() != retry.retry()
+            || record.retry_deadline() != retry.retry_deadline()
+            || record.retry_deadline().is_some()
+                == matches!(record.retry(), StorageRetryState::None)
+            || prepared.backing().is_read_only() != config.read_only()
+            || prepared.mapping().is_read_only() != config.read_only()
+            || prepared.rate_limiter() != config.rate_limiter()
+        {
+            return false;
+        }
+        if record.is_root_device() && root_key.replace(record.key()).is_some() {
+            return false;
+        }
+    }
+
+    bundle.root_key() == root_key && bundle.root_key() == plan.root_key
+}
+
 fn validate_snapshot_v2_multi_block_pci_resource_plan(
     bundle: &PreparedSnapshotV2MultiBlockPciBundle,
     plan: &HvfSnapshotV2MultiBlockPlatformPlanParts,
@@ -12346,6 +12779,114 @@ fn failed_snapshot_v2_multi_block_mmio_after_platform(
     HvfSnapshotV2MultiBlockMmioRestoreError::after_platform(stage, failure, cleanup)
 }
 
+struct HvfSnapshotV2StorageMmioCleanup<'a> {
+    block_scheduler: &'a mut Option<HvfArm64BootLimiterRetryWakeupScheduler>,
+    pmem_scheduler: &'a mut Option<HvfArm64BootLimiterRetryWakeupScheduler>,
+    async_runtime: Option<&'a SharedBlockAsyncRuntime>,
+    registration_owner: &'a MmioRegistrationOwner,
+    registration_leases: &'a [MmioRegistrationLease],
+    pmem_devices: &'a mut Vec<PreparedPmemDevice>,
+    failures: Vec<HvfSnapshotV2StorageMmioRestoreCleanupFailure>,
+}
+
+fn failed_snapshot_v2_storage_mmio_after_platform(
+    mut platform: RestoredHvfSnapshotV2Platform,
+    stage: HvfSnapshotV2StorageMmioRestoreStage,
+    failure: HvfSnapshotV2StorageMmioRestoreFailure,
+    cleanup: HvfSnapshotV2StorageMmioCleanup<'_>,
+) -> HvfSnapshotV2StorageMmioRestoreError {
+    let HvfSnapshotV2StorageMmioCleanup {
+        block_scheduler,
+        pmem_scheduler,
+        async_runtime,
+        registration_owner,
+        registration_leases,
+        pmem_devices,
+        failures: mut cleanup,
+    } = cleanup;
+    if pmem_scheduler
+        .as_mut()
+        .is_some_and(|scheduler| scheduler.stop_with_result().is_err())
+    {
+        cleanup.push(HvfSnapshotV2StorageMmioRestoreCleanupFailure::PmemRetryScheduler);
+    }
+    drop(pmem_scheduler.take());
+    if block_scheduler
+        .as_mut()
+        .is_some_and(|scheduler| scheduler.stop_with_result().is_err())
+    {
+        cleanup.push(HvfSnapshotV2StorageMmioRestoreCleanupFailure::BlockRetryScheduler);
+    }
+    drop(block_scheduler.take());
+
+    let registrations_released = match platform.mmio_dispatcher().lock() {
+        Ok(mut dispatcher) => {
+            let mut released = true;
+            for (index, lease) in registration_leases.iter().enumerate().rev() {
+                if let Err(source) = dispatcher.release_owned_handler(registration_owner, lease) {
+                    cleanup.push(
+                        HvfSnapshotV2StorageMmioRestoreCleanupFailure::Registration {
+                            index,
+                            source,
+                        },
+                    );
+                    released = false;
+                }
+            }
+            released
+        }
+        Err(_) => {
+            cleanup.push(HvfSnapshotV2StorageMmioRestoreCleanupFailure::DispatcherUnavailable);
+            false
+        }
+    };
+
+    if registrations_released {
+        for (index, device) in pmem_devices.iter().enumerate().rev() {
+            if let Err(source) = platform
+                .backend_mut()
+                .take_runtime_pmem_mapping(device.guest_range(), false)
+            {
+                cleanup
+                    .push(HvfSnapshotV2StorageMmioRestoreCleanupFailure::Mapping { index, source });
+            }
+        }
+        pmem_devices.clear();
+
+        if let Some(runtime) = async_runtime {
+            let needs_memory = match runtime.shutdown_if_idle() {
+                Ok(idle) => !idle,
+                Err(source) => {
+                    cleanup.push(HvfSnapshotV2StorageMmioRestoreCleanupFailure::Async(source));
+                    true
+                }
+            };
+            if needs_memory {
+                match platform.guest_memory_mut() {
+                    Ok(memory) => {
+                        if let Err(source) = runtime.shutdown(memory) {
+                            cleanup
+                                .push(HvfSnapshotV2StorageMmioRestoreCleanupFailure::Async(source));
+                        }
+                    }
+                    Err(source) => cleanup.push(
+                        HvfSnapshotV2StorageMmioRestoreCleanupFailure::AsyncGuestMemory(source),
+                    ),
+                }
+            }
+        }
+    }
+
+    if let Err(source) = platform.shutdown() {
+        cleanup.push(HvfSnapshotV2StorageMmioRestoreCleanupFailure::Platform(
+            source,
+        ));
+    }
+    pmem_devices.clear();
+
+    HvfSnapshotV2StorageMmioRestoreError::after_platform(stage, failure, cleanup)
+}
+
 struct PreparedHvfSnapshotV2MultiBlockPciPublication {
     endpoint: PreparedSnapshotV2MultiBlockPciEndpoint,
     interrupts: HvfGicMsiDeviceInterruptResources,
@@ -12533,7 +13074,7 @@ impl OwnedHvfArm64BootSession {
             backend,
             mmio_dispatcher: prepared.mmio_dispatcher,
             runtime_resources: prepared.runtime_resources,
-            _restored_snapshot_v2_mmio_registrations: None,
+            restored_snapshot_v2_mmio_registrations: None,
             restored_snapshot_v2_memory_binding: None,
             restored_snapshot_v2_machine: None,
             cpu_template_application: prepared.cpu_template_application,
@@ -12798,7 +13339,7 @@ impl OwnedHvfArm64BootSession {
             backend: parts.backend,
             mmio_dispatcher: parts.mmio_dispatcher,
             runtime_resources,
-            _restored_snapshot_v2_mmio_registrations: None,
+            restored_snapshot_v2_mmio_registrations: None,
             restored_snapshot_v2_memory_binding: Some(parts.memory_binding),
             restored_snapshot_v2_machine: Some(parts.machine),
             cpu_template_application,
@@ -13160,10 +13701,11 @@ impl OwnedHvfArm64BootSession {
             backend: parts.backend,
             mmio_dispatcher: parts.mmio_dispatcher,
             runtime_resources,
-            _restored_snapshot_v2_mmio_registrations: Some(
+            restored_snapshot_v2_mmio_registrations: Some(
                 HvfSnapshotV2MultiBlockMmioRegistrations {
-                    _owner: registration_owner,
-                    _leases: registration_leases,
+                    owner: registration_owner,
+                    leases: registration_leases,
+                    pmem_ranges: Vec::new(),
                 },
             ),
             restored_snapshot_v2_memory_binding: Some(parts.memory_binding),
@@ -13209,6 +13751,576 @@ impl OwnedHvfArm64BootSession {
             session,
             drive_configs,
         })
+    }
+
+    /// Reconstructs one exact-2.6 block-and-pmem MMIO vector without
+    /// publishing a process session, controller, or public load path.
+    #[doc(hidden)]
+    pub fn restore_snapshot_v2_storage_mmio(
+        state: HvfSnapshotV2PlatformState,
+        memory: GuestMemory,
+        process_shell: HvfSnapshotV2DefaultProcessShell,
+        bundle: PreparedSnapshotV2StorageBundle,
+        plan: HvfSnapshotV2StorageMmioPlatformPlan,
+    ) -> Result<RestoredHvfSnapshotV2StorageMmioOwners, HvfSnapshotV2StorageMmioRestoreError> {
+        Self::restore_snapshot_v2_storage_mmio_inner(
+            state,
+            memory,
+            process_shell,
+            bundle,
+            plan,
+            None,
+        )
+    }
+
+    /// Deterministically fails after one pmem mapping is installed but before
+    /// its handler becomes reachable. This exists only for signed rollback
+    /// certification; normal reconstruction never selects the fault.
+    #[doc(hidden)]
+    pub fn restore_snapshot_v2_storage_mmio_with_pmem_publication_fault(
+        state: HvfSnapshotV2PlatformState,
+        memory: GuestMemory,
+        process_shell: HvfSnapshotV2DefaultProcessShell,
+        bundle: PreparedSnapshotV2StorageBundle,
+        plan: HvfSnapshotV2StorageMmioPlatformPlan,
+        pmem_index: usize,
+    ) -> Result<RestoredHvfSnapshotV2StorageMmioOwners, HvfSnapshotV2StorageMmioRestoreError> {
+        Self::restore_snapshot_v2_storage_mmio_inner(
+            state,
+            memory,
+            process_shell,
+            bundle,
+            plan,
+            Some(pmem_index),
+        )
+    }
+
+    fn restore_snapshot_v2_storage_mmio_inner(
+        state: HvfSnapshotV2PlatformState,
+        memory: GuestMemory,
+        process_shell: HvfSnapshotV2DefaultProcessShell,
+        bundle: PreparedSnapshotV2StorageBundle,
+        plan: HvfSnapshotV2StorageMmioPlatformPlan,
+        publication_fault_pmem_index: Option<usize>,
+    ) -> Result<RestoredHvfSnapshotV2StorageMmioOwners, HvfSnapshotV2StorageMmioRestoreError> {
+        let mut ranges = Vec::new();
+        ranges
+            .try_reserve_exact(memory.regions().len())
+            .map_err(|_| {
+                HvfSnapshotV2StorageMmioRestoreError::preflight(
+                    HvfSnapshotV2StorageMmioRestoreStage::MemoryLayout,
+                    HvfSnapshotV2StorageMmioRestoreFailure::Allocation,
+                )
+            })?;
+        ranges.extend(memory.regions().iter().map(|region| region.range()));
+        let layout = GuestMemoryLayout::new(ranges).map_err(|_| {
+            HvfSnapshotV2StorageMmioRestoreError::preflight(
+                HvfSnapshotV2StorageMmioRestoreStage::MemoryLayout,
+                HvfSnapshotV2StorageMmioRestoreFailure::MemoryLayout,
+            )
+        })?;
+        let source_fdt = state.machine().fdt();
+        let retained_fdt = Arm64FdtGuestMemoryWrite {
+            address: source_fdt.address(),
+            size: usize::try_from(source_fdt.size()).map_err(|_| {
+                HvfSnapshotV2StorageMmioRestoreError::preflight(
+                    HvfSnapshotV2StorageMmioRestoreStage::MemoryLayout,
+                    HvfSnapshotV2StorageMmioRestoreFailure::Allocation,
+                )
+            })?,
+        };
+        let prepared = bundle.prepare_mmio_transport().map_err(|source| {
+            HvfSnapshotV2StorageMmioRestoreError::preflight(
+                HvfSnapshotV2StorageMmioRestoreStage::Transport,
+                HvfSnapshotV2StorageMmioRestoreFailure::Transport(source),
+            )
+        })?;
+        let plan = plan.into_parts();
+        if !validate_snapshot_v2_storage_mmio_resource_plan(&prepared, &plan) {
+            return Err(
+                HvfSnapshotV2StorageMmioRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2StorageMmioRestoreStage::ResourcePlan,
+                    HvfSnapshotV2StorageMmioRestoreFailure::ResourcePlan,
+                    prepared,
+                ),
+            );
+        }
+
+        let HvfSnapshotV2StorageMmioPlatformPlanParts {
+            root_key: _,
+            command_line,
+            block_metrics_ids,
+            pmem_metrics_ids,
+            block_retries,
+            pmem_retries,
+            block_records: planned_block_records,
+            pmem_records: planned_pmem_records,
+            serial_interrupt,
+            vmgenid_interrupt,
+            vmclock_interrupt,
+        } = plan;
+        let block_count = planned_block_records.len();
+        let pmem_count = planned_pmem_records.len();
+        let record_count = block_count.saturating_add(pmem_count);
+        if publication_fault_pmem_index.is_some_and(|index| index >= pmem_count) {
+            return Err(
+                HvfSnapshotV2StorageMmioRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2StorageMmioRestoreStage::ResourcePlan,
+                    HvfSnapshotV2StorageMmioRestoreFailure::ResourcePlan,
+                    prepared,
+                ),
+            );
+        }
+        let earliest_block_retry_deadline = block_retries
+            .iter()
+            .filter_map(|retry| retry.retry_deadline())
+            .min();
+        let earliest_pmem_retry_deadline = pmem_retries
+            .iter()
+            .filter_map(|retry| retry.retry_deadline())
+            .min();
+        let block_device_metrics =
+            match SharedBlockDeviceMetricsRegistry::from_owned_drive_ids_with_capacity(
+                block_metrics_ids,
+                block_count,
+            ) {
+                Ok(metrics) => metrics,
+                Err(source) => {
+                    return Err(
+                        HvfSnapshotV2StorageMmioRestoreError::with_prepared_bundle_abort(
+                            HvfSnapshotV2StorageMmioRestoreStage::BlockMetrics,
+                            HvfSnapshotV2StorageMmioRestoreFailure::BlockMetrics(source),
+                            prepared,
+                        ),
+                    );
+                }
+            };
+        let pmem_device_metrics =
+            match SharedPmemDeviceMetricsRegistry::from_owned_device_ids_with_capacity(
+                pmem_metrics_ids,
+                pmem_count,
+            ) {
+                Ok(metrics) => metrics,
+                Err(source) => {
+                    return Err(
+                        HvfSnapshotV2StorageMmioRestoreError::with_prepared_bundle_abort(
+                            HvfSnapshotV2StorageMmioRestoreStage::PmemMetrics,
+                            HvfSnapshotV2StorageMmioRestoreFailure::PmemMetrics(source),
+                            prepared,
+                        ),
+                    );
+                }
+            };
+
+        let mut block_devices = Vec::new();
+        let mut pmem_devices = Vec::new();
+        let mut pmem_mmio_devices = Vec::new();
+        let mut pmem_ranges = Vec::new();
+        let mut block_interrupt_lines = Vec::new();
+        let mut pmem_interrupt_lines = Vec::new();
+        let mut registration_leases = Vec::new();
+        let mut cleanup = Vec::new();
+        let storage_capacity_ok = block_devices.try_reserve_exact(block_count).is_ok()
+            && pmem_devices.try_reserve_exact(pmem_count).is_ok()
+            && pmem_mmio_devices.try_reserve_exact(pmem_count).is_ok()
+            && pmem_ranges.try_reserve_exact(pmem_count).is_ok()
+            && block_interrupt_lines.try_reserve_exact(block_count).is_ok()
+            && pmem_interrupt_lines.try_reserve_exact(pmem_count).is_ok()
+            && registration_leases.try_reserve_exact(record_count).is_ok()
+            && cleanup
+                .try_reserve_exact(record_count.saturating_mul(2).saturating_add(8))
+                .is_ok();
+        if !storage_capacity_ok {
+            return Err(
+                HvfSnapshotV2StorageMmioRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2StorageMmioRestoreStage::ResourcePlan,
+                    HvfSnapshotV2StorageMmioRestoreFailure::Allocation,
+                    prepared,
+                ),
+            );
+        }
+
+        let shell_plan = HvfSnapshotV2StorageMmioShellPlan {
+            command_line: &command_line,
+            block_records: &planned_block_records,
+            pmem_records: &planned_pmem_records,
+            serial_interrupt,
+            vmgenid_interrupt,
+            vmclock_interrupt,
+        };
+        let mut platform = match restore_hvf_snapshot_v2_storage_mmio_process_platform(
+            state,
+            memory,
+            process_shell,
+            shell_plan,
+        ) {
+            Ok(platform) => platform,
+            Err(source) => {
+                return Err(HvfSnapshotV2StorageMmioRestoreError::platform(
+                    source, prepared,
+                ));
+            }
+        };
+        let (_root_key, block_bundle, pmem_configs, pmem_records) = prepared.into_parts();
+        let mut drive_configs = DriveConfigs::new();
+        let mut block_records = Vec::new();
+        let mut async_runtime = None;
+        if let Some(block_bundle) = block_bundle {
+            let (configs, records, runtime, async_generations) = block_bundle.into_parts();
+            debug_assert_eq!(
+                async_generations.len(),
+                records
+                    .iter()
+                    .filter(|record| record.async_generation().is_some())
+                    .count()
+            );
+            drop(async_generations);
+            drive_configs = configs;
+            block_records = records;
+            async_runtime = runtime;
+        }
+
+        let registration_owner = MmioRegistrationOwner::new();
+        let install_result = (|| {
+            for (index, (record, planned)) in block_records
+                .into_iter()
+                .zip(planned_block_records)
+                .enumerate()
+            {
+                let (
+                    _key,
+                    drive_id,
+                    _is_root_device,
+                    _retry,
+                    _retry_deadline,
+                    region,
+                    interrupt_line,
+                    _async_generation,
+                    handler,
+                ) = record.into_parts();
+                let request = [MmioRegionRequest::new(
+                    region.range().start(),
+                    region.range().size(),
+                )];
+                let lease = {
+                    let mut dispatcher = platform.mmio_dispatcher().lock().map_err(|_| {
+                        (
+                            HvfSnapshotV2StorageMmioRestoreStage::Registration { index },
+                            HvfSnapshotV2StorageMmioRestoreFailure::DispatcherUnavailable,
+                        )
+                    })?;
+                    dispatcher
+                        .register_owned_handler(&registration_owner, region.id(), &request, handler)
+                        .map_err(|source| {
+                            (
+                                HvfSnapshotV2StorageMmioRestoreStage::Registration { index },
+                                HvfSnapshotV2StorageMmioRestoreFailure::Registration(source),
+                            )
+                        })?
+                };
+                registration_leases.push(lease);
+                if registration_leases.last().is_none_or(|lease| {
+                    lease.region_id() != region.id() || lease.regions() != [region]
+                }) {
+                    return Err((
+                        HvfSnapshotV2StorageMmioRestoreStage::Registration { index },
+                        HvfSnapshotV2StorageMmioRestoreFailure::ResourcePlan,
+                    ));
+                }
+                block_devices.push(Arm64BootBlockDevice {
+                    registration: BlockMmioDeviceRegistration::from_restored(
+                        index, drive_id, region,
+                    ),
+                    fdt_device: planned.fdt_device(),
+                });
+                block_interrupt_lines.push(interrupt_line);
+            }
+
+            for (pmem_index, (record, planned)) in pmem_records
+                .into_iter()
+                .zip(planned_pmem_records)
+                .enumerate()
+            {
+                let registration_index = block_count.saturating_add(pmem_index);
+                let (
+                    _key,
+                    _is_root_device,
+                    _retry,
+                    _retry_deadline,
+                    region,
+                    interrupt_line,
+                    prepared_device,
+                    handler,
+                ) = record.into_parts();
+                let mut pmem_id = String::new();
+                pmem_id
+                    .try_reserve_exact(prepared_device.id().len())
+                    .map_err(|_| {
+                        (
+                            HvfSnapshotV2StorageMmioRestoreStage::ResourcePlan,
+                            HvfSnapshotV2StorageMmioRestoreFailure::Allocation,
+                        )
+                    })?;
+                pmem_id.push_str(prepared_device.id());
+                let guest_range = prepared_device.guest_range();
+                let file_len = prepared_device.mapping().file_len();
+                let config_space = prepared_device.config_space();
+                platform
+                    .backend_mut()
+                    .map_runtime_pmem_device(&prepared_device)
+                    .map_err(|source| {
+                        (
+                            HvfSnapshotV2StorageMmioRestoreStage::Mapping { index: pmem_index },
+                            HvfSnapshotV2StorageMmioRestoreFailure::Mapping(source),
+                        )
+                    })?;
+                pmem_ranges.push(guest_range);
+                pmem_devices.push(prepared_device);
+                if publication_fault_pmem_index == Some(pmem_index) {
+                    return Err((
+                        HvfSnapshotV2StorageMmioRestoreStage::Registration {
+                            index: registration_index,
+                        },
+                        HvfSnapshotV2StorageMmioRestoreFailure::InjectedPublication,
+                    ));
+                }
+
+                let request = [MmioRegionRequest::new(
+                    region.range().start(),
+                    region.range().size(),
+                )];
+                let lease = {
+                    let mut dispatcher = platform.mmio_dispatcher().lock().map_err(|_| {
+                        (
+                            HvfSnapshotV2StorageMmioRestoreStage::Registration {
+                                index: registration_index,
+                            },
+                            HvfSnapshotV2StorageMmioRestoreFailure::DispatcherUnavailable,
+                        )
+                    })?;
+                    dispatcher
+                        .register_owned_handler(&registration_owner, region.id(), &request, handler)
+                        .map_err(|source| {
+                            (
+                                HvfSnapshotV2StorageMmioRestoreStage::Registration {
+                                    index: registration_index,
+                                },
+                                HvfSnapshotV2StorageMmioRestoreFailure::Registration(source),
+                            )
+                        })?
+                };
+                registration_leases.push(lease);
+                if registration_leases.last().is_none_or(|lease| {
+                    lease.region_id() != region.id() || lease.regions() != [region]
+                }) {
+                    return Err((
+                        HvfSnapshotV2StorageMmioRestoreStage::Registration {
+                            index: registration_index,
+                        },
+                        HvfSnapshotV2StorageMmioRestoreFailure::ResourcePlan,
+                    ));
+                }
+                pmem_mmio_devices.push(Arm64BootPmemDevice {
+                    registration: PmemMmioDeviceRegistration::from_restored(
+                        pmem_index,
+                        pmem_id,
+                        region,
+                        guest_range,
+                        file_len,
+                        config_space,
+                    ),
+                    fdt_device: planned.fdt_device(),
+                });
+                pmem_interrupt_lines.push(interrupt_line);
+            }
+            Ok(())
+        })();
+        let mut block_retry_wakeup_scheduler = None;
+        let mut pmem_retry_wakeup_scheduler = None;
+        if let Err((stage, failure)) = install_result {
+            return Err(failed_snapshot_v2_storage_mmio_after_platform(
+                platform,
+                stage,
+                failure,
+                HvfSnapshotV2StorageMmioCleanup {
+                    block_scheduler: &mut block_retry_wakeup_scheduler,
+                    pmem_scheduler: &mut pmem_retry_wakeup_scheduler,
+                    async_runtime: async_runtime.as_ref(),
+                    registration_owner: &registration_owner,
+                    registration_leases: &registration_leases,
+                    pmem_devices: &mut pmem_devices,
+                    failures: cleanup,
+                },
+            ));
+        }
+
+        let block_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        if block_count == 0 {
+            block_retry_wakeup_scheduler =
+                Some(HvfArm64BootLimiterRetryWakeupScheduler::inactive());
+        } else {
+            let vcpu_control = platform.control();
+            block_retry_wakeup_scheduler =
+                match HvfArm64BootLimiterRetryWakeupScheduler::start_with_cancellation(
+                    BLOCK_RETRY_WAKEUP_SCHEDULER_THREAD_NAME,
+                    block_retry_wakeup.clone(),
+                    move || vcpu_control.request_wakeup(),
+                ) {
+                    Ok(scheduler) => Some(scheduler),
+                    Err(source) => {
+                        return Err(failed_snapshot_v2_storage_mmio_after_platform(
+                            platform,
+                            HvfSnapshotV2StorageMmioRestoreStage::BlockRetryScheduler,
+                            HvfSnapshotV2StorageMmioRestoreFailure::RetryScheduler(source.kind()),
+                            HvfSnapshotV2StorageMmioCleanup {
+                                block_scheduler: &mut block_retry_wakeup_scheduler,
+                                pmem_scheduler: &mut pmem_retry_wakeup_scheduler,
+                                async_runtime: async_runtime.as_ref(),
+                                registration_owner: &registration_owner,
+                                registration_leases: &registration_leases,
+                                pmem_devices: &mut pmem_devices,
+                                failures: cleanup,
+                            },
+                        ));
+                    }
+                };
+        }
+        let pmem_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        if pmem_count == 0 {
+            pmem_retry_wakeup_scheduler = Some(HvfArm64BootLimiterRetryWakeupScheduler::inactive());
+        } else {
+            let vcpu_control = platform.control();
+            pmem_retry_wakeup_scheduler =
+                match HvfArm64BootLimiterRetryWakeupScheduler::start_with_cancellation(
+                    PMEM_RETRY_WAKEUP_SCHEDULER_THREAD_NAME,
+                    pmem_retry_wakeup.clone(),
+                    move || vcpu_control.request_wakeup(),
+                ) {
+                    Ok(scheduler) => Some(scheduler),
+                    Err(source) => {
+                        return Err(failed_snapshot_v2_storage_mmio_after_platform(
+                            platform,
+                            HvfSnapshotV2StorageMmioRestoreStage::PmemRetryScheduler,
+                            HvfSnapshotV2StorageMmioRestoreFailure::RetryScheduler(source.kind()),
+                            HvfSnapshotV2StorageMmioCleanup {
+                                block_scheduler: &mut block_retry_wakeup_scheduler,
+                                pmem_scheduler: &mut pmem_retry_wakeup_scheduler,
+                                async_runtime: async_runtime.as_ref(),
+                                registration_owner: &registration_owner,
+                                registration_leases: &registration_leases,
+                                pmem_devices: &mut pmem_devices,
+                                failures: cleanup,
+                            },
+                        ));
+                    }
+                };
+        }
+        let Some(block_retry_wakeup_scheduler) = block_retry_wakeup_scheduler.take() else {
+            std::process::abort();
+        };
+        let Some(pmem_retry_wakeup_scheduler) = pmem_retry_wakeup_scheduler.take() else {
+            std::process::abort();
+        };
+        block_retry_wakeup_scheduler.schedule_deadline(earliest_block_retry_deadline);
+        pmem_retry_wakeup_scheduler.schedule_deadline(earliest_pmem_retry_deadline);
+
+        let parts = platform.into_parts();
+        let machine_config = parts.machine.machine();
+        let cpu_template_application = parts.machine.cpu_template().cloned();
+        let cache_source = crate::vcpu_config::HvfArm64VcpuCacheFdtSource::new(
+            parts.compatibility.identification().id_aa64mmfr2_el1(),
+            parts.compatibility.cache_manifest(),
+        );
+        let gic = parts.compatibility.gic_metadata();
+        let serial_interrupt_line = parts
+            .serial_device
+            .as_ref()
+            .map(|device| device.fdt_device.interrupt_line);
+        let vmgenid_interrupt_line = parts.vmgenid_device.fdt_device.interrupt_line;
+        let vmclock_interrupt_line = parts.vmclock_device.fdt_device.interrupt_line;
+        let runtime_resources = Arm64BootRuntimeResources {
+            machine_config,
+            layout,
+            boot_origin: None,
+            retained_fdt: Some(retained_fdt),
+            rtc_device: Some(parts.rtc_device),
+            serial_device: parts.serial_device,
+            vmgenid_device: parts.vmgenid_device,
+            vmclock_device: parts.vmclock_device,
+            pvtime_state: Arm64BootPvTimeState::restored(parts.pvtime_layout),
+            block_devices,
+            block_async_runtime: async_runtime.unwrap_or_default(),
+            pci_block_devices: Vec::new(),
+            pmem_devices,
+            pmem_mmio_devices,
+            network_devices: Vec::new(),
+            pci_network_devices: Vec::new(),
+            vsock_device: None,
+            pci_vsock_device: None,
+            balloon_device: None,
+            pci_balloon_device: None,
+            memory_hotplug_device: None,
+            pci_memory_hotplug_device: None,
+            entropy_device: None,
+            pci_entropy_device: None,
+            pci_validation: None,
+        };
+        let network_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        let entropy_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        let session = Self {
+            runner: parts.runner,
+            backend: parts.backend,
+            mmio_dispatcher: parts.mmio_dispatcher,
+            runtime_resources,
+            restored_snapshot_v2_mmio_registrations: Some(
+                HvfSnapshotV2MultiBlockMmioRegistrations {
+                    owner: registration_owner,
+                    leases: registration_leases,
+                    pmem_ranges,
+                },
+            ),
+            restored_snapshot_v2_memory_binding: Some(parts.memory_binding),
+            restored_snapshot_v2_machine: Some(parts.machine),
+            cpu_template_application,
+            pci_validation_endpoint: None,
+            pci_data_devices: None,
+            cache_source,
+            cache_hierarchy: None,
+            control_wakeup: HvfArm64BootRunLoopControlWakeupToken::default(),
+            run_loop_wakeup: HvfArm64BootRunLoopWakeupToken::default(),
+            block_retry_wakeup,
+            block_retry_wakeup_scheduler,
+            pmem_retry_wakeup,
+            pmem_retry_wakeup_scheduler,
+            network_retry_wakeup,
+            network_retry_wakeup_scheduler: HvfArm64BootLimiterRetryWakeupScheduler::inactive(),
+            entropy_retry_wakeup,
+            entropy_retry_wakeup_scheduler: HvfArm64BootLimiterRetryWakeupScheduler::inactive(),
+            entropy_source: VirtioRngOsEntropySource::new(),
+            block_device_metrics,
+            pmem_device_metrics,
+            balloon_device_metrics: SharedBalloonDeviceMetrics::default(),
+            memory_hotplug_device_metrics: None,
+            network_interface_metrics: SharedNetworkInterfaceMetricsRegistry::default(),
+            vsock_device_metrics: SharedVsockDeviceMetrics::default(),
+            entropy_device_metrics: SharedEntropyDeviceMetrics::default(),
+            gic,
+            block_interrupt_lines,
+            pmem_interrupt_lines,
+            network_interrupt_lines: Vec::new(),
+            vsock_interrupt_line: None,
+            balloon_interrupt_line: None,
+            entropy_interrupt_line: None,
+            memory_hotplug_interrupt_line: None,
+            serial_interrupt_line,
+            serial_input: None,
+            vmgenid_interrupt_line,
+            vmclock_interrupt_line,
+            boot_registers: None,
+        };
+        let configs =
+            CaptureReadyStorageConfigs::new(drive_configs.into_vec(), pmem_configs.into_vec());
+        Ok(RestoredHvfSnapshotV2StorageMmioOwners { session, configs })
     }
 
     /// Reconstructs one exact profile-2 PCI vector inside a private canonical
@@ -13890,7 +15002,7 @@ impl OwnedHvfArm64BootSession {
             backend: parts.backend,
             mmio_dispatcher: parts.mmio_dispatcher,
             runtime_resources,
-            _restored_snapshot_v2_mmio_registrations: None,
+            restored_snapshot_v2_mmio_registrations: None,
             restored_snapshot_v2_memory_binding: Some(parts.memory_binding),
             restored_snapshot_v2_machine: Some(parts.machine),
             cpu_template_application,
@@ -14230,7 +15342,7 @@ impl OwnedHvfArm64BootSession {
             backend,
             mmio_dispatcher,
             runtime_resources,
-            _restored_snapshot_v2_mmio_registrations: None,
+            restored_snapshot_v2_mmio_registrations: None,
             restored_snapshot_v2_memory_binding: None,
             restored_snapshot_v2_machine: None,
             cpu_template_application: None,
@@ -14627,24 +15739,85 @@ impl OwnedHvfArm64BootSession {
         }
     }
 
+    fn teardown_restored_snapshot_v2_mmio(
+        &mut self,
+    ) -> Result<(), HvfSnapshotV2StorageMmioRestoreCleanupFailure> {
+        let Some(registrations) = self.restored_snapshot_v2_mmio_registrations.as_mut() else {
+            return Ok(());
+        };
+
+        if !registrations.leases.is_empty() {
+            let mut dispatcher = self.mmio_dispatcher.lock().map_err(|_| {
+                HvfSnapshotV2StorageMmioRestoreCleanupFailure::DispatcherUnavailable
+            })?;
+            while let Some(lease) = registrations.leases.last() {
+                let index = registrations.leases.len() - 1;
+                dispatcher
+                    .release_owned_handler(&registrations.owner, lease)
+                    .map_err(|source| {
+                        HvfSnapshotV2StorageMmioRestoreCleanupFailure::Registration {
+                            index,
+                            source,
+                        }
+                    })?;
+                registrations.leases.pop();
+            }
+        }
+
+        while let Some(range) = registrations.pmem_ranges.last().copied() {
+            let index = registrations.pmem_ranges.len() - 1;
+            self.backend
+                .take_runtime_pmem_mapping(range, false)
+                .map_err(
+                    |source| HvfSnapshotV2StorageMmioRestoreCleanupFailure::Mapping {
+                        index,
+                        source,
+                    },
+                )?;
+            registrations.pmem_ranges.pop();
+        }
+
+        self.runtime_resources.block_devices.clear();
+        self.runtime_resources.pmem_mmio_devices.clear();
+        self.runtime_resources.pmem_devices.clear();
+        self.restored_snapshot_v2_mmio_registrations = None;
+        Ok(())
+    }
+
     pub fn shutdown(&mut self) -> Result<(), HvfArm64BootSessionShutdownError> {
         self.block_retry_wakeup_scheduler.stop();
         self.pmem_retry_wakeup_scheduler.stop();
         self.network_retry_wakeup_scheduler.stop();
         self.entropy_retry_wakeup_scheduler.stop();
         let runner_result = self.runner.shutdown();
-        let block_async_result = if runner_result.is_ok() {
-            shutdown_block_async_before_guest_memory_teardown(
-                &mut self.backend,
-                &self.runtime_resources,
-            )
+        let had_restored_snapshot_v2_mmio = self.restored_snapshot_v2_mmio_registrations.is_some();
+        let restored_snapshot_v2_mmio_result = if runner_result.is_ok() {
+            self.teardown_restored_snapshot_v2_mmio()
         } else {
             Ok(())
         };
+        let block_async_result =
+            if runner_result.is_ok() && restored_snapshot_v2_mmio_result.is_ok() {
+                shutdown_block_async_before_guest_memory_teardown(
+                    &mut self.backend,
+                    &self.runtime_resources,
+                )
+            } else {
+                Ok(())
+            };
+        if had_restored_snapshot_v2_mmio
+            && restored_snapshot_v2_mmio_result.is_ok()
+            && block_async_result.is_ok()
+        {
+            self.block_device_metrics = SharedBlockDeviceMetricsRegistry::default();
+            self.pmem_device_metrics = SharedPmemDeviceMetricsRegistry::default();
+        }
         let pci_data_result = self.teardown_pci_data_devices();
         let pci_result = self.teardown_pci_validation_endpoint();
         let result = if let Err(source) = runner_result {
             Err(HvfArm64BootSessionShutdownError::Vcpu { source })
+        } else if let Err(source) = restored_snapshot_v2_mmio_result {
+            Err(HvfArm64BootSessionShutdownError::RestoredSnapshotV2Mmio { source })
         } else if let Err(source) = block_async_result {
             Err(source)
         } else if let Err(source) = pci_data_result {
@@ -21199,6 +22372,9 @@ pub enum HvfArm64BootSessionShutdownError {
     Vcpu {
         source: HvfVcpuRunCoordinatorError,
     },
+    RestoredSnapshotV2Mmio {
+        source: HvfSnapshotV2StorageMmioRestoreCleanupFailure,
+    },
     BlockAsyncGuestMemory {
         source: HvfGuestMemoryMappingError,
     },
@@ -21225,6 +22401,10 @@ impl fmt::Display for HvfArm64BootSessionShutdownError {
                     "failed to shut down HVF boot-session vCPU topology: {source}"
                 )
             }
+            Self::RestoredSnapshotV2Mmio { source } => write!(
+                f,
+                "failed to tear down restored snapshot MMIO ownership: {source}"
+            ),
             Self::BlockAsyncGuestMemory { source } => {
                 write!(
                     f,
@@ -21251,6 +22431,7 @@ impl std::error::Error for HvfArm64BootSessionShutdownError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Vcpu { source } => Some(source),
+            Self::RestoredSnapshotV2Mmio { source } => Some(source),
             Self::BlockAsyncGuestMemory { source } => Some(source),
             Self::BlockAsync { source } => Some(source),
             Self::PciValidation { source } => Some(source),
@@ -34144,6 +35325,47 @@ mod tests {
             ),
             vec![
                 super::HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure::Platform(
+                    crate::snapshot_v2_platform::HvfSnapshotV2PlatformShutdownError::Backend(
+                        super::BackendError::Hypervisor("secret-cleanup/path".to_string()),
+                    ),
+                ),
+            ],
+        );
+        assert!(incomplete.has_incomplete_cleanup());
+        assert!(incomplete.is_terminal());
+        let debug = format!("{incomplete:?}");
+        let cleanup_debug = format!("{:?}", incomplete.cleanup_failures());
+        assert!(debug.contains("<redacted>"));
+        assert!(cleanup_debug.contains("<redacted>"));
+        for diagnostics in [debug, incomplete.to_string(), cleanup_debug] {
+            assert!(!diagnostics.contains("secret-cleanup"));
+        }
+    }
+
+    #[test]
+    fn native_v2_storage_mmio_errors_preserve_terminality_and_redact_cleanup() {
+        let retryable = super::HvfSnapshotV2StorageMmioRestoreError::preflight(
+            super::HvfSnapshotV2StorageMmioRestoreStage::ResourcePlan,
+            super::HvfSnapshotV2StorageMmioRestoreFailure::ResourcePlan,
+        );
+        assert!(!retryable.has_incomplete_cleanup());
+        assert!(!retryable.is_terminal());
+
+        let clean_rollback = super::HvfSnapshotV2StorageMmioRestoreError::after_platform(
+            super::HvfSnapshotV2StorageMmioRestoreStage::Registration { index: 1 },
+            super::HvfSnapshotV2StorageMmioRestoreFailure::InjectedPublication,
+            Vec::new(),
+        );
+        assert!(!clean_rollback.has_incomplete_cleanup());
+        assert!(!clean_rollback.is_terminal());
+
+        let incomplete = super::HvfSnapshotV2StorageMmioRestoreError::after_platform(
+            super::HvfSnapshotV2StorageMmioRestoreStage::PmemRetryScheduler,
+            super::HvfSnapshotV2StorageMmioRestoreFailure::RetryScheduler(
+                io::ErrorKind::PermissionDenied,
+            ),
+            vec![
+                super::HvfSnapshotV2StorageMmioRestoreCleanupFailure::Platform(
                     crate::snapshot_v2_platform::HvfSnapshotV2PlatformShutdownError::Backend(
                         super::BackendError::Hypervisor("secret-cleanup/path".to_string()),
                     ),

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -6896,31 +6896,36 @@ fn prepares_internal_hvf_arm64_boot_session() {
 #[test]
 fn capture_ready_storage_traverses_signed_mmio_and_pci_owners() {
     use std::fs::OpenOptions;
+    use std::os::unix::fs::FileExt;
     use std::time::Instant;
 
     use bangbang_hvf::{
-        HvfArm64BootSessionConfig, HvfArm64BootSnapshotV2CaptureInput,
-        HvfArm64BootStorageCaptureErrorKind, HvfArm64BootStorageCaptureStage,
-        HvfSnapshotV2BootState, HvfSnapshotV2NativePath, HvfSnapshotV2StorageState,
-        OwnedHvfArm64BootSession,
+        HvfArm64BootSerialDeviceConfig, HvfArm64BootSessionConfig,
+        HvfArm64BootSnapshotV2CaptureInput, HvfArm64BootStorageCaptureErrorKind,
+        HvfArm64BootStorageCaptureStage, HvfSnapshotV2BootState, HvfSnapshotV2DefaultProcessShell,
+        HvfSnapshotV2NativePath, HvfSnapshotV2StorageMmioProcessConfig, HvfSnapshotV2StorageState,
+        HvfVcpuRunStepOutcome, OwnedHvfArm64BootSession,
+        prepare_hvf_snapshot_v2_storage_mmio_platform_plan,
     };
     use bangbang_runtime::VmmAction;
     use bangbang_runtime::block::{
-        BlockCaptureIoEngine, BlockMmioLayout, DriveCacheType, DriveConfigInput, DriveIoEngine,
-        PreparedBlockDevice,
+        BlockCaptureIoEngine, BlockFileBacking, BlockMmioLayout, DriveCacheType, DriveConfigInput,
+        DriveIoEngine, PreparedBlockDevice,
     };
     use bangbang_runtime::boot::BootSourceConfigInput;
-    use bangbang_runtime::memory::GuestAddress;
+    use bangbang_runtime::memory::{GuestAddress, GuestMemory, GuestMemoryLayout};
     use bangbang_runtime::mmio::MmioRegionId;
     use bangbang_runtime::network::NetworkMmioLayout;
     use bangbang_runtime::pmem::{
         PmemConfig, PmemConfigInput, PmemFileBacking, PmemMmioLayout, VIRTIO_PMEM_ALIGNMENT,
     };
+    use bangbang_runtime::serial::{SharedSerialOutput, SharedSerialOutputBuffer};
     use bangbang_runtime::snapshot_device_v2::{
         SnapshotV2DeviceTransport, SnapshotV2DeviceTransportKind,
     };
     use bangbang_runtime::snapshot_device_v2_6::{
         NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2StorageDeviceGraph,
+        SnapshotV2StorageRestorePlan,
     };
     use bangbang_runtime::storage_capture::{
         CaptureReadyStorageConfigs, StorageDeviceOrigin, StorageTransportState,
@@ -6976,13 +6981,22 @@ fn capture_ready_storage_traverses_signed_mmio_and_pci_owners() {
                 .with_read_only(true),
         ))
         .expect("read-only MMIO pmem should configure");
+    let mmio_serial = SharedSerialOutputBuffer::default();
     let mmio_session_config = HvfArm64BootSessionConfig::new(
         BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1)),
         PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500)),
         NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000)),
         VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
-        test_rtc_mmio_layout(),
-    );
+        bangbang_runtime::rtc::RtcMmioLayout::new(
+            GuestAddress::new(0x4000_1000),
+            MmioRegionId::new(10),
+        ),
+    )
+    .with_serial_device(HvfArm64BootSerialDeviceConfig::new(
+        MmioRegionId::new(20),
+        GuestAddress::new(0x4000_2000),
+        SharedSerialOutput::from(mmio_serial),
+    ));
     let mut mmio_session = OwnedHvfArm64BootSession::new(&mmio_controller, mmio_session_config)
         .expect("signed MMIO storage session should prepare");
     let mmio_configs = CaptureReadyStorageConfigs::new(
@@ -7260,10 +7274,265 @@ fn capture_ready_storage_traverses_signed_mmio_and_pci_owners() {
     ] {
         assert!(!mmio_debug.contains(&private_path));
     }
+
+    let restored_layout =
+        GuestMemoryLayout::new(mmio_session.runtime_resources().layout.ranges().to_vec())
+            .expect("MMIO profile-3 destination layout should validate");
+    let mut fault_memory = GuestMemory::allocate(&restored_layout)
+        .expect("MMIO profile-3 fault destination memory should allocate");
+    let mut restored_memory = GuestMemory::allocate(&restored_layout)
+        .expect("MMIO profile-3 destination memory should allocate");
+    let source_memory = mmio_session
+        .guest_memory()
+        .expect("MMIO profile-3 source memory should remain mapped");
+    let mut copy_buffer = vec![0_u8; 64 * 1024];
+    for range in restored_layout.ranges() {
+        let mut copied = 0_u64;
+        while copied < range.size() {
+            let remaining = range.size() - copied;
+            let count =
+                usize::try_from(remaining.min(
+                    u64::try_from(copy_buffer.len()).expect("copy buffer length should fit u64"),
+                ))
+                .expect("MMIO profile-3 copy count should fit usize");
+            let address = range
+                .start()
+                .checked_add(copied)
+                .expect("MMIO profile-3 copy address should fit");
+            source_memory
+                .read_slice(&mut copy_buffer[..count], address)
+                .expect("MMIO profile-3 source memory should read");
+            fault_memory
+                .write_slice(&copy_buffer[..count], address)
+                .expect("MMIO profile-3 fault destination memory should write");
+            restored_memory
+                .write_slice(&copy_buffer[..count], address)
+                .expect("MMIO profile-3 destination memory should write");
+            copied += u64::try_from(count).expect("copy count should fit u64");
+        }
+    }
     drop(mmio_guard);
     mmio_session
         .shutdown()
         .expect("signed MMIO storage session should shut down");
+
+    let (source_platform, source_graph) = mmio_complete.into_parts();
+    let reopen_block_backings = || {
+        source_graph
+            .block_records()
+            .iter()
+            .map(|record| {
+                BlockFileBacking::open_snapshot(
+                    std::path::Path::new(record.config().selector()),
+                    record.config().is_read_only(),
+                )
+                .map(|(backing, _identity)| backing)
+                .expect("MMIO profile-3 block backing should reopen")
+            })
+            .collect::<Vec<_>>()
+    };
+    let reopen_pmem_backings = || {
+        mmio_controller
+            .pmem_configs()
+            .iter()
+            .map(|config| {
+                PmemFileBacking::open(config).expect("MMIO profile-3 pmem backing should reopen")
+            })
+            .collect::<Vec<_>>()
+    };
+    let restore_process_config = HvfSnapshotV2StorageMmioProcessConfig::new(
+        BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1)),
+        PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500)),
+    );
+    let restore_now = Instant::now();
+
+    let fault_bundle =
+        SnapshotV2StorageRestorePlan::prepare(source_graph.clone(), &fault_memory, restore_now)
+            .expect("MMIO profile-3 fault restore plan should validate")
+            .prepare_backings(reopen_block_backings(), reopen_pmem_backings(), || false)
+            .expect("MMIO profile-3 fault backings should prepare");
+    let fault_plan = prepare_hvf_snapshot_v2_storage_mmio_platform_plan(
+        &source_platform,
+        &fault_bundle,
+        restore_process_config,
+    )
+    .expect("MMIO profile-3 fault platform plan should validate");
+    let fault_shell = HvfSnapshotV2DefaultProcessShell::new(SharedSerialOutput::from(
+        SharedSerialOutputBuffer::default(),
+    ));
+    let fault =
+        OwnedHvfArm64BootSession::restore_snapshot_v2_storage_mmio_with_pmem_publication_fault(
+            source_platform.clone(),
+            fault_memory,
+            fault_shell,
+            fault_bundle,
+            fault_plan,
+            0,
+        )
+        .expect_err("injected post-mapping publication fault should reject");
+    assert_eq!(
+        fault.stage(),
+        bangbang_hvf::HvfSnapshotV2StorageMmioRestoreStage::Registration {
+            index: source_graph.block_records().len(),
+        }
+    );
+    assert!(fault.cleanup_failures().is_empty());
+    assert!(!fault.is_terminal());
+    let fault_diagnostics = format!("{fault:?} {fault}");
+    for private_path in [
+        path_text(mmio_root.path()),
+        path_text(mmio_async.path()),
+        path_text(mmio_pmem.path()),
+        path_text(mmio_read_only_pmem.path()),
+    ] {
+        assert!(!fault_diagnostics.contains(&private_path));
+    }
+
+    let restore_bundle =
+        SnapshotV2StorageRestorePlan::prepare(source_graph.clone(), &restored_memory, restore_now)
+            .expect("MMIO profile-3 restore plan should validate")
+            .prepare_backings(reopen_block_backings(), reopen_pmem_backings(), || false)
+            .expect("MMIO profile-3 backings should prepare");
+    let restore_plan = prepare_hvf_snapshot_v2_storage_mmio_platform_plan(
+        &source_platform,
+        &restore_bundle,
+        restore_process_config,
+    )
+    .expect("MMIO profile-3 platform plan should validate");
+    let restored_serial = SharedSerialOutputBuffer::default();
+    let restore_shell =
+        HvfSnapshotV2DefaultProcessShell::new(SharedSerialOutput::from(restored_serial));
+    let restored_owners = OwnedHvfArm64BootSession::restore_snapshot_v2_storage_mmio(
+        source_platform.clone(),
+        restored_memory,
+        restore_shell,
+        restore_bundle,
+        restore_plan,
+    )
+    .unwrap_or_else(|error| panic!("MMIO profile-3 owners should restore: {error:?}"));
+    assert_eq!(restored_owners.configs(), &mmio_configs);
+    let (mut restored, restored_configs) = restored_owners.into_parts();
+    assert_eq!(restored_configs, mmio_configs);
+    assert_eq!(restored.runtime_resources().block_devices.len(), 2);
+    assert_eq!(restored.runtime_resources().pmem_devices.len(), 2);
+    assert_eq!(restored.runtime_resources().pmem_mmio_devices.len(), 2);
+    assert!(restored.runtime_resources().pci_block_devices.is_empty());
+    assert!(!restored.uses_pci_data_devices());
+
+    for ((device, registration), record) in restored
+        .runtime_resources()
+        .pmem_devices
+        .iter()
+        .zip(&restored.runtime_resources().pmem_mmio_devices)
+        .zip(source_graph.pmem_records())
+    {
+        let SnapshotV2DeviceTransport::Mmio(transport) = record.transport() else {
+            panic!("restored profile-3 pmem record should use MMIO");
+        };
+        assert_eq!(device.id(), record.config().pmem_id());
+        assert_eq!(device.guest_range(), record.pmem().guest_range());
+        assert_eq!(device.config_space(), record.pmem().config_space());
+        assert_eq!(registration.registration.region(), transport.region());
+        assert_eq!(
+            registration.fdt_device.interrupt_line,
+            transport.interrupt_line()
+        );
+    }
+    let block_metrics = restored.shared_block_device_metrics();
+    for config in restored_configs.drives() {
+        assert!(
+            block_metrics
+                .per_drive(config.drive_id())
+                .expect("restored block metrics owner should exist")
+                .snapshot()
+                .is_empty()
+        );
+    }
+    let pmem_metrics = restored.shared_pmem_device_metrics();
+    for config in restored_configs.pmem() {
+        assert!(
+            pmem_metrics
+                .per_device(config.id())
+                .expect("restored pmem metrics owner should exist")
+                .snapshot()
+                .is_empty()
+        );
+    }
+
+    let restored_guard = restored
+        .quiesce_limiter_retry_wakeups()
+        .expect("restored profile-3 retry publishers should quiesce");
+    let recaptured_graph = restored
+        .capture_snapshot_v2_storage_device_graph_at(
+            &restored_configs,
+            &restored_guard,
+            restore_now,
+        )
+        .expect("restored MMIO profile-3 graph should recapture");
+    assert_eq!(recaptured_graph, source_graph);
+    let recaptured_memory = TempFile::new_len("restored-mmio-profile-3-memory", 0)
+        .expect("restored MMIO profile-3 memory artifact should create");
+    let mut recaptured_writer = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(recaptured_memory.path())
+        .expect("restored MMIO profile-3 memory artifact should open");
+    let recaptured_boot = HvfSnapshotV2BootState::try_new(
+        HvfSnapshotV2NativePath::try_new(mmio_kernel.path().as_os_str())
+            .expect("restored MMIO profile-3 kernel path should validate"),
+        None,
+        None,
+    )
+    .expect("restored MMIO profile-3 boot metadata should validate");
+    let recaptured_platform = restored
+        .capture_snapshot_v2_storage_platform_with_cancel(
+            HvfArm64BootSnapshotV2CaptureInput::new(recaptured_boot),
+            &mut recaptured_writer,
+            |_| false,
+        )
+        .expect("restored MMIO profile-3 platform should recapture");
+    assert_native_v2_platform_recapture_equivalent(&source_platform, &recaptured_platform);
+    drop(restored_guard);
+
+    const RESTORED_PMEM_WRITE_OFFSET: u64 = 4096;
+    const RESTORED_PMEM_WRITE_VALUE: u32 = 0x1631_cafe;
+    let restored_entry = GuestAddress::new(
+        restored
+            .capture_arm64_general_register_state()
+            .expect("restored MMIO profile-3 registers should capture")
+            .pc(),
+    );
+    let restored_target = restored.runtime_resources().pmem_devices[0]
+        .guest_range()
+        .start()
+        .checked_add(RESTORED_PMEM_WRITE_OFFSET)
+        .expect("restored MMIO profile-3 pmem target should fit");
+    let restored_program =
+        arm64_store_u32_and_hvc_program(restored_target.raw_value(), RESTORED_PMEM_WRITE_VALUE);
+    restored
+        .guest_memory_mut()
+        .expect("restored MMIO profile-3 guest memory should map")
+        .write_slice(&restored_program, restored_entry)
+        .expect("restored MMIO profile-3 guest program should write");
+    restored
+        .resume_after_snapshot_v2_capture()
+        .expect("restored MMIO profile-3 runner should resume");
+    assert!(matches!(
+        restored
+            .run_once_and_handle_mmio()
+            .expect("restored guest should reach HVC through the pmem mapping"),
+        HvfVcpuRunStepOutcome::Hvc { exit, .. } if exit.immediate() == 0
+    ));
+    let observer =
+        std::fs::File::open(mmio_pmem.path()).expect("restored pmem observer should open");
+    let mut observed = [0_u8; std::mem::size_of::<u32>()];
+    observer
+        .read_exact_at(&mut observed, RESTORED_PMEM_WRITE_OFFSET)
+        .expect("restored pmem observer should read");
+    assert_eq!(u32::from_le_bytes(observed), RESTORED_PMEM_WRITE_VALUE);
+    restored
+        .shutdown()
+        .expect("restored MMIO profile-3 session should tear down in ownership order");
 
     let pci_kernel = TempFile::new("capture-ready-pci-kernel", &image)
         .expect("PCI capture kernel should create");

--- a/crates/runtime/src/block.rs
+++ b/crates/runtime/src/block.rs
@@ -775,6 +775,12 @@ impl DriveConfigs {
         &self.configs
     }
 
+    /// Consumes the validated configuration set in canonical device order.
+    #[doc(hidden)]
+    pub fn into_vec(self) -> Vec<DriveConfig> {
+        self.configs
+    }
+
     pub fn has_root_device(&self) -> bool {
         self.configs.iter().any(DriveConfig::is_root_device)
     }

--- a/crates/runtime/src/boot.rs
+++ b/crates/runtime/src/boot.rs
@@ -201,6 +201,25 @@ pub fn canonical_process_root_block_command_line(
     Ok(command_line.text)
 }
 
+/// Builds the canonical process command line for one root pmem device.
+///
+/// The stable pmem configuration index determines the Linux namespace name.
+/// Transport policy remains before root selection and Linux init arguments
+/// remain after the canonical ` -- ` separator.
+pub fn canonical_process_root_pmem_command_line(
+    boot_args: Option<&str>,
+    pci_enabled: bool,
+    pmem_index: usize,
+    read_only: bool,
+) -> Result<String, BootCommandLineError> {
+    let mut command_line = validate_command_line_text(Some(
+        &canonical_process_block_command_line(boot_args, pci_enabled)?,
+    ))?;
+    let (root, mode) = root_pmem_kernel_arguments(pmem_index, read_only);
+    command_line = command_line.with_appended_kernel_args([root.as_str(), mode])?;
+    Ok(command_line.text)
+}
+
 /// Returns the canonical Linux root selector and access-mode arguments.
 pub fn root_block_kernel_arguments(
     partuuid: Option<&str>,
@@ -209,6 +228,13 @@ pub fn root_block_kernel_arguments(
     let root = partuuid
         .map(|partuuid| format!("root=PARTUUID={partuuid}"))
         .unwrap_or_else(|| "root=/dev/vda".to_string());
+    let mode = if read_only { "ro" } else { "rw" };
+    (root, mode)
+}
+
+/// Returns the canonical Linux pmem root selector and access-mode arguments.
+pub fn root_pmem_kernel_arguments(pmem_index: usize, read_only: bool) -> (String, &'static str) {
+    let root = format!("root=/dev/pmem{pmem_index}");
     let mode = if read_only { "ro" } else { "rw" };
     (root, mode)
 }
@@ -1257,7 +1283,7 @@ mod tests {
         BootPayloadKind, BootSource, BootSourceConfigError, BootSourceConfigInput, BootSourceFiles,
         BootSourceLoadError, DEFAULT_KERNEL_COMMAND_LINE, INIT_ARGS_SEPARATOR, KernelImageError,
         canonical_process_block_command_line, canonical_process_root_block_command_line,
-        validate_command_line_text,
+        canonical_process_root_pmem_command_line, validate_command_line_text,
     };
     use crate::memory::{GuestAddress, GuestMemory, GuestMemoryLayout, aarch64};
 
@@ -1799,6 +1825,15 @@ mod tests {
                 false,
             ),
             Ok("console=ttyS0 pci=off root=PARTUUID=1111-2222 rw -- /init".to_string())
+        );
+        assert_eq!(
+            canonical_process_root_pmem_command_line(
+                Some("console=ttyS0 -- /init"),
+                false,
+                3,
+                true,
+            ),
+            Ok("console=ttyS0 pci=off root=/dev/pmem3 ro -- /init".to_string())
         );
     }
 

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -2862,6 +2862,52 @@ impl SharedPmemDeviceMetricsRegistry {
         })
     }
 
+    /// Builds a bounded registry by consuming already-validated owned IDs.
+    #[doc(hidden)]
+    pub fn from_owned_device_ids_with_capacity(
+        device_ids: Vec<String>,
+        capacity: usize,
+    ) -> Result<Self, PmemDeviceMetricsRegistryError> {
+        if device_ids.len() > capacity {
+            return Err(PmemDeviceMetricsRegistryError::Capacity);
+        }
+        let mut entries = Vec::new();
+        entries
+            .try_reserve_exact(capacity)
+            .map_err(|_| PmemDeviceMetricsRegistryError::Capacity)?;
+        let mut reservations = Vec::new();
+        reservations
+            .try_reserve_exact(capacity)
+            .map_err(|_| PmemDeviceMetricsRegistryError::Capacity)?;
+        for device_id in device_ids {
+            if entries
+                .iter()
+                .any(|entry: &PmemDeviceMetricsRegistryEntry| entry.device_id == device_id)
+            {
+                return Err(PmemDeviceMetricsRegistryError::DuplicateDevice);
+            }
+            let generation = u64::try_from(entries.len())
+                .map_err(|_| PmemDeviceMetricsRegistryError::GenerationExhausted)?;
+            entries.push(PmemDeviceMetricsRegistryEntry {
+                generation,
+                device_id,
+                metrics: SharedPmemDeviceMetrics::default(),
+                lease_claimed: false,
+            });
+        }
+        let next_generation = u64::try_from(entries.len())
+            .map_err(|_| PmemDeviceMetricsRegistryError::GenerationExhausted)?;
+        Ok(Self {
+            aggregate: SharedPmemDeviceMetrics::default(),
+            per_device: Arc::new(Mutex::new(PmemDeviceMetricsRegistryState {
+                entries,
+                reservations,
+                next_generation,
+                capacity,
+            })),
+        })
+    }
+
     pub fn prepare_device(
         &self,
         device_id: impl Into<String>,

--- a/crates/runtime/src/pmem.rs
+++ b/crates/runtime/src/pmem.rs
@@ -2350,6 +2350,12 @@ impl PmemConfigs {
         &self.configs
     }
 
+    /// Consumes the validated configuration set in canonical device order.
+    #[doc(hidden)]
+    pub fn into_vec(self) -> Vec<PmemConfig> {
+        self.configs
+    }
+
     pub(crate) fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.configs.try_reserve_exact(additional)
     }
@@ -4220,6 +4226,12 @@ impl PmemMmioLayout {
         self
     }
 
+    /// Computes one canonical device region without registering a handler.
+    pub fn region_at(self, index: usize) -> Result<MmioRegion, PmemMmioRegistrationError> {
+        self.validate()?;
+        self.placement(index).map(|placement| placement.region)
+    }
+
     fn validate(self) -> Result<(), PmemMmioRegistrationError> {
         if self.address_stride < VIRTIO_MMIO_DEVICE_WINDOW_SIZE {
             return Err(PmemMmioRegistrationError::AddressStrideTooSmall {
@@ -4303,6 +4315,27 @@ pub struct PmemMmioDeviceRegistration {
 }
 
 impl PmemMmioDeviceRegistration {
+    /// Reconstructs registration metadata for an already installed retained
+    /// MMIO handler and mapped pmem owner.
+    #[doc(hidden)]
+    pub fn from_restored(
+        index: usize,
+        pmem_id: String,
+        region: MmioRegion,
+        guest_range: GuestMemoryRange,
+        file_len: u64,
+        config_space: VirtioPmemConfigSpace,
+    ) -> Self {
+        Self {
+            index,
+            pmem_id,
+            region,
+            guest_range,
+            file_len,
+            config_space,
+        }
+    }
+
     pub const fn index(&self) -> usize {
         self.index
     }

--- a/crates/runtime/src/snapshot_device_v2.rs
+++ b/crates/runtime/src/snapshot_device_v2.rs
@@ -567,7 +567,10 @@ pub struct SnapshotV2MmioDeviceState {
 }
 
 impl SnapshotV2MmioDeviceState {
-    pub(crate) const fn from_parts(
+    /// Reassembles already-validated retained selectors and placement before
+    /// graph-wide validation.
+    #[doc(hidden)]
+    pub const fn from_parts(
         device_feature_select: u32,
         driver_feature_select: u32,
         queue_select: u32,
@@ -1649,8 +1652,16 @@ pub(crate) fn restore_mmio_transport_state(
     common: &SnapshotV2VirtioState,
     mmio: &SnapshotV2MmioDeviceState,
 ) -> Result<VirtioMmioTransportState, SnapshotV2RootTransportRestoreError> {
+    restore_mmio_transport_state_for_device(VIRTIO_BLOCK_DEVICE_ID, common, mmio)
+}
+
+pub(crate) fn restore_mmio_transport_state_for_device(
+    device_id: u32,
+    common: &SnapshotV2VirtioState,
+    mmio: &SnapshotV2MmioDeviceState,
+) -> Result<VirtioMmioTransportState, SnapshotV2RootTransportRestoreError> {
     let device = VirtioMmioDeviceRegisters::with_vendor_id_and_config_generation(
-        VIRTIO_BLOCK_DEVICE_ID,
+        device_id,
         VIRTIO_MMIO_VENDOR_ID,
         common.available_features(),
         common.config_generation(),

--- a/crates/runtime/src/snapshot_device_v2_6.rs
+++ b/crates/runtime/src/snapshot_device_v2_6.rs
@@ -38,7 +38,10 @@ mod restore;
 pub use restore::{
     PreparedSnapshotV2PmemRecord, PreparedSnapshotV2PmemRecordParts,
     PreparedSnapshotV2StorageBundle, PreparedSnapshotV2StorageBundleParts,
-    SnapshotV2StorageBundleError, SnapshotV2StorageCleanupError, SnapshotV2StorageRestorePlan,
+    PreparedSnapshotV2StorageMmioBundle, PreparedSnapshotV2StorageMmioBundleParts,
+    PreparedSnapshotV2StorageMmioPmemRecord, PreparedSnapshotV2StorageMmioPmemRecordParts,
+    SnapshotV2StorageBundleError, SnapshotV2StorageCleanupError,
+    SnapshotV2StorageMmioTransportError, SnapshotV2StorageRestorePlan,
     SnapshotV2StorageRestorePlanError,
 };
 

--- a/crates/runtime/src/snapshot_device_v2_6/restore.rs
+++ b/crates/runtime/src/snapshot_device_v2_6/restore.rs
@@ -7,18 +7,28 @@ use super::*;
 
 use crate::block::async_executor::BlockAsyncRuntimeError;
 use crate::block::{BlockFileBacking, DriveConfigs};
+use crate::interrupt::GuestInterruptLine;
 use crate::memory::{GuestMemory, GuestMemoryRange};
+use crate::mmio::MmioRegion;
 use crate::pmem::{
     PmemConfigInput, PmemConfigs, PmemFileBacking, PreparedPmemDevice,
-    PreparedSnapshotPmemDeviceError, PreparedSnapshotPmemDeviceParts, VirtioPmemDevice,
-    VirtioPmemRateLimiterState, VirtioPmemTokenBucketState,
+    PreparedSnapshotPmemDeviceError, PreparedSnapshotPmemDeviceParts, VIRTIO_PMEM_DEVICE_ID,
+    VIRTIO_PMEM_QUEUE_SIZES, VirtioPmemDevice, VirtioPmemMmioHandler, VirtioPmemRateLimiterState,
+    VirtioPmemTokenBucketState,
+};
+use crate::snapshot_device_v2::{
+    SnapshotV2RootTransportRestoreError, restore_mmio_transport_state_for_device,
 };
 use crate::snapshot_device_v2_5::{
-    PreparedSnapshotV2MultiBlockBundle, SnapshotV2MultiBlockBundleError,
-    SnapshotV2MultiBlockCleanupError, SnapshotV2MultiBlockDeviceGraph,
+    PreparedSnapshotV2MultiBlockBundle, PreparedSnapshotV2MultiBlockMmioBundle,
+    SnapshotV2MultiBlockBundleError, SnapshotV2MultiBlockCleanupError,
+    SnapshotV2MultiBlockDeviceGraph, SnapshotV2MultiBlockMmioTransportError,
     SnapshotV2MultiBlockRestorePlan, SnapshotV2MultiBlockRestorePlanError,
 };
-use crate::virtio_mmio::VirtioMmioQueueState;
+use crate::virtio_mmio::{
+    VirtioMmioQueueState, VirtioMmioRegisterHandler, VirtioMmioRegisterHandlerError,
+    VirtioMmioTransportStateError,
+};
 
 /// Complete pure destination proof for one detached profile-3 graph.
 pub struct SnapshotV2StorageRestorePlan {
@@ -538,6 +548,94 @@ impl fmt::Debug for PreparedSnapshotV2PmemRecord {
     }
 }
 
+/// One exact profile-3 pmem MMIO handler and its still-unpublished mapping
+/// owner.
+pub struct PreparedSnapshotV2StorageMmioPmemRecord {
+    key: SnapshotV2DeviceKey,
+    is_root: bool,
+    retry: StorageRetryState,
+    retry_deadline: Option<Instant>,
+    region: MmioRegion,
+    interrupt_line: GuestInterruptLine,
+    prepared_device: PreparedPmemDevice,
+    handler: VirtioPmemMmioHandler,
+}
+
+/// Consumed exact pmem MMIO metadata, mapping owner, and handler.
+pub type PreparedSnapshotV2StorageMmioPmemRecordParts = (
+    SnapshotV2DeviceKey,
+    bool,
+    StorageRetryState,
+    Option<Instant>,
+    MmioRegion,
+    GuestInterruptLine,
+    PreparedPmemDevice,
+    VirtioPmemMmioHandler,
+);
+
+impl PreparedSnapshotV2StorageMmioPmemRecord {
+    pub const fn key(&self) -> SnapshotV2DeviceKey {
+        self.key
+    }
+
+    pub fn pmem_id(&self) -> &str {
+        self.prepared_device.id()
+    }
+
+    pub const fn is_root_device(&self) -> bool {
+        self.is_root
+    }
+
+    pub const fn retry(&self) -> StorageRetryState {
+        self.retry
+    }
+
+    pub const fn retry_deadline(&self) -> Option<Instant> {
+        self.retry_deadline
+    }
+
+    pub const fn region(&self) -> MmioRegion {
+        self.region
+    }
+
+    pub const fn interrupt_line(&self) -> GuestInterruptLine {
+        self.interrupt_line
+    }
+
+    pub const fn prepared_device(&self) -> &PreparedPmemDevice {
+        &self.prepared_device
+    }
+
+    /// Borrows the reconstructed but still-unpublished MMIO handler.
+    #[doc(hidden)]
+    pub const fn handler(&self) -> &VirtioPmemMmioHandler {
+        &self.handler
+    }
+
+    /// Consumes the unpublished handler and authoritative mapping owner.
+    pub fn into_parts(self) -> PreparedSnapshotV2StorageMmioPmemRecordParts {
+        (
+            self.key,
+            self.is_root,
+            self.retry,
+            self.retry_deadline,
+            self.region,
+            self.interrupt_line,
+            self.prepared_device,
+            self.handler,
+        )
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2StorageMmioPmemRecord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2StorageMmioPmemRecord")
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
 /// Canonical move-only pathless profile-3 block-and-pmem vector.
 pub struct PreparedSnapshotV2StorageBundle {
     root_key: Option<SnapshotV2DeviceKey>,
@@ -577,6 +675,134 @@ impl PreparedSnapshotV2StorageBundle {
         &self.pmem_records
     }
 
+    /// Reconstructs every exact MMIO handler without publishing a bus or
+    /// registering a pmem mapping with a hypervisor.
+    pub fn prepare_mmio_transport(
+        self,
+    ) -> Result<PreparedSnapshotV2StorageMmioBundle, SnapshotV2StorageMmioTransportError> {
+        self.prepare_mmio_transport_with_reserve(&mut SystemRestoreReserve)
+    }
+
+    fn prepare_mmio_transport_with_reserve(
+        mut self,
+        reserve: &mut impl StorageRestoreReserve,
+    ) -> Result<PreparedSnapshotV2StorageMmioBundle, SnapshotV2StorageMmioTransportError> {
+        if self.transport_kind != SnapshotV2DeviceTransportKind::Mmio {
+            return Err(
+                self.mmio_transport_error(SnapshotV2StorageMmioTransportErrorKind::TransportPolicy)
+            );
+        }
+
+        let block = match self.block.take() {
+            Some(block) => match block.prepare_mmio_transport() {
+                Ok(block) => Some(block),
+                Err(source) => {
+                    return Err(SnapshotV2StorageMmioTransportError::new(
+                        SnapshotV2StorageMmioTransportErrorKind::Block(source),
+                        None,
+                    ));
+                }
+            },
+            None => None,
+        };
+
+        let mut prepared_pmem = Vec::new();
+        if reserve
+            .reserve_vec(&mut prepared_pmem, self.pmem_records.len())
+            .is_err()
+        {
+            return Err(storage_mmio_transport_error_after_block(
+                SnapshotV2StorageMmioTransportErrorKind::Allocation,
+                block,
+            ));
+        }
+
+        let root_key = self.root_key;
+        let pmem_configs = std::mem::take(&mut self.pmem_configs);
+        let records = std::mem::take(&mut self.pmem_records);
+        for record in records {
+            let (
+                key,
+                is_root,
+                _queue_ranges,
+                retry,
+                retry_deadline,
+                virtio,
+                transport,
+                prepared_device,
+                device,
+            ) = record.into_parts();
+            let SnapshotV2DeviceTransport::Mmio(mmio) = transport else {
+                release_storage_mmio_pmem_records(&mut prepared_pmem);
+                drop(prepared_device);
+                return Err(storage_mmio_transport_error_after_block(
+                    SnapshotV2StorageMmioTransportErrorKind::TransportPolicy,
+                    block,
+                ));
+            };
+            let retained = match restore_mmio_transport_state_for_device(
+                VIRTIO_PMEM_DEVICE_ID,
+                &virtio,
+                &mmio,
+            ) {
+                Ok(retained) => retained,
+                Err(source) => {
+                    release_storage_mmio_pmem_records(&mut prepared_pmem);
+                    drop(prepared_device);
+                    return Err(storage_mmio_transport_error_after_block(
+                        SnapshotV2StorageMmioTransportErrorKind::PmemState(source),
+                        block,
+                    ));
+                }
+            };
+            let config_space = prepared_device.config_space();
+            let activation_is_active = device.is_activated();
+            let mut handler = match VirtioMmioRegisterHandler::with_device_config_and_activation(
+                VIRTIO_PMEM_DEVICE_ID,
+                config_space.available_features(),
+                &VIRTIO_PMEM_QUEUE_SIZES,
+                config_space,
+                device,
+            ) {
+                Ok(handler) => handler,
+                Err(source) => {
+                    release_storage_mmio_pmem_records(&mut prepared_pmem);
+                    drop(prepared_device);
+                    return Err(storage_mmio_transport_error_after_block(
+                        SnapshotV2StorageMmioTransportErrorKind::PmemHandler(source),
+                        block,
+                    ));
+                }
+            };
+            if let Err(source) = handler.restore_transport_state(&retained, activation_is_active) {
+                release_storage_mmio_pmem_records(&mut prepared_pmem);
+                drop(prepared_device);
+                drop(handler);
+                return Err(storage_mmio_transport_error_after_block(
+                    SnapshotV2StorageMmioTransportErrorKind::PmemTransport(source),
+                    block,
+                ));
+            }
+            prepared_pmem.push(PreparedSnapshotV2StorageMmioPmemRecord {
+                key,
+                is_root,
+                retry,
+                retry_deadline,
+                region: mmio.region(),
+                interrupt_line: mmio.interrupt_line(),
+                prepared_device,
+                handler,
+            });
+        }
+
+        Ok(PreparedSnapshotV2StorageMmioBundle {
+            root_key,
+            block,
+            pmem_configs,
+            pmem_records: prepared_pmem,
+        })
+    }
+
     /// Transfers every detached storage owner to the transport layer.
     pub fn into_parts(mut self) -> PreparedSnapshotV2StorageBundleParts {
         (
@@ -596,6 +822,17 @@ impl PreparedSnapshotV2StorageBundle {
             .take()
             .map_or(Ok(()), PreparedSnapshotV2MultiBlockBundle::abort)
             .map_err(SnapshotV2StorageCleanupError::new)
+    }
+
+    fn mmio_transport_error(
+        self,
+        kind: SnapshotV2StorageMmioTransportErrorKind,
+    ) -> SnapshotV2StorageMmioTransportError {
+        let cleanup = self
+            .abort()
+            .err()
+            .map(SnapshotV2StorageCleanupError::into_source);
+        SnapshotV2StorageMmioTransportError::new(kind, cleanup)
     }
 }
 
@@ -620,6 +857,185 @@ impl fmt::Debug for PreparedSnapshotV2StorageBundle {
             .field("transport", &self.transport_kind)
             .field("state", &"<redacted>")
             .finish()
+    }
+}
+
+/// Move-only exact profile-3 MMIO storage product awaiting one private
+/// dispatcher and hypervisor mapping transaction.
+pub struct PreparedSnapshotV2StorageMmioBundle {
+    root_key: Option<SnapshotV2DeviceKey>,
+    block: Option<PreparedSnapshotV2MultiBlockMmioBundle>,
+    pmem_configs: PmemConfigs,
+    pmem_records: Vec<PreparedSnapshotV2StorageMmioPmemRecord>,
+}
+
+/// Consumed exact MMIO storage bundle parts.
+pub type PreparedSnapshotV2StorageMmioBundleParts = (
+    Option<SnapshotV2DeviceKey>,
+    Option<PreparedSnapshotV2MultiBlockMmioBundle>,
+    PmemConfigs,
+    Vec<PreparedSnapshotV2StorageMmioPmemRecord>,
+);
+
+impl PreparedSnapshotV2StorageMmioBundle {
+    pub const fn root_key(&self) -> Option<SnapshotV2DeviceKey> {
+        self.root_key
+    }
+
+    pub const fn block_bundle(&self) -> Option<&PreparedSnapshotV2MultiBlockMmioBundle> {
+        self.block.as_ref()
+    }
+
+    pub const fn pmem_configs(&self) -> &PmemConfigs {
+        &self.pmem_configs
+    }
+
+    pub fn pmem_records(&self) -> &[PreparedSnapshotV2StorageMmioPmemRecord] {
+        &self.pmem_records
+    }
+
+    pub fn into_parts(mut self) -> PreparedSnapshotV2StorageMmioBundleParts {
+        (
+            self.root_key,
+            self.block.take(),
+            std::mem::take(&mut self.pmem_configs),
+            std::mem::take(&mut self.pmem_records),
+        )
+    }
+
+    pub fn abort(mut self) -> Result<(), SnapshotV2StorageCleanupError> {
+        release_storage_mmio_pmem_records(&mut self.pmem_records);
+        self.block
+            .take()
+            .map_or(Ok(()), PreparedSnapshotV2MultiBlockMmioBundle::abort)
+            .map_err(SnapshotV2StorageCleanupError::new)
+    }
+}
+
+impl Drop for PreparedSnapshotV2StorageMmioBundle {
+    fn drop(&mut self) {
+        release_storage_mmio_pmem_records(&mut self.pmem_records);
+        if let Some(block) = self.block.take() {
+            let _ = block.abort();
+        }
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2StorageMmioBundle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2StorageMmioBundle")
+            .field(
+                "block_count",
+                &self
+                    .block
+                    .as_ref()
+                    .map_or(0, |bundle| bundle.records().len()),
+            )
+            .field("pmem_count", &self.pmem_records.len())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+enum SnapshotV2StorageMmioTransportErrorKind {
+    TransportPolicy,
+    Allocation,
+    Block(SnapshotV2MultiBlockMmioTransportError),
+    PmemState(SnapshotV2RootTransportRestoreError),
+    PmemHandler(VirtioMmioRegisterHandlerError),
+    PmemTransport(VirtioMmioTransportStateError),
+}
+
+/// Redacted failure while consuming profile-3 storage owners into exact MMIO
+/// handlers.
+pub struct SnapshotV2StorageMmioTransportError {
+    kind: Box<SnapshotV2StorageMmioTransportErrorKind>,
+    cleanup: Option<SnapshotV2MultiBlockCleanupError>,
+}
+
+impl SnapshotV2StorageMmioTransportError {
+    fn new(
+        kind: SnapshotV2StorageMmioTransportErrorKind,
+        cleanup: Option<SnapshotV2MultiBlockCleanupError>,
+    ) -> Self {
+        Self {
+            kind: Box::new(kind),
+            cleanup,
+        }
+    }
+
+    pub fn cleanup_failed(&self) -> bool {
+        self.cleanup.is_some()
+            || matches!(
+                self.kind.as_ref(),
+                SnapshotV2StorageMmioTransportErrorKind::Block(source)
+                    if source.cleanup_failed()
+            )
+    }
+}
+
+impl fmt::Debug for SnapshotV2StorageMmioTransportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self.kind.as_ref() {
+            SnapshotV2StorageMmioTransportErrorKind::TransportPolicy => "transport-policy",
+            SnapshotV2StorageMmioTransportErrorKind::Allocation => "allocation",
+            SnapshotV2StorageMmioTransportErrorKind::Block(_) => "block",
+            SnapshotV2StorageMmioTransportErrorKind::PmemState(_) => "pmem-state",
+            SnapshotV2StorageMmioTransportErrorKind::PmemHandler(_) => "pmem-handler",
+            SnapshotV2StorageMmioTransportErrorKind::PmemTransport(_) => "pmem-transport",
+        };
+        formatter
+            .debug_struct("SnapshotV2StorageMmioTransportError")
+            .field("kind", &kind)
+            .field("cleanup_failed", &self.cleanup_failed())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotV2StorageMmioTransportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self.kind.as_ref() {
+            SnapshotV2StorageMmioTransportErrorKind::TransportPolicy => {
+                "snapshot storage MMIO transport policy is invalid"
+            }
+            SnapshotV2StorageMmioTransportErrorKind::Allocation => {
+                "snapshot storage MMIO transport allocation failed"
+            }
+            SnapshotV2StorageMmioTransportErrorKind::Block(_) => {
+                "snapshot storage block MMIO reconstruction failed"
+            }
+            SnapshotV2StorageMmioTransportErrorKind::PmemState(_) => {
+                "snapshot storage pmem MMIO retained state is invalid"
+            }
+            SnapshotV2StorageMmioTransportErrorKind::PmemHandler(_) => {
+                "snapshot storage pmem MMIO handler construction failed"
+            }
+            SnapshotV2StorageMmioTransportErrorKind::PmemTransport(_) => {
+                "snapshot storage pmem MMIO transport reconstruction failed"
+            }
+        })?;
+        if self.cleanup_failed() {
+            formatter.write_str("; cleanup also failed")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for SnapshotV2StorageMmioTransportError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self.kind.as_ref() {
+            SnapshotV2StorageMmioTransportErrorKind::Block(source) => Some(source),
+            SnapshotV2StorageMmioTransportErrorKind::PmemState(source) => Some(source),
+            SnapshotV2StorageMmioTransportErrorKind::PmemHandler(source) => Some(source),
+            SnapshotV2StorageMmioTransportErrorKind::PmemTransport(source) => Some(source),
+            SnapshotV2StorageMmioTransportErrorKind::TransportPolicy
+            | SnapshotV2StorageMmioTransportErrorKind::Allocation => self
+                .cleanup
+                .as_ref()
+                .map(|source| source as &(dyn std::error::Error + 'static)),
+        }
     }
 }
 
@@ -808,6 +1224,10 @@ impl SnapshotV2StorageCleanupError {
     const fn new(source: SnapshotV2MultiBlockCleanupError) -> Self {
         Self { source }
     }
+
+    fn into_source(self) -> SnapshotV2MultiBlockCleanupError {
+        self.source
+    }
 }
 
 impl fmt::Debug for SnapshotV2StorageCleanupError {
@@ -955,8 +1375,30 @@ pub(super) fn prepare_backings_with_pmem_fault_for_test(
     )
 }
 
+#[cfg(test)]
+pub(super) fn prepare_mmio_transport_with_failing_reserve_for_test(
+    bundle: PreparedSnapshotV2StorageBundle,
+) -> Result<PreparedSnapshotV2StorageMmioBundle, SnapshotV2StorageMmioTransportError> {
+    bundle.prepare_mmio_transport_with_reserve(&mut FailingStorageRestoreReserve::new(0))
+}
+
 fn release_pmem_records(records: &mut Vec<PreparedSnapshotV2PmemRecord>) {
     while records.pop().is_some() {}
+}
+
+fn release_storage_mmio_pmem_records(records: &mut Vec<PreparedSnapshotV2StorageMmioPmemRecord>) {
+    while records.pop().is_some() {}
+}
+
+fn storage_mmio_transport_error_after_block(
+    kind: SnapshotV2StorageMmioTransportErrorKind,
+    block: Option<PreparedSnapshotV2MultiBlockMmioBundle>,
+) -> SnapshotV2StorageMmioTransportError {
+    let cleanup = block
+        .map(PreparedSnapshotV2MultiBlockMmioBundle::abort)
+        .transpose()
+        .err();
+    SnapshotV2StorageMmioTransportError::new(kind, cleanup)
 }
 
 fn abort_block_bundle(

--- a/crates/runtime/src/snapshot_device_v2_6/tests.rs
+++ b/crates/runtime/src/snapshot_device_v2_6/tests.rs
@@ -697,6 +697,139 @@ fn later_pmem_construction_fault_releases_the_prepared_prefix_and_allows_retry()
 }
 
 #[test]
+fn mmio_handoff_preserves_exact_pmem_transport_semantics_and_storage_order() {
+    for (blocks, pmems, root) in [
+        (1, 0, Some(DEVICE_KIND_BLOCK)),
+        (0, 1, Some(DEVICE_KIND_PMEM)),
+        (1, 1, Some(DEVICE_KIND_BLOCK)),
+        (0, 1, None),
+    ] {
+        let graph = fixture_graph(SnapshotV2DeviceTransportKind::Mmio, blocks, pmems, root);
+        let expected = graph.clone();
+        let memory = restore_memory_for(&graph);
+        let now = Instant::now();
+        let (_files, block_backings, pmem_backings) = restore_backings(&graph);
+        let bundle = SnapshotV2StorageRestorePlan::prepare(graph, &memory, now)
+            .expect("MMIO handoff plan should prepare")
+            .prepare_backings(block_backings, pmem_backings, || false)
+            .expect("MMIO handoff bundle should prepare");
+
+        let mmio = bundle
+            .prepare_mmio_transport()
+            .expect("MMIO handoff should reconstruct");
+        assert_eq!(mmio.root_key(), expected.root_key());
+        assert_eq!(
+            mmio.block_bundle()
+                .map_or(0, |bundle| bundle.records().len()),
+            blocks
+        );
+        assert_eq!(mmio.pmem_records().len(), pmems);
+        assert_eq!(mmio.pmem_configs().as_slice().len(), pmems);
+        for (record, expected) in mmio.pmem_records().iter().zip(expected.pmem_records()) {
+            let SnapshotV2DeviceTransport::Mmio(expected_mmio) = expected.transport() else {
+                panic!("fixture pmem transport should be MMIO");
+            };
+            let expected_transport =
+                crate::snapshot_device_v2::restore_mmio_transport_state_for_device(
+                    crate::pmem::VIRTIO_PMEM_DEVICE_ID,
+                    expected.virtio(),
+                    expected_mmio,
+                )
+                .expect("fixture retained transport should restore");
+            assert_eq!(record.key(), expected.key());
+            assert_eq!(record.pmem_id(), expected.config().pmem_id());
+            assert_eq!(record.is_root_device(), expected.is_root());
+            assert_eq!(record.retry(), expected.pmem().retry());
+            assert_eq!(
+                record.retry_deadline(),
+                Some(now + Duration::from_nanos(99))
+            );
+            assert_eq!(record.region(), expected_mmio.region());
+            assert_eq!(record.interrupt_line(), expected_mmio.interrupt_line());
+            assert_eq!(
+                record.prepared_device().guest_range(),
+                expected.pmem().guest_range()
+            );
+            assert_eq!(record.handler().transport_state(), expected_transport);
+            let recaptured = record
+                .handler()
+                .capture_pmem_device_state_at(
+                    expected.pmem().file_bytes(),
+                    expected.config().rate_limiter(),
+                    now,
+                )
+                .expect("reconstructed pmem handler should recapture");
+            assert_eq!(recaptured.active_queue(), expected.pmem().active_queue());
+            assert_eq!(
+                recaptured.pending_rate_limited_queue(),
+                expected.pmem().pending_rate_limited_queue()
+            );
+            assert_eq!(
+                recaptured.rate_limiter().bandwidth().map(|bucket| (
+                    bucket.budget(),
+                    bucket.remaining_burst(),
+                    bucket.age_nanos(),
+                )),
+                expected.pmem().limiter().bandwidth().map(|bucket| (
+                    bucket.budget(),
+                    bucket.remaining_burst(),
+                    bucket.age_nanos(),
+                ))
+            );
+        }
+        let debug = format!("{mmio:?}");
+        for secret in ["pmem-selector", "root=", "PARTUUID"] {
+            assert!(!debug.contains(secret));
+        }
+        mmio.abort()
+            .expect("MMIO handoff should release every unpublished owner");
+    }
+}
+
+#[test]
+fn mmio_handoff_rejects_pci_and_allocation_faults_with_clean_owner_release() {
+    let pci = fixture_graph(SnapshotV2DeviceTransportKind::Pci, 0, 1, None);
+    let memory = restore_memory_for(&pci);
+    let (_files, blocks, pmems) = restore_backings(&pci);
+    let bundle = SnapshotV2StorageRestorePlan::prepare(pci, &memory, Instant::now())
+        .expect("PCI rejection plan should prepare")
+        .prepare_backings(blocks, pmems, || false)
+        .expect("PCI rejection bundle should prepare");
+    let error = bundle
+        .prepare_mmio_transport()
+        .expect_err("PCI storage must not fall back to MMIO");
+    assert!(!error.cleanup_failed());
+
+    let graph = fixture_graph(
+        SnapshotV2DeviceTransportKind::Mmio,
+        2,
+        1,
+        Some(DEVICE_KIND_BLOCK),
+    );
+    let memory = restore_memory_for(&graph);
+    let (_files, blocks, pmems) = restore_backings(&graph);
+    let bundle = SnapshotV2StorageRestorePlan::prepare(graph, &memory, Instant::now())
+        .expect("allocation handoff plan should prepare")
+        .prepare_backings(blocks, pmems, || false)
+        .expect("allocation handoff bundle should prepare");
+    let async_runtime = bundle
+        .block_bundle()
+        .and_then(|bundle| bundle.async_runtime())
+        .cloned();
+    let error = super::restore::prepare_mmio_transport_with_failing_reserve_for_test(bundle)
+        .expect_err("pmem MMIO record reservation should fail explicitly");
+    assert!(!error.cleanup_failed());
+    if let Some(runtime) = async_runtime {
+        assert_eq!(
+            runtime
+                .generation_count()
+                .expect("Async runtime should remain observable"),
+            0
+        );
+    }
+}
+
+#[test]
 fn profile_identity_is_exact_distinct_and_bounded() {
     assert_eq!(
         NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -514,7 +514,8 @@ if contains native_v2_process "${selected_tests[@]}"; then
   for signed_snapshot_test in \
     vmm::tests::signed_native_v1_public_dispatch_restores_frozen_file_pair \
     vmm::tests::signed_native_v2_process_publishes_recaptures_and_resumes_private_pair \
-    vmm::tests::signed_native_v2_root_process_commits_complete_mmio_and_pci_owners_atomically; do
+    vmm::tests::signed_native_v2_root_process_commits_complete_mmio_and_pci_owners_atomically \
+    vmm::tests::signed_native_v2_storage_destination_stays_private_and_paused_through_commit; do
     if [[ "${#test_args[@]}" -eq 0 ]]; then
       "$native_v2_process_bin" \
         --test-threads=1 \


### PR DESCRIPTION
## Summary

- reconstruct exact native-v2.6 block and pmem snapshot owners as one ordered
  MMIO storage product
- map pmem backings before handler reachability, then publish metrics, retry
  schedulers, FDT state, and the paused private process transaction atomically
- preserve rooted/rootless placement, queue and limiter state, cleanup evidence,
  and pathless backing ownership across rollback, retry, shutdown, and recapture
- add host-free matrix/fault coverage plus signed lifecycle, guest-write, and
  private process-composition tests

## Scope exclusions

- PCI reconstruction and public exact-v2.6 activation remain follow-up work
- snapshot format selection, artifact classification, API routing, and the
  already activated exact-v2.5 path are unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh` (without `--allow-unsupported`; 343 signed
  test executions passed)

Closes #1631

Parent delivery issue: #1534
