### PR TITLE
feat: reconstruct PCI virtio-mem snapshot owners

### DIFF
--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -255,7 +255,9 @@ pub use startup::{
     HvfSnapshotV2EntropyPciRestoreError, HvfSnapshotV2EntropyPciRestoreFailure,
     HvfSnapshotV2EntropyPciRestoreStage, HvfSnapshotV2MemoryHotplugMmioRestoreError,
     HvfSnapshotV2MemoryHotplugMmioRestoreFailure, HvfSnapshotV2MemoryHotplugMmioRestoreFault,
-    HvfSnapshotV2MemoryHotplugMmioRestoreStage, HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure,
+    HvfSnapshotV2MemoryHotplugMmioRestoreStage, HvfSnapshotV2MemoryHotplugPciRestoreError,
+    HvfSnapshotV2MemoryHotplugPciRestoreFailure, HvfSnapshotV2MemoryHotplugPciRestoreFault,
+    HvfSnapshotV2MemoryHotplugPciRestoreStage, HvfSnapshotV2MultiBlockMmioRestoreCleanupFailure,
     HvfSnapshotV2MultiBlockMmioRestoreError, HvfSnapshotV2MultiBlockMmioRestoreFailure,
     HvfSnapshotV2MultiBlockMmioRestoreStage, HvfSnapshotV2MultiBlockPciRestoreCleanupFailure,
     HvfSnapshotV2MultiBlockPciRestoreError, HvfSnapshotV2MultiBlockPciRestoreFailure,
@@ -269,9 +271,9 @@ pub use startup::{
     PreparedHvfArm64BootPciNetworkRemoval, RestoredHvfArm64BootSession,
     RestoredHvfSnapshotV2BalloonMmioOwners, RestoredHvfSnapshotV2BalloonPciOwners,
     RestoredHvfSnapshotV2EntropyMmioOwners, RestoredHvfSnapshotV2EntropyPciOwners,
-    RestoredHvfSnapshotV2MemoryHotplugMmioOwners, RestoredHvfSnapshotV2MultiBlockMmioOwners,
-    RestoredHvfSnapshotV2MultiBlockPciOwners, RestoredHvfSnapshotV2StorageMmioOwners,
-    RestoredHvfSnapshotV2StoragePciOwners,
+    RestoredHvfSnapshotV2MemoryHotplugMmioOwners, RestoredHvfSnapshotV2MemoryHotplugPciOwners,
+    RestoredHvfSnapshotV2MultiBlockMmioOwners, RestoredHvfSnapshotV2MultiBlockPciOwners,
+    RestoredHvfSnapshotV2StorageMmioOwners, RestoredHvfSnapshotV2StoragePciOwners,
 };
 pub use topology::{
     HvfVcpuTopology, HvfVcpuTopologyAllocation, HvfVcpuTopologyCreateStage, HvfVcpuTopologyError,

--- a/crates/hvf/src/snapshot_v2_memory_hotplug_platform.rs
+++ b/crates/hvf/src/snapshot_v2_memory_hotplug_platform.rs
@@ -641,6 +641,22 @@ pub struct HvfSnapshotV2MemoryHotplugPciPlatformPlan {
     vmclock_interrupt: GuestInterruptLine,
 }
 
+pub(crate) struct HvfSnapshotV2MemoryHotplugPciPlatformPlanParts {
+    pub(crate) product: HvfSnapshotV2MemoryHotplugPreparedProduct,
+    pub(crate) mapping: HvfSnapshotV2MemoryHotplugMappingPlan,
+    pub(crate) balloon: Option<HvfSnapshotV2BalloonPciEndpointPlan>,
+    pub(crate) storage: Option<HvfSnapshotV2StoragePciPlatformPlan>,
+    pub(crate) entropy: Option<HvfSnapshotV2EntropyPciEndpointPlan>,
+    pub(crate) memory_hotplug: HvfSnapshotV2MemoryHotplugPciEndpointPlan,
+    pub(crate) host: Arm64FdtPciHost,
+    pub(crate) msi: HvfGicMsiMetadata,
+    pub(crate) endpoint_count: usize,
+    pub(crate) route_demand: usize,
+    pub(crate) serial_interrupt: GuestInterruptLine,
+    pub(crate) vmgenid_interrupt: GuestInterruptLine,
+    pub(crate) vmclock_interrupt: GuestInterruptLine,
+}
+
 impl HvfSnapshotV2MemoryHotplugPciPlatformPlan {
     pub const fn kind(&self) -> HvfSnapshotV2MemoryHotplugProductKind {
         self.product.kind()
@@ -692,6 +708,24 @@ impl HvfSnapshotV2MemoryHotplugPciPlatformPlan {
 
     pub const fn vmclock_interrupt(&self) -> GuestInterruptLine {
         self.vmclock_interrupt
+    }
+
+    pub(crate) fn into_parts(self) -> HvfSnapshotV2MemoryHotplugPciPlatformPlanParts {
+        HvfSnapshotV2MemoryHotplugPciPlatformPlanParts {
+            product: self.product,
+            mapping: self.mapping,
+            balloon: self.balloon,
+            storage: self.storage,
+            entropy: self.entropy,
+            memory_hotplug: self.memory_hotplug,
+            host: self.host,
+            msi: self.msi,
+            endpoint_count: self.endpoint_count,
+            route_demand: self.route_demand,
+            serial_interrupt: self.serial_interrupt,
+            vmgenid_interrupt: self.vmgenid_interrupt,
+            vmclock_interrupt: self.vmclock_interrupt,
+        }
     }
 }
 

--- a/crates/hvf/src/snapshot_v2_platform.rs
+++ b/crates/hvf/src/snapshot_v2_platform.rs
@@ -1666,6 +1666,42 @@ pub(crate) fn restore_hvf_snapshot_v2_serial_memory_hotplug_mmio_process_platfor
     )
 }
 
+pub(crate) fn restore_hvf_snapshot_v2_serial_memory_hotplug_pci_process_platform(
+    state: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    shell: HvfSnapshotV2RestoredSerialShell,
+    process: HvfSnapshotV2SerialOnlyProcessConfig,
+    mapping: &HvfSnapshotV2MemoryHotplugMappingPlan,
+) -> Result<RestoredHvfSnapshotV2Platform, HvfSnapshotV2PlatformRestoreError> {
+    restore_hvf_snapshot_v2_platform_with_shell_and_mapping(
+        state,
+        memory,
+        Some(HvfSnapshotV2ProcessShellRestore::SerialOnly {
+            shell: shell.into(),
+            process,
+        }),
+        HvfSnapshotV2MemoryMappingRestore::MemoryHotplug(mapping),
+    )
+}
+
+pub(crate) fn restore_hvf_snapshot_v2_serial_storage_memory_hotplug_pci_process_platform(
+    state: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    shell: HvfSnapshotV2RestoredSerialShell,
+    plan: HvfSnapshotV2StoragePciShellPlan<'_>,
+    mapping: &HvfSnapshotV2MemoryHotplugMappingPlan,
+) -> Result<RestoredHvfSnapshotV2Platform, HvfSnapshotV2PlatformRestoreError> {
+    restore_hvf_snapshot_v2_platform_with_shell_and_mapping(
+        state,
+        memory,
+        Some(HvfSnapshotV2ProcessShellRestore::StoragePci {
+            shell: shell.into(),
+            plan,
+        }),
+        HvfSnapshotV2MemoryMappingRestore::MemoryHotplug(mapping),
+    )
+}
+
 #[derive(Clone, Copy)]
 enum HvfSnapshotV2MemoryMappingRestore<'a> {
     Ordinary,

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -114,7 +114,7 @@ use bangbang_runtime::snapshot_device::{
 };
 use bangbang_runtime::snapshot_device_v2::{
     NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, PreparedSnapshotV2PciRoot,
-    PreparedSnapshotV2RootBlock, PreparedSnapshotV2RootTransport,
+    PreparedSnapshotV2RootBlock, PreparedSnapshotV2RootTransport, SnapshotV2DeviceTransport,
     SnapshotV2RootTransportRestoreError,
 };
 use bangbang_runtime::snapshot_device_v2_5::{
@@ -140,9 +140,10 @@ use bangbang_runtime::snapshot_entropy_v2_8::{
 use bangbang_runtime::snapshot_format::SnapshotFormatVersion;
 use bangbang_runtime::snapshot_format_v2::NATIVE_V2_LEGACY_PLATFORM_VERSION;
 use bangbang_runtime::snapshot_memory_hotplug_v2_10::{
-    NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+    NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION, PreparedSnapshotV2MemoryHotplugTopology,
     SnapshotV2MemoryHotplugControllerProjection, SnapshotV2MemoryHotplugMmioHandlerError,
-    SnapshotV2MemoryHotplugState, SnapshotV2MemoryHotplugStateCaptureError,
+    SnapshotV2MemoryHotplugPciEndpointError, SnapshotV2MemoryHotplugState,
+    SnapshotV2MemoryHotplugStateCaptureError,
 };
 use bangbang_runtime::snapshot_memory_v2::{
     SnapshotV2MemoryBinding, SnapshotV2MemoryIoStage, SnapshotV2MemoryWriteError,
@@ -268,7 +269,8 @@ use crate::snapshot_v2_entropy_platform::{
 };
 use crate::snapshot_v2_memory_hotplug_platform::{
     HvfSnapshotV2MemoryHotplugMmioPlatformPlan, HvfSnapshotV2MemoryHotplugMmioPlatformPlanParts,
-    HvfSnapshotV2MemoryHotplugPreparedProductParts,
+    HvfSnapshotV2MemoryHotplugPciEndpointPlan, HvfSnapshotV2MemoryHotplugPciPlatformPlan,
+    HvfSnapshotV2MemoryHotplugPciPlatformPlanParts, HvfSnapshotV2MemoryHotplugPreparedProductParts,
 };
 use crate::snapshot_v2_multi_block_platform::{
     HvfSnapshotV2MultiBlockPlatformPlan, HvfSnapshotV2MultiBlockPlatformPlanParts,
@@ -288,8 +290,10 @@ use crate::snapshot_v2_platform::{
     restore_hvf_snapshot_v2_serial_balloon_mmio_process_platform,
     restore_hvf_snapshot_v2_serial_entropy_mmio_process_platform,
     restore_hvf_snapshot_v2_serial_memory_hotplug_mmio_process_platform,
+    restore_hvf_snapshot_v2_serial_memory_hotplug_pci_process_platform,
     restore_hvf_snapshot_v2_serial_only_process_platform,
     restore_hvf_snapshot_v2_serial_storage_entropy_mmio_process_platform,
+    restore_hvf_snapshot_v2_serial_storage_memory_hotplug_pci_process_platform,
     restore_hvf_snapshot_v2_serial_storage_mmio_process_platform,
     restore_hvf_snapshot_v2_serial_storage_pci_process_platform,
     restore_hvf_snapshot_v2_storage_mmio_process_platform,
@@ -3542,6 +3546,10 @@ enum HvfSnapshotV2StorageProcessShell {
         interrupts: HvfSnapshotV2MemoryHotplugMmioInterruptPlan,
         mapping: HvfSnapshotV2MemoryHotplugMappingPlan,
     },
+    RestoredMemoryHotplugPci {
+        shell: HvfSnapshotV2RestoredSerialShell,
+        mapping: HvfSnapshotV2MemoryHotplugMappingPlan,
+    },
 }
 
 enum HvfSnapshotV2SerialProcessShell {
@@ -3560,6 +3568,11 @@ enum HvfSnapshotV2SerialProcessShell {
     MemoryHotplugMmio {
         shell: HvfSnapshotV2RestoredSerialShell,
         interrupts: HvfSnapshotV2MemoryHotplugMmioInterruptPlan,
+        mapping: HvfSnapshotV2MemoryHotplugMappingPlan,
+    },
+    MemoryHotplugPci {
+        shell: HvfSnapshotV2RestoredSerialShell,
+        process: HvfSnapshotV2SerialOnlyProcessConfig,
         mapping: HvfSnapshotV2MemoryHotplugMappingPlan,
     },
 }
@@ -3587,6 +3600,7 @@ impl HvfSnapshotV2SerialProcessShell {
     const fn pci_enabled(&self) -> bool {
         match self {
             Self::SerialOnly { process, .. } => process.pci_enabled(),
+            Self::MemoryHotplugPci { process, .. } => process.pci_enabled(),
             Self::EntropyMmio { .. }
             | Self::BalloonMmio { .. }
             | Self::MemoryHotplugMmio { .. } => false,
@@ -4567,6 +4581,431 @@ impl fmt::Display for HvfSnapshotV2BalloonPciRestoreError {
 }
 
 impl std::error::Error for HvfSnapshotV2BalloonPciRestoreError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.failure.as_ref())
+    }
+}
+
+/// One complete, still-unpublished exact-2.10 PCI virtio-mem product.
+#[doc(hidden)]
+pub struct RestoredHvfSnapshotV2MemoryHotplugPciOwners {
+    session: OwnedHvfArm64BootSession,
+    state: SnapshotV2MemoryHotplugState,
+    controller: SnapshotV2MemoryHotplugControllerProjection,
+    storage_configs: Option<CaptureReadyStorageConfigs>,
+    entropy_config: Option<EntropyConfig>,
+    balloon_config: Option<BalloonConfig>,
+}
+
+impl RestoredHvfSnapshotV2MemoryHotplugPciOwners {
+    /// Returns the complete Paused destination session.
+    pub const fn session(&self) -> &OwnedHvfArm64BootSession {
+        &self.session
+    }
+
+    /// Returns the exact normalized portable virtio-mem state.
+    pub const fn state(&self) -> &SnapshotV2MemoryHotplugState {
+        &self.state
+    }
+
+    /// Returns the exact public memory-hotplug controller projection.
+    pub const fn controller(&self) -> SnapshotV2MemoryHotplugControllerProjection {
+        self.controller
+    }
+
+    /// Returns restored storage configuration when present.
+    pub const fn storage_configs(&self) -> Option<&CaptureReadyStorageConfigs> {
+        self.storage_configs.as_ref()
+    }
+
+    /// Returns the exact public entropy configuration when present.
+    pub const fn entropy_config(&self) -> Option<EntropyConfig> {
+        self.entropy_config
+    }
+
+    /// Returns the exact public balloon configuration when present.
+    pub const fn balloon_config(&self) -> Option<BalloonConfig> {
+        self.balloon_config
+    }
+
+    /// Consumes the complete unpublished owner graph.
+    pub fn into_parts(
+        self,
+    ) -> (
+        OwnedHvfArm64BootSession,
+        SnapshotV2MemoryHotplugState,
+        SnapshotV2MemoryHotplugControllerProjection,
+        Option<CaptureReadyStorageConfigs>,
+        Option<EntropyConfig>,
+        Option<BalloonConfig>,
+    ) {
+        (
+            self.session,
+            self.state,
+            self.controller,
+            self.storage_configs,
+            self.entropy_config,
+            self.balloon_config,
+        )
+    }
+}
+
+impl fmt::Debug for RestoredHvfSnapshotV2MemoryHotplugPciOwners {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RestoredHvfSnapshotV2MemoryHotplugPciOwners")
+            .field("has_storage", &self.storage_configs.is_some())
+            .field("has_entropy", &self.entropy_config.is_some())
+            .field("has_balloon", &self.balloon_config.is_some())
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Deterministic exact-2.10 PCI owner fault used by rollback tests.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfSnapshotV2MemoryHotplugPciRestoreFault {
+    Platform,
+    RegistryCreation,
+    RegistryRelease,
+    EndpointPreparation,
+    BalloonPublication,
+    StoragePublication,
+    EntropyPublication,
+    MemoryHotplugPublication,
+    ManagerInsertion,
+    Recapture,
+    SessionAssembly,
+}
+
+/// Stage at which exact-2.10 PCI virtio-mem reconstruction stopped.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfSnapshotV2MemoryHotplugPciRestoreStage {
+    Product,
+    Platform,
+    Registry,
+    Endpoint,
+    BalloonPublication,
+    StoragePublication,
+    EntropyPublication,
+    MemoryHotplugPublication,
+    ManagerInsertion,
+    Recapture,
+    SessionAssembly,
+}
+
+/// Primary exact-2.10 PCI virtio-mem reconstruction failure.
+#[doc(hidden)]
+pub enum HvfSnapshotV2MemoryHotplugPciRestoreFailure {
+    Product,
+    SerialPlatform(Box<HvfSnapshotV2SerialOnlyRestoreError>),
+    StoragePlatform(Box<HvfSnapshotV2StoragePciRestoreError>),
+    BalloonPlatform(Box<HvfSnapshotV2BalloonPciRestoreError>),
+    EntropyPlatform(Box<HvfSnapshotV2EntropyPciRestoreError>),
+    PciData(HvfArm64BootPciDataError),
+    GuestMemory {
+        source: HvfGuestMemoryMappingError,
+        cleanup: Option<GuestMessageInterruptResourcesError>,
+    },
+    Endpoint {
+        source: SnapshotV2MemoryHotplugPciEndpointError,
+        cleanup: Option<GuestMessageInterruptResourcesError>,
+    },
+    RegistryCleanup {
+        cleanup: Option<GuestMessageInterruptResourcesError>,
+    },
+    DispatcherUnavailable {
+        cleanup: Option<GuestMessageInterruptResourcesError>,
+    },
+    Publication(VirtioPciPublicationError),
+    Quiescence(HvfArm64BootLimiterRetryWakeupQuiescenceError),
+    Capture(HvfArm64BootMemoryHotplugCaptureError),
+    Normalize(HvfArm64BootMemoryHotplugSnapshotV2CaptureError),
+    StateMismatch,
+    MappingMismatch,
+    Injected(HvfSnapshotV2MemoryHotplugPciRestoreFault),
+}
+
+impl HvfSnapshotV2MemoryHotplugPciRestoreFailure {
+    fn interrupt_cleanup_failed(&self) -> bool {
+        matches!(
+            self,
+            Self::Endpoint {
+                cleanup: Some(_),
+                ..
+            } | Self::GuestMemory {
+                cleanup: Some(_),
+                ..
+            } | Self::RegistryCleanup { cleanup: Some(_) }
+                | Self::DispatcherUnavailable { cleanup: Some(_) }
+        )
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2MemoryHotplugPciRestoreFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::Product => "product",
+            Self::SerialPlatform(_) => "serial-platform",
+            Self::StoragePlatform(_) => "storage-platform",
+            Self::BalloonPlatform(_) => "balloon-platform",
+            Self::EntropyPlatform(_) => "entropy-platform",
+            Self::PciData(_) => "pci-data",
+            Self::GuestMemory { .. } => "guest-memory",
+            Self::Endpoint { .. } => "endpoint",
+            Self::RegistryCleanup { .. } => "registry",
+            Self::DispatcherUnavailable { .. } => "dispatcher",
+            Self::Publication(_) => "publication",
+            Self::Quiescence(_) => "quiescence",
+            Self::Capture(_) => "capture",
+            Self::Normalize(_) => "normalization",
+            Self::StateMismatch => "state-mismatch",
+            Self::MappingMismatch => "mapping-mismatch",
+            Self::Injected(fault) => match fault {
+                HvfSnapshotV2MemoryHotplugPciRestoreFault::Platform
+                | HvfSnapshotV2MemoryHotplugPciRestoreFault::RegistryCreation
+                | HvfSnapshotV2MemoryHotplugPciRestoreFault::RegistryRelease
+                | HvfSnapshotV2MemoryHotplugPciRestoreFault::EndpointPreparation
+                | HvfSnapshotV2MemoryHotplugPciRestoreFault::BalloonPublication
+                | HvfSnapshotV2MemoryHotplugPciRestoreFault::StoragePublication
+                | HvfSnapshotV2MemoryHotplugPciRestoreFault::EntropyPublication
+                | HvfSnapshotV2MemoryHotplugPciRestoreFault::MemoryHotplugPublication
+                | HvfSnapshotV2MemoryHotplugPciRestoreFault::ManagerInsertion
+                | HvfSnapshotV2MemoryHotplugPciRestoreFault::Recapture
+                | HvfSnapshotV2MemoryHotplugPciRestoreFault::SessionAssembly => "injected",
+            },
+        };
+        formatter
+            .debug_struct("HvfSnapshotV2MemoryHotplugPciRestoreFailure")
+            .field("kind", &kind)
+            .field("source", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2MemoryHotplugPciRestoreFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Product => "exact-2.10 PCI virtio-mem product plan diverged",
+            Self::SerialPlatform(_) => "virtio-mem PCI serial platform reconstruction failed",
+            Self::StoragePlatform(_) => "virtio-mem PCI storage publication failed",
+            Self::BalloonPlatform(_) => "virtio-mem PCI balloon publication failed",
+            Self::EntropyPlatform(_) => "virtio-mem PCI entropy publication failed",
+            Self::PciData(_) => "exact-2.10 PCI virtio-mem manager is unavailable",
+            Self::GuestMemory { .. } => "exact-2.10 PCI destination memory is unavailable",
+            Self::Endpoint { .. } => "exact-2.10 virtio-mem endpoint reconstruction failed",
+            Self::RegistryCleanup { .. } => "exact-2.10 virtio-mem registry transaction failed",
+            Self::DispatcherUnavailable { .. } => {
+                "exact-2.10 virtio-mem PCI dispatcher is unavailable"
+            }
+            Self::Publication(_) => "exact-2.10 virtio-mem endpoint publication failed",
+            Self::Quiescence(_) => "exact-2.10 PCI destination quiescence failed",
+            Self::Capture(_) => "exact-2.10 PCI virtio-mem live capture failed",
+            Self::Normalize(_) => "exact-2.10 PCI virtio-mem normalization failed",
+            Self::StateMismatch => "exact-2.10 PCI virtio-mem portable state diverged",
+            Self::MappingMismatch => "exact-2.10 PCI virtio-mem mapping state diverged",
+            Self::Injected(_) => "exact-2.10 PCI rollback fault was injected",
+        })
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2MemoryHotplugPciRestoreFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::SerialPlatform(source) => Some(source.as_ref()),
+            Self::StoragePlatform(source) => Some(source.as_ref()),
+            Self::BalloonPlatform(source) => Some(source.as_ref()),
+            Self::EntropyPlatform(source) => Some(source.as_ref()),
+            Self::PciData(source) => Some(source),
+            Self::GuestMemory { source, .. } => Some(source),
+            Self::Endpoint { source, .. } => Some(source),
+            Self::Publication(source) => Some(source),
+            Self::Quiescence(source) => Some(source),
+            Self::Capture(source) => Some(source),
+            Self::Normalize(source) => Some(source),
+            Self::Product
+            | Self::RegistryCleanup { .. }
+            | Self::DispatcherUnavailable { .. }
+            | Self::StateMismatch
+            | Self::MappingMismatch
+            | Self::Injected(_) => None,
+        }
+    }
+}
+
+/// Redacted exact-2.10 PCI virtio-mem failure and cleanup evidence.
+#[doc(hidden)]
+pub struct HvfSnapshotV2MemoryHotplugPciRestoreError {
+    stage: HvfSnapshotV2MemoryHotplugPciRestoreStage,
+    failure: Box<HvfSnapshotV2MemoryHotplugPciRestoreFailure>,
+    committed: bool,
+    cleanup: Option<Box<HvfArm64BootSessionShutdownError>>,
+}
+
+impl HvfSnapshotV2MemoryHotplugPciRestoreError {
+    fn preflight(
+        stage: HvfSnapshotV2MemoryHotplugPciRestoreStage,
+        failure: HvfSnapshotV2MemoryHotplugPciRestoreFailure,
+    ) -> Self {
+        Self {
+            stage,
+            failure: Box::new(failure),
+            committed: false,
+            cleanup: None,
+        }
+    }
+
+    fn serial_platform(source: HvfSnapshotV2SerialOnlyRestoreError) -> Self {
+        Self {
+            stage: HvfSnapshotV2MemoryHotplugPciRestoreStage::Platform,
+            committed: source.is_terminal(),
+            failure: Box::new(HvfSnapshotV2MemoryHotplugPciRestoreFailure::SerialPlatform(
+                Box::new(source),
+            )),
+            cleanup: None,
+        }
+    }
+
+    fn storage_platform(source: HvfSnapshotV2StoragePciRestoreError) -> Self {
+        Self {
+            stage: HvfSnapshotV2MemoryHotplugPciRestoreStage::StoragePublication,
+            committed: source.is_terminal(),
+            failure: Box::new(
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::StoragePlatform(Box::new(source)),
+            ),
+            cleanup: None,
+        }
+    }
+
+    fn balloon_platform(source: HvfSnapshotV2BalloonPciRestoreError) -> Self {
+        Self {
+            stage: HvfSnapshotV2MemoryHotplugPciRestoreStage::BalloonPublication,
+            committed: source.is_terminal(),
+            failure: Box::new(
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::BalloonPlatform(Box::new(source)),
+            ),
+            cleanup: None,
+        }
+    }
+
+    fn entropy_platform(source: HvfSnapshotV2EntropyPciRestoreError) -> Self {
+        Self {
+            stage: HvfSnapshotV2MemoryHotplugPciRestoreStage::EntropyPublication,
+            committed: source.is_terminal(),
+            failure: Box::new(
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::EntropyPlatform(Box::new(source)),
+            ),
+            cleanup: None,
+        }
+    }
+
+    fn after_session(
+        mut session: OwnedHvfArm64BootSession,
+        stage: HvfSnapshotV2MemoryHotplugPciRestoreStage,
+        failure: HvfSnapshotV2MemoryHotplugPciRestoreFailure,
+    ) -> Self {
+        Self {
+            stage,
+            failure: Box::new(failure),
+            committed: true,
+            cleanup: session.shutdown().err().map(Box::new),
+        }
+    }
+
+    /// Returns the aggregate transition at which reconstruction stopped.
+    pub const fn stage(&self) -> HvfSnapshotV2MemoryHotplugPciRestoreStage {
+        self.stage
+    }
+
+    /// Returns whether reverse cleanup did not complete.
+    pub fn has_incomplete_cleanup(&self) -> bool {
+        self.cleanup.is_some()
+            || self.failure.interrupt_cleanup_failed()
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::SerialPlatform(source)
+                    if source.has_incomplete_cleanup()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::StoragePlatform(source)
+                    if !source.cleanup_failures().is_empty()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::BalloonPlatform(source)
+                    if source.has_incomplete_cleanup()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::EntropyPlatform(source)
+                    if source.has_incomplete_cleanup()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::Publication(
+                    VirtioPciPublicationError::Rollback { .. }
+                )
+            )
+    }
+
+    /// Returns whether retry safety cannot be proven.
+    pub fn is_terminal(&self) -> bool {
+        self.committed
+            || self.has_incomplete_cleanup()
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::SerialPlatform(source)
+                    if source.is_terminal()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::StoragePlatform(source)
+                    if source.is_terminal()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::BalloonPlatform(source)
+                    if source.is_terminal()
+            )
+            || matches!(
+                self.failure.as_ref(),
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::EntropyPlatform(source)
+                    if source.is_terminal()
+            )
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2MemoryHotplugPciRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2MemoryHotplugPciRestoreError")
+            .field("stage", &self.stage)
+            .field("terminal", &self.is_terminal())
+            .field("cleanup_failed", &self.has_incomplete_cleanup())
+            .field("failure", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2MemoryHotplugPciRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "exact-2.10 PCI virtio-mem reconstruction failed at {:?} ({})",
+            self.stage,
+            if self.is_terminal() {
+                "terminal"
+            } else {
+                "retryable"
+            }
+        )
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2MemoryHotplugPciRestoreError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(self.failure.as_ref())
     }
@@ -14947,6 +15386,24 @@ fn snapshot_v2_balloon_pci_plan_matches(
             .is_ok_and(|count| count >= plan.route_count())
 }
 
+fn snapshot_v2_memory_hotplug_pci_plan_matches(
+    topology: &PreparedSnapshotV2MemoryHotplugTopology,
+    plan: HvfSnapshotV2MemoryHotplugPciEndpointPlan,
+) -> bool {
+    let SnapshotV2DeviceTransport::Pci(transport) = topology.state().transport() else {
+        return false;
+    };
+    transport.origin() == StorageDeviceOrigin::Startup
+        && transport.origin() == plan.origin()
+        && transport.sbdf() == plan.sbdf()
+        && transport.bar_range() == plan.bar_range()
+        && transport.phase() == VirtioPciEndpointPhase::Active
+        && plan.route_count() == VIRTIO_MEM_QUEUE_SIZES.len().saturating_add(1)
+        && plan.route_count() == 2
+        && usize::try_from(plan.msi_interrupt_count())
+            .is_ok_and(|count| count >= plan.route_count())
+}
+
 fn validate_snapshot_v2_multi_block_mmio_resource_plan(
     bundle: &PreparedSnapshotV2MultiBlockMmioBundle,
     plan: &HvfSnapshotV2MultiBlockPlatformPlanParts,
@@ -16265,6 +16722,13 @@ impl OwnedHvfArm64BootSession {
                     vmclock_interrupt: interrupts.vmclock,
                 },
                 &mapping,
+            ),
+            HvfSnapshotV2SerialProcessShell::MemoryHotplugPci {
+                shell,
+                process,
+                mapping,
+            } => restore_hvf_snapshot_v2_serial_memory_hotplug_pci_process_platform(
+                state, memory, shell, process, &mapping,
             ),
         }
         .map_err(HvfSnapshotV2SerialOnlyRestoreError::Platform)?;
@@ -18072,6 +18536,709 @@ impl OwnedHvfArm64BootSession {
         Ok(session)
     }
 
+    /// Reconstructs one closed exact-2.10 PCI virtio-mem product without
+    /// publishing a controller or public load path.
+    #[doc(hidden)]
+    pub fn restore_snapshot_v2_memory_hotplug_pci(
+        state: HvfSnapshotV2PlatformState,
+        process_shell: HvfSnapshotV2RestoredSerialShell,
+        serial_input: Option<SerialStdioInput>,
+        plan: HvfSnapshotV2MemoryHotplugPciPlatformPlan,
+    ) -> Result<
+        RestoredHvfSnapshotV2MemoryHotplugPciOwners,
+        HvfSnapshotV2MemoryHotplugPciRestoreError,
+    > {
+        Self::restore_snapshot_v2_memory_hotplug_pci_inner(
+            state,
+            process_shell,
+            serial_input,
+            plan,
+            None,
+        )
+    }
+
+    /// Reconstructs exact-2.10 PCI virtio-mem owners with one deterministic
+    /// aggregate rollback fault.
+    #[doc(hidden)]
+    pub fn restore_snapshot_v2_memory_hotplug_pci_with_fault(
+        state: HvfSnapshotV2PlatformState,
+        process_shell: HvfSnapshotV2RestoredSerialShell,
+        serial_input: Option<SerialStdioInput>,
+        plan: HvfSnapshotV2MemoryHotplugPciPlatformPlan,
+        fault: HvfSnapshotV2MemoryHotplugPciRestoreFault,
+    ) -> Result<
+        RestoredHvfSnapshotV2MemoryHotplugPciOwners,
+        HvfSnapshotV2MemoryHotplugPciRestoreError,
+    > {
+        Self::restore_snapshot_v2_memory_hotplug_pci_inner(
+            state,
+            process_shell,
+            serial_input,
+            plan,
+            Some(fault),
+        )
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn restore_snapshot_v2_memory_hotplug_pci_inner(
+        state: HvfSnapshotV2PlatformState,
+        process_shell: HvfSnapshotV2RestoredSerialShell,
+        serial_input: Option<SerialStdioInput>,
+        plan: HvfSnapshotV2MemoryHotplugPciPlatformPlan,
+        fault: Option<HvfSnapshotV2MemoryHotplugPciRestoreFault>,
+    ) -> Result<
+        RestoredHvfSnapshotV2MemoryHotplugPciOwners,
+        HvfSnapshotV2MemoryHotplugPciRestoreError,
+    > {
+        let HvfSnapshotV2MemoryHotplugPciPlatformPlanParts {
+            product,
+            mapping,
+            balloon: balloon_endpoint,
+            storage: storage_platform,
+            entropy: entropy_endpoint,
+            memory_hotplug: memory_hotplug_endpoint,
+            host,
+            msi,
+            endpoint_count,
+            route_demand,
+            serial_interrupt,
+            vmgenid_interrupt,
+            vmclock_interrupt,
+        } = plan.into_parts();
+        let expected_host = Arm64PciAddressPlan::firecracker_v1_16()
+            .map(bangbang_runtime::fdt::Arm64FdtPciHost::from_address_plan)
+            .map_err(|_| {
+                HvfSnapshotV2MemoryHotplugPciRestoreError::preflight(
+                    HvfSnapshotV2MemoryHotplugPciRestoreStage::Product,
+                    HvfSnapshotV2MemoryHotplugPciRestoreFailure::Product,
+                )
+            })?;
+        let storage_count = storage_platform
+            .as_ref()
+            .map_or(0, |storage| storage.pci().record_count());
+        let storage_route_demand = storage_platform
+            .as_ref()
+            .map_or(0, |storage| storage.pci().route_demand());
+        let balloon_route_demand =
+            balloon_endpoint.map_or(0, HvfSnapshotV2BalloonPciEndpointPlan::route_count);
+        let entropy_route_demand =
+            entropy_endpoint.map_or(0, HvfSnapshotV2EntropyPciEndpointPlan::route_count);
+        let expected_route_demand = balloon_route_demand
+            .checked_add(storage_route_demand)
+            .and_then(|count| count.checked_add(entropy_route_demand))
+            .and_then(|count| count.checked_add(memory_hotplug_endpoint.route_count()));
+        let preceding_entropy = usize::from(balloon_endpoint.is_some()).checked_add(storage_count);
+        let expected_endpoint_count = preceding_entropy
+            .and_then(|count| count.checked_add(usize::from(entropy_endpoint.is_some())))
+            .and_then(|count| count.checked_add(1));
+        let fixed_interrupts_are_distinct = serial_interrupt != vmgenid_interrupt
+            && serial_interrupt != vmclock_interrupt
+            && vmgenid_interrupt != vmclock_interrupt;
+        let platform_matches = expected_host == host
+            && state.global().compatibility().gic_metadata().msi == Some(msi)
+            && memory_hotplug_endpoint.origin() == StorageDeviceOrigin::Startup
+            && memory_hotplug_endpoint.route_count() == 2
+            && memory_hotplug_endpoint.msi_interrupt_count() == msi.interrupt_range.count
+            && expected_route_demand == Some(route_demand)
+            && expected_endpoint_count == Some(endpoint_count)
+            && usize::try_from(msi.interrupt_range.count).is_ok_and(|count| route_demand <= count)
+            && fixed_interrupts_are_distinct
+            && balloon_endpoint
+                .is_none_or(|balloon| balloon.msi_interrupt_count() == msi.interrupt_range.count)
+            && storage_platform.as_ref().is_none_or(|storage| {
+                storage.pci().host() == host
+                    && storage.pci().msi() == msi
+                    && storage.serial_interrupt() == serial_interrupt
+                    && storage.vmgenid_interrupt() == vmgenid_interrupt
+                    && storage.vmclock_interrupt() == vmclock_interrupt
+            })
+            && entropy_endpoint.is_none_or(|entropy| {
+                Some(entropy.preceding_endpoint_count()) == preceding_entropy
+                    && entropy.msi_interrupt_count() == msi.interrupt_range.count
+            });
+        if !platform_matches {
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::preflight(
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::Product,
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::Product,
+            ));
+        }
+
+        let (topology, memory, balloon, storage_bundle, entropy) = match product.into_parts() {
+            HvfSnapshotV2MemoryHotplugPreparedProductParts::Base { topology, memory } => {
+                (topology, memory, None, None, None)
+            }
+            HvfSnapshotV2MemoryHotplugPreparedProductParts::Storage {
+                topology,
+                memory,
+                storage,
+            } => (topology, memory, None, Some(storage), None),
+            HvfSnapshotV2MemoryHotplugPreparedProductParts::Entropy {
+                topology,
+                memory,
+                entropy,
+            } => (topology, memory, None, None, Some(entropy)),
+            HvfSnapshotV2MemoryHotplugPreparedProductParts::StorageEntropy {
+                topology,
+                memory,
+                storage,
+                entropy,
+            } => (topology, memory, None, Some(storage), Some(entropy)),
+            HvfSnapshotV2MemoryHotplugPreparedProductParts::Balloon {
+                topology,
+                memory,
+                balloon,
+            } => (topology, memory, Some(balloon), None, None),
+            HvfSnapshotV2MemoryHotplugPreparedProductParts::BalloonStorage {
+                topology,
+                memory,
+                balloon,
+                storage,
+            } => (topology, memory, Some(balloon), Some(storage), None),
+            HvfSnapshotV2MemoryHotplugPreparedProductParts::BalloonEntropy {
+                topology,
+                memory,
+                balloon,
+                entropy,
+            } => (topology, memory, Some(balloon), None, Some(entropy)),
+            HvfSnapshotV2MemoryHotplugPreparedProductParts::BalloonStorageEntropy {
+                topology,
+                memory,
+                balloon,
+                storage,
+                entropy,
+            } => (
+                topology,
+                memory,
+                Some(balloon),
+                Some(storage),
+                Some(entropy),
+            ),
+        };
+        let has_balloon = balloon.is_some();
+        let has_storage = storage_bundle.is_some();
+        let has_entropy = entropy.is_some();
+        let product_matches = has_balloon == balloon_endpoint.is_some()
+            && has_storage == storage_platform.is_some()
+            && has_entropy == entropy_endpoint.is_some()
+            && snapshot_v2_memory_hotplug_pci_plan_matches(&topology, memory_hotplug_endpoint)
+            && balloon
+                .as_ref()
+                .zip(balloon_endpoint)
+                .is_none_or(|(balloon, endpoint)| {
+                    snapshot_v2_balloon_pci_plan_matches(balloon, endpoint)
+                })
+            && entropy
+                .as_ref()
+                .zip(entropy_endpoint)
+                .is_none_or(|(entropy, endpoint)| {
+                    snapshot_v2_entropy_pci_plan_matches(entropy, endpoint)
+                })
+            && (fault != Some(HvfSnapshotV2MemoryHotplugPciRestoreFault::BalloonPublication)
+                || has_balloon)
+            && (fault != Some(HvfSnapshotV2MemoryHotplugPciRestoreFault::StoragePublication)
+                || has_storage)
+            && (fault != Some(HvfSnapshotV2MemoryHotplugPciRestoreFault::EntropyPublication)
+                || has_entropy);
+        if !product_matches {
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::preflight(
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::Product,
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::Product,
+            ));
+        }
+
+        let balloon_config = balloon.as_ref().map(SnapshotV2BalloonRestorePlan::config);
+        let entropy_config = entropy.as_ref().map(SnapshotV2EntropyRestorePlan::config);
+        let (mut session, mut storage_configs) = match (storage_bundle, storage_platform) {
+            (None, None) => {
+                let mut session = Self::restore_snapshot_v2_serial_only_inner(
+                    state,
+                    memory,
+                    HvfSnapshotV2SerialProcessShell::MemoryHotplugPci {
+                        shell: process_shell,
+                        process:
+                            HvfSnapshotV2SerialOnlyProcessConfig::with_exact_pci_msi_interrupt_count(
+                                memory_hotplug_endpoint.msi_interrupt_count(),
+                            ),
+                        mapping: mapping.clone(),
+                    },
+                    serial_input,
+                )
+                .map_err(HvfSnapshotV2MemoryHotplugPciRestoreError::serial_platform)?;
+                if let Some(balloon) = balloon {
+                    let Some(endpoint) = balloon_endpoint else {
+                        return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                            session,
+                            HvfSnapshotV2MemoryHotplugPciRestoreStage::Product,
+                            HvfSnapshotV2MemoryHotplugPciRestoreFailure::Product,
+                        ));
+                    };
+                    session =
+                        Self::attach_snapshot_v2_balloon_pci(session, endpoint, balloon, None)
+                            .map_err(HvfSnapshotV2MemoryHotplugPciRestoreError::balloon_platform)?;
+                }
+                (session, None)
+            }
+            (Some(bundle), Some(storage_plan)) => {
+                let publication = match (balloon_endpoint, balloon) {
+                    (Some(endpoint), Some(balloon)) => {
+                        HvfSnapshotV2StoragePciPublicationInput::balloon(endpoint, balloon, None)
+                    }
+                    (None, None) => HvfSnapshotV2StoragePciPublicationInput::empty(),
+                    _ => {
+                        return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::preflight(
+                            HvfSnapshotV2MemoryHotplugPciRestoreStage::Product,
+                            HvfSnapshotV2MemoryHotplugPciRestoreFailure::Product,
+                        ));
+                    }
+                };
+                let restored = Self::restore_snapshot_v2_storage_pci_inner(
+                    state,
+                    memory,
+                    HvfSnapshotV2StorageProcessShell::RestoredMemoryHotplugPci {
+                        shell: process_shell,
+                        mapping: mapping.clone(),
+                    },
+                    serial_input,
+                    bundle,
+                    storage_plan,
+                    publication,
+                )
+                .map_err(HvfSnapshotV2MemoryHotplugPciRestoreError::storage_platform)?;
+                let (session, configs) = restored.into_parts();
+                (session, Some(configs))
+            }
+            (None, Some(_)) | (Some(_), None) => {
+                return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::preflight(
+                    HvfSnapshotV2MemoryHotplugPciRestoreStage::Product,
+                    HvfSnapshotV2MemoryHotplugPciRestoreFailure::Product,
+                ));
+            }
+        };
+
+        if fault == Some(HvfSnapshotV2MemoryHotplugPciRestoreFault::Platform) {
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::Platform,
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::Injected(
+                    HvfSnapshotV2MemoryHotplugPciRestoreFault::Platform,
+                ),
+            ));
+        }
+        if fault == Some(HvfSnapshotV2MemoryHotplugPciRestoreFault::BalloonPublication) {
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::BalloonPublication,
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::Injected(
+                    HvfSnapshotV2MemoryHotplugPciRestoreFault::BalloonPublication,
+                ),
+            ));
+        }
+        if fault == Some(HvfSnapshotV2MemoryHotplugPciRestoreFault::StoragePublication) {
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::StoragePublication,
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::Injected(
+                    HvfSnapshotV2MemoryHotplugPciRestoreFault::StoragePublication,
+                ),
+            ));
+        }
+
+        if let Some(entropy) = entropy {
+            let Some(endpoint) = entropy_endpoint else {
+                return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2MemoryHotplugPciRestoreStage::Product,
+                    HvfSnapshotV2MemoryHotplugPciRestoreFailure::Product,
+                ));
+            };
+            let restored = Self::attach_snapshot_v2_entropy_pci(
+                session,
+                endpoint,
+                entropy,
+                storage_configs,
+                false,
+                VirtioRngOsEntropySource::new,
+                usize::from(has_balloon),
+            )
+            .map_err(HvfSnapshotV2MemoryHotplugPciRestoreError::entropy_platform)?;
+            let (restored_session, restored_entropy_config, restored_storage_configs) =
+                restored.into_parts();
+            session = restored_session;
+            storage_configs = restored_storage_configs;
+            if Some(restored_entropy_config) != entropy_config {
+                return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2MemoryHotplugPciRestoreStage::EntropyPublication,
+                    HvfSnapshotV2MemoryHotplugPciRestoreFailure::Product,
+                ));
+            }
+        }
+        if fault == Some(HvfSnapshotV2MemoryHotplugPciRestoreFault::EntropyPublication) {
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::EntropyPublication,
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::Injected(
+                    HvfSnapshotV2MemoryHotplugPciRestoreFault::EntropyPublication,
+                ),
+            ));
+        }
+
+        let preceding_endpoint_count = endpoint_count.saturating_sub(1);
+        let prefix_matches = endpoint_count > 0
+            && session.pci_data_devices.as_ref().is_some_and(|manager| {
+                manager.balloon.is_some() == has_balloon
+                    && manager.block.len().saturating_add(manager.pmem.len()) == storage_count
+                    && manager.entropy.is_some() == has_entropy
+                    && manager.network.is_empty()
+                    && manager.vsock.is_none()
+                    && manager.memory_hotplug.is_none()
+                    && manager.endpoint_count() == preceding_endpoint_count
+                    && manager.msi_interrupts.as_ref().is_some_and(|interrupts| {
+                        interrupts.lease_count()
+                            == usize::try_from(memory_hotplug_endpoint.msi_interrupt_count())
+                                .unwrap_or(0)
+                    })
+            });
+        if !prefix_matches {
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::ManagerInsertion,
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::Product,
+            ));
+        }
+        let (restored_session, expected_state, controller) =
+            Self::attach_snapshot_v2_memory_hotplug_pci(
+                session,
+                memory_hotplug_endpoint,
+                topology,
+                preceding_endpoint_count,
+                fault,
+            )?;
+        session = restored_session;
+
+        if fault == Some(HvfSnapshotV2MemoryHotplugPciRestoreFault::Recapture) {
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::Recapture,
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::Injected(
+                    HvfSnapshotV2MemoryHotplugPciRestoreFault::Recapture,
+                ),
+            ));
+        }
+        let recaptured = {
+            let guard = session
+                .quiesce_limiter_retry_wakeups()
+                .map_err(HvfSnapshotV2MemoryHotplugPciRestoreFailure::Quiescence);
+            match guard {
+                Ok(guard) => {
+                    let captured = session
+                        .capture_ready_memory_hotplug_state(Some(controller.config()), &guard)
+                        .map_err(HvfSnapshotV2MemoryHotplugPciRestoreFailure::Capture)
+                        .and_then(|captured| {
+                            captured.ok_or(HvfSnapshotV2MemoryHotplugPciRestoreFailure::Product)
+                        })
+                        .and_then(|captured| {
+                            captured
+                                .try_to_snapshot_v2(controller.requested_size_mib())
+                                .map_err(HvfSnapshotV2MemoryHotplugPciRestoreFailure::Normalize)
+                        });
+                    drop(guard);
+                    captured
+                }
+                Err(failure) => Err(failure),
+            }
+        };
+        let recaptured = match recaptured {
+            Ok(recaptured) => recaptured,
+            Err(failure) => {
+                return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2MemoryHotplugPciRestoreStage::Recapture,
+                    failure,
+                ));
+            }
+        };
+        if recaptured.state() != &expected_state {
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::Recapture,
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::StateMismatch,
+            ));
+        }
+        if !mapping.matches_capture(recaptured.mapping()) {
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::Recapture,
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::MappingMismatch,
+            ));
+        }
+        drop(recaptured);
+
+        if fault == Some(HvfSnapshotV2MemoryHotplugPciRestoreFault::SessionAssembly) {
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::SessionAssembly,
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::Injected(
+                    HvfSnapshotV2MemoryHotplugPciRestoreFault::SessionAssembly,
+                ),
+            ));
+        }
+        Ok(RestoredHvfSnapshotV2MemoryHotplugPciOwners {
+            session,
+            state: expected_state,
+            controller,
+            storage_configs,
+            entropy_config,
+            balloon_config,
+        })
+    }
+
+    fn attach_snapshot_v2_memory_hotplug_pci(
+        mut session: OwnedHvfArm64BootSession,
+        endpoint_plan: HvfSnapshotV2MemoryHotplugPciEndpointPlan,
+        topology: PreparedSnapshotV2MemoryHotplugTopology,
+        preceding_endpoint_count: usize,
+        fault: Option<HvfSnapshotV2MemoryHotplugPciRestoreFault>,
+    ) -> Result<
+        (
+            OwnedHvfArm64BootSession,
+            SnapshotV2MemoryHotplugState,
+            SnapshotV2MemoryHotplugControllerProjection,
+        ),
+        HvfSnapshotV2MemoryHotplugPciRestoreError,
+    > {
+        let owner_is_vacant = session.runtime_resources.memory_hotplug_device.is_none()
+            && session
+                .runtime_resources
+                .pci_memory_hotplug_device
+                .is_none()
+            && session.memory_hotplug_interrupt_line.is_none()
+            && endpoint_plan.origin() == StorageDeviceOrigin::Startup
+            && endpoint_plan.route_count() == 2
+            && session.pci_data_devices.as_ref().is_some_and(|manager| {
+                manager.memory_hotplug.is_none()
+                    && manager.endpoint_count() == preceding_endpoint_count
+                    && manager.msi_interrupts.as_ref().is_some_and(|interrupts| {
+                        interrupts.lease_count()
+                            == usize::try_from(endpoint_plan.msi_interrupt_count()).unwrap_or(0)
+                    })
+            });
+        if !owner_is_vacant {
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::ManagerInsertion,
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::Product,
+            ));
+        }
+        if fault == Some(HvfSnapshotV2MemoryHotplugPciRestoreFault::RegistryCreation) {
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::Registry,
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::Injected(
+                    HvfSnapshotV2MemoryHotplugPciRestoreFault::RegistryCreation,
+                ),
+            ));
+        }
+        let mut interrupts = match session.pci_data_devices.as_ref() {
+            Some(manager) => match manager.shared_msi_registry() {
+                Ok(interrupts) => interrupts,
+                Err(source) => {
+                    return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                        session,
+                        HvfSnapshotV2MemoryHotplugPciRestoreStage::Registry,
+                        HvfSnapshotV2MemoryHotplugPciRestoreFailure::PciData(source),
+                    ));
+                }
+            },
+            None => {
+                return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2MemoryHotplugPciRestoreStage::Product,
+                    HvfSnapshotV2MemoryHotplugPciRestoreFailure::Product,
+                ));
+            }
+        };
+        if fault == Some(HvfSnapshotV2MemoryHotplugPciRestoreFault::RegistryRelease) {
+            let cleanup = interrupts.release().err();
+            let failure = cleanup.map_or_else(
+                || {
+                    HvfSnapshotV2MemoryHotplugPciRestoreFailure::Injected(
+                        HvfSnapshotV2MemoryHotplugPciRestoreFault::RegistryRelease,
+                    )
+                },
+                |cleanup| HvfSnapshotV2MemoryHotplugPciRestoreFailure::RegistryCleanup {
+                    cleanup: Some(cleanup),
+                },
+            );
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::Registry,
+                failure,
+            ));
+        }
+        if fault == Some(HvfSnapshotV2MemoryHotplugPciRestoreFault::EndpointPreparation) {
+            let cleanup = interrupts.release().err();
+            let failure = cleanup.map_or_else(
+                || {
+                    HvfSnapshotV2MemoryHotplugPciRestoreFailure::Injected(
+                        HvfSnapshotV2MemoryHotplugPciRestoreFault::EndpointPreparation,
+                    )
+                },
+                |cleanup| HvfSnapshotV2MemoryHotplugPciRestoreFailure::RegistryCleanup {
+                    cleanup: Some(cleanup),
+                },
+            );
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::Endpoint,
+                failure,
+            ));
+        }
+
+        let prepared = match session.backend.mapped_guest_memory() {
+            Ok(memory) => topology.into_pci_endpoint(
+                memory,
+                endpoint_plan.bar_region_id(),
+                interrupts.registry(),
+            ),
+            Err(source) => {
+                let cleanup = interrupts.release().err();
+                return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2MemoryHotplugPciRestoreStage::Endpoint,
+                    HvfSnapshotV2MemoryHotplugPciRestoreFailure::GuestMemory { source, cleanup },
+                ));
+            }
+        };
+        let prepared = match prepared {
+            Ok(prepared) => prepared,
+            Err(source) => {
+                let cleanup = interrupts.release().err();
+                return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2MemoryHotplugPciRestoreStage::Endpoint,
+                    HvfSnapshotV2MemoryHotplugPciRestoreFailure::Endpoint { source, cleanup },
+                ));
+            }
+        };
+        if prepared.origin() != endpoint_plan.origin()
+            || prepared.endpoint().sbdf() != endpoint_plan.sbdf()
+            || prepared.endpoint().bar_range() != endpoint_plan.bar_range()
+            || prepared.endpoint().region_id() != endpoint_plan.bar_region_id()
+        {
+            drop(prepared);
+            let cleanup = interrupts.release().err();
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::Product,
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::RegistryCleanup { cleanup },
+            ));
+        }
+        if fault == Some(HvfSnapshotV2MemoryHotplugPciRestoreFault::MemoryHotplugPublication) {
+            drop(prepared);
+            let cleanup = interrupts.release().err();
+            let failure = cleanup.map_or_else(
+                || {
+                    HvfSnapshotV2MemoryHotplugPciRestoreFailure::Injected(
+                        HvfSnapshotV2MemoryHotplugPciRestoreFault::MemoryHotplugPublication,
+                    )
+                },
+                |cleanup| HvfSnapshotV2MemoryHotplugPciRestoreFailure::RegistryCleanup {
+                    cleanup: Some(cleanup),
+                },
+            );
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::MemoryHotplugPublication,
+                failure,
+            ));
+        }
+        let (expected_state, controller, _plugged_ranges, _queue_ranges, origin, metrics, endpoint) =
+            prepared.into_parts();
+        if origin != StorageDeviceOrigin::Startup {
+            drop(endpoint);
+            let cleanup = interrupts.release().err();
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::Product,
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::RegistryCleanup { cleanup },
+            ));
+        }
+
+        let (dispatcher_owner, segment) = match session.pci_data_devices.as_ref() {
+            Some(manager) => (
+                Arc::clone(&manager.dispatcher),
+                manager.validation.segment().clone(),
+            ),
+            None => {
+                drop(endpoint);
+                let cleanup = interrupts.release().err();
+                return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2MemoryHotplugPciRestoreStage::Product,
+                    HvfSnapshotV2MemoryHotplugPciRestoreFailure::RegistryCleanup { cleanup },
+                ));
+            }
+        };
+        let mut dispatcher = match dispatcher_owner.lock() {
+            Ok(dispatcher) => dispatcher,
+            Err(_) => {
+                drop(endpoint);
+                let cleanup = interrupts.release().err();
+                return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2MemoryHotplugPciRestoreStage::MemoryHotplugPublication,
+                    HvfSnapshotV2MemoryHotplugPciRestoreFailure::DispatcherUnavailable { cleanup },
+                ));
+            }
+        };
+        let publication = match session.pci_data_devices.as_mut() {
+            Some(manager) => endpoint
+                .publish(
+                    manager.validation.bar_allocator_mut(),
+                    segment,
+                    &mut dispatcher,
+                    interrupts,
+                )
+                .map(|published| {
+                    manager.memory_hotplug = Some(HvfArm64BootPciMemoryHotplugDevice {
+                        published,
+                        queue_deliveries: 0,
+                        metrics: metrics.clone(),
+                    });
+                }),
+            None => {
+                drop(dispatcher);
+                drop(endpoint);
+                let cleanup = interrupts.release().err();
+                return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2MemoryHotplugPciRestoreStage::Product,
+                    HvfSnapshotV2MemoryHotplugPciRestoreFailure::RegistryCleanup { cleanup },
+                ));
+            }
+        };
+        drop(dispatcher);
+        if let Err(source) = publication {
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::MemoryHotplugPublication,
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::Publication(source),
+            ));
+        }
+        session.memory_hotplug_device_metrics = Some(metrics);
+        if fault == Some(HvfSnapshotV2MemoryHotplugPciRestoreFault::ManagerInsertion) {
+            return Err(HvfSnapshotV2MemoryHotplugPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2MemoryHotplugPciRestoreStage::ManagerInsertion,
+                HvfSnapshotV2MemoryHotplugPciRestoreFailure::Injected(
+                    HvfSnapshotV2MemoryHotplugPciRestoreFault::ManagerInsertion,
+                ),
+            ));
+        }
+        Ok((session, expected_state, controller))
+    }
+
     /// Reconstructs one exact-2.8 serial plus MMIO entropy destination.
     #[doc(hidden)]
     pub fn restore_snapshot_v2_serial_entropy_mmio(
@@ -19713,6 +20880,15 @@ impl OwnedHvfArm64BootSession {
                 },
                 &mapping,
             ),
+            HvfSnapshotV2StorageProcessShell::RestoredMemoryHotplugPci { .. } => {
+                return Err(
+                    HvfSnapshotV2StorageMmioRestoreError::with_prepared_bundle_abort(
+                        HvfSnapshotV2StorageMmioRestoreStage::ResourcePlan,
+                        HvfSnapshotV2StorageMmioRestoreFailure::ResourcePlan,
+                        prepared_owner.bundle,
+                    ),
+                );
+            }
         };
         let mut platform = match restored {
             Ok(platform) => platform,
@@ -20486,6 +21662,11 @@ impl OwnedHvfArm64BootSession {
             HvfSnapshotV2StorageProcessShell::Restored(shell) => {
                 restore_hvf_snapshot_v2_serial_storage_pci_process_platform(
                     state, memory, shell, shell_plan,
+                )
+            }
+            HvfSnapshotV2StorageProcessShell::RestoredMemoryHotplugPci { shell, mapping } => {
+                restore_hvf_snapshot_v2_serial_storage_memory_hotplug_pci_process_platform(
+                    state, memory, shell, shell_plan, &mapping,
                 )
             }
             HvfSnapshotV2StorageProcessShell::RestoredEntropyMmio { .. }

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -10803,6 +10803,101 @@ fn activate_balloon_capture_queues_with_pending_inflate(
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn activate_memory_hotplug_capture_queue(
+    session: &mut bangbang_hvf::OwnedHvfArm64BootSession,
+    transport_base: bangbang_runtime::memory::GuestAddress,
+) {
+    use bangbang_runtime::memory::GuestAddress;
+    use bangbang_runtime::memory_hotplug::{
+        VIRTIO_FEATURE_VERSION_1, VIRTIO_MEM_F_UNPLUGGED_INACCESSIBLE, VIRTIO_MEM_QUEUE_SIZE,
+    };
+    use bangbang_runtime::virtio::{
+        VIRTIO_DEVICE_STATUS_ACKNOWLEDGE, VIRTIO_DEVICE_STATUS_DRIVER,
+        VIRTIO_DEVICE_STATUS_DRIVER_OK, VIRTIO_DEVICE_STATUS_FEATURES_OK,
+    };
+
+    const DESCRIPTOR: GuestAddress = GuestAddress::new(0x8120_0000);
+    const AVAILABLE: GuestAddress = GuestAddress::new(0x8121_0000);
+    const USED: GuestAddress = GuestAddress::new(0x8122_0000);
+
+    let dispatcher = session.mmio_dispatcher();
+    let memory = session
+        .guest_memory_mut()
+        .expect("signed virtio-mem guest memory should remain mapped");
+    memory
+        .write_slice(&[0; 16], DESCRIPTOR)
+        .expect("virtio-mem descriptor should reset");
+    memory
+        .write_slice(&[0; 4], AVAILABLE)
+        .expect("virtio-mem available ring should reset");
+    memory
+        .write_slice(&[0; 4], USED)
+        .expect("virtio-mem used ring should reset");
+
+    let mut dispatcher = dispatcher
+        .lock()
+        .expect("signed virtio-mem MMIO dispatcher should not be poisoned");
+    let write =
+        |dispatcher: &mut bangbang_runtime::mmio::MmioDispatcher, offset: u64, data: &[u8]| {
+            write_entropy_capture_mmio(
+                dispatcher,
+                transport_base
+                    .checked_add(offset)
+                    .expect("virtio-mem transport address should not overflow"),
+                data,
+            );
+        };
+    let features =
+        (1_u64 << VIRTIO_FEATURE_VERSION_1) | (1_u64 << VIRTIO_MEM_F_UNPLUGGED_INACCESSIBLE);
+    let features_ok = VIRTIO_DEVICE_STATUS_ACKNOWLEDGE
+        | VIRTIO_DEVICE_STATUS_DRIVER
+        | VIRTIO_DEVICE_STATUS_FEATURES_OK;
+    for status in [
+        VIRTIO_DEVICE_STATUS_ACKNOWLEDGE,
+        VIRTIO_DEVICE_STATUS_ACKNOWLEDGE | VIRTIO_DEVICE_STATUS_DRIVER,
+    ] {
+        write(
+            &mut dispatcher,
+            0x14,
+            &[u8::try_from(status).expect("virtio status should fit u8")],
+        );
+    }
+    for selector in [0_u32, 1] {
+        write(&mut dispatcher, 0x08, &selector.to_le_bytes());
+        write(
+            &mut dispatcher,
+            0x0c,
+            &u32::try_from((features >> (selector * 32)) & u64::from(u32::MAX))
+                .expect("one virtio-mem feature word should fit")
+                .to_le_bytes(),
+        );
+    }
+    write(
+        &mut dispatcher,
+        0x14,
+        &[u8::try_from(features_ok).expect("virtio status should fit u8")],
+    );
+    write(&mut dispatcher, 0x16, &0_u16.to_le_bytes());
+    write(&mut dispatcher, 0x18, &VIRTIO_MEM_QUEUE_SIZE.to_le_bytes());
+    for (offset, address) in [(0x20, DESCRIPTOR), (0x28, AVAILABLE), (0x30, USED)] {
+        write(
+            &mut dispatcher,
+            offset,
+            &u32::try_from(address.raw_value())
+                .expect("virtio-mem queue address should fit")
+                .to_le_bytes(),
+        );
+    }
+    write(&mut dispatcher, 0x1c, &1_u16.to_le_bytes());
+    write(
+        &mut dispatcher,
+        0x14,
+        &[u8::try_from(features_ok | VIRTIO_DEVICE_STATUS_DRIVER_OK)
+            .expect("virtio status should fit u8")],
+    );
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 fn copy_signed_session_guest_memory(
     session: &bangbang_hvf::OwnedHvfArm64BootSession,
 ) -> bangbang_runtime::memory::GuestMemory {
@@ -14843,6 +14938,287 @@ fn restores_signed_memory_hotplug_only_mmio_owners_and_rolls_back_faults() {
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 #[test]
+fn restores_signed_memory_hotplug_only_pci_owners_and_rolls_back_faults() {
+    use std::io::Cursor;
+
+    use bangbang_hvf::{
+        HvfArm64BootMemoryHotplugDeviceConfig, HvfArm64BootMemoryHotplugTransportState,
+        HvfArm64BootPciDataDeviceKind, HvfArm64BootSerialDeviceConfig, HvfArm64BootSessionConfig,
+        HvfArm64BootSnapshotV2CaptureInput, HvfSnapshotV2BootState,
+        HvfSnapshotV2MemoryHotplugPciRestoreFault, HvfSnapshotV2MemoryHotplugPreparedProduct,
+        HvfSnapshotV2MemoryHotplugState, HvfSnapshotV2NativePath, HvfSnapshotV2RestoredSerialShell,
+        OwnedHvfArm64BootSession, prepare_hvf_snapshot_v2_memory_hotplug_pci_platform_plan,
+    };
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::block::BlockMmioLayout;
+    use bangbang_runtime::boot::BootSourceConfigInput;
+    use bangbang_runtime::machine::MachineConfigInput;
+    use bangbang_runtime::memory::GuestAddress;
+    use bangbang_runtime::memory_hotplug::{MemoryHotplugConfigInput, VirtioMemMmioLayout};
+    use bangbang_runtime::mmio::MmioRegionId;
+    use bangbang_runtime::network::NetworkMmioLayout;
+    use bangbang_runtime::pmem::PmemMmioLayout;
+    use bangbang_runtime::serial::{
+        SerialMmioDevice, SharedSerialOutput, SharedSerialOutputBuffer,
+    };
+    use bangbang_runtime::snapshot_memory_hotplug_v2_10::PreparedSnapshotV2MemoryHotplugTopology;
+    use bangbang_runtime::snapshot_memory_v2::materialize_snapshot_v2_memory_hotplug_file;
+    use bangbang_runtime::snapshot_serial_v2_7::SnapshotV2SerialState;
+    use bangbang_runtime::virtio_pci::VirtioPciEndpointPhase;
+    use bangbang_runtime::vsock::VsockMmioLayout;
+
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let image = arm64_image().expect("test arm64 image should build");
+    let kernel = TempFile::new("restore-memory-hotplug-only-pci-kernel", &image)
+        .expect("memory-hotplug-only PCI kernel should create");
+    let mut controller = bangbang_runtime::VmmController::new("test", "0.1.0", "bangbang");
+    controller
+        .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            kernel.path(),
+        )))
+        .expect("memory-hotplug-only PCI boot source should configure");
+    controller
+        .handle_action(VmmAction::PutMachineConfig(
+            MachineConfigInput::new(1, 128).with_track_dirty_pages(true),
+        ))
+        .expect("memory-hotplug-only PCI dirty tracking should configure");
+    controller
+        .handle_action(VmmAction::PutMemoryHotplug(MemoryHotplugConfigInput::new(
+            128, 2, 128,
+        )))
+        .expect("memory-hotplug-only PCI device should configure");
+    let memory_hotplug_config = controller
+        .memory_hotplug_config()
+        .expect("memory-hotplug-only PCI config should exist");
+    let requested_size_mib = controller
+        .memory_hotplug_status()
+        .expect("memory-hotplug-only PCI status should exist")
+        .requested_size_mib();
+
+    let session_config = HvfArm64BootSessionConfig::new(
+        BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1)),
+        PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500)),
+        NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000)),
+        VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
+        bangbang_runtime::rtc::RtcMmioLayout::new(
+            GuestAddress::new(0x4000_1000),
+            MmioRegionId::new(10),
+        ),
+    )
+    .with_memory_hotplug_device(HvfArm64BootMemoryHotplugDeviceConfig::new(
+        VirtioMemMmioLayout::new(GuestAddress::new(0x4000_8000), MmioRegionId::new(4001)),
+    ))
+    .with_serial_device(HvfArm64BootSerialDeviceConfig::new(
+        MmioRegionId::new(20),
+        GuestAddress::new(0x4000_2000),
+        SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+    ))
+    .with_pci_enabled();
+    let mut source = OwnedHvfArm64BootSession::new(&controller, session_config)
+        .expect("signed memory-hotplug-only PCI source should prepare");
+    let guard = source
+        .quiesce_limiter_retry_wakeups()
+        .expect("memory-hotplug-only PCI source should quiesce");
+    let inactive = source
+        .capture_ready_memory_hotplug_state(Some(memory_hotplug_config), &guard)
+        .expect("inactive memory-hotplug-only PCI source should capture")
+        .expect("inactive memory-hotplug-only PCI source should retain its device");
+    let HvfArm64BootMemoryHotplugTransportState::Pci { bar_range, .. } = inactive.transport()
+    else {
+        panic!("memory-hotplug-only PCI source should retain PCI ownership");
+    };
+    let transport_base = bar_range.start();
+    drop(guard);
+    activate_memory_hotplug_capture_queue(&mut source, transport_base);
+
+    let guard = source
+        .quiesce_limiter_retry_wakeups()
+        .expect("active memory-hotplug-only PCI source should quiesce");
+    let memory_hotplug_capture = source
+        .capture_ready_memory_hotplug_state(Some(memory_hotplug_config), &guard)
+        .expect("active memory-hotplug-only PCI source should capture")
+        .expect("active memory-hotplug-only PCI source should retain its device")
+        .try_to_snapshot_v2(requested_size_mib)
+        .expect("active memory-hotplug-only PCI capture should convert");
+    assert!(memory_hotplug_capture.state().virtio().is_activated());
+    assert!(memory_hotplug_capture.state().active_queue().is_some());
+    let serial = SnapshotV2SerialState::try_from_capture_ready(
+        source
+            .capture_ready_serial_state(controller.serial_config().clone(), &guard)
+            .expect("memory-hotplug-only PCI serial should capture"),
+    )
+    .expect("memory-hotplug-only PCI serial capture should convert");
+    drop(guard);
+
+    source
+        .pause_for_snapshot_v2_capture()
+        .expect("memory-hotplug-only PCI source should pause");
+    let boot = HvfSnapshotV2BootState::try_new(
+        HvfSnapshotV2NativePath::try_new(kernel.path().as_os_str())
+            .expect("memory-hotplug-only PCI kernel path should validate"),
+        None,
+        None,
+    )
+    .expect("memory-hotplug-only PCI boot metadata should validate");
+    let mut memory_writer = Cursor::new(Vec::new());
+    let platform = source
+        .capture_snapshot_v2_memory_hotplug_platform_with_cancel(
+            HvfArm64BootSnapshotV2CaptureInput::new(boot),
+            Some(memory_hotplug_capture),
+            &mut memory_writer,
+            |_| false,
+        )
+        .expect("exact-2.10 memory-hotplug-only PCI platform should capture");
+    HvfSnapshotV2MemoryHotplugState::try_new(platform.clone(), None, serial.clone(), None, None)
+        .expect("memory-hotplug-only exact-2.10 PCI product should compose");
+    let memory_image = TempFile::new(
+        "restore-memory-hotplug-only-pci-image",
+        memory_writer.get_ref(),
+    )
+    .expect("memory-hotplug-only PCI image should persist");
+    source
+        .shutdown()
+        .expect("signed memory-hotplug-only PCI source should shut down");
+
+    let platform_state = platform.platform().clone();
+    let portable_state = platform
+        .memory_hotplug()
+        .expect("captured exact-2.10 PCI platform should retain memory-hotplug")
+        .clone();
+    let prepare_plan = || {
+        let topology = PreparedSnapshotV2MemoryHotplugTopology::prepare(
+            portable_state.clone(),
+            platform_state.memory().clone(),
+        )
+        .expect("memory-hotplug-only PCI topology should prepare");
+        let memory = materialize_snapshot_v2_memory_hotplug_file(
+            &topology,
+            std::fs::File::open(memory_image.path())
+                .expect("memory-hotplug-only PCI image should reopen"),
+        )
+        .expect("memory-hotplug-only PCI destination should materialize");
+        prepare_hvf_snapshot_v2_memory_hotplug_pci_platform_plan(
+            &platform_state,
+            HvfSnapshotV2MemoryHotplugPreparedProduct::serial_memory_hotplug(topology, memory),
+        )
+        .expect("memory-hotplug-only PCI owner plan should prepare")
+    };
+    let restored_shell = || {
+        HvfSnapshotV2RestoredSerialShell::new(
+            SerialMmioDevice::from_capture_state_with_shared_output(
+                SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+                serial.device().clone(),
+            ),
+        )
+    };
+
+    for fault in [
+        HvfSnapshotV2MemoryHotplugPciRestoreFault::Platform,
+        HvfSnapshotV2MemoryHotplugPciRestoreFault::RegistryCreation,
+        HvfSnapshotV2MemoryHotplugPciRestoreFault::RegistryRelease,
+        HvfSnapshotV2MemoryHotplugPciRestoreFault::EndpointPreparation,
+        HvfSnapshotV2MemoryHotplugPciRestoreFault::MemoryHotplugPublication,
+        HvfSnapshotV2MemoryHotplugPciRestoreFault::ManagerInsertion,
+        HvfSnapshotV2MemoryHotplugPciRestoreFault::Recapture,
+        HvfSnapshotV2MemoryHotplugPciRestoreFault::SessionAssembly,
+    ] {
+        let error = OwnedHvfArm64BootSession::restore_snapshot_v2_memory_hotplug_pci_with_fault(
+            platform_state.clone(),
+            restored_shell(),
+            None,
+            prepare_plan(),
+            fault,
+        )
+        .expect_err("injected memory-hotplug-only PCI owner fault should reject");
+        assert!(error.is_terminal());
+        assert!(
+            !error.has_incomplete_cleanup(),
+            "{fault:?} should roll back cleanly: {error:?}"
+        );
+        let diagnostics = format!("{error:?} {error}");
+        assert!(diagnostics.contains("<redacted>"));
+        assert!(!diagnostics.contains("1073774592"));
+    }
+
+    let mut destination_mapping_identities = Vec::new();
+    for _ in 0..2 {
+        let owners = OwnedHvfArm64BootSession::restore_snapshot_v2_memory_hotplug_pci(
+            platform_state.clone(),
+            restored_shell(),
+            None,
+            prepare_plan(),
+        )
+        .unwrap_or_else(|error| {
+            let source = std::error::Error::source(&error);
+            let detail = source.and_then(std::error::Error::source);
+            panic!(
+                "memory-hotplug-only PCI owners should restore: {error:?}, source={source:?}, detail={detail:?}"
+            )
+        });
+        assert_eq!(owners.state(), &portable_state);
+        assert_eq!(owners.controller().config(), memory_hotplug_config);
+        assert_eq!(owners.controller().requested_size_mib(), requested_size_mib);
+        assert!(owners.storage_configs().is_none());
+        assert!(owners.entropy_config().is_none());
+        assert!(owners.balloon_config().is_none());
+        assert!(
+            owners
+                .session()
+                .shared_memory_hotplug_device_metrics()
+                .expect("restored PCI memory-hotplug metrics should exist")
+                .snapshot()
+                .is_empty()
+        );
+        let diagnostics = owners
+            .session()
+            .pci_data_device_diagnostics()
+            .expect("restored PCI memory-hotplug manager should exist")
+            .expect("restored PCI memory-hotplug diagnostics should inspect");
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].kind,
+            HvfArm64BootPciDataDeviceKind::MemoryHotplug
+        );
+        assert_eq!(
+            diagnostics[0].transport.phase,
+            VirtioPciEndpointPhase::Active
+        );
+        assert!(diagnostics[0].transport.device_activated);
+        assert_eq!(diagnostics[0].queue_deliveries, 0);
+
+        let (mut restored, state, controller, storage, entropy, balloon) = owners.into_parts();
+        assert_eq!(state, portable_state);
+        assert!(storage.is_none());
+        assert!(entropy.is_none());
+        assert!(balloon.is_none());
+        assert!(restored.uses_pci_data_devices());
+        assert!(restored.runtime_resources().memory_hotplug_device.is_none());
+        let guard = restored
+            .quiesce_limiter_retry_wakeups()
+            .expect("restored memory-hotplug-only PCI owner should quiesce");
+        let recaptured = restored
+            .capture_ready_memory_hotplug_state(Some(controller.config()), &guard)
+            .expect("restored memory-hotplug-only PCI owner should capture")
+            .expect("restored memory-hotplug-only PCI device should exist")
+            .try_to_snapshot_v2(controller.requested_size_mib())
+            .expect("restored memory-hotplug-only PCI capture should convert");
+        assert_eq!(recaptured.state(), &portable_state);
+        destination_mapping_identities.push(recaptured.mapping().mapping_identity());
+        drop(guard);
+        restored
+            .shutdown()
+            .expect("restored memory-hotplug-only PCI destination should shut down");
+    }
+    assert_ne!(
+        destination_mapping_identities[0],
+        destination_mapping_identities[1]
+    );
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
 fn restores_signed_all_optional_memory_hotplug_mmio_owners_and_rolls_back_prefixes() {
     use std::io::Cursor;
     use std::time::Instant;
@@ -15227,6 +15603,773 @@ fn restores_signed_all_optional_memory_hotplug_mmio_owners_and_rolls_back_prefix
     restored
         .shutdown()
         .expect("restored all-optional destination should shut down");
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn restores_signed_all_optional_memory_hotplug_pci_owners_and_rolls_back_prefixes() {
+    use std::io::Cursor;
+    use std::time::Instant;
+
+    use bangbang_hvf::{
+        HvfArm64BootBalloonDeviceConfig, HvfArm64BootEntropyDeviceConfig,
+        HvfArm64BootMemoryHotplugDeviceConfig, HvfArm64BootPciDataDeviceKind,
+        HvfArm64BootSerialDeviceConfig, HvfArm64BootSessionConfig,
+        HvfArm64BootSnapshotV2CaptureInput, HvfSnapshotV2BootState,
+        HvfSnapshotV2MemoryHotplugPciRestoreFault, HvfSnapshotV2MemoryHotplugPreparedProduct,
+        HvfSnapshotV2MemoryHotplugState, HvfSnapshotV2NativePath, HvfSnapshotV2RestoredSerialShell,
+        OwnedHvfArm64BootSession, prepare_hvf_snapshot_v2_memory_hotplug_pci_platform_plan,
+    };
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::balloon::{
+        BalloonConfigInput, BalloonMmioLayout, VIRTIO_BALLOON_FREE_PAGE_HINT_DONE,
+    };
+    use bangbang_runtime::block::{
+        BlockFileBacking, BlockMmioLayout, DriveConfigInput, DriveIoEngine,
+    };
+    use bangbang_runtime::boot::BootSourceConfigInput;
+    use bangbang_runtime::entropy::{EntropyConfigInput, EntropyMmioLayout};
+    use bangbang_runtime::machine::MachineConfigInput;
+    use bangbang_runtime::memory::GuestAddress;
+    use bangbang_runtime::memory_hotplug::{MemoryHotplugConfigInput, VirtioMemMmioLayout};
+    use bangbang_runtime::mmio::MmioRegionId;
+    use bangbang_runtime::network::NetworkMmioLayout;
+    use bangbang_runtime::pmem::PmemMmioLayout;
+    use bangbang_runtime::serial::{
+        SerialMmioDevice, SharedSerialOutput, SharedSerialOutputBuffer,
+    };
+    use bangbang_runtime::snapshot_balloon_v2_9::SnapshotV2BalloonRestorePlan;
+    use bangbang_runtime::snapshot_device_v2_6::SnapshotV2StorageRestorePlan;
+    use bangbang_runtime::snapshot_entropy_v2_8::SnapshotV2EntropyRestorePlan;
+    use bangbang_runtime::snapshot_memory_hotplug_v2_10::PreparedSnapshotV2MemoryHotplugTopology;
+    use bangbang_runtime::snapshot_memory_v2::materialize_snapshot_v2_memory_hotplug_file;
+    use bangbang_runtime::snapshot_serial_v2_7::SnapshotV2SerialState;
+    use bangbang_runtime::storage_capture::CaptureReadyStorageConfigs;
+    use bangbang_runtime::virtio_pci::VirtioPciEndpointPhase;
+    use bangbang_runtime::vsock::VsockMmioLayout;
+
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let image = arm64_image().expect("test arm64 image should build");
+    let kernel = TempFile::new("restore-all-memory-hotplug-pci-kernel", &image)
+        .expect("all-optional PCI memory-hotplug kernel should create");
+    let root = TempFile::new_len("restore-all-memory-hotplug-pci-root", 4096)
+        .expect("all-optional PCI memory-hotplug root should create");
+    let mut controller = bangbang_runtime::VmmController::new("test", "0.1.0", "bangbang");
+    controller
+        .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            kernel.path(),
+        )))
+        .expect("all-optional PCI memory-hotplug boot source should configure");
+    controller
+        .handle_action(VmmAction::PutMachineConfig(
+            MachineConfigInput::new(1, 128).with_track_dirty_pages(true),
+        ))
+        .expect("all-optional PCI memory-hotplug dirty tracking should configure");
+    controller
+        .handle_action(VmmAction::PutDrive(
+            DriveConfigInput::new("rootfs", "rootfs", root.path(), true)
+                .with_is_read_only(true)
+                .with_io_engine(DriveIoEngine::Sync),
+        ))
+        .expect("all-optional PCI memory-hotplug root should configure");
+    controller
+        .handle_action(VmmAction::PutBalloon(
+            BalloonConfigInput::new(8, true)
+                .with_stats_polling_interval_s(1)
+                .with_free_page_hinting(true)
+                .with_free_page_reporting(true),
+        ))
+        .expect("all-optional PCI memory-hotplug balloon should configure");
+    controller
+        .handle_action(VmmAction::PutEntropy(EntropyConfigInput::new()))
+        .expect("all-optional PCI memory-hotplug entropy should configure");
+    controller
+        .handle_action(VmmAction::PutMemoryHotplug(MemoryHotplugConfigInput::new(
+            128, 2, 128,
+        )))
+        .expect("all-optional PCI memory-hotplug device should configure");
+    let balloon_config = controller
+        .balloon_config()
+        .expect("all-optional PCI balloon config should exist");
+    let entropy_config = controller
+        .entropy_config()
+        .expect("all-optional PCI entropy config should exist");
+    let memory_hotplug_config = controller
+        .memory_hotplug_config()
+        .expect("all-optional PCI memory-hotplug config should exist");
+    let requested_size_mib = controller
+        .memory_hotplug_status()
+        .expect("all-optional PCI memory-hotplug status should exist")
+        .requested_size_mib();
+
+    let block_layout = BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1));
+    let pmem_layout = PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500));
+    let session_config = HvfArm64BootSessionConfig::new(
+        block_layout,
+        pmem_layout,
+        NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000)),
+        VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
+        bangbang_runtime::rtc::RtcMmioLayout::new(
+            GuestAddress::new(0x4000_1000),
+            MmioRegionId::new(10),
+        ),
+    )
+    .with_balloon_device(HvfArm64BootBalloonDeviceConfig::new(
+        BalloonMmioLayout::new(GuestAddress::new(0x4000_6000), MmioRegionId::new(3000)),
+    ))
+    .with_entropy_device(HvfArm64BootEntropyDeviceConfig::new(
+        EntropyMmioLayout::new(GuestAddress::new(0x4000_7000), MmioRegionId::new(3001)),
+    ))
+    .with_memory_hotplug_device(HvfArm64BootMemoryHotplugDeviceConfig::new(
+        VirtioMemMmioLayout::new(GuestAddress::new(0x4000_8000), MmioRegionId::new(4001)),
+    ))
+    .with_serial_device(HvfArm64BootSerialDeviceConfig::new(
+        MmioRegionId::new(20),
+        GuestAddress::new(0x4000_2000),
+        SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+    ))
+    .with_pci_enabled();
+    let mut source = OwnedHvfArm64BootSession::new(&controller, session_config)
+        .expect("signed all-optional PCI memory-hotplug source should prepare");
+    let source_configs =
+        CaptureReadyStorageConfigs::new(controller.drive_configs().to_vec(), Vec::new());
+    let capture_now = Instant::now();
+    let guard = source
+        .quiesce_limiter_retry_wakeups()
+        .expect("all-optional PCI memory-hotplug source should quiesce");
+    let graph = source
+        .capture_snapshot_v2_storage_device_graph_at(&source_configs, &guard, capture_now)
+        .expect("all-optional PCI storage graph should capture");
+    let balloon = source
+        .capture_ready_balloon_state(Some(balloon_config), &guard)
+        .expect("all-optional PCI balloon should capture")
+        .expect("all-optional PCI balloon should exist")
+        .try_to_snapshot_v2()
+        .expect("all-optional PCI balloon capture should convert");
+    let entropy = source
+        .capture_ready_entropy_state_at(Some(entropy_config), &guard, capture_now)
+        .expect("all-optional PCI entropy should capture")
+        .expect("all-optional PCI entropy should exist")
+        .try_to_snapshot_v2()
+        .expect("all-optional PCI entropy capture should convert");
+    let memory_hotplug_capture = source
+        .capture_ready_memory_hotplug_state(Some(memory_hotplug_config), &guard)
+        .expect("all-optional PCI memory-hotplug should capture")
+        .expect("all-optional PCI memory-hotplug should exist")
+        .try_to_snapshot_v2(requested_size_mib)
+        .expect("all-optional PCI memory-hotplug capture should convert");
+    let serial = SnapshotV2SerialState::try_from_capture_ready(
+        source
+            .capture_ready_serial_state(controller.serial_config().clone(), &guard)
+            .expect("all-optional PCI serial should capture"),
+    )
+    .expect("all-optional PCI serial capture should convert");
+    drop(guard);
+
+    source
+        .pause_for_snapshot_v2_capture()
+        .expect("all-optional PCI memory-hotplug source should pause");
+    let boot = HvfSnapshotV2BootState::try_new(
+        HvfSnapshotV2NativePath::try_new(kernel.path().as_os_str())
+            .expect("all-optional PCI memory-hotplug kernel path should validate"),
+        None,
+        None,
+    )
+    .expect("all-optional PCI memory-hotplug boot metadata should validate");
+    let mut memory_writer = Cursor::new(Vec::new());
+    let platform = source
+        .capture_snapshot_v2_memory_hotplug_platform_with_cancel(
+            HvfArm64BootSnapshotV2CaptureInput::new(boot),
+            Some(memory_hotplug_capture),
+            &mut memory_writer,
+            |_| false,
+        )
+        .expect("all-optional exact-2.10 PCI platform should capture");
+    HvfSnapshotV2MemoryHotplugState::try_new(
+        platform.clone(),
+        Some(graph.clone()),
+        serial.clone(),
+        Some(entropy.clone()),
+        Some(balloon.clone()),
+    )
+    .expect("all-optional exact-2.10 PCI product should compose");
+    let memory_image = TempFile::new(
+        "restore-all-memory-hotplug-pci-image",
+        memory_writer.get_ref(),
+    )
+    .expect("all-optional PCI memory-hotplug image should persist");
+    source
+        .shutdown()
+        .expect("signed all-optional PCI memory-hotplug source should shut down");
+
+    let platform_state = platform.platform().clone();
+    let portable_state = platform
+        .memory_hotplug()
+        .expect("all-optional PCI platform should retain memory-hotplug")
+        .clone();
+    let prepare_plan = || {
+        let topology = PreparedSnapshotV2MemoryHotplugTopology::prepare(
+            portable_state.clone(),
+            platform_state.memory().clone(),
+        )
+        .expect("all-optional PCI memory-hotplug topology should prepare");
+        let memory = materialize_snapshot_v2_memory_hotplug_file(
+            &topology,
+            std::fs::File::open(memory_image.path())
+                .expect("all-optional PCI memory-hotplug image should reopen"),
+        )
+        .expect("all-optional PCI memory-hotplug destination should materialize");
+        let restore_now = Instant::now();
+        let balloon_plan = SnapshotV2BalloonRestorePlan::prepare(balloon.clone(), &memory)
+            .expect("all-optional PCI balloon restore plan should prepare");
+        let entropy_plan =
+            SnapshotV2EntropyRestorePlan::prepare(entropy.clone(), &memory, restore_now)
+                .expect("all-optional PCI entropy restore plan should prepare");
+        let backing = BlockFileBacking::open_snapshot(
+            std::path::Path::new(graph.block_records()[0].config().selector()),
+            graph.block_records()[0].config().is_read_only(),
+        )
+        .expect("all-optional PCI block backing should reopen")
+        .0;
+        let bundle = SnapshotV2StorageRestorePlan::prepare(graph.clone(), &memory, restore_now)
+            .expect("all-optional PCI storage restore plan should prepare")
+            .prepare_backings(vec![backing], Vec::new(), || false)
+            .expect("all-optional PCI storage backing bundle should prepare");
+        prepare_hvf_snapshot_v2_memory_hotplug_pci_platform_plan(
+            &platform_state,
+            HvfSnapshotV2MemoryHotplugPreparedProduct::
+                serial_balloon_storage_entropy_memory_hotplug(
+                    topology,
+                    memory,
+                    balloon_plan,
+                    bundle,
+                    entropy_plan,
+                ),
+        )
+        .expect("all-optional PCI memory-hotplug owner plan should prepare")
+    };
+    let restored_shell = || {
+        HvfSnapshotV2RestoredSerialShell::new(
+            SerialMmioDevice::from_capture_state_with_shared_output(
+                SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+                serial.device().clone(),
+            ),
+        )
+    };
+
+    for fault in [
+        HvfSnapshotV2MemoryHotplugPciRestoreFault::BalloonPublication,
+        HvfSnapshotV2MemoryHotplugPciRestoreFault::StoragePublication,
+        HvfSnapshotV2MemoryHotplugPciRestoreFault::EntropyPublication,
+    ] {
+        let error = OwnedHvfArm64BootSession::restore_snapshot_v2_memory_hotplug_pci_with_fault(
+            platform_state.clone(),
+            restored_shell(),
+            None,
+            prepare_plan(),
+            fault,
+        )
+        .expect_err("injected all-optional PCI publication fault should reject");
+        assert!(error.is_terminal());
+        assert!(
+            !error.has_incomplete_cleanup(),
+            "{fault:?} should roll back cleanly: {error:?}"
+        );
+    }
+
+    let owners = OwnedHvfArm64BootSession::restore_snapshot_v2_memory_hotplug_pci(
+        platform_state.clone(),
+        restored_shell(),
+        None,
+        prepare_plan(),
+    )
+    .unwrap_or_else(|error| {
+        let source = std::error::Error::source(&error);
+        let detail = source.and_then(std::error::Error::source);
+        panic!(
+            "all-optional PCI memory-hotplug owners should restore: {error:?}, source={source:?}, detail={detail:?}"
+        )
+    });
+    assert_eq!(owners.state(), &portable_state);
+    assert_eq!(owners.balloon_config(), Some(balloon_config));
+    assert_eq!(owners.entropy_config(), Some(entropy_config));
+    assert_eq!(
+        owners
+            .storage_configs()
+            .expect("restored all-optional PCI storage configs should exist"),
+        &source_configs
+    );
+    assert!(
+        owners
+            .session()
+            .shared_memory_hotplug_device_metrics()
+            .expect("restored all-optional PCI memory-hotplug metrics should exist")
+            .snapshot()
+            .is_empty()
+    );
+    assert!(
+        owners
+            .session()
+            .shared_balloon_device_metrics()
+            .snapshot()
+            .is_empty()
+    );
+    assert!(
+        owners
+            .session()
+            .shared_entropy_device_metrics()
+            .snapshot()
+            .is_empty()
+    );
+    let diagnostics = owners
+        .session()
+        .pci_data_device_diagnostics()
+        .expect("all-optional PCI manager should exist")
+        .expect("all-optional PCI diagnostics should inspect");
+    assert_eq!(diagnostics.len(), 4);
+    assert_eq!(diagnostics[0].kind, HvfArm64BootPciDataDeviceKind::Balloon);
+    assert_eq!(diagnostics[1].kind, HvfArm64BootPciDataDeviceKind::Block);
+    assert_eq!(diagnostics[2].kind, HvfArm64BootPciDataDeviceKind::Entropy);
+    assert_eq!(
+        diagnostics[3].kind,
+        HvfArm64BootPciDataDeviceKind::MemoryHotplug
+    );
+    assert!(diagnostics.iter().all(|entry| {
+        entry.transport.phase == VirtioPciEndpointPhase::Active && entry.queue_deliveries == 0
+    }));
+
+    let (mut restored, state, controller, storage, returned_entropy, returned_balloon) =
+        owners.into_parts();
+    assert_eq!(state, portable_state);
+    assert_eq!(returned_entropy, Some(entropy_config));
+    assert_eq!(returned_balloon, Some(balloon_config));
+    let storage = storage.expect("restored all-optional PCI storage configs should remain");
+    assert!(restored.uses_pci_data_devices());
+    assert!(restored.runtime_resources().block_devices.is_empty());
+    assert!(restored.runtime_resources().balloon_device.is_none());
+    assert!(restored.runtime_resources().entropy_device.is_none());
+    assert!(restored.runtime_resources().memory_hotplug_device.is_none());
+
+    let guard = restored
+        .quiesce_limiter_retry_wakeups()
+        .expect("restored all-optional PCI owners should quiesce");
+    let recaptured_memory_hotplug = restored
+        .capture_ready_memory_hotplug_state(Some(controller.config()), &guard)
+        .expect("restored all-optional PCI memory-hotplug should capture")
+        .expect("restored all-optional PCI memory-hotplug should exist")
+        .try_to_snapshot_v2(controller.requested_size_mib())
+        .expect("restored all-optional PCI memory-hotplug capture should convert");
+    assert_eq!(recaptured_memory_hotplug.state(), &portable_state);
+    let recaptured_balloon = restored
+        .capture_ready_balloon_state(Some(balloon_config), &guard)
+        .expect("restored all-optional PCI balloon should capture")
+        .expect("restored all-optional PCI balloon should exist")
+        .try_to_snapshot_v2()
+        .expect("restored all-optional PCI balloon capture should convert");
+    assert_eq!(recaptured_balloon.config(), balloon.config());
+    assert_eq!(
+        recaptured_balloon.config_space().free_page_hint_cmd_id(),
+        VIRTIO_BALLOON_FREE_PAGE_HINT_DONE
+    );
+    assert_eq!(recaptured_balloon.accounting(), balloon.accounting());
+    assert_eq!(recaptured_balloon.virtio(), balloon.virtio());
+    assert_eq!(recaptured_balloon.transport(), balloon.transport());
+    let recaptured_entropy = restored
+        .capture_ready_entropy_state_at(Some(entropy_config), &guard, capture_now)
+        .expect("restored all-optional PCI entropy should capture")
+        .expect("restored all-optional PCI entropy should exist")
+        .try_to_snapshot_v2()
+        .expect("restored all-optional PCI entropy capture should convert");
+    assert_eq!(recaptured_entropy, entropy);
+    let recaptured_graph = restored
+        .capture_snapshot_v2_storage_device_graph_at(&storage, &guard, capture_now)
+        .expect("restored all-optional PCI storage graph should capture");
+    assert_eq!(recaptured_graph, graph);
+    drop(guard);
+    restored
+        .shutdown()
+        .expect("restored all-optional PCI destination should shut down");
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn restores_signed_all_eight_memory_hotplug_pci_product_shapes() {
+    use std::io::Cursor;
+    use std::time::Instant;
+
+    use bangbang_hvf::{
+        HvfArm64BootBalloonDeviceConfig, HvfArm64BootEntropyDeviceConfig,
+        HvfArm64BootMemoryHotplugDeviceConfig, HvfArm64BootPciDataDeviceKind,
+        HvfArm64BootSerialDeviceConfig, HvfArm64BootSessionConfig,
+        HvfArm64BootSnapshotV2CaptureInput, HvfSnapshotV2BootState,
+        HvfSnapshotV2MemoryHotplugPreparedProduct, HvfSnapshotV2MemoryHotplugState,
+        HvfSnapshotV2NativePath, HvfSnapshotV2RestoredSerialShell, OwnedHvfArm64BootSession,
+        prepare_hvf_snapshot_v2_memory_hotplug_pci_platform_plan,
+    };
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::balloon::{BalloonConfigInput, BalloonMmioLayout};
+    use bangbang_runtime::block::{
+        BlockFileBacking, BlockMmioLayout, DriveConfigInput, DriveIoEngine,
+    };
+    use bangbang_runtime::boot::BootSourceConfigInput;
+    use bangbang_runtime::entropy::{EntropyConfigInput, EntropyMmioLayout};
+    use bangbang_runtime::machine::MachineConfigInput;
+    use bangbang_runtime::memory::GuestAddress;
+    use bangbang_runtime::memory_hotplug::{MemoryHotplugConfigInput, VirtioMemMmioLayout};
+    use bangbang_runtime::mmio::MmioRegionId;
+    use bangbang_runtime::network::NetworkMmioLayout;
+    use bangbang_runtime::pmem::PmemMmioLayout;
+    use bangbang_runtime::serial::{
+        SerialMmioDevice, SharedSerialOutput, SharedSerialOutputBuffer,
+    };
+    use bangbang_runtime::snapshot_balloon_v2_9::SnapshotV2BalloonRestorePlan;
+    use bangbang_runtime::snapshot_device_v2_6::SnapshotV2StorageRestorePlan;
+    use bangbang_runtime::snapshot_entropy_v2_8::SnapshotV2EntropyRestorePlan;
+    use bangbang_runtime::snapshot_memory_hotplug_v2_10::PreparedSnapshotV2MemoryHotplugTopology;
+    use bangbang_runtime::snapshot_memory_v2::materialize_snapshot_v2_memory_hotplug_file;
+    use bangbang_runtime::snapshot_serial_v2_7::SnapshotV2SerialState;
+    use bangbang_runtime::storage_capture::CaptureReadyStorageConfigs;
+    use bangbang_runtime::vsock::VsockMmioLayout;
+
+    fn run_case(image: &[u8], has_balloon: bool, has_storage: bool, has_entropy: bool) {
+        let kernel = TempFile::new("restore-memory-hotplug-pci-matrix-kernel", image)
+            .expect("PCI matrix kernel should create");
+        let root = has_storage.then(|| {
+            TempFile::new_len("restore-memory-hotplug-pci-matrix-root", 4096)
+                .expect("PCI matrix root should create")
+        });
+        let mut controller = bangbang_runtime::VmmController::new("test", "0.1.0", "bangbang");
+        controller
+            .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+                kernel.path(),
+            )))
+            .expect("PCI matrix boot source should configure");
+        controller
+            .handle_action(VmmAction::PutMachineConfig(
+                MachineConfigInput::new(1, 128).with_track_dirty_pages(true),
+            ))
+            .expect("PCI matrix dirty tracking should configure");
+        if let Some(root) = &root {
+            controller
+                .handle_action(VmmAction::PutDrive(
+                    DriveConfigInput::new("rootfs", "rootfs", root.path(), true)
+                        .with_is_read_only(true)
+                        .with_io_engine(DriveIoEngine::Sync),
+                ))
+                .expect("PCI matrix root should configure");
+        }
+        if has_balloon {
+            controller
+                .handle_action(VmmAction::PutBalloon(BalloonConfigInput::new(8, false)))
+                .expect("PCI matrix balloon should configure");
+        }
+        if has_entropy {
+            controller
+                .handle_action(VmmAction::PutEntropy(EntropyConfigInput::new()))
+                .expect("PCI matrix entropy should configure");
+        }
+        controller
+            .handle_action(VmmAction::PutMemoryHotplug(MemoryHotplugConfigInput::new(
+                128, 2, 128,
+            )))
+            .expect("PCI matrix memory-hotplug should configure");
+        let memory_hotplug_config = controller
+            .memory_hotplug_config()
+            .expect("PCI matrix memory-hotplug config should exist");
+        let requested_size_mib = controller
+            .memory_hotplug_status()
+            .expect("PCI matrix memory-hotplug status should exist")
+            .requested_size_mib();
+
+        let block_layout =
+            BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1));
+        let pmem_layout =
+            PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500));
+        let mut session_config = HvfArm64BootSessionConfig::new(
+            block_layout,
+            pmem_layout,
+            NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000)),
+            VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
+            bangbang_runtime::rtc::RtcMmioLayout::new(
+                GuestAddress::new(0x4000_1000),
+                MmioRegionId::new(10),
+            ),
+        )
+        .with_memory_hotplug_device(HvfArm64BootMemoryHotplugDeviceConfig::new(
+            VirtioMemMmioLayout::new(GuestAddress::new(0x4000_8000), MmioRegionId::new(4001)),
+        ))
+        .with_serial_device(HvfArm64BootSerialDeviceConfig::new(
+            MmioRegionId::new(20),
+            GuestAddress::new(0x4000_2000),
+            SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+        ))
+        .with_pci_enabled();
+        if has_balloon {
+            session_config =
+                session_config.with_balloon_device(HvfArm64BootBalloonDeviceConfig::new(
+                    BalloonMmioLayout::new(GuestAddress::new(0x4000_6000), MmioRegionId::new(3000)),
+                ));
+        }
+        if has_entropy {
+            session_config =
+                session_config.with_entropy_device(HvfArm64BootEntropyDeviceConfig::new(
+                    EntropyMmioLayout::new(GuestAddress::new(0x4000_7000), MmioRegionId::new(3001)),
+                ));
+        }
+
+        let mut source = OwnedHvfArm64BootSession::new(&controller, session_config)
+            .expect("signed PCI matrix source should prepare");
+        let storage_configs = has_storage.then(|| {
+            CaptureReadyStorageConfigs::new(controller.drive_configs().to_vec(), Vec::new())
+        });
+        let capture_now = Instant::now();
+        let guard = source
+            .quiesce_limiter_retry_wakeups()
+            .expect("PCI matrix source should quiesce");
+        let graph = storage_configs.as_ref().map(|configs| {
+            source
+                .capture_snapshot_v2_storage_device_graph_at(configs, &guard, capture_now)
+                .expect("PCI matrix storage graph should capture")
+        });
+        let balloon = controller.balloon_config().map(|config| {
+            source
+                .capture_ready_balloon_state(Some(config), &guard)
+                .expect("PCI matrix balloon should capture")
+                .expect("configured PCI matrix balloon should exist")
+                .try_to_snapshot_v2()
+                .expect("PCI matrix balloon capture should convert")
+        });
+        let entropy = controller.entropy_config().map(|config| {
+            source
+                .capture_ready_entropy_state_at(Some(config), &guard, capture_now)
+                .expect("PCI matrix entropy should capture")
+                .expect("configured PCI matrix entropy should exist")
+                .try_to_snapshot_v2()
+                .expect("PCI matrix entropy capture should convert")
+        });
+        let memory_hotplug = source
+            .capture_ready_memory_hotplug_state(Some(memory_hotplug_config), &guard)
+            .expect("PCI matrix memory-hotplug should capture")
+            .expect("PCI matrix memory-hotplug should exist")
+            .try_to_snapshot_v2(requested_size_mib)
+            .expect("PCI matrix memory-hotplug capture should convert");
+        let serial = SnapshotV2SerialState::try_from_capture_ready(
+            source
+                .capture_ready_serial_state(controller.serial_config().clone(), &guard)
+                .expect("PCI matrix serial should capture"),
+        )
+        .expect("PCI matrix serial capture should convert");
+        drop(guard);
+
+        source
+            .pause_for_snapshot_v2_capture()
+            .expect("PCI matrix source should pause");
+        let boot = HvfSnapshotV2BootState::try_new(
+            HvfSnapshotV2NativePath::try_new(kernel.path().as_os_str())
+                .expect("PCI matrix kernel path should validate"),
+            None,
+            None,
+        )
+        .expect("PCI matrix boot metadata should validate");
+        let mut memory_writer = Cursor::new(Vec::new());
+        let platform = source
+            .capture_snapshot_v2_memory_hotplug_platform_with_cancel(
+                HvfArm64BootSnapshotV2CaptureInput::new(boot),
+                Some(memory_hotplug),
+                &mut memory_writer,
+                |_| false,
+            )
+            .expect("PCI matrix exact-2.10 platform should capture");
+        HvfSnapshotV2MemoryHotplugState::try_new(
+            platform.clone(),
+            graph.clone(),
+            serial.clone(),
+            entropy.clone(),
+            balloon.clone(),
+        )
+        .expect("PCI matrix exact-2.10 product should compose");
+        let memory_image = TempFile::new(
+            "restore-memory-hotplug-pci-matrix-image",
+            memory_writer.get_ref(),
+        )
+        .expect("PCI matrix memory image should persist");
+        source
+            .shutdown()
+            .expect("signed PCI matrix source should shut down");
+
+        let platform_state = platform.platform().clone();
+        let portable_state = platform
+            .memory_hotplug()
+            .expect("PCI matrix platform should retain memory-hotplug")
+            .clone();
+        let topology = PreparedSnapshotV2MemoryHotplugTopology::prepare(
+            portable_state.clone(),
+            platform_state.memory().clone(),
+        )
+        .expect("PCI matrix topology should prepare");
+        let memory = materialize_snapshot_v2_memory_hotplug_file(
+            &topology,
+            std::fs::File::open(memory_image.path()).expect("PCI matrix image should reopen"),
+        )
+        .expect("PCI matrix destination should materialize");
+        let restore_now = Instant::now();
+        let balloon_plan = balloon.map(|state| {
+            SnapshotV2BalloonRestorePlan::prepare(state, &memory)
+                .expect("PCI matrix balloon restore plan should prepare")
+        });
+        let entropy_plan = entropy.map(|state| {
+            SnapshotV2EntropyRestorePlan::prepare(state, &memory, restore_now)
+                .expect("PCI matrix entropy restore plan should prepare")
+        });
+        let storage_bundle = graph.map(|graph| {
+            let backing = BlockFileBacking::open_snapshot(
+                std::path::Path::new(graph.block_records()[0].config().selector()),
+                graph.block_records()[0].config().is_read_only(),
+            )
+            .expect("PCI matrix block backing should reopen")
+            .0;
+            SnapshotV2StorageRestorePlan::prepare(graph, &memory, restore_now)
+                .expect("PCI matrix storage restore plan should prepare")
+                .prepare_backings(vec![backing], Vec::new(), || false)
+                .expect("PCI matrix storage backing bundle should prepare")
+        });
+        let product = match (balloon_plan, storage_bundle, entropy_plan) {
+            (None, None, None) => {
+                HvfSnapshotV2MemoryHotplugPreparedProduct::serial_memory_hotplug(topology, memory)
+            }
+            (None, Some(storage), None) => {
+                HvfSnapshotV2MemoryHotplugPreparedProduct::serial_storage_memory_hotplug(
+                    topology, memory, storage,
+                )
+            }
+            (None, None, Some(entropy)) => {
+                HvfSnapshotV2MemoryHotplugPreparedProduct::serial_entropy_memory_hotplug(
+                    topology, memory, entropy,
+                )
+            }
+            (None, Some(storage), Some(entropy)) => {
+                HvfSnapshotV2MemoryHotplugPreparedProduct::
+                    serial_storage_entropy_memory_hotplug(
+                        topology, memory, storage, entropy,
+                    )
+            }
+            (Some(balloon), None, None) => {
+                HvfSnapshotV2MemoryHotplugPreparedProduct::serial_balloon_memory_hotplug(
+                    topology, memory, balloon,
+                )
+            }
+            (Some(balloon), Some(storage), None) => {
+                HvfSnapshotV2MemoryHotplugPreparedProduct::
+                    serial_balloon_storage_memory_hotplug(
+                        topology, memory, balloon, storage,
+                    )
+            }
+            (Some(balloon), None, Some(entropy)) => {
+                HvfSnapshotV2MemoryHotplugPreparedProduct::
+                    serial_balloon_entropy_memory_hotplug(
+                        topology, memory, balloon, entropy,
+                    )
+            }
+            (Some(balloon), Some(storage), Some(entropy)) => {
+                HvfSnapshotV2MemoryHotplugPreparedProduct::
+                    serial_balloon_storage_entropy_memory_hotplug(
+                        topology, memory, balloon, storage, entropy,
+                    )
+            }
+        };
+        let plan =
+            prepare_hvf_snapshot_v2_memory_hotplug_pci_platform_plan(&platform_state, product)
+                .expect("PCI matrix owner plan should prepare");
+        assert_eq!(
+            plan.endpoint_count(),
+            1 + usize::from(has_balloon) + usize::from(has_storage) + usize::from(has_entropy)
+        );
+        assert_eq!(plan.memory_hotplug().route_count(), 2);
+        let restored_shell = HvfSnapshotV2RestoredSerialShell::new(
+            SerialMmioDevice::from_capture_state_with_shared_output(
+                SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+                serial.device().clone(),
+            ),
+        );
+        let owners = OwnedHvfArm64BootSession::restore_snapshot_v2_memory_hotplug_pci(
+            platform_state,
+            restored_shell,
+            None,
+            plan,
+        )
+        .unwrap_or_else(|error| {
+            panic!(
+                "PCI matrix balloon={has_balloon} storage={has_storage} entropy={has_entropy} should restore: {error:?}"
+            )
+        });
+        assert_eq!(owners.state(), &portable_state);
+        assert_eq!(owners.balloon_config().is_some(), has_balloon);
+        assert_eq!(owners.storage_configs().is_some(), has_storage);
+        assert_eq!(owners.entropy_config().is_some(), has_entropy);
+        let diagnostics = owners
+            .session()
+            .pci_data_device_diagnostics()
+            .expect("PCI matrix manager should exist")
+            .expect("PCI matrix diagnostics should inspect");
+        let mut expected_kinds = Vec::new();
+        if has_balloon {
+            expected_kinds.push(HvfArm64BootPciDataDeviceKind::Balloon);
+        }
+        if has_storage {
+            expected_kinds.push(HvfArm64BootPciDataDeviceKind::Block);
+        }
+        if has_entropy {
+            expected_kinds.push(HvfArm64BootPciDataDeviceKind::Entropy);
+        }
+        expected_kinds.push(HvfArm64BootPciDataDeviceKind::MemoryHotplug);
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|entry| entry.kind)
+                .collect::<Vec<_>>(),
+            expected_kinds
+        );
+        let metrics = owners
+            .session()
+            .shared_memory_hotplug_device_metrics()
+            .expect("PCI matrix memory-hotplug metrics should exist");
+        let (mut restored, _, controller, _, _, _) = owners.into_parts();
+        let guard = restored
+            .quiesce_limiter_retry_wakeups()
+            .expect("PCI matrix destination should quiesce");
+        let recaptured = restored
+            .capture_ready_memory_hotplug_state(Some(controller.config()), &guard)
+            .expect("PCI matrix destination should capture")
+            .expect("PCI matrix destination memory-hotplug should exist")
+            .try_to_snapshot_v2(controller.requested_size_mib())
+            .expect("PCI matrix destination capture should convert");
+        assert_eq!(recaptured.state(), &portable_state);
+        drop(guard);
+        restored
+            .shutdown()
+            .expect("PCI matrix destination should shut down");
+        assert_eq!(metrics.snapshot().teardown_count(), 1);
+        assert_eq!(metrics.snapshot().teardown_fails(), 0);
+    }
+
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let image = arm64_image().expect("test arm64 image should build");
+    for (has_balloon, has_storage, has_entropy) in [
+        (false, false, false),
+        (false, true, false),
+        (false, false, true),
+        (false, true, true),
+        (true, false, false),
+        (true, true, false),
+        (true, false, true),
+        (true, true, true),
+    ] {
+        run_case(&image, has_balloon, has_storage, has_entropy);
+    }
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/crates/runtime/src/snapshot_memory_hotplug_v2_10.rs
+++ b/crates/runtime/src/snapshot_memory_hotplug_v2_10.rs
@@ -18,7 +18,9 @@ use crate::memory_hotplug::{
     VirtioMemDeviceCaptureState, VirtioMemMmioCaptureState, VirtioMemMmioHandler,
     VirtioMemPciCaptureState, VirtioMemQueue, VirtioMemQueueBuildError, VirtioMemQueueCaptureError,
 };
-use crate::mmio::MmioRegion;
+use crate::message_interrupt::GuestMessageInterruptRegistry;
+use crate::metrics::SharedMemoryHotplugDeviceMetrics;
+use crate::mmio::{MmioRegion, MmioRegionId};
 use crate::pci::PciSbdf;
 use crate::snapshot_device_v2::{
     SnapshotV2DeviceGraphCaptureError, SnapshotV2DeviceTransport,
@@ -33,7 +35,11 @@ use crate::snapshot_device_v2_5::{
 use crate::snapshot_format::SnapshotFormatVersion;
 use crate::snapshot_memory_v2::{SnapshotV2MemoryBinding, SnapshotV2MemoryExtent};
 use crate::storage_capture::StorageDeviceOrigin;
+use crate::virtio::VirtioDeviceType;
 use crate::virtio_mmio::{VirtioMmioQueueState, VirtioMmioRegisterHandlerError};
+use crate::virtio_pci::{
+    PreparedVirtioPciEndpoint, VirtioPciEndpointError, VirtioPciIdentity, VirtioPciTransportState,
+};
 
 mod codec;
 
@@ -351,6 +357,53 @@ pub type PreparedSnapshotV2MemoryHotplugTopologyParts = (
     SnapshotV2MemoryHotplugControllerProjection,
 );
 
+enum RestoreSnapshotV2MemoryHotplugDeviceError {
+    QueueContinuation(VirtioMemQueueBuildError),
+    QueueMemory(VirtioMemQueueCaptureError),
+    Device,
+}
+
+fn restore_snapshot_v2_memory_hotplug_device(
+    state: &SnapshotV2MemoryHotplugState,
+    destination_memory: &GuestMemory,
+) -> Result<VirtioMemDevice, RestoreSnapshotV2MemoryHotplugDeviceError> {
+    let queue_state = state.virtio().queues().first().ok_or(
+        RestoreSnapshotV2MemoryHotplugDeviceError::QueueContinuation(
+            VirtioMemQueueBuildError::QueueNotReady,
+        ),
+    )?;
+    let transport_queue = VirtioMmioQueueState::from_parts(
+        queue_state.max_size(),
+        queue_state.size(),
+        queue_state.ready(),
+        queue_state.descriptor_table(),
+        queue_state.driver_ring(),
+        queue_state.device_ring(),
+    );
+    let active_queue = state
+        .active_queue()
+        .map(|cursor| {
+            let queue = VirtioMemQueue::from_snapshot_state(
+                &transport_queue,
+                cursor.next_available(),
+                cursor.next_used(),
+            )
+            .map_err(RestoreSnapshotV2MemoryHotplugDeviceError::QueueContinuation)?;
+            queue
+                .validate_snapshot_state(&transport_queue, destination_memory)
+                .map_err(RestoreSnapshotV2MemoryHotplugDeviceError::QueueMemory)?;
+            Ok(queue)
+        })
+        .transpose()?;
+    VirtioMemDevice::from_snapshot_parts(
+        active_queue,
+        state
+            .plugged_ranges()
+            .map(|range| (range.start_block(), range.block_count())),
+    )
+    .map_err(|_| RestoreSnapshotV2MemoryHotplugDeviceError::Device)
+}
+
 /// Immutable owner-free exact-2.10 virtio-mem topology.
 ///
 /// The value contains only checked snapshot facts. It owns no guest mapping,
@@ -448,42 +501,19 @@ impl PreparedSnapshotV2MemoryHotplugTopology {
         let SnapshotV2DeviceTransport::Mmio(mmio) = state.transport() else {
             return Err(SnapshotV2MemoryHotplugMmioHandlerError::WrongTransport);
         };
-        let queue_state = state.virtio().queues().first().ok_or(
-            SnapshotV2MemoryHotplugMmioHandlerError::QueueContinuation(
-                VirtioMemQueueBuildError::QueueNotReady,
-            ),
-        )?;
-        let transport_queue = VirtioMmioQueueState::from_parts(
-            queue_state.max_size(),
-            queue_state.size(),
-            queue_state.ready(),
-            queue_state.descriptor_table(),
-            queue_state.driver_ring(),
-            queue_state.device_ring(),
-        );
-        let active_queue = state
-            .active_queue()
-            .map(|cursor| {
-                let queue = VirtioMemQueue::from_snapshot_state(
-                    &transport_queue,
-                    cursor.next_available(),
-                    cursor.next_used(),
-                )
-                .map_err(SnapshotV2MemoryHotplugMmioHandlerError::QueueContinuation)?;
-                queue
-                    .validate_snapshot_state(&transport_queue, destination_memory)
-                    .map_err(SnapshotV2MemoryHotplugMmioHandlerError::QueueMemory)?;
-                Ok(queue)
-            })
-            .transpose()?;
-        let activation_is_active = active_queue.is_some();
-        let device = VirtioMemDevice::from_snapshot_parts(
-            active_queue,
-            state
-                .plugged_ranges()
-                .map(|range| (range.start_block(), range.block_count())),
-        )
-        .map_err(|_| SnapshotV2MemoryHotplugMmioHandlerError::Device)?;
+        let device = restore_snapshot_v2_memory_hotplug_device(&state, destination_memory)
+            .map_err(|source| match source {
+                RestoreSnapshotV2MemoryHotplugDeviceError::QueueContinuation(source) => {
+                    SnapshotV2MemoryHotplugMmioHandlerError::QueueContinuation(source)
+                }
+                RestoreSnapshotV2MemoryHotplugDeviceError::QueueMemory(source) => {
+                    SnapshotV2MemoryHotplugMmioHandlerError::QueueMemory(source)
+                }
+                RestoreSnapshotV2MemoryHotplugDeviceError::Device => {
+                    SnapshotV2MemoryHotplugMmioHandlerError::Device
+                }
+            })?;
+        let activation_is_active = device.is_activated();
         let retained = restore_mmio_transport_state_for_device_with_config_status_gate(
             VIRTIO_MEM_DEVICE_ID,
             state.virtio(),
@@ -531,6 +561,79 @@ impl PreparedSnapshotV2MemoryHotplugTopology {
             region,
             interrupt_line,
             handler,
+        })
+    }
+
+    /// Consumes one checked PCI topology into a complete retained endpoint
+    /// against the destination mixed-memory owner.
+    ///
+    /// The caller supplies one fresh destination message registry and the
+    /// dispatcher region reserved by the destination platform plan. The
+    /// returned value owns no route resources, dispatcher registration,
+    /// BAR/function lease, mapper, metrics registry, or VM authority.
+    #[doc(hidden)]
+    pub fn into_pci_endpoint(
+        self,
+        destination_memory: &GuestMemory,
+        region_id: MmioRegionId,
+        messages: GuestMessageInterruptRegistry,
+    ) -> Result<PreparedSnapshotV2MemoryHotplugPciEndpoint, SnapshotV2MemoryHotplugPciEndpointError>
+    {
+        let Self {
+            memory: _,
+            plugged_ranges,
+            queue_ranges,
+            state,
+            controller,
+        } = self;
+        let SnapshotV2DeviceTransport::Pci(pci) = state.transport() else {
+            return Err(SnapshotV2MemoryHotplugPciEndpointError::WrongTransport);
+        };
+        let device = restore_snapshot_v2_memory_hotplug_device(&state, destination_memory)
+            .map_err(|source| match source {
+                RestoreSnapshotV2MemoryHotplugDeviceError::QueueContinuation(source) => {
+                    SnapshotV2MemoryHotplugPciEndpointError::QueueContinuation(source)
+                }
+                RestoreSnapshotV2MemoryHotplugDeviceError::QueueMemory(source) => {
+                    SnapshotV2MemoryHotplugPciEndpointError::QueueMemory(source)
+                }
+                RestoreSnapshotV2MemoryHotplugDeviceError::Device => {
+                    SnapshotV2MemoryHotplugPciEndpointError::Device
+                }
+            })?;
+        let activation_is_active = device.is_activated();
+        let metrics = device.shared_metrics();
+        let device_type = VirtioDeviceType::new(VIRTIO_MEM_DEVICE_ID)
+            .map_err(|_| SnapshotV2MemoryHotplugPciEndpointError::DeviceType)?;
+        let identity = VirtioPciIdentity::new(device_type, state.virtio().available_features())
+            .with_config_generation(state.virtio().config_generation());
+        let origin = pci.origin();
+        let retained =
+            VirtioPciTransportState::from_snapshot_v2_parts(identity, state.virtio(), pci, false)
+                .map_err(SnapshotV2MemoryHotplugPciEndpointError::RetainedTransport)?;
+        let endpoint = PreparedVirtioPciEndpoint::new(
+            identity,
+            &VIRTIO_MEM_QUEUE_SIZES,
+            state.config_space(),
+            device,
+            activation_is_active,
+            false,
+            &retained,
+            pci.sbdf(),
+            pci.bar_range(),
+            region_id,
+            messages,
+        )
+        .map_err(SnapshotV2MemoryHotplugPciEndpointError::Endpoint)?;
+
+        Ok(PreparedSnapshotV2MemoryHotplugPciEndpoint {
+            expected_state: state,
+            controller,
+            plugged_ranges,
+            queue_ranges,
+            origin,
+            metrics,
+            endpoint,
         })
     }
 }
@@ -627,6 +730,156 @@ impl fmt::Debug for PreparedSnapshotV2MemoryHotplugMmioHandler {
             .debug_struct("PreparedSnapshotV2MemoryHotplugMmioHandler")
             .field("state", &REDACTED)
             .finish()
+    }
+}
+
+/// One checked exact-2.10 virtio-mem endpoint awaiting destination PCI
+/// publication.
+#[doc(hidden)]
+pub struct PreparedSnapshotV2MemoryHotplugPciEndpoint {
+    expected_state: SnapshotV2MemoryHotplugState,
+    controller: SnapshotV2MemoryHotplugControllerProjection,
+    plugged_ranges: Vec<GuestMemoryRange>,
+    queue_ranges: Option<[GuestMemoryRange; 3]>,
+    origin: StorageDeviceOrigin,
+    metrics: SharedMemoryHotplugDeviceMetrics,
+    endpoint: PreparedVirtioPciEndpoint<VirtioMemConfigSpace, VirtioMemDevice>,
+}
+
+/// Consumed checked virtio-mem continuation and retained PCI endpoint.
+#[doc(hidden)]
+pub type PreparedSnapshotV2MemoryHotplugPciEndpointParts = (
+    SnapshotV2MemoryHotplugState,
+    SnapshotV2MemoryHotplugControllerProjection,
+    Vec<GuestMemoryRange>,
+    Option<[GuestMemoryRange; 3]>,
+    StorageDeviceOrigin,
+    SharedMemoryHotplugDeviceMetrics,
+    PreparedVirtioPciEndpoint<VirtioMemConfigSpace, VirtioMemDevice>,
+);
+
+impl PreparedSnapshotV2MemoryHotplugPciEndpoint {
+    /// Returns the exact normalized portable state this endpoint must retain.
+    pub const fn expected_state(&self) -> &SnapshotV2MemoryHotplugState {
+        &self.expected_state
+    }
+
+    /// Returns the public controller projection reconstructed with the device.
+    pub const fn controller(&self) -> SnapshotV2MemoryHotplugControllerProjection {
+        self.controller
+    }
+
+    /// Returns canonical shared-aperture ranges retained as plugged memory.
+    pub fn plugged_ranges(&self) -> &[GuestMemoryRange] {
+        &self.plugged_ranges
+    }
+
+    /// Returns the descriptor, available, and used ranges for an active queue.
+    pub const fn queue_ranges(&self) -> Option<[GuestMemoryRange; 3]> {
+        self.queue_ranges
+    }
+
+    /// Returns the retained startup/runtime origin.
+    pub const fn origin(&self) -> StorageDeviceOrigin {
+        self.origin
+    }
+
+    /// Returns the fresh destination-local device metrics.
+    pub fn shared_metrics(&self) -> SharedMemoryHotplugDeviceMetrics {
+        self.metrics.clone()
+    }
+
+    /// Returns the complete retained endpoint before publication.
+    pub const fn endpoint(
+        &self,
+    ) -> &PreparedVirtioPciEndpoint<VirtioMemConfigSpace, VirtioMemDevice> {
+        &self.endpoint
+    }
+
+    /// Consumes the checked continuation and retained endpoint.
+    pub fn into_parts(self) -> PreparedSnapshotV2MemoryHotplugPciEndpointParts {
+        (
+            self.expected_state,
+            self.controller,
+            self.plugged_ranges,
+            self.queue_ranges,
+            self.origin,
+            self.metrics,
+            self.endpoint,
+        )
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2MemoryHotplugPciEndpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2MemoryHotplugPciEndpoint")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Failure while binding a checked virtio-mem topology to a destination PCI
+/// registry.
+#[doc(hidden)]
+pub enum SnapshotV2MemoryHotplugPciEndpointError {
+    /// The checked topology selects MMIO rather than PCI.
+    WrongTransport,
+    /// The retained active queue cursors could not be reconstructed.
+    QueueContinuation(VirtioMemQueueBuildError),
+    /// The retained active queue does not resolve against destination memory.
+    QueueMemory(VirtioMemQueueCaptureError),
+    /// The canonical plugged-range device inventory could not be rebuilt.
+    Device,
+    /// The fixed virtio-mem PCI identity cannot be represented.
+    DeviceType,
+    /// The detached PCI transport could not be reconstructed.
+    RetainedTransport(VirtioPciEndpointError),
+    /// The retained endpoint could not be reconstructed exactly.
+    Endpoint(VirtioPciEndpointError),
+}
+
+impl fmt::Debug for SnapshotV2MemoryHotplugPciEndpointError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::WrongTransport => "wrong-transport",
+            Self::QueueContinuation(_) => "queue-continuation",
+            Self::QueueMemory(_) => "queue-memory",
+            Self::Device => "device",
+            Self::DeviceType => "device-type",
+            Self::RetainedTransport(_) => "retained-transport",
+            Self::Endpoint(_) => "endpoint",
+        };
+        formatter
+            .debug_struct("SnapshotV2MemoryHotplugPciEndpointError")
+            .field("kind", &kind)
+            .field("source", &REDACTED)
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotV2MemoryHotplugPciEndpointError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::WrongTransport => "native-v2 virtio-mem topology is not PCI",
+            Self::QueueContinuation(_) => "native-v2 virtio-mem PCI queue continuation is invalid",
+            Self::QueueMemory(_) => "native-v2 virtio-mem PCI queue is outside destination memory",
+            Self::Device => "native-v2 virtio-mem PCI device reconstruction failed",
+            Self::DeviceType => "native-v2 virtio-mem PCI identity is invalid",
+            Self::RetainedTransport(_) => "native-v2 virtio-mem detached PCI transport is invalid",
+            Self::Endpoint(_) => "native-v2 virtio-mem PCI endpoint reconstruction failed",
+        })
+    }
+}
+
+impl std::error::Error for SnapshotV2MemoryHotplugPciEndpointError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::QueueContinuation(source) => Some(source),
+            Self::QueueMemory(source) => Some(source),
+            Self::RetainedTransport(source) | Self::Endpoint(source) => Some(source),
+            Self::WrongTransport | Self::Device | Self::DeviceType => None,
+        }
     }
 }
 

--- a/crates/runtime/src/snapshot_memory_hotplug_v2_10/tests.rs
+++ b/crates/runtime/src/snapshot_memory_hotplug_v2_10/tests.rs
@@ -6,6 +6,10 @@ use crate::memory::{GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRan
 use crate::memory_hotplug::{
     MemoryHotplugConfigInput, VIRTIO_MEM_DEFAULT_REGION_ADDRESS, VIRTIO_MEM_QUEUE_SIZE,
 };
+use crate::message_interrupt::{
+    GuestMessage, GuestMessageInterrupt, GuestMessageInterruptRegistry,
+    GuestMessageInterruptSignalError,
+};
 use crate::mmio::{MmioRegion, MmioRegionId};
 use crate::pci::{
     PCI_BAR64_START, PCI_BUS_ZERO, PCI_FIRST_ENDPOINT_DEVICE, PCI_FUNCTION_ZERO, PCI_SEGMENT_ZERO,
@@ -25,10 +29,12 @@ use crate::virtio::{
 };
 use crate::virtio_mmio::VIRTIO_MMIO_DEVICE_WINDOW_SIZE;
 use crate::virtio_pci::{
-    VIRTIO_PCI_CAPABILITY_BAR_INDEX, VIRTIO_PCI_CAPABILITY_BAR_SIZE, VirtioPciEndpointPhase,
+    VIRTIO_PCI_CAPABILITY_BAR_INDEX, VIRTIO_PCI_CAPABILITY_BAR_SIZE, VirtioPciEndpointError,
+    VirtioPciEndpointPhase,
 };
 
 use std::io::Cursor;
+use std::sync::Arc;
 
 const HEALTHY_DRIVER_OK: u32 = VIRTIO_DEVICE_STATUS_ACKNOWLEDGE
     | VIRTIO_DEVICE_STATUS_DRIVER
@@ -41,6 +47,40 @@ const DIRECTORY_PAYLOAD_OFFSET: usize = 8;
 const DIRECTORY_LENGTH_OFFSET: usize = 16;
 const INACTIVE_MMIO_FIXTURE_HEX: &str = include_str!("fixtures/inactive-mmio.hex");
 const ACTIVE_PCI_FIXTURE_HEX: &str = include_str!("fixtures/active-pci.hex");
+
+#[derive(Debug)]
+struct TestMessageRoute(GuestMessage);
+
+impl GuestMessageInterrupt for TestMessageRoute {
+    fn matches(&self, message: GuestMessage) -> bool {
+        self.0 == message
+    }
+
+    fn signal(&self, message: GuestMessage) -> Result<(), GuestMessageInterruptSignalError> {
+        if self.matches(message) {
+            Ok(())
+        } else {
+            Err(GuestMessageInterruptSignalError::new(
+                "test route rejected an unknown message",
+                false,
+            ))
+        }
+    }
+}
+
+fn memory_hotplug_message_registry(route_count: usize) -> GuestMessageInterruptRegistry {
+    let messages = [
+        GuestMessage::new(0x0800_0040, 64),
+        GuestMessage::new(0x0800_0040, 96),
+    ];
+    let routes: Vec<Arc<dyn GuestMessageInterrupt>> = messages
+        .into_iter()
+        .take(route_count)
+        .map(|message| Arc::new(TestMessageRoute(message)) as Arc<dyn GuestMessageInterrupt>)
+        .collect();
+    GuestMessageInterruptRegistry::new(routes)
+        .expect("memory-hotplug message registry should validate")
+}
 
 fn config(total_size_mib: u64, block_size_mib: u64, slot_size_mib: u64) -> MemoryHotplugConfig {
     MemoryHotplugConfig::try_from(MemoryHotplugConfigInput::new(
@@ -638,6 +678,199 @@ fn active_mmio_topology_restores_nonzero_queue_cursors_and_rejects_memory_drift(
             .snapshot()
             .is_empty()
     );
+}
+
+#[test]
+fn inactive_pci_topology_reconstructs_an_exact_retained_endpoint() {
+    let state = inactive_pci_state();
+    let ranges = vec![
+        plugged_guest_test_range(&state, 1, 2),
+        plugged_guest_test_range(&state, 5, 3),
+    ];
+    let binding = binding_for_ranges(
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        ranges.clone(),
+    );
+    let memory = destination_memory_for_ranges(ranges);
+    let expected_pci = match state.transport() {
+        SnapshotV2DeviceTransport::Pci(pci) => pci,
+        SnapshotV2DeviceTransport::Mmio(_) => panic!("fixture should select PCI"),
+    };
+
+    let prepared = PreparedSnapshotV2MemoryHotplugTopology::prepare(state.clone(), binding)
+        .expect("inactive PCI topology should prepare")
+        .into_pci_endpoint(
+            &memory,
+            MmioRegionId::new(700),
+            memory_hotplug_message_registry(2),
+        )
+        .expect("inactive PCI endpoint should reconstruct");
+
+    assert_eq!(prepared.expected_state(), &state);
+    assert_eq!(prepared.controller().config(), state.config());
+    assert_eq!(prepared.controller().requested_size_mib(), 128);
+    assert_eq!(
+        prepared.plugged_ranges(),
+        [
+            plugged_guest_test_range(&state, 1, 2),
+            plugged_guest_test_range(&state, 5, 3),
+        ]
+    );
+    assert_eq!(prepared.queue_ranges(), None);
+    assert_eq!(prepared.origin(), StorageDeviceOrigin::Startup);
+    assert_eq!(prepared.endpoint().sbdf(), expected_pci.sbdf());
+    assert_eq!(prepared.endpoint().bar_range(), expected_pci.bar_range());
+    assert_eq!(prepared.endpoint().region_id(), MmioRegionId::new(700));
+    assert!(prepared.shared_metrics().snapshot().is_empty());
+
+    let diagnostics = format!("{prepared:?}");
+    assert!(diagnostics.contains(REDACTED));
+    assert!(!diagnostics.contains(&expected_pci.bar_range().start().to_string()));
+}
+
+#[test]
+fn active_pci_topology_restores_nonzero_queue_cursors_and_rejects_memory_drift() {
+    let state = active_pci_state();
+    let queue = state
+        .virtio()
+        .queues()
+        .first()
+        .expect("active fixture should retain one queue");
+    let ranges = vec![
+        test_range(0x10_0000, 0x50_000),
+        plugged_guest_test_range(&state, 0, 1),
+        plugged_guest_test_range(&state, 7, 2),
+        plugged_guest_test_range(&state, 127, 1),
+    ];
+
+    let unmapped_queue_memory = destination_memory_for_ranges(ranges[1..].to_vec());
+    let unmapped_error = PreparedSnapshotV2MemoryHotplugTopology::prepare(
+        state.clone(),
+        binding_for_ranges(
+            NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+            ranges.clone(),
+        ),
+    )
+    .expect("active PCI topology should prepare")
+    .into_pci_endpoint(
+        &unmapped_queue_memory,
+        MmioRegionId::new(700),
+        memory_hotplug_message_registry(2),
+    )
+    .expect_err("unmapped PCI queue must reject");
+    assert!(matches!(
+        unmapped_error,
+        SnapshotV2MemoryHotplugPciEndpointError::QueueMemory(_)
+    ));
+
+    let mismatched_indices_memory = destination_memory_for_ranges(ranges.clone());
+    let cursor_error = PreparedSnapshotV2MemoryHotplugTopology::prepare(
+        state.clone(),
+        binding_for_ranges(
+            NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+            ranges.clone(),
+        ),
+    )
+    .expect("active PCI topology should prepare")
+    .into_pci_endpoint(
+        &mismatched_indices_memory,
+        MmioRegionId::new(700),
+        memory_hotplug_message_registry(2),
+    )
+    .expect_err("mismatched PCI queue cursors must reject");
+    assert!(matches!(
+        cursor_error,
+        SnapshotV2MemoryHotplugPciEndpointError::QueueMemory(
+            VirtioMemQueueCaptureError::UsedCursorMismatch
+        )
+    ));
+
+    let mut memory = destination_memory_for_ranges(ranges.clone());
+    set_queue_indices(
+        &mut memory,
+        queue.driver_ring(),
+        queue.device_ring(),
+        state
+            .active_queue()
+            .expect("active fixture should retain queue cursors")
+            .next_used(),
+    );
+    let prepared = PreparedSnapshotV2MemoryHotplugTopology::prepare(
+        state.clone(),
+        binding_for_ranges(NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION, ranges),
+    )
+    .expect("active PCI topology should prepare")
+    .into_pci_endpoint(
+        &memory,
+        MmioRegionId::new(700),
+        memory_hotplug_message_registry(2),
+    )
+    .expect("active PCI endpoint should reconstruct");
+
+    assert_eq!(prepared.expected_state(), &state);
+    assert!(prepared.queue_ranges().is_some());
+    assert!(prepared.shared_metrics().snapshot().is_empty());
+}
+
+#[test]
+fn pci_endpoint_materialization_rejects_wrong_transport_and_route_geometry() {
+    let mmio = inactive_mmio_state();
+    let mmio_ranges = vec![
+        plugged_guest_test_range(&mmio, 1, 2),
+        plugged_guest_test_range(&mmio, 5, 3),
+    ];
+    let memory = destination_memory_for_ranges(mmio_ranges.clone());
+    let wrong_transport = PreparedSnapshotV2MemoryHotplugTopology::prepare(
+        mmio,
+        binding_for_ranges(
+            NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+            mmio_ranges,
+        ),
+    )
+    .expect("MMIO topology should prepare")
+    .into_pci_endpoint(
+        &memory,
+        MmioRegionId::new(700),
+        memory_hotplug_message_registry(2),
+    )
+    .expect_err("MMIO topology must not materialize a PCI endpoint");
+    assert!(matches!(
+        wrong_transport,
+        SnapshotV2MemoryHotplugPciEndpointError::WrongTransport
+    ));
+
+    let pci = inactive_pci_state();
+    let pci_ranges = vec![
+        plugged_guest_test_range(&pci, 1, 2),
+        plugged_guest_test_range(&pci, 5, 3),
+    ];
+    let memory = destination_memory_for_ranges(pci_ranges.clone());
+    let route_error = PreparedSnapshotV2MemoryHotplugTopology::prepare(
+        pci,
+        binding_for_ranges(
+            NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+            pci_ranges,
+        ),
+    )
+    .expect("PCI topology should prepare")
+    .into_pci_endpoint(
+        &memory,
+        MmioRegionId::new(700),
+        memory_hotplug_message_registry(1),
+    )
+    .expect_err("one route cannot satisfy virtio-mem MSI-X");
+    assert!(matches!(
+        route_error,
+        SnapshotV2MemoryHotplugPciEndpointError::Endpoint(
+            VirtioPciEndpointError::MessageRouteCount {
+                expected: 2,
+                actual: 1
+            }
+        )
+    ));
+    let diagnostics = format!("{route_error:?} {route_error}");
+    assert!(diagnostics.contains(REDACTED));
+    assert!(!diagnostics.contains(&PCI_BAR64_START.to_string()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- reconstruct exact native-v2 2.10 virtio-mem PCI devices from retained queue, common virtio, BAR, MSI-X, and mapping state
- publish the restored endpoint last after optional balloon, storage, and entropy owners, with transactional rollback and fresh destination metrics
- certify active queue continuation, all eight optional-device product shapes, recapture equality, mapping freshness, and every aggregate failure seam on signed Apple Silicon HVF

## Scope exclusions

- keeps the public exact-2.10 snapshot load path closed; activation remains owned by #1697
- does not change the native-v2 wire format or Firecracker artifact compatibility claims

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `CARGO_BUILD_JOBS=2 scripts/run-integration-tests.sh`

Closes #1696

Parent: #1538
