### PR TITLE
feat: plan balloon snapshot platform products

### DIFF
--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -25,6 +25,7 @@ mod snapshot;
 mod snapshot_bundle;
 mod snapshot_restore;
 mod snapshot_v2;
+mod snapshot_v2_balloon_platform;
 mod snapshot_v2_entropy_platform;
 mod snapshot_v2_multi_block_platform;
 mod snapshot_v2_platform;
@@ -151,6 +152,15 @@ pub use snapshot_v2::{
     encode_hvf_snapshot_v2_multi_block_state, encode_hvf_snapshot_v2_platform_state,
     encode_hvf_snapshot_v2_serial_state, encode_hvf_snapshot_v2_state,
     encode_hvf_snapshot_v2_storage_state,
+};
+pub use snapshot_v2_balloon_platform::{
+    HvfSnapshotV2BalloonEntropyMmioEndpointPlan, HvfSnapshotV2BalloonMmioEndpointPlan,
+    HvfSnapshotV2BalloonMmioPlatformPlan, HvfSnapshotV2BalloonMmioProcessConfig,
+    HvfSnapshotV2BalloonPciEndpointPlan, HvfSnapshotV2BalloonPciPlatformPlan,
+    HvfSnapshotV2BalloonPreparedProduct, HvfSnapshotV2BalloonProductKind,
+    PrepareHvfSnapshotV2BalloonPlatformPlanError,
+    prepare_hvf_snapshot_v2_balloon_mmio_platform_plan,
+    prepare_hvf_snapshot_v2_balloon_pci_platform_plan,
 };
 pub use snapshot_v2_entropy_platform::{
     HvfSnapshotV2EntropyPciEndpointPlan, HvfSnapshotV2StorageEntropyPciPlatformPlan,

--- a/crates/hvf/src/snapshot_v2_balloon_platform.rs
+++ b/crates/hvf/src/snapshot_v2_balloon_platform.rs
@@ -1,0 +1,2023 @@
+//! Host-free exact native-v2 2.9 balloon platform-product planning.
+
+use std::fmt;
+
+use bangbang_runtime::balloon::BalloonMmioLayout;
+use bangbang_runtime::entropy::{EntropyMmioLayout, VIRTIO_RNG_QUEUE_SIZES};
+use bangbang_runtime::fdt::{Arm64FdtPciHost, Arm64FdtRegion, Arm64FdtVirtioMmioDevice};
+use bangbang_runtime::interrupt::GuestInterruptLine;
+use bangbang_runtime::memory::GuestMemoryRange;
+use bangbang_runtime::mmio::{MmioRegion, MmioRegionId};
+use bangbang_runtime::pci::{Arm64PciAddressPlan, PciSbdf};
+use bangbang_runtime::rtc::RtcMmioLayout;
+use bangbang_runtime::snapshot_balloon_v2_9::{
+    PreparedSnapshotV2BalloonTransport, SnapshotV2BalloonRestorePlan,
+};
+use bangbang_runtime::snapshot_device_v2::{
+    SnapshotV2DeviceTransport, SnapshotV2DeviceTransportKind,
+};
+use bangbang_runtime::snapshot_device_v2_6::PreparedSnapshotV2StorageBundle;
+use bangbang_runtime::snapshot_entropy_v2_8::{
+    PreparedSnapshotV2EntropyTransport, SnapshotV2EntropyRestorePlan,
+};
+use bangbang_runtime::storage_capture::StorageDeviceOrigin;
+use bangbang_runtime::virtio_mmio::VIRTIO_MMIO_DEVICE_WINDOW_SIZE;
+use bangbang_runtime::virtio_pci::VirtioPciEndpointPhase;
+
+use crate::gic::{HvfGicInterruptLineAllocator, HvfGicMsiMetadata};
+use crate::snapshot_v2::HvfSnapshotV2PlatformState;
+use crate::snapshot_v2_entropy_platform::{
+    HvfSnapshotV2EntropyPciEndpointPlan, PrepareHvfSnapshotV2EntropyPciPlatformPlanError,
+    prepare_hvf_snapshot_v2_entropy_pci_platform_plan_with_prefix,
+    register_active_retained_pci_routes,
+};
+use crate::snapshot_v2_multi_block_platform::{
+    snapshot_v2_pci_endpoint_placement, snapshot_v2_pci_endpoint_route_count,
+};
+use crate::snapshot_v2_platform::{PROCESS_RTC_MMIO_BASE, PROCESS_RTC_MMIO_REGION_ID};
+use crate::snapshot_v2_storage_platform::{
+    HvfSnapshotV2StorageMmioPlatformPlan, HvfSnapshotV2StorageMmioPlatformPrefix,
+    HvfSnapshotV2StorageMmioProcessConfig, HvfSnapshotV2StoragePciPlatformPlan,
+    HvfSnapshotV2StoragePciPlatformPrefix, PrepareHvfSnapshotV2StorageMmioPlatformPlanError,
+    PrepareHvfSnapshotV2StoragePciPlatformPlanError, mmio_region_conflicts_with_platform,
+    prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix,
+    prepare_hvf_snapshot_v2_storage_pci_platform_plan_with_prefix,
+    queue_ranges_conflict_with_pci_platform, queue_ranges_conflict_with_platform,
+    register_active_pci_routes,
+};
+use crate::startup::{PCI_ENDPOINT_SLOT_COUNT, pci_balloon_restore_gic_msi_configuration};
+
+const REDACTED: &str = "<redacted>";
+
+/// One supported exact-2.9 balloon product shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HvfSnapshotV2BalloonProductKind {
+    /// Restored serial plus balloon.
+    SerialBalloon,
+    /// Restored serial, balloon, and storage.
+    SerialBalloonStorage,
+    /// Restored serial, balloon, and entropy.
+    SerialBalloonEntropy,
+    /// Restored serial, balloon, storage, and entropy.
+    SerialBalloonStorageEntropy,
+}
+
+enum HvfSnapshotV2BalloonPreparedProductParts {
+    Balloon {
+        balloon: SnapshotV2BalloonRestorePlan,
+    },
+    Storage {
+        balloon: SnapshotV2BalloonRestorePlan,
+        storage: PreparedSnapshotV2StorageBundle,
+    },
+    Entropy {
+        balloon: SnapshotV2BalloonRestorePlan,
+        entropy: SnapshotV2EntropyRestorePlan,
+    },
+    StorageEntropy {
+        balloon: SnapshotV2BalloonRestorePlan,
+        storage: PreparedSnapshotV2StorageBundle,
+        entropy: SnapshotV2EntropyRestorePlan,
+    },
+}
+
+/// One closed set of detached exact-2.9 component continuations.
+///
+/// Construction consumes every component into one tagged shape. A successful
+/// platform plan retains this value so independently prepared balloon,
+/// storage, and entropy continuations cannot be recombined afterward.
+pub struct HvfSnapshotV2BalloonPreparedProduct {
+    parts: HvfSnapshotV2BalloonPreparedProductParts,
+}
+
+impl HvfSnapshotV2BalloonPreparedProduct {
+    /// Closes one serial-plus-balloon product.
+    pub fn serial_balloon(balloon: SnapshotV2BalloonRestorePlan) -> Self {
+        Self {
+            parts: HvfSnapshotV2BalloonPreparedProductParts::Balloon { balloon },
+        }
+    }
+
+    /// Closes one serial-plus-balloon-and-storage product.
+    pub fn serial_balloon_storage(
+        balloon: SnapshotV2BalloonRestorePlan,
+        storage: PreparedSnapshotV2StorageBundle,
+    ) -> Self {
+        Self {
+            parts: HvfSnapshotV2BalloonPreparedProductParts::Storage { balloon, storage },
+        }
+    }
+
+    /// Closes one serial-plus-balloon-and-entropy product.
+    pub fn serial_balloon_entropy(
+        balloon: SnapshotV2BalloonRestorePlan,
+        entropy: SnapshotV2EntropyRestorePlan,
+    ) -> Self {
+        Self {
+            parts: HvfSnapshotV2BalloonPreparedProductParts::Entropy { balloon, entropy },
+        }
+    }
+
+    /// Closes one serial-plus-balloon-storage-and-entropy product.
+    pub fn serial_balloon_storage_entropy(
+        balloon: SnapshotV2BalloonRestorePlan,
+        storage: PreparedSnapshotV2StorageBundle,
+        entropy: SnapshotV2EntropyRestorePlan,
+    ) -> Self {
+        Self {
+            parts: HvfSnapshotV2BalloonPreparedProductParts::StorageEntropy {
+                balloon,
+                storage,
+                entropy,
+            },
+        }
+    }
+
+    /// Returns the closed product shape.
+    pub const fn kind(&self) -> HvfSnapshotV2BalloonProductKind {
+        match self.parts {
+            HvfSnapshotV2BalloonPreparedProductParts::Balloon { .. } => {
+                HvfSnapshotV2BalloonProductKind::SerialBalloon
+            }
+            HvfSnapshotV2BalloonPreparedProductParts::Storage { .. } => {
+                HvfSnapshotV2BalloonProductKind::SerialBalloonStorage
+            }
+            HvfSnapshotV2BalloonPreparedProductParts::Entropy { .. } => {
+                HvfSnapshotV2BalloonProductKind::SerialBalloonEntropy
+            }
+            HvfSnapshotV2BalloonPreparedProductParts::StorageEntropy { .. } => {
+                HvfSnapshotV2BalloonProductKind::SerialBalloonStorageEntropy
+            }
+        }
+    }
+
+    /// Returns the owned detached balloon continuation.
+    pub const fn balloon(&self) -> &SnapshotV2BalloonRestorePlan {
+        match &self.parts {
+            HvfSnapshotV2BalloonPreparedProductParts::Balloon { balloon }
+            | HvfSnapshotV2BalloonPreparedProductParts::Storage { balloon, .. }
+            | HvfSnapshotV2BalloonPreparedProductParts::Entropy { balloon, .. }
+            | HvfSnapshotV2BalloonPreparedProductParts::StorageEntropy { balloon, .. } => balloon,
+        }
+    }
+
+    /// Returns the owned detached storage continuation when present.
+    pub const fn storage(&self) -> Option<&PreparedSnapshotV2StorageBundle> {
+        match &self.parts {
+            HvfSnapshotV2BalloonPreparedProductParts::Balloon { .. }
+            | HvfSnapshotV2BalloonPreparedProductParts::Entropy { .. } => None,
+            HvfSnapshotV2BalloonPreparedProductParts::Storage { storage, .. }
+            | HvfSnapshotV2BalloonPreparedProductParts::StorageEntropy { storage, .. } => {
+                Some(storage)
+            }
+        }
+    }
+
+    /// Returns the owned detached entropy continuation when present.
+    pub const fn entropy(&self) -> Option<&SnapshotV2EntropyRestorePlan> {
+        match &self.parts {
+            HvfSnapshotV2BalloonPreparedProductParts::Balloon { .. }
+            | HvfSnapshotV2BalloonPreparedProductParts::Storage { .. } => None,
+            HvfSnapshotV2BalloonPreparedProductParts::Entropy { entropy, .. }
+            | HvfSnapshotV2BalloonPreparedProductParts::StorageEntropy { entropy, .. } => {
+                Some(entropy)
+            }
+        }
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2BalloonPreparedProduct {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2BalloonPreparedProduct")
+            .field("kind", &self.kind())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Canonical destination layouts for one balloon-aware MMIO process.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct HvfSnapshotV2BalloonMmioProcessConfig {
+    balloon_layout: BalloonMmioLayout,
+    storage: HvfSnapshotV2StorageMmioProcessConfig,
+    entropy_layout: EntropyMmioLayout,
+}
+
+impl HvfSnapshotV2BalloonMmioProcessConfig {
+    /// Creates one closed destination MMIO placement policy.
+    pub const fn new(
+        balloon_layout: BalloonMmioLayout,
+        storage: HvfSnapshotV2StorageMmioProcessConfig,
+        entropy_layout: EntropyMmioLayout,
+    ) -> Self {
+        Self {
+            balloon_layout,
+            storage,
+            entropy_layout,
+        }
+    }
+
+    /// Returns the canonical balloon MMIO layout.
+    pub const fn balloon_layout(self) -> BalloonMmioLayout {
+        self.balloon_layout
+    }
+
+    /// Returns the canonical block/pmem MMIO layouts.
+    pub const fn storage(self) -> HvfSnapshotV2StorageMmioProcessConfig {
+        self.storage
+    }
+
+    /// Returns the canonical entropy MMIO layout.
+    pub const fn entropy_layout(self) -> EntropyMmioLayout {
+        self.entropy_layout
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2BalloonMmioProcessConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2BalloonMmioProcessConfig")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Exact typed placement of one restored MMIO balloon endpoint.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct HvfSnapshotV2BalloonMmioEndpointPlan {
+    region: MmioRegion,
+    interrupt_line: GuestInterruptLine,
+    fdt_device: Arm64FdtVirtioMmioDevice,
+}
+
+impl HvfSnapshotV2BalloonMmioEndpointPlan {
+    /// Returns the exact dispatcher region.
+    pub const fn region(self) -> MmioRegion {
+        self.region
+    }
+
+    /// Returns the first optional product SPI.
+    pub const fn interrupt_line(self) -> GuestInterruptLine {
+        self.interrupt_line
+    }
+
+    /// Returns the semantic FDT device fact.
+    pub const fn fdt_device(self) -> Arm64FdtVirtioMmioDevice {
+        self.fdt_device
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2BalloonMmioEndpointPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2BalloonMmioEndpointPlan")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Exact typed placement of one restored MMIO entropy endpoint.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct HvfSnapshotV2BalloonEntropyMmioEndpointPlan {
+    region: MmioRegion,
+    interrupt_line: GuestInterruptLine,
+    fdt_device: Arm64FdtVirtioMmioDevice,
+}
+
+impl HvfSnapshotV2BalloonEntropyMmioEndpointPlan {
+    /// Returns the exact dispatcher region.
+    pub const fn region(self) -> MmioRegion {
+        self.region
+    }
+
+    /// Returns the exact following optional SPI.
+    pub const fn interrupt_line(self) -> GuestInterruptLine {
+        self.interrupt_line
+    }
+
+    /// Returns the semantic FDT device fact.
+    pub const fn fdt_device(self) -> Arm64FdtVirtioMmioDevice {
+        self.fdt_device
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2BalloonEntropyMmioEndpointPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2BalloonEntropyMmioEndpointPlan")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Exact typed placement of one restored PCI balloon endpoint.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct HvfSnapshotV2BalloonPciEndpointPlan {
+    origin: StorageDeviceOrigin,
+    sbdf: PciSbdf,
+    bar_region_id: MmioRegionId,
+    bar_range: GuestMemoryRange,
+    route_count: usize,
+    msi_interrupt_count: u32,
+}
+
+impl HvfSnapshotV2BalloonPciEndpointPlan {
+    /// Returns the retained startup/runtime origin.
+    pub const fn origin(self) -> StorageDeviceOrigin {
+        self.origin
+    }
+
+    /// Returns the exact slot-zero function.
+    pub const fn sbdf(self) -> PciSbdf {
+        self.sbdf
+    }
+
+    /// Returns the exact dispatcher region ID.
+    pub const fn bar_region_id(self) -> MmioRegionId {
+        self.bar_region_id
+    }
+
+    /// Returns the exact retained capability BAR.
+    pub const fn bar_range(self) -> GuestMemoryRange {
+        self.bar_range
+    }
+
+    /// Returns queue count plus one configuration route.
+    pub const fn route_count(self) -> usize {
+        self.route_count
+    }
+
+    /// Returns the exact retained canonical GICv2m pool size.
+    pub const fn msi_interrupt_count(self) -> u32 {
+        self.msi_interrupt_count
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2BalloonPciEndpointPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2BalloonPciEndpointPlan")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Complete immutable exact-2.9 balloon-aware MMIO product proof.
+pub struct HvfSnapshotV2BalloonMmioPlatformPlan {
+    product: HvfSnapshotV2BalloonPreparedProduct,
+    balloon: HvfSnapshotV2BalloonMmioEndpointPlan,
+    storage: Option<HvfSnapshotV2StorageMmioPlatformPlan>,
+    entropy: Option<HvfSnapshotV2BalloonEntropyMmioEndpointPlan>,
+    serial_interrupt: GuestInterruptLine,
+    vmgenid_interrupt: GuestInterruptLine,
+    vmclock_interrupt: GuestInterruptLine,
+}
+
+impl HvfSnapshotV2BalloonMmioPlatformPlan {
+    /// Returns the closed product shape.
+    pub const fn kind(&self) -> HvfSnapshotV2BalloonProductKind {
+        self.product.kind()
+    }
+
+    /// Returns the retained prepared components.
+    pub const fn product(&self) -> &HvfSnapshotV2BalloonPreparedProduct {
+        &self.product
+    }
+
+    /// Returns the checked balloon endpoint.
+    pub const fn balloon(&self) -> HvfSnapshotV2BalloonMmioEndpointPlan {
+        self.balloon
+    }
+
+    /// Returns the checked storage platform continuation when present.
+    pub const fn storage(&self) -> Option<&HvfSnapshotV2StorageMmioPlatformPlan> {
+        self.storage.as_ref()
+    }
+
+    /// Returns the checked entropy endpoint when present.
+    pub const fn entropy(&self) -> Option<HvfSnapshotV2BalloonEntropyMmioEndpointPlan> {
+        self.entropy
+    }
+
+    /// Returns the final exact serial SPI.
+    pub const fn serial_interrupt(&self) -> GuestInterruptLine {
+        self.serial_interrupt
+    }
+
+    /// Returns the final exact VMGenID SPI.
+    pub const fn vmgenid_interrupt(&self) -> GuestInterruptLine {
+        self.vmgenid_interrupt
+    }
+
+    /// Returns the final exact VMClock SPI.
+    pub const fn vmclock_interrupt(&self) -> GuestInterruptLine {
+        self.vmclock_interrupt
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2BalloonMmioPlatformPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2BalloonMmioPlatformPlan")
+            .field("kind", &self.kind())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Complete immutable exact-2.9 balloon-aware PCI product proof.
+pub struct HvfSnapshotV2BalloonPciPlatformPlan {
+    product: HvfSnapshotV2BalloonPreparedProduct,
+    balloon: HvfSnapshotV2BalloonPciEndpointPlan,
+    storage: Option<HvfSnapshotV2StoragePciPlatformPlan>,
+    entropy: Option<HvfSnapshotV2EntropyPciEndpointPlan>,
+    host: Arm64FdtPciHost,
+    msi: HvfGicMsiMetadata,
+    route_demand: usize,
+    serial_interrupt: GuestInterruptLine,
+    vmgenid_interrupt: GuestInterruptLine,
+    vmclock_interrupt: GuestInterruptLine,
+}
+
+impl HvfSnapshotV2BalloonPciPlatformPlan {
+    /// Returns the closed product shape.
+    pub const fn kind(&self) -> HvfSnapshotV2BalloonProductKind {
+        self.product.kind()
+    }
+
+    /// Returns the retained prepared components.
+    pub const fn product(&self) -> &HvfSnapshotV2BalloonPreparedProduct {
+        &self.product
+    }
+
+    /// Returns the checked slot-zero balloon endpoint.
+    pub const fn balloon(&self) -> HvfSnapshotV2BalloonPciEndpointPlan {
+        self.balloon
+    }
+
+    /// Returns the checked storage platform continuation when present.
+    pub const fn storage(&self) -> Option<&HvfSnapshotV2StoragePciPlatformPlan> {
+        self.storage.as_ref()
+    }
+
+    /// Returns the checked following entropy endpoint when present.
+    pub const fn entropy(&self) -> Option<HvfSnapshotV2EntropyPciEndpointPlan> {
+        self.entropy
+    }
+
+    /// Returns the coherent retained PCI host.
+    pub const fn host(&self) -> Arm64FdtPciHost {
+        self.host
+    }
+
+    /// Returns the coherent retained GICv2m metadata.
+    pub const fn msi(&self) -> HvfGicMsiMetadata {
+        self.msi
+    }
+
+    /// Returns total configuration-plus-queue route demand.
+    pub const fn route_demand(&self) -> usize {
+        self.route_demand
+    }
+
+    /// Returns the final exact serial SPI.
+    pub const fn serial_interrupt(&self) -> GuestInterruptLine {
+        self.serial_interrupt
+    }
+
+    /// Returns the final exact VMGenID SPI.
+    pub const fn vmgenid_interrupt(&self) -> GuestInterruptLine {
+        self.vmgenid_interrupt
+    }
+
+    /// Returns the final exact VMClock SPI.
+    pub const fn vmclock_interrupt(&self) -> GuestInterruptLine {
+        self.vmclock_interrupt
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2BalloonPciPlatformPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2BalloonPciPlatformPlan")
+            .field("kind", &self.kind())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Redacted rejection from exact-2.9 balloon platform-product planning.
+pub enum PrepareHvfSnapshotV2BalloonPlatformPlanError {
+    /// The captured product platform profile is not the process profile.
+    PlatformProfile,
+    /// Prepared components do not all select the requested transport.
+    TransportPolicy,
+    /// A retained region, interrupt, endpoint, BAR, or host identity diverged.
+    ResourcePlan,
+    /// The complete product exceeds the canonical PCI endpoint capacity.
+    PciCapacity { count: usize, maximum: usize },
+    /// A queue, device region, or pmem mapping conflicts with another owner.
+    RangeConflict,
+    /// Active MSI messages are malformed, out of range, or collide.
+    RouteConflict,
+    /// A temporary destination-only inventory could not reserve capacity.
+    Allocation,
+    /// Prefix-aware MMIO storage planning failed.
+    StorageMmio(Box<PrepareHvfSnapshotV2StorageMmioPlatformPlanError>),
+    /// Prefix-aware PCI storage planning failed.
+    StoragePci(Box<PrepareHvfSnapshotV2StoragePciPlatformPlanError>),
+    /// Prefix-aware PCI entropy planning failed.
+    EntropyPci(Box<PrepareHvfSnapshotV2EntropyPciPlatformPlanError>),
+}
+
+impl fmt::Debug for PrepareHvfSnapshotV2BalloonPlatformPlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let category = match self {
+            Self::PlatformProfile => "platform-profile",
+            Self::TransportPolicy => "transport-policy",
+            Self::ResourcePlan => "resource-plan",
+            Self::PciCapacity { .. } => "pci-capacity",
+            Self::RangeConflict => "range-conflict",
+            Self::RouteConflict => "route-conflict",
+            Self::Allocation => "allocation",
+            Self::StorageMmio(_) => "storage-mmio",
+            Self::StoragePci(_) => "storage-pci",
+            Self::EntropyPci(_) => "entropy-pci",
+        };
+        formatter
+            .debug_struct("PrepareHvfSnapshotV2BalloonPlatformPlanError")
+            .field("category", &category)
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+impl fmt::Display for PrepareHvfSnapshotV2BalloonPlatformPlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::PlatformProfile => {
+                "native-v2 balloon platform does not use the product process profile"
+            }
+            Self::TransportPolicy => "native-v2 balloon product transport policy is inconsistent",
+            Self::ResourcePlan => "native-v2 balloon platform resources are inconsistent",
+            Self::PciCapacity { .. } => {
+                "native-v2 balloon product PCI endpoint capacity is exceeded"
+            }
+            Self::RangeConflict => {
+                "native-v2 balloon product ranges overlap another platform owner"
+            }
+            Self::RouteConflict => "native-v2 balloon product active MSI routes are inconsistent",
+            Self::Allocation => "native-v2 balloon platform temporary inventory allocation failed",
+            Self::StorageMmio(_) => "native-v2 balloon-prefixed MMIO storage planning failed",
+            Self::StoragePci(_) => "native-v2 balloon-prefixed PCI storage planning failed",
+            Self::EntropyPci(_) => "native-v2 balloon-prefixed PCI entropy planning failed",
+        })
+    }
+}
+
+impl std::error::Error for PrepareHvfSnapshotV2BalloonPlatformPlanError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::StorageMmio(source) => Some(source),
+            Self::StoragePci(source) => Some(source),
+            Self::EntropyPci(source) => Some(source),
+            Self::PlatformProfile
+            | Self::TransportPolicy
+            | Self::ResourcePlan
+            | Self::PciCapacity { .. }
+            | Self::RangeConflict
+            | Self::RouteConflict
+            | Self::Allocation => None,
+        }
+    }
+}
+
+/// Proves one complete balloon-aware MMIO product before live construction.
+pub fn prepare_hvf_snapshot_v2_balloon_mmio_platform_plan(
+    platform: &HvfSnapshotV2PlatformState,
+    product: HvfSnapshotV2BalloonPreparedProduct,
+    process: HvfSnapshotV2BalloonMmioProcessConfig,
+) -> Result<HvfSnapshotV2BalloonMmioPlatformPlan, PrepareHvfSnapshotV2BalloonPlatformPlanError> {
+    prepare_balloon_mmio_platform_plan(
+        platform,
+        product,
+        process,
+        &mut SystemBalloonPlatformPlanReserve,
+    )
+}
+
+/// Proves one complete balloon-aware PCI product before live construction.
+pub fn prepare_hvf_snapshot_v2_balloon_pci_platform_plan(
+    platform: &HvfSnapshotV2PlatformState,
+    product: HvfSnapshotV2BalloonPreparedProduct,
+) -> Result<HvfSnapshotV2BalloonPciPlatformPlan, PrepareHvfSnapshotV2BalloonPlatformPlanError> {
+    prepare_balloon_pci_platform_plan(platform, product, &mut SystemBalloonPlatformPlanReserve)
+}
+
+fn prepare_balloon_mmio_platform_plan(
+    platform: &HvfSnapshotV2PlatformState,
+    product: HvfSnapshotV2BalloonPreparedProduct,
+    process: HvfSnapshotV2BalloonMmioProcessConfig,
+    reserve: &mut impl BalloonPlatformPlanReserve,
+) -> Result<HvfSnapshotV2BalloonMmioPlatformPlan, PrepareHvfSnapshotV2BalloonPlatformPlanError> {
+    validate_product_profile(platform)?;
+    if platform
+        .global()
+        .compatibility()
+        .gic_metadata()
+        .msi
+        .is_some()
+        || product.balloon().transport_kind() != SnapshotV2DeviceTransportKind::Mmio
+        || product
+            .storage()
+            .is_some_and(|storage| storage.transport_kind() != SnapshotV2DeviceTransportKind::Mmio)
+        || product
+            .entropy()
+            .is_some_and(|entropy| entropy.transport_kind() != SnapshotV2DeviceTransportKind::Mmio)
+    {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::TransportPolicy);
+    }
+
+    let expected_balloon_region = mmio_region(
+        process.balloon_layout().region_id(),
+        process.balloon_layout().address(),
+    )?;
+    let PreparedSnapshotV2BalloonTransport::Mmio(balloon_transport) = product.balloon().transport()
+    else {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::TransportPolicy);
+    };
+    if balloon_transport.region() != expected_balloon_region
+        || mmio_region_conflicts_with_platform(
+            platform,
+            expected_balloon_region,
+            &platform.global().compatibility().gic_metadata(),
+        )
+        .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?
+    {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan);
+    }
+    for ranges in product.balloon().queue_ranges() {
+        if queue_ranges_conflict_with_platform(platform, Some(*ranges))
+            .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?
+        {
+            return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::RangeConflict);
+        }
+    }
+    let balloon_interrupt = balloon_transport.interrupt_line();
+
+    let entropy_endpoint = product
+        .entropy()
+        .map(|entropy| prepare_entropy_mmio_endpoint(platform, entropy, process.entropy_layout()))
+        .transpose()?;
+
+    let storage_plan = product
+        .storage()
+        .map(|storage| {
+            prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix(
+                platform,
+                storage,
+                process.storage(),
+                HvfSnapshotV2StorageMmioPlatformPrefix::one(
+                    expected_balloon_region,
+                    balloon_interrupt,
+                ),
+                entropy_endpoint.map(|entropy| entropy.interrupt_line()),
+            )
+            .map_err(|source| {
+                PrepareHvfSnapshotV2BalloonPlatformPlanError::StorageMmio(Box::new(source))
+            })
+        })
+        .transpose()?;
+
+    let (serial_interrupt, vmgenid_interrupt, vmclock_interrupt) =
+        validate_mmio_interrupt_sequence(
+            platform,
+            balloon_interrupt,
+            storage_plan.as_ref(),
+            entropy_endpoint,
+        )?;
+
+    let region_count = 1_usize
+        .checked_add(storage_record_count_mmio(storage_plan.as_ref()))
+        .and_then(|count| count.checked_add(usize::from(entropy_endpoint.is_some())))
+        .ok_or(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    let queue_count = product_queue_range_count(&product)?;
+    let pmem_count = product
+        .storage()
+        .map_or(0, |storage| storage.pmem_records().len());
+    let mut regions = Vec::new();
+    let mut queues = Vec::new();
+    let mut pmem = Vec::new();
+    reserve.reserve(&mut regions, region_count)?;
+    reserve.reserve(&mut queues, queue_count)?;
+    reserve.reserve(&mut pmem, pmem_count)?;
+    regions.push(expected_balloon_region);
+    if let Some(storage) = &storage_plan {
+        regions.extend(
+            storage
+                .block_records()
+                .iter()
+                .chain(storage.pmem_records())
+                .map(|record| record.region()),
+        );
+    }
+    if let Some(entropy) = entropy_endpoint {
+        regions.push(entropy.region());
+    }
+    append_product_memory_ranges(&product, &mut queues, &mut pmem);
+    if !aggregate_ranges_are_disjoint(&regions, &queues, &pmem) {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::RangeConflict);
+    }
+
+    Ok(HvfSnapshotV2BalloonMmioPlatformPlan {
+        product,
+        balloon: HvfSnapshotV2BalloonMmioEndpointPlan {
+            region: expected_balloon_region,
+            interrupt_line: balloon_interrupt,
+            fdt_device: mmio_fdt_device(expected_balloon_region, balloon_interrupt),
+        },
+        storage: storage_plan,
+        entropy: entropy_endpoint,
+        serial_interrupt,
+        vmgenid_interrupt,
+        vmclock_interrupt,
+    })
+}
+
+fn prepare_balloon_pci_platform_plan(
+    platform: &HvfSnapshotV2PlatformState,
+    product: HvfSnapshotV2BalloonPreparedProduct,
+    reserve: &mut impl BalloonPlatformPlanReserve,
+) -> Result<HvfSnapshotV2BalloonPciPlatformPlan, PrepareHvfSnapshotV2BalloonPlatformPlanError> {
+    validate_product_profile(platform)?;
+    if product.balloon().transport_kind() != SnapshotV2DeviceTransportKind::Pci
+        || product
+            .storage()
+            .is_some_and(|storage| storage.transport_kind() != SnapshotV2DeviceTransportKind::Pci)
+        || product
+            .entropy()
+            .is_some_and(|entropy| entropy.transport_kind() != SnapshotV2DeviceTransportKind::Pci)
+    {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::TransportPolicy);
+    }
+    let PreparedSnapshotV2BalloonTransport::Pci(balloon_transport) = product.balloon().transport()
+    else {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::TransportPolicy);
+    };
+    let address_plan = Arm64PciAddressPlan::firecracker_v1_16()
+        .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    let host = Arm64FdtPciHost::from_address_plan(address_plan);
+    let gic = platform.global().compatibility().gic_metadata();
+    let msi = gic
+        .msi
+        .ok_or(PrepareHvfSnapshotV2BalloonPlatformPlanError::TransportPolicy)?;
+    let queue_count = balloon_transport.device().queue_layout().queue_count();
+    let balloon_route_count = snapshot_v2_pci_endpoint_route_count(queue_count)
+        .filter(|count| (3..=6).contains(count))
+        .ok_or(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    let expected_msi =
+        pci_balloon_restore_gic_msi_configuration(queue_count, product.entropy().is_some())
+            .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    let expected_msi_interrupt_count = expected_msi.interrupt_count().get();
+    let balloon_placement = snapshot_v2_pci_endpoint_placement(address_plan, 0)
+        .ok_or(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    if msi.interrupt_range.count != expected_msi_interrupt_count
+        || balloon_transport.origin() != StorageDeviceOrigin::Startup
+        || balloon_transport.sbdf() != balloon_placement.sbdf
+        || balloon_transport.bar_range() != balloon_placement.bar_range
+        || balloon_transport.retained().phase() != VirtioPciEndpointPhase::Active
+    {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan);
+    }
+    let balloon_origin = balloon_transport.origin();
+    for ranges in product.balloon().queue_ranges() {
+        if queue_ranges_conflict_with_pci_platform(platform, Some(*ranges), &gic, address_plan)
+            .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?
+        {
+            return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::RangeConflict);
+        }
+    }
+
+    let reserved_entropy = usize::from(product.entropy().is_some());
+    let storage_plan = product
+        .storage()
+        .map(|storage| {
+            prepare_hvf_snapshot_v2_storage_pci_platform_plan_with_prefix(
+                platform,
+                storage,
+                HvfSnapshotV2StoragePciPlatformPrefix::exact(
+                    1,
+                    reserved_entropy,
+                    expected_msi_interrupt_count,
+                ),
+            )
+            .map_err(|source| {
+                PrepareHvfSnapshotV2BalloonPlatformPlanError::StoragePci(Box::new(source))
+            })
+        })
+        .transpose()?;
+    let storage_count = storage_plan
+        .as_ref()
+        .map_or(0, |storage| storage.pci().record_count());
+    let preceding_entropy = 1_usize
+        .checked_add(storage_count)
+        .ok_or(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    let storage_pair = match (product.storage(), storage_plan.as_ref()) {
+        (Some(storage), Some(plan)) => Some((storage, plan)),
+        (None, None) => None,
+        _ => return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan),
+    };
+    let entropy_endpoint = product
+        .entropy()
+        .map(|entropy| {
+            prepare_hvf_snapshot_v2_entropy_pci_platform_plan_with_prefix(
+                platform,
+                storage_pair,
+                entropy,
+                1,
+                preceding_entropy,
+                expected_msi_interrupt_count,
+            )
+            .map_err(|source| {
+                PrepareHvfSnapshotV2BalloonPlatformPlanError::EntropyPci(Box::new(source))
+            })
+        })
+        .transpose()?;
+
+    let endpoint_count = preceding_entropy
+        .checked_add(usize::from(entropy_endpoint.is_some()))
+        .ok_or(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    if endpoint_count > PCI_ENDPOINT_SLOT_COUNT {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::PciCapacity {
+            count: endpoint_count,
+            maximum: PCI_ENDPOINT_SLOT_COUNT,
+        });
+    }
+    let storage_route_demand = storage_plan
+        .as_ref()
+        .map_or(0, |storage| storage.pci().route_demand());
+    let entropy_route_demand = entropy_endpoint.map_or(0, |entropy| entropy.route_count());
+    let route_demand = balloon_route_count
+        .checked_add(storage_route_demand)
+        .and_then(|count| count.checked_add(entropy_route_demand))
+        .ok_or(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    if route_demand
+        > usize::try_from(msi.interrupt_range.count)
+            .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?
+    {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::RouteConflict);
+    }
+
+    let queue_range_count = product_queue_range_count(&product)?;
+    let pmem_count = product
+        .storage()
+        .map_or(0, |storage| storage.pmem_records().len());
+    let mut queues = Vec::new();
+    let mut pmem = Vec::new();
+    let mut active_routes = Vec::new();
+    let mut endpoint_bars = Vec::new();
+    reserve.reserve(&mut queues, queue_range_count)?;
+    reserve.reserve(&mut pmem, pmem_count)?;
+    reserve.reserve(&mut active_routes, route_demand)?;
+    reserve.reserve(&mut endpoint_bars, endpoint_count)?;
+    append_product_memory_ranges(&product, &mut queues, &mut pmem);
+    if !aggregate_ranges_are_disjoint(&[], &queues, &pmem) {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::RangeConflict);
+    }
+
+    endpoint_bars.push(balloon_placement.bar_range);
+    if let Some(storage) = &storage_plan {
+        if storage.pci().host() != host || storage.pci().msi() != msi {
+            return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan);
+        }
+        endpoint_bars.extend(
+            storage
+                .pci()
+                .block_records()
+                .iter()
+                .chain(storage.pci().pmem_records())
+                .map(|record| record.bar_range()),
+        );
+    }
+    if let Some(entropy) = entropy_endpoint {
+        if entropy.msi_interrupt_count() != expected_msi_interrupt_count {
+            return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan);
+        }
+        endpoint_bars.push(entropy.bar_range());
+    }
+    if !ranges_are_pairwise_disjoint(&endpoint_bars) {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan);
+    }
+
+    if !register_active_retained_pci_routes(
+        balloon_transport.retained().msix_state(),
+        msi,
+        queue_count,
+        balloon_route_count,
+        &mut active_routes,
+    ) {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::RouteConflict);
+    }
+    if let Some(storage) = product.storage() {
+        for record in storage
+            .block_bundle()
+            .map_or(&[][..], |block| block.records())
+            .iter()
+        {
+            let SnapshotV2DeviceTransport::Pci(captured) = record.transport() else {
+                return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::TransportPolicy);
+            };
+            if !register_active_pci_routes(captured, &mut active_routes) {
+                return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::RouteConflict);
+            }
+        }
+        for record in storage.pmem_records() {
+            let SnapshotV2DeviceTransport::Pci(captured) = record.transport() else {
+                return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::TransportPolicy);
+            };
+            if !register_active_pci_routes(captured, &mut active_routes) {
+                return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::RouteConflict);
+            }
+        }
+    }
+    if let Some(entropy) = product.entropy() {
+        let PreparedSnapshotV2EntropyTransport::Pci(entropy_transport) = entropy.transport() else {
+            return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::TransportPolicy);
+        };
+        let route_count = snapshot_v2_pci_endpoint_route_count(VIRTIO_RNG_QUEUE_SIZES.len())
+            .ok_or(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+        if !register_active_retained_pci_routes(
+            entropy_transport.retained().msix_state(),
+            msi,
+            VIRTIO_RNG_QUEUE_SIZES.len(),
+            route_count,
+            &mut active_routes,
+        ) {
+            return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::RouteConflict);
+        }
+    }
+
+    let (serial_interrupt, vmgenid_interrupt, vmclock_interrupt) =
+        validate_pci_interrupt_sequence(platform, storage_plan.as_ref())?;
+    Ok(HvfSnapshotV2BalloonPciPlatformPlan {
+        product,
+        balloon: HvfSnapshotV2BalloonPciEndpointPlan {
+            origin: balloon_origin,
+            sbdf: balloon_placement.sbdf,
+            bar_region_id: balloon_placement.bar_region_id,
+            bar_range: balloon_placement.bar_range,
+            route_count: balloon_route_count,
+            msi_interrupt_count: expected_msi_interrupt_count,
+        },
+        storage: storage_plan,
+        entropy: entropy_endpoint,
+        host,
+        msi,
+        route_demand,
+        serial_interrupt,
+        vmgenid_interrupt,
+        vmclock_interrupt,
+    })
+}
+
+fn validate_product_profile(
+    platform: &HvfSnapshotV2PlatformState,
+) -> Result<(), PrepareHvfSnapshotV2BalloonPlatformPlanError> {
+    if !platform.machine().fdt().is_product_process_profile()
+        || platform.time().rtc_layout()
+            != RtcMmioLayout::new(PROCESS_RTC_MMIO_BASE, PROCESS_RTC_MMIO_REGION_ID)
+    {
+        Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::PlatformProfile)
+    } else {
+        Ok(())
+    }
+}
+
+fn prepare_entropy_mmio_endpoint(
+    platform: &HvfSnapshotV2PlatformState,
+    entropy: &SnapshotV2EntropyRestorePlan,
+    layout: EntropyMmioLayout,
+) -> Result<HvfSnapshotV2BalloonEntropyMmioEndpointPlan, PrepareHvfSnapshotV2BalloonPlatformPlanError>
+{
+    let PreparedSnapshotV2EntropyTransport::Mmio(transport) = entropy.transport() else {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::TransportPolicy);
+    };
+    let expected_region = mmio_region(layout.region_id(), layout.address())?;
+    if transport.region() != expected_region
+        || mmio_region_conflicts_with_platform(
+            platform,
+            expected_region,
+            &platform.global().compatibility().gic_metadata(),
+        )
+        .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?
+        || queue_ranges_conflict_with_platform(platform, entropy.queue_ranges())
+            .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?
+    {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::RangeConflict);
+    }
+    Ok(HvfSnapshotV2BalloonEntropyMmioEndpointPlan {
+        region: expected_region,
+        interrupt_line: transport.interrupt_line(),
+        fdt_device: mmio_fdt_device(expected_region, transport.interrupt_line()),
+    })
+}
+
+fn validate_mmio_interrupt_sequence(
+    platform: &HvfSnapshotV2PlatformState,
+    balloon_interrupt: GuestInterruptLine,
+    storage: Option<&HvfSnapshotV2StorageMmioPlatformPlan>,
+    entropy: Option<HvfSnapshotV2BalloonEntropyMmioEndpointPlan>,
+) -> Result<
+    (GuestInterruptLine, GuestInterruptLine, GuestInterruptLine),
+    PrepareHvfSnapshotV2BalloonPlatformPlanError,
+> {
+    let mut allocator = HvfGicInterruptLineAllocator::from_metadata(
+        &platform.global().compatibility().gic_metadata(),
+    )
+    .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    if allocator
+        .allocate()
+        .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?
+        != balloon_interrupt
+    {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan);
+    }
+    if let Some(storage) = storage {
+        for record in storage.block_records().iter().chain(storage.pmem_records()) {
+            if allocator
+                .allocate()
+                .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?
+                != record.interrupt_line()
+            {
+                return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan);
+            }
+        }
+    }
+    if let Some(entropy) = entropy
+        && allocator
+            .allocate()
+            .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?
+            != entropy.interrupt_line()
+    {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan);
+    }
+    let serial = allocator
+        .allocate()
+        .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    let vmgenid = allocator
+        .allocate()
+        .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    let vmclock = allocator
+        .allocate()
+        .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    if storage.is_some_and(|storage| {
+        storage.serial_interrupt() != serial
+            || storage.vmgenid_interrupt() != vmgenid
+            || storage.vmclock_interrupt() != vmclock
+    }) || platform.time().vmgenid().interrupt_line() != vmgenid
+        || platform.time().vmclock().interrupt_line() != vmclock
+    {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan);
+    }
+    Ok((serial, vmgenid, vmclock))
+}
+
+fn validate_pci_interrupt_sequence(
+    platform: &HvfSnapshotV2PlatformState,
+    storage: Option<&HvfSnapshotV2StoragePciPlatformPlan>,
+) -> Result<
+    (GuestInterruptLine, GuestInterruptLine, GuestInterruptLine),
+    PrepareHvfSnapshotV2BalloonPlatformPlanError,
+> {
+    let mut allocator = HvfGicInterruptLineAllocator::from_metadata(
+        &platform.global().compatibility().gic_metadata(),
+    )
+    .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    let serial = allocator
+        .allocate()
+        .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    let vmgenid = allocator
+        .allocate()
+        .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    let vmclock = allocator
+        .allocate()
+        .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    if storage.is_some_and(|storage| {
+        storage.serial_interrupt() != serial
+            || storage.vmgenid_interrupt() != vmgenid
+            || storage.vmclock_interrupt() != vmclock
+    }) || platform.time().vmgenid().interrupt_line() != vmgenid
+        || platform.time().vmclock().interrupt_line() != vmclock
+    {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan);
+    }
+    Ok((serial, vmgenid, vmclock))
+}
+
+fn mmio_region(
+    region_id: MmioRegionId,
+    address: bangbang_runtime::memory::GuestAddress,
+) -> Result<MmioRegion, PrepareHvfSnapshotV2BalloonPlatformPlanError> {
+    MmioRegion::new(region_id, address, VIRTIO_MMIO_DEVICE_WINDOW_SIZE)
+        .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)
+}
+
+fn mmio_fdt_device(
+    region: MmioRegion,
+    interrupt_line: GuestInterruptLine,
+) -> Arm64FdtVirtioMmioDevice {
+    Arm64FdtVirtioMmioDevice {
+        region: Arm64FdtRegion {
+            base: region.range().start().raw_value(),
+            size: region.range().size(),
+        },
+        interrupt_line,
+    }
+}
+
+fn storage_record_count_mmio(storage: Option<&HvfSnapshotV2StorageMmioPlatformPlan>) -> usize {
+    storage.map_or(0, |storage| {
+        storage.block_records().len() + storage.pmem_records().len()
+    })
+}
+
+fn product_queue_range_count(
+    product: &HvfSnapshotV2BalloonPreparedProduct,
+) -> Result<usize, PrepareHvfSnapshotV2BalloonPlatformPlanError> {
+    let mut count = product
+        .balloon()
+        .queue_ranges()
+        .len()
+        .checked_mul(3)
+        .ok_or(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    if let Some(storage) = product.storage() {
+        let active_block = storage
+            .block_bundle()
+            .map_or(&[][..], |block| block.records())
+            .iter()
+            .filter(|record| record.queue_ranges().is_some())
+            .count();
+        let active_pmem = storage
+            .pmem_records()
+            .iter()
+            .filter(|record| record.queue_ranges().is_some())
+            .count();
+        let active_storage = active_block
+            .checked_add(active_pmem)
+            .ok_or(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+        count = count
+            .checked_add(
+                active_storage
+                    .checked_mul(3)
+                    .ok_or(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?,
+            )
+            .ok_or(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    }
+    if product
+        .entropy()
+        .is_some_and(|entropy| entropy.queue_ranges().is_some())
+    {
+        count = count
+            .checked_add(3)
+            .ok_or(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?;
+    }
+    Ok(count)
+}
+
+fn append_product_memory_ranges(
+    product: &HvfSnapshotV2BalloonPreparedProduct,
+    queues: &mut Vec<GuestMemoryRange>,
+    pmem: &mut Vec<GuestMemoryRange>,
+) {
+    for ranges in product.balloon().queue_ranges() {
+        queues.extend(*ranges);
+    }
+    if let Some(storage) = product.storage() {
+        for record in storage
+            .block_bundle()
+            .map_or(&[][..], |block| block.records())
+            .iter()
+        {
+            if let Some(ranges) = record.queue_ranges() {
+                queues.extend(ranges);
+            }
+        }
+        for record in storage.pmem_records() {
+            if let Some(ranges) = record.queue_ranges() {
+                queues.extend(ranges);
+            }
+        }
+        pmem.extend(
+            storage
+                .pmem_records()
+                .iter()
+                .map(|record| record.prepared_device().guest_range()),
+        );
+    }
+    if let Some(ranges) = product
+        .entropy()
+        .and_then(SnapshotV2EntropyRestorePlan::queue_ranges)
+    {
+        queues.extend(ranges);
+    }
+}
+
+fn aggregate_ranges_are_disjoint(
+    regions: &[MmioRegion],
+    queues: &[GuestMemoryRange],
+    pmem: &[GuestMemoryRange],
+) -> bool {
+    for (index, region) in regions.iter().enumerate() {
+        if regions
+            .iter()
+            .skip(index.saturating_add(1))
+            .any(|other| region.id() == other.id() || region.range().overlaps(other.range()))
+            || queues.iter().any(|queue| queue.overlaps(region.range()))
+            || pmem.iter().any(|mapping| mapping.overlaps(region.range()))
+        {
+            return false;
+        }
+    }
+    ranges_are_pairwise_disjoint(queues)
+        && ranges_are_pairwise_disjoint(pmem)
+        && !queues
+            .iter()
+            .any(|queue| pmem.iter().any(|mapping| queue.overlaps(*mapping)))
+}
+
+fn ranges_are_pairwise_disjoint(ranges: &[GuestMemoryRange]) -> bool {
+    ranges.iter().enumerate().all(|(index, range)| {
+        ranges
+            .iter()
+            .skip(index.saturating_add(1))
+            .all(|other| !range.overlaps(*other))
+    })
+}
+
+trait BalloonPlatformPlanReserve {
+    fn reserve<T>(
+        &mut self,
+        values: &mut Vec<T>,
+        additional: usize,
+    ) -> Result<(), PrepareHvfSnapshotV2BalloonPlatformPlanError>;
+}
+
+struct SystemBalloonPlatformPlanReserve;
+
+impl BalloonPlatformPlanReserve for SystemBalloonPlatformPlanReserve {
+    fn reserve<T>(
+        &mut self,
+        values: &mut Vec<T>,
+        additional: usize,
+    ) -> Result<(), PrepareHvfSnapshotV2BalloonPlatformPlanError> {
+        values
+            .try_reserve_exact(additional)
+            .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::Allocation)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bangbang_runtime::balloon::VirtioBalloonQueueLayout;
+    use bangbang_runtime::fdt::ARM64_GICV2M_MSI_SET_SPI_NSR_OFFSET;
+    use bangbang_runtime::memory::{GuestAddress, GuestMemory, GuestMemoryLayout};
+    use bangbang_runtime::snapshot_balloon_v2_9::{
+        NATIVE_V2_BALLOON_STATE_COMPATIBILITY_VERSION, SnapshotV2BalloonState,
+    };
+    use bangbang_runtime::snapshot_device_v2::SnapshotV2MmioDeviceState;
+
+    use super::*;
+
+    const DIRECTORY_OFFSET: usize = 64;
+    const DIRECTORY_ENTRY_BYTES: usize = 32;
+    const DIRECTORY_PAYLOAD_OFFSET: usize = 8;
+    const RESTORE_LOW_MEMORY_SIZE: u64 = 0x10_0000;
+    const RESTORE_QUEUE_MEMORY_START: u64 = 0x8000_0000;
+    const RESTORE_QUEUE_STRIDE: u64 = 0x1_0000;
+    const AVAILABLE_INDEX_OFFSET: u64 = 2;
+    const AVAILABLE_RING_OFFSET: u64 = 4;
+    const USED_INDEX_OFFSET: u64 = 2;
+    const ACTIVE_BALLOON_PCI_HEX: &str =
+        include_str!("../../runtime/src/snapshot_balloon_v2_9/fixtures/active-pci.hex");
+    const INACTIVE_BALLOON_MMIO_HEX: &str =
+        include_str!("../../runtime/src/snapshot_balloon_v2_9/fixtures/inactive-mmio.hex");
+    const BALLOON_MMIO_BASE: GuestAddress = GuestAddress::new(0x4000_8000);
+    const BALLOON_MMIO_REGION_ID: MmioRegionId = MmioRegionId::new(4000);
+    const ENTROPY_MMIO_BASE: GuestAddress = GuestAddress::new(0x4000_7000);
+    const ENTROPY_MMIO_REGION_ID: MmioRegionId = MmioRegionId::new(3000);
+
+    fn process_config() -> HvfSnapshotV2BalloonMmioProcessConfig {
+        HvfSnapshotV2BalloonMmioProcessConfig::new(
+            BalloonMmioLayout::new(BALLOON_MMIO_BASE, BALLOON_MMIO_REGION_ID),
+            crate::snapshot_v2_storage_platform::tests::process_config(),
+            EntropyMmioLayout::new(ENTROPY_MMIO_BASE, ENTROPY_MMIO_REGION_ID),
+        )
+    }
+
+    fn fixture_bytes(hex: &str) -> Vec<u8> {
+        let compact: Vec<u8> = hex
+            .bytes()
+            .filter(|byte| !byte.is_ascii_whitespace())
+            .collect();
+        compact
+            .chunks_exact(2)
+            .map(|pair| {
+                u8::from_str_radix(
+                    std::str::from_utf8(pair).expect("fixture hex should be UTF-8"),
+                    16,
+                )
+                .expect("fixture hex should decode")
+            })
+            .collect()
+    }
+
+    fn inactive_memory() -> GuestMemory {
+        let layout = GuestMemoryLayout::new(vec![
+            GuestMemoryRange::new(GuestAddress::new(0), 0x20_0000)
+                .expect("test memory range should validate"),
+        ])
+        .expect("test memory layout should validate");
+        GuestMemory::allocate(&layout).expect("test memory should allocate")
+    }
+
+    fn balloon_mmio_plan(
+        queue_count: usize,
+        interrupt: u32,
+        region: MmioRegion,
+    ) -> SnapshotV2BalloonRestorePlan {
+        assert_eq!(queue_count, 2);
+        let state = SnapshotV2BalloonState::decode(
+            NATIVE_V2_BALLOON_STATE_COMPATIBILITY_VERSION,
+            &fixture_bytes(INACTIVE_BALLOON_MMIO_HEX),
+        )
+        .expect("inactive MMIO balloon fixture should decode");
+        let SnapshotV2DeviceTransport::Mmio(captured) = state.transport() else {
+            panic!("inactive MMIO balloon fixture should select MMIO");
+        };
+        let state = SnapshotV2BalloonState::try_new(
+            state.config(),
+            state.config_space(),
+            *state.continuation(),
+            state.accounting().clone(),
+            state.virtio().clone(),
+            SnapshotV2DeviceTransport::Mmio(SnapshotV2MmioDeviceState::from_parts(
+                captured.device_feature_select(),
+                captured.driver_feature_select(),
+                captured.queue_select(),
+                region,
+                GuestInterruptLine::new(interrupt).expect("interrupt should validate"),
+            )),
+        )
+        .expect("MMIO balloon state should validate");
+        SnapshotV2BalloonRestorePlan::prepare(state, &inactive_memory())
+            .expect("MMIO balloon plan should prepare")
+    }
+
+    fn balloon_pci_plan(
+        queue_count: usize,
+        platform: &HvfSnapshotV2PlatformState,
+        slot: usize,
+        route_offset: u32,
+        active_route: bool,
+    ) -> SnapshotV2BalloonRestorePlan {
+        assert_eq!(queue_count, 5);
+        let address_plan =
+            Arm64PciAddressPlan::firecracker_v1_16().expect("address plan should validate");
+        let placement = snapshot_v2_pci_endpoint_placement(address_plan, slot)
+            .expect("balloon placement should validate");
+        let msi = platform
+            .global()
+            .compatibility()
+            .gic_metadata()
+            .msi
+            .expect("PCI platform should retain MSI metadata");
+        let mut bytes = fixture_bytes(ACTIVE_BALLOON_PCI_HEX);
+        let transport_offset = section_payload_offset(&bytes, 3);
+        bytes[transport_offset + 11] = placement.sbdf.device();
+        bytes[transport_offset + 16..transport_offset + 24]
+            .copy_from_slice(&placement.bar_range.start().raw_value().to_le_bytes());
+        let message_address = msi
+            .region
+            .base
+            .checked_add(ARM64_GICV2M_MSI_SET_SPI_NSR_OFFSET)
+            .expect("MSI address should fit");
+        for index in 0..=queue_count {
+            let entry = transport_offset + 96 + index * 16;
+            bytes[entry..entry + 4].copy_from_slice(
+                &u32::try_from(message_address & u64::from(u32::MAX))
+                    .expect("low message address should fit")
+                    .to_le_bytes(),
+            );
+            bytes[entry + 4..entry + 8].copy_from_slice(
+                &u32::try_from(message_address >> 32)
+                    .expect("high message address should fit")
+                    .to_le_bytes(),
+            );
+            let data = msi
+                .interrupt_range
+                .base
+                .checked_add(route_offset)
+                .and_then(|base| base.checked_add(u32::try_from(index).expect("index should fit")))
+                .expect("message data should fit");
+            bytes[entry + 8..entry + 12].copy_from_slice(&data.to_le_bytes());
+            if !active_route {
+                bytes[entry + 12..entry + 16].copy_from_slice(&1_u32.to_le_bytes());
+            }
+        }
+        let state =
+            SnapshotV2BalloonState::decode(NATIVE_V2_BALLOON_STATE_COMPATIBILITY_VERSION, &bytes)
+                .expect("relocated PCI balloon fixture should decode");
+        let mut memory = balloon_restore_memory(&state);
+        initialize_balloon_restore_memory(&mut memory, &state);
+        SnapshotV2BalloonRestorePlan::prepare(state, &memory)
+            .expect("PCI balloon plan should prepare")
+    }
+
+    fn entropy_mmio_plan(interrupt: u32) -> SnapshotV2EntropyRestorePlan {
+        let region = mmio_region(ENTROPY_MMIO_REGION_ID, ENTROPY_MMIO_BASE)
+            .expect("entropy region should validate");
+        crate::snapshot_v2_entropy_platform::tests::entropy_mmio_plan_at(
+            region,
+            GuestInterruptLine::new(interrupt).expect("interrupt should validate"),
+        )
+    }
+
+    fn entropy_pci_plan(
+        platform: &HvfSnapshotV2PlatformState,
+        slot: usize,
+        route_offset: u32,
+        active_route: bool,
+    ) -> SnapshotV2EntropyRestorePlan {
+        let msi = platform
+            .global()
+            .compatibility()
+            .gic_metadata()
+            .msi
+            .expect("PCI platform should retain MSI metadata");
+        let first_message_data = msi
+            .interrupt_range
+            .base
+            .checked_add(route_offset)
+            .expect("entropy message data should fit");
+        crate::snapshot_v2_entropy_platform::tests::entropy_plan_at_with_routes(
+            slot,
+            first_message_data,
+            active_route,
+        )
+    }
+
+    fn unreferenced_entropy_pci_plan(
+        platform: &HvfSnapshotV2PlatformState,
+        slot: usize,
+        route_offset: u32,
+    ) -> SnapshotV2EntropyRestorePlan {
+        let msi = platform
+            .global()
+            .compatibility()
+            .gic_metadata()
+            .msi
+            .expect("PCI platform should retain MSI metadata");
+        let first_message_data = msi
+            .interrupt_range
+            .base
+            .checked_add(route_offset)
+            .expect("entropy message data should fit");
+        crate::snapshot_v2_entropy_platform::tests::entropy_plan_at_with_unreferenced_routes(
+            slot,
+            first_message_data,
+        )
+    }
+
+    fn section_payload_offset(bytes: &[u8], section_index: usize) -> usize {
+        let entry = DIRECTORY_OFFSET + section_index * DIRECTORY_ENTRY_BYTES;
+        usize::try_from(u64::from_le_bytes(
+            bytes[entry + DIRECTORY_PAYLOAD_OFFSET..entry + DIRECTORY_PAYLOAD_OFFSET + 8]
+                .try_into()
+                .expect("section payload offset should exist"),
+        ))
+        .expect("section payload offset should fit")
+    }
+
+    fn balloon_restore_memory(state: &SnapshotV2BalloonState) -> GuestMemory {
+        let mut ranges = vec![
+            GuestMemoryRange::new(GuestAddress::new(0), RESTORE_LOW_MEMORY_SIZE)
+                .expect("low restore memory should validate"),
+        ];
+        if state.virtio().is_activated() {
+            ranges.push(
+                GuestMemoryRange::new(
+                    GuestAddress::new(RESTORE_QUEUE_MEMORY_START),
+                    u64::try_from(state.virtio().queues().len()).expect("queue count should fit")
+                        * RESTORE_QUEUE_STRIDE,
+                )
+                .expect("queue restore memory should validate"),
+            );
+        }
+        let layout = GuestMemoryLayout::new(ranges).expect("restore layout should validate");
+        GuestMemory::allocate(&layout).expect("restore memory should allocate")
+    }
+
+    fn initialize_balloon_restore_memory(memory: &mut GuestMemory, state: &SnapshotV2BalloonState) {
+        let Some(active) = state.continuation().active_queues() else {
+            return;
+        };
+        let layout = VirtioBalloonQueueLayout::from_config(state.config());
+        let cursors = [
+            Some(active.inflate()),
+            Some(active.deflate()),
+            active.statistics(),
+            active.free_page_hinting(),
+            active.free_page_reporting(),
+        ];
+        for (queue, cursor) in state
+            .virtio()
+            .queues()
+            .iter()
+            .zip(cursors.into_iter().flatten())
+        {
+            write_memory_u16(
+                memory,
+                queue
+                    .driver_ring()
+                    .checked_add(AVAILABLE_INDEX_OFFSET)
+                    .expect("available index should fit"),
+                cursor.next_available(),
+            );
+            write_memory_u16(
+                memory,
+                queue
+                    .device_ring()
+                    .checked_add(USED_INDEX_OFFSET)
+                    .expect("used index should fit"),
+                cursor.next_used(),
+            );
+        }
+        if let Some(pending_head) = state.continuation().statistics_pending_descriptor_head() {
+            let statistics = layout
+                .statistics()
+                .expect("pending statistics require statistics queue");
+            let cursor = active
+                .statistics()
+                .expect("pending statistics require retained cursors");
+            let queue = &state.virtio().queues()[statistics.index()];
+            let ring_index = cursor.next_available().wrapping_sub(1) % queue.size();
+            write_memory_u16(
+                memory,
+                queue
+                    .driver_ring()
+                    .checked_add(AVAILABLE_RING_OFFSET + u64::from(ring_index) * 2)
+                    .expect("pending statistics entry should fit"),
+                pending_head,
+            );
+        }
+    }
+
+    fn write_memory_u16(memory: &mut GuestMemory, address: GuestAddress, value: u16) {
+        memory
+            .write_slice(&value.to_le_bytes(), address)
+            .expect("restore fixture write should succeed");
+    }
+
+    fn platform_with_msi_count(
+        platform: HvfSnapshotV2PlatformState,
+        interrupt_count: u32,
+    ) -> HvfSnapshotV2PlatformState {
+        let (memory, machine, global, topology, vcpus, time) = platform.into_parts();
+        let (compatibility, gic_device) = global.into_parts();
+        let mut gic = compatibility.gic_metadata();
+        let mut msi = gic.msi.expect("PCI platform should retain MSI metadata");
+        msi.interrupt_range.count = interrupt_count;
+        gic.msi = Some(msi);
+        let compatibility = crate::snapshot_bundle::HvfSnapshotV1CompatibilityState::new(
+            compatibility.identification(),
+            compatibility.optional_sve_sme_identification(),
+            compatibility.cache_manifest(),
+            compatibility.primary_mpidr(),
+            gic,
+            compatibility.rtc_mmio_layout(),
+        );
+        let global =
+            crate::snapshot_v2::HvfSnapshotV2GlobalState::try_new(compatibility, gic_device)
+                .expect("mutated PCI global state should validate");
+        HvfSnapshotV2PlatformState::try_new(memory, machine, global, topology, vcpus, time)
+            .expect("mutated PCI platform should validate")
+    }
+
+    fn pci_platform(queue_count: usize, entropy: bool) -> HvfSnapshotV2PlatformState {
+        let platform = crate::snapshot_v2_multi_block_platform::tests::product_pci_platform();
+        let expected = pci_balloon_restore_gic_msi_configuration(queue_count, entropy)
+            .expect("balloon-aware MSI profile should validate")
+            .interrupt_count()
+            .get();
+        platform_with_msi_count(platform, expected)
+    }
+
+    #[test]
+    fn all_four_mmio_product_shapes_close_balloon_first_order() {
+        let balloon_region = mmio_region(BALLOON_MMIO_REGION_ID, BALLOON_MMIO_BASE)
+            .expect("balloon region should validate");
+
+        let platform = crate::snapshot_v2_multi_block_platform::tests::product_mmio_platform(1);
+        let plan = prepare_hvf_snapshot_v2_balloon_mmio_platform_plan(
+            &platform,
+            HvfSnapshotV2BalloonPreparedProduct::serial_balloon(balloon_mmio_plan(
+                2,
+                32,
+                balloon_region,
+            )),
+            process_config(),
+        )
+        .expect("serial balloon MMIO product should plan");
+        assert_eq!(plan.kind(), HvfSnapshotV2BalloonProductKind::SerialBalloon);
+        assert_eq!(plan.balloon().interrupt_line().raw_value(), 32);
+        assert_eq!(plan.serial_interrupt().raw_value(), 33);
+
+        let platform = crate::snapshot_v2_multi_block_platform::tests::product_mmio_platform(2);
+        let plan = prepare_hvf_snapshot_v2_balloon_mmio_platform_plan(
+            &platform,
+            HvfSnapshotV2BalloonPreparedProduct::serial_balloon_entropy(
+                balloon_mmio_plan(2, 32, balloon_region),
+                entropy_mmio_plan(33),
+            ),
+            process_config(),
+        )
+        .expect("serial balloon entropy MMIO product should plan");
+        assert_eq!(
+            plan.kind(),
+            HvfSnapshotV2BalloonProductKind::SerialBalloonEntropy
+        );
+        assert_eq!(
+            plan.entropy()
+                .expect("entropy endpoint should exist")
+                .interrupt_line()
+                .raw_value(),
+            33
+        );
+        assert_eq!(plan.serial_interrupt().raw_value(), 34);
+
+        let fixture =
+            crate::snapshot_v2_storage_platform::tests::balloon_prefixed_rootless_block_mmio_fixture(
+                false,
+            );
+        let plan = prepare_hvf_snapshot_v2_balloon_mmio_platform_plan(
+            &fixture.platform,
+            HvfSnapshotV2BalloonPreparedProduct::serial_balloon_storage(
+                balloon_mmio_plan(2, 32, balloon_region),
+                fixture.bundle,
+            ),
+            process_config(),
+        )
+        .expect("serial balloon storage MMIO product should plan");
+        assert_eq!(
+            plan.kind(),
+            HvfSnapshotV2BalloonProductKind::SerialBalloonStorage
+        );
+        assert_eq!(
+            plan.storage()
+                .expect("storage plan should exist")
+                .block_records()[0]
+                .interrupt_line()
+                .raw_value(),
+            33
+        );
+        assert_eq!(plan.serial_interrupt().raw_value(), 35);
+
+        let fixture =
+            crate::snapshot_v2_storage_platform::tests::balloon_prefixed_rootless_block_mmio_fixture(
+                true,
+            );
+        let plan = prepare_hvf_snapshot_v2_balloon_mmio_platform_plan(
+            &fixture.platform,
+            HvfSnapshotV2BalloonPreparedProduct::serial_balloon_storage_entropy(
+                balloon_mmio_plan(2, 32, balloon_region),
+                fixture.bundle,
+                entropy_mmio_plan(35),
+            ),
+            process_config(),
+        )
+        .expect("complete balloon MMIO product should plan");
+        assert_eq!(
+            plan.kind(),
+            HvfSnapshotV2BalloonProductKind::SerialBalloonStorageEntropy
+        );
+        assert_eq!(
+            plan.entropy()
+                .expect("entropy endpoint should exist")
+                .interrupt_line()
+                .raw_value(),
+            35
+        );
+        assert_eq!(plan.serial_interrupt().raw_value(), 36);
+    }
+
+    #[test]
+    fn pci_balloon_route_demand_tracks_two_through_five_queues() {
+        for (queue_count, expected_without_entropy, expected_with_entropy) in
+            [(2, 93, 92), (3, 94, 93), (4, 95, 94), (5, 96, 95)]
+        {
+            assert_eq!(
+                snapshot_v2_pci_endpoint_route_count(queue_count),
+                Some(queue_count + 1)
+            );
+            assert_eq!(
+                pci_balloon_restore_gic_msi_configuration(queue_count, false)
+                    .expect("MSI profile should validate")
+                    .interrupt_count()
+                    .get(),
+                expected_without_entropy
+            );
+            assert_eq!(
+                pci_balloon_restore_gic_msi_configuration(queue_count, true)
+                    .expect("MSI profile should validate")
+                    .interrupt_count()
+                    .get(),
+                expected_with_entropy
+            );
+        }
+
+        let platform = pci_platform(5, false);
+        let plan = prepare_hvf_snapshot_v2_balloon_pci_platform_plan(
+            &platform,
+            HvfSnapshotV2BalloonPreparedProduct::serial_balloon(balloon_pci_plan(
+                5, &platform, 0, 0, true,
+            )),
+        )
+        .expect("five-queue balloon PCI product should plan");
+        assert_eq!(plan.balloon().route_count(), 6);
+        assert_eq!(plan.route_demand(), 6);
+        assert_eq!(
+            plan.balloon().msi_interrupt_count(),
+            pci_balloon_restore_gic_msi_configuration(5, false)
+                .expect("MSI profile should validate")
+                .interrupt_count()
+                .get()
+        );
+    }
+
+    #[test]
+    fn all_four_pci_product_shapes_close_balloon_slot_zero_order() {
+        let platform = pci_platform(5, false);
+        let plan = prepare_hvf_snapshot_v2_balloon_pci_platform_plan(
+            &platform,
+            HvfSnapshotV2BalloonPreparedProduct::serial_balloon(balloon_pci_plan(
+                5, &platform, 0, 0, true,
+            )),
+        )
+        .expect("serial balloon PCI product should plan");
+        assert_eq!(plan.balloon().sbdf().device(), 1);
+
+        let platform = pci_platform(5, true);
+        let plan = prepare_hvf_snapshot_v2_balloon_pci_platform_plan(
+            &platform,
+            HvfSnapshotV2BalloonPreparedProduct::serial_balloon_entropy(
+                balloon_pci_plan(5, &platform, 0, 0, true),
+                entropy_pci_plan(&platform, 1, 16, true),
+            ),
+        )
+        .expect("serial balloon entropy PCI product should plan");
+        assert_eq!(
+            plan.entropy()
+                .expect("entropy endpoint should exist")
+                .preceding_endpoint_count(),
+            1
+        );
+
+        let fixture =
+            crate::snapshot_v2_storage_platform::tests::balloon_prefixed_rootless_block_pci_fixture(
+            );
+        let platform = platform_with_msi_count(
+            fixture.platform,
+            pci_balloon_restore_gic_msi_configuration(5, false)
+                .expect("MSI profile should validate")
+                .interrupt_count()
+                .get(),
+        );
+        let plan = prepare_hvf_snapshot_v2_balloon_pci_platform_plan(
+            &platform,
+            HvfSnapshotV2BalloonPreparedProduct::serial_balloon_storage(
+                balloon_pci_plan(5, &platform, 0, 0, true),
+                fixture.bundle,
+            ),
+        )
+        .expect("serial balloon storage PCI product should plan");
+        assert_eq!(
+            plan.storage()
+                .expect("storage plan should exist")
+                .pci()
+                .block_records()[0]
+                .sbdf()
+                .device(),
+            2
+        );
+
+        let fixture =
+            crate::snapshot_v2_storage_platform::tests::balloon_prefixed_rootless_block_pci_fixture(
+            );
+        let platform = platform_with_msi_count(
+            fixture.platform,
+            pci_balloon_restore_gic_msi_configuration(5, true)
+                .expect("MSI profile should validate")
+                .interrupt_count()
+                .get(),
+        );
+        let plan = prepare_hvf_snapshot_v2_balloon_pci_platform_plan(
+            &platform,
+            HvfSnapshotV2BalloonPreparedProduct::serial_balloon_storage_entropy(
+                balloon_pci_plan(5, &platform, 0, 0, true),
+                fixture.bundle,
+                entropy_pci_plan(&platform, 2, 16, true),
+            ),
+        )
+        .expect("complete balloon PCI product should plan");
+        assert_eq!(
+            plan.entropy()
+                .expect("entropy endpoint should exist")
+                .preceding_endpoint_count(),
+            2
+        );
+        assert_eq!(plan.route_demand(), 10);
+    }
+
+    #[test]
+    fn wrong_mmio_and_pci_order_are_rejected() {
+        let balloon_region = mmio_region(BALLOON_MMIO_REGION_ID, BALLOON_MMIO_BASE)
+            .expect("balloon region should validate");
+        let platform = crate::snapshot_v2_multi_block_platform::tests::product_mmio_platform(1);
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_balloon_mmio_platform_plan(
+                &platform,
+                HvfSnapshotV2BalloonPreparedProduct::serial_balloon(balloon_mmio_plan(
+                    2,
+                    33,
+                    balloon_region,
+                )),
+                process_config(),
+            ),
+            Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)
+        ));
+
+        let platform = pci_platform(5, false);
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_balloon_pci_platform_plan(
+                &platform,
+                HvfSnapshotV2BalloonPreparedProduct::serial_balloon(balloon_pci_plan(
+                    5, &platform, 1, 0, true,
+                )),
+            ),
+            Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)
+        ));
+    }
+
+    #[test]
+    fn genuine_active_route_collisions_are_rejected() {
+        let platform = pci_platform(5, true);
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_balloon_pci_platform_plan(
+                &platform,
+                HvfSnapshotV2BalloonPreparedProduct::serial_balloon_entropy(
+                    balloon_pci_plan(5, &platform, 0, 0, true),
+                    entropy_pci_plan(&platform, 1, 1, true),
+                ),
+            ),
+            Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::RouteConflict)
+        ));
+    }
+
+    #[test]
+    fn masked_and_unreferenced_routes_do_not_create_collisions() {
+        let platform = pci_platform(5, true);
+        let plan = prepare_hvf_snapshot_v2_balloon_pci_platform_plan(
+            &platform,
+            HvfSnapshotV2BalloonPreparedProduct::serial_balloon_entropy(
+                balloon_pci_plan(5, &platform, 0, 0, true),
+                entropy_pci_plan(&platform, 1, 1, false),
+            ),
+        )
+        .expect("masked duplicate messages should not create an active collision");
+        assert_eq!(
+            plan.kind(),
+            HvfSnapshotV2BalloonProductKind::SerialBalloonEntropy
+        );
+
+        let plan = prepare_hvf_snapshot_v2_balloon_pci_platform_plan(
+            &platform,
+            HvfSnapshotV2BalloonPreparedProduct::serial_balloon_entropy(
+                balloon_pci_plan(5, &platform, 0, 0, true),
+                unreferenced_entropy_pci_plan(&platform, 1, 1),
+            ),
+        )
+        .expect("unreferenced duplicate messages should not create an active collision");
+        assert_eq!(
+            plan.kind(),
+            HvfSnapshotV2BalloonProductKind::SerialBalloonEntropy
+        );
+    }
+
+    #[test]
+    fn aggregate_ranges_and_every_inventory_reservation_are_checked() {
+        let first = MmioRegion::new(MmioRegionId::new(1), GuestAddress::new(0x1000), 0x1000)
+            .expect("first region should validate");
+        let duplicate_id = MmioRegion::new(MmioRegionId::new(1), GuestAddress::new(0x4000), 0x1000)
+            .expect("duplicate-ID region should validate");
+        assert!(!aggregate_ranges_are_disjoint(
+            &[first, duplicate_id],
+            &[],
+            &[]
+        ));
+        let queue = GuestMemoryRange::new(GuestAddress::new(0x1800), 0x100)
+            .expect("queue range should validate");
+        assert!(!aggregate_ranges_are_disjoint(&[first], &[queue], &[]));
+
+        struct FailingReserve {
+            calls: usize,
+            fail_at: usize,
+        }
+        impl BalloonPlatformPlanReserve for FailingReserve {
+            fn reserve<T>(
+                &mut self,
+                values: &mut Vec<T>,
+                additional: usize,
+            ) -> Result<(), PrepareHvfSnapshotV2BalloonPlatformPlanError> {
+                let call = self.calls;
+                self.calls = self.calls.saturating_add(1);
+                if call == self.fail_at {
+                    Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::Allocation)
+                } else {
+                    values
+                        .try_reserve_exact(additional)
+                        .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::Allocation)
+                }
+            }
+        }
+
+        let balloon_region = mmio_region(BALLOON_MMIO_REGION_ID, BALLOON_MMIO_BASE)
+            .expect("balloon region should validate");
+        for fail_at in 0..3 {
+            let platform = crate::snapshot_v2_multi_block_platform::tests::product_mmio_platform(1);
+            assert!(matches!(
+                prepare_balloon_mmio_platform_plan(
+                    &platform,
+                    HvfSnapshotV2BalloonPreparedProduct::serial_balloon(balloon_mmio_plan(
+                        2,
+                        32,
+                        balloon_region,
+                    )),
+                    process_config(),
+                    &mut FailingReserve { calls: 0, fail_at },
+                ),
+                Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::Allocation)
+            ));
+        }
+        for fail_at in 0..4 {
+            let platform = pci_platform(5, false);
+            assert!(matches!(
+                prepare_balloon_pci_platform_plan(
+                    &platform,
+                    HvfSnapshotV2BalloonPreparedProduct::serial_balloon(balloon_pci_plan(
+                        5, &platform, 0, 0, true,
+                    )),
+                    &mut FailingReserve { calls: 0, fail_at },
+                ),
+                Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::Allocation)
+            ));
+        }
+    }
+
+    #[test]
+    fn product_and_errors_are_value_redacted() {
+        let platform = crate::snapshot_v2_multi_block_platform::tests::product_mmio_platform(1);
+        let balloon_region = mmio_region(BALLOON_MMIO_REGION_ID, BALLOON_MMIO_BASE)
+            .expect("balloon region should validate");
+        let product = HvfSnapshotV2BalloonPreparedProduct::serial_balloon(balloon_mmio_plan(
+            2,
+            32,
+            balloon_region,
+        ));
+        let product_debug = format!("{product:?}");
+        assert!(product_debug.contains(REDACTED));
+        assert!(!product_debug.contains("40008000"));
+        let plan = prepare_hvf_snapshot_v2_balloon_mmio_platform_plan(
+            &platform,
+            product,
+            process_config(),
+        )
+        .expect("redaction fixture should plan");
+        assert!(format!("{plan:?}").contains(REDACTED));
+        for error in [
+            PrepareHvfSnapshotV2BalloonPlatformPlanError::PlatformProfile,
+            PrepareHvfSnapshotV2BalloonPlatformPlanError::TransportPolicy,
+            PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan,
+            PrepareHvfSnapshotV2BalloonPlatformPlanError::PciCapacity {
+                count: 32,
+                maximum: 31,
+            },
+            PrepareHvfSnapshotV2BalloonPlatformPlanError::RangeConflict,
+            PrepareHvfSnapshotV2BalloonPlatformPlanError::RouteConflict,
+            PrepareHvfSnapshotV2BalloonPlatformPlanError::Allocation,
+        ] {
+            assert!(format!("{error:?}").contains(REDACTED));
+            assert!(!format!("{error:?}").contains("40008000"));
+        }
+    }
+}

--- a/crates/hvf/src/snapshot_v2_balloon_platform.rs
+++ b/crates/hvf/src/snapshot_v2_balloon_platform.rs
@@ -1004,13 +1004,15 @@ fn prepare_entropy_mmio_endpoint(
         return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::TransportPolicy);
     };
     let expected_region = mmio_region(layout.region_id(), layout.address())?;
-    if transport.region() != expected_region
-        || mmio_region_conflicts_with_platform(
-            platform,
-            expected_region,
-            &platform.global().compatibility().gic_metadata(),
-        )
-        .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?
+    if transport.region() != expected_region {
+        return Err(PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan);
+    }
+    if mmio_region_conflicts_with_platform(
+        platform,
+        expected_region,
+        &platform.global().compatibility().gic_metadata(),
+    )
+    .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?
         || queue_ranges_conflict_with_platform(platform, entropy.queue_ranges())
             .map_err(|_| PrepareHvfSnapshotV2BalloonPlatformPlanError::ResourcePlan)?
     {

--- a/crates/hvf/src/snapshot_v2_entropy_platform.rs
+++ b/crates/hvf/src/snapshot_v2_entropy_platform.rs
@@ -208,6 +208,8 @@ pub fn prepare_hvf_snapshot_v2_serial_entropy_pci_platform_plan(
         None,
         entropy,
         0,
+        0,
+        None,
         &mut SystemEntropyPciPlatformPlanReserve,
     )
 }
@@ -229,13 +231,37 @@ pub fn prepare_hvf_snapshot_v2_storage_entropy_pci_platform_plan(
         platform,
         Some((bundle, &storage)),
         entropy,
+        0,
         preceding_endpoint_count,
+        None,
         &mut SystemEntropyPciPlatformPlanReserve,
     )?;
     Ok(HvfSnapshotV2StorageEntropyPciPlatformPlan {
         storage,
         entropy: entropy_plan,
     })
+}
+
+pub(crate) fn prepare_hvf_snapshot_v2_entropy_pci_platform_plan_with_prefix(
+    platform: &HvfSnapshotV2PlatformState,
+    storage: Option<(
+        &PreparedSnapshotV2StorageBundle,
+        &HvfSnapshotV2StoragePciPlatformPlan,
+    )>,
+    entropy: &SnapshotV2EntropyRestorePlan,
+    storage_start_slot: usize,
+    preceding_endpoint_count: usize,
+    exact_msi_interrupt_count: u32,
+) -> Result<HvfSnapshotV2EntropyPciEndpointPlan, PrepareHvfSnapshotV2EntropyPciPlatformPlanError> {
+    prepare_entropy_pci_endpoint_plan(
+        platform,
+        storage,
+        entropy,
+        storage_start_slot,
+        preceding_endpoint_count,
+        Some(exact_msi_interrupt_count),
+        &mut SystemEntropyPciPlatformPlanReserve,
+    )
 }
 
 fn prepare_entropy_pci_endpoint_plan(
@@ -245,7 +271,9 @@ fn prepare_entropy_pci_endpoint_plan(
         &HvfSnapshotV2StoragePciPlatformPlan,
     )>,
     entropy: &SnapshotV2EntropyRestorePlan,
+    storage_start_slot: usize,
     preceding_endpoint_count: usize,
+    exact_msi_interrupt_count: Option<u32>,
     reserve: &mut impl EntropyPciPlatformPlanReserve,
 ) -> Result<HvfSnapshotV2EntropyPciEndpointPlan, PrepareHvfSnapshotV2EntropyPciPlatformPlanError> {
     if !platform.machine().fdt().is_product_process_profile()
@@ -280,9 +308,14 @@ fn prepare_entropy_pci_endpoint_plan(
         .map_err(|_| PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan)?;
     let expected_entropy_msi = pci_entropy_restore_gic_msi_configuration()
         .map_err(|_| PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan)?;
-    if msi.interrupt_range.count != expected_msi.interrupt_count().get()
-        && msi.interrupt_range.count != expected_entropy_msi.interrupt_count().get()
-    {
+    let msi_profile_matches = exact_msi_interrupt_count.map_or_else(
+        || {
+            msi.interrupt_range.count == expected_msi.interrupt_count().get()
+                || msi.interrupt_range.count == expected_entropy_msi.interrupt_count().get()
+        },
+        |expected| msi.interrupt_range.count == expected,
+    );
+    if !msi_profile_matches {
         return Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan);
     }
     let address_plan = Arm64PciAddressPlan::firecracker_v1_16()
@@ -321,7 +354,13 @@ fn prepare_entropy_pci_endpoint_plan(
     if let Some((bundle, storage_plan)) = storage {
         if storage_plan.pci().host() != Arm64FdtPciHost::from_address_plan(address_plan)
             || storage_plan.pci().msi() != msi
-            || !validate_storage_prefix(bundle, storage_plan, address_plan, &mut active_routes)
+            || !validate_storage_prefix(
+                bundle,
+                storage_plan,
+                address_plan,
+                storage_start_slot,
+                &mut active_routes,
+            )
         {
             return Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::ResourcePlan);
         }
@@ -329,9 +368,10 @@ fn prepare_entropy_pci_endpoint_plan(
             return Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::QueueConflict);
         }
     }
-    if !register_active_retained_routes(
+    if !register_active_retained_pci_routes(
         entropy_transport.retained().msix_state(),
         msi,
+        VIRTIO_RNG_QUEUE_SIZES.len(),
         route_count,
         &mut active_routes,
     ) {
@@ -352,6 +392,7 @@ fn validate_storage_prefix(
     bundle: &PreparedSnapshotV2StorageBundle,
     plan: &HvfSnapshotV2StoragePciPlatformPlan,
     address_plan: Arm64PciAddressPlan,
+    storage_start_slot: usize,
     active_routes: &mut Vec<(u64, u32)>,
 ) -> bool {
     let block_records = bundle
@@ -380,7 +421,10 @@ fn validate_storage_prefix(
         )
         .enumerate()
         .all(|(index, (transport, planned))| {
-            let Some(placement) = snapshot_v2_pci_endpoint_placement(address_plan, index) else {
+            let Some(slot) = storage_start_slot.checked_add(index) else {
+                return false;
+            };
+            let Some(placement) = snapshot_v2_pci_endpoint_placement(address_plan, slot) else {
                 return false;
             };
             let SnapshotV2DeviceTransport::Pci(captured) = transport else {
@@ -430,9 +474,10 @@ fn entropy_queue_conflicts_with_storage(
     })
 }
 
-fn register_active_retained_routes(
+pub(crate) fn register_active_retained_pci_routes(
     state: &VirtioPciMsixState,
     msi: crate::gic::HvfGicMsiMetadata,
+    queue_count: usize,
     route_count: usize,
     active_routes: &mut Vec<(u64, u32)>,
 ) -> bool {
@@ -450,13 +495,19 @@ fn register_active_retained_routes(
     else {
         return false;
     };
+    let pending_mask = match route_count {
+        0 => return false,
+        count if count < u64::BITS as usize => (1_u64 << count) - 1,
+        count if count == u64::BITS as usize => u64::MAX,
+        _ => return false,
+    };
     if state.vector_count() != route_count
         || state.pending_words().len() != 1
-        || state.queue_vectors().len() != VIRTIO_RNG_QUEUE_SIZES.len()
+        || state.queue_vectors().len() != queue_count
         || state
             .pending_words()
             .first()
-            .is_none_or(|pending| pending & !((1_u64 << route_count) - 1) != 0)
+            .is_none_or(|pending| pending & !pending_mask != 0)
         || !valid_vector(state.config_vector(), route_count)
         || !state
             .queue_vectors()
@@ -525,13 +576,16 @@ impl EntropyPciPlatformPlanReserve for SystemEntropyPciPlatformPlanReserve {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::time::Instant;
 
+    use bangbang_runtime::interrupt::GuestInterruptLine;
     use bangbang_runtime::memory::{
         GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange,
     };
+    use bangbang_runtime::mmio::MmioRegion;
     use bangbang_runtime::pci::Arm64PciAddressPlan;
+    use bangbang_runtime::snapshot_device_v2::SnapshotV2MmioDeviceState;
     use bangbang_runtime::snapshot_entropy_v2_8::{
         NATIVE_V2_ENTROPY_STATE_COMPATIBILITY_VERSION, NATIVE_V2_ENTROPY_STATE_HEADER_BYTES,
         NATIVE_V2_ENTROPY_STATE_SECTION_ENTRY_BYTES, SnapshotV2EntropyState,
@@ -627,7 +681,12 @@ mod tests {
         memory
     }
 
-    fn entropy_state_at(index: usize, first_message_data: u32) -> SnapshotV2EntropyState {
+    fn entropy_state_at(
+        index: usize,
+        first_message_data: u32,
+        active_routes: bool,
+        referenced_routes: bool,
+    ) -> SnapshotV2EntropyState {
         let mut bytes = fixture_bytes(ACTIVE_PCI_HEX);
         let common_directory_entry =
             NATIVE_V2_ENTROPY_STATE_HEADER_BYTES + NATIVE_V2_ENTROPY_STATE_SECTION_ENTRY_BYTES;
@@ -666,17 +725,87 @@ mod tests {
             .copy_from_slice(&placement.bar_range.start().raw_value().to_le_bytes());
         bytes[transport_offset + 104..transport_offset + 108]
             .copy_from_slice(&first_message_data.to_le_bytes());
+        if !active_routes {
+            bytes[transport_offset + 108..transport_offset + 112]
+                .copy_from_slice(&1_u32.to_le_bytes());
+            bytes[transport_offset + 124..transport_offset + 128]
+                .copy_from_slice(&1_u32.to_le_bytes());
+        }
+        if !referenced_routes {
+            bytes[transport_offset + 68..transport_offset + 70]
+                .copy_from_slice(&u16::MAX.to_le_bytes());
+            bytes[transport_offset + 128..transport_offset + 136].fill(0);
+            bytes[transport_offset + 136..transport_offset + 138]
+                .copy_from_slice(&u16::MAX.to_le_bytes());
+        }
         SnapshotV2EntropyState::decode(NATIVE_V2_ENTROPY_STATE_COMPATIBILITY_VERSION, &bytes)
             .expect("relocated entropy fixture should decode")
     }
 
-    fn entropy_plan_at(index: usize, first_message_data: u32) -> SnapshotV2EntropyRestorePlan {
+    pub(crate) fn entropy_plan_at(
+        index: usize,
+        first_message_data: u32,
+    ) -> SnapshotV2EntropyRestorePlan {
+        entropy_plan_at_with_routes(index, first_message_data, true)
+    }
+
+    pub(crate) fn entropy_plan_at_with_routes(
+        index: usize,
+        first_message_data: u32,
+        active_routes: bool,
+    ) -> SnapshotV2EntropyRestorePlan {
         SnapshotV2EntropyRestorePlan::prepare(
-            entropy_state_at(index, first_message_data),
+            entropy_state_at(index, first_message_data, active_routes, true),
             &restore_memory(true),
             Instant::now(),
         )
         .expect("entropy restore plan should prepare")
+    }
+
+    pub(crate) fn entropy_plan_at_with_unreferenced_routes(
+        index: usize,
+        first_message_data: u32,
+    ) -> SnapshotV2EntropyRestorePlan {
+        SnapshotV2EntropyRestorePlan::prepare(
+            entropy_state_at(index, first_message_data, true, false),
+            &restore_memory(true),
+            Instant::now(),
+        )
+        .expect("unreferenced entropy restore plan should prepare")
+    }
+
+    pub(crate) fn entropy_mmio_plan_at(
+        region: MmioRegion,
+        interrupt_line: GuestInterruptLine,
+    ) -> SnapshotV2EntropyRestorePlan {
+        let state = SnapshotV2EntropyState::decode(
+            NATIVE_V2_ENTROPY_STATE_COMPATIBILITY_VERSION,
+            &fixture_bytes(INACTIVE_MMIO_HEX),
+        )
+        .expect("MMIO entropy fixture should decode");
+        let (config, active_queue, limiter, retry, pending, virtio, transport) = state.into_parts();
+        let SnapshotV2DeviceTransport::Mmio(captured) = transport else {
+            panic!("MMIO entropy fixture should retain MMIO transport");
+        };
+        let transport = SnapshotV2DeviceTransport::Mmio(SnapshotV2MmioDeviceState::from_parts(
+            captured.device_feature_select(),
+            captured.driver_feature_select(),
+            captured.queue_select(),
+            region,
+            interrupt_line,
+        ));
+        let state = SnapshotV2EntropyState::try_new(
+            config,
+            active_queue,
+            limiter,
+            retry,
+            pending,
+            virtio,
+            transport,
+        )
+        .expect("relined MMIO entropy state should validate");
+        SnapshotV2EntropyRestorePlan::prepare(state, &restore_memory(false), Instant::now())
+            .expect("relined MMIO entropy plan should prepare")
     }
 
     fn with_msi_interrupt_count(
@@ -826,7 +955,9 @@ mod tests {
             &platform,
             None,
             &last_entropy,
+            0,
             PCI_ENDPOINT_SLOT_COUNT - 1,
+            None,
             &mut SystemEntropyPciPlatformPlanReserve,
         )
         .expect("30 preceding storage endpoints should leave one entropy slot");
@@ -841,7 +972,9 @@ mod tests {
                 &platform,
                 None,
                 &entropy,
+                0,
                 PCI_ENDPOINT_SLOT_COUNT,
+                None,
                 &mut SystemEntropyPciPlatformPlanReserve,
             ),
             Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::PciCapacity {
@@ -861,7 +994,15 @@ mod tests {
             }
         }
         assert!(matches!(
-            prepare_entropy_pci_endpoint_plan(&platform, None, &entropy, 0, &mut FailingReserve,),
+            prepare_entropy_pci_endpoint_plan(
+                &platform,
+                None,
+                &entropy,
+                0,
+                0,
+                None,
+                &mut FailingReserve,
+            ),
             Err(PrepareHvfSnapshotV2EntropyPciPlatformPlanError::Allocation)
         ));
     }

--- a/crates/hvf/src/snapshot_v2_storage_platform.rs
+++ b/crates/hvf/src/snapshot_v2_storage_platform.rs
@@ -645,6 +645,102 @@ enum StorageRoot<'a> {
     },
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct HvfSnapshotV2StorageMmioPlatformPrefix {
+    region: Option<MmioRegion>,
+    interrupt: Option<GuestInterruptLine>,
+}
+
+impl HvfSnapshotV2StorageMmioPlatformPrefix {
+    pub(crate) const EMPTY: Self = Self {
+        region: None,
+        interrupt: None,
+    };
+
+    pub(crate) const fn one(region: MmioRegion, interrupt: GuestInterruptLine) -> Self {
+        Self {
+            region: Some(region),
+            interrupt: Some(interrupt),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum HvfSnapshotV2StoragePciMsiProfile {
+    Root,
+    RootOrEntropy,
+    Exact(u32),
+}
+
+#[derive(Clone, Copy)]
+enum HvfSnapshotV2StoragePciPlacement {
+    Retained,
+    Sequential { start_slot: usize },
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct HvfSnapshotV2StoragePciPlatformPrefix {
+    preceding_endpoint_count: usize,
+    reserved_following_endpoint_count: usize,
+    msi_profile: HvfSnapshotV2StoragePciMsiProfile,
+    placement: HvfSnapshotV2StoragePciPlacement,
+}
+
+impl HvfSnapshotV2StoragePciPlatformPrefix {
+    pub(crate) const fn root() -> Self {
+        Self {
+            preceding_endpoint_count: 0,
+            reserved_following_endpoint_count: 0,
+            msi_profile: HvfSnapshotV2StoragePciMsiProfile::Root,
+            placement: HvfSnapshotV2StoragePciPlacement::Retained,
+        }
+    }
+
+    pub(crate) const fn entropy() -> Self {
+        Self {
+            preceding_endpoint_count: 0,
+            reserved_following_endpoint_count: 1,
+            msi_profile: HvfSnapshotV2StoragePciMsiProfile::RootOrEntropy,
+            placement: HvfSnapshotV2StoragePciPlacement::Retained,
+        }
+    }
+
+    pub(crate) const fn exact(
+        preceding_endpoint_count: usize,
+        reserved_following_endpoint_count: usize,
+        msi_interrupt_count: u32,
+    ) -> Self {
+        Self {
+            preceding_endpoint_count,
+            reserved_following_endpoint_count,
+            msi_profile: HvfSnapshotV2StoragePciMsiProfile::Exact(msi_interrupt_count),
+            placement: HvfSnapshotV2StoragePciPlacement::Sequential {
+                start_slot: preceding_endpoint_count,
+            },
+        }
+    }
+
+    const fn storage_endpoint_capacity(self) -> Option<usize> {
+        match PCI_ENDPOINT_SLOT_COUNT.checked_sub(self.preceding_endpoint_count) {
+            Some(remaining) => remaining.checked_sub(self.reserved_following_endpoint_count),
+            None => None,
+        }
+    }
+
+    fn expected_slot(
+        self,
+        storage_index: usize,
+    ) -> Result<Option<usize>, PrepareHvfSnapshotV2StoragePciPlatformPlanError> {
+        match self.placement {
+            HvfSnapshotV2StoragePciPlacement::Retained => Ok(None),
+            HvfSnapshotV2StoragePciPlacement::Sequential { start_slot } => start_slot
+                .checked_add(storage_index)
+                .map(Some)
+                .ok_or(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan),
+        }
+    }
+}
+
 /// Proves a complete exact-2.6 block+pmem MMIO product before live HVF
 /// construction.
 pub fn prepare_hvf_snapshot_v2_storage_mmio_platform_plan(
@@ -657,6 +753,7 @@ pub fn prepare_hvf_snapshot_v2_storage_mmio_platform_plan(
         platform,
         bundle,
         process,
+        HvfSnapshotV2StorageMmioPlatformPrefix::EMPTY,
         None,
         &mut SystemStoragePlatformPlanReserve,
     )
@@ -676,7 +773,26 @@ pub fn prepare_hvf_snapshot_v2_storage_entropy_mmio_platform_plan(
         platform,
         bundle,
         process,
+        HvfSnapshotV2StorageMmioPlatformPrefix::EMPTY,
         Some(entropy_interrupt),
+        &mut SystemStoragePlatformPlanReserve,
+    )
+}
+
+pub(crate) fn prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix(
+    platform: &HvfSnapshotV2PlatformState,
+    bundle: &PreparedSnapshotV2StorageBundle,
+    process: HvfSnapshotV2StorageMmioProcessConfig,
+    prefix: HvfSnapshotV2StorageMmioPlatformPrefix,
+    entropy_interrupt: Option<GuestInterruptLine>,
+) -> Result<HvfSnapshotV2StorageMmioPlatformPlan, PrepareHvfSnapshotV2StorageMmioPlatformPlanError>
+{
+    prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with(
+        platform,
+        bundle,
+        process,
+        prefix,
+        entropy_interrupt,
         &mut SystemStoragePlatformPlanReserve,
     )
 }
@@ -685,6 +801,7 @@ fn prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with(
     platform: &HvfSnapshotV2PlatformState,
     bundle: &PreparedSnapshotV2StorageBundle,
     process: HvfSnapshotV2StorageMmioProcessConfig,
+    prefix: HvfSnapshotV2StorageMmioPlatformPrefix,
     entropy_interrupt: Option<GuestInterruptLine>,
     reserve: &mut impl StoragePlatformPlanReserve,
 ) -> Result<HvfSnapshotV2StorageMmioPlatformPlan, PrepareHvfSnapshotV2StorageMmioPlatformPlanError>
@@ -731,7 +848,24 @@ fn prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with(
     reserve.reserve(&mut pmem_retries, pmem_records.len())?;
     reserve.reserve(&mut planned_block, block_records.len())?;
     reserve.reserve(&mut planned_pmem, pmem_records.len())?;
-    reserve.reserve(&mut planned_regions, record_count)?;
+    reserve.reserve(
+        &mut planned_regions,
+        record_count + usize::from(prefix.region.is_some()),
+    )?;
+
+    if prefix.region.is_some() != prefix.interrupt.is_some() {
+        return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan);
+    }
+    if let Some(region) = prefix.region {
+        if mmio_region_conflicts_with_platform(
+            platform,
+            region,
+            &platform.global().compatibility().gic_metadata(),
+        )? {
+            return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan);
+        }
+        planned_regions.push(region);
+    }
 
     let mut root_key = None;
     let mut root = None;
@@ -797,6 +931,14 @@ fn prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with(
     }
     let mut interrupt_allocator = HvfGicInterruptLineAllocator::from_metadata(&gic)
         .map_err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::Interrupt)?;
+    if let Some(expected) = prefix.interrupt
+        && interrupt_allocator
+            .allocate()
+            .map_err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::Interrupt)?
+            != expected
+    {
+        return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan);
+    }
     for (record, planned) in block_records.iter().zip(&mut planned_block) {
         let interrupt = interrupt_allocator
             .allocate()
@@ -943,7 +1085,7 @@ pub fn prepare_hvf_snapshot_v2_storage_pci_platform_plan(
     prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
         platform,
         bundle,
-        false,
+        HvfSnapshotV2StoragePciPlatformPrefix::root(),
         &mut SystemStoragePciPlatformPlanReserve,
     )
 }
@@ -955,7 +1097,20 @@ pub(crate) fn prepare_hvf_snapshot_v2_storage_pci_platform_plan_for_entropy(
     prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
         platform,
         bundle,
-        true,
+        HvfSnapshotV2StoragePciPlatformPrefix::entropy(),
+        &mut SystemStoragePciPlatformPlanReserve,
+    )
+}
+
+pub(crate) fn prepare_hvf_snapshot_v2_storage_pci_platform_plan_with_prefix(
+    platform: &HvfSnapshotV2PlatformState,
+    bundle: &PreparedSnapshotV2StorageBundle,
+    prefix: HvfSnapshotV2StoragePciPlatformPrefix,
+) -> Result<HvfSnapshotV2StoragePciPlatformPlan, PrepareHvfSnapshotV2StoragePciPlatformPlanError> {
+    prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
+        platform,
+        bundle,
+        prefix,
         &mut SystemStoragePciPlatformPlanReserve,
     )
 }
@@ -963,7 +1118,7 @@ pub(crate) fn prepare_hvf_snapshot_v2_storage_pci_platform_plan_for_entropy(
 fn prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
     platform: &HvfSnapshotV2PlatformState,
     bundle: &PreparedSnapshotV2StorageBundle,
-    allow_entropy_msi_profile: bool,
+    prefix: HvfSnapshotV2StoragePciPlatformPrefix,
     reserve: &mut impl StoragePciPlatformPlanReserve,
 ) -> Result<HvfSnapshotV2StoragePciPlatformPlan, PrepareHvfSnapshotV2StoragePciPlatformPlanError> {
     if !platform.machine().fdt().is_product_process_profile()
@@ -999,11 +1154,14 @@ fn prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
     {
         return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::Cardinality);
     }
-    if record_count > PCI_ENDPOINT_SLOT_COUNT {
+    let maximum = prefix
+        .storage_endpoint_capacity()
+        .ok_or(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
+    if record_count > maximum {
         return Err(
             PrepareHvfSnapshotV2StoragePciPlatformPlanError::PciCapacity {
                 count: record_count,
-                maximum: PCI_ENDPOINT_SLOT_COUNT,
+                maximum,
             },
         );
     }
@@ -1014,10 +1172,19 @@ fn prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
         .ok_or(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
     let expected_msi = pci_root_restore_gic_msi_configuration()
         .map_err(|_| PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
-    let entropy_msi_matches = allow_entropy_msi_profile
-        && pci_entropy_restore_gic_msi_configuration()
-            .is_ok_and(|expected| msi.interrupt_range.count == expected.interrupt_count().get());
-    if msi.interrupt_range.count != expected_msi.interrupt_count().get() && !entropy_msi_matches {
+    let msi_profile_matches = match prefix.msi_profile {
+        HvfSnapshotV2StoragePciMsiProfile::Root => {
+            msi.interrupt_range.count == expected_msi.interrupt_count().get()
+        }
+        HvfSnapshotV2StoragePciMsiProfile::RootOrEntropy => {
+            msi.interrupt_range.count == expected_msi.interrupt_count().get()
+                || pci_entropy_restore_gic_msi_configuration().is_ok_and(|expected| {
+                    msi.interrupt_range.count == expected.interrupt_count().get()
+                })
+        }
+        HvfSnapshotV2StoragePciMsiProfile::Exact(expected) => msi.interrupt_range.count == expected,
+    };
+    if !msi_profile_matches {
         return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan);
     }
     let address_plan = Arm64PciAddressPlan::firecracker_v1_16()
@@ -1079,10 +1246,11 @@ fn prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
 
     let mut root_key = None;
     let mut root = None;
-    for ((record, config), projected_retry) in block_records
+    for (block_index, ((record, config), projected_retry)) in block_records
         .iter()
         .zip(block_configs)
         .zip(block_retry_projection)
+        .enumerate()
     {
         let read_only = config
             .is_read_only()
@@ -1129,6 +1297,7 @@ fn prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
         let planned = plan_pci_record(
             record.key(),
             record.transport(),
+            prefix.expected_slot(block_index)?,
             block_route_count,
             VIRTIO_BLOCK_QUEUE_SIZES.len(),
             msi,
@@ -1193,6 +1362,12 @@ fn prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
         let planned = plan_pci_record(
             record.key(),
             record.transport(),
+            prefix.expected_slot(
+                block_records
+                    .len()
+                    .checked_add(pmem_index)
+                    .ok_or(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?,
+            )?,
             pmem_route_count,
             VIRTIO_PMEM_QUEUE_SIZES.len(),
             msi,
@@ -1262,6 +1437,7 @@ fn prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
 fn plan_pci_record(
     key: SnapshotV2DeviceKey,
     transport: &SnapshotV2DeviceTransport,
+    expected_slot: Option<usize>,
     route_count: usize,
     queue_count: usize,
     msi: HvfGicMsiMetadata,
@@ -1272,12 +1448,15 @@ fn plan_pci_record(
     let SnapshotV2DeviceTransport::Pci(captured) = transport else {
         return Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::TransportPolicy);
     };
-    let slot = captured
-        .sbdf()
-        .device()
-        .checked_sub(PCI_FIRST_ENDPOINT_DEVICE)
-        .map(usize::from)
-        .ok_or(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
+    let slot = match expected_slot {
+        Some(slot) => slot,
+        None => captured
+            .sbdf()
+            .device()
+            .checked_sub(PCI_FIRST_ENDPOINT_DEVICE)
+            .map(usize::from)
+            .ok_or(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?,
+    };
     let placement = snapshot_v2_pci_endpoint_placement(address_plan, slot)
         .ok_or(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)?;
     if captured.sbdf() != placement.sbdf
@@ -1402,7 +1581,7 @@ fn validate_and_set_interrupt(
     Ok(())
 }
 
-fn queue_ranges_conflict_with_platform(
+pub(crate) fn queue_ranges_conflict_with_platform(
     platform: &HvfSnapshotV2PlatformState,
     queue_ranges: Option<[GuestMemoryRange; 3]>,
 ) -> Result<bool, PrepareHvfSnapshotV2StorageMmioPlatformPlanError> {
@@ -1477,7 +1656,7 @@ fn mapping_range_conflicts_with_platform(
     Ok(false)
 }
 
-fn mmio_region_conflicts_with_platform(
+pub(crate) fn mmio_region_conflicts_with_platform(
     platform: &HvfSnapshotV2PlatformState,
     region: MmioRegion,
     gic: &HvfGicMetadata,
@@ -2020,6 +2199,97 @@ pub(crate) mod tests {
         pci_fixture(BLOCK_ROOTLESS_PCI_HEX)
     }
 
+    pub(crate) fn balloon_prefixed_rootless_block_pci_fixture() -> StorageFixture {
+        let mut bytes = fixture_bytes(BLOCK_ROOTLESS_PCI_HEX);
+        let transport_offset = section_payload_offset(&bytes, 3);
+        let address_plan =
+            Arm64PciAddressPlan::firecracker_v1_16().expect("PCI address plan should validate");
+        let placement = snapshot_v2_pci_endpoint_placement(address_plan, 1)
+            .expect("balloon-prefixed storage placement should validate");
+        bytes[transport_offset + 11] = placement.sbdf.device();
+        bytes[transport_offset + 16..transport_offset + 24]
+            .copy_from_slice(&placement.bar_range.start().raw_value().to_le_bytes());
+        let graph = SnapshotV2StorageDeviceGraph::decode(
+            NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            &bytes,
+        )
+        .expect("balloon-prefixed storage graph should decode");
+        let platform = crate::snapshot_v2_multi_block_platform::tests::product_pci_platform();
+        let (bundle, files) = bundle_from_graph(graph);
+        StorageFixture {
+            platform,
+            bundle,
+            _files: files,
+        }
+    }
+
+    pub(crate) fn balloon_prefixed_rootless_block_mmio_fixture(
+        entropy_configured: bool,
+    ) -> StorageFixture {
+        let mut bytes = fixture_bytes(PROFILE_2_ROOTLESS_MMIO_HEX);
+        let record_count = SnapshotV2MultiBlockDeviceGraph::decode(
+            NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            &bytes,
+        )
+        .expect("rootless block graph should decode")
+        .records()
+        .len();
+        for index in 0..record_count {
+            let transport_offset = section_payload_offset(&bytes, index * 4 + 3);
+            let interrupt = 33_u32
+                .checked_add(u32::try_from(index).expect("block index should fit"))
+                .expect("block interrupt should fit");
+            bytes[transport_offset + 12..transport_offset + 16]
+                .copy_from_slice(&interrupt.to_le_bytes());
+        }
+        let block_records = SnapshotV2MultiBlockDeviceGraph::decode(
+            NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            &bytes,
+        )
+        .expect("balloon-prefixed block graph should decode")
+        .records()
+        .to_vec();
+        let optional_device_count = 1 + block_records.len() + usize::from(entropy_configured);
+        let graph = SnapshotV2StorageDeviceGraph::try_from_parts(
+            None,
+            SnapshotV2DeviceTransportKind::Mmio,
+            block_records,
+            Vec::new(),
+        )
+        .expect("balloon-prefixed storage graph should validate");
+        let platform = crate::snapshot_v2_multi_block_platform::tests::product_mmio_platform(
+            optional_device_count,
+        );
+        let (bundle, files) = bundle_from_graph(graph);
+        StorageFixture {
+            platform,
+            bundle,
+            _files: files,
+        }
+    }
+
+    fn section_payload_offset(bytes: &[u8], section_index: usize) -> usize {
+        let directory = usize::try_from(u64::from_le_bytes(
+            bytes[48..56]
+                .try_into()
+                .expect("section directory offset should be present"),
+        ))
+        .expect("section directory offset should fit");
+        let entry = directory
+            .checked_add(
+                section_index
+                    .checked_mul(32)
+                    .expect("section entry offset should fit"),
+            )
+            .expect("section entry should fit");
+        usize::try_from(u64::from_le_bytes(
+            bytes[entry + 16..entry + 24]
+                .try_into()
+                .expect("section payload offset should be present"),
+        ))
+        .expect("section payload offset should fit")
+    }
+
     pub(crate) fn pci_fdt_plan_fixture() -> (
         HvfSnapshotV2PlatformState,
         HvfSnapshotV2StoragePciPlatformPlan,
@@ -2053,7 +2323,7 @@ pub(crate) mod tests {
         (fixture.platform, plan)
     }
 
-    const fn process_config() -> HvfSnapshotV2StorageMmioProcessConfig {
+    pub(crate) const fn process_config() -> HvfSnapshotV2StorageMmioProcessConfig {
         HvfSnapshotV2StorageMmioProcessConfig::new(
             BlockMmioLayout::new(BLOCK_MMIO_BASE, BLOCK_MMIO_REGION_ID),
             PmemMmioLayout::new(PMEM_MMIO_BASE, PMEM_MMIO_REGION_ID),
@@ -2313,6 +2583,141 @@ pub(crate) mod tests {
             .expect("conflict fixture should abort cleanly");
     }
 
+    #[test]
+    fn pci_prefix_capacity_is_exact_for_balloon_and_entropy_products() {
+        assert_eq!(
+            HvfSnapshotV2StoragePciPlatformPrefix::root().storage_endpoint_capacity(),
+            Some(31)
+        );
+        assert_eq!(
+            HvfSnapshotV2StoragePciPlatformPrefix::entropy().storage_endpoint_capacity(),
+            Some(30)
+        );
+        assert_eq!(
+            HvfSnapshotV2StoragePciPlatformPrefix::exact(1, 0, 1).storage_endpoint_capacity(),
+            Some(30)
+        );
+        assert_eq!(
+            HvfSnapshotV2StoragePciPlatformPrefix::exact(1, 1, 1).storage_endpoint_capacity(),
+            Some(29)
+        );
+    }
+
+    #[test]
+    fn legacy_pci_retains_slots_while_exact_prefix_requires_sequential_placement() {
+        let fixture = balloon_prefixed_rootless_block_pci_fixture();
+        let msi_interrupt_count = fixture
+            .platform
+            .global()
+            .compatibility()
+            .gic_metadata()
+            .msi
+            .expect("PCI fixture should retain MSI metadata")
+            .interrupt_range
+            .count;
+        let legacy =
+            prepare_hvf_snapshot_v2_storage_pci_platform_plan(&fixture.platform, &fixture.bundle)
+                .expect("legacy storage should retain a valid nonzero endpoint slot");
+        assert_eq!(legacy.pci().block_records()[0].sbdf().device(), 2);
+        let exact = prepare_hvf_snapshot_v2_storage_pci_platform_plan_with_prefix(
+            &fixture.platform,
+            &fixture.bundle,
+            HvfSnapshotV2StoragePciPlatformPrefix::exact(1, 0, msi_interrupt_count),
+        )
+        .expect("exact prefix should accept storage at its first sequential slot");
+        assert_eq!(exact.pci().block_records()[0].sbdf().device(), 2);
+        fixture
+            .bundle
+            .abort()
+            .expect("retained-slot fixture should abort cleanly");
+
+        let fixture = rootless_block_pci_fixture();
+        let msi_interrupt_count = fixture
+            .platform
+            .global()
+            .compatibility()
+            .gic_metadata()
+            .msi
+            .expect("PCI fixture should retain MSI metadata")
+            .interrupt_range
+            .count;
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_storage_pci_platform_plan_with_prefix(
+                &fixture.platform,
+                &fixture.bundle,
+                HvfSnapshotV2StoragePciPlatformPrefix::exact(1, 0, msi_interrupt_count),
+            ),
+            Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::ResourcePlan)
+        ));
+        fixture
+            .bundle
+            .abort()
+            .expect("wrong-slot fixture should abort cleanly");
+    }
+
+    #[test]
+    fn zero_prefix_planners_are_identical_to_legacy_storage_entrypoints() {
+        let fixture = fixture(FixtureShape::MixedBlockRoot);
+        let legacy = prepare_hvf_snapshot_v2_storage_mmio_platform_plan(
+            &fixture.platform,
+            &fixture.bundle,
+            process_config(),
+        )
+        .expect("legacy MMIO storage plan should validate");
+        let prefixed = prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix(
+            &fixture.platform,
+            &fixture.bundle,
+            process_config(),
+            HvfSnapshotV2StorageMmioPlatformPrefix::EMPTY,
+            None,
+        )
+        .expect("zero-prefix MMIO storage plan should validate");
+        assert_eq!(legacy.root_key(), prefixed.root_key());
+        assert_eq!(legacy.command_line(), prefixed.command_line());
+        assert_eq!(legacy.block_metrics_ids(), prefixed.block_metrics_ids());
+        assert_eq!(legacy.pmem_metrics_ids(), prefixed.pmem_metrics_ids());
+        assert_eq!(legacy.block_retries(), prefixed.block_retries());
+        assert_eq!(legacy.pmem_retries(), prefixed.pmem_retries());
+        assert_eq!(legacy.block_records(), prefixed.block_records());
+        assert_eq!(legacy.pmem_records(), prefixed.pmem_records());
+        assert_eq!(legacy.serial_interrupt(), prefixed.serial_interrupt());
+        assert_eq!(legacy.vmgenid_interrupt(), prefixed.vmgenid_interrupt());
+        assert_eq!(legacy.vmclock_interrupt(), prefixed.vmclock_interrupt());
+        fixture
+            .bundle
+            .abort()
+            .expect("MMIO equivalence fixture should abort cleanly");
+
+        let fixture = pci_fixture(MIXED_PMEM_ROOT_PCI_HEX);
+        let legacy =
+            prepare_hvf_snapshot_v2_storage_pci_platform_plan(&fixture.platform, &fixture.bundle)
+                .expect("legacy PCI storage plan should validate");
+        let prefixed = prepare_hvf_snapshot_v2_storage_pci_platform_plan_with_prefix(
+            &fixture.platform,
+            &fixture.bundle,
+            HvfSnapshotV2StoragePciPlatformPrefix::root(),
+        )
+        .expect("zero-prefix PCI storage plan should validate");
+        assert_eq!(legacy.root_key(), prefixed.root_key());
+        assert_eq!(legacy.command_line(), prefixed.command_line());
+        assert_eq!(legacy.block_metrics_ids(), prefixed.block_metrics_ids());
+        assert_eq!(legacy.pmem_metrics_ids(), prefixed.pmem_metrics_ids());
+        assert_eq!(legacy.block_retries(), prefixed.block_retries());
+        assert_eq!(legacy.pmem_retries(), prefixed.pmem_retries());
+        assert_eq!(legacy.pci().host(), prefixed.pci().host());
+        assert_eq!(legacy.pci().msi(), prefixed.pci().msi());
+        assert_eq!(legacy.pci().route_demand(), prefixed.pci().route_demand());
+        assert_eq!(legacy.pci().block_records(), prefixed.pci().block_records());
+        assert_eq!(legacy.pci().pmem_records(), prefixed.pci().pmem_records());
+        assert_eq!(legacy.serial_interrupt(), prefixed.serial_interrupt());
+        assert_eq!(legacy.vmgenid_interrupt(), prefixed.vmgenid_interrupt());
+        assert_eq!(legacy.vmclock_interrupt(), prefixed.vmclock_interrupt());
+        fixture
+            .bundle
+            .abort()
+            .expect("PCI equivalence fixture should abort cleanly");
+    }
+
     struct FailingReserve {
         calls: usize,
         fail_at: usize,
@@ -2363,6 +2768,7 @@ pub(crate) mod tests {
                     &fixture.platform,
                     &fixture.bundle,
                     process_config(),
+                    HvfSnapshotV2StorageMmioPlatformPrefix::EMPTY,
                     None,
                     &mut FailingReserve { calls: 0, fail_at },
                 ),
@@ -2383,7 +2789,7 @@ pub(crate) mod tests {
                 prepare_hvf_snapshot_v2_storage_pci_platform_plan_with(
                     &fixture.platform,
                     &fixture.bundle,
-                    false,
+                    HvfSnapshotV2StoragePciPlatformPrefix::root(),
                     &mut FailingReserve { calls: 0, fail_at },
                 ),
                 Err(PrepareHvfSnapshotV2StoragePciPlatformPlanError::Allocation)

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -27043,6 +27043,22 @@ pub(crate) fn pci_entropy_restore_gic_msi_configuration()
     pci_all_virtio_gic_msi_configuration_for_fixed_demand(fixed_demand)
 }
 
+pub(crate) fn pci_balloon_restore_gic_msi_configuration(
+    queue_count: usize,
+    entropy_configured: bool,
+) -> Result<HvfGicMsiConfiguration, HvfArm64BootPciDataError> {
+    let fixed_demand = pci_all_virtio_resource_demand(
+        0,
+        0,
+        0,
+        Some(queue_count),
+        false,
+        entropy_configured,
+        false,
+    )?;
+    pci_all_virtio_gic_msi_configuration_for_fixed_demand(fixed_demand)
+}
+
 pub(crate) fn pci_root_restore_bar_region_id() -> Result<MmioRegionId, HvfArm64BootPciDataError> {
     pci_data_region_id(0)
 }


### PR DESCRIPTION
## Summary

- add one closed exact-2.9 balloon product boundary for all four MMIO and PCI storage/entropy shapes
- validate balloon-first placement, complete range and active-route inventories, exact endpoint capacity, and queue-derived GICv2m demand before owner construction
- add narrow prefix-aware storage and entropy planning seams while preserving legacy retained-slot behavior

## Scope exclusions

- VM, dispatcher, interrupt, BAR/function, route-registry, mapping, scheduler, metrics, session, and owner construction remain deferred

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five Apple-target integration-test Clippy commands from `AGENTS.md`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- signed integration targets through `scripts/run-integration-tests.sh` without `--allow-unsupported`, including direct HVF, guest boot, App Sandbox, and production bundle suites

Closes #1677