### PR TITLE
feat: activate native-v2 2.7 serial snapshots

### DIFF
--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -2302,13 +2302,15 @@ mod tests {
         BootRunLoopMetricStatus, MetricsConfigInput, MetricsDiagnostics,
     };
     use bangbang_runtime::network::NetworkRuntimeMutationError;
-    use bangbang_runtime::serial::SerialConfig;
+    use bangbang_runtime::serial::{
+        CaptureReadySerialState, SerialConfig, SerialConfigInput, SerialMmioDevice,
+    };
     use bangbang_runtime::snapshot::{
         SnapshotLoadInput, SnapshotV1ControllerCommit, SnapshotV2ControllerCommit,
     };
     use bangbang_runtime::snapshot_artifact::{
         LoadedNativeSnapshotArtifacts, NativeSnapshotArtifactState,
-        NativeSnapshotPublicationOutcome, NativeV2StorageSnapshotCandidateState,
+        NativeSnapshotPublicationOutcome, NativeV2SerialSnapshotCandidateState,
         SnapshotArtifactPaths, SnapshotPublicationOutcome, publish_native_snapshot_artifacts_with,
         publish_snapshot_artifacts_with,
     };
@@ -2318,12 +2320,16 @@ mod tests {
         NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2StorageDeviceGraph,
     };
     use bangbang_runtime::snapshot_format_v2::{
-        NATIVE_V2_DEVICE_GRAPH_COMPONENT_KEY, NATIVE_V2_MEMORY_COMPONENT_KEY, SnapshotV2Component,
-        SnapshotV2ComponentDisposition, encode_snapshot_v2_state_with_compatibility_version,
+        NATIVE_V2_DEVICE_GRAPH_COMPONENT_KEY, NATIVE_V2_MEMORY_COMPONENT_KEY,
+        NATIVE_V2_SERIAL_COMPONENT_KEY, SnapshotV2Component, SnapshotV2ComponentDisposition,
+        encode_snapshot_v2_state_with_compatibility_version,
     };
     use bangbang_runtime::snapshot_memory::write_snapshot_memory_image;
     use bangbang_runtime::snapshot_memory_v2::{
         SnapshotV2MemoryBinding, write_snapshot_v2_memory_image_with_cancel,
+    };
+    use bangbang_runtime::snapshot_serial_v2_7::{
+        NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION, SnapshotV2SerialState,
     };
     use bangbang_runtime::startup::Arm64BootResources;
     use bangbang_runtime::{BackendError, VmmActionError, VmmController};
@@ -2338,9 +2344,9 @@ mod tests {
         ProcessSessionDiagnostics, ProcessSessionExitStatus,
         ProcessSnapshotV2MultiBlockLoadRequest, ProcessSnapshotV2MultiBlockLoadSuccess,
         ProcessSnapshotV2RootLoadCompletion, ProcessSnapshotV2RootLoadRequest,
-        ProcessSnapshotV2RootLoadSuccess, ProcessSnapshotV2StorageLoadRequest,
-        ProcessSnapshotV2StorageLoadSuccess, ProcessVmm, ProcessVmnetAuthority,
-        SnapshotV1LoadSuccess, SnapshotV2LoadSuccess,
+        ProcessSnapshotV2RootLoadSuccess, ProcessSnapshotV2SerialLoadRequest,
+        ProcessSnapshotV2StorageLoadRequest, ProcessSnapshotV2StorageLoadSuccess, ProcessVmm,
+        ProcessVmnetAuthority, SnapshotV1LoadSuccess, SnapshotV2LoadSuccess,
     };
     use bangbang_runtime::storage_capture::CaptureReadyStorageConfigs;
 
@@ -2872,7 +2878,7 @@ mod tests {
             }
             let NativeV2SnapshotPublicationRequest {
                 input: _,
-                serial_config: _,
+                serial_config,
                 storage_configs: _,
                 expected_transport,
                 cancellation,
@@ -2899,7 +2905,11 @@ mod tests {
                             },
                         )
                     })?;
-                Ok(fake_native_v2_current_state(&binding, expected_transport))
+                Ok(fake_native_v2_current_state(
+                    &binding,
+                    expected_transport,
+                    serial_config,
+                ))
             })
             .map_err(Box::new)
             .map_err(NativeV2SnapshotPublicationError::Transaction)
@@ -3147,6 +3157,111 @@ mod tests {
                 commit,
             ))
         }
+
+        fn load_prepared_snapshot_v2_serial(
+            &mut self,
+            request: ProcessSnapshotV2SerialLoadRequest<'_>,
+        ) -> Result<SnapshotV2LoadSuccess<Self::Session>, NativeV2SnapshotLoadError> {
+            let ProcessSnapshotV2SerialLoadRequest {
+                controller: _,
+                vmnet_authority: _,
+                #[cfg(target_os = "macos")]
+                    contained_restore_authority: _,
+                pci_enabled: _,
+                input,
+                candidate,
+                memory: _,
+                cancellation,
+            } = request;
+            if !self.snapshot_operations_succeed {
+                return Err(NativeV2SnapshotLoadError::ProcessPreparation(
+                    BackendError::InvalidState("test snapshot load failed"),
+                ));
+            }
+            let boot_source = BootSourceConfigInput::new("/private/fake-api-restored-vmlinux")
+                .validate()
+                .map_err(|_| {
+                    NativeV2SnapshotLoadError::ProcessPreparation(BackendError::InvalidState(
+                        "fake snapshot boot configuration failed",
+                    ))
+                })?;
+            let drives = candidate
+                .device_graph()
+                .into_iter()
+                .flat_map(SnapshotV2StorageDeviceGraph::block_records)
+                .map(|record| {
+                    let config = record.config();
+                    let mut input = DriveConfigInput::new(
+                        config.drive_id(),
+                        config.drive_id(),
+                        config.selector(),
+                        config.is_root(),
+                    )
+                    .with_is_read_only(config.is_read_only())
+                    .with_cache_type(config.cache_type())
+                    .with_io_engine(config.io_engine());
+                    if let Some(partuuid) = config.partuuid() {
+                        input = input.with_partuuid(partuuid);
+                    }
+                    if let Some(rate_limiter) = config.rate_limiter() {
+                        input = input.with_rate_limiter(rate_limiter);
+                    }
+                    input.validate()
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| NativeV2SnapshotLoadError::CandidateMismatch)?;
+            let pmem = candidate
+                .device_graph()
+                .into_iter()
+                .flat_map(SnapshotV2StorageDeviceGraph::pmem_records)
+                .map(|record| {
+                    let config = record.config();
+                    let mut input = PmemConfigInput::new(config.pmem_id(), config.selector())
+                        .with_root_device(config.is_root())
+                        .with_read_only(config.is_read_only());
+                    if let Some(rate_limiter) = config.rate_limiter() {
+                        input = input.with_rate_limiter(rate_limiter);
+                    }
+                    PmemConfig::try_from(input)
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| NativeV2SnapshotLoadError::CandidateMismatch)?;
+            let mut serial_input = SerialConfigInput::new();
+            if let Some(selector) = candidate.serial().endpoint_intent().configured_selector() {
+                serial_input = serial_input.with_serial_out_path(selector);
+            }
+            if let Some(rate_limiter) = candidate.serial().rate_limiter() {
+                serial_input = serial_input.with_rate_limiter(rate_limiter);
+            }
+            let serial_config = serial_input
+                .validate()
+                .map_err(|_| NativeV2SnapshotLoadError::CandidateMismatch)?;
+            if !cancellation.try_seal_commit() {
+                return Err(NativeV2SnapshotLoadError::Cancelled);
+            }
+            let machine =
+                MachineConfig::default().with_track_dirty_pages(input.track_dirty_pages());
+            let commit = if candidate.device_graph().is_some() {
+                SnapshotV2ControllerCommit::with_storage_and_serial_configs(
+                    machine,
+                    boot_source,
+                    CaptureReadyStorageConfigs::new(drives, pmem),
+                    serial_config,
+                    input.resume_vm(),
+                )
+            } else {
+                SnapshotV2ControllerCommit::with_serial_config(
+                    machine,
+                    boot_source,
+                    serial_config,
+                    input.resume_vm(),
+                )
+            };
+            Ok(SnapshotV2LoadSuccess::new(
+                TestSession::without_boot_run_loop_status(),
+                commit,
+            ))
+        }
     }
 
     fn test_controller() -> ProcessVmm<TestInstanceStarter> {
@@ -3222,6 +3337,7 @@ mod tests {
     fn fake_native_v2_current_state(
         binding: &SnapshotV2MemoryBinding,
         transport: SnapshotV2DeviceTransportKind,
+        serial_config: SerialConfig,
     ) -> NativeSnapshotArtifactState {
         let fixture = match transport {
             SnapshotV2DeviceTransportKind::Mmio => {
@@ -3252,6 +3368,16 @@ mod tests {
         let memory = binding
             .encode()
             .expect("native-v2 fixture memory binding should encode");
+        let serial_device = SerialMmioDevice::discarding()
+            .capture_state()
+            .expect("native-v2 fixture serial device should capture");
+        let serial = SnapshotV2SerialState::try_from_capture_ready(CaptureReadySerialState::new(
+            serial_config,
+            serial_device,
+        ))
+        .expect("native-v2 fixture serial state should capture")
+        .encode(NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION)
+        .expect("native-v2 fixture serial state should encode");
         let components = [
             SnapshotV2Component::new(
                 NATIVE_V2_MEMORY_COMPONENT_KEY,
@@ -3263,14 +3389,19 @@ mod tests {
                 SnapshotV2ComponentDisposition::Semantic,
                 &graph,
             ),
+            SnapshotV2Component::new(
+                NATIVE_V2_SERIAL_COMPONENT_KEY,
+                SnapshotV2ComponentDisposition::Semantic,
+                &serial,
+            ),
         ];
         let encoded = encode_snapshot_v2_state_with_compatibility_version(
-            NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION,
             &[],
             &components,
         )
         .expect("native-v2 fixture state should encode");
-        NativeV2StorageSnapshotCandidateState::from_storage_device_graph_v2_6(encoded)
+        NativeV2SerialSnapshotCandidateState::from_serial_state_v2_7(encoded)
             .expect("native-v2 fixture candidate should close")
             .into_current_artifact_state()
     }
@@ -3293,6 +3424,7 @@ mod tests {
             Ok::<_, ()>(fake_native_v2_current_state(
                 &binding,
                 SnapshotV2DeviceTransportKind::Mmio,
+                SerialConfig::default(),
             ))
         })
         .expect("native-v2 fixture should publish");

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -57,11 +57,11 @@ use bangbang_hvf::{
     PrepareHvfSnapshotV2StoragePciPlatformPlanError, PreparedHvfArm64BootPciNetworkRemoval,
     PreparedHvfSnapshotV1Load, PreparedHvfSnapshotV1State, RestoredHvfSnapshotV2Platform,
     decode_hvf_snapshot_v2_multi_block_state, decode_hvf_snapshot_v2_platform_state,
-    decode_hvf_snapshot_v2_state, decode_hvf_snapshot_v2_storage_state,
-    encode_hvf_snapshot_v2_multi_block_state, encode_hvf_snapshot_v2_serial_state,
-    encode_hvf_snapshot_v2_state, encode_hvf_snapshot_v2_storage_state,
-    prepare_hvf_snapshot_v2_multi_block_platform_plan, prepare_hvf_snapshot_v2_root_plan,
-    prepare_hvf_snapshot_v2_storage_mmio_platform_plan,
+    decode_hvf_snapshot_v2_serial_state, decode_hvf_snapshot_v2_state,
+    decode_hvf_snapshot_v2_storage_state, encode_hvf_snapshot_v2_multi_block_state,
+    encode_hvf_snapshot_v2_serial_state, encode_hvf_snapshot_v2_state,
+    encode_hvf_snapshot_v2_storage_state, prepare_hvf_snapshot_v2_multi_block_platform_plan,
+    prepare_hvf_snapshot_v2_root_plan, prepare_hvf_snapshot_v2_storage_mmio_platform_plan,
     prepare_hvf_snapshot_v2_storage_pci_platform_plan, restore_hvf_snapshot_v2_process_platform,
 };
 use bangbang_runtime::balloon::BalloonMmioLayout;
@@ -136,15 +136,15 @@ use bangbang_runtime::snapshot_artifact::SnapshotStagingTracker;
 use bangbang_runtime::snapshot_artifact::{
     LoadedNativeSnapshotArtifacts, NativeSnapshotArtifactFamily, NativeSnapshotArtifactState,
     NativeSnapshotArtifactStateError, NativeSnapshotPublicationOutcome,
-    NativeV2MultiBlockSnapshotCandidateState, NativeV2SnapshotArtifactProfile,
-    NativeV2SnapshotCandidateState, NativeV2SnapshotCandidateStateError,
-    NativeV2StorageSnapshotCandidateState, PreparedNativeSnapshotState, SnapshotArtifactLoadError,
-    SnapshotArtifactOutput, SnapshotArtifactOutputs, SnapshotArtifactPaths,
-    SnapshotCommitDurability, SnapshotMemoryStagingWriter, SnapshotPublicationOutcome,
-    SnapshotPublicationTransactionError, load_prepared_native_snapshot_memory_file,
-    load_prepared_native_snapshot_memory_path, load_snapshot_artifacts,
-    prepare_native_snapshot_state_file, prepare_native_snapshot_state_path,
-    prepare_snapshot_state_file, prepare_snapshot_state_path,
+    NativeV2MultiBlockSnapshotCandidateState, NativeV2SerialSnapshotCandidateState,
+    NativeV2SnapshotArtifactProfile, NativeV2SnapshotCandidateState,
+    NativeV2SnapshotCandidateStateError, NativeV2StorageSnapshotCandidateState,
+    PreparedNativeSnapshotState, SnapshotArtifactLoadError, SnapshotArtifactOutput,
+    SnapshotArtifactOutputs, SnapshotArtifactPaths, SnapshotCommitDurability,
+    SnapshotMemoryStagingWriter, SnapshotPublicationOutcome, SnapshotPublicationTransactionError,
+    load_prepared_native_snapshot_memory_file, load_prepared_native_snapshot_memory_path,
+    load_snapshot_artifacts, prepare_native_snapshot_state_file,
+    prepare_native_snapshot_state_path, prepare_snapshot_state_file, prepare_snapshot_state_path,
     publish_native_snapshot_artifacts_to_with, publish_native_snapshot_artifacts_with,
     publish_snapshot_artifacts_to_with, publish_snapshot_artifacts_with,
 };
@@ -175,7 +175,8 @@ use bangbang_runtime::snapshot_memory::{
 };
 use bangbang_runtime::snapshot_memory_v2::{SnapshotV2MemoryIoStage, SnapshotV2MemoryWriteError};
 use bangbang_runtime::snapshot_serial_v2_7::{
-    SnapshotV2SerialState, SnapshotV2SerialStateCaptureError,
+    NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION, SnapshotV2SerialState,
+    SnapshotV2SerialStateCaptureError,
 };
 use bangbang_runtime::startup::{
     Arm64BootBalloonDevice, Arm64BootBlockDevice, Arm64BootNetworkDevice,
@@ -242,7 +243,8 @@ use crate::snapshot_restore_resources::{
 use crate::snapshot_serial_restore::{
     PreparedSnapshotV2SerialDestinationCommitError,
     PreparedSnapshotV2SerialDestinationConstructionError, PreparedSnapshotV2SerialRestoreBundle,
-    PreparedSnapshotV2SerialRestoreOwners, SnapshotV2SerialStorageAdoptionError,
+    PreparedSnapshotV2SerialRestoreOwners, SnapshotV2SerialRestoreBundleError,
+    SnapshotV2SerialStorageAdoptionError, prepare_native_v2_serial_restore_bundle,
 };
 #[cfg(target_os = "macos")]
 use crate::vsock_restore::{
@@ -384,6 +386,18 @@ pub(crate) struct ProcessSnapshotV2StorageLoadRequest<'a> {
     pub(crate) pci_enabled: bool,
     pub(crate) input: &'a SnapshotLoadInput,
     pub(crate) candidate: NativeV2StorageSnapshotCandidateState,
+    pub(crate) memory: GuestMemory,
+    pub(crate) cancellation: NativeV2SnapshotCaptureCancellation,
+}
+
+pub(crate) struct ProcessSnapshotV2SerialLoadRequest<'a> {
+    pub(crate) controller: &'a VmmController,
+    pub(crate) vmnet_authority: ProcessVmnetAuthority,
+    #[cfg(target_os = "macos")]
+    pub(crate) contained_restore_authority: Option<&'a ContainedSnapshotRestoreAuthority>,
+    pub(crate) pci_enabled: bool,
+    pub(crate) input: &'a SnapshotLoadInput,
+    pub(crate) candidate: NativeV2SerialSnapshotCandidateState,
     pub(crate) memory: GuestMemory,
     pub(crate) cancellation: NativeV2SnapshotCaptureCancellation,
 }
@@ -582,6 +596,15 @@ pub(crate) trait InstanceStartExecutor {
         ))
     }
 
+    fn load_prepared_snapshot_v2_serial(
+        &mut self,
+        _request: ProcessSnapshotV2SerialLoadRequest<'_>,
+    ) -> Result<SnapshotV2LoadSuccess<Self::Session>, NativeV2SnapshotLoadError> {
+        Err(NativeV2SnapshotLoadError::ProcessPreparation(
+            BackendError::InvalidState("native-v2 serial snapshot loading is unavailable"),
+        ))
+    }
+
     fn commit_prepared_snapshot_v2_root_load(
         &mut self,
         _completion: ProcessSnapshotV2RootLoadCompletion,
@@ -657,6 +680,10 @@ enum NativeV2SnapshotCaptureProfile {
         storage_configs: CaptureReadyStorageConfigs,
         expected_transport: SnapshotV2DeviceTransportKind,
     },
+    #[allow(
+        dead_code,
+        reason = "exact-2.6 capture remains a compatibility-only typed seam"
+    )]
     Storage {
         storage_configs: CaptureReadyStorageConfigs,
         expected_transport: SnapshotV2DeviceTransportKind,
@@ -686,7 +713,18 @@ struct NativeV2MultiBlockCandidateProductProfile {
     expected_transport: SnapshotV2DeviceTransportKind,
 }
 
+#[allow(
+    dead_code,
+    reason = "exact-2.6 product classification remains compatibility-tested after activation"
+)]
 struct NativeV2StorageCandidateProductProfile {
+    input: HvfArm64BootSnapshotV2CaptureInput,
+    serial_config: SerialConfig,
+    storage_configs: CaptureReadyStorageConfigs,
+    expected_transport: SnapshotV2DeviceTransportKind,
+}
+
+struct NativeV2SerialCandidateProductProfile {
     input: HvfArm64BootSnapshotV2CaptureInput,
     serial_config: SerialConfig,
     storage_configs: CaptureReadyStorageConfigs,
@@ -744,6 +782,10 @@ pub(crate) enum NativeV2MultiBlockCandidateProfileError {
     IncompatibleProcessMode,
 }
 
+#[allow(
+    dead_code,
+    reason = "exact-2.6 product classification remains compatibility-tested after activation"
+)]
 #[derive(Debug)]
 pub(crate) enum NativeV2StorageCandidateProfileError {
     MissingBootSource,
@@ -787,6 +829,54 @@ impl std::error::Error for NativeV2StorageCandidateProfileError {
             | Self::InvalidBootMetadata
             | Self::TransportCapacity
             | Self::NonCanonicalSerial
+            | Self::OptionalDevices
+            | Self::MmdsStateUnavailable
+            | Self::IncompatibleProcessMode => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum NativeV2SerialCandidateProfileError {
+    MissingBootSource,
+    InvalidBootMetadata,
+    StorageProfile(SnapshotV2StorageDeviceGraphCaptureError),
+    SerialProfile(SnapshotV2SerialStateCaptureError),
+    TransportCapacity,
+    OptionalDevices,
+    MmdsStateUnavailable,
+    IncompatibleProcessMode,
+}
+
+impl fmt::Display for NativeV2SerialCandidateProfileError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingBootSource => formatter.write_str("boot source is not configured"),
+            Self::InvalidBootMetadata => formatter.write_str("boot metadata is invalid"),
+            Self::StorageProfile(_) => {
+                formatter.write_str("block-and-pmem inventory is unsupported")
+            }
+            Self::SerialProfile(_) => formatter.write_str("serial configuration is unsupported"),
+            Self::TransportCapacity => formatter.write_str("device transport capacity is exceeded"),
+            Self::OptionalDevices => {
+                formatter.write_str("optional device or MMDS state is configured")
+            }
+            Self::MmdsStateUnavailable => formatter.write_str("MMDS state is unavailable"),
+            Self::IncompatibleProcessMode => {
+                formatter.write_str("process boot mode is incompatible")
+            }
+        }
+    }
+}
+
+impl std::error::Error for NativeV2SerialCandidateProfileError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::StorageProfile(source) => Some(source),
+            Self::SerialProfile(source) => Some(source),
+            Self::MissingBootSource
+            | Self::InvalidBootMetadata
+            | Self::TransportCapacity
             | Self::OptionalDevices
             | Self::MmdsStateUnavailable
             | Self::IncompatibleProcessMode => None,
@@ -1362,7 +1452,7 @@ pub(crate) enum NativeV1SnapshotPublicationProducerError {
 pub(crate) enum NativeV2SnapshotPublicationError {
     Preflight(VmmActionError),
     CaptureReadyPreflight(SnapshotCaptureReadyPreflightError),
-    Profile(NativeV2StorageCandidateProfileError),
+    Profile(NativeV2SerialCandidateProfileError),
     Resource(GrantClaimError),
     SessionUnavailable,
     ConfigurationUnavailable,
@@ -1387,7 +1477,7 @@ impl fmt::Display for NativeV2SnapshotPublicationError {
             Self::Profile(source) => {
                 write!(
                     formatter,
-                    "native-v2 block-and-pmem profile is unsupported: {source}"
+                    "native-v2 serial profile is unsupported: {source}"
                 )
             }
             Self::Resource(source) => {
@@ -1984,6 +2074,71 @@ impl fmt::Display for NativeV2StorageDestinationLoadError {
 #[cfg(target_os = "macos")]
 impl std::error::Error for NativeV2StorageDestinationLoadError {}
 
+#[cfg(target_os = "macos")]
+pub(crate) struct NativeV2SerialDestinationLoadError {
+    terminal: bool,
+    detail: Option<String>,
+}
+
+#[cfg(target_os = "macos")]
+impl NativeV2SerialDestinationLoadError {
+    const fn new(terminal: bool) -> Self {
+        Self {
+            terminal,
+            detail: None,
+        }
+    }
+
+    fn with_source(terminal: bool, source: &(dyn std::error::Error + 'static)) -> Self {
+        let mut leaf = source;
+        while let Some(next) = leaf.source() {
+            leaf = next;
+        }
+        Self {
+            terminal,
+            detail: Some(leaf.to_string()),
+        }
+    }
+
+    const fn is_terminal(&self) -> bool {
+        self.terminal
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl fmt::Debug for NativeV2SerialDestinationLoadError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("NativeV2SerialDestinationLoadError")
+            .field("terminal", &self.terminal)
+            .field("has_detail", &self.detail.is_some())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl fmt::Display for NativeV2SerialDestinationLoadError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "native-v2 2.7 serial destination transaction failed ({})",
+            if self.terminal {
+                "terminal"
+            } else {
+                "retryable"
+            }
+        )?;
+        if let Some(detail) = &self.detail {
+            write!(formatter, ": {detail}")?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl std::error::Error for NativeV2SerialDestinationLoadError {}
+
 #[allow(
     dead_code,
     reason = "native-v2 process restore is target-gated and exercised by signed integration coverage"
@@ -2019,6 +2174,10 @@ pub(crate) enum NativeV2SnapshotLoadError {
     },
     #[cfg(target_os = "macos")]
     StorageDestination(NativeV2StorageDestinationLoadError),
+    #[cfg(target_os = "macos")]
+    SerialBundle(SnapshotV2SerialRestoreBundleError),
+    #[cfg(target_os = "macos")]
+    SerialDestination(NativeV2SerialDestinationLoadError),
     AfterResourceAdoption {
         source: Box<NativeV2SnapshotLoadError>,
     },
@@ -2089,6 +2248,12 @@ impl NativeV2SnapshotLoadError {
             | Self::StoragePciPlatformPlan { cleanup_failed, .. } => *cleanup_failed,
             #[cfg(target_os = "macos")]
             Self::StorageDestination(source) => source.is_terminal(),
+            #[cfg(target_os = "macos")]
+            Self::SerialBundle(source) => {
+                source.disposition() == SnapshotRestoreResourceDisposition::Terminal
+            }
+            #[cfg(target_os = "macos")]
+            Self::SerialDestination(source) => source.is_terminal(),
             Self::Restore(source) => source.is_committed() || !source.cleanup_failures().is_empty(),
             Self::RootRestore(source) => source.is_terminal(),
             Self::Preflight(_)
@@ -2196,6 +2361,15 @@ impl fmt::Display for NativeV2SnapshotLoadError {
             }
             #[cfg(target_os = "macos")]
             Self::StorageDestination(source) => source.fmt(formatter),
+            #[cfg(target_os = "macos")]
+            Self::SerialBundle(source) => {
+                write!(
+                    formatter,
+                    "native-v2 2.7 serial resource bundle preparation failed: {source}"
+                )
+            }
+            #[cfg(target_os = "macos")]
+            Self::SerialDestination(source) => source.fmt(formatter),
             Self::AfterResourceAdoption { source } => {
                 write!(
                     formatter,
@@ -2332,6 +2506,10 @@ impl std::error::Error for NativeV2SnapshotLoadError {
             Self::StoragePciPlatformPlan { source, .. } => Some(source),
             #[cfg(target_os = "macos")]
             Self::StorageDestination(source) => Some(source),
+            #[cfg(target_os = "macos")]
+            Self::SerialBundle(source) => Some(source),
+            #[cfg(target_os = "macos")]
+            Self::SerialDestination(source) => Some(source),
             Self::AfterResourceAdoption { source } => Some(source.as_ref()),
             #[cfg(target_os = "macos")]
             Self::RootResourceCleanup { source, .. } => Some(source.as_ref()),
@@ -5906,7 +6084,8 @@ where
             }
             NativeV2SnapshotArtifactProfile::DeviceGraphV2_4
             | NativeV2SnapshotArtifactProfile::MultiBlockDeviceGraphV2_5
-            | NativeV2SnapshotArtifactProfile::StorageDeviceGraphV2_6 => {
+            | NativeV2SnapshotArtifactProfile::StorageDeviceGraphV2_6
+            | NativeV2SnapshotArtifactProfile::SerialStateV2_7 => {
                 self.starter
                     .preflight_snapshot_v2_root_process(self.pci_enabled)
                     .map_err(NativeV2SnapshotLoadError::Preflight)?;
@@ -6077,7 +6256,7 @@ where
             }
             NativeV2SnapshotArtifactProfile::StorageDeviceGraphV2_6 => {
                 let (candidate, memory) = artifacts
-                    .into_current_v2_candidate()
+                    .into_v2_6_candidate()
                     .map_err(NativeV2SnapshotLoadError::ArtifactState)
                     .map_err(|source| {
                         if resource_adopted {
@@ -6091,6 +6270,45 @@ where
                 let restored = self
                     .starter
                     .load_prepared_snapshot_v2_storage(ProcessSnapshotV2StorageLoadRequest {
+                        controller: &self.controller,
+                        vmnet_authority: self.vmnet_authority,
+                        #[cfg(target_os = "macos")]
+                        contained_restore_authority: self.contained_restore_authority.as_ref(),
+                        pci_enabled: self.pci_enabled,
+                        input,
+                        candidate,
+                        memory,
+                        cancellation: self.snapshot_capture_cancellation.clone(),
+                    })
+                    .map_err(|source| {
+                        if resource_adopted {
+                            NativeV2SnapshotLoadError::AfterResourceAdoption {
+                                source: Box::new(source),
+                            }
+                        } else {
+                            source
+                        }
+                    })?;
+                let (session, controller_commit) = restored.into_parts();
+                self.started_session = Some(session);
+                Ok(self.controller.commit_snapshot_v2_load(controller_commit))
+            }
+            NativeV2SnapshotArtifactProfile::SerialStateV2_7 => {
+                let (candidate, memory) = artifacts
+                    .into_current_v2_candidate()
+                    .map_err(NativeV2SnapshotLoadError::ArtifactState)
+                    .map_err(|source| {
+                        if resource_adopted {
+                            NativeV2SnapshotLoadError::AfterResourceAdoption {
+                                source: Box::new(source),
+                            }
+                        } else {
+                            source
+                        }
+                    })?;
+                let restored = self
+                    .starter
+                    .load_prepared_snapshot_v2_serial(ProcessSnapshotV2SerialLoadRequest {
                         controller: &self.controller,
                         vmnet_authority: self.vmnet_authority,
                         #[cfg(target_os = "macos")]
@@ -6964,6 +7182,10 @@ where
         })
     }
 
+    #[allow(
+        dead_code,
+        reason = "exact-2.6 product classification remains compatibility-tested after activation"
+    )]
     fn native_v2_storage_candidate_product_profile(
         &self,
     ) -> Result<NativeV2StorageCandidateProductProfile, NativeV2StorageCandidateProfileError> {
@@ -7033,7 +7255,80 @@ where
         })
     }
 
-    /// Publishes one strictly admitted paused source as a native-v2 2.6 pair.
+    fn native_v2_serial_candidate_product_profile(
+        &self,
+    ) -> Result<NativeV2SerialCandidateProductProfile, NativeV2SerialCandidateProfileError> {
+        self.starter
+            .preflight_snapshot_v2_root_process(self.pci_enabled)
+            .map_err(|_| NativeV2SerialCandidateProfileError::IncompatibleProcessMode)?;
+
+        let boot = self
+            .controller
+            .boot_source_config()
+            .ok_or(NativeV2SerialCandidateProfileError::MissingBootSource)?;
+        let kernel = HvfSnapshotV2NativePath::try_new(boot.kernel_image_path().as_os_str())
+            .map_err(|_| NativeV2SerialCandidateProfileError::InvalidBootMetadata)?;
+        let initrd = boot
+            .initrd_path()
+            .map(|path| HvfSnapshotV2NativePath::try_new(path.as_os_str()))
+            .transpose()
+            .map_err(|_| NativeV2SerialCandidateProfileError::InvalidBootMetadata)?;
+        let boot = HvfSnapshotV2BootState::try_new(kernel, initrd, boot.boot_args())
+            .map_err(|_| NativeV2SerialCandidateProfileError::InvalidBootMetadata)?;
+
+        let drives = self.controller.drive_configs();
+        let pmem = self.controller.pmem_configs();
+        let storage_resource_count = drives
+            .len()
+            .checked_add(pmem.len())
+            .ok_or(NativeV2SerialCandidateProfileError::TransportCapacity)?;
+        if storage_resource_count != 0 {
+            SnapshotV2StorageDeviceGraph::preflight_capture_configs(
+                NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                drives,
+                pmem,
+            )
+            .map_err(NativeV2SerialCandidateProfileError::StorageProfile)?;
+        }
+        SnapshotV2SerialState::preflight_capture(
+            self.controller.serial_config(),
+            storage_resource_count,
+        )
+        .map_err(NativeV2SerialCandidateProfileError::SerialProfile)?;
+        let pci_capacity = usize::from(PCI_LAST_ENDPOINT_DEVICE - PCI_FIRST_ENDPOINT_DEVICE + 1);
+        if self.pci_enabled && storage_resource_count > pci_capacity {
+            return Err(NativeV2SerialCandidateProfileError::TransportCapacity);
+        }
+        if !self.controller.network_interface_configs().is_empty()
+            || self.controller.vsock_config().is_some()
+            || self.controller.balloon_config().is_some()
+            || self.controller.memory_hotplug_config().is_some()
+            || self.controller.entropy_config().is_some()
+        {
+            return Err(NativeV2SerialCandidateProfileError::OptionalDevices);
+        }
+        let has_mmds_state = self
+            .controller
+            .mmds_state_handle()
+            .with(|state| state.config().is_some() || state.data_store_present())
+            .map_err(|_| NativeV2SerialCandidateProfileError::MmdsStateUnavailable)?;
+        if has_mmds_state {
+            return Err(NativeV2SerialCandidateProfileError::OptionalDevices);
+        }
+
+        Ok(NativeV2SerialCandidateProductProfile {
+            input: HvfArm64BootSnapshotV2CaptureInput::new(boot),
+            serial_config: self.controller.serial_config().clone(),
+            storage_configs: CaptureReadyStorageConfigs::new(drives.to_vec(), pmem.to_vec()),
+            expected_transport: if self.pci_enabled {
+                SnapshotV2DeviceTransportKind::Pci
+            } else {
+                SnapshotV2DeviceTransportKind::Mmio
+            },
+        })
+    }
+
+    /// Publishes one strictly admitted paused source as a native-v2 2.7 pair.
     ///
     /// The public create action reaches this seam after request normalization.
     pub(crate) fn publish_native_v2_snapshot(
@@ -7043,30 +7338,18 @@ where
         self.controller
             .preflight_create_snapshot_v2_request(input)
             .map_err(NativeV2SnapshotPublicationError::Preflight)?;
-        let NativeV2StorageCandidateProductProfile {
+        let NativeV2SerialCandidateProductProfile {
             input: capture_input,
             serial_config,
             storage_configs,
             expected_transport,
         } = self
-            .native_v2_storage_candidate_product_profile()
+            .native_v2_serial_candidate_product_profile()
             .map_err(NativeV2SnapshotPublicationError::Profile)?;
         let cancellation = self.snapshot_capture_cancellation.clone();
-        let serial = self
+        let _serial = self
             .preflight_snapshot_capture_ready(cancellation.clone())
             .map_err(SnapshotCaptureReadyPreflightError::into_native_v2)?;
-        let canonical_serial = SerialMmioDevice::discarding()
-            .capture_state()
-            .map_err(|_| {
-                NativeV2SnapshotPublicationError::Profile(
-                    NativeV2StorageCandidateProfileError::NonCanonicalSerial,
-                )
-            })?;
-        if serial.config() != &SerialConfig::default() || serial.device() != &canonical_serial {
-            return Err(NativeV2SnapshotPublicationError::Profile(
-                NativeV2StorageCandidateProfileError::NonCanonicalSerial,
-            ));
-        }
         if self.started_session.is_none() {
             return Err(NativeV2SnapshotPublicationError::SessionUnavailable);
         }
@@ -7410,6 +7693,9 @@ impl HvfInstanceStartExecutor {
             NativeV2SnapshotArtifactProfile::StorageDeviceGraphV2_6 => {
                 NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION
             }
+            NativeV2SnapshotArtifactProfile::SerialStateV2_7 => {
+                NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION
+            }
         };
         let structural = decode_snapshot_v2_state_with_compatibility_version(bytes, version)
             .map_err(NativeV2SnapshotLoadError::CandidateFormat)?;
@@ -7428,6 +7714,10 @@ impl HvfInstanceStartExecutor {
             }
             NativeV2SnapshotArtifactProfile::StorageDeviceGraphV2_6 => {
                 decode_hvf_snapshot_v2_storage_state(&structural)
+                    .map_err(NativeV2SnapshotLoadError::Decode)?;
+            }
+            NativeV2SnapshotArtifactProfile::SerialStateV2_7 => {
+                decode_hvf_snapshot_v2_serial_state(&structural)
                     .map_err(NativeV2SnapshotLoadError::Decode)?;
             }
         }
@@ -8099,6 +8389,9 @@ impl PreparedHvfSnapshotV2StorageDestination {
             HvfProcessSession::SnapshotV2(_) => Err(BackendError::InvalidState(
                 "exact-2.6 storage destination has the wrong worker type",
             )),
+            HvfProcessSession::SerialSnapshotV2(_) => Err(BackendError::InvalidState(
+                "exact-2.6 storage destination has a serial wrapper",
+            )),
         };
         drop(self);
         result
@@ -8655,13 +8948,14 @@ impl std::error::Error for HvfSnapshotV2SerialDestinationCleanupError {
 /// outside the worker and is finished only after worker, UART, input, and
 /// active-output teardown.
 #[cfg(target_os = "macos")]
-struct HvfSnapshotV2SerialDestination {
+pub(crate) struct HvfSnapshotV2SerialDestination {
     session: Option<Box<HvfProcessSession>>,
     storage_configs: Option<CaptureReadyStorageConfigs>,
     has_storage: bool,
     serial_config: Option<SerialConfig>,
     serial_output: Option<SharedSerialOutput>,
     restoration: Option<SerialStdioRestoration>,
+    unavailable_diagnostics: (),
 }
 
 #[cfg(target_os = "macos")]
@@ -8715,6 +9009,30 @@ impl HvfSnapshotV2SerialDestination {
             .resume()
     }
 
+    fn boot_mut(&mut self) -> Option<&mut HvfBootRunLoopSupervisor> {
+        self.session
+            .as_deref_mut()
+            .and_then(HvfProcessSession::boot_mut)
+    }
+
+    fn diagnostics(&self) -> &dyn ProcessSessionDiagnostics {
+        match self.session.as_deref() {
+            Some(session) => session.diagnostics(),
+            None => &self.unavailable_diagnostics,
+        }
+    }
+
+    fn diagnostics_mut(&mut self) -> &mut dyn ProcessSessionDiagnostics {
+        match self.session.as_deref_mut() {
+            Some(session) => session.diagnostics_mut(),
+            None => &mut self.unavailable_diagnostics,
+        }
+    }
+
+    fn serial_output_clone(&self) -> Option<SharedSerialOutput> {
+        self.serial_output.clone()
+    }
+
     fn cleanup(&mut self) -> Result<(), HvfSnapshotV2SerialDestinationCleanupError> {
         let session = match self.session.as_deref_mut() {
             Some(HvfProcessSession::Boot(supervisor)) => supervisor
@@ -8728,6 +9046,9 @@ impl HvfSnapshotV2SerialDestination {
                 .err(),
             Some(HvfProcessSession::SnapshotV2(_)) => Some(BackendError::InvalidState(
                 "exact-2.7 destination has the wrong worker type",
+            )),
+            Some(HvfProcessSession::SerialSnapshotV2(_)) => Some(BackendError::InvalidState(
+                "exact-2.7 destination is recursively wrapped",
             )),
             None => None,
         };
@@ -9181,6 +9502,7 @@ fn prepare_hvf_native_v2_serial_destination(
                 serial_config: Some(serial_config),
                 serial_output: Some(serial_output),
                 restoration,
+                unavailable_diagnostics: (),
             })
         })
         .map_err(PrepareHvfSnapshotV2SerialDestinationError::Construction)?;
@@ -10489,6 +10811,119 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
     }
 
     #[cfg(target_os = "macos")]
+    fn load_prepared_snapshot_v2_serial(
+        &mut self,
+        request: ProcessSnapshotV2SerialLoadRequest<'_>,
+    ) -> Result<SnapshotV2LoadSuccess<Self::Session>, NativeV2SnapshotLoadError> {
+        let ProcessSnapshotV2SerialLoadRequest {
+            controller,
+            vmnet_authority,
+            contained_restore_authority,
+            pci_enabled,
+            input,
+            candidate,
+            memory,
+            cancellation,
+        } = request;
+        self.preflight_snapshot_v2_root_process(pci_enabled)
+            .map_err(NativeV2SnapshotLoadError::Preflight)?;
+
+        let (bytes, binding, candidate_graph, candidate_serial) = candidate.into_parts();
+        let structural = decode_snapshot_v2_state_with_compatibility_version(
+            &bytes,
+            NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION,
+        )
+        .map_err(NativeV2SnapshotLoadError::CandidateFormat)?;
+        let decoded = decode_hvf_snapshot_v2_serial_state(&structural)
+            .map_err(NativeV2SnapshotLoadError::Decode)?;
+        if decoded.platform().memory() != &binding
+            || decoded.device_graph() != candidate_graph.as_ref()
+            || decoded.serial() != &candidate_serial
+        {
+            return Err(NativeV2SnapshotLoadError::CandidateMismatch);
+        }
+        let (platform, graph, serial) = decoded.into_parts();
+        drop(candidate_graph);
+        drop(candidate_serial);
+
+        let expected_transport = if pci_enabled {
+            SnapshotV2DeviceTransportKind::Pci
+        } else {
+            SnapshotV2DeviceTransportKind::Mmio
+        };
+        if graph
+            .as_ref()
+            .is_some_and(|graph| graph.transport_kind() != expected_transport)
+        {
+            return Err(NativeV2SnapshotLoadError::Preflight(
+                VmmActionError::SnapshotUnsupported,
+            ));
+        }
+
+        let boot = native_v2_boot_source_config(platform.machine().boot())
+            .map_err(NativeV2SnapshotLoadError::BootMetadata)?;
+        let machine = snapshot_destination_machine_config(
+            platform.machine().machine(),
+            input.track_dirty_pages(),
+        );
+        let bundle = prepare_native_v2_serial_restore_bundle(
+            graph.as_ref(),
+            serial,
+            contained_restore_authority,
+            || cancellation.is_cancelled(),
+        )
+        .map_err(NativeV2SnapshotLoadError::SerialBundle)?;
+        let (packet_io, mmds_metrics) =
+            match ProcessNetworkPacketIoProvider::from_controller(controller, vmnet_authority) {
+                Ok(prepared) => prepared,
+                Err(source) => {
+                    if bundle.abort().is_err() {
+                        return Err(NativeV2SnapshotLoadError::SerialDestination(
+                            NativeV2SerialDestinationLoadError::new(true),
+                        ));
+                    }
+                    return Err(NativeV2SnapshotLoadError::ProcessPreparation(
+                        BackendError::Hypervisor(format!(
+                            "failed to build native-v2 network packet I/O provider: {source}"
+                        )),
+                    ));
+                }
+            };
+
+        let (destination, controller_commit) =
+            prepare_hvf_native_v2_serial_destination(PrepareHvfSnapshotV2SerialDestinationInput {
+                platform,
+                graph,
+                memory,
+                pci_enabled,
+                packet_io,
+                mmds_metrics,
+                vmnet_authority,
+                bundle,
+                machine,
+                boot,
+                resume_requested: input.resume_vm(),
+                cancellation,
+            })
+            .map_err(|source| {
+                let terminal = source.is_terminal();
+                NativeV2SnapshotLoadError::SerialDestination(
+                    NativeV2SerialDestinationLoadError::with_source(terminal, &source),
+                )
+            })?;
+        let serial_output = destination.serial_output_clone().ok_or_else(|| {
+            NativeV2SnapshotLoadError::SerialDestination(NativeV2SerialDestinationLoadError::new(
+                true,
+            ))
+        })?;
+        self.active_serial_output = Some(serial_output);
+        Ok(SnapshotV2LoadSuccess::new(
+            HvfProcessSession::SerialSnapshotV2(Box::new(destination)),
+            controller_commit,
+        ))
+    }
+
+    #[cfg(target_os = "macos")]
     fn commit_prepared_snapshot_v2_root_load(
         &mut self,
         completion: ProcessSnapshotV2RootLoadCompletion,
@@ -10544,6 +10979,8 @@ pub(crate) type HvfSnapshotV2RunLoopSupervisor = BootRunLoopSupervisor<ProcessHv
 pub(crate) enum HvfProcessSession {
     Boot(HvfBootRunLoopSupervisor),
     SnapshotV2(HvfSnapshotV2RunLoopSupervisor),
+    #[cfg(target_os = "macos")]
+    SerialSnapshotV2(Box<HvfSnapshotV2SerialDestination>),
 }
 
 impl HvfProcessSession {
@@ -10551,6 +10988,8 @@ impl HvfProcessSession {
         match self {
             Self::Boot(session) => Some(session),
             Self::SnapshotV2(_) => None,
+            #[cfg(target_os = "macos")]
+            Self::SerialSnapshotV2(destination) => destination.boot_mut(),
         }
     }
 
@@ -10558,6 +10997,8 @@ impl HvfProcessSession {
         match self {
             Self::Boot(session) => session,
             Self::SnapshotV2(session) => session,
+            #[cfg(target_os = "macos")]
+            Self::SerialSnapshotV2(destination) => destination.diagnostics(),
         }
     }
 
@@ -10565,6 +11006,8 @@ impl HvfProcessSession {
         match self {
             Self::Boot(session) => session,
             Self::SnapshotV2(session) => session,
+            #[cfg(target_os = "macos")]
+            Self::SerialSnapshotV2(destination) => destination.diagnostics_mut(),
         }
     }
 }
@@ -10576,6 +11019,11 @@ impl fmt::Debug for HvfProcessSession {
             Self::SnapshotV2(session) => {
                 formatter.debug_tuple("SnapshotV2").field(session).finish()
             }
+            #[cfg(target_os = "macos")]
+            Self::SerialSnapshotV2(destination) => formatter
+                .debug_tuple("SerialSnapshotV2")
+                .field(destination)
+                .finish(),
         }
     }
 }
@@ -17501,6 +17949,8 @@ where
         cancellation: NativeV2SnapshotCaptureCancellation,
     ) -> Result<NativeSnapshotPublicationOutcome, Box<NativeV2SnapshotPublicationTransactionError>>
     {
+        preflight_native_v2_serial_capture(&serial_config, &storage_configs)
+            .map_err(native_v2_snapshot_transaction_error_before_staging)?;
         let active_capture = self
             .register_snapshot_capture_raw(cancellation.clone())
             .map_err(|source| {
@@ -17537,14 +17987,26 @@ where
                     ));
                 }
 
-                capture_canonical_native_v2_serial(session, serial_config, &guard)
-                    .map_err(native_v2_snapshot_transaction_error_before_staging)?;
+                let serial = session
+                    .capture_native_v2_serial(serial_config, &guard)
+                    .map_err(|source| {
+                        native_v2_snapshot_transaction_error_before_staging(
+                            NativeV2SnapshotCaptureError::Serial { source },
+                        )
+                    })?;
+                let serial =
+                    SnapshotV2SerialState::try_from_capture_ready(serial).map_err(|source| {
+                        native_v2_snapshot_transaction_error_before_staging(
+                            NativeV2SnapshotCaptureError::SerialState { source },
+                        )
+                    })?;
 
                 let result = destination.publish(|writer| {
                     let state = capture_and_recover_native_v2_state(
                         session,
                         input,
-                        NativeV2SnapshotCaptureProfile::Storage {
+                        NativeV2SnapshotCaptureProfile::Serial {
+                            serial,
                             storage_configs,
                             expected_transport,
                         },
@@ -17552,13 +18014,13 @@ where
                         Box::new(writer),
                         &cancellation,
                         |encoded| {
-                            NativeV2StorageSnapshotCandidateState::from_storage_device_graph_v2_6(
-                                encoded,
-                            )
-                            .map(NativeV2StorageSnapshotCandidateState::into_current_artifact_state)
-                            .map_err(|source| {
-                                NativeV2SnapshotCaptureError::CandidateState { source }
-                            })
+                            NativeV2SerialSnapshotCandidateState::from_serial_state_v2_7(encoded)
+                                .map(
+                                    NativeV2SerialSnapshotCandidateState::into_current_artifact_state,
+                                )
+                                .map_err(|source| {
+                                    NativeV2SnapshotCaptureError::CandidateState { source }
+                                })
                         },
                     )
                     .map_err(NativeV2SnapshotPublicationProducerError::Capture)?;
@@ -18810,13 +19272,14 @@ mod tests {
     };
     use bangbang_runtime::snapshot_artifact::{
         LoadedNativeSnapshotArtifacts, NativeSnapshotPublicationOutcome,
-        NativeV2StorageSnapshotCandidateState, SnapshotArtifactOutputs, SnapshotArtifactPaths,
+        NativeV2SerialSnapshotCandidateState, SnapshotArtifactOutputs, SnapshotArtifactPaths,
         SnapshotPublicationOutcome, publish_snapshot_artifacts_with,
     };
     #[cfg(target_os = "macos")]
     use bangbang_runtime::snapshot_artifact::{
-        NativeSnapshotArtifactFamily, NativeV2SnapshotCandidateState, SnapshotArtifactOutput,
-        SnapshotCommitDurability, load_native_snapshot_artifacts, load_snapshot_artifacts,
+        NativeSnapshotArtifactFamily, NativeV2SnapshotArtifactProfile,
+        NativeV2SnapshotCandidateState, SnapshotArtifactOutput, SnapshotCommitDurability,
+        load_native_snapshot_artifacts, load_snapshot_artifacts,
     };
     #[cfg(target_os = "macos")]
     use bangbang_runtime::snapshot_commit::SnapshotCommitKind;
@@ -18910,13 +19373,13 @@ mod tests {
         NativeV1SnapshotLoadError, NativeV1SnapshotPublicationError,
         NativeV1SnapshotPublicationProducerError, NativeV1SnapshotPublicationTransactionError,
         NativeV2MultiBlockCandidateProfileError, NativeV2RootCandidateProcessError,
-        NativeV2RootCandidateProfileError, NativeV2SnapshotCaptureCancellation,
-        NativeV2SnapshotCaptureError, NativeV2SnapshotCaptureSession, NativeV2SnapshotCaptureStage,
-        NativeV2SnapshotLoadError, NativeV2SnapshotMultiBlockCaptureError,
-        NativeV2SnapshotPublicationDestination, NativeV2SnapshotPublicationError,
-        NativeV2SnapshotPublicationProducerError, NativeV2SnapshotPublicationRequest,
-        NativeV2SnapshotRootCaptureError, NativeV2SnapshotStorageCaptureError,
-        NativeV2StorageCandidateProfileError, NetworkPacketIoRunLoopSession,
+        NativeV2RootCandidateProfileError, NativeV2SerialCandidateProfileError,
+        NativeV2SnapshotCaptureCancellation, NativeV2SnapshotCaptureError,
+        NativeV2SnapshotCaptureSession, NativeV2SnapshotCaptureStage, NativeV2SnapshotLoadError,
+        NativeV2SnapshotMultiBlockCaptureError, NativeV2SnapshotPublicationDestination,
+        NativeV2SnapshotPublicationError, NativeV2SnapshotPublicationProducerError,
+        NativeV2SnapshotPublicationRequest, NativeV2SnapshotRootCaptureError,
+        NativeV2SnapshotStorageCaptureError, NetworkPacketIoRunLoopSession,
         NoopProcessNetworkTxPacketSink, ProcessCaptureReadyNetworkError, ProcessHvfBootSession,
         ProcessMmdsPacketDetourConfig, ProcessNetworkPacketIoProvider,
         ProcessNetworkPacketIoProviderBuildError, ProcessNetworkPacketIoRegistry,
@@ -18924,13 +19387,13 @@ mod tests {
         ProcessRuntimeNetworkPacketIoProvider, ProcessSessionDiagnostics, ProcessSessionExitStatus,
         ProcessSnapshotV2MultiBlockLoadRequest, ProcessSnapshotV2MultiBlockLoadSuccess,
         ProcessSnapshotV2RootLoadCompletion, ProcessSnapshotV2RootLoadRequest,
-        ProcessSnapshotV2RootLoadSuccess, ProcessSnapshotV2StorageLoadRequest,
-        ProcessSnapshotV2StorageLoadSuccess, ProcessVmm, ProcessVmnetAuthority,
-        ProcessVmnetPacketIoBackendFactory, SerialGrantState, SnapshotCreateSession,
-        SnapshotV1LoadSuccess, SnapshotV2LoadSuccess, default_hvf_boot_run_loop_step_limit,
-        default_hvf_boot_session_config, native_v2_platform_capture_is_terminal,
-        require_native_v1_composite_record, snapshot_destination_machine_config,
-        vsock_capture_error_from_boot_run_loop_command,
+        ProcessSnapshotV2RootLoadSuccess, ProcessSnapshotV2SerialLoadRequest,
+        ProcessSnapshotV2StorageLoadRequest, ProcessSnapshotV2StorageLoadSuccess, ProcessVmm,
+        ProcessVmnetAuthority, ProcessVmnetPacketIoBackendFactory, SerialGrantState,
+        SnapshotCreateSession, SnapshotV1LoadSuccess, SnapshotV2LoadSuccess,
+        default_hvf_boot_run_loop_step_limit, default_hvf_boot_session_config,
+        native_v2_platform_capture_is_terminal, require_native_v1_composite_record,
+        snapshot_destination_machine_config, vsock_capture_error_from_boot_run_loop_command,
     };
     #[cfg(target_os = "macos")]
     use super::{
@@ -20052,6 +20515,7 @@ mod tests {
 
     fn publish_fake_native_v2_snapshot(
         session: &mut FakeSession,
+        serial_config: SerialConfig,
         transport: SnapshotV2DeviceTransportKind,
         has_block: bool,
         has_pmem: bool,
@@ -20086,23 +20550,40 @@ mod tests {
                         },
                     )
                 })?;
-                let graph = fake_native_v2_storage_device_graph(transport, has_block, has_pmem)
-                    .encode(NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION)
-                    .expect("fixed fake native-v2 graph should encode");
-                let components = [
-                    SnapshotV2Component::new(
-                        NATIVE_V2_MEMORY_COMPONENT_KEY,
-                        SnapshotV2ComponentDisposition::Semantic,
-                        &memory,
-                    ),
-                    SnapshotV2Component::new(
+                let graph = (has_block || has_pmem).then(|| {
+                    fake_native_v2_storage_device_graph(transport, has_block, has_pmem)
+                        .encode(NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION)
+                        .expect("fixed fake native-v2 graph should encode")
+                });
+                let serial_device = SerialMmioDevice::discarding()
+                    .capture_state()
+                    .expect("fake serial device should capture");
+                let serial = SnapshotV2SerialState::try_from_capture_ready(
+                    CaptureReadySerialState::new(serial_config, serial_device),
+                )
+                .expect("fake serial state should capture")
+                .encode(NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION)
+                .expect("fake serial state should encode");
+                let mut components = Vec::with_capacity(3);
+                components.push(SnapshotV2Component::new(
+                    NATIVE_V2_MEMORY_COMPONENT_KEY,
+                    SnapshotV2ComponentDisposition::Semantic,
+                    &memory,
+                ));
+                if let Some(graph) = &graph {
+                    components.push(SnapshotV2Component::new(
                         NATIVE_V2_DEVICE_GRAPH_COMPONENT_KEY,
                         SnapshotV2ComponentDisposition::Semantic,
-                        &graph,
-                    ),
-                ];
+                        graph,
+                    ));
+                }
+                components.push(SnapshotV2Component::new(
+                    NATIVE_V2_SERIAL_COMPONENT_KEY,
+                    SnapshotV2ComponentDisposition::Semantic,
+                    &serial,
+                ));
                 let encoded = encode_snapshot_v2_state_with_compatibility_version(
-                    NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                    NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION,
                     &[],
                     &components,
                 )
@@ -20113,8 +20594,8 @@ mod tests {
                         },
                     )
                 })?;
-                NativeV2StorageSnapshotCandidateState::from_storage_device_graph_v2_6(encoded)
-                    .map(NativeV2StorageSnapshotCandidateState::into_current_artifact_state)
+                NativeV2SerialSnapshotCandidateState::from_serial_state_v2_7(encoded)
+                    .map(NativeV2SerialSnapshotCandidateState::into_current_artifact_state)
                     .map_err(|source| {
                         NativeV2SnapshotPublicationProducerError::Capture(
                             NativeV2SnapshotCaptureError::CandidateState { source },
@@ -20604,9 +21085,9 @@ mod tests {
                 expected_transport,
                 cancellation: _,
             } = request;
-            assert_eq!(serial_config, SerialConfig::default());
             publish_fake_native_v2_snapshot(
                 session,
+                serial_config,
                 expected_transport,
                 !storage_configs.drives().is_empty(),
                 !storage_configs.pmem().is_empty(),
@@ -20630,9 +21111,9 @@ mod tests {
                 expected_transport,
                 cancellation: _,
             } = request;
-            assert_eq!(serial_config, SerialConfig::default());
             publish_fake_native_v2_snapshot(
                 session,
+                serial_config,
                 expected_transport,
                 !storage_configs.drives().is_empty(),
                 !storage_configs.pmem().is_empty(),
@@ -20989,6 +21470,128 @@ mod tests {
                 }
             };
             Ok(ProcessSnapshotV2StorageLoadSuccess::new(session, commit))
+        }
+
+        fn load_prepared_snapshot_v2_serial(
+            &mut self,
+            request: ProcessSnapshotV2SerialLoadRequest<'_>,
+        ) -> Result<SnapshotV2LoadSuccess<Self::Session>, NativeV2SnapshotLoadError> {
+            let ProcessSnapshotV2SerialLoadRequest {
+                controller,
+                vmnet_authority,
+                #[cfg(target_os = "macos")]
+                    contained_restore_authority: _,
+                pci_enabled,
+                input,
+                candidate,
+                memory: _,
+                cancellation,
+            } = request;
+            let expected_transport = if pci_enabled {
+                SnapshotV2DeviceTransportKind::Pci
+            } else {
+                SnapshotV2DeviceTransportKind::Mmio
+            };
+            if candidate
+                .device_graph()
+                .is_some_and(|graph| graph.transport_kind() != expected_transport)
+            {
+                return Err(NativeV2SnapshotLoadError::Preflight(
+                    VmmActionError::SnapshotUnsupported,
+                ));
+            }
+            let drive_configs = candidate
+                .device_graph()
+                .into_iter()
+                .flat_map(SnapshotV2StorageDeviceGraph::block_records)
+                .map(|record| {
+                    let config = record.config();
+                    let mut input = DriveConfigInput::new(
+                        config.drive_id(),
+                        config.drive_id(),
+                        config.selector(),
+                        config.is_root(),
+                    )
+                    .with_is_read_only(config.is_read_only())
+                    .with_cache_type(config.cache_type())
+                    .with_io_engine(config.io_engine());
+                    if let Some(partuuid) = config.partuuid() {
+                        input = input.with_partuuid(partuuid);
+                    }
+                    if let Some(rate_limiter) = config.rate_limiter() {
+                        input = input.with_rate_limiter(rate_limiter);
+                    }
+                    input.validate()
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| NativeV2SnapshotLoadError::CandidateMismatch)?;
+            let pmem_configs = candidate
+                .device_graph()
+                .into_iter()
+                .flat_map(SnapshotV2StorageDeviceGraph::pmem_records)
+                .map(|record| {
+                    let config = record.config();
+                    let mut input = PmemConfigInput::new(config.pmem_id(), config.selector())
+                        .with_root_device(config.is_root())
+                        .with_read_only(config.is_read_only());
+                    if let Some(rate_limiter) = config.rate_limiter() {
+                        input = input.with_rate_limiter(rate_limiter);
+                    }
+                    PmemConfig::try_from(input)
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| NativeV2SnapshotLoadError::CandidateMismatch)?;
+            let mut serial_input = SerialConfigInput::new();
+            if let Some(selector) = candidate.serial().endpoint_intent().configured_selector() {
+                serial_input = serial_input.with_serial_out_path(selector);
+            }
+            if let Some(rate_limiter) = candidate.serial().rate_limiter() {
+                serial_input = serial_input.with_rate_limiter(rate_limiter);
+            }
+            let serial_config = serial_input
+                .validate()
+                .map_err(|_| NativeV2SnapshotLoadError::CandidateMismatch)?;
+            if !cancellation.try_seal_commit() {
+                return Err(NativeV2SnapshotLoadError::Cancelled);
+            }
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.last_vmnet_authority = Some(vmnet_authority);
+            assert_eq!(controller.instance_info().state, InstanceState::NotStarted);
+            if self.result == FakeSnapshotLoadResult::Terminal {
+                return Err(NativeV2SnapshotLoadError::ProcessTerminal);
+            }
+
+            let boot_source = BootSourceConfigInput::new("/private/restored-vmlinux")
+                .validate()
+                .expect("fake restored boot source should validate");
+            let machine =
+                MachineConfig::default().with_track_dirty_pages(input.track_dirty_pages());
+            let commit = if candidate.device_graph().is_some() {
+                SnapshotV2ControllerCommit::with_storage_and_serial_configs(
+                    machine,
+                    boot_source,
+                    CaptureReadyStorageConfigs::new(drive_configs, pmem_configs),
+                    serial_config,
+                    input.resume_vm(),
+                )
+            } else {
+                SnapshotV2ControllerCommit::with_serial_config(
+                    machine,
+                    boot_source,
+                    serial_config,
+                    input.resume_vm(),
+                )
+            };
+            let session = match self.result {
+                FakeSnapshotLoadResult::ResumeFailure => FakeSession::with_resume_result(
+                    77,
+                    BackendError::Hypervisor("private-resume-sentinel".to_owned()),
+                ),
+                FakeSnapshotLoadResult::Success | FakeSnapshotLoadResult::Terminal => {
+                    FakeSession::new(77)
+                }
+            };
+            Ok(SnapshotV2LoadSuccess::new(session, commit))
         }
     }
 
@@ -24030,6 +24633,7 @@ mod tests {
         let mut session = FakeSession::new(0);
         publish_fake_native_v2_snapshot(
             &mut session,
+            SerialConfig::default(),
             transport,
             true,
             false,
@@ -24262,7 +24866,10 @@ mod tests {
             .into_current_v2_candidate()
             .expect("published PCI pair should retain a current candidate");
         assert_eq!(
-            candidate.device_graph().transport_kind(),
+            candidate
+                .device_graph()
+                .expect("published PCI pair should retain its storage graph")
+                .transport_kind(),
             SnapshotV2DeviceTransportKind::Pci
         );
         directory.assert_no_staging();
@@ -32086,23 +32693,20 @@ mod tests {
                     });
 
                 let loaded = load_native_snapshot_artifacts(&paths)
-                    .expect("public exact-2.6 storage pair should load");
+                    .expect("public exact-2.7 serial-storage pair should load");
                 let (candidate, _) = loaded
                     .into_current_v2_candidate()
                     .expect("public storage pair should retain the exact current candidate");
                 assert_eq!(
                     candidate.version(),
-                    NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION
+                    NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION
                 );
-                assert_eq!(candidate.device_graph().transport_kind(), transport);
-                assert_eq!(
-                    candidate.device_graph().block_records().len(),
-                    usize::from(has_block)
-                );
-                assert_eq!(
-                    candidate.device_graph().pmem_records().len(),
-                    usize::from(has_pmem)
-                );
+                let graph = candidate
+                    .device_graph()
+                    .expect("public storage pair should retain its storage graph");
+                assert_eq!(graph.transport_kind(), transport);
+                assert_eq!(graph.block_records().len(), usize::from(has_block));
+                assert_eq!(graph.pmem_records().len(), usize::from(has_pmem));
 
                 let starter = FakeSnapshotLoadStarter::new(FakeSnapshotLoadResult::Success);
                 let calls = starter.calls();
@@ -32365,7 +32969,7 @@ mod tests {
     #[test]
     #[ignore = "requires the signed native_v2_process integration group"]
     fn signed_native_v2_process_publishes_recaptures_and_resumes_private_pair() {
-        use bangbang_hvf::{HvfArm64StableVcpuDisposition, decode_hvf_snapshot_v2_storage_state};
+        use bangbang_hvf::{HvfArm64StableVcpuDisposition, decode_hvf_snapshot_v2_serial_state};
         use bangbang_runtime::snapshot_format_v2::decode_snapshot_v2_state;
 
         const ARM64_IMAGE_HEADER_SIZE: usize = 64;
@@ -32431,8 +33035,8 @@ mod tests {
                 .expect("native-v2 load should retain structural bytes"),
         )
         .expect("real process native-v2 state should decode structurally");
-        let first_state = decode_hvf_snapshot_v2_storage_state(&first_structural)
-            .expect("real process native-v2 storage state should cross-validate");
+        let first_state = decode_hvf_snapshot_v2_serial_state(&first_structural)
+            .expect("real process native-v2 serial state should cross-validate");
         let first_platform = first_state.platform();
         assert_eq!(first_platform.topology().members().len(), 2);
         assert!(matches!(
@@ -32443,12 +33047,21 @@ mod tests {
             first_platform.topology().members()[1].disposition(),
             HvfArm64StableVcpuDisposition::Offline
         ));
-        assert_eq!(first_state.device_graph().block_records().len(), 1);
-        assert!(first_state.device_graph().block_records()[0].is_root());
-        assert!(first_state.device_graph().pmem_records().is_empty());
+        let first_graph = first_state
+            .device_graph()
+            .expect("real process native-v2 state should retain storage");
+        assert_eq!(first_graph.block_records().len(), 1);
+        assert!(first_graph.block_records()[0].is_root());
+        assert!(first_graph.pmem_records().is_empty());
         assert_eq!(
-            first_state.device_graph().transport_kind(),
+            first_graph.transport_kind(),
             SnapshotV2DeviceTransportKind::Mmio
+        );
+        assert!(
+            first_state
+                .serial()
+                .endpoint_intent()
+                .is_default_process_stdio()
         );
         drop(first_state);
         drop(first);
@@ -32517,6 +33130,28 @@ mod tests {
         paused_destination
             .handle_action(VmmAction::Pause)
             .expect("restored destination should pause again");
+
+        let recaptured_directory =
+            TempSnapshotDirectory::new("signed-native-v2-restored-recapture");
+        let recaptured_paths = recaptured_directory.paths();
+        assert_eq!(
+            paused_destination.handle_action(VmmAction::CreateSnapshot(SnapshotCreateInput::new(
+                SnapshotType::Full,
+                recaptured_paths.state(),
+                recaptured_paths.memory(),
+            ),)),
+            Ok(VmmData::Empty)
+        );
+        let recaptured = load_native_snapshot_artifacts(&recaptured_paths)
+            .expect("restored exact-2.7 destination should publish again");
+        assert_eq!(
+            recaptured
+                .state()
+                .v2_profile()
+                .expect("recaptured destination should retain a closed profile"),
+            NativeV2SnapshotArtifactProfile::SerialStateV2_7
+        );
+        recaptured_directory.assert_no_staging();
         drop(paused_destination);
 
         let authority = snapshot_root_file_grant_authority_for_test(
@@ -33179,6 +33814,9 @@ mod tests {
                 super::HvfProcessSession::SnapshotV2(_) => {
                     panic!("exact-2.6 storage handoff should use the boot supervisor");
                 }
+                super::HvfProcessSession::SerialSnapshotV2(_) => {
+                    panic!("exact-2.6 storage handoff should not use the serial wrapper");
+                }
             }
             drop(session);
         }
@@ -33417,6 +34055,9 @@ mod tests {
                 super::HvfProcessSession::SnapshotV2(_) => {
                     panic!("exact-2.7 serial handoff should use the boot supervisor");
                 }
+                super::HvfProcessSession::SerialSnapshotV2(_) => {
+                    panic!("private exact-2.7 destination should not be recursively wrapped");
+                }
             }
 
             destination
@@ -33430,6 +34071,9 @@ mod tests {
                 super::HvfProcessSession::Boot(supervisor) => supervisor,
                 super::HvfProcessSession::SnapshotV2(_) => {
                     panic!("exact-2.7 serial handoff should retain the boot supervisor")
+                }
+                super::HvfProcessSession::SerialSnapshotV2(_) => {
+                    panic!("private exact-2.7 destination should not be recursively wrapped")
                 }
             };
             supervisor
@@ -33719,6 +34363,9 @@ mod tests {
                 super::HvfProcessSession::SnapshotV2(_) => {
                     panic!("exact-2.7 serial-storage handoff should use the boot supervisor")
                 }
+                super::HvfProcessSession::SerialSnapshotV2(_) => {
+                    panic!("private exact-2.7 destination should not be recursively wrapped")
+                }
             };
             supervisor
                 .pause()
@@ -33859,24 +34506,26 @@ mod tests {
         drive
             .handle_action(VmmAction::Pause)
             .expect("empty-drive source should pause");
-        assert!(matches!(
-            drive.publish_native_v2_snapshot(&drive_input),
-            Err(NativeV2SnapshotPublicationError::Profile(
-                NativeV2StorageCandidateProfileError::StorageProfile(_)
-            ))
-        ));
+        drive
+            .publish_native_v2_snapshot(&drive_input)
+            .expect("serial-only exact-2.7 source should publish without storage");
         assert_eq!(
             drive
                 .started_session
                 .as_ref()
-                .expect("drive rejection should retain the source")
+                .expect("serial-only publication should retain the source")
                 .native_snapshot_publication_count,
-            0
+            1
         );
         assert_eq!(
-            drive.starter.snapshot_storage_preflight_calls, 0,
-            "invalid drive inventory must reject before capture-owner preflight"
+            drive.starter.snapshot_storage_preflight_calls, 1,
+            "serial-only publication should preflight the empty storage owner set"
         );
+        let (candidate, _) = load_native_snapshot_artifacts(&drive_paths)
+            .expect("serial-only pair should load")
+            .into_current_v2_candidate()
+            .expect("serial-only pair should close as exact 2.7");
+        assert!(candidate.device_graph().is_none());
         drive_directory.assert_no_staging();
 
         let mut vhost = configured_vmm(FakeStarter::success(186));
@@ -33936,7 +34585,7 @@ mod tests {
                 optional_paths.memory(),
             )),
             Err(NativeV2SnapshotPublicationError::Profile(
-                NativeV2StorageCandidateProfileError::OptionalDevices
+                NativeV2SerialCandidateProfileError::OptionalDevices
             ))
         ));
         assert_eq!(
@@ -33953,9 +34602,11 @@ mod tests {
             serial_paths.memory(),
         );
         let mut serial = snapshot_profile_vmm(FakeStarter::success(175));
+        let serial_sink = TempFilePath::create("native-v2-process-serial-output");
         serial
             .handle_action(VmmAction::PutSerial(
                 SerialConfigInput::new()
+                    .with_serial_out_path(serial_sink.path().to_string_lossy())
                     .with_rate_limiter(SerialRateLimiterConfig::new(1, None, 1_000)),
             ))
             .expect("custom serial config should store");
@@ -33965,23 +34616,37 @@ mod tests {
         serial
             .handle_action(VmmAction::Pause)
             .expect("custom serial source should pause");
-        assert!(matches!(
-            serial.publish_native_v2_snapshot(&serial_input),
-            Err(NativeV2SnapshotPublicationError::Profile(
-                NativeV2StorageCandidateProfileError::NonCanonicalSerial
-            ))
-        ));
+        serial
+            .publish_native_v2_snapshot(&serial_input)
+            .expect("configured serial state should publish in exact 2.7");
         assert_eq!(
             serial
                 .started_session
                 .as_ref()
-                .expect("serial rejection should retain the source")
+                .expect("serial publication should retain the source")
                 .native_snapshot_publication_count,
-            0
+            1
         );
         assert_eq!(
-            serial.starter.snapshot_storage_preflight_calls, 0,
-            "serial rejection must precede capture-owner preflight"
+            serial.starter.snapshot_storage_preflight_calls, 1,
+            "configured serial publication should preflight every capture owner"
+        );
+        let (candidate, _) = load_native_snapshot_artifacts(&serial_paths)
+            .expect("configured serial snapshot should load")
+            .into_current_v2_candidate()
+            .expect("configured serial snapshot should close as exact 2.7");
+        assert_eq!(
+            candidate.serial().rate_limiter(),
+            Some(SerialRateLimiterConfig::new(1, None, 1_000))
+        );
+        assert_eq!(
+            candidate.serial().endpoint_intent().configured_selector(),
+            Some(
+                serial_sink
+                    .path()
+                    .to_str()
+                    .expect("serial sink path should be UTF-8")
+            )
         );
         serial_directory.assert_no_staging();
 
@@ -33989,25 +34654,22 @@ mod tests {
         let live_serial_paths = live_serial_directory.paths();
         let mut live_serial = paused_native_v2_profile_vmm(FakeStarter::success(189));
         live_serial.starter.snapshot_serial_preflight_canonical = false;
-        assert!(matches!(
-            live_serial.publish_native_v2_snapshot(&SnapshotCreateInput::new(
+        live_serial
+            .publish_native_v2_snapshot(&SnapshotCreateInput::new(
                 SnapshotType::Full,
                 live_serial_paths.state(),
                 live_serial_paths.memory(),
-            )),
-            Err(NativeV2SnapshotPublicationError::Profile(
-                NativeV2StorageCandidateProfileError::NonCanonicalSerial
             ))
-        ));
+            .expect("live serial capture should no longer be rejected as noncanonical");
         assert_eq!(live_serial.starter.snapshot_serial_preflight_calls, 1);
         let live_serial_session = live_serial
             .started_session
             .as_ref()
-            .expect("live serial rejection should retain the source");
-        assert_eq!(live_serial_session.native_snapshot_publication_count, 0);
-        assert_eq!(live_serial_session.native_snapshot_producer_count, 0);
-        assert!(!live_serial_paths.state().exists());
-        assert!(!live_serial_paths.memory().exists());
+            .expect("live serial publication should retain the source");
+        assert_eq!(live_serial_session.native_snapshot_publication_count, 1);
+        assert_eq!(live_serial_session.native_snapshot_producer_count, 1);
+        assert!(live_serial_paths.state().exists());
+        assert!(live_serial_paths.memory().exists());
         live_serial_directory.assert_no_staging();
 
         let unavailable_directory = TempSnapshotDirectory::new("native-v2-process-no-session");
@@ -39175,9 +39837,9 @@ mod tests {
                 "v2-pause",
                 "v2-storage-normalize",
                 "v2-storage-transport",
-                "v2-storage-platform",
-                "v2-storage-compose",
-                "v2-storage-encode",
+                "v2-serial-platform",
+                "v2-serial-compose",
+                "v2-serial-encode",
                 "v2-recover",
                 "v2-published",
                 "aux-drop",
@@ -39221,7 +39883,7 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn native_v2_supervisor_rejects_noncanonical_uart_before_staging() {
+    fn native_v2_supervisor_publishes_complete_noncanonical_uart_state() {
         let control = FakeRunLoopControl::default();
         let drop_count = Arc::new(AtomicU64::new(0));
         let (max_steps_sender, max_steps_receiver) = mpsc::channel();
@@ -39240,7 +39902,7 @@ mod tests {
         let directory = TempSnapshotDirectory::new("native-v2-noncanonical-uart");
         let paths = directory.paths();
 
-        let error = supervisor
+        let outcome = supervisor
             .publish_native_v2_snapshot(
                 native_v2_test_capture_input(),
                 SerialConfig::default(),
@@ -39249,23 +39911,35 @@ mod tests {
                 &paths,
                 NativeV2SnapshotCaptureCancellation::default(),
             )
-            .expect_err("mutated UART state should fail closed");
-        assert!(matches!(
-            error.producer().map(|producer| producer.source()),
-            Some(NativeV2SnapshotPublicationProducerError::Capture(
-                NativeV2SnapshotCaptureError::NonCanonicalSerial
-            ))
-        ));
+            .expect("mutated UART state should publish as complete exact-2.7 state");
+        assert_eq!(outcome.family(), NativeSnapshotArtifactFamily::V2);
+        let (candidate, _) = load_native_snapshot_artifacts(&paths)
+            .expect("mutated UART pair should load")
+            .into_current_v2_candidate()
+            .expect("mutated UART pair should close as exact 2.7");
+        assert_eq!(candidate.serial().device().receive_bytes(), b"x");
         assert_eq!(
             events
                 .lock()
                 .expect("noncanonical UART events should lock")
                 .as_slice(),
-            ["aux-acquire", "v2-serial", "aux-drop"]
+            [
+                "aux-acquire",
+                "v2-serial",
+                "v2-pause",
+                "v2-storage-normalize",
+                "v2-storage-transport",
+                "v2-serial-platform",
+                "v2-serial-compose",
+                "v2-serial-encode",
+                "v2-recover",
+                "v2-published",
+                "aux-drop",
+            ]
         );
         assert_eq!(supervisor.status(), BootRunLoopWorkerStatus::Paused);
-        assert!(!paths.state().exists());
-        assert!(!paths.memory().exists());
+        assert!(paths.state().exists());
+        assert!(paths.memory().exists());
         directory.assert_no_staging();
 
         drop(supervisor);

--- a/crates/bangbang/tests/app_sandbox_process_e2e.rs
+++ b/crates/bangbang/tests/app_sandbox_process_e2e.rs
@@ -104,7 +104,7 @@ fn sandboxed_bundle_reports_current_native_v2_snapshot_version() {
         output.stdout,
         output.stderr
     );
-    assert_eq!(output.stdout.trim(), "v2.6.0");
+    assert_eq!(output.stdout.trim(), "v2.7.0");
     assert_eq!(output.stderr, "");
 }
 

--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -26,13 +26,11 @@ mod macos_arm64 {
     use std::process::{Command, Stdio};
     use std::time::{Duration, Instant};
 
-    use bangbang_hvf::decode_hvf_snapshot_v2_storage_state;
+    use bangbang_hvf::decode_hvf_snapshot_v2_serial_state;
     use bangbang_runtime::block::{DriveCacheType, DriveIoEngine};
     use bangbang_runtime::snapshot_device_v2::SnapshotV2DeviceTransportKind;
-    use bangbang_runtime::snapshot_device_v2_6::{
-        NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2StorageDeviceGraph,
-    };
-    use bangbang_runtime::snapshot_format_v2::decode_snapshot_v2_state_with_compatibility_version;
+    use bangbang_runtime::snapshot_device_v2_6::SnapshotV2StorageDeviceGraph;
+    use bangbang_runtime::snapshot_format_v2::decode_snapshot_v2_state;
     use bangbang_runtime::storage_capture::StorageRetryState;
 
     use crate::macos_virtual_block::{
@@ -1991,10 +1989,11 @@ mod macos_arm64 {
         assert!(!paused_stdout.contains(GUEST_SERIAL_RX_SUCCESS_MARKER));
         assert!(!paused_stdout.contains(GUEST_SERIAL_RX_FAILURE_MARKER));
 
-        assert_capture_ready_snapshot_rejected_without_artifacts(
+        assert_capture_ready_snapshot_succeeds(
             &socket_path,
             test_dir.path(),
             "paused serial stdio capture preflight",
+            false,
         );
         let captured_stdout = bangbang.stdout_snapshot();
         assert!(!captured_stdout.contains(GUEST_SERIAL_RX_SUCCESS_MARKER));
@@ -6737,10 +6736,11 @@ mod macos_arm64 {
             !reused_config.contains(path_text(&second_backing_path)),
             "same-ID replacement must remove the intermediate backing projection: {reused_config}"
         );
-        assert_capture_ready_snapshot_rejected_without_artifacts(
+        assert_capture_ready_snapshot_succeeds(
             &socket_path,
             test_dir.path(),
             "paused dynamic PCI Async storage preflight",
+            true,
         );
         write_block_marker_at(
             &control_backing_path,
@@ -7776,10 +7776,11 @@ mod macos_arm64 {
             path_text(&second_backing_path),
             "GET /vm/config after pmem reuse",
         );
-        assert_capture_ready_snapshot_rejected_without_artifacts(
+        assert_capture_ready_snapshot_succeeds(
             &socket_path,
             test_dir.path(),
             "paused dynamic PCI pmem storage preflight",
+            true,
         );
         write_block_marker_at(
             &control_backing_path,
@@ -7999,10 +8000,11 @@ mod macos_arm64 {
             &http_json(&socket_path, "PATCH", "/vm", r#"{"state":"Paused"}"#),
             "pause before direct pmem storage preflight",
         );
-        assert_capture_ready_snapshot_rejected_without_artifacts(
+        assert_capture_ready_snapshot_succeeds(
             &socket_path,
             test_dir.path(),
             "paused direct pmem storage preflight",
+            true,
         );
         assert_no_content_response(
             &http_json(&socket_path, "PATCH", "/vm", r#"{"state":"Resumed"}"#),
@@ -11178,7 +11180,7 @@ mod macos_arm64 {
             "native-v2 description should succeed; stderr:\n{}",
             described.stderr
         );
-        assert_eq!(described.stdout.trim(), "v2.6.0");
+        assert_eq!(described.stdout.trim(), "v2.7.0");
 
         let collision = http_json_with_io_timeout(
             &source_socket,
@@ -11701,7 +11703,7 @@ mod macos_arm64 {
             "{transport} native-v2 root description should succeed; stderr:\n{}",
             described.stderr
         );
-        assert_eq!(described.stdout.trim(), "v2.6.0");
+        assert_eq!(described.stdout.trim(), "v2.7.0");
         let source_output = source.terminate();
         assert_clean_shutdown(
             source_output,
@@ -12813,14 +12815,12 @@ mod macos_arm64 {
                 state_path.display()
             )
         });
-        let structural = decode_snapshot_v2_state_with_compatibility_version(
-            &bytes,
-            NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
-        )
-        .expect("native-v2 state should decode structurally");
-        decode_hvf_snapshot_v2_storage_state(&structural)
+        let structural =
+            decode_snapshot_v2_state(&bytes).expect("native-v2 state should decode structurally");
+        decode_hvf_snapshot_v2_serial_state(&structural)
             .expect("native-v2 state should decode semantically")
             .device_graph()
+            .expect("storage-bearing native-v2 state should contain a device graph")
             .clone()
     }
 
@@ -13067,6 +13067,42 @@ mod macos_arm64 {
             context,
             "Snapshot and restore are not supported.",
         );
+    }
+
+    fn assert_capture_ready_snapshot_succeeds(
+        socket_path: &Path,
+        directory: &Path,
+        context: &str,
+        expect_storage: bool,
+    ) {
+        let state_path = directory.join("capture-ready.state");
+        let memory_path = directory.join("capture-ready.memory");
+        let response = http_json_with_io_timeout(
+            socket_path,
+            "PUT",
+            "/snapshot/create",
+            &format!(
+                r#"{{"snapshot_type":"Full","snapshot_path":{},"mem_file_path":{}}}"#,
+                json_string(path_text(&state_path)),
+                json_string(path_text(&memory_path))
+            ),
+            GUEST_EXECUTION_TIMEOUT,
+        );
+
+        assert_no_content_response(&response, context);
+        assert!(state_path.is_file(), "{context} state should exist");
+        assert!(memory_path.is_file(), "{context} memory should exist");
+        let bytes = fs::read(&state_path).expect("capture-ready state should read");
+        let structural =
+            decode_snapshot_v2_state(&bytes).expect("capture-ready state should be exact current");
+        let serial = decode_hvf_snapshot_v2_serial_state(&structural)
+            .expect("capture-ready state should use the exact-2.7 serial profile");
+        assert_eq!(
+            serial.device_graph().is_some(),
+            expect_storage,
+            "{context} storage profile presence should match"
+        );
+        assert_no_snapshot_staging(directory);
     }
 
     fn assert_snapshot_rejected_without_artifacts(

--- a/crates/hvf/src/snapshot_v2/tests.rs
+++ b/crates/hvf/src/snapshot_v2/tests.rs
@@ -994,19 +994,8 @@ fn internal_exact_minor_seven_serial_only_mmio_and_pci_states_round_trip() {
         let original = complete_serial_state_fixture(graph_hex, serial_hex);
         let encoded = encode_hvf_snapshot_v2_serial_state(&original)
             .expect("complete minor-seven serial state should encode");
-        assert!(matches!(
-            decode_snapshot_v2_state(&encoded),
-            Err(SnapshotV2DecodeError::UnsupportedVersion {
-                found,
-                supported,
-            }) if found == NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION
-                && supported == NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION
-        ));
-        let structural = decode_snapshot_v2_state_with_compatibility_version(
-            &encoded,
-            NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION,
-        )
-        .expect("minor-seven serial state should decode structurally");
+        let structural =
+            decode_snapshot_v2_state(&encoded).expect("current minor-seven state should decode");
         assert_eq!(
             structural.metadata().version(),
             NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -1468,7 +1468,7 @@ fn run_native_v2_snapshot_grant_case(bundle: &Path, enable_pci: bool) {
     assert_output_success(&describe_output, "granted snapshot description");
     assert_eq!(
         String::from_utf8_lossy(&describe_output.stdout).trim(),
-        "v2.6.0"
+        "v2.7.0"
     );
     assert_snapshot_output_redacted(&describe_output, &describe.sensitive_strings());
 

--- a/crates/runtime/src/pmem.rs
+++ b/crates/runtime/src/pmem.rs
@@ -3898,6 +3898,9 @@ impl PreparedPmemDevice {
             self.guest_range.start().raw_value(),
             self.guest_range.size(),
         );
+        // The rate limiter is live-mutable after this immutable mapping owner
+        // is prepared. Snapshot graph capture validates the controller value
+        // against the live device state; it is not part of backing identity.
         if self.id != config.id()
             || self.backing.is_read_only() != config.read_only()
             || self.mapping.is_read_only() != config.read_only()
@@ -3910,7 +3913,6 @@ impl PreparedPmemDevice {
                 .validate_alignment(VIRTIO_PMEM_ALIGNMENT)
                 .is_err()
             || self.config_space != expected_config_space
-            || self.rate_limiter != config.rate_limiter()
         {
             return Err(PmemSnapshotPersistenceError::ConfigurationMismatch);
         }
@@ -7663,10 +7665,19 @@ mod tests {
             config_space: VirtioPmemConfigSpace::new(range.start().raw_value(), range.size()),
             rate_limiter: config.rate_limiter(),
         };
+        let updated_config = config.updated(
+            &PmemUpdateInput::new(config.id(), config.id())
+                .with_rate_limiter(PmemRateLimiterConfig::new(
+                    None,
+                    Some(PmemTokenBucketConfig::new(2, Some(1), 100)),
+                ))
+                .validate()
+                .expect("live rate-limiter update should validate"),
+        );
 
         let binding = prepared
-            .snapshot_persistence_binding(&config)
-            .expect("writable pmem binding should validate");
+            .snapshot_persistence_binding(&updated_config)
+            .expect("writable pmem binding should survive live rate-limiter updates");
         assert!(!binding.is_read_only());
         assert_eq!(binding.file_len(), 4);
         assert_eq!(binding.mapped_len(), VIRTIO_PMEM_ALIGNMENT);

--- a/crates/runtime/src/snapshot_artifact.rs
+++ b/crates/runtime/src/snapshot_artifact.rs
@@ -36,8 +36,8 @@ use crate::snapshot_format::{
 };
 use crate::snapshot_format_v2::{
     NATIVE_V2_DEVICE_GRAPH_COMPONENT_KEY, NATIVE_V2_LEGACY_PLATFORM_VERSION,
-    NATIVE_V2_SNAPSHOT_VERSION, SnapshotV2ComponentDisposition, SnapshotV2DecodeError,
-    decode_snapshot_v2_state_with_compatibility_version,
+    NATIVE_V2_SERIAL_COMPONENT_KEY, NATIVE_V2_SNAPSHOT_VERSION, SnapshotV2ComponentDisposition,
+    SnapshotV2DecodeError, decode_snapshot_v2_state_with_compatibility_version,
 };
 #[cfg(target_os = "macos")]
 use crate::snapshot_format_v2::{NATIVE_V2_SNAPSHOT_MAX_FILE_BYTES, decode_snapshot_v2_state};
@@ -53,6 +53,10 @@ use crate::snapshot_memory_v2::{
 #[cfg(target_os = "macos")]
 use crate::snapshot_memory_v2::{
     load_snapshot_v2_memory_file, verify_snapshot_v2_memory_image_output,
+};
+use crate::snapshot_serial_v2_7::{
+    NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION, SnapshotV2SerialState,
+    SnapshotV2SerialStateDecodeError,
 };
 
 const REDACTED: &str = "<redacted>";
@@ -86,6 +90,8 @@ pub enum NativeV2SnapshotArtifactProfile {
     MultiBlockDeviceGraphV2_5,
     /// Exact 2.6 block-and-pmem storage graph profile 3.
     StorageDeviceGraphV2_6,
+    /// Exact 2.7 serial profile with optional unchanged profile-3 storage.
+    SerialStateV2_7,
 }
 
 /// Validation failure for one owned native snapshot artifact state.
@@ -190,8 +196,8 @@ impl NativeSnapshotArtifactState {
 
     /// Validates exact current-version native-v2 bytes for publication.
     pub fn from_current_v2(bytes: Vec<u8>) -> Result<Self, NativeSnapshotArtifactStateError> {
-        NativeV2StorageSnapshotCandidateState::from_storage_device_graph_v2_6(bytes)
-            .map(NativeV2StorageSnapshotCandidateState::into_current_artifact_state)
+        NativeV2SerialSnapshotCandidateState::from_serial_state_v2_7(bytes)
+            .map(NativeV2SerialSnapshotCandidateState::into_current_artifact_state)
             .map_err(NativeSnapshotArtifactStateError::CurrentV2Profile)
     }
 
@@ -323,7 +329,7 @@ impl NativeSnapshotArtifactState {
         };
         if *version == NATIVE_V2_SNAPSHOT_VERSION && binding.version() == NATIVE_V2_SNAPSHOT_VERSION
         {
-            let (actual_binding, _) = decode_storage_device_graph_v2_6(bytes)
+            let (actual_binding, _, _) = decode_serial_state_v2_7(bytes)
                 .map_err(NativeSnapshotArtifactStateError::CurrentV2Profile)?;
             if &actual_binding == binding {
                 Ok(())
@@ -551,8 +557,8 @@ impl NativeV2StorageSnapshotCandidateState {
         (self.bytes, self.binding, self.device_graph)
     }
 
-    /// Consumes this exact current candidate into artifact authority.
-    pub fn into_current_artifact_state(self) -> NativeSnapshotArtifactState {
+    /// Consumes this exact 2.6 candidate into compatible artifact authority.
+    pub fn into_compatible_artifact_state(self) -> NativeSnapshotArtifactState {
         let (bytes, binding, _) = self.into_parts();
         NativeSnapshotArtifactState {
             inner: NativeSnapshotArtifactStateInner::V2 {
@@ -572,6 +578,96 @@ impl fmt::Debug for NativeV2StorageSnapshotCandidateState {
             .field("state", &REDACTED)
             .field("memory_binding", &REDACTED)
             .field("device_graph", &REDACTED)
+            .finish()
+    }
+}
+
+/// One closed exact native-v2 2.7 serial candidate.
+///
+/// The required serial singleton and optional unchanged profile-3 storage
+/// graph are derived from the same immutable bytes as the retained memory
+/// commitment. This is the only native-v2 candidate that can enter the
+/// current publication authority.
+pub struct NativeV2SerialSnapshotCandidateState {
+    bytes: Vec<u8>,
+    binding: SnapshotV2MemoryBinding,
+    device_graph: Option<SnapshotV2StorageDeviceGraph>,
+    serial: SnapshotV2SerialState,
+}
+
+impl NativeV2SerialSnapshotCandidateState {
+    /// Validates and retains one exact serial-bearing native-v2 2.7 state.
+    pub fn from_serial_state_v2_7(
+        bytes: Vec<u8>,
+    ) -> Result<Self, NativeV2SnapshotCandidateStateError> {
+        let (binding, device_graph, serial) = decode_serial_state_v2_7(&bytes)?;
+        Ok(Self {
+            bytes,
+            binding,
+            device_graph,
+            serial,
+        })
+    }
+
+    /// Returns the exact current compatibility version.
+    pub const fn version(&self) -> SnapshotFormatVersion {
+        NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION
+    }
+
+    /// Returns the immutable encoded state bytes.
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Returns the memory commitment derived from the encoded state.
+    pub const fn memory_binding(&self) -> &SnapshotV2MemoryBinding {
+        &self.binding
+    }
+
+    /// Returns the optional unchanged profile-3 storage graph.
+    pub const fn device_graph(&self) -> Option<&SnapshotV2StorageDeviceGraph> {
+        self.device_graph.as_ref()
+    }
+
+    /// Returns the required complete serial state.
+    pub const fn serial(&self) -> &SnapshotV2SerialState {
+        &self.serial
+    }
+
+    /// Consumes the closed candidate into its exact committed components.
+    pub fn into_parts(
+        self,
+    ) -> (
+        Vec<u8>,
+        SnapshotV2MemoryBinding,
+        Option<SnapshotV2StorageDeviceGraph>,
+        SnapshotV2SerialState,
+    ) {
+        (self.bytes, self.binding, self.device_graph, self.serial)
+    }
+
+    /// Consumes this exact current candidate into artifact authority.
+    pub fn into_current_artifact_state(self) -> NativeSnapshotArtifactState {
+        let (bytes, binding, _, _) = self.into_parts();
+        NativeSnapshotArtifactState {
+            inner: NativeSnapshotArtifactStateInner::V2 {
+                bytes,
+                version: NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION,
+                binding,
+            },
+        }
+    }
+}
+
+impl fmt::Debug for NativeV2SerialSnapshotCandidateState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("NativeV2SerialSnapshotCandidateState")
+            .field("version", &self.version())
+            .field("has_storage", &self.device_graph.is_some())
+            .field("state", &REDACTED)
+            .field("memory_binding", &REDACTED)
+            .field("serial", &REDACTED)
             .finish()
     }
 }
@@ -675,15 +771,80 @@ fn decode_storage_device_graph_v2_6(
     Ok((binding, device_graph))
 }
 
+fn decode_serial_state_v2_7(
+    bytes: &[u8],
+) -> Result<
+    (
+        SnapshotV2MemoryBinding,
+        Option<SnapshotV2StorageDeviceGraph>,
+        SnapshotV2SerialState,
+    ),
+    NativeV2SnapshotCandidateStateError,
+> {
+    let state = decode_snapshot_v2_state_with_compatibility_version(
+        bytes,
+        NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION,
+    )
+    .map_err(NativeV2SnapshotCandidateStateError::Format)?;
+    let version = state.metadata().version();
+    if version != NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION {
+        return Err(NativeV2SnapshotCandidateStateError::UnexpectedVersion { found: version });
+    }
+    let binding = decode_snapshot_v2_memory_binding(&state)
+        .map_err(NativeV2SnapshotCandidateStateError::Memory)?;
+    if binding.version() != version {
+        return Err(NativeV2SnapshotCandidateStateError::VersionMismatch {
+            state: version,
+            memory: binding.version(),
+        });
+    }
+
+    let mut graph_components = state
+        .components()
+        .filter(|component| component.key().kind() == NATIVE_V2_DEVICE_GRAPH_COMPONENT_KEY.kind());
+    let graph = graph_components.next();
+    if graph_components.next().is_some()
+        || graph.is_some_and(|component| {
+            component.key() != NATIVE_V2_DEVICE_GRAPH_COMPONENT_KEY
+                || component.disposition() != SnapshotV2ComponentDisposition::Semantic
+        })
+    {
+        return Err(NativeV2SnapshotCandidateStateError::InvalidDeviceGraphComponent);
+    }
+    let device_graph = graph
+        .map(|component| {
+            SnapshotV2StorageDeviceGraph::decode(
+                NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                component.payload(),
+            )
+            .map_err(NativeV2SnapshotCandidateStateError::StorageDeviceGraph)
+        })
+        .transpose()?;
+
+    let mut serial_components = state
+        .components()
+        .filter(|component| component.key().kind() == NATIVE_V2_SERIAL_COMPONENT_KEY.kind());
+    let serial = serial_components
+        .next()
+        .ok_or(NativeV2SnapshotCandidateStateError::MissingSerialState)?;
+    if serial_components.next().is_some()
+        || serial.key() != NATIVE_V2_SERIAL_COMPONENT_KEY
+        || serial.disposition() != SnapshotV2ComponentDisposition::Semantic
+    {
+        return Err(NativeV2SnapshotCandidateStateError::InvalidSerialComponent);
+    }
+    let serial = SnapshotV2SerialState::decode(version, serial.payload())
+        .map_err(NativeV2SnapshotCandidateStateError::SerialState)?;
+    Ok((binding, device_graph, serial))
+}
+
 fn classify_native_v2_profile(
     bytes: &[u8],
     expected_binding: &SnapshotV2MemoryBinding,
 ) -> Result<NativeV2SnapshotArtifactProfile, NativeV2SnapshotCandidateStateError> {
-    let state = decode_snapshot_v2_state_with_compatibility_version(
-        bytes,
-        NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
-    )
-    .map_err(NativeV2SnapshotCandidateStateError::Format)?;
+    let state =
+        decode_snapshot_v2_state_with_compatibility_version(bytes, NATIVE_V2_SNAPSHOT_VERSION)
+            .map_err(NativeV2SnapshotCandidateStateError::Format)?;
     let version = state.metadata().version();
     let binding = decode_snapshot_v2_memory_binding(&state)
         .map_err(NativeV2SnapshotCandidateStateError::Memory)?;
@@ -728,6 +889,30 @@ fn classify_native_v2_profile(
             SnapshotV2StorageDeviceGraph::decode(version, graph.payload())
                 .map_err(NativeV2SnapshotCandidateStateError::StorageDeviceGraph)?;
             Ok(NativeV2SnapshotArtifactProfile::StorageDeviceGraphV2_6)
+        }
+        NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION => {
+            if let Some(graph) = graph {
+                SnapshotV2StorageDeviceGraph::decode(
+                    NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+                    graph.payload(),
+                )
+                .map_err(NativeV2SnapshotCandidateStateError::StorageDeviceGraph)?;
+            }
+            let mut serial_components = state.components().filter(|component| {
+                component.key().kind() == NATIVE_V2_SERIAL_COMPONENT_KEY.kind()
+            });
+            let serial = serial_components
+                .next()
+                .ok_or(NativeV2SnapshotCandidateStateError::MissingSerialState)?;
+            if serial_components.next().is_some()
+                || serial.key() != NATIVE_V2_SERIAL_COMPONENT_KEY
+                || serial.disposition() != SnapshotV2ComponentDisposition::Semantic
+            {
+                return Err(NativeV2SnapshotCandidateStateError::InvalidSerialComponent);
+            }
+            SnapshotV2SerialState::decode(version, serial.payload())
+                .map_err(NativeV2SnapshotCandidateStateError::SerialState)?;
+            Ok(NativeV2SnapshotArtifactProfile::SerialStateV2_7)
         }
         _ => Err(NativeV2SnapshotCandidateStateError::UnexpectedVersion { found: version }),
     }
@@ -774,6 +959,12 @@ pub enum NativeV2SnapshotCandidateStateError {
     MultiBlockDeviceGraph(SnapshotV2MultiBlockDeviceGraphDecodeError),
     /// The required block-and-pmem storage-graph payload is invalid.
     StorageDeviceGraph(SnapshotV2StorageDeviceGraphDecodeError),
+    /// The exact-2.7 state omits its required serial singleton.
+    MissingSerialState,
+    /// The required serial state is not one semantic singleton component.
+    InvalidSerialComponent,
+    /// The required serial-state payload is invalid.
+    SerialState(SnapshotV2SerialStateDecodeError),
 }
 
 impl fmt::Display for NativeV2SnapshotCandidateStateError {
@@ -818,6 +1009,18 @@ impl fmt::Display for NativeV2SnapshotCandidateStateError {
                     "invalid native-v2 candidate storage device graph: {source}"
                 )
             }
+            Self::MissingSerialState => {
+                formatter.write_str("native-v2 candidate serial state is missing")
+            }
+            Self::InvalidSerialComponent => {
+                formatter.write_str("native-v2 candidate serial component is invalid")
+            }
+            Self::SerialState(source) => {
+                write!(
+                    formatter,
+                    "invalid native-v2 candidate serial state: {source}"
+                )
+            }
         }
     }
 }
@@ -830,10 +1033,13 @@ impl std::error::Error for NativeV2SnapshotCandidateStateError {
             Self::DeviceGraph(source) => Some(source),
             Self::MultiBlockDeviceGraph(source) => Some(source),
             Self::StorageDeviceGraph(source) => Some(source),
+            Self::SerialState(source) => Some(source),
             Self::UnexpectedVersion { .. }
             | Self::VersionMismatch { .. }
             | Self::MissingDeviceGraph
-            | Self::InvalidDeviceGraphComponent => None,
+            | Self::InvalidDeviceGraphComponent
+            | Self::MissingSerialState
+            | Self::InvalidSerialComponent => None,
         }
     }
 }
@@ -1778,11 +1984,11 @@ impl LoadedNativeSnapshotArtifacts {
         Ok((candidate, memory))
     }
 
-    /// Consumes one exact current 2.6 pair into the storage load handoff.
+    /// Consumes one exact compatible 2.6 pair into the storage load handoff.
     ///
     /// The state bytes are neither reopened nor re-encoded, and the already
     /// loaded guest memory remains bound to the candidate derived from them.
-    pub fn into_current_v2_candidate(
+    pub fn into_v2_6_candidate(
         self,
     ) -> Result<
         (NativeV2StorageSnapshotCandidateState, GuestMemory),
@@ -1799,6 +2005,28 @@ impl LoadedNativeSnapshotArtifacts {
         let candidate =
             NativeV2StorageSnapshotCandidateState::from_storage_device_graph_v2_6(bytes)
                 .map_err(NativeSnapshotArtifactStateError::CurrentV2Profile)?;
+        debug_assert_eq!(candidate.memory_binding(), &binding);
+        Ok((candidate, memory))
+    }
+
+    /// Consumes one exact current 2.7 pair into the serial load handoff.
+    ///
+    /// The state bytes are neither reopened nor re-encoded, and the already
+    /// loaded guest memory remains bound to the candidate derived from them.
+    pub fn into_current_v2_candidate(
+        self,
+    ) -> Result<(NativeV2SerialSnapshotCandidateState, GuestMemory), NativeSnapshotArtifactStateError>
+    {
+        let actual = self.family();
+        let (state, memory) = self.into_parts();
+        let (bytes, binding) = state.into_v2_parts().map_err(|_| {
+            NativeSnapshotArtifactStateError::UnexpectedFamily {
+                expected: NativeSnapshotArtifactFamily::V2,
+                actual,
+            }
+        })?;
+        let candidate = NativeV2SerialSnapshotCandidateState::from_serial_state_v2_7(bytes)
+            .map_err(NativeSnapshotArtifactStateError::CurrentV2Profile)?;
         debug_assert_eq!(candidate.memory_binding(), &binding);
         Ok((candidate, memory))
     }

--- a/crates/runtime/src/snapshot_artifact/tests.rs
+++ b/crates/runtime/src/snapshot_artifact/tests.rs
@@ -5,6 +5,8 @@ use crate::memory::{
     GuestMemoryRegionBacking, aarch64,
 };
 #[cfg(target_os = "macos")]
+use crate::serial::{CaptureReadySerialState, SerialConfig, SerialMmioDevice};
+#[cfg(target_os = "macos")]
 use crate::snapshot_device_v2::{
     NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2DeviceTransportKind,
 };
@@ -12,13 +14,16 @@ use crate::snapshot_device_v2::{
 use crate::snapshot_device_v2_6::NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION;
 #[cfg(target_os = "macos")]
 use crate::snapshot_format_v2::{
-    NATIVE_V2_DEVICE_GRAPH_COMPONENT_KEY, NATIVE_V2_MEMORY_COMPONENT_KEY, SnapshotV2Component,
-    SnapshotV2ComponentDisposition, encode_snapshot_v2_state_with_compatibility_version,
+    NATIVE_V2_DEVICE_GRAPH_COMPONENT_KEY, NATIVE_V2_MEMORY_COMPONENT_KEY,
+    NATIVE_V2_SERIAL_COMPONENT_KEY, SnapshotV2Component, SnapshotV2ComponentDisposition,
+    SnapshotV2ComponentKey, encode_snapshot_v2_state_with_compatibility_version,
 };
 #[cfg(target_os = "macos")]
 use crate::snapshot_memory_v2::{
     write_snapshot_v2_memory_image, write_snapshot_v2_memory_image_with_compatibility_version,
 };
+#[cfg(target_os = "macos")]
+use crate::snapshot_serial_v2_7::SnapshotV2SerialState;
 
 #[cfg(target_os = "macos")]
 use std::fs;
@@ -122,8 +127,8 @@ fn closed_native_state_derives_v2_binding_and_redacts_owned_bytes() {
     assert_eq!(
         state
             .v2_profile()
-            .expect("current state should classify as exact profile 3"),
-        NativeV2SnapshotArtifactProfile::StorageDeviceGraphV2_6
+            .expect("current state should classify as exact serial profile"),
+        NativeV2SnapshotArtifactProfile::SerialStateV2_7
     );
     assert!(state.v1_record().is_none());
     let debug = format!("{state:?}");
@@ -247,7 +252,7 @@ fn closed_native_state_derives_v2_binding_and_redacts_owned_bytes() {
 
 #[cfg(target_os = "macos")]
 #[test]
-fn current_v2_artifact_boundary_rejects_graphless_minor_five() {
+fn current_v2_artifact_boundary_rejects_missing_serial_state() {
     let memory = test_v2_memory();
     let mut image = Cursor::new(Vec::new());
     let binding = write_snapshot_v2_memory_image_with_compatibility_version(
@@ -255,10 +260,10 @@ fn current_v2_artifact_boundary_rejects_graphless_minor_five() {
         &mut image,
         NATIVE_V2_SNAPSHOT_VERSION,
     )
-    .expect("graphless minor-five memory should encode internally");
+    .expect("graphless current memory should encode internally");
     let binding_payload = binding
         .encode()
-        .expect("graphless minor-five binding should encode");
+        .expect("graphless current binding should encode");
     let memory_component = SnapshotV2Component::new(
         NATIVE_V2_MEMORY_COMPONENT_KEY,
         SnapshotV2ComponentDisposition::Semantic,
@@ -269,19 +274,87 @@ fn current_v2_artifact_boundary_rejects_graphless_minor_five() {
         &[],
         &[memory_component],
     )
-    .expect("graphless minor-five state should encode internally");
+    .expect("graphless current state should encode internally");
 
     assert!(matches!(
         NativeSnapshotArtifactState::from_current_v2(bytes),
         Err(NativeSnapshotArtifactStateError::CurrentV2Profile(
-            NativeV2SnapshotCandidateStateError::MissingDeviceGraph
+            NativeV2SnapshotCandidateStateError::MissingSerialState
         ))
     ));
 }
 
 #[cfg(target_os = "macos")]
 #[test]
-fn current_v2_artifact_boundary_accepts_exact_minor_six_storage() {
+fn current_v2_artifact_boundary_rejects_duplicate_and_nonsemantic_serial_state() {
+    let memory = test_v2_memory();
+    let mut image = Cursor::new(Vec::new());
+    let binding = write_snapshot_v2_memory_image_with_compatibility_version(
+        &memory,
+        &mut image,
+        NATIVE_V2_SNAPSHOT_VERSION,
+    )
+    .expect("current memory should encode internally");
+    let binding_payload = binding.encode().expect("current binding should encode");
+    let serial_device = SerialMmioDevice::discarding()
+        .capture_state()
+        .expect("serial fixture should capture");
+    let serial_payload = SnapshotV2SerialState::try_from_capture_ready(
+        CaptureReadySerialState::new(SerialConfig::default(), serial_device),
+    )
+    .expect("serial fixture should normalize")
+    .encode(NATIVE_V2_SNAPSHOT_VERSION)
+    .expect("serial fixture should encode");
+    let memory_component = SnapshotV2Component::new(
+        NATIVE_V2_MEMORY_COMPONENT_KEY,
+        SnapshotV2ComponentDisposition::Semantic,
+        &binding_payload,
+    );
+    let serial = SnapshotV2Component::new(
+        NATIVE_V2_SERIAL_COMPONENT_KEY,
+        SnapshotV2ComponentDisposition::Semantic,
+        &serial_payload,
+    );
+    let duplicate_serial = SnapshotV2Component::new(
+        SnapshotV2ComponentKey::new(NATIVE_V2_SERIAL_COMPONENT_KEY.kind(), 1),
+        SnapshotV2ComponentDisposition::Semantic,
+        &serial_payload,
+    );
+    let duplicate = encode_snapshot_v2_state_with_compatibility_version(
+        NATIVE_V2_SNAPSHOT_VERSION,
+        &[],
+        &[memory_component, serial, duplicate_serial],
+    )
+    .expect("structural encoder should retain duplicate serial-kind fixture");
+    assert!(matches!(
+        NativeSnapshotArtifactState::from_current_v2(duplicate),
+        Err(NativeSnapshotArtifactStateError::CurrentV2Profile(
+            NativeV2SnapshotCandidateStateError::InvalidSerialComponent
+        ))
+    ));
+
+    let nonsemantic_serial = SnapshotV2Component::new(
+        NATIVE_V2_SERIAL_COMPONENT_KEY,
+        SnapshotV2ComponentDisposition::NonSemantic,
+        &serial_payload,
+    );
+    let nonsemantic = encode_snapshot_v2_state_with_compatibility_version(
+        NATIVE_V2_SNAPSHOT_VERSION,
+        &[],
+        &[memory_component, nonsemantic_serial],
+    )
+    .expect("structural encoder should retain nonsemantic serial fixture");
+    assert!(matches!(
+        NativeSnapshotArtifactState::from_current_v2(nonsemantic),
+        Err(NativeSnapshotArtifactStateError::CurrentV2Profile(
+            NativeV2SnapshotCandidateStateError::InvalidSerialComponent
+        ))
+    ));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn compatible_v2_artifact_boundary_accepts_exact_minor_six_storage() {
     let memory = test_v2_memory();
     let mut image = Cursor::new(Vec::new());
     let binding = write_snapshot_v2_memory_image_with_compatibility_version(
@@ -315,8 +388,8 @@ fn current_v2_artifact_boundary_accepts_exact_minor_six_storage() {
     )
     .expect("internal minor-six state should encode explicitly");
 
-    let state = NativeSnapshotArtifactState::from_current_v2(bytes)
-        .expect("exact minor-six storage state should be current");
+    let state = NativeSnapshotArtifactState::from_compatible_bytes(bytes)
+        .expect("exact minor-six storage state should remain compatible");
     assert_eq!(
         state
             .v2_profile()
@@ -2622,6 +2695,15 @@ fn current_v2_state(binding: &SnapshotV2MemoryBinding) -> Result<Vec<u8>, String
     let graph_payload = fixture_bytes(include_str!(
         "../snapshot_device_v2_6/fixtures/block-root-mmio.hex"
     ));
+    let serial_device = SerialMmioDevice::discarding()
+        .capture_state()
+        .map_err(|source| source.to_string())?;
+    let serial_payload = SnapshotV2SerialState::try_from_capture_ready(
+        CaptureReadySerialState::new(SerialConfig::default(), serial_device),
+    )
+    .map_err(|source| source.to_string())?
+    .encode(NATIVE_V2_SNAPSHOT_VERSION)
+    .map_err(|source| source.to_string())?;
     let components = [
         SnapshotV2Component::new(
             NATIVE_V2_MEMORY_COMPONENT_KEY,
@@ -2632,6 +2714,11 @@ fn current_v2_state(binding: &SnapshotV2MemoryBinding) -> Result<Vec<u8>, String
             NATIVE_V2_DEVICE_GRAPH_COMPONENT_KEY,
             SnapshotV2ComponentDisposition::Semantic,
             &graph_payload,
+        ),
+        SnapshotV2Component::new(
+            NATIVE_V2_SERIAL_COMPONENT_KEY,
+            SnapshotV2ComponentDisposition::Semantic,
+            &serial_payload,
         ),
     ];
     encode_snapshot_v2_state_with_compatibility_version(

--- a/crates/runtime/src/snapshot_format_v2.rs
+++ b/crates/runtime/src/snapshot_format_v2.rs
@@ -41,7 +41,7 @@ pub const NATIVE_V2_SNAPSHOT_FOUNDATION_VERSION: SnapshotFormatVersion =
     SnapshotFormatVersion::new(2, 0, 0);
 
 /// Semantic version emitted by the current native-v2 writer.
-pub const NATIVE_V2_SNAPSHOT_VERSION: SnapshotFormatVersion = SnapshotFormatVersion::new(2, 6, 0);
+pub const NATIVE_V2_SNAPSHOT_VERSION: SnapshotFormatVersion = SnapshotFormatVersion::new(2, 7, 0);
 
 /// Newest compatibility version understood through an explicit internal seam.
 const NATIVE_V2_LATEST_KNOWN_COMPATIBILITY_VERSION: SnapshotFormatVersion =
@@ -60,18 +60,18 @@ const _: () = assert!(
         && NATIVE_V2_LEGACY_PLATFORM_VERSION.minor() < NATIVE_V2_SNAPSHOT_VERSION.minor()
 );
 const _: () = assert!(
-    NATIVE_V2_SNAPSHOT_VERSION.major()
-        == NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION.major()
-        && NATIVE_V2_SNAPSHOT_VERSION.minor()
-            == NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION.minor()
-        && NATIVE_V2_SNAPSHOT_VERSION.patch()
-            == NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION.patch()
+    NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION.major()
+        == NATIVE_V2_SNAPSHOT_VERSION.major()
+        && NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION.minor() + 1
+            == NATIVE_V2_SNAPSHOT_VERSION.minor()
+        && NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION.patch() == 0
 );
 const _: () = assert!(
     NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION.major() == NATIVE_V2_SNAPSHOT_VERSION.major()
         && NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION.minor()
-            == NATIVE_V2_SNAPSHOT_VERSION.minor() + 1
-        && NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION.patch() == 0
+            == NATIVE_V2_SNAPSHOT_VERSION.minor()
+        && NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION.patch()
+            == NATIVE_V2_SNAPSHOT_VERSION.patch()
 );
 
 /// Fixed native-v2 state header size.

--- a/crates/runtime/src/snapshot_format_v2/tests.rs
+++ b/crates/runtime/src/snapshot_format_v2/tests.rs
@@ -204,7 +204,7 @@ fn production_catalog_accepts_all_current_semantic_kinds_and_nonsemantic_extensi
 }
 
 #[test]
-fn device_graph_starts_at_four_serial_starts_at_seven_and_writer_stays_at_six() {
+fn device_graph_starts_at_four_and_writer_activates_serial_at_seven() {
     assert_eq!(NATIVE_V2_DEVICE_GRAPH_COMPONENT_KEY.kind(), 7);
     assert_eq!(NATIVE_V2_DEVICE_GRAPH_COMPONENT_KEY.instance(), 0);
     assert_eq!(
@@ -213,7 +213,11 @@ fn device_graph_starts_at_four_serial_starts_at_seven_and_writer_stays_at_six() 
     );
     assert_eq!(
         NATIVE_V2_SNAPSHOT_VERSION,
-        NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION
+        NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION
+    );
+    assert_eq!(
+        NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+        SnapshotFormatVersion::new(2, 6, 0)
     );
     assert_eq!(
         NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
@@ -263,7 +267,7 @@ fn device_graph_starts_at_four_serial_starts_at_seven_and_writer_stays_at_six() 
             .expect("current state should decode")
             .metadata()
             .version(),
-        NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION
+        NATIVE_V2_SNAPSHOT_VERSION
     );
 
     let downgraded = with_u16_field_and_checksum(&encoded, VERSION_MINOR_OFFSET, 3);
@@ -354,13 +358,16 @@ fn device_graph_starts_at_four_serial_starts_at_seven_and_writer_stays_at_six() 
         decoded_serial.component(NATIVE_V2_SERIAL_COMPONENT_KEY),
         Some(serial)
     );
-    assert!(matches!(
-        decode_snapshot_v2_state(&serial_state),
-        Err(SnapshotV2DecodeError::UnsupportedVersion {
-            found,
-            supported: NATIVE_V2_SNAPSHOT_VERSION,
-        }) if found == NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION
-    ));
+    let public_serial =
+        decode_snapshot_v2_state(&serial_state).expect("current public seam should decode 2.7");
+    assert_eq!(
+        public_serial.metadata().version(),
+        NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION
+    );
+    assert_eq!(
+        public_serial.component(NATIVE_V2_SERIAL_COMPONENT_KEY),
+        Some(serial)
+    );
 
     let downgraded_serial = with_u16_field_and_checksum(&serial_state, VERSION_MINOR_OFFSET, 6);
     assert_eq!(
@@ -444,11 +451,11 @@ fn version_policy_rejects_major_and_newer_minor_but_accepts_patch() {
         })
     );
 
-    let minor = with_u16_field(&EMPTY_V2_FIXTURE, VERSION_MINOR_OFFSET, 7);
+    let minor = with_u16_field(&EMPTY_V2_FIXTURE, VERSION_MINOR_OFFSET, 8);
     assert_eq!(
         decode_snapshot_v2_state(&minor),
         Err(SnapshotV2DecodeError::UnsupportedVersion {
-            found: SnapshotFormatVersion::new(2, 7, 0),
+            found: SnapshotFormatVersion::new(2, 8, 0),
             supported: NATIVE_V2_SNAPSHOT_VERSION,
         })
     );


### PR DESCRIPTION
## Summary

- advance the current bangbang-native writer, artifact classifier, CLI reporting, and public Full/File/COW lifecycle to exact 2.7 serial snapshots
- publish and restore serial-only or optional profile-3 storage state while preserving paused atomic commit, fresh endpoint ownership, diagnostics, recapture, and cleanup
- retain exact native-v1 and native-v2 2.3–2.6 compatibility, and fix pmem persistence preflight after live limiter updates

## Scope exclusions

- optional devices, MMDS, vhost-user, native-v2 Uffd, Diff, overrides/editing, Firecracker artifact interoperability, and broad documentation/certification remain unsupported or are owned by #1652

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- all five signed Apple-target Clippy commands documented in `AGENTS.md`
- `scripts/run-integration-tests.sh`

Closes #1651
Parent: #1535
