### PR TITLE
feat: materialize mixed native-v2 snapshot memory

### DIFF
--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -12,6 +12,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 #[cfg(test)]
+use std::sync::Weak;
+#[cfg(test)]
 use std::sync::atomic::AtomicUsize;
 
 use crate::memory_dirty::{GuestMemoryDirtyTracker, GuestMemoryDirtyTrackerError};
@@ -488,6 +490,21 @@ pub struct GuestMemory {
     access_profile: GuestMemoryAccessProfile,
 }
 
+#[cfg(test)]
+#[derive(Debug)]
+pub(crate) struct GuestMemoryOwnerProbe {
+    mappings: Vec<Weak<GuestMemoryMapping>>,
+}
+
+#[cfg(test)]
+impl GuestMemoryOwnerProbe {
+    pub(crate) fn all_released(&self) -> bool {
+        self.mappings
+            .iter()
+            .all(|mapping| mapping.strong_count() == 0)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum GuestMemoryAccessProfile {
     Eager,
@@ -564,6 +581,40 @@ impl fmt::Debug for GuestMemoryAtomicU64 {
 }
 
 impl GuestMemory {
+    /// Constructs an internal eager owner before its first region is attached.
+    ///
+    /// This is intentionally narrower than [`GuestMemoryLayout`]: public
+    /// allocation still rejects empty layouts, while transactional builders
+    /// can accumulate reservations and active views without a placeholder
+    /// mapping.
+    pub(crate) fn empty_with_backing(backing: GuestMemoryBacking) -> Self {
+        Self {
+            regions: Vec::new(),
+            shared_reservations: Vec::new(),
+            dirty_tracker: None,
+            backing,
+            access_profile: GuestMemoryAccessProfile::Eager,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn try_owner_probe(&self) -> Result<GuestMemoryOwnerProbe, TryReserveError> {
+        let mut mappings = Vec::new();
+        mappings.try_reserve_exact(self.regions.len())?;
+        mappings.extend(
+            self.regions
+                .iter()
+                .map(|region| Arc::downgrade(&region.mapping)),
+        );
+        mappings.try_reserve_exact(self.shared_reservations.len())?;
+        mappings.extend(
+            self.shared_reservations
+                .iter()
+                .map(|region| Arc::downgrade(&region.mapping)),
+        );
+        Ok(GuestMemoryOwnerProbe { mappings })
+    }
+
     pub fn allocate(layout: &GuestMemoryLayout) -> Result<Self, GuestMemoryAllocationError> {
         Self::allocate_with_backing(layout, GuestMemoryBacking::Anonymous)
     }

--- a/crates/runtime/src/snapshot_artifact.rs
+++ b/crates/runtime/src/snapshot_artifact.rs
@@ -62,8 +62,11 @@ use crate::snapshot_memory_hotplug_v2_10::{
     SnapshotV2MemoryHotplugState, SnapshotV2MemoryHotplugStateDecodeError,
 };
 use crate::snapshot_memory_v2::{
-    SnapshotV2MemoryBinding, SnapshotV2MemoryLoadError, SnapshotV2MemoryStateError,
-    decode_snapshot_v2_memory_binding,
+    SnapshotV2MemoryBinding, SnapshotV2MemoryHotplugMaterializationError,
+    SnapshotV2MemoryHotplugMaterializationStage, SnapshotV2MemoryLoadError,
+    SnapshotV2MemoryStateError, decode_snapshot_v2_memory_binding,
+    materialize_snapshot_v2_memory_hotplug_file,
+    materialize_snapshot_v2_memory_hotplug_file_with_cancel,
 };
 #[cfg(target_os = "macos")]
 use crate::snapshot_memory_v2::{
@@ -1048,6 +1051,61 @@ impl PreparedNativeV2MemoryHotplugSnapshotCandidateState {
         &self.topology
     }
 
+    /// Materializes the exact candidate from one adopted memory descriptor.
+    pub fn materialize_memory_file(
+        self,
+        file: File,
+    ) -> Result<
+        MaterializedNativeV2MemoryHotplugSnapshotCandidateState,
+        SnapshotV2MemoryHotplugMaterializationError,
+    > {
+        let memory = materialize_snapshot_v2_memory_hotplug_file(&self.topology, file)?;
+        Ok(self.with_materialized_memory(memory))
+    }
+
+    /// Materializes the exact candidate with stable cancellation checkpoints.
+    pub fn materialize_memory_file_with_cancel<C>(
+        self,
+        file: File,
+        is_cancelled: C,
+    ) -> Result<
+        MaterializedNativeV2MemoryHotplugSnapshotCandidateState,
+        SnapshotV2MemoryHotplugMaterializationError,
+    >
+    where
+        C: FnMut(SnapshotV2MemoryHotplugMaterializationStage) -> bool,
+    {
+        let memory = materialize_snapshot_v2_memory_hotplug_file_with_cancel(
+            &self.topology,
+            file,
+            is_cancelled,
+        )?;
+        Ok(self.with_materialized_memory(memory))
+    }
+
+    fn with_materialized_memory(
+        self,
+        memory: GuestMemory,
+    ) -> MaterializedNativeV2MemoryHotplugSnapshotCandidateState {
+        let Self {
+            bytes,
+            device_graph,
+            serial,
+            entropy,
+            balloon,
+            topology,
+        } = self;
+        MaterializedNativeV2MemoryHotplugSnapshotCandidateState {
+            bytes,
+            device_graph,
+            serial,
+            entropy,
+            balloon,
+            topology,
+            memory,
+        }
+    }
+
     /// Consumes the candidate into its exact still-detached components.
     pub fn into_parts(self) -> PreparedNativeV2MemoryHotplugSnapshotCandidateParts {
         (
@@ -1071,6 +1129,108 @@ impl fmt::Debug for PreparedNativeV2MemoryHotplugSnapshotCandidateState {
             .field("has_balloon", &self.balloon.is_some())
             .field("state", &REDACTED)
             .field("memory_topology", &REDACTED)
+            .field("serial", &REDACTED)
+            .finish()
+    }
+}
+
+/// One unpublished exact-2.10 candidate with fully materialized mixed memory.
+///
+/// Exact encoded state, optional product components, prepared topology, and
+/// destination memory remain attached until the later platform-planning
+/// boundary consumes this value.
+pub struct MaterializedNativeV2MemoryHotplugSnapshotCandidateState {
+    bytes: Vec<u8>,
+    device_graph: Option<SnapshotV2StorageDeviceGraph>,
+    serial: SnapshotV2SerialState,
+    entropy: Option<SnapshotV2EntropyState>,
+    balloon: Option<SnapshotV2BalloonState>,
+    topology: PreparedSnapshotV2MemoryHotplugTopology,
+    memory: GuestMemory,
+}
+
+/// Owned exact components of one materialized memory-bearing 2.10 candidate.
+pub type MaterializedNativeV2MemoryHotplugSnapshotCandidateParts = (
+    Vec<u8>,
+    Option<SnapshotV2StorageDeviceGraph>,
+    SnapshotV2SerialState,
+    Option<SnapshotV2EntropyState>,
+    Option<SnapshotV2BalloonState>,
+    PreparedSnapshotV2MemoryHotplugTopology,
+    GuestMemory,
+);
+
+impl MaterializedNativeV2MemoryHotplugSnapshotCandidateState {
+    /// Returns the exact candidate compatibility version.
+    pub const fn version(&self) -> SnapshotFormatVersion {
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION
+    }
+
+    /// Returns the unchanged immutable encoded state bytes.
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Returns the exact binding attached to the materialized topology.
+    pub const fn memory_binding(&self) -> &SnapshotV2MemoryBinding {
+        self.topology.memory().binding()
+    }
+
+    /// Returns the optional unchanged profile-3 storage graph.
+    pub const fn device_graph(&self) -> Option<&SnapshotV2StorageDeviceGraph> {
+        self.device_graph.as_ref()
+    }
+
+    /// Returns the required unchanged exact-2.7 serial state.
+    pub const fn serial(&self) -> &SnapshotV2SerialState {
+        &self.serial
+    }
+
+    /// Returns the optional unchanged exact-2.8 entropy state.
+    pub const fn entropy(&self) -> Option<&SnapshotV2EntropyState> {
+        self.entropy.as_ref()
+    }
+
+    /// Returns the optional unchanged exact-2.9 balloon state.
+    pub const fn balloon(&self) -> Option<&SnapshotV2BalloonState> {
+        self.balloon.as_ref()
+    }
+
+    /// Returns the complete prepared kind-1/kind-11 topology.
+    pub const fn topology(&self) -> &PreparedSnapshotV2MemoryHotplugTopology {
+        &self.topology
+    }
+
+    /// Returns the mixed private-base/shared-aperture guest-memory owner.
+    pub const fn memory(&self) -> &GuestMemory {
+        &self.memory
+    }
+
+    /// Consumes the candidate into one inseparable exact-parts handoff.
+    pub fn into_parts(self) -> MaterializedNativeV2MemoryHotplugSnapshotCandidateParts {
+        (
+            self.bytes,
+            self.device_graph,
+            self.serial,
+            self.entropy,
+            self.balloon,
+            self.topology,
+            self.memory,
+        )
+    }
+}
+
+impl fmt::Debug for MaterializedNativeV2MemoryHotplugSnapshotCandidateState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MaterializedNativeV2MemoryHotplugSnapshotCandidateState")
+            .field("version", &self.version())
+            .field("has_storage", &self.device_graph.is_some())
+            .field("has_entropy", &self.entropy.is_some())
+            .field("has_balloon", &self.balloon.is_some())
+            .field("state", &REDACTED)
+            .field("memory_topology", &REDACTED)
+            .field("memory", &REDACTED)
             .field("serial", &REDACTED)
             .finish()
     }

--- a/crates/runtime/src/snapshot_artifact/tests.rs
+++ b/crates/runtime/src/snapshot_artifact/tests.rs
@@ -42,9 +42,11 @@ use std::fs;
 #[cfg(target_os = "macos")]
 use std::io::{BufRead, BufReader, Cursor, Seek, SeekFrom, Write};
 #[cfg(target_os = "macos")]
+use std::os::fd::AsFd;
+#[cfg(target_os = "macos")]
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 #[cfg(target_os = "macos")]
-use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
+use std::os::unix::fs::{FileExt, MetadataExt, PermissionsExt, symlink};
 #[cfg(target_os = "macos")]
 use std::os::unix::net::UnixListener;
 #[cfg(target_os = "macos")]
@@ -771,6 +773,7 @@ fn exact_minor_nine_candidate_rejects_balloon_cardinality_payload_and_version_mi
 #[cfg(target_os = "macos")]
 #[test]
 fn exact_minor_ten_products_prepare_or_preserve_every_optional_component_product() {
+    let directory = TestDirectory::new("mixed-products");
     let storage_payload = fixture_bytes(include_str!(
         "../snapshot_device_v2_6/fixtures/block-root-mmio.hex"
     ));
@@ -789,33 +792,67 @@ fn exact_minor_ten_products_prepare_or_preserve_every_optional_component_product
     )
     .expect("base exact 2.10 memory should encode internally");
 
+    let inactive_mmio_payload = fixture_bytes(include_str!(
+        "../snapshot_memory_hotplug_v2_10/fixtures/inactive-mmio.hex"
+    ));
+    let inactive_mmio_state = SnapshotV2MemoryHotplugState::decode(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        &inactive_mmio_payload,
+    )
+    .expect("inactive MMIO exact 2.10 fixture should decode");
+    let active_pci_payload = fixture_bytes(include_str!(
+        "../snapshot_memory_hotplug_v2_10/fixtures/active-pci.hex"
+    ));
+    let active_pci_state = SnapshotV2MemoryHotplugState::decode(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        &active_pci_payload,
+    )
+    .expect("active PCI exact 2.10 fixture should decode");
+    let (active_config, active_config_space, active_queue, active_bitmap, active_virtio, _) =
+        active_pci_state.clone().into_parts();
+    let (_, _, _, _, _, inactive_mmio_transport) = inactive_mmio_state.clone().into_parts();
+    let active_mmio_state = SnapshotV2MemoryHotplugState::try_new(
+        active_config,
+        active_config_space,
+        active_queue,
+        active_bitmap,
+        active_virtio,
+        inactive_mmio_transport,
+    )
+    .expect("active MMIO exact 2.10 state should validate");
+    let active_mmio_payload = active_mmio_state
+        .encode(NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION)
+        .expect("active MMIO exact 2.10 state should encode");
+
     let mut profiles = Vec::new();
-    for payload in [
-        fixture_bytes(include_str!(
-            "../snapshot_memory_hotplug_v2_10/fixtures/inactive-mmio.hex"
-        )),
-        fixture_bytes(include_str!(
-            "../snapshot_memory_hotplug_v2_10/fixtures/active-pci.hex"
-        )),
+    for (payload, state) in [
+        (inactive_mmio_payload, inactive_mmio_state),
+        (active_mmio_payload, active_mmio_state),
+        (active_pci_payload, active_pci_state),
     ] {
-        let state = SnapshotV2MemoryHotplugState::decode(
-            NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
-            &payload,
-        )
-        .expect("exact 2.10 virtio-mem fixture should decode");
         let memory = test_v2_memory_with_hotplug(&state);
+        let mut image = Cursor::new(Vec::new());
         let binding = write_snapshot_v2_memory_image_with_compatibility_version(
             &memory,
-            &mut Cursor::new(Vec::new()),
+            &mut image,
             NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
         )
         .expect("dynamic exact 2.10 memory should encode internally");
-        profiles.push((payload, state, binding));
+        profiles.push((payload, state, binding, image.into_inner()));
     }
 
     let mut prepared_count = 0;
     let mut compatible_count = 0;
-    for (memory_hotplug_payload, memory_hotplug_state, hotplug_binding) in &profiles {
+    let mut materialized_count = 0;
+    for (
+        profile_index,
+        (memory_hotplug_payload, memory_hotplug_state, hotplug_binding, memory_image),
+    ) in profiles.iter().enumerate()
+    {
+        let image_path = directory
+            .path
+            .join(format!("memory-profile-{profile_index}.snap"));
+        fs::write(&image_path, memory_image).expect("profile memory image should write");
         for with_storage in [false, true] {
             for with_entropy in [false, true] {
                 for with_balloon in [false, true] {
@@ -922,6 +959,33 @@ fn exact_minor_ten_products_prepare_or_preserve_every_optional_component_product
                             let prepared_debug = format!("{prepared:?}");
                             assert!(prepared_debug.contains(REDACTED));
                             assert!(!prepared_debug.contains("BANGME2"));
+
+                            let materialized = prepared_memory_hotplug_candidate(bytes.clone())
+                                .materialize_memory_file(
+                                    File::open(&image_path)
+                                        .expect("profile image should open read-only"),
+                                )
+                                .expect("every exact optional product should materialize");
+                            assert_eq!(materialized.bytes(), bytes);
+                            assert_eq!(materialized.memory_binding(), binding);
+                            assert_eq!(materialized.device_graph(), expected_device_graph.as_ref());
+                            assert_eq!(materialized.serial(), &expected_serial);
+                            assert_eq!(materialized.entropy(), expected_entropy.as_ref());
+                            assert_eq!(materialized.balloon(), expected_balloon.as_ref());
+                            assert_eq!(materialized.topology().state(), memory_hotplug_state);
+                            assert!(
+                                materialized
+                                    .memory()
+                                    .dirty_tracker()
+                                    .expect("materialized product should track dirty pages")
+                                    .dirty_pages()
+                                    .expect("materialized product dirty pages should query")
+                                    .is_empty()
+                            );
+                            let materialized_debug = format!("{materialized:?}");
+                            assert!(materialized_debug.contains(REDACTED));
+                            assert!(!materialized_debug.contains("BANGME2"));
+                            materialized_count += 1;
                             prepared_count += 1;
                         } else {
                             let compatible_candidate = preparation
@@ -958,8 +1022,699 @@ fn exact_minor_ten_products_prepare_or_preserve_every_optional_component_product
             }
         }
     }
-    assert_eq!(prepared_count, 16);
-    assert_eq!(compatible_count, 16);
+    assert_eq!(prepared_count, 24);
+    assert_eq!(compatible_count, 24);
+    assert_eq!(materialized_count, 24);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn exact_minor_ten_materialization_preserves_bytes_ownership_and_clean_isolation() {
+    let directory = TestDirectory::new("mixed-memory");
+    let memory_hotplug_payload = fixture_bytes(include_str!(
+        "../snapshot_memory_hotplug_v2_10/fixtures/active-pci.hex"
+    ));
+    let state = SnapshotV2MemoryHotplugState::decode(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        &memory_hotplug_payload,
+    )
+    .expect("active exact 2.10 virtio-mem fixture should decode");
+    let mut source_memory = test_v2_memory_with_hotplug(&state);
+    let source_ranges = source_memory
+        .regions()
+        .iter()
+        .map(|region| region.range())
+        .collect::<Vec<_>>();
+    for (region_index, range) in source_ranges.iter().copied().enumerate() {
+        let length = usize::try_from(range.size()).expect("fixture range should fit usize");
+        let bytes = (0..length)
+            .map(|byte_index| {
+                u8::try_from((region_index * 73 + byte_index) % 251)
+                    .expect("fixture byte should fit")
+            })
+            .collect::<Vec<_>>();
+        source_memory
+            .write_slice(&bytes, range.start())
+            .expect("fixture bytes should write");
+    }
+    let source_tracker = source_memory
+        .enable_dirty_tracking()
+        .expect("source fixture dirty tracking should enable");
+    assert_eq!(source_tracker.clear_quiesced(), 1);
+    assert_eq!(source_tracker.clear_quiesced(), 2);
+    source_memory
+        .write_slice(&[0x3c], source_ranges[0].start())
+        .expect("source fixture should record a later dirty epoch");
+    assert_eq!(source_tracker.epoch(), 2);
+    assert!(
+        !source_tracker
+            .dirty_pages()
+            .expect("source fixture dirty pages should query")
+            .is_empty()
+    );
+
+    let mut image = Cursor::new(Vec::new());
+    let binding = write_snapshot_v2_memory_image_with_compatibility_version(
+        &source_memory,
+        &mut image,
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+    )
+    .expect("mixed exact 2.10 memory should encode");
+    let image = image.into_inner();
+    let state_bytes = memory_hotplug_v2_10_state(
+        &binding,
+        None,
+        &[],
+        &[],
+        &[(
+            NATIVE_V2_MEMORY_HOTPLUG_COMPONENT_KEY,
+            SnapshotV2ComponentDisposition::Semantic,
+            memory_hotplug_payload.as_slice(),
+        )],
+    )
+    .expect("mixed exact 2.10 state should encode");
+
+    let source_path = directory.path.join("memory.snap");
+    let retained_path = directory.path.join("retained.snap");
+    fs::write(&source_path, &image).expect("source image should write");
+    let adopted = File::open(&source_path).expect("source image should open read-only");
+    fs::rename(&source_path, &retained_path).expect("opened source path should move");
+    fs::write(&source_path, vec![0xa5; image.len()])
+        .expect("replacement path should contain unrelated bytes");
+
+    let first = prepared_memory_hotplug_candidate(state_bytes.clone())
+        .materialize_memory_file(adopted)
+        .expect("adopted descriptor should materialize despite path replacement");
+    let second = prepared_memory_hotplug_candidate(state_bytes.clone())
+        .materialize_memory_file(
+            File::open(&retained_path).expect("retained source should reopen read-only"),
+        )
+        .expect("same image should materialize independently");
+
+    assert_eq!(first.bytes(), state_bytes);
+    assert_eq!(first.memory_binding(), &binding);
+    assert_eq!(first.topology().state(), &state);
+    let aperture = GuestMemoryRange::new(
+        GuestAddress::new(state.config_space().addr()),
+        state.config_space().region_size(),
+    )
+    .expect("fixture aperture should validate");
+    let first_reservation = first
+        .memory()
+        .shared_reservation_capture_state(aperture)
+        .expect("first shared reservation should exist");
+    let second_reservation = second
+        .memory()
+        .shared_reservation_capture_state(aperture)
+        .expect("second shared reservation should exist");
+    assert_ne!(
+        first_reservation.mapping_identity(),
+        second_reservation.mapping_identity()
+    );
+
+    for classified in first.topology().memory().classified_extents() {
+        if classified.class()
+            == crate::snapshot_memory_hotplug_v2_10::SnapshotV2MemoryHotplugExtentClass::Base
+        {
+            let region = first
+                .memory()
+                .regions()
+                .iter()
+                .find(|region| region.range() == classified.extent().range())
+                .expect("every base extent should remain an active region");
+            assert_eq!(region.backing(), GuestMemoryRegionBacking::PrivateFile);
+        }
+    }
+    for range in first.topology().plugged_ranges() {
+        let region = first
+            .memory()
+            .regions()
+            .iter()
+            .find(|region| region.range() == *range)
+            .expect("every canonical plugged range should be active");
+        assert_eq!(region.backing(), GuestMemoryRegionBacking::Shared);
+        assert_eq!(
+            region.mapping_identity(),
+            first_reservation.mapping_identity()
+        );
+    }
+
+    for range in source_ranges {
+        let length = usize::try_from(range.size()).expect("fixture range should fit usize");
+        let mut expected = vec![0; length];
+        let mut first_actual = vec![0; length];
+        let mut second_actual = vec![0; length];
+        source_memory
+            .read_slice(&mut expected, range.start())
+            .expect("source bytes should read");
+        first
+            .memory()
+            .read_slice(&mut first_actual, range.start())
+            .expect("first materialized bytes should read");
+        second
+            .memory()
+            .read_slice(&mut second_actual, range.start())
+            .expect("second materialized bytes should read");
+        assert_eq!(first_actual, expected);
+        assert_eq!(second_actual, expected);
+    }
+
+    let offline = (0..state.config_space().region_size() / state.config_space().block_size())
+        .map(|block| {
+            GuestAddress::new(
+                state.config_space().addr() + block * state.config_space().block_size(),
+            )
+        })
+        .find(|address| {
+            !first
+                .topology()
+                .plugged_ranges()
+                .iter()
+                .any(|range| range.contains(*address))
+        })
+        .expect("active fixture should retain at least one offline block");
+    assert!(
+        first.memory().read_slice(&mut [0], offline).is_err(),
+        "offline aperture bytes must remain inaccessible"
+    );
+    for materialized in [&first, &second] {
+        let tracker = materialized
+            .memory()
+            .dirty_tracker()
+            .expect("materialized memory should have a dirty tracker");
+        assert_eq!(tracker.epoch(), 0);
+        assert!(
+            tracker
+                .dirty_pages()
+                .expect("clean dirty pages should query")
+                .is_empty()
+        );
+    }
+
+    let debug = format!("{first:?}");
+    assert!(debug.contains(REDACTED));
+    assert!(!debug.contains("BANGME2"));
+    assert!(!debug.contains(&state.config_space().addr().to_string()));
+
+    let (_, _, _, _, _, first_topology, mut first_memory) = first.into_parts();
+    let base_range = first_topology
+        .memory()
+        .classified_extents()
+        .find(|classified| {
+            classified.class()
+                == crate::snapshot_memory_hotplug_v2_10::SnapshotV2MemoryHotplugExtentClass::Base
+        })
+        .expect("mixed fixture should contain base memory")
+        .extent()
+        .range();
+    let mut second_base_before = [0_u8; 1];
+    second
+        .memory()
+        .read_slice(&mut second_base_before, base_range.start())
+        .expect("second base byte should read");
+    first_memory
+        .write_slice(&[second_base_before[0] ^ 0xff], base_range.start())
+        .expect("first private base byte should accept a COW write");
+    let mut second_base_after = [0_u8; 1];
+    second
+        .memory()
+        .read_slice(&mut second_base_after, base_range.start())
+        .expect("second base byte should remain readable");
+    assert_eq!(second_base_after, second_base_before);
+
+    let dynamic_range = *first_topology
+        .plugged_ranges()
+        .first()
+        .expect("active fixture should contain plugged memory");
+    let mut second_before = [0_u8; 1];
+    second
+        .memory()
+        .read_slice(&mut second_before, dynamic_range.start())
+        .expect("second dynamic byte should read");
+    first_memory
+        .write_slice(&[second_before[0] ^ 0xff], dynamic_range.start())
+        .expect("first dynamic byte should mutate independently");
+    let mut second_after = [0_u8; 1];
+    second
+        .memory()
+        .read_slice(&mut second_after, dynamic_range.start())
+        .expect("second dynamic byte should remain readable");
+    assert_eq!(second_after, second_before);
+
+    let tracker = first_memory
+        .dirty_tracker()
+        .expect("first dirty tracker should remain attached");
+    assert!(
+        !tracker
+            .dirty_pages()
+            .expect("dirty pages should query")
+            .is_empty()
+    );
+    assert_eq!(tracker.clear_quiesced(), 1);
+    assert!(
+        tracker
+            .dirty_pages()
+            .expect("cleared dirty pages should query")
+            .is_empty()
+    );
+    first_memory
+        .remove_region(dynamic_range)
+        .expect("dynamic view should remove");
+    assert!(!tracker.contains_range(dynamic_range));
+    first_memory
+        .insert_region(dynamic_range)
+        .expect("dynamic view should reinsert from the retained reservation");
+    assert!(tracker.contains_range(dynamic_range));
+    assert!(
+        !tracker
+            .dirty_pages()
+            .expect("reinserted dirty pages should query")
+            .is_empty(),
+        "reinserted dynamic memory must be conservatively dirty"
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn exact_minor_ten_materialization_cancels_at_every_accumulated_stage_and_retries() {
+    let directory = TestDirectory::new("mixed-cancel");
+    let memory_hotplug_payload = fixture_bytes(include_str!(
+        "../snapshot_memory_hotplug_v2_10/fixtures/active-pci.hex"
+    ));
+    let state = SnapshotV2MemoryHotplugState::decode(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        &memory_hotplug_payload,
+    )
+    .expect("active exact 2.10 virtio-mem fixture should decode");
+    let memory = test_v2_memory_with_hotplug(&state);
+    let mut image = Cursor::new(Vec::new());
+    let binding = write_snapshot_v2_memory_image_with_compatibility_version(
+        &memory,
+        &mut image,
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+    )
+    .expect("mixed exact 2.10 memory should encode");
+    let state_bytes = memory_hotplug_v2_10_state(
+        &binding,
+        None,
+        &[],
+        &[],
+        &[(
+            NATIVE_V2_MEMORY_HOTPLUG_COMPONENT_KEY,
+            SnapshotV2ComponentDisposition::Semantic,
+            memory_hotplug_payload.as_slice(),
+        )],
+    )
+    .expect("mixed exact 2.10 state should encode");
+    let source_path = directory.path.join("memory.snap");
+    fs::write(&source_path, image.into_inner()).expect("source image should write");
+
+    let stages = [
+        SnapshotV2MemoryHotplugMaterializationStage::SourceValidation,
+        SnapshotV2MemoryHotplugMaterializationStage::BaseInventory,
+        SnapshotV2MemoryHotplugMaterializationStage::BaseMappings,
+        SnapshotV2MemoryHotplugMaterializationStage::BaseStability,
+        SnapshotV2MemoryHotplugMaterializationStage::ApertureReservation,
+        SnapshotV2MemoryHotplugMaterializationStage::PluggedViews,
+        SnapshotV2MemoryHotplugMaterializationStage::CopyBuffer,
+        SnapshotV2MemoryHotplugMaterializationStage::DynamicCopy,
+        SnapshotV2MemoryHotplugMaterializationStage::DirtyTracking,
+        SnapshotV2MemoryHotplugMaterializationStage::FinalStability,
+        SnapshotV2MemoryHotplugMaterializationStage::Complete,
+    ];
+    for target in stages {
+        let error = prepared_memory_hotplug_candidate(state_bytes.clone())
+            .materialize_memory_file_with_cancel(
+                File::open(&source_path).expect("source should reopen read-only"),
+                |stage| stage == target,
+            )
+            .expect_err("targeted checkpoint should cancel");
+        assert!(matches!(
+            error,
+            SnapshotV2MemoryHotplugMaterializationError::Cancelled { stage }
+                if stage == target
+        ));
+        let diagnostic = format!("{error:?} {error}");
+        assert!(!diagnostic.contains(&state.config_space().addr().to_string()));
+        assert!(!diagnostic.contains("memory.snap"));
+    }
+
+    for (target, target_occurrence) in [
+        (SnapshotV2MemoryHotplugMaterializationStage::PluggedViews, 2),
+        (SnapshotV2MemoryHotplugMaterializationStage::DynamicCopy, 2),
+    ] {
+        let mut occurrence = 0;
+        let error = prepared_memory_hotplug_candidate(state_bytes.clone())
+            .materialize_memory_file_with_cancel(
+                File::open(&source_path).expect("source should reopen read-only"),
+                |stage| {
+                    if stage == target {
+                        occurrence += 1;
+                    }
+                    stage == target && occurrence == target_occurrence
+                },
+            )
+            .expect_err("later repeated checkpoint should cancel");
+        assert!(matches!(
+            error,
+            SnapshotV2MemoryHotplugMaterializationError::Cancelled { stage }
+                if stage == target
+        ));
+        assert_eq!(occurrence, target_occurrence);
+    }
+
+    prepared_memory_hotplug_candidate(state_bytes)
+        .materialize_memory_file(
+            File::open(&source_path).expect("source should reopen after every rollback"),
+        )
+        .expect("a fresh transaction should succeed after every cancellation");
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn exact_minor_ten_materialization_detects_both_mutation_windows_and_short_reads() {
+    let directory = TestDirectory::new("mixed-mutate");
+    let memory_hotplug_payload = fixture_bytes(include_str!(
+        "../snapshot_memory_hotplug_v2_10/fixtures/active-pci.hex"
+    ));
+    let state = SnapshotV2MemoryHotplugState::decode(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        &memory_hotplug_payload,
+    )
+    .expect("active exact 2.10 virtio-mem fixture should decode");
+    let memory = test_v2_memory_with_hotplug(&state);
+    let mut image = Cursor::new(Vec::new());
+    let binding = write_snapshot_v2_memory_image_with_compatibility_version(
+        &memory,
+        &mut image,
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+    )
+    .expect("mixed exact 2.10 memory should encode");
+    let image = image.into_inner();
+    let state_bytes = memory_hotplug_v2_10_state(
+        &binding,
+        None,
+        &[],
+        &[],
+        &[(
+            NATIVE_V2_MEMORY_HOTPLUG_COMPONENT_KEY,
+            SnapshotV2ComponentDisposition::Semantic,
+            memory_hotplug_payload.as_slice(),
+        )],
+    )
+    .expect("mixed exact 2.10 state should encode");
+
+    for target in [
+        SnapshotV2MemoryHotplugMaterializationStage::BaseStability,
+        SnapshotV2MemoryHotplugMaterializationStage::FinalStability,
+    ] {
+        let source_path = directory.path.join(format!("mutation-{target:?}.snap"));
+        fs::write(&source_path, &image).expect("source image should write");
+        let adopted = File::open(&source_path).expect("source should open read-only");
+        let writable = fs::OpenOptions::new()
+            .write(true)
+            .open(&source_path)
+            .expect("test mutation handle should open");
+        let mut mutated = false;
+        let error = prepared_memory_hotplug_candidate(state_bytes.clone())
+            .materialize_memory_file_with_cancel(adopted, |stage| {
+                if stage == target && !mutated {
+                    writable
+                        .write_at(&[0x5a], binding.extents()[0].file_offset())
+                        .expect("test source mutation should write");
+                    mutated = true;
+                }
+                false
+            })
+            .expect_err("source mutation should fail the adjacent stability gate");
+        assert!(matches!(
+            error,
+            SnapshotV2MemoryHotplugMaterializationError::Source { stage, .. }
+                if stage == target
+        ));
+    }
+
+    let short_path = directory.path.join("short.snap");
+    fs::write(&short_path, &image).expect("short-read source should write");
+    let adopted = File::open(&short_path).expect("short-read source should open read-only");
+    let writable = fs::OpenOptions::new()
+        .write(true)
+        .open(&short_path)
+        .expect("truncate handle should open");
+    let mut truncated = false;
+    let error = prepared_memory_hotplug_candidate(state_bytes)
+        .materialize_memory_file_with_cancel(adopted, |stage| {
+            if stage == SnapshotV2MemoryHotplugMaterializationStage::DynamicCopy && !truncated {
+                writable
+                    .set_len(0)
+                    .expect("test source truncation should succeed");
+                truncated = true;
+            }
+            false
+        })
+        .expect_err("truncation during positional copy should fail");
+    assert!(matches!(
+        error,
+        SnapshotV2MemoryHotplugMaterializationError::Read {
+            stage: SnapshotV2MemoryHotplugMaterializationStage::DynamicCopy,
+            kind: io::ErrorKind::UnexpectedEof,
+        }
+    ));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn exact_minor_ten_dynamic_only_materialization_uses_no_placeholder_or_private_mapping() {
+    let directory = TestDirectory::new("mixed-dynamic");
+    let memory_hotplug_payload = fixture_bytes(include_str!(
+        "../snapshot_memory_hotplug_v2_10/fixtures/inactive-mmio.hex"
+    ));
+    let state = SnapshotV2MemoryHotplugState::decode(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        &memory_hotplug_payload,
+    )
+    .expect("inactive exact 2.10 virtio-mem fixture should decode");
+    let memory = test_v2_memory_with_hotplug_data_only(&state);
+    let mut image = Cursor::new(Vec::new());
+    let binding = write_snapshot_v2_memory_image_with_compatibility_version(
+        &memory,
+        &mut image,
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+    )
+    .expect("dynamic-only exact 2.10 memory should encode");
+    let state_bytes = memory_hotplug_v2_10_state(
+        &binding,
+        None,
+        &[],
+        &[],
+        &[(
+            NATIVE_V2_MEMORY_HOTPLUG_COMPONENT_KEY,
+            SnapshotV2ComponentDisposition::Semantic,
+            memory_hotplug_payload.as_slice(),
+        )],
+    )
+    .expect("dynamic-only exact 2.10 state should encode");
+    let source_path = directory.path.join("memory.snap");
+    fs::write(&source_path, image.into_inner()).expect("source image should write");
+
+    let materialized = prepared_memory_hotplug_candidate(state_bytes)
+        .materialize_memory_file(
+            File::open(&source_path).expect("dynamic-only source should open read-only"),
+        )
+        .expect("dynamic-only topology should materialize");
+    assert_eq!(
+        materialized.memory().regions().len(),
+        materialized.topology().plugged_ranges().len()
+    );
+    assert!(
+        materialized
+            .memory()
+            .regions()
+            .iter()
+            .all(|region| region.backing() == GuestMemoryRegionBacking::Shared)
+    );
+    assert!(
+        materialized
+            .memory()
+            .dirty_tracker()
+            .expect("dynamic-only dirty tracker should exist")
+            .dirty_pages()
+            .expect("dynamic-only dirty pages should query")
+            .is_empty()
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn exact_minor_ten_fresh_process_uses_distinct_unlinked_backing_and_independent_bytes() {
+    let directory = TestDirectory::new("mixed-process");
+    let memory_hotplug_payload = fixture_bytes(include_str!(
+        "../snapshot_memory_hotplug_v2_10/fixtures/active-pci.hex"
+    ));
+    let state = SnapshotV2MemoryHotplugState::decode(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        &memory_hotplug_payload,
+    )
+    .expect("active exact 2.10 virtio-mem fixture should decode");
+    let memory = test_v2_memory_with_hotplug(&state);
+    let mut image = Cursor::new(Vec::new());
+    let binding = write_snapshot_v2_memory_image_with_compatibility_version(
+        &memory,
+        &mut image,
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+    )
+    .expect("mixed exact 2.10 memory should encode");
+    let state_bytes = memory_hotplug_v2_10_state(
+        &binding,
+        None,
+        &[],
+        &[],
+        &[(
+            NATIVE_V2_MEMORY_HOTPLUG_COMPONENT_KEY,
+            SnapshotV2ComponentDisposition::Semantic,
+            memory_hotplug_payload.as_slice(),
+        )],
+    )
+    .expect("mixed exact 2.10 state should encode");
+    let state_path = directory.path.join("state.snap");
+    let memory_path = directory.path.join("memory.snap");
+    fs::write(&state_path, &state_bytes).expect("child state should write");
+    fs::write(&memory_path, image.into_inner()).expect("child memory should write");
+
+    let parent = prepared_memory_hotplug_candidate(state_bytes)
+        .materialize_memory_file(
+            File::open(&memory_path).expect("parent source should open read-only"),
+        )
+        .expect("parent memory should materialize");
+    let aperture = GuestMemoryRange::new(
+        GuestAddress::new(state.config_space().addr()),
+        state.config_space().region_size(),
+    )
+    .expect("fixture aperture should validate");
+    let parent_metadata = shared_reservation_metadata(parent.memory(), aperture);
+    assert_eq!(parent_metadata.nlink(), 0);
+
+    let executable = std::env::current_exe().expect("test executable should resolve");
+    let mut child = Command::new(executable)
+        .arg("--ignored")
+        .arg("--exact")
+        .arg("snapshot_artifact::tests::mixed_memory_materialization_child")
+        .arg("--nocapture")
+        .arg("--test-threads=1")
+        .env("BANGBANG_MIXED_STATE", &state_path)
+        .env("BANGBANG_MIXED_MEMORY", &memory_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("mixed-memory child should spawn");
+    let mut child_stdin = child.stdin.take().expect("child stdin should exist");
+    let mut child_stdout = BufReader::new(child.stdout.take().expect("child stdout should exist"));
+    let child_identity = loop {
+        let mut line = String::new();
+        let count = child_stdout
+            .read_line(&mut line)
+            .expect("child ready output should read");
+        assert_ne!(count, 0, "child exited before publishing its identity");
+        let Some(marker) = line.find("mixed-child:ready ") else {
+            continue;
+        };
+        let values = line[marker + "mixed-child:ready ".len()..]
+            .split_whitespace()
+            .map(|value| value.parse::<u64>().expect("child identity should parse"))
+            .collect::<Vec<_>>();
+        assert_eq!(values.len(), 4);
+        break (values[0], values[1], values[2], values[3]);
+    };
+    assert_eq!(child_identity.2, 0);
+    assert_ne!(
+        (parent_metadata.dev(), parent_metadata.ino()),
+        (child_identity.0, child_identity.1),
+        "concurrently live fresh-process reservations must be different unlinked objects"
+    );
+    assert_eq!(child_identity.3, 0);
+
+    let (_, _, _, _, _, topology, mut parent_memory) = parent.into_parts();
+    let dynamic_start = topology
+        .plugged_ranges()
+        .first()
+        .expect("active fixture should contain plugged memory")
+        .start();
+    parent_memory
+        .write_slice(&[0x5a], dynamic_start)
+        .expect("parent destination byte should mutate");
+    child_stdin
+        .write_all(&[1])
+        .expect("child continuation signal should write");
+    drop(child_stdin);
+    let mut remainder = String::new();
+    child_stdout
+        .read_to_string(&mut remainder)
+        .expect("child completion output should read");
+    let status = child.wait().expect("mixed-memory child should wait");
+    assert!(status.success(), "{remainder}");
+    assert!(
+        remainder.contains("mixed-child:byte 0"),
+        "child destination should not observe parent mutation: {remainder}"
+    );
+    let mut source_byte = [0_u8; 1];
+    File::open(&memory_path)
+        .expect("source should reopen read-only")
+        .read_exact_at(&mut source_byte, binding.extents()[1].file_offset())
+        .expect("source sentinel should read");
+    assert_eq!(source_byte, [0]);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "launched by the mixed-memory fresh-process parent"]
+fn mixed_memory_materialization_child() {
+    let Some(state_path) = std::env::var_os("BANGBANG_MIXED_STATE") else {
+        return;
+    };
+    let Some(memory_path) = std::env::var_os("BANGBANG_MIXED_MEMORY") else {
+        return;
+    };
+    let state_bytes = fs::read(state_path).expect("child state should read");
+    let materialized = prepared_memory_hotplug_candidate(state_bytes)
+        .materialize_memory_file(
+            File::open(memory_path).expect("child source should open read-only"),
+        )
+        .expect("child memory should materialize");
+    let config = materialized.topology().state().config_space();
+    let aperture = GuestMemoryRange::new(GuestAddress::new(config.addr()), config.region_size())
+        .expect("child aperture should validate");
+    let metadata = shared_reservation_metadata(materialized.memory(), aperture);
+    let dynamic_start = materialized
+        .topology()
+        .plugged_ranges()
+        .first()
+        .expect("child should contain plugged memory")
+        .start();
+    let mut byte = [0_u8; 1];
+    materialized
+        .memory()
+        .read_slice(&mut byte, dynamic_start)
+        .expect("child destination byte should read");
+    println!(
+        "mixed-child:ready {} {} {} {}",
+        metadata.dev(),
+        metadata.ino(),
+        metadata.nlink(),
+        byte[0]
+    );
+    io::stdout()
+        .flush()
+        .expect("child ready signal should flush");
+    let mut start = [0_u8; 1];
+    io::stdin()
+        .read_exact(&mut start)
+        .expect("parent continuation signal should arrive");
+    materialized
+        .memory()
+        .read_slice(&mut byte, dynamic_start)
+        .expect("child destination byte should remain readable");
+    println!("mixed-child:byte {}", byte[0]);
 }
 
 #[cfg(target_os = "macos")]
@@ -3775,6 +4530,41 @@ fn memory_hotplug_v2_10_state(
         &components,
     )
     .map_err(|source| source.to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn prepared_memory_hotplug_candidate(
+    bytes: Vec<u8>,
+) -> PreparedNativeV2MemoryHotplugSnapshotCandidateState {
+    let preparation =
+        NativeV2MemoryHotplugSnapshotCandidateState::from_memory_hotplug_state_v2_10(bytes)
+            .expect("exact 2.10 candidate should validate")
+            .prepare()
+            .expect("exact 2.10 topology should prepare");
+    match preparation {
+        NativeV2MemoryHotplugSnapshotPreparation::Prepared(candidate) => Some(candidate),
+        NativeV2MemoryHotplugSnapshotPreparation::Compatible(_) => None,
+    }
+    .expect("kind-11 fixture should produce a prepared candidate")
+}
+
+#[cfg(target_os = "macos")]
+fn shared_reservation_metadata(memory: &GuestMemory, aperture: GuestMemoryRange) -> fs::Metadata {
+    let reservation = memory
+        .shared_export_regions()
+        .find(|region| region.range() == aperture)
+        .expect("shared aperture reservation should be exportable");
+    let backing = reservation
+        .try_clone_shared_backing()
+        .expect("shared reservation descriptor should duplicate")
+        .expect("reservation should be descriptor-backed");
+    let descriptor = backing
+        .as_fd()
+        .try_clone_to_owned()
+        .expect("reservation descriptor should duplicate for inspection");
+    File::from(descriptor)
+        .metadata()
+        .expect("reservation descriptor metadata should inspect")
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/runtime/src/snapshot_memory_v2.rs
+++ b/crates/runtime/src/snapshot_memory_v2.rs
@@ -26,6 +26,14 @@ use crate::snapshot_format_v2::{
 };
 use crate::snapshot_memory_hotplug_v2_10::NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION;
 
+mod materialize;
+
+pub use materialize::{
+    SnapshotV2MemoryHotplugMaterializationError, SnapshotV2MemoryHotplugMaterializationStage,
+    materialize_snapshot_v2_memory_hotplug_file,
+    materialize_snapshot_v2_memory_hotplug_file_with_cancel,
+};
+
 /// Fixed magic shared by the v2 state binding and memory-image prefix.
 pub const NATIVE_V2_MEMORY_MAGIC: [u8; 8] = *b"BANGM2A\0";
 
@@ -842,20 +850,7 @@ fn load_snapshot_v2_memory_binding_from_file_with_hook(
     file: File,
     mut hook: impl FnMut(SnapshotV2MemoryLoadStage, &File),
 ) -> Result<GuestMemory, SnapshotV2MemoryLoadError> {
-    let before = inspect_file(&file)?;
-    if before.length != binding.file_length() {
-        return Err(SnapshotV2MemoryLoadError::FileLengthMismatch);
-    }
-    hook(SnapshotV2MemoryLoadStage::Preflight, &file);
-
-    verify_memory_metadata(binding, &file)?;
-    hook(SnapshotV2MemoryLoadStage::Metadata, &file);
-    let after_metadata = inspect_file(&file)?;
-    if after_metadata != before {
-        return Err(SnapshotV2MemoryLoadError::SourceChanged);
-    }
-
-    let file = Arc::new(file);
+    let source = ValidatedSnapshotV2MemorySource::new_with_hook(binding, file, &mut hook)?;
     let mut ranges = Vec::new();
     ranges
         .try_reserve_exact(binding.extents().len())
@@ -868,17 +863,59 @@ fn load_snapshot_v2_memory_binding_from_file_with_hook(
     );
     let memory = GuestMemory::from_private_file_ranges(
         &ranges,
-        Arc::clone(&file),
+        Arc::clone(source.file()),
         GuestMemoryBacking::Anonymous,
     )
     .map_err(|source| SnapshotV2MemoryLoadError::Mapping { source })?;
-    hook(SnapshotV2MemoryLoadStage::Mapping, file.as_ref());
-    let after_mapping = inspect_file(file.as_ref())?;
-    if after_mapping != before {
+    hook(SnapshotV2MemoryLoadStage::Mapping, source.file().as_ref());
+    if let Err(error) = source.verify_unchanged() {
         drop(memory);
-        return Err(SnapshotV2MemoryLoadError::SourceChanged);
+        return Err(error);
     }
     Ok(memory)
+}
+
+struct ValidatedSnapshotV2MemorySource {
+    file: Arc<File>,
+    facts: FileFacts,
+}
+
+impl ValidatedSnapshotV2MemorySource {
+    fn new_with_hook(
+        binding: &SnapshotV2MemoryBinding,
+        file: File,
+        mut hook: impl FnMut(SnapshotV2MemoryLoadStage, &File),
+    ) -> Result<Self, SnapshotV2MemoryLoadError> {
+        let facts = inspect_file(&file)?;
+        if facts.length != binding.file_length() {
+            return Err(SnapshotV2MemoryLoadError::FileLengthMismatch);
+        }
+        hook(SnapshotV2MemoryLoadStage::Preflight, &file);
+
+        verify_memory_metadata(binding, &file)?;
+        hook(SnapshotV2MemoryLoadStage::Metadata, &file);
+        let after_metadata = inspect_file(&file)?;
+        if after_metadata != facts {
+            return Err(SnapshotV2MemoryLoadError::SourceChanged);
+        }
+
+        Ok(Self {
+            file: Arc::new(file),
+            facts,
+        })
+    }
+
+    fn file(&self) -> &Arc<File> {
+        &self.file
+    }
+
+    fn verify_unchanged(&self) -> Result<(), SnapshotV2MemoryLoadError> {
+        if inspect_file(self.file.as_ref())? == self.facts {
+            Ok(())
+        } else {
+            Err(SnapshotV2MemoryLoadError::SourceChanged)
+        }
+    }
 }
 
 /// Verifies one transaction-owned native-v2 staging descriptor without mapping it.

--- a/crates/runtime/src/snapshot_memory_v2/materialize.rs
+++ b/crates/runtime/src/snapshot_memory_v2/materialize.rs
@@ -1,0 +1,1170 @@
+use std::collections::TryReserveError;
+use std::fmt;
+use std::fs::File;
+use std::io;
+use std::os::unix::fs::FileExt;
+use std::sync::Arc;
+
+use crate::memory::{
+    GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryAllocationError,
+    GuestMemoryBacking, GuestMemoryRange,
+};
+use crate::memory_dirty::GuestMemoryDirtyTrackerError;
+use crate::snapshot_memory_hotplug_v2_10::{
+    PreparedSnapshotV2MemoryHotplugTopology, SnapshotV2MemoryHotplugExtentClass,
+};
+
+use super::{
+    COPY_CHUNK_BYTES, SnapshotV2MemoryLoadError, SnapshotV2MemoryLoadStage,
+    ValidatedSnapshotV2MemorySource,
+};
+
+/// Stable, value-redacted checkpoint in exact-2.10 memory materialization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2MemoryHotplugMaterializationStage {
+    /// Validate the adopted memory-image descriptor and its bound metadata.
+    SourceValidation,
+    /// Collect the ordered private base-memory inventory.
+    BaseInventory,
+    /// Construct private File/COW mappings for all base extents.
+    BaseMappings,
+    /// Recheck the retained source after base mappings exist.
+    BaseStability,
+    /// Create the fresh shared reservation for the whole virtio-mem aperture.
+    ApertureReservation,
+    /// Insert one canonical active view into the shared reservation.
+    PluggedViews,
+    /// Allocate the bounded positional-copy buffer.
+    CopyBuffer,
+    /// Copy one bounded chunk from a committed dynamic extent.
+    DynamicCopy,
+    /// Establish the clean destination dirty-tracking generation.
+    DirtyTracking,
+    /// Recheck the retained source after all destination bytes exist.
+    FinalStability,
+    /// Complete the transaction without another fallible ownership transition.
+    Complete,
+}
+
+impl fmt::Display for SnapshotV2MemoryHotplugMaterializationStage {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::SourceValidation => "source validation",
+            Self::BaseInventory => "base inventory",
+            Self::BaseMappings => "base mappings",
+            Self::BaseStability => "base stability",
+            Self::ApertureReservation => "aperture reservation",
+            Self::PluggedViews => "plugged views",
+            Self::CopyBuffer => "copy buffer",
+            Self::DynamicCopy => "dynamic copy",
+            Self::DirtyTracking => "dirty tracking",
+            Self::FinalStability => "final stability",
+            Self::Complete => "completion",
+        })
+    }
+}
+
+/// Failure while constructing unpublished mixed exact-2.10 guest memory.
+pub enum SnapshotV2MemoryHotplugMaterializationError {
+    /// The caller cancelled at a stable, value-redacted checkpoint.
+    Cancelled {
+        /// Checkpoint at which cancellation was observed.
+        stage: SnapshotV2MemoryHotplugMaterializationStage,
+    },
+    /// The adopted native-v2 image failed validation or changed.
+    Source {
+        /// Checkpoint at which source validation failed.
+        stage: SnapshotV2MemoryHotplugMaterializationStage,
+        /// Existing native-v2 retained-source failure.
+        source: SnapshotV2MemoryLoadError,
+    },
+    /// Bounded transaction metadata could not be reserved.
+    MetadataAllocation {
+        /// Checkpoint at which metadata allocation failed.
+        stage: SnapshotV2MemoryHotplugMaterializationStage,
+        /// Fallible collection reservation failure.
+        source: TryReserveError,
+    },
+    /// Destination memory ownership could not be constructed.
+    Memory {
+        /// Checkpoint at which guest-memory construction failed.
+        stage: SnapshotV2MemoryHotplugMaterializationStage,
+        /// Guest-memory allocation or topology failure.
+        source: GuestMemoryAllocationError,
+    },
+    /// A bounded positional source read failed or ended early.
+    Read {
+        /// Copy checkpoint at which reading failed.
+        stage: SnapshotV2MemoryHotplugMaterializationStage,
+        /// Stable I/O failure class without a path or descriptor.
+        kind: io::ErrorKind,
+    },
+    /// A copied chunk could not be written into active destination memory.
+    Write {
+        /// Copy checkpoint at which the destination write failed.
+        stage: SnapshotV2MemoryHotplugMaterializationStage,
+        /// Guest-memory access failure.
+        source: GuestMemoryAccessError,
+    },
+    /// The clean destination dirty generation could not be created.
+    DirtyTracking {
+        /// Checkpoint at which dirty metadata creation failed.
+        stage: SnapshotV2MemoryHotplugMaterializationStage,
+        /// Dirty-tracker construction failure.
+        source: GuestMemoryDirtyTrackerError,
+    },
+    /// Prepared topology or checked copy arithmetic was internally inconsistent.
+    InvalidTopology {
+        /// Checkpoint at which the inconsistency was detected.
+        stage: SnapshotV2MemoryHotplugMaterializationStage,
+    },
+}
+
+impl SnapshotV2MemoryHotplugMaterializationError {
+    /// Returns the stable materialization checkpoint associated with the error.
+    pub const fn stage(&self) -> SnapshotV2MemoryHotplugMaterializationStage {
+        match self {
+            Self::Cancelled { stage }
+            | Self::Source { stage, .. }
+            | Self::MetadataAllocation { stage, .. }
+            | Self::Memory { stage, .. }
+            | Self::Read { stage, .. }
+            | Self::Write { stage, .. }
+            | Self::DirtyTracking { stage, .. }
+            | Self::InvalidTopology { stage } => *stage,
+        }
+    }
+}
+
+impl fmt::Debug for SnapshotV2MemoryHotplugMaterializationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::Cancelled { .. } => "cancelled",
+            Self::Source { .. } => "source",
+            Self::MetadataAllocation { .. } => "metadata allocation",
+            Self::Memory { .. } => "memory",
+            Self::Read { .. } => "read",
+            Self::Write { .. } => "write",
+            Self::DirtyTracking { .. } => "dirty tracking",
+            Self::InvalidTopology { .. } => "invalid topology",
+        };
+        formatter
+            .debug_struct("SnapshotV2MemoryHotplugMaterializationError")
+            .field("stage", &self.stage())
+            .field("kind", &kind)
+            .field("details", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotV2MemoryHotplugMaterializationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let action = match self {
+            Self::Cancelled { .. } => "was cancelled",
+            Self::Source { .. } => "source validation failed",
+            Self::MetadataAllocation { .. } => "metadata allocation failed",
+            Self::Memory { .. } => "memory construction failed",
+            Self::Read { .. } => "source read failed",
+            Self::Write { .. } => "destination write failed",
+            Self::DirtyTracking { .. } => "dirty-tracking setup failed",
+            Self::InvalidTopology { .. } => "found an invalid prepared topology",
+        };
+        write!(
+            formatter,
+            "native-v2 memory-hotplug materialization {action} during {}",
+            self.stage()
+        )
+    }
+}
+
+impl std::error::Error for SnapshotV2MemoryHotplugMaterializationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Source { source, .. } => Some(source),
+            Self::MetadataAllocation { source, .. } => Some(source),
+            Self::Memory { source, .. } => Some(source),
+            Self::Write { source, .. } => Some(source),
+            Self::DirtyTracking { source, .. } => Some(source),
+            Self::Cancelled { .. } | Self::Read { .. } | Self::InvalidTopology { .. } => None,
+        }
+    }
+}
+
+/// Materializes one prepared exact-2.10 topology from an adopted descriptor.
+///
+/// The result keeps base memory as private File/COW mappings and creates a
+/// fresh descriptor-backed shared reservation for the virtio-mem aperture.
+/// No path is opened and no platform or device authority is constructed.
+pub fn materialize_snapshot_v2_memory_hotplug_file(
+    topology: &PreparedSnapshotV2MemoryHotplugTopology,
+    file: File,
+) -> Result<GuestMemory, SnapshotV2MemoryHotplugMaterializationError> {
+    materialize_snapshot_v2_memory_hotplug_file_with_cancel(topology, file, |_| false)
+}
+
+/// Materializes one prepared topology with stable cancellation checkpoints.
+///
+/// Repeated `PluggedViews` and `DynamicCopy` observations intentionally carry
+/// no range, index, file offset, descriptor, or host-address value.
+pub fn materialize_snapshot_v2_memory_hotplug_file_with_cancel<C>(
+    topology: &PreparedSnapshotV2MemoryHotplugTopology,
+    file: File,
+    is_cancelled: C,
+) -> Result<GuestMemory, SnapshotV2MemoryHotplugMaterializationError>
+where
+    C: FnMut(SnapshotV2MemoryHotplugMaterializationStage) -> bool,
+{
+    materialize_with_policy(
+        topology,
+        file,
+        &mut SystemMaterializationPolicy { is_cancelled },
+    )
+}
+
+trait MaterializationPolicy {
+    fn checkpoint(
+        &mut self,
+        stage: SnapshotV2MemoryHotplugMaterializationStage,
+    ) -> Result<(), SnapshotV2MemoryHotplugMaterializationError>;
+
+    fn source_validation_hook(&mut self, _stage: SnapshotV2MemoryLoadStage, _file: &File) {}
+
+    fn reserve_base_ranges(
+        &mut self,
+        ranges: &mut Vec<(GuestMemoryRange, u64)>,
+        count: usize,
+    ) -> Result<(), TryReserveError> {
+        ranges.try_reserve_exact(count)
+    }
+
+    fn reserve_copy_buffer(
+        &mut self,
+        buffer: &mut Vec<u8>,
+        count: usize,
+    ) -> Result<(), TryReserveError> {
+        buffer.try_reserve_exact(count)
+    }
+
+    fn map_base_memory(
+        &mut self,
+        ranges: &[(GuestMemoryRange, u64)],
+        file: Arc<File>,
+    ) -> Result<GuestMemory, GuestMemoryAllocationError> {
+        GuestMemory::from_private_file_ranges(ranges, file, GuestMemoryBacking::Anonymous)
+    }
+
+    fn reserve_aperture(
+        &mut self,
+        memory: &mut GuestMemory,
+        range: GuestMemoryRange,
+    ) -> Result<(), GuestMemoryAllocationError> {
+        memory.reserve_shared_region(range)
+    }
+
+    fn insert_view(
+        &mut self,
+        memory: &mut GuestMemory,
+        range: GuestMemoryRange,
+    ) -> Result<(), GuestMemoryAllocationError> {
+        memory.insert_region(range)
+    }
+
+    fn read_at(&mut self, file: &File, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
+        file.read_at(buffer, offset)
+    }
+
+    fn write_chunk(
+        &mut self,
+        memory: &mut GuestMemory,
+        buffer: &[u8],
+        address: GuestAddress,
+    ) -> Result<(), GuestMemoryAccessError> {
+        memory.write_slice(buffer, address)
+    }
+
+    fn enable_dirty_tracking(
+        &mut self,
+        memory: &mut GuestMemory,
+    ) -> Result<(), GuestMemoryDirtyTrackerError> {
+        memory.enable_dirty_tracking().map(|_| ())
+    }
+}
+
+struct SystemMaterializationPolicy<C> {
+    is_cancelled: C,
+}
+
+impl<C> MaterializationPolicy for SystemMaterializationPolicy<C>
+where
+    C: FnMut(SnapshotV2MemoryHotplugMaterializationStage) -> bool,
+{
+    fn checkpoint(
+        &mut self,
+        stage: SnapshotV2MemoryHotplugMaterializationStage,
+    ) -> Result<(), SnapshotV2MemoryHotplugMaterializationError> {
+        if (self.is_cancelled)(stage) {
+            Err(SnapshotV2MemoryHotplugMaterializationError::Cancelled { stage })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn materialize_with_policy(
+    topology: &PreparedSnapshotV2MemoryHotplugTopology,
+    file: File,
+    policy: &mut impl MaterializationPolicy,
+) -> Result<GuestMemory, SnapshotV2MemoryHotplugMaterializationError> {
+    use SnapshotV2MemoryHotplugMaterializationStage as Stage;
+
+    policy.checkpoint(Stage::SourceValidation)?;
+    let source = ValidatedSnapshotV2MemorySource::new_with_hook(
+        topology.memory().binding(),
+        file,
+        |stage, file| policy.source_validation_hook(stage, file),
+    )
+    .map_err(
+        |source| SnapshotV2MemoryHotplugMaterializationError::Source {
+            stage: Stage::SourceValidation,
+            source,
+        },
+    )?;
+
+    policy.checkpoint(Stage::BaseInventory)?;
+    let mut base_ranges = Vec::new();
+    policy
+        .reserve_base_ranges(&mut base_ranges, topology.memory().extent_count())
+        .map_err(
+            |source| SnapshotV2MemoryHotplugMaterializationError::MetadataAllocation {
+                stage: Stage::BaseInventory,
+                source,
+            },
+        )?;
+    let mut has_dynamic_extents = false;
+    for classified in topology.memory().classified_extents() {
+        match classified.class() {
+            SnapshotV2MemoryHotplugExtentClass::Base => {
+                let extent = classified.extent();
+                base_ranges.push((extent.range(), extent.file_offset()));
+            }
+            SnapshotV2MemoryHotplugExtentClass::Dynamic => has_dynamic_extents = true,
+        }
+    }
+
+    policy.checkpoint(Stage::BaseMappings)?;
+    let mut memory = if base_ranges.is_empty() {
+        GuestMemory::empty_with_backing(GuestMemoryBacking::Anonymous)
+    } else {
+        policy
+            .map_base_memory(&base_ranges, Arc::clone(source.file()))
+            .map_err(
+                |source| SnapshotV2MemoryHotplugMaterializationError::Memory {
+                    stage: Stage::BaseMappings,
+                    source,
+                },
+            )?
+    };
+
+    policy.checkpoint(Stage::BaseStability)?;
+    source.verify_unchanged().map_err(|source| {
+        SnapshotV2MemoryHotplugMaterializationError::Source {
+            stage: Stage::BaseStability,
+            source,
+        }
+    })?;
+
+    let config = topology.state().config_space();
+    let aperture = GuestMemoryRange::new(GuestAddress::new(config.addr()), config.region_size())
+        .map_err(
+            |_| SnapshotV2MemoryHotplugMaterializationError::InvalidTopology {
+                stage: Stage::ApertureReservation,
+            },
+        )?;
+    policy.checkpoint(Stage::ApertureReservation)?;
+    policy
+        .reserve_aperture(&mut memory, aperture)
+        .map_err(
+            |source| SnapshotV2MemoryHotplugMaterializationError::Memory {
+                stage: Stage::ApertureReservation,
+                source,
+            },
+        )?;
+
+    if topology.plugged_ranges().is_empty() {
+        policy.checkpoint(Stage::PluggedViews)?;
+    }
+    for range in topology.plugged_ranges().iter().copied() {
+        policy.checkpoint(Stage::PluggedViews)?;
+        policy.insert_view(&mut memory, range).map_err(|source| {
+            SnapshotV2MemoryHotplugMaterializationError::Memory {
+                stage: Stage::PluggedViews,
+                source,
+            }
+        })?;
+    }
+
+    if has_dynamic_extents {
+        policy.checkpoint(Stage::CopyBuffer)?;
+        let mut buffer = Vec::new();
+        policy
+            .reserve_copy_buffer(&mut buffer, COPY_CHUNK_BYTES)
+            .map_err(
+                |source| SnapshotV2MemoryHotplugMaterializationError::MetadataAllocation {
+                    stage: Stage::CopyBuffer,
+                    source,
+                },
+            )?;
+        buffer.resize(COPY_CHUNK_BYTES, 0);
+
+        for classified in topology.memory().classified_extents() {
+            if classified.class() != SnapshotV2MemoryHotplugExtentClass::Dynamic {
+                continue;
+            }
+            copy_dynamic_extent(
+                &source,
+                &mut memory,
+                classified.extent().range(),
+                classified.extent().file_offset(),
+                &mut buffer,
+                policy,
+            )?;
+        }
+    }
+
+    policy.checkpoint(Stage::DirtyTracking)?;
+    policy
+        .enable_dirty_tracking(&mut memory)
+        .map_err(
+            |source| SnapshotV2MemoryHotplugMaterializationError::DirtyTracking {
+                stage: Stage::DirtyTracking,
+                source,
+            },
+        )?;
+
+    policy.checkpoint(Stage::FinalStability)?;
+    source.verify_unchanged().map_err(|source| {
+        SnapshotV2MemoryHotplugMaterializationError::Source {
+            stage: Stage::FinalStability,
+            source,
+        }
+    })?;
+    policy.checkpoint(Stage::Complete)?;
+    Ok(memory)
+}
+
+fn copy_dynamic_extent(
+    source: &ValidatedSnapshotV2MemorySource,
+    memory: &mut GuestMemory,
+    range: GuestMemoryRange,
+    file_offset: u64,
+    buffer: &mut [u8],
+    policy: &mut impl MaterializationPolicy,
+) -> Result<(), SnapshotV2MemoryHotplugMaterializationError> {
+    let stage = SnapshotV2MemoryHotplugMaterializationStage::DynamicCopy;
+    let mut copied = 0_u64;
+    while copied < range.size() {
+        policy.checkpoint(stage)?;
+        let remaining = range.size() - copied;
+        let buffer_length = u64::try_from(buffer.len())
+            .map_err(|_| SnapshotV2MemoryHotplugMaterializationError::InvalidTopology { stage })?;
+        let chunk_length = usize::try_from(remaining.min(buffer_length))
+            .map_err(|_| SnapshotV2MemoryHotplugMaterializationError::InvalidTopology { stage })?;
+        let chunk = buffer
+            .get_mut(..chunk_length)
+            .ok_or(SnapshotV2MemoryHotplugMaterializationError::InvalidTopology { stage })?;
+        let position = file_offset
+            .checked_add(copied)
+            .ok_or(SnapshotV2MemoryHotplugMaterializationError::InvalidTopology { stage })?;
+        read_exact_at(source.file().as_ref(), chunk, position, policy).map_err(|error| {
+            SnapshotV2MemoryHotplugMaterializationError::Read {
+                stage,
+                kind: error.kind(),
+            }
+        })?;
+        let destination = range
+            .start()
+            .checked_add(copied)
+            .ok_or(SnapshotV2MemoryHotplugMaterializationError::InvalidTopology { stage })?;
+        policy
+            .write_chunk(memory, chunk, destination)
+            .map_err(
+                |source| SnapshotV2MemoryHotplugMaterializationError::Write { stage, source },
+            )?;
+        let chunk_length = u64::try_from(chunk_length)
+            .map_err(|_| SnapshotV2MemoryHotplugMaterializationError::InvalidTopology { stage })?;
+        copied = copied
+            .checked_add(chunk_length)
+            .ok_or(SnapshotV2MemoryHotplugMaterializationError::InvalidTopology { stage })?;
+    }
+    Ok(())
+}
+
+fn read_exact_at(
+    file: &File,
+    mut buffer: &mut [u8],
+    mut offset: u64,
+    policy: &mut impl MaterializationPolicy,
+) -> io::Result<()> {
+    while !buffer.is_empty() {
+        match policy.read_at(file, buffer, offset) {
+            Ok(0) => return Err(io::Error::from(io::ErrorKind::UnexpectedEof)),
+            Ok(count) => {
+                let count_u64 = u64::try_from(count)
+                    .map_err(|_| io::Error::from(io::ErrorKind::InvalidData))?;
+                offset = offset
+                    .checked_add(count_u64)
+                    .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidData))?;
+                buffer = buffer
+                    .get_mut(count..)
+                    .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidData))?;
+            }
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::io::{Cursor, Write};
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use crate::memory::{
+        GuestMemoryLayout, GuestMemoryOwnerProbe, GuestMemoryRegionBacking, aarch64,
+    };
+    use crate::snapshot_memory_hotplug_v2_10::{
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION, SnapshotV2MemoryHotplugState,
+    };
+    use crate::snapshot_memory_v2::write_snapshot_v2_memory_image_with_compatibility_version;
+
+    use super::*;
+
+    static NEXT_TEST_IMAGE: AtomicU64 = AtomicU64::new(0);
+
+    #[derive(Debug)]
+    struct TestImage {
+        path: PathBuf,
+    }
+
+    impl TestImage {
+        fn create(bytes: &[u8]) -> Self {
+            let (image, mut file) = Self::create_empty();
+            file.write_all(bytes).expect("test image should write");
+            drop(file);
+            image
+        }
+
+        fn create_empty() -> (Self, File) {
+            let sequence = NEXT_TEST_IMAGE.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "bangbang-mixed-memory-{}-{sequence}.snap",
+                std::process::id()
+            ));
+            let file = fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create_new(true)
+                .open(&path)
+                .expect("test image should create");
+            (Self { path }, file)
+        }
+
+        fn open(&self) -> File {
+            File::open(&self.path).expect("test image should open read-only")
+        }
+    }
+
+    impl Drop for TestImage {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+
+    fn fixture_bytes(hex: &str) -> Vec<u8> {
+        let compact = hex.split_whitespace().collect::<String>();
+        compact
+            .as_bytes()
+            .chunks_exact(2)
+            .map(|pair| {
+                let pair = std::str::from_utf8(pair).expect("fixture hex should be UTF-8");
+                u8::from_str_radix(pair, 16).expect("fixture hex should decode")
+            })
+            .collect()
+    }
+
+    fn mixed_fixture() -> (PreparedSnapshotV2MemoryHotplugTopology, TestImage) {
+        let state = SnapshotV2MemoryHotplugState::decode(
+            NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+            &fixture_bytes(include_str!(
+                "../snapshot_memory_hotplug_v2_10/fixtures/inactive-mmio.hex"
+            )),
+        )
+        .expect("inactive exact 2.10 state should decode");
+        let mut ranges = vec![
+            GuestMemoryRange::new(
+                GuestAddress::new(aarch64::DRAM_MEM_START),
+                4 * aarch64::GUEST_PAGE_SIZE,
+            )
+            .expect("base range should validate"),
+        ];
+        let config = state.config_space();
+        ranges.extend(state.plugged_ranges().map(|plugged| {
+            let start = config.addr() + plugged.start_block() * config.block_size();
+            GuestMemoryRange::new(
+                GuestAddress::new(start),
+                plugged.block_count() * config.block_size(),
+            )
+            .expect("plugged range should validate")
+        }));
+        ranges.sort_by_key(|range| range.start());
+        let layout = GuestMemoryLayout::new(ranges).expect("mixed layout should validate");
+        let memory = GuestMemory::allocate(&layout).expect("mixed memory should allocate");
+        let mut image = Cursor::new(Vec::new());
+        let binding = write_snapshot_v2_memory_image_with_compatibility_version(
+            &memory,
+            &mut image,
+            NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        )
+        .expect("mixed image should encode");
+        let topology = PreparedSnapshotV2MemoryHotplugTopology::prepare(state, binding)
+            .expect("mixed topology should prepare");
+        (topology, TestImage::create(&image.into_inner()))
+    }
+
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum FailurePoint {
+        BaseMapping,
+        Reservation,
+        LaterView,
+        LaterWrite,
+        DirtyTracking,
+        FinalStability,
+    }
+
+    struct OperationFailurePolicy {
+        target: FailurePoint,
+        view_count: usize,
+        write_count: usize,
+        probe: Option<GuestMemoryOwnerProbe>,
+    }
+
+    impl OperationFailurePolicy {
+        fn new(target: FailurePoint) -> Self {
+            Self {
+                target,
+                view_count: 0,
+                write_count: 0,
+                probe: None,
+            }
+        }
+
+        fn capture(&mut self, memory: &GuestMemory) {
+            self.probe = Some(
+                memory
+                    .try_owner_probe()
+                    .expect("test owner probe should allocate"),
+            );
+        }
+    }
+
+    impl MaterializationPolicy for OperationFailurePolicy {
+        fn checkpoint(
+            &mut self,
+            stage: SnapshotV2MemoryHotplugMaterializationStage,
+        ) -> Result<(), SnapshotV2MemoryHotplugMaterializationError> {
+            if self.target == FailurePoint::FinalStability
+                && stage == SnapshotV2MemoryHotplugMaterializationStage::FinalStability
+            {
+                Err(SnapshotV2MemoryHotplugMaterializationError::InvalidTopology { stage })
+            } else {
+                Ok(())
+            }
+        }
+
+        fn map_base_memory(
+            &mut self,
+            ranges: &[(GuestMemoryRange, u64)],
+            file: Arc<File>,
+        ) -> Result<GuestMemory, GuestMemoryAllocationError> {
+            if self.target == FailurePoint::BaseMapping {
+                Err(GuestMemoryAllocationError::InvalidHostPageSize)
+            } else {
+                GuestMemory::from_private_file_ranges(ranges, file, GuestMemoryBacking::Anonymous)
+            }
+        }
+
+        fn reserve_aperture(
+            &mut self,
+            memory: &mut GuestMemory,
+            range: GuestMemoryRange,
+        ) -> Result<(), GuestMemoryAllocationError> {
+            if self.target == FailurePoint::Reservation {
+                self.capture(memory);
+                Err(GuestMemoryAllocationError::ProtectedLazyMutation)
+            } else {
+                memory.reserve_shared_region(range)
+            }
+        }
+
+        fn insert_view(
+            &mut self,
+            memory: &mut GuestMemory,
+            range: GuestMemoryRange,
+        ) -> Result<(), GuestMemoryAllocationError> {
+            self.view_count += 1;
+            if self.target == FailurePoint::LaterView && self.view_count == 2 {
+                self.capture(memory);
+                Err(GuestMemoryAllocationError::ProtectedLazyMutation)
+            } else {
+                memory.insert_region(range)
+            }
+        }
+
+        fn write_chunk(
+            &mut self,
+            memory: &mut GuestMemory,
+            buffer: &[u8],
+            address: GuestAddress,
+        ) -> Result<(), GuestMemoryAccessError> {
+            self.write_count += 1;
+            if self.target == FailurePoint::LaterWrite && self.write_count == 2 {
+                self.capture(memory);
+                Err(GuestMemoryAccessError::DirtyTrackingState)
+            } else {
+                memory.write_slice(buffer, address)
+            }
+        }
+
+        fn enable_dirty_tracking(
+            &mut self,
+            memory: &mut GuestMemory,
+        ) -> Result<(), GuestMemoryDirtyTrackerError> {
+            if self.target == FailurePoint::DirtyTracking {
+                self.capture(memory);
+                let mut metadata = Vec::<u8>::new();
+                let source = metadata
+                    .try_reserve_exact(usize::MAX)
+                    .expect_err("test dirty metadata allocation should fail");
+                Err(GuestMemoryDirtyTrackerError::MetadataAllocationFailed { source })
+            } else {
+                memory.enable_dirty_tracking().map(|_| {
+                    if self.target == FailurePoint::FinalStability {
+                        self.capture(memory);
+                    }
+                })
+            }
+        }
+    }
+
+    #[test]
+    fn injected_failures_release_every_accumulated_owner_and_allow_retry() {
+        let (topology, image) = mixed_fixture();
+        for (target, expected_stage) in [
+            (
+                FailurePoint::BaseMapping,
+                SnapshotV2MemoryHotplugMaterializationStage::BaseMappings,
+            ),
+            (
+                FailurePoint::Reservation,
+                SnapshotV2MemoryHotplugMaterializationStage::ApertureReservation,
+            ),
+            (
+                FailurePoint::LaterView,
+                SnapshotV2MemoryHotplugMaterializationStage::PluggedViews,
+            ),
+            (
+                FailurePoint::LaterWrite,
+                SnapshotV2MemoryHotplugMaterializationStage::DynamicCopy,
+            ),
+            (
+                FailurePoint::DirtyTracking,
+                SnapshotV2MemoryHotplugMaterializationStage::DirtyTracking,
+            ),
+            (
+                FailurePoint::FinalStability,
+                SnapshotV2MemoryHotplugMaterializationStage::FinalStability,
+            ),
+        ] {
+            let mut policy = OperationFailurePolicy::new(target);
+            let error = materialize_with_policy(&topology, image.open(), &mut policy)
+                .expect_err("injected operation should fail");
+            assert_eq!(error.stage(), expected_stage);
+            if target != FailurePoint::BaseMapping {
+                assert!(
+                    policy
+                        .probe
+                        .as_ref()
+                        .expect("failure after ownership should retain a weak probe")
+                        .all_released(),
+                    "every accumulated mapping should be released"
+                );
+            }
+        }
+
+        let memory = materialize_snapshot_v2_memory_hotplug_file(&topology, image.open())
+            .expect("fresh materialization should succeed after injected rollback");
+        assert!(
+            memory
+                .regions()
+                .iter()
+                .any(|region| region.backing() == GuestMemoryRegionBacking::PrivateFile)
+        );
+        assert!(
+            memory
+                .regions()
+                .iter()
+                .any(|region| region.backing() == GuestMemoryRegionBacking::Shared)
+        );
+    }
+
+    struct AllocationFailurePolicy {
+        copy_buffer: bool,
+        probe: Option<GuestMemoryOwnerProbe>,
+    }
+
+    impl MaterializationPolicy for AllocationFailurePolicy {
+        fn checkpoint(
+            &mut self,
+            _stage: SnapshotV2MemoryHotplugMaterializationStage,
+        ) -> Result<(), SnapshotV2MemoryHotplugMaterializationError> {
+            Ok(())
+        }
+
+        fn reserve_base_ranges(
+            &mut self,
+            ranges: &mut Vec<(GuestMemoryRange, u64)>,
+            count: usize,
+        ) -> Result<(), TryReserveError> {
+            if self.copy_buffer {
+                ranges.try_reserve_exact(count)
+            } else {
+                ranges.try_reserve_exact(usize::MAX)
+            }
+        }
+
+        fn insert_view(
+            &mut self,
+            memory: &mut GuestMemory,
+            range: GuestMemoryRange,
+        ) -> Result<(), GuestMemoryAllocationError> {
+            memory.insert_region(range)?;
+            if self.copy_buffer {
+                self.probe = Some(
+                    memory
+                        .try_owner_probe()
+                        .expect("test owner probe should allocate"),
+                );
+            }
+            Ok(())
+        }
+
+        fn reserve_copy_buffer(
+            &mut self,
+            buffer: &mut Vec<u8>,
+            count: usize,
+        ) -> Result<(), TryReserveError> {
+            if self.copy_buffer {
+                buffer.try_reserve_exact(usize::MAX)
+            } else {
+                buffer.try_reserve_exact(count)
+            }
+        }
+    }
+
+    #[test]
+    fn bounded_metadata_allocation_failures_are_staged_and_transactional() {
+        let (topology, image) = mixed_fixture();
+        for (copy_buffer, expected_stage) in [
+            (
+                false,
+                SnapshotV2MemoryHotplugMaterializationStage::BaseInventory,
+            ),
+            (
+                true,
+                SnapshotV2MemoryHotplugMaterializationStage::CopyBuffer,
+            ),
+        ] {
+            let mut policy = AllocationFailurePolicy {
+                copy_buffer,
+                probe: None,
+            };
+            let error = materialize_with_policy(&topology, image.open(), &mut policy)
+                .expect_err("injected metadata allocation should fail");
+            assert!(matches!(
+                error,
+                SnapshotV2MemoryHotplugMaterializationError::MetadataAllocation { stage, .. }
+                    if stage == expected_stage
+            ));
+            if copy_buffer {
+                assert!(
+                    policy
+                        .probe
+                        .as_ref()
+                        .expect("copy-buffer failure should follow accumulated ownership")
+                        .all_released()
+                );
+            }
+        }
+    }
+
+    struct InterruptedReadPolicy {
+        interrupted: bool,
+    }
+
+    impl MaterializationPolicy for InterruptedReadPolicy {
+        fn checkpoint(
+            &mut self,
+            _stage: SnapshotV2MemoryHotplugMaterializationStage,
+        ) -> Result<(), SnapshotV2MemoryHotplugMaterializationError> {
+            Ok(())
+        }
+
+        fn read_at(&mut self, file: &File, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
+            if !self.interrupted {
+                self.interrupted = true;
+                Err(io::Error::from(io::ErrorKind::Interrupted))
+            } else {
+                file.read_at(buffer, offset)
+            }
+        }
+    }
+
+    #[test]
+    fn interrupted_positional_read_is_retried_without_changing_the_clean_result() {
+        let (topology, image) = mixed_fixture();
+        let mut policy = InterruptedReadPolicy { interrupted: false };
+        let memory = materialize_with_policy(&topology, image.open(), &mut policy)
+            .expect("interrupted read should retry");
+        assert!(policy.interrupted);
+        let tracker = memory
+            .dirty_tracker()
+            .expect("successful materialization should enable dirty tracking");
+        assert_eq!(tracker.epoch(), 0);
+        assert!(
+            tracker
+                .dirty_pages()
+                .expect("clean dirty pages should query")
+                .is_empty()
+        );
+    }
+
+    struct FailingReadPolicy {
+        read_count: usize,
+        probe: Option<GuestMemoryOwnerProbe>,
+    }
+
+    impl MaterializationPolicy for FailingReadPolicy {
+        fn checkpoint(
+            &mut self,
+            _stage: SnapshotV2MemoryHotplugMaterializationStage,
+        ) -> Result<(), SnapshotV2MemoryHotplugMaterializationError> {
+            Ok(())
+        }
+
+        fn read_at(&mut self, file: &File, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
+            self.read_count += 1;
+            if self.read_count == 2 {
+                Err(io::Error::from(io::ErrorKind::PermissionDenied))
+            } else {
+                file.read_at(buffer, offset)
+            }
+        }
+
+        fn write_chunk(
+            &mut self,
+            memory: &mut GuestMemory,
+            buffer: &[u8],
+            address: GuestAddress,
+        ) -> Result<(), GuestMemoryAccessError> {
+            memory.write_slice(buffer, address)?;
+            if self.probe.is_none() {
+                self.probe = Some(
+                    memory
+                        .try_owner_probe()
+                        .expect("test owner probe should allocate"),
+                );
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn positional_read_error_after_partial_population_releases_owners() {
+        let (topology, image) = mixed_fixture();
+        let mut policy = FailingReadPolicy {
+            read_count: 0,
+            probe: None,
+        };
+        let error = materialize_with_policy(&topology, image.open(), &mut policy)
+            .expect_err("injected positional read should fail");
+        assert!(matches!(
+            error,
+            SnapshotV2MemoryHotplugMaterializationError::Read {
+                stage: SnapshotV2MemoryHotplugMaterializationStage::DynamicCopy,
+                kind: io::ErrorKind::PermissionDenied,
+            }
+        ));
+        assert!(
+            policy
+                .probe
+                .as_ref()
+                .expect("partial population should capture accumulated owners")
+                .all_released()
+        );
+    }
+
+    #[test]
+    fn empty_plugged_topology_retains_only_private_base_and_an_offline_reservation() {
+        let original = SnapshotV2MemoryHotplugState::decode(
+            NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+            &fixture_bytes(include_str!(
+                "../snapshot_memory_hotplug_v2_10/fixtures/inactive-mmio.hex"
+            )),
+        )
+        .expect("inactive exact 2.10 state should decode");
+        let (config, config_space, active_queue, bitmap, virtio, transport) = original.into_parts();
+        let state = SnapshotV2MemoryHotplugState::try_new(
+            config,
+            config_space.with_plugged_size(0),
+            active_queue,
+            vec![0_u8; bitmap.len()],
+            virtio,
+            transport,
+        )
+        .expect("empty plugged topology should validate");
+        let base = GuestMemoryRange::new(
+            GuestAddress::new(aarch64::DRAM_MEM_START),
+            4 * aarch64::GUEST_PAGE_SIZE,
+        )
+        .expect("base range should validate");
+        let layout = GuestMemoryLayout::new(vec![base]).expect("base layout should validate");
+        let source = GuestMemory::allocate(&layout).expect("base memory should allocate");
+        let mut image_bytes = Cursor::new(Vec::new());
+        let binding = write_snapshot_v2_memory_image_with_compatibility_version(
+            &source,
+            &mut image_bytes,
+            NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        )
+        .expect("base image should encode");
+        let topology = PreparedSnapshotV2MemoryHotplugTopology::prepare(state, binding)
+            .expect("empty plugged topology should prepare");
+        assert!(topology.plugged_ranges().is_empty());
+        let image = TestImage::create(&image_bytes.into_inner());
+
+        let memory = materialize_snapshot_v2_memory_hotplug_file(&topology, image.open())
+            .expect("empty plugged topology should materialize");
+        assert_eq!(memory.regions().len(), 1);
+        assert_eq!(
+            memory.regions()[0].backing(),
+            GuestMemoryRegionBacking::PrivateFile
+        );
+        let config = topology.state().config_space();
+        let aperture =
+            GuestMemoryRange::new(GuestAddress::new(config.addr()), config.region_size())
+                .expect("empty aperture should validate");
+        memory
+            .shared_reservation_capture_state(aperture)
+            .expect("offline aperture reservation should remain owned");
+        assert!(
+            memory.read_slice(&mut [0], aperture.start()).is_err(),
+            "offline aperture must remain absent from active memory"
+        );
+        assert!(
+            memory
+                .dirty_tracker()
+                .expect("base dirty tracker should exist")
+                .dirty_pages()
+                .expect("base dirty pages should query")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn maximum_fragment_inventory_normalizes_into_one_bounded_shared_view() {
+        const MIB: u64 = 1024 * 1024;
+        const FRAGMENT_BYTES: u64 = 16 * 1024;
+        const EXTENT_COUNT: usize = 4096;
+
+        let original = SnapshotV2MemoryHotplugState::decode(
+            NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+            &fixture_bytes(include_str!(
+                "../snapshot_memory_hotplug_v2_10/fixtures/inactive-mmio.hex"
+            )),
+        )
+        .expect("inactive exact 2.10 state should decode");
+        let (config, config_space, active_queue, _, virtio, transport) = original.into_parts();
+        assert!(active_queue.is_none());
+        let mut bitmap = vec![0_u8; 64];
+        bitmap
+            .get_mut(..4)
+            .expect("first 32 blocks should fit the bitmap")
+            .fill(u8::MAX);
+        let state = SnapshotV2MemoryHotplugState::try_new(
+            config,
+            config_space.with_plugged_size(64 * MIB),
+            active_queue,
+            bitmap,
+            virtio,
+            transport,
+        )
+        .expect("maximum-fragment topology state should validate");
+
+        let aperture_start = state.config_space().addr();
+        let ranges = (0..EXTENT_COUNT)
+            .map(|index| {
+                let offset =
+                    u64::try_from(index).expect("extent index should fit") * FRAGMENT_BYTES;
+                GuestMemoryRange::new(GuestAddress::new(aperture_start + offset), FRAGMENT_BYTES)
+                    .expect("fragment range should validate")
+            })
+            .collect::<Vec<_>>();
+        let layout =
+            GuestMemoryLayout::new(ranges.clone()).expect("fragment layout should validate");
+        let mut source = GuestMemory::allocate(&layout).expect("fragment memory should allocate");
+        for (index, range) in ranges.iter().copied().enumerate() {
+            source
+                .write_slice(
+                    &[u8::try_from(index % 251).expect("sentinel should fit")],
+                    range.start(),
+                )
+                .expect("fragment sentinel should write");
+        }
+
+        let (image, mut writer) = TestImage::create_empty();
+        let binding = write_snapshot_v2_memory_image_with_compatibility_version(
+            &source,
+            &mut writer,
+            NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        )
+        .expect("maximum-fragment image should encode");
+        writer.flush().expect("maximum-fragment image should flush");
+        drop(writer);
+        assert_eq!(binding.extents().len(), EXTENT_COUNT);
+        let topology = PreparedSnapshotV2MemoryHotplugTopology::prepare(state, binding)
+            .expect("maximum-fragment topology should prepare");
+        assert_eq!(topology.memory().extent_count(), EXTENT_COUNT);
+        assert_eq!(topology.plugged_ranges().len(), 1);
+
+        let memory = materialize_snapshot_v2_memory_hotplug_file(&topology, image.open())
+            .expect("maximum-fragment image should materialize");
+        assert_eq!(memory.regions().len(), 1);
+        assert_eq!(
+            memory.regions()[0].backing(),
+            GuestMemoryRegionBacking::Shared
+        );
+        for index in [0, 127, 2048, EXTENT_COUNT - 1] {
+            let mut actual = [0_u8; 1];
+            memory
+                .read_slice(&mut actual, ranges[index].start())
+                .expect("materialized sentinel should read");
+            assert_eq!(
+                actual[0],
+                u8::try_from(index % 251).expect("sentinel should fit")
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a transactional exact-2.10 materializer that adopts one validated
  read-only memory descriptor, keeps base extents as private File/COW mappings,
  and populates canonical plugged views in one fresh shared aperture
- establish a clean destination dirty epoch after bounded positional copying,
  with stable cancellation/error stages and rollback of every unpublished owner
- return a named materialized candidate that keeps exact state, optional
  product components, prepared topology, and guest memory inseparable
- cover empty, mixed, dynamic-only, fragmented, maximum-bound, repeated-load,
  path-replacement, mutation, cancellation, rollback, and fresh-process
  isolation behavior

## Scope exclusions

- no public exact-2.10 activation or snapshot endpoint
- no HVF mapping plan, VM/device owner, interrupt, controller, or dispatcher
- no signed guest execution, documentation, or capability-inventory change

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented Apple-target integration-test Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `git diff --check`

Closes #1693

Parent delivery issue: #1538
