### PR TITLE
fix: account PCI storage retry owners

### DIFF
--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -6620,17 +6620,37 @@ impl CaptureReadySharedStorageRetryAttribution {
         &mut self,
         pending: bool,
     ) -> Result<StorageRetryState, HvfArm64BootStorageCaptureError> {
-        if !pending {
-            return Ok(StorageRetryState::None);
-        }
-        if self.shared == StorageRetryState::None {
+        self.account_pending_owner(pending)?;
+        Ok(if pending {
+            self.shared
+        } else {
+            StorageRetryState::None
+        })
+    }
+
+    fn account_endpoint_retry(
+        &mut self,
+        retry: StorageRetryState,
+    ) -> Result<(), HvfArm64BootStorageCaptureError> {
+        // PCI retains the exact endpoint-local retry in the artifact, while
+        // the shared scheduler retains only the aggregate wakeup. Their
+        // independently materialized durations can differ, so family
+        // consistency depends on retry ownership rather than exact duration.
+        self.account_pending_owner(retry != StorageRetryState::None)
+    }
+
+    fn account_pending_owner(
+        &mut self,
+        pending: bool,
+    ) -> Result<(), HvfArm64BootStorageCaptureError> {
+        if pending && self.shared == StorageRetryState::None {
             return Err(HvfArm64BootStorageCaptureError::new(
                 HvfArm64BootStorageCaptureErrorKind::RetryState,
                 false,
             ));
         }
-        self.has_pending_owner = true;
-        Ok(self.shared)
+        self.has_pending_owner |= pending;
+        Ok(())
     }
 
     fn finish(self) -> Result<(), HvfArm64BootStorageCaptureError> {
@@ -8644,10 +8664,9 @@ fn capture_ready_storage_transaction_at_with_cancel(
                         false,
                     ));
                 }
-                CaptureReadyBlockOwner::Pci {
-                    index,
-                    retry: storage_retry_state_at(device.retry_deadline, now)?,
-                }
+                let retry = storage_retry_state_at(device.retry_deadline, now)?;
+                block_retry_attribution.account_endpoint_retry(retry)?;
+                CaptureReadyBlockOwner::Pci { index, retry }
             }
             _ => {
                 return Err(HvfArm64BootStorageCaptureError::new(
@@ -8710,10 +8729,9 @@ fn capture_ready_storage_transaction_at_with_cancel(
                         false,
                     ));
                 }
-                CaptureReadyPmemOwner::Pci {
-                    index,
-                    retry: storage_retry_state_at(device.retry_deadline, now)?,
-                }
+                let retry = storage_retry_state_at(device.retry_deadline, now)?;
+                pmem_retry_attribution.account_endpoint_retry(retry)?;
+                CaptureReadyPmemOwner::Pci { index, retry }
             }
             _ => {
                 return Err(HvfArm64BootStorageCaptureError::new(
@@ -26968,6 +26986,36 @@ mod tests {
         let error = missing_owner
             .finish()
             .expect_err("scheduler retry without a pending owner must fail");
+        assert_eq!(
+            error.kind(),
+            HvfArm64BootStorageCaptureErrorKind::RetryState
+        );
+        assert!(!error.terminal());
+    }
+
+    #[test]
+    fn shared_storage_retry_attribution_accounts_endpoint_local_pci_retries() {
+        let shared = StorageRetryState::After {
+            remaining_nanos: 100,
+        };
+        let mut attribution = CaptureReadySharedStorageRetryAttribution::new(shared);
+        attribution
+            .account_endpoint_retry(StorageRetryState::None)
+            .expect("idle PCI peer should not own the shared scheduler");
+        attribution
+            .account_endpoint_retry(StorageRetryState::After {
+                remaining_nanos: 75,
+            })
+            .expect("pending PCI endpoint should account for the shared scheduler");
+        attribution
+            .finish()
+            .expect("endpoint-local retry should satisfy family ownership");
+
+        let mut missing_scheduler =
+            CaptureReadySharedStorageRetryAttribution::new(StorageRetryState::None);
+        let error = missing_scheduler
+            .account_endpoint_retry(StorageRetryState::Immediate)
+            .expect_err("PCI endpoint retry without a family scheduler must fail");
         assert_eq!(
             error.kind(),
             HvfArm64BootStorageCaptureErrorKind::RetryState


### PR DESCRIPTION
## Summary

- count endpoint-local PCI block and pmem retry states as owners of the shared family scheduler
- keep the exact PCI retry in each endpoint record without copying the aggregate scheduler value into it
- retain both scheduler/owner mismatch checks and the repaired MMIO-only attribution behavior

## Context

PR #1643 repaired MMIO retry attribution but its final family consistency check counted only MMIO pending owners. PCI endpoints also feed their earliest deadline into the same family scheduler, so the signed PCI certification cell exposed a valid scheduler as apparently ownerless.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- composed #1634 signed direct MMIO/PCI rooted/mixed matrix: 1 passed in 140.14 seconds

Closes #1642
