### PR TITLE
feat: reconstruct PCI entropy snapshot owners

### DIFF
--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -25,6 +25,7 @@ mod snapshot;
 mod snapshot_bundle;
 mod snapshot_restore;
 mod snapshot_v2;
+mod snapshot_v2_entropy_platform;
 mod snapshot_v2_multi_block_platform;
 mod snapshot_v2_platform;
 mod snapshot_v2_storage_platform;
@@ -150,6 +151,12 @@ pub use snapshot_v2::{
     encode_hvf_snapshot_v2_serial_state, encode_hvf_snapshot_v2_state,
     encode_hvf_snapshot_v2_storage_state,
 };
+pub use snapshot_v2_entropy_platform::{
+    HvfSnapshotV2EntropyPciEndpointPlan, HvfSnapshotV2StorageEntropyPciPlatformPlan,
+    PrepareHvfSnapshotV2EntropyPciPlatformPlanError,
+    prepare_hvf_snapshot_v2_serial_entropy_pci_platform_plan,
+    prepare_hvf_snapshot_v2_storage_entropy_pci_platform_plan,
+};
 pub use snapshot_v2_multi_block_platform::{
     HvfSnapshotV2MultiBlockMmioRecordPlan, HvfSnapshotV2MultiBlockPciPlan,
     HvfSnapshotV2MultiBlockPciRecordPlan, HvfSnapshotV2MultiBlockPlatformPlan,
@@ -216,21 +223,22 @@ pub use startup::{
     HvfArm64BootVsockNotificationDispatchError, HvfArm64BootVsockNotificationDispatches,
     HvfArm64BootVsockTransportState, HvfSnapshotV2EntropyMmioRestoreError,
     HvfSnapshotV2EntropyMmioRestoreFailure, HvfSnapshotV2EntropyMmioRestoreStage,
-    HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure, HvfSnapshotV2MultiBlockMmioRestoreError,
-    HvfSnapshotV2MultiBlockMmioRestoreFailure, HvfSnapshotV2MultiBlockMmioRestoreStage,
-    HvfSnapshotV2MultiBlockPciRestoreCleanupFailure, HvfSnapshotV2MultiBlockPciRestoreError,
-    HvfSnapshotV2MultiBlockPciRestoreFailure, HvfSnapshotV2MultiBlockPciRestoreStage,
-    HvfSnapshotV2RootRestoreCleanupFailure, HvfSnapshotV2RootRestoreError,
-    HvfSnapshotV2RootRestoreFailure, HvfSnapshotV2RootRestoreStage,
+    HvfSnapshotV2EntropyPciRestoreError, HvfSnapshotV2EntropyPciRestoreFailure,
+    HvfSnapshotV2EntropyPciRestoreStage, HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure,
+    HvfSnapshotV2MultiBlockMmioRestoreError, HvfSnapshotV2MultiBlockMmioRestoreFailure,
+    HvfSnapshotV2MultiBlockMmioRestoreStage, HvfSnapshotV2MultiBlockPciRestoreCleanupFailure,
+    HvfSnapshotV2MultiBlockPciRestoreError, HvfSnapshotV2MultiBlockPciRestoreFailure,
+    HvfSnapshotV2MultiBlockPciRestoreStage, HvfSnapshotV2RootRestoreCleanupFailure,
+    HvfSnapshotV2RootRestoreError, HvfSnapshotV2RootRestoreFailure, HvfSnapshotV2RootRestoreStage,
     HvfSnapshotV2SerialOnlyRestoreError, HvfSnapshotV2StorageMmioRestoreCleanupFailure,
     HvfSnapshotV2StorageMmioRestoreError, HvfSnapshotV2StorageMmioRestoreFailure,
     HvfSnapshotV2StorageMmioRestoreStage, HvfSnapshotV2StoragePciRestoreCleanupFailure,
     HvfSnapshotV2StoragePciRestoreError, HvfSnapshotV2StoragePciRestoreFailure,
     HvfSnapshotV2StoragePciRestoreStage, OwnedHvfArm64BootSession,
     PreparedHvfArm64BootPciNetworkRemoval, RestoredHvfArm64BootSession,
-    RestoredHvfSnapshotV2EntropyMmioOwners, RestoredHvfSnapshotV2MultiBlockMmioOwners,
-    RestoredHvfSnapshotV2MultiBlockPciOwners, RestoredHvfSnapshotV2StorageMmioOwners,
-    RestoredHvfSnapshotV2StoragePciOwners,
+    RestoredHvfSnapshotV2EntropyMmioOwners, RestoredHvfSnapshotV2EntropyPciOwners,
+    RestoredHvfSnapshotV2MultiBlockMmioOwners, RestoredHvfSnapshotV2MultiBlockPciOwners,
+    RestoredHvfSnapshotV2StorageMmioOwners, RestoredHvfSnapshotV2StoragePciOwners,
 };
 pub use topology::{
     HvfVcpuTopology, HvfVcpuTopologyAllocation, HvfVcpuTopologyCreateStage, HvfVcpuTopologyError,

--- a/crates/hvf/src/snapshot_v2_entropy_platform.rs
+++ b/crates/hvf/src/snapshot_v2_entropy_platform.rs
@@ -1,0 +1,921 @@
+//! Host-free exact native-v2 2.8 PCI entropy platform planning.
+
+use std::fmt;
+
+use bangbang_runtime::block::VIRTIO_BLOCK_QUEUE_SIZES;
+use bangbang_runtime::entropy::VIRTIO_RNG_QUEUE_SIZES;
+use bangbang_runtime::fdt::{ARM64_GICV2M_MSI_SET_SPI_NSR_OFFSET, Arm64FdtPciHost};
+use bangbang_runtime::memory::GuestMemoryRange;
+use bangbang_runtime::mmio::MmioRegionId;
+use bangbang_runtime::pci::{Arm64PciAddressPlan, PciSbdf};
+use bangbang_runtime::pmem::VIRTIO_PMEM_QUEUE_SIZES;
+use bangbang_runtime::rtc::RtcMmioLayout;
+use bangbang_runtime::snapshot_device_v2::{
+    SnapshotV2DeviceTransport, SnapshotV2DeviceTransportKind,
+};
+use bangbang_runtime::snapshot_device_v2_6::PreparedSnapshotV2StorageBundle;
+use bangbang_runtime::snapshot_entropy_v2_8::{
+    PreparedSnapshotV2EntropyTransport, SnapshotV2EntropyRestorePlan,
+};
+use bangbang_runtime::storage_capture::StorageDeviceOrigin;
+use bangbang_runtime::virtio_pci::{
+    VIRTIO_PCI_NO_VECTOR, VirtioPciEndpointPhase, VirtioPciMsixState,
+};
+
+use crate::snapshot_v2::HvfSnapshotV2PlatformState;
+use crate::snapshot_v2_multi_block_platform::{
+    snapshot_v2_pci_endpoint_placement, snapshot_v2_pci_endpoint_route_count,
+};
+use crate::snapshot_v2_platform::{PROCESS_RTC_MMIO_BASE, PROCESS_RTC_MMIO_REGION_ID};
+use crate::snapshot_v2_storage_platform::{
+    HvfSnapshotV2StoragePciPlatformPlan, PrepareHvfSnapshotV2StoragePciPlatformPlanError,
+    prepare_hvf_snapshot_v2_storage_pci_platform_plan_for_entropy,
+    queue_ranges_conflict_with_pci_platform, register_active_pci_routes,
+};
+use crate::startup::{
+    PCI_ENDPOINT_SLOT_COUNT, pci_entropy_restore_gic_msi_configuration,
+    pci_root_restore_gic_msi_configuration,
+};
+
+const REDACTED: &str = "<redacted>";
+
+/// Exact destination PCI placement reserved for restored entropy.
+#[doc(hidden)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct HvfSnapshotV2EntropyPciEndpointPlan {
+    preceding_endpoint_count: usize,
+    sbdf: PciSbdf,
+    bar_region_id: MmioRegionId,
+    bar_range: GuestMemoryRange,
+    route_count: usize,
+    msi_interrupt_count: u32,
+}
+
+impl HvfSnapshotV2EntropyPciEndpointPlan {
+    /// Returns how many storage endpoints must already be published.
+    pub const fn preceding_endpoint_count(self) -> usize {
+        self.preceding_endpoint_count
+    }
+
+    /// Returns the exact retained PCI function.
+    pub const fn sbdf(self) -> PciSbdf {
+        self.sbdf
+    }
+
+    /// Returns the exact dispatcher identity for the capability BAR.
+    pub const fn bar_region_id(self) -> MmioRegionId {
+        self.bar_region_id
+    }
+
+    /// Returns the exact retained capability BAR.
+    pub const fn bar_range(self) -> GuestMemoryRange {
+        self.bar_range
+    }
+
+    /// Returns the configuration-plus-queue MSI-X route demand.
+    pub const fn route_count(self) -> usize {
+        self.route_count
+    }
+
+    pub(crate) const fn msi_interrupt_count(self) -> u32 {
+        self.msi_interrupt_count
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2EntropyPciEndpointPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2EntropyPciEndpointPlan")
+            .field("preceding_endpoint_count", &self.preceding_endpoint_count)
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// One combined exact-2.8 storage-then-entropy PCI proof.
+#[doc(hidden)]
+pub struct HvfSnapshotV2StorageEntropyPciPlatformPlan {
+    storage: HvfSnapshotV2StoragePciPlatformPlan,
+    entropy: HvfSnapshotV2EntropyPciEndpointPlan,
+}
+
+impl HvfSnapshotV2StorageEntropyPciPlatformPlan {
+    /// Returns the checked storage platform plan.
+    pub const fn storage(&self) -> &HvfSnapshotV2StoragePciPlatformPlan {
+        &self.storage
+    }
+
+    /// Returns the checked entropy endpoint plan.
+    pub const fn entropy(&self) -> HvfSnapshotV2EntropyPciEndpointPlan {
+        self.entropy
+    }
+
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        HvfSnapshotV2StoragePciPlatformPlan,
+        HvfSnapshotV2EntropyPciEndpointPlan,
+    ) {
+        (self.storage, self.entropy)
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2StorageEntropyPciPlatformPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2StorageEntropyPciPlatformPlan")
+            .field("storage_endpoint_count", &self.storage.pci().record_count())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Redacted rejection from exact-2.8 PCI entropy platform planning.
+#[doc(hidden)]
+pub enum PrepareHvfSnapshotV2EntropyPciPlatformPlanError {
+    /// The existing storage graph could not form its own canonical PCI plan.
+    Storage(PrepareHvfSnapshotV2StoragePciPlatformPlanError),
+    /// The entropy continuation does not select PCI.
+    TransportPolicy,
+    /// The entropy queue overlaps platform- or storage-owned memory.
+    QueueConflict,
+    /// A destination-only vector could not reserve its fallible inventory.
+    Allocation,
+    /// The combined storage-plus-entropy endpoint capacity is exhausted.
+    PciCapacity { count: usize, maximum: usize },
+    /// Retained placement, route, or destination resource state diverged.
+    ResourcePlan,
+}
+
+impl fmt::Debug for PrepareHvfSnapshotV2EntropyPciPlatformPlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let category = match self {
+            Self::Storage(_) => "storage",
+            Self::TransportPolicy => "transport-policy",
+            Self::QueueConflict => "queue-conflict",
+            Self::Allocation => "allocation",
+            Self::PciCapacity { .. } => "pci-capacity",
+            Self::ResourcePlan => "resource-plan",
+        };
+        formatter
+            .debug_struct("PrepareHvfSnapshotV2EntropyPciPlatformPlanError")
+            .field("category", &category)
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+impl fmt::Display for PrepareHvfSnapshotV2EntropyPciPlatformPlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Storage(_) => "native-v2 storage PCI platform planning failed",
+            Self::TransportPolicy => "native-v2 entropy PCI transport policy is inconsistent",
+            Self::QueueConflict => {
+                "native-v2 entropy queue overlaps platform- or storage-owned memory"
+            }
+            Self::Allocation => "native-v2 entropy PCI platform allocation failed",
+            Self::PciCapacity { .. } => {
+                "native-v2 storage-plus-entropy PCI endpoint capacity is exceeded"
+            }
+            Self::ResourcePlan => {
+                "native-v2 storage-plus-entropy PCI platform resources are inconsistent"
+            }
+        })
+    }
+}
+
+impl std::error::Error for PrepareHvfSnapshotV2EntropyPciPlatformPlanError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Storage(source) => Some(source),
+            Self::TransportPolicy
+            | Self::QueueConflict
+            | Self::Allocation
+            | Self::PciCapacity { .. }
+            | Self::ResourcePlan => None,
+        }
+    }
+}
+
+/// Proves one serial-plus-entropy PCI product before live HVF construction.
+#[doc(hidden)]
+pub fn prepare_hvf_snapshot_v2_serial_entropy_pci_platform_plan(
+    platform: &HvfSnapshotV2PlatformState,
+    entropy: &SnapshotV2EntropyRestorePlan,
+) -> Result<HvfSnapshotV2EntropyPciEndpointPlan, PrepareHvfSnapshotV2EntropyPciPlatformPlanError> {
+    prepare_entropy_pci_endpoint_plan(
+        platform,
+        None,
+        entropy,
+        0,
+        &mut SystemEntropyPciPlatformPlanReserve,
+    )
+}
+
+/// Proves one storage-then-entropy PCI product before live HVF construction.
+#[doc(hidden)]
+pub fn prepare_hvf_snapshot_v2_storage_entropy_pci_platform_plan(
+    platform: &HvfSnapshotV2PlatformState,
+    bundle: &PreparedSnapshotV2StorageBundle,
+    entropy: &SnapshotV2EntropyRestorePlan,
+) -> Result<
+    HvfSnapshotV2StorageEntropyPciPlatformPlan,
+    PrepareHvfSnapshotV2EntropyPciPlatformPlanError,
+> {
+    let storage = prepare_hvf_snapshot_v2_storage_pci_platform_plan_for_entropy(platform, bundle)
+        .map_err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::Storage)?;
+    let preceding_endpoint_count = storage.pci().record_count();
+    let entropy_plan = prepare_entropy_pci_endpoint_plan(
+        platform,
+        Some((bundle, &storage)),
+        entropy,
+        preceding_endpoint_count,
+        &mut SystemEntropyPciPlatformPlanReserve,
+    )?;
+    Ok(HvfSnapshotV2StorageEntropyPciPlatformPlan {
+        storage,
+        entropy: entropy_plan,
+    })
+}
+
+fn prepare_entropy_pci_endpoint_plan(
+    platform: &HvfSnapshotV2PlatformState,
+    storage: Option<(
+        &PreparedSnapshotV2StorageBundle,
+        &HvfSnapshotV2StoragePciPlatformPlan,
+    )>,
+    entropy: &SnapshotV2EntropyRestorePlan,
+    preceding_endpoint_count: usize,
+    reserve: &mut impl EntropyPciPlatformPlanReserve,
+) -> Result<HvfSnapshotV2EntropyPciEndpointPlan, PrepareHvfSnapshotV2EntropyPciPlatformPlanError> {
+    if !platform.machine().fdt().is_product_process_profile()
+        || platform.time().rtc_layout()
+            != RtcMmioLayout::new(PROCESS_RTC_MMIO_BASE, PROCESS_RTC_MMIO_REGION_ID)
+    {
+        return Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan);
+    }
+    if entropy.transport_kind() != SnapshotV2DeviceTransportKind::Pci {
+        return Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::TransportPolicy);
+    }
+    let PreparedSnapshotV2EntropyTransport::Pci(entropy_transport) = entropy.transport() else {
+        return Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::TransportPolicy);
+    };
+    let endpoint_count = preceding_endpoint_count
+        .checked_add(1)
+        .ok_or(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan)?;
+    if endpoint_count > PCI_ENDPOINT_SLOT_COUNT {
+        return Err(
+            PrepareHvfSnapshotV2EntropyPciPlatformPlanError::PciCapacity {
+                count: endpoint_count,
+                maximum: PCI_ENDPOINT_SLOT_COUNT,
+            },
+        );
+    }
+
+    let gic = platform.global().compatibility().gic_metadata();
+    let msi = gic
+        .msi
+        .ok_or(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan)?;
+    let expected_msi = pci_root_restore_gic_msi_configuration()
+        .map_err(|_| PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan)?;
+    let expected_entropy_msi = pci_entropy_restore_gic_msi_configuration()
+        .map_err(|_| PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan)?;
+    if msi.interrupt_range.count != expected_msi.interrupt_count().get()
+        && msi.interrupt_range.count != expected_entropy_msi.interrupt_count().get()
+    {
+        return Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan);
+    }
+    let address_plan = Arm64PciAddressPlan::firecracker_v1_16()
+        .map_err(|_| PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan)?;
+    let placement = snapshot_v2_pci_endpoint_placement(address_plan, preceding_endpoint_count)
+        .ok_or(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan)?;
+    let route_count = snapshot_v2_pci_endpoint_route_count(VIRTIO_RNG_QUEUE_SIZES.len())
+        .ok_or(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan)?;
+
+    if entropy_transport.origin() != StorageDeviceOrigin::Startup
+        || entropy_transport.sbdf() != placement.sbdf
+        || entropy_transport.bar_range() != placement.bar_range
+        || entropy_transport.retained().phase() != VirtioPciEndpointPhase::Active
+    {
+        return Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan);
+    }
+    if queue_ranges_conflict_with_pci_platform(platform, entropy.queue_ranges(), &gic, address_plan)
+        .map_err(|_| PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan)?
+    {
+        return Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::QueueConflict);
+    }
+
+    let storage_route_demand = storage.map_or(0, |(_, plan)| plan.pci().route_demand());
+    let combined_route_demand = storage_route_demand
+        .checked_add(route_count)
+        .ok_or(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan)?;
+    if combined_route_demand
+        > usize::try_from(msi.interrupt_range.count)
+            .map_err(|_| PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan)?
+    {
+        return Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan);
+    }
+
+    let mut active_routes = Vec::new();
+    reserve.reserve(&mut active_routes, combined_route_demand)?;
+    if let Some((bundle, storage_plan)) = storage {
+        if storage_plan.pci().host() != Arm64FdtPciHost::from_address_plan(address_plan)
+            || storage_plan.pci().msi() != msi
+            || !validate_storage_prefix(bundle, storage_plan, address_plan, &mut active_routes)
+        {
+            return Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan);
+        }
+        if entropy_queue_conflicts_with_storage(entropy.queue_ranges(), bundle) {
+            return Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::QueueConflict);
+        }
+    }
+    if !register_active_retained_routes(
+        entropy_transport.retained().msix_state(),
+        msi,
+        route_count,
+        &mut active_routes,
+    ) {
+        return Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan);
+    }
+
+    Ok(HvfSnapshotV2EntropyPciEndpointPlan {
+        preceding_endpoint_count,
+        sbdf: placement.sbdf,
+        bar_region_id: placement.bar_region_id,
+        bar_range: placement.bar_range,
+        route_count,
+        msi_interrupt_count: msi.interrupt_range.count,
+    })
+}
+
+fn validate_storage_prefix(
+    bundle: &PreparedSnapshotV2StorageBundle,
+    plan: &HvfSnapshotV2StoragePciPlatformPlan,
+    address_plan: Arm64PciAddressPlan,
+    active_routes: &mut Vec<(u64, u32)>,
+) -> bool {
+    let block_records = bundle
+        .block_bundle()
+        .map_or(&[][..], |block| block.records());
+    let pmem_records = bundle.pmem_records();
+    let block_route_count = snapshot_v2_pci_endpoint_route_count(VIRTIO_BLOCK_QUEUE_SIZES.len());
+    let pmem_route_count = snapshot_v2_pci_endpoint_route_count(VIRTIO_PMEM_QUEUE_SIZES.len());
+    if block_records.len() != plan.pci().block_records().len()
+        || pmem_records.len() != plan.pci().pmem_records().len()
+        || block_route_count.is_none()
+        || pmem_route_count.is_none()
+    {
+        return false;
+    }
+
+    block_records
+        .iter()
+        .map(|record| record.transport())
+        .zip(plan.pci().block_records())
+        .chain(
+            pmem_records
+                .iter()
+                .map(|record| record.transport())
+                .zip(plan.pci().pmem_records()),
+        )
+        .enumerate()
+        .all(|(index, (transport, planned))| {
+            let Some(placement) = snapshot_v2_pci_endpoint_placement(address_plan, index) else {
+                return false;
+            };
+            let SnapshotV2DeviceTransport::Pci(captured) = transport else {
+                return false;
+            };
+            let expected_route_count = if index < block_records.len() {
+                block_route_count
+            } else {
+                pmem_route_count
+            };
+            planned.sbdf() == placement.sbdf
+                && planned.bar_region_id() == placement.bar_region_id
+                && planned.bar_range() == placement.bar_range
+                && Some(planned.route_count()) == expected_route_count
+                && captured.sbdf() == placement.sbdf
+                && captured.bar_range() == placement.bar_range
+                && register_active_pci_routes(captured, active_routes)
+        })
+}
+
+fn entropy_queue_conflicts_with_storage(
+    entropy_ranges: Option<[GuestMemoryRange; 3]>,
+    bundle: &PreparedSnapshotV2StorageBundle,
+) -> bool {
+    let Some(entropy_ranges) = entropy_ranges else {
+        return false;
+    };
+    let block_records = bundle
+        .block_bundle()
+        .map_or(&[][..], |block| block.records());
+    entropy_ranges.iter().any(|entropy_range| {
+        block_records
+            .iter()
+            .filter_map(|record| record.queue_ranges())
+            .chain(
+                bundle
+                    .pmem_records()
+                    .iter()
+                    .filter_map(|record| record.queue_ranges()),
+            )
+            .flatten()
+            .any(|storage_range| entropy_range.overlaps(storage_range))
+            || bundle
+                .pmem_records()
+                .iter()
+                .any(|record| entropy_range.overlaps(record.prepared_device().guest_range()))
+    })
+}
+
+fn register_active_retained_routes(
+    state: &VirtioPciMsixState,
+    msi: crate::gic::HvfGicMsiMetadata,
+    route_count: usize,
+    active_routes: &mut Vec<(u64, u32)>,
+) -> bool {
+    let Some(expected_address) = msi
+        .region
+        .base
+        .checked_add(ARM64_GICV2M_MSI_SET_SPI_NSR_OFFSET)
+    else {
+        return false;
+    };
+    let Some(interrupt_end) = msi
+        .interrupt_range
+        .base
+        .checked_add(msi.interrupt_range.count)
+    else {
+        return false;
+    };
+    if state.vector_count() != route_count
+        || state.pending_words().len() != 1
+        || state.queue_vectors().len() != VIRTIO_RNG_QUEUE_SIZES.len()
+        || state
+            .pending_words()
+            .first()
+            .is_none_or(|pending| pending & !((1_u64 << route_count) - 1) != 0)
+        || !valid_vector(state.config_vector(), route_count)
+        || !state
+            .queue_vectors()
+            .iter()
+            .copied()
+            .all(|vector| valid_vector(vector, route_count))
+    {
+        return false;
+    }
+
+    state.entries().iter().enumerate().all(|(index, entry)| {
+        if entry.vector_control() & !1 != 0 {
+            return false;
+        }
+        let Ok(vector) = u16::try_from(index) else {
+            return false;
+        };
+        let referenced = state.config_vector() == vector || state.queue_vectors().contains(&vector);
+        let pending = state
+            .pending_words()
+            .get(index / u64::BITS as usize)
+            .is_some_and(|word| word & (1_u64 << (index % u64::BITS as usize)) != 0);
+        if entry.is_masked() || (!referenced && !pending) {
+            return true;
+        }
+        let address = (u64::from(entry.message_address_high()) << 32)
+            | u64::from(entry.message_address_low());
+        let data = entry.message_data();
+        let route = (address, data);
+        if address != expected_address
+            || data < msi.interrupt_range.base
+            || data >= interrupt_end
+            || active_routes.contains(&route)
+        {
+            return false;
+        }
+        active_routes.push(route);
+        true
+    })
+}
+
+const fn valid_vector(vector: u16, count: usize) -> bool {
+    vector == VIRTIO_PCI_NO_VECTOR || (vector as usize) < count
+}
+
+trait EntropyPciPlatformPlanReserve {
+    fn reserve<T>(
+        &mut self,
+        values: &mut Vec<T>,
+        additional: usize,
+    ) -> Result<(), PrepareHvfSnapshotV2EntropyPciPlatformPlanError>;
+}
+
+struct SystemEntropyPciPlatformPlanReserve;
+
+impl EntropyPciPlatformPlanReserve for SystemEntropyPciPlatformPlanReserve {
+    fn reserve<T>(
+        &mut self,
+        values: &mut Vec<T>,
+        additional: usize,
+    ) -> Result<(), PrepareHvfSnapshotV2EntropyPciPlatformPlanError> {
+        values
+            .try_reserve_exact(additional)
+            .map_err(|_| PrepareHvfSnapshotV2EntropyPciPlatformPlanError::Allocation)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use bangbang_runtime::memory::{
+        GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange,
+    };
+    use bangbang_runtime::pci::Arm64PciAddressPlan;
+    use bangbang_runtime::snapshot_entropy_v2_8::{
+        NATIVE_V2_ENTROPY_STATE_COMPATIBILITY_VERSION, NATIVE_V2_ENTROPY_STATE_HEADER_BYTES,
+        NATIVE_V2_ENTROPY_STATE_SECTION_ENTRY_BYTES, SnapshotV2EntropyState,
+    };
+
+    use super::*;
+
+    const ACTIVE_PCI_HEX: &str =
+        include_str!("../../runtime/src/snapshot_entropy_v2_8/fixtures/active-pci.hex");
+    const INACTIVE_MMIO_HEX: &str =
+        include_str!("../../runtime/src/snapshot_entropy_v2_8/fixtures/inactive-mmio.hex");
+    const RESTORE_MEMORY_SIZE: u64 = 0x20_0000;
+    const DESCRIPTOR_TABLE: GuestAddress = GuestAddress::new(0x2_0000);
+    const AVAILABLE_RING: GuestAddress = GuestAddress::new(0x4_0000);
+    const USED_RING: GuestAddress = GuestAddress::new(0x6_0000);
+    const DATA_BUFFER: GuestAddress = GuestAddress::new(0x8_0000);
+
+    fn fixture_bytes(hex: &str) -> Vec<u8> {
+        hex.trim()
+            .as_bytes()
+            .chunks_exact(2)
+            .map(|pair| {
+                u8::from_str_radix(
+                    std::str::from_utf8(pair).expect("fixture hex should be UTF-8"),
+                    16,
+                )
+                .expect("fixture hex should decode")
+            })
+            .collect()
+    }
+
+    fn restore_memory(active: bool) -> GuestMemory {
+        let layout = GuestMemoryLayout::new(vec![
+            GuestMemoryRange::new(GuestAddress::new(0), RESTORE_MEMORY_SIZE)
+                .expect("entropy restore range should validate"),
+        ])
+        .expect("entropy restore layout should validate");
+        let mut memory =
+            GuestMemory::allocate(&layout).expect("entropy restore memory should allocate");
+        if active {
+            memory
+                .write_slice(&DATA_BUFFER.raw_value().to_le_bytes(), DESCRIPTOR_TABLE)
+                .expect("entropy descriptor address should write");
+            memory
+                .write_slice(
+                    &8_u32.to_le_bytes(),
+                    DESCRIPTOR_TABLE
+                        .checked_add(8)
+                        .expect("entropy descriptor length address should fit"),
+                )
+                .expect("entropy descriptor length should write");
+            memory
+                .write_slice(
+                    &2_u16.to_le_bytes(),
+                    DESCRIPTOR_TABLE
+                        .checked_add(12)
+                        .expect("entropy descriptor flags address should fit"),
+                )
+                .expect("entropy descriptor flags should write");
+            memory
+                .write_slice(
+                    &0_u16.to_le_bytes(),
+                    DESCRIPTOR_TABLE
+                        .checked_add(14)
+                        .expect("entropy descriptor next address should fit"),
+                )
+                .expect("entropy descriptor next should write");
+            memory
+                .write_slice(
+                    &0_u16.to_le_bytes(),
+                    AVAILABLE_RING
+                        .checked_add(16)
+                        .expect("entropy available entry address should fit"),
+                )
+                .expect("entropy available entry should write");
+            memory
+                .write_slice(
+                    &7_u16.to_le_bytes(),
+                    AVAILABLE_RING
+                        .checked_add(2)
+                        .expect("entropy available index address should fit"),
+                )
+                .expect("entropy available index should write");
+            memory
+                .write_slice(
+                    &6_u16.to_le_bytes(),
+                    USED_RING
+                        .checked_add(2)
+                        .expect("entropy used index address should fit"),
+                )
+                .expect("entropy used index should write");
+        }
+        memory
+    }
+
+    fn entropy_state_at(index: usize, first_message_data: u32) -> SnapshotV2EntropyState {
+        let mut bytes = fixture_bytes(ACTIVE_PCI_HEX);
+        let common_directory_entry =
+            NATIVE_V2_ENTROPY_STATE_HEADER_BYTES + NATIVE_V2_ENTROPY_STATE_SECTION_ENTRY_BYTES;
+        let common_offset_start = common_directory_entry + 8;
+        let common_offset = usize::try_from(u64::from_le_bytes(
+            bytes[common_offset_start..common_offset_start + 8]
+                .try_into()
+                .expect("common offset should be present"),
+        ))
+        .expect("common offset should fit usize");
+        for (offset, address) in [
+            (40, DESCRIPTOR_TABLE),
+            (48, AVAILABLE_RING),
+            (56, USED_RING),
+        ] {
+            bytes[common_offset + offset..common_offset + offset + 8]
+                .copy_from_slice(&address.raw_value().to_le_bytes());
+        }
+
+        let transport_directory_entry =
+            NATIVE_V2_ENTROPY_STATE_HEADER_BYTES + 2 * NATIVE_V2_ENTROPY_STATE_SECTION_ENTRY_BYTES;
+        let offset_start = transport_directory_entry + 8;
+        let transport_offset = usize::try_from(u64::from_le_bytes(
+            bytes[offset_start..offset_start + 8]
+                .try_into()
+                .expect("transport offset should be present"),
+        ))
+        .expect("transport offset should fit usize");
+        let placement = snapshot_v2_pci_endpoint_placement(
+            Arm64PciAddressPlan::firecracker_v1_16().expect("PCI address plan should validate"),
+            index,
+        )
+        .expect("entropy placement should exist");
+        bytes[transport_offset + 11] = placement.sbdf.device();
+        bytes[transport_offset + 16..transport_offset + 24]
+            .copy_from_slice(&placement.bar_range.start().raw_value().to_le_bytes());
+        bytes[transport_offset + 104..transport_offset + 108]
+            .copy_from_slice(&first_message_data.to_le_bytes());
+        SnapshotV2EntropyState::decode(NATIVE_V2_ENTROPY_STATE_COMPATIBILITY_VERSION, &bytes)
+            .expect("relocated entropy fixture should decode")
+    }
+
+    fn entropy_plan_at(index: usize, first_message_data: u32) -> SnapshotV2EntropyRestorePlan {
+        SnapshotV2EntropyRestorePlan::prepare(
+            entropy_state_at(index, first_message_data),
+            &restore_memory(true),
+            Instant::now(),
+        )
+        .expect("entropy restore plan should prepare")
+    }
+
+    fn with_msi_interrupt_count(
+        platform: HvfSnapshotV2PlatformState,
+        interrupt_count: u32,
+    ) -> HvfSnapshotV2PlatformState {
+        let (memory, machine, global, topology, vcpus, time) = platform.into_parts();
+        let (compatibility, gic_device) = global.into_parts();
+        let mut gic = compatibility.gic_metadata();
+        let mut msi = gic.msi.expect("PCI platform should contain MSI metadata");
+        msi.interrupt_range.count = interrupt_count;
+        gic.msi = Some(msi);
+        let compatibility = crate::snapshot_bundle::HvfSnapshotV1CompatibilityState::new(
+            compatibility.identification(),
+            compatibility.optional_sve_sme_identification(),
+            compatibility.cache_manifest(),
+            compatibility.primary_mpidr(),
+            gic,
+            compatibility.rtc_mmio_layout(),
+        );
+        let global =
+            crate::snapshot_v2::HvfSnapshotV2GlobalState::try_new(compatibility, gic_device)
+                .expect("mutated PCI global state should validate");
+        HvfSnapshotV2PlatformState::try_new(memory, machine, global, topology, vcpus, time)
+            .expect("mutated PCI platform should cross-validate")
+    }
+
+    #[test]
+    fn serial_entropy_plan_selects_the_exact_first_pci_endpoint() {
+        let platform = crate::snapshot_v2_multi_block_platform::tests::product_pci_platform();
+        let msi = platform
+            .global()
+            .compatibility()
+            .gic_metadata()
+            .msi
+            .expect("product PCI platform should retain MSI metadata");
+        let entropy = entropy_plan_at(0, msi.interrupt_range.base);
+        let plan = prepare_hvf_snapshot_v2_serial_entropy_pci_platform_plan(&platform, &entropy)
+            .expect("serial PCI entropy plan should validate");
+        let placement = snapshot_v2_pci_endpoint_placement(
+            Arm64PciAddressPlan::firecracker_v1_16().expect("PCI address plan should validate"),
+            0,
+        )
+        .expect("first PCI placement should exist");
+        assert_eq!(plan.preceding_endpoint_count(), 0);
+        assert_eq!(plan.sbdf(), placement.sbdf);
+        assert_eq!(plan.bar_region_id(), placement.bar_region_id);
+        assert_eq!(plan.bar_range(), placement.bar_range);
+        assert_eq!(plan.route_count(), VIRTIO_RNG_QUEUE_SIZES.len() + 1);
+        let debug = format!("{plan:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains(&placement.bar_range.start().raw_value().to_string()));
+    }
+
+    #[test]
+    fn combined_storage_entropy_plan_proves_storage_prefix_then_entropy() {
+        let fixture = crate::snapshot_v2_storage_platform::tests::rootless_block_pci_fixture();
+        let msi = fixture
+            .platform
+            .global()
+            .compatibility()
+            .gic_metadata()
+            .msi
+            .expect("product PCI platform should retain MSI metadata");
+        let message_data = msi
+            .interrupt_range
+            .base
+            .checked_add(msi.interrupt_range.count - 1)
+            .expect("last MSI INTID should fit");
+        let entropy = entropy_plan_at(1, message_data);
+        let plan = prepare_hvf_snapshot_v2_storage_entropy_pci_platform_plan(
+            &fixture.platform,
+            &fixture.bundle,
+            &entropy,
+        )
+        .expect("storage-plus-entropy PCI plan should validate");
+        assert_eq!(plan.storage().pci().record_count(), 1);
+        assert_eq!(plan.entropy().preceding_endpoint_count(), 1);
+        let placement = snapshot_v2_pci_endpoint_placement(
+            Arm64PciAddressPlan::firecracker_v1_16().expect("PCI address plan should validate"),
+            1,
+        )
+        .expect("second PCI placement should exist");
+        assert_eq!(plan.entropy().sbdf(), placement.sbdf);
+
+        let SnapshotV2DeviceTransport::Pci(storage_transport) = fixture
+            .bundle
+            .block_bundle()
+            .expect("combined fixture should contain block storage")
+            .records()[0]
+            .transport()
+        else {
+            panic!("combined fixture storage should use PCI");
+        };
+        let storage_message_data = storage_transport
+            .msix()
+            .entries()
+            .iter()
+            .enumerate()
+            .find_map(|(index, entry)| {
+                let vector = u16::try_from(index).ok()?;
+                let referenced = storage_transport.msix().config_vector() == vector
+                    || storage_transport.msix().queue_vectors().contains(&vector);
+                (entry.vector_control() & 1 == 0 && referenced).then_some(entry.message_data())
+            })
+            .expect("combined fixture should retain one active storage route");
+        let colliding_entropy = entropy_plan_at(1, storage_message_data);
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_storage_entropy_pci_platform_plan(
+                &fixture.platform,
+                &fixture.bundle,
+                &colliding_entropy,
+            ),
+            Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan)
+        ));
+
+        fixture
+            .bundle
+            .abort()
+            .expect("planned storage bundle should abort cleanly");
+    }
+
+    #[test]
+    fn wrong_transport_capacity_and_reservation_fail_before_construction() {
+        let platform = crate::snapshot_v2_multi_block_platform::tests::product_pci_platform();
+        let mmio = SnapshotV2EntropyState::decode(
+            NATIVE_V2_ENTROPY_STATE_COMPATIBILITY_VERSION,
+            &fixture_bytes(INACTIVE_MMIO_HEX),
+        )
+        .expect("MMIO entropy fixture should decode");
+        let mmio =
+            SnapshotV2EntropyRestorePlan::prepare(mmio, &restore_memory(false), Instant::now())
+                .expect("MMIO entropy restore plan should prepare");
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_serial_entropy_pci_platform_plan(&platform, &mmio),
+            Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::TransportPolicy)
+        ));
+
+        let msi = platform
+            .global()
+            .compatibility()
+            .gic_metadata()
+            .msi
+            .expect("product PCI platform should retain MSI metadata");
+        let last_entropy = entropy_plan_at(PCI_ENDPOINT_SLOT_COUNT - 1, msi.interrupt_range.base);
+        let last_plan = prepare_entropy_pci_endpoint_plan(
+            &platform,
+            None,
+            &last_entropy,
+            PCI_ENDPOINT_SLOT_COUNT - 1,
+            &mut SystemEntropyPciPlatformPlanReserve,
+        )
+        .expect("30 preceding storage endpoints should leave one entropy slot");
+        assert_eq!(
+            last_plan.preceding_endpoint_count(),
+            PCI_ENDPOINT_SLOT_COUNT - 1
+        );
+
+        let entropy = entropy_plan_at(0, msi.interrupt_range.base);
+        assert!(matches!(
+            prepare_entropy_pci_endpoint_plan(
+                &platform,
+                None,
+                &entropy,
+                PCI_ENDPOINT_SLOT_COUNT,
+                &mut SystemEntropyPciPlatformPlanReserve,
+            ),
+            Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::PciCapacity {
+                count,
+                maximum,
+            }) if count == PCI_ENDPOINT_SLOT_COUNT + 1 && maximum == PCI_ENDPOINT_SLOT_COUNT
+        ));
+
+        struct FailingReserve;
+        impl EntropyPciPlatformPlanReserve for FailingReserve {
+            fn reserve<T>(
+                &mut self,
+                _values: &mut Vec<T>,
+                _additional: usize,
+            ) -> Result<(), PrepareHvfSnapshotV2EntropyPciPlatformPlanError> {
+                Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::Allocation)
+            }
+        }
+        assert!(matches!(
+            prepare_entropy_pci_endpoint_plan(&platform, None, &entropy, 0, &mut FailingReserve,),
+            Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::Allocation)
+        ));
+    }
+
+    #[test]
+    fn placement_and_active_route_divergence_are_rejected() {
+        let platform = crate::snapshot_v2_multi_block_platform::tests::product_pci_platform();
+        let msi = platform
+            .global()
+            .compatibility()
+            .gic_metadata()
+            .msi
+            .expect("product PCI platform should retain MSI metadata");
+        let wrong_placement = entropy_plan_at(1, msi.interrupt_range.base);
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_serial_entropy_pci_platform_plan(&platform, &wrong_placement,),
+            Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan)
+        ));
+
+        let entropy_pool_count = pci_entropy_restore_gic_msi_configuration()
+            .expect("entropy PCI MSI profile should validate")
+            .interrupt_count()
+            .get();
+        let entropy_profile = with_msi_interrupt_count(platform.clone(), entropy_pool_count);
+        let canonical_entropy = entropy_plan_at(0, msi.interrupt_range.base);
+        prepare_hvf_snapshot_v2_serial_entropy_pci_platform_plan(
+            &entropy_profile,
+            &canonical_entropy,
+        )
+        .expect("fixed-entropy MSI profile should remain canonical");
+
+        let wrong_profile = with_msi_interrupt_count(
+            platform.clone(),
+            entropy_pool_count
+                .checked_sub(1)
+                .expect("wrong MSI profile count should remain nonzero"),
+        );
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_serial_entropy_pci_platform_plan(
+                &wrong_profile,
+                &canonical_entropy,
+            ),
+            Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan)
+        ));
+
+        let bad_message = msi
+            .interrupt_range
+            .base
+            .checked_add(msi.interrupt_range.count)
+            .expect("first out-of-range INTID should fit");
+        let wrong_route = entropy_plan_at(0, bad_message);
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_serial_entropy_pci_platform_plan(&platform, &wrong_route),
+            Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan)
+        ));
+    }
+}

--- a/crates/hvf/src/snapshot_v2_platform.rs
+++ b/crates/hvf/src/snapshot_v2_platform.rs
@@ -383,12 +383,25 @@ impl fmt::Debug for HvfSnapshotV2RestoredSerialShell {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HvfSnapshotV2SerialOnlyProcessConfig {
     pci_enabled: bool,
+    exact_pci_msi_interrupt_count: Option<u32>,
 }
 
 impl HvfSnapshotV2SerialOnlyProcessConfig {
     /// Select the exact destination process PCI policy.
     pub const fn new(pci_enabled: bool) -> Self {
-        Self { pci_enabled }
+        Self {
+            pci_enabled,
+            exact_pci_msi_interrupt_count: None,
+        }
+    }
+
+    pub(crate) const fn with_exact_pci_msi_interrupt_count(
+        exact_pci_msi_interrupt_count: u32,
+    ) -> Self {
+        Self {
+            pci_enabled: true,
+            exact_pci_msi_interrupt_count: Some(exact_pci_msi_interrupt_count),
+        }
     }
 
     /// Returns whether the destination selected the product PCI host.
@@ -2477,11 +2490,14 @@ fn prepare_process_shell(
             HvfSnapshotV2ProcessShellRestore::SerialOnly { shell, process } => {
                 let policy_matches = match (process.pci_enabled(), gic.msi) {
                     (false, None) => true,
-                    (true, Some(msi)) => {
-                        pci_root_restore_gic_msi_configuration().is_ok_and(|expected| {
-                            msi.interrupt_range.count == expected.interrupt_count().get()
-                        })
-                    }
+                    (true, Some(msi)) => process.exact_pci_msi_interrupt_count.map_or_else(
+                        || {
+                            pci_root_restore_gic_msi_configuration().is_ok_and(|expected| {
+                                msi.interrupt_range.count == expected.interrupt_count().get()
+                            })
+                        },
+                        |expected| msi.interrupt_range.count == expected,
+                    ),
                     (false, Some(_)) | (true, None) => false,
                 };
                 if !policy_matches {

--- a/crates/hvf/src/snapshot_v2_storage_platform.rs
+++ b/crates/hvf/src/snapshot_v2_storage_platform.rs
@@ -40,7 +40,10 @@ use crate::snapshot_v2_platform::{
     PROCESS_RTC_MMIO_BASE, PROCESS_RTC_MMIO_REGION_ID, PROCESS_SERIAL_MMIO_BASE,
     PROCESS_SERIAL_MMIO_REGION_ID,
 };
-use crate::startup::{PCI_ENDPOINT_SLOT_COUNT, pci_root_restore_gic_msi_configuration};
+use crate::startup::{
+    PCI_ENDPOINT_SLOT_COUNT, pci_entropy_restore_gic_msi_configuration,
+    pci_root_restore_gic_msi_configuration,
+};
 
 const REDACTED: &str = "<redacted>";
 
@@ -940,6 +943,19 @@ pub fn prepare_hvf_snapshot_v2_storage_pci_platform_plan(
     prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
         platform,
         bundle,
+        false,
+        &mut SystemStoragePciPlatformPlanReserve,
+    )
+}
+
+pub(crate) fn prepare_hvf_snapshot_v2_storage_pci_platform_plan_for_entropy(
+    platform: &HvfSnapshotV2PlatformState,
+    bundle: &PreparedSnapshotV2StorageBundle,
+) -> Result<HvfSnapshotV2StoragePciPlatformPlan, PrepareHvfSnapshotV2StoragePciPlatformPlanError> {
+    prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
+        platform,
+        bundle,
+        true,
         &mut SystemStoragePciPlatformPlanReserve,
     )
 }
@@ -947,6 +963,7 @@ pub fn prepare_hvf_snapshot_v2_storage_pci_platform_plan(
 fn prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
     platform: &HvfSnapshotV2PlatformState,
     bundle: &PreparedSnapshotV2StorageBundle,
+    allow_entropy_msi_profile: bool,
     reserve: &mut impl StoragePciPlatformPlanReserve,
 ) -> Result<HvfSnapshotV2StoragePciPlatformPlan, PrepareHvfSnapshotV2StoragePciPlatformPlanError> {
     if !platform.machine().fdt().is_product_process_profile()
@@ -997,7 +1014,10 @@ fn prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
         .ok_or(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
     let expected_msi = pci_root_restore_gic_msi_configuration()
         .map_err(|_| PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
-    if msi.interrupt_range.count != expected_msi.interrupt_count().get() {
+    let entropy_msi_matches = allow_entropy_msi_profile
+        && pci_entropy_restore_gic_msi_configuration()
+            .is_ok_and(|expected| msi.interrupt_range.count == expected.interrupt_count().get());
+    if msi.interrupt_range.count != expected_msi.interrupt_count().get() && !entropy_msi_matches {
         return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan);
     }
     let address_plan = Arm64PciAddressPlan::firecracker_v1_16()
@@ -1279,7 +1299,7 @@ fn plan_pci_record(
     })
 }
 
-fn register_active_pci_routes(
+pub(crate) fn register_active_pci_routes(
     state: &bangbang_runtime::snapshot_device_v2::SnapshotV2PciDeviceState,
     active_routes: &mut Vec<(u64, u32)>,
 ) -> bool {
@@ -1493,7 +1513,7 @@ fn mmio_region_conflicts_with_platform(
     Ok(false)
 }
 
-fn queue_ranges_conflict_with_pci_platform(
+pub(crate) fn queue_ranges_conflict_with_pci_platform(
     platform: &HvfSnapshotV2PlatformState,
     queue_ranges: Option<[GuestMemoryRange; 3]>,
     gic: &HvfGicMetadata,
@@ -1749,9 +1769,9 @@ pub(crate) mod tests {
         PmemRootless,
     }
 
-    struct StorageFixture {
-        platform: HvfSnapshotV2PlatformState,
-        bundle: PreparedSnapshotV2StorageBundle,
+    pub(crate) struct StorageFixture {
+        pub(crate) platform: HvfSnapshotV2PlatformState,
+        pub(crate) bundle: PreparedSnapshotV2StorageBundle,
         _files: Vec<TempBacking>,
     }
 
@@ -1994,6 +2014,10 @@ pub(crate) mod tests {
             bundle,
             _files: files,
         }
+    }
+
+    pub(crate) fn rootless_block_pci_fixture() -> StorageFixture {
+        pci_fixture(BLOCK_ROOTLESS_PCI_HEX)
     }
 
     pub(crate) fn pci_fdt_plan_fixture() -> (
@@ -2359,6 +2383,7 @@ pub(crate) mod tests {
                 prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
                     &fixture.platform,
                     &fixture.bundle,
+                    false,
                     &mut FailingReserve { calls: 0, fail_at },
                 ),
                 Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::Allocation)

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -60,7 +60,9 @@ use bangbang_runtime::memory_hotplug::{
     VirtioMemDevice, VirtioMemMmioCaptureState, VirtioMemMmioLayout, VirtioMemMutationExecutor,
     VirtioMemPciCaptureError, VirtioMemPciCaptureState,
 };
-use bangbang_runtime::message_interrupt::GuestMessageInterruptResources;
+use bangbang_runtime::message_interrupt::{
+    GuestMessageInterruptResources, GuestMessageInterruptResourcesError,
+};
 use bangbang_runtime::metrics::{
     BlockDeviceMetricsLease, BlockDeviceMetricsRegistryError, NetworkInterfaceMetricsLease,
     PmemDeviceMetricsLease, PmemDeviceMetricsRegistryError, SharedBalloonDeviceMetrics,
@@ -125,8 +127,8 @@ use bangbang_runtime::snapshot_device_v2_6::{
 };
 use bangbang_runtime::snapshot_entropy_v2_8::{
     NATIVE_V2_ENTROPY_STATE_COMPATIBILITY_VERSION, PreparedSnapshotV2EntropyMmioHandler,
-    SnapshotV2EntropyMmioHandlerError, SnapshotV2EntropyRestorePlan, SnapshotV2EntropyState,
-    SnapshotV2EntropyStateCaptureError,
+    SnapshotV2EntropyMmioHandlerError, SnapshotV2EntropyPciEndpointError,
+    SnapshotV2EntropyRestorePlan, SnapshotV2EntropyState, SnapshotV2EntropyStateCaptureError,
 };
 use bangbang_runtime::snapshot_format::SnapshotFormatVersion;
 use bangbang_runtime::snapshot_format_v2::NATIVE_V2_LEGACY_PLATFORM_VERSION;
@@ -240,6 +242,9 @@ use crate::snapshot_v2::{
     HvfSnapshotV2BootState, HvfSnapshotV2BuildError, HvfSnapshotV2FdtState,
     HvfSnapshotV2GlobalState, HvfSnapshotV2MachineState, HvfSnapshotV2PlatformState,
     HvfSnapshotV2PvTimeVcpuState, HvfSnapshotV2TimeState, HvfSnapshotV2VcpuState,
+};
+use crate::snapshot_v2_entropy_platform::{
+    HvfSnapshotV2EntropyPciEndpointPlan, HvfSnapshotV2StorageEntropyPciPlatformPlan,
 };
 use crate::snapshot_v2_multi_block_platform::{
     HvfSnapshotV2MultiBlockPlatformPlan, HvfSnapshotV2MultiBlockPlatformPlanParts,
@@ -3771,6 +3776,286 @@ impl fmt::Display for HvfSnapshotV2EntropyMmioRestoreError {
 }
 
 impl std::error::Error for HvfSnapshotV2EntropyMmioRestoreError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.failure.as_ref())
+    }
+}
+
+/// One complete, still-unpublished exact-2.8 PCI entropy destination.
+#[doc(hidden)]
+pub struct RestoredHvfSnapshotV2EntropyPciOwners {
+    session: OwnedHvfArm64BootSession,
+    entropy_config: EntropyConfig,
+    storage_configs: Option<CaptureReadyStorageConfigs>,
+}
+
+impl RestoredHvfSnapshotV2EntropyPciOwners {
+    /// Returns the complete Paused destination session.
+    pub const fn session(&self) -> &OwnedHvfArm64BootSession {
+        &self.session
+    }
+
+    /// Returns the exact public entropy configuration.
+    pub const fn entropy_config(&self) -> EntropyConfig {
+        self.entropy_config
+    }
+
+    /// Returns restored storage configuration when storage shares the owner.
+    pub const fn storage_configs(&self) -> Option<&CaptureReadyStorageConfigs> {
+        self.storage_configs.as_ref()
+    }
+
+    /// Consumes all restored owners without discarding configuration.
+    pub fn into_parts(
+        self,
+    ) -> (
+        OwnedHvfArm64BootSession,
+        EntropyConfig,
+        Option<CaptureReadyStorageConfigs>,
+    ) {
+        (self.session, self.entropy_config, self.storage_configs)
+    }
+}
+
+impl fmt::Debug for RestoredHvfSnapshotV2EntropyPciOwners {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RestoredHvfSnapshotV2EntropyPciOwners")
+            .field("has_storage", &self.storage_configs.is_some())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Stage at which exact-2.8 PCI entropy owner reconstruction stopped.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfSnapshotV2EntropyPciRestoreStage {
+    SerialPlatform,
+    StoragePlatform,
+    ResourcePlan,
+    InterruptRoutes,
+    Endpoint,
+    Publication,
+    RetryScheduler,
+}
+
+/// Primary exact-2.8 PCI entropy owner reconstruction failure.
+#[doc(hidden)]
+pub enum HvfSnapshotV2EntropyPciRestoreFailure {
+    SerialPlatform(Box<HvfSnapshotV2SerialOnlyRestoreError>),
+    StoragePlatform(Box<HvfSnapshotV2StoragePciRestoreError>),
+    ResourcePlan,
+    ResourcePlanCleanup {
+        cleanup: Option<GuestMessageInterruptResourcesError>,
+    },
+    PciData(HvfArm64BootPciDataError),
+    Endpoint {
+        source: SnapshotV2EntropyPciEndpointError,
+        cleanup: Option<GuestMessageInterruptResourcesError>,
+    },
+    DispatcherUnavailable {
+        cleanup: Option<GuestMessageInterruptResourcesError>,
+    },
+    Publication(VirtioPciPublicationError),
+    RetryScheduler(io::ErrorKind),
+    InjectedRetryScheduler,
+}
+
+impl HvfSnapshotV2EntropyPciRestoreFailure {
+    fn interrupt_cleanup_failed(&self) -> bool {
+        matches!(
+            self,
+            Self::Endpoint {
+                cleanup: Some(_),
+                ..
+            } | Self::DispatcherUnavailable { cleanup: Some(_) }
+                | Self::ResourcePlanCleanup { cleanup: Some(_) }
+        )
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2EntropyPciRestoreFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::SerialPlatform(_) => "serial-platform",
+            Self::StoragePlatform(_) => "storage-platform",
+            Self::ResourcePlan | Self::ResourcePlanCleanup { .. } => "resource-plan",
+            Self::PciData(_) => "pci-data",
+            Self::Endpoint { .. } => "endpoint",
+            Self::DispatcherUnavailable { .. } => "dispatcher",
+            Self::Publication(_) => "publication",
+            Self::RetryScheduler(_) => "retry-scheduler",
+            Self::InjectedRetryScheduler => "injected-retry-scheduler",
+        };
+        formatter
+            .debug_struct("HvfSnapshotV2EntropyPciRestoreFailure")
+            .field("kind", &kind)
+            .field("source", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2EntropyPciRestoreFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::SerialPlatform(_) => "serial-only HVF platform reconstruction failed",
+            Self::StoragePlatform(_) => "storage-bearing HVF platform reconstruction failed",
+            Self::ResourcePlan | Self::ResourcePlanCleanup { .. } => {
+                "exact-2.8 PCI entropy resource plan diverged"
+            }
+            Self::PciData(_) => "exact-2.8 PCI entropy manager is unavailable",
+            Self::Endpoint { .. } => "exact-2.8 PCI entropy endpoint reconstruction failed",
+            Self::DispatcherUnavailable { .. } => "exact-2.8 PCI entropy dispatcher is unavailable",
+            Self::Publication(_) => "exact-2.8 PCI entropy endpoint publication failed",
+            Self::RetryScheduler(kind) => {
+                return write!(
+                    formatter,
+                    "exact-2.8 PCI entropy retry scheduler startup failed: {kind:?}"
+                );
+            }
+            Self::InjectedRetryScheduler => {
+                "exact-2.8 PCI entropy retry scheduler certification fault was injected"
+            }
+        })
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2EntropyPciRestoreFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::SerialPlatform(source) => Some(source.as_ref()),
+            Self::StoragePlatform(source) => Some(source.as_ref()),
+            Self::PciData(source) => Some(source),
+            Self::Endpoint { source, .. } => Some(source),
+            Self::Publication(source) => Some(source),
+            Self::ResourcePlan
+            | Self::ResourcePlanCleanup { .. }
+            | Self::DispatcherUnavailable { .. }
+            | Self::RetryScheduler(_)
+            | Self::InjectedRetryScheduler => None,
+        }
+    }
+}
+
+/// Redacted exact-2.8 PCI entropy owner failure and cleanup evidence.
+#[doc(hidden)]
+pub struct HvfSnapshotV2EntropyPciRestoreError {
+    stage: HvfSnapshotV2EntropyPciRestoreStage,
+    failure: Box<HvfSnapshotV2EntropyPciRestoreFailure>,
+    committed: bool,
+    cleanup: Option<Box<HvfArm64BootSessionShutdownError>>,
+}
+
+impl HvfSnapshotV2EntropyPciRestoreError {
+    fn preflight(
+        stage: HvfSnapshotV2EntropyPciRestoreStage,
+        failure: HvfSnapshotV2EntropyPciRestoreFailure,
+    ) -> Self {
+        Self {
+            stage,
+            failure: Box::new(failure),
+            committed: false,
+            cleanup: None,
+        }
+    }
+
+    fn serial_platform(source: HvfSnapshotV2SerialOnlyRestoreError) -> Self {
+        Self {
+            stage: HvfSnapshotV2EntropyPciRestoreStage::SerialPlatform,
+            committed: source.is_terminal(),
+            failure: Box::new(HvfSnapshotV2EntropyPciRestoreFailure::SerialPlatform(
+                Box::new(source),
+            )),
+            cleanup: None,
+        }
+    }
+
+    fn storage_platform(source: HvfSnapshotV2StoragePciRestoreError) -> Self {
+        Self {
+            stage: HvfSnapshotV2EntropyPciRestoreStage::StoragePlatform,
+            committed: source.is_terminal(),
+            failure: Box::new(HvfSnapshotV2EntropyPciRestoreFailure::StoragePlatform(
+                Box::new(source),
+            )),
+            cleanup: None,
+        }
+    }
+
+    fn after_platform(
+        mut session: OwnedHvfArm64BootSession,
+        stage: HvfSnapshotV2EntropyPciRestoreStage,
+        failure: HvfSnapshotV2EntropyPciRestoreFailure,
+    ) -> Self {
+        let cleanup = session.shutdown().err().map(Box::new);
+        Self {
+            stage,
+            failure: Box::new(failure),
+            committed: true,
+            cleanup,
+        }
+    }
+
+    pub const fn stage(&self) -> HvfSnapshotV2EntropyPciRestoreStage {
+        self.stage
+    }
+
+    /// Returns whether reverse cleanup did not complete.
+    pub fn has_incomplete_cleanup(&self) -> bool {
+        self.cleanup.is_some()
+            || self.failure.interrupt_cleanup_failed()
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2EntropyPciRestoreFailure::SerialPlatform(source)
+                    if source.has_incomplete_cleanup()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2EntropyPciRestoreFailure::StoragePlatform(source)
+                    if source.has_incomplete_cleanup()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2EntropyPciRestoreFailure::Publication(
+                    VirtioPciPublicationError::Rollback { .. }
+                )
+            )
+    }
+
+    /// Returns whether retry safety cannot be proven.
+    pub fn is_terminal(&self) -> bool {
+        self.committed || self.has_incomplete_cleanup()
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2EntropyPciRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2EntropyPciRestoreError")
+            .field("stage", &self.stage)
+            .field("terminal", &self.is_terminal())
+            .field("cleanup_failed", &self.has_incomplete_cleanup())
+            .field("failure", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2EntropyPciRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "exact-2.8 PCI entropy owner reconstruction failed at {:?} ({})",
+            self.stage,
+            if self.is_terminal() {
+                "terminal"
+            } else {
+                "retryable"
+            }
+        )
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2EntropyPciRestoreError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(self.failure.as_ref())
     }
@@ -13396,6 +13681,21 @@ fn failed_snapshot_v2_root_after_platform(
     HvfSnapshotV2RootRestoreError::after_platform(stage, failure, cleanup)
 }
 
+fn snapshot_v2_entropy_pci_plan_matches(
+    entropy: &SnapshotV2EntropyRestorePlan,
+    plan: HvfSnapshotV2EntropyPciEndpointPlan,
+) -> bool {
+    let bangbang_runtime::snapshot_entropy_v2_8::PreparedSnapshotV2EntropyTransport::Pci(transport) =
+        entropy.transport()
+    else {
+        return false;
+    };
+    transport.origin() == StorageDeviceOrigin::Startup
+        && transport.sbdf() == plan.sbdf()
+        && transport.bar_range() == plan.bar_range()
+        && plan.route_count() == VIRTIO_RNG_QUEUE_SIZES.len().saturating_add(1)
+}
+
 fn validate_snapshot_v2_multi_block_mmio_resource_plan(
     bundle: &PreparedSnapshotV2MultiBlockMmioBundle,
     plan: &HvfSnapshotV2MultiBlockPlatformPlanParts,
@@ -15001,6 +15301,301 @@ impl OwnedHvfArm64BootSession {
             .entropy_retry_wakeup_scheduler
             .schedule_deadline(retry_deadline);
         Ok(RestoredHvfSnapshotV2EntropyMmioOwners {
+            session,
+            entropy_config: config,
+            storage_configs,
+        })
+    }
+
+    /// Reconstructs one exact-2.8 serial plus PCI entropy destination.
+    #[doc(hidden)]
+    pub fn restore_snapshot_v2_serial_entropy_pci(
+        state: HvfSnapshotV2PlatformState,
+        memory: GuestMemory,
+        process_shell: HvfSnapshotV2RestoredSerialShell,
+        serial_input: Option<SerialStdioInput>,
+        endpoint_plan: HvfSnapshotV2EntropyPciEndpointPlan,
+        entropy: SnapshotV2EntropyRestorePlan,
+    ) -> Result<RestoredHvfSnapshotV2EntropyPciOwners, HvfSnapshotV2EntropyPciRestoreError> {
+        Self::restore_snapshot_v2_serial_entropy_pci_inner(
+            state,
+            memory,
+            process_shell,
+            serial_input,
+            endpoint_plan,
+            entropy,
+            false,
+        )
+    }
+
+    /// Injects failure after PCI publication for signed rollback
+    /// certification.
+    #[doc(hidden)]
+    pub fn restore_snapshot_v2_serial_entropy_pci_with_scheduler_fault(
+        state: HvfSnapshotV2PlatformState,
+        memory: GuestMemory,
+        process_shell: HvfSnapshotV2RestoredSerialShell,
+        serial_input: Option<SerialStdioInput>,
+        endpoint_plan: HvfSnapshotV2EntropyPciEndpointPlan,
+        entropy: SnapshotV2EntropyRestorePlan,
+    ) -> Result<RestoredHvfSnapshotV2EntropyPciOwners, HvfSnapshotV2EntropyPciRestoreError> {
+        Self::restore_snapshot_v2_serial_entropy_pci_inner(
+            state,
+            memory,
+            process_shell,
+            serial_input,
+            endpoint_plan,
+            entropy,
+            true,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn restore_snapshot_v2_serial_entropy_pci_inner(
+        state: HvfSnapshotV2PlatformState,
+        memory: GuestMemory,
+        process_shell: HvfSnapshotV2RestoredSerialShell,
+        serial_input: Option<SerialStdioInput>,
+        endpoint_plan: HvfSnapshotV2EntropyPciEndpointPlan,
+        entropy: SnapshotV2EntropyRestorePlan,
+        inject_scheduler_failure: bool,
+    ) -> Result<RestoredHvfSnapshotV2EntropyPciOwners, HvfSnapshotV2EntropyPciRestoreError> {
+        if !snapshot_v2_entropy_pci_plan_matches(&entropy, endpoint_plan) {
+            return Err(HvfSnapshotV2EntropyPciRestoreError::preflight(
+                HvfSnapshotV2EntropyPciRestoreStage::ResourcePlan,
+                HvfSnapshotV2EntropyPciRestoreFailure::ResourcePlan,
+            ));
+        }
+        let session = Self::restore_snapshot_v2_serial_only_inner(
+            state,
+            memory,
+            HvfSnapshotV2SerialProcessShell::SerialOnly {
+                shell: process_shell,
+                process: HvfSnapshotV2SerialOnlyProcessConfig::with_exact_pci_msi_interrupt_count(
+                    endpoint_plan.msi_interrupt_count(),
+                ),
+            },
+            serial_input,
+        )
+        .map_err(HvfSnapshotV2EntropyPciRestoreError::serial_platform)?;
+        Self::attach_snapshot_v2_entropy_pci(
+            session,
+            endpoint_plan,
+            entropy,
+            None,
+            inject_scheduler_failure,
+        )
+    }
+
+    /// Reconstructs one exact-2.8 storage, serial, and PCI entropy
+    /// destination without publishing it.
+    #[doc(hidden)]
+    pub fn restore_snapshot_v2_serial_storage_entropy_pci(
+        state: HvfSnapshotV2PlatformState,
+        memory: GuestMemory,
+        process_shell: HvfSnapshotV2RestoredSerialShell,
+        serial_input: Option<SerialStdioInput>,
+        bundle: PreparedSnapshotV2StorageBundle,
+        plan: HvfSnapshotV2StorageEntropyPciPlatformPlan,
+        entropy: SnapshotV2EntropyRestorePlan,
+    ) -> Result<RestoredHvfSnapshotV2EntropyPciOwners, HvfSnapshotV2EntropyPciRestoreError> {
+        let (storage_plan, endpoint_plan) = plan.into_parts();
+        if !snapshot_v2_entropy_pci_plan_matches(&entropy, endpoint_plan) {
+            return Err(HvfSnapshotV2EntropyPciRestoreError::preflight(
+                HvfSnapshotV2EntropyPciRestoreStage::ResourcePlan,
+                HvfSnapshotV2EntropyPciRestoreFailure::ResourcePlan,
+            ));
+        }
+        let restored = Self::restore_snapshot_v2_storage_pci_inner(
+            state,
+            memory,
+            HvfSnapshotV2StorageProcessShell::Restored(process_shell),
+            serial_input,
+            bundle,
+            storage_plan,
+            None,
+        )
+        .map_err(HvfSnapshotV2EntropyPciRestoreError::storage_platform)?;
+        let (session, storage_configs) = restored.into_parts();
+        Self::attach_snapshot_v2_entropy_pci(
+            session,
+            endpoint_plan,
+            entropy,
+            Some(storage_configs),
+            false,
+        )
+    }
+
+    fn attach_snapshot_v2_entropy_pci(
+        mut session: OwnedHvfArm64BootSession,
+        endpoint_plan: HvfSnapshotV2EntropyPciEndpointPlan,
+        entropy: SnapshotV2EntropyRestorePlan,
+        storage_configs: Option<CaptureReadyStorageConfigs>,
+        inject_scheduler_failure: bool,
+    ) -> Result<RestoredHvfSnapshotV2EntropyPciOwners, HvfSnapshotV2EntropyPciRestoreError> {
+        let owner_is_vacant = session.runtime_resources.entropy_device.is_none()
+            && session.runtime_resources.pci_entropy_device.is_none()
+            && session.entropy_interrupt_line.is_none()
+            && session.entropy_retry_wakeup_scheduler.thread.is_none()
+            && session.pci_data_devices.as_ref().is_some_and(|manager| {
+                manager.entropy.is_none()
+                    && manager.network.is_empty()
+                    && manager.balloon.is_none()
+                    && manager.vsock.is_none()
+                    && manager.memory_hotplug.is_none()
+                    && manager.endpoint_count() == endpoint_plan.preceding_endpoint_count()
+                    && manager.block.len().saturating_add(manager.pmem.len())
+                        == endpoint_plan.preceding_endpoint_count()
+            });
+        if !owner_is_vacant {
+            return Err(HvfSnapshotV2EntropyPciRestoreError::after_platform(
+                session,
+                HvfSnapshotV2EntropyPciRestoreStage::ResourcePlan,
+                HvfSnapshotV2EntropyPciRestoreFailure::ResourcePlan,
+            ));
+        }
+
+        let mut interrupts = match session.pci_data_devices.as_ref() {
+            Some(manager) => match manager.shared_msi_registry() {
+                Ok(interrupts) => interrupts,
+                Err(source) => {
+                    return Err(HvfSnapshotV2EntropyPciRestoreError::after_platform(
+                        session,
+                        HvfSnapshotV2EntropyPciRestoreStage::InterruptRoutes,
+                        HvfSnapshotV2EntropyPciRestoreFailure::PciData(source),
+                    ));
+                }
+            },
+            None => {
+                return Err(HvfSnapshotV2EntropyPciRestoreError::after_platform(
+                    session,
+                    HvfSnapshotV2EntropyPciRestoreStage::ResourcePlan,
+                    HvfSnapshotV2EntropyPciRestoreFailure::ResourcePlan,
+                ));
+            }
+        };
+        let entropy =
+            match entropy.into_pci_endpoint(endpoint_plan.bar_region_id(), interrupts.registry()) {
+                Ok(entropy) => entropy,
+                Err(source) => {
+                    let cleanup = interrupts.release().err();
+                    return Err(HvfSnapshotV2EntropyPciRestoreError::after_platform(
+                        session,
+                        HvfSnapshotV2EntropyPciRestoreStage::Endpoint,
+                        HvfSnapshotV2EntropyPciRestoreFailure::Endpoint { source, cleanup },
+                    ));
+                }
+            };
+        if entropy.endpoint().sbdf() != endpoint_plan.sbdf()
+            || entropy.endpoint().bar_range() != endpoint_plan.bar_range()
+            || entropy.endpoint().region_id() != endpoint_plan.bar_region_id()
+        {
+            drop(entropy);
+            let cleanup = interrupts.release().err();
+            return Err(HvfSnapshotV2EntropyPciRestoreError::after_platform(
+                session,
+                HvfSnapshotV2EntropyPciRestoreStage::ResourcePlan,
+                HvfSnapshotV2EntropyPciRestoreFailure::ResourcePlanCleanup { cleanup },
+            ));
+        }
+        let (config, _queue_ranges, _retry, retry_deadline, origin, endpoint) =
+            entropy.into_parts();
+        if origin != StorageDeviceOrigin::Startup {
+            drop(endpoint);
+            let cleanup = interrupts.release().err();
+            return Err(HvfSnapshotV2EntropyPciRestoreError::after_platform(
+                session,
+                HvfSnapshotV2EntropyPciRestoreStage::ResourcePlan,
+                HvfSnapshotV2EntropyPciRestoreFailure::ResourcePlanCleanup { cleanup },
+            ));
+        }
+
+        let publication = {
+            let manager = match session.pci_data_devices.as_mut() {
+                Some(manager) => manager,
+                None => {
+                    drop(endpoint);
+                    let cleanup = interrupts.release().err();
+                    return Err(HvfSnapshotV2EntropyPciRestoreError::after_platform(
+                        session,
+                        HvfSnapshotV2EntropyPciRestoreStage::ResourcePlan,
+                        HvfSnapshotV2EntropyPciRestoreFailure::ResourcePlanCleanup { cleanup },
+                    ));
+                }
+            };
+            let dispatcher_owner = Arc::clone(&manager.dispatcher);
+            let segment = manager.validation.segment().clone();
+            let mut dispatcher = match dispatcher_owner.lock() {
+                Ok(dispatcher) => dispatcher,
+                Err(_) => {
+                    drop(endpoint);
+                    let cleanup = interrupts.release().err();
+                    return Err(HvfSnapshotV2EntropyPciRestoreError::after_platform(
+                        session,
+                        HvfSnapshotV2EntropyPciRestoreStage::Publication,
+                        HvfSnapshotV2EntropyPciRestoreFailure::DispatcherUnavailable { cleanup },
+                    ));
+                }
+            };
+            match endpoint.publish(
+                manager.validation.bar_allocator_mut(),
+                segment,
+                &mut dispatcher,
+                interrupts,
+            ) {
+                Ok(published) => {
+                    // This transfer is deliberately immediate and infallible:
+                    // no published endpoint can exist outside the canonical
+                    // manager owner, even when a later scheduler step fails.
+                    manager.entropy = Some(HvfArm64BootPciEntropyDevice {
+                        published,
+                        queue_deliveries: 0,
+                    });
+                    Ok(())
+                }
+                Err(source) => Err(source),
+            }
+        };
+        if let Err(source) = publication {
+            return Err(HvfSnapshotV2EntropyPciRestoreError::after_platform(
+                session,
+                HvfSnapshotV2EntropyPciRestoreStage::Publication,
+                HvfSnapshotV2EntropyPciRestoreFailure::Publication(source),
+            ));
+        }
+
+        session.entropy_source = VirtioRngOsEntropySource::new();
+        session.entropy_device_metrics = SharedEntropyDeviceMetrics::default();
+        session.entropy_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        if inject_scheduler_failure {
+            return Err(HvfSnapshotV2EntropyPciRestoreError::after_platform(
+                session,
+                HvfSnapshotV2EntropyPciRestoreStage::RetryScheduler,
+                HvfSnapshotV2EntropyPciRestoreFailure::InjectedRetryScheduler,
+            ));
+        }
+        let vcpu_control = session.runner.control();
+        session.entropy_retry_wakeup_scheduler =
+            match HvfArm64BootLimiterRetryWakeupScheduler::start_with_cancellation(
+                ENTROPY_RETRY_WAKEUP_SCHEDULER_THREAD_NAME,
+                session.entropy_retry_wakeup.clone(),
+                move || vcpu_control.request_wakeup(),
+            ) {
+                Ok(scheduler) => scheduler,
+                Err(source) => {
+                    return Err(HvfSnapshotV2EntropyPciRestoreError::after_platform(
+                        session,
+                        HvfSnapshotV2EntropyPciRestoreStage::RetryScheduler,
+                        HvfSnapshotV2EntropyPciRestoreFailure::RetryScheduler(source.kind()),
+                    ));
+                }
+            };
+
+        // Deadline publication is intentionally the final graph operation.
+        session
+            .entropy_retry_wakeup_scheduler
+            .schedule_deadline(retry_deadline);
+        Ok(RestoredHvfSnapshotV2EntropyPciOwners {
             session,
             entropy_config: config,
             storage_configs,
@@ -26287,6 +26882,12 @@ fn pci_all_virtio_gic_msi_configuration(
 pub(crate) fn pci_root_restore_gic_msi_configuration()
 -> Result<HvfGicMsiConfiguration, HvfArm64BootPciDataError> {
     let fixed_demand = pci_all_virtio_resource_demand(0, 0, 0, None, false, false, false)?;
+    pci_all_virtio_gic_msi_configuration_for_fixed_demand(fixed_demand)
+}
+
+pub(crate) fn pci_entropy_restore_gic_msi_configuration()
+-> Result<HvfGicMsiConfiguration, HvfArm64BootPciDataError> {
+    let fixed_demand = pci_all_virtio_resource_demand(0, 0, 0, None, false, true, false)?;
     pci_all_virtio_gic_msi_configuration_for_fixed_demand(fixed_demand)
 }
 
@@ -38594,6 +39195,45 @@ mod tests {
         assert!(diagnostics.contains("<redacted>"));
         assert!(diagnostics.contains("cleanup_failed"));
         assert!(!diagnostics.contains("secret-entropy-cleanup"));
+    }
+
+    #[test]
+    fn native_v2_entropy_pci_errors_distinguish_commit_from_cleanup_failure() {
+        let retryable = super::HvfSnapshotV2EntropyPciRestoreError::preflight(
+            super::HvfSnapshotV2EntropyPciRestoreStage::ResourcePlan,
+            super::HvfSnapshotV2EntropyPciRestoreFailure::ResourcePlan,
+        );
+        assert!(!retryable.is_terminal());
+        assert!(!retryable.has_incomplete_cleanup());
+
+        let committed = super::HvfSnapshotV2EntropyPciRestoreError::serial_platform(
+            super::HvfSnapshotV2SerialOnlyRestoreError::PciOwner {
+                source: super::HvfArm64BootPciDataError::new("secret-pci-owner/path"),
+                cleanup: None,
+            },
+        );
+        assert!(committed.is_terminal());
+        assert!(!committed.has_incomplete_cleanup());
+
+        let incomplete = super::HvfSnapshotV2EntropyPciRestoreError::serial_platform(
+            super::HvfSnapshotV2SerialOnlyRestoreError::RetryScheduler {
+                scheduler: "entropy-retry",
+                source: io::ErrorKind::PermissionDenied,
+                cleanup: Some(Box::new(
+                    super::HvfArm64BootSessionShutdownError::DestroyVm {
+                        source: super::BackendError::Hypervisor(
+                            "secret-pci-cleanup/path".to_string(),
+                        ),
+                    },
+                )),
+            },
+        );
+        assert!(incomplete.is_terminal());
+        assert!(incomplete.has_incomplete_cleanup());
+        let diagnostics = format!("{incomplete:?} {incomplete}");
+        assert!(diagnostics.contains("<redacted>"));
+        assert!(diagnostics.contains("cleanup_failed"));
+        assert!(!diagnostics.contains("secret-pci-cleanup"));
     }
 
     #[test]

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -11888,6 +11888,335 @@ fn restores_signed_serial_entropy_mmio_owners_with_exact_retry_semantics() {
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 #[test]
+fn restores_signed_serial_entropy_pci_owners_with_exact_retry_semantics() {
+    use std::io::Cursor;
+    use std::time::Instant;
+
+    use bangbang_hvf::{
+        HvfArm64BootEntropyDeviceConfig, HvfArm64BootEntropyTransportState,
+        HvfArm64BootSerialDeviceConfig, HvfArm64BootSessionConfig,
+        HvfArm64BootSnapshotV2CaptureInput, HvfSnapshotV2BootState,
+        HvfSnapshotV2EntropyPciRestoreStage, HvfSnapshotV2EntropyState, HvfSnapshotV2NativePath,
+        HvfSnapshotV2RestoredSerialShell, OwnedHvfArm64BootSession,
+        prepare_hvf_snapshot_v2_serial_entropy_pci_platform_plan,
+    };
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::block::BlockMmioLayout;
+    use bangbang_runtime::boot::BootSourceConfigInput;
+    use bangbang_runtime::entropy::{
+        EntropyConfigInput, EntropyMmioLayout, EntropyRateLimiterConfig, EntropyTokenBucketConfig,
+    };
+    use bangbang_runtime::memory::{GuestAddress, GuestMemory, GuestMemoryLayout};
+    use bangbang_runtime::mmio::MmioRegionId;
+    use bangbang_runtime::network::NetworkMmioLayout;
+    use bangbang_runtime::pmem::PmemMmioLayout;
+    use bangbang_runtime::serial::{
+        SerialMmioDevice, SharedSerialOutput, SharedSerialOutputBuffer,
+    };
+    use bangbang_runtime::snapshot_device_v2::SnapshotV2DeviceTransport;
+    use bangbang_runtime::snapshot_entropy_v2_8::{
+        SnapshotV2EntropyRestorePlan, SnapshotV2EntropyRetryState, SnapshotV2EntropyState,
+    };
+    use bangbang_runtime::snapshot_serial_v2_7::SnapshotV2SerialState;
+    use bangbang_runtime::vsock::VsockMmioLayout;
+
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let image = arm64_image().expect("test arm64 image should build");
+    let kernel = TempFile::new("restore-serial-entropy-pci-kernel", &image)
+        .expect("serial PCI entropy kernel should create");
+    let mut controller = bangbang_runtime::VmmController::new("test", "0.1.0", "bangbang");
+    controller
+        .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            kernel.path(),
+        )))
+        .expect("serial PCI entropy boot source should configure");
+    let limiter = EntropyRateLimiterConfig::new(
+        Some(EntropyTokenBucketConfig::new(4, None, 60_000)),
+        Some(EntropyTokenBucketConfig::new(1, None, 60_000)),
+    );
+    controller
+        .handle_action(VmmAction::PutEntropy(
+            EntropyConfigInput::new().with_rate_limiter(limiter),
+        ))
+        .expect("serial PCI entropy device should configure");
+    let entropy_config = controller
+        .entropy_config()
+        .expect("serial PCI entropy configuration should exist");
+    let session_config = HvfArm64BootSessionConfig::new(
+        BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1)),
+        PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500)),
+        NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000)),
+        VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
+        bangbang_runtime::rtc::RtcMmioLayout::new(
+            GuestAddress::new(0x4000_1000),
+            MmioRegionId::new(10),
+        ),
+    )
+    .with_entropy_device(HvfArm64BootEntropyDeviceConfig::new(
+        EntropyMmioLayout::new(GuestAddress::new(0x4000_7000), MmioRegionId::new(3001)),
+    ))
+    .with_serial_device(HvfArm64BootSerialDeviceConfig::new(
+        MmioRegionId::new(20),
+        GuestAddress::new(0x4000_2000),
+        SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+    ))
+    .with_pci_enabled();
+    let mut source = OwnedHvfArm64BootSession::new(&controller, session_config)
+        .expect("signed serial PCI entropy source should prepare");
+
+    let inactive_guard = source
+        .quiesce_limiter_retry_wakeups()
+        .expect("inactive PCI entropy publishers should quiesce");
+    let inactive_now = Instant::now();
+    let inactive_capture = source
+        .capture_ready_entropy_state_at(Some(entropy_config), &inactive_guard, inactive_now)
+        .expect("inactive PCI entropy owner should capture")
+        .expect("inactive PCI entropy device should exist");
+    let entropy_base = match inactive_capture.transport() {
+        HvfArm64BootEntropyTransportState::Pci { bar_range, .. } => bar_range.start(),
+        HvfArm64BootEntropyTransportState::Mmio { .. } => {
+            panic!("PCI-enabled entropy source should own a PCI endpoint")
+        }
+    };
+    let inactive = inactive_capture
+        .try_to_snapshot_v2()
+        .expect("inactive PCI entropy capture should convert");
+    drop(inactive_guard);
+
+    let retry_after = activate_and_notify_entropy_capture_queue(&mut source, entropy_base, true);
+    assert!(retry_after > std::time::Duration::ZERO);
+    let active_guard = source
+        .quiesce_limiter_retry_wakeups()
+        .expect("active PCI entropy publishers should quiesce");
+    let active_now = Instant::now();
+    let delayed = source
+        .capture_ready_entropy_state_at(Some(entropy_config), &active_guard, active_now)
+        .expect("delayed PCI entropy owner should capture")
+        .expect("delayed PCI entropy device should exist")
+        .try_to_snapshot_v2()
+        .expect("delayed PCI entropy capture should convert");
+    let serial_capture = source
+        .capture_ready_serial_state(controller.serial_config().clone(), &active_guard)
+        .expect("serial state should become capture-ready");
+    let serial = SnapshotV2SerialState::try_from_capture_ready(serial_capture)
+        .expect("serial capture should convert to exact 2.7");
+    drop(active_guard);
+    assert!(matches!(
+        delayed.retry(),
+        SnapshotV2EntropyRetryState::After { .. }
+    ));
+    let (config, queue, limiter, _retry, pending, virtio, transport) = delayed.clone().into_parts();
+    let immediate = SnapshotV2EntropyState::try_new(
+        config,
+        queue,
+        limiter,
+        SnapshotV2EntropyRetryState::Immediate,
+        pending,
+        virtio,
+        transport,
+    )
+    .expect("pending delayed PCI state should admit immediate retry");
+
+    source
+        .pause_for_snapshot_v2_capture()
+        .expect("serial PCI entropy source should pause");
+    let boot = HvfSnapshotV2BootState::try_new(
+        HvfSnapshotV2NativePath::try_new(kernel.path().as_os_str())
+            .expect("serial PCI entropy kernel path should validate"),
+        None,
+        None,
+    )
+    .expect("serial PCI entropy boot metadata should validate");
+    let mut memory_writer = Cursor::new(Vec::new());
+    let platform = source
+        .capture_snapshot_v2_entropy_platform_with_cancel(
+            HvfArm64BootSnapshotV2CaptureInput::new(boot),
+            &mut memory_writer,
+            |_| false,
+        )
+        .expect("exact-2.8 serial PCI entropy platform should capture");
+    for entropy in [&inactive, &delayed, &immediate] {
+        HvfSnapshotV2EntropyState::try_new(
+            platform.clone(),
+            None,
+            serial.clone(),
+            Some(entropy.clone()),
+        )
+        .expect("exact-2.8 serial PCI entropy composition should validate");
+        assert!(matches!(
+            entropy.transport(),
+            SnapshotV2DeviceTransport::Pci(_)
+        ));
+    }
+
+    let layout = GuestMemoryLayout::new(source.runtime_resources().layout.ranges().to_vec())
+        .expect("serial PCI entropy destination layout should validate");
+    let source_memory = source
+        .guest_memory()
+        .expect("serial PCI entropy source memory should remain mapped");
+    let mut destination_memories = Vec::new();
+    destination_memories
+        .try_reserve_exact(4)
+        .expect("PCI destination memory vector should reserve");
+    for _ in 0..4 {
+        let mut destination =
+            GuestMemory::allocate(&layout).expect("serial PCI entropy destination should allocate");
+        let mut buffer = vec![0_u8; 64 * 1024];
+        for range in layout.ranges() {
+            let mut copied = 0_u64;
+            while copied < range.size() {
+                let remaining = range.size() - copied;
+                let count =
+                    usize::try_from(remaining.min(
+                        u64::try_from(buffer.len()).expect("copy buffer length should fit u64"),
+                    ))
+                    .expect("copy size should fit usize");
+                let address = range
+                    .start()
+                    .checked_add(copied)
+                    .expect("copy address should fit");
+                source_memory
+                    .read_slice(&mut buffer[..count], address)
+                    .expect("source guest bytes should read");
+                destination
+                    .write_slice(&buffer[..count], address)
+                    .expect("destination guest bytes should write");
+                copied += u64::try_from(count).expect("copy count should fit u64");
+            }
+        }
+        destination_memories.push(destination);
+    }
+    source
+        .shutdown()
+        .expect("signed serial PCI entropy source should shut down");
+
+    let restored_shell = || {
+        HvfSnapshotV2RestoredSerialShell::new(
+            SerialMmioDevice::from_capture_state_with_shared_output(
+                SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+                serial.device().clone(),
+            ),
+        )
+    };
+
+    let fault_now = Instant::now();
+    let fault_plan = SnapshotV2EntropyRestorePlan::prepare(
+        inactive.clone(),
+        &destination_memories[0],
+        fault_now,
+    )
+    .expect("fault PCI entropy plan should prepare");
+    let fault_endpoint_plan =
+        prepare_hvf_snapshot_v2_serial_entropy_pci_platform_plan(&platform, &fault_plan)
+            .expect("fault PCI entropy platform plan should prepare");
+    let fault =
+        OwnedHvfArm64BootSession::restore_snapshot_v2_serial_entropy_pci_with_scheduler_fault(
+            platform.clone(),
+            destination_memories.remove(0),
+            restored_shell(),
+            None,
+            fault_endpoint_plan,
+            fault_plan,
+        )
+        .expect_err("injected PCI entropy scheduler fault should reject");
+    assert_eq!(
+        fault.stage(),
+        HvfSnapshotV2EntropyPciRestoreStage::RetryScheduler
+    );
+    assert!(fault.is_terminal());
+    assert!(!fault.has_incomplete_cleanup());
+    let diagnostics = format!("{fault:?} {fault}");
+    assert!(diagnostics.contains("<redacted>"));
+    assert!(!diagnostics.contains(&entropy_base.raw_value().to_string()));
+
+    for (name, expected) in [
+        ("none", inactive),
+        ("delayed", delayed),
+        ("immediate", immediate),
+    ] {
+        let restore_now = Instant::now();
+        let restore_plan = SnapshotV2EntropyRestorePlan::prepare(
+            expected.clone(),
+            &destination_memories[0],
+            restore_now,
+        )
+        .unwrap_or_else(|error| panic!("{name} PCI entropy plan should prepare: {error:?}"));
+        let endpoint_plan =
+            prepare_hvf_snapshot_v2_serial_entropy_pci_platform_plan(&platform, &restore_plan)
+                .unwrap_or_else(|error| {
+                    panic!("{name} PCI entropy platform plan should prepare: {error:?}")
+                });
+        let owners = OwnedHvfArm64BootSession::restore_snapshot_v2_serial_entropy_pci(
+            platform.clone(),
+            destination_memories.remove(0),
+            restored_shell(),
+            None,
+            endpoint_plan,
+            restore_plan,
+        )
+        .unwrap_or_else(|error| panic!("{name} PCI entropy owners should restore: {error:?}"));
+        assert_eq!(owners.entropy_config(), entropy_config);
+        assert!(owners.storage_configs().is_none());
+        assert!(
+            owners
+                .session()
+                .shared_entropy_device_metrics()
+                .snapshot()
+                .is_empty()
+        );
+        let (mut destination, returned_config, storage_configs) = owners.into_parts();
+        assert_eq!(returned_config, entropy_config);
+        assert!(storage_configs.is_none());
+        assert!(destination.runtime_resources().entropy_device.is_none());
+        assert!(destination.runtime_resources().pci_entropy_device.is_none());
+        assert!(destination.uses_pci_data_devices());
+        let guard = destination
+            .quiesce_limiter_retry_wakeups()
+            .unwrap_or_else(|error| panic!("{name} retry publishers should quiesce: {error:?}"));
+        let recaptured = destination
+            .capture_ready_entropy_state_at(Some(returned_config), &guard, restore_now)
+            .unwrap_or_else(|error| panic!("{name} PCI entropy owner should recapture: {error:?}"))
+            .expect("restored PCI entropy device should exist")
+            .try_to_snapshot_v2()
+            .unwrap_or_else(|error| {
+                panic!("{name} PCI entropy recapture should convert: {error:?}")
+            });
+        assert_eq!(
+            recaptured, expected,
+            "{name} PCI entropy state should be exact"
+        );
+        assert!(matches!(
+            recaptured.transport(),
+            SnapshotV2DeviceTransport::Pci(_)
+        ));
+        drop(guard);
+        if name == "none" {
+            let SnapshotV2DeviceTransport::Pci(transport) = recaptured.transport() else {
+                panic!("restored inactive entropy should retain PCI placement");
+            };
+            let retry_after = activate_and_notify_entropy_capture_queue(
+                &mut destination,
+                transport.bar_range().start(),
+                true,
+            );
+            assert!(retry_after > std::time::Duration::ZERO);
+            assert!(
+                !destination
+                    .shared_entropy_device_metrics()
+                    .snapshot()
+                    .is_empty()
+            );
+        }
+        destination.shutdown().unwrap_or_else(|error| {
+            panic!("{name} PCI entropy destination should shut down: {error}")
+        });
+    }
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
 fn restores_signed_storage_serial_entropy_mmio_owner_graph() {
     use std::io::Cursor;
     use std::time::Instant;
@@ -12131,6 +12460,256 @@ fn restores_signed_storage_serial_entropy_mmio_owner_graph() {
     restored
         .shutdown()
         .expect("restored storage entropy destination should shut down");
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn restores_signed_storage_serial_entropy_pci_owner_graph() {
+    use std::io::Cursor;
+    use std::time::Instant;
+
+    use bangbang_hvf::{
+        HvfArm64BootEntropyDeviceConfig, HvfArm64BootSerialDeviceConfig, HvfArm64BootSessionConfig,
+        HvfArm64BootSnapshotV2CaptureInput, HvfSnapshotV2BootState, HvfSnapshotV2EntropyState,
+        HvfSnapshotV2NativePath, HvfSnapshotV2RestoredSerialShell, OwnedHvfArm64BootSession,
+        prepare_hvf_snapshot_v2_storage_entropy_pci_platform_plan,
+    };
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::block::{
+        BlockFileBacking, BlockMmioLayout, DriveConfigInput, DriveIoEngine,
+    };
+    use bangbang_runtime::boot::BootSourceConfigInput;
+    use bangbang_runtime::entropy::{EntropyConfigInput, EntropyMmioLayout};
+    use bangbang_runtime::memory::{GuestAddress, GuestMemory, GuestMemoryLayout};
+    use bangbang_runtime::mmio::MmioRegionId;
+    use bangbang_runtime::network::NetworkMmioLayout;
+    use bangbang_runtime::pmem::PmemMmioLayout;
+    use bangbang_runtime::serial::{
+        SerialMmioDevice, SharedSerialOutput, SharedSerialOutputBuffer,
+    };
+    use bangbang_runtime::snapshot_device_v2::{
+        SnapshotV2DeviceTransport, SnapshotV2DeviceTransportKind,
+    };
+    use bangbang_runtime::snapshot_device_v2_6::SnapshotV2StorageRestorePlan;
+    use bangbang_runtime::snapshot_entropy_v2_8::SnapshotV2EntropyRestorePlan;
+    use bangbang_runtime::snapshot_serial_v2_7::SnapshotV2SerialState;
+    use bangbang_runtime::storage_capture::CaptureReadyStorageConfigs;
+    use bangbang_runtime::vsock::VsockMmioLayout;
+
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let image = arm64_image().expect("test arm64 image should build");
+    let kernel = TempFile::new("restore-storage-entropy-pci-kernel", &image)
+        .expect("storage PCI entropy kernel should create");
+    let root = TempFile::new_len("restore-storage-entropy-pci-root", 4096)
+        .expect("storage PCI entropy root should create");
+    let mut controller = bangbang_runtime::VmmController::new("test", "0.1.0", "bangbang");
+    controller
+        .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            kernel.path(),
+        )))
+        .expect("storage PCI entropy boot source should configure");
+    controller
+        .handle_action(VmmAction::PutDrive(
+            DriveConfigInput::new("rootfs", "rootfs", root.path(), true)
+                .with_is_read_only(true)
+                .with_io_engine(DriveIoEngine::Sync),
+        ))
+        .expect("storage PCI entropy root should configure");
+    controller
+        .handle_action(VmmAction::PutEntropy(EntropyConfigInput::new()))
+        .expect("storage PCI entropy device should configure");
+    let entropy_config = controller
+        .entropy_config()
+        .expect("storage PCI entropy configuration should exist");
+    let session_config = HvfArm64BootSessionConfig::new(
+        BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1)),
+        PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500)),
+        NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000)),
+        VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
+        bangbang_runtime::rtc::RtcMmioLayout::new(
+            GuestAddress::new(0x4000_1000),
+            MmioRegionId::new(10),
+        ),
+    )
+    .with_entropy_device(HvfArm64BootEntropyDeviceConfig::new(
+        EntropyMmioLayout::new(GuestAddress::new(0x4000_7000), MmioRegionId::new(3001)),
+    ))
+    .with_serial_device(HvfArm64BootSerialDeviceConfig::new(
+        MmioRegionId::new(20),
+        GuestAddress::new(0x4000_2000),
+        SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+    ))
+    .with_pci_enabled();
+    let mut source = OwnedHvfArm64BootSession::new(&controller, session_config)
+        .expect("signed storage PCI entropy source should prepare");
+    let source_configs =
+        CaptureReadyStorageConfigs::new(controller.drive_configs().to_vec(), Vec::new());
+    let guard = source
+        .quiesce_limiter_retry_wakeups()
+        .expect("storage PCI entropy publishers should quiesce");
+    let capture_now = Instant::now();
+    let graph = source
+        .capture_snapshot_v2_storage_device_graph_at(&source_configs, &guard, capture_now)
+        .expect("PCI storage graph should capture");
+    assert_eq!(graph.transport_kind(), SnapshotV2DeviceTransportKind::Pci);
+    let entropy = source
+        .capture_ready_entropy_state_at(Some(entropy_config), &guard, capture_now)
+        .expect("storage PCI entropy owner should capture")
+        .expect("storage PCI entropy device should exist")
+        .try_to_snapshot_v2()
+        .expect("storage PCI entropy capture should convert");
+    assert!(matches!(
+        entropy.transport(),
+        SnapshotV2DeviceTransport::Pci(_)
+    ));
+    let serial = SnapshotV2SerialState::try_from_capture_ready(
+        source
+            .capture_ready_serial_state(controller.serial_config().clone(), &guard)
+            .expect("storage PCI serial state should capture"),
+    )
+    .expect("storage PCI serial capture should convert");
+    drop(guard);
+
+    source
+        .pause_for_snapshot_v2_capture()
+        .expect("storage PCI entropy source should pause");
+    let boot = HvfSnapshotV2BootState::try_new(
+        HvfSnapshotV2NativePath::try_new(kernel.path().as_os_str())
+            .expect("storage PCI entropy kernel path should validate"),
+        None,
+        None,
+    )
+    .expect("storage PCI entropy boot metadata should validate");
+    let mut memory_writer = Cursor::new(Vec::new());
+    let platform = source
+        .capture_snapshot_v2_entropy_platform_with_cancel(
+            HvfArm64BootSnapshotV2CaptureInput::new(boot),
+            &mut memory_writer,
+            |_| false,
+        )
+        .expect("storage PCI entropy exact-2.8 platform should capture");
+    HvfSnapshotV2EntropyState::try_new(
+        platform.clone(),
+        Some(graph.clone()),
+        serial.clone(),
+        Some(entropy.clone()),
+    )
+    .expect("storage, serial, and PCI entropy composition should validate");
+
+    let layout = GuestMemoryLayout::new(source.runtime_resources().layout.ranges().to_vec())
+        .expect("storage PCI entropy destination layout should validate");
+    let mut destination =
+        GuestMemory::allocate(&layout).expect("storage PCI entropy destination should allocate");
+    let source_memory = source
+        .guest_memory()
+        .expect("storage PCI entropy source memory should remain mapped");
+    let mut buffer = vec![0_u8; 64 * 1024];
+    for range in layout.ranges() {
+        let mut copied = 0_u64;
+        while copied < range.size() {
+            let remaining = range.size() - copied;
+            let count = usize::try_from(
+                remaining
+                    .min(u64::try_from(buffer.len()).expect("copy buffer length should fit u64")),
+            )
+            .expect("copy size should fit usize");
+            let address = range
+                .start()
+                .checked_add(copied)
+                .expect("copy address should fit");
+            source_memory
+                .read_slice(&mut buffer[..count], address)
+                .expect("storage PCI entropy source bytes should read");
+            destination
+                .write_slice(&buffer[..count], address)
+                .expect("storage PCI entropy destination bytes should write");
+            copied += u64::try_from(count).expect("copy count should fit u64");
+        }
+    }
+    source
+        .shutdown()
+        .expect("signed storage PCI entropy source should shut down");
+
+    let restore_now = Instant::now();
+    let entropy_plan =
+        SnapshotV2EntropyRestorePlan::prepare(entropy.clone(), &destination, restore_now)
+            .expect("storage PCI entropy restore plan should prepare");
+    let backing = BlockFileBacking::open_snapshot(
+        std::path::Path::new(graph.block_records()[0].config().selector()),
+        graph.block_records()[0].config().is_read_only(),
+    )
+    .expect("storage PCI entropy block backing should reopen")
+    .0;
+    let bundle = SnapshotV2StorageRestorePlan::prepare(graph.clone(), &destination, restore_now)
+        .expect("storage PCI entropy graph restore plan should prepare")
+        .prepare_backings(vec![backing], Vec::new(), || false)
+        .expect("storage PCI entropy backing bundle should prepare");
+    let combined_plan = prepare_hvf_snapshot_v2_storage_entropy_pci_platform_plan(
+        &platform,
+        &bundle,
+        &entropy_plan,
+    )
+    .expect("storage PCI entropy combined plan should prepare");
+    assert_eq!(combined_plan.storage().pci().record_count(), 1);
+    assert_eq!(combined_plan.entropy().preceding_endpoint_count(), 1);
+    let shell = HvfSnapshotV2RestoredSerialShell::new(
+        SerialMmioDevice::from_capture_state_with_shared_output(
+            SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+            serial.device().clone(),
+        ),
+    );
+    let owners = OwnedHvfArm64BootSession::restore_snapshot_v2_serial_storage_entropy_pci(
+        platform,
+        destination,
+        shell,
+        None,
+        bundle,
+        combined_plan,
+        entropy_plan,
+    )
+    .unwrap_or_else(|error| panic!("storage PCI entropy owners should restore: {error:?}"));
+    assert_eq!(owners.entropy_config(), entropy_config);
+    assert_eq!(
+        owners
+            .storage_configs()
+            .expect("restored PCI storage configurations should exist"),
+        &source_configs
+    );
+    let (mut restored, returned_entropy_config, returned_storage_configs) = owners.into_parts();
+    let returned_storage_configs =
+        returned_storage_configs.expect("restored PCI storage configurations should be retained");
+    assert_eq!(returned_storage_configs, source_configs);
+    assert!(restored.uses_pci_data_devices());
+    assert!(restored.runtime_resources().block_devices.is_empty());
+    assert!(restored.runtime_resources().entropy_device.is_none());
+    assert!(restored.runtime_resources().pci_entropy_device.is_none());
+    assert!(
+        restored
+            .shared_entropy_device_metrics()
+            .snapshot()
+            .is_empty()
+    );
+
+    let guard = restored
+        .quiesce_limiter_retry_wakeups()
+        .expect("restored storage PCI entropy publishers should quiesce");
+    let recaptured_entropy = restored
+        .capture_ready_entropy_state_at(Some(returned_entropy_config), &guard, restore_now)
+        .expect("restored storage PCI entropy owner should capture")
+        .expect("restored storage PCI entropy device should exist")
+        .try_to_snapshot_v2()
+        .expect("restored storage PCI entropy capture should convert");
+    assert_eq!(recaptured_entropy, entropy);
+    let recaptured_graph = restored
+        .capture_snapshot_v2_storage_device_graph_at(&returned_storage_configs, &guard, restore_now)
+        .expect("restored PCI storage graph should recapture");
+    assert_eq!(recaptured_graph, graph);
+    drop(guard);
+    restored
+        .shutdown()
+        .expect("restored storage PCI entropy destination should shut down");
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/crates/runtime/src/snapshot_entropy_v2_8.rs
+++ b/crates/runtime/src/snapshot_entropy_v2_8.rs
@@ -17,7 +17,8 @@ use crate::entropy::{
 };
 use crate::interrupt::GuestInterruptLine;
 use crate::memory::{GuestMemory, GuestMemoryRange};
-use crate::mmio::MmioRegion;
+use crate::message_interrupt::GuestMessageInterruptRegistry;
+use crate::mmio::{MmioRegion, MmioRegionId};
 use crate::pci::PciSbdf;
 use crate::snapshot_device_v2::{
     SnapshotV2DeviceGraphCaptureError, SnapshotV2DeviceTransport, SnapshotV2DeviceTransportKind,
@@ -30,11 +31,13 @@ use crate::snapshot_device_v2_5::{
 };
 use crate::snapshot_format::SnapshotFormatVersion;
 use crate::storage_capture::StorageDeviceOrigin;
-use crate::virtio::VirtioDeviceType;
+use crate::virtio::{UnsupportedVirtioDeviceConfig, VirtioDeviceType};
 use crate::virtio_mmio::{
     VIRTIO_MMIO_VERSION_1_FEATURE, VirtioMmioQueueState, VirtioMmioTransportState,
 };
-use crate::virtio_pci::{VirtioPciIdentity, VirtioPciTransportState};
+use crate::virtio_pci::{
+    PreparedVirtioPciEndpoint, VirtioPciEndpointError, VirtioPciIdentity, VirtioPciTransportState,
+};
 
 mod codec;
 
@@ -667,6 +670,56 @@ impl SnapshotV2EntropyRestorePlan {
             handler,
         })
     }
+
+    /// Consumes a checked PCI plan into one complete retained endpoint.
+    ///
+    /// The caller supplies one fresh destination message registry and the
+    /// dispatcher region reserved by the destination platform plan. The
+    /// returned value still owns no route resources, dispatcher registration,
+    /// BAR/function lease, entropy source, metrics, scheduler, or VM
+    /// authority.
+    #[doc(hidden)]
+    pub fn into_pci_endpoint(
+        self,
+        region_id: MmioRegionId,
+        messages: GuestMessageInterruptRegistry,
+    ) -> Result<PreparedSnapshotV2EntropyPciEndpoint, SnapshotV2EntropyPciEndpointError> {
+        let Self {
+            config,
+            queue_ranges,
+            retry,
+            retry_deadline,
+            transport,
+        } = self;
+        let PreparedSnapshotV2EntropyTransport::Pci(pci) = transport else {
+            return Err(SnapshotV2EntropyPciEndpointError::WrongTransport);
+        };
+        let (origin, sbdf, bar_range, identity, device, retained) = pci.into_parts();
+        let activation_is_active = device.is_activated();
+        let endpoint = PreparedVirtioPciEndpoint::new(
+            identity,
+            &VIRTIO_RNG_QUEUE_SIZES,
+            UnsupportedVirtioDeviceConfig,
+            device,
+            activation_is_active,
+            false,
+            &retained,
+            sbdf,
+            bar_range,
+            region_id,
+            messages,
+        )
+        .map_err(SnapshotV2EntropyPciEndpointError::Endpoint)?;
+
+        Ok(PreparedSnapshotV2EntropyPciEndpoint {
+            config,
+            queue_ranges,
+            retry,
+            retry_deadline,
+            origin,
+            endpoint,
+        })
+    }
 }
 
 impl fmt::Debug for SnapshotV2EntropyRestorePlan {
@@ -941,6 +994,126 @@ impl fmt::Debug for PreparedSnapshotV2EntropyPciTransport {
             .debug_struct("PreparedSnapshotV2EntropyPciTransport")
             .field("state", &REDACTED)
             .finish()
+    }
+}
+
+/// One checked exact-2.8 entropy endpoint awaiting destination PCI
+/// publication.
+#[doc(hidden)]
+pub struct PreparedSnapshotV2EntropyPciEndpoint {
+    config: EntropyConfig,
+    queue_ranges: Option<[GuestMemoryRange; 3]>,
+    retry: SnapshotV2EntropyRetryState,
+    retry_deadline: Option<Instant>,
+    origin: StorageDeviceOrigin,
+    endpoint: PreparedVirtioPciEndpoint<UnsupportedVirtioDeviceConfig, VirtioRngDevice>,
+}
+
+/// Consumed checked entropy continuation and retained PCI endpoint.
+#[doc(hidden)]
+pub type PreparedSnapshotV2EntropyPciEndpointParts = (
+    EntropyConfig,
+    Option<[GuestMemoryRange; 3]>,
+    SnapshotV2EntropyRetryState,
+    Option<Instant>,
+    StorageDeviceOrigin,
+    PreparedVirtioPciEndpoint<UnsupportedVirtioDeviceConfig, VirtioRngDevice>,
+);
+
+impl PreparedSnapshotV2EntropyPciEndpoint {
+    /// Returns the exact public entropy configuration.
+    pub const fn config(&self) -> EntropyConfig {
+        self.config
+    }
+
+    /// Returns loaded-memory ranges occupied by an active queue.
+    pub const fn queue_ranges(&self) -> Option<[GuestMemoryRange; 3]> {
+        self.queue_ranges
+    }
+
+    /// Returns the retained retry disposition.
+    pub const fn retry(&self) -> SnapshotV2EntropyRetryState {
+        self.retry
+    }
+
+    /// Returns the destination-local deadline without scheduling it.
+    pub const fn retry_deadline(&self) -> Option<Instant> {
+        self.retry_deadline
+    }
+
+    /// Returns the retained startup/runtime origin.
+    pub const fn origin(&self) -> StorageDeviceOrigin {
+        self.origin
+    }
+
+    /// Returns the complete retained endpoint before publication.
+    pub const fn endpoint(
+        &self,
+    ) -> &PreparedVirtioPciEndpoint<UnsupportedVirtioDeviceConfig, VirtioRngDevice> {
+        &self.endpoint
+    }
+
+    /// Consumes the checked continuation and retained endpoint.
+    pub fn into_parts(self) -> PreparedSnapshotV2EntropyPciEndpointParts {
+        (
+            self.config,
+            self.queue_ranges,
+            self.retry,
+            self.retry_deadline,
+            self.origin,
+            self.endpoint,
+        )
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2EntropyPciEndpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2EntropyPciEndpoint")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Failure while binding a checked entropy plan to a destination PCI
+/// registry.
+#[doc(hidden)]
+pub enum SnapshotV2EntropyPciEndpointError {
+    /// The checked plan selects MMIO rather than PCI.
+    WrongTransport,
+    /// The retained endpoint could not be reconstructed exactly.
+    Endpoint(VirtioPciEndpointError),
+}
+
+impl fmt::Debug for SnapshotV2EntropyPciEndpointError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::WrongTransport => "wrong-transport",
+            Self::Endpoint(_) => "endpoint",
+        };
+        formatter
+            .debug_struct("SnapshotV2EntropyPciEndpointError")
+            .field("kind", &kind)
+            .field("source", &REDACTED)
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotV2EntropyPciEndpointError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::WrongTransport => "native-v2 entropy restore plan is not PCI",
+            Self::Endpoint(_) => "native-v2 entropy PCI endpoint reconstruction failed",
+        })
+    }
+}
+
+impl std::error::Error for SnapshotV2EntropyPciEndpointError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::WrongTransport => None,
+            Self::Endpoint(source) => Some(source),
+        }
     }
 }
 

--- a/crates/runtime/src/snapshot_entropy_v2_8/tests.rs
+++ b/crates/runtime/src/snapshot_entropy_v2_8/tests.rs
@@ -1,9 +1,15 @@
 use super::codec::{self, ReservePolicy};
 use super::*;
 
+use std::sync::Arc;
+
 use crate::entropy::{EntropyMmioDeviceRegistration, VirtioRngRetryCaptureState};
 use crate::interrupt::GuestInterruptLine;
 use crate::memory::{GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange};
+use crate::message_interrupt::{
+    GuestMessage, GuestMessageInterrupt, GuestMessageInterruptRegistry,
+    GuestMessageInterruptSignalError,
+};
 use crate::mmio::{MmioRegion, MmioRegionId};
 use crate::pci::{
     PCI_BAR64_START, PCI_BUS_ZERO, PCI_FIRST_ENDPOINT_DEVICE, PCI_FUNCTION_ZERO, PCI_SEGMENT_ZERO,
@@ -39,6 +45,39 @@ const ACTIVE_DATA: GuestAddress = GuestAddress::new(0x18_0000);
 const AVAILABLE_INDEX_OFFSET: u64 = 2;
 const AVAILABLE_RING_OFFSET: u64 = 4;
 const USED_INDEX_OFFSET: u64 = 2;
+
+#[derive(Debug)]
+struct TestMessageRoute(GuestMessage);
+
+impl GuestMessageInterrupt for TestMessageRoute {
+    fn matches(&self, message: GuestMessage) -> bool {
+        self.0 == message
+    }
+
+    fn signal(&self, message: GuestMessage) -> Result<(), GuestMessageInterruptSignalError> {
+        if self.matches(message) {
+            Ok(())
+        } else {
+            Err(GuestMessageInterruptSignalError::new(
+                "test route rejected an unknown message",
+                false,
+            ))
+        }
+    }
+}
+
+fn entropy_message_registry(route_count: usize) -> GuestMessageInterruptRegistry {
+    let messages = [
+        GuestMessage::new(0x0800_0040, 64),
+        GuestMessage::new(0x0800_0040, 96),
+    ];
+    let routes: Vec<Arc<dyn GuestMessageInterrupt>> = messages
+        .into_iter()
+        .take(route_count)
+        .map(|message| Arc::new(TestMessageRoute(message)) as Arc<dyn GuestMessageInterrupt>)
+        .collect();
+    GuestMessageInterruptRegistry::new(routes).expect("entropy message registry should validate")
+}
 
 fn inactive_mmio_state() -> SnapshotV2EntropyState {
     let bandwidth = EntropyTokenBucketConfig::new(0, Some(7), 100);
@@ -523,6 +562,77 @@ fn pci_restore_plan_rejects_mmio_handler_materialization() {
     assert_eq!(
         error.to_string(),
         "native-v2 entropy restore plan is not MMIO"
+    );
+}
+
+#[test]
+fn active_pci_restore_plan_materializes_exact_retained_endpoint() {
+    let state = active_pci_state();
+    let mut memory = restore_memory();
+    write_pending_queue(&mut memory, ACTIVE_DESCRIPTOR_TABLE, 7, 6);
+    let now = Instant::now();
+    let prepared = SnapshotV2EntropyRestorePlan::prepare(state.clone(), &memory, now)
+        .expect("active PCI restore plan should prepare")
+        .into_pci_endpoint(MmioRegionId::new(700), entropy_message_registry(2))
+        .expect("active PCI endpoint should materialize");
+
+    assert_eq!(prepared.config(), state.config());
+    assert!(prepared.queue_ranges().is_some());
+    assert_eq!(
+        prepared.retry(),
+        SnapshotV2EntropyRetryState::try_after(75_000_000).expect("delayed retry should validate")
+    );
+    assert_eq!(
+        prepared.retry_deadline(),
+        now.checked_add(Duration::from_millis(75))
+    );
+    assert_eq!(prepared.origin(), StorageDeviceOrigin::Startup);
+    assert_eq!(prepared.endpoint().sbdf(), pci_transport().sbdf());
+    assert_eq!(prepared.endpoint().bar_range(), pci_transport().bar_range());
+    assert_eq!(prepared.endpoint().region_id(), MmioRegionId::new(700));
+
+    let debug = format!("{prepared:?}");
+    assert!(debug.contains("<redacted>"));
+    for sentinel in ["1048576", "134217792", "25000000", "75000000"] {
+        assert!(!debug.contains(sentinel));
+    }
+}
+
+#[test]
+fn pci_endpoint_materialization_rejects_wrong_transport_and_route_geometry() {
+    let memory = restore_memory();
+    let wrong_transport =
+        SnapshotV2EntropyRestorePlan::prepare(inactive_mmio_state(), &memory, Instant::now())
+            .expect("inactive MMIO restore plan should prepare")
+            .into_pci_endpoint(MmioRegionId::new(700), entropy_message_registry(2))
+            .expect_err("MMIO plan must not materialize a PCI endpoint");
+    assert!(matches!(
+        wrong_transport,
+        SnapshotV2EntropyPciEndpointError::WrongTransport
+    ));
+    assert_eq!(
+        wrong_transport.to_string(),
+        "native-v2 entropy restore plan is not PCI"
+    );
+
+    let mut memory = restore_memory();
+    write_pending_queue(&mut memory, ACTIVE_DESCRIPTOR_TABLE, 7, 6);
+    let route_error =
+        SnapshotV2EntropyRestorePlan::prepare(active_pci_state(), &memory, Instant::now())
+            .expect("active PCI restore plan should prepare")
+            .into_pci_endpoint(MmioRegionId::new(700), entropy_message_registry(1))
+            .expect_err("one route cannot satisfy entropy MSI-X geometry");
+    assert!(matches!(
+        route_error,
+        SnapshotV2EntropyPciEndpointError::Endpoint(VirtioPciEndpointError::MessageRouteCount {
+            expected: 2,
+            actual: 1
+        })
+    ));
+    assert!(format!("{route_error:?}").contains("<redacted>"));
+    assert_eq!(
+        route_error.to_string(),
+        "native-v2 entropy PCI endpoint reconstruction failed"
     );
 }
 


### PR DESCRIPTION
## Summary

- materialize checked exact-2.8 PCI entropy state as an exact retained virtio-pci endpoint
- preflight serial and storage-plus-entropy placement, 30/31 endpoint capacity, GICv2m routes, active-message uniqueness, and memory conflicts before HVF mutation
- attach entropy through the canonical restored PCI manager with fresh source, metrics, wake/scheduler ownership, deadline-last publication, and terminal reverse cleanup
- certify inactive, delayed, and immediate retry recapture plus storage-bearing owner graphs on signed HVF

## Scope

Public exact-2.8 load and activation remain disabled for #1665. Documentation and capability inventory promotion remain deferred to #1666.

Closes #1664

## Verification

- cargo fmt --all -- --check
- cargo run -p bangbang-firecracker-capability-audit --locked -- validate
- cargo check --workspace --all-targets --all-features --locked
- cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- all documented Apple-target Clippy commands
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps --locked
- scripts/run-integration-tests.sh