### PR TITLE
feat: prepare decoded balloon snapshot state

### DIFF
--- a/crates/runtime/src/balloon.rs
+++ b/crates/runtime/src/balloon.rs
@@ -1337,6 +1337,17 @@ impl VirtioBalloonPfnRange {
         }
     }
 
+    pub(crate) fn from_snapshot_parts(
+        start_pfn: u32,
+        page_count: u32,
+    ) -> Result<Self, VirtioBalloonMemoryAccountingRestoreError> {
+        let range = Self::new(start_pfn, page_count);
+        if page_count == 0 || range.end_pfn_exclusive() > u64::from(u32::MAX) + 1 {
+            return Err(VirtioBalloonMemoryAccountingRestoreError::Range);
+        }
+        Ok(range)
+    }
+
     pub const fn start_pfn(self) -> u32 {
         self.start_pfn
     }
@@ -1466,6 +1477,36 @@ impl VirtioBalloonMemoryAccounting {
         self.inflated_page_ranges.is_empty()
     }
 
+    pub(crate) fn from_snapshot_ranges(
+        inflated_page_ranges: Vec<VirtioBalloonPfnRange>,
+        inflated_page_count: u64,
+    ) -> Result<Self, VirtioBalloonMemoryAccountingRestoreError> {
+        let mut previous_end = None;
+        let mut actual_page_count = 0_u64;
+        for range in inflated_page_ranges.iter().copied() {
+            let start = u64::from(range.start_pfn());
+            let end = range.end_pfn_exclusive();
+            if range.page_count() == 0
+                || end <= start
+                || end > u64::from(u32::MAX) + 1
+                || previous_end.is_some_and(|previous| start <= previous)
+            {
+                return Err(VirtioBalloonMemoryAccountingRestoreError::Canonicality);
+            }
+            actual_page_count = actual_page_count
+                .checked_add(u64::from(range.page_count()))
+                .ok_or(VirtioBalloonMemoryAccountingRestoreError::Total)?;
+            previous_end = Some(end);
+        }
+        if actual_page_count != inflated_page_count {
+            return Err(VirtioBalloonMemoryAccountingRestoreError::Total);
+        }
+
+        Ok(Self {
+            inflated_page_ranges,
+        })
+    }
+
     /// Fallibly clones the detached compact PFN accounting state.
     pub fn try_clone(&self) -> Result<Self, TryReserveError> {
         let mut inflated_page_ranges = Vec::new();
@@ -1574,6 +1615,31 @@ impl VirtioBalloonMemoryAccounting {
         Ok(())
     }
 }
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VirtioBalloonMemoryAccountingRestoreError {
+    Range,
+    Canonicality,
+    Total,
+}
+
+impl fmt::Debug for VirtioBalloonMemoryAccountingRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+impl fmt::Display for VirtioBalloonMemoryAccountingRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Range => "restored virtio-balloon PFN range is invalid",
+            Self::Canonicality => "restored virtio-balloon accounting is not canonical",
+            Self::Total => "restored virtio-balloon accounting total is invalid",
+        })
+    }
+}
+
+impl std::error::Error for VirtioBalloonMemoryAccountingRestoreError {}
 
 fn prepare_balloon_accounting(
     accounting: &VirtioBalloonMemoryAccounting,
@@ -2395,6 +2461,55 @@ impl std::error::Error for VirtioBalloonQueueBuildError {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VirtioBalloonQueueRestoreError {
+    QueueNotReady,
+    AvailableRingInvalid,
+    UsedRingInvalid,
+    QueueRangeInvalid,
+    QueueRangesOverlap,
+    UsedCursorMismatch,
+    AvailableCursorOutOfBounds,
+    UnpublishedDescriptorCountMismatch,
+    StatisticsDescriptorMismatch,
+    StatisticsDescriptorDuplicated,
+    ActiveQueueShape,
+}
+
+impl fmt::Debug for VirtioBalloonQueueRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+impl fmt::Display for VirtioBalloonQueueRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::QueueNotReady => "restored virtio-balloon queue is not ready",
+            Self::AvailableRingInvalid => "restored virtio-balloon available ring is invalid",
+            Self::UsedRingInvalid => "restored virtio-balloon used ring is invalid",
+            Self::QueueRangeInvalid => "restored virtio-balloon queue range is invalid",
+            Self::QueueRangesOverlap => "restored virtio-balloon queue ranges overlap",
+            Self::UsedCursorMismatch => "restored virtio-balloon used cursor is invalid",
+            Self::AvailableCursorOutOfBounds => {
+                "restored virtio-balloon available cursor is invalid"
+            }
+            Self::UnpublishedDescriptorCountMismatch => {
+                "restored virtio-balloon unpublished descriptor count is invalid"
+            }
+            Self::StatisticsDescriptorMismatch => {
+                "restored virtio-balloon statistics descriptor is invalid"
+            }
+            Self::StatisticsDescriptorDuplicated => {
+                "restored virtio-balloon statistics descriptor is duplicated"
+            }
+            Self::ActiveQueueShape => "restored virtio-balloon active queue shape is invalid",
+        })
+    }
+}
+
+impl std::error::Error for VirtioBalloonQueueRestoreError {}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VirtioBalloonQueue {
     available: VirtqueueAvailableRing,
@@ -2425,12 +2540,114 @@ impl VirtioBalloonQueue {
         Ok(Self { available, used })
     }
 
+    pub(crate) fn from_snapshot_state(
+        queue: &VirtioMmioQueueState,
+        next_available: u16,
+        next_used: u16,
+    ) -> Result<Self, VirtioBalloonQueueRestoreError> {
+        if !queue.ready() {
+            return Err(VirtioBalloonQueueRestoreError::QueueNotReady);
+        }
+
+        let available = VirtqueueAvailableRing::with_next_avail(
+            queue.descriptor_table(),
+            queue.driver_ring(),
+            queue.size(),
+            next_available,
+        )
+        .map_err(|_| VirtioBalloonQueueRestoreError::AvailableRingInvalid)?;
+        let used = VirtqueueUsedRing::with_next_used(queue.device_ring(), queue.size(), next_used)
+            .map_err(|_| VirtioBalloonQueueRestoreError::UsedRingInvalid)?;
+
+        Ok(Self { available, used })
+    }
+
     pub const fn available_ring(&self) -> &VirtqueueAvailableRing {
         &self.available
     }
 
     pub const fn used_ring(&self) -> &VirtqueueUsedRing {
         &self.used
+    }
+
+    pub(crate) fn validate_snapshot_state(
+        &self,
+        memory: &GuestMemory,
+        statistics_pending_descriptor_head: Option<u16>,
+    ) -> Result<(), VirtioBalloonQueueRestoreError> {
+        self.available
+            .validate_mapped(memory)
+            .map_err(|_| VirtioBalloonQueueRestoreError::AvailableRingInvalid)?;
+        self.used
+            .validate_mapped(memory)
+            .map_err(|_| VirtioBalloonQueueRestoreError::UsedRingInvalid)?;
+        let descriptor_range = self
+            .available
+            .descriptor_table_range()
+            .map_err(|_| VirtioBalloonQueueRestoreError::QueueRangeInvalid)?;
+        let available_range = self
+            .available
+            .available_ring_range()
+            .map_err(|_| VirtioBalloonQueueRestoreError::QueueRangeInvalid)?;
+        let used_range = self
+            .used
+            .used_ring_range()
+            .map_err(|_| VirtioBalloonQueueRestoreError::QueueRangeInvalid)?;
+        if descriptor_range.overlaps(available_range)
+            || descriptor_range.overlaps(used_range)
+            || available_range.overlaps(used_range)
+        {
+            return Err(VirtioBalloonQueueRestoreError::QueueRangesOverlap);
+        }
+
+        let used_index = self
+            .used
+            .used_index(memory)
+            .map_err(|_| VirtioBalloonQueueRestoreError::UsedRingInvalid)?;
+        if used_index != self.used.next_used() {
+            return Err(VirtioBalloonQueueRestoreError::UsedCursorMismatch);
+        }
+        let available_index = self
+            .available
+            .available_index(memory)
+            .map_err(|_| VirtioBalloonQueueRestoreError::AvailableRingInvalid)?;
+        if available_index.wrapping_sub(self.available.next_avail()) > self.available.queue_size() {
+            return Err(VirtioBalloonQueueRestoreError::AvailableCursorOutOfBounds);
+        }
+
+        let unpublished = self
+            .available
+            .next_avail()
+            .wrapping_sub(self.used.next_used());
+        if unpublished != u16::from(statistics_pending_descriptor_head.is_some()) {
+            return Err(VirtioBalloonQueueRestoreError::UnpublishedDescriptorCountMismatch);
+        }
+
+        let Some(statistics_pending_descriptor_head) = statistics_pending_descriptor_head else {
+            return Ok(());
+        };
+        let pending_available_index = self.available.next_avail().wrapping_sub(1);
+        let pending_head = self
+            .available
+            .descriptor_head_at_available_index(memory, pending_available_index)
+            .map_err(|_| VirtioBalloonQueueRestoreError::AvailableRingInvalid)?;
+        if pending_head != statistics_pending_descriptor_head {
+            return Err(VirtioBalloonQueueRestoreError::StatisticsDescriptorMismatch);
+        }
+
+        let mut available_entry = self.available.next_avail();
+        while available_entry != available_index {
+            let head = self
+                .available
+                .descriptor_head_at_available_index(memory, available_entry)
+                .map_err(|_| VirtioBalloonQueueRestoreError::AvailableRingInvalid)?;
+            if head == statistics_pending_descriptor_head {
+                return Err(VirtioBalloonQueueRestoreError::StatisticsDescriptorDuplicated);
+            }
+            available_entry = available_entry.wrapping_add(1);
+        }
+
+        Ok(())
     }
 
     fn capture_state(
@@ -3883,6 +4100,30 @@ impl VirtioBalloonActiveQueues {
         })
     }
 
+    pub(crate) fn from_snapshot_parts(
+        layout: VirtioBalloonQueueLayout,
+        inflate: VirtioBalloonQueue,
+        deflate: VirtioBalloonQueue,
+        statistics: Option<VirtioBalloonQueue>,
+        free_page_hinting: Option<VirtioBalloonQueue>,
+        free_page_reporting: Option<VirtioBalloonQueue>,
+    ) -> Result<Self, VirtioBalloonQueueRestoreError> {
+        if statistics.is_some() != layout.statistics().is_some()
+            || free_page_hinting.is_some() != layout.free_page_hinting().is_some()
+            || free_page_reporting.is_some() != layout.free_page_reporting().is_some()
+        {
+            return Err(VirtioBalloonQueueRestoreError::ActiveQueueShape);
+        }
+
+        Ok(Self {
+            inflate,
+            deflate,
+            statistics,
+            free_page_hinting,
+            free_page_reporting,
+        })
+    }
+
     pub const fn inflate(&self) -> &VirtioBalloonQueue {
         &self.inflate
     }
@@ -4304,6 +4545,33 @@ impl std::error::Error for VirtioBalloonPciCaptureError {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VirtioBalloonDeviceRestoreError {
+    QueueShape,
+    Statistics,
+    Hinting,
+    Accounting,
+}
+
+impl fmt::Debug for VirtioBalloonDeviceRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+impl fmt::Display for VirtioBalloonDeviceRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::QueueShape => "restored virtio-balloon queue shape is invalid",
+            Self::Statistics => "restored virtio-balloon statistics state is invalid",
+            Self::Hinting => "restored virtio-balloon hinting state is invalid",
+            Self::Accounting => "restored virtio-balloon accounting state is invalid",
+        })
+    }
+}
+
+impl std::error::Error for VirtioBalloonDeviceRestoreError {}
+
 #[derive(Debug)]
 pub struct VirtioBalloonDevice {
     queue_layout: VirtioBalloonQueueLayout,
@@ -4346,6 +4614,72 @@ impl VirtioBalloonDevice {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn from_snapshot_parts(
+        queue_layout: VirtioBalloonQueueLayout,
+        active_queues: Option<VirtioBalloonActiveQueues>,
+        memory_accounting: VirtioBalloonMemoryAccounting,
+        stats_polling_interval_s: u16,
+        statistics: BalloonOptionalStats,
+        statistics_pending_descriptor_head: Option<u16>,
+        hinting_host_cmd: u32,
+        hinting_guest_cmd: Option<u32>,
+        hinting_last_cmd: u32,
+        hinting_acknowledge_on_stop: bool,
+    ) -> Result<Self, VirtioBalloonDeviceRestoreError> {
+        if active_queues
+            .as_ref()
+            .is_some_and(|active| active.queue_count() != queue_layout.queue_count())
+        {
+            return Err(VirtioBalloonDeviceRestoreError::QueueShape);
+        }
+
+        let statistics_enabled = queue_layout.statistics().is_some();
+        if statistics_enabled != (stats_polling_interval_s > 0)
+            || (!statistics_enabled
+                && (!statistics.is_empty() || statistics_pending_descriptor_head.is_some()))
+            || active_queues.is_none() && !statistics.is_empty()
+            || statistics_pending_descriptor_head.is_some()
+                && active_queues
+                    .as_ref()
+                    .and_then(VirtioBalloonActiveQueues::statistics)
+                    .is_none()
+        {
+            return Err(VirtioBalloonDeviceRestoreError::Statistics);
+        }
+
+        if active_queues.is_none() && !memory_accounting.is_empty() {
+            return Err(VirtioBalloonDeviceRestoreError::Accounting);
+        }
+
+        if queue_layout.free_page_hinting().is_none() {
+            if hinting_host_cmd != VIRTIO_BALLOON_FREE_PAGE_HINT_STOP
+                || hinting_guest_cmd.is_some()
+                || hinting_last_cmd != VIRTIO_BALLOON_FREE_PAGE_HINT_STOP
+                || !hinting_acknowledge_on_stop
+            {
+                return Err(VirtioBalloonDeviceRestoreError::Hinting);
+            }
+        } else if hinting_host_cmd != VIRTIO_BALLOON_FREE_PAGE_HINT_DONE
+            || hinting_last_cmd == VIRTIO_BALLOON_FREE_PAGE_HINT_DONE
+        {
+            return Err(VirtioBalloonDeviceRestoreError::Hinting);
+        }
+
+        Ok(Self {
+            queue_layout,
+            active_queues,
+            memory_accounting,
+            stats_polling_interval_s,
+            statistics,
+            statistics_pending_descriptor_head,
+            hinting_host_cmd,
+            hinting_guest_cmd,
+            hinting_last_cmd,
+            hinting_acknowledge_on_stop,
+        })
+    }
+
     pub const fn queue_layout(&self) -> VirtioBalloonQueueLayout {
         self.queue_layout
     }
@@ -4368,6 +4702,16 @@ impl VirtioBalloonDevice {
 
     pub const fn statistics(&self) -> BalloonOptionalStats {
         self.statistics
+    }
+
+    /// Returns the statistics descriptor consumed but not yet returned.
+    pub const fn statistics_pending_descriptor_head(&self) -> Option<u16> {
+        self.statistics_pending_descriptor_head
+    }
+
+    /// Returns the last allocated host free-page-hinting command identifier.
+    pub const fn hinting_last_cmd(&self) -> u32 {
+        self.hinting_last_cmd
     }
 
     pub const fn stats_polling_interval_s(&self) -> u16 {
@@ -7954,6 +8298,106 @@ mod tests {
             ]
         );
         assert_eq!(accounting.inflated_page_count(), u64::from(u32::MAX) + 1);
+    }
+
+    #[test]
+    fn restored_memory_accounting_rechecks_ranges_canonicality_and_total() {
+        assert_eq!(
+            VirtioBalloonPfnRange::from_snapshot_parts(1, 0).unwrap_err(),
+            VirtioBalloonMemoryAccountingRestoreError::Range
+        );
+        assert_eq!(
+            VirtioBalloonPfnRange::from_snapshot_parts(u32::MAX, 2).unwrap_err(),
+            VirtioBalloonMemoryAccountingRestoreError::Range
+        );
+
+        let first = VirtioBalloonPfnRange::from_snapshot_parts(1, 2)
+            .expect("first restored range should validate");
+        let second = VirtioBalloonPfnRange::from_snapshot_parts(4, 1)
+            .expect("second restored range should validate");
+        let restored = VirtioBalloonMemoryAccounting::from_snapshot_ranges(vec![first, second], 3)
+            .expect("canonical restored accounting should validate");
+        assert_eq!(restored.inflated_page_ranges(), &[first, second]);
+        assert_eq!(restored.inflated_page_count(), 3);
+
+        let adjacent = VirtioBalloonPfnRange::from_snapshot_parts(3, 1)
+            .expect("adjacent restored range should validate individually");
+        assert_eq!(
+            VirtioBalloonMemoryAccounting::from_snapshot_ranges(vec![first, adjacent], 3)
+                .unwrap_err(),
+            VirtioBalloonMemoryAccountingRestoreError::Canonicality
+        );
+        assert_eq!(
+            VirtioBalloonMemoryAccounting::from_snapshot_ranges(vec![first, second], 4)
+                .unwrap_err(),
+            VirtioBalloonMemoryAccountingRestoreError::Total
+        );
+    }
+
+    #[test]
+    fn restored_device_constructor_rechecks_inactive_statistics_accounting_and_hinting() {
+        let layout =
+            VirtioBalloonQueueLayout::from_config(balloon_config(64, true, 5, false, false));
+        let mut statistics = BalloonOptionalStats::new();
+        assert!(statistics.record_stat(VirtioBalloonStat::new(VIRTIO_BALLOON_S_SWAP_IN, 1,)));
+        assert_eq!(
+            VirtioBalloonDevice::from_snapshot_parts(
+                layout,
+                None,
+                VirtioBalloonMemoryAccounting::new(),
+                5,
+                statistics,
+                None,
+                VIRTIO_BALLOON_FREE_PAGE_HINT_STOP,
+                None,
+                VIRTIO_BALLOON_FREE_PAGE_HINT_STOP,
+                true,
+            )
+            .unwrap_err(),
+            VirtioBalloonDeviceRestoreError::Statistics
+        );
+
+        let accounting = VirtioBalloonMemoryAccounting::from_snapshot_ranges(
+            vec![
+                VirtioBalloonPfnRange::from_snapshot_parts(1, 1)
+                    .expect("restored accounting range should validate"),
+            ],
+            1,
+        )
+        .expect("restored accounting should validate");
+        assert_eq!(
+            VirtioBalloonDevice::from_snapshot_parts(
+                layout,
+                None,
+                accounting,
+                5,
+                BalloonOptionalStats::new(),
+                None,
+                VIRTIO_BALLOON_FREE_PAGE_HINT_STOP,
+                None,
+                VIRTIO_BALLOON_FREE_PAGE_HINT_STOP,
+                true,
+            )
+            .unwrap_err(),
+            VirtioBalloonDeviceRestoreError::Accounting
+        );
+
+        assert_eq!(
+            VirtioBalloonDevice::from_snapshot_parts(
+                layout,
+                None,
+                VirtioBalloonMemoryAccounting::new(),
+                5,
+                BalloonOptionalStats::new(),
+                None,
+                VIRTIO_BALLOON_FREE_PAGE_HINT_DONE,
+                None,
+                VIRTIO_BALLOON_FREE_PAGE_HINT_STOP,
+                true,
+            )
+            .unwrap_err(),
+            VirtioBalloonDeviceRestoreError::Hinting
+        );
     }
 
     #[test]

--- a/crates/runtime/src/snapshot_balloon_v2_9.rs
+++ b/crates/runtime/src/snapshot_balloon_v2_9.rs
@@ -11,23 +11,33 @@ use std::fmt;
 use crate::balloon::{
     BalloonConfig, BalloonOptionalStats, VIRTIO_BALLOON_DEVICE_ID,
     VIRTIO_BALLOON_FREE_PAGE_HINT_DONE, VIRTIO_BALLOON_FREE_PAGE_HINT_STOP,
-    VIRTIO_BALLOON_QUEUE_SIZE, VirtioBalloonConfigSpace, VirtioBalloonDeviceCaptureState,
-    VirtioBalloonMmioCaptureState, VirtioBalloonPciCaptureState, VirtioBalloonQueueCaptureState,
-    VirtioBalloonQueueLayout, available_features, mib_to_4k_pages,
+    VIRTIO_BALLOON_PAGE_SIZE, VIRTIO_BALLOON_QUEUE_SIZE, VIRTIO_BALLOON_S_ALLOC_STALL,
+    VIRTIO_BALLOON_S_ASYNC_RECLAIM, VIRTIO_BALLOON_S_ASYNC_SCAN, VIRTIO_BALLOON_S_AVAIL,
+    VIRTIO_BALLOON_S_CACHES, VIRTIO_BALLOON_S_DIRECT_RECLAIM, VIRTIO_BALLOON_S_DIRECT_SCAN,
+    VIRTIO_BALLOON_S_HTLB_PGALLOC, VIRTIO_BALLOON_S_HTLB_PGFAIL, VIRTIO_BALLOON_S_MAJFLT,
+    VIRTIO_BALLOON_S_MEMFREE, VIRTIO_BALLOON_S_MEMTOT, VIRTIO_BALLOON_S_MINFLT,
+    VIRTIO_BALLOON_S_OOM_KILL, VIRTIO_BALLOON_S_SWAP_IN, VIRTIO_BALLOON_S_SWAP_OUT,
+    VirtioBalloonActiveQueues, VirtioBalloonConfigSpace, VirtioBalloonDevice,
+    VirtioBalloonDeviceCaptureState, VirtioBalloonMemoryAccounting, VirtioBalloonMmioCaptureState,
+    VirtioBalloonPciCaptureState, VirtioBalloonPfnRange, VirtioBalloonQueue,
+    VirtioBalloonQueueCaptureState, VirtioBalloonQueueConfig, VirtioBalloonQueueLayout,
+    VirtioBalloonStat, available_features, mib_to_4k_pages,
 };
 use crate::interrupt::GuestInterruptLine;
-use crate::memory::GuestMemoryRange;
+use crate::memory::{GuestAddress, GuestMemory, GuestMemoryRange};
 use crate::mmio::MmioRegion;
 use crate::pci::{
     PCI_BAR64_SIZE, PCI_BAR64_START, PCI_BUS_ZERO, PCI_FIRST_ENDPOINT_DEVICE, PCI_FUNCTION_ZERO,
     PCI_LAST_ENDPOINT_DEVICE, PCI_SEGMENT_ZERO, PciBarAddressSpace, PciBarPrefetchable, PciSbdf,
 };
 use crate::snapshot_device_v2::{
-    SnapshotV2DeviceGraphCaptureError, SnapshotV2DeviceTransport, SnapshotV2InterruptIntent,
-    SnapshotV2PciDeviceState, SnapshotV2PciMsixState, SnapshotV2VirtioQueueState,
-    SnapshotV2VirtioState, capture_mmio_common_for_device_with_queue_count_and_config_status_gate,
+    SnapshotV2DeviceGraphCaptureError, SnapshotV2DeviceTransport, SnapshotV2DeviceTransportKind,
+    SnapshotV2InterruptIntent, SnapshotV2PciDeviceState, SnapshotV2PciMsixState,
+    SnapshotV2VirtioQueueState, SnapshotV2VirtioState,
+    capture_mmio_common_for_device_with_queue_count_and_config_status_gate,
     capture_mmio_transport_parts, capture_pci_common_for_device_with_queue_count,
-    capture_pci_transport_parts_with_queue_count,
+    capture_pci_transport_parts_with_queue_count, range_is_wholly_contained,
+    restore_mmio_transport_state_for_device_with_config_status_gate,
 };
 use crate::snapshot_device_v2_5::queue_ranges;
 use crate::snapshot_format::SnapshotFormatVersion;
@@ -35,12 +45,15 @@ use crate::storage_capture::StorageDeviceOrigin;
 use crate::virtio::{
     VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DEVICE_NEEDS_RESET,
     VIRTIO_DEVICE_STATUS_DRIVER, VIRTIO_DEVICE_STATUS_DRIVER_OK, VIRTIO_DEVICE_STATUS_FAILED,
-    VIRTIO_DEVICE_STATUS_FEATURES_OK, VIRTIO_DEVICE_STATUS_INIT,
+    VIRTIO_DEVICE_STATUS_FEATURES_OK, VIRTIO_DEVICE_STATUS_INIT, VirtioDeviceType,
 };
-use crate::virtio_mmio::{VIRTIO_MMIO_DEVICE_WINDOW_SIZE, VIRTIO_MMIO_VERSION_1_FEATURE};
+use crate::virtio_mmio::{
+    VIRTIO_MMIO_DEVICE_WINDOW_SIZE, VIRTIO_MMIO_VERSION_1_FEATURE, VirtioMmioQueueState,
+    VirtioMmioTransportState,
+};
 use crate::virtio_pci::{
     VIRTIO_PCI_CAPABILITY_BAR_INDEX, VIRTIO_PCI_CAPABILITY_BAR_SIZE, VIRTIO_PCI_MAX_MSIX_VECTORS,
-    VIRTIO_PCI_NO_VECTOR, VirtioPciEndpointPhase,
+    VIRTIO_PCI_NO_VECTOR, VirtioPciEndpointPhase, VirtioPciIdentity, VirtioPciTransportState,
 };
 
 mod codec;
@@ -687,6 +700,615 @@ impl fmt::Debug for SnapshotV2BalloonState {
             .field("state", &REDACTED)
             .finish()
     }
+}
+
+/// Complete exact-2.9 balloon continuation validated against adopted memory.
+///
+/// The plan contains only detached runtime and transport values. It owns no
+/// timer, notifier, interrupt route, dispatcher, PCI endpoint, metrics,
+/// reclaim adviser, thread, platform VM, or publication authority.
+pub struct SnapshotV2BalloonRestorePlan {
+    config: BalloonConfig,
+    config_space: VirtioBalloonConfigSpace,
+    queue_ranges: Vec<[GuestMemoryRange; 3]>,
+    transport: PreparedSnapshotV2BalloonTransport,
+}
+
+impl SnapshotV2BalloonRestorePlan {
+    /// Validates and reconstructs one decoded balloon continuation.
+    pub fn prepare(
+        state: SnapshotV2BalloonState,
+        memory: &GuestMemory,
+    ) -> Result<Self, SnapshotV2BalloonRestorePlanError> {
+        prepare_balloon_restore_plan(state, memory, BalloonRestoreReservePolicy::System)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn prepare_with_queue_range_allocation_failure(
+        state: SnapshotV2BalloonState,
+        memory: &GuestMemory,
+    ) -> Result<Self, SnapshotV2BalloonRestorePlanError> {
+        prepare_balloon_restore_plan(state, memory, BalloonRestoreReservePolicy::FailQueueRanges)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn prepare_with_accounting_allocation_failure(
+        state: SnapshotV2BalloonState,
+        memory: &GuestMemory,
+    ) -> Result<Self, SnapshotV2BalloonRestorePlanError> {
+        prepare_balloon_restore_plan(state, memory, BalloonRestoreReservePolicy::FailAccounting)
+    }
+
+    /// Returns the exact external balloon configuration.
+    pub const fn config(&self) -> BalloonConfig {
+        self.config
+    }
+
+    /// Returns guest-visible configuration after destination normalization.
+    pub const fn config_space(&self) -> VirtioBalloonConfigSpace {
+        self.config_space
+    }
+
+    /// Returns all loaded-memory ranges occupied by active queues.
+    pub fn queue_ranges(&self) -> &[[GuestMemoryRange; 3]] {
+        &self.queue_ranges
+    }
+
+    /// Returns the selected transport kind.
+    pub const fn transport_kind(&self) -> SnapshotV2DeviceTransportKind {
+        self.transport.kind()
+    }
+
+    /// Returns the checked detached transport.
+    pub const fn transport(&self) -> &PreparedSnapshotV2BalloonTransport {
+        &self.transport
+    }
+
+    /// Consumes the plan into configuration, ranges, and detached transport.
+    pub fn into_parts(
+        self,
+    ) -> (
+        BalloonConfig,
+        VirtioBalloonConfigSpace,
+        Vec<[GuestMemoryRange; 3]>,
+        PreparedSnapshotV2BalloonTransport,
+    ) {
+        (
+            self.config,
+            self.config_space,
+            self.queue_ranges,
+            self.transport,
+        )
+    }
+}
+
+impl fmt::Debug for SnapshotV2BalloonRestorePlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2BalloonRestorePlan")
+            .field("transport", &self.transport_kind())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// One checked detached MMIO or PCI balloon transport.
+pub enum PreparedSnapshotV2BalloonTransport {
+    /// Value-only virtio-mmio continuation.
+    Mmio(Box<PreparedSnapshotV2BalloonMmioTransport>),
+    /// Value-only virtio-pci continuation.
+    Pci(Box<PreparedSnapshotV2BalloonPciTransport>),
+}
+
+impl PreparedSnapshotV2BalloonTransport {
+    /// Returns the selected transport kind.
+    pub const fn kind(&self) -> SnapshotV2DeviceTransportKind {
+        match self {
+            Self::Mmio(_) => SnapshotV2DeviceTransportKind::Mmio,
+            Self::Pci(_) => SnapshotV2DeviceTransportKind::Pci,
+        }
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2BalloonTransport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2BalloonTransport")
+            .field("kind", &self.kind())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Checked value-only MMIO balloon continuation.
+pub struct PreparedSnapshotV2BalloonMmioTransport {
+    region: MmioRegion,
+    interrupt_line: GuestInterruptLine,
+    device: VirtioBalloonDevice,
+    retained: VirtioMmioTransportState,
+}
+
+impl PreparedSnapshotV2BalloonMmioTransport {
+    /// Returns the exact retained MMIO region.
+    pub const fn region(&self) -> MmioRegion {
+        self.region
+    }
+
+    /// Returns the exact retained guest interrupt line.
+    pub const fn interrupt_line(&self) -> GuestInterruptLine {
+        self.interrupt_line
+    }
+
+    /// Returns the detached balloon device.
+    pub const fn device(&self) -> &VirtioBalloonDevice {
+        &self.device
+    }
+
+    /// Returns detached MMIO register, queue, and interrupt state.
+    pub const fn retained(&self) -> &VirtioMmioTransportState {
+        &self.retained
+    }
+
+    /// Consumes the value into placement, device, and retained transport.
+    pub fn into_parts(
+        self,
+    ) -> (
+        MmioRegion,
+        GuestInterruptLine,
+        VirtioBalloonDevice,
+        VirtioMmioTransportState,
+    ) {
+        (self.region, self.interrupt_line, self.device, self.retained)
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2BalloonMmioTransport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2BalloonMmioTransport")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Checked value-only PCI balloon continuation.
+pub struct PreparedSnapshotV2BalloonPciTransport {
+    origin: StorageDeviceOrigin,
+    sbdf: PciSbdf,
+    bar_range: GuestMemoryRange,
+    identity: VirtioPciIdentity,
+    device: VirtioBalloonDevice,
+    retained: VirtioPciTransportState,
+}
+
+impl PreparedSnapshotV2BalloonPciTransport {
+    /// Returns the retained startup/runtime origin.
+    pub const fn origin(&self) -> StorageDeviceOrigin {
+        self.origin
+    }
+
+    /// Returns the exact retained PCI function.
+    pub const fn sbdf(&self) -> PciSbdf {
+        self.sbdf
+    }
+
+    /// Returns the exact retained capability BAR.
+    pub const fn bar_range(&self) -> GuestMemoryRange {
+        self.bar_range
+    }
+
+    /// Returns the fixed balloon PCI identity.
+    pub const fn identity(&self) -> VirtioPciIdentity {
+        self.identity
+    }
+
+    /// Returns the detached balloon device.
+    pub const fn device(&self) -> &VirtioBalloonDevice {
+        &self.device
+    }
+
+    /// Returns detached PCI configuration, queue, and MSI-X state.
+    pub const fn retained(&self) -> &VirtioPciTransportState {
+        &self.retained
+    }
+
+    /// Consumes placement, identity, device, and retained transport.
+    pub fn into_parts(
+        self,
+    ) -> (
+        StorageDeviceOrigin,
+        PciSbdf,
+        GuestMemoryRange,
+        VirtioPciIdentity,
+        VirtioBalloonDevice,
+        VirtioPciTransportState,
+    ) {
+        (
+            self.origin,
+            self.sbdf,
+            self.bar_range,
+            self.identity,
+            self.device,
+            self.retained,
+        )
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2BalloonPciTransport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2BalloonPciTransport")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Failure while proving decoded balloon state against destination memory.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2BalloonRestorePlanError {
+    /// The decoded typed state no longer satisfies the exact profile.
+    InvalidState,
+    /// A bounded restore inventory could not be allocated.
+    Allocation,
+    /// A queue range is not wholly contained by adopted guest memory.
+    QueueMemory,
+    /// Queue cursors, rings, or retained statistics work are inconsistent.
+    QueueContinuation,
+    /// A retained inflated-PFN range is not fully mapped.
+    AccountingMemory,
+    /// Exact host inflated-PFN accounting could not be reconstructed.
+    Accounting,
+    /// Detached balloon device continuation could not be reconstructed.
+    Device,
+    /// The fixed balloon virtio identity cannot be represented.
+    DeviceType,
+    /// Detached MMIO retained state reconstruction failed.
+    MmioTransport,
+    /// Detached PCI retained state reconstruction failed.
+    PciTransport,
+}
+
+impl fmt::Debug for SnapshotV2BalloonRestorePlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+impl fmt::Display for SnapshotV2BalloonRestorePlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidState => "native-v2 balloon restore state is invalid",
+            Self::Allocation => "native-v2 balloon restore allocation failed",
+            Self::QueueMemory => "native-v2 balloon restore queue memory is invalid",
+            Self::QueueContinuation => "native-v2 balloon restore queue continuation is invalid",
+            Self::AccountingMemory => "native-v2 balloon restore accounting memory is invalid",
+            Self::Accounting => "native-v2 balloon restore accounting state is invalid",
+            Self::Device => "native-v2 balloon restore device state is invalid",
+            Self::DeviceType => "native-v2 balloon restore device identity is invalid",
+            Self::MmioTransport => "native-v2 balloon MMIO retained state is invalid",
+            Self::PciTransport => "native-v2 balloon PCI retained state is invalid",
+        })
+    }
+}
+
+impl std::error::Error for SnapshotV2BalloonRestorePlanError {}
+
+#[derive(Clone, Copy)]
+enum BalloonRestoreReservePolicy {
+    System,
+    #[cfg(test)]
+    FailQueueRanges,
+    #[cfg(test)]
+    FailAccounting,
+}
+
+impl BalloonRestoreReservePolicy {
+    fn reserve_queue_ranges(
+        self,
+        ranges: &mut Vec<[GuestMemoryRange; 3]>,
+        count: usize,
+    ) -> Result<(), SnapshotV2BalloonRestorePlanError> {
+        #[cfg(test)]
+        if matches!(self, Self::FailQueueRanges) {
+            return Err(SnapshotV2BalloonRestorePlanError::Allocation);
+        }
+        ranges
+            .try_reserve_exact(count)
+            .map_err(|_| SnapshotV2BalloonRestorePlanError::Allocation)
+    }
+
+    fn reserve_accounting(
+        self,
+        ranges: &mut Vec<VirtioBalloonPfnRange>,
+        count: usize,
+    ) -> Result<(), SnapshotV2BalloonRestorePlanError> {
+        #[cfg(test)]
+        if matches!(self, Self::FailAccounting) {
+            return Err(SnapshotV2BalloonRestorePlanError::Allocation);
+        }
+        ranges
+            .try_reserve_exact(count)
+            .map_err(|_| SnapshotV2BalloonRestorePlanError::Allocation)
+    }
+}
+
+fn prepare_balloon_restore_plan(
+    state: SnapshotV2BalloonState,
+    memory: &GuestMemory,
+    reserve_policy: BalloonRestoreReservePolicy,
+) -> Result<SnapshotV2BalloonRestorePlan, SnapshotV2BalloonRestorePlanError> {
+    validate_balloon_state(&state).map_err(|_| SnapshotV2BalloonRestorePlanError::InvalidState)?;
+
+    let queue_layout = VirtioBalloonQueueLayout::from_config(state.config);
+    let mut restored_queue_ranges = Vec::new();
+    reserve_policy.reserve_queue_ranges(&mut restored_queue_ranges, state.virtio.queues().len())?;
+    for queue in state.virtio.queues() {
+        let Some(ranges) =
+            queue_ranges(queue).map_err(|_| SnapshotV2BalloonRestorePlanError::InvalidState)?
+        else {
+            continue;
+        };
+        if ranges
+            .iter()
+            .copied()
+            .any(|range| !range_is_wholly_contained(memory, range))
+        {
+            return Err(SnapshotV2BalloonRestorePlanError::QueueMemory);
+        }
+        restored_queue_ranges.push(ranges);
+    }
+
+    for range in state.accounting.ranges().iter().copied() {
+        let range = balloon_accounting_guest_range(range)?;
+        memory
+            .validate_mapped_range(range)
+            .map_err(|_| SnapshotV2BalloonRestorePlanError::AccountingMemory)?;
+    }
+
+    let SnapshotV2BalloonState {
+        config,
+        mut config_space,
+        continuation,
+        accounting,
+        virtio,
+        transport,
+    } = state;
+    let SnapshotV2BalloonContinuationState {
+        active_queues,
+        stats_polling_interval_s,
+        statistics,
+        statistics_pending_descriptor_head,
+        hinting,
+    } = continuation;
+
+    let mut accounting_ranges = Vec::new();
+    reserve_policy.reserve_accounting(&mut accounting_ranges, accounting.ranges.len())?;
+    for range in accounting.ranges {
+        accounting_ranges.push(
+            VirtioBalloonPfnRange::from_snapshot_parts(range.start_pfn(), range.page_count())
+                .map_err(|_| SnapshotV2BalloonRestorePlanError::Accounting)?,
+        );
+    }
+    let accounting = VirtioBalloonMemoryAccounting::from_snapshot_ranges(
+        accounting_ranges,
+        accounting.inflated_page_count,
+    )
+    .map_err(|_| SnapshotV2BalloonRestorePlanError::Accounting)?;
+
+    let active_queues = active_queues
+        .map(|active| {
+            restore_balloon_active_queues(
+                queue_layout,
+                active,
+                statistics_pending_descriptor_head,
+                &virtio,
+                memory,
+            )
+        })
+        .transpose()?;
+    let statistics = restore_balloon_statistics(statistics);
+
+    let hinting_host_cmd = if config.free_page_hinting() {
+        config_space = config_space.with_free_page_hint_cmd_id(VIRTIO_BALLOON_FREE_PAGE_HINT_DONE);
+        VIRTIO_BALLOON_FREE_PAGE_HINT_DONE
+    } else {
+        VIRTIO_BALLOON_FREE_PAGE_HINT_STOP
+    };
+    let device = VirtioBalloonDevice::from_snapshot_parts(
+        queue_layout,
+        active_queues,
+        accounting,
+        stats_polling_interval_s,
+        statistics,
+        statistics_pending_descriptor_head,
+        hinting_host_cmd,
+        hinting.guest_cmd(),
+        hinting.last_cmd(),
+        hinting.acknowledge_on_stop(),
+    )
+    .map_err(|_| SnapshotV2BalloonRestorePlanError::Device)?;
+
+    let transport = match transport {
+        SnapshotV2DeviceTransport::Mmio(mmio) => {
+            let retained = restore_mmio_transport_state_for_device_with_config_status_gate(
+                VIRTIO_BALLOON_DEVICE_ID,
+                &virtio,
+                &mmio,
+                true,
+            )
+            .map_err(|_| SnapshotV2BalloonRestorePlanError::MmioTransport)?;
+            PreparedSnapshotV2BalloonTransport::Mmio(Box::new(
+                PreparedSnapshotV2BalloonMmioTransport {
+                    region: mmio.region(),
+                    interrupt_line: mmio.interrupt_line(),
+                    device,
+                    retained,
+                },
+            ))
+        }
+        SnapshotV2DeviceTransport::Pci(pci) => {
+            let device_type = VirtioDeviceType::new(VIRTIO_BALLOON_DEVICE_ID)
+                .map_err(|_| SnapshotV2BalloonRestorePlanError::DeviceType)?;
+            let identity = VirtioPciIdentity::new(device_type, virtio.available_features())
+                .with_config_generation(virtio.config_generation());
+            let retained =
+                VirtioPciTransportState::from_snapshot_v2_parts(identity, &virtio, &pci, false)
+                    .map_err(|_| SnapshotV2BalloonRestorePlanError::PciTransport)?;
+            PreparedSnapshotV2BalloonTransport::Pci(Box::new(
+                PreparedSnapshotV2BalloonPciTransport {
+                    origin: pci.origin(),
+                    sbdf: pci.sbdf(),
+                    bar_range: pci.bar_range(),
+                    identity,
+                    device,
+                    retained,
+                },
+            ))
+        }
+    };
+
+    Ok(SnapshotV2BalloonRestorePlan {
+        config,
+        config_space,
+        queue_ranges: restored_queue_ranges,
+        transport,
+    })
+}
+
+fn balloon_accounting_guest_range(
+    range: SnapshotV2BalloonPfnRange,
+) -> Result<GuestMemoryRange, SnapshotV2BalloonRestorePlanError> {
+    let start = u64::from(range.start_pfn())
+        .checked_mul(VIRTIO_BALLOON_PAGE_SIZE)
+        .ok_or(SnapshotV2BalloonRestorePlanError::Accounting)?;
+    let size = u64::from(range.page_count())
+        .checked_mul(VIRTIO_BALLOON_PAGE_SIZE)
+        .ok_or(SnapshotV2BalloonRestorePlanError::Accounting)?;
+    GuestMemoryRange::new(GuestAddress::new(start), size)
+        .map_err(|_| SnapshotV2BalloonRestorePlanError::Accounting)
+}
+
+fn restore_balloon_active_queues(
+    layout: VirtioBalloonQueueLayout,
+    active: SnapshotV2BalloonActiveQueuesState,
+    statistics_pending_descriptor_head: Option<u16>,
+    virtio: &SnapshotV2VirtioState,
+    memory: &GuestMemory,
+) -> Result<VirtioBalloonActiveQueues, SnapshotV2BalloonRestorePlanError> {
+    let inflate = restore_balloon_queue(layout.inflate(), active.inflate(), None, virtio, memory)?;
+    let deflate = restore_balloon_queue(layout.deflate(), active.deflate(), None, virtio, memory)?;
+    let statistics = restore_optional_balloon_queue(
+        layout.statistics(),
+        active.statistics(),
+        statistics_pending_descriptor_head,
+        virtio,
+        memory,
+    )?;
+    let free_page_hinting = restore_optional_balloon_queue(
+        layout.free_page_hinting(),
+        active.free_page_hinting(),
+        None,
+        virtio,
+        memory,
+    )?;
+    let free_page_reporting = restore_optional_balloon_queue(
+        layout.free_page_reporting(),
+        active.free_page_reporting(),
+        None,
+        virtio,
+        memory,
+    )?;
+
+    VirtioBalloonActiveQueues::from_snapshot_parts(
+        layout,
+        inflate,
+        deflate,
+        statistics,
+        free_page_hinting,
+        free_page_reporting,
+    )
+    .map_err(|_| SnapshotV2BalloonRestorePlanError::QueueContinuation)
+}
+
+fn restore_optional_balloon_queue(
+    config: Option<VirtioBalloonQueueConfig>,
+    cursor: Option<SnapshotV2BalloonQueueState>,
+    statistics_pending_descriptor_head: Option<u16>,
+    virtio: &SnapshotV2VirtioState,
+    memory: &GuestMemory,
+) -> Result<Option<VirtioBalloonQueue>, SnapshotV2BalloonRestorePlanError> {
+    match (config, cursor) {
+        (Some(config), Some(cursor)) => restore_balloon_queue(
+            config,
+            cursor,
+            statistics_pending_descriptor_head,
+            virtio,
+            memory,
+        )
+        .map(Some),
+        (None, None) => Ok(None),
+        _ => Err(SnapshotV2BalloonRestorePlanError::QueueContinuation),
+    }
+}
+
+fn restore_balloon_queue(
+    config: VirtioBalloonQueueConfig,
+    cursor: SnapshotV2BalloonQueueState,
+    statistics_pending_descriptor_head: Option<u16>,
+    virtio: &SnapshotV2VirtioState,
+    memory: &GuestMemory,
+) -> Result<VirtioBalloonQueue, SnapshotV2BalloonRestorePlanError> {
+    let queue = virtio
+        .queues()
+        .get(config.index())
+        .ok_or(SnapshotV2BalloonRestorePlanError::QueueContinuation)?;
+    let queue = VirtioMmioQueueState::from_parts(
+        queue.max_size(),
+        queue.size(),
+        queue.ready(),
+        queue.descriptor_table(),
+        queue.driver_ring(),
+        queue.device_ring(),
+    );
+    let queue = VirtioBalloonQueue::from_snapshot_state(
+        &queue,
+        cursor.next_available(),
+        cursor.next_used(),
+    )
+    .map_err(|_| SnapshotV2BalloonRestorePlanError::QueueContinuation)?;
+    queue
+        .validate_snapshot_state(memory, statistics_pending_descriptor_head)
+        .map_err(|_| SnapshotV2BalloonRestorePlanError::QueueContinuation)?;
+    Ok(queue)
+}
+
+fn restore_balloon_statistics(statistics: SnapshotV2BalloonStatistics) -> BalloonOptionalStats {
+    let tags = [
+        VIRTIO_BALLOON_S_SWAP_IN,
+        VIRTIO_BALLOON_S_SWAP_OUT,
+        VIRTIO_BALLOON_S_MAJFLT,
+        VIRTIO_BALLOON_S_MINFLT,
+        VIRTIO_BALLOON_S_MEMFREE,
+        VIRTIO_BALLOON_S_MEMTOT,
+        VIRTIO_BALLOON_S_AVAIL,
+        VIRTIO_BALLOON_S_CACHES,
+        VIRTIO_BALLOON_S_HTLB_PGALLOC,
+        VIRTIO_BALLOON_S_HTLB_PGFAIL,
+        VIRTIO_BALLOON_S_OOM_KILL,
+        VIRTIO_BALLOON_S_ALLOC_STALL,
+        VIRTIO_BALLOON_S_ASYNC_SCAN,
+        VIRTIO_BALLOON_S_DIRECT_SCAN,
+        VIRTIO_BALLOON_S_ASYNC_RECLAIM,
+        VIRTIO_BALLOON_S_DIRECT_RECLAIM,
+    ];
+    let mut restored = BalloonOptionalStats::new();
+    for (tag, value) in tags.into_iter().zip(*statistics.values()) {
+        if let Some(value) = value {
+            let recorded = restored.record_stat(VirtioBalloonStat::new(tag, value));
+            debug_assert!(recorded);
+        }
+    }
+    restored
 }
 
 fn preflight_balloon_capture(

--- a/crates/runtime/src/snapshot_balloon_v2_9/tests.rs
+++ b/crates/runtime/src/snapshot_balloon_v2_9/tests.rs
@@ -1,6 +1,6 @@
 use crate::balloon::{BalloonConfigInput, VIRTIO_BALLOON_FREE_PAGE_HINT_STOP};
 use crate::interrupt::GuestInterruptLine;
-use crate::memory::{GuestAddress, GuestMemoryRange};
+use crate::memory::{GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange};
 use crate::mmio::{MmioRegion, MmioRegionId};
 use crate::pci::{
     PCI_BAR64_START, PCI_BUS_ZERO, PCI_FUNCTION_ZERO, PCI_SEGMENT_ZERO, PciBarAddressSpace,
@@ -16,7 +16,7 @@ use crate::snapshot_device_v2::{
 use crate::storage_capture::StorageDeviceOrigin;
 use crate::virtio::{
     VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DRIVER, VIRTIO_DEVICE_STATUS_DRIVER_OK,
-    VIRTIO_DEVICE_STATUS_FEATURES_OK,
+    VIRTIO_DEVICE_STATUS_FEATURES_OK, VirtioInterruptIntent,
 };
 use crate::virtio_mmio::VIRTIO_MMIO_DEVICE_WINDOW_SIZE;
 use crate::virtio_pci::{
@@ -31,6 +31,12 @@ const DIRECTORY_ENTRY_BYTES: usize = 32;
 const DIRECTORY_PAYLOAD_OFFSET: usize = 8;
 const DIRECTORY_LENGTH_OFFSET: usize = 16;
 const PAYLOAD_OFFSET: usize = 192;
+const RESTORE_LOW_MEMORY_SIZE: u64 = 0x10_0000;
+const RESTORE_QUEUE_MEMORY_START: u64 = 0x8000_0000;
+const RESTORE_QUEUE_STRIDE: u64 = 0x1_0000;
+const AVAILABLE_INDEX_OFFSET: u64 = 2;
+const AVAILABLE_RING_OFFSET: u64 = 4;
+const USED_INDEX_OFFSET: u64 = 2;
 
 fn config(stats: bool, hinting: bool, reporting: bool) -> BalloonConfig {
     BalloonConfigInput::new(64, true)
@@ -284,6 +290,176 @@ fn state(
         },
     )
     .expect("test state should validate")
+}
+
+fn restore_memory(state: &SnapshotV2BalloonState) -> GuestMemory {
+    let mut ranges = vec![
+        GuestMemoryRange::new(GuestAddress::new(0), RESTORE_LOW_MEMORY_SIZE)
+            .expect("low restore memory should validate"),
+    ];
+    if state.virtio().is_activated() {
+        ranges.push(
+            GuestMemoryRange::new(
+                GuestAddress::new(RESTORE_QUEUE_MEMORY_START),
+                u64::try_from(state.virtio().queues().len()).expect("queue count should fit")
+                    * RESTORE_QUEUE_STRIDE,
+            )
+            .expect("queue restore memory should validate"),
+        );
+    }
+    let layout = GuestMemoryLayout::new(ranges).expect("restore memory layout should validate");
+    GuestMemory::allocate(&layout).expect("restore memory should allocate")
+}
+
+fn queue_only_restore_memory(state: &SnapshotV2BalloonState) -> GuestMemory {
+    let queue_size = u64::try_from(state.virtio().queues().len()).expect("queue count should fit")
+        * RESTORE_QUEUE_STRIDE;
+    let layout = GuestMemoryLayout::new(vec![
+        GuestMemoryRange::new(GuestAddress::new(RESTORE_QUEUE_MEMORY_START), queue_size)
+            .expect("queue restore memory should validate"),
+    ])
+    .expect("queue-only restore layout should validate");
+    GuestMemory::allocate(&layout).expect("queue-only restore memory should allocate")
+}
+
+fn initialize_restore_queue_memory(memory: &mut GuestMemory, state: &SnapshotV2BalloonState) {
+    let Some(active) = state.continuation().active_queues() else {
+        return;
+    };
+    let layout = VirtioBalloonQueueLayout::from_config(state.config());
+    for (index, queue) in state.virtio().queues().iter().enumerate() {
+        let cursor = active
+            .cursor_for_layout(layout, index)
+            .expect("active queue should have retained cursors");
+        write_memory_u16(
+            memory,
+            queue
+                .driver_ring()
+                .checked_add(AVAILABLE_INDEX_OFFSET)
+                .expect("available index address should fit"),
+            cursor.next_available(),
+        );
+        write_memory_u16(
+            memory,
+            queue
+                .device_ring()
+                .checked_add(USED_INDEX_OFFSET)
+                .expect("used index address should fit"),
+            cursor.next_used(),
+        );
+    }
+
+    if let Some(pending_head) = state.continuation().statistics_pending_descriptor_head() {
+        let statistics = layout
+            .statistics()
+            .expect("pending statistics require a statistics queue");
+        let cursor = active
+            .statistics()
+            .expect("pending statistics require active statistics cursors");
+        let queue = state
+            .virtio()
+            .queues()
+            .get(statistics.index())
+            .expect("statistics queue should exist");
+        let ring_index = cursor.next_available().wrapping_sub(1) % queue.size();
+        write_memory_u16(
+            memory,
+            queue
+                .driver_ring()
+                .checked_add(AVAILABLE_RING_OFFSET + u64::from(ring_index) * 2)
+                .expect("pending statistics entry should fit"),
+            pending_head,
+        );
+    }
+}
+
+fn write_memory_u16(memory: &mut GuestMemory, address: GuestAddress, value: u16) {
+    memory
+        .write_slice(&value.to_le_bytes(), address)
+        .expect("u16 restore fixture write should succeed");
+}
+
+fn restore_memory_bytes(memory: &GuestMemory) -> Vec<u8> {
+    let total = memory
+        .regions()
+        .iter()
+        .map(|region| {
+            usize::try_from(region.range().size()).expect("test memory region size should fit")
+        })
+        .sum();
+    let mut bytes = Vec::with_capacity(total);
+    for region in memory.regions() {
+        let start = bytes.len();
+        bytes.resize(
+            start
+                + usize::try_from(region.range().size())
+                    .expect("test memory region size should fit"),
+            0,
+        );
+        memory
+            .read_slice(&mut bytes[start..], region.range().start())
+            .expect("restore fixture memory should read");
+    }
+    bytes
+}
+
+fn prepared_device(plan: &SnapshotV2BalloonRestorePlan) -> &VirtioBalloonDevice {
+    match plan.transport() {
+        PreparedSnapshotV2BalloonTransport::Mmio(mmio) => mmio.device(),
+        PreparedSnapshotV2BalloonTransport::Pci(pci) => pci.device(),
+    }
+}
+
+fn assert_restored_queue_cursors(
+    device: &VirtioBalloonDevice,
+    expected: SnapshotV2BalloonActiveQueuesState,
+) {
+    let active = device
+        .active_queues()
+        .expect("expected active restored queues");
+    let pairs = [
+        (Some(active.inflate()), Some(expected.inflate())),
+        (Some(active.deflate()), Some(expected.deflate())),
+        (active.statistics(), expected.statistics()),
+        (active.free_page_hinting(), expected.free_page_hinting()),
+        (active.free_page_reporting(), expected.free_page_reporting()),
+    ];
+    for (actual, expected) in pairs {
+        match (actual, expected) {
+            (Some(actual), Some(expected)) => {
+                assert_eq!(
+                    actual.available_ring().next_avail(),
+                    expected.next_available()
+                );
+                assert_eq!(actual.used_ring().next_used(), expected.next_used());
+            }
+            (None, None) => {}
+            _ => panic!("restored active queue shape should match"),
+        }
+    }
+}
+
+fn assert_restored_device_registers(
+    actual: &crate::virtio_mmio::VirtioMmioDeviceRegisters,
+    expected: &SnapshotV2VirtioState,
+) {
+    assert_eq!(actual.device_id(), VIRTIO_BALLOON_DEVICE_ID);
+    assert_eq!(actual.device_features(), expected.available_features());
+    assert_eq!(actual.driver_features(), expected.driver_features());
+    assert_eq!(actual.config_generation(), expected.config_generation());
+    assert_eq!(actual.status(), expected.status());
+}
+
+fn assert_restored_queue_state(
+    actual: &VirtioMmioQueueState,
+    expected: &SnapshotV2VirtioQueueState,
+) {
+    assert_eq!(actual.max_size(), expected.max_size());
+    assert_eq!(actual.size(), expected.size());
+    assert_eq!(actual.ready(), expected.ready());
+    assert_eq!(actual.descriptor_table(), expected.descriptor_table());
+    assert_eq!(actual.driver_ring(), expected.driver_ring());
+    assert_eq!(actual.device_ring(), expected.device_ring());
 }
 
 #[test]
@@ -885,6 +1061,604 @@ fn allocation_failures_are_deterministic_and_redacted() {
         assert!(!display.contains("2147483648"));
         assert!(!debug.contains("2147483648"));
     }
+}
+
+#[test]
+fn restore_plan_reconstructs_every_queue_layout_and_transport() {
+    for statistics_enabled in [false, true] {
+        for hinting_enabled in [false, true] {
+            for reporting_enabled in [false, true] {
+                let config = config(statistics_enabled, hinting_enabled, reporting_enabled);
+                for pci in [false, true] {
+                    for activated in [false, true] {
+                        let expected =
+                            state(config, activated, pci, activated && statistics_enabled);
+                        let mut memory = restore_memory(&expected);
+                        initialize_restore_queue_memory(&mut memory, &expected);
+                        let plan = SnapshotV2BalloonRestorePlan::prepare(expected.clone(), &memory)
+                            .expect("valid balloon restore state should prepare");
+
+                        assert_eq!(plan.config(), config);
+                        assert_eq!(
+                            plan.config_space().num_pages(),
+                            mib_to_4k_pages(config.amount_mib())
+                                .expect("test page count should fit")
+                        );
+                        assert_eq!(
+                            plan.config_space().actual_pages(),
+                            if activated { 17 } else { 0 }
+                        );
+                        assert_eq!(
+                            plan.config_space().free_page_hint_cmd_id(),
+                            if hinting_enabled {
+                                VIRTIO_BALLOON_FREE_PAGE_HINT_DONE
+                            } else {
+                                VIRTIO_BALLOON_FREE_PAGE_HINT_STOP
+                            }
+                        );
+                        assert_eq!(
+                            plan.queue_ranges().len(),
+                            if activated {
+                                VirtioBalloonQueueLayout::from_config(config).queue_count()
+                            } else {
+                                0
+                            }
+                        );
+                        assert_eq!(
+                            plan.transport_kind(),
+                            if pci {
+                                SnapshotV2DeviceTransportKind::Pci
+                            } else {
+                                SnapshotV2DeviceTransportKind::Mmio
+                            }
+                        );
+
+                        let device = prepared_device(&plan);
+                        assert_eq!(
+                            device.queue_layout(),
+                            VirtioBalloonQueueLayout::from_config(config)
+                        );
+                        assert_eq!(device.is_activated(), activated);
+                        assert_eq!(
+                            device.memory_accounting().inflated_page_count(),
+                            if activated { 3 } else { 0 }
+                        );
+                        assert_eq!(
+                            device
+                                .memory_accounting()
+                                .inflated_page_ranges()
+                                .iter()
+                                .map(|range| (range.start_pfn(), range.page_count()))
+                                .collect::<Vec<_>>(),
+                            expected
+                                .accounting()
+                                .ranges()
+                                .iter()
+                                .map(|range| (range.start_pfn(), range.page_count()))
+                                .collect::<Vec<_>>()
+                        );
+                        assert_eq!(
+                            device.stats_polling_interval_s(),
+                            config.stats_polling_interval_s()
+                        );
+                        assert_eq!(
+                            device.statistics_pending_descriptor_head(),
+                            (activated && statistics_enabled).then_some(0)
+                        );
+                        assert_eq!(
+                            device.statistics(),
+                            restore_balloon_statistics(expected.continuation().statistics())
+                        );
+                        if let Some(active) = expected.continuation().active_queues() {
+                            assert_restored_queue_cursors(device, active);
+                        } else {
+                            assert!(device.active_queues().is_none());
+                        }
+
+                        if hinting_enabled {
+                            let hinting = device
+                                .hinting_status()
+                                .expect("restored hinting should remain enabled");
+                            assert_eq!(hinting.host_cmd(), VIRTIO_BALLOON_FREE_PAGE_HINT_DONE);
+                            assert_eq!(hinting.guest_cmd(), None);
+                            assert_eq!(
+                                device.hinting_last_cmd(),
+                                VIRTIO_BALLOON_FREE_PAGE_HINT_STOP
+                            );
+                            assert!(
+                                device
+                                    .hinting_acknowledge_on_stop()
+                                    .expect("restored hint policy should exist")
+                            );
+                        } else {
+                            assert!(device.hinting_status().is_err());
+                            assert_eq!(
+                                device.hinting_last_cmd(),
+                                VIRTIO_BALLOON_FREE_PAGE_HINT_STOP
+                            );
+                        }
+
+                        match plan.transport() {
+                            PreparedSnapshotV2BalloonTransport::Mmio(mmio) => {
+                                assert!(!pci);
+                                let SnapshotV2DeviceTransport::Mmio(expected_mmio) =
+                                    expected.transport()
+                                else {
+                                    panic!("expected MMIO source transport");
+                                };
+                                assert_eq!(mmio.region(), expected_mmio.region());
+                                assert_eq!(mmio.interrupt_line(), expected_mmio.interrupt_line());
+                                assert_restored_device_registers(
+                                    mmio.retained().device_registers(),
+                                    expected.virtio(),
+                                );
+                                assert_eq!(
+                                    mmio.retained().device_registers().device_features_select(),
+                                    expected_mmio.device_feature_select()
+                                );
+                                assert_eq!(
+                                    mmio.retained().device_registers().driver_features_select(),
+                                    expected_mmio.driver_feature_select()
+                                );
+                                assert_eq!(
+                                    mmio.retained().queue_select(),
+                                    expected_mmio.queue_select()
+                                );
+                                assert_eq!(
+                                    mmio.retained().queues().len(),
+                                    VirtioBalloonQueueLayout::from_config(config).queue_count()
+                                );
+                                for (actual, expected_queue) in mmio
+                                    .retained()
+                                    .queues()
+                                    .iter()
+                                    .zip(expected.virtio().queues())
+                                {
+                                    assert_restored_queue_state(actual, expected_queue);
+                                }
+                                assert_eq!(mmio.retained().is_device_activated(), activated);
+                                assert!(mmio.retained().requires_device_config_write_status());
+                                assert_eq!(
+                                    mmio.retained()
+                                        .pending_notifications()
+                                        .iter()
+                                        .copied()
+                                        .enumerate()
+                                        .filter(|(_, pending)| *pending)
+                                        .map(|(index, _)| {
+                                            u16::try_from(index)
+                                                .expect("queue index should fit u16")
+                                        })
+                                        .collect::<Vec<_>>(),
+                                    expected.virtio().pending_notifications()
+                                );
+                            }
+                            PreparedSnapshotV2BalloonTransport::Pci(pci_transport) => {
+                                assert!(pci);
+                                let SnapshotV2DeviceTransport::Pci(expected_pci) =
+                                    expected.transport()
+                                else {
+                                    panic!("expected PCI source transport");
+                                };
+                                assert_eq!(pci_transport.origin(), expected_pci.origin());
+                                assert_eq!(pci_transport.sbdf(), expected_pci.sbdf());
+                                assert_eq!(pci_transport.bar_range(), expected_pci.bar_range());
+                                assert_eq!(
+                                    pci_transport.identity().device_type().raw_value(),
+                                    VIRTIO_BALLOON_DEVICE_ID
+                                );
+                                assert_restored_device_registers(
+                                    pci_transport.retained().device_registers(),
+                                    expected.virtio(),
+                                );
+                                assert_eq!(
+                                    pci_transport.retained().device_feature_select(),
+                                    expected_pci.device_feature_select()
+                                );
+                                assert_eq!(
+                                    pci_transport.retained().driver_feature_select(),
+                                    expected_pci.driver_feature_select()
+                                );
+                                assert_eq!(
+                                    pci_transport.retained().queue_select(),
+                                    expected_pci.queue_select()
+                                );
+                                assert_eq!(
+                                    pci_transport.retained().queues().queue_count(),
+                                    VirtioBalloonQueueLayout::from_config(config).queue_count()
+                                );
+                                for (index, expected_queue) in
+                                    expected.virtio().queues().iter().enumerate()
+                                {
+                                    let index =
+                                        u32::try_from(index).expect("queue index should fit u32");
+                                    let actual = pci_transport
+                                        .retained()
+                                        .queues()
+                                        .queue(index)
+                                        .expect("restored PCI queue should exist");
+                                    assert_restored_queue_state(actual, expected_queue);
+                                }
+                                assert_eq!(
+                                    pci_transport
+                                        .retained()
+                                        .queue_notifications()
+                                        .pending_queue_notifications()
+                                        .into_iter()
+                                        .map(|index| {
+                                            u16::try_from(index)
+                                                .expect("queue index should fit u16")
+                                        })
+                                        .collect::<Vec<_>>(),
+                                    expected.virtio().pending_notifications()
+                                );
+                                assert_eq!(
+                                    pci_transport
+                                        .retained()
+                                        .interrupt_intents()
+                                        .iter()
+                                        .copied()
+                                        .map(|intent| match intent {
+                                            VirtioInterruptIntent::Queue { queue_index } => {
+                                                SnapshotV2InterruptIntent::Queue { queue_index }
+                                            }
+                                            VirtioInterruptIntent::Configuration => {
+                                                SnapshotV2InterruptIntent::Configuration
+                                            }
+                                        })
+                                        .collect::<Vec<_>>(),
+                                    expected.virtio().interrupt_intents()
+                                );
+                                assert_eq!(
+                                    pci_transport.retained().msix_vector_count(),
+                                    VirtioBalloonQueueLayout::from_config(config).queue_count() + 1
+                                );
+                                let actual_msix = pci_transport.retained().msix_state();
+                                let expected_msix = expected_pci.msix();
+                                assert_eq!(
+                                    actual_msix.pending_words(),
+                                    expected_msix.pending_words()
+                                );
+                                assert_eq!(actual_msix.enabled(), expected_msix.enabled());
+                                assert_eq!(
+                                    actual_msix.function_masked(),
+                                    expected_msix.function_masked()
+                                );
+                                assert_eq!(
+                                    actual_msix.config_vector(),
+                                    expected_msix.config_vector()
+                                );
+                                assert_eq!(
+                                    actual_msix.queue_vectors(),
+                                    expected_msix.queue_vectors()
+                                );
+                                assert_eq!(
+                                    actual_msix.pending_transition_observed(),
+                                    expected_msix.pending_transition_observed()
+                                );
+                                for (actual, expected_entry) in
+                                    actual_msix.entries().iter().zip(expected_msix.entries())
+                                {
+                                    assert_eq!(
+                                        actual.message_address_low(),
+                                        expected_entry.message_address_low()
+                                    );
+                                    assert_eq!(
+                                        actual.message_address_high(),
+                                        expected_entry.message_address_high()
+                                    );
+                                    assert_eq!(
+                                        actual.message_data(),
+                                        expected_entry.message_data()
+                                    );
+                                    assert_eq!(
+                                        actual.vector_control(),
+                                        expected_entry.vector_control()
+                                    );
+                                }
+                                assert_eq!(
+                                    pci_transport.retained().is_device_activated(),
+                                    activated
+                                );
+                                assert!(
+                                    !pci_transport
+                                        .retained()
+                                        .requires_device_config_write_status()
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn restore_plan_normalizes_enabled_hinting_after_retaining_checked_history() {
+    let config = config(false, true, false);
+    let mut expected = state(config, true, false, false);
+    expected.config_space = expected.config_space.with_free_page_hint_cmd_id(9);
+    expected.continuation.hinting = SnapshotV2BalloonHintState::new(9, Some(9), 9, false);
+    validate_balloon_state(&expected).expect("source hint history should validate");
+
+    let mut memory = restore_memory(&expected);
+    initialize_restore_queue_memory(&mut memory, &expected);
+    let plan = SnapshotV2BalloonRestorePlan::prepare(expected, &memory)
+        .expect("enabled hint history should prepare");
+    let device = prepared_device(&plan);
+    let hinting = device
+        .hinting_status()
+        .expect("restored hinting should remain enabled");
+
+    assert_eq!(
+        plan.config_space().free_page_hint_cmd_id(),
+        VIRTIO_BALLOON_FREE_PAGE_HINT_DONE
+    );
+    assert_eq!(hinting.host_cmd(), VIRTIO_BALLOON_FREE_PAGE_HINT_DONE);
+    assert_eq!(hinting.guest_cmd(), Some(9));
+    assert_eq!(device.hinting_last_cmd(), 9);
+    assert!(
+        !device
+            .hinting_acknowledge_on_stop()
+            .expect("restored hint policy should exist")
+    );
+}
+
+#[test]
+fn restore_plan_preserves_wrapping_queue_cursors_and_pending_statistics() {
+    let config = config(true, false, false);
+    let mut expected = state(config, true, false, true);
+    let idle = SnapshotV2BalloonQueueState::try_new(u16::MAX, u16::MAX, VIRTIO_BALLOON_QUEUE_SIZE)
+        .expect("wrapping idle cursors should validate");
+    let pending = SnapshotV2BalloonQueueState::try_new(0, u16::MAX, VIRTIO_BALLOON_QUEUE_SIZE)
+        .expect("wrapping pending cursors should validate");
+    expected.continuation.active_queues = Some(
+        SnapshotV2BalloonActiveQueuesState::try_new(config, idle, idle, Some(pending), None, None)
+            .expect("wrapping active queue cursors should validate"),
+    );
+    validate_balloon_state(&expected).expect("wrapping source state should validate");
+
+    let mut memory = restore_memory(&expected);
+    initialize_restore_queue_memory(&mut memory, &expected);
+    let plan = SnapshotV2BalloonRestorePlan::prepare(expected, &memory)
+        .expect("wrapping queue continuation should prepare");
+    let active = prepared_device(&plan)
+        .active_queues()
+        .expect("restored queues should remain active");
+    assert_eq!(active.inflate().available_ring().next_avail(), u16::MAX);
+    assert_eq!(active.inflate().used_ring().next_used(), u16::MAX);
+    let statistics = active
+        .statistics()
+        .expect("restored statistics queue should exist");
+    assert_eq!(statistics.available_ring().next_avail(), 0);
+    assert_eq!(statistics.used_ring().next_used(), u16::MAX);
+    assert_eq!(
+        prepared_device(&plan).statistics_pending_descriptor_head(),
+        Some(0)
+    );
+}
+
+#[test]
+fn restore_plan_rejects_destination_memory_and_queue_continuation_mismatches() {
+    let config = config(true, true, true);
+    let expected = state(config, true, false, true);
+
+    let mut invalid = expected.clone();
+    invalid.config_space = invalid
+        .config_space
+        .with_num_pages(invalid.config_space.num_pages() + 1);
+    let memory = restore_memory(&expected);
+    assert_eq!(
+        SnapshotV2BalloonRestorePlan::prepare(invalid, &memory).unwrap_err(),
+        SnapshotV2BalloonRestorePlanError::InvalidState
+    );
+
+    let low = GuestMemoryRange::new(GuestAddress::new(0), RESTORE_LOW_MEMORY_SIZE)
+        .expect("low memory should validate");
+    let truncated_queue =
+        GuestMemoryRange::new(GuestAddress::new(RESTORE_QUEUE_MEMORY_START), 0x4000)
+            .expect("truncated queue memory should validate");
+    let memory = GuestMemory::allocate(
+        &GuestMemoryLayout::new(vec![low, truncated_queue])
+            .expect("truncated layout should validate"),
+    )
+    .expect("truncated restore memory should allocate");
+    assert_eq!(
+        SnapshotV2BalloonRestorePlan::prepare(expected.clone(), &memory).unwrap_err(),
+        SnapshotV2BalloonRestorePlanError::QueueMemory
+    );
+
+    let mut memory = queue_only_restore_memory(&expected);
+    initialize_restore_queue_memory(&mut memory, &expected);
+    assert_eq!(
+        SnapshotV2BalloonRestorePlan::prepare(expected.clone(), &memory).unwrap_err(),
+        SnapshotV2BalloonRestorePlanError::AccountingMemory
+    );
+
+    let mut memory = restore_memory(&expected);
+    initialize_restore_queue_memory(&mut memory, &expected);
+    let inflate = expected
+        .virtio()
+        .queues()
+        .first()
+        .expect("inflate queue should exist");
+    write_memory_u16(
+        &mut memory,
+        inflate
+            .device_ring()
+            .checked_add(USED_INDEX_OFFSET)
+            .expect("used index address should fit"),
+        8,
+    );
+    assert_eq!(
+        SnapshotV2BalloonRestorePlan::prepare(expected.clone(), &memory).unwrap_err(),
+        SnapshotV2BalloonRestorePlanError::QueueContinuation
+    );
+
+    let mut memory = restore_memory(&expected);
+    initialize_restore_queue_memory(&mut memory, &expected);
+    let layout = VirtioBalloonQueueLayout::from_config(config);
+    let statistics = layout.statistics().expect("statistics queue should exist");
+    let queue = expected
+        .virtio()
+        .queues()
+        .get(statistics.index())
+        .expect("statistics queue state should exist");
+    let cursor = expected
+        .continuation()
+        .active_queues()
+        .and_then(SnapshotV2BalloonActiveQueuesState::statistics)
+        .expect("statistics cursors should exist");
+    let pending_ring_index = cursor.next_available().wrapping_sub(1) % queue.size();
+    write_memory_u16(
+        &mut memory,
+        queue
+            .driver_ring()
+            .checked_add(AVAILABLE_RING_OFFSET + u64::from(pending_ring_index) * 2)
+            .expect("pending entry address should fit"),
+        1,
+    );
+    assert_eq!(
+        SnapshotV2BalloonRestorePlan::prepare(expected.clone(), &memory).unwrap_err(),
+        SnapshotV2BalloonRestorePlanError::QueueContinuation
+    );
+
+    let mut memory = restore_memory(&expected);
+    initialize_restore_queue_memory(&mut memory, &expected);
+    write_memory_u16(
+        &mut memory,
+        queue
+            .driver_ring()
+            .checked_add(AVAILABLE_INDEX_OFFSET)
+            .expect("available index address should fit"),
+        cursor.next_available().wrapping_add(1),
+    );
+    let duplicate_ring_index = cursor.next_available() % queue.size();
+    write_memory_u16(
+        &mut memory,
+        queue
+            .driver_ring()
+            .checked_add(AVAILABLE_RING_OFFSET + u64::from(duplicate_ring_index) * 2)
+            .expect("duplicate entry address should fit"),
+        0,
+    );
+    assert_eq!(
+        SnapshotV2BalloonRestorePlan::prepare(expected, &memory).unwrap_err(),
+        SnapshotV2BalloonRestorePlanError::QueueContinuation
+    );
+}
+
+#[test]
+fn restore_plan_accepts_accounting_across_adjacent_mapped_regions() {
+    let config = config(false, false, false);
+    let mut expected = state(config, true, false, false);
+    expected.accounting = SnapshotV2BalloonAccountingState::try_new(
+        vec![
+            SnapshotV2BalloonPfnRange::try_new(3, 2)
+                .expect("cross-region accounting range should validate"),
+        ],
+        2,
+    )
+    .expect("cross-region accounting should validate");
+    let queue_size = u64::try_from(expected.virtio().queues().len())
+        .expect("queue count should fit")
+        * RESTORE_QUEUE_STRIDE;
+    let layout = GuestMemoryLayout::new(vec![
+        GuestMemoryRange::new(GuestAddress::new(0), 0x4000)
+            .expect("first accounting region should validate"),
+        GuestMemoryRange::new(GuestAddress::new(0x4000), RESTORE_LOW_MEMORY_SIZE - 0x4000)
+            .expect("second accounting region should validate"),
+        GuestMemoryRange::new(GuestAddress::new(RESTORE_QUEUE_MEMORY_START), queue_size)
+            .expect("queue region should validate"),
+    ])
+    .expect("adjacent accounting layout should validate");
+    let mut memory = GuestMemory::allocate(&layout).expect("restore memory should allocate");
+    initialize_restore_queue_memory(&mut memory, &expected);
+
+    let plan = SnapshotV2BalloonRestorePlan::prepare(expected, &memory)
+        .expect("accounting spanning adjacent mapped regions should prepare");
+    assert_eq!(
+        prepared_device(&plan)
+            .memory_accounting()
+            .inflated_page_count(),
+        2
+    );
+}
+
+#[test]
+fn restore_plan_allocation_isolation_and_diagnostics_are_deterministic() {
+    let config = config(true, true, true);
+    let expected = state(config, true, false, true);
+    let mut memory = restore_memory(&expected);
+    initialize_restore_queue_memory(&mut memory, &expected);
+    let before = restore_memory_bytes(&memory);
+
+    assert_eq!(
+        SnapshotV2BalloonRestorePlan::prepare_with_queue_range_allocation_failure(
+            expected.clone(),
+            &memory,
+        )
+        .unwrap_err(),
+        SnapshotV2BalloonRestorePlanError::Allocation
+    );
+    assert_eq!(
+        SnapshotV2BalloonRestorePlan::prepare_with_accounting_allocation_failure(
+            expected.clone(),
+            &memory,
+        )
+        .unwrap_err(),
+        SnapshotV2BalloonRestorePlanError::Allocation
+    );
+
+    let first = SnapshotV2BalloonRestorePlan::prepare(expected.clone(), &memory)
+        .expect("first restore plan should prepare");
+    let second = SnapshotV2BalloonRestorePlan::prepare(expected, &memory)
+        .expect("second restore plan should prepare");
+    assert_eq!(restore_memory_bytes(&memory), before);
+    assert_ne!(
+        first.queue_ranges().as_ptr(),
+        second.queue_ranges().as_ptr()
+    );
+    assert_ne!(
+        prepared_device(&first)
+            .memory_accounting()
+            .inflated_page_ranges()
+            .as_ptr(),
+        prepared_device(&second)
+            .memory_accounting()
+            .inflated_page_ranges()
+            .as_ptr()
+    );
+
+    let debug = format!("{first:?}");
+    assert!(debug.contains("<redacted>"));
+    assert!(!debug.contains("2147483648"));
+    for error in [
+        SnapshotV2BalloonRestorePlanError::InvalidState,
+        SnapshotV2BalloonRestorePlanError::QueueMemory,
+        SnapshotV2BalloonRestorePlanError::AccountingMemory,
+        SnapshotV2BalloonRestorePlanError::QueueContinuation,
+        SnapshotV2BalloonRestorePlanError::Allocation,
+    ] {
+        assert!(!format!("{error:?}").contains("2147483648"));
+        assert!(!error.to_string().contains("2147483648"));
+    }
+
+    let (_, _, _, first_transport) = first.into_parts();
+    let (_, _, _, second_transport) = second.into_parts();
+    let PreparedSnapshotV2BalloonTransport::Mmio(first) = first_transport else {
+        panic!("expected MMIO restore transport");
+    };
+    let PreparedSnapshotV2BalloonTransport::Mmio(second) = second_transport else {
+        panic!("expected MMIO restore transport");
+    };
+    let (_, _, mut first_device, _) = (*first).into_parts();
+    let (_, _, second_device, _) = (*second).into_parts();
+    first_device.reset();
+    assert!(first_device.memory_accounting().is_empty());
+    assert_eq!(second_device.memory_accounting().inflated_page_count(), 3);
+    assert!(second_device.is_activated());
 }
 
 struct FailAtReserve {

--- a/crates/runtime/src/virtio_queue.rs
+++ b/crates/runtime/src/virtio_queue.rs
@@ -488,6 +488,22 @@ impl VirtqueueAvailableRing {
         read_available_ring_u16(memory, self.available_ring, self.queue_size, address)
     }
 
+    pub(crate) fn descriptor_head_at_available_index(
+        &self,
+        memory: &GuestMemory,
+        available_index: u16,
+    ) -> Result<u16, VirtqueueAvailableRingError> {
+        validate_available_ring_range(memory, self.available_ring, self.queue_size)?;
+
+        // Match the normal pop ordering point before observing a ring entry.
+        fence(Ordering::Acquire);
+
+        let ring_index = available_index % self.queue_size;
+        let head_address =
+            available_ring_entry_address(self.available_ring, self.queue_size, ring_index)?;
+        read_available_ring_u16(memory, self.available_ring, self.queue_size, head_address)
+    }
+
     pub fn used_event(&self, memory: &GuestMemory) -> Result<u16, VirtqueueAvailableRingError> {
         validate_available_ring_range(memory, self.available_ring, self.queue_size)?;
 


### PR DESCRIPTION
## Summary

- add checked balloon queue, active-set, accounting, and detached-device
  reconstruction for exact native-v2 2.9 state
- prepare memory-validated MMIO or PCI retained transports while normalizing
  enabled destination hinting to DONE
- preserve exact queue cursors, latest and pending statistics, hint history,
  host PFN accounting, common registers, notifications, interrupts, and MSI-X
  state
- reject destination memory holes, cursor and retained-head inconsistencies,
  malformed accounting, allocation failures, and invalid detached state with
  value-redacted diagnostics

## Scope exclusions

- no HVF VM, dispatcher, notifier, route, PCI endpoint, timer, metrics, system
  adviser, thread, owner publication, or public exact-2.9 activation
- exact-2.8 restore and the public snapshot version gate remain unchanged

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented Apple-target Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh` without `--allow-unsupported`

Closes #1676.
