### PR TITLE
feat: restore snapshot pmem owners over PCI

### DIFF
--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -45,7 +45,8 @@ use bangbang_hvf::{
     HvfSnapshotV2MultiBlockState, HvfSnapshotV2NativePath, HvfSnapshotV2PlatformRestoreError,
     HvfSnapshotV2PlatformState, HvfSnapshotV2RootProcessConfig, HvfSnapshotV2RootResourcePlan,
     HvfSnapshotV2RootRestoreError, HvfSnapshotV2State, HvfSnapshotV2StorageMmioPlatformPlan,
-    HvfSnapshotV2StorageMmioRestoreError, HvfVcpuRunControl, HvfVcpuRunCoordinatorError,
+    HvfSnapshotV2StorageMmioRestoreError, HvfSnapshotV2StoragePciPlatformPlan,
+    HvfSnapshotV2StoragePciRestoreError, HvfVcpuRunControl, HvfVcpuRunCoordinatorError,
     HvfVcpuRunStepOutcome, OwnedHvfArm64BootSession, PrepareHvfSnapshotV1LoadError,
     PrepareHvfSnapshotV2MultiBlockPlatformPlanError, PrepareHvfSnapshotV2RootPlanError,
     PreparedHvfArm64BootPciNetworkRemoval, PreparedHvfSnapshotV1Load, PreparedHvfSnapshotV1State,
@@ -7252,6 +7253,13 @@ impl HvfSnapshotV2RestoreDisposition for HvfSnapshotV2StorageMmioRestoreError {
 }
 
 #[cfg(target_os = "macos")]
+impl HvfSnapshotV2RestoreDisposition for HvfSnapshotV2StoragePciRestoreError {
+    fn is_terminal(&self) -> bool {
+        self.is_terminal()
+    }
+}
+
+#[cfg(target_os = "macos")]
 enum HvfSnapshotV2ProcessConstructionError<E> {
     Restore(E),
     RunReady {
@@ -7650,10 +7658,10 @@ impl fmt::Display for PreparedHvfSnapshotV2StorageControllerError {
 impl std::error::Error for PreparedHvfSnapshotV2StorageControllerError {}
 
 #[cfg(target_os = "macos")]
-enum PrepareHvfSnapshotV2StorageDestinationError {
+enum PrepareHvfSnapshotV2StorageDestinationError<E> {
     Construction(
         PreparedSnapshotV2StorageDestinationConstructionError<
-            HvfSnapshotV2ProcessConstructionError<HvfSnapshotV2StorageMmioRestoreError>,
+            HvfSnapshotV2ProcessConstructionError<E>,
         >,
     ),
     Commit(
@@ -7665,7 +7673,10 @@ enum PrepareHvfSnapshotV2StorageDestinationError {
 }
 
 #[cfg(target_os = "macos")]
-impl PrepareHvfSnapshotV2StorageDestinationError {
+impl<E> PrepareHvfSnapshotV2StorageDestinationError<E>
+where
+    E: HvfSnapshotV2RestoreDisposition,
+{
     fn is_terminal(&self) -> bool {
         match self {
             Self::Construction(source) => {
@@ -7684,7 +7695,10 @@ impl PrepareHvfSnapshotV2StorageDestinationError {
 }
 
 #[cfg(target_os = "macos")]
-impl fmt::Debug for PrepareHvfSnapshotV2StorageDestinationError {
+impl<E> fmt::Debug for PrepareHvfSnapshotV2StorageDestinationError<E>
+where
+    E: HvfSnapshotV2RestoreDisposition,
+{
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         let stage = match self {
             Self::Construction(_) => "construction",
@@ -7700,7 +7714,10 @@ impl fmt::Debug for PrepareHvfSnapshotV2StorageDestinationError {
 }
 
 #[cfg(target_os = "macos")]
-impl fmt::Display for PrepareHvfSnapshotV2StorageDestinationError {
+impl<E> fmt::Display for PrepareHvfSnapshotV2StorageDestinationError<E>
+where
+    E: HvfSnapshotV2RestoreDisposition,
+{
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             formatter,
@@ -7715,7 +7732,10 @@ impl fmt::Display for PrepareHvfSnapshotV2StorageDestinationError {
 }
 
 #[cfg(target_os = "macos")]
-impl std::error::Error for PrepareHvfSnapshotV2StorageDestinationError {
+impl<E> std::error::Error for PrepareHvfSnapshotV2StorageDestinationError<E>
+where
+    E: HvfSnapshotV2RestoreDisposition + std::error::Error + 'static,
+{
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Construction(source) => Some(source),
@@ -7763,7 +7783,7 @@ fn prepare_hvf_native_v2_storage_mmio_destination(
         PreparedHvfSnapshotV2StorageControllerProjection,
         SharedSerialOutput,
     ),
-    PrepareHvfSnapshotV2StorageDestinationError,
+    PrepareHvfSnapshotV2StorageDestinationError<HvfSnapshotV2StorageMmioRestoreError>,
 > {
     let PrepareHvfSnapshotV2StorageMmioDestinationInput {
         platform,
@@ -7783,6 +7803,125 @@ fn prepare_hvf_native_v2_storage_mmio_destination(
     let destination = bundle
         .construct_destination(|bundle| {
             let owners = OwnedHvfArm64BootSession::restore_snapshot_v2_storage_mmio(
+                platform,
+                memory,
+                process_shell,
+                bundle,
+                plan,
+            )
+            .map_err(HvfSnapshotV2ProcessConstructionError::Restore)?;
+            let (mut session, configs) = owners.into_parts();
+            if let Err(source) = session.resume_after_snapshot_v2_capture() {
+                let cleanup = session
+                    .shutdown()
+                    .err()
+                    .map(|source| BackendError::Hypervisor(source.to_string()));
+                return Err(HvfSnapshotV2ProcessConstructionError::RunReady { source, cleanup });
+            }
+            let process_session = ProcessHvfBootSession::new_with_vmnet_authority(
+                session,
+                packet_io,
+                mmds_metrics,
+                vmnet_authority,
+            );
+            let supervisor = match HvfBootRunLoopSupervisor::start_paused(
+                process_session,
+                default_hvf_boot_run_loop_step_limit(),
+            ) {
+                Ok(supervisor) => supervisor,
+                Err(error) => {
+                    let (source, mut failed_session) = error.into_parts();
+                    let cleanup = failed_session
+                        .session
+                        .shutdown()
+                        .err()
+                        .map(|source| BackendError::Hypervisor(source.to_string()));
+                    return Err(HvfSnapshotV2ProcessConstructionError::WorkerStart {
+                        source,
+                        cleanup,
+                    });
+                }
+            };
+            Ok(PreparedHvfSnapshotV2StorageDestination {
+                session: Box::new(HvfProcessSession::Boot(supervisor)),
+                configs: Some(configs),
+                serial_output,
+            })
+        })
+        .map_err(PrepareHvfSnapshotV2StorageDestinationError::Construction)?;
+    let (destination, controller) = destination
+        .commit(
+            |destination| {
+                if !cancellation.try_seal_commit() {
+                    return Err((
+                        destination,
+                        PreparedHvfSnapshotV2StorageControllerError::Cancelled,
+                    ));
+                }
+                destination.prepare_controller(machine, boot, resume_requested)
+            },
+            PreparedHvfSnapshotV2StorageDestination::shutdown,
+        )
+        .map_err(PrepareHvfSnapshotV2StorageDestinationError::Commit)?;
+    let (session, serial_output) = destination.into_parts();
+    Ok((session, controller, serial_output))
+}
+
+#[cfg(target_os = "macos")]
+#[allow(
+    dead_code,
+    reason = "exact-2.6 process restore remains private until the public activation slice"
+)]
+struct PrepareHvfSnapshotV2StoragePciDestinationInput {
+    platform: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    process_shell: HvfSnapshotV2DefaultProcessShell,
+    packet_io: ProcessNetworkPacketIoProvider,
+    mmds_metrics: Option<SharedMmdsMetrics>,
+    vmnet_authority: ProcessVmnetAuthority,
+    serial_output: SharedSerialOutput,
+    bundle: PreparedSnapshotV2StorageRestoreBundle,
+    plan: HvfSnapshotV2StoragePciPlatformPlan,
+    machine: bangbang_runtime::machine::MachineConfig,
+    boot: bangbang_runtime::boot::BootSourceConfig,
+    resume_requested: bool,
+    cancellation: NativeV2SnapshotCaptureCancellation,
+}
+
+/// Builds one complete exact-2.6 PCI worker behind the private Paused gate.
+#[cfg(target_os = "macos")]
+#[allow(
+    dead_code,
+    reason = "exact-2.6 process restore remains private until the public activation slice"
+)]
+fn prepare_hvf_native_v2_storage_pci_destination(
+    input: PrepareHvfSnapshotV2StoragePciDestinationInput,
+) -> Result<
+    (
+        HvfProcessSession,
+        PreparedHvfSnapshotV2StorageControllerProjection,
+        SharedSerialOutput,
+    ),
+    PrepareHvfSnapshotV2StorageDestinationError<HvfSnapshotV2StoragePciRestoreError>,
+> {
+    let PrepareHvfSnapshotV2StoragePciDestinationInput {
+        platform,
+        memory,
+        process_shell,
+        packet_io,
+        mmds_metrics,
+        vmnet_authority,
+        serial_output,
+        bundle,
+        plan,
+        machine,
+        boot,
+        resume_requested,
+        cancellation,
+    } = input;
+    let destination = bundle
+        .construct_destination(|bundle| {
+            let owners = OwnedHvfArm64BootSession::restore_snapshot_v2_storage_pci(
                 platform,
                 memory,
                 process_shell,
@@ -30191,247 +30330,328 @@ mod tests {
             .copy_from_slice(&(ARM64_IMAGE_HEADER_SIZE as u64).to_le_bytes());
         image[ARM64_IMAGE_MAGIC_OFFSET..ARM64_IMAGE_MAGIC_OFFSET + 4]
             .copy_from_slice(&ARM64_IMAGE_MAGIC.to_le_bytes());
-        let kernel = TempFilePath::create_with_bytes("signed-native-v2-storage-kernel", &image);
-        let root = TempFilePath::create_with_bytes("signed-native-v2-storage-root", &[0_u8; 4096]);
-        let pmem = TempFilePath::create_with_bytes(
-            "signed-native-v2-storage-pmem",
-            &vec![
-                0_u8;
-                usize::try_from(VIRTIO_PMEM_ALIGNMENT).expect("pmem alignment should fit usize")
-            ],
-        );
 
-        let mut source_controller =
-            VmmController::new("native-v2-storage-source", "0.1.0", "bangbang");
-        source_controller
-            .handle_action(VmmAction::PutMachineConfig(MachineConfigInput::new(1, 16)))
-            .expect("storage source machine should configure");
-        source_controller
-            .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
-                kernel.path(),
-            )))
-            .expect("storage source boot metadata should configure");
-        source_controller
-            .handle_action(VmmAction::PutDrive(
-                DriveConfigInput::new("rootfs", "rootfs", root.path(), true)
-                    .with_is_read_only(true)
-                    .with_io_engine(DriveIoEngine::Sync),
-            ))
-            .expect("storage source block root should configure");
-        source_controller
-            .handle_action(VmmAction::PutPmem(PmemConfigInput::new(
-                "pmem0",
-                pmem.path().to_string_lossy().into_owned(),
-            )))
-            .expect("storage source pmem should configure");
+        for (case, pci_enabled) in [("mmio", false), ("pci", true)] {
+            let kernel = TempFilePath::create_with_bytes(
+                &format!("signed-native-v2-storage-{case}-kernel"),
+                &image,
+            );
+            let root = TempFilePath::create_with_bytes(
+                &format!("signed-native-v2-storage-{case}-root"),
+                &[0_u8; 4096],
+            );
+            let pmem = TempFilePath::create_with_bytes(
+                &format!("signed-native-v2-storage-{case}-pmem"),
+                &vec![
+                    0_u8;
+                    usize::try_from(VIRTIO_PMEM_ALIGNMENT)
+                        .expect("pmem alignment should fit usize")
+                ],
+            );
 
-        let source_serial = SharedSerialOutput::from(SharedSerialOutputBuffer::default());
-        let mut source_session = super::OwnedHvfArm64BootSession::new(
-            &source_controller,
-            default_hvf_boot_session_config(source_serial),
-        )
-        .expect("signed exact-2.6 source should prepare");
-        let expected_configs = CaptureReadyStorageConfigs::new(
-            source_controller.drive_configs().to_vec(),
-            source_controller.pmem_configs().to_vec(),
-        );
-        let capture_now = Instant::now();
-        let capture_guard = source_session
-            .quiesce_limiter_retry_wakeups()
-            .expect("storage source retry publishers should quiesce");
-        let graph = source_session
-            .capture_snapshot_v2_storage_device_graph_at(
-                &expected_configs,
-                &capture_guard,
-                capture_now,
+            let mut source_controller = VmmController::new(
+                format!("native-v2-storage-{case}-source"),
+                "0.1.0",
+                "bangbang",
+            );
+            source_controller
+                .handle_action(VmmAction::PutMachineConfig(MachineConfigInput::new(1, 16)))
+                .expect("storage source machine should configure");
+            source_controller
+                .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+                    kernel.path(),
+                )))
+                .expect("storage source boot metadata should configure");
+            source_controller
+                .handle_action(VmmAction::PutDrive(
+                    DriveConfigInput::new("rootfs", "rootfs", root.path(), true)
+                        .with_is_read_only(true)
+                        .with_io_engine(DriveIoEngine::Sync),
+                ))
+                .expect("storage source block root should configure");
+            source_controller
+                .handle_action(VmmAction::PutPmem(PmemConfigInput::new(
+                    "pmem0",
+                    pmem.path().to_string_lossy().into_owned(),
+                )))
+                .expect("storage source pmem should configure");
+
+            let source_serial = SharedSerialOutput::from(SharedSerialOutputBuffer::default());
+            let mut source_config = default_hvf_boot_session_config(source_serial);
+            if pci_enabled {
+                source_config = source_config.with_pci_enabled();
+            }
+            let mut source_session =
+                super::OwnedHvfArm64BootSession::new(&source_controller, source_config)
+                    .expect("signed exact-2.6 source should prepare");
+            let expected_configs = CaptureReadyStorageConfigs::new(
+                source_controller.drive_configs().to_vec(),
+                source_controller.pmem_configs().to_vec(),
+            );
+            let capture_now = Instant::now();
+            let capture_guard = source_session
+                .quiesce_limiter_retry_wakeups()
+                .expect("storage source retry publishers should quiesce");
+            let graph = source_session
+                .capture_snapshot_v2_storage_device_graph_at(
+                    &expected_configs,
+                    &capture_guard,
+                    capture_now,
+                )
+                .expect("signed exact-2.6 storage graph should capture");
+
+            let restored_layout =
+                GuestMemoryLayout::new(source_session.runtime_resources().layout.ranges().to_vec())
+                    .expect("storage destination layout should validate");
+            let copy_source_memory = || {
+                let mut destination = GuestMemory::allocate(&restored_layout)
+                    .expect("storage destination memory should allocate");
+                let source = source_session
+                    .guest_memory()
+                    .expect("storage source memory should remain mapped");
+                let mut buffer = vec![0_u8; 64 * 1024];
+                for range in restored_layout.ranges() {
+                    let mut copied = 0_u64;
+                    while copied < range.size() {
+                        let count = usize::try_from(
+                            (range.size() - copied).min(
+                                u64::try_from(buffer.len())
+                                    .expect("storage copy buffer length should fit u64"),
+                            ),
+                        )
+                        .expect("storage memory copy length should fit usize");
+                        let address = range
+                            .start()
+                            .checked_add(copied)
+                            .expect("storage memory copy address should fit");
+                        source
+                            .read_slice(&mut buffer[..count], address)
+                            .expect("storage source memory should read");
+                        destination
+                            .write_slice(&buffer[..count], address)
+                            .expect("storage destination memory should write");
+                        copied += u64::try_from(count).expect("storage copy length should fit u64");
+                    }
+                }
+                destination
+            };
+            let cancelled_memory = copy_source_memory();
+            let committed_memory = copy_source_memory();
+
+            source_session
+                .pause_for_snapshot_v2_capture()
+                .expect("storage source topology should pause");
+            let boot_state = HvfSnapshotV2BootState::try_new(
+                HvfSnapshotV2NativePath::try_new(kernel.path().as_os_str())
+                    .expect("storage source kernel path should validate"),
+                None,
+                None,
             )
-            .expect("signed exact-2.6 storage graph should capture");
+            .expect("storage source boot state should validate");
+            let mut memory_output = Cursor::new(Vec::new());
+            let platform = source_session
+                .capture_snapshot_v2_storage_platform_with_cancel(
+                    HvfArm64BootSnapshotV2CaptureInput::new(boot_state),
+                    &mut memory_output,
+                    |_| false,
+                )
+                .expect("signed exact-2.6 storage platform should capture");
+            drop(capture_guard);
+            source_session
+                .shutdown()
+                .expect("storage source should shut down");
 
-        let restored_layout =
-            GuestMemoryLayout::new(source_session.runtime_resources().layout.ranges().to_vec())
-                .expect("storage destination layout should validate");
-        let copy_source_memory = || {
-            let mut destination = GuestMemory::allocate(&restored_layout)
-                .expect("storage destination memory should allocate");
-            let source = source_session
-                .guest_memory()
-                .expect("storage source memory should remain mapped");
-            let mut buffer = vec![0_u8; 64 * 1024];
-            for range in restored_layout.ranges() {
-                let mut copied = 0_u64;
-                while copied < range.size() {
-                    let count = usize::try_from(
-                        (range.size() - copied).min(
-                            u64::try_from(buffer.len())
-                                .expect("storage copy buffer length should fit u64"),
-                        ),
+            let machine = snapshot_destination_machine_config(platform.machine().machine(), false);
+            let boot = super::native_v2_boot_source_config(platform.machine().boot())
+                .expect("storage destination boot projection should validate");
+            let process = bangbang_hvf::HvfSnapshotV2StorageMmioProcessConfig::new(
+                BlockMmioLayout::new(DEFAULT_BLOCK_MMIO_BASE, DEFAULT_BLOCK_MMIO_REGION_ID),
+                PmemMmioLayout::new(DEFAULT_PMEM_MMIO_BASE, DEFAULT_PMEM_MMIO_REGION_ID),
+            );
+
+            let cancelled_bundle =
+                super::RequestedSnapshotRestoreResources::prepare_native_v2_storage_restore_bundle(
+                    graph.clone(),
+                    &cancelled_memory,
+                    Instant::now(),
+                    None,
+                    || false,
+                )
+                .expect("cancelled storage bundle should prepare");
+            let cancelled_serial = SharedSerialOutput::from(SharedSerialOutputBuffer::default());
+            let cancelled_shell =
+                super::HvfSnapshotV2DefaultProcessShell::new(cancelled_serial.clone());
+            let (cancelled_packet_io, cancelled_mmds_metrics) =
+                ProcessNetworkPacketIoProvider::from_controller(
+                    &source_controller,
+                    ProcessVmnetAuthority::Direct,
+                )
+                .expect("cancelled storage packet I/O should prepare");
+            let cancellation = NativeV2SnapshotCaptureCancellation::default();
+            cancellation.cancel();
+            if pci_enabled {
+                let cancelled_plan =
+                    bangbang_hvf::prepare_hvf_snapshot_v2_storage_pci_platform_plan(
+                        &platform,
+                        cancelled_bundle
+                            .bundle()
+                            .expect("cancelled PCI storage bundle owner should remain present"),
                     )
-                    .expect("storage memory copy length should fit usize");
-                    let address = range
-                        .start()
-                        .checked_add(copied)
-                        .expect("storage memory copy address should fit");
-                    source
-                        .read_slice(&mut buffer[..count], address)
-                        .expect("storage source memory should read");
-                    destination
-                        .write_slice(&buffer[..count], address)
-                        .expect("storage destination memory should write");
-                    copied += u64::try_from(count).expect("storage copy length should fit u64");
+                    .expect("cancelled PCI storage platform plan should prepare");
+                let cancelled = super::prepare_hvf_native_v2_storage_pci_destination(
+                    super::PrepareHvfSnapshotV2StoragePciDestinationInput {
+                        platform: platform.clone(),
+                        memory: cancelled_memory,
+                        process_shell: cancelled_shell,
+                        packet_io: cancelled_packet_io,
+                        mmds_metrics: cancelled_mmds_metrics,
+                        vmnet_authority: ProcessVmnetAuthority::Direct,
+                        serial_output: cancelled_serial,
+                        bundle: cancelled_bundle,
+                        plan: cancelled_plan,
+                        machine,
+                        boot: boot.clone(),
+                        resume_requested: false,
+                        cancellation,
+                    },
+                )
+                .expect_err("cancellation should prevent private PCI storage commit");
+                assert!(!cancelled.is_terminal());
+                assert!(matches!(
+                    cancelled,
+                    super::PrepareHvfSnapshotV2StorageDestinationError::Commit(_)
+                ));
+            } else {
+                let cancelled_plan =
+                    bangbang_hvf::prepare_hvf_snapshot_v2_storage_mmio_platform_plan(
+                        &platform,
+                        cancelled_bundle
+                            .bundle()
+                            .expect("cancelled MMIO storage bundle owner should remain present"),
+                        process,
+                    )
+                    .expect("cancelled MMIO storage platform plan should prepare");
+                let cancelled = super::prepare_hvf_native_v2_storage_mmio_destination(
+                    super::PrepareHvfSnapshotV2StorageMmioDestinationInput {
+                        platform: platform.clone(),
+                        memory: cancelled_memory,
+                        process_shell: cancelled_shell,
+                        packet_io: cancelled_packet_io,
+                        mmds_metrics: cancelled_mmds_metrics,
+                        vmnet_authority: ProcessVmnetAuthority::Direct,
+                        serial_output: cancelled_serial,
+                        bundle: cancelled_bundle,
+                        plan: cancelled_plan,
+                        machine,
+                        boot: boot.clone(),
+                        resume_requested: false,
+                        cancellation,
+                    },
+                )
+                .expect_err("cancellation should prevent private MMIO storage commit");
+                assert!(!cancelled.is_terminal());
+                assert!(matches!(
+                    cancelled,
+                    super::PrepareHvfSnapshotV2StorageDestinationError::Commit(_)
+                ));
+            }
+
+            let committed_bundle =
+                super::RequestedSnapshotRestoreResources::prepare_native_v2_storage_restore_bundle(
+                    graph,
+                    &committed_memory,
+                    Instant::now(),
+                    None,
+                    || false,
+                )
+                .expect("committed storage bundle should prepare after rollback");
+            let committed_serial = SharedSerialOutput::from(SharedSerialOutputBuffer::default());
+            let committed_shell =
+                super::HvfSnapshotV2DefaultProcessShell::new(committed_serial.clone());
+            let (committed_packet_io, committed_mmds_metrics) =
+                ProcessNetworkPacketIoProvider::from_controller(
+                    &source_controller,
+                    ProcessVmnetAuthority::Direct,
+                )
+                .expect("committed storage packet I/O should prepare");
+            let (session, projection, returned_serial) = if pci_enabled {
+                let committed_plan =
+                    bangbang_hvf::prepare_hvf_snapshot_v2_storage_pci_platform_plan(
+                        &platform,
+                        committed_bundle
+                            .bundle()
+                            .expect("committed PCI storage bundle owner should remain present"),
+                    )
+                    .expect("committed PCI storage platform plan should prepare");
+                super::prepare_hvf_native_v2_storage_pci_destination(
+                    super::PrepareHvfSnapshotV2StoragePciDestinationInput {
+                        platform,
+                        memory: committed_memory,
+                        process_shell: committed_shell,
+                        packet_io: committed_packet_io,
+                        mmds_metrics: committed_mmds_metrics,
+                        vmnet_authority: ProcessVmnetAuthority::Direct,
+                        serial_output: committed_serial,
+                        bundle: committed_bundle,
+                        plan: committed_plan,
+                        machine,
+                        boot: boot.clone(),
+                        resume_requested: false,
+                        cancellation: NativeV2SnapshotCaptureCancellation::default(),
+                    },
+                )
+                .unwrap_or_else(|error| {
+                    panic!("private exact-2.6 PCI storage destination should commit: {error:?}")
+                })
+            } else {
+                let committed_plan =
+                    bangbang_hvf::prepare_hvf_snapshot_v2_storage_mmio_platform_plan(
+                        &platform,
+                        committed_bundle
+                            .bundle()
+                            .expect("committed MMIO storage bundle owner should remain present"),
+                        process,
+                    )
+                    .expect("committed MMIO storage platform plan should prepare");
+                super::prepare_hvf_native_v2_storage_mmio_destination(
+                    super::PrepareHvfSnapshotV2StorageMmioDestinationInput {
+                        platform,
+                        memory: committed_memory,
+                        process_shell: committed_shell,
+                        packet_io: committed_packet_io,
+                        mmds_metrics: committed_mmds_metrics,
+                        vmnet_authority: ProcessVmnetAuthority::Direct,
+                        serial_output: committed_serial,
+                        bundle: committed_bundle,
+                        plan: committed_plan,
+                        machine,
+                        boot: boot.clone(),
+                        resume_requested: false,
+                        cancellation: NativeV2SnapshotCaptureCancellation::default(),
+                    },
+                )
+                .unwrap_or_else(|error| {
+                    panic!("private exact-2.6 MMIO storage destination should commit: {error:?}")
+                })
+            };
+            assert_eq!(projection.machine, machine);
+            assert_eq!(projection.boot, boot);
+            assert_eq!(projection.configs, expected_configs);
+            assert!(!projection.resume_requested);
+            assert_eq!(
+                returned_serial.metrics(),
+                bangbang_runtime::serial::SerialOutputMetrics::default()
+            );
+            match &session {
+                super::HvfProcessSession::Boot(supervisor) => {
+                    assert_eq!(supervisor.status(), BootRunLoopWorkerStatus::Paused);
+                }
+                super::HvfProcessSession::SnapshotV2(_) => {
+                    panic!("exact-2.6 storage handoff should use the boot supervisor");
                 }
             }
-            destination
-        };
-        let cancelled_memory = copy_source_memory();
-        let committed_memory = copy_source_memory();
-
-        source_session
-            .pause_for_snapshot_v2_capture()
-            .expect("storage source topology should pause");
-        let boot_state = HvfSnapshotV2BootState::try_new(
-            HvfSnapshotV2NativePath::try_new(kernel.path().as_os_str())
-                .expect("storage source kernel path should validate"),
-            None,
-            None,
-        )
-        .expect("storage source boot state should validate");
-        let mut memory_output = Cursor::new(Vec::new());
-        let platform = source_session
-            .capture_snapshot_v2_storage_platform_with_cancel(
-                HvfArm64BootSnapshotV2CaptureInput::new(boot_state),
-                &mut memory_output,
-                |_| false,
-            )
-            .expect("signed exact-2.6 storage platform should capture");
-        drop(capture_guard);
-        source_session
-            .shutdown()
-            .expect("storage source should shut down");
-
-        let machine = snapshot_destination_machine_config(platform.machine().machine(), false);
-        let boot = super::native_v2_boot_source_config(platform.machine().boot())
-            .expect("storage destination boot projection should validate");
-        let process = bangbang_hvf::HvfSnapshotV2StorageMmioProcessConfig::new(
-            BlockMmioLayout::new(DEFAULT_BLOCK_MMIO_BASE, DEFAULT_BLOCK_MMIO_REGION_ID),
-            PmemMmioLayout::new(DEFAULT_PMEM_MMIO_BASE, DEFAULT_PMEM_MMIO_REGION_ID),
-        );
-
-        let cancelled_bundle =
-            super::RequestedSnapshotRestoreResources::prepare_native_v2_storage_restore_bundle(
-                graph.clone(),
-                &cancelled_memory,
-                Instant::now(),
-                None,
-                || false,
-            )
-            .expect("cancelled storage bundle should prepare");
-        let cancelled_plan = bangbang_hvf::prepare_hvf_snapshot_v2_storage_mmio_platform_plan(
-            &platform,
-            cancelled_bundle
-                .bundle()
-                .expect("cancelled storage bundle owner should remain present"),
-            process,
-        )
-        .expect("cancelled storage platform plan should prepare");
-        let cancelled_serial = SharedSerialOutput::from(SharedSerialOutputBuffer::default());
-        let cancelled_shell =
-            super::HvfSnapshotV2DefaultProcessShell::new(cancelled_serial.clone());
-        let (cancelled_packet_io, cancelled_mmds_metrics) =
-            ProcessNetworkPacketIoProvider::from_controller(
-                &source_controller,
-                ProcessVmnetAuthority::Direct,
-            )
-            .expect("cancelled storage packet I/O should prepare");
-        let cancellation = NativeV2SnapshotCaptureCancellation::default();
-        cancellation.cancel();
-        let cancelled = super::prepare_hvf_native_v2_storage_mmio_destination(
-            super::PrepareHvfSnapshotV2StorageMmioDestinationInput {
-                platform: platform.clone(),
-                memory: cancelled_memory,
-                process_shell: cancelled_shell,
-                packet_io: cancelled_packet_io,
-                mmds_metrics: cancelled_mmds_metrics,
-                vmnet_authority: ProcessVmnetAuthority::Direct,
-                serial_output: cancelled_serial,
-                bundle: cancelled_bundle,
-                plan: cancelled_plan,
-                machine,
-                boot: boot.clone(),
-                resume_requested: false,
-                cancellation,
-            },
-        )
-        .expect_err("cancellation should prevent private storage commit");
-        assert!(!cancelled.is_terminal());
-        assert!(matches!(
-            cancelled,
-            super::PrepareHvfSnapshotV2StorageDestinationError::Commit(_)
-        ));
-
-        let committed_bundle =
-            super::RequestedSnapshotRestoreResources::prepare_native_v2_storage_restore_bundle(
-                graph,
-                &committed_memory,
-                Instant::now(),
-                None,
-                || false,
-            )
-            .expect("committed storage bundle should prepare after rollback");
-        let committed_plan = bangbang_hvf::prepare_hvf_snapshot_v2_storage_mmio_platform_plan(
-            &platform,
-            committed_bundle
-                .bundle()
-                .expect("committed storage bundle owner should remain present"),
-            process,
-        )
-        .expect("committed storage platform plan should prepare");
-        let committed_serial = SharedSerialOutput::from(SharedSerialOutputBuffer::default());
-        let committed_shell =
-            super::HvfSnapshotV2DefaultProcessShell::new(committed_serial.clone());
-        let (committed_packet_io, committed_mmds_metrics) =
-            ProcessNetworkPacketIoProvider::from_controller(
-                &source_controller,
-                ProcessVmnetAuthority::Direct,
-            )
-            .expect("committed storage packet I/O should prepare");
-        let (session, projection, returned_serial) =
-            super::prepare_hvf_native_v2_storage_mmio_destination(
-                super::PrepareHvfSnapshotV2StorageMmioDestinationInput {
-                    platform,
-                    memory: committed_memory,
-                    process_shell: committed_shell,
-                    packet_io: committed_packet_io,
-                    mmds_metrics: committed_mmds_metrics,
-                    vmnet_authority: ProcessVmnetAuthority::Direct,
-                    serial_output: committed_serial,
-                    bundle: committed_bundle,
-                    plan: committed_plan,
-                    machine,
-                    boot: boot.clone(),
-                    resume_requested: false,
-                    cancellation: NativeV2SnapshotCaptureCancellation::default(),
-                },
-            )
-            .unwrap_or_else(|error| {
-                panic!("private exact-2.6 storage destination should commit: {error:?}")
-            });
-        assert_eq!(projection.machine, machine);
-        assert_eq!(projection.boot, boot);
-        assert_eq!(projection.configs, expected_configs);
-        assert!(!projection.resume_requested);
-        assert_eq!(
-            returned_serial.metrics(),
-            bangbang_runtime::serial::SerialOutputMetrics::default()
-        );
-        match &session {
-            super::HvfProcessSession::Boot(supervisor) => {
-                assert_eq!(supervisor.status(), BootRunLoopWorkerStatus::Paused);
-            }
-            super::HvfProcessSession::SnapshotV2(_) => {
-                panic!("exact-2.6 storage handoff should use the boot supervisor");
-            }
+            drop(session);
         }
-        drop(session);
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -166,9 +166,12 @@ pub use snapshot_v2_platform::{
 };
 pub use snapshot_v2_storage_platform::{
     HvfSnapshotV2StorageMmioPlatformPlan, HvfSnapshotV2StorageMmioProcessConfig,
-    HvfSnapshotV2StorageMmioRecordPlan, HvfSnapshotV2StorageRetryPlan,
-    PrepareHvfSnapshotV2StorageMmioPlatformPlanError,
+    HvfSnapshotV2StorageMmioRecordPlan, HvfSnapshotV2StoragePciHostPlan,
+    HvfSnapshotV2StoragePciPlatformPlan, HvfSnapshotV2StoragePciRecordPlan,
+    HvfSnapshotV2StorageRetryPlan, PrepareHvfSnapshotV2StorageMmioPlatformPlanError,
+    PrepareHvfSnapshotV2StoragePciPlatformPlanError,
     prepare_hvf_snapshot_v2_storage_mmio_platform_plan,
+    prepare_hvf_snapshot_v2_storage_pci_platform_plan,
 };
 pub use startup::{
     HvfArm64BootBalloonCaptureError, HvfArm64BootBalloonCaptureState,
@@ -213,9 +216,11 @@ pub use startup::{
     HvfSnapshotV2RootRestoreFailure, HvfSnapshotV2RootRestoreStage,
     HvfSnapshotV2StorageMmioRestoreCleanupFailure, HvfSnapshotV2StorageMmioRestoreError,
     HvfSnapshotV2StorageMmioRestoreFailure, HvfSnapshotV2StorageMmioRestoreStage,
+    HvfSnapshotV2StoragePciRestoreCleanupFailure, HvfSnapshotV2StoragePciRestoreError,
+    HvfSnapshotV2StoragePciRestoreFailure, HvfSnapshotV2StoragePciRestoreStage,
     OwnedHvfArm64BootSession, PreparedHvfArm64BootPciNetworkRemoval, RestoredHvfArm64BootSession,
     RestoredHvfSnapshotV2MultiBlockMmioOwners, RestoredHvfSnapshotV2MultiBlockPciOwners,
-    RestoredHvfSnapshotV2StorageMmioOwners,
+    RestoredHvfSnapshotV2StorageMmioOwners, RestoredHvfSnapshotV2StoragePciOwners,
 };
 pub use topology::{
     HvfVcpuTopology, HvfVcpuTopologyAllocation, HvfVcpuTopologyCreateStage, HvfVcpuTopologyError,

--- a/crates/hvf/src/snapshot_v2_multi_block_platform.rs
+++ b/crates/hvf/src/snapshot_v2_multi_block_platform.rs
@@ -49,6 +49,13 @@ use crate::startup::{
 const REDACTED: &str = "<redacted>";
 const PCI_GENERIC_WRITABLE_OFFSETS: [u16; 4] = [0x04, 0x05, 0x0c, 0x3c];
 
+#[derive(Clone, Copy)]
+pub(crate) struct HvfSnapshotV2PciEndpointPlacement {
+    pub(crate) sbdf: PciSbdf,
+    pub(crate) bar_region_id: MmioRegionId,
+    pub(crate) bar_range: GuestMemoryRange,
+}
+
 /// Destination process policy for a profile-2 block vector.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct HvfSnapshotV2MultiBlockProcessConfig {
@@ -828,46 +835,23 @@ fn prepare_pci_plan(
     let mut planned = Vec::new();
     reserve.reserve(&mut planned, records.len())?;
     for (index, record) in records.iter().enumerate() {
-        let device = PCI_FIRST_ENDPOINT_DEVICE
-            .checked_add(
-                u8::try_from(index)
-                    .map_err(|_| PrepareHvfSnapshotV2MultiBlockPlatformPlanError::ResourcePlan)?,
-            )
+        let placement = snapshot_v2_pci_endpoint_placement(address_plan, index)
             .ok_or(PrepareHvfSnapshotV2MultiBlockPlatformPlanError::ResourcePlan)?;
-        let sbdf = PciSbdf::new(PCI_SEGMENT_ZERO, PCI_BUS_ZERO, device, PCI_FUNCTION_ZERO)
-            .map_err(|_| PrepareHvfSnapshotV2MultiBlockPlatformPlanError::ResourcePlan)?;
-        let offset = u64::try_from(index)
-            .ok()
-            .and_then(|index| index.checked_mul(VIRTIO_PCI_CAPABILITY_BAR_SIZE))
-            .ok_or(PrepareHvfSnapshotV2MultiBlockPlatformPlanError::ResourcePlan)?;
-        let bar_start = address_plan
-            .bar64()
-            .start()
-            .checked_add(offset)
-            .ok_or(PrepareHvfSnapshotV2MultiBlockPlatformPlanError::ResourcePlan)?;
-        let bar_range = GuestMemoryRange::new(bar_start, VIRTIO_PCI_CAPABILITY_BAR_SIZE)
-            .map_err(|_| PrepareHvfSnapshotV2MultiBlockPlatformPlanError::ResourcePlan)?;
-        if bar_range.end_exclusive().raw_value() > address_plan.bar64().end_exclusive().raw_value()
-        {
-            return Err(PrepareHvfSnapshotV2MultiBlockPlatformPlanError::ResourcePlan);
-        }
-        let bar_region_id = pci_data_region_id(index)
-            .map_err(|_| PrepareHvfSnapshotV2MultiBlockPlatformPlanError::ResourcePlan)?;
         let SnapshotV2DeviceTransport::Pci(captured) = record.transport() else {
             return Err(PrepareHvfSnapshotV2MultiBlockPlatformPlanError::TransportPolicy);
         };
-        if captured.sbdf() != sbdf
-            || captured.bar_range() != bar_range
-            || !valid_pci_record(captured, msi)
+        if captured.sbdf() != placement.sbdf
+            || captured.bar_range() != placement.bar_range
+            || !valid_snapshot_v2_pci_record(captured, msi, VIRTIO_BLOCK_QUEUE_SIZES.len())
         {
             return Err(PrepareHvfSnapshotV2MultiBlockPlatformPlanError::ResourcePlan);
         }
         planned.push(HvfSnapshotV2MultiBlockPciRecordPlan {
             key: record.key(),
             origin: captured.origin(),
-            sbdf,
-            bar_region_id,
-            bar_range,
+            sbdf: placement.sbdf,
+            bar_region_id: placement.bar_region_id,
+            bar_range: placement.bar_range,
             route_count: routes_per_record,
         });
     }
@@ -893,9 +877,7 @@ fn pci_route_demand(
             },
         );
     }
-    let routes_per_record = VIRTIO_BLOCK_QUEUE_SIZES
-        .len()
-        .checked_add(1)
+    let routes_per_record = snapshot_v2_pci_endpoint_route_count(VIRTIO_BLOCK_QUEUE_SIZES.len())
         .ok_or(PrepareHvfSnapshotV2MultiBlockPlatformPlanError::ResourcePlan)?;
     let route_demand = record_count
         .checked_mul(routes_per_record)
@@ -909,7 +891,40 @@ fn pci_route_demand(
     Ok((routes_per_record, route_demand))
 }
 
-fn valid_pci_record(state: &SnapshotV2PciDeviceState, msi: HvfGicMsiMetadata) -> bool {
+pub(crate) fn snapshot_v2_pci_endpoint_placement(
+    address_plan: Arm64PciAddressPlan,
+    index: usize,
+) -> Option<HvfSnapshotV2PciEndpointPlacement> {
+    if index >= PCI_ENDPOINT_SLOT_COUNT {
+        return None;
+    }
+    let device = PCI_FIRST_ENDPOINT_DEVICE.checked_add(u8::try_from(index).ok()?)?;
+    let sbdf = PciSbdf::new(PCI_SEGMENT_ZERO, PCI_BUS_ZERO, device, PCI_FUNCTION_ZERO).ok()?;
+    let offset = u64::try_from(index)
+        .ok()?
+        .checked_mul(VIRTIO_PCI_CAPABILITY_BAR_SIZE)?;
+    let bar_start = address_plan.bar64().start().checked_add(offset)?;
+    let bar_range = GuestMemoryRange::new(bar_start, VIRTIO_PCI_CAPABILITY_BAR_SIZE).ok()?;
+    if bar_range.end_exclusive().raw_value() > address_plan.bar64().end_exclusive().raw_value() {
+        return None;
+    }
+    let bar_region_id = pci_data_region_id(index).ok()?;
+    Some(HvfSnapshotV2PciEndpointPlacement {
+        sbdf,
+        bar_region_id,
+        bar_range,
+    })
+}
+
+pub(crate) const fn snapshot_v2_pci_endpoint_route_count(queue_count: usize) -> Option<usize> {
+    queue_count.checked_add(1)
+}
+
+pub(crate) fn valid_snapshot_v2_pci_record(
+    state: &SnapshotV2PciDeviceState,
+    msi: HvfGicMsiMetadata,
+    queue_count: usize,
+) -> bool {
     state.phase() == VirtioPciEndpointPhase::Active
         && state.bar_index() == VIRTIO_PCI_CAPABILITY_BAR_INDEX
         && state.bar_address_space() == PciBarAddressSpace::Memory64
@@ -924,15 +939,15 @@ fn valid_pci_record(state: &SnapshotV2PciDeviceState, msi: HvfGicMsiMetadata) ->
             .iter()
             .map(|probe| probe.index())
             .eq([0, 1])
-        && valid_pci_msix(state.msix())
+        && valid_pci_msix(state.msix(), queue_count)
         && pci_msix_routes_match_gic(state.msix(), msi)
 }
 
-fn valid_pci_msix(state: &SnapshotV2PciMsixState) -> bool {
-    state.entries().len() == VIRTIO_BLOCK_QUEUE_SIZES.len() + 1
+fn valid_pci_msix(state: &SnapshotV2PciMsixState, queue_count: usize) -> bool {
+    state.entries().len() == queue_count + 1
         && state.entries().len() <= VIRTIO_PCI_MAX_MSIX_VECTORS
         && state.pending_words().len() == 1
-        && state.queue_vectors().len() == VIRTIO_BLOCK_QUEUE_SIZES.len()
+        && state.queue_vectors().len() == queue_count
         && state
             .pending_words()
             .first()
@@ -1412,7 +1427,7 @@ pub(crate) mod tests {
         (platform, fixture.bundle, plan)
     }
 
-    fn product_pci_platform() -> HvfSnapshotV2PlatformState {
+    pub(crate) fn product_pci_platform() -> HvfSnapshotV2PlatformState {
         let (platform, root, _process) =
             crate::snapshot_v2_platform::tests::pci_root_plan_fixture();
         drop(root);

--- a/crates/hvf/src/snapshot_v2_platform.rs
+++ b/crates/hvf/src/snapshot_v2_platform.rs
@@ -70,7 +70,9 @@ use crate::snapshot_v2::{
 use crate::snapshot_v2_multi_block_platform::{
     HvfSnapshotV2MultiBlockMmioRecordPlan, HvfSnapshotV2MultiBlockPciPlan,
 };
-use crate::snapshot_v2_storage_platform::HvfSnapshotV2StorageMmioRecordPlan;
+use crate::snapshot_v2_storage_platform::{
+    HvfSnapshotV2StorageMmioRecordPlan, HvfSnapshotV2StoragePciHostPlan,
+};
 use crate::startup::{
     HvfArm64BootSnapshotV2CaptureError, HvfArm64BootSnapshotV2CaptureStage,
     HvfArm64BootVmClockRestoreError, HvfArm64BootVmGenIdRestoreError,
@@ -376,6 +378,14 @@ pub(crate) struct HvfSnapshotV2StorageMmioShellPlan<'a> {
     pub(crate) vmclock_interrupt: GuestInterruptLine,
 }
 
+pub(crate) struct HvfSnapshotV2StoragePciShellPlan<'a> {
+    pub(crate) command_line: &'a str,
+    pub(crate) pci: &'a HvfSnapshotV2StoragePciHostPlan,
+    pub(crate) serial_interrupt: GuestInterruptLine,
+    pub(crate) vmgenid_interrupt: GuestInterruptLine,
+    pub(crate) vmclock_interrupt: GuestInterruptLine,
+}
+
 enum HvfSnapshotV2ProcessShellRestore<'a> {
     DeviceFree(HvfSnapshotV2DefaultProcessShell),
     Root {
@@ -394,6 +404,10 @@ enum HvfSnapshotV2ProcessShellRestore<'a> {
     StorageMmio {
         shell: HvfSnapshotV2DefaultProcessShell,
         plan: HvfSnapshotV2StorageMmioShellPlan<'a>,
+    },
+    StoragePci {
+        shell: HvfSnapshotV2DefaultProcessShell,
+        plan: HvfSnapshotV2StoragePciShellPlan<'a>,
     },
 }
 
@@ -415,6 +429,10 @@ enum HvfSnapshotV2ProcessBlockFdtPlan<'a> {
         command_line: &'a str,
         block_records: &'a [HvfSnapshotV2StorageMmioRecordPlan],
         pmem_records: &'a [HvfSnapshotV2StorageMmioRecordPlan],
+    },
+    StoragePci {
+        command_line: &'a str,
+        pci: &'a HvfSnapshotV2StoragePciHostPlan,
     },
 }
 
@@ -1363,6 +1381,19 @@ pub(crate) fn restore_hvf_snapshot_v2_storage_mmio_process_platform(
         state,
         memory,
         Some(HvfSnapshotV2ProcessShellRestore::StorageMmio { shell, plan }),
+    )
+}
+
+pub(crate) fn restore_hvf_snapshot_v2_storage_pci_process_platform(
+    state: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    shell: HvfSnapshotV2DefaultProcessShell,
+    plan: HvfSnapshotV2StoragePciShellPlan<'_>,
+) -> Result<RestoredHvfSnapshotV2Platform, HvfSnapshotV2PlatformRestoreError> {
+    restore_hvf_snapshot_v2_platform_with_shell(
+        state,
+        memory,
+        Some(HvfSnapshotV2ProcessShellRestore::StoragePci { shell, plan }),
     )
 }
 
@@ -2385,6 +2416,30 @@ fn prepare_process_shell(
                     )),
                 )
             }
+            HvfSnapshotV2ProcessShellRestore::StoragePci { shell, plan } => {
+                if plan.pci.record_count() == 0
+                    || plan.pci.route_demand() == 0
+                    || gic.msi != Some(plan.pci.msi())
+                {
+                    return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellFdt {
+                        mismatch: HvfSnapshotV2ProcessFdtMismatch::Profile,
+                    });
+                }
+                (
+                    shell,
+                    HvfSnapshotV2ProcessBlockFdtPlan::StoragePci {
+                        command_line: plan.command_line,
+                        pci: plan.pci,
+                    },
+                    true,
+                    false,
+                    Some((
+                        plan.serial_interrupt,
+                        plan.vmgenid_interrupt,
+                        plan.vmclock_interrupt,
+                    )),
+                )
+            }
         };
     let serial_interrupt = allocator
         .allocate()
@@ -2505,6 +2560,7 @@ fn validate_process_fdt(
         HvfSnapshotV2ProcessBlockFdtPlan::Root { .. } => 1,
         HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockMmio { records, .. } => records.len(),
         HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockPci { .. } => 1,
+        HvfSnapshotV2ProcessBlockFdtPlan::StoragePci { .. } => 1,
         HvfSnapshotV2ProcessBlockFdtPlan::StorageMmio {
             block_records,
             pmem_records,
@@ -2628,6 +2684,9 @@ fn validate_process_fdt(
         HvfSnapshotV2ProcessBlockFdtPlan::StorageMmio { command_line, .. } => chosen
             .prop_str("bootargs")
             .is_ok_and(|arguments| arguments == *command_line),
+        HvfSnapshotV2ProcessBlockFdtPlan::StoragePci { command_line, .. } => chosen
+            .prop_str("bootargs")
+            .is_ok_and(|arguments| arguments == *command_line),
         HvfSnapshotV2ProcessBlockFdtPlan::None => {
             let expected = expected_process_boot_arguments(state.machine().boot().boot_arguments())
                 .ok_or(HvfSnapshotV2ProcessFdtMismatch::Boot)?;
@@ -2652,6 +2711,7 @@ fn validate_process_fdt(
             transport: HvfSnapshotV2RootTransportPlan::Pci { .. },
             ..
         } | HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockPci { .. }
+            | HvfSnapshotV2ProcessBlockFdtPlan::StoragePci { .. }
     ));
     if intc.children.len() != expected_gic_children
         || !intc
@@ -2823,6 +2883,18 @@ fn validate_process_block_nodes(
             return Ok(());
         }
         HvfSnapshotV2ProcessBlockFdtPlan::MultiBlockPci { pci, .. } => {
+            let canonical_host = Arm64PciAddressPlan::firecracker_v1_16()
+                .map(bangbang_runtime::fdt::Arm64FdtPciHost::from_address_plan)
+                .ok();
+            if canonical_host != Some(pci.host())
+                || !validate_process_pci_host(root_node)
+                || !validate_process_gic_msi(intc, pci.msi())
+            {
+                return Err(HvfSnapshotV2ProcessFdtMismatch::Pci);
+            }
+            return Ok(());
+        }
+        HvfSnapshotV2ProcessBlockFdtPlan::StoragePci { pci, .. } => {
             let canonical_host = Arm64PciAddressPlan::firecracker_v1_16()
                 .map(bangbang_runtime::fdt::Arm64FdtPciHost::from_address_plan)
                 .ok();
@@ -4288,6 +4360,63 @@ pub(crate) mod tests {
                 &block
             ),
             Err(HvfSnapshotV2ProcessFdtMismatch::Boot)
+        );
+    }
+
+    #[test]
+    fn storage_pci_fdt_requires_one_host_for_the_heterogeneous_vector() {
+        let (platform, plan) = crate::snapshot_v2_storage_platform::tests::pci_fdt_plan_fixture();
+        let pci = plan.pci();
+        assert_eq!(pci.block_records().len(), 1);
+        assert_eq!(pci.pmem_records().len(), 1);
+        let shell = (
+            bangbang_runtime::fdt::Arm64FdtSerialDevice {
+                region: bangbang_runtime::fdt::Arm64FdtRegion {
+                    base: PROCESS_SERIAL_MMIO_BASE.raw_value(),
+                    size: SERIAL_MMIO_DEVICE_WINDOW_SIZE,
+                },
+                interrupt_line: plan.serial_interrupt(),
+            },
+            bangbang_runtime::fdt::Arm64FdtRtcDevice {
+                region: bangbang_runtime::fdt::Arm64FdtRegion {
+                    base: PROCESS_RTC_MMIO_BASE.raw_value(),
+                    size: RTC_MMIO_DEVICE_WINDOW_SIZE,
+                },
+            },
+            bangbang_runtime::fdt::Arm64FdtVmGenIdDevice {
+                region: platform.time().vmgenid().fdt_region(),
+                interrupt_line: plan.vmgenid_interrupt(),
+            },
+            bangbang_runtime::fdt::Arm64FdtVmClockDevice {
+                region: platform.time().vmclock().fdt_region(),
+                interrupt_line: plan.vmclock_interrupt(),
+            },
+        );
+        let block = HvfSnapshotV2ProcessBlockFdtPlan::StoragePci {
+            command_line: plan.command_line(),
+            pci,
+        };
+        let valid = build_process_fdt_fixture_with_profile(
+            &platform,
+            shell,
+            &[],
+            plan.command_line(),
+            Some(pci.host()),
+        );
+        assert_eq!(
+            validate_process_fdt(&valid, &platform, plan.serial_interrupt(), &block),
+            Ok(())
+        );
+        let missing_host = build_process_fdt_fixture_with_profile(
+            &platform,
+            shell,
+            &[],
+            plan.command_line(),
+            None,
+        );
+        assert_eq!(
+            validate_process_fdt(&missing_host, &platform, plan.serial_interrupt(), &block),
+            Err(HvfSnapshotV2ProcessFdtMismatch::RootInventory)
         );
     }
 

--- a/crates/hvf/src/snapshot_v2_storage_platform.rs
+++ b/crates/hvf/src/snapshot_v2_storage_platform.rs
@@ -3,16 +3,19 @@
 use std::fmt;
 use std::time::Instant;
 
-use bangbang_runtime::block::{BlockMmioLayout, BlockMmioRegistrationError};
+use bangbang_runtime::block::{
+    BlockMmioLayout, BlockMmioRegistrationError, VIRTIO_BLOCK_QUEUE_SIZES,
+};
 use bangbang_runtime::boot::{
     BootCommandLineError, canonical_process_block_command_line,
     canonical_process_root_block_command_line, canonical_process_root_pmem_command_line,
 };
-use bangbang_runtime::fdt::{Arm64FdtRegion, Arm64FdtVirtioMmioDevice};
+use bangbang_runtime::fdt::{Arm64FdtPciHost, Arm64FdtRegion, Arm64FdtVirtioMmioDevice};
 use bangbang_runtime::interrupt::GuestInterruptLine;
 use bangbang_runtime::memory::{GuestAddress, GuestMemoryRange};
-use bangbang_runtime::mmio::MmioRegion;
-use bangbang_runtime::pmem::{PmemMmioLayout, PmemMmioRegistrationError};
+use bangbang_runtime::mmio::{MmioRegion, MmioRegionId};
+use bangbang_runtime::pci::{Arm64PciAddressPlan, PCI_FIRST_ENDPOINT_DEVICE, PciSbdf};
+use bangbang_runtime::pmem::{PmemMmioLayout, PmemMmioRegistrationError, VIRTIO_PMEM_QUEUE_SIZES};
 use bangbang_runtime::pvtime::ARM64_PVTIME_STRUCTURE_SIZE;
 use bangbang_runtime::rtc::{RTC_MMIO_DEVICE_WINDOW_SIZE, RtcMmioLayout};
 use bangbang_runtime::serial::SERIAL_MMIO_DEVICE_WINDOW_SIZE;
@@ -22,14 +25,22 @@ use bangbang_runtime::snapshot_device_v2::{
 use bangbang_runtime::snapshot_device_v2_6::{
     NATIVE_V2_STORAGE_DEVICE_GRAPH_MAX_RECORDS, PreparedSnapshotV2StorageBundle,
 };
-use bangbang_runtime::storage_capture::StorageRetryState;
+use bangbang_runtime::storage_capture::{StorageDeviceOrigin, StorageRetryState};
 
-use crate::gic::{HvfGicInterruptLineAllocator, HvfGicMetadata, HvfInterruptLineAllocationError};
+use crate::gic::{
+    HvfGicInterruptLineAllocator, HvfGicMetadata, HvfGicMsiMetadata,
+    HvfInterruptLineAllocationError,
+};
 use crate::snapshot_v2::HvfSnapshotV2PlatformState;
+use crate::snapshot_v2_multi_block_platform::{
+    snapshot_v2_pci_endpoint_placement, snapshot_v2_pci_endpoint_route_count,
+    valid_snapshot_v2_pci_record,
+};
 use crate::snapshot_v2_platform::{
     PROCESS_RTC_MMIO_BASE, PROCESS_RTC_MMIO_REGION_ID, PROCESS_SERIAL_MMIO_BASE,
     PROCESS_SERIAL_MMIO_REGION_ID,
 };
+use crate::startup::{PCI_ENDPOINT_SLOT_COUNT, pci_root_restore_gic_msi_configuration};
 
 const REDACTED: &str = "<redacted>";
 
@@ -251,6 +262,209 @@ impl fmt::Debug for HvfSnapshotV2StorageMmioPlatformPlan {
     }
 }
 
+/// One canonical exact-2.6 PCI endpoint in combined block-then-pmem order.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct HvfSnapshotV2StoragePciRecordPlan {
+    key: SnapshotV2DeviceKey,
+    origin: StorageDeviceOrigin,
+    sbdf: PciSbdf,
+    bar_region_id: MmioRegionId,
+    bar_range: GuestMemoryRange,
+    route_count: usize,
+}
+
+impl HvfSnapshotV2StoragePciRecordPlan {
+    pub const fn key(self) -> SnapshotV2DeviceKey {
+        self.key
+    }
+
+    pub const fn origin(self) -> StorageDeviceOrigin {
+        self.origin
+    }
+
+    pub const fn sbdf(self) -> PciSbdf {
+        self.sbdf
+    }
+
+    pub const fn bar_region_id(self) -> MmioRegionId {
+        self.bar_region_id
+    }
+
+    pub const fn bar_range(self) -> GuestMemoryRange {
+        self.bar_range
+    }
+
+    pub const fn route_count(self) -> usize {
+        self.route_count
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2StoragePciRecordPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2StoragePciRecordPlan")
+            .field("origin", &self.origin)
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// One canonical PCI host shared by every exact-2.6 storage endpoint.
+pub struct HvfSnapshotV2StoragePciHostPlan {
+    host: Arm64FdtPciHost,
+    msi: HvfGicMsiMetadata,
+    route_demand: usize,
+    block_records: Vec<HvfSnapshotV2StoragePciRecordPlan>,
+    pmem_records: Vec<HvfSnapshotV2StoragePciRecordPlan>,
+}
+
+impl HvfSnapshotV2StoragePciHostPlan {
+    pub const fn host(&self) -> Arm64FdtPciHost {
+        self.host
+    }
+
+    pub const fn msi(&self) -> HvfGicMsiMetadata {
+        self.msi
+    }
+
+    pub const fn route_demand(&self) -> usize {
+        self.route_demand
+    }
+
+    pub fn block_records(&self) -> &[HvfSnapshotV2StoragePciRecordPlan] {
+        &self.block_records
+    }
+
+    pub fn pmem_records(&self) -> &[HvfSnapshotV2StoragePciRecordPlan] {
+        &self.pmem_records
+    }
+
+    pub fn record_count(&self) -> usize {
+        self.block_records.len() + self.pmem_records.len()
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2StoragePciHostPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2StoragePciHostPlan")
+            .field("block_count", &self.block_records.len())
+            .field("pmem_count", &self.pmem_records.len())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Complete pre-HVF exact-2.6 heterogeneous PCI storage proof.
+pub struct HvfSnapshotV2StoragePciPlatformPlan {
+    root_key: Option<SnapshotV2DeviceKey>,
+    command_line: String,
+    block_metrics_ids: Vec<String>,
+    pmem_metrics_ids: Vec<String>,
+    block_retries: Vec<HvfSnapshotV2StorageRetryPlan>,
+    pmem_retries: Vec<HvfSnapshotV2StorageRetryPlan>,
+    pci: HvfSnapshotV2StoragePciHostPlan,
+    serial_interrupt: GuestInterruptLine,
+    vmgenid_interrupt: GuestInterruptLine,
+    vmclock_interrupt: GuestInterruptLine,
+}
+
+pub(crate) struct HvfSnapshotV2StoragePciPlatformPlanParts {
+    pub(crate) root_key: Option<SnapshotV2DeviceKey>,
+    pub(crate) command_line: String,
+    pub(crate) block_metrics_ids: Vec<String>,
+    pub(crate) pmem_metrics_ids: Vec<String>,
+    pub(crate) block_retries: Vec<HvfSnapshotV2StorageRetryPlan>,
+    pub(crate) pmem_retries: Vec<HvfSnapshotV2StorageRetryPlan>,
+    pub(crate) pci: HvfSnapshotV2StoragePciHostPlan,
+    pub(crate) serial_interrupt: GuestInterruptLine,
+    pub(crate) vmgenid_interrupt: GuestInterruptLine,
+    pub(crate) vmclock_interrupt: GuestInterruptLine,
+}
+
+impl HvfSnapshotV2StoragePciPlatformPlan {
+    pub const fn root_key(&self) -> Option<SnapshotV2DeviceKey> {
+        self.root_key
+    }
+
+    pub fn command_line(&self) -> &str {
+        &self.command_line
+    }
+
+    pub fn block_metrics_ids(&self) -> &[String] {
+        &self.block_metrics_ids
+    }
+
+    pub fn pmem_metrics_ids(&self) -> &[String] {
+        &self.pmem_metrics_ids
+    }
+
+    pub fn block_retries(&self) -> &[HvfSnapshotV2StorageRetryPlan] {
+        &self.block_retries
+    }
+
+    pub fn pmem_retries(&self) -> &[HvfSnapshotV2StorageRetryPlan] {
+        &self.pmem_retries
+    }
+
+    pub fn earliest_block_retry_deadline(&self) -> Option<Instant> {
+        self.block_retries
+            .iter()
+            .filter_map(|retry| retry.retry_deadline)
+            .min()
+    }
+
+    pub fn earliest_pmem_retry_deadline(&self) -> Option<Instant> {
+        self.pmem_retries
+            .iter()
+            .filter_map(|retry| retry.retry_deadline)
+            .min()
+    }
+
+    pub const fn pci(&self) -> &HvfSnapshotV2StoragePciHostPlan {
+        &self.pci
+    }
+
+    pub const fn serial_interrupt(&self) -> GuestInterruptLine {
+        self.serial_interrupt
+    }
+
+    pub const fn vmgenid_interrupt(&self) -> GuestInterruptLine {
+        self.vmgenid_interrupt
+    }
+
+    pub const fn vmclock_interrupt(&self) -> GuestInterruptLine {
+        self.vmclock_interrupt
+    }
+
+    pub(crate) fn into_parts(self) -> HvfSnapshotV2StoragePciPlatformPlanParts {
+        HvfSnapshotV2StoragePciPlatformPlanParts {
+            root_key: self.root_key,
+            command_line: self.command_line,
+            block_metrics_ids: self.block_metrics_ids,
+            pmem_metrics_ids: self.pmem_metrics_ids,
+            block_retries: self.block_retries,
+            pmem_retries: self.pmem_retries,
+            pci: self.pci,
+            serial_interrupt: self.serial_interrupt,
+            vmgenid_interrupt: self.vmgenid_interrupt,
+            vmclock_interrupt: self.vmclock_interrupt,
+        }
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2StoragePciPlatformPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2StoragePciPlatformPlan")
+            .field("block_count", &self.pci.block_records.len())
+            .field("pmem_count", &self.pci.pmem_records.len())
+            .field("has_root", &self.root_key.is_some())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
 /// Redacted rejection from exact-2.6 host-free MMIO platform planning.
 pub enum PrepareHvfSnapshotV2StorageMmioPlatformPlanError {
     PlatformProfile,
@@ -331,6 +545,88 @@ impl std::error::Error for PrepareHvfSnapshotV2StorageMmioPlatformPlanError {
             | Self::QueuePlatformConflict
             | Self::PmemRangeConflict
             | Self::ResourcePlan => None,
+        }
+    }
+}
+
+/// Redacted rejection from exact-2.6 host-free PCI platform planning.
+pub enum PrepareHvfSnapshotV2StoragePciPlatformPlanError {
+    PlatformProfile,
+    Cardinality,
+    Allocation,
+    RecordIdentity,
+    RootIdentity,
+    TransportPolicy,
+    CommandLine(BootCommandLineError),
+    QueuePlatformConflict,
+    PmemRangeConflict,
+    Interrupt(HvfInterruptLineAllocationError),
+    ResourcePlan,
+    PciCapacity { count: usize, maximum: usize },
+}
+
+impl fmt::Debug for PrepareHvfSnapshotV2StoragePciPlatformPlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let category = match self {
+            Self::PlatformProfile => "platform-profile",
+            Self::Cardinality => "cardinality",
+            Self::Allocation => "allocation",
+            Self::RecordIdentity => "record-identity",
+            Self::RootIdentity => "root-identity",
+            Self::TransportPolicy => "transport-policy",
+            Self::CommandLine(_) => "command-line",
+            Self::QueuePlatformConflict => "queue-platform-conflict",
+            Self::PmemRangeConflict => "pmem-range-conflict",
+            Self::Interrupt(_) => "interrupt",
+            Self::ResourcePlan => "resource-plan",
+            Self::PciCapacity { .. } => "pci-capacity",
+        };
+        formatter
+            .debug_struct("PrepareHvfSnapshotV2StoragePciPlatformPlanError")
+            .field("category", &category)
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+impl fmt::Display for PrepareHvfSnapshotV2StoragePciPlatformPlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::PlatformProfile => "native-v2 storage PCI platform profile is not canonical",
+            Self::Cardinality => "native-v2 storage PCI platform cardinality is inconsistent",
+            Self::Allocation => "native-v2 storage PCI platform allocation failed",
+            Self::RecordIdentity => "native-v2 storage PCI record identity is inconsistent",
+            Self::RootIdentity => "native-v2 storage PCI root identity is inconsistent",
+            Self::TransportPolicy => "native-v2 storage PCI transport policy is inconsistent",
+            Self::CommandLine(_) => "native-v2 storage PCI process command line is invalid",
+            Self::QueuePlatformConflict => {
+                "native-v2 storage PCI queue overlaps platform-owned memory"
+            }
+            Self::PmemRangeConflict => {
+                "native-v2 storage PCI pmem mapping overlaps platform-owned resources"
+            }
+            Self::Interrupt(_) => "native-v2 storage PCI interrupt demand is invalid",
+            Self::ResourcePlan => "native-v2 storage PCI platform resources are inconsistent",
+            Self::PciCapacity { .. } => "native-v2 storage PCI endpoint capacity is exceeded",
+        })
+    }
+}
+
+impl std::error::Error for PrepareHvfSnapshotV2StoragePciPlatformPlanError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::CommandLine(source) => Some(source),
+            Self::Interrupt(source) => Some(source),
+            Self::PlatformProfile
+            | Self::Cardinality
+            | Self::Allocation
+            | Self::RecordIdentity
+            | Self::RootIdentity
+            | Self::TransportPolicy
+            | Self::QueuePlatformConflict
+            | Self::PmemRangeConflict
+            | Self::ResourcePlan
+            | Self::PciCapacity { .. } => None,
         }
     }
 }
@@ -606,6 +902,388 @@ fn prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with(
     })
 }
 
+/// Proves one complete exact-2.6 block-then-pmem PCI product before any live
+/// Hypervisor.framework construction.
+pub fn prepare_hvf_snapshot_v2_storage_pci_platform_plan(
+    platform: &HvfSnapshotV2PlatformState,
+    bundle: &PreparedSnapshotV2StorageBundle,
+) -> Result<HvfSnapshotV2StoragePciPlatformPlan, PrepareHvfSnapshotV2StoragePciPlatformPlanError> {
+    prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
+        platform,
+        bundle,
+        &mut SystemStoragePciPlatformPlanReserve,
+    )
+}
+
+fn prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
+    platform: &HvfSnapshotV2PlatformState,
+    bundle: &PreparedSnapshotV2StorageBundle,
+    reserve: &mut impl StoragePciPlatformPlanReserve,
+) -> Result<HvfSnapshotV2StoragePciPlatformPlan, PrepareHvfSnapshotV2StoragePciPlatformPlanError> {
+    if !platform.machine().fdt().is_product_process_profile()
+        || platform.time().rtc_layout()
+            != RtcMmioLayout::new(PROCESS_RTC_MMIO_BASE, PROCESS_RTC_MMIO_REGION_ID)
+    {
+        return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::PlatformProfile);
+    }
+    if bundle.transport_kind() != SnapshotV2DeviceTransportKind::Pci {
+        return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::TransportPolicy);
+    }
+
+    let block_records = bundle
+        .block_bundle()
+        .map_or(&[][..], |block| block.records());
+    let block_configs = bundle
+        .block_bundle()
+        .map_or(&[][..], |block| block.drive_configs().as_slice());
+    let block_retry_projection = bundle
+        .block_bundle()
+        .map_or(&[][..], |block| block.retry_projection());
+    let pmem_records = bundle.pmem_records();
+    let pmem_configs = bundle.pmem_configs().as_slice();
+    let record_count = block_records
+        .len()
+        .checked_add(pmem_records.len())
+        .ok_or(PrepareHvfSnapshotV2StoragePciPlatformPlanError::Cardinality)?;
+    if record_count == 0
+        || record_count > usize::from(NATIVE_V2_STORAGE_DEVICE_GRAPH_MAX_RECORDS)
+        || block_records.len() != block_configs.len()
+        || block_records.len() != block_retry_projection.len()
+        || pmem_records.len() != pmem_configs.len()
+    {
+        return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::Cardinality);
+    }
+    if record_count > PCI_ENDPOINT_SLOT_COUNT {
+        return Err(
+            PrepareHvfSnapshotV2StoragePciPlatformPlanError::PciCapacity {
+                count: record_count,
+                maximum: PCI_ENDPOINT_SLOT_COUNT,
+            },
+        );
+    }
+
+    let gic = platform.global().compatibility().gic_metadata();
+    let msi = gic
+        .msi
+        .ok_or(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
+    let expected_msi = pci_root_restore_gic_msi_configuration()
+        .map_err(|_| PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
+    if msi.interrupt_range.count != expected_msi.interrupt_count().get() {
+        return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan);
+    }
+    let address_plan = Arm64PciAddressPlan::firecracker_v1_16()
+        .map_err(|_| PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
+
+    let block_route_count = snapshot_v2_pci_endpoint_route_count(VIRTIO_BLOCK_QUEUE_SIZES.len())
+        .ok_or(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
+    let pmem_route_count = snapshot_v2_pci_endpoint_route_count(VIRTIO_PMEM_QUEUE_SIZES.len())
+        .ok_or(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
+    let route_demand = block_records
+        .len()
+        .checked_mul(block_route_count)
+        .and_then(|demand| {
+            pmem_records
+                .len()
+                .checked_mul(pmem_route_count)
+                .and_then(|pmem| demand.checked_add(pmem))
+        })
+        .ok_or(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
+    if route_demand
+        > usize::try_from(msi.interrupt_range.count)
+            .map_err(|_| PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?
+    {
+        return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan);
+    }
+
+    let mut block_metrics_ids = Vec::new();
+    let mut pmem_metrics_ids = Vec::new();
+    let mut block_retries = Vec::new();
+    let mut pmem_retries = Vec::new();
+    let mut planned_block = Vec::new();
+    let mut planned_pmem = Vec::new();
+    let mut planned_pmem_ranges = Vec::new();
+    let mut all_queue_ranges = Vec::new();
+    let mut active_msi_routes = Vec::new();
+    let mut used_pci_slots = Vec::new();
+    reserve.reserve(&mut block_metrics_ids, block_records.len())?;
+    reserve.reserve(&mut pmem_metrics_ids, pmem_records.len())?;
+    reserve.reserve(&mut block_retries, block_records.len())?;
+    reserve.reserve(&mut pmem_retries, pmem_records.len())?;
+    reserve.reserve(&mut planned_block, block_records.len())?;
+    reserve.reserve(&mut planned_pmem, pmem_records.len())?;
+    reserve.reserve(&mut planned_pmem_ranges, pmem_records.len())?;
+    reserve.reserve(&mut all_queue_ranges, record_count.saturating_mul(3))?;
+    reserve.reserve(&mut active_msi_routes, route_demand)?;
+    reserve.reserve(&mut used_pci_slots, record_count)?;
+
+    for ranges in block_records
+        .iter()
+        .filter_map(|record| record.queue_ranges())
+        .chain(
+            pmem_records
+                .iter()
+                .filter_map(|record| record.queue_ranges()),
+        )
+    {
+        all_queue_ranges.extend(ranges);
+    }
+
+    let mut root_key = None;
+    let mut root = None;
+    for ((record, config), projected_retry) in block_records
+        .iter()
+        .zip(block_configs)
+        .zip(block_retry_projection)
+    {
+        let read_only = config
+            .is_read_only()
+            .ok_or(PrepareHvfSnapshotV2StoragePciPlatformPlanError::RecordIdentity)?;
+        if record.transport().kind() != SnapshotV2DeviceTransportKind::Pci
+            || record.key() != projected_retry.key()
+            || record.retry() != projected_retry.retry()
+            || record.retry_deadline() != projected_retry.retry_deadline()
+            || record.drive_id() != config.drive_id()
+            || record.is_root_device() != config.is_root_device()
+            || record.config_space().is_read_only() != read_only
+            || record.device().device().io_engine() != config.io_engine()
+            || record.device().cache_type() != config.cache_type()
+            || config.is_vhost_user()
+            || block_metrics_ids
+                .iter()
+                .any(|candidate| candidate == config.drive_id())
+        {
+            return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::RecordIdentity);
+        }
+        if queue_ranges_conflict_with_pci_platform(
+            platform,
+            record.queue_ranges(),
+            &gic,
+            address_plan,
+        )? {
+            return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::QueuePlatformConflict);
+        }
+        if config.is_root_device() {
+            if root_key.replace(record.key()).is_some() || root.is_some() {
+                return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::RootIdentity);
+            }
+            root = Some(StorageRoot::Block {
+                partuuid: config.partuuid(),
+                read_only,
+            });
+        }
+        block_metrics_ids.push(pci_try_clone(config.drive_id())?);
+        block_retries.push(HvfSnapshotV2StorageRetryPlan {
+            key: record.key(),
+            retry: record.retry(),
+            retry_deadline: record.retry_deadline(),
+        });
+        let planned = plan_pci_record(
+            record.key(),
+            record.transport(),
+            block_route_count,
+            VIRTIO_BLOCK_QUEUE_SIZES.len(),
+            msi,
+            address_plan,
+            &mut active_msi_routes,
+            &mut used_pci_slots,
+        )?;
+        planned_block.push(planned);
+    }
+
+    for (pmem_index, (record, config)) in pmem_records.iter().zip(pmem_configs).enumerate() {
+        let prepared = record.prepared_device();
+        let guest_range = prepared.guest_range();
+        if record.transport().kind() != SnapshotV2DeviceTransportKind::Pci
+            || record.pmem_id() != config.id()
+            || record.is_root_device() != config.root_device()
+            || prepared.id() != config.id()
+            || prepared.backing().is_read_only() != config.read_only()
+            || prepared.mapping().is_read_only() != config.read_only()
+            || prepared.rate_limiter() != config.rate_limiter()
+            || prepared.config_space().available_features() != record.virtio().available_features()
+            || prepared.mapping().mapped_len() != guest_range.size()
+            || pmem_metrics_ids
+                .iter()
+                .any(|candidate| candidate == config.id())
+        {
+            return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::RecordIdentity);
+        }
+        if mapping_range_conflicts_with_pci_platform(platform, guest_range, &gic, address_plan)?
+            || planned_pmem_ranges
+                .iter()
+                .any(|planned: &GuestMemoryRange| planned.overlaps(guest_range))
+            || all_queue_ranges
+                .iter()
+                .any(|queue| queue.overlaps(guest_range))
+        {
+            return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::PmemRangeConflict);
+        }
+        if queue_ranges_conflict_with_pci_platform(
+            platform,
+            record.queue_ranges(),
+            &gic,
+            address_plan,
+        )? {
+            return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::QueuePlatformConflict);
+        }
+        if config.root_device() {
+            if root_key.replace(record.key()).is_some() || root.is_some() {
+                return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::RootIdentity);
+            }
+            root = Some(StorageRoot::Pmem {
+                index: pmem_index,
+                read_only: config.read_only(),
+            });
+        }
+        pmem_metrics_ids.push(pci_try_clone(config.id())?);
+        pmem_retries.push(HvfSnapshotV2StorageRetryPlan {
+            key: record.key(),
+            retry: record.retry(),
+            retry_deadline: record.retry_deadline(),
+        });
+        let planned = plan_pci_record(
+            record.key(),
+            record.transport(),
+            pmem_route_count,
+            VIRTIO_PMEM_QUEUE_SIZES.len(),
+            msi,
+            address_plan,
+            &mut active_msi_routes,
+            &mut used_pci_slots,
+        )?;
+        planned_pmem_ranges.push(guest_range);
+        planned_pmem.push(planned);
+    }
+
+    if bundle.root_key() != root_key || bundle.root_key().is_some() != root.is_some() {
+        return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::RootIdentity);
+    }
+    let base_arguments = platform.machine().boot().boot_arguments();
+    let command_line = match root {
+        Some(StorageRoot::Block {
+            partuuid,
+            read_only,
+        }) => canonical_process_root_block_command_line(base_arguments, true, partuuid, read_only),
+        Some(StorageRoot::Pmem { index, read_only }) => {
+            canonical_process_root_pmem_command_line(base_arguments, true, index, read_only)
+        }
+        None => canonical_process_block_command_line(base_arguments, true),
+    }
+    .map_err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::CommandLine)?;
+
+    let mut interrupt_allocator = HvfGicInterruptLineAllocator::from_metadata(&gic)
+        .map_err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::Interrupt)?;
+    let serial_interrupt = interrupt_allocator
+        .allocate()
+        .map_err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::Interrupt)?;
+    let vmgenid_interrupt = interrupt_allocator
+        .allocate()
+        .map_err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::Interrupt)?;
+    let vmclock_interrupt = interrupt_allocator
+        .allocate()
+        .map_err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::Interrupt)?;
+    if platform.time().vmgenid().interrupt_line() != vmgenid_interrupt
+        || platform.time().vmclock().interrupt_line() != vmclock_interrupt
+        || planned_block.len() + planned_pmem.len() != record_count
+    {
+        return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan);
+    }
+
+    Ok(HvfSnapshotV2StoragePciPlatformPlan {
+        root_key,
+        command_line,
+        block_metrics_ids,
+        pmem_metrics_ids,
+        block_retries,
+        pmem_retries,
+        pci: HvfSnapshotV2StoragePciHostPlan {
+            host: Arm64FdtPciHost::from_address_plan(address_plan),
+            msi,
+            route_demand,
+            block_records: planned_block,
+            pmem_records: planned_pmem,
+        },
+        serial_interrupt,
+        vmgenid_interrupt,
+        vmclock_interrupt,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn plan_pci_record(
+    key: SnapshotV2DeviceKey,
+    transport: &SnapshotV2DeviceTransport,
+    route_count: usize,
+    queue_count: usize,
+    msi: HvfGicMsiMetadata,
+    address_plan: Arm64PciAddressPlan,
+    active_routes: &mut Vec<(u64, u32)>,
+    used_slots: &mut Vec<usize>,
+) -> Result<HvfSnapshotV2StoragePciRecordPlan, PrepareHvfSnapshotV2StoragePciPlatformPlanError> {
+    let SnapshotV2DeviceTransport::Pci(captured) = transport else {
+        return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::TransportPolicy);
+    };
+    let slot = captured
+        .sbdf()
+        .device()
+        .checked_sub(PCI_FIRST_ENDPOINT_DEVICE)
+        .map(usize::from)
+        .ok_or(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
+    let placement = snapshot_v2_pci_endpoint_placement(address_plan, slot)
+        .ok_or(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
+    if captured.sbdf() != placement.sbdf
+        || captured.bar_range() != placement.bar_range
+        || used_slots.contains(&slot)
+        || !valid_snapshot_v2_pci_record(captured, msi, queue_count)
+        || !register_active_pci_routes(captured, active_routes)
+    {
+        return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan);
+    }
+    used_slots.push(slot);
+    Ok(HvfSnapshotV2StoragePciRecordPlan {
+        key,
+        origin: captured.origin(),
+        sbdf: placement.sbdf,
+        bar_region_id: placement.bar_region_id,
+        bar_range: placement.bar_range,
+        route_count,
+    })
+}
+
+fn register_active_pci_routes(
+    state: &bangbang_runtime::snapshot_device_v2::SnapshotV2PciDeviceState,
+    active_routes: &mut Vec<(u64, u32)>,
+) -> bool {
+    state
+        .msix()
+        .entries()
+        .iter()
+        .enumerate()
+        .all(|(index, entry)| {
+            let Ok(vector) = u16::try_from(index) else {
+                return false;
+            };
+            let referenced = state.msix().config_vector() == vector
+                || state.msix().queue_vectors().contains(&vector);
+            let pending = state
+                .msix()
+                .pending_words()
+                .get(index / u64::BITS as usize)
+                .is_some_and(|word| word & (1_u64 << (index % u64::BITS as usize)) != 0);
+            if entry.vector_control() & 1 != 0 || (!referenced && !pending) {
+                return true;
+            }
+            let address = (u64::from(entry.message_address_high()) << 32)
+                | u64::from(entry.message_address_low());
+            let route = (address, entry.message_data());
+            if active_routes.contains(&route) {
+                return false;
+            }
+            active_routes.push(route);
+            true
+        })
+}
+
 fn validate_platform_profile(
     platform: &HvfSnapshotV2PlatformState,
 ) -> Result<(), PrepareHvfSnapshotV2StorageMmioPlatformPlanError> {
@@ -786,6 +1464,103 @@ fn mmio_region_conflicts_with_platform(
     Ok(false)
 }
 
+fn queue_ranges_conflict_with_pci_platform(
+    platform: &HvfSnapshotV2PlatformState,
+    queue_ranges: Option<[GuestMemoryRange; 3]>,
+    gic: &HvfGicMetadata,
+    address_plan: Arm64PciAddressPlan,
+) -> Result<bool, PrepareHvfSnapshotV2StoragePciPlatformPlanError> {
+    let Some(queue_ranges) = queue_ranges else {
+        return Ok(false);
+    };
+    let fdt = platform.machine().fdt();
+    let fdt_range = GuestMemoryRange::new(fdt.address(), u64::from(fdt.size()))
+        .map_err(|_| PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
+    let msi = gic
+        .msi
+        .ok_or(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
+    let fixed = [
+        fdt_range,
+        platform.time().vmgenid().range(),
+        platform.time().vmclock().range(),
+        gic_region_range(gic.distributor)
+            .map_err(|_| PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?,
+        gic_region_range(gic.redistributor.region)
+            .map_err(|_| PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?,
+        gic_region_range(msi.region)
+            .map_err(|_| PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?,
+        address_plan.ecam_reservation(),
+        address_plan.bar32(),
+        address_plan.bar64(),
+    ];
+    if queue_ranges
+        .iter()
+        .any(|queue| fixed.into_iter().any(|reserved| queue.overlaps(reserved)))
+    {
+        return Ok(true);
+    }
+    let pvtime_size = u64::try_from(ARM64_PVTIME_STRUCTURE_SIZE)
+        .map_err(|_| PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
+    for record in platform.time().pvtime_vcpus() {
+        let range = GuestMemoryRange::new(record.record_ipa(), pvtime_size)
+            .map_err(|_| PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
+        if queue_ranges.iter().any(|queue| queue.overlaps(range)) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn mapping_range_conflicts_with_pci_platform(
+    platform: &HvfSnapshotV2PlatformState,
+    range: GuestMemoryRange,
+    gic: &HvfGicMetadata,
+    address_plan: Arm64PciAddressPlan,
+) -> Result<bool, PrepareHvfSnapshotV2StoragePciPlatformPlanError> {
+    if platform
+        .memory()
+        .extents()
+        .iter()
+        .any(|extent| range.overlaps(extent.range()))
+    {
+        return Ok(true);
+    }
+    let fdt = platform.machine().fdt();
+    let msi = gic
+        .msi
+        .ok_or(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
+    let fixed = [
+        GuestMemoryRange::new(fdt.address(), u64::from(fdt.size())),
+        Ok(platform.time().vmgenid().range()),
+        Ok(platform.time().vmclock().range()),
+        GuestMemoryRange::new(PROCESS_SERIAL_MMIO_BASE, SERIAL_MMIO_DEVICE_WINDOW_SIZE),
+        GuestMemoryRange::new(PROCESS_RTC_MMIO_BASE, RTC_MMIO_DEVICE_WINDOW_SIZE),
+        gic_region_range(gic.distributor),
+        gic_region_range(gic.redistributor.region),
+        gic_region_range(msi.region),
+        Ok(address_plan.ecam_reservation()),
+        Ok(address_plan.bar32()),
+        Ok(address_plan.bar64()),
+    ];
+    for fixed in fixed {
+        let fixed =
+            fixed.map_err(|_| PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
+        if range.overlaps(fixed) {
+            return Ok(true);
+        }
+    }
+    let pvtime_size = u64::try_from(ARM64_PVTIME_STRUCTURE_SIZE)
+        .map_err(|_| PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
+    for record in platform.time().pvtime_vcpus() {
+        let pvtime = GuestMemoryRange::new(record.record_ipa(), pvtime_size)
+            .map_err(|_| PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
+        if range.overlaps(pvtime) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 fn gic_region_range(
     region: crate::gic::HvfGicRegion,
 ) -> Result<GuestMemoryRange, bangbang_runtime::memory::GuestMemoryError> {
@@ -797,6 +1572,15 @@ fn try_clone(value: &str) -> Result<String, PrepareHvfSnapshotV2StorageMmioPlatf
     cloned
         .try_reserve_exact(value.len())
         .map_err(|_| PrepareHvfSnapshotV2StorageMmioPlatformPlanError::Allocation)?;
+    cloned.push_str(value);
+    Ok(cloned)
+}
+
+fn pci_try_clone(value: &str) -> Result<String, PrepareHvfSnapshotV2StoragePciPlatformPlanError> {
+    let mut cloned = String::new();
+    cloned
+        .try_reserve_exact(value.len())
+        .map_err(|_| PrepareHvfSnapshotV2StoragePciPlatformPlanError::Allocation)?;
     cloned.push_str(value);
     Ok(cloned)
 }
@@ -823,8 +1607,30 @@ impl StoragePlatformPlanReserve for SystemStoragePlatformPlanReserve {
     }
 }
 
+trait StoragePciPlatformPlanReserve {
+    fn reserve<T>(
+        &mut self,
+        values: &mut Vec<T>,
+        additional: usize,
+    ) -> Result<(), PrepareHvfSnapshotV2StoragePciPlatformPlanError>;
+}
+
+struct SystemStoragePciPlatformPlanReserve;
+
+impl StoragePciPlatformPlanReserve for SystemStoragePciPlatformPlanReserve {
+    fn reserve<T>(
+        &mut self,
+        values: &mut Vec<T>,
+        additional: usize,
+    ) -> Result<(), PrepareHvfSnapshotV2StoragePciPlatformPlanError> {
+        values
+            .try_reserve_exact(additional)
+            .map_err(|_| PrepareHvfSnapshotV2StoragePciPlatformPlanError::Allocation)
+    }
+}
+
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::fs::{self, OpenOptions};
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -856,6 +1662,10 @@ mod tests {
         include_str!("../../runtime/src/snapshot_device_v2_6/fixtures/mixed-block-root-mmio.hex");
     const PMEM_ROOTLESS_PCI_HEX: &str =
         include_str!("../../runtime/src/snapshot_device_v2_6/fixtures/pmem-rootless-pci.hex");
+    const BLOCK_ROOTLESS_PCI_HEX: &str =
+        include_str!("../../runtime/src/snapshot_device_v2_6/fixtures/block-rootless-pci.hex");
+    const MIXED_PMEM_ROOT_PCI_HEX: &str =
+        include_str!("../../runtime/src/snapshot_device_v2_6/fixtures/mixed-pmem-root-pci.hex");
     const PROFILE_2_ROOTLESS_MMIO_HEX: &str =
         include_str!("../../runtime/src/snapshot_device_v2_5/fixtures/rootless-mmio.hex");
 
@@ -1146,6 +1956,32 @@ mod tests {
         }
     }
 
+    fn pci_fixture(hex: &str) -> StorageFixture {
+        let graph = storage_graph(hex);
+        let platform = crate::snapshot_v2_multi_block_platform::tests::product_pci_platform();
+        let (bundle, files) = bundle_from_graph(graph);
+        StorageFixture {
+            platform,
+            bundle,
+            _files: files,
+        }
+    }
+
+    pub(crate) fn pci_fdt_plan_fixture() -> (
+        HvfSnapshotV2PlatformState,
+        HvfSnapshotV2StoragePciPlatformPlan,
+    ) {
+        let fixture = pci_fixture(MIXED_PMEM_ROOT_PCI_HEX);
+        let plan =
+            prepare_hvf_snapshot_v2_storage_pci_platform_plan(&fixture.platform, &fixture.bundle)
+                .expect("storage PCI FDT plan should validate");
+        fixture
+            .bundle
+            .abort()
+            .expect("storage PCI FDT bundle should abort");
+        (fixture.platform, plan)
+    }
+
     const fn process_config() -> HvfSnapshotV2StorageMmioProcessConfig {
         HvfSnapshotV2StorageMmioProcessConfig::new(
             BlockMmioLayout::new(BLOCK_MMIO_BASE, BLOCK_MMIO_REGION_ID),
@@ -1247,6 +2083,62 @@ mod tests {
     }
 
     #[test]
+    fn pci_shape_matrix_projects_one_combined_host_and_endpoint_order() {
+        for (hex, block_count, pmem_count, has_root) in [
+            (BLOCK_ROOTLESS_PCI_HEX, 1, 0, false),
+            (PMEM_ROOTLESS_PCI_HEX, 0, 1, false),
+            (MIXED_PMEM_ROOT_PCI_HEX, 1, 1, true),
+        ] {
+            let fixture = pci_fixture(hex);
+            let plan = prepare_hvf_snapshot_v2_storage_pci_platform_plan(
+                &fixture.platform,
+                &fixture.bundle,
+            )
+            .expect("storage PCI matrix entry should plan");
+            assert_eq!(plan.pci().block_records().len(), block_count);
+            assert_eq!(plan.pci().pmem_records().len(), pmem_count);
+            assert_eq!(plan.pci().record_count(), block_count + pmem_count);
+            assert_eq!(plan.root_key().is_some(), has_root);
+            assert!(!plan.command_line().contains("pci=off"));
+            if has_root {
+                assert!(plan.command_line().contains("root=/dev/pmem0"));
+            } else {
+                assert!(!plan.command_line().contains("root="));
+            }
+            let address_plan =
+                Arm64PciAddressPlan::firecracker_v1_16().expect("PCI plan should build");
+            let mut expected_routes = 0;
+            for (index, record) in plan
+                .pci()
+                .block_records()
+                .iter()
+                .chain(plan.pci().pmem_records())
+                .enumerate()
+            {
+                let placement = snapshot_v2_pci_endpoint_placement(address_plan, index)
+                    .expect("combined endpoint placement should exist");
+                assert_eq!(record.sbdf(), placement.sbdf);
+                assert_eq!(record.bar_region_id(), placement.bar_region_id);
+                assert_eq!(record.bar_range(), placement.bar_range);
+                expected_routes += record.route_count();
+            }
+            assert_eq!(plan.pci().route_demand(), expected_routes);
+            assert_eq!(
+                plan.pci().host(),
+                Arm64FdtPciHost::from_address_plan(address_plan)
+            );
+            let debug = format!("{plan:?}");
+            for secret in ["rootfs", "pmem_0", "PARTUUID", "root=/dev/pmem"] {
+                assert!(!debug.contains(secret));
+            }
+            fixture
+                .bundle
+                .abort()
+                .expect("planned PCI storage bundle should abort cleanly");
+        }
+    }
+
+    #[test]
     fn placement_interrupt_and_fixed_range_conflicts_fail_before_construction() {
         let fixture = fixture(FixtureShape::MixedBlockRoot);
         let shifted = HvfSnapshotV2StorageMmioProcessConfig::new(
@@ -1318,6 +2210,24 @@ mod tests {
         }
     }
 
+    impl StoragePciPlatformPlanReserve for FailingReserve {
+        fn reserve<T>(
+            &mut self,
+            values: &mut Vec<T>,
+            additional: usize,
+        ) -> Result<(), PrepareHvfSnapshotV2StoragePciPlatformPlanError> {
+            let call = self.calls;
+            self.calls = self.calls.saturating_add(1);
+            if call == self.fail_at {
+                Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::Allocation)
+            } else {
+                values
+                    .try_reserve_exact(additional)
+                    .map_err(|_| PrepareHvfSnapshotV2StoragePciPlatformPlanError::Allocation)
+            }
+        }
+    }
+
     #[test]
     fn every_platform_inventory_reservation_reports_explicit_allocation_failure() {
         for fail_at in 0..7 {
@@ -1335,6 +2245,25 @@ mod tests {
                 .bundle
                 .abort()
                 .expect("allocation fixture should abort cleanly");
+        }
+    }
+
+    #[test]
+    fn every_pci_platform_inventory_reservation_reports_explicit_allocation_failure() {
+        for fail_at in 0..10 {
+            let fixture = pci_fixture(MIXED_PMEM_ROOT_PCI_HEX);
+            assert!(matches!(
+                prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
+                    &fixture.platform,
+                    &fixture.bundle,
+                    &mut FailingReserve { calls: 0, fail_at },
+                ),
+                Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::Allocation)
+            ));
+            fixture
+                .bundle
+                .abort()
+                .expect("PCI allocation fixture should abort cleanly");
         }
     }
 }

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -31,7 +31,7 @@ use bangbang_runtime::block::{
 };
 use bangbang_runtime::boot::{
     BootSourceFiles, canonical_process_block_command_line,
-    canonical_process_root_block_command_line,
+    canonical_process_root_block_command_line, canonical_process_root_pmem_command_line,
 };
 use bangbang_runtime::boot_timer::{
     BootTimerMmioLayout, BootTimerMmioRegistrationError, register_boot_timer_mmio,
@@ -117,8 +117,10 @@ use bangbang_runtime::snapshot_device_v2_5::{
 };
 use bangbang_runtime::snapshot_device_v2_6::{
     NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION, PreparedSnapshotV2StorageBundle,
-    PreparedSnapshotV2StorageMmioBundle, SnapshotV2StorageCleanupError,
+    PreparedSnapshotV2StorageMmioBundle, PreparedSnapshotV2StoragePciBundle,
+    PreparedSnapshotV2StoragePciPmemEndpoint, SnapshotV2StorageCleanupError,
     SnapshotV2StorageDeviceGraph, SnapshotV2StorageMmioTransportError,
+    SnapshotV2StoragePciTransportError,
 };
 use bangbang_runtime::snapshot_format::SnapshotFormatVersion;
 use bangbang_runtime::snapshot_format_v2::NATIVE_V2_LEGACY_PLATFORM_VERSION;
@@ -241,13 +243,16 @@ use crate::snapshot_v2_platform::{
     HvfSnapshotV2MultiBlockPciShellPlan, HvfSnapshotV2PlatformRestoreError,
     HvfSnapshotV2PlatformShutdownError, HvfSnapshotV2RootResourcePlan,
     HvfSnapshotV2RootTransportPlan, HvfSnapshotV2StorageMmioShellPlan,
-    RestoredHvfSnapshotV2Platform, restore_hvf_snapshot_v2_multi_block_mmio_process_platform,
+    HvfSnapshotV2StoragePciShellPlan, RestoredHvfSnapshotV2Platform,
+    restore_hvf_snapshot_v2_multi_block_mmio_process_platform,
     restore_hvf_snapshot_v2_multi_block_pci_process_platform,
     restore_hvf_snapshot_v2_root_process_platform,
     restore_hvf_snapshot_v2_storage_mmio_process_platform,
+    restore_hvf_snapshot_v2_storage_pci_process_platform,
 };
 use crate::snapshot_v2_storage_platform::{
     HvfSnapshotV2StorageMmioPlatformPlan, HvfSnapshotV2StorageMmioPlatformPlanParts,
+    HvfSnapshotV2StoragePciPlatformPlan, HvfSnapshotV2StoragePciPlatformPlanParts,
 };
 use crate::topology::{HvfVcpuTopologyError, prepare_ordered_mpidrs};
 use crate::vcpu::{
@@ -3415,6 +3420,7 @@ pub struct OwnedHvfArm64BootSession {
     mmio_dispatcher: Arc<Mutex<MmioDispatcher>>,
     runtime_resources: Arm64BootRuntimeResources,
     restored_snapshot_v2_mmio_registrations: Option<HvfSnapshotV2MultiBlockMmioRegistrations>,
+    restored_snapshot_v2_pci_pmem_ranges: Option<Vec<GuestMemoryRange>>,
     restored_snapshot_v2_memory_binding: Option<SnapshotV2MemoryBinding>,
     restored_snapshot_v2_machine: Option<HvfSnapshotV2MachineState>,
     cpu_template_application: Option<crate::cpu_template::HvfArm64CpuTemplateApplicationState>,
@@ -4160,6 +4166,363 @@ impl fmt::Display for HvfSnapshotV2StorageMmioRestoreError {
 }
 
 impl std::error::Error for HvfSnapshotV2StorageMmioRestoreError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.failure.as_ref())
+    }
+}
+
+/// One complete, still-private exact-2.6 PCI storage destination and ordered
+/// controller projection.
+pub struct RestoredHvfSnapshotV2StoragePciOwners {
+    session: OwnedHvfArm64BootSession,
+    configs: CaptureReadyStorageConfigs,
+}
+
+impl RestoredHvfSnapshotV2StoragePciOwners {
+    pub const fn session(&self) -> &OwnedHvfArm64BootSession {
+        &self.session
+    }
+
+    pub const fn configs(&self) -> &CaptureReadyStorageConfigs {
+        &self.configs
+    }
+
+    pub fn into_parts(self) -> (OwnedHvfArm64BootSession, CaptureReadyStorageConfigs) {
+        (self.session, self.configs)
+    }
+}
+
+impl fmt::Debug for RestoredHvfSnapshotV2StoragePciOwners {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RestoredHvfSnapshotV2StoragePciOwners")
+            .field("block_count", &self.configs.drives().len())
+            .field("pmem_count", &self.configs.pmem().len())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Stage at which exact-2.6 heterogeneous PCI owner reconstruction stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfSnapshotV2StoragePciRestoreStage {
+    MemoryLayout,
+    Transport,
+    ResourcePlan,
+    BlockMetrics,
+    PmemMetrics,
+    Platform,
+    PciHost,
+    PciRoutes,
+    EndpointPreparation { index: usize },
+    Mapping { index: usize },
+    Publication { index: usize },
+    BlockRetryScheduler,
+    PmemRetryScheduler,
+}
+
+/// Primary failure from exact-2.6 heterogeneous PCI reconstruction.
+pub enum HvfSnapshotV2StoragePciRestoreFailure {
+    Allocation,
+    MemoryLayout,
+    Transport(SnapshotV2StoragePciTransportError),
+    ResourcePlan,
+    BlockMetrics(BlockDeviceMetricsRegistryError),
+    PmemMetrics(PmemDeviceMetricsRegistryError),
+    Platform(Box<HvfSnapshotV2PlatformRestoreError>),
+    DispatcherUnavailable,
+    PciHost(Arm64BootResourceError),
+    PciData(HvfArm64BootPciDataError),
+    PciRoutes(HvfGicMsiDeviceInterruptResourceError),
+    PciEndpoint(SnapshotV2RootTransportRestoreError),
+    Mapping(HvfGuestMemoryMappingError),
+    PciPublication(VirtioPciPublicationError),
+    InjectedPublication,
+    RetryScheduler(io::ErrorKind),
+}
+
+impl fmt::Debug for HvfSnapshotV2StoragePciRestoreFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::Allocation => "allocation",
+            Self::MemoryLayout => "memory-layout",
+            Self::Transport(_) => "transport",
+            Self::ResourcePlan => "resource-plan",
+            Self::BlockMetrics(_) => "block-metrics",
+            Self::PmemMetrics(_) => "pmem-metrics",
+            Self::Platform(_) => "platform",
+            Self::DispatcherUnavailable => "dispatcher",
+            Self::PciHost(_) => "pci-host",
+            Self::PciData(_) => "pci-data",
+            Self::PciRoutes(_) => "pci-routes",
+            Self::PciEndpoint(_) => "pci-endpoint",
+            Self::Mapping(_) => "mapping",
+            Self::PciPublication(_) => "pci-publication",
+            Self::InjectedPublication => "injected-publication",
+            Self::RetryScheduler(_) => "retry-scheduler",
+        };
+        formatter
+            .debug_struct("HvfSnapshotV2StoragePciRestoreFailure")
+            .field("kind", &kind)
+            .field("source", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2StoragePciRestoreFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Allocation => "exact-2.6 PCI owner allocation failed",
+            Self::MemoryLayout => "restored memory layout is invalid",
+            Self::Transport(_) => "exact-2.6 PCI transport reconstruction failed",
+            Self::ResourcePlan => "exact-2.6 PCI resource plan diverged",
+            Self::BlockMetrics(_) => "exact-2.6 block metrics ownership failed",
+            Self::PmemMetrics(_) => "exact-2.6 pmem metrics ownership failed",
+            Self::Platform(_) => "HVF platform reconstruction failed",
+            Self::DispatcherUnavailable => "exact-2.6 PCI dispatcher is unavailable",
+            Self::PciHost(_) => "exact-2.6 PCI host reconstruction failed",
+            Self::PciData(_) => "exact-2.6 PCI manager reconstruction failed",
+            Self::PciRoutes(_) => "exact-2.6 PCI route reconstruction failed",
+            Self::PciEndpoint(_) => "exact-2.6 PCI endpoint preparation failed",
+            Self::Mapping(_) => "exact-2.6 pmem mapping reconstruction failed",
+            Self::PciPublication(_) => "exact-2.6 PCI endpoint publication failed",
+            Self::InjectedPublication => {
+                "exact-2.6 PCI publication certification fault was injected"
+            }
+            Self::RetryScheduler(kind) => {
+                return write!(
+                    formatter,
+                    "storage retry scheduler startup failed: {kind:?}"
+                );
+            }
+        })
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2StoragePciRestoreFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Transport(source) => Some(source),
+            Self::BlockMetrics(source) => Some(source),
+            Self::PmemMetrics(source) => Some(source),
+            Self::Platform(source) => Some(source.as_ref()),
+            Self::PciHost(source) => Some(source),
+            Self::PciData(source) => Some(source),
+            Self::PciRoutes(HvfGicMsiDeviceInterruptResourceError::Rollback { .. })
+            | Self::PciPublication(VirtioPciPublicationError::Rollback { .. }) => None,
+            Self::PciRoutes(source) => Some(source),
+            Self::PciEndpoint(source) => Some(source),
+            Self::Mapping(source) => Some(source),
+            Self::PciPublication(source) => Some(source),
+            Self::Allocation
+            | Self::MemoryLayout
+            | Self::ResourcePlan
+            | Self::DispatcherUnavailable
+            | Self::InjectedPublication
+            | Self::RetryScheduler(_) => None,
+        }
+    }
+}
+
+/// Cleanup uncertainty retained after exact-2.6 PCI reconstruction failed.
+pub enum HvfSnapshotV2StoragePciRestoreCleanupFailure {
+    PreparedBundle(SnapshotV2StorageCleanupError),
+    BlockRetryScheduler,
+    PmemRetryScheduler,
+    AsyncGuestMemory(HvfGuestMemoryMappingError),
+    Async(BlockAsyncRuntimeError),
+    Pci(HvfArm64BootPciDataError),
+    Mapping {
+        index: usize,
+        source: HvfGuestMemoryMappingError,
+    },
+    Platform(HvfSnapshotV2PlatformShutdownError),
+}
+
+impl fmt::Debug for HvfSnapshotV2StoragePciRestoreCleanupFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::PreparedBundle(_) => "prepared-bundle",
+            Self::BlockRetryScheduler => "block-retry-scheduler",
+            Self::PmemRetryScheduler => "pmem-retry-scheduler",
+            Self::AsyncGuestMemory(_) => "async-guest-memory",
+            Self::Async(_) => "async-runtime",
+            Self::Pci(_) => "pci-owner",
+            Self::Mapping { .. } => "mapping",
+            Self::Platform(_) => "platform",
+        };
+        formatter
+            .debug_struct("HvfSnapshotV2StoragePciRestoreCleanupFailure")
+            .field("kind", &kind)
+            .field("source", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2StoragePciRestoreCleanupFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::PreparedBundle(_) => "prepared storage bundle cleanup failed",
+            Self::BlockRetryScheduler => "block retry scheduler cleanup failed",
+            Self::PmemRetryScheduler => "pmem retry scheduler cleanup failed",
+            Self::AsyncGuestMemory(_) => "Async cleanup could not borrow guest memory",
+            Self::Async(_) => "Async runtime cleanup failed",
+            Self::Pci(_) => "PCI owner cleanup failed",
+            Self::Mapping { .. } => "pmem mapping cleanup failed",
+            Self::Platform(_) => "HVF platform cleanup failed",
+        })
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2StoragePciRestoreCleanupFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::PreparedBundle(source) => Some(source),
+            Self::AsyncGuestMemory(source) => Some(source),
+            Self::Async(source) => Some(source),
+            Self::Pci(source) => Some(source),
+            Self::Mapping { source, .. } => Some(source),
+            Self::Platform(source) => Some(source),
+            Self::BlockRetryScheduler | Self::PmemRetryScheduler => None,
+        }
+    }
+}
+
+/// Redacted exact-2.6 PCI reconstruction failure with ordered cleanup evidence.
+pub struct HvfSnapshotV2StoragePciRestoreError {
+    stage: HvfSnapshotV2StoragePciRestoreStage,
+    failure: Box<HvfSnapshotV2StoragePciRestoreFailure>,
+    cleanup: Vec<HvfSnapshotV2StoragePciRestoreCleanupFailure>,
+}
+
+impl HvfSnapshotV2StoragePciRestoreError {
+    fn preflight(
+        stage: HvfSnapshotV2StoragePciRestoreStage,
+        failure: HvfSnapshotV2StoragePciRestoreFailure,
+    ) -> Self {
+        Self {
+            stage,
+            failure: Box::new(failure),
+            cleanup: Vec::new(),
+        }
+    }
+
+    fn with_prepared_bundle_abort(
+        stage: HvfSnapshotV2StoragePciRestoreStage,
+        failure: HvfSnapshotV2StoragePciRestoreFailure,
+        bundle: PreparedSnapshotV2StoragePciBundle,
+    ) -> Self {
+        let cleanup = bundle
+            .abort()
+            .err()
+            .map(HvfSnapshotV2StoragePciRestoreCleanupFailure::PreparedBundle)
+            .into_iter()
+            .collect();
+        Self {
+            stage,
+            failure: Box::new(failure),
+            cleanup,
+        }
+    }
+
+    fn platform(
+        source: HvfSnapshotV2PlatformRestoreError,
+        bundle: PreparedSnapshotV2StoragePciBundle,
+    ) -> Self {
+        Self::with_prepared_bundle_abort(
+            HvfSnapshotV2StoragePciRestoreStage::Platform,
+            HvfSnapshotV2StoragePciRestoreFailure::Platform(Box::new(source)),
+            bundle,
+        )
+    }
+
+    fn after_platform(
+        stage: HvfSnapshotV2StoragePciRestoreStage,
+        failure: HvfSnapshotV2StoragePciRestoreFailure,
+        cleanup: Vec<HvfSnapshotV2StoragePciRestoreCleanupFailure>,
+    ) -> Self {
+        Self {
+            stage,
+            failure: Box::new(failure),
+            cleanup,
+        }
+    }
+
+    pub const fn stage(&self) -> HvfSnapshotV2StoragePciRestoreStage {
+        self.stage
+    }
+
+    pub fn cleanup_failures(&self) -> &[HvfSnapshotV2StoragePciRestoreCleanupFailure] {
+        &self.cleanup
+    }
+
+    pub fn has_incomplete_cleanup(&self) -> bool {
+        !self.cleanup.is_empty()
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2StoragePciRestoreFailure::Transport(source)
+                    if source.cleanup_failed()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2StoragePciRestoreFailure::Platform(source)
+                    if !source.cleanup_failures().is_empty()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2StoragePciRestoreFailure::PciRoutes(
+                    HvfGicMsiDeviceInterruptResourceError::Rollback { .. }
+                )
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2StoragePciRestoreFailure::PciPublication(
+                    VirtioPciPublicationError::Rollback { .. }
+                )
+            )
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        self.has_incomplete_cleanup()
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2StoragePciRestoreFailure::Platform(source)
+                    if source.is_committed()
+            )
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2StoragePciRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2StoragePciRestoreError")
+            .field("stage", &self.stage)
+            .field("failure", &"<redacted>")
+            .field("cleanup_count", &self.cleanup.len())
+            .field("terminal", &self.is_terminal())
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2StoragePciRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "exact-2.6 PCI owner reconstruction failed at {:?}: {}",
+            self.stage, self.failure
+        )?;
+        if !self.cleanup.is_empty() {
+            write!(
+                formatter,
+                "; {} cleanup failure(s) retained",
+                self.cleanup.len()
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2StoragePciRestoreError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(self.failure.as_ref())
     }
@@ -12584,6 +12947,163 @@ fn validate_snapshot_v2_storage_mmio_resource_plan(
     bundle.root_key() == root_key && bundle.root_key() == plan.root_key
 }
 
+fn validate_snapshot_v2_storage_pci_resource_plan(
+    bundle: &PreparedSnapshotV2StoragePciBundle,
+    plan: &HvfSnapshotV2StoragePciPlatformPlanParts,
+    base_arguments: Option<&str>,
+) -> bool {
+    let block_records = bundle
+        .block_bundle()
+        .map_or(&[][..], PreparedSnapshotV2MultiBlockPciBundle::records);
+    let block_configs = bundle
+        .block_bundle()
+        .map_or(&[][..], |block| block.drive_configs().as_slice());
+    let pmem_records = bundle.pmem_records();
+    let pmem_configs = bundle.pmem_configs().as_slice();
+    let planned_block = plan.pci.block_records();
+    let planned_pmem = plan.pci.pmem_records();
+    let record_count = block_records.len().saturating_add(pmem_records.len());
+    if record_count == 0
+        || record_count > PCI_ENDPOINT_SLOT_COUNT
+        || block_records.len() != block_configs.len()
+        || block_records.len() != planned_block.len()
+        || block_records.len() != plan.block_metrics_ids.len()
+        || block_records.len() != plan.block_retries.len()
+        || pmem_records.len() != pmem_configs.len()
+        || pmem_records.len() != planned_pmem.len()
+        || pmem_records.len() != plan.pmem_metrics_ids.len()
+        || pmem_records.len() != plan.pmem_retries.len()
+        || plan.pci.record_count() != record_count
+    {
+        return false;
+    }
+
+    let mut root_key = None;
+    let mut block_root = None;
+    let mut pmem_root = None;
+    let mut route_demand = 0_usize;
+    let expected_block_routes = VIRTIO_BLOCK_QUEUE_SIZES.len().checked_add(1);
+    for (index, ((((record, config), planned), retry), metrics_id)) in block_records
+        .iter()
+        .zip(block_configs)
+        .zip(planned_block)
+        .zip(&plan.block_retries)
+        .zip(&plan.block_metrics_ids)
+        .enumerate()
+    {
+        let async_binding_matches = match config.io_engine() {
+            Some(DriveIoEngine::Sync) => record.async_generation().is_none(),
+            Some(DriveIoEngine::Async) => record.async_generation().is_some(),
+            None => false,
+        };
+        if record.key() != planned.key()
+            || record.key() != retry.key()
+            || record.drive_id() != config.drive_id()
+            || record.drive_id() != metrics_id
+            || record.is_root_device() != config.is_root_device()
+            || record.origin() != planned.origin()
+            || record.sbdf() != planned.sbdf()
+            || record.bar_range() != planned.bar_range()
+            || snapshot_v2_storage_pci_region_id(record.sbdf()) != Some(planned.bar_region_id())
+            || Some(planned.route_count()) != expected_block_routes
+            || record.retry() != retry.retry()
+            || record.retry_deadline() != retry.retry_deadline()
+            || record.retry_deadline().is_some()
+                == matches!(record.retry(), StorageRetryState::None)
+            || !async_binding_matches
+            || (record.is_root_device() && index != 0)
+        {
+            return false;
+        }
+        route_demand = match route_demand.checked_add(planned.route_count()) {
+            Some(demand) => demand,
+            None => return false,
+        };
+        if record.is_root_device() {
+            if root_key.replace(record.key()).is_some() {
+                return false;
+            }
+            block_root = Some(config);
+        }
+    }
+
+    let expected_pmem_routes = VIRTIO_PMEM_QUEUE_SIZES.len().checked_add(1);
+    for (pmem_index, ((((record, config), planned), retry), metrics_id)) in pmem_records
+        .iter()
+        .zip(pmem_configs)
+        .zip(planned_pmem)
+        .zip(&plan.pmem_retries)
+        .zip(&plan.pmem_metrics_ids)
+        .enumerate()
+    {
+        let prepared = record.prepared_device();
+        if record.key() != planned.key()
+            || record.key() != retry.key()
+            || record.pmem_id() != config.id()
+            || record.pmem_id() != metrics_id
+            || record.is_root_device() != config.root_device()
+            || record.origin() != planned.origin()
+            || record.sbdf() != planned.sbdf()
+            || record.bar_range() != planned.bar_range()
+            || snapshot_v2_storage_pci_region_id(record.sbdf()) != Some(planned.bar_region_id())
+            || Some(planned.route_count()) != expected_pmem_routes
+            || record.retry() != retry.retry()
+            || record.retry_deadline() != retry.retry_deadline()
+            || record.retry_deadline().is_some()
+                == matches!(record.retry(), StorageRetryState::None)
+            || prepared.backing().is_read_only() != config.read_only()
+            || prepared.mapping().is_read_only() != config.read_only()
+            || prepared.rate_limiter() != config.rate_limiter()
+        {
+            return false;
+        }
+        route_demand = match route_demand.checked_add(planned.route_count()) {
+            Some(demand) => demand,
+            None => return false,
+        };
+        if record.is_root_device() {
+            if root_key.replace(record.key()).is_some() {
+                return false;
+            }
+            pmem_root = Some((pmem_index, config));
+        }
+    }
+
+    let expected_command_line = match (block_root, pmem_root) {
+        (Some(config), None) => {
+            let Some(read_only) = config.is_read_only() else {
+                return false;
+            };
+            canonical_process_root_block_command_line(
+                base_arguments,
+                true,
+                config.partuuid(),
+                read_only,
+            )
+        }
+        (None, Some((index, config))) => canonical_process_root_pmem_command_line(
+            base_arguments,
+            true,
+            index,
+            config.read_only(),
+        ),
+        (None, None) => canonical_process_block_command_line(base_arguments, true),
+        (Some(_), Some(_)) => return false,
+    };
+    expected_command_line.is_ok_and(|expected| expected == plan.command_line)
+        && bundle.root_key() == root_key
+        && bundle.root_key() == plan.root_key
+        && route_demand == plan.pci.route_demand()
+}
+
+fn snapshot_v2_storage_pci_region_id(sbdf: PciSbdf) -> Option<MmioRegionId> {
+    let slot = sbdf
+        .device()
+        .checked_sub(PCI_FIRST_ENDPOINT_DEVICE)
+        .map(usize::from)?;
+    pci_data_region_id(slot).ok()
+}
+
 fn validate_snapshot_v2_multi_block_pci_resource_plan(
     bundle: &PreparedSnapshotV2MultiBlockPciBundle,
     plan: &HvfSnapshotV2MultiBlockPlatformPlanParts,
@@ -12887,6 +13407,162 @@ fn failed_snapshot_v2_storage_mmio_after_platform(
     HvfSnapshotV2StorageMmioRestoreError::after_platform(stage, failure, cleanup)
 }
 
+enum PreparedHvfSnapshotV2StoragePciPublication {
+    Block {
+        endpoint: PreparedSnapshotV2MultiBlockPciEndpoint,
+        interrupts: HvfGicMsiDeviceInterruptResources,
+        metrics_lease: BlockDeviceMetricsLease,
+    },
+    Pmem {
+        endpoint: PreparedSnapshotV2StoragePciPmemEndpoint,
+        interrupts: HvfGicMsiDeviceInterruptResources,
+        metrics_lease: PmemDeviceMetricsLease,
+    },
+}
+
+fn release_unpublished_snapshot_v2_storage_pci_interrupts<I: GuestMessageInterruptResources>(
+    index: usize,
+    interrupts: &mut I,
+    cleanup: &mut Vec<HvfSnapshotV2StoragePciRestoreCleanupFailure>,
+) {
+    if let Err(source) = interrupts.release() {
+        cleanup.push(HvfSnapshotV2StoragePciRestoreCleanupFailure::Pci(
+            HvfArm64BootPciDataError::new(format!(
+                "failed to release unpublished exact-2.6 PCI endpoint {index} routes: {source}"
+            )),
+        ));
+    }
+}
+
+fn release_unpublished_snapshot_v2_storage_pci_publications(
+    publications: &mut [Option<PreparedHvfSnapshotV2StoragePciPublication>],
+    cleanup: &mut Vec<HvfSnapshotV2StoragePciRestoreCleanupFailure>,
+) {
+    for (index, publication) in publications.iter_mut().enumerate().rev() {
+        let Some(publication) = publication.take() else {
+            continue;
+        };
+        release_unpublished_snapshot_v2_storage_pci_publication(index, publication, cleanup);
+    }
+}
+
+fn release_unpublished_snapshot_v2_storage_pci_publication(
+    index: usize,
+    publication: PreparedHvfSnapshotV2StoragePciPublication,
+    cleanup: &mut Vec<HvfSnapshotV2StoragePciRestoreCleanupFailure>,
+) {
+    match publication {
+        PreparedHvfSnapshotV2StoragePciPublication::Block {
+            endpoint,
+            mut interrupts,
+            metrics_lease,
+        } => {
+            drop(endpoint);
+            drop(metrics_lease);
+            release_unpublished_snapshot_v2_storage_pci_interrupts(index, &mut interrupts, cleanup);
+        }
+        PreparedHvfSnapshotV2StoragePciPublication::Pmem {
+            endpoint,
+            mut interrupts,
+            metrics_lease,
+        } => {
+            drop(endpoint);
+            drop(metrics_lease);
+            release_unpublished_snapshot_v2_storage_pci_interrupts(index, &mut interrupts, cleanup);
+        }
+    }
+}
+
+struct HvfSnapshotV2StoragePciCleanup<'a> {
+    block_scheduler: &'a mut Option<HvfArm64BootLimiterRetryWakeupScheduler>,
+    pmem_scheduler: &'a mut Option<HvfArm64BootLimiterRetryWakeupScheduler>,
+    async_runtime: Option<&'a SharedBlockAsyncRuntime>,
+    pci_data_devices: &'a mut Option<HvfArm64BootPciDataDevices>,
+    pmem_devices: &'a mut Vec<PreparedPmemDevice>,
+    failures: Vec<HvfSnapshotV2StoragePciRestoreCleanupFailure>,
+}
+
+fn failed_snapshot_v2_storage_pci_after_platform(
+    mut platform: RestoredHvfSnapshotV2Platform,
+    stage: HvfSnapshotV2StoragePciRestoreStage,
+    failure: HvfSnapshotV2StoragePciRestoreFailure,
+    cleanup: HvfSnapshotV2StoragePciCleanup<'_>,
+) -> HvfSnapshotV2StoragePciRestoreError {
+    let HvfSnapshotV2StoragePciCleanup {
+        block_scheduler,
+        pmem_scheduler,
+        async_runtime,
+        pci_data_devices,
+        pmem_devices,
+        mut failures,
+    } = cleanup;
+    if pmem_scheduler
+        .as_mut()
+        .is_some_and(|scheduler| scheduler.stop_with_result().is_err())
+    {
+        failures.push(HvfSnapshotV2StoragePciRestoreCleanupFailure::PmemRetryScheduler);
+    }
+    drop(pmem_scheduler.take());
+    if block_scheduler
+        .as_mut()
+        .is_some_and(|scheduler| scheduler.stop_with_result().is_err())
+    {
+        failures.push(HvfSnapshotV2StoragePciRestoreCleanupFailure::BlockRetryScheduler);
+    }
+    drop(block_scheduler.take());
+
+    if let Some(runtime) = async_runtime {
+        let needs_memory = match runtime.shutdown_if_idle() {
+            Ok(idle) => !idle,
+            Err(source) => {
+                failures.push(HvfSnapshotV2StoragePciRestoreCleanupFailure::Async(source));
+                true
+            }
+        };
+        if needs_memory {
+            match platform.guest_memory_mut() {
+                Ok(memory) => {
+                    if let Err(source) = runtime.shutdown(memory) {
+                        failures.push(HvfSnapshotV2StoragePciRestoreCleanupFailure::Async(source));
+                    }
+                }
+                Err(source) => failures
+                    .push(HvfSnapshotV2StoragePciRestoreCleanupFailure::AsyncGuestMemory(source)),
+            }
+        }
+    }
+
+    let mut pci_clean = true;
+    if let Some(manager) = pci_data_devices.as_mut() {
+        manager.teardown_exhaustive(|source| {
+            pci_clean = false;
+            failures.push(HvfSnapshotV2StoragePciRestoreCleanupFailure::Pci(source));
+        });
+    }
+    drop(pci_data_devices.take());
+
+    if pci_clean {
+        for (index, device) in pmem_devices.iter().enumerate().rev() {
+            if let Err(source) = platform
+                .backend_mut()
+                .take_runtime_pmem_mapping(device.guest_range(), false)
+            {
+                failures
+                    .push(HvfSnapshotV2StoragePciRestoreCleanupFailure::Mapping { index, source });
+            }
+        }
+        pmem_devices.clear();
+    }
+
+    if let Err(source) = platform.shutdown() {
+        failures.push(HvfSnapshotV2StoragePciRestoreCleanupFailure::Platform(
+            source,
+        ));
+    }
+
+    HvfSnapshotV2StoragePciRestoreError::after_platform(stage, failure, failures)
+}
+
 struct PreparedHvfSnapshotV2MultiBlockPciPublication {
     endpoint: PreparedSnapshotV2MultiBlockPciEndpoint,
     interrupts: HvfGicMsiDeviceInterruptResources,
@@ -13075,6 +13751,7 @@ impl OwnedHvfArm64BootSession {
             mmio_dispatcher: prepared.mmio_dispatcher,
             runtime_resources: prepared.runtime_resources,
             restored_snapshot_v2_mmio_registrations: None,
+            restored_snapshot_v2_pci_pmem_ranges: None,
             restored_snapshot_v2_memory_binding: None,
             restored_snapshot_v2_machine: None,
             cpu_template_application: prepared.cpu_template_application,
@@ -13340,6 +14017,7 @@ impl OwnedHvfArm64BootSession {
             mmio_dispatcher: parts.mmio_dispatcher,
             runtime_resources,
             restored_snapshot_v2_mmio_registrations: None,
+            restored_snapshot_v2_pci_pmem_ranges: None,
             restored_snapshot_v2_memory_binding: Some(parts.memory_binding),
             restored_snapshot_v2_machine: Some(parts.machine),
             cpu_template_application,
@@ -13708,6 +14386,7 @@ impl OwnedHvfArm64BootSession {
                     pmem_ranges: Vec::new(),
                 },
             ),
+            restored_snapshot_v2_pci_pmem_ranges: None,
             restored_snapshot_v2_memory_binding: Some(parts.memory_binding),
             restored_snapshot_v2_machine: Some(parts.machine),
             cpu_template_application,
@@ -14279,6 +14958,7 @@ impl OwnedHvfArm64BootSession {
                     pmem_ranges,
                 },
             ),
+            restored_snapshot_v2_pci_pmem_ranges: None,
             restored_snapshot_v2_memory_binding: Some(parts.memory_binding),
             restored_snapshot_v2_machine: Some(parts.machine),
             cpu_template_application,
@@ -14321,6 +15001,994 @@ impl OwnedHvfArm64BootSession {
         let configs =
             CaptureReadyStorageConfigs::new(drive_configs.into_vec(), pmem_configs.into_vec());
         Ok(RestoredHvfSnapshotV2StorageMmioOwners { session, configs })
+    }
+
+    /// Reconstructs one exact-2.6 heterogeneous PCI vector without publishing
+    /// a process session, controller, or public load path.
+    #[doc(hidden)]
+    pub fn restore_snapshot_v2_storage_pci(
+        state: HvfSnapshotV2PlatformState,
+        memory: GuestMemory,
+        process_shell: HvfSnapshotV2DefaultProcessShell,
+        bundle: PreparedSnapshotV2StorageBundle,
+        plan: HvfSnapshotV2StoragePciPlatformPlan,
+    ) -> Result<RestoredHvfSnapshotV2StoragePciOwners, HvfSnapshotV2StoragePciRestoreError> {
+        Self::restore_snapshot_v2_storage_pci_inner(
+            state,
+            memory,
+            process_shell,
+            bundle,
+            plan,
+            None,
+        )
+    }
+
+    /// Deterministically fails after one pmem mapping is installed but before
+    /// its PCI endpoint becomes reachable.
+    #[doc(hidden)]
+    pub fn restore_snapshot_v2_storage_pci_with_pmem_publication_fault(
+        state: HvfSnapshotV2PlatformState,
+        memory: GuestMemory,
+        process_shell: HvfSnapshotV2DefaultProcessShell,
+        bundle: PreparedSnapshotV2StorageBundle,
+        plan: HvfSnapshotV2StoragePciPlatformPlan,
+        pmem_index: usize,
+    ) -> Result<RestoredHvfSnapshotV2StoragePciOwners, HvfSnapshotV2StoragePciRestoreError> {
+        Self::restore_snapshot_v2_storage_pci_inner(
+            state,
+            memory,
+            process_shell,
+            bundle,
+            plan,
+            Some(pmem_index),
+        )
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn restore_snapshot_v2_storage_pci_inner(
+        state: HvfSnapshotV2PlatformState,
+        memory: GuestMemory,
+        process_shell: HvfSnapshotV2DefaultProcessShell,
+        bundle: PreparedSnapshotV2StorageBundle,
+        plan: HvfSnapshotV2StoragePciPlatformPlan,
+        publication_fault_pmem_index: Option<usize>,
+    ) -> Result<RestoredHvfSnapshotV2StoragePciOwners, HvfSnapshotV2StoragePciRestoreError> {
+        let mut ranges = Vec::new();
+        ranges
+            .try_reserve_exact(memory.regions().len())
+            .map_err(|_| {
+                HvfSnapshotV2StoragePciRestoreError::preflight(
+                    HvfSnapshotV2StoragePciRestoreStage::MemoryLayout,
+                    HvfSnapshotV2StoragePciRestoreFailure::Allocation,
+                )
+            })?;
+        ranges.extend(memory.regions().iter().map(|region| region.range()));
+        let layout = GuestMemoryLayout::new(ranges).map_err(|_| {
+            HvfSnapshotV2StoragePciRestoreError::preflight(
+                HvfSnapshotV2StoragePciRestoreStage::MemoryLayout,
+                HvfSnapshotV2StoragePciRestoreFailure::MemoryLayout,
+            )
+        })?;
+        let source_fdt = state.machine().fdt();
+        let retained_fdt = Arm64FdtGuestMemoryWrite {
+            address: source_fdt.address(),
+            size: usize::try_from(source_fdt.size()).map_err(|_| {
+                HvfSnapshotV2StoragePciRestoreError::preflight(
+                    HvfSnapshotV2StoragePciRestoreStage::MemoryLayout,
+                    HvfSnapshotV2StoragePciRestoreFailure::Allocation,
+                )
+            })?,
+        };
+        let prepared = bundle.prepare_pci_transport().map_err(|source| {
+            HvfSnapshotV2StoragePciRestoreError::preflight(
+                HvfSnapshotV2StoragePciRestoreStage::Transport,
+                HvfSnapshotV2StoragePciRestoreFailure::Transport(source),
+            )
+        })?;
+        let plan = plan.into_parts();
+        if !validate_snapshot_v2_storage_pci_resource_plan(
+            &prepared,
+            &plan,
+            state.machine().boot().boot_arguments(),
+        ) {
+            return Err(
+                HvfSnapshotV2StoragePciRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2StoragePciRestoreStage::ResourcePlan,
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan,
+                    prepared,
+                ),
+            );
+        }
+
+        let HvfSnapshotV2StoragePciPlatformPlanParts {
+            root_key: _,
+            command_line,
+            block_metrics_ids,
+            pmem_metrics_ids,
+            block_retries,
+            pmem_retries,
+            pci: pci_plan,
+            serial_interrupt,
+            vmgenid_interrupt,
+            vmclock_interrupt,
+        } = plan;
+        let block_count = pci_plan.block_records().len();
+        let pmem_count = pci_plan.pmem_records().len();
+        let record_count = block_count.saturating_add(pmem_count);
+        if publication_fault_pmem_index.is_some_and(|index| index >= pmem_count) {
+            return Err(
+                HvfSnapshotV2StoragePciRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2StoragePciRestoreStage::ResourcePlan,
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan,
+                    prepared,
+                ),
+            );
+        }
+        let earliest_block_retry_deadline = block_retries
+            .iter()
+            .filter_map(|retry| retry.retry_deadline())
+            .min();
+        let earliest_pmem_retry_deadline = pmem_retries
+            .iter()
+            .filter_map(|retry| retry.retry_deadline())
+            .min();
+        let block_device_metrics =
+            match SharedBlockDeviceMetricsRegistry::from_owned_drive_ids_with_capacity(
+                block_metrics_ids,
+                PCI_ENDPOINT_SLOT_COUNT,
+            ) {
+                Ok(metrics) => metrics,
+                Err(source) => {
+                    return Err(
+                        HvfSnapshotV2StoragePciRestoreError::with_prepared_bundle_abort(
+                            HvfSnapshotV2StoragePciRestoreStage::BlockMetrics,
+                            HvfSnapshotV2StoragePciRestoreFailure::BlockMetrics(source),
+                            prepared,
+                        ),
+                    );
+                }
+            };
+        let pmem_device_metrics =
+            match SharedPmemDeviceMetricsRegistry::from_owned_device_ids_with_capacity(
+                pmem_metrics_ids,
+                PCI_ENDPOINT_SLOT_COUNT,
+            ) {
+                Ok(metrics) => metrics,
+                Err(source) => {
+                    return Err(
+                        HvfSnapshotV2StoragePciRestoreError::with_prepared_bundle_abort(
+                            HvfSnapshotV2StoragePciRestoreStage::PmemMetrics,
+                            HvfSnapshotV2StoragePciRestoreFailure::PmemMetrics(source),
+                            prepared,
+                        ),
+                    );
+                }
+            };
+
+        let mut pmem_static_reserved_ranges = Vec::new();
+        let mut block = Vec::new();
+        let mut network = Vec::new();
+        let mut pmem = Vec::new();
+        let mut prepared_publications = Vec::new();
+        let mut pmem_devices = Vec::new();
+        let mut pmem_ranges = Vec::new();
+        let route_count = match usize::try_from(pci_plan.msi().interrupt_range.count) {
+            Ok(route_count) => route_count,
+            Err(_) => {
+                return Err(
+                    HvfSnapshotV2StoragePciRestoreError::with_prepared_bundle_abort(
+                        HvfSnapshotV2StoragePciRestoreStage::ResourcePlan,
+                        HvfSnapshotV2StoragePciRestoreFailure::Allocation,
+                        prepared,
+                    ),
+                );
+            }
+        };
+        let mut exact_intids = Vec::new();
+        let mut cleanup = Vec::new();
+        let capacity_ok = pmem_static_reserved_ranges
+            .try_reserve_exact(layout.ranges().len())
+            .is_ok()
+            && block.try_reserve_exact(PCI_ENDPOINT_SLOT_COUNT).is_ok()
+            && network.try_reserve_exact(PCI_ENDPOINT_SLOT_COUNT).is_ok()
+            && pmem.try_reserve_exact(PCI_ENDPOINT_SLOT_COUNT).is_ok()
+            && prepared_publications
+                .try_reserve_exact(record_count)
+                .is_ok()
+            && pmem_devices.try_reserve_exact(pmem_count).is_ok()
+            && pmem_ranges.try_reserve_exact(pmem_count).is_ok()
+            && exact_intids.try_reserve_exact(route_count).is_ok()
+            && cleanup
+                .try_reserve_exact(record_count.saturating_mul(2).saturating_add(10))
+                .is_ok();
+        if !capacity_ok {
+            return Err(
+                HvfSnapshotV2StoragePciRestoreError::with_prepared_bundle_abort(
+                    HvfSnapshotV2StoragePciRestoreStage::ResourcePlan,
+                    HvfSnapshotV2StoragePciRestoreFailure::Allocation,
+                    prepared,
+                ),
+            );
+        }
+        pmem_static_reserved_ranges.extend(layout.ranges().iter().copied());
+        for offset in 0..pci_plan.msi().interrupt_range.count {
+            let Some(intid) = pci_plan.msi().interrupt_range.base.checked_add(offset) else {
+                return Err(
+                    HvfSnapshotV2StoragePciRestoreError::with_prepared_bundle_abort(
+                        HvfSnapshotV2StoragePciRestoreStage::ResourcePlan,
+                        HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan,
+                        prepared,
+                    ),
+                );
+            };
+            exact_intids.push(intid);
+        }
+
+        let shell_plan = HvfSnapshotV2StoragePciShellPlan {
+            command_line: &command_line,
+            pci: &pci_plan,
+            serial_interrupt,
+            vmgenid_interrupt,
+            vmclock_interrupt,
+        };
+        let mut platform = match restore_hvf_snapshot_v2_storage_pci_process_platform(
+            state,
+            memory,
+            process_shell,
+            shell_plan,
+        ) {
+            Ok(platform) => platform,
+            Err(source) => {
+                return Err(HvfSnapshotV2StoragePciRestoreError::platform(
+                    source, prepared,
+                ));
+            }
+        };
+        let (_root_key, block_bundle, pmem_configs, pmem_records) = prepared.into_parts();
+        let mut drive_configs = DriveConfigs::new();
+        let mut block_records = Vec::new();
+        let mut async_runtime = None;
+        if let Some(block_bundle) = block_bundle {
+            let (configs, records, runtime, async_generations) = block_bundle.into_parts();
+            debug_assert_eq!(
+                async_generations.len(),
+                records
+                    .iter()
+                    .filter(|record| record.async_generation().is_some())
+                    .count()
+            );
+            drop(async_generations);
+            drive_configs = configs;
+            block_records = records;
+            async_runtime = runtime;
+        }
+
+        let mut block_retry_wakeup_scheduler = None;
+        let mut pmem_retry_wakeup_scheduler = None;
+        let mut pci_data_devices = None;
+        macro_rules! fail_after_platform {
+            ($stage:expr, $failure:expr) => {{
+                release_unpublished_snapshot_v2_storage_pci_publications(
+                    &mut prepared_publications,
+                    &mut cleanup,
+                );
+                return Err(failed_snapshot_v2_storage_pci_after_platform(
+                    platform,
+                    $stage,
+                    $failure,
+                    HvfSnapshotV2StoragePciCleanup {
+                        block_scheduler: &mut block_retry_wakeup_scheduler,
+                        pmem_scheduler: &mut pmem_retry_wakeup_scheduler,
+                        async_runtime: async_runtime.as_ref(),
+                        pci_data_devices: &mut pci_data_devices,
+                        pmem_devices: &mut pmem_devices,
+                        failures: cleanup,
+                    },
+                ));
+            }};
+        }
+
+        let validation = {
+            let dispatcher_owner = Arc::clone(platform.mmio_dispatcher());
+            let mut dispatcher = match dispatcher_owner.lock() {
+                Ok(dispatcher) => dispatcher,
+                Err(_) => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::PciHost,
+                    HvfSnapshotV2StoragePciRestoreFailure::DispatcherUnavailable
+                ),
+            };
+            match prepare_restored_pci_validation(&mut dispatcher) {
+                Ok(validation) => validation,
+                Err(source) => {
+                    drop(dispatcher);
+                    fail_after_platform!(
+                        HvfSnapshotV2StoragePciRestoreStage::PciHost,
+                        HvfSnapshotV2StoragePciRestoreFailure::PciHost(source)
+                    )
+                }
+            }
+        };
+        let available_slots = match validation
+            .segment()
+            .with_segment(|segment| segment.available_endpoint_slots())
+        {
+            Ok(available_slots) => available_slots,
+            Err(source) => fail_after_platform!(
+                HvfSnapshotV2StoragePciRestoreStage::PciHost,
+                HvfSnapshotV2StoragePciRestoreFailure::PciData(HvfArm64BootPciDataError::new(
+                    format!("failed to inspect restored PCI endpoint capacity: {source}")
+                ))
+            ),
+        };
+        if available_slots < PCI_ENDPOINT_SLOT_COUNT {
+            fail_after_platform!(
+                HvfSnapshotV2StoragePciRestoreStage::PciHost,
+                HvfSnapshotV2StoragePciRestoreFailure::PciData(HvfArm64BootPciDataError::new(
+                    "restored PCI segment cannot retain complete endpoint headroom"
+                ))
+            );
+        }
+        let available_bars = match pci_data_available_bar_count(validation.bar_allocator()) {
+            Ok(available_bars) => available_bars,
+            Err(source) => fail_after_platform!(
+                HvfSnapshotV2StoragePciRestoreStage::PciHost,
+                HvfSnapshotV2StoragePciRestoreFailure::PciData(source)
+            ),
+        };
+        if available_bars < PCI_ENDPOINT_SLOT_COUNT {
+            fail_after_platform!(
+                HvfSnapshotV2StoragePciRestoreStage::PciHost,
+                HvfSnapshotV2StoragePciRestoreFailure::PciData(HvfArm64BootPciDataError::new(
+                    "restored PCI BAR allocator cannot retain complete endpoint headroom"
+                ))
+            );
+        }
+        let bar_plan = match pci_data_bar_plan(validation.bar_allocator(), PCI_ENDPOINT_SLOT_COUNT)
+        {
+            Ok(bar_plan) => bar_plan,
+            Err(source) => fail_after_platform!(
+                HvfSnapshotV2StoragePciRestoreStage::PciHost,
+                HvfSnapshotV2StoragePciRestoreFailure::PciData(source)
+            ),
+        };
+        {
+            let dispatcher_owner = Arc::clone(platform.mmio_dispatcher());
+            let dispatcher = match dispatcher_owner.lock() {
+                Ok(dispatcher) => dispatcher,
+                Err(_) => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::PciHost,
+                    HvfSnapshotV2StoragePciRestoreFailure::DispatcherUnavailable
+                ),
+            };
+            if let Err(source) = preflight_pci_data_dispatcher(&dispatcher, &bar_plan) {
+                drop(dispatcher);
+                fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::PciHost,
+                    HvfSnapshotV2StoragePciRestoreFailure::PciData(source)
+                );
+            }
+        }
+        let signaler = match platform.backend().gic_msi_signaler() {
+            Some(signaler) => signaler,
+            None => fail_after_platform!(
+                HvfSnapshotV2StoragePciRestoreStage::PciRoutes,
+                HvfSnapshotV2StoragePciRestoreFailure::PciData(HvfArm64BootPciDataError::new(
+                    "restored PCI vector requires a GICv2m MSI signaler"
+                ))
+            ),
+        };
+        let msi_interrupts =
+            match HvfGicMsiDeviceInterruptResources::allocate_exact(signaler, &exact_intids) {
+                Ok(interrupts) => interrupts,
+                Err(source) => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::PciRoutes,
+                    HvfSnapshotV2StoragePciRestoreFailure::PciRoutes(source)
+                ),
+            };
+        pci_data_devices = Some(HvfArm64BootPciDataDevices {
+            validation,
+            dispatcher: Arc::clone(platform.mmio_dispatcher()),
+            msi_interrupts: Some(msi_interrupts),
+            balloon: None,
+            block,
+            network,
+            pmem,
+            vsock: None,
+            entropy: None,
+            memory_hotplug: None,
+            pmem_static_reserved_ranges,
+            runtime_hotplug: true,
+        });
+
+        for (index, (record, planned)) in block_records
+            .into_iter()
+            .zip(pci_plan.block_records())
+            .enumerate()
+        {
+            let manager = match pci_data_devices.as_mut() {
+                Some(manager) => manager,
+                None => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::PciRoutes,
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                ),
+            };
+            let mut interrupts = match manager.shared_msi_registry() {
+                Ok(interrupts) => interrupts,
+                Err(source) => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::EndpointPreparation { index },
+                    HvfSnapshotV2StoragePciRestoreFailure::PciData(source)
+                ),
+            };
+            let endpoint =
+                match record.prepare_endpoint(planned.bar_region_id(), interrupts.registry()) {
+                    Ok(endpoint) => endpoint,
+                    Err(source) => {
+                        release_unpublished_snapshot_v2_storage_pci_interrupts(
+                            index,
+                            &mut interrupts,
+                            &mut cleanup,
+                        );
+                        fail_after_platform!(
+                            HvfSnapshotV2StoragePciRestoreStage::EndpointPreparation { index },
+                            HvfSnapshotV2StoragePciRestoreFailure::PciEndpoint(source)
+                        )
+                    }
+                };
+            let metrics_lease = match block_device_metrics.claim_drive_lease(endpoint.drive_id()) {
+                Ok(lease) => lease,
+                Err(source) => {
+                    drop(endpoint);
+                    release_unpublished_snapshot_v2_storage_pci_interrupts(
+                        index,
+                        &mut interrupts,
+                        &mut cleanup,
+                    );
+                    fail_after_platform!(
+                        HvfSnapshotV2StoragePciRestoreStage::EndpointPreparation { index },
+                        HvfSnapshotV2StoragePciRestoreFailure::BlockMetrics(source)
+                    )
+                }
+            };
+            prepared_publications.push(Some(PreparedHvfSnapshotV2StoragePciPublication::Block {
+                endpoint,
+                interrupts,
+                metrics_lease,
+            }));
+        }
+        for (pmem_index, (record, planned)) in pmem_records
+            .into_iter()
+            .zip(pci_plan.pmem_records())
+            .enumerate()
+        {
+            let index = block_count.saturating_add(pmem_index);
+            let manager = match pci_data_devices.as_mut() {
+                Some(manager) => manager,
+                None => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::PciRoutes,
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                ),
+            };
+            let mut interrupts = match manager.shared_msi_registry() {
+                Ok(interrupts) => interrupts,
+                Err(source) => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::EndpointPreparation { index },
+                    HvfSnapshotV2StoragePciRestoreFailure::PciData(source)
+                ),
+            };
+            let endpoint =
+                match record.prepare_endpoint(planned.bar_region_id(), interrupts.registry()) {
+                    Ok(endpoint) => endpoint,
+                    Err(source) => {
+                        release_unpublished_snapshot_v2_storage_pci_interrupts(
+                            index,
+                            &mut interrupts,
+                            &mut cleanup,
+                        );
+                        fail_after_platform!(
+                            HvfSnapshotV2StoragePciRestoreStage::EndpointPreparation { index },
+                            HvfSnapshotV2StoragePciRestoreFailure::PciEndpoint(source)
+                        )
+                    }
+                };
+            let metrics_lease = match pmem_device_metrics.claim_device_lease(endpoint.pmem_id()) {
+                Ok(lease) => lease,
+                Err(source) => {
+                    drop(endpoint);
+                    release_unpublished_snapshot_v2_storage_pci_interrupts(
+                        index,
+                        &mut interrupts,
+                        &mut cleanup,
+                    );
+                    fail_after_platform!(
+                        HvfSnapshotV2StoragePciRestoreStage::EndpointPreparation { index },
+                        HvfSnapshotV2StoragePciRestoreFailure::PmemMetrics(source)
+                    )
+                }
+            };
+            prepared_publications.push(Some(PreparedHvfSnapshotV2StoragePciPublication::Pmem {
+                endpoint,
+                interrupts,
+                metrics_lease,
+            }));
+        }
+
+        let block_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        if block_count == 0 {
+            block_retry_wakeup_scheduler =
+                Some(HvfArm64BootLimiterRetryWakeupScheduler::inactive());
+        } else {
+            let vcpu_control = platform.control();
+            block_retry_wakeup_scheduler =
+                match HvfArm64BootLimiterRetryWakeupScheduler::start_with_cancellation(
+                    BLOCK_RETRY_WAKEUP_SCHEDULER_THREAD_NAME,
+                    block_retry_wakeup.clone(),
+                    move || vcpu_control.request_wakeup(),
+                ) {
+                    Ok(scheduler) => Some(scheduler),
+                    Err(source) => {
+                        release_unpublished_snapshot_v2_storage_pci_publications(
+                            &mut prepared_publications,
+                            &mut cleanup,
+                        );
+                        fail_after_platform!(
+                            HvfSnapshotV2StoragePciRestoreStage::BlockRetryScheduler,
+                            HvfSnapshotV2StoragePciRestoreFailure::RetryScheduler(source.kind())
+                        )
+                    }
+                };
+        }
+        let pmem_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        if pmem_count == 0 {
+            pmem_retry_wakeup_scheduler = Some(HvfArm64BootLimiterRetryWakeupScheduler::inactive());
+        } else {
+            let vcpu_control = platform.control();
+            pmem_retry_wakeup_scheduler =
+                match HvfArm64BootLimiterRetryWakeupScheduler::start_with_cancellation(
+                    PMEM_RETRY_WAKEUP_SCHEDULER_THREAD_NAME,
+                    pmem_retry_wakeup.clone(),
+                    move || vcpu_control.request_wakeup(),
+                ) {
+                    Ok(scheduler) => Some(scheduler),
+                    Err(source) => {
+                        release_unpublished_snapshot_v2_storage_pci_publications(
+                            &mut prepared_publications,
+                            &mut cleanup,
+                        );
+                        fail_after_platform!(
+                            HvfSnapshotV2StoragePciRestoreStage::PmemRetryScheduler,
+                            HvfSnapshotV2StoragePciRestoreFailure::RetryScheduler(source.kind())
+                        )
+                    }
+                };
+        }
+
+        for index in 0..block_count {
+            let planned = match pci_plan.block_records().get(index) {
+                Some(planned) => planned,
+                None => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                ),
+            };
+            let publication = match prepared_publications.get_mut(index).and_then(Option::take) {
+                Some(PreparedHvfSnapshotV2StoragePciPublication::Block {
+                    endpoint,
+                    interrupts,
+                    metrics_lease,
+                }) => (endpoint, interrupts, metrics_lease),
+                Some(other) => {
+                    release_unpublished_snapshot_v2_storage_pci_publication(
+                        index,
+                        other,
+                        &mut cleanup,
+                    );
+                    fail_after_platform!(
+                        HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                        HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                    )
+                }
+                None => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                ),
+            };
+            let (endpoint, mut interrupts, metrics_lease) = publication;
+            if endpoint.key() != planned.key() {
+                drop(endpoint);
+                drop(metrics_lease);
+                release_unpublished_snapshot_v2_storage_pci_interrupts(
+                    index,
+                    &mut interrupts,
+                    &mut cleanup,
+                );
+                fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                );
+            }
+            let (
+                _key,
+                drive_id,
+                is_root_device,
+                _retry,
+                retry_deadline,
+                origin,
+                _async_generation,
+                endpoint,
+            ) = endpoint.into_parts();
+            let (dispatcher_owner, segment) = match pci_data_devices.as_ref() {
+                Some(manager) if manager.block.len() == index => (
+                    Arc::clone(&manager.dispatcher),
+                    manager.validation.segment().clone(),
+                ),
+                _ => {
+                    drop(endpoint);
+                    drop(metrics_lease);
+                    release_unpublished_snapshot_v2_storage_pci_interrupts(
+                        index,
+                        &mut interrupts,
+                        &mut cleanup,
+                    );
+                    fail_after_platform!(
+                        HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                        HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                    )
+                }
+            };
+            let mut dispatcher = match dispatcher_owner.lock() {
+                Ok(dispatcher) => dispatcher,
+                Err(_) => {
+                    drop(endpoint);
+                    drop(metrics_lease);
+                    release_unpublished_snapshot_v2_storage_pci_interrupts(
+                        index,
+                        &mut interrupts,
+                        &mut cleanup,
+                    );
+                    fail_after_platform!(
+                        HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                        HvfSnapshotV2StoragePciRestoreFailure::DispatcherUnavailable
+                    )
+                }
+            };
+            let publication = match pci_data_devices.as_mut() {
+                Some(manager) => endpoint.publish(
+                    manager.validation.bar_allocator_mut(),
+                    segment,
+                    &mut dispatcher,
+                    interrupts,
+                ),
+                None => {
+                    drop(dispatcher);
+                    drop(endpoint);
+                    drop(metrics_lease);
+                    release_unpublished_snapshot_v2_storage_pci_interrupts(
+                        index,
+                        &mut interrupts,
+                        &mut cleanup,
+                    );
+                    fail_after_platform!(
+                        HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                        HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                    )
+                }
+            };
+            drop(dispatcher);
+            let published = match publication {
+                Ok(published) => published,
+                Err(source) => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                    HvfSnapshotV2StoragePciRestoreFailure::PciPublication(source)
+                ),
+            };
+            let Some(manager) = pci_data_devices.as_mut() else {
+                fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                );
+            };
+            manager.block.push(HvfArm64BootPciBlockDevice {
+                drive_id,
+                is_root_device,
+                origin,
+                published,
+                queue_deliveries: 0,
+                retry_deadline,
+                _metrics_lease: Some(metrics_lease),
+            });
+        }
+
+        for pmem_index in 0..pmem_count {
+            let index = block_count.saturating_add(pmem_index);
+            let planned = match pci_plan.pmem_records().get(pmem_index) {
+                Some(planned) => planned,
+                None => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                ),
+            };
+            let publication = match prepared_publications.get_mut(index).and_then(Option::take) {
+                Some(PreparedHvfSnapshotV2StoragePciPublication::Pmem {
+                    endpoint,
+                    interrupts,
+                    metrics_lease,
+                }) => (endpoint, interrupts, metrics_lease),
+                Some(other) => {
+                    release_unpublished_snapshot_v2_storage_pci_publication(
+                        index,
+                        other,
+                        &mut cleanup,
+                    );
+                    fail_after_platform!(
+                        HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                        HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                    )
+                }
+                None => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                ),
+            };
+            let (endpoint, mut interrupts, metrics_lease) = publication;
+            if endpoint.key() != planned.key() {
+                drop(endpoint);
+                drop(metrics_lease);
+                release_unpublished_snapshot_v2_storage_pci_interrupts(
+                    index,
+                    &mut interrupts,
+                    &mut cleanup,
+                );
+                fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                );
+            }
+            let (_key, _is_root_device, _retry, retry_deadline, origin, prepared_device, endpoint) =
+                endpoint.into_parts();
+            let mut pmem_id = String::new();
+            if pmem_id
+                .try_reserve_exact(prepared_device.id().len())
+                .is_err()
+            {
+                drop(endpoint);
+                drop(metrics_lease);
+                release_unpublished_snapshot_v2_storage_pci_interrupts(
+                    index,
+                    &mut interrupts,
+                    &mut cleanup,
+                );
+                fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                    HvfSnapshotV2StoragePciRestoreFailure::Allocation
+                );
+            }
+            pmem_id.push_str(prepared_device.id());
+            let guest_range = prepared_device.guest_range();
+            if let Err(source) = platform
+                .backend_mut()
+                .map_runtime_pmem_device(&prepared_device)
+            {
+                drop(endpoint);
+                drop(metrics_lease);
+                release_unpublished_snapshot_v2_storage_pci_interrupts(
+                    index,
+                    &mut interrupts,
+                    &mut cleanup,
+                );
+                fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::Mapping { index: pmem_index },
+                    HvfSnapshotV2StoragePciRestoreFailure::Mapping(source)
+                );
+            }
+            pmem_ranges.push(guest_range);
+            pmem_devices.push(prepared_device);
+            if publication_fault_pmem_index == Some(pmem_index) {
+                drop(endpoint);
+                drop(metrics_lease);
+                release_unpublished_snapshot_v2_storage_pci_interrupts(
+                    index,
+                    &mut interrupts,
+                    &mut cleanup,
+                );
+                fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                    HvfSnapshotV2StoragePciRestoreFailure::InjectedPublication
+                );
+            }
+            let (dispatcher_owner, segment) = match pci_data_devices.as_ref() {
+                Some(manager) if manager.pmem.len() == pmem_index => (
+                    Arc::clone(&manager.dispatcher),
+                    manager.validation.segment().clone(),
+                ),
+                _ => {
+                    drop(endpoint);
+                    drop(metrics_lease);
+                    release_unpublished_snapshot_v2_storage_pci_interrupts(
+                        index,
+                        &mut interrupts,
+                        &mut cleanup,
+                    );
+                    fail_after_platform!(
+                        HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                        HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                    )
+                }
+            };
+            let mut dispatcher = match dispatcher_owner.lock() {
+                Ok(dispatcher) => dispatcher,
+                Err(_) => {
+                    drop(endpoint);
+                    drop(metrics_lease);
+                    release_unpublished_snapshot_v2_storage_pci_interrupts(
+                        index,
+                        &mut interrupts,
+                        &mut cleanup,
+                    );
+                    fail_after_platform!(
+                        HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                        HvfSnapshotV2StoragePciRestoreFailure::DispatcherUnavailable
+                    )
+                }
+            };
+            let publication = match pci_data_devices.as_mut() {
+                Some(manager) => endpoint.publish(
+                    manager.validation.bar_allocator_mut(),
+                    segment,
+                    &mut dispatcher,
+                    interrupts,
+                ),
+                None => {
+                    drop(dispatcher);
+                    drop(endpoint);
+                    drop(metrics_lease);
+                    release_unpublished_snapshot_v2_storage_pci_interrupts(
+                        index,
+                        &mut interrupts,
+                        &mut cleanup,
+                    );
+                    fail_after_platform!(
+                        HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                        HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                    )
+                }
+            };
+            drop(dispatcher);
+            let published = match publication {
+                Ok(published) => published,
+                Err(source) => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                    HvfSnapshotV2StoragePciRestoreFailure::PciPublication(source)
+                ),
+            };
+            let Some(manager) = pci_data_devices.as_mut() else {
+                fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::Publication { index },
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                );
+            };
+            manager.pmem.push(HvfArm64BootPciPmemDevice {
+                pmem_id,
+                guest_range,
+                origin,
+                published,
+                queue_deliveries: 0,
+                retry_deadline,
+                _metrics_lease: Some(metrics_lease),
+            });
+        }
+
+        release_unpublished_snapshot_v2_storage_pci_publications(
+            &mut prepared_publications,
+            &mut cleanup,
+        );
+        if !cleanup.is_empty() {
+            fail_after_platform!(
+                HvfSnapshotV2StoragePciRestoreStage::ResourcePlan,
+                HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+            );
+        }
+
+        let Some(block_retry_wakeup_scheduler) = block_retry_wakeup_scheduler.take() else {
+            std::process::abort();
+        };
+        let Some(pmem_retry_wakeup_scheduler) = pmem_retry_wakeup_scheduler.take() else {
+            std::process::abort();
+        };
+        block_retry_wakeup_scheduler.schedule_deadline(earliest_block_retry_deadline);
+        pmem_retry_wakeup_scheduler.schedule_deadline(earliest_pmem_retry_deadline);
+
+        let parts = platform.into_parts();
+        let machine_config = parts.machine.machine();
+        let cpu_template_application = parts.machine.cpu_template().cloned();
+        let cache_source = crate::vcpu_config::HvfArm64VcpuCacheFdtSource::new(
+            parts.compatibility.identification().id_aa64mmfr2_el1(),
+            parts.compatibility.cache_manifest(),
+        );
+        let gic = parts.compatibility.gic_metadata();
+        let serial_interrupt_line = parts
+            .serial_device
+            .as_ref()
+            .map(|device| device.fdt_device.interrupt_line);
+        let vmgenid_interrupt_line = parts.vmgenid_device.fdt_device.interrupt_line;
+        let vmclock_interrupt_line = parts.vmclock_device.fdt_device.interrupt_line;
+        let runtime_resources = Arm64BootRuntimeResources {
+            machine_config,
+            layout,
+            boot_origin: None,
+            retained_fdt: Some(retained_fdt),
+            rtc_device: Some(parts.rtc_device),
+            serial_device: parts.serial_device,
+            vmgenid_device: parts.vmgenid_device,
+            vmclock_device: parts.vmclock_device,
+            pvtime_state: Arm64BootPvTimeState::restored(parts.pvtime_layout),
+            block_devices: Vec::new(),
+            block_async_runtime: async_runtime.unwrap_or_default(),
+            pci_block_devices: Vec::new(),
+            pmem_devices,
+            pmem_mmio_devices: Vec::new(),
+            network_devices: Vec::new(),
+            pci_network_devices: Vec::new(),
+            vsock_device: None,
+            pci_vsock_device: None,
+            balloon_device: None,
+            pci_balloon_device: None,
+            memory_hotplug_device: None,
+            pci_memory_hotplug_device: None,
+            entropy_device: None,
+            pci_entropy_device: None,
+            pci_validation: None,
+        };
+        let network_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        let entropy_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        let session = Self {
+            runner: parts.runner,
+            backend: parts.backend,
+            mmio_dispatcher: parts.mmio_dispatcher,
+            runtime_resources,
+            restored_snapshot_v2_mmio_registrations: None,
+            restored_snapshot_v2_pci_pmem_ranges: Some(pmem_ranges),
+            restored_snapshot_v2_memory_binding: Some(parts.memory_binding),
+            restored_snapshot_v2_machine: Some(parts.machine),
+            cpu_template_application,
+            pci_validation_endpoint: None,
+            pci_data_devices,
+            cache_source,
+            cache_hierarchy: None,
+            control_wakeup: HvfArm64BootRunLoopControlWakeupToken::default(),
+            run_loop_wakeup: HvfArm64BootRunLoopWakeupToken::default(),
+            block_retry_wakeup,
+            block_retry_wakeup_scheduler,
+            pmem_retry_wakeup,
+            pmem_retry_wakeup_scheduler,
+            network_retry_wakeup,
+            network_retry_wakeup_scheduler: HvfArm64BootLimiterRetryWakeupScheduler::inactive(),
+            entropy_retry_wakeup,
+            entropy_retry_wakeup_scheduler: HvfArm64BootLimiterRetryWakeupScheduler::inactive(),
+            entropy_source: VirtioRngOsEntropySource::new(),
+            block_device_metrics,
+            pmem_device_metrics,
+            balloon_device_metrics: SharedBalloonDeviceMetrics::default(),
+            memory_hotplug_device_metrics: None,
+            network_interface_metrics: SharedNetworkInterfaceMetricsRegistry::default(),
+            vsock_device_metrics: SharedVsockDeviceMetrics::default(),
+            entropy_device_metrics: SharedEntropyDeviceMetrics::default(),
+            gic,
+            block_interrupt_lines: Vec::new(),
+            pmem_interrupt_lines: Vec::new(),
+            network_interrupt_lines: Vec::new(),
+            vsock_interrupt_line: None,
+            balloon_interrupt_line: None,
+            entropy_interrupt_line: None,
+            memory_hotplug_interrupt_line: None,
+            serial_interrupt_line,
+            serial_input: None,
+            vmgenid_interrupt_line,
+            vmclock_interrupt_line,
+            boot_registers: None,
+        };
+        let configs =
+            CaptureReadyStorageConfigs::new(drive_configs.into_vec(), pmem_configs.into_vec());
+        Ok(RestoredHvfSnapshotV2StoragePciOwners { session, configs })
     }
 
     /// Reconstructs one exact profile-2 PCI vector inside a private canonical
@@ -15003,6 +16671,7 @@ impl OwnedHvfArm64BootSession {
             mmio_dispatcher: parts.mmio_dispatcher,
             runtime_resources,
             restored_snapshot_v2_mmio_registrations: None,
+            restored_snapshot_v2_pci_pmem_ranges: None,
             restored_snapshot_v2_memory_binding: Some(parts.memory_binding),
             restored_snapshot_v2_machine: Some(parts.machine),
             cpu_template_application,
@@ -15343,6 +17012,7 @@ impl OwnedHvfArm64BootSession {
             mmio_dispatcher,
             runtime_resources,
             restored_snapshot_v2_mmio_registrations: None,
+            restored_snapshot_v2_pci_pmem_ranges: None,
             restored_snapshot_v2_memory_binding: None,
             restored_snapshot_v2_machine: None,
             cpu_template_application: None,
@@ -15784,6 +17454,29 @@ impl OwnedHvfArm64BootSession {
         Ok(())
     }
 
+    fn teardown_restored_snapshot_v2_pci_pmem(
+        &mut self,
+    ) -> Result<(), HvfSnapshotV2StoragePciRestoreCleanupFailure> {
+        let Some(ranges) = self.restored_snapshot_v2_pci_pmem_ranges.as_mut() else {
+            return Ok(());
+        };
+        while let Some(range) = ranges.last().copied() {
+            let index = ranges.len() - 1;
+            self.backend
+                .take_runtime_pmem_mapping(range, false)
+                .map_err(
+                    |source| HvfSnapshotV2StoragePciRestoreCleanupFailure::Mapping {
+                        index,
+                        source,
+                    },
+                )?;
+            ranges.pop();
+        }
+        self.runtime_resources.pmem_devices.clear();
+        self.restored_snapshot_v2_pci_pmem_ranges = None;
+        Ok(())
+    }
+
     pub fn shutdown(&mut self) -> Result<(), HvfArm64BootSessionShutdownError> {
         self.block_retry_wakeup_scheduler.stop();
         self.pmem_retry_wakeup_scheduler.stop();
@@ -15791,6 +17484,7 @@ impl OwnedHvfArm64BootSession {
         self.entropy_retry_wakeup_scheduler.stop();
         let runner_result = self.runner.shutdown();
         let had_restored_snapshot_v2_mmio = self.restored_snapshot_v2_mmio_registrations.is_some();
+        let had_restored_snapshot_v2_pci_pmem = self.restored_snapshot_v2_pci_pmem_ranges.is_some();
         let restored_snapshot_v2_mmio_result = if runner_result.is_ok() {
             self.teardown_restored_snapshot_v2_mmio()
         } else {
@@ -15813,6 +17507,23 @@ impl OwnedHvfArm64BootSession {
             self.pmem_device_metrics = SharedPmemDeviceMetricsRegistry::default();
         }
         let pci_data_result = self.teardown_pci_data_devices();
+        let restored_snapshot_v2_pci_pmem_result = if runner_result.is_ok()
+            && restored_snapshot_v2_mmio_result.is_ok()
+            && block_async_result.is_ok()
+            && pci_data_result.is_ok()
+        {
+            self.teardown_restored_snapshot_v2_pci_pmem()
+        } else {
+            Ok(())
+        };
+        if had_restored_snapshot_v2_pci_pmem
+            && block_async_result.is_ok()
+            && pci_data_result.is_ok()
+            && restored_snapshot_v2_pci_pmem_result.is_ok()
+        {
+            self.block_device_metrics = SharedBlockDeviceMetricsRegistry::default();
+            self.pmem_device_metrics = SharedPmemDeviceMetricsRegistry::default();
+        }
         let pci_result = self.teardown_pci_validation_endpoint();
         let result = if let Err(source) = runner_result {
             Err(HvfArm64BootSessionShutdownError::Vcpu { source })
@@ -15822,6 +17533,8 @@ impl OwnedHvfArm64BootSession {
             Err(source)
         } else if let Err(source) = pci_data_result {
             Err(HvfArm64BootSessionShutdownError::PciData { source })
+        } else if let Err(source) = restored_snapshot_v2_pci_pmem_result {
+            Err(HvfArm64BootSessionShutdownError::RestoredSnapshotV2PciPmem { source })
         } else if let Err(source) = pci_result {
             Err(HvfArm64BootSessionShutdownError::PciValidation { source })
         } else {
@@ -22375,6 +24088,9 @@ pub enum HvfArm64BootSessionShutdownError {
     RestoredSnapshotV2Mmio {
         source: HvfSnapshotV2StorageMmioRestoreCleanupFailure,
     },
+    RestoredSnapshotV2PciPmem {
+        source: HvfSnapshotV2StoragePciRestoreCleanupFailure,
+    },
     BlockAsyncGuestMemory {
         source: HvfGuestMemoryMappingError,
     },
@@ -22405,6 +24121,10 @@ impl fmt::Display for HvfArm64BootSessionShutdownError {
                 f,
                 "failed to tear down restored snapshot MMIO ownership: {source}"
             ),
+            Self::RestoredSnapshotV2PciPmem { source } => write!(
+                f,
+                "failed to tear down restored snapshot PCI pmem ownership: {source}"
+            ),
             Self::BlockAsyncGuestMemory { source } => {
                 write!(
                     f,
@@ -22432,6 +24152,7 @@ impl std::error::Error for HvfArm64BootSessionShutdownError {
         match self {
             Self::Vcpu { source } => Some(source),
             Self::RestoredSnapshotV2Mmio { source } => Some(source),
+            Self::RestoredSnapshotV2PciPmem { source } => Some(source),
             Self::BlockAsyncGuestMemory { source } => Some(source),
             Self::BlockAsync { source } => Some(source),
             Self::PciValidation { source } => Some(source),
@@ -35380,6 +37101,73 @@ mod tests {
         assert!(cleanup_debug.contains("<redacted>"));
         for diagnostics in [debug, incomplete.to_string(), cleanup_debug] {
             assert!(!diagnostics.contains("secret-cleanup"));
+        }
+    }
+
+    #[test]
+    fn native_v2_storage_pci_errors_preserve_terminality_and_redact_cleanup() {
+        let retryable = super::HvfSnapshotV2StoragePciRestoreError::preflight(
+            super::HvfSnapshotV2StoragePciRestoreStage::ResourcePlan,
+            super::HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan,
+        );
+        assert!(!retryable.has_incomplete_cleanup());
+        assert!(!retryable.is_terminal());
+
+        let clean_rollback = super::HvfSnapshotV2StoragePciRestoreError::after_platform(
+            super::HvfSnapshotV2StoragePciRestoreStage::Publication { index: 1 },
+            super::HvfSnapshotV2StoragePciRestoreFailure::InjectedPublication,
+            Vec::new(),
+        );
+        assert!(!clean_rollback.has_incomplete_cleanup());
+        assert!(!clean_rollback.is_terminal());
+
+        let publication_rollback = super::HvfSnapshotV2StoragePciRestoreError::after_platform(
+            super::HvfSnapshotV2StoragePciRestoreStage::Publication { index: 1 },
+            super::HvfSnapshotV2StoragePciRestoreFailure::PciPublication(
+                super::VirtioPciPublicationError::Rollback {
+                    primary: "secret-primary/path".to_owned(),
+                    cleanup: "secret-publication-cleanup/path".to_owned(),
+                },
+            ),
+            Vec::new(),
+        );
+        assert!(publication_rollback.has_incomplete_cleanup());
+        assert!(publication_rollback.is_terminal());
+        assert!(!format!("{publication_rollback:?}").contains("secret-primary"));
+        assert!(
+            !publication_rollback
+                .to_string()
+                .contains("secret-publication-cleanup")
+        );
+        let publication_failure =
+            std::error::Error::source(&publication_rollback).expect("failure should be retained");
+        assert!(publication_failure.source().is_none());
+
+        let incomplete = super::HvfSnapshotV2StoragePciRestoreError::after_platform(
+            super::HvfSnapshotV2StoragePciRestoreStage::PmemRetryScheduler,
+            super::HvfSnapshotV2StoragePciRestoreFailure::RetryScheduler(
+                io::ErrorKind::PermissionDenied,
+            ),
+            vec![
+                super::HvfSnapshotV2StoragePciRestoreCleanupFailure::Pci(
+                    super::HvfArm64BootPciDataError::new("secret-pci-cleanup/path"),
+                ),
+                super::HvfSnapshotV2StoragePciRestoreCleanupFailure::Platform(
+                    crate::snapshot_v2_platform::HvfSnapshotV2PlatformShutdownError::Backend(
+                        super::BackendError::Hypervisor("secret-platform-cleanup/path".to_string()),
+                    ),
+                ),
+            ],
+        );
+        assert!(incomplete.has_incomplete_cleanup());
+        assert!(incomplete.is_terminal());
+        let debug = format!("{incomplete:?}");
+        let cleanup_debug = format!("{:?}", incomplete.cleanup_failures());
+        assert!(debug.contains("<redacted>"));
+        assert!(cleanup_debug.contains("<redacted>"));
+        for diagnostics in [debug, incomplete.to_string(), cleanup_debug] {
+            assert!(!diagnostics.contains("secret-pci"));
+            assert!(!diagnostics.contains("secret-platform"));
         }
     }
 

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -6906,6 +6906,7 @@ fn capture_ready_storage_traverses_signed_mmio_and_pci_owners() {
         HvfSnapshotV2NativePath, HvfSnapshotV2StorageMmioProcessConfig, HvfSnapshotV2StorageState,
         HvfVcpuRunStepOutcome, OwnedHvfArm64BootSession,
         prepare_hvf_snapshot_v2_storage_mmio_platform_plan,
+        prepare_hvf_snapshot_v2_storage_pci_platform_plan,
     };
     use bangbang_runtime::VmmAction;
     use bangbang_runtime::block::{
@@ -7565,14 +7566,23 @@ fn capture_ready_storage_traverses_signed_mmio_and_pci_owners() {
             path_text(pci_startup_pmem.path()),
         )))
         .expect("startup PCI pmem should configure");
+    let pci_serial = SharedSerialOutputBuffer::default();
     let pci_session_config = HvfArm64BootSessionConfig::new(
         BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1)),
         PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500)),
         NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000)),
         VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
-        test_rtc_mmio_layout(),
+        bangbang_runtime::rtc::RtcMmioLayout::new(
+            GuestAddress::new(0x4000_1000),
+            MmioRegionId::new(10),
+        ),
     )
-    .with_pci_enabled();
+    .with_pci_enabled()
+    .with_serial_device(HvfArm64BootSerialDeviceConfig::new(
+        MmioRegionId::new(20),
+        GuestAddress::new(0x4000_2000),
+        SharedSerialOutput::from(pci_serial),
+    ));
     let mut pci_session = OwnedHvfArm64BootSession::new(&pci_controller, pci_session_config)
         .expect("signed startup PCI storage session should prepare");
 
@@ -7764,10 +7774,250 @@ fn capture_ready_storage_traverses_signed_mmio_and_pci_owners() {
     ] {
         assert!(!pci_debug.contains(&private_path));
     }
+
+    let pci_restored_layout =
+        GuestMemoryLayout::new(pci_session.runtime_resources().layout.ranges().to_vec())
+            .expect("PCI profile-3 destination layout should validate");
+    let mut pci_fault_memory = GuestMemory::allocate(&pci_restored_layout)
+        .expect("PCI profile-3 fault destination memory should allocate");
+    let mut pci_restored_memory = GuestMemory::allocate(&pci_restored_layout)
+        .expect("PCI profile-3 destination memory should allocate");
+    let pci_source_memory = pci_session
+        .guest_memory()
+        .expect("PCI profile-3 source memory should remain mapped");
+    let mut pci_copy_buffer = vec![0_u8; 64 * 1024];
+    for range in pci_restored_layout.ranges() {
+        let mut copied = 0_u64;
+        while copied < range.size() {
+            let count = usize::try_from(
+                (range.size() - copied).min(
+                    u64::try_from(pci_copy_buffer.len())
+                        .expect("PCI copy buffer length should fit u64"),
+                ),
+            )
+            .expect("PCI profile-3 copy count should fit usize");
+            let address = range
+                .start()
+                .checked_add(copied)
+                .expect("PCI profile-3 copy address should fit");
+            pci_source_memory
+                .read_slice(&mut pci_copy_buffer[..count], address)
+                .expect("PCI profile-3 source memory should read");
+            pci_fault_memory
+                .write_slice(&pci_copy_buffer[..count], address)
+                .expect("PCI profile-3 fault destination memory should write");
+            pci_restored_memory
+                .write_slice(&pci_copy_buffer[..count], address)
+                .expect("PCI profile-3 destination memory should write");
+            copied += u64::try_from(count).expect("PCI copy count should fit u64");
+        }
+    }
+    pci_session
+        .pause_for_snapshot_v2_capture()
+        .expect("PCI profile-3 source should pause");
+    let pci_boot = HvfSnapshotV2BootState::try_new(
+        HvfSnapshotV2NativePath::try_new(pci_kernel.path().as_os_str())
+            .expect("PCI profile-3 kernel path should validate"),
+        None,
+        None,
+    )
+    .expect("PCI profile-3 boot metadata should validate");
+    let pci_memory = TempFile::new_len("capture-ready-pci-profile-3-memory", 0)
+        .expect("PCI profile-3 memory artifact should create");
+    let mut pci_memory_writer = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(pci_memory.path())
+        .expect("PCI profile-3 memory artifact should open");
+    let pci_platform = pci_session
+        .capture_snapshot_v2_storage_platform_with_cancel(
+            HvfArm64BootSnapshotV2CaptureInput::new(pci_boot),
+            &mut pci_memory_writer,
+            |_| false,
+        )
+        .expect("PCI exact 2.6 platform should capture");
+    assert_eq!(
+        pci_memory_writer
+            .metadata()
+            .expect("PCI profile-3 memory metadata should read")
+            .len(),
+        pci_platform.memory().file_length()
+    );
+    drop(pci_memory_writer);
     drop(pci_guard);
     pci_session
         .shutdown()
         .expect("signed PCI storage session should shut down");
+
+    let reopen_pci_block_backings = || {
+        pci_graph
+            .block_records()
+            .iter()
+            .map(|record| {
+                BlockFileBacking::open_snapshot(
+                    std::path::Path::new(record.config().selector()),
+                    record.config().is_read_only(),
+                )
+                .map(|(backing, _identity)| backing)
+                .expect("PCI profile-3 block backing should reopen")
+            })
+            .collect::<Vec<_>>()
+    };
+    let reopen_pci_pmem_backings = || {
+        pci_controller
+            .pmem_configs()
+            .iter()
+            .map(|config| {
+                PmemFileBacking::open(config).expect("PCI profile-3 pmem backing should reopen")
+            })
+            .collect::<Vec<_>>()
+    };
+    let pci_restore_now = Instant::now();
+    let pci_fault_bundle = SnapshotV2StorageRestorePlan::prepare(
+        pci_graph.clone(),
+        &pci_fault_memory,
+        pci_restore_now,
+    )
+    .expect("PCI profile-3 fault restore plan should validate")
+    .prepare_backings(
+        reopen_pci_block_backings(),
+        reopen_pci_pmem_backings(),
+        || false,
+    )
+    .expect("PCI profile-3 fault backings should prepare");
+    let pci_fault_plan =
+        prepare_hvf_snapshot_v2_storage_pci_platform_plan(&pci_platform, &pci_fault_bundle)
+            .expect("PCI profile-3 fault platform plan should validate");
+    let pci_fault_shell = HvfSnapshotV2DefaultProcessShell::new(SharedSerialOutput::from(
+        SharedSerialOutputBuffer::default(),
+    ));
+    let pci_fault =
+        OwnedHvfArm64BootSession::restore_snapshot_v2_storage_pci_with_pmem_publication_fault(
+            pci_platform.clone(),
+            pci_fault_memory,
+            pci_fault_shell,
+            pci_fault_bundle,
+            pci_fault_plan,
+            0,
+        )
+        .expect_err("injected PCI post-mapping publication fault should reject");
+    assert_eq!(
+        pci_fault.stage(),
+        bangbang_hvf::HvfSnapshotV2StoragePciRestoreStage::Publication {
+            index: pci_graph.block_records().len(),
+        }
+    );
+    assert!(
+        pci_fault.cleanup_failures().is_empty(),
+        "PCI publication rollback should be complete: {:?}",
+        pci_fault.cleanup_failures()
+    );
+    assert!(!pci_fault.is_terminal());
+    let pci_fault_diagnostics = format!("{pci_fault:?} {pci_fault}");
+    for private_path in [
+        path_text(pci_root.path()),
+        path_text(pci_startup_pmem.path()),
+        path_text(pci_dynamic_async.path()),
+        path_text(pci_dynamic_pmem.path()),
+    ] {
+        assert!(!pci_fault_diagnostics.contains(&private_path));
+    }
+
+    let pci_restore_bundle = SnapshotV2StorageRestorePlan::prepare(
+        pci_graph.clone(),
+        &pci_restored_memory,
+        pci_restore_now,
+    )
+    .expect("PCI profile-3 restore plan should validate")
+    .prepare_backings(
+        reopen_pci_block_backings(),
+        reopen_pci_pmem_backings(),
+        || false,
+    )
+    .expect("PCI profile-3 backings should prepare");
+    let pci_restore_plan =
+        prepare_hvf_snapshot_v2_storage_pci_platform_plan(&pci_platform, &pci_restore_bundle)
+            .expect("PCI profile-3 platform plan should validate");
+    let pci_restore_shell = HvfSnapshotV2DefaultProcessShell::new(SharedSerialOutput::from(
+        SharedSerialOutputBuffer::default(),
+    ));
+    let pci_restored_owners = OwnedHvfArm64BootSession::restore_snapshot_v2_storage_pci(
+        pci_platform,
+        pci_restored_memory,
+        pci_restore_shell,
+        pci_restore_bundle,
+        pci_restore_plan,
+    )
+    .unwrap_or_else(|error| panic!("PCI profile-3 owners should restore: {error:?}"));
+    assert_eq!(pci_restored_owners.configs(), &pci_configs);
+    let (mut pci_restored, pci_restored_configs) = pci_restored_owners.into_parts();
+    assert_eq!(pci_restored_configs, pci_configs);
+    assert!(pci_restored.uses_pci_data_devices());
+    assert!(pci_restored.runtime_resources().block_devices.is_empty());
+    assert_eq!(pci_restored.runtime_resources().pmem_devices.len(), 2);
+    assert!(
+        pci_restored
+            .runtime_resources()
+            .pmem_mmio_devices
+            .is_empty()
+    );
+    let pci_restored_guard = pci_restored
+        .quiesce_limiter_retry_wakeups()
+        .expect("restored PCI profile-3 retry publishers should quiesce");
+    let pci_recaptured_graph = pci_restored
+        .capture_snapshot_v2_storage_device_graph_at(
+            &pci_restored_configs,
+            &pci_restored_guard,
+            pci_restore_now,
+        )
+        .expect("restored PCI profile-3 graph should recapture");
+    assert_eq!(pci_recaptured_graph, pci_graph);
+    drop(pci_restored_guard);
+
+    const RESTORED_PCI_PMEM_WRITE_OFFSET: u64 = 8192;
+    const RESTORED_PCI_PMEM_WRITE_VALUE: u32 = 0x1632_cafe;
+    let pci_restored_entry = GuestAddress::new(
+        pci_restored
+            .capture_arm64_general_register_state()
+            .expect("restored PCI profile-3 registers should capture")
+            .pc(),
+    );
+    let pci_restored_target = pci_restored.runtime_resources().pmem_devices[0]
+        .guest_range()
+        .start()
+        .checked_add(RESTORED_PCI_PMEM_WRITE_OFFSET)
+        .expect("restored PCI profile-3 pmem target should fit");
+    let pci_restored_program = arm64_store_u32_and_hvc_program(
+        pci_restored_target.raw_value(),
+        RESTORED_PCI_PMEM_WRITE_VALUE,
+    );
+    pci_restored
+        .guest_memory_mut()
+        .expect("restored PCI profile-3 guest memory should map")
+        .write_slice(&pci_restored_program, pci_restored_entry)
+        .expect("restored PCI profile-3 guest program should write");
+    pci_restored
+        .resume_after_snapshot_v2_capture()
+        .expect("restored PCI profile-3 runner should resume");
+    assert!(matches!(
+        pci_restored
+            .run_once_and_handle_mmio()
+            .expect("restored PCI guest should reach HVC through its pmem mapping"),
+        HvfVcpuRunStepOutcome::Hvc { exit, .. } if exit.immediate() == 0
+    ));
+    let pci_observer =
+        std::fs::File::open(pci_startup_pmem.path()).expect("restored PCI pmem should open");
+    let mut pci_observed = [0_u8; std::mem::size_of::<u32>()];
+    pci_observer
+        .read_exact_at(&mut pci_observed, RESTORED_PCI_PMEM_WRITE_OFFSET)
+        .expect("restored PCI pmem observer should read");
+    assert_eq!(
+        u32::from_le_bytes(pci_observed),
+        RESTORED_PCI_PMEM_WRITE_VALUE
+    );
+    pci_restored
+        .shutdown()
+        .expect("restored PCI profile-3 session should tear down in ownership order");
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/crates/runtime/src/snapshot_device_v2_6.rs
+++ b/crates/runtime/src/snapshot_device_v2_6.rs
@@ -40,8 +40,11 @@ pub use restore::{
     PreparedSnapshotV2StorageBundle, PreparedSnapshotV2StorageBundleParts,
     PreparedSnapshotV2StorageMmioBundle, PreparedSnapshotV2StorageMmioBundleParts,
     PreparedSnapshotV2StorageMmioPmemRecord, PreparedSnapshotV2StorageMmioPmemRecordParts,
-    SnapshotV2StorageBundleError, SnapshotV2StorageCleanupError,
-    SnapshotV2StorageMmioTransportError, SnapshotV2StorageRestorePlan,
+    PreparedSnapshotV2StoragePciBundle, PreparedSnapshotV2StoragePciBundleParts,
+    PreparedSnapshotV2StoragePciPmemEndpoint, PreparedSnapshotV2StoragePciPmemEndpointParts,
+    PreparedSnapshotV2StoragePciPmemRecord, SnapshotV2StorageBundleError,
+    SnapshotV2StorageCleanupError, SnapshotV2StorageMmioTransportError,
+    SnapshotV2StoragePciTransportError, SnapshotV2StorageRestorePlan,
     SnapshotV2StorageRestorePlanError,
 };
 

--- a/crates/runtime/src/snapshot_device_v2_6/restore.rs
+++ b/crates/runtime/src/snapshot_device_v2_6/restore.rs
@@ -9,26 +9,31 @@ use crate::block::async_executor::BlockAsyncRuntimeError;
 use crate::block::{BlockFileBacking, DriveConfigs};
 use crate::interrupt::GuestInterruptLine;
 use crate::memory::{GuestMemory, GuestMemoryRange};
-use crate::mmio::MmioRegion;
+use crate::message_interrupt::GuestMessageInterruptRegistry;
+use crate::mmio::{MmioRegion, MmioRegionId};
+use crate::pci::PciSbdf;
 use crate::pmem::{
     PmemConfigInput, PmemConfigs, PmemFileBacking, PreparedPmemDevice,
     PreparedSnapshotPmemDeviceError, PreparedSnapshotPmemDeviceParts, VIRTIO_PMEM_DEVICE_ID,
-    VIRTIO_PMEM_QUEUE_SIZES, VirtioPmemDevice, VirtioPmemMmioHandler, VirtioPmemRateLimiterState,
-    VirtioPmemTokenBucketState,
+    VIRTIO_PMEM_QUEUE_SIZES, VirtioPmemConfigSpace, VirtioPmemDevice, VirtioPmemMmioHandler,
+    VirtioPmemRateLimiterState, VirtioPmemTokenBucketState,
 };
 use crate::snapshot_device_v2::{
     SnapshotV2RootTransportRestoreError, restore_mmio_transport_state_for_device,
 };
 use crate::snapshot_device_v2_5::{
     PreparedSnapshotV2MultiBlockBundle, PreparedSnapshotV2MultiBlockMmioBundle,
-    SnapshotV2MultiBlockBundleError, SnapshotV2MultiBlockCleanupError,
-    SnapshotV2MultiBlockDeviceGraph, SnapshotV2MultiBlockMmioTransportError,
+    PreparedSnapshotV2MultiBlockPciBundle, SnapshotV2MultiBlockBundleError,
+    SnapshotV2MultiBlockCleanupError, SnapshotV2MultiBlockDeviceGraph,
+    SnapshotV2MultiBlockMmioTransportError, SnapshotV2MultiBlockPciTransportError,
     SnapshotV2MultiBlockRestorePlan, SnapshotV2MultiBlockRestorePlanError,
 };
+use crate::virtio::VirtioDeviceType;
 use crate::virtio_mmio::{
     VirtioMmioQueueState, VirtioMmioRegisterHandler, VirtioMmioRegisterHandlerError,
     VirtioMmioTransportStateError,
 };
+use crate::virtio_pci::{PreparedVirtioPciEndpoint, VirtioPciIdentity, VirtioPciTransportState};
 
 /// Complete pure destination proof for one detached profile-3 graph.
 pub struct SnapshotV2StorageRestorePlan {
@@ -636,6 +641,159 @@ impl fmt::Debug for PreparedSnapshotV2StorageMmioPmemRecord {
     }
 }
 
+/// One exact detached profile-3 PCI pmem owner awaiting live route resources.
+pub struct PreparedSnapshotV2StoragePciPmemRecord {
+    key: SnapshotV2DeviceKey,
+    is_root: bool,
+    retry: StorageRetryState,
+    retry_deadline: Option<Instant>,
+    origin: StorageDeviceOrigin,
+    sbdf: PciSbdf,
+    bar_range: GuestMemoryRange,
+    prepared_device: PreparedPmemDevice,
+    config_space: VirtioPmemConfigSpace,
+    device: VirtioPmemDevice,
+    identity: VirtioPciIdentity,
+    retained: VirtioPciTransportState,
+}
+
+impl PreparedSnapshotV2StoragePciPmemRecord {
+    pub const fn key(&self) -> SnapshotV2DeviceKey {
+        self.key
+    }
+
+    pub fn pmem_id(&self) -> &str {
+        self.prepared_device.id()
+    }
+
+    pub const fn is_root_device(&self) -> bool {
+        self.is_root
+    }
+
+    pub const fn retry(&self) -> StorageRetryState {
+        self.retry
+    }
+
+    pub const fn retry_deadline(&self) -> Option<Instant> {
+        self.retry_deadline
+    }
+
+    pub const fn origin(&self) -> StorageDeviceOrigin {
+        self.origin
+    }
+
+    pub const fn sbdf(&self) -> PciSbdf {
+        self.sbdf
+    }
+
+    pub const fn bar_range(&self) -> GuestMemoryRange {
+        self.bar_range
+    }
+
+    pub const fn prepared_device(&self) -> &PreparedPmemDevice {
+        &self.prepared_device
+    }
+
+    /// Completes retained endpoint preparation against the destination's
+    /// fresh shared message registry without publishing live resources.
+    pub fn prepare_endpoint(
+        self,
+        region_id: MmioRegionId,
+        messages: GuestMessageInterruptRegistry,
+    ) -> Result<PreparedSnapshotV2StoragePciPmemEndpoint, SnapshotV2RootTransportRestoreError> {
+        let endpoint = PreparedVirtioPciEndpoint::new(
+            self.identity,
+            &VIRTIO_PMEM_QUEUE_SIZES,
+            self.config_space,
+            self.device,
+            self.retained.is_device_activated(),
+            false,
+            &self.retained,
+            self.sbdf,
+            self.bar_range,
+            region_id,
+            messages,
+        )
+        .map_err(SnapshotV2RootTransportRestoreError::Pci)?;
+        Ok(PreparedSnapshotV2StoragePciPmemEndpoint {
+            key: self.key,
+            is_root: self.is_root,
+            retry: self.retry,
+            retry_deadline: self.retry_deadline,
+            origin: self.origin,
+            prepared_device: self.prepared_device,
+            endpoint,
+        })
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2StoragePciPmemRecord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2StoragePciPmemRecord")
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// One fully checked, still-unpublished exact-2.6 PCI pmem endpoint and
+/// authoritative mapping owner.
+pub struct PreparedSnapshotV2StoragePciPmemEndpoint {
+    key: SnapshotV2DeviceKey,
+    is_root: bool,
+    retry: StorageRetryState,
+    retry_deadline: Option<Instant>,
+    origin: StorageDeviceOrigin,
+    prepared_device: PreparedPmemDevice,
+    endpoint: PreparedVirtioPciEndpoint<VirtioPmemConfigSpace, VirtioPmemDevice>,
+}
+
+/// Consumed exact pmem owner metadata, mapping, and retained PCI endpoint.
+pub type PreparedSnapshotV2StoragePciPmemEndpointParts = (
+    SnapshotV2DeviceKey,
+    bool,
+    StorageRetryState,
+    Option<Instant>,
+    StorageDeviceOrigin,
+    PreparedPmemDevice,
+    PreparedVirtioPciEndpoint<VirtioPmemConfigSpace, VirtioPmemDevice>,
+);
+
+impl PreparedSnapshotV2StoragePciPmemEndpoint {
+    pub const fn key(&self) -> SnapshotV2DeviceKey {
+        self.key
+    }
+
+    pub fn pmem_id(&self) -> &str {
+        self.prepared_device.id()
+    }
+
+    pub const fn prepared_device(&self) -> &PreparedPmemDevice {
+        &self.prepared_device
+    }
+
+    pub fn into_parts(self) -> PreparedSnapshotV2StoragePciPmemEndpointParts {
+        (
+            self.key,
+            self.is_root,
+            self.retry,
+            self.retry_deadline,
+            self.origin,
+            self.prepared_device,
+            self.endpoint,
+        )
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2StoragePciPmemEndpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2StoragePciPmemEndpoint")
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
 /// Canonical move-only pathless profile-3 block-and-pmem vector.
 pub struct PreparedSnapshotV2StorageBundle {
     root_key: Option<SnapshotV2DeviceKey>,
@@ -803,6 +961,126 @@ impl PreparedSnapshotV2StorageBundle {
         })
     }
 
+    /// Reconstructs every exact PCI endpoint owner without publishing a BAR,
+    /// function, route, dispatcher handler, or pmem mapping.
+    pub fn prepare_pci_transport(
+        self,
+    ) -> Result<PreparedSnapshotV2StoragePciBundle, SnapshotV2StoragePciTransportError> {
+        self.prepare_pci_transport_with_reserve(&mut SystemRestoreReserve)
+    }
+
+    fn prepare_pci_transport_with_reserve(
+        mut self,
+        reserve: &mut impl StorageRestoreReserve,
+    ) -> Result<PreparedSnapshotV2StoragePciBundle, SnapshotV2StoragePciTransportError> {
+        if self.transport_kind != SnapshotV2DeviceTransportKind::Pci {
+            return Err(
+                self.pci_transport_error(SnapshotV2StoragePciTransportErrorKind::TransportPolicy)
+            );
+        }
+
+        let block = match self.block.take() {
+            Some(block) => match block.prepare_pci_transport() {
+                Ok(block) => Some(block),
+                Err(source) => {
+                    return Err(SnapshotV2StoragePciTransportError::new(
+                        SnapshotV2StoragePciTransportErrorKind::Block(source),
+                        None,
+                    ));
+                }
+            },
+            None => None,
+        };
+
+        let mut prepared_pmem = Vec::new();
+        if reserve
+            .reserve_vec(&mut prepared_pmem, self.pmem_records.len())
+            .is_err()
+        {
+            return Err(storage_pci_transport_error_after_block(
+                SnapshotV2StoragePciTransportErrorKind::Allocation,
+                block,
+            ));
+        }
+
+        let root_key = self.root_key;
+        let pmem_configs = std::mem::take(&mut self.pmem_configs);
+        let records = std::mem::take(&mut self.pmem_records);
+        for record in records {
+            let (
+                key,
+                is_root,
+                _queue_ranges,
+                retry,
+                retry_deadline,
+                virtio,
+                transport,
+                prepared_device,
+                device,
+            ) = record.into_parts();
+            let SnapshotV2DeviceTransport::Pci(pci) = transport else {
+                release_storage_pci_pmem_records(&mut prepared_pmem);
+                drop(prepared_device);
+                return Err(storage_pci_transport_error_after_block(
+                    SnapshotV2StoragePciTransportErrorKind::TransportPolicy,
+                    block,
+                ));
+            };
+            let device_type = match VirtioDeviceType::new(VIRTIO_PMEM_DEVICE_ID) {
+                Ok(device_type) => device_type,
+                Err(source) => {
+                    release_storage_pci_pmem_records(&mut prepared_pmem);
+                    drop(prepared_device);
+                    return Err(storage_pci_transport_error_after_block(
+                        SnapshotV2StoragePciTransportErrorKind::PmemState(
+                            SnapshotV2RootTransportRestoreError::DeviceType(source),
+                        ),
+                        block,
+                    ));
+                }
+            };
+            let identity = VirtioPciIdentity::new(device_type, virtio.available_features())
+                .with_config_generation(virtio.config_generation());
+            let retained = match VirtioPciTransportState::from_snapshot_v2_parts(
+                identity, &virtio, &pci, false,
+            ) {
+                Ok(retained) => retained,
+                Err(source) => {
+                    release_storage_pci_pmem_records(&mut prepared_pmem);
+                    drop(prepared_device);
+                    return Err(storage_pci_transport_error_after_block(
+                        SnapshotV2StoragePciTransportErrorKind::PmemState(
+                            SnapshotV2RootTransportRestoreError::Pci(source),
+                        ),
+                        block,
+                    ));
+                }
+            };
+            let config_space = prepared_device.config_space();
+            prepared_pmem.push(PreparedSnapshotV2StoragePciPmemRecord {
+                key,
+                is_root,
+                retry,
+                retry_deadline,
+                origin: pci.origin(),
+                sbdf: pci.sbdf(),
+                bar_range: pci.bar_range(),
+                prepared_device,
+                config_space,
+                device,
+                identity,
+                retained,
+            });
+        }
+
+        Ok(PreparedSnapshotV2StoragePciBundle {
+            root_key,
+            block,
+            pmem_configs,
+            pmem_records: prepared_pmem,
+        })
+    }
+
     /// Transfers every detached storage owner to the transport layer.
     pub fn into_parts(mut self) -> PreparedSnapshotV2StorageBundleParts {
         (
@@ -833,6 +1111,17 @@ impl PreparedSnapshotV2StorageBundle {
             .err()
             .map(SnapshotV2StorageCleanupError::into_source);
         SnapshotV2StorageMmioTransportError::new(kind, cleanup)
+    }
+
+    fn pci_transport_error(
+        self,
+        kind: SnapshotV2StoragePciTransportErrorKind,
+    ) -> SnapshotV2StoragePciTransportError {
+        let cleanup = self
+            .abort()
+            .err()
+            .map(SnapshotV2StorageCleanupError::into_source);
+        SnapshotV2StoragePciTransportError::new(kind, cleanup)
     }
 }
 
@@ -925,6 +1214,84 @@ impl fmt::Debug for PreparedSnapshotV2StorageMmioBundle {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("PreparedSnapshotV2StorageMmioBundle")
+            .field(
+                "block_count",
+                &self
+                    .block
+                    .as_ref()
+                    .map_or(0, |bundle| bundle.records().len()),
+            )
+            .field("pmem_count", &self.pmem_records.len())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Move-only exact profile-3 PCI storage product awaiting one private
+/// heterogeneous manager and hypervisor mapping transaction.
+pub struct PreparedSnapshotV2StoragePciBundle {
+    root_key: Option<SnapshotV2DeviceKey>,
+    block: Option<PreparedSnapshotV2MultiBlockPciBundle>,
+    pmem_configs: PmemConfigs,
+    pmem_records: Vec<PreparedSnapshotV2StoragePciPmemRecord>,
+}
+
+/// Consumed exact PCI storage bundle parts.
+pub type PreparedSnapshotV2StoragePciBundleParts = (
+    Option<SnapshotV2DeviceKey>,
+    Option<PreparedSnapshotV2MultiBlockPciBundle>,
+    PmemConfigs,
+    Vec<PreparedSnapshotV2StoragePciPmemRecord>,
+);
+
+impl PreparedSnapshotV2StoragePciBundle {
+    pub const fn root_key(&self) -> Option<SnapshotV2DeviceKey> {
+        self.root_key
+    }
+
+    pub const fn block_bundle(&self) -> Option<&PreparedSnapshotV2MultiBlockPciBundle> {
+        self.block.as_ref()
+    }
+
+    pub const fn pmem_configs(&self) -> &PmemConfigs {
+        &self.pmem_configs
+    }
+
+    pub fn pmem_records(&self) -> &[PreparedSnapshotV2StoragePciPmemRecord] {
+        &self.pmem_records
+    }
+
+    pub fn into_parts(mut self) -> PreparedSnapshotV2StoragePciBundleParts {
+        (
+            self.root_key,
+            self.block.take(),
+            std::mem::take(&mut self.pmem_configs),
+            std::mem::take(&mut self.pmem_records),
+        )
+    }
+
+    pub fn abort(mut self) -> Result<(), SnapshotV2StorageCleanupError> {
+        release_storage_pci_pmem_records(&mut self.pmem_records);
+        self.block
+            .take()
+            .map_or(Ok(()), PreparedSnapshotV2MultiBlockPciBundle::abort)
+            .map_err(SnapshotV2StorageCleanupError::new)
+    }
+}
+
+impl Drop for PreparedSnapshotV2StoragePciBundle {
+    fn drop(&mut self) {
+        release_storage_pci_pmem_records(&mut self.pmem_records);
+        if let Some(block) = self.block.take() {
+            let _ = block.abort();
+        }
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2StoragePciBundle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2StoragePciBundle")
             .field(
                 "block_count",
                 &self
@@ -1032,6 +1399,95 @@ impl std::error::Error for SnapshotV2StorageMmioTransportError {
             SnapshotV2StorageMmioTransportErrorKind::PmemTransport(source) => Some(source),
             SnapshotV2StorageMmioTransportErrorKind::TransportPolicy
             | SnapshotV2StorageMmioTransportErrorKind::Allocation => self
+                .cleanup
+                .as_ref()
+                .map(|source| source as &(dyn std::error::Error + 'static)),
+        }
+    }
+}
+
+enum SnapshotV2StoragePciTransportErrorKind {
+    TransportPolicy,
+    Allocation,
+    Block(SnapshotV2MultiBlockPciTransportError),
+    PmemState(SnapshotV2RootTransportRestoreError),
+}
+
+/// Redacted failure while consuming profile-3 storage owners into exact PCI
+/// endpoint state.
+pub struct SnapshotV2StoragePciTransportError {
+    kind: Box<SnapshotV2StoragePciTransportErrorKind>,
+    cleanup: Option<SnapshotV2MultiBlockCleanupError>,
+}
+
+impl SnapshotV2StoragePciTransportError {
+    fn new(
+        kind: SnapshotV2StoragePciTransportErrorKind,
+        cleanup: Option<SnapshotV2MultiBlockCleanupError>,
+    ) -> Self {
+        Self {
+            kind: Box::new(kind),
+            cleanup,
+        }
+    }
+
+    pub fn cleanup_failed(&self) -> bool {
+        self.cleanup.is_some()
+            || matches!(
+                self.kind.as_ref(),
+                SnapshotV2StoragePciTransportErrorKind::Block(source)
+                    if source.cleanup_failed()
+            )
+    }
+}
+
+impl fmt::Debug for SnapshotV2StoragePciTransportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self.kind.as_ref() {
+            SnapshotV2StoragePciTransportErrorKind::TransportPolicy => "transport-policy",
+            SnapshotV2StoragePciTransportErrorKind::Allocation => "allocation",
+            SnapshotV2StoragePciTransportErrorKind::Block(_) => "block",
+            SnapshotV2StoragePciTransportErrorKind::PmemState(_) => "pmem-state",
+        };
+        formatter
+            .debug_struct("SnapshotV2StoragePciTransportError")
+            .field("kind", &kind)
+            .field("cleanup_failed", &self.cleanup_failed())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotV2StoragePciTransportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self.kind.as_ref() {
+            SnapshotV2StoragePciTransportErrorKind::TransportPolicy => {
+                "snapshot storage PCI transport policy is invalid"
+            }
+            SnapshotV2StoragePciTransportErrorKind::Allocation => {
+                "snapshot storage PCI transport allocation failed"
+            }
+            SnapshotV2StoragePciTransportErrorKind::Block(_) => {
+                "snapshot storage block PCI reconstruction failed"
+            }
+            SnapshotV2StoragePciTransportErrorKind::PmemState(_) => {
+                "snapshot storage pmem PCI retained state is invalid"
+            }
+        })?;
+        if self.cleanup_failed() {
+            formatter.write_str("; cleanup also failed")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for SnapshotV2StoragePciTransportError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self.kind.as_ref() {
+            SnapshotV2StoragePciTransportErrorKind::Block(source) => Some(source),
+            SnapshotV2StoragePciTransportErrorKind::PmemState(source) => Some(source),
+            SnapshotV2StoragePciTransportErrorKind::TransportPolicy
+            | SnapshotV2StoragePciTransportErrorKind::Allocation => self
                 .cleanup
                 .as_ref()
                 .map(|source| source as &(dyn std::error::Error + 'static)),
@@ -1382,11 +1838,22 @@ pub(super) fn prepare_mmio_transport_with_failing_reserve_for_test(
     bundle.prepare_mmio_transport_with_reserve(&mut FailingStorageRestoreReserve::new(0))
 }
 
+#[cfg(test)]
+pub(super) fn prepare_pci_transport_with_failing_reserve_for_test(
+    bundle: PreparedSnapshotV2StorageBundle,
+) -> Result<PreparedSnapshotV2StoragePciBundle, SnapshotV2StoragePciTransportError> {
+    bundle.prepare_pci_transport_with_reserve(&mut FailingStorageRestoreReserve::new(0))
+}
+
 fn release_pmem_records(records: &mut Vec<PreparedSnapshotV2PmemRecord>) {
     while records.pop().is_some() {}
 }
 
 fn release_storage_mmio_pmem_records(records: &mut Vec<PreparedSnapshotV2StorageMmioPmemRecord>) {
+    while records.pop().is_some() {}
+}
+
+fn release_storage_pci_pmem_records(records: &mut Vec<PreparedSnapshotV2StoragePciPmemRecord>) {
     while records.pop().is_some() {}
 }
 
@@ -1399,6 +1866,17 @@ fn storage_mmio_transport_error_after_block(
         .transpose()
         .err();
     SnapshotV2StorageMmioTransportError::new(kind, cleanup)
+}
+
+fn storage_pci_transport_error_after_block(
+    kind: SnapshotV2StoragePciTransportErrorKind,
+    block: Option<PreparedSnapshotV2MultiBlockPciBundle>,
+) -> SnapshotV2StoragePciTransportError {
+    let cleanup = block
+        .map(PreparedSnapshotV2MultiBlockPciBundle::abort)
+        .transpose()
+        .err();
+    SnapshotV2StoragePciTransportError::new(kind, cleanup)
 }
 
 fn abort_block_bundle(

--- a/crates/runtime/src/snapshot_device_v2_6/tests.rs
+++ b/crates/runtime/src/snapshot_device_v2_6/tests.rs
@@ -830,6 +830,111 @@ fn mmio_handoff_rejects_pci_and_allocation_faults_with_clean_owner_release() {
 }
 
 #[test]
+fn pci_handoff_preserves_exact_pmem_placement_and_storage_order() {
+    for (blocks, pmems, root) in [
+        (1, 0, Some(DEVICE_KIND_BLOCK)),
+        (0, 1, Some(DEVICE_KIND_PMEM)),
+        (1, 1, Some(DEVICE_KIND_BLOCK)),
+        (0, 1, None),
+    ] {
+        let graph = fixture_graph(SnapshotV2DeviceTransportKind::Pci, blocks, pmems, root);
+        let expected = graph.clone();
+        let memory = restore_memory_for(&graph);
+        let now = Instant::now();
+        let (_files, block_backings, pmem_backings) = restore_backings(&graph);
+        let bundle = SnapshotV2StorageRestorePlan::prepare(graph, &memory, now)
+            .expect("PCI handoff plan should prepare")
+            .prepare_backings(block_backings, pmem_backings, || false)
+            .expect("PCI handoff bundle should prepare");
+
+        let pci = bundle
+            .prepare_pci_transport()
+            .expect("PCI handoff should reconstruct");
+        assert_eq!(pci.root_key(), expected.root_key());
+        assert_eq!(
+            pci.block_bundle()
+                .map_or(0, |bundle| bundle.records().len()),
+            blocks
+        );
+        assert_eq!(pci.pmem_records().len(), pmems);
+        assert_eq!(pci.pmem_configs().as_slice().len(), pmems);
+        for (record, expected) in pci.pmem_records().iter().zip(expected.pmem_records()) {
+            let SnapshotV2DeviceTransport::Pci(expected_pci) = expected.transport() else {
+                panic!("fixture pmem transport should be PCI");
+            };
+            assert_eq!(record.key(), expected.key());
+            assert_eq!(record.pmem_id(), expected.config().pmem_id());
+            assert_eq!(record.is_root_device(), expected.is_root());
+            assert_eq!(record.retry(), expected.pmem().retry());
+            assert_eq!(
+                record.retry_deadline(),
+                Some(now + Duration::from_nanos(99))
+            );
+            assert_eq!(record.origin(), expected_pci.origin());
+            assert_eq!(record.sbdf(), expected_pci.sbdf());
+            assert_eq!(record.bar_range(), expected_pci.bar_range());
+            assert_eq!(
+                record.prepared_device().guest_range(),
+                expected.pmem().guest_range()
+            );
+            assert_eq!(
+                record.prepared_device().config_space(),
+                expected.pmem().config_space()
+            );
+        }
+        let debug = format!("{pci:?}");
+        for secret in ["pmem-selector", "root=", "PARTUUID"] {
+            assert!(!debug.contains(secret));
+        }
+        pci.abort()
+            .expect("PCI handoff should release every unpublished owner");
+    }
+}
+
+#[test]
+fn pci_handoff_rejects_mmio_and_allocation_faults_with_clean_owner_release() {
+    let mmio = fixture_graph(SnapshotV2DeviceTransportKind::Mmio, 0, 1, None);
+    let memory = restore_memory_for(&mmio);
+    let (_files, blocks, pmems) = restore_backings(&mmio);
+    let bundle = SnapshotV2StorageRestorePlan::prepare(mmio, &memory, Instant::now())
+        .expect("MMIO rejection plan should prepare")
+        .prepare_backings(blocks, pmems, || false)
+        .expect("MMIO rejection bundle should prepare");
+    let error = bundle
+        .prepare_pci_transport()
+        .expect_err("MMIO storage must not fall back to PCI");
+    assert!(!error.cleanup_failed());
+
+    let graph = fixture_graph(
+        SnapshotV2DeviceTransportKind::Pci,
+        2,
+        1,
+        Some(DEVICE_KIND_BLOCK),
+    );
+    let memory = restore_memory_for(&graph);
+    let (_files, blocks, pmems) = restore_backings(&graph);
+    let bundle = SnapshotV2StorageRestorePlan::prepare(graph, &memory, Instant::now())
+        .expect("allocation handoff plan should prepare")
+        .prepare_backings(blocks, pmems, || false)
+        .expect("allocation handoff bundle should prepare");
+    let async_runtime = bundle
+        .block_bundle()
+        .and_then(|bundle| bundle.async_runtime())
+        .cloned();
+    let error = super::restore::prepare_pci_transport_with_failing_reserve_for_test(bundle)
+        .expect_err("pmem PCI record reservation should fail explicitly");
+    assert!(!error.cleanup_failed());
+    if let Some(runtime) = async_runtime {
+        assert_eq!(
+            runtime
+                .generation_count()
+                .expect("Async runtime should remain observable"),
+            0
+        );
+    }
+}
+
+#[test]
 fn profile_identity_is_exact_distinct_and_bounded() {
     assert_eq!(
         NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,


### PR DESCRIPTION
## Summary

- add the private exact-native-v2 2.6 heterogeneous PCI transport, platform,
  shell, and destination transactions for block and pmem owners
- preserve captured origin, SBDF, BAR, MSI-X, interrupt, queue, activation,
  retry, root, and configuration state while creating fresh destination-local
  owners
- map each restored pmem range before publishing its PCI endpoint and retain
  failure-atomic reverse cleanup through normal shutdown and injected faults
- extend the private Paused process handoff and signed lifecycle coverage

## Compatibility and scope

- exact-native-v2 2.3, 2.4, and 2.5 entry points and behavior remain unchanged
- exact 2.6 remains private; public writer/reader activation stays in #1633
- final direct/App Sandbox product certification stays in #1634

## Verification

- complete 14-command repository gate from `AGENTS.md`
- 1,394 HVF library tests
- strict workspace and all five Apple-target Clippy commands
- signed integration wrapper without `--allow-unsupported`: 343 executions
  across lifecycle, guest boot, private native-v2, App Sandbox, production
  bundle, and executable suites

Closes #1632
