### PR TITLE
feat: prepare decoded virtio-mem snapshot topology

### DIFF
--- a/crates/runtime/src/snapshot_artifact.rs
+++ b/crates/runtime/src/snapshot_artifact.rs
@@ -57,7 +57,8 @@ use crate::snapshot_memory::{
 #[cfg(target_os = "macos")]
 use crate::snapshot_memory::{load_snapshot_memory_image, verify_snapshot_memory_image_output};
 use crate::snapshot_memory_hotplug_v2_10::{
-    NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION, SnapshotV2MemoryHotplugBindingError,
+    NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION, PreparedSnapshotV2MemoryHotplugTopology,
+    SnapshotV2MemoryHotplugBindingError, SnapshotV2MemoryHotplugPreparationError,
     SnapshotV2MemoryHotplugState, SnapshotV2MemoryHotplugStateDecodeError,
 };
 use crate::snapshot_memory_v2::{
@@ -940,6 +941,171 @@ pub type NativeV2MemoryHotplugSnapshotCandidateParts = (
     Option<SnapshotV2MemoryHotplugState>,
 );
 
+/// Prepared exact-2.10 artifact outcome before memory mapping.
+pub enum NativeV2MemoryHotplugSnapshotPreparation {
+    /// The original exact candidate has no kind-11 component and remains on
+    /// its compatible internal path unchanged.
+    Compatible(NativeV2MemoryHotplugSnapshotCandidateState),
+    /// The memory-bearing candidate has a closed owner-free virtio-mem
+    /// topology.
+    Prepared(PreparedNativeV2MemoryHotplugSnapshotCandidateState),
+}
+
+impl NativeV2MemoryHotplugSnapshotPreparation {
+    /// Returns the unchanged compatible candidate when kind 11 was absent.
+    pub const fn compatible(&self) -> Option<&NativeV2MemoryHotplugSnapshotCandidateState> {
+        match self {
+            Self::Compatible(candidate) => Some(candidate),
+            Self::Prepared(_) => None,
+        }
+    }
+
+    /// Returns the prepared memory-bearing candidate when kind 11 was present.
+    pub const fn prepared(&self) -> Option<&PreparedNativeV2MemoryHotplugSnapshotCandidateState> {
+        match self {
+            Self::Compatible(_) => None,
+            Self::Prepared(candidate) => Some(candidate),
+        }
+    }
+}
+
+impl fmt::Debug for NativeV2MemoryHotplugSnapshotPreparation {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let outcome = match self {
+            Self::Compatible(_) => "compatible",
+            Self::Prepared(_) => "prepared",
+        };
+        formatter
+            .debug_struct("NativeV2MemoryHotplugSnapshotPreparation")
+            .field("outcome", &outcome)
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// One memory-bearing exact-2.10 candidate with prepared topology.
+///
+/// The candidate keeps all components from the same immutable encoded state.
+/// It owns no opened memory image, mapping, host resource, device, or platform
+/// VM authority.
+pub struct PreparedNativeV2MemoryHotplugSnapshotCandidateState {
+    bytes: Vec<u8>,
+    device_graph: Option<SnapshotV2StorageDeviceGraph>,
+    serial: SnapshotV2SerialState,
+    entropy: Option<SnapshotV2EntropyState>,
+    balloon: Option<SnapshotV2BalloonState>,
+    topology: PreparedSnapshotV2MemoryHotplugTopology,
+}
+
+/// Owned exact components of one prepared memory-bearing 2.10 candidate.
+pub type PreparedNativeV2MemoryHotplugSnapshotCandidateParts = (
+    Vec<u8>,
+    Option<SnapshotV2StorageDeviceGraph>,
+    SnapshotV2SerialState,
+    Option<SnapshotV2EntropyState>,
+    Option<SnapshotV2BalloonState>,
+    PreparedSnapshotV2MemoryHotplugTopology,
+);
+
+impl PreparedNativeV2MemoryHotplugSnapshotCandidateState {
+    /// Returns the exact candidate compatibility version.
+    pub const fn version(&self) -> SnapshotFormatVersion {
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION
+    }
+
+    /// Returns the unchanged immutable encoded state bytes.
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Returns the exact binding attached to the prepared extent partition.
+    pub const fn memory_binding(&self) -> &SnapshotV2MemoryBinding {
+        self.topology.memory().binding()
+    }
+
+    /// Returns the optional unchanged profile-3 storage graph.
+    pub const fn device_graph(&self) -> Option<&SnapshotV2StorageDeviceGraph> {
+        self.device_graph.as_ref()
+    }
+
+    /// Returns the required unchanged exact-2.7 serial state.
+    pub const fn serial(&self) -> &SnapshotV2SerialState {
+        &self.serial
+    }
+
+    /// Returns the optional unchanged exact-2.8 entropy state.
+    pub const fn entropy(&self) -> Option<&SnapshotV2EntropyState> {
+        self.entropy.as_ref()
+    }
+
+    /// Returns the optional unchanged exact-2.9 balloon state.
+    pub const fn balloon(&self) -> Option<&SnapshotV2BalloonState> {
+        self.balloon.as_ref()
+    }
+
+    /// Returns the closed owner-free kind-1/kind-11 topology.
+    pub const fn topology(&self) -> &PreparedSnapshotV2MemoryHotplugTopology {
+        &self.topology
+    }
+
+    /// Consumes the candidate into its exact still-detached components.
+    pub fn into_parts(self) -> PreparedNativeV2MemoryHotplugSnapshotCandidateParts {
+        (
+            self.bytes,
+            self.device_graph,
+            self.serial,
+            self.entropy,
+            self.balloon,
+            self.topology,
+        )
+    }
+}
+
+impl fmt::Debug for PreparedNativeV2MemoryHotplugSnapshotCandidateState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedNativeV2MemoryHotplugSnapshotCandidateState")
+            .field("version", &self.version())
+            .field("has_storage", &self.device_graph.is_some())
+            .field("has_entropy", &self.entropy.is_some())
+            .field("has_balloon", &self.balloon.is_some())
+            .field("state", &REDACTED)
+            .field("memory_topology", &REDACTED)
+            .field("serial", &REDACTED)
+            .finish()
+    }
+}
+
+/// Failure while preparing one exact-2.10 artifact candidate.
+pub enum NativeV2MemoryHotplugSnapshotPreparationError {
+    /// The closed kind-1/kind-11 topology could not be prepared.
+    Topology(SnapshotV2MemoryHotplugPreparationError),
+}
+
+impl fmt::Debug for NativeV2MemoryHotplugSnapshotPreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+impl fmt::Display for NativeV2MemoryHotplugSnapshotPreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Topology(_) => {
+                formatter.write_str("native-v2 virtio-mem artifact topology is invalid")
+            }
+        }
+    }
+}
+
+impl std::error::Error for NativeV2MemoryHotplugSnapshotPreparationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Topology(source) => Some(source),
+        }
+    }
+}
+
 impl NativeV2MemoryHotplugSnapshotCandidateState {
     /// Validates and retains one exact native-v2 2.10 state.
     pub fn from_memory_hotplug_state_v2_10(
@@ -996,6 +1162,45 @@ impl NativeV2MemoryHotplugSnapshotCandidateState {
     /// Returns the optional exact-2.10 virtio-mem state.
     pub const fn memory_hotplug(&self) -> Option<&SnapshotV2MemoryHotplugState> {
         self.memory_hotplug.as_ref()
+    }
+
+    /// Prepares kind-11 topology or preserves this candidate unchanged when
+    /// kind 11 is absent.
+    pub fn prepare(
+        self,
+    ) -> Result<
+        NativeV2MemoryHotplugSnapshotPreparation,
+        NativeV2MemoryHotplugSnapshotPreparationError,
+    > {
+        if self.memory_hotplug.is_none() {
+            return Ok(NativeV2MemoryHotplugSnapshotPreparation::Compatible(self));
+        }
+
+        let Self {
+            bytes,
+            binding,
+            device_graph,
+            serial,
+            entropy,
+            balloon,
+            memory_hotplug,
+        } = self;
+        let state =
+            memory_hotplug.ok_or(NativeV2MemoryHotplugSnapshotPreparationError::Topology(
+                SnapshotV2MemoryHotplugPreparationError::InvalidState,
+            ))?;
+        let topology = PreparedSnapshotV2MemoryHotplugTopology::prepare(state, binding)
+            .map_err(NativeV2MemoryHotplugSnapshotPreparationError::Topology)?;
+        Ok(NativeV2MemoryHotplugSnapshotPreparation::Prepared(
+            PreparedNativeV2MemoryHotplugSnapshotCandidateState {
+                bytes,
+                device_graph,
+                serial,
+                entropy,
+                balloon,
+                topology,
+            },
+        ))
     }
 
     /// Consumes the candidate into its exact committed components.

--- a/crates/runtime/src/snapshot_artifact/tests.rs
+++ b/crates/runtime/src/snapshot_artifact/tests.rs
@@ -770,7 +770,7 @@ fn exact_minor_nine_candidate_rejects_balloon_cardinality_payload_and_version_mi
 
 #[cfg(target_os = "macos")]
 #[test]
-fn exact_minor_ten_candidate_classifies_all_sixteen_optional_component_products() {
+fn exact_minor_ten_products_prepare_or_preserve_every_optional_component_product() {
     let storage_payload = fixture_bytes(include_str!(
         "../snapshot_device_v2_6/fixtures/block-root-mmio.hex"
     ));
@@ -780,14 +780,6 @@ fn exact_minor_ten_candidate_classifies_all_sixteen_optional_component_products(
     let balloon_payload = fixture_bytes(include_str!(
         "../snapshot_balloon_v2_9/fixtures/active-pci.hex"
     ));
-    let memory_hotplug_payload = fixture_bytes(include_str!(
-        "../snapshot_memory_hotplug_v2_10/fixtures/inactive-mmio.hex"
-    ));
-    let memory_hotplug_state = SnapshotV2MemoryHotplugState::decode(
-        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
-        &memory_hotplug_payload,
-    )
-    .expect("exact 2.10 virtio-mem fixture should decode");
     let base_memory = test_v2_memory();
     let mut base_image = Cursor::new(Vec::new());
     let base_binding = write_snapshot_v2_memory_image_with_compatibility_version(
@@ -796,113 +788,178 @@ fn exact_minor_ten_candidate_classifies_all_sixteen_optional_component_products(
         NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
     )
     .expect("base exact 2.10 memory should encode internally");
-    let hotplug_memory = test_v2_memory_with_hotplug(&memory_hotplug_state);
-    let mut hotplug_image = Cursor::new(Vec::new());
-    let hotplug_binding = write_snapshot_v2_memory_image_with_compatibility_version(
-        &hotplug_memory,
-        &mut hotplug_image,
-        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
-    )
-    .expect("dynamic exact 2.10 memory should encode internally");
 
-    let mut product_count = 0;
-    for with_storage in [false, true] {
-        for with_entropy in [false, true] {
-            for with_balloon in [false, true] {
-                for with_memory_hotplug in [false, true] {
-                    let entropy_components = if with_entropy {
-                        vec![(
-                            NATIVE_V2_ENTROPY_COMPONENT_KEY,
-                            SnapshotV2ComponentDisposition::Semantic,
-                            entropy_payload.as_slice(),
-                        )]
-                    } else {
-                        Vec::new()
-                    };
-                    let balloon_components = if with_balloon {
-                        vec![(
-                            NATIVE_V2_BALLOON_COMPONENT_KEY,
-                            SnapshotV2ComponentDisposition::Semantic,
-                            balloon_payload.as_slice(),
-                        )]
-                    } else {
-                        Vec::new()
-                    };
-                    let memory_hotplug_components = if with_memory_hotplug {
-                        vec![(
-                            NATIVE_V2_MEMORY_HOTPLUG_COMPONENT_KEY,
-                            SnapshotV2ComponentDisposition::Semantic,
-                            memory_hotplug_payload.as_slice(),
-                        )]
-                    } else {
-                        Vec::new()
-                    };
-                    let binding = if with_memory_hotplug {
-                        &hotplug_binding
-                    } else {
-                        &base_binding
-                    };
-                    let bytes = memory_hotplug_v2_10_state(
-                        binding,
-                        with_storage.then_some(storage_payload.as_slice()),
-                        &entropy_components,
-                        &balloon_components,
-                        &memory_hotplug_components,
-                    )
-                    .expect("exact 2.10 product should encode");
+    let mut profiles = Vec::new();
+    for payload in [
+        fixture_bytes(include_str!(
+            "../snapshot_memory_hotplug_v2_10/fixtures/inactive-mmio.hex"
+        )),
+        fixture_bytes(include_str!(
+            "../snapshot_memory_hotplug_v2_10/fixtures/active-pci.hex"
+        )),
+    ] {
+        let state = SnapshotV2MemoryHotplugState::decode(
+            NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+            &payload,
+        )
+        .expect("exact 2.10 virtio-mem fixture should decode");
+        let memory = test_v2_memory_with_hotplug(&state);
+        let binding = write_snapshot_v2_memory_image_with_compatibility_version(
+            &memory,
+            &mut Cursor::new(Vec::new()),
+            NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        )
+        .expect("dynamic exact 2.10 memory should encode internally");
+        profiles.push((payload, state, binding));
+    }
 
-                    assert!(matches!(
-                        NativeSnapshotArtifactState::from_current_v2(bytes.clone()),
-                        Err(NativeSnapshotArtifactStateError::CurrentV2Profile(_))
-                    ));
-                    assert!(matches!(
-                        NativeSnapshotArtifactState::from_compatible_bytes(bytes.clone()),
-                        Err(NativeSnapshotArtifactStateError::Format(
-                            NativeSnapshotFormatError::NativeV2(
-                                SnapshotV2DecodeError::UnsupportedVersion { .. }
-                            )
-                        ))
-                    ));
-
-                    let candidate =
-                        NativeV2MemoryHotplugSnapshotCandidateState::from_memory_hotplug_state_v2_10(
-                            bytes.clone(),
+    let mut prepared_count = 0;
+    let mut compatible_count = 0;
+    for (memory_hotplug_payload, memory_hotplug_state, hotplug_binding) in &profiles {
+        for with_storage in [false, true] {
+            for with_entropy in [false, true] {
+                for with_balloon in [false, true] {
+                    for with_memory_hotplug in [false, true] {
+                        let entropy_components = if with_entropy {
+                            vec![(
+                                NATIVE_V2_ENTROPY_COMPONENT_KEY,
+                                SnapshotV2ComponentDisposition::Semantic,
+                                entropy_payload.as_slice(),
+                            )]
+                        } else {
+                            Vec::new()
+                        };
+                        let balloon_components = if with_balloon {
+                            vec![(
+                                NATIVE_V2_BALLOON_COMPONENT_KEY,
+                                SnapshotV2ComponentDisposition::Semantic,
+                                balloon_payload.as_slice(),
+                            )]
+                        } else {
+                            Vec::new()
+                        };
+                        let memory_hotplug_components = if with_memory_hotplug {
+                            vec![(
+                                NATIVE_V2_MEMORY_HOTPLUG_COMPONENT_KEY,
+                                SnapshotV2ComponentDisposition::Semantic,
+                                memory_hotplug_payload.as_slice(),
+                            )]
+                        } else {
+                            Vec::new()
+                        };
+                        let binding = if with_memory_hotplug {
+                            hotplug_binding
+                        } else {
+                            &base_binding
+                        };
+                        let bytes = memory_hotplug_v2_10_state(
+                            binding,
+                            with_storage.then_some(storage_payload.as_slice()),
+                            &entropy_components,
+                            &balloon_components,
+                            &memory_hotplug_components,
                         )
-                        .expect("exact 2.10 candidate should validate");
-                    assert_eq!(
-                        candidate.version(),
-                        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION
-                    );
-                    assert_eq!(candidate.memory_binding(), binding);
-                    assert_eq!(candidate.device_graph().is_some(), with_storage);
-                    assert_eq!(candidate.entropy().is_some(), with_entropy);
-                    assert_eq!(candidate.balloon().is_some(), with_balloon);
-                    assert_eq!(candidate.memory_hotplug().is_some(), with_memory_hotplug);
-                    assert_eq!(candidate.bytes(), bytes);
-                    let debug = format!("{candidate:?}");
-                    assert!(debug.contains(REDACTED));
-                    assert!(!debug.contains("BANGME2"));
+                        .expect("exact 2.10 product should encode");
 
-                    let compatible = candidate.into_compatible_artifact_state();
-                    assert_eq!(
-                        compatible
-                            .v2_profile()
-                            .expect("internal exact 2.10 state should classify"),
-                        NativeV2SnapshotArtifactProfile::MemoryHotplugStateV2_10
-                    );
-                    assert!(matches!(
-                        compatible.validate_for_publication(),
-                        Err(NativeSnapshotArtifactStateError::NonCurrentV2Publication {
-                            state: NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
-                            memory: NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
-                        })
-                    ));
-                    product_count += 1;
+                        assert!(matches!(
+                            NativeSnapshotArtifactState::from_current_v2(bytes.clone()),
+                            Err(NativeSnapshotArtifactStateError::CurrentV2Profile(_))
+                        ));
+                        assert!(matches!(
+                            NativeSnapshotArtifactState::from_compatible_bytes(bytes.clone()),
+                            Err(NativeSnapshotArtifactStateError::Format(
+                                NativeSnapshotFormatError::NativeV2(
+                                    SnapshotV2DecodeError::UnsupportedVersion { .. }
+                                )
+                            ))
+                        ));
+
+                        let candidate =
+                            NativeV2MemoryHotplugSnapshotCandidateState::from_memory_hotplug_state_v2_10(
+                                bytes.clone(),
+                            )
+                            .expect("exact 2.10 candidate should validate");
+                        assert_eq!(
+                            candidate.version(),
+                            NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION
+                        );
+                        assert_eq!(candidate.memory_binding(), binding);
+                        assert_eq!(candidate.device_graph().is_some(), with_storage);
+                        assert_eq!(candidate.entropy().is_some(), with_entropy);
+                        assert_eq!(candidate.balloon().is_some(), with_balloon);
+                        assert_eq!(candidate.memory_hotplug().is_some(), with_memory_hotplug);
+                        assert_eq!(candidate.bytes(), bytes);
+                        let debug = format!("{candidate:?}");
+                        assert!(debug.contains(REDACTED));
+                        assert!(!debug.contains("BANGME2"));
+                        let expected_device_graph = candidate.device_graph().cloned();
+                        let expected_serial = candidate.serial().clone();
+                        let expected_entropy = candidate.entropy().cloned();
+                        let expected_balloon = candidate.balloon().cloned();
+
+                        let preparation = candidate
+                            .prepare()
+                            .expect("exact 2.10 candidate should prepare");
+                        let preparation_debug = format!("{preparation:?}");
+                        assert!(preparation_debug.contains(REDACTED));
+                        assert!(!preparation_debug.contains("BANGME2"));
+                        if with_memory_hotplug {
+                            let prepared = preparation
+                                .prepared()
+                                .expect("kind-11 product should be prepared");
+                            assert!(preparation.compatible().is_none());
+                            assert_eq!(prepared.bytes(), bytes);
+                            assert_eq!(prepared.memory_binding(), binding);
+                            assert_eq!(prepared.device_graph(), expected_device_graph.as_ref());
+                            assert_eq!(prepared.serial(), &expected_serial);
+                            assert_eq!(prepared.entropy(), expected_entropy.as_ref());
+                            assert_eq!(prepared.balloon(), expected_balloon.as_ref());
+                            assert_eq!(prepared.topology().state(), memory_hotplug_state);
+                            assert_eq!(
+                                prepared.topology().queue_ranges().is_some(),
+                                memory_hotplug_state.virtio().is_activated()
+                            );
+                            let prepared_debug = format!("{prepared:?}");
+                            assert!(prepared_debug.contains(REDACTED));
+                            assert!(!prepared_debug.contains("BANGME2"));
+                            prepared_count += 1;
+                        } else {
+                            let compatible_candidate = preparation
+                                .compatible()
+                                .expect("no-kind-11 product should remain compatible");
+                            assert!(preparation.prepared().is_none());
+                            assert_eq!(compatible_candidate.bytes(), bytes);
+                            assert_eq!(compatible_candidate.memory_binding(), binding);
+                            assert!(compatible_candidate.memory_hotplug().is_none());
+                            compatible_count += 1;
+                        }
+
+                        let compatible =
+                            NativeV2MemoryHotplugSnapshotCandidateState::from_memory_hotplug_state_v2_10(
+                                bytes,
+                            )
+                            .expect("exact 2.10 compatibility candidate should validate")
+                            .into_compatible_artifact_state();
+                        assert_eq!(
+                            compatible
+                                .v2_profile()
+                                .expect("internal exact 2.10 state should classify"),
+                            NativeV2SnapshotArtifactProfile::MemoryHotplugStateV2_10
+                        );
+                        assert!(matches!(
+                            compatible.validate_for_publication(),
+                            Err(NativeSnapshotArtifactStateError::NonCurrentV2Publication {
+                                state: NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+                                memory: NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+                            })
+                        ));
+                    }
                 }
             }
         }
     }
-    assert_eq!(product_count, 16);
+    assert_eq!(prepared_count, 16);
+    assert_eq!(compatible_count, 16);
 }
 
 #[cfg(target_os = "macos")]
@@ -936,6 +993,53 @@ fn exact_minor_ten_candidate_rejects_mismatched_memory_and_virtio_mem_coverage()
         NativeV2MemoryHotplugSnapshotCandidateState::from_memory_hotplug_state_v2_10(bytes),
         Err(NativeV2SnapshotCandidateStateError::MemoryHotplugBinding(_))
     ));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn exact_minor_ten_preparation_rejects_queue_missing_from_the_closed_binding() {
+    let memory_hotplug_payload = fixture_bytes(include_str!(
+        "../snapshot_memory_hotplug_v2_10/fixtures/active-pci.hex"
+    ));
+    let state = SnapshotV2MemoryHotplugState::decode(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        &memory_hotplug_payload,
+    )
+    .expect("active exact 2.10 virtio-mem fixture should decode");
+    let memory = test_v2_memory_with_hotplug_data_only(&state);
+    let binding = write_snapshot_v2_memory_image_with_compatibility_version(
+        &memory,
+        &mut Cursor::new(Vec::new()),
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+    )
+    .expect("dynamic-only exact 2.10 memory should encode");
+    let bytes = memory_hotplug_v2_10_state(
+        &binding,
+        None,
+        &[],
+        &[],
+        &[(
+            NATIVE_V2_MEMORY_HOTPLUG_COMPONENT_KEY,
+            SnapshotV2ComponentDisposition::Semantic,
+            memory_hotplug_payload.as_slice(),
+        )],
+    )
+    .expect("queue-missing product should remain structurally encodable");
+    let candidate =
+        NativeV2MemoryHotplugSnapshotCandidateState::from_memory_hotplug_state_v2_10(bytes)
+            .expect("kind-1 and plugged union should close before queue preparation");
+    let error = candidate
+        .prepare()
+        .expect_err("queue addresses missing from kind 1 should reject");
+    assert!(matches!(
+        error,
+        NativeV2MemoryHotplugSnapshotPreparationError::Topology(
+            SnapshotV2MemoryHotplugPreparationError::QueueMemory
+        )
+    ));
+    let diagnostic = format!("{error:?} {error}");
+    assert!(!diagnostic.contains(&state.config_space().addr().to_string()));
+    assert!(!diagnostic.contains("BANGME2"));
 }
 
 #[cfg(target_os = "macos")]
@@ -3382,13 +3486,38 @@ fn test_v2_memory() -> GuestMemory {
 
 #[cfg(target_os = "macos")]
 fn test_v2_memory_with_hotplug(state: &SnapshotV2MemoryHotplugState) -> GuestMemory {
-    let mut ranges = vec![
+    let mut ranges = Vec::new();
+    if let Some(queue) = state.virtio().queues().first()
+        && let Some(queue_ranges) = crate::snapshot_device_v2_5::queue_ranges(queue)
+            .expect("fixture queue ranges should validate")
+    {
+        let alignment = 4 * aarch64::GUEST_PAGE_SIZE;
+        let start = queue_ranges
+            .iter()
+            .map(|range| range.start().raw_value())
+            .min()
+            .expect("active queue should have ranges")
+            & !(alignment - 1);
+        let end = queue_ranges
+            .iter()
+            .map(|range| range.end_exclusive().raw_value())
+            .max()
+            .expect("active queue should have ranges")
+            .checked_add(alignment - 1)
+            .expect("fixture queue end should fit")
+            & !(alignment - 1);
+        ranges.push(
+            GuestMemoryRange::new(GuestAddress::new(start), end - start)
+                .expect("queue base-memory fixture should validate"),
+        );
+    }
+    ranges.push(
         GuestMemoryRange::new(
             GuestAddress::new(aarch64::DRAM_MEM_START),
             u64::try_from(TEST_MEMORY_BYTES).expect("fixture size should fit u64"),
         )
         .expect("native-v2 fixture range should be valid"),
-    ];
+    );
     let config_space = state.config_space();
     for plugged in state.plugged_ranges() {
         let offset = plugged
@@ -3408,8 +3537,36 @@ fn test_v2_memory_with_hotplug(state: &SnapshotV2MemoryHotplugState) -> GuestMem
                 .expect("fixture plugged range should validate"),
         );
     }
+    ranges.sort_by_key(|range| range.start());
     let layout = GuestMemoryLayout::new(ranges).expect("hotplug fixture layout should validate");
     GuestMemory::allocate(&layout).expect("hotplug fixture memory should allocate")
+}
+
+#[cfg(target_os = "macos")]
+fn test_v2_memory_with_hotplug_data_only(state: &SnapshotV2MemoryHotplugState) -> GuestMemory {
+    let config_space = state.config_space();
+    let ranges = state
+        .plugged_ranges()
+        .map(|plugged| {
+            let offset = plugged
+                .start_block()
+                .checked_mul(config_space.block_size())
+                .expect("fixture plugged offset should fit");
+            let start = config_space
+                .addr()
+                .checked_add(offset)
+                .expect("fixture plugged start should fit");
+            let length = plugged
+                .block_count()
+                .checked_mul(config_space.block_size())
+                .expect("fixture plugged length should fit");
+            GuestMemoryRange::new(GuestAddress::new(start), length)
+                .expect("fixture plugged range should validate")
+        })
+        .collect::<Vec<_>>();
+    let layout =
+        GuestMemoryLayout::new(ranges).expect("dynamic-only fixture layout should validate");
+    GuestMemory::allocate(&layout).expect("dynamic-only fixture memory should allocate")
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/runtime/src/snapshot_memory_hotplug_v2_10.rs
+++ b/crates/runtime/src/snapshot_memory_hotplug_v2_10.rs
@@ -9,12 +9,12 @@ use std::fmt;
 use std::iter::FusedIterator;
 
 use crate::interrupt::GuestInterruptLine;
-use crate::memory::{GuestMemoryRange, aarch64};
+use crate::memory::{GuestAddress, GuestMemoryRange, aarch64};
 use crate::memory_hotplug::{
-    MemoryHotplugConfig, MemoryHotplugConfigInput, VIRTIO_FEATURE_VERSION_1,
-    VIRTIO_MEM_DEFAULT_REGION_ADDRESS, VIRTIO_MEM_DEVICE_ID, VIRTIO_MEM_F_UNPLUGGED_INACCESSIBLE,
-    VIRTIO_MEM_QUEUE_SIZE, VirtioMemConfigSpace, VirtioMemDeviceCaptureState,
-    VirtioMemMmioCaptureState, VirtioMemPciCaptureState,
+    MemoryHotplugConfig, MemoryHotplugConfigInput, MemoryHotplugSizeUpdateInput,
+    VIRTIO_FEATURE_VERSION_1, VIRTIO_MEM_DEFAULT_REGION_ADDRESS, VIRTIO_MEM_DEVICE_ID,
+    VIRTIO_MEM_F_UNPLUGGED_INACCESSIBLE, VIRTIO_MEM_QUEUE_SIZE, VirtioMemConfigSpace,
+    VirtioMemDeviceCaptureState, VirtioMemMmioCaptureState, VirtioMemPciCaptureState,
 };
 use crate::mmio::MmioRegion;
 use crate::pci::PciSbdf;
@@ -27,7 +27,7 @@ use crate::snapshot_device_v2_5::{
     queue_ranges, validate_mmio, validate_pci, validate_virtio_with_queue_size,
 };
 use crate::snapshot_format::SnapshotFormatVersion;
-use crate::snapshot_memory_v2::SnapshotV2MemoryBinding;
+use crate::snapshot_memory_v2::{SnapshotV2MemoryBinding, SnapshotV2MemoryExtent};
 use crate::storage_capture::StorageDeviceOrigin;
 
 mod codec;
@@ -222,6 +222,215 @@ impl fmt::Debug for SnapshotV2MemoryHotplugPluggedRanges<'_> {
         formatter
             .debug_struct("SnapshotV2MemoryHotplugPluggedRanges")
             .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Destination ownership class of one exact kind-1 memory extent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2MemoryHotplugExtentClass {
+    /// Memory outside the virtio-mem aperture, retained as base RAM.
+    Base,
+    /// Plugged memory inside the virtio-mem aperture.
+    Dynamic,
+}
+
+/// Immutable classified view of one original ordered kind-1 extent.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotV2MemoryHotplugClassifiedExtent {
+    extent: SnapshotV2MemoryExtent,
+    class: SnapshotV2MemoryHotplugExtentClass,
+}
+
+impl SnapshotV2MemoryHotplugClassifiedExtent {
+    /// Returns the unchanged original GPA and file-offset record.
+    pub const fn extent(self) -> SnapshotV2MemoryExtent {
+        self.extent
+    }
+
+    /// Returns whether the original extent is base or dynamic memory.
+    pub const fn class(self) -> SnapshotV2MemoryHotplugExtentClass {
+        self.class
+    }
+}
+
+impl fmt::Debug for SnapshotV2MemoryHotplugClassifiedExtent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2MemoryHotplugClassifiedExtent")
+            .field("class", &self.class)
+            .field("extent", &REDACTED)
+            .finish()
+    }
+}
+
+/// Checked controller values retained before destination owner construction.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotV2MemoryHotplugControllerProjection {
+    config: MemoryHotplugConfig,
+    requested_size_mib: u64,
+}
+
+impl SnapshotV2MemoryHotplugControllerProjection {
+    /// Returns the validated external virtio-mem configuration.
+    pub const fn config(self) -> MemoryHotplugConfig {
+        self.config
+    }
+
+    /// Returns the validated requested size in MiB.
+    pub const fn requested_size_mib(self) -> u64 {
+        self.requested_size_mib
+    }
+}
+
+impl fmt::Debug for SnapshotV2MemoryHotplugControllerProjection {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2MemoryHotplugControllerProjection")
+            .field("controller", &REDACTED)
+            .finish()
+    }
+}
+
+/// Original kind-1 binding and its cardinality-locked extent partition.
+///
+/// This value keeps the private classification vector attached to the exact
+/// binding so callers cannot recombine tags with a different image.
+#[derive(PartialEq, Eq)]
+pub struct PreparedSnapshotV2MemoryHotplugMemory {
+    binding: SnapshotV2MemoryBinding,
+    extent_classes: Vec<SnapshotV2MemoryHotplugExtentClass>,
+}
+
+impl PreparedSnapshotV2MemoryHotplugMemory {
+    /// Returns the unchanged exact state/image binding.
+    pub const fn binding(&self) -> &SnapshotV2MemoryBinding {
+        &self.binding
+    }
+
+    /// Returns the number of original ordered extents.
+    pub fn extent_count(&self) -> usize {
+        self.extent_classes.len()
+    }
+
+    /// Iterates over original extents paired with their immutable class.
+    pub fn classified_extents(
+        &self,
+    ) -> impl ExactSizeIterator<Item = SnapshotV2MemoryHotplugClassifiedExtent> + '_ {
+        self.binding
+            .extents()
+            .iter()
+            .copied()
+            .zip(self.extent_classes.iter().copied())
+            .map(|(extent, class)| SnapshotV2MemoryHotplugClassifiedExtent { extent, class })
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2MemoryHotplugMemory {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2MemoryHotplugMemory")
+            .field("version", &self.binding.version())
+            .field("extent_count", &self.extent_classes.len())
+            .field("binding", &REDACTED)
+            .finish()
+    }
+}
+
+/// Owned parts of one prepared exact-2.10 virtio-mem topology.
+pub type PreparedSnapshotV2MemoryHotplugTopologyParts = (
+    PreparedSnapshotV2MemoryHotplugMemory,
+    Vec<GuestMemoryRange>,
+    Option<[GuestMemoryRange; 3]>,
+    SnapshotV2MemoryHotplugState,
+    SnapshotV2MemoryHotplugControllerProjection,
+);
+
+/// Immutable owner-free exact-2.10 virtio-mem topology.
+///
+/// The value contains only checked snapshot facts. It owns no guest mapping,
+/// memory descriptor, device, notifier, interrupt, platform slot, or VM
+/// authority.
+#[derive(PartialEq, Eq)]
+pub struct PreparedSnapshotV2MemoryHotplugTopology {
+    memory: PreparedSnapshotV2MemoryHotplugMemory,
+    plugged_ranges: Vec<GuestMemoryRange>,
+    queue_ranges: Option<[GuestMemoryRange; 3]>,
+    state: SnapshotV2MemoryHotplugState,
+    controller: SnapshotV2MemoryHotplugControllerProjection,
+}
+
+impl PreparedSnapshotV2MemoryHotplugTopology {
+    /// Validates and prepares one closed kind-1/kind-11 state pair.
+    pub fn prepare(
+        state: SnapshotV2MemoryHotplugState,
+        binding: SnapshotV2MemoryBinding,
+    ) -> Result<Self, SnapshotV2MemoryHotplugPreparationError> {
+        prepare_memory_hotplug_topology(state, binding, TopologyReservePolicy::System)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn prepare_with_extent_class_allocation_failure(
+        state: SnapshotV2MemoryHotplugState,
+        binding: SnapshotV2MemoryBinding,
+    ) -> Result<Self, SnapshotV2MemoryHotplugPreparationError> {
+        prepare_memory_hotplug_topology(state, binding, TopologyReservePolicy::FailExtentClasses)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn prepare_with_plugged_range_allocation_failure(
+        state: SnapshotV2MemoryHotplugState,
+        binding: SnapshotV2MemoryBinding,
+    ) -> Result<Self, SnapshotV2MemoryHotplugPreparationError> {
+        prepare_memory_hotplug_topology(state, binding, TopologyReservePolicy::FailPluggedRanges)
+    }
+
+    /// Returns the exact binding and attached extent classification.
+    pub const fn memory(&self) -> &PreparedSnapshotV2MemoryHotplugMemory {
+        &self.memory
+    }
+
+    /// Returns canonical maximal plugged GPA regions.
+    pub fn plugged_ranges(&self) -> &[GuestMemoryRange] {
+        &self.plugged_ranges
+    }
+
+    /// Returns descriptor, available-ring, and used-ring GPA ranges.
+    pub const fn queue_ranges(&self) -> Option<[GuestMemoryRange; 3]> {
+        self.queue_ranges
+    }
+
+    /// Returns the complete typed device and transport continuation.
+    pub const fn state(&self) -> &SnapshotV2MemoryHotplugState {
+        &self.state
+    }
+
+    /// Returns the checked controller configuration and requested size.
+    pub const fn controller(&self) -> SnapshotV2MemoryHotplugControllerProjection {
+        self.controller
+    }
+
+    /// Consumes the topology into its still-detached prepared parts.
+    pub fn into_parts(self) -> PreparedSnapshotV2MemoryHotplugTopologyParts {
+        (
+            self.memory,
+            self.plugged_ranges,
+            self.queue_ranges,
+            self.state,
+            self.controller,
+        )
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2MemoryHotplugTopology {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2MemoryHotplugTopology")
+            .field("version", &self.state.compatibility_version())
+            .field("extent_count", &self.memory.extent_count())
+            .field("plugged_range_count", &self.plugged_ranges.len())
+            .field("has_queue_ranges", &self.queue_ranges.is_some())
+            .field("topology", &REDACTED)
             .finish()
     }
 }
@@ -736,6 +945,238 @@ fn count_ranges(bitmap: &[u8], block_count: usize) -> usize {
                 && (*index == 0 || !bitmap_bit(bitmap, index.saturating_sub(1)))
         })
         .count()
+}
+
+#[derive(Clone, Copy)]
+enum TopologyReservePolicy {
+    System,
+    #[cfg(test)]
+    FailExtentClasses,
+    #[cfg(test)]
+    FailPluggedRanges,
+}
+
+impl TopologyReservePolicy {
+    fn reserve_extent_classes(
+        self,
+        classes: &mut Vec<SnapshotV2MemoryHotplugExtentClass>,
+        count: usize,
+    ) -> Result<(), SnapshotV2MemoryHotplugPreparationError> {
+        #[cfg(test)]
+        if matches!(self, Self::FailExtentClasses) {
+            return Err(SnapshotV2MemoryHotplugPreparationError::Allocation);
+        }
+        classes
+            .try_reserve_exact(count)
+            .map_err(|_| SnapshotV2MemoryHotplugPreparationError::Allocation)
+    }
+
+    fn reserve_plugged_ranges(
+        self,
+        ranges: &mut Vec<GuestMemoryRange>,
+        count: usize,
+    ) -> Result<(), SnapshotV2MemoryHotplugPreparationError> {
+        #[cfg(test)]
+        if matches!(self, Self::FailPluggedRanges) {
+            return Err(SnapshotV2MemoryHotplugPreparationError::Allocation);
+        }
+        ranges
+            .try_reserve_exact(count)
+            .map_err(|_| SnapshotV2MemoryHotplugPreparationError::Allocation)
+    }
+}
+
+fn prepare_memory_hotplug_topology(
+    state: SnapshotV2MemoryHotplugState,
+    binding: SnapshotV2MemoryBinding,
+    reserve_policy: TopologyReservePolicy,
+) -> Result<PreparedSnapshotV2MemoryHotplugTopology, SnapshotV2MemoryHotplugPreparationError> {
+    validate_memory_hotplug_state(&state)
+        .map_err(|_| SnapshotV2MemoryHotplugPreparationError::InvalidState)?;
+    state
+        .validate_memory_binding(&binding)
+        .map_err(SnapshotV2MemoryHotplugPreparationError::Binding)?;
+
+    let config_space = state.config_space();
+    let aperture = GuestMemoryRange::new(
+        GuestAddress::new(config_space.addr()),
+        config_space.region_size(),
+    )
+    .map_err(|_| SnapshotV2MemoryHotplugPreparationError::Aperture)?;
+    let queue = state
+        .virtio()
+        .queues()
+        .first()
+        .ok_or(SnapshotV2MemoryHotplugPreparationError::InvalidState)?;
+    let restored_queue_ranges =
+        queue_ranges(queue).map_err(|_| SnapshotV2MemoryHotplugPreparationError::Queue)?;
+    if let Some(ranges) = restored_queue_ranges {
+        for range in ranges {
+            validate_prepared_queue_range(&state, &binding, aperture, range)?;
+        }
+    }
+
+    let requested_size = config_space.requested_size();
+    if !requested_size.is_multiple_of(MIB) {
+        return Err(SnapshotV2MemoryHotplugPreparationError::Controller);
+    }
+    let requested_size_mib = requested_size / MIB;
+    if requested_size_mib.checked_mul(MIB) != Some(requested_size) {
+        return Err(SnapshotV2MemoryHotplugPreparationError::Controller);
+    }
+    let update = state
+        .config()
+        .validate_size_update(MemoryHotplugSizeUpdateInput::new(requested_size_mib))
+        .map_err(|_| SnapshotV2MemoryHotplugPreparationError::Controller)?;
+    if update.requested_size() != requested_size {
+        return Err(SnapshotV2MemoryHotplugPreparationError::Controller);
+    }
+    let controller = SnapshotV2MemoryHotplugControllerProjection {
+        config: state.config(),
+        requested_size_mib,
+    };
+
+    let mut extent_classes = Vec::new();
+    reserve_policy.reserve_extent_classes(&mut extent_classes, binding.extents().len())?;
+    for extent in binding.extents() {
+        let class = if range_is_wholly_contained(aperture, extent.range()) {
+            SnapshotV2MemoryHotplugExtentClass::Dynamic
+        } else {
+            SnapshotV2MemoryHotplugExtentClass::Base
+        };
+        extent_classes.push(class);
+    }
+
+    let plugged_range_count = state.plugged_ranges().len();
+    let mut plugged_ranges = Vec::new();
+    reserve_policy.reserve_plugged_ranges(&mut plugged_ranges, plugged_range_count)?;
+    for plugged in state.plugged_ranges() {
+        plugged_ranges.push(plugged_guest_range(config_space, plugged)?);
+    }
+
+    debug_assert_eq!(binding.extents().len(), extent_classes.len());
+    debug_assert_eq!(plugged_range_count, plugged_ranges.len());
+
+    Ok(PreparedSnapshotV2MemoryHotplugTopology {
+        memory: PreparedSnapshotV2MemoryHotplugMemory {
+            binding,
+            extent_classes,
+        },
+        plugged_ranges,
+        queue_ranges: restored_queue_ranges,
+        state,
+        controller,
+    })
+}
+
+fn validate_prepared_queue_range(
+    state: &SnapshotV2MemoryHotplugState,
+    binding: &SnapshotV2MemoryBinding,
+    aperture: GuestMemoryRange,
+    queue_range: GuestMemoryRange,
+) -> Result<(), SnapshotV2MemoryHotplugPreparationError> {
+    if queue_range.overlaps(aperture) {
+        if !range_is_wholly_contained(aperture, queue_range) {
+            return Err(SnapshotV2MemoryHotplugPreparationError::QueueBoundary);
+        }
+        for plugged in state.plugged_ranges() {
+            let plugged_range = plugged_guest_range(state.config_space(), plugged)?;
+            if range_is_wholly_contained(plugged_range, queue_range) {
+                return Ok(());
+            }
+        }
+        return Err(SnapshotV2MemoryHotplugPreparationError::QueueMemory);
+    }
+
+    if binding.extents().iter().any(|extent| {
+        !extent.range().overlaps(aperture) && range_is_wholly_contained(extent.range(), queue_range)
+    }) {
+        Ok(())
+    } else {
+        Err(SnapshotV2MemoryHotplugPreparationError::QueueMemory)
+    }
+}
+
+fn plugged_guest_range(
+    config_space: VirtioMemConfigSpace,
+    plugged: SnapshotV2MemoryHotplugPluggedRange,
+) -> Result<GuestMemoryRange, SnapshotV2MemoryHotplugPreparationError> {
+    let offset = plugged
+        .start_block()
+        .checked_mul(config_space.block_size())
+        .ok_or(SnapshotV2MemoryHotplugPreparationError::Aperture)?;
+    let length = plugged
+        .block_count()
+        .checked_mul(config_space.block_size())
+        .ok_or(SnapshotV2MemoryHotplugPreparationError::Aperture)?;
+    let start = config_space
+        .addr()
+        .checked_add(offset)
+        .ok_or(SnapshotV2MemoryHotplugPreparationError::Aperture)?;
+    GuestMemoryRange::new(GuestAddress::new(start), length)
+        .map_err(|_| SnapshotV2MemoryHotplugPreparationError::Aperture)
+}
+
+const fn range_is_wholly_contained(outer: GuestMemoryRange, inner: GuestMemoryRange) -> bool {
+    outer.start().raw_value() <= inner.start().raw_value()
+        && inner.end_exclusive().raw_value() <= outer.end_exclusive().raw_value()
+}
+
+/// Failure while preparing owner-free exact-2.10 virtio-mem topology.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2MemoryHotplugPreparationError {
+    /// The retained typed state no longer satisfies its exact profile.
+    InvalidState,
+    /// Kind-1 memory and kind 11 do not form one closed topology.
+    Binding(SnapshotV2MemoryHotplugBindingError),
+    /// The checked aperture or plugged GPA projection is invalid.
+    Aperture,
+    /// Queue range derivation failed.
+    Queue,
+    /// A queue range crosses the virtio-mem aperture boundary.
+    QueueBoundary,
+    /// A queue range is not contained by one planned destination region.
+    QueueMemory,
+    /// Controller requested-size projection is invalid.
+    Controller,
+    /// Bounded topology metadata could not be reserved.
+    Allocation,
+}
+
+impl fmt::Debug for SnapshotV2MemoryHotplugPreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+impl fmt::Display for SnapshotV2MemoryHotplugPreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidState => "native-v2 virtio-mem preparation state is invalid",
+            Self::Binding(_) => "native-v2 virtio-mem preparation binding is invalid",
+            Self::Aperture => "native-v2 virtio-mem preparation aperture is invalid",
+            Self::Queue => "native-v2 virtio-mem preparation queue is invalid",
+            Self::QueueBoundary => "native-v2 virtio-mem preparation queue crosses the aperture",
+            Self::QueueMemory => "native-v2 virtio-mem preparation queue memory is invalid",
+            Self::Controller => "native-v2 virtio-mem preparation controller state is invalid",
+            Self::Allocation => "native-v2 virtio-mem preparation allocation failed",
+        })
+    }
+}
+
+impl std::error::Error for SnapshotV2MemoryHotplugPreparationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Binding(source) => Some(source),
+            Self::InvalidState
+            | Self::Aperture
+            | Self::Queue
+            | Self::QueueBoundary
+            | Self::QueueMemory
+            | Self::Controller
+            | Self::Allocation => None,
+        }
+    }
 }
 
 /// Failure while closing exact-2.10 kind-1 memory extents against kind 11.

--- a/crates/runtime/src/snapshot_memory_hotplug_v2_10/tests.rs
+++ b/crates/runtime/src/snapshot_memory_hotplug_v2_10/tests.rs
@@ -12,10 +12,10 @@ use crate::pci::{
     PciBarAddressSpace, PciBarPrefetchable, PciSbdf,
 };
 use crate::snapshot_device_v2::{
-    SnapshotV2InterruptIntent, SnapshotV2MmioDeviceState, SnapshotV2PciBarProbeState,
-    SnapshotV2PciDeviceState, SnapshotV2PciDeviceStateParts, SnapshotV2PciMsixState,
-    SnapshotV2PciMsixStateParts, SnapshotV2PciMsixTableEntry, SnapshotV2PciWritableByte,
-    SnapshotV2VirtioQueueState, SnapshotV2VirtioStateParts,
+    SnapshotV2DeviceTransportKind, SnapshotV2InterruptIntent, SnapshotV2MmioDeviceState,
+    SnapshotV2PciBarProbeState, SnapshotV2PciDeviceState, SnapshotV2PciDeviceStateParts,
+    SnapshotV2PciMsixState, SnapshotV2PciMsixStateParts, SnapshotV2PciMsixTableEntry,
+    SnapshotV2PciWritableByte, SnapshotV2VirtioQueueState, SnapshotV2VirtioStateParts,
 };
 use crate::snapshot_memory_v2::write_snapshot_v2_memory_image_with_compatibility_version;
 use crate::storage_capture::StorageDeviceOrigin;
@@ -98,6 +98,18 @@ fn inactive_virtio() -> SnapshotV2VirtioState {
 }
 
 fn active_virtio() -> SnapshotV2VirtioState {
+    active_virtio_with_queue(
+        GuestAddress::new(0x10_0000),
+        GuestAddress::new(0x12_0000),
+        GuestAddress::new(0x14_0000),
+    )
+}
+
+fn active_virtio_with_queue(
+    descriptor_table: GuestAddress,
+    driver_ring: GuestAddress,
+    device_ring: GuestAddress,
+) -> SnapshotV2VirtioState {
     SnapshotV2VirtioState::from_parts(SnapshotV2VirtioStateParts {
         available_features: REQUIRED_FEATURES,
         driver_features: REQUIRED_FEATURES,
@@ -108,9 +120,9 @@ fn active_virtio() -> SnapshotV2VirtioState {
             VIRTIO_MEM_QUEUE_SIZE,
             VIRTIO_MEM_QUEUE_SIZE,
             true,
-            GuestAddress::new(0x10_0000),
-            GuestAddress::new(0x12_0000),
-            GuestAddress::new(0x14_0000),
+            descriptor_table,
+            driver_ring,
+            device_ring,
         )],
         pending_notifications: vec![0],
         interrupt_intents: vec![
@@ -346,6 +358,339 @@ fn kind_one_binding_closes_fragmented_plugged_unions_and_rejects_hostile_coverag
         assert!(!diagnostics.contains(&config_space.addr().to_string()));
         assert!(!diagnostics.contains(&first_start.to_string()));
     }
+}
+
+fn test_range(start: u64, size: u64) -> GuestMemoryRange {
+    GuestMemoryRange::new(GuestAddress::new(start), size)
+        .expect("test guest-memory range should validate")
+}
+
+fn plugged_guest_test_range(
+    state: &SnapshotV2MemoryHotplugState,
+    start_block: u64,
+    block_count: u64,
+) -> GuestMemoryRange {
+    let config_space = state.config_space();
+    let start = config_space
+        .addr()
+        .checked_add(
+            start_block
+                .checked_mul(config_space.block_size())
+                .expect("test plugged offset should fit"),
+        )
+        .expect("test plugged start should fit");
+    let size = block_count
+        .checked_mul(config_space.block_size())
+        .expect("test plugged size should fit");
+    test_range(start, size)
+}
+
+fn active_mmio_state_with_queue(
+    plugged_ranges: &[(usize, usize)],
+    descriptor_table: GuestAddress,
+    driver_ring: GuestAddress,
+    device_ring: GuestAddress,
+) -> SnapshotV2MemoryHotplugState {
+    let plugged_blocks = plugged_ranges
+        .iter()
+        .map(|(_, count)| u64::try_from(*count).expect("test block count should fit u64"))
+        .sum();
+    SnapshotV2MemoryHotplugState::try_new(
+        base_config(),
+        base_config_space(plugged_blocks),
+        Some(
+            SnapshotV2MemoryHotplugQueueState::try_new(7, 7)
+                .expect("equal active cursors should validate"),
+        ),
+        bitmap_with_ranges(plugged_ranges),
+        active_virtio_with_queue(descriptor_table, driver_ring, device_ring),
+        SnapshotV2DeviceTransport::Mmio(mmio_transport()),
+    )
+    .expect("active MMIO topology fixture should validate")
+}
+
+#[test]
+fn prepared_topology_preserves_ordered_partition_ranges_and_controller_projection() {
+    let state = inactive_mmio_state();
+    let aperture_start = state.config_space().addr();
+    let aperture_end = aperture_start + state.config_space().region_size();
+    let first = plugged_guest_test_range(&state, 1, 2);
+    let second = plugged_guest_test_range(&state, 5, 3);
+    let binding = binding_for_ranges(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        vec![
+            test_range(aarch64::DRAM_MEM_START, 4 * aarch64::GUEST_PAGE_SIZE),
+            test_range(first.start().raw_value(), state.config_space().block_size()),
+            test_range(
+                first.start().raw_value() + state.config_space().block_size(),
+                state.config_space().block_size(),
+            ),
+            second,
+            test_range(aperture_end, 4 * aarch64::GUEST_PAGE_SIZE),
+        ],
+    );
+    let expected_binding = binding.clone();
+    let expected_offsets = binding
+        .extents()
+        .iter()
+        .map(|extent| extent.file_offset())
+        .collect::<Vec<_>>();
+
+    let prepared = PreparedSnapshotV2MemoryHotplugTopology::prepare(state.clone(), binding)
+        .expect("closed fragmented topology should prepare");
+    assert_eq!(prepared.memory().binding(), &expected_binding);
+    assert_eq!(prepared.memory().extent_count(), 5);
+    let classified = prepared.memory().classified_extents().collect::<Vec<_>>();
+    assert_eq!(
+        classified
+            .iter()
+            .map(|classified| classified.class())
+            .collect::<Vec<_>>(),
+        vec![
+            SnapshotV2MemoryHotplugExtentClass::Base,
+            SnapshotV2MemoryHotplugExtentClass::Dynamic,
+            SnapshotV2MemoryHotplugExtentClass::Dynamic,
+            SnapshotV2MemoryHotplugExtentClass::Dynamic,
+            SnapshotV2MemoryHotplugExtentClass::Base,
+        ]
+    );
+    assert_eq!(
+        classified
+            .iter()
+            .map(|classified| classified.extent().file_offset())
+            .collect::<Vec<_>>(),
+        expected_offsets
+    );
+    assert_eq!(prepared.plugged_ranges(), &[first, second]);
+    assert_eq!(prepared.queue_ranges(), None);
+    assert_eq!(prepared.state(), &state);
+    assert_eq!(prepared.controller().config(), base_config());
+    assert_eq!(prepared.controller().requested_size_mib(), 128);
+    assert_eq!(
+        prepared.state().transport().kind(),
+        SnapshotV2DeviceTransportKind::Mmio
+    );
+
+    let sentinel = aperture_start.to_string();
+    for diagnostic in [
+        format!("{prepared:?}"),
+        format!("{:?}", prepared.memory()),
+        format!("{:?}", prepared.controller()),
+        format!("{:?}", classified[1]),
+    ] {
+        assert!(diagnostic.contains(REDACTED));
+        assert!(!diagnostic.contains(&sentinel));
+    }
+}
+
+#[test]
+fn prepared_topology_retains_active_pci_queue_in_one_base_extent() {
+    let state = active_pci_state();
+    let binding = binding_for_ranges(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        vec![
+            test_range(0x10_0000, 0x50_000),
+            plugged_guest_test_range(&state, 0, 1),
+            plugged_guest_test_range(&state, 7, 2),
+            plugged_guest_test_range(&state, 127, 1),
+        ],
+    );
+
+    let prepared = PreparedSnapshotV2MemoryHotplugTopology::prepare(state.clone(), binding)
+        .expect("active PCI queue in base memory should prepare");
+    assert!(prepared.queue_ranges().is_some());
+    assert!(prepared.state().active_queue().is_some());
+    assert_eq!(
+        prepared.state().transport().kind(),
+        SnapshotV2DeviceTransportKind::Pci
+    );
+    assert_eq!(
+        prepared
+            .memory()
+            .classified_extents()
+            .map(|classified| classified.class())
+            .collect::<Vec<_>>(),
+        vec![
+            SnapshotV2MemoryHotplugExtentClass::Base,
+            SnapshotV2MemoryHotplugExtentClass::Dynamic,
+            SnapshotV2MemoryHotplugExtentClass::Dynamic,
+            SnapshotV2MemoryHotplugExtentClass::Dynamic,
+        ]
+    );
+}
+
+#[test]
+fn dynamic_queue_uses_canonical_plugged_region_not_source_fragment_boundaries() {
+    let aperture = VIRTIO_MEM_DEFAULT_REGION_ADDRESS.raw_value();
+    let split = aperture + 2 * MIB;
+    let state = active_mmio_state_with_queue(
+        &[(0, 2)],
+        GuestAddress::new(split - 2048),
+        GuestAddress::new(aperture + 0x1000),
+        GuestAddress::new(aperture + 3 * MIB),
+    );
+    let binding = binding_for_ranges(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        vec![test_range(aperture, 2 * MIB), test_range(split, 2 * MIB)],
+    );
+
+    let prepared = PreparedSnapshotV2MemoryHotplugTopology::prepare(state, binding)
+        .expect("queue spanning adjacent dynamic source extents should prepare");
+    assert_eq!(prepared.plugged_ranges(), &[test_range(aperture, 4 * MIB)]);
+    assert!(
+        prepared
+            .memory()
+            .classified_extents()
+            .all(|classified| classified.class() == SnapshotV2MemoryHotplugExtentClass::Dynamic)
+    );
+}
+
+#[test]
+fn queue_topology_rejects_missing_gaps_source_boundaries_and_aperture_crossing() {
+    let active = active_pci_state();
+    let dynamic_only = binding_for_ranges(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        vec![
+            plugged_guest_test_range(&active, 0, 1),
+            plugged_guest_test_range(&active, 7, 2),
+            plugged_guest_test_range(&active, 127, 1),
+        ],
+    );
+    assert!(matches!(
+        PreparedSnapshotV2MemoryHotplugTopology::prepare_with_extent_class_allocation_failure(
+            active.clone(),
+            dynamic_only.clone(),
+        ),
+        Err(SnapshotV2MemoryHotplugPreparationError::QueueMemory)
+    ));
+    assert!(matches!(
+        PreparedSnapshotV2MemoryHotplugTopology::prepare(active, dynamic_only),
+        Err(SnapshotV2MemoryHotplugPreparationError::QueueMemory)
+    ));
+
+    let aperture = VIRTIO_MEM_DEFAULT_REGION_ADDRESS.raw_value();
+    let base_split = 0x20_0000;
+    let base_crossing = active_mmio_state_with_queue(
+        &[(0, 1)],
+        GuestAddress::new(base_split - 2048),
+        GuestAddress::new(base_split + 0x1_0000),
+        GuestAddress::new(base_split + 0x2_0000),
+    );
+    let base_fragmented = binding_for_ranges(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        vec![
+            test_range(
+                base_split - 4 * aarch64::GUEST_PAGE_SIZE,
+                4 * aarch64::GUEST_PAGE_SIZE,
+            ),
+            test_range(base_split, 0x30_000),
+            plugged_guest_test_range(&base_crossing, 0, 1),
+        ],
+    );
+    assert!(matches!(
+        PreparedSnapshotV2MemoryHotplugTopology::prepare(base_crossing, base_fragmented),
+        Err(SnapshotV2MemoryHotplugPreparationError::QueueMemory)
+    ));
+
+    let plugged_gap = active_mmio_state_with_queue(
+        &[(0, 1), (2, 1)],
+        GuestAddress::new(aperture + 2 * MIB - 2048),
+        GuestAddress::new(aperture + 0x1000),
+        GuestAddress::new(aperture + 4 * MIB + 0x1000),
+    );
+    let separated = binding_for_ranges(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        vec![
+            plugged_guest_test_range(&plugged_gap, 0, 1),
+            plugged_guest_test_range(&plugged_gap, 2, 1),
+        ],
+    );
+    assert!(matches!(
+        PreparedSnapshotV2MemoryHotplugTopology::prepare(plugged_gap, separated),
+        Err(SnapshotV2MemoryHotplugPreparationError::QueueMemory)
+    ));
+
+    let boundary_crossing = active_mmio_state_with_queue(
+        &[(0, 1)],
+        GuestAddress::new(aperture - 2048),
+        GuestAddress::new(aperture + 0x1000),
+        GuestAddress::new(aperture + 0x2000),
+    );
+    let boundary_binding = binding_for_ranges(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        vec![
+            test_range(
+                aperture - 4 * aarch64::GUEST_PAGE_SIZE,
+                4 * aarch64::GUEST_PAGE_SIZE,
+            ),
+            plugged_guest_test_range(&boundary_crossing, 0, 1),
+        ],
+    );
+    assert!(matches!(
+        PreparedSnapshotV2MemoryHotplugTopology::prepare(boundary_crossing, boundary_binding),
+        Err(SnapshotV2MemoryHotplugPreparationError::QueueBoundary)
+    ));
+}
+
+#[test]
+fn empty_topology_and_both_reservation_failures_are_deterministic() {
+    let empty = SnapshotV2MemoryHotplugState::try_new(
+        base_config(),
+        base_config_space(0),
+        None,
+        bitmap_with_ranges(&[]),
+        inactive_virtio(),
+        SnapshotV2DeviceTransport::Mmio(mmio_transport()),
+    )
+    .expect("empty topology state should validate");
+    let empty_binding = binding_for_ranges(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        vec![test_range(
+            aarch64::DRAM_MEM_START,
+            4 * aarch64::GUEST_PAGE_SIZE,
+        )],
+    );
+    let prepared =
+        PreparedSnapshotV2MemoryHotplugTopology::prepare(empty.clone(), empty_binding.clone())
+            .expect("empty plugged topology should prepare");
+    assert!(prepared.plugged_ranges().is_empty());
+    assert_eq!(
+        prepared
+            .memory()
+            .classified_extents()
+            .next()
+            .expect("base extent should remain")
+            .class(),
+        SnapshotV2MemoryHotplugExtentClass::Base
+    );
+
+    assert!(matches!(
+        PreparedSnapshotV2MemoryHotplugTopology::prepare_with_extent_class_allocation_failure(
+            empty,
+            empty_binding,
+        ),
+        Err(SnapshotV2MemoryHotplugPreparationError::Allocation)
+    ));
+    let nonempty = inactive_mmio_state();
+    let nonempty_binding = binding_for_ranges(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        vec![
+            plugged_guest_test_range(&nonempty, 1, 2),
+            plugged_guest_test_range(&nonempty, 5, 3),
+        ],
+    );
+    assert!(matches!(
+        PreparedSnapshotV2MemoryHotplugTopology::prepare_with_plugged_range_allocation_failure(
+            nonempty,
+            nonempty_binding,
+        ),
+        Err(SnapshotV2MemoryHotplugPreparationError::Allocation)
+    ));
+    let error = SnapshotV2MemoryHotplugPreparationError::Binding(
+        SnapshotV2MemoryHotplugBindingError::Coverage,
+    );
+    assert!(format!("{error:?}").contains("binding"));
+    assert!(!format!("{error:?} {error}").contains("536870912"));
 }
 
 fn section_offset(bytes: &[u8], index: usize) -> usize {


### PR DESCRIPTION
## Summary

- add an immutable, owner-free exact-2.10 virtio-mem topology that preserves
  the original memory binding with cardinality-locked base/dynamic extent tags
- retain canonical plugged GPA ranges, queue-ring geometry, complete decoded
  device/transport state, and a checked controller requested-size projection
- add an artifact preparation outcome that leaves no-kind-11 candidates
  unchanged and closes memory-bearing candidates without mapping memory
- cover MMIO/PCI, active/inactive, empty/separated/fragmented topology,
  planned-region queue validation, allocation failures, redaction, and every
  optional artifact component product

## Scope exclusions

- no memory-file descriptor retention, mapping, copy, dirty tracking, or clone
- no live virtio-mem owner, notifier, interrupt, MMIO/PCI endpoint, or HVF plan
- no public exact-2.10 activation or change to the public exact-2.9 writer/load
  boundary

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`

Closes #1692

Parent context: #1538
