### PR TITLE
fix: attribute shared MMIO storage retries

### DIFF
--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -6602,6 +6602,48 @@ const fn storage_retry_state(state: SnapshotV1BlockRetryState) -> StorageRetrySt
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CaptureReadySharedStorageRetryAttribution {
+    shared: StorageRetryState,
+    has_pending_owner: bool,
+}
+
+impl CaptureReadySharedStorageRetryAttribution {
+    const fn new(shared: StorageRetryState) -> Self {
+        Self {
+            shared,
+            has_pending_owner: false,
+        }
+    }
+
+    fn attribute(
+        &mut self,
+        pending: bool,
+    ) -> Result<StorageRetryState, HvfArm64BootStorageCaptureError> {
+        if !pending {
+            return Ok(StorageRetryState::None);
+        }
+        if self.shared == StorageRetryState::None {
+            return Err(HvfArm64BootStorageCaptureError::new(
+                HvfArm64BootStorageCaptureErrorKind::RetryState,
+                false,
+            ));
+        }
+        self.has_pending_owner = true;
+        Ok(self.shared)
+    }
+
+    fn finish(self) -> Result<(), HvfArm64BootStorageCaptureError> {
+        if self.shared != StorageRetryState::None && !self.has_pending_owner {
+            return Err(HvfArm64BootStorageCaptureError::new(
+                HvfArm64BootStorageCaptureErrorKind::RetryState,
+                false,
+            ));
+        }
+        Ok(())
+    }
+}
+
 fn storage_retry_state_at(
     deadline: Option<Instant>,
     now: Instant,
@@ -8388,6 +8430,10 @@ fn capture_ready_storage_transaction_at_with_cancel(
     let shared_pmem_retry = storage_retry_state(guard.pmem_retry_state_at(now).map_err(|_| {
         HvfArm64BootStorageCaptureError::new(HvfArm64BootStorageCaptureErrorKind::RetryState, false)
     })?);
+    let mut block_retry_attribution =
+        CaptureReadySharedStorageRetryAttribution::new(shared_block_retry);
+    let mut pmem_retry_attribution =
+        CaptureReadySharedStorageRetryAttribution::new(shared_pmem_retry);
     let mut mmio_dispatcher_guard =
         lock_boot_mmio_dispatcher(mmio_dispatcher).map_err(|error| match error {
             HvfArm64BootMmioDispatcherError::Busy => HvfArm64BootStorageCaptureError::new(
@@ -8561,10 +8607,23 @@ fn capture_ready_storage_transaction_at_with_cancel(
         let pci_match = pci_matches.next().map(|(index, _)| index);
         let duplicate_pci = pci_matches.next().is_some();
         let owner = match (mmio_match, duplicate_mmio, pci_match, duplicate_pci) {
-            (Some(interrupt_line), false, None, false) => CaptureReadyBlockOwner::Mmio {
-                retry: shared_block_retry,
-                interrupt_line,
-            },
+            (Some(interrupt_line), false, None, false) => {
+                let pending = runtime_resources
+                    .capture_ready_mmio_block_has_pending_rate_limited_queue(
+                        &mut mmio_dispatcher_guard,
+                        config.drive_id(),
+                    )
+                    .map_err(|_| {
+                        HvfArm64BootStorageCaptureError::new(
+                            HvfArm64BootStorageCaptureErrorKind::BlockCapture,
+                            false,
+                        )
+                    })?;
+                CaptureReadyBlockOwner::Mmio {
+                    retry: block_retry_attribution.attribute(pending)?,
+                    interrupt_line,
+                }
+            }
             (None, false, Some(index), false) => {
                 let device = pci_data_devices
                     .as_ref()
@@ -8599,6 +8658,7 @@ fn capture_ready_storage_transaction_at_with_cancel(
         };
         block_owners.push(owner);
     }
+    block_retry_attribution.finish()?;
 
     for config in configs.pmem() {
         let mut mmio_matches = runtime_resources
@@ -8615,9 +8675,22 @@ fn capture_ready_storage_transaction_at_with_cancel(
         let pci_match = pci_matches.next().map(|(index, _)| index);
         let duplicate_pci = pci_matches.next().is_some();
         let owner = match (mmio_match, duplicate_mmio, pci_match, duplicate_pci) {
-            (true, false, None, false) => CaptureReadyPmemOwner::Mmio {
-                retry: shared_pmem_retry,
-            },
+            (true, false, None, false) => {
+                let pending = runtime_resources
+                    .capture_ready_mmio_pmem_has_pending_rate_limited_queue(
+                        &mut mmio_dispatcher_guard,
+                        config.id(),
+                    )
+                    .map_err(|_| {
+                        HvfArm64BootStorageCaptureError::new(
+                            HvfArm64BootStorageCaptureErrorKind::PmemCapture,
+                            false,
+                        )
+                    })?;
+                CaptureReadyPmemOwner::Mmio {
+                    retry: pmem_retry_attribution.attribute(pending)?,
+                }
+            }
             (false, false, Some(index), false) => {
                 let device = pci_data_devices
                     .as_ref()
@@ -8651,6 +8724,7 @@ fn capture_ready_storage_transaction_at_with_cancel(
         };
         pmem_owners.push(owner);
     }
+    pmem_retry_attribution.finish()?;
 
     if mode != CaptureReadyStorageMode::Diagnostic {
         let first_is_mmio = block_owners
@@ -25885,7 +25959,7 @@ mod tests {
         memory_hotplug_status_for_device, pending_serial_interrupt_intent_for_device,
         update_memory_hotplug_config_for_device,
     };
-    use bangbang_runtime::storage_capture::CaptureReadyStorageConfigs;
+    use bangbang_runtime::storage_capture::{CaptureReadyStorageConfigs, StorageRetryState};
     use bangbang_runtime::virtio_mmio::{
         VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DRIVER,
         VIRTIO_DEVICE_STATUS_DRIVER_OK, VIRTIO_DEVICE_STATUS_FEATURES_OK,
@@ -25902,12 +25976,13 @@ mod tests {
     };
 
     use super::{
-        CaptureReadyMmioBlockInterrupt, HvfArm64BootBalloonDeviceConfig,
-        HvfArm64BootBalloonNotificationDispatchError, HvfArm64BootBlockNotificationDispatchError,
-        HvfArm64BootEntropyDeviceConfig, HvfArm64BootEntropyNotificationDispatchError,
-        HvfArm64BootInterruptLinePurpose, HvfArm64BootInterruptRequest,
-        HvfArm64BootLimiterRetrySnapshotError, HvfArm64BootLimiterRetryWakeupOwner,
-        HvfArm64BootLimiterRetryWakeupQuiescenceError, HvfArm64BootLimiterRetryWakeupScheduler,
+        CaptureReadyMmioBlockInterrupt, CaptureReadySharedStorageRetryAttribution,
+        HvfArm64BootBalloonDeviceConfig, HvfArm64BootBalloonNotificationDispatchError,
+        HvfArm64BootBlockNotificationDispatchError, HvfArm64BootEntropyDeviceConfig,
+        HvfArm64BootEntropyNotificationDispatchError, HvfArm64BootInterruptLinePurpose,
+        HvfArm64BootInterruptRequest, HvfArm64BootLimiterRetrySnapshotError,
+        HvfArm64BootLimiterRetryWakeupOwner, HvfArm64BootLimiterRetryWakeupQuiescenceError,
+        HvfArm64BootLimiterRetryWakeupScheduler,
         HvfArm64BootLimiterRetryWakeupSchedulerQuiescenceError,
         HvfArm64BootLimiterRetryWakeupSchedulerStatus, HvfArm64BootLimiterRetryWakeupToken,
         HvfArm64BootMemoryHotplugDeviceConfig, HvfArm64BootMemoryHotplugNotificationDispatchError,
@@ -25916,10 +25991,10 @@ mod tests {
         HvfArm64BootRunLoopControlWakeupToken, HvfArm64BootRunLoopOutcome,
         HvfArm64BootRunLoopStopToken, HvfArm64BootSerialDeviceConfig, HvfArm64BootSerialInput,
         HvfArm64BootSerialInputDispatchError, HvfArm64BootSessionConfig, HvfArm64BootSessionError,
-        HvfArm64BootTimeIdentityRestoreError, HvfArm64BootTimerDeviceConfig,
-        HvfArm64BootVmClockRestoreError, HvfArm64BootVmGenIdRestoreError,
-        HvfArm64BootVsockNotificationDispatchError, PCI_ENDPOINT_SLOT_COUNT,
-        allocate_interrupt_lines, capture_hvf_snapshot_v2_time_state,
+        HvfArm64BootStorageCaptureErrorKind, HvfArm64BootTimeIdentityRestoreError,
+        HvfArm64BootTimerDeviceConfig, HvfArm64BootVmClockRestoreError,
+        HvfArm64BootVmGenIdRestoreError, HvfArm64BootVsockNotificationDispatchError,
+        PCI_ENDPOINT_SLOT_COUNT, allocate_interrupt_lines, capture_hvf_snapshot_v2_time_state,
         collect_balloon_notification_dispatches, collect_block_notification_dispatches,
         collect_entropy_notification_dispatches, collect_memory_hotplug_notification_dispatches,
         collect_network_notification_dispatches, collect_vsock_notification_dispatches,
@@ -26815,6 +26890,89 @@ mod tests {
         while state.publication_in_flight {
             state = super::wait_limiter_retry_wakeup_state(&scheduler.shared, state);
         }
+    }
+
+    #[test]
+    fn shared_storage_retry_attribution_covers_zero_one_and_multiple_pending_owners() {
+        let mut zero = CaptureReadySharedStorageRetryAttribution::new(StorageRetryState::None);
+        assert_eq!(
+            zero.attribute(false)
+                .expect("idle owner without a scheduler should attribute"),
+            StorageRetryState::None
+        );
+        zero.finish()
+            .expect("zero pending owners should accept an idle scheduler");
+
+        let mut one = CaptureReadySharedStorageRetryAttribution::new(StorageRetryState::Immediate);
+        assert_eq!(
+            one.attribute(false)
+                .expect("idle peer should retain no retry"),
+            StorageRetryState::None
+        );
+        assert_eq!(
+            one.attribute(true)
+                .expect("pending owner should receive the shared retry"),
+            StorageRetryState::Immediate
+        );
+        one.finish()
+            .expect("one pending owner should account for the scheduler");
+
+        let retry = StorageRetryState::After {
+            remaining_nanos: 25,
+        };
+        let mut multiple = CaptureReadySharedStorageRetryAttribution::new(retry);
+        assert_eq!(
+            multiple
+                .attribute(true)
+                .expect("first pending owner should receive the shared retry"),
+            retry
+        );
+        assert_eq!(
+            multiple
+                .attribute(false)
+                .expect("idle middle peer should retain no retry"),
+            StorageRetryState::None
+        );
+        assert_eq!(
+            multiple
+                .attribute(true)
+                .expect("second pending owner should receive the shared retry"),
+            retry
+        );
+        multiple
+            .finish()
+            .expect("multiple pending owners should share one family scheduler");
+    }
+
+    #[test]
+    fn shared_storage_retry_attribution_rejects_both_mismatch_directions() {
+        let mut missing_scheduler =
+            CaptureReadySharedStorageRetryAttribution::new(StorageRetryState::None);
+        let error = missing_scheduler
+            .attribute(true)
+            .expect_err("pending work without a scheduler must fail");
+        assert_eq!(
+            error.kind(),
+            HvfArm64BootStorageCaptureErrorKind::RetryState
+        );
+        assert!(!error.terminal());
+
+        let mut missing_owner =
+            CaptureReadySharedStorageRetryAttribution::new(StorageRetryState::Immediate);
+        assert_eq!(
+            missing_owner
+                .attribute(false)
+                .expect("idle owner observation should succeed"),
+            StorageRetryState::None
+        );
+        let error = missing_owner
+            .finish()
+            .expect_err("scheduler retry without a pending owner must fail");
+        assert_eq!(
+            error.kind(),
+            HvfArm64BootStorageCaptureErrorKind::RetryState
+        );
+        assert!(!error.terminal());
     }
 
     #[test]

--- a/crates/runtime/src/block.rs
+++ b/crates/runtime/src/block.rs
@@ -8223,6 +8223,10 @@ impl VirtioBlockMmioHandler {
         self.activation_handler().backend_kind()
     }
 
+    pub fn has_pending_block_rate_limited_queue(&self) -> bool {
+        self.activation_handler().has_pending_rate_limited_queue()
+    }
+
     pub fn block_snapshot_persistence_binding(
         &self,
         config: &DriveConfig,

--- a/crates/runtime/src/pmem.rs
+++ b/crates/runtime/src/pmem.rs
@@ -1608,6 +1608,10 @@ impl<C: VirtioMmioDeviceConfigHandler> VirtioMmioRegisterHandler<C, VirtioPmemDe
 }
 
 impl VirtioPmemMmioHandler {
+    pub fn has_pending_pmem_rate_limited_queue(&self) -> bool {
+        self.activation_handler().has_pending_rate_limited_queue()
+    }
+
     pub fn capture_pmem_device_state_at(
         &self,
         expected_file_len: u64,

--- a/crates/runtime/src/snapshot_device_v2_5.rs
+++ b/crates/runtime/src/snapshot_device_v2_5.rs
@@ -751,24 +751,11 @@ pub(crate) fn validate_record(
         return Err(GraphValidationError::Block);
     }
     validate_limiter_relationship(record.config.rate_limiter, block.limiter())?;
-    if block.retry() != StorageRetryState::None
-        && (block.active_queue().is_none() || block.limiter().is_empty())
-    {
-        return Err(GraphValidationError::Block);
-    }
-    if matches!(
+    validate_block_retry_state(
+        block.active_queue().is_some(),
+        block.limiter(),
         block.retry(),
-        StorageRetryState::After { remaining_nanos: 0 }
-    ) {
-        return Err(GraphValidationError::Block);
-    }
-    if block.retry() != StorageRetryState::None
-        && block
-            .active_queue()
-            .is_some_and(|queue| queue.next_available() == queue.next_used())
-    {
-        return Err(GraphValidationError::Block);
-    }
+    )?;
 
     let expected_features = VirtioBlockConfigSpace::new(
         record.block.backing_bytes,
@@ -794,6 +781,23 @@ pub(crate) fn validate_record(
         SnapshotV2DeviceTransport::Mmio(state) => validate_mmio(state),
         SnapshotV2DeviceTransport::Pci(state) => validate_pci(state),
     }
+}
+
+fn validate_block_retry_state(
+    has_active_queue: bool,
+    limiter: SnapshotV2BlockLimiterState,
+    retry: StorageRetryState,
+) -> Result<(), GraphValidationError> {
+    // A throttled descriptor remains authoritative in the guest available
+    // ring until admission succeeds. The device-local available and used
+    // cursors can therefore be equal; restore validation cross-checks the
+    // guest ring before rebuilding the pending retry.
+    if (retry != StorageRetryState::None && (!has_active_queue || limiter.is_empty()))
+        || matches!(retry, StorageRetryState::After { remaining_nanos: 0 })
+    {
+        return Err(GraphValidationError::Block);
+    }
+    Ok(())
 }
 
 fn validate_limiter_config(

--- a/crates/runtime/src/snapshot_device_v2_5/capture.rs
+++ b/crates/runtime/src/snapshot_device_v2_5/capture.rs
@@ -272,13 +272,8 @@ fn capture_multi_block_state(
         .map_err(|_| SnapshotV2MultiBlockDeviceGraphCaptureError::InconsistentBlockState)?;
     let active_queue = device.active_queue();
     let retry = state.retry();
-    if (retry != StorageRetryState::None && (active_queue.is_none() || limiter.is_empty()))
-        || matches!(retry, StorageRetryState::After { remaining_nanos: 0 })
-        || (retry != StorageRetryState::None
-            && active_queue.is_some_and(|queue| queue.next_available() == queue.next_used()))
-    {
-        return Err(SnapshotV2MultiBlockDeviceGraphCaptureError::InconsistentBlockState);
-    }
+    validate_block_retry_state(active_queue.is_some(), limiter, retry)
+        .map_err(|_| SnapshotV2MultiBlockDeviceGraphCaptureError::InconsistentBlockState)?;
     Ok(SnapshotV2MultiBlockState {
         backing_bytes: backing.len(),
         continuation: SnapshotV2BlockState::from_parts(

--- a/crates/runtime/src/snapshot_device_v2_5/tests.rs
+++ b/crates/runtime/src/snapshot_device_v2_5/tests.rs
@@ -439,6 +439,21 @@ fn fixture_matrix_covers_required_semantic_variants() {
 }
 
 #[test]
+fn pending_retry_accepts_equal_device_local_queue_cursors() {
+    let mut graph = fixture_graph(SnapshotV2DeviceTransportKind::Mmio, false);
+    let continuation = graph.records[0].block.continuation();
+    graph.records[0].block.continuation = SnapshotV2BlockState::from_parts(
+        continuation.capacity_sectors(),
+        continuation.device_id(),
+        Some(VirtioBlockQueueState::new(6, 6)),
+        continuation.limiter(),
+        continuation.retry(),
+    );
+
+    assert_eq!(validate_graph(&graph), Ok(()));
+}
+
+#[test]
 fn drive_config_projection_is_complete_ordered_and_all_or_nothing() {
     for with_root in [false, true] {
         let graph = fixture_graph(SnapshotV2DeviceTransportKind::Mmio, with_root);

--- a/crates/runtime/src/snapshot_device_v2_6.rs
+++ b/crates/runtime/src/snapshot_device_v2_6.rs
@@ -864,13 +864,13 @@ fn validate_pmem_state_local(state: &SnapshotV2PmemState) -> Result<(), GraphVal
     {
         return Err(GraphValidationError::Pmem);
     }
-    if state.pending_rate_limited_queue
-        && (state.active_queue.is_none()
-            || state.limiter.is_empty()
-            || state.retry == StorageRetryState::None
-            || state
-                .active_queue
-                .is_some_and(|queue| queue.next_available() == queue.next_used()))
+    if state.pending_rate_limited_queue != (state.retry != StorageRetryState::None)
+        || (state.pending_rate_limited_queue
+            && (state.active_queue.is_none()
+                || state.limiter.is_empty()
+                || state
+                    .active_queue
+                    .is_some_and(|queue| queue.next_available() == queue.next_used())))
     {
         return Err(GraphValidationError::Pmem);
     }

--- a/crates/runtime/src/snapshot_device_v2_6.rs
+++ b/crates/runtime/src/snapshot_device_v2_6.rs
@@ -866,11 +866,7 @@ fn validate_pmem_state_local(state: &SnapshotV2PmemState) -> Result<(), GraphVal
     }
     if state.pending_rate_limited_queue != (state.retry != StorageRetryState::None)
         || (state.pending_rate_limited_queue
-            && (state.active_queue.is_none()
-                || state.limiter.is_empty()
-                || state
-                    .active_queue
-                    .is_some_and(|queue| queue.next_available() == queue.next_used())))
+            && (state.active_queue.is_none() || state.limiter.is_empty()))
     {
         return Err(GraphValidationError::Pmem);
     }

--- a/crates/runtime/src/snapshot_device_v2_6/tests.rs
+++ b/crates/runtime/src/snapshot_device_v2_6/tests.rs
@@ -1247,6 +1247,11 @@ fn build_rejects_empty_root_order_selector_geometry_and_resource_conflicts() {
 #[test]
 fn pending_rate_limit_state_requires_queue_limiter_and_retry() {
     let baseline = fixture_graph(SnapshotV2DeviceTransportKind::Mmio, 0, 1, None);
+    let mut equal_internal_cursors = baseline.clone();
+    equal_internal_cursors.pmem_records[0].pmem.active_queue =
+        Some(VirtioPmemQueueState::new(6, 6));
+    assert_eq!(validate_graph(&equal_internal_cursors), Ok(()));
+
     for mutate in [
         |record: &mut SnapshotV2PmemDeviceRecord| record.pmem.active_queue = None,
         |record: &mut SnapshotV2PmemDeviceRecord| {

--- a/crates/runtime/src/snapshot_device_v2_6/tests.rs
+++ b/crates/runtime/src/snapshot_device_v2_6/tests.rs
@@ -1265,7 +1265,7 @@ fn pending_rate_limit_state_requires_queue_limiter_and_retry() {
     retry_without_pending.pmem_records[0]
         .pmem
         .pending_rate_limited_queue = false;
-    assert!(validate_graph(&retry_without_pending).is_ok());
+    assert!(validate_graph(&retry_without_pending).is_err());
 }
 
 #[test]

--- a/crates/runtime/src/startup.rs
+++ b/crates/runtime/src/startup.rs
@@ -3320,6 +3320,18 @@ impl Arm64BootRuntimeResources {
             .map(|handler| handler.block_async_binding())
     }
 
+    pub fn capture_ready_mmio_block_has_pending_rate_limited_queue(
+        &self,
+        mmio_dispatcher: &mut MmioDispatcher,
+        drive_id: &str,
+    ) -> Result<bool, Arm64BootStorageCaptureError> {
+        let device = unique_mmio_block_device(&self.block_devices, drive_id)?;
+        mmio_dispatcher
+            .handler_mut::<VirtioBlockMmioHandler>(device.registration.region_id())
+            .map_err(|_| Arm64BootStorageCaptureError::BlockHandler)
+            .map(|handler| handler.has_pending_block_rate_limited_queue())
+    }
+
     pub fn capture_ready_mmio_block_snapshot_persistence_binding(
         &self,
         mmio_dispatcher: &mut MmioDispatcher,
@@ -3448,6 +3460,18 @@ impl Arm64BootRuntimeResources {
             retry,
             captured,
         ))
+    }
+
+    pub fn capture_ready_mmio_pmem_has_pending_rate_limited_queue(
+        &self,
+        mmio_dispatcher: &mut MmioDispatcher,
+        pmem_id: &str,
+    ) -> Result<bool, Arm64BootStorageCaptureError> {
+        let device = unique_mmio_pmem_device(&self.pmem_mmio_devices, pmem_id)?;
+        mmio_dispatcher
+            .handler_mut::<VirtioPmemMmioHandler>(device.registration.region_id())
+            .map_err(|_| Arm64BootStorageCaptureError::PmemHandler)
+            .map(|handler| handler.has_pending_pmem_rate_limited_queue())
     }
 
     pub fn capture_ready_pmem_snapshot_persistence_binding(


### PR DESCRIPTION
## Summary

- attribute shared MMIO block and pmem retry state only to owners with pending rate-limited work
- reject scheduler/owner mismatches before capture mutation while leaving per-device PCI retry capture unchanged
- accept the real throttled queue shape where device-local cursors are equal and retain the restore-time guest available-ring cross-check

## Scope

PCI retry attribution remains per-device and is intentionally unchanged.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- composed signed certification run completed both MMIO rooted and mixed snapshot/restore cases; it then stopped on an independent PCI retry-capture gap

Closes #1642
