### PR TITLE
feat: reconstruct MMIO virtio-mem snapshot owners

### DIFF
--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -36760,6 +36760,29 @@ mod tests {
     }
 
     #[test]
+    fn runtime_snapshot_create_policy_still_rejects_memory_hotplug_before_session_barrier() {
+        let mut vmm = configured_vmm(FakeStarter::success(177));
+        vmm.handle_action(VmmAction::PutMemoryHotplug(memory_hotplug_config_input()))
+            .expect("memory-hotplug should configure");
+        vmm.handle_action(VmmAction::InstanceStart)
+            .expect("memory-hotplug instance should start");
+        vmm.handle_action(VmmAction::Pause)
+            .expect("memory-hotplug instance should pause");
+
+        assert_eq!(
+            vmm.handle_action(snapshot_create_action(SnapshotType::Full)),
+            Err(VmmActionError::SnapshotUnsupported)
+        );
+        let session = vmm
+            .started_session
+            .as_ref()
+            .expect("rejected memory-hotplug snapshot should retain its session");
+        assert_eq!(session.snapshot_create_barrier_count, 0);
+        assert_eq!(session.native_snapshot_publication_count, 0);
+        assert_eq!(session.native_snapshot_producer_count, 0);
+    }
+
+    #[test]
     fn broad_snapshot_profile_runs_complete_storage_preflight_before_profile_rejection() {
         let state_path = missing_temp_child_path("broad-storage.state");
         let memory_path = state_path.with_file_name("broad-storage.memory");

--- a/crates/hvf/src/backend.rs
+++ b/crates/hvf/src/backend.rs
@@ -17,8 +17,9 @@ use crate::lazy_guest_fault::HvfLazyGuestFaultHandler;
 use crate::lazy_host_fault::{HvfLazyGuestMemoryConsumer, HvfLazyPageResolver};
 use crate::memory::{
     HvfGuestMemoryMapping, HvfGuestMemoryMappingError, HvfHostMemoryMapping, HvfMemoryMapper,
-    HvfMemoryPermissions, HvfPmemFlushExecutor, HvfVirtioMemMappingCaptureError,
-    HvfVirtioMemMappingCaptureState, HvfVirtioMemMutationExecutor, RealHvfMemoryMapper,
+    HvfMemoryPermissions, HvfPmemFlushExecutor, HvfSnapshotV2MemoryHotplugMappingPlan,
+    HvfVirtioMemMappingCaptureError, HvfVirtioMemMappingCaptureState, HvfVirtioMemMutationExecutor,
+    RealHvfMemoryMapper,
 };
 use crate::runner::{HvfVcpuRunner, HvfVcpuRunnerError};
 use crate::topology::{HvfVcpuTopology, HvfVcpuTopologyError};
@@ -97,6 +98,36 @@ impl HvfBackend {
         }
 
         self.map_guest_memory_with_configured_mapper(memory, permissions)
+    }
+
+    pub(crate) fn map_snapshot_v2_memory_hotplug(
+        &mut self,
+        memory: GuestMemory,
+        plan: &HvfSnapshotV2MemoryHotplugMappingPlan,
+        permissions: HvfMemoryPermissions,
+    ) -> Result<(), HvfGuestMemoryMappingError> {
+        if !Self::is_supported_target() {
+            return Err(BackendError::Unsupported(crate::ffi::UNSUPPORTED_TARGET_MESSAGE).into());
+        }
+
+        self.validate_guest_memory_mapping_state()?;
+        match HvfGuestMemoryMapping::map_snapshot_v2_memory_hotplug_with_mapper(
+            memory,
+            plan,
+            permissions,
+            Arc::clone(&self.memory_mapper),
+        ) {
+            Ok(mapping) => {
+                self.guest_memory = Some(mapping);
+                Ok(())
+            }
+            Err(failed_mapping) => {
+                if failed_mapping.mapping.has_mapped_regions() {
+                    self.guest_memory = Some(failed_mapping.mapping);
+                }
+                Err(failed_mapping.error)
+            }
+        }
     }
 
     /// Map resolver-owned anonymous memory and force first guest accesses to

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -253,7 +253,9 @@ pub use startup::{
     HvfSnapshotV2BalloonPciRestoreStage, HvfSnapshotV2EntropyMmioRestoreError,
     HvfSnapshotV2EntropyMmioRestoreFailure, HvfSnapshotV2EntropyMmioRestoreStage,
     HvfSnapshotV2EntropyPciRestoreError, HvfSnapshotV2EntropyPciRestoreFailure,
-    HvfSnapshotV2EntropyPciRestoreStage, HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure,
+    HvfSnapshotV2EntropyPciRestoreStage, HvfSnapshotV2MemoryHotplugMmioRestoreError,
+    HvfSnapshotV2MemoryHotplugMmioRestoreFailure, HvfSnapshotV2MemoryHotplugMmioRestoreFault,
+    HvfSnapshotV2MemoryHotplugMmioRestoreStage, HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure,
     HvfSnapshotV2MultiBlockMmioRestoreError, HvfSnapshotV2MultiBlockMmioRestoreFailure,
     HvfSnapshotV2MultiBlockMmioRestoreStage, HvfSnapshotV2MultiBlockPciRestoreCleanupFailure,
     HvfSnapshotV2MultiBlockPciRestoreError, HvfSnapshotV2MultiBlockPciRestoreFailure,
@@ -267,8 +269,9 @@ pub use startup::{
     PreparedHvfArm64BootPciNetworkRemoval, RestoredHvfArm64BootSession,
     RestoredHvfSnapshotV2BalloonMmioOwners, RestoredHvfSnapshotV2BalloonPciOwners,
     RestoredHvfSnapshotV2EntropyMmioOwners, RestoredHvfSnapshotV2EntropyPciOwners,
-    RestoredHvfSnapshotV2MultiBlockMmioOwners, RestoredHvfSnapshotV2MultiBlockPciOwners,
-    RestoredHvfSnapshotV2StorageMmioOwners, RestoredHvfSnapshotV2StoragePciOwners,
+    RestoredHvfSnapshotV2MemoryHotplugMmioOwners, RestoredHvfSnapshotV2MultiBlockMmioOwners,
+    RestoredHvfSnapshotV2MultiBlockPciOwners, RestoredHvfSnapshotV2StorageMmioOwners,
+    RestoredHvfSnapshotV2StoragePciOwners,
 };
 pub use topology::{
     HvfVcpuTopology, HvfVcpuTopologyAllocation, HvfVcpuTopologyCreateStage, HvfVcpuTopologyError,

--- a/crates/hvf/src/memory.rs
+++ b/crates/hvf/src/memory.rs
@@ -703,7 +703,7 @@ fn normalize_capture_ranges(ranges: &mut Vec<GuestMemoryRange>) -> bool {
 /// The plan classifies private Base memory as static HVF mappings and active
 /// shared virtio-mem views as dynamic mappings. It retains no host address,
 /// descriptor, mapper, or VM authority.
-#[derive(PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct HvfSnapshotV2MemoryHotplugMappingPlan {
     static_ranges: Vec<GuestMemoryRange>,
     dynamic_ranges: Vec<GuestMemoryRange>,
@@ -760,6 +760,21 @@ impl HvfSnapshotV2MemoryHotplugMappingPlan {
     /// Returns the clean materialization epoch.
     pub const fn dirty_epoch(&self) -> u64 {
         self.dirty_epoch
+    }
+
+    pub(crate) fn matches_capture(&self, capture: &HvfVirtioMemMappingCaptureState) -> bool {
+        capture.reservation() == self.reservation
+            && capture.active_ranges() == self.dynamic_ranges
+            && capture.active_bytes() == self.active_bytes
+            && capture.offline_bytes() == self.offline_bytes
+            && capture.current_memory_bytes() == self.current_memory_bytes
+            && capture
+                .current_memory_bytes()
+                .checked_sub(capture.active_bytes())
+                == Some(self.base_bytes)
+            && capture.guest_dirty_tracking()
+            && capture.hvf_dirty_tracking()
+            && capture.dirty_epoch() == Some(self.dirty_epoch)
     }
 }
 
@@ -1049,6 +1064,99 @@ fn checked_range_bytes(
     })
 }
 
+fn validate_snapshot_v2_memory_hotplug_mapping(
+    memory: &GuestMemory,
+    plan: &HvfSnapshotV2MemoryHotplugMappingPlan,
+    permissions: HvfMemoryPermissions,
+    page_size: u64,
+) -> Result<Vec<HvfMemoryMapRequest>, HvfGuestMemoryMappingError> {
+    const INVALID_PLAN: HvfGuestMemoryMappingError = HvfGuestMemoryMappingError::InvalidState(
+        "native-v2 memory-hotplug mapping plan no longer matches guest memory",
+    );
+
+    if plan.dirty_page_size != page_size || plan.dirty_epoch != 0 {
+        return Err(INVALID_PLAN);
+    }
+    let aperture = plan.reservation.range();
+    let reservation = memory
+        .shared_reservation_capture_state(aperture)
+        .map_err(|_| INVALID_PLAN)?;
+    if reservation != plan.reservation {
+        return Err(INVALID_PLAN);
+    }
+
+    let requests = validated_map_requests(memory, permissions, page_size)?;
+    let expected_region_count = plan
+        .static_ranges
+        .len()
+        .checked_add(plan.dynamic_ranges.len())
+        .ok_or(INVALID_PLAN)?;
+    if requests.len() != expected_region_count || memory.regions().len() != expected_region_count {
+        return Err(INVALID_PLAN);
+    }
+
+    let mut static_index = 0;
+    let mut dynamic_index = 0;
+    for region in memory.regions() {
+        let range = region.range();
+        if range.overlaps(aperture) {
+            if range.start() < aperture.start()
+                || range.end_exclusive() > aperture.end_exclusive()
+                || plan.dynamic_ranges.get(dynamic_index) != Some(&range)
+                || region.backing() != GuestMemoryRegionBacking::Shared
+                || region.mapping_identity() != reservation.mapping_identity()
+                || region.validate_shared_backing().ok() != Some(true)
+            {
+                return Err(INVALID_PLAN);
+            }
+            dynamic_index += 1;
+        } else {
+            if plan.static_ranges.get(static_index) != Some(&range)
+                || region.backing() != GuestMemoryRegionBacking::PrivateFile
+            {
+                return Err(INVALID_PLAN);
+            }
+            static_index += 1;
+        }
+    }
+    if static_index != plan.static_ranges.len() || dynamic_index != plan.dynamic_ranges.len() {
+        return Err(INVALID_PLAN);
+    }
+
+    let dirty = memory.dirty_tracker().ok_or(INVALID_PLAN)?;
+    if dirty.page_size() != plan.dirty_page_size
+        || dirty.epoch() != plan.dirty_epoch
+        || memory
+            .regions()
+            .iter()
+            .any(|region| !dirty.contains_range(region.range()))
+        || !dirty.dirty_pages().map_err(|_| INVALID_PLAN)?.is_empty()
+    {
+        return Err(INVALID_PLAN);
+    }
+
+    let base_bytes = plan.static_ranges.iter().try_fold(0_u64, |bytes, range| {
+        bytes.checked_add(range.size()).ok_or(INVALID_PLAN)
+    })?;
+    let active_bytes = plan.dynamic_ranges.iter().try_fold(0_u64, |bytes, range| {
+        bytes.checked_add(range.size()).ok_or(INVALID_PLAN)
+    })?;
+    let offline_bytes = aperture
+        .size()
+        .checked_sub(active_bytes)
+        .ok_or(INVALID_PLAN)?;
+    let current_memory_bytes = base_bytes.checked_add(active_bytes).ok_or(INVALID_PLAN)?;
+    if base_bytes != plan.base_bytes
+        || active_bytes != plan.active_bytes
+        || offline_bytes != plan.offline_bytes
+        || current_memory_bytes != plan.current_memory_bytes
+        || memory.total_size() != current_memory_bytes
+    {
+        return Err(INVALID_PLAN);
+    }
+    Ok(requests)
+}
+
 #[cfg(test)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum HvfSnapshotV2MemoryHotplugMappingPlanFailureStage {
@@ -1176,6 +1284,32 @@ impl HvfGuestMemoryMapping {
         }
     }
 
+    pub(crate) fn map_snapshot_v2_memory_hotplug_with_mapper(
+        memory: GuestMemory,
+        plan: &HvfSnapshotV2MemoryHotplugMappingPlan,
+        permissions: HvfMemoryPermissions,
+        mapper: Arc<dyn HvfMemoryMapper>,
+    ) -> Result<Self, Box<FailedGuestMemoryMapping>> {
+        let mut mapping = Self {
+            memory: Some(memory),
+            state: HvfGuestMemoryMappingState {
+                host_memory: Vec::new(),
+                host_memory_should_flush: false,
+                host_memory_flushed: false,
+                mapped_regions: Vec::new(),
+                dynamic_regions: Vec::new(),
+                mapper,
+                dirty_write_tracker: None,
+                protection_poisoned: false,
+            },
+        };
+
+        match mapping.map_snapshot_v2_memory_hotplug(plan, permissions) {
+            Ok(()) => Ok(mapping),
+            Err(error) => Err(Box::new(FailedGuestMemoryMapping { mapping, error })),
+        }
+    }
+
     pub(crate) fn map_lazy_with_mapper(
         regions: &[GuestMemoryRegion],
         permissions: HvfMemoryPermissions,
@@ -1218,6 +1352,7 @@ impl HvfGuestMemoryMapping {
                 .map_err(|source| HvfGuestMemoryMappingError::DirtyWriteTrackingStop { source })?;
         }
         let failures = self.state.unmap_mapped_regions();
+        self.state.sync_dynamic_regions_to_mapped_regions();
         if !failures.is_empty() {
             return Err(HvfGuestMemoryMappingError::UnmapFailed { failures });
         }
@@ -1232,7 +1367,7 @@ impl HvfGuestMemoryMapping {
     }
 
     #[cfg(test)]
-    fn has_dynamic_regions(&self) -> bool {
+    pub(crate) fn has_dynamic_regions(&self) -> bool {
         self.state.has_dynamic_regions()
     }
 
@@ -1532,6 +1667,21 @@ impl HvfGuestMemoryMapping {
                 "guest memory owner is missing",
             ))?;
         self.state.map_all(memory, permissions)
+    }
+
+    fn map_snapshot_v2_memory_hotplug(
+        &mut self,
+        plan: &HvfSnapshotV2MemoryHotplugMappingPlan,
+        permissions: HvfMemoryPermissions,
+    ) -> Result<(), HvfGuestMemoryMappingError> {
+        let memory = self
+            .memory
+            .as_ref()
+            .ok_or(HvfGuestMemoryMappingError::InvalidState(
+                "guest memory owner is missing",
+            ))?;
+        self.state
+            .map_snapshot_v2_memory_hotplug(memory, plan, permissions)
     }
 
     fn map_lazy_all(
@@ -2049,6 +2199,46 @@ impl HvfGuestMemoryMappingState {
         Ok(())
     }
 
+    fn map_snapshot_v2_memory_hotplug(
+        &mut self,
+        memory: &GuestMemory,
+        plan: &HvfSnapshotV2MemoryHotplugMappingPlan,
+        permissions: HvfMemoryPermissions,
+    ) -> Result<(), HvfGuestMemoryMappingError> {
+        let page_size = host_page_size()?;
+        let requests =
+            validate_snapshot_v2_memory_hotplug_mapping(memory, plan, permissions, page_size)?;
+        self.mapped_regions
+            .try_reserve_exact(requests.len())
+            .map_err(
+                |source| HvfGuestMemoryMappingError::MappingMetadataAllocationFailed { source },
+            )?;
+        self.dynamic_regions
+            .try_reserve_exact(plan.dynamic_ranges.len())
+            .map_err(
+                |source| HvfGuestMemoryMappingError::MappingMetadataAllocationFailed { source },
+            )?;
+
+        let aperture = plan.reservation.range();
+        for request in requests {
+            let mapped_region = request.mapped_region(permissions);
+            if let Err(source) = self.mapper.map_region(request, permissions) {
+                let cleanup_failures = self.unmap_mapped_regions();
+                self.sync_dynamic_regions_to_mapped_regions();
+                return Err(HvfGuestMemoryMappingError::MapFailed {
+                    range: request.range,
+                    source,
+                    cleanup_failures,
+                });
+            }
+            self.mapped_regions.push(mapped_region);
+            if request.range.overlaps(aperture) {
+                self.dynamic_regions.push(request.range);
+            }
+        }
+        Ok(())
+    }
+
     fn map_regions(
         &mut self,
         regions: &[GuestMemoryRegion],
@@ -2126,6 +2316,14 @@ impl HvfGuestMemoryMappingState {
         }
 
         failures
+    }
+
+    fn sync_dynamic_regions_to_mapped_regions(&mut self) {
+        self.dynamic_regions.retain(|range| {
+            self.mapped_regions
+                .iter()
+                .any(|mapped| mapped.range == *range)
+        });
     }
 
     fn flush_host_memory(&mut self) -> Result<(), HvfGuestMemoryMappingError> {

--- a/crates/hvf/src/snapshot_v2/tests.rs
+++ b/crates/hvf/src/snapshot_v2/tests.rs
@@ -775,7 +775,7 @@ pub(crate) fn product_memory_hotplug_fixture(
     .expect("relocated virtio-mem fixture should decode")
 }
 
-fn product_serial_fixture() -> SnapshotV2SerialState {
+pub(crate) fn product_serial_fixture() -> SnapshotV2SerialState {
     SnapshotV2SerialState::decode(
         NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION,
         &fixture_bytes(SERIAL_CONFIGURED_FIXTURE_HEX),

--- a/crates/hvf/src/snapshot_v2_memory_hotplug_platform.rs
+++ b/crates/hvf/src/snapshot_v2_memory_hotplug_platform.rs
@@ -82,7 +82,7 @@ pub enum HvfSnapshotV2MemoryHotplugProductKind {
     SerialBalloonStorageEntropyMemoryHotplug,
 }
 
-enum HvfSnapshotV2MemoryHotplugPreparedProductParts {
+pub(crate) enum HvfSnapshotV2MemoryHotplugPreparedProductParts {
     Base {
         topology: PreparedSnapshotV2MemoryHotplugTopology,
         memory: GuestMemory,
@@ -363,6 +363,10 @@ impl HvfSnapshotV2MemoryHotplugPreparedProduct {
             | HvfSnapshotV2MemoryHotplugPreparedProductParts::StorageEntropy { .. } => None,
         }
     }
+
+    pub(crate) fn into_parts(self) -> HvfSnapshotV2MemoryHotplugPreparedProductParts {
+        self.parts
+    }
 }
 
 impl fmt::Debug for HvfSnapshotV2MemoryHotplugPreparedProduct {
@@ -546,6 +550,18 @@ pub struct HvfSnapshotV2MemoryHotplugMmioPlatformPlan {
     vmclock_interrupt: GuestInterruptLine,
 }
 
+pub(crate) struct HvfSnapshotV2MemoryHotplugMmioPlatformPlanParts {
+    pub(crate) product: HvfSnapshotV2MemoryHotplugPreparedProduct,
+    pub(crate) mapping: HvfSnapshotV2MemoryHotplugMappingPlan,
+    pub(crate) balloon: Option<HvfSnapshotV2BalloonMmioEndpointPlan>,
+    pub(crate) storage: Option<HvfSnapshotV2StorageMmioPlatformPlan>,
+    pub(crate) entropy: Option<HvfSnapshotV2MemoryHotplugEntropyMmioEndpointPlan>,
+    pub(crate) memory_hotplug: HvfSnapshotV2MemoryHotplugMmioEndpointPlan,
+    pub(crate) serial_interrupt: GuestInterruptLine,
+    pub(crate) vmgenid_interrupt: GuestInterruptLine,
+    pub(crate) vmclock_interrupt: GuestInterruptLine,
+}
+
 impl HvfSnapshotV2MemoryHotplugMmioPlatformPlan {
     pub const fn kind(&self) -> HvfSnapshotV2MemoryHotplugProductKind {
         self.product.kind()
@@ -581,6 +597,20 @@ impl HvfSnapshotV2MemoryHotplugMmioPlatformPlan {
 
     pub const fn vmclock_interrupt(&self) -> GuestInterruptLine {
         self.vmclock_interrupt
+    }
+
+    pub(crate) fn into_parts(self) -> HvfSnapshotV2MemoryHotplugMmioPlatformPlanParts {
+        HvfSnapshotV2MemoryHotplugMmioPlatformPlanParts {
+            product: self.product,
+            mapping: self.mapping,
+            balloon: self.balloon,
+            storage: self.storage,
+            entropy: self.entropy,
+            memory_hotplug: self.memory_hotplug,
+            serial_interrupt: self.serial_interrupt,
+            vmgenid_interrupt: self.vmgenid_interrupt,
+            vmclock_interrupt: self.vmclock_interrupt,
+        }
     }
 }
 
@@ -946,6 +976,7 @@ fn validate_product_profile_and_binding(
     product: &HvfSnapshotV2MemoryHotplugPreparedProduct,
 ) -> Result<(), PrepareHvfSnapshotV2MemoryHotplugPlatformPlanError> {
     if !platform.machine().fdt().is_product_process_profile()
+        || !platform.machine().machine().track_dirty_pages()
         || platform.time().rtc_layout()
             != RtcMmioLayout::new(PROCESS_RTC_MMIO_BASE, PROCESS_RTC_MMIO_REGION_ID)
     {
@@ -1825,12 +1856,17 @@ mod tests {
     use std::fs::{self, File, OpenOptions};
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex};
     use std::time::Instant;
 
+    use bangbang_runtime::BackendError;
     use bangbang_runtime::balloon::VirtioBalloonQueueLayout;
     use bangbang_runtime::block::{BlockFileBacking, BlockMmioLayout};
     use bangbang_runtime::memory::{GuestMemoryLayout, aarch64};
     use bangbang_runtime::pmem::{PmemFileBacking, PmemMmioLayout};
+    use bangbang_runtime::serial::{
+        SerialMmioDevice, SharedSerialOutput, SharedSerialOutputBuffer,
+    };
     use bangbang_runtime::snapshot_balloon_v2_9::{
         NATIVE_V2_BALLOON_STATE_COMPATIBILITY_VERSION, SnapshotV2BalloonRestorePlan,
         SnapshotV2BalloonState,
@@ -1858,19 +1894,24 @@ mod tests {
     use super::*;
     use crate::gic::{HvfGicInterruptRange, HvfGicRegion};
     use crate::memory::{
-        HvfSnapshotV2MemoryHotplugMappingPlanFailureStage,
+        HvfGuestMemoryMapping, HvfMappedGuestMemoryRegion, HvfMemoryMapRequest, HvfMemoryMapper,
+        HvfMemoryPermissions, HvfSnapshotV2MemoryHotplugMappingPlanFailureStage,
         PrepareHvfSnapshotV2MemoryHotplugMappingPlanError,
         prepare_hvf_snapshot_v2_memory_hotplug_mapping_plan_with_failure,
     };
     use crate::snapshot_bundle::HvfSnapshotV1CompatibilityState;
     use crate::snapshot_v2::{
-        HvfSnapshotV2GlobalState, HvfSnapshotV2MemoryHotplugPlatformState, HvfSnapshotV2TimeState,
+        HvfSnapshotV2GlobalState, HvfSnapshotV2MachineState,
+        HvfSnapshotV2MemoryHotplugPlatformState, HvfSnapshotV2TimeState,
         tests::{
             FIXTURE_MEMORY_MIB, memory_hotplug_active_ranges, memory_hotplug_capture_fixture,
             memory_hotplug_product_entropy_fixture, product_balloon_fixture,
-            product_memory_hotplug_fixture, product_storage_fixture, try_exact_minor_ten_platform,
+            product_memory_hotplug_fixture, product_serial_fixture, product_storage_fixture,
+            try_exact_minor_ten_platform,
         },
     };
+    use crate::snapshot_v2_platform::HvfSnapshotV2RestoredSerialShell;
+    use crate::startup::{HvfSnapshotV2MemoryHotplugMmioRestoreFault, OwnedHvfArm64BootSession};
 
     const MIB: u64 = 1024 * 1024;
     const COMPONENT_HEADER_BYTES: usize = 64;
@@ -1900,6 +1941,101 @@ mod tests {
     const ENTROPY_DATA_BUFFER: GuestAddress = GuestAddress::new(0x8007_0000);
     static NEXT_IMAGE: AtomicU64 = AtomicU64::new(0);
     static NEXT_BACKING: AtomicU64 = AtomicU64::new(0);
+
+    #[derive(Debug, Default)]
+    struct MemoryHotplugMappingTestMapper {
+        state: Mutex<MemoryHotplugMappingTestMapperState>,
+    }
+
+    impl MemoryHotplugMappingTestMapper {
+        fn failing(fail_map_on: Option<usize>, fail_unmap_on: Option<usize>) -> Self {
+            Self {
+                state: Mutex::new(MemoryHotplugMappingTestMapperState {
+                    fail_map_on,
+                    fail_unmap_on,
+                    ..MemoryHotplugMappingTestMapperState::default()
+                }),
+            }
+        }
+
+        fn mapped_ranges(&self) -> Vec<GuestMemoryRange> {
+            self.state
+                .lock()
+                .expect("mapping test state should not be poisoned")
+                .mapped_ranges
+                .clone()
+        }
+
+        fn unmapped_ranges(&self) -> Vec<GuestMemoryRange> {
+            self.state
+                .lock()
+                .expect("mapping test state should not be poisoned")
+                .unmapped_ranges
+                .clone()
+        }
+
+        fn allow_unmaps(&self) {
+            self.state
+                .lock()
+                .expect("mapping test state should not be poisoned")
+                .fail_unmap_on = None;
+        }
+    }
+
+    impl HvfMemoryMapper for MemoryHotplugMappingTestMapper {
+        fn map_region(
+            &self,
+            request: HvfMemoryMapRequest,
+            _permissions: HvfMemoryPermissions,
+        ) -> Result<(), BackendError> {
+            let mut state = self
+                .state
+                .lock()
+                .expect("mapping test state should not be poisoned");
+            state.mapped_ranges.push(request.range());
+            if state.fail_map_on == Some(state.mapped_ranges.len()) {
+                Err(BackendError::Hypervisor(
+                    "injected mixed map failure".to_string(),
+                ))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn unmap_region(
+            &self,
+            mapped_region: HvfMappedGuestMemoryRegion,
+        ) -> Result<(), BackendError> {
+            let mut state = self
+                .state
+                .lock()
+                .expect("mapping test state should not be poisoned");
+            state.unmapped_ranges.push(mapped_region.range);
+            if state.fail_unmap_on == Some(state.unmapped_ranges.len()) {
+                Err(BackendError::Hypervisor(
+                    "injected mixed unmap failure".to_string(),
+                ))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn protect_region(
+            &self,
+            _range: GuestMemoryRange,
+            _permissions: HvfMemoryPermissions,
+        ) -> Result<(), BackendError> {
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct MemoryHotplugMappingTestMapperState {
+        mapped_ranges: Vec<GuestMemoryRange>,
+        unmapped_ranges: Vec<GuestMemoryRange>,
+        fail_map_on: Option<usize>,
+        fail_unmap_on: Option<usize>,
+    }
 
     struct TestImage {
         path: PathBuf,
@@ -1966,6 +2102,26 @@ mod tests {
             .expect("exact-2.10 platform should validate")
             .platform()
             .clone();
+        let (memory_binding, machine, global, stable, vcpus, time) = platform.into_parts();
+        let machine = HvfSnapshotV2MachineState::try_new(
+            machine.machine().with_track_dirty_pages(true),
+            machine.boot().clone(),
+            machine.fdt(),
+            machine.cpu_template().cloned(),
+        )
+        .expect("tracked exact-2.10 machine should validate");
+        let platform = HvfSnapshotV2MemoryHotplugPlatformState::try_new(
+            memory_binding,
+            machine,
+            global,
+            stable,
+            vcpus,
+            time,
+            Some(memory_hotplug_capture_fixture(state.clone())),
+        )
+        .expect("tracked exact-2.10 platform should validate")
+        .platform()
+        .clone();
         let topology = PreparedSnapshotV2MemoryHotplugTopology::prepare(state, binding)
             .expect("memory-hotplug topology should prepare");
         let memory = materialize_snapshot_v2_memory_hotplug_file(
@@ -2818,6 +2974,25 @@ mod tests {
             );
             assert_eq!(plan.mapping().base_bytes(), FIXTURE_MEMORY_MIB * MIB);
             assert_eq!(plan.mapping().dirty_epoch(), 0);
+
+            let serial = product_serial_fixture();
+            let shell = HvfSnapshotV2RestoredSerialShell::new(
+                SerialMmioDevice::from_capture_state_with_shared_output(
+                    SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+                    serial.device().clone(),
+                ),
+            );
+            let error =
+                OwnedHvfArm64BootSession::restore_snapshot_v2_memory_hotplug_mmio_with_fault(
+                    platform,
+                    shell,
+                    None,
+                    plan,
+                    HvfSnapshotV2MemoryHotplugMmioRestoreFault::InterruptSetup,
+                )
+                .expect_err("all eight MMIO product tags should reach owner preflight");
+            assert!(!error.is_terminal());
+            assert!(!error.has_incomplete_cleanup());
         }
     }
 
@@ -3161,5 +3336,191 @@ mod tests {
             assert!(diagnostics.contains("<redacted>"));
             assert!(!diagnostics.contains(&plan.reservation().range().start().to_string()));
         }
+    }
+
+    #[test]
+    fn mixed_mapping_materializes_static_and_dynamic_owners_and_survives_remap() {
+        let fixture = materialized_fixture(product_memory_hotplug_fixture(
+            SnapshotV2DeviceTransportKind::Mmio,
+        ));
+        let MaterializedFixture {
+            platform: _,
+            topology,
+            memory,
+            _image,
+        } = fixture;
+        let config = topology.state().config();
+        let plan = prepare_hvf_snapshot_v2_memory_hotplug_mapping_plan(
+            &topology,
+            &memory,
+            FIXTURE_MEMORY_MIB * MIB,
+        )
+        .expect("mixed mapping should plan");
+        let restored = topology
+            .into_mmio_handler(&memory)
+            .expect("inactive MMIO handler should reconstruct");
+        let expected_ranges = memory
+            .regions()
+            .iter()
+            .map(|region| region.range())
+            .collect::<Vec<_>>();
+        let mapper = Arc::new(MemoryHotplugMappingTestMapper::default());
+        let mut mapping = HvfGuestMemoryMapping::map_snapshot_v2_memory_hotplug_with_mapper(
+            memory,
+            &plan,
+            HvfMemoryPermissions::GUEST_RAM,
+            mapper.clone(),
+        )
+        .expect("mixed mapping should materialize");
+
+        assert_eq!(mapper.mapped_ranges(), expected_ranges);
+        assert!(mapping.has_dynamic_regions());
+        mapping
+            .start_dirty_write_tracking()
+            .expect("restored mixed mapping should start HVF dirty tracking");
+        let capture = restored
+            .handler()
+            .capture_memory_hotplug_state(
+                config,
+                mapping
+                    .memory()
+                    .expect("restored mapping should retain guest memory"),
+            )
+            .expect("restored virtio-mem handler should capture");
+        let mapping_capture = mapping
+            .capture_virtio_mem_mapping_state(capture.device())
+            .expect("restored owners should close over the mapping proof");
+        assert!(plan.matches_capture(&mapping_capture));
+
+        let dynamic_range = plan.dynamic_ranges()[0];
+        mapping
+            .unmap_dynamic_region(dynamic_range)
+            .expect("restored dynamic owner should unplug");
+        mapping
+            .map_dynamic_region(dynamic_range, HvfMemoryPermissions::GUEST_RAM)
+            .expect("restored dynamic owner should remap");
+        let remapped_capture = mapping
+            .capture_virtio_mem_mapping_state(capture.device())
+            .expect("remapped owners should close over the original proof");
+        assert!(plan.matches_capture(&remapped_capture));
+
+        mapping.unmap_all().expect("mixed mapping should unmap");
+        assert!(!mapping.has_mapped_regions());
+        assert!(!mapping.has_dynamic_regions());
+    }
+
+    #[test]
+    fn mixed_mapping_rolls_back_every_map_boundary_in_reverse_order() {
+        let region_count = {
+            let fixture = materialized_fixture(product_memory_hotplug_fixture(
+                SnapshotV2DeviceTransportKind::Mmio,
+            ));
+            fixture.memory.regions().len()
+        };
+        assert!(region_count >= 3);
+
+        for fail_map_on in 1..=region_count {
+            let fixture = materialized_fixture(product_memory_hotplug_fixture(
+                SnapshotV2DeviceTransportKind::Mmio,
+            ));
+            let plan = prepare_hvf_snapshot_v2_memory_hotplug_mapping_plan(
+                &fixture.topology,
+                &fixture.memory,
+                FIXTURE_MEMORY_MIB * MIB,
+            )
+            .expect("mixed mapping should plan");
+            let expected_ranges = fixture
+                .memory
+                .regions()
+                .iter()
+                .map(|region| region.range())
+                .collect::<Vec<_>>();
+            let mapper = Arc::new(MemoryHotplugMappingTestMapper::failing(
+                Some(fail_map_on),
+                None,
+            ));
+            let failure = HvfGuestMemoryMapping::map_snapshot_v2_memory_hotplug_with_mapper(
+                fixture.memory,
+                &plan,
+                HvfMemoryPermissions::GUEST_RAM,
+                mapper.clone(),
+            )
+            .expect_err("injected map boundary should fail");
+            let mut expected_unmaps = expected_ranges[..fail_map_on - 1].to_vec();
+            expected_unmaps.reverse();
+
+            assert_eq!(
+                mapper.mapped_ranges(),
+                expected_ranges[..fail_map_on].to_vec()
+            );
+            assert_eq!(mapper.unmapped_ranges(), expected_unmaps);
+            assert!(matches!(
+                failure.error,
+                crate::memory::HvfGuestMemoryMappingError::MapFailed {
+                    range,
+                    ref cleanup_failures,
+                    ..
+                } if range == expected_ranges[fail_map_on - 1] && cleanup_failures.is_empty()
+            ));
+            assert!(!failure.mapping.has_mapped_regions());
+            assert!(!failure.mapping.has_dynamic_regions());
+        }
+    }
+
+    #[test]
+    fn mixed_mapping_retains_only_failed_cleanup_owners_until_retry() {
+        let fixture = materialized_fixture(product_memory_hotplug_fixture(
+            SnapshotV2DeviceTransportKind::Mmio,
+        ));
+        let plan = prepare_hvf_snapshot_v2_memory_hotplug_mapping_plan(
+            &fixture.topology,
+            &fixture.memory,
+            FIXTURE_MEMORY_MIB * MIB,
+        )
+        .expect("mixed mapping should plan");
+        let region_count = fixture.memory.regions().len();
+        assert!(region_count >= 3);
+        let expected_ranges = fixture
+            .memory
+            .regions()
+            .iter()
+            .map(|region| region.range())
+            .collect::<Vec<_>>();
+        let retained_dynamic_range = expected_ranges[region_count - 2];
+        assert!(plan.dynamic_ranges().contains(&retained_dynamic_range));
+        let mapper = Arc::new(MemoryHotplugMappingTestMapper::failing(
+            Some(region_count),
+            Some(1),
+        ));
+        let mut failure = HvfGuestMemoryMapping::map_snapshot_v2_memory_hotplug_with_mapper(
+            fixture.memory,
+            &plan,
+            HvfMemoryPermissions::GUEST_RAM,
+            mapper.clone(),
+        )
+        .expect_err("map plus reverse-cleanup failure should retain authority");
+
+        assert!(matches!(
+            failure.error,
+            crate::memory::HvfGuestMemoryMappingError::MapFailed {
+                ref cleanup_failures,
+                ..
+            } if cleanup_failures.len() == 1
+                && cleanup_failures[0].range() == retained_dynamic_range
+        ));
+        assert!(failure.mapping.has_mapped_regions());
+        assert!(failure.mapping.has_dynamic_regions());
+
+        mapper.allow_unmaps();
+        failure
+            .mapping
+            .unmap_all()
+            .expect("retained cleanup owner should retry");
+        assert!(!failure.mapping.has_mapped_regions());
+        assert!(!failure.mapping.has_dynamic_regions());
+        assert_eq!(
+            mapper.unmapped_ranges().last(),
+            Some(&retained_dynamic_range)
+        );
     }
 }

--- a/crates/hvf/src/snapshot_v2_platform.rs
+++ b/crates/hvf/src/snapshot_v2_platform.rs
@@ -57,7 +57,9 @@ use crate::gic::{
     HvfGicError, HvfGicInterruptLineAllocator, HvfGicMetadata, HvfGicMsiConfiguration,
     HvfGicSpiSignalError, HvfGicSpiSignaler, HvfInterruptLineAllocationError,
 };
-use crate::memory::{HvfGuestMemoryMappingError, HvfMemoryPermissions};
+use crate::memory::{
+    HvfGuestMemoryMappingError, HvfMemoryPermissions, HvfSnapshotV2MemoryHotplugMappingPlan,
+};
 use crate::pvtime::HvfArm64PvTimeAccountingConfig;
 use crate::runner::{HvfArm64SnapshotV2VcpuRestore, HvfVcpuRunStepOutcome, HvfVcpuRunnerError};
 use crate::session_vcpu::{
@@ -463,6 +465,18 @@ pub(crate) struct HvfSnapshotV2BalloonMmioShellPlan<'a> {
     pub(crate) vmclock_interrupt: GuestInterruptLine,
 }
 
+pub(crate) struct HvfSnapshotV2MemoryHotplugMmioShellPlan<'a> {
+    pub(crate) balloon_interrupt: Option<GuestInterruptLine>,
+    pub(crate) command_line: Option<&'a str>,
+    pub(crate) block_records: &'a [HvfSnapshotV2StorageMmioRecordPlan],
+    pub(crate) pmem_records: &'a [HvfSnapshotV2StorageMmioRecordPlan],
+    pub(crate) entropy_interrupt: Option<GuestInterruptLine>,
+    pub(crate) memory_hotplug_interrupt: GuestInterruptLine,
+    pub(crate) serial_interrupt: GuestInterruptLine,
+    pub(crate) vmgenid_interrupt: GuestInterruptLine,
+    pub(crate) vmclock_interrupt: GuestInterruptLine,
+}
+
 pub(crate) struct HvfSnapshotV2StoragePciShellPlan<'a> {
     pub(crate) command_line: &'a str,
     pub(crate) pci: &'a HvfSnapshotV2StoragePciHostPlan,
@@ -506,6 +520,10 @@ enum HvfSnapshotV2ProcessShellRestore<'a> {
     BalloonMmio {
         shell: HvfSnapshotV2ProcessSerialShell,
         plan: HvfSnapshotV2BalloonMmioShellPlan<'a>,
+    },
+    MemoryHotplugMmio {
+        shell: HvfSnapshotV2ProcessSerialShell,
+        plan: HvfSnapshotV2MemoryHotplugMmioShellPlan<'a>,
     },
     StoragePci {
         shell: HvfSnapshotV2ProcessSerialShell,
@@ -1622,6 +1640,44 @@ fn restore_hvf_snapshot_v2_platform_with_shell(
     memory: GuestMemory,
     process_shell: Option<HvfSnapshotV2ProcessShellRestore<'_>>,
 ) -> Result<RestoredHvfSnapshotV2Platform, HvfSnapshotV2PlatformRestoreError> {
+    restore_hvf_snapshot_v2_platform_with_shell_and_mapping(
+        state,
+        memory,
+        process_shell,
+        HvfSnapshotV2MemoryMappingRestore::Ordinary,
+    )
+}
+
+pub(crate) fn restore_hvf_snapshot_v2_serial_memory_hotplug_mmio_process_platform(
+    state: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    shell: HvfSnapshotV2RestoredSerialShell,
+    plan: HvfSnapshotV2MemoryHotplugMmioShellPlan<'_>,
+    mapping: &HvfSnapshotV2MemoryHotplugMappingPlan,
+) -> Result<RestoredHvfSnapshotV2Platform, HvfSnapshotV2PlatformRestoreError> {
+    restore_hvf_snapshot_v2_platform_with_shell_and_mapping(
+        state,
+        memory,
+        Some(HvfSnapshotV2ProcessShellRestore::MemoryHotplugMmio {
+            shell: shell.into(),
+            plan,
+        }),
+        HvfSnapshotV2MemoryMappingRestore::MemoryHotplug(mapping),
+    )
+}
+
+#[derive(Clone, Copy)]
+enum HvfSnapshotV2MemoryMappingRestore<'a> {
+    Ordinary,
+    MemoryHotplug(&'a HvfSnapshotV2MemoryHotplugMappingPlan),
+}
+
+fn restore_hvf_snapshot_v2_platform_with_shell_and_mapping(
+    state: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    process_shell: Option<HvfSnapshotV2ProcessShellRestore<'_>>,
+    mapping: HvfSnapshotV2MemoryMappingRestore<'_>,
+) -> Result<RestoredHvfSnapshotV2Platform, HvfSnapshotV2PlatformRestoreError> {
     debug_assert!(cleanup_sequence(RestoreOwnership::Empty).is_empty());
     let mut cleanup = Vec::new();
     if cleanup.try_reserve_exact(2).is_err() {
@@ -1717,7 +1773,15 @@ fn restore_hvf_snapshot_v2_platform_with_shell(
             cleanup,
         ));
     }
-    if let Err(source) = backend.map_guest_memory(memory, HvfMemoryPermissions::GUEST_RAM) {
+    let mapped = match mapping {
+        HvfSnapshotV2MemoryMappingRestore::Ordinary => {
+            backend.map_guest_memory(memory, HvfMemoryPermissions::GUEST_RAM)
+        }
+        HvfSnapshotV2MemoryMappingRestore::MemoryHotplug(plan) => {
+            backend.map_snapshot_v2_memory_hotplug(memory, plan, HvfMemoryPermissions::GUEST_RAM)
+        }
+    };
+    if let Err(source) = mapped {
         return Err(failed_restore(
             HvfSnapshotV2PlatformRestoreStage::Memory,
             HvfSnapshotV2PlatformRestoreFailure::MapMemory(source),
@@ -2763,6 +2827,67 @@ fn prepare_process_shell(
                         .allocate()
                         .map_err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterrupt)?
                         != entropy_interrupt
+                {
+                    return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterruptIdentity);
+                }
+                let block_plan = match plan.command_line {
+                    Some(command_line) => HvfSnapshotV2ProcessBlockFdtPlan::StorageMmio {
+                        command_line,
+                        block_records: plan.block_records,
+                        pmem_records: plan.pmem_records,
+                    },
+                    None => HvfSnapshotV2ProcessBlockFdtPlan::None,
+                };
+                (
+                    shell,
+                    block_plan,
+                    true,
+                    false,
+                    Some((
+                        plan.serial_interrupt,
+                        plan.vmgenid_interrupt,
+                        plan.vmclock_interrupt,
+                    )),
+                )
+            }
+            HvfSnapshotV2ProcessShellRestore::MemoryHotplugMmio { shell, plan } => {
+                let storage_count = plan.block_records.len() + plan.pmem_records.len();
+                if gic.msi.is_some() || plan.command_line.is_some() != (storage_count != 0) {
+                    return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellFdt {
+                        mismatch: HvfSnapshotV2ProcessFdtMismatch::Profile,
+                    });
+                }
+                if let Some(balloon_interrupt) = plan.balloon_interrupt
+                    && allocator
+                        .allocate()
+                        .map_err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterrupt)?
+                        != balloon_interrupt
+                {
+                    return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterruptIdentity);
+                }
+                for record in plan.block_records.iter().chain(plan.pmem_records) {
+                    if allocator
+                        .allocate()
+                        .map_err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterrupt)?
+                        != record.interrupt_line()
+                    {
+                        return Err(
+                            HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterruptIdentity,
+                        );
+                    }
+                }
+                if let Some(entropy_interrupt) = plan.entropy_interrupt
+                    && allocator
+                        .allocate()
+                        .map_err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterrupt)?
+                        != entropy_interrupt
+                {
+                    return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterruptIdentity);
+                }
+                if allocator
+                    .allocate()
+                    .map_err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterrupt)?
+                    != plan.memory_hotplug_interrupt
                 {
                     return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterruptIdentity);
                 }

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -57,8 +57,9 @@ use bangbang_runtime::memory::{
 use bangbang_runtime::memory_hotplug::{
     MemoryHotplugConfig, MemoryHotplugSizeUpdate, MemoryHotplugStatus, MemoryHotplugStatusError,
     MemoryHotplugUpdateError, VIRTIO_MEM_DEVICE_ID, VIRTIO_MEM_QUEUE_SIZES, VirtioMemConfigSpace,
-    VirtioMemDevice, VirtioMemMmioCaptureState, VirtioMemMmioLayout, VirtioMemMutationExecutor,
-    VirtioMemPciCaptureError, VirtioMemPciCaptureState,
+    VirtioMemDevice, VirtioMemMmioCaptureState, VirtioMemMmioDeviceRegistration,
+    VirtioMemMmioHandler, VirtioMemMmioLayout, VirtioMemMutationExecutor, VirtioMemPciCaptureError,
+    VirtioMemPciCaptureState,
 };
 use bangbang_runtime::message_interrupt::{
     GuestMessageInterruptResources, GuestMessageInterruptResourcesError,
@@ -139,8 +140,9 @@ use bangbang_runtime::snapshot_entropy_v2_8::{
 use bangbang_runtime::snapshot_format::SnapshotFormatVersion;
 use bangbang_runtime::snapshot_format_v2::NATIVE_V2_LEGACY_PLATFORM_VERSION;
 use bangbang_runtime::snapshot_memory_hotplug_v2_10::{
-    NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION, SnapshotV2MemoryHotplugState,
-    SnapshotV2MemoryHotplugStateCaptureError,
+    NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+    SnapshotV2MemoryHotplugControllerProjection, SnapshotV2MemoryHotplugMmioHandlerError,
+    SnapshotV2MemoryHotplugState, SnapshotV2MemoryHotplugStateCaptureError,
 };
 use bangbang_runtime::snapshot_memory_v2::{
     SnapshotV2MemoryBinding, SnapshotV2MemoryIoStage, SnapshotV2MemoryWriteError,
@@ -156,7 +158,7 @@ use bangbang_runtime::startup::{
     Arm64BootEntropyDeviceConfig as RuntimeArm64BootEntropyDeviceConfig,
     Arm64BootEntropyNotificationDispatch, Arm64BootEntropyNotificationDispatchError,
     Arm64BootEntropyNotificationDispatches, Arm64BootEntropySourceProvider,
-    Arm64BootMemoryHotplugCaptureError,
+    Arm64BootMemoryHotplugCaptureError, Arm64BootMemoryHotplugDevice,
     Arm64BootMemoryHotplugDeviceConfig as RuntimeArm64BootMemoryHotplugDeviceConfig,
     Arm64BootMemoryHotplugNotificationDispatch, Arm64BootMemoryHotplugNotificationDispatchError,
     Arm64BootMemoryHotplugNotificationDispatches, Arm64BootNetworkInterface,
@@ -223,7 +225,8 @@ use crate::gic::{
 };
 use crate::memory::{
     HvfGuestMemoryMappingError, HvfMemoryPermissions, HvfPmemFlushExecutor,
-    HvfVirtioMemMappingCaptureError, HvfVirtioMemMappingCaptureState,
+    HvfSnapshotV2MemoryHotplugMappingPlan, HvfVirtioMemMappingCaptureError,
+    HvfVirtioMemMappingCaptureState,
 };
 use crate::paused_topology::HvfArm64StablePausedTopologyState;
 use crate::psci::PsciCpuPowerCoordinator;
@@ -263,22 +266,28 @@ use crate::snapshot_v2_balloon_platform::{
 use crate::snapshot_v2_entropy_platform::{
     HvfSnapshotV2EntropyPciEndpointPlan, HvfSnapshotV2StorageEntropyPciPlatformPlan,
 };
+use crate::snapshot_v2_memory_hotplug_platform::{
+    HvfSnapshotV2MemoryHotplugMmioPlatformPlan, HvfSnapshotV2MemoryHotplugMmioPlatformPlanParts,
+    HvfSnapshotV2MemoryHotplugPreparedProductParts,
+};
 use crate::snapshot_v2_multi_block_platform::{
     HvfSnapshotV2MultiBlockPlatformPlan, HvfSnapshotV2MultiBlockPlatformPlanParts,
     HvfSnapshotV2MultiBlockTransportPlan,
 };
 use crate::snapshot_v2_platform::{
     HvfSnapshotV2BalloonMmioShellPlan, HvfSnapshotV2DefaultProcessShell,
-    HvfSnapshotV2MultiBlockMmioShellPlan, HvfSnapshotV2MultiBlockPciShellPlan,
-    HvfSnapshotV2PlatformRestoreError, HvfSnapshotV2PlatformShutdownError,
-    HvfSnapshotV2RestoredSerialShell, HvfSnapshotV2RootResourcePlan,
-    HvfSnapshotV2RootTransportPlan, HvfSnapshotV2SerialOnlyProcessConfig,
-    HvfSnapshotV2StorageMmioShellPlan, HvfSnapshotV2StoragePciShellPlan,
-    RestoredHvfSnapshotV2Platform, restore_hvf_snapshot_v2_multi_block_mmio_process_platform,
+    HvfSnapshotV2MemoryHotplugMmioShellPlan, HvfSnapshotV2MultiBlockMmioShellPlan,
+    HvfSnapshotV2MultiBlockPciShellPlan, HvfSnapshotV2PlatformRestoreError,
+    HvfSnapshotV2PlatformShutdownError, HvfSnapshotV2RestoredSerialShell,
+    HvfSnapshotV2RootResourcePlan, HvfSnapshotV2RootTransportPlan,
+    HvfSnapshotV2SerialOnlyProcessConfig, HvfSnapshotV2StorageMmioShellPlan,
+    HvfSnapshotV2StoragePciShellPlan, RestoredHvfSnapshotV2Platform,
+    restore_hvf_snapshot_v2_multi_block_mmio_process_platform,
     restore_hvf_snapshot_v2_multi_block_pci_process_platform,
     restore_hvf_snapshot_v2_root_process_platform,
     restore_hvf_snapshot_v2_serial_balloon_mmio_process_platform,
     restore_hvf_snapshot_v2_serial_entropy_mmio_process_platform,
+    restore_hvf_snapshot_v2_serial_memory_hotplug_mmio_process_platform,
     restore_hvf_snapshot_v2_serial_only_process_platform,
     restore_hvf_snapshot_v2_serial_storage_entropy_mmio_process_platform,
     restore_hvf_snapshot_v2_serial_storage_mmio_process_platform,
@@ -3528,6 +3537,11 @@ enum HvfSnapshotV2StorageProcessShell {
         shell: HvfSnapshotV2RestoredSerialShell,
         interrupts: HvfSnapshotV2BalloonMmioInterruptPlan,
     },
+    RestoredMemoryHotplugMmio {
+        shell: HvfSnapshotV2RestoredSerialShell,
+        interrupts: HvfSnapshotV2MemoryHotplugMmioInterruptPlan,
+        mapping: HvfSnapshotV2MemoryHotplugMappingPlan,
+    },
 }
 
 enum HvfSnapshotV2SerialProcessShell {
@@ -3543,6 +3557,11 @@ enum HvfSnapshotV2SerialProcessShell {
         shell: HvfSnapshotV2RestoredSerialShell,
         interrupts: HvfSnapshotV2BalloonMmioInterruptPlan,
     },
+    MemoryHotplugMmio {
+        shell: HvfSnapshotV2RestoredSerialShell,
+        interrupts: HvfSnapshotV2MemoryHotplugMmioInterruptPlan,
+        mapping: HvfSnapshotV2MemoryHotplugMappingPlan,
+    },
 }
 
 #[derive(Clone, Copy)]
@@ -3554,11 +3573,23 @@ struct HvfSnapshotV2BalloonMmioInterruptPlan {
     vmclock: GuestInterruptLine,
 }
 
+#[derive(Clone, Copy)]
+struct HvfSnapshotV2MemoryHotplugMmioInterruptPlan {
+    balloon: Option<GuestInterruptLine>,
+    entropy: Option<GuestInterruptLine>,
+    memory_hotplug: GuestInterruptLine,
+    serial: GuestInterruptLine,
+    vmgenid: GuestInterruptLine,
+    vmclock: GuestInterruptLine,
+}
+
 impl HvfSnapshotV2SerialProcessShell {
     const fn pci_enabled(&self) -> bool {
         match self {
             Self::SerialOnly { process, .. } => process.pci_enabled(),
-            Self::EntropyMmio { .. } | Self::BalloonMmio { .. } => false,
+            Self::EntropyMmio { .. }
+            | Self::BalloonMmio { .. }
+            | Self::MemoryHotplugMmio { .. } => false,
         }
     }
 }
@@ -3619,6 +3650,329 @@ impl fmt::Debug for RestoredHvfSnapshotV2BalloonMmioOwners {
             .field("has_entropy", &self.entropy_config.is_some())
             .field("state", &"<redacted>")
             .finish()
+    }
+}
+
+/// One complete, still-unpublished exact-2.10 MMIO virtio-mem product.
+#[doc(hidden)]
+pub struct RestoredHvfSnapshotV2MemoryHotplugMmioOwners {
+    session: OwnedHvfArm64BootSession,
+    state: SnapshotV2MemoryHotplugState,
+    controller: SnapshotV2MemoryHotplugControllerProjection,
+    storage_configs: Option<CaptureReadyStorageConfigs>,
+    entropy_config: Option<EntropyConfig>,
+    balloon_config: Option<BalloonConfig>,
+}
+
+impl RestoredHvfSnapshotV2MemoryHotplugMmioOwners {
+    pub const fn session(&self) -> &OwnedHvfArm64BootSession {
+        &self.session
+    }
+
+    pub const fn state(&self) -> &SnapshotV2MemoryHotplugState {
+        &self.state
+    }
+
+    pub const fn controller(&self) -> SnapshotV2MemoryHotplugControllerProjection {
+        self.controller
+    }
+
+    pub const fn storage_configs(&self) -> Option<&CaptureReadyStorageConfigs> {
+        self.storage_configs.as_ref()
+    }
+
+    pub const fn entropy_config(&self) -> Option<EntropyConfig> {
+        self.entropy_config
+    }
+
+    pub const fn balloon_config(&self) -> Option<BalloonConfig> {
+        self.balloon_config
+    }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        OwnedHvfArm64BootSession,
+        SnapshotV2MemoryHotplugState,
+        SnapshotV2MemoryHotplugControllerProjection,
+        Option<CaptureReadyStorageConfigs>,
+        Option<EntropyConfig>,
+        Option<BalloonConfig>,
+    ) {
+        (
+            self.session,
+            self.state,
+            self.controller,
+            self.storage_configs,
+            self.entropy_config,
+            self.balloon_config,
+        )
+    }
+}
+
+impl fmt::Debug for RestoredHvfSnapshotV2MemoryHotplugMmioOwners {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RestoredHvfSnapshotV2MemoryHotplugMmioOwners")
+            .field("has_storage", &self.storage_configs.is_some())
+            .field("has_entropy", &self.entropy_config.is_some())
+            .field("has_balloon", &self.balloon_config.is_some())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Deterministic exact-2.10 MMIO owner fault used by rollback tests.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfSnapshotV2MemoryHotplugMmioRestoreFault {
+    InterruptSetup,
+    Platform,
+    BalloonPublication,
+    StoragePublication,
+    EntropyPublication,
+    Registration,
+    MemoryHotplugInsertion,
+    Recapture,
+    SessionAssembly,
+}
+
+/// Stage at which exact-2.10 MMIO virtio-mem reconstruction stopped.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfSnapshotV2MemoryHotplugMmioRestoreStage {
+    Product,
+    Handler,
+    InterruptSetup,
+    Platform,
+    BalloonPublication,
+    StoragePublication,
+    EntropyPublication,
+    Registration,
+    MemoryHotplugInsertion,
+    Recapture,
+    SessionAssembly,
+}
+
+/// Primary exact-2.10 MMIO virtio-mem reconstruction failure.
+#[doc(hidden)]
+pub enum HvfSnapshotV2MemoryHotplugMmioRestoreFailure {
+    Product,
+    Allocation,
+    Handler(SnapshotV2MemoryHotplugMmioHandlerError),
+    InterruptSetup(HvfGicSpiSignalError),
+    SerialPlatform(Box<HvfSnapshotV2SerialOnlyRestoreError>),
+    StoragePlatform(Box<HvfSnapshotV2StorageMmioRestoreError>),
+    BalloonPlatform(Box<HvfSnapshotV2BalloonMmioRestoreError>),
+    EntropyPlatform(Box<HvfSnapshotV2EntropyMmioRestoreError>),
+    DispatcherUnavailable,
+    Registration(MmioRegistrationError),
+    Quiescence(HvfArm64BootLimiterRetryWakeupQuiescenceError),
+    Capture(HvfArm64BootMemoryHotplugCaptureError),
+    Normalize(HvfArm64BootMemoryHotplugSnapshotV2CaptureError),
+    StateMismatch,
+    MappingMismatch,
+    Injected(HvfSnapshotV2MemoryHotplugMmioRestoreFault),
+}
+
+impl fmt::Debug for HvfSnapshotV2MemoryHotplugMmioRestoreFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let injected = match self {
+            Self::Injected(fault) => Some(fault),
+            _ => None,
+        };
+        let category = match self {
+            Self::Product => "product",
+            Self::Allocation => "allocation",
+            Self::Handler(_) => "handler",
+            Self::InterruptSetup(_) => "interrupt-setup",
+            Self::SerialPlatform(_) => "serial-platform",
+            Self::StoragePlatform(_) => "storage-platform",
+            Self::BalloonPlatform(_) => "balloon-platform",
+            Self::EntropyPlatform(_) => "entropy-platform",
+            Self::DispatcherUnavailable => "dispatcher",
+            Self::Registration(_) => "registration",
+            Self::Quiescence(_) => "quiescence",
+            Self::Capture(_) => "capture",
+            Self::Normalize(_) => "normalization",
+            Self::StateMismatch => "state-mismatch",
+            Self::MappingMismatch => "mapping-mismatch",
+            Self::Injected(_) => "injected",
+        };
+        formatter
+            .debug_struct("HvfSnapshotV2MemoryHotplugMmioRestoreFailure")
+            .field("category", &category)
+            .field("injected", &injected)
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2MemoryHotplugMmioRestoreFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Product => "exact-2.10 MMIO product proof is inconsistent",
+            Self::Allocation => "exact-2.10 MMIO owner allocation failed",
+            Self::Handler(_) => "exact-2.10 virtio-mem handler reconstruction failed",
+            Self::InterruptSetup(_) => "exact-2.10 virtio-mem interrupt setup failed",
+            Self::SerialPlatform(_) => "exact-2.10 serial platform reconstruction failed",
+            Self::StoragePlatform(_) => "exact-2.10 storage platform reconstruction failed",
+            Self::BalloonPlatform(_) => "exact-2.10 balloon publication failed",
+            Self::EntropyPlatform(_) => "exact-2.10 entropy publication failed",
+            Self::DispatcherUnavailable => "exact-2.10 MMIO dispatcher is unavailable",
+            Self::Registration(_) => "exact-2.10 virtio-mem registration failed",
+            Self::Quiescence(_) => "exact-2.10 destination quiescence failed",
+            Self::Capture(_) => "exact-2.10 virtio-mem live capture failed",
+            Self::Normalize(_) => "exact-2.10 virtio-mem normalization failed",
+            Self::StateMismatch => "exact-2.10 virtio-mem portable state diverged",
+            Self::MappingMismatch => "exact-2.10 virtio-mem mapping state diverged",
+            Self::Injected(_) => "exact-2.10 MMIO rollback fault was injected",
+        })
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2MemoryHotplugMmioRestoreFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Handler(source) => Some(source),
+            Self::InterruptSetup(source) => Some(source),
+            Self::SerialPlatform(source) => Some(source.as_ref()),
+            Self::StoragePlatform(source) => Some(source.as_ref()),
+            Self::BalloonPlatform(source) => Some(source.as_ref()),
+            Self::EntropyPlatform(source) => Some(source.as_ref()),
+            Self::Registration(source) => Some(source),
+            Self::Quiescence(source) => Some(source),
+            Self::Capture(source) => Some(source),
+            Self::Normalize(source) => Some(source),
+            Self::Product
+            | Self::Allocation
+            | Self::DispatcherUnavailable
+            | Self::StateMismatch
+            | Self::MappingMismatch
+            | Self::Injected(_) => None,
+        }
+    }
+}
+
+/// Redacted exact-2.10 MMIO aggregate reconstruction error.
+#[doc(hidden)]
+pub struct HvfSnapshotV2MemoryHotplugMmioRestoreError {
+    stage: HvfSnapshotV2MemoryHotplugMmioRestoreStage,
+    failure: Box<HvfSnapshotV2MemoryHotplugMmioRestoreFailure>,
+    committed: bool,
+    cleanup: Option<Box<HvfArm64BootSessionShutdownError>>,
+}
+
+impl HvfSnapshotV2MemoryHotplugMmioRestoreError {
+    fn preflight(
+        stage: HvfSnapshotV2MemoryHotplugMmioRestoreStage,
+        failure: HvfSnapshotV2MemoryHotplugMmioRestoreFailure,
+    ) -> Self {
+        Self {
+            stage,
+            failure: Box::new(failure),
+            committed: false,
+            cleanup: None,
+        }
+    }
+
+    fn after_session(
+        mut session: OwnedHvfArm64BootSession,
+        stage: HvfSnapshotV2MemoryHotplugMmioRestoreStage,
+        failure: HvfSnapshotV2MemoryHotplugMmioRestoreFailure,
+    ) -> Self {
+        Self {
+            stage,
+            failure: Box::new(failure),
+            committed: true,
+            cleanup: session.shutdown().err().map(Box::new),
+        }
+    }
+
+    pub const fn stage(&self) -> HvfSnapshotV2MemoryHotplugMmioRestoreStage {
+        self.stage
+    }
+
+    pub fn has_incomplete_cleanup(&self) -> bool {
+        self.cleanup.is_some()
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::SerialPlatform(source)
+                    if source.has_incomplete_cleanup()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::StoragePlatform(source)
+                    if source.has_incomplete_cleanup()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::BalloonPlatform(source)
+                    if source.has_incomplete_cleanup()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::EntropyPlatform(source)
+                    if source.has_incomplete_cleanup()
+            )
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        self.committed
+            || self.has_incomplete_cleanup()
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::SerialPlatform(source)
+                    if source.is_terminal()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::StoragePlatform(source)
+                    if source.is_terminal()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::BalloonPlatform(source)
+                    if source.is_terminal()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::EntropyPlatform(source)
+                    if source.is_terminal()
+            )
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2MemoryHotplugMmioRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2MemoryHotplugMmioRestoreError")
+            .field("stage", &self.stage)
+            .field("terminal", &self.is_terminal())
+            .field("cleanup_failed", &self.has_incomplete_cleanup())
+            .field("failure", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2MemoryHotplugMmioRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "exact-2.10 MMIO virtio-mem reconstruction failed at {:?} ({})",
+            self.stage,
+            if self.is_terminal() {
+                "terminal"
+            } else {
+                "retryable"
+            }
+        )
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2MemoryHotplugMmioRestoreError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.failure.as_ref())
     }
 }
 
@@ -15140,6 +15494,7 @@ struct HvfSnapshotV2StorageMmioPublicationInput {
     balloon: Option<PreparedSnapshotV2BalloonMmioHandler>,
     pmem_fault_index: Option<usize>,
     balloon_fault: Option<HvfSnapshotV2BalloonMmioRestoreFault>,
+    additional_registration_capacity: usize,
 }
 
 impl HvfSnapshotV2StorageMmioPublicationInput {
@@ -15148,6 +15503,7 @@ impl HvfSnapshotV2StorageMmioPublicationInput {
             balloon: None,
             pmem_fault_index: None,
             balloon_fault: None,
+            additional_registration_capacity: 0,
         }
     }
 
@@ -15159,6 +15515,19 @@ impl HvfSnapshotV2StorageMmioPublicationInput {
             balloon: Some(balloon),
             pmem_fault_index: None,
             balloon_fault: fault,
+            additional_registration_capacity: 0,
+        }
+    }
+
+    fn memory_hotplug(
+        balloon: Option<PreparedSnapshotV2BalloonMmioHandler>,
+        additional_registration_capacity: usize,
+    ) -> Self {
+        Self {
+            balloon,
+            pmem_fault_index: None,
+            balloon_fault: None,
+            additional_registration_capacity,
         }
     }
 
@@ -15167,6 +15536,7 @@ impl HvfSnapshotV2StorageMmioPublicationInput {
             balloon: None,
             pmem_fault_index: Some(index),
             balloon_fault: None,
+            additional_registration_capacity: 0,
         }
     }
 }
@@ -15178,8 +15548,12 @@ struct PreparedHvfSnapshotV2BalloonMmioRegistrationPrefix {
 
 impl PreparedHvfSnapshotV2BalloonMmioRegistrationPrefix {
     fn try_new() -> Result<Self, TryReserveError> {
+        Self::try_with_capacity(1)
+    }
+
+    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
         let mut leases = Vec::new();
-        leases.try_reserve_exact(1)?;
+        leases.try_reserve_exact(capacity)?;
         Ok(Self {
             owner: MmioRegistrationOwner::new(),
             leases,
@@ -15861,6 +16235,27 @@ impl OwnedHvfArm64BootSession {
                     },
                 )
             }
+            HvfSnapshotV2SerialProcessShell::MemoryHotplugMmio {
+                shell,
+                interrupts,
+                mapping,
+            } => restore_hvf_snapshot_v2_serial_memory_hotplug_mmio_process_platform(
+                state,
+                memory,
+                shell,
+                HvfSnapshotV2MemoryHotplugMmioShellPlan {
+                    balloon_interrupt: interrupts.balloon,
+                    command_line: None,
+                    block_records: &[],
+                    pmem_records: &[],
+                    entropy_interrupt: interrupts.entropy,
+                    memory_hotplug_interrupt: interrupts.memory_hotplug,
+                    serial_interrupt: interrupts.serial,
+                    vmgenid_interrupt: interrupts.vmgenid,
+                    vmclock_interrupt: interrupts.vmclock,
+                },
+                &mapping,
+            ),
         }
         .map_err(HvfSnapshotV2SerialOnlyRestoreError::Platform)?;
         let parts = platform.into_parts();
@@ -16511,6 +16906,658 @@ impl OwnedHvfArm64BootSession {
         });
         session.balloon_interrupt_line = Some(interrupt_line);
         session.balloon_device_metrics = SharedBalloonDeviceMetrics::default();
+        Ok(session)
+    }
+
+    /// Reconstructs one closed exact-2.10 MMIO virtio-mem product without
+    /// publishing a controller or public load path.
+    #[doc(hidden)]
+    pub fn restore_snapshot_v2_memory_hotplug_mmio(
+        state: HvfSnapshotV2PlatformState,
+        process_shell: HvfSnapshotV2RestoredSerialShell,
+        serial_input: Option<SerialStdioInput>,
+        plan: HvfSnapshotV2MemoryHotplugMmioPlatformPlan,
+    ) -> Result<
+        RestoredHvfSnapshotV2MemoryHotplugMmioOwners,
+        HvfSnapshotV2MemoryHotplugMmioRestoreError,
+    > {
+        Self::restore_snapshot_v2_memory_hotplug_mmio_inner(
+            state,
+            process_shell,
+            serial_input,
+            plan,
+            None,
+        )
+    }
+
+    /// Reconstructs exact-2.10 MMIO virtio-mem owners with one deterministic
+    /// aggregate rollback fault.
+    #[doc(hidden)]
+    pub fn restore_snapshot_v2_memory_hotplug_mmio_with_fault(
+        state: HvfSnapshotV2PlatformState,
+        process_shell: HvfSnapshotV2RestoredSerialShell,
+        serial_input: Option<SerialStdioInput>,
+        plan: HvfSnapshotV2MemoryHotplugMmioPlatformPlan,
+        fault: HvfSnapshotV2MemoryHotplugMmioRestoreFault,
+    ) -> Result<
+        RestoredHvfSnapshotV2MemoryHotplugMmioOwners,
+        HvfSnapshotV2MemoryHotplugMmioRestoreError,
+    > {
+        Self::restore_snapshot_v2_memory_hotplug_mmio_inner(
+            state,
+            process_shell,
+            serial_input,
+            plan,
+            Some(fault),
+        )
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn restore_snapshot_v2_memory_hotplug_mmio_inner(
+        state: HvfSnapshotV2PlatformState,
+        process_shell: HvfSnapshotV2RestoredSerialShell,
+        serial_input: Option<SerialStdioInput>,
+        plan: HvfSnapshotV2MemoryHotplugMmioPlatformPlan,
+        fault: Option<HvfSnapshotV2MemoryHotplugMmioRestoreFault>,
+    ) -> Result<
+        RestoredHvfSnapshotV2MemoryHotplugMmioOwners,
+        HvfSnapshotV2MemoryHotplugMmioRestoreError,
+    > {
+        let HvfSnapshotV2MemoryHotplugMmioPlatformPlanParts {
+            product,
+            mapping,
+            balloon: balloon_endpoint,
+            storage: storage_platform,
+            entropy: entropy_endpoint,
+            memory_hotplug: memory_hotplug_endpoint,
+            serial_interrupt,
+            vmgenid_interrupt,
+            vmclock_interrupt,
+        } = plan.into_parts();
+        let (topology, memory, balloon, storage_bundle, entropy) = match product.into_parts() {
+            HvfSnapshotV2MemoryHotplugPreparedProductParts::Base { topology, memory } => {
+                (topology, memory, None, None, None)
+            }
+            HvfSnapshotV2MemoryHotplugPreparedProductParts::Storage {
+                topology,
+                memory,
+                storage,
+            } => (topology, memory, None, Some(storage), None),
+            HvfSnapshotV2MemoryHotplugPreparedProductParts::Entropy {
+                topology,
+                memory,
+                entropy,
+            } => (topology, memory, None, None, Some(entropy)),
+            HvfSnapshotV2MemoryHotplugPreparedProductParts::StorageEntropy {
+                topology,
+                memory,
+                storage,
+                entropy,
+            } => (topology, memory, None, Some(storage), Some(entropy)),
+            HvfSnapshotV2MemoryHotplugPreparedProductParts::Balloon {
+                topology,
+                memory,
+                balloon,
+            } => (topology, memory, Some(balloon), None, None),
+            HvfSnapshotV2MemoryHotplugPreparedProductParts::BalloonStorage {
+                topology,
+                memory,
+                balloon,
+                storage,
+            } => (topology, memory, Some(balloon), Some(storage), None),
+            HvfSnapshotV2MemoryHotplugPreparedProductParts::BalloonEntropy {
+                topology,
+                memory,
+                balloon,
+                entropy,
+            } => (topology, memory, Some(balloon), None, Some(entropy)),
+            HvfSnapshotV2MemoryHotplugPreparedProductParts::BalloonStorageEntropy {
+                topology,
+                memory,
+                balloon,
+                storage,
+                entropy,
+            } => (
+                topology,
+                memory,
+                Some(balloon),
+                Some(storage),
+                Some(entropy),
+            ),
+        };
+        let has_balloon = balloon.is_some();
+        let has_storage = storage_bundle.is_some();
+        let has_entropy = entropy.is_some();
+        if has_balloon != balloon_endpoint.is_some()
+            || has_storage != storage_platform.is_some()
+            || has_entropy != entropy_endpoint.is_some()
+            || fault == Some(HvfSnapshotV2MemoryHotplugMmioRestoreFault::BalloonPublication)
+                && !has_balloon
+            || fault == Some(HvfSnapshotV2MemoryHotplugMmioRestoreFault::StoragePublication)
+                && !has_storage
+            || fault == Some(HvfSnapshotV2MemoryHotplugMmioRestoreFault::EntropyPublication)
+                && !has_entropy
+        {
+            return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::preflight(
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::Product,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Product,
+            ));
+        }
+
+        let memory_hotplug = topology.into_mmio_handler(&memory).map_err(|source| {
+            HvfSnapshotV2MemoryHotplugMmioRestoreError::preflight(
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::Handler,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Handler(source),
+            )
+        })?;
+        if memory_hotplug.region() != memory_hotplug_endpoint.region()
+            || memory_hotplug.interrupt_line() != memory_hotplug_endpoint.interrupt_line()
+        {
+            return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::preflight(
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::Product,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Product,
+            ));
+        }
+        let balloon_config = balloon.as_ref().map(SnapshotV2BalloonRestorePlan::config);
+        let balloon = balloon
+            .map(SnapshotV2BalloonRestorePlan::into_mmio_handler)
+            .transpose()
+            .map_err(|source| {
+                HvfSnapshotV2MemoryHotplugMmioRestoreError::preflight(
+                    HvfSnapshotV2MemoryHotplugMmioRestoreStage::Handler,
+                    HvfSnapshotV2MemoryHotplugMmioRestoreFailure::BalloonPlatform(Box::new(
+                        HvfSnapshotV2BalloonMmioRestoreError::preflight(
+                            HvfSnapshotV2BalloonMmioRestoreStage::BalloonHandler,
+                            HvfSnapshotV2BalloonMmioRestoreFailure::BalloonHandler(source),
+                        ),
+                    )),
+                )
+            })?;
+        if balloon
+            .as_ref()
+            .zip(balloon_endpoint)
+            .is_some_and(|(handler, endpoint)| {
+                handler.region() != endpoint.region()
+                    || handler.interrupt_line() != endpoint.interrupt_line()
+            })
+        {
+            return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::preflight(
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::Product,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Product,
+            ));
+        }
+        let entropy_config = entropy.as_ref().map(SnapshotV2EntropyRestorePlan::config);
+        let entropy = entropy
+            .map(SnapshotV2EntropyRestorePlan::into_mmio_handler)
+            .transpose()
+            .map_err(|source| {
+                HvfSnapshotV2MemoryHotplugMmioRestoreError::preflight(
+                    HvfSnapshotV2MemoryHotplugMmioRestoreStage::Handler,
+                    HvfSnapshotV2MemoryHotplugMmioRestoreFailure::EntropyPlatform(Box::new(
+                        HvfSnapshotV2EntropyMmioRestoreError::preflight(
+                            HvfSnapshotV2EntropyMmioRestoreStage::Handler,
+                            HvfSnapshotV2EntropyMmioRestoreFailure::Handler(source),
+                        ),
+                    )),
+                )
+            })?;
+        if entropy
+            .as_ref()
+            .zip(entropy_endpoint)
+            .is_some_and(|(handler, endpoint)| {
+                handler.region() != endpoint.region()
+                    || handler.interrupt_line() != endpoint.interrupt_line()
+            })
+        {
+            return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::preflight(
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::Product,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Product,
+            ));
+        }
+
+        if fault == Some(HvfSnapshotV2MemoryHotplugMmioRestoreFault::InterruptSetup) {
+            return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::preflight(
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::InterruptSetup,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Injected(
+                    HvfSnapshotV2MemoryHotplugMmioRestoreFault::InterruptSetup,
+                ),
+            ));
+        }
+        let signaler =
+            HvfGicSpiSignaler::from_metadata(&state.global().compatibility().gic_metadata())
+                .map_err(|source| {
+                    HvfSnapshotV2MemoryHotplugMmioRestoreError::preflight(
+                        HvfSnapshotV2MemoryHotplugMmioRestoreStage::InterruptSetup,
+                        HvfSnapshotV2MemoryHotplugMmioRestoreFailure::InterruptSetup(source),
+                    )
+                })?;
+        for interrupt_line in balloon
+            .as_ref()
+            .map(PreparedSnapshotV2BalloonMmioHandler::interrupt_line)
+            .into_iter()
+            .chain(
+                entropy
+                    .as_ref()
+                    .map(PreparedSnapshotV2EntropyMmioHandler::interrupt_line),
+            )
+            .chain([memory_hotplug.interrupt_line()])
+        {
+            signaler.validate_line(interrupt_line).map_err(|source| {
+                HvfSnapshotV2MemoryHotplugMmioRestoreError::preflight(
+                    HvfSnapshotV2MemoryHotplugMmioRestoreStage::InterruptSetup,
+                    HvfSnapshotV2MemoryHotplugMmioRestoreFailure::InterruptSetup(source),
+                )
+            })?;
+        }
+
+        let standalone_registration = if has_storage {
+            None
+        } else {
+            let capacity = usize::from(has_balloon)
+                .checked_add(usize::from(has_entropy))
+                .and_then(|count| count.checked_add(1))
+                .ok_or_else(|| {
+                    HvfSnapshotV2MemoryHotplugMmioRestoreError::preflight(
+                        HvfSnapshotV2MemoryHotplugMmioRestoreStage::Product,
+                        HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Allocation,
+                    )
+                })?;
+            Some(
+                PreparedHvfSnapshotV2BalloonMmioRegistrationPrefix::try_with_capacity(capacity)
+                    .map_err(|_| {
+                        HvfSnapshotV2MemoryHotplugMmioRestoreError::preflight(
+                            HvfSnapshotV2MemoryHotplugMmioRestoreStage::Product,
+                            HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Allocation,
+                        )
+                    })?,
+            )
+        };
+        let interrupts = HvfSnapshotV2MemoryHotplugMmioInterruptPlan {
+            balloon: balloon_endpoint.map(|endpoint| endpoint.interrupt_line()),
+            entropy: entropy_endpoint.map(|endpoint| endpoint.interrupt_line()),
+            memory_hotplug: memory_hotplug_endpoint.interrupt_line(),
+            serial: serial_interrupt,
+            vmgenid: vmgenid_interrupt,
+            vmclock: vmclock_interrupt,
+        };
+        let suffix_capacity = usize::from(has_entropy).saturating_add(1);
+        let (mut session, mut storage_configs) = match (storage_bundle, storage_platform) {
+            (None, None) => {
+                let mut session = Self::restore_snapshot_v2_serial_only_inner(
+                    state,
+                    memory,
+                    HvfSnapshotV2SerialProcessShell::MemoryHotplugMmio {
+                        shell: process_shell,
+                        interrupts,
+                        mapping: mapping.clone(),
+                    },
+                    serial_input,
+                )
+                .map_err(|source| {
+                    HvfSnapshotV2MemoryHotplugMmioRestoreError::preflight(
+                        HvfSnapshotV2MemoryHotplugMmioRestoreStage::Platform,
+                        HvfSnapshotV2MemoryHotplugMmioRestoreFailure::SerialPlatform(Box::new(
+                            source,
+                        )),
+                    )
+                })?;
+                let registration = standalone_registration.unwrap_or_else(|| {
+                    std::process::abort();
+                });
+                if let Some(balloon) = balloon {
+                    session =
+                        Self::attach_snapshot_v2_balloon_mmio(session, balloon, registration, None)
+                            .map_err(|source| {
+                                HvfSnapshotV2MemoryHotplugMmioRestoreError::preflight(
+                                    HvfSnapshotV2MemoryHotplugMmioRestoreStage::BalloonPublication,
+                                    HvfSnapshotV2MemoryHotplugMmioRestoreFailure::BalloonPlatform(
+                                        Box::new(source),
+                                    ),
+                                )
+                            })?;
+                } else {
+                    let PreparedHvfSnapshotV2BalloonMmioRegistrationPrefix { owner, leases } =
+                        registration;
+                    session.restored_snapshot_v2_mmio_registrations =
+                        Some(HvfSnapshotV2MultiBlockMmioRegistrations {
+                            owner,
+                            leases,
+                            pmem_ranges: Vec::new(),
+                        });
+                }
+                (session, None)
+            }
+            (Some(bundle), Some(storage_plan)) => {
+                let restored = Self::restore_snapshot_v2_storage_mmio_inner(
+                    state,
+                    memory,
+                    HvfSnapshotV2StorageProcessShell::RestoredMemoryHotplugMmio {
+                        shell: process_shell,
+                        interrupts,
+                        mapping: mapping.clone(),
+                    },
+                    serial_input,
+                    bundle,
+                    storage_plan,
+                    HvfSnapshotV2StorageMmioPublicationInput::memory_hotplug(
+                        balloon,
+                        suffix_capacity,
+                    ),
+                )
+                .map_err(|source| {
+                    HvfSnapshotV2MemoryHotplugMmioRestoreError::preflight(
+                        HvfSnapshotV2MemoryHotplugMmioRestoreStage::StoragePublication,
+                        HvfSnapshotV2MemoryHotplugMmioRestoreFailure::StoragePlatform(Box::new(
+                            source,
+                        )),
+                    )
+                })?;
+                let (session, configs) = restored.into_parts();
+                (session, Some(configs))
+            }
+            (None, Some(_)) | (Some(_), None) => {
+                return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::preflight(
+                    HvfSnapshotV2MemoryHotplugMmioRestoreStage::Product,
+                    HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Product,
+                ));
+            }
+        };
+
+        if fault == Some(HvfSnapshotV2MemoryHotplugMmioRestoreFault::Platform) {
+            return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::Platform,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Injected(
+                    HvfSnapshotV2MemoryHotplugMmioRestoreFault::Platform,
+                ),
+            ));
+        }
+        if fault == Some(HvfSnapshotV2MemoryHotplugMmioRestoreFault::StoragePublication) {
+            return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::StoragePublication,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Injected(
+                    HvfSnapshotV2MemoryHotplugMmioRestoreFault::StoragePublication,
+                ),
+            ));
+        }
+        if fault == Some(HvfSnapshotV2MemoryHotplugMmioRestoreFault::BalloonPublication) {
+            return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::BalloonPublication,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Injected(
+                    HvfSnapshotV2MemoryHotplugMmioRestoreFault::BalloonPublication,
+                ),
+            ));
+        }
+
+        if let Some(entropy) = entropy {
+            let restored = Self::attach_snapshot_v2_entropy_mmio(
+                session,
+                entropy,
+                storage_configs,
+                false,
+                VirtioRngOsEntropySource::new,
+            )
+            .map_err(|source| {
+                HvfSnapshotV2MemoryHotplugMmioRestoreError::preflight(
+                    HvfSnapshotV2MemoryHotplugMmioRestoreStage::EntropyPublication,
+                    HvfSnapshotV2MemoryHotplugMmioRestoreFailure::EntropyPlatform(Box::new(source)),
+                )
+            })?;
+            let (restored_session, restored_entropy_config, restored_storage_configs) =
+                restored.into_parts();
+            session = restored_session;
+            storage_configs = restored_storage_configs;
+            if Some(restored_entropy_config) != entropy_config {
+                return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2MemoryHotplugMmioRestoreStage::EntropyPublication,
+                    HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Product,
+                ));
+            }
+        }
+        if fault == Some(HvfSnapshotV2MemoryHotplugMmioRestoreFault::EntropyPublication) {
+            return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::EntropyPublication,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Injected(
+                    HvfSnapshotV2MemoryHotplugMmioRestoreFault::EntropyPublication,
+                ),
+            ));
+        }
+
+        let (
+            expected_state,
+            controller,
+            _plugged_ranges,
+            _queue_ranges,
+            region,
+            interrupt_line,
+            handler,
+        ) = memory_hotplug.into_parts();
+        session = Self::attach_snapshot_v2_memory_hotplug_mmio(
+            session,
+            region,
+            interrupt_line,
+            memory_hotplug_endpoint.fdt_device(),
+            handler,
+            fault,
+        )?;
+
+        if fault == Some(HvfSnapshotV2MemoryHotplugMmioRestoreFault::Recapture) {
+            return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::Recapture,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Injected(
+                    HvfSnapshotV2MemoryHotplugMmioRestoreFault::Recapture,
+                ),
+            ));
+        }
+        let recaptured = {
+            let guard = session
+                .quiesce_limiter_retry_wakeups()
+                .map_err(HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Quiescence);
+            match guard {
+                Ok(guard) => {
+                    let captured = session
+                        .capture_ready_memory_hotplug_state(Some(controller.config()), &guard)
+                        .map_err(HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Capture)
+                        .and_then(|captured| {
+                            captured.ok_or(HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Product)
+                        })
+                        .and_then(|captured| {
+                            captured
+                                .try_to_snapshot_v2(controller.requested_size_mib())
+                                .map_err(HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Normalize)
+                        });
+                    drop(guard);
+                    captured
+                }
+                Err(failure) => Err(failure),
+            }
+        };
+        let recaptured = match recaptured {
+            Ok(recaptured) => recaptured,
+            Err(failure) => {
+                return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2MemoryHotplugMmioRestoreStage::Recapture,
+                    failure,
+                ));
+            }
+        };
+        if recaptured.state() != &expected_state {
+            return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::Recapture,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::StateMismatch,
+            ));
+        }
+        if !mapping.matches_capture(recaptured.mapping()) {
+            return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::Recapture,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::MappingMismatch,
+            ));
+        }
+        drop(recaptured);
+
+        if fault == Some(HvfSnapshotV2MemoryHotplugMmioRestoreFault::SessionAssembly) {
+            return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::SessionAssembly,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Injected(
+                    HvfSnapshotV2MemoryHotplugMmioRestoreFault::SessionAssembly,
+                ),
+            ));
+        }
+        Ok(RestoredHvfSnapshotV2MemoryHotplugMmioOwners {
+            session,
+            state: expected_state,
+            controller,
+            storage_configs,
+            entropy_config,
+            balloon_config,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn attach_snapshot_v2_memory_hotplug_mmio(
+        mut session: OwnedHvfArm64BootSession,
+        region: MmioRegion,
+        interrupt_line: GuestInterruptLine,
+        fdt_device: Arm64FdtVirtioMmioDevice,
+        handler: VirtioMemMmioHandler,
+        fault: Option<HvfSnapshotV2MemoryHotplugMmioRestoreFault>,
+    ) -> Result<OwnedHvfArm64BootSession, HvfSnapshotV2MemoryHotplugMmioRestoreError> {
+        let owner_is_vacant = session.runtime_resources.memory_hotplug_device.is_none()
+            && session
+                .runtime_resources
+                .pci_memory_hotplug_device
+                .is_none()
+            && session.memory_hotplug_interrupt_line.is_none()
+            && session.pci_data_devices.is_none()
+            && !session
+                .block_interrupt_lines
+                .iter()
+                .chain(&session.pmem_interrupt_lines)
+                .chain(&session.network_interrupt_lines)
+                .copied()
+                .chain(session.vsock_interrupt_line)
+                .chain(session.balloon_interrupt_line)
+                .chain(session.entropy_interrupt_line)
+                .chain(session.serial_interrupt_line)
+                .chain([
+                    session.vmgenid_interrupt_line,
+                    session.vmclock_interrupt_line,
+                ])
+                .any(|retained| retained == interrupt_line)
+            && session
+                .restored_snapshot_v2_mmio_registrations
+                .as_ref()
+                .is_some_and(|registrations| {
+                    registrations.leases.len() < registrations.leases.capacity()
+                });
+        if !owner_is_vacant {
+            return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::MemoryHotplugInsertion,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Product,
+            ));
+        }
+        let signaler = match HvfGicSpiSignaler::from_metadata(&session.gic) {
+            Ok(signaler) => signaler,
+            Err(source) => {
+                return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2MemoryHotplugMmioRestoreStage::InterruptSetup,
+                    HvfSnapshotV2MemoryHotplugMmioRestoreFailure::InterruptSetup(source),
+                ));
+            }
+        };
+        if let Err(source) = signaler.validate_line(interrupt_line) {
+            return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::InterruptSetup,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::InterruptSetup(source),
+            ));
+        }
+
+        let metrics = handler.shared_memory_hotplug_metrics();
+        let request = [MmioRegionRequest::new(
+            region.range().start(),
+            region.range().size(),
+        )];
+        let registration_result = match session.restored_snapshot_v2_mmio_registrations.as_ref() {
+            Some(registrations) => match session.mmio_dispatcher.lock() {
+                Ok(mut dispatcher) => dispatcher
+                    .validate_owned_handler(region.id(), &request)
+                    .and_then(|()| {
+                        dispatcher.register_owned_handler(
+                            &registrations.owner,
+                            region.id(),
+                            &request,
+                            handler,
+                        )
+                    })
+                    .map_err(HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Registration),
+                Err(_) => Err(HvfSnapshotV2MemoryHotplugMmioRestoreFailure::DispatcherUnavailable),
+            },
+            None => Err(HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Product),
+        };
+        let lease = match registration_result {
+            Ok(lease) => lease,
+            Err(failure) => {
+                return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2MemoryHotplugMmioRestoreStage::Registration,
+                    failure,
+                ));
+            }
+        };
+        let registration_matches = session
+            .restored_snapshot_v2_mmio_registrations
+            .as_mut()
+            .is_some_and(|registrations| {
+                registrations.leases.push(lease);
+                registrations.leases.last().is_some_and(|lease| {
+                    lease.region_id() == region.id() && lease.regions() == [region]
+                })
+            });
+        if !registration_matches {
+            return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::Registration,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Product,
+            ));
+        }
+        if fault == Some(HvfSnapshotV2MemoryHotplugMmioRestoreFault::Registration) {
+            return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::Registration,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Injected(
+                    HvfSnapshotV2MemoryHotplugMmioRestoreFault::Registration,
+                ),
+            ));
+        }
+
+        session.runtime_resources.memory_hotplug_device = Some(Arm64BootMemoryHotplugDevice {
+            registration: VirtioMemMmioDeviceRegistration::from_restored(region),
+            fdt_device,
+            metrics: metrics.clone(),
+        });
+        session.memory_hotplug_interrupt_line = Some(interrupt_line);
+        session.memory_hotplug_device_metrics = Some(metrics);
+        if fault == Some(HvfSnapshotV2MemoryHotplugMmioRestoreFault::MemoryHotplugInsertion) {
+            return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugMmioRestoreStage::MemoryHotplugInsertion,
+                HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Injected(
+                    HvfSnapshotV2MemoryHotplugMmioRestoreFault::MemoryHotplugInsertion,
+                ),
+            ));
+        }
         Ok(session)
     }
 
@@ -18390,6 +19437,7 @@ impl OwnedHvfArm64BootSession {
             balloon,
             pmem_fault_index: publication_fault_pmem_index,
             balloon_fault: balloon_publication_fault,
+            additional_registration_capacity,
         } = publication;
         let mut ranges = Vec::new();
         ranges
@@ -18452,7 +19500,8 @@ impl OwnedHvfArm64BootSession {
         let balloon_count = usize::from(balloon.is_some());
         let record_count = balloon_count
             .saturating_add(block_count)
-            .saturating_add(pmem_count);
+            .saturating_add(pmem_count)
+            .saturating_add(additional_registration_capacity);
         if publication_fault_pmem_index.is_some_and(|index| index >= pmem_count)
             || (balloon_publication_fault.is_some() && balloon.is_none())
         {
@@ -18626,6 +19675,27 @@ impl OwnedHvfArm64BootSession {
                     },
                 )
             }
+            HvfSnapshotV2StorageProcessShell::RestoredMemoryHotplugMmio {
+                shell,
+                interrupts,
+                mapping,
+            } => restore_hvf_snapshot_v2_serial_memory_hotplug_mmio_process_platform(
+                state,
+                memory,
+                shell,
+                HvfSnapshotV2MemoryHotplugMmioShellPlan {
+                    balloon_interrupt: interrupts.balloon,
+                    command_line: Some(&prepared_owner.command_line),
+                    block_records: &prepared_owner.planned_block_records,
+                    pmem_records: &prepared_owner.planned_pmem_records,
+                    entropy_interrupt: interrupts.entropy,
+                    memory_hotplug_interrupt: interrupts.memory_hotplug,
+                    serial_interrupt: interrupts.serial,
+                    vmgenid_interrupt: interrupts.vmgenid,
+                    vmclock_interrupt: interrupts.vmclock,
+                },
+                &mapping,
+            ),
         };
         let mut platform = match restored {
             Ok(platform) => platform,
@@ -19402,7 +20472,8 @@ impl OwnedHvfArm64BootSession {
                 )
             }
             HvfSnapshotV2StorageProcessShell::RestoredEntropyMmio { .. }
-            | HvfSnapshotV2StorageProcessShell::RestoredBalloonMmio { .. } => {
+            | HvfSnapshotV2StorageProcessShell::RestoredBalloonMmio { .. }
+            | HvfSnapshotV2StorageProcessShell::RestoredMemoryHotplugMmio { .. } => {
                 return Err(
                     HvfSnapshotV2StoragePciRestoreError::with_prepared_bundle_abort(
                         HvfSnapshotV2StoragePciRestoreStage::ResourcePlan,
@@ -21797,6 +22868,7 @@ impl OwnedHvfArm64BootSession {
     ) -> Result<(), HvfSnapshotV2StorageMmioRestoreCleanupFailure> {
         let had_balloon = self.runtime_resources.balloon_device.is_some();
         let had_entropy = self.runtime_resources.entropy_device.is_some();
+        let had_memory_hotplug = self.runtime_resources.memory_hotplug_device.is_some();
         let Some(registrations) = self.restored_snapshot_v2_mmio_registrations.as_mut() else {
             return Ok(());
         };
@@ -21839,6 +22911,8 @@ impl OwnedHvfArm64BootSession {
         self.balloon_interrupt_line = None;
         self.runtime_resources.entropy_device = None;
         self.entropy_interrupt_line = None;
+        self.runtime_resources.memory_hotplug_device = None;
+        self.memory_hotplug_interrupt_line = None;
         self.entropy_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
         self.entropy_source = VirtioRngOsEntropySource::new();
         if had_entropy {
@@ -21846,6 +22920,9 @@ impl OwnedHvfArm64BootSession {
         }
         if had_balloon {
             self.balloon_device_metrics = SharedBalloonDeviceMetrics::default();
+        }
+        if had_memory_hotplug {
+            self.memory_hotplug_device_metrics = None;
         }
         self.restored_snapshot_v2_mmio_registrations = None;
         Ok(())

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -17211,9 +17211,16 @@ impl OwnedHvfArm64BootSession {
                         )),
                     )
                 })?;
-                let registration = standalone_registration.unwrap_or_else(|| {
-                    std::process::abort();
-                });
+                let registration = match standalone_registration {
+                    Some(registration) => registration,
+                    None => {
+                        return Err(HvfSnapshotV2MemoryHotplugMmioRestoreError::after_session(
+                            session,
+                            HvfSnapshotV2MemoryHotplugMmioRestoreStage::Product,
+                            HvfSnapshotV2MemoryHotplugMmioRestoreFailure::Product,
+                        ));
+                    }
+                };
                 if let Some(balloon) = balloon {
                     session =
                         Self::attach_snapshot_v2_balloon_mmio(session, balloon, registration, None)

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -3665,30 +3665,37 @@ pub struct RestoredHvfSnapshotV2MemoryHotplugMmioOwners {
 }
 
 impl RestoredHvfSnapshotV2MemoryHotplugMmioOwners {
+    /// Returns the complete Paused destination session.
     pub const fn session(&self) -> &OwnedHvfArm64BootSession {
         &self.session
     }
 
+    /// Returns the exact normalized portable virtio-mem state.
     pub const fn state(&self) -> &SnapshotV2MemoryHotplugState {
         &self.state
     }
 
+    /// Returns the exact public memory-hotplug controller projection.
     pub const fn controller(&self) -> SnapshotV2MemoryHotplugControllerProjection {
         self.controller
     }
 
+    /// Returns restored storage configuration when present.
     pub const fn storage_configs(&self) -> Option<&CaptureReadyStorageConfigs> {
         self.storage_configs.as_ref()
     }
 
+    /// Returns the exact public entropy configuration when present.
     pub const fn entropy_config(&self) -> Option<EntropyConfig> {
         self.entropy_config
     }
 
+    /// Returns the exact public balloon configuration when present.
     pub const fn balloon_config(&self) -> Option<BalloonConfig> {
         self.balloon_config
     }
 
+    /// Consumes the complete unpublished owner graph.
     pub fn into_parts(
         self,
     ) -> (
@@ -3889,10 +3896,12 @@ impl HvfSnapshotV2MemoryHotplugMmioRestoreError {
         }
     }
 
+    /// Returns the aggregate transition at which reconstruction stopped.
     pub const fn stage(&self) -> HvfSnapshotV2MemoryHotplugMmioRestoreStage {
         self.stage
     }
 
+    /// Returns whether reverse cleanup did not complete.
     pub fn has_incomplete_cleanup(&self) -> bool {
         self.cleanup.is_some()
             || matches!(
@@ -3917,6 +3926,7 @@ impl HvfSnapshotV2MemoryHotplugMmioRestoreError {
             )
     }
 
+    /// Returns whether retry safety cannot be proven.
     pub fn is_terminal(&self) -> bool {
         self.committed
             || self.has_incomplete_cleanup()

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -14581,6 +14581,656 @@ fn capture_ready_memory_hotplug_traverses_signed_mmio_and_pci_owners() {
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 #[test]
+fn restores_signed_memory_hotplug_only_mmio_owners_and_rolls_back_faults() {
+    use std::io::Cursor;
+
+    use bangbang_hvf::{
+        HvfArm64BootMemoryHotplugDeviceConfig, HvfArm64BootSerialDeviceConfig,
+        HvfArm64BootSessionConfig, HvfArm64BootSnapshotV2CaptureInput, HvfSnapshotV2BootState,
+        HvfSnapshotV2MemoryHotplugMmioProcessConfig, HvfSnapshotV2MemoryHotplugMmioRestoreFault,
+        HvfSnapshotV2MemoryHotplugPreparedProduct, HvfSnapshotV2MemoryHotplugState,
+        HvfSnapshotV2NativePath, HvfSnapshotV2RestoredSerialShell,
+        HvfSnapshotV2StorageMmioProcessConfig, OwnedHvfArm64BootSession,
+        prepare_hvf_snapshot_v2_memory_hotplug_mmio_platform_plan,
+    };
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::block::BlockMmioLayout;
+    use bangbang_runtime::boot::BootSourceConfigInput;
+    use bangbang_runtime::entropy::EntropyMmioLayout;
+    use bangbang_runtime::machine::MachineConfigInput;
+    use bangbang_runtime::memory::GuestAddress;
+    use bangbang_runtime::memory_hotplug::{MemoryHotplugConfigInput, VirtioMemMmioLayout};
+    use bangbang_runtime::mmio::MmioRegionId;
+    use bangbang_runtime::network::NetworkMmioLayout;
+    use bangbang_runtime::pmem::PmemMmioLayout;
+    use bangbang_runtime::serial::{
+        SerialMmioDevice, SharedSerialOutput, SharedSerialOutputBuffer,
+    };
+    use bangbang_runtime::snapshot_memory_hotplug_v2_10::PreparedSnapshotV2MemoryHotplugTopology;
+    use bangbang_runtime::snapshot_memory_v2::materialize_snapshot_v2_memory_hotplug_file;
+    use bangbang_runtime::snapshot_serial_v2_7::SnapshotV2SerialState;
+    use bangbang_runtime::vsock::VsockMmioLayout;
+
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let image = arm64_image().expect("test arm64 image should build");
+    let kernel = TempFile::new("restore-memory-hotplug-only-kernel", &image)
+        .expect("memory-hotplug-only kernel should create");
+    let mut controller = bangbang_runtime::VmmController::new("test", "0.1.0", "bangbang");
+    controller
+        .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            kernel.path(),
+        )))
+        .expect("memory-hotplug-only boot source should configure");
+    controller
+        .handle_action(VmmAction::PutMachineConfig(
+            MachineConfigInput::new(1, 128).with_track_dirty_pages(true),
+        ))
+        .expect("memory-hotplug-only dirty tracking should configure");
+    controller
+        .handle_action(VmmAction::PutMemoryHotplug(MemoryHotplugConfigInput::new(
+            128, 2, 128,
+        )))
+        .expect("memory-hotplug-only device should configure");
+    let memory_hotplug_config = controller
+        .memory_hotplug_config()
+        .expect("memory-hotplug-only config should exist");
+    let requested_size_mib = controller
+        .memory_hotplug_status()
+        .expect("memory-hotplug-only status should exist")
+        .requested_size_mib();
+
+    let block_layout = BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1));
+    let pmem_layout = PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500));
+    let balloon_layout = bangbang_runtime::balloon::BalloonMmioLayout::new(
+        GuestAddress::new(0x4000_6000),
+        MmioRegionId::new(3000),
+    );
+    let entropy_layout =
+        EntropyMmioLayout::new(GuestAddress::new(0x4000_7000), MmioRegionId::new(3001));
+    let memory_hotplug_layout =
+        VirtioMemMmioLayout::new(GuestAddress::new(0x4000_8000), MmioRegionId::new(4001));
+    let session_config = HvfArm64BootSessionConfig::new(
+        block_layout,
+        pmem_layout,
+        NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000)),
+        VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
+        bangbang_runtime::rtc::RtcMmioLayout::new(
+            GuestAddress::new(0x4000_1000),
+            MmioRegionId::new(10),
+        ),
+    )
+    .with_memory_hotplug_device(HvfArm64BootMemoryHotplugDeviceConfig::new(
+        memory_hotplug_layout,
+    ))
+    .with_serial_device(HvfArm64BootSerialDeviceConfig::new(
+        MmioRegionId::new(20),
+        GuestAddress::new(0x4000_2000),
+        SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+    ));
+    let mut source = OwnedHvfArm64BootSession::new(&controller, session_config)
+        .expect("signed memory-hotplug-only source should prepare");
+    let guard = source
+        .quiesce_limiter_retry_wakeups()
+        .expect("memory-hotplug-only source should quiesce");
+    let memory_hotplug_capture = source
+        .capture_ready_memory_hotplug_state(Some(memory_hotplug_config), &guard)
+        .expect("memory-hotplug-only source should capture")
+        .expect("memory-hotplug-only source should retain its device")
+        .try_to_snapshot_v2(requested_size_mib)
+        .expect("memory-hotplug-only capture should convert");
+    let serial = SnapshotV2SerialState::try_from_capture_ready(
+        source
+            .capture_ready_serial_state(controller.serial_config().clone(), &guard)
+            .expect("memory-hotplug-only serial should capture"),
+    )
+    .expect("memory-hotplug-only serial capture should convert");
+    drop(guard);
+
+    source
+        .pause_for_snapshot_v2_capture()
+        .expect("memory-hotplug-only source should pause");
+    let boot = HvfSnapshotV2BootState::try_new(
+        HvfSnapshotV2NativePath::try_new(kernel.path().as_os_str())
+            .expect("memory-hotplug-only kernel path should validate"),
+        None,
+        None,
+    )
+    .expect("memory-hotplug-only boot metadata should validate");
+    let mut memory_writer = Cursor::new(Vec::new());
+    let platform = source
+        .capture_snapshot_v2_memory_hotplug_platform_with_cancel(
+            HvfArm64BootSnapshotV2CaptureInput::new(boot),
+            Some(memory_hotplug_capture),
+            &mut memory_writer,
+            |_| false,
+        )
+        .expect("exact-2.10 memory-hotplug-only platform should capture");
+    HvfSnapshotV2MemoryHotplugState::try_new(platform.clone(), None, serial.clone(), None, None)
+        .expect("memory-hotplug-only exact-2.10 product should compose");
+    let memory_image = TempFile::new("restore-memory-hotplug-only-image", memory_writer.get_ref())
+        .expect("memory-hotplug-only image should persist");
+    source
+        .shutdown()
+        .expect("signed memory-hotplug-only source should shut down");
+
+    let platform_state = platform.platform().clone();
+    let portable_state = platform
+        .memory_hotplug()
+        .expect("captured exact-2.10 platform should retain memory-hotplug")
+        .clone();
+    let process = HvfSnapshotV2MemoryHotplugMmioProcessConfig::new(
+        balloon_layout,
+        HvfSnapshotV2StorageMmioProcessConfig::new(block_layout, pmem_layout),
+        entropy_layout,
+        memory_hotplug_layout,
+    );
+    let prepare_plan = || {
+        let topology = PreparedSnapshotV2MemoryHotplugTopology::prepare(
+            portable_state.clone(),
+            platform_state.memory().clone(),
+        )
+        .expect("memory-hotplug-only topology should prepare");
+        let memory = materialize_snapshot_v2_memory_hotplug_file(
+            &topology,
+            std::fs::File::open(memory_image.path())
+                .expect("memory-hotplug-only image should reopen"),
+        )
+        .expect("memory-hotplug-only destination should materialize");
+        prepare_hvf_snapshot_v2_memory_hotplug_mmio_platform_plan(
+            &platform_state,
+            HvfSnapshotV2MemoryHotplugPreparedProduct::serial_memory_hotplug(topology, memory),
+            process,
+        )
+        .expect("memory-hotplug-only owner plan should prepare")
+    };
+    let restored_shell = || {
+        HvfSnapshotV2RestoredSerialShell::new(
+            SerialMmioDevice::from_capture_state_with_shared_output(
+                SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+                serial.device().clone(),
+            ),
+        )
+    };
+
+    for fault in [
+        HvfSnapshotV2MemoryHotplugMmioRestoreFault::InterruptSetup,
+        HvfSnapshotV2MemoryHotplugMmioRestoreFault::Platform,
+        HvfSnapshotV2MemoryHotplugMmioRestoreFault::Registration,
+        HvfSnapshotV2MemoryHotplugMmioRestoreFault::MemoryHotplugInsertion,
+        HvfSnapshotV2MemoryHotplugMmioRestoreFault::Recapture,
+        HvfSnapshotV2MemoryHotplugMmioRestoreFault::SessionAssembly,
+    ] {
+        let error = OwnedHvfArm64BootSession::restore_snapshot_v2_memory_hotplug_mmio_with_fault(
+            platform_state.clone(),
+            restored_shell(),
+            None,
+            prepare_plan(),
+            fault,
+        )
+        .expect_err("injected memory-hotplug-only owner fault should reject");
+        assert!(
+            !error.has_incomplete_cleanup(),
+            "{fault:?} should roll back cleanly: {error:?}"
+        );
+        assert_eq!(
+            error.is_terminal(),
+            fault != HvfSnapshotV2MemoryHotplugMmioRestoreFault::InterruptSetup
+        );
+        let diagnostics = format!("{error:?} {error}");
+        assert!(diagnostics.contains("<redacted>"));
+        assert!(!diagnostics.contains("1073774592"));
+    }
+
+    let mut destination_mapping_identities = Vec::new();
+    for _ in 0..2 {
+        let owners = OwnedHvfArm64BootSession::restore_snapshot_v2_memory_hotplug_mmio(
+            platform_state.clone(),
+            restored_shell(),
+            None,
+            prepare_plan(),
+        )
+        .unwrap_or_else(|error| {
+            let source = std::error::Error::source(&error);
+            let detail = source.and_then(std::error::Error::source);
+            panic!(
+                "memory-hotplug-only owners should restore: {error:?}, source={source:?}, detail={detail:?}"
+            )
+        });
+        assert_eq!(owners.state(), &portable_state);
+        assert_eq!(owners.controller().config(), memory_hotplug_config);
+        assert_eq!(owners.controller().requested_size_mib(), requested_size_mib);
+        assert!(owners.storage_configs().is_none());
+        assert!(owners.entropy_config().is_none());
+        assert!(owners.balloon_config().is_none());
+        assert!(
+            owners
+                .session()
+                .shared_memory_hotplug_device_metrics()
+                .expect("restored memory-hotplug metrics should exist")
+                .snapshot()
+                .is_empty()
+        );
+
+        let (mut restored, state, controller, storage, entropy, balloon) = owners.into_parts();
+        assert_eq!(state, portable_state);
+        assert!(storage.is_none());
+        assert!(entropy.is_none());
+        assert!(balloon.is_none());
+        assert!(restored.runtime_resources().memory_hotplug_device.is_some());
+        let guard = restored
+            .quiesce_limiter_retry_wakeups()
+            .expect("restored memory-hotplug-only owner should quiesce");
+        let recaptured = restored
+            .capture_ready_memory_hotplug_state(Some(controller.config()), &guard)
+            .expect("restored memory-hotplug-only owner should capture")
+            .expect("restored memory-hotplug-only device should exist")
+            .try_to_snapshot_v2(controller.requested_size_mib())
+            .expect("restored memory-hotplug-only capture should convert");
+        assert_eq!(recaptured.state(), &portable_state);
+        destination_mapping_identities.push(recaptured.mapping().mapping_identity());
+        drop(guard);
+        restored
+            .shutdown()
+            .expect("restored memory-hotplug-only destination should shut down");
+    }
+    assert_ne!(
+        destination_mapping_identities[0],
+        destination_mapping_identities[1]
+    );
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn restores_signed_all_optional_memory_hotplug_mmio_owners_and_rolls_back_prefixes() {
+    use std::io::Cursor;
+    use std::time::Instant;
+
+    use bangbang_hvf::{
+        HvfArm64BootBalloonDeviceConfig, HvfArm64BootEntropyDeviceConfig,
+        HvfArm64BootMemoryHotplugDeviceConfig, HvfArm64BootSerialDeviceConfig,
+        HvfArm64BootSessionConfig, HvfArm64BootSnapshotV2CaptureInput, HvfSnapshotV2BootState,
+        HvfSnapshotV2MemoryHotplugMmioProcessConfig, HvfSnapshotV2MemoryHotplugMmioRestoreFault,
+        HvfSnapshotV2MemoryHotplugPreparedProduct, HvfSnapshotV2MemoryHotplugState,
+        HvfSnapshotV2NativePath, HvfSnapshotV2RestoredSerialShell,
+        HvfSnapshotV2StorageMmioProcessConfig, OwnedHvfArm64BootSession,
+        prepare_hvf_snapshot_v2_memory_hotplug_mmio_platform_plan,
+    };
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::balloon::{
+        BalloonConfigInput, BalloonMmioLayout, VIRTIO_BALLOON_FREE_PAGE_HINT_DONE,
+    };
+    use bangbang_runtime::block::{
+        BlockFileBacking, BlockMmioLayout, DriveConfigInput, DriveIoEngine,
+    };
+    use bangbang_runtime::boot::BootSourceConfigInput;
+    use bangbang_runtime::entropy::{EntropyConfigInput, EntropyMmioLayout};
+    use bangbang_runtime::machine::MachineConfigInput;
+    use bangbang_runtime::memory::GuestAddress;
+    use bangbang_runtime::memory_hotplug::{MemoryHotplugConfigInput, VirtioMemMmioLayout};
+    use bangbang_runtime::mmio::MmioRegionId;
+    use bangbang_runtime::network::NetworkMmioLayout;
+    use bangbang_runtime::pmem::PmemMmioLayout;
+    use bangbang_runtime::serial::{
+        SerialMmioDevice, SharedSerialOutput, SharedSerialOutputBuffer,
+    };
+    use bangbang_runtime::snapshot_balloon_v2_9::SnapshotV2BalloonRestorePlan;
+    use bangbang_runtime::snapshot_device_v2_6::SnapshotV2StorageRestorePlan;
+    use bangbang_runtime::snapshot_entropy_v2_8::SnapshotV2EntropyRestorePlan;
+    use bangbang_runtime::snapshot_memory_hotplug_v2_10::PreparedSnapshotV2MemoryHotplugTopology;
+    use bangbang_runtime::snapshot_memory_v2::materialize_snapshot_v2_memory_hotplug_file;
+    use bangbang_runtime::snapshot_serial_v2_7::SnapshotV2SerialState;
+    use bangbang_runtime::storage_capture::CaptureReadyStorageConfigs;
+    use bangbang_runtime::vsock::VsockMmioLayout;
+
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let image = arm64_image().expect("test arm64 image should build");
+    let kernel = TempFile::new("restore-all-memory-hotplug-kernel", &image)
+        .expect("all-optional memory-hotplug kernel should create");
+    let root = TempFile::new_len("restore-all-memory-hotplug-root", 4096)
+        .expect("all-optional memory-hotplug root should create");
+    let mut controller = bangbang_runtime::VmmController::new("test", "0.1.0", "bangbang");
+    controller
+        .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            kernel.path(),
+        )))
+        .expect("all-optional memory-hotplug boot source should configure");
+    controller
+        .handle_action(VmmAction::PutMachineConfig(
+            MachineConfigInput::new(1, 128).with_track_dirty_pages(true),
+        ))
+        .expect("all-optional memory-hotplug dirty tracking should configure");
+    controller
+        .handle_action(VmmAction::PutDrive(
+            DriveConfigInput::new("rootfs", "rootfs", root.path(), true)
+                .with_is_read_only(true)
+                .with_io_engine(DriveIoEngine::Sync),
+        ))
+        .expect("all-optional memory-hotplug root should configure");
+    controller
+        .handle_action(VmmAction::PutBalloon(
+            BalloonConfigInput::new(8, true)
+                .with_stats_polling_interval_s(1)
+                .with_free_page_hinting(true)
+                .with_free_page_reporting(true),
+        ))
+        .expect("all-optional memory-hotplug balloon should configure");
+    controller
+        .handle_action(VmmAction::PutEntropy(EntropyConfigInput::new()))
+        .expect("all-optional memory-hotplug entropy should configure");
+    controller
+        .handle_action(VmmAction::PutMemoryHotplug(MemoryHotplugConfigInput::new(
+            128, 2, 128,
+        )))
+        .expect("all-optional memory-hotplug device should configure");
+    let balloon_config = controller
+        .balloon_config()
+        .expect("all-optional balloon config should exist");
+    let entropy_config = controller
+        .entropy_config()
+        .expect("all-optional entropy config should exist");
+    let memory_hotplug_config = controller
+        .memory_hotplug_config()
+        .expect("all-optional memory-hotplug config should exist");
+    let requested_size_mib = controller
+        .memory_hotplug_status()
+        .expect("all-optional memory-hotplug status should exist")
+        .requested_size_mib();
+
+    let block_layout = BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1));
+    let pmem_layout = PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500));
+    let balloon_layout =
+        BalloonMmioLayout::new(GuestAddress::new(0x4000_6000), MmioRegionId::new(3000));
+    let entropy_layout =
+        EntropyMmioLayout::new(GuestAddress::new(0x4000_7000), MmioRegionId::new(3001));
+    let memory_hotplug_layout =
+        VirtioMemMmioLayout::new(GuestAddress::new(0x4000_8000), MmioRegionId::new(4001));
+    let session_config = HvfArm64BootSessionConfig::new(
+        block_layout,
+        pmem_layout,
+        NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000)),
+        VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
+        bangbang_runtime::rtc::RtcMmioLayout::new(
+            GuestAddress::new(0x4000_1000),
+            MmioRegionId::new(10),
+        ),
+    )
+    .with_balloon_device(HvfArm64BootBalloonDeviceConfig::new(balloon_layout))
+    .with_entropy_device(HvfArm64BootEntropyDeviceConfig::new(entropy_layout))
+    .with_memory_hotplug_device(HvfArm64BootMemoryHotplugDeviceConfig::new(
+        memory_hotplug_layout,
+    ))
+    .with_serial_device(HvfArm64BootSerialDeviceConfig::new(
+        MmioRegionId::new(20),
+        GuestAddress::new(0x4000_2000),
+        SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+    ));
+    let mut source = OwnedHvfArm64BootSession::new(&controller, session_config)
+        .expect("signed all-optional memory-hotplug source should prepare");
+    let source_configs =
+        CaptureReadyStorageConfigs::new(controller.drive_configs().to_vec(), Vec::new());
+    let capture_now = Instant::now();
+    let guard = source
+        .quiesce_limiter_retry_wakeups()
+        .expect("all-optional memory-hotplug source should quiesce");
+    let graph = source
+        .capture_snapshot_v2_storage_device_graph_at(&source_configs, &guard, capture_now)
+        .expect("all-optional storage graph should capture");
+    let balloon = source
+        .capture_ready_balloon_state(Some(balloon_config), &guard)
+        .expect("all-optional balloon should capture")
+        .expect("all-optional balloon should exist")
+        .try_to_snapshot_v2()
+        .expect("all-optional balloon capture should convert");
+    let entropy = source
+        .capture_ready_entropy_state_at(Some(entropy_config), &guard, capture_now)
+        .expect("all-optional entropy should capture")
+        .expect("all-optional entropy should exist")
+        .try_to_snapshot_v2()
+        .expect("all-optional entropy capture should convert");
+    let memory_hotplug_capture = source
+        .capture_ready_memory_hotplug_state(Some(memory_hotplug_config), &guard)
+        .expect("all-optional memory-hotplug should capture")
+        .expect("all-optional memory-hotplug should exist")
+        .try_to_snapshot_v2(requested_size_mib)
+        .expect("all-optional memory-hotplug capture should convert");
+    let serial = SnapshotV2SerialState::try_from_capture_ready(
+        source
+            .capture_ready_serial_state(controller.serial_config().clone(), &guard)
+            .expect("all-optional serial should capture"),
+    )
+    .expect("all-optional serial capture should convert");
+    drop(guard);
+
+    source
+        .pause_for_snapshot_v2_capture()
+        .expect("all-optional memory-hotplug source should pause");
+    let boot = HvfSnapshotV2BootState::try_new(
+        HvfSnapshotV2NativePath::try_new(kernel.path().as_os_str())
+            .expect("all-optional memory-hotplug kernel path should validate"),
+        None,
+        None,
+    )
+    .expect("all-optional memory-hotplug boot metadata should validate");
+    let mut memory_writer = Cursor::new(Vec::new());
+    let platform = source
+        .capture_snapshot_v2_memory_hotplug_platform_with_cancel(
+            HvfArm64BootSnapshotV2CaptureInput::new(boot),
+            Some(memory_hotplug_capture),
+            &mut memory_writer,
+            |_| false,
+        )
+        .expect("all-optional exact-2.10 platform should capture");
+    HvfSnapshotV2MemoryHotplugState::try_new(
+        platform.clone(),
+        Some(graph.clone()),
+        serial.clone(),
+        Some(entropy.clone()),
+        Some(balloon.clone()),
+    )
+    .expect("all-optional exact-2.10 product should compose");
+    let memory_image = TempFile::new("restore-all-memory-hotplug-image", memory_writer.get_ref())
+        .expect("all-optional memory-hotplug image should persist");
+    source
+        .shutdown()
+        .expect("signed all-optional memory-hotplug source should shut down");
+
+    let platform_state = platform.platform().clone();
+    let portable_state = platform
+        .memory_hotplug()
+        .expect("all-optional platform should retain memory-hotplug")
+        .clone();
+    let process = HvfSnapshotV2MemoryHotplugMmioProcessConfig::new(
+        balloon_layout,
+        HvfSnapshotV2StorageMmioProcessConfig::new(block_layout, pmem_layout),
+        entropy_layout,
+        memory_hotplug_layout,
+    );
+    let prepare_plan = || {
+        let topology = PreparedSnapshotV2MemoryHotplugTopology::prepare(
+            portable_state.clone(),
+            platform_state.memory().clone(),
+        )
+        .expect("all-optional memory-hotplug topology should prepare");
+        let memory = materialize_snapshot_v2_memory_hotplug_file(
+            &topology,
+            std::fs::File::open(memory_image.path())
+                .expect("all-optional memory-hotplug image should reopen"),
+        )
+        .expect("all-optional memory-hotplug destination should materialize");
+        let restore_now = Instant::now();
+        let balloon_plan = SnapshotV2BalloonRestorePlan::prepare(balloon.clone(), &memory)
+            .expect("all-optional balloon restore plan should prepare");
+        let entropy_plan =
+            SnapshotV2EntropyRestorePlan::prepare(entropy.clone(), &memory, restore_now)
+                .expect("all-optional entropy restore plan should prepare");
+        let backing = BlockFileBacking::open_snapshot(
+            std::path::Path::new(graph.block_records()[0].config().selector()),
+            graph.block_records()[0].config().is_read_only(),
+        )
+        .expect("all-optional block backing should reopen")
+        .0;
+        let bundle = SnapshotV2StorageRestorePlan::prepare(graph.clone(), &memory, restore_now)
+            .expect("all-optional storage restore plan should prepare")
+            .prepare_backings(vec![backing], Vec::new(), || false)
+            .expect("all-optional storage backing bundle should prepare");
+        prepare_hvf_snapshot_v2_memory_hotplug_mmio_platform_plan(
+            &platform_state,
+            HvfSnapshotV2MemoryHotplugPreparedProduct::
+                serial_balloon_storage_entropy_memory_hotplug(
+                    topology,
+                    memory,
+                    balloon_plan,
+                    bundle,
+                    entropy_plan,
+                ),
+            process,
+        )
+        .expect("all-optional memory-hotplug owner plan should prepare")
+    };
+    let restored_shell = || {
+        HvfSnapshotV2RestoredSerialShell::new(
+            SerialMmioDevice::from_capture_state_with_shared_output(
+                SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+                serial.device().clone(),
+            ),
+        )
+    };
+
+    for fault in [
+        HvfSnapshotV2MemoryHotplugMmioRestoreFault::BalloonPublication,
+        HvfSnapshotV2MemoryHotplugMmioRestoreFault::StoragePublication,
+        HvfSnapshotV2MemoryHotplugMmioRestoreFault::EntropyPublication,
+    ] {
+        let error = OwnedHvfArm64BootSession::restore_snapshot_v2_memory_hotplug_mmio_with_fault(
+            platform_state.clone(),
+            restored_shell(),
+            None,
+            prepare_plan(),
+            fault,
+        )
+        .expect_err("injected all-optional publication fault should reject");
+        assert!(error.is_terminal());
+        assert!(
+            !error.has_incomplete_cleanup(),
+            "{fault:?} should roll back cleanly: {error:?}"
+        );
+    }
+
+    let owners = OwnedHvfArm64BootSession::restore_snapshot_v2_memory_hotplug_mmio(
+        platform_state.clone(),
+        restored_shell(),
+        None,
+        prepare_plan(),
+    )
+    .unwrap_or_else(|error| {
+        let source = std::error::Error::source(&error);
+        let detail = source.and_then(std::error::Error::source);
+        panic!(
+            "all-optional memory-hotplug owners should restore: {error:?}, source={source:?}, detail={detail:?}"
+        )
+    });
+    assert_eq!(owners.state(), &portable_state);
+    assert_eq!(owners.balloon_config(), Some(balloon_config));
+    assert_eq!(owners.entropy_config(), Some(entropy_config));
+    assert_eq!(
+        owners
+            .storage_configs()
+            .expect("restored all-optional storage configs should exist"),
+        &source_configs
+    );
+    assert!(
+        owners
+            .session()
+            .shared_memory_hotplug_device_metrics()
+            .expect("restored all-optional memory-hotplug metrics should exist")
+            .snapshot()
+            .is_empty()
+    );
+    assert!(
+        owners
+            .session()
+            .shared_balloon_device_metrics()
+            .snapshot()
+            .is_empty()
+    );
+    assert!(
+        owners
+            .session()
+            .shared_entropy_device_metrics()
+            .snapshot()
+            .is_empty()
+    );
+
+    let (mut restored, state, controller, storage, returned_entropy, returned_balloon) =
+        owners.into_parts();
+    assert_eq!(state, portable_state);
+    assert_eq!(returned_entropy, Some(entropy_config));
+    assert_eq!(returned_balloon, Some(balloon_config));
+    let storage = storage.expect("restored all-optional storage configs should remain");
+    assert_eq!(restored.runtime_resources().block_devices.len(), 1);
+    assert!(restored.runtime_resources().balloon_device.is_some());
+    assert!(restored.runtime_resources().entropy_device.is_some());
+    assert!(restored.runtime_resources().memory_hotplug_device.is_some());
+
+    let guard = restored
+        .quiesce_limiter_retry_wakeups()
+        .expect("restored all-optional owners should quiesce");
+    let recaptured_memory_hotplug = restored
+        .capture_ready_memory_hotplug_state(Some(controller.config()), &guard)
+        .expect("restored all-optional memory-hotplug should capture")
+        .expect("restored all-optional memory-hotplug should exist")
+        .try_to_snapshot_v2(controller.requested_size_mib())
+        .expect("restored all-optional memory-hotplug capture should convert");
+    assert_eq!(recaptured_memory_hotplug.state(), &portable_state);
+    let recaptured_balloon = restored
+        .capture_ready_balloon_state(Some(balloon_config), &guard)
+        .expect("restored all-optional balloon should capture")
+        .expect("restored all-optional balloon should exist")
+        .try_to_snapshot_v2()
+        .expect("restored all-optional balloon capture should convert");
+    assert_eq!(recaptured_balloon.config(), balloon.config());
+    assert_eq!(
+        recaptured_balloon.config_space().num_pages(),
+        balloon.config_space().num_pages()
+    );
+    assert_eq!(
+        recaptured_balloon.config_space().actual_pages(),
+        balloon.config_space().actual_pages()
+    );
+    assert_eq!(
+        recaptured_balloon.config_space().free_page_hint_cmd_id(),
+        VIRTIO_BALLOON_FREE_PAGE_HINT_DONE
+    );
+    assert_eq!(recaptured_balloon.accounting(), balloon.accounting());
+    assert_eq!(recaptured_balloon.virtio(), balloon.virtio());
+    assert_eq!(recaptured_balloon.transport(), balloon.transport());
+    assert_eq!(
+        recaptured_balloon.continuation().active_queues(),
+        balloon.continuation().active_queues()
+    );
+    let recaptured_entropy = restored
+        .capture_ready_entropy_state_at(Some(entropy_config), &guard, capture_now)
+        .expect("restored all-optional entropy should capture")
+        .expect("restored all-optional entropy should exist")
+        .try_to_snapshot_v2()
+        .expect("restored all-optional entropy capture should convert");
+    assert_eq!(recaptured_entropy, entropy);
+    let recaptured_graph = restored
+        .capture_snapshot_v2_storage_device_graph_at(&storage, &guard, capture_now)
+        .expect("restored all-optional storage graph should capture");
+    assert_eq!(recaptured_graph, graph);
+    drop(guard);
+    restored
+        .shutdown()
+        .expect("restored all-optional destination should shut down");
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
 fn guest_write_to_writable_pmem_is_visible_before_any_pmem_flush() {
     use std::os::unix::fs::FileExt;
 

--- a/crates/runtime/src/memory_hotplug.rs
+++ b/crates/runtime/src/memory_hotplug.rs
@@ -640,6 +640,13 @@ pub struct VirtioMemMmioDeviceRegistration {
 }
 
 impl VirtioMemMmioDeviceRegistration {
+    /// Reconstructs registration metadata for a checked, already retained
+    /// MMIO region without publishing it.
+    #[doc(hidden)]
+    pub const fn from_restored(region: MmioRegion) -> Self {
+        Self { region }
+    }
+
     pub const fn region(self) -> MmioRegion {
         self.region
     }
@@ -1995,17 +2002,26 @@ impl VirtioMemQueue {
     pub fn from_mmio_queue_state(
         queue: &VirtioMmioQueueState,
     ) -> Result<Self, VirtioMemQueueBuildError> {
+        Self::from_snapshot_state(queue, 0, 0)
+    }
+
+    pub(crate) fn from_snapshot_state(
+        queue: &VirtioMmioQueueState,
+        next_available: u16,
+        next_used: u16,
+    ) -> Result<Self, VirtioMemQueueBuildError> {
         if !queue.ready() {
             return Err(VirtioMemQueueBuildError::QueueNotReady);
         }
 
-        let available = VirtqueueAvailableRing::new(
+        let available = VirtqueueAvailableRing::with_next_avail(
             queue.descriptor_table(),
             queue.driver_ring(),
             queue.size(),
+            next_available,
         )
         .map_err(|source| VirtioMemQueueBuildError::AvailableRing { source })?;
-        let used = VirtqueueUsedRing::new(queue.device_ring(), queue.size())
+        let used = VirtqueueUsedRing::with_next_used(queue.device_ring(), queue.size(), next_used)
             .map_err(|source| VirtioMemQueueBuildError::UsedRing { source })?;
 
         Ok(Self { available, used })
@@ -2088,6 +2104,14 @@ impl VirtioMemQueue {
             next_available: self.available.next_avail(),
             next_used: self.used.next_used(),
         })
+    }
+
+    pub(crate) fn validate_snapshot_state(
+        &self,
+        transport: &VirtioMmioQueueState,
+        memory: &GuestMemory,
+    ) -> Result<(), VirtioMemQueueCaptureError> {
+        self.capture_state(transport, memory).map(|_| ())
     }
 
     #[cfg(test)]
@@ -2897,6 +2921,35 @@ impl VirtioMemDevice {
         }
     }
 
+    pub(crate) fn from_snapshot_parts<I>(
+        active_queue: Option<VirtioMemQueue>,
+        plugged_ranges: I,
+    ) -> Result<Self, VirtioMemDeviceRestoreError>
+    where
+        I: ExactSizeIterator<Item = (u64, u64)>,
+    {
+        let mut ranges = Vec::new();
+        ranges
+            .try_reserve_exact(plugged_ranges.len())
+            .map_err(|source| VirtioMemDeviceRestoreError::Allocation { source })?;
+        let mut previous_end = None;
+        for (range_index, (start_block, block_count)) in plugged_ranges.enumerate() {
+            let range = VirtioMemBlockRange::new(start_block, block_count)
+                .ok_or(VirtioMemDeviceRestoreError::PluggedRangeInvalid { range_index })?;
+            if previous_end.is_some_and(|end| range.start() <= end) {
+                return Err(VirtioMemDeviceRestoreError::PluggedRangeInvalid { range_index });
+            }
+            previous_end = Some(range.end());
+            ranges.push(range);
+        }
+
+        Ok(Self {
+            active_queue,
+            plugged_blocks: VirtioMemPluggedBlocks { ranges },
+            metrics: SharedMemoryHotplugDeviceMetrics::default(),
+        })
+    }
+
     pub fn shared_metrics(&self) -> SharedMemoryHotplugDeviceMetrics {
         self.metrics.clone()
     }
@@ -3162,6 +3215,37 @@ impl VirtioMemDevice {
 impl Default for VirtioMemDevice {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum VirtioMemDeviceRestoreError {
+    Allocation { source: TryReserveError },
+    PluggedRangeInvalid { range_index: usize },
+}
+
+impl fmt::Display for VirtioMemDeviceRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Allocation { .. } => {
+                formatter.write_str("failed to reserve restored virtio-mem plugged ranges")
+            }
+            Self::PluggedRangeInvalid { range_index } => {
+                write!(
+                    formatter,
+                    "restored virtio-mem plugged range {range_index} is invalid"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for VirtioMemDeviceRestoreError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Allocation { source } => Some(source),
+            Self::PluggedRangeInvalid { .. } => None,
+        }
     }
 }
 

--- a/crates/runtime/src/snapshot_memory_hotplug_v2_10.rs
+++ b/crates/runtime/src/snapshot_memory_hotplug_v2_10.rs
@@ -9,19 +9,23 @@ use std::fmt;
 use std::iter::FusedIterator;
 
 use crate::interrupt::GuestInterruptLine;
-use crate::memory::{GuestAddress, GuestMemoryRange, aarch64};
+use crate::memory::{GuestAddress, GuestMemory, GuestMemoryRange, aarch64};
 use crate::memory_hotplug::{
     MemoryHotplugConfig, MemoryHotplugConfigInput, MemoryHotplugSizeUpdateInput,
     VIRTIO_FEATURE_VERSION_1, VIRTIO_MEM_DEFAULT_REGION_ADDRESS, VIRTIO_MEM_DEVICE_ID,
-    VIRTIO_MEM_F_UNPLUGGED_INACCESSIBLE, VIRTIO_MEM_QUEUE_SIZE, VirtioMemConfigSpace,
-    VirtioMemDeviceCaptureState, VirtioMemMmioCaptureState, VirtioMemPciCaptureState,
+    VIRTIO_MEM_F_UNPLUGGED_INACCESSIBLE, VIRTIO_MEM_QUEUE_SIZE, VIRTIO_MEM_QUEUE_SIZES,
+    VirtioMemConfigSpace, VirtioMemDevice, VirtioMemDeviceCaptureError,
+    VirtioMemDeviceCaptureState, VirtioMemMmioCaptureState, VirtioMemMmioHandler,
+    VirtioMemPciCaptureState, VirtioMemQueue, VirtioMemQueueBuildError, VirtioMemQueueCaptureError,
 };
 use crate::mmio::MmioRegion;
 use crate::pci::PciSbdf;
 use crate::snapshot_device_v2::{
-    SnapshotV2DeviceGraphCaptureError, SnapshotV2DeviceTransport, SnapshotV2VirtioState,
+    SnapshotV2DeviceGraphCaptureError, SnapshotV2DeviceTransport,
+    SnapshotV2RootTransportRestoreError, SnapshotV2VirtioState,
     capture_mmio_common_for_device_with_config_status_gate, capture_mmio_transport,
     capture_pci_common_for_device, capture_pci_transport_parts,
+    restore_mmio_transport_state_for_device_with_config_status_gate,
 };
 use crate::snapshot_device_v2_5::{
     queue_ranges, validate_mmio, validate_pci, validate_virtio_with_queue_size,
@@ -29,6 +33,7 @@ use crate::snapshot_device_v2_5::{
 use crate::snapshot_format::SnapshotFormatVersion;
 use crate::snapshot_memory_v2::{SnapshotV2MemoryBinding, SnapshotV2MemoryExtent};
 use crate::storage_capture::StorageDeviceOrigin;
+use crate::virtio_mmio::{VirtioMmioQueueState, VirtioMmioRegisterHandlerError};
 
 mod codec;
 
@@ -420,6 +425,114 @@ impl PreparedSnapshotV2MemoryHotplugTopology {
             self.controller,
         )
     }
+
+    /// Consumes one checked MMIO topology into a complete inert register
+    /// handler against the destination mixed-memory owner.
+    ///
+    /// The returned value owns no dispatcher registration, notifier,
+    /// interrupt route, platform slot, mapper, metrics registry, or VM
+    /// authority.
+    #[doc(hidden)]
+    pub fn into_mmio_handler(
+        self,
+        destination_memory: &GuestMemory,
+    ) -> Result<PreparedSnapshotV2MemoryHotplugMmioHandler, SnapshotV2MemoryHotplugMmioHandlerError>
+    {
+        let Self {
+            memory: _,
+            plugged_ranges,
+            queue_ranges,
+            state,
+            controller,
+        } = self;
+        let SnapshotV2DeviceTransport::Mmio(mmio) = state.transport() else {
+            return Err(SnapshotV2MemoryHotplugMmioHandlerError::WrongTransport);
+        };
+        let queue_state = state.virtio().queues().first().ok_or(
+            SnapshotV2MemoryHotplugMmioHandlerError::QueueContinuation(
+                VirtioMemQueueBuildError::QueueNotReady,
+            ),
+        )?;
+        let transport_queue = VirtioMmioQueueState::from_parts(
+            queue_state.max_size(),
+            queue_state.size(),
+            queue_state.ready(),
+            queue_state.descriptor_table(),
+            queue_state.driver_ring(),
+            queue_state.device_ring(),
+        );
+        let active_queue = state
+            .active_queue()
+            .map(|cursor| {
+                let queue = VirtioMemQueue::from_snapshot_state(
+                    &transport_queue,
+                    cursor.next_available(),
+                    cursor.next_used(),
+                )
+                .map_err(SnapshotV2MemoryHotplugMmioHandlerError::QueueContinuation)?;
+                queue
+                    .validate_snapshot_state(&transport_queue, destination_memory)
+                    .map_err(SnapshotV2MemoryHotplugMmioHandlerError::QueueMemory)?;
+                Ok(queue)
+            })
+            .transpose()?;
+        let activation_is_active = active_queue.is_some();
+        let device = VirtioMemDevice::from_snapshot_parts(
+            active_queue,
+            state
+                .plugged_ranges()
+                .map(|range| (range.start_block(), range.block_count())),
+        )
+        .map_err(|_| SnapshotV2MemoryHotplugMmioHandlerError::Device)?;
+        let retained = restore_mmio_transport_state_for_device_with_config_status_gate(
+            VIRTIO_MEM_DEVICE_ID,
+            state.virtio(),
+            mmio,
+            true,
+        )
+        .map_err(SnapshotV2MemoryHotplugMmioHandlerError::RetainedTransport)?;
+        let registers = *retained.device_registers();
+        let mut handler =
+            VirtioMemMmioHandler::with_vendor_id_and_config_generation_and_device_config_and_activation(
+                registers.device_id(),
+                registers.vendor_id(),
+                registers.device_features(),
+                registers.config_generation(),
+                &VIRTIO_MEM_QUEUE_SIZES,
+                state.config_space(),
+                device,
+            )
+            .map_err(SnapshotV2MemoryHotplugMmioHandlerError::Handler)?;
+        handler
+            .restore_transport_state(&retained, activation_is_active)
+            .map_err(|_| SnapshotV2MemoryHotplugMmioHandlerError::Transport)?;
+
+        let region = mmio.region();
+        let interrupt_line = mmio.interrupt_line();
+        let captured = handler
+            .capture_memory_hotplug_state(state.config(), destination_memory)
+            .map_err(SnapshotV2MemoryHotplugMmioHandlerError::Capture)?;
+        let normalized = SnapshotV2MemoryHotplugState::try_from_mmio_capture(
+            state.config(),
+            region,
+            interrupt_line,
+            &captured,
+        )
+        .map_err(SnapshotV2MemoryHotplugMmioHandlerError::Normalize)?;
+        if normalized != state {
+            return Err(SnapshotV2MemoryHotplugMmioHandlerError::StateMismatch);
+        }
+
+        Ok(PreparedSnapshotV2MemoryHotplugMmioHandler {
+            expected_state: state,
+            controller,
+            plugged_ranges,
+            queue_ranges,
+            region,
+            interrupt_line,
+            handler,
+        })
+    }
 }
 
 impl fmt::Debug for PreparedSnapshotV2MemoryHotplugTopology {
@@ -432,6 +545,131 @@ impl fmt::Debug for PreparedSnapshotV2MemoryHotplugTopology {
             .field("has_queue_ranges", &self.queue_ranges.is_some())
             .field("topology", &REDACTED)
             .finish()
+    }
+}
+
+/// One checked, complete, and still-unpublished MMIO virtio-mem handler.
+#[doc(hidden)]
+pub struct PreparedSnapshotV2MemoryHotplugMmioHandler {
+    expected_state: SnapshotV2MemoryHotplugState,
+    controller: SnapshotV2MemoryHotplugControllerProjection,
+    plugged_ranges: Vec<GuestMemoryRange>,
+    queue_ranges: Option<[GuestMemoryRange; 3]>,
+    region: MmioRegion,
+    interrupt_line: GuestInterruptLine,
+    handler: VirtioMemMmioHandler,
+}
+
+impl PreparedSnapshotV2MemoryHotplugMmioHandler {
+    pub const fn expected_state(&self) -> &SnapshotV2MemoryHotplugState {
+        &self.expected_state
+    }
+
+    pub const fn controller(&self) -> SnapshotV2MemoryHotplugControllerProjection {
+        self.controller
+    }
+
+    pub fn plugged_ranges(&self) -> &[GuestMemoryRange] {
+        &self.plugged_ranges
+    }
+
+    pub const fn queue_ranges(&self) -> Option<[GuestMemoryRange; 3]> {
+        self.queue_ranges
+    }
+
+    pub const fn region(&self) -> MmioRegion {
+        self.region
+    }
+
+    pub const fn interrupt_line(&self) -> GuestInterruptLine {
+        self.interrupt_line
+    }
+
+    pub const fn handler(&self) -> &VirtioMemMmioHandler {
+        &self.handler
+    }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        SnapshotV2MemoryHotplugState,
+        SnapshotV2MemoryHotplugControllerProjection,
+        Vec<GuestMemoryRange>,
+        Option<[GuestMemoryRange; 3]>,
+        MmioRegion,
+        GuestInterruptLine,
+        VirtioMemMmioHandler,
+    ) {
+        (
+            self.expected_state,
+            self.controller,
+            self.plugged_ranges,
+            self.queue_ranges,
+            self.region,
+            self.interrupt_line,
+            self.handler,
+        )
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2MemoryHotplugMmioHandler {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2MemoryHotplugMmioHandler")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Failure while materializing a checked topology as an inert MMIO handler.
+#[doc(hidden)]
+pub enum SnapshotV2MemoryHotplugMmioHandlerError {
+    WrongTransport,
+    QueueContinuation(VirtioMemQueueBuildError),
+    QueueMemory(VirtioMemQueueCaptureError),
+    Device,
+    RetainedTransport(SnapshotV2RootTransportRestoreError),
+    Handler(VirtioMmioRegisterHandlerError),
+    Transport,
+    Capture(VirtioMemDeviceCaptureError),
+    Normalize(SnapshotV2MemoryHotplugStateCaptureError),
+    StateMismatch,
+}
+
+impl fmt::Debug for SnapshotV2MemoryHotplugMmioHandlerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+impl fmt::Display for SnapshotV2MemoryHotplugMmioHandlerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::WrongTransport => "native-v2 virtio-mem plan does not select MMIO",
+            Self::QueueContinuation(_) => "native-v2 virtio-mem queue continuation is invalid",
+            Self::QueueMemory(_) => "native-v2 virtio-mem queue memory is invalid",
+            Self::Device => "native-v2 virtio-mem device reconstruction failed",
+            Self::RetainedTransport(_) => "native-v2 virtio-mem retained MMIO transport is invalid",
+            Self::Handler(_) => "native-v2 virtio-mem MMIO handler construction failed",
+            Self::Transport => "native-v2 virtio-mem MMIO transport restoration failed",
+            Self::Capture(_) => "native-v2 virtio-mem restored handler capture failed",
+            Self::Normalize(_) => "native-v2 virtio-mem restored handler normalization failed",
+            Self::StateMismatch => "native-v2 virtio-mem restored handler state diverged",
+        })
+    }
+}
+
+impl std::error::Error for SnapshotV2MemoryHotplugMmioHandlerError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::QueueContinuation(source) => Some(source),
+            Self::QueueMemory(source) => Some(source),
+            Self::RetainedTransport(source) => Some(source),
+            Self::Handler(source) => Some(source),
+            Self::Capture(source) => Some(source),
+            Self::Normalize(source) => Some(source),
+            Self::WrongTransport | Self::Device | Self::Transport | Self::StateMismatch => None,
+        }
     }
 }
 

--- a/crates/runtime/src/snapshot_memory_hotplug_v2_10.rs
+++ b/crates/runtime/src/snapshot_memory_hotplug_v2_10.rs
@@ -561,34 +561,43 @@ pub struct PreparedSnapshotV2MemoryHotplugMmioHandler {
 }
 
 impl PreparedSnapshotV2MemoryHotplugMmioHandler {
+    /// Returns the exact normalized portable state this handler must retain.
     pub const fn expected_state(&self) -> &SnapshotV2MemoryHotplugState {
         &self.expected_state
     }
 
+    /// Returns the public controller projection reconstructed with the device.
     pub const fn controller(&self) -> SnapshotV2MemoryHotplugControllerProjection {
         self.controller
     }
 
+    /// Returns canonical shared-aperture ranges retained as plugged memory.
     pub fn plugged_ranges(&self) -> &[GuestMemoryRange] {
         &self.plugged_ranges
     }
 
+    /// Returns the descriptor, available, and used ranges for an active queue.
     pub const fn queue_ranges(&self) -> Option<[GuestMemoryRange; 3]> {
         self.queue_ranges
     }
 
+    /// Returns the exact retained MMIO region.
     pub const fn region(&self) -> MmioRegion {
         self.region
     }
 
+    /// Returns the exact retained guest interrupt line.
     pub const fn interrupt_line(&self) -> GuestInterruptLine {
         self.interrupt_line
     }
 
+    /// Returns the fully restored, still-unpublished register handler.
     pub const fn handler(&self) -> &VirtioMemMmioHandler {
         &self.handler
     }
 
+    /// Consumes the value into portable state, controller and memory proofs,
+    /// placement, and the inert handler.
     pub fn into_parts(
         self,
     ) -> (
@@ -624,15 +633,25 @@ impl fmt::Debug for PreparedSnapshotV2MemoryHotplugMmioHandler {
 /// Failure while materializing a checked topology as an inert MMIO handler.
 #[doc(hidden)]
 pub enum SnapshotV2MemoryHotplugMmioHandlerError {
+    /// The checked topology selects PCI rather than MMIO.
     WrongTransport,
+    /// The retained active queue cursors could not be reconstructed.
     QueueContinuation(VirtioMemQueueBuildError),
+    /// The retained active queue does not resolve against destination memory.
     QueueMemory(VirtioMemQueueCaptureError),
+    /// The canonical plugged-range device inventory could not be rebuilt.
     Device,
+    /// The retained common MMIO transport state is invalid.
     RetainedTransport(SnapshotV2RootTransportRestoreError),
+    /// The exact virtio-mem register handler could not be constructed.
     Handler(VirtioMmioRegisterHandlerError),
+    /// The retained transport state could not be applied to the handler.
     Transport,
+    /// The restored live handler could not be captured.
     Capture(VirtioMemDeviceCaptureError),
+    /// The restored handler capture could not be normalized.
     Normalize(SnapshotV2MemoryHotplugStateCaptureError),
+    /// The normalized restored handler differs from the decoded input.
     StateMismatch,
 }
 

--- a/crates/runtime/src/snapshot_memory_hotplug_v2_10/tests.rs
+++ b/crates/runtime/src/snapshot_memory_hotplug_v2_10/tests.rs
@@ -273,6 +273,36 @@ fn binding_for_ranges(
     .expect("binding fixture should encode")
 }
 
+fn destination_memory_for_ranges(ranges: Vec<GuestMemoryRange>) -> GuestMemory {
+    let layout = GuestMemoryLayout::new(ranges).expect("destination layout should validate");
+    GuestMemory::allocate(&layout).expect("destination memory should allocate")
+}
+
+fn set_queue_indices(
+    memory: &mut GuestMemory,
+    driver_ring: GuestAddress,
+    device_ring: GuestAddress,
+    index: u16,
+) {
+    let index_offset = 2;
+    memory
+        .write_slice(
+            &index.to_le_bytes(),
+            driver_ring
+                .checked_add(index_offset)
+                .expect("available-ring index address should fit"),
+        )
+        .expect("available-ring index should write");
+    memory
+        .write_slice(
+            &index.to_le_bytes(),
+            device_ring
+                .checked_add(index_offset)
+                .expect("used-ring index address should fit"),
+        )
+        .expect("used-ring index should write");
+}
+
 #[test]
 fn kind_one_binding_closes_fragmented_plugged_unions_and_rejects_hostile_coverage() {
     let state = inactive_mmio_state();
@@ -481,6 +511,156 @@ fn prepared_topology_preserves_ordered_partition_ranges_and_controller_projectio
         assert!(diagnostic.contains(REDACTED));
         assert!(!diagnostic.contains(&sentinel));
     }
+}
+
+#[test]
+fn inactive_mmio_topology_reconstructs_an_exact_handler_with_fresh_metrics() {
+    let state = inactive_mmio_state();
+    let ranges = vec![
+        plugged_guest_test_range(&state, 1, 2),
+        plugged_guest_test_range(&state, 5, 3),
+    ];
+    let binding = binding_for_ranges(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        ranges.clone(),
+    );
+    let memory = destination_memory_for_ranges(ranges);
+
+    let prepared = PreparedSnapshotV2MemoryHotplugTopology::prepare(state.clone(), binding)
+        .expect("inactive MMIO topology should prepare")
+        .into_mmio_handler(&memory)
+        .expect("inactive MMIO handler should reconstruct");
+
+    assert_eq!(prepared.expected_state(), &state);
+    assert_eq!(prepared.controller().config(), state.config());
+    assert_eq!(prepared.controller().requested_size_mib(), 128);
+    assert_eq!(
+        prepared.plugged_ranges(),
+        [
+            plugged_guest_test_range(&state, 1, 2),
+            plugged_guest_test_range(&state, 5, 3),
+        ]
+    );
+    assert_eq!(prepared.queue_ranges(), None);
+    assert_eq!(prepared.region(), mmio_transport().region());
+    assert_eq!(prepared.interrupt_line(), mmio_transport().interrupt_line());
+    assert!(
+        prepared
+            .handler()
+            .shared_memory_hotplug_metrics()
+            .snapshot()
+            .is_empty()
+    );
+}
+
+#[test]
+fn active_mmio_topology_restores_nonzero_queue_cursors_and_rejects_memory_drift() {
+    let state = active_mmio_state();
+    let queue = state
+        .virtio()
+        .queues()
+        .first()
+        .expect("active fixture should retain one queue");
+    let ranges = vec![
+        test_range(0x10_0000, 0x50_000),
+        plugged_guest_test_range(&state, 0, 1),
+        plugged_guest_test_range(&state, 7, 2),
+        plugged_guest_test_range(&state, 127, 1),
+    ];
+    let binding = binding_for_ranges(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        ranges.clone(),
+    );
+    let prepared = PreparedSnapshotV2MemoryHotplugTopology::prepare(state.clone(), binding)
+        .expect("active MMIO topology should prepare");
+
+    let unmapped_queue_memory = destination_memory_for_ranges(ranges[1..].to_vec());
+    assert!(matches!(
+        PreparedSnapshotV2MemoryHotplugTopology::prepare(
+            state.clone(),
+            binding_for_ranges(
+                NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+                ranges.clone(),
+            ),
+        )
+        .expect("active MMIO topology should prepare")
+        .into_mmio_handler(&unmapped_queue_memory),
+        Err(SnapshotV2MemoryHotplugMmioHandlerError::QueueMemory(_))
+    ));
+
+    let mismatched_indices_memory = destination_memory_for_ranges(ranges.clone());
+    assert!(matches!(
+        PreparedSnapshotV2MemoryHotplugTopology::prepare(
+            state.clone(),
+            binding_for_ranges(
+                NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+                ranges.clone(),
+            ),
+        )
+        .expect("active MMIO topology should prepare")
+        .into_mmio_handler(&mismatched_indices_memory),
+        Err(SnapshotV2MemoryHotplugMmioHandlerError::QueueMemory(
+            VirtioMemQueueCaptureError::UsedCursorMismatch
+        ))
+    ));
+
+    let mut memory = destination_memory_for_ranges(ranges);
+    set_queue_indices(
+        &mut memory,
+        queue.driver_ring(),
+        queue.device_ring(),
+        state
+            .active_queue()
+            .expect("active fixture should retain queue cursors")
+            .next_used(),
+    );
+    let restored = prepared
+        .into_mmio_handler(&memory)
+        .expect("active MMIO handler should reconstruct");
+    let captured = restored
+        .handler()
+        .capture_memory_hotplug_state(state.config(), &memory)
+        .expect("restored active handler should capture");
+    let normalized = SnapshotV2MemoryHotplugState::try_from_mmio_capture(
+        state.config(),
+        restored.region(),
+        restored.interrupt_line(),
+        &captured,
+    )
+    .expect("restored active capture should normalize");
+
+    assert_eq!(normalized, state);
+    assert!(restored.queue_ranges().is_some());
+    assert!(
+        restored
+            .handler()
+            .shared_memory_hotplug_metrics()
+            .snapshot()
+            .is_empty()
+    );
+}
+
+#[test]
+fn pci_topology_cannot_materialize_an_mmio_handler() {
+    let state = active_pci_state();
+    let ranges = vec![
+        test_range(0x10_0000, 0x50_000),
+        plugged_guest_test_range(&state, 0, 1),
+        plugged_guest_test_range(&state, 7, 2),
+        plugged_guest_test_range(&state, 127, 1),
+    ];
+    let binding = binding_for_ranges(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        ranges.clone(),
+    );
+    let memory = destination_memory_for_ranges(ranges);
+
+    assert!(matches!(
+        PreparedSnapshotV2MemoryHotplugTopology::prepare(state, binding)
+            .expect("PCI topology should prepare")
+            .into_mmio_handler(&memory),
+        Err(SnapshotV2MemoryHotplugMmioHandlerError::WrongTransport)
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- reconstruct fresh inactive and active exact-2.10 MMIO virtio-mem handlers from typed snapshot state, preserving transport registers, queue cursors, activation, config space, and canonical plugged ranges while starting destination-local metrics
- materialize mixed guest memory with static Base mappings and dynamic shared-aperture mappings, then prove dirty coverage, byte accounting, mapping identity, immediate normalized recapture, and reverse-order rollback
- assemble every balloon/storage/entropy MMIO product combination inside the unpublished HVF transaction and certify memory-hotplug-only plus all-optional owner graphs on signed Hypervisor.framework
- keep public snapshot create/load rejection in place

## Scope

- this PR only adds the internal unpublished MMIO owner reconstruction required by exact 2.10
- PCI virtio-mem owners and public snapshot activation remain deferred
- exact 2.3–2.9 and non-virtio-mem exact-2.10 restore paths retain their existing mapping and owner behavior

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented `aarch64-apple-darwin` integration-target Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test hvf_lifecycle` (94 signed tests)

The full signed integration wrapper also passed the HVF lifecycle, guest boot, executable, and App Sandbox targets. Its long production-bundle sequence exhibited unrelated non-deterministic socket/process disconnects across repeated runs; every affected production-bundle test passed immediately when rerun alone.

Closes #1695

Parent context: #1538
