### PR TITLE
feat: resolve network snapshot overrides

### DIFF
--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -168,9 +168,10 @@ use bangbang_runtime::snapshot_artifact::{
     NativeV2NetworkSnapshotCandidateState, NativeV2SerialSnapshotCandidateState,
     NativeV2SnapshotArtifactProfile, NativeV2SnapshotCandidateState,
     NativeV2SnapshotCandidateStateError, NativeV2StorageSnapshotCandidateState,
-    PreparedNativeSnapshotState, SnapshotArtifactLoadError, SnapshotArtifactOutput,
-    SnapshotArtifactOutputs, SnapshotArtifactPaths, SnapshotCommitDurability,
-    SnapshotMemoryStagingWriter, SnapshotPublicationOutcome, SnapshotPublicationTransactionError,
+    PreparedNativeSnapshotState, PreparedNativeV2NetworkSnapshotCandidateState,
+    SnapshotArtifactLoadError, SnapshotArtifactOutput, SnapshotArtifactOutputs,
+    SnapshotArtifactPaths, SnapshotCommitDurability, SnapshotMemoryStagingWriter,
+    SnapshotPublicationOutcome, SnapshotPublicationTransactionError,
     load_prepared_native_snapshot_memory_file, load_prepared_native_snapshot_memory_path,
     load_snapshot_artifacts, prepare_native_snapshot_state_file,
     prepare_native_snapshot_state_path, prepare_snapshot_state_file, prepare_snapshot_state_path,
@@ -18416,6 +18417,168 @@ impl std::error::Error for ProcessNetworkPacketIoProviderBuildError {
     }
 }
 
+/// Value-only exact-2.11 network restore plan before any provider access.
+///
+/// The plan retains the complete owner-free runtime candidate, parsed macOS
+/// destination grammar, and immutable process authority. It owns no backend,
+/// descriptor, provider, callback, metric, MMDS owner, or platform resource.
+pub(crate) struct PreparedProcessSnapshotV2NetworkRestorePlan {
+    candidate: PreparedNativeV2NetworkSnapshotCandidateState,
+    vmnet_configs: Vec<VmnetInterfaceConfig>,
+    all_mmds: bool,
+    authority: ProcessVmnetAuthority,
+}
+
+pub(crate) type PreparedProcessSnapshotV2NetworkRestorePlanParts = (
+    PreparedNativeV2NetworkSnapshotCandidateState,
+    Vec<VmnetInterfaceConfig>,
+    bool,
+    ProcessVmnetAuthority,
+);
+
+impl PreparedProcessSnapshotV2NetworkRestorePlan {
+    pub(crate) const fn candidate(&self) -> &PreparedNativeV2NetworkSnapshotCandidateState {
+        &self.candidate
+    }
+
+    pub(crate) fn vmnet_configs(&self) -> &[VmnetInterfaceConfig] {
+        &self.vmnet_configs
+    }
+
+    pub(crate) const fn all_mmds(&self) -> bool {
+        self.all_mmds
+    }
+
+    pub(crate) const fn authority(&self) -> ProcessVmnetAuthority {
+        self.authority
+    }
+
+    pub(crate) fn into_parts(self) -> PreparedProcessSnapshotV2NetworkRestorePlanParts {
+        (
+            self.candidate,
+            self.vmnet_configs,
+            self.all_mmds,
+            self.authority,
+        )
+    }
+}
+
+impl fmt::Debug for PreparedProcessSnapshotV2NetworkRestorePlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedProcessSnapshotV2NetworkRestorePlan")
+            .field("interface_count", &self.vmnet_configs.len())
+            .field("all_mmds", &self.all_mmds)
+            .field("authority", &self.authority)
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+enum ProcessSnapshotV2NetworkRestorePlanError {
+    Allocation {
+        source: TryReserveError,
+    },
+    Selector {
+        source: VmnetHostDeviceNameConfigError,
+    },
+    Authority(ProcessVmnetAuthorityValidationError),
+}
+
+impl fmt::Debug for ProcessSnapshotV2NetworkRestorePlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Allocation { .. } => "ProcessSnapshotV2NetworkRestorePlanError::Allocation",
+            Self::Selector { .. } => "ProcessSnapshotV2NetworkRestorePlanError::Selector",
+            Self::Authority(source) => {
+                let _ = source;
+                "ProcessSnapshotV2NetworkRestorePlanError::Authority"
+            }
+        })
+    }
+}
+
+impl fmt::Display for ProcessSnapshotV2NetworkRestorePlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Allocation { .. } => "failed to allocate exact-2.11 network restore value plan",
+            Self::Selector { .. } => "exact-2.11 network restore destination selector is invalid",
+            Self::Authority(_) => "exact-2.11 network restore destination authority is invalid",
+        })
+    }
+}
+
+impl std::error::Error for ProcessSnapshotV2NetworkRestorePlanError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Allocation { source } => Some(source),
+            Self::Selector { source } => Some(source),
+            Self::Authority(_) => None,
+        }
+    }
+}
+
+fn prepare_process_snapshot_v2_network_restore_plan(
+    candidate: PreparedNativeV2NetworkSnapshotCandidateState,
+    authority: ProcessVmnetAuthority,
+) -> Result<PreparedProcessSnapshotV2NetworkRestorePlan, ProcessSnapshotV2NetworkRestorePlanError> {
+    let interfaces = candidate.topology().interfaces();
+    let mut vmnet_configs = Vec::new();
+    vmnet_configs
+        .try_reserve_exact(interfaces.len())
+        .map_err(|source| ProcessSnapshotV2NetworkRestorePlanError::Allocation { source })?;
+    for interface in interfaces {
+        let vmnet =
+            VmnetInterfaceConfig::from_host_dev_name(interface.controller().host_dev_name())
+                .map_err(|source| ProcessSnapshotV2NetworkRestorePlanError::Selector { source })?;
+        vmnet_configs.push(vmnet);
+    }
+
+    let all_mmds = !interfaces.is_empty()
+        && interfaces
+            .iter()
+            .all(|interface| interface.mmds_stack().is_some());
+    validate_process_vmnet_authority_for_resolved_configs(
+        vmnet_configs.len(),
+        all_mmds,
+        authority,
+        &vmnet_configs,
+    )
+    .map_err(ProcessSnapshotV2NetworkRestorePlanError::Authority)?;
+
+    Ok(PreparedProcessSnapshotV2NetworkRestorePlan {
+        candidate,
+        vmnet_configs,
+        all_mmds,
+        authority,
+    })
+}
+
+type ProcessSnapshotV2NetworkRestorePlanBuilder = fn(
+    PreparedNativeV2NetworkSnapshotCandidateState,
+    ProcessVmnetAuthority,
+) -> Result<
+    PreparedProcessSnapshotV2NetworkRestorePlan,
+    ProcessSnapshotV2NetworkRestorePlanError,
+>;
+
+const _: ProcessSnapshotV2NetworkRestorePlanBuilder =
+    prepare_process_snapshot_v2_network_restore_plan;
+const _: fn(
+    &PreparedProcessSnapshotV2NetworkRestorePlan,
+) -> &PreparedNativeV2NetworkSnapshotCandidateState =
+    PreparedProcessSnapshotV2NetworkRestorePlan::candidate;
+const _: fn(&PreparedProcessSnapshotV2NetworkRestorePlan) -> &[VmnetInterfaceConfig] =
+    PreparedProcessSnapshotV2NetworkRestorePlan::vmnet_configs;
+const _: fn(&PreparedProcessSnapshotV2NetworkRestorePlan) -> bool =
+    PreparedProcessSnapshotV2NetworkRestorePlan::all_mmds;
+const _: fn(&PreparedProcessSnapshotV2NetworkRestorePlan) -> ProcessVmnetAuthority =
+    PreparedProcessSnapshotV2NetworkRestorePlan::authority;
+const _: fn(
+    PreparedProcessSnapshotV2NetworkRestorePlan,
+) -> PreparedProcessSnapshotV2NetworkRestorePlanParts =
+    PreparedProcessSnapshotV2NetworkRestorePlan::into_parts;
+
 #[derive(Debug)]
 enum ProcessVmnetAuthorityValidationError {
     Provider(ProcessNetworkPacketIoProviderBuildError),
@@ -18469,19 +18632,64 @@ fn validate_process_vmnet_authority_for_configs(
     all_mmds: bool,
     authority: ProcessVmnetAuthority,
 ) -> Result<(), ProcessVmnetAuthorityValidationError> {
-    validate_network_interface_count(configs.len()).map_err(|source| {
+    let required_authority = required_process_vmnet_authority(configs.len(), all_mmds, authority)?;
+    for config in configs {
+        let vmnet =
+            VmnetInterfaceConfig::from_host_dev_name(config.host_dev_name()).map_err(|source| {
+                ProcessVmnetAuthorityValidationError::Provider(
+                    ProcessNetworkPacketIoProviderBuildError::HostDeviceName { source },
+                )
+            })?;
+        if let Some(authority) = required_authority
+            && !vmnet_authority_allows(authority, &vmnet)
+        {
+            return Err(ProcessVmnetAuthorityValidationError::HostNetworkNotAuthorized);
+        }
+    }
+    Ok(())
+}
+
+fn validate_process_vmnet_authority_for_resolved_configs(
+    interface_count: usize,
+    all_mmds: bool,
+    authority: ProcessVmnetAuthority,
+    vmnet_configs: &[VmnetInterfaceConfig],
+) -> Result<(), ProcessVmnetAuthorityValidationError> {
+    if interface_count != vmnet_configs.len() {
+        return Err(ProcessVmnetAuthorityValidationError::Provider(
+            ProcessNetworkPacketIoProviderBuildError::AuthorityMismatch,
+        ));
+    }
+    let required_authority =
+        required_process_vmnet_authority(interface_count, all_mmds, authority)?;
+    if let Some(authority) = required_authority
+        && vmnet_configs
+            .iter()
+            .any(|vmnet| !vmnet_authority_allows(authority, vmnet))
+    {
+        return Err(ProcessVmnetAuthorityValidationError::HostNetworkNotAuthorized);
+    }
+    Ok(())
+}
+
+fn required_process_vmnet_authority(
+    interface_count: usize,
+    all_mmds: bool,
+    authority: ProcessVmnetAuthority,
+) -> Result<Option<VmnetAuthority>, ProcessVmnetAuthorityValidationError> {
+    validate_network_interface_count(interface_count).map_err(|source| {
         ProcessVmnetAuthorityValidationError::Provider(
             ProcessNetworkPacketIoProviderBuildError::NetworkInterfaceCount { source },
         )
     })?;
     let contained_authority = authority.contained_authority();
 
-    let required_authority = match (all_mmds, configs.is_empty()) {
+    let required_authority = match (all_mmds, interface_count == 0) {
         (true, _) | (_, true) => None,
         (false, false) => contained_authority,
     };
     if let Some(authority) = required_authority
-        && configs.len()
+        && interface_count
             > usize::from(
                 authority
                     .max_interfaces()
@@ -18490,22 +18698,7 @@ fn validate_process_vmnet_authority_for_configs(
     {
         return Err(ProcessVmnetAuthorityValidationError::HostNetworkNotAuthorized);
     }
-
-    for config in configs {
-        let vmnet =
-            VmnetInterfaceConfig::from_host_dev_name(config.host_dev_name()).map_err(|source| {
-                ProcessVmnetAuthorityValidationError::Provider(
-                    ProcessNetworkPacketIoProviderBuildError::HostDeviceName { source },
-                )
-            })?;
-        let Some(authority) = required_authority else {
-            continue;
-        };
-        if !vmnet_authority_allows(authority, &vmnet) {
-            return Err(ProcessVmnetAuthorityValidationError::HostNetworkNotAuthorized);
-        }
-    }
-    Ok(())
+    Ok(required_authority)
 }
 
 fn vmnet_authority_allows(authority: VmnetAuthority, vmnet: &VmnetInterfaceConfig) -> bool {
@@ -24444,9 +24637,10 @@ mod tests {
         SharedVsockDeviceMetrics, VsockDeviceMetrics,
     };
     use bangbang_runtime::mmds::{
-        MmdsConfig, MmdsConfigInput, MmdsContentInput, MmdsStateHandle, MmdsVersion,
+        DEFAULT_MMDS_IPV4_ADDRESS, DEFAULT_MMDS_MAC_ADDRESS, MMDS_GUEST_TCP_PORT, MmdsConfig,
+        MmdsConfigInput, MmdsContentInput, MmdsStateHandle, MmdsVersion,
     };
-    use bangbang_runtime::mmio::MmioRegion;
+    use bangbang_runtime::mmio::{MmioRegion, MmioRegionId};
     use bangbang_runtime::network::{
         GuestMacAddress, MAX_NETWORK_INTERFACE_COUNT, NetworkDeviceProfile, NetworkInterfaceConfig,
         NetworkInterfaceConfigError, NetworkInterfaceConfigInput, NetworkInterfaceConfigs,
@@ -24473,16 +24667,17 @@ mod tests {
     };
     use bangbang_runtime::snapshot::{
         SnapshotCreateInput, SnapshotLoadInput, SnapshotMemoryBackend, SnapshotMemoryBackendType,
-        SnapshotType, SnapshotV1ControllerCommit, SnapshotV2ControllerCommit,
-        SnapshotV2ControllerCommitProductConfigs,
+        SnapshotNetworkOverride, SnapshotType, SnapshotV1ControllerCommit,
+        SnapshotV2ControllerCommit, SnapshotV2ControllerCommitProductConfigs,
     };
     use bangbang_runtime::snapshot_artifact::{
         LoadedNativeSnapshotArtifacts, NativeSnapshotPublicationOutcome,
         NativeV2BalloonSnapshotCandidateState, NativeV2EntropySnapshotCandidateState,
         NativeV2MemoryHotplugSnapshotCandidateState, NativeV2MemoryHotplugSnapshotPreparation,
-        NativeV2NetworkSnapshotCandidateState, NativeV2SnapshotArtifactProfile,
-        PreparedNativeSnapshotState, SnapshotArtifactOutputs, SnapshotArtifactPaths,
-        SnapshotPublicationOutcome, publish_snapshot_artifacts_with,
+        NativeV2NetworkSnapshotCandidateState, NativeV2NetworkSnapshotPreparation,
+        NativeV2SnapshotArtifactProfile, PreparedNativeSnapshotState,
+        PreparedNativeV2NetworkSnapshotCandidateState, SnapshotArtifactOutputs,
+        SnapshotArtifactPaths, SnapshotPublicationOutcome, publish_snapshot_artifacts_with,
     };
     #[cfg(target_os = "macos")]
     use bangbang_runtime::snapshot_artifact::{
@@ -24498,7 +24693,8 @@ mod tests {
     use bangbang_runtime::snapshot_commit::SnapshotCommitRecord;
     use bangbang_runtime::snapshot_device_v2::{
         NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2DeviceGraph,
-        SnapshotV2DeviceGraphCaptureError, SnapshotV2DeviceTransportKind,
+        SnapshotV2DeviceGraphCaptureError, SnapshotV2DeviceTransport,
+        SnapshotV2DeviceTransportKind, SnapshotV2MmioDeviceState,
     };
     use bangbang_runtime::snapshot_device_v2_5::{
         NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2MultiBlockDeviceGraph,
@@ -24527,7 +24723,9 @@ mod tests {
         write_snapshot_v2_memory_image_with_compatibility_version_and_cancel,
     };
     use bangbang_runtime::snapshot_network_v2_11::{
-        NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION, SnapshotV2NetworkState,
+        NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION, SnapshotV2MmdsInterfaceState,
+        SnapshotV2MmdsState, SnapshotV2NetworkBackendClass, SnapshotV2NetworkInterfaceState,
+        SnapshotV2NetworkInterfaceStateParts, SnapshotV2NetworkState,
         SnapshotV2NetworkStateBuildError,
     };
     use bangbang_runtime::snapshot_serial_v2_7::{
@@ -24565,7 +24763,7 @@ mod tests {
     use crate::host_network::vmnet::{
         VmnetError, VmnetInterfaceBackend, VmnetInterfaceConfig, VmnetInterfaceDescriptor,
         VmnetInterfaceDescriptorError, VmnetInterfaceParameters, VmnetInterfaceStartDisposition,
-        VmnetInterfaceStartError, VmnetOperation, VmnetPacketAvailableCallback,
+        VmnetInterfaceStartError, VmnetMode, VmnetOperation, VmnetPacketAvailableCallback,
         VmnetPacketIoBackend, VmnetPacketIoError, VmnetReadPacket, VmnetStartedInterface,
         VmnetStatus, VmnetWritePacket,
     };
@@ -24621,13 +24819,14 @@ mod tests {
         ProcessRuntimeNetworkPacketIoProvider, ProcessSessionDiagnostics, ProcessSessionExitStatus,
         ProcessSnapshotV2BalloonLoadRequest, ProcessSnapshotV2EntropyLoadRequest,
         ProcessSnapshotV2MemoryHotplugLoadRequest, ProcessSnapshotV2MultiBlockLoadRequest,
-        ProcessSnapshotV2MultiBlockLoadSuccess, ProcessSnapshotV2RootLoadCompletion,
-        ProcessSnapshotV2RootLoadRequest, ProcessSnapshotV2RootLoadSuccess,
-        ProcessSnapshotV2SerialLoadRequest, ProcessSnapshotV2StorageLoadRequest,
-        ProcessSnapshotV2StorageLoadSuccess, ProcessVmm, ProcessVmnetAuthority,
-        ProcessVmnetPacketIoBackendFactory, SerialGrantState, SnapshotCreateSession,
-        SnapshotV1LoadSuccess, SnapshotV2LoadSuccess, default_hvf_boot_run_loop_step_limit,
-        default_hvf_boot_session_config, native_v2_platform_capture_is_terminal,
+        ProcessSnapshotV2MultiBlockLoadSuccess, ProcessSnapshotV2NetworkRestorePlanError,
+        ProcessSnapshotV2RootLoadCompletion, ProcessSnapshotV2RootLoadRequest,
+        ProcessSnapshotV2RootLoadSuccess, ProcessSnapshotV2SerialLoadRequest,
+        ProcessSnapshotV2StorageLoadRequest, ProcessSnapshotV2StorageLoadSuccess, ProcessVmm,
+        ProcessVmnetAuthority, ProcessVmnetPacketIoBackendFactory, SerialGrantState,
+        SnapshotCreateSession, SnapshotV1LoadSuccess, SnapshotV2LoadSuccess,
+        default_hvf_boot_run_loop_step_limit, default_hvf_boot_session_config,
+        native_v2_platform_capture_is_terminal, prepare_process_snapshot_v2_network_restore_plan,
         require_native_v1_composite_record, snapshot_destination_machine_config,
         vsock_capture_error_from_boot_run_loop_command,
     };
@@ -31275,6 +31474,184 @@ mod tests {
     }
 
     #[cfg(target_os = "macos")]
+    fn copied_inactive_mmio_network_interface(
+        source: &SnapshotV2NetworkInterfaceState,
+        index: usize,
+        backend: SnapshotV2NetworkBackendClass,
+    ) -> SnapshotV2NetworkInterfaceState {
+        let SnapshotV2DeviceTransport::Mmio(mmio) = source.transport() else {
+            panic!("partial-MMDS fixture source must use MMIO");
+        };
+        let offset = u64::try_from(index).expect("fixture interface index should fit")
+            * VIRTIO_MMIO_DEVICE_WINDOW_SIZE;
+        let region = MmioRegion::new(
+            MmioRegionId::new(
+                mmio.region()
+                    .id()
+                    .raw_value()
+                    .checked_add(u64::try_from(index).unwrap())
+                    .expect("fixture region ID should fit"),
+            ),
+            GuestAddress::new(
+                mmio.region()
+                    .range()
+                    .start()
+                    .raw_value()
+                    .checked_add(offset)
+                    .expect("fixture MMIO placement should fit"),
+            ),
+            VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+        )
+        .expect("fixture MMIO region should validate");
+        let transport = SnapshotV2DeviceTransport::Mmio(SnapshotV2MmioDeviceState::from_parts(
+            mmio.device_feature_select(),
+            mmio.driver_feature_select(),
+            mmio.queue_select(),
+            region,
+            GuestInterruptLine::new(
+                mmio.interrupt_line()
+                    .raw_value()
+                    .checked_add(u32::try_from(index).unwrap())
+                    .expect("fixture interrupt should fit"),
+            )
+            .expect("fixture interrupt should validate"),
+        ));
+        let guest_mac = GuestMacAddress::from_bytes([
+            0x02,
+            0,
+            0,
+            0,
+            0x40,
+            u8::try_from(index).expect("fixture MAC index should fit"),
+        ]);
+        let profile = NetworkDeviceProfile::new(Some(guest_mac), source.requested_mtu());
+
+        SnapshotV2NetworkInterfaceState::try_from_parts(SnapshotV2NetworkInterfaceStateParts {
+            iface_id: format!("eth{index}"),
+            captured_selector: format!("captured{index}"),
+            requested_guest_mac: Some(guest_mac),
+            requested_mtu: source.requested_mtu(),
+            profile,
+            backend,
+            local: source.local().clone(),
+            virtio: source.virtio().clone(),
+            rx_limiter: source.rx_limiter(),
+            tx_limiter: source.tx_limiter(),
+            transport,
+        })
+        .expect("copied network interface should validate")
+    }
+
+    #[cfg(target_os = "macos")]
+    fn fake_partial_mmds_network_state() -> SnapshotV2NetworkState {
+        let base = fake_native_v2_network_state(SnapshotV2DeviceTransportKind::Mmio);
+        let source = &base.interfaces()[0];
+        let interfaces = (0..2)
+            .map(|index| {
+                copied_inactive_mmio_network_interface(
+                    source,
+                    index,
+                    SnapshotV2NetworkBackendClass::Vmnet,
+                )
+            })
+            .collect::<Vec<_>>();
+        let mmds = SnapshotV2MmdsState::new(
+            MmdsVersion::V2,
+            Some(DEFAULT_MMDS_IPV4_ADDRESS),
+            true,
+            vec![SnapshotV2MmdsInterfaceState::new(
+                0,
+                DEFAULT_MMDS_MAC_ADDRESS,
+                DEFAULT_MMDS_IPV4_ADDRESS,
+                MMDS_GUEST_TCP_PORT,
+            )],
+        );
+
+        SnapshotV2NetworkState::try_new(interfaces, Some(mmds))
+            .expect("partial-MMDS network state should validate")
+    }
+
+    #[cfg(target_os = "macos")]
+    fn prepared_native_v2_network_restore_candidate(
+        state: SnapshotV2NetworkState,
+        selectors: &[&str],
+    ) -> PreparedNativeV2NetworkSnapshotCandidateState {
+        assert_eq!(selectors.len(), state.interfaces().len());
+        let range = GuestMemoryRange::new(GuestAddress::new(0x8000_0000), 16 * 1024)
+            .expect("exact-2.11 fixture memory range should validate");
+        let layout = GuestMemoryLayout::new(vec![range])
+            .expect("exact-2.11 fixture memory layout should validate");
+        let memory =
+            GuestMemory::allocate(&layout).expect("exact-2.11 fixture memory should allocate");
+        let mut image = Cursor::new(Vec::new());
+        let binding = write_snapshot_v2_memory_image_with_compatibility_version_and_cancel(
+            &memory,
+            &mut image,
+            NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
+            |_| false,
+        )
+        .expect("exact-2.11 fixture memory should encode")
+        .encode()
+        .expect("exact-2.11 fixture binding should encode");
+        let serial_device = SerialMmioDevice::discarding()
+            .capture_state()
+            .expect("exact-2.11 fixture serial device should capture");
+        let serial = SnapshotV2SerialState::try_from_capture_ready(CaptureReadySerialState::new(
+            SerialConfig::default(),
+            serial_device,
+        ))
+        .expect("exact-2.11 fixture serial state should validate")
+        .encode(NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION)
+        .expect("exact-2.11 fixture serial state should encode");
+        let network = state
+            .encode(NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION)
+            .expect("exact-2.11 fixture network state should encode");
+        let components = [
+            SnapshotV2Component::new(
+                NATIVE_V2_MEMORY_COMPONENT_KEY,
+                SnapshotV2ComponentDisposition::Semantic,
+                &binding,
+            ),
+            SnapshotV2Component::new(
+                NATIVE_V2_SERIAL_COMPONENT_KEY,
+                SnapshotV2ComponentDisposition::Semantic,
+                &serial,
+            ),
+            SnapshotV2Component::new(
+                NATIVE_V2_NETWORK_COMPONENT_KEY,
+                SnapshotV2ComponentDisposition::Semantic,
+                &network,
+            ),
+        ];
+        let encoded = encode_snapshot_v2_state_with_compatibility_version(
+            NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
+            &[],
+            &components,
+        )
+        .expect("exact-2.11 fixture candidate should encode");
+        let candidate = NativeV2NetworkSnapshotCandidateState::from_network_state_v2_11(encoded)
+            .expect("exact-2.11 fixture candidate should validate");
+        let overrides = state
+            .interfaces()
+            .iter()
+            .zip(selectors)
+            .map(|(interface, selector)| {
+                SnapshotNetworkOverride::new(interface.iface_id(), *selector)
+            })
+            .collect::<Vec<_>>();
+
+        match candidate
+            .prepare(&overrides)
+            .expect("exact-2.11 fixture candidate should prepare")
+        {
+            NativeV2NetworkSnapshotPreparation::Prepared(candidate) => candidate,
+            NativeV2NetworkSnapshotPreparation::Compatible(_) => {
+                panic!("network-bearing fixture must not remain compatible")
+            }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
     fn fake_native_v2_network_capture_profile(
         transport: SnapshotV2DeviceTransportKind,
     ) -> (
@@ -34582,6 +34959,250 @@ mod tests {
         );
         assert_eq!(provider.entries.len(), 1);
         assert_eq!(provider.reserved_macs, [realized]);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn exact_minor_eleven_process_value_plan_parses_direct_modes_in_saved_order() {
+        for (selector, expected_mode, expected_bridge) in [
+            ("vmnet:host", VmnetMode::Host, None),
+            ("vmnet:shared", VmnetMode::Shared, None),
+            (
+                "vmnet:bridged:private-bridge",
+                VmnetMode::Bridged,
+                Some("private-bridge"),
+            ),
+        ] {
+            let candidate = prepared_native_v2_network_restore_candidate(
+                fake_native_v2_network_state(SnapshotV2DeviceTransportKind::Mmio),
+                &[selector],
+            );
+            let expected_bytes = candidate.bytes().to_vec();
+            let plan = prepare_process_snapshot_v2_network_restore_plan(
+                candidate,
+                ProcessVmnetAuthority::Direct,
+            )
+            .expect("direct value plan should accept every supported vmnet mode");
+
+            assert_eq!(plan.candidate().bytes(), expected_bytes);
+            assert_eq!(plan.vmnet_configs().len(), 1);
+            assert_eq!(plan.vmnet_configs()[0].mode(), expected_mode);
+            assert_eq!(
+                plan.vmnet_configs()[0].bridged_interface_name(),
+                expected_bridge
+            );
+            assert!(!plan.all_mmds());
+            assert_eq!(plan.authority(), ProcessVmnetAuthority::Direct);
+            let debug = format!("{plan:?}");
+            assert!(debug.contains("<redacted>"));
+            assert!(!debug.contains(selector));
+            assert!(!debug.contains("private-bridge"));
+
+            let (candidate, vmnet, all_mmds, authority) = plan.into_parts();
+            assert_eq!(candidate.bytes(), expected_bytes);
+            assert_eq!(vmnet.len(), 1);
+            assert!(!all_mmds);
+            assert_eq!(authority, ProcessVmnetAuthority::Direct);
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn exact_minor_eleven_contained_value_plan_enforces_mode_bridge_and_count_policy() {
+        for (selector, authority) in [
+            (
+                "vmnet:host",
+                VmnetAuthority::try_new(true, false, 1, &[])
+                    .expect("host-only authority should validate"),
+            ),
+            (
+                "vmnet:shared",
+                VmnetAuthority::try_new(false, true, 1, &[])
+                    .expect("shared-only authority should validate"),
+            ),
+            (
+                "vmnet:bridged:private-bridge",
+                VmnetAuthority::try_new(false, false, 1, &["private-bridge"])
+                    .expect("bridge-only authority should validate"),
+            ),
+        ] {
+            let plan = prepare_process_snapshot_v2_network_restore_plan(
+                prepared_native_v2_network_restore_candidate(
+                    fake_native_v2_network_state(SnapshotV2DeviceTransportKind::Mmio),
+                    &[selector],
+                ),
+                contained_vmnet_authority_for_session(0x61, authority),
+            )
+            .expect("matching contained vmnet authority should prepare");
+            assert!(!plan.all_mmds());
+            assert_eq!(plan.vmnet_configs().len(), 1);
+        }
+
+        for (selector, authority) in [
+            ("vmnet:host", VmnetAuthority::denied()),
+            (
+                "vmnet:shared",
+                VmnetAuthority::try_new(true, false, 1, &[])
+                    .expect("host-only authority should validate"),
+            ),
+            (
+                "vmnet:bridged:other-bridge",
+                VmnetAuthority::try_new(false, false, 1, &["private-bridge"])
+                    .expect("bridge-only authority should validate"),
+            ),
+        ] {
+            let error = prepare_process_snapshot_v2_network_restore_plan(
+                prepared_native_v2_network_restore_candidate(
+                    fake_native_v2_network_state(SnapshotV2DeviceTransportKind::Mmio),
+                    &[selector],
+                ),
+                contained_vmnet_authority_for_session(0x62, authority),
+            )
+            .expect_err("mismatched contained vmnet authority must fail");
+            assert!(matches!(
+                error,
+                ProcessSnapshotV2NetworkRestorePlanError::Authority(
+                    super::ProcessVmnetAuthorityValidationError::HostNetworkNotAuthorized
+                )
+            ));
+        }
+
+        let partial = fake_partial_mmds_network_state();
+        let one_shared = VmnetAuthority::try_new(false, true, 1, &[])
+            .expect("one-interface shared authority should validate");
+        let error = prepare_process_snapshot_v2_network_restore_plan(
+            prepared_native_v2_network_restore_candidate(
+                partial,
+                &["vmnet:shared", "vmnet:shared"],
+            ),
+            contained_vmnet_authority_for_session(0x63, one_shared),
+        )
+        .expect_err("partial MMDS still needs capacity for both vmnet interfaces");
+        assert!(matches!(
+            error,
+            ProcessSnapshotV2NetworkRestorePlanError::Authority(
+                super::ProcessVmnetAuthorityValidationError::HostNetworkNotAuthorized
+            )
+        ));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn exact_minor_eleven_mmds_value_plan_distinguishes_absent_partial_and_all() {
+        let shared_two = VmnetAuthority::try_new(false, true, 2, &[])
+            .expect("two-interface shared authority should validate");
+        let partial = prepare_process_snapshot_v2_network_restore_plan(
+            prepared_native_v2_network_restore_candidate(
+                fake_partial_mmds_network_state(),
+                &["vmnet:shared", "vmnet:shared"],
+            ),
+            contained_vmnet_authority_for_session(0x64, shared_two),
+        )
+        .expect("partial-MMDS destination should prepare with vmnet authority");
+        assert!(!partial.all_mmds());
+        assert!(
+            partial.candidate().topology().interfaces()[0]
+                .mmds_stack()
+                .is_some()
+        );
+        assert!(
+            partial.candidate().topology().interfaces()[1]
+                .mmds_stack()
+                .is_none()
+        );
+
+        let absent = prepare_process_snapshot_v2_network_restore_plan(
+            prepared_native_v2_network_restore_candidate(
+                fake_native_v2_network_state(SnapshotV2DeviceTransportKind::Mmio),
+                &["vmnet:shared"],
+            ),
+            contained_vmnet_authority_for_session(
+                0x65,
+                VmnetAuthority::try_new(false, true, 1, &[])
+                    .expect("shared authority should validate"),
+            ),
+        )
+        .expect("MMDS-absent destination should prepare with vmnet authority");
+        assert!(!absent.all_mmds());
+        assert!(
+            absent.candidate().topology().interfaces()[0]
+                .mmds_stack()
+                .is_none()
+        );
+
+        let all = prepare_process_snapshot_v2_network_restore_plan(
+            prepared_native_v2_network_restore_candidate(
+                fake_native_v2_network_state(SnapshotV2DeviceTransportKind::Pci),
+                &["vmnet:bridged:ungranted-private-bridge"],
+            ),
+            contained_vmnet_authority_for_session(0x66, VmnetAuthority::denied()),
+        )
+        .expect("all-MMDS destination should not consume vmnet authority");
+        assert!(all.all_mmds());
+        assert!(
+            all.candidate().topology().interfaces()[0]
+                .mmds_stack()
+                .is_some()
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn exact_minor_eleven_value_failures_stop_before_every_provider_seam() {
+        let mut factory = RecordingVmnetPacketIoBackendFactory::default();
+        let events = factory.events();
+
+        let selector_error = prepare_process_snapshot_v2_network_restore_plan(
+            prepared_native_v2_network_restore_candidate(
+                fake_partial_mmds_network_state(),
+                &["vmnet:shared", "private-invalid-selector"],
+            ),
+            contained_vmnet_authority_for_session(0x67, VmnetAuthority::denied()),
+        )
+        .expect_err("invalid selector must fail before contained policy");
+        assert!(matches!(
+            selector_error,
+            ProcessSnapshotV2NetworkRestorePlanError::Selector { .. }
+        ));
+        assert!(recorded_events(&events).is_empty());
+
+        let all_mmds_selector_error = prepare_process_snapshot_v2_network_restore_plan(
+            prepared_native_v2_network_restore_candidate(
+                fake_native_v2_network_state(SnapshotV2DeviceTransportKind::Pci),
+                &["private-all-mmds-invalid-selector"],
+            ),
+            contained_vmnet_authority_for_session(0x68, VmnetAuthority::denied()),
+        )
+        .expect_err("all-MMDS destinations still require valid selector grammar");
+        assert!(matches!(
+            all_mmds_selector_error,
+            ProcessSnapshotV2NetworkRestorePlanError::Selector { .. }
+        ));
+        assert!(recorded_events(&events).is_empty());
+
+        let authority_error = prepare_process_snapshot_v2_network_restore_plan(
+            prepared_native_v2_network_restore_candidate(
+                fake_native_v2_network_state(SnapshotV2DeviceTransportKind::Mmio),
+                &["vmnet:shared"],
+            ),
+            contained_vmnet_authority_for_session(0x69, VmnetAuthority::denied()),
+        )
+        .expect_err("contained authority must reject host networking");
+        assert!(matches!(
+            authority_error,
+            ProcessSnapshotV2NetworkRestorePlanError::Authority(_)
+        ));
+        assert!(recorded_events(&events).is_empty());
+
+        let diagnostic = format!(
+            "{selector_error:?} {selector_error} {all_mmds_selector_error:?} \
+             {all_mmds_selector_error} {authority_error:?} {authority_error}"
+        );
+        assert!(!diagnostic.contains("private-invalid-selector"));
+        assert!(!diagnostic.contains("private-all-mmds-invalid-selector"));
+        assert!(!diagnostic.contains("ungranted-private-bridge"));
+
+        let _ = &mut factory;
     }
 
     #[test]

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -35148,10 +35148,7 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn exact_minor_eleven_value_failures_stop_before_every_provider_seam() {
-        let mut factory = RecordingVmnetPacketIoBackendFactory::default();
-        let events = factory.events();
-
+    fn exact_minor_eleven_value_failures_are_redacted_before_every_provider_seam() {
         let selector_error = prepare_process_snapshot_v2_network_restore_plan(
             prepared_native_v2_network_restore_candidate(
                 fake_partial_mmds_network_state(),
@@ -35164,7 +35161,6 @@ mod tests {
             selector_error,
             ProcessSnapshotV2NetworkRestorePlanError::Selector { .. }
         ));
-        assert!(recorded_events(&events).is_empty());
 
         let all_mmds_selector_error = prepare_process_snapshot_v2_network_restore_plan(
             prepared_native_v2_network_restore_candidate(
@@ -35178,7 +35174,6 @@ mod tests {
             all_mmds_selector_error,
             ProcessSnapshotV2NetworkRestorePlanError::Selector { .. }
         ));
-        assert!(recorded_events(&events).is_empty());
 
         let authority_error = prepare_process_snapshot_v2_network_restore_plan(
             prepared_native_v2_network_restore_candidate(
@@ -35192,7 +35187,6 @@ mod tests {
             authority_error,
             ProcessSnapshotV2NetworkRestorePlanError::Authority(_)
         ));
-        assert!(recorded_events(&events).is_empty());
 
         let diagnostic = format!(
             "{selector_error:?} {selector_error} {all_mmds_selector_error:?} \
@@ -35201,8 +35195,6 @@ mod tests {
         assert!(!diagnostic.contains("private-invalid-selector"));
         assert!(!diagnostic.contains("private-all-mmds-invalid-selector"));
         assert!(!diagnostic.contains("ungranted-private-bridge"));
-
-        let _ = &mut factory;
     }
 
     #[test]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -47,6 +47,7 @@ pub mod snapshot_format_v2;
 pub mod snapshot_memory;
 pub mod snapshot_memory_hotplug_v2_10;
 pub mod snapshot_memory_v2;
+pub mod snapshot_network_restore_v2_11;
 pub mod snapshot_network_v2_11;
 pub mod snapshot_restore;
 pub mod snapshot_serial_v2_7;

--- a/crates/runtime/src/network.rs
+++ b/crates/runtime/src/network.rs
@@ -567,6 +567,38 @@ impl NetworkInterfaceConfig {
         self.tx_rate_limiter
     }
 
+    /// Builds a controller projection from already typed snapshot fields.
+    ///
+    /// The caller supplies owned, fallibly copied identifiers. This keeps
+    /// snapshot restore from formatting a typed guest MAC back through an
+    /// untrusted string while retaining the ordinary controller validation.
+    pub(crate) fn try_from_snapshot_projection(
+        iface_id: String,
+        host_dev_name: String,
+        guest_mac: Option<GuestMacAddress>,
+        mtu: Option<u16>,
+        rx_rate_limiter: Option<NetworkRateLimiterConfig>,
+        tx_rate_limiter: Option<NetworkRateLimiterConfig>,
+    ) -> Result<Self, NetworkInterfaceConfigError> {
+        validate_interface_id(InterfaceIdSource::Path, &iface_id)?;
+        if host_dev_name.is_empty() {
+            return Err(NetworkInterfaceConfigError::EmptyHostDeviceName);
+        }
+        if let Some(mtu) = mtu
+            && !(VIRTIO_NET_MIN_MTU..=VIRTIO_NET_MAX_MTU).contains(&mtu)
+        {
+            return Err(NetworkInterfaceConfigError::InvalidMtu { mtu });
+        }
+        Ok(Self {
+            iface_id,
+            host_dev_name,
+            guest_mac,
+            mtu,
+            rx_rate_limiter: rx_rate_limiter.and_then(NetworkRateLimiterConfig::normalized),
+            tx_rate_limiter: tx_rate_limiter.and_then(NetworkRateLimiterConfig::normalized),
+        })
+    }
+
     fn updated(&self, update: &NetworkInterfaceUpdate) -> Self {
         Self {
             iface_id: self.iface_id.clone(),

--- a/crates/runtime/src/snapshot_artifact.rs
+++ b/crates/runtime/src/snapshot_artifact.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::memory::GuestMemory;
+use crate::snapshot::SnapshotNetworkOverride;
 use crate::snapshot_balloon_v2_9::{
     NATIVE_V2_BALLOON_STATE_COMPATIBILITY_VERSION, SnapshotV2BalloonState,
     SnapshotV2BalloonStateDecodeError,
@@ -72,10 +73,15 @@ use crate::snapshot_memory_v2::{
 use crate::snapshot_memory_v2::{
     load_snapshot_v2_memory_file, verify_snapshot_v2_memory_image_output,
 };
+use crate::snapshot_network_restore_v2_11::{
+    PreparedSnapshotV2NetworkRestoreTopology, SnapshotV2NetworkRestorePreparationError,
+    SnapshotV2NetworkRestorePreparationStage,
+};
 use crate::snapshot_network_v2_11::{
     NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION, SnapshotV2NetworkState,
     SnapshotV2NetworkStateDecodeError,
 };
+use crate::snapshot_restore::{SnapshotRestoreManifest, SnapshotRestoreManifestError};
 use crate::snapshot_serial_v2_7::{
     NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION, SnapshotV2SerialState,
     SnapshotV2SerialStateDecodeError,
@@ -1439,6 +1445,201 @@ pub type NativeV2NetworkSnapshotCandidateParts = (
     Option<SnapshotV2NetworkState>,
 );
 
+/// Exact-2.11 network preparation outcome before any host operation.
+pub enum NativeV2NetworkSnapshotPreparation {
+    /// The original candidate has no network component and no caller
+    /// overrides, so its compatible internal path remains unchanged.
+    Compatible(NativeV2NetworkSnapshotCandidateState),
+    /// The network-bearing candidate has a complete resource manifest and
+    /// immutable owner-free destination topology.
+    Prepared(PreparedNativeV2NetworkSnapshotCandidateState),
+}
+
+impl NativeV2NetworkSnapshotPreparation {
+    /// Returns the unchanged network-free candidate, when applicable.
+    pub const fn compatible(&self) -> Option<&NativeV2NetworkSnapshotCandidateState> {
+        match self {
+            Self::Compatible(candidate) => Some(candidate),
+            Self::Prepared(_) => None,
+        }
+    }
+
+    /// Returns the prepared network-bearing candidate, when applicable.
+    pub const fn prepared(&self) -> Option<&PreparedNativeV2NetworkSnapshotCandidateState> {
+        match self {
+            Self::Compatible(_) => None,
+            Self::Prepared(candidate) => Some(candidate),
+        }
+    }
+}
+
+impl fmt::Debug for NativeV2NetworkSnapshotPreparation {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let outcome = match self {
+            Self::Compatible(_) => "compatible",
+            Self::Prepared(_) => "prepared",
+        };
+        formatter
+            .debug_struct("NativeV2NetworkSnapshotPreparation")
+            .field("outcome", &outcome)
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// One network-bearing exact-2.11 candidate with owner-free restore topology.
+///
+/// All retained components came from the same immutable encoded state. This
+/// value owns no descriptor, provider, packet-I/O owner, callback, metric,
+/// datastore, platform slot, or VM authority.
+pub struct PreparedNativeV2NetworkSnapshotCandidateState {
+    bytes: Vec<u8>,
+    binding: SnapshotV2MemoryBinding,
+    device_graph: Option<SnapshotV2StorageDeviceGraph>,
+    serial: SnapshotV2SerialState,
+    entropy: Option<SnapshotV2EntropyState>,
+    balloon: Option<SnapshotV2BalloonState>,
+    memory_hotplug: Option<SnapshotV2MemoryHotplugState>,
+    topology: PreparedSnapshotV2NetworkRestoreTopology,
+    manifest: SnapshotRestoreManifest,
+}
+
+/// Owned exact components of one prepared network-bearing 2.11 candidate.
+pub type PreparedNativeV2NetworkSnapshotCandidateParts = (
+    Vec<u8>,
+    SnapshotV2MemoryBinding,
+    Option<SnapshotV2StorageDeviceGraph>,
+    SnapshotV2SerialState,
+    Option<SnapshotV2EntropyState>,
+    Option<SnapshotV2BalloonState>,
+    Option<SnapshotV2MemoryHotplugState>,
+    PreparedSnapshotV2NetworkRestoreTopology,
+    SnapshotRestoreManifest,
+);
+
+impl PreparedNativeV2NetworkSnapshotCandidateState {
+    /// Returns the exact candidate compatibility version.
+    pub const fn version(&self) -> SnapshotFormatVersion {
+        NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION
+    }
+
+    /// Returns the unchanged immutable encoded state bytes.
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Returns the memory commitment derived from the same bytes.
+    pub const fn memory_binding(&self) -> &SnapshotV2MemoryBinding {
+        &self.binding
+    }
+
+    /// Returns the optional unchanged exact-2.6 storage graph.
+    pub const fn device_graph(&self) -> Option<&SnapshotV2StorageDeviceGraph> {
+        self.device_graph.as_ref()
+    }
+
+    /// Returns the required unchanged exact-2.7 serial state.
+    pub const fn serial(&self) -> &SnapshotV2SerialState {
+        &self.serial
+    }
+
+    /// Returns the optional unchanged exact-2.8 entropy state.
+    pub const fn entropy(&self) -> Option<&SnapshotV2EntropyState> {
+        self.entropy.as_ref()
+    }
+
+    /// Returns the optional unchanged exact-2.9 balloon state.
+    pub const fn balloon(&self) -> Option<&SnapshotV2BalloonState> {
+        self.balloon.as_ref()
+    }
+
+    /// Returns the optional unchanged exact-2.10 virtio-mem state.
+    pub const fn memory_hotplug(&self) -> Option<&SnapshotV2MemoryHotplugState> {
+        self.memory_hotplug.as_ref()
+    }
+
+    /// Returns the immutable owner-free network/MMDS topology.
+    pub const fn topology(&self) -> &PreparedSnapshotV2NetworkRestoreTopology {
+        &self.topology
+    }
+
+    /// Returns the complete storage, serial, and network resource manifest.
+    pub const fn manifest(&self) -> &SnapshotRestoreManifest {
+        &self.manifest
+    }
+
+    /// Consumes the candidate into its exact still-detached components.
+    pub fn into_parts(self) -> PreparedNativeV2NetworkSnapshotCandidateParts {
+        (
+            self.bytes,
+            self.binding,
+            self.device_graph,
+            self.serial,
+            self.entropy,
+            self.balloon,
+            self.memory_hotplug,
+            self.topology,
+            self.manifest,
+        )
+    }
+}
+
+impl fmt::Debug for PreparedNativeV2NetworkSnapshotCandidateState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedNativeV2NetworkSnapshotCandidateState")
+            .field("version", &self.version())
+            .field("has_storage", &self.device_graph.is_some())
+            .field("has_entropy", &self.entropy.is_some())
+            .field("has_balloon", &self.balloon.is_some())
+            .field("has_memory_hotplug", &self.memory_hotplug.is_some())
+            .field("state", &REDACTED)
+            .field("memory_binding", &REDACTED)
+            .field("serial", &REDACTED)
+            .field("network_topology", &REDACTED)
+            .field("manifest", &REDACTED)
+            .finish()
+    }
+}
+
+/// Failure while preparing one exact-2.11 network artifact candidate.
+pub enum NativeV2NetworkSnapshotPreparationError {
+    /// Caller overrides were supplied without a saved network component.
+    OverridesWithoutNetwork,
+    /// The complete restore resource manifest could not be derived.
+    Manifest(SnapshotRestoreManifestError),
+    /// The owner-free destination topology could not be prepared.
+    Topology(SnapshotV2NetworkRestorePreparationError),
+}
+
+impl fmt::Debug for NativeV2NetworkSnapshotPreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+impl fmt::Display for NativeV2NetworkSnapshotPreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::OverridesWithoutNetwork => {
+                "native-v2 network overrides require saved network state"
+            }
+            Self::Manifest(_) => "native-v2 network restore manifest is invalid",
+            Self::Topology(_) => "native-v2 network restore topology is invalid",
+        })
+    }
+}
+
+impl std::error::Error for NativeV2NetworkSnapshotPreparationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::OverridesWithoutNetwork => None,
+            Self::Manifest(source) => Some(source),
+            Self::Topology(source) => Some(source),
+        }
+    }
+}
+
 impl NativeV2NetworkSnapshotCandidateState {
     /// Validates and retains one exact native-v2 2.11 state.
     pub fn from_network_state_v2_11(
@@ -1501,6 +1702,73 @@ impl NativeV2NetworkSnapshotCandidateState {
     /// Returns the optional exact-2.11 network/MMDS aggregate.
     pub const fn network(&self) -> Option<&SnapshotV2NetworkState> {
         self.network.as_ref()
+    }
+
+    /// Prepares a complete exact-2.11 network restore candidate.
+    ///
+    /// A network-free candidate is preserved unchanged only when the caller
+    /// also supplies no network overrides.
+    pub fn prepare(
+        self,
+        overrides: &[SnapshotNetworkOverride],
+    ) -> Result<NativeV2NetworkSnapshotPreparation, NativeV2NetworkSnapshotPreparationError> {
+        self.prepare_with_cancel(overrides, |_| false)
+    }
+
+    /// Prepares with stable owner-free topology cancellation checkpoints.
+    pub fn prepare_with_cancel<C>(
+        self,
+        overrides: &[SnapshotNetworkOverride],
+        is_cancelled: C,
+    ) -> Result<NativeV2NetworkSnapshotPreparation, NativeV2NetworkSnapshotPreparationError>
+    where
+        C: FnMut(SnapshotV2NetworkRestorePreparationStage) -> bool,
+    {
+        if self.network.is_none() {
+            if overrides.is_empty() {
+                return Ok(NativeV2NetworkSnapshotPreparation::Compatible(self));
+            }
+            return Err(NativeV2NetworkSnapshotPreparationError::OverridesWithoutNetwork);
+        }
+
+        let Self {
+            bytes,
+            binding,
+            device_graph,
+            serial,
+            entropy,
+            balloon,
+            memory_hotplug,
+            network,
+        } = self;
+        let network =
+            network.ok_or(NativeV2NetworkSnapshotPreparationError::OverridesWithoutNetwork)?;
+        let manifest = SnapshotRestoreManifest::try_from_native_v2_network_state(
+            device_graph.as_ref(),
+            &serial,
+            Some(&network),
+        )
+        .map_err(NativeV2NetworkSnapshotPreparationError::Manifest)?;
+        let topology = PreparedSnapshotV2NetworkRestoreTopology::prepare_with_cancel(
+            network,
+            overrides,
+            is_cancelled,
+        )
+        .map_err(NativeV2NetworkSnapshotPreparationError::Topology)?;
+
+        Ok(NativeV2NetworkSnapshotPreparation::Prepared(
+            PreparedNativeV2NetworkSnapshotCandidateState {
+                bytes,
+                binding,
+                device_graph,
+                serial,
+                entropy,
+                balloon,
+                memory_hotplug,
+                topology,
+                manifest,
+            },
+        ))
     }
 
     /// Consumes the candidate into its inseparable exact components.

--- a/crates/runtime/src/snapshot_artifact/tests.rs
+++ b/crates/runtime/src/snapshot_artifact/tests.rs
@@ -939,6 +939,129 @@ fn exact_minor_eleven_candidate_closes_every_optional_component_product() {
 
 #[cfg(target_os = "macos")]
 #[test]
+fn exact_minor_eleven_network_candidate_prepares_complete_owner_free_handoff() {
+    let network_payload = fixture_bytes(include_str!(
+        "../snapshot_network_v2_11/fixtures/inactive-mmio.hex"
+    ));
+    let candidate = exact_minor_eleven_candidate(Some(&network_payload));
+    let expected_bytes = candidate.bytes().to_vec();
+    let expected_binding = candidate.memory_binding().clone();
+    let expected_serial = candidate.serial().clone();
+    let network = candidate
+        .network()
+        .expect("fixture candidate should contain network state")
+        .clone();
+    let overrides = network
+        .interfaces()
+        .iter()
+        .map(|interface| SnapshotNetworkOverride::new(interface.iface_id(), "vmnet:shared"))
+        .collect::<Vec<_>>();
+
+    let preparation = candidate
+        .prepare(&overrides)
+        .expect("complete explicit override set should prepare");
+    assert!(preparation.compatible().is_none());
+    let prepared = preparation
+        .prepared()
+        .expect("network-bearing candidate should be prepared");
+    assert_eq!(prepared.bytes(), expected_bytes);
+    assert_eq!(prepared.memory_binding(), &expected_binding);
+    assert_eq!(prepared.serial(), &expected_serial);
+    assert!(prepared.device_graph().is_none());
+    assert!(prepared.entropy().is_none());
+    assert!(prepared.balloon().is_none());
+    assert!(prepared.memory_hotplug().is_none());
+    assert_eq!(
+        prepared.topology().interfaces().len(),
+        network.interfaces().len()
+    );
+    assert_eq!(prepared.manifest().len(), network.interfaces().len());
+    assert_eq!(
+        prepared.manifest().overrides().count(),
+        network.interfaces().len()
+    );
+    for (index, (entry, source)) in prepared
+        .topology()
+        .interfaces()
+        .iter()
+        .zip(network.interfaces())
+        .enumerate()
+    {
+        assert_eq!(entry.source_index(), u16::try_from(index).unwrap());
+        assert_eq!(entry.portable(), source);
+        assert_eq!(entry.controller().host_dev_name(), "vmnet:shared");
+        assert!(prepared.manifest().is_overridden(entry.resource_key()));
+    }
+    let debug = format!("{preparation:?} {prepared:?}");
+    assert!(debug.contains(REDACTED));
+    assert!(!debug.contains("vmnet:shared"));
+    assert!(!debug.contains(network.interfaces()[0].iface_id()));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn exact_minor_eleven_network_free_candidate_requires_empty_overrides() {
+    let compatible = exact_minor_eleven_candidate(None);
+    let expected_bytes = compatible.bytes().to_vec();
+    let preparation = compatible
+        .prepare(&[])
+        .expect("network-free candidate should preserve its compatible path");
+    assert!(preparation.prepared().is_none());
+    assert_eq!(
+        preparation
+            .compatible()
+            .expect("network-free candidate should remain compatible")
+            .bytes(),
+        expected_bytes
+    );
+
+    let error = exact_minor_eleven_candidate(None)
+        .prepare(&[SnapshotNetworkOverride::new(
+            "private-interface",
+            "vmnet:private-selector",
+        )])
+        .expect_err("override without saved network state must fail");
+    assert!(matches!(
+        error,
+        NativeV2NetworkSnapshotPreparationError::OverridesWithoutNetwork
+    ));
+    let diagnostic = format!("{error:?} {error}");
+    assert!(!diagnostic.contains("private-interface"));
+    assert!(!diagnostic.contains("private-selector"));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn exact_minor_eleven_candidate_propagates_stable_network_cancellation() {
+    let network_payload = fixture_bytes(include_str!(
+        "../snapshot_network_v2_11/fixtures/inactive-mmio.hex"
+    ));
+    let candidate = exact_minor_eleven_candidate(Some(&network_payload));
+    let overrides = candidate
+        .network()
+        .expect("fixture candidate should contain network state")
+        .interfaces()
+        .iter()
+        .map(|interface| SnapshotNetworkOverride::new(interface.iface_id(), "vmnet:shared"))
+        .collect::<Vec<_>>();
+    let error = candidate
+        .prepare_with_cancel(&overrides, |stage| {
+            stage == SnapshotV2NetworkRestorePreparationStage::Completion
+        })
+        .expect_err("completion cancellation must prevent publication");
+
+    assert!(matches!(
+        error,
+        NativeV2NetworkSnapshotPreparationError::Topology(
+            SnapshotV2NetworkRestorePreparationError::Cancelled {
+                stage: SnapshotV2NetworkRestorePreparationStage::Completion,
+            }
+        )
+    ));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
 fn exact_minor_eleven_candidate_rejects_invalid_or_non_singleton_network_components() {
     let memory = test_v2_memory();
     let mut image = Cursor::new(Vec::new());
@@ -2548,6 +2671,57 @@ fn fixture_bytes(hex: &str) -> Vec<u8> {
             u8::from_str_radix(pair, 16).expect("fixture hex should decode")
         })
         .collect()
+}
+
+#[cfg(target_os = "macos")]
+fn exact_minor_eleven_candidate(
+    network_payload: Option<&[u8]>,
+) -> NativeV2NetworkSnapshotCandidateState {
+    let memory = test_v2_memory();
+    let mut image = Cursor::new(Vec::new());
+    let binding = write_snapshot_v2_memory_image_with_compatibility_version(
+        &memory,
+        &mut image,
+        NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
+    )
+    .expect("exact-2.11 memory should encode internally");
+    let binding_payload = binding.encode().expect("memory binding should encode");
+    let serial_device = SerialMmioDevice::discarding()
+        .capture_state()
+        .expect("fixture serial device should capture");
+    let serial_payload = SnapshotV2SerialState::try_from_capture_ready(
+        CaptureReadySerialState::new(SerialConfig::default(), serial_device),
+    )
+    .expect("fixture serial state should validate")
+    .encode(NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION)
+    .expect("fixture serial state should encode");
+
+    let memory_component = SnapshotV2Component::new(
+        NATIVE_V2_MEMORY_COMPONENT_KEY,
+        SnapshotV2ComponentDisposition::Semantic,
+        &binding_payload,
+    );
+    let serial_component = SnapshotV2Component::new(
+        NATIVE_V2_SERIAL_COMPONENT_KEY,
+        SnapshotV2ComponentDisposition::Semantic,
+        &serial_payload,
+    );
+    let mut components = vec![memory_component, serial_component];
+    if let Some(network_payload) = network_payload {
+        components.push(SnapshotV2Component::new(
+            NATIVE_V2_NETWORK_COMPONENT_KEY,
+            SnapshotV2ComponentDisposition::Semantic,
+            network_payload,
+        ));
+    }
+    let bytes = encode_snapshot_v2_state_with_compatibility_version(
+        NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
+        &[],
+        &components,
+    )
+    .expect("exact-2.11 candidate should encode");
+    NativeV2NetworkSnapshotCandidateState::from_network_state_v2_11(bytes)
+        .expect("exact-2.11 candidate should close")
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/runtime/src/snapshot_device_v2.rs
+++ b/crates/runtime/src/snapshot_device_v2.rs
@@ -136,6 +136,7 @@ const PCI_QUEUE_VECTOR_BYTES: usize = 2;
 const DEVICE_KIND_BLOCK: u32 = 1;
 const DEVICE_KIND_PMEM: u32 = 2;
 const DEVICE_KIND_SERIAL: u32 = 3;
+const DEVICE_KIND_NETWORK: u32 = 4;
 const DEVICE_INSTANCE_ROOT: u32 = 0;
 const SECTION_KIND_CONFIG: u16 = 1;
 const SECTION_KIND_BLOCK: u16 = 2;
@@ -198,6 +199,13 @@ impl SnapshotV2DeviceKey {
         Self {
             kind: DEVICE_KIND_SERIAL,
             instance: 0,
+        }
+    }
+
+    pub(crate) const fn network(instance: u32) -> Self {
+        Self {
+            kind: DEVICE_KIND_NETWORK,
+            instance,
         }
     }
 

--- a/crates/runtime/src/snapshot_network_restore_v2_11.rs
+++ b/crates/runtime/src/snapshot_network_restore_v2_11.rs
@@ -1,0 +1,970 @@
+//! Host-operation-free exact-2.11 network destination preparation.
+
+use std::fmt;
+
+use crate::mmds::{MmdsConfig, MmdsConfigInput};
+use crate::network::{NetworkInterfaceConfig, NetworkRateLimiterConfig, NetworkTokenBucketConfig};
+use crate::snapshot::SnapshotNetworkOverride;
+use crate::snapshot_device_v2::SnapshotV2DeviceKey;
+use crate::snapshot_network_v2_11::{
+    NATIVE_V2_NETWORK_MAX_CAPTURED_SELECTOR_BYTES, NATIVE_V2_NETWORK_MAX_INTERFACE_ID_BYTES,
+    NATIVE_V2_NETWORK_MAX_INTERFACES, SnapshotV2MmdsInterfaceState, SnapshotV2MmdsState,
+    SnapshotV2NetworkInterfaceState, SnapshotV2NetworkLimiterState, SnapshotV2NetworkState,
+    SnapshotV2NetworkTokenBucketState,
+};
+use crate::snapshot_restore::{
+    SnapshotRestorePublicId, SnapshotRestorePublicIdError, SnapshotRestoreResourceClass,
+    SnapshotRestoreResourceKey,
+};
+
+const REDACTED: &str = "<redacted>";
+
+/// Stable cancellation checkpoints before an owner-free topology is published.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2NetworkRestorePreparationStage {
+    /// Before retaining any caller value.
+    Start,
+    /// Before validating and retaining one caller override.
+    Override,
+    /// Before projecting one destination controller entry.
+    Controller,
+    /// Before projecting global MMDS configuration.
+    Mmds,
+    /// After complete validation and before returning the immutable result.
+    Completion,
+}
+
+/// One exact destination entry paired with its portable continuation.
+#[derive(PartialEq, Eq)]
+pub struct PreparedSnapshotV2NetworkRestoreInterface {
+    source_index: u16,
+    resource_key: SnapshotRestoreResourceKey,
+    controller: NetworkInterfaceConfig,
+    portable: SnapshotV2NetworkInterfaceState,
+    mmds_stack: Option<SnapshotV2MmdsInterfaceState>,
+}
+
+impl PreparedSnapshotV2NetworkRestoreInterface {
+    /// Returns the saved configuration-order index.
+    pub const fn source_index(&self) -> u16 {
+        self.source_index
+    }
+
+    /// Returns the exact packet-I/O resource identity.
+    pub const fn resource_key(&self) -> &SnapshotRestoreResourceKey {
+        &self.resource_key
+    }
+
+    /// Returns destination controller configuration with the explicit selector.
+    pub const fn controller(&self) -> &NetworkInterfaceConfig {
+        &self.controller
+    }
+
+    /// Returns the unchanged portable device continuation.
+    pub const fn portable(&self) -> &SnapshotV2NetworkInterfaceState {
+        &self.portable
+    }
+
+    /// Returns the selected fresh-MMDS stack seed, when configured.
+    pub const fn mmds_stack(&self) -> Option<SnapshotV2MmdsInterfaceState> {
+        self.mmds_stack
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2NetworkRestoreInterface {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2NetworkRestoreInterface")
+            .field("source_index", &self.source_index)
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Immutable exact-2.11 network/controller/MMDS destination topology.
+///
+/// The value owns no descriptor, provider, packet owner, callback, metric,
+/// datastore, token, session, device, platform slot, or VM authority.
+#[derive(PartialEq, Eq)]
+pub struct PreparedSnapshotV2NetworkRestoreTopology {
+    interfaces: Vec<PreparedSnapshotV2NetworkRestoreInterface>,
+    mmds_state: Option<SnapshotV2MmdsState>,
+    mmds_controller: Option<MmdsConfig>,
+}
+
+impl PreparedSnapshotV2NetworkRestoreTopology {
+    /// Resolves one complete explicit override vector.
+    pub fn prepare(
+        state: SnapshotV2NetworkState,
+        overrides: &[SnapshotNetworkOverride],
+    ) -> Result<Self, SnapshotV2NetworkRestorePreparationError> {
+        prepare_network_restore_topology(state, overrides, |_| false, AllocationPolicy::System)
+    }
+
+    /// Resolves with stable cancellation checkpoints.
+    pub fn prepare_with_cancel<C>(
+        state: SnapshotV2NetworkState,
+        overrides: &[SnapshotNetworkOverride],
+        is_cancelled: C,
+    ) -> Result<Self, SnapshotV2NetworkRestorePreparationError>
+    where
+        C: FnMut(SnapshotV2NetworkRestorePreparationStage) -> bool,
+    {
+        prepare_network_restore_topology(state, overrides, is_cancelled, AllocationPolicy::System)
+    }
+
+    /// Returns interfaces in immutable saved configuration order.
+    pub fn interfaces(&self) -> &[PreparedSnapshotV2NetworkRestoreInterface] {
+        &self.interfaces
+    }
+
+    /// Returns the unchanged portable MMDS continuation.
+    pub const fn mmds_state(&self) -> Option<&SnapshotV2MmdsState> {
+        self.mmds_state.as_ref()
+    }
+
+    /// Returns destination MMDS controller configuration without live state.
+    pub const fn mmds_controller(&self) -> Option<&MmdsConfig> {
+        self.mmds_controller.as_ref()
+    }
+
+    /// Consumes the topology into still owner-free prepared parts.
+    pub fn into_parts(self) -> PreparedSnapshotV2NetworkRestoreTopologyParts {
+        (self.interfaces, self.mmds_state, self.mmds_controller)
+    }
+}
+
+/// Owned parts of one prepared exact-2.11 network destination topology.
+pub type PreparedSnapshotV2NetworkRestoreTopologyParts = (
+    Vec<PreparedSnapshotV2NetworkRestoreInterface>,
+    Option<SnapshotV2MmdsState>,
+    Option<MmdsConfig>,
+);
+
+impl fmt::Debug for PreparedSnapshotV2NetworkRestoreTopology {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2NetworkRestoreTopology")
+            .field("interface_count", &self.interfaces.len())
+            .field("mmds", &self.mmds_state.as_ref().map(|_| "<configured>"))
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Pure exact-2.11 destination-resolution failure.
+pub enum SnapshotV2NetworkRestorePreparationError {
+    /// More caller entries were supplied than the network ceiling.
+    TooManyOverrides,
+    /// A caller interface identifier is malformed or overlong.
+    InvalidInterfaceId,
+    /// A caller destination selector is empty, overlong, or contains controls.
+    InvalidDestinationSelector,
+    /// A caller interface does not exist in the saved network vector.
+    UnknownInterface,
+    /// More than one caller entry targets the same saved interface.
+    DuplicateInterface,
+    /// At least one saved interface has no explicit destination.
+    MissingInterface,
+    /// A destination controller projection contradicted validated portable state.
+    Controller,
+    /// A destination MMDS controller projection contradicted validated state.
+    Mmds,
+    /// A stable network resource public ID could not be retained.
+    ResourceId {
+        /// Public-ID validation or allocation failure.
+        source: SnapshotRestorePublicIdError,
+    },
+    /// Bounded topology storage could not be allocated.
+    Allocation,
+    /// Preparation was cancelled at a stable owner-free stage.
+    Cancelled {
+        /// The checkpoint that observed cancellation.
+        stage: SnapshotV2NetworkRestorePreparationStage,
+    },
+}
+
+impl fmt::Debug for SnapshotV2NetworkRestorePreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::TooManyOverrides => "SnapshotV2NetworkRestorePreparationError::TooManyOverrides",
+            Self::InvalidInterfaceId => {
+                "SnapshotV2NetworkRestorePreparationError::InvalidInterfaceId"
+            }
+            Self::InvalidDestinationSelector => {
+                "SnapshotV2NetworkRestorePreparationError::InvalidDestinationSelector"
+            }
+            Self::UnknownInterface => "SnapshotV2NetworkRestorePreparationError::UnknownInterface",
+            Self::DuplicateInterface => {
+                "SnapshotV2NetworkRestorePreparationError::DuplicateInterface"
+            }
+            Self::MissingInterface => "SnapshotV2NetworkRestorePreparationError::MissingInterface",
+            Self::Controller => "SnapshotV2NetworkRestorePreparationError::Controller",
+            Self::Mmds => "SnapshotV2NetworkRestorePreparationError::Mmds",
+            Self::ResourceId { .. } => "SnapshotV2NetworkRestorePreparationError::ResourceId",
+            Self::Allocation => "SnapshotV2NetworkRestorePreparationError::Allocation",
+            Self::Cancelled { .. } => "SnapshotV2NetworkRestorePreparationError::Cancelled",
+        })
+    }
+}
+
+impl fmt::Display for SnapshotV2NetworkRestorePreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::TooManyOverrides => "network snapshot override count exceeds its maximum",
+            Self::InvalidInterfaceId => "network snapshot override interface ID is invalid",
+            Self::InvalidDestinationSelector => {
+                "network snapshot override destination selector is invalid"
+            }
+            Self::UnknownInterface => "network snapshot override targets an unknown interface",
+            Self::DuplicateInterface => "network snapshot override interface is duplicated",
+            Self::MissingInterface => "network snapshot override set is incomplete",
+            Self::Controller => "network snapshot destination controller projection is invalid",
+            Self::Mmds => "network snapshot destination MMDS projection is invalid",
+            Self::ResourceId { .. } => "network snapshot resource identity is invalid",
+            Self::Allocation => "network snapshot destination allocation failed",
+            Self::Cancelled { .. } => "network snapshot destination preparation was cancelled",
+        })
+    }
+}
+
+impl std::error::Error for SnapshotV2NetworkRestorePreparationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::ResourceId { source } => Some(source),
+            Self::TooManyOverrides
+            | Self::InvalidInterfaceId
+            | Self::InvalidDestinationSelector
+            | Self::UnknownInterface
+            | Self::DuplicateInterface
+            | Self::MissingInterface
+            | Self::Controller
+            | Self::Mmds
+            | Self::Allocation
+            | Self::Cancelled { .. } => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AllocationFailure {
+    OverrideSlots,
+    DestinationSelector,
+    ControllerConfigs,
+    InterfaceId,
+    ResourceKeys,
+    MmdsInterfaceIds,
+    MmdsInterfaceId,
+    PreparedInterfaces,
+}
+
+#[derive(Clone, Copy)]
+enum AllocationPolicy {
+    System,
+    #[cfg(test)]
+    Fail(AllocationFailure),
+}
+
+impl AllocationPolicy {
+    fn fails(self, point: AllocationFailure) -> bool {
+        #[cfg(test)]
+        {
+            matches!(self, Self::Fail(failure) if failure == point)
+        }
+        #[cfg(not(test))]
+        {
+            let _ = (self, point);
+            false
+        }
+    }
+
+    fn reserve<T>(
+        self,
+        values: &mut Vec<T>,
+        count: usize,
+        point: AllocationFailure,
+    ) -> Result<(), SnapshotV2NetworkRestorePreparationError> {
+        if self.fails(point) {
+            return Err(SnapshotV2NetworkRestorePreparationError::Allocation);
+        }
+        values
+            .try_reserve_exact(count)
+            .map_err(|_| SnapshotV2NetworkRestorePreparationError::Allocation)
+    }
+
+    fn copy_string(
+        self,
+        value: &str,
+        point: AllocationFailure,
+    ) -> Result<String, SnapshotV2NetworkRestorePreparationError> {
+        if self.fails(point) {
+            return Err(SnapshotV2NetworkRestorePreparationError::Allocation);
+        }
+        let mut copy = String::new();
+        copy.try_reserve_exact(value.len())
+            .map_err(|_| SnapshotV2NetworkRestorePreparationError::Allocation)?;
+        copy.push_str(value);
+        Ok(copy)
+    }
+}
+
+fn prepare_network_restore_topology<C>(
+    state: SnapshotV2NetworkState,
+    overrides: &[SnapshotNetworkOverride],
+    mut is_cancelled: C,
+    allocation: AllocationPolicy,
+) -> Result<PreparedSnapshotV2NetworkRestoreTopology, SnapshotV2NetworkRestorePreparationError>
+where
+    C: FnMut(SnapshotV2NetworkRestorePreparationStage) -> bool,
+{
+    check_cancelled(
+        &mut is_cancelled,
+        SnapshotV2NetworkRestorePreparationStage::Start,
+    )?;
+    if overrides.len() > NATIVE_V2_NETWORK_MAX_INTERFACES {
+        return Err(SnapshotV2NetworkRestorePreparationError::TooManyOverrides);
+    }
+
+    let interfaces = state.interfaces();
+    let mut destinations = Vec::new();
+    allocation.reserve(
+        &mut destinations,
+        interfaces.len(),
+        AllocationFailure::OverrideSlots,
+    )?;
+    destinations.resize_with(interfaces.len(), || None);
+
+    for requested in overrides {
+        check_cancelled(
+            &mut is_cancelled,
+            SnapshotV2NetworkRestorePreparationStage::Override,
+        )?;
+        validate_requested_interface_id(requested.iface_id())?;
+        validate_destination_selector(requested.host_dev_name())?;
+        let index = interfaces
+            .iter()
+            .position(|interface| interface.iface_id() == requested.iface_id())
+            .ok_or(SnapshotV2NetworkRestorePreparationError::UnknownInterface)?;
+        let slot = destinations
+            .get_mut(index)
+            .ok_or(SnapshotV2NetworkRestorePreparationError::UnknownInterface)?;
+        if slot.is_some() {
+            return Err(SnapshotV2NetworkRestorePreparationError::DuplicateInterface);
+        }
+        *slot = Some(allocation.copy_string(
+            requested.host_dev_name(),
+            AllocationFailure::DestinationSelector,
+        )?);
+    }
+    if destinations.iter().any(Option::is_none) {
+        return Err(SnapshotV2NetworkRestorePreparationError::MissingInterface);
+    }
+
+    let mut controllers = Vec::new();
+    allocation.reserve(
+        &mut controllers,
+        interfaces.len(),
+        AllocationFailure::ControllerConfigs,
+    )?;
+    let mut resource_keys = Vec::new();
+    allocation.reserve(
+        &mut resource_keys,
+        interfaces.len(),
+        AllocationFailure::ResourceKeys,
+    )?;
+    for (index, (interface, destination)) in interfaces.iter().zip(destinations).enumerate() {
+        check_cancelled(
+            &mut is_cancelled,
+            SnapshotV2NetworkRestorePreparationStage::Controller,
+        )?;
+        let iface_id =
+            allocation.copy_string(interface.iface_id(), AllocationFailure::InterfaceId)?;
+        let controller = NetworkInterfaceConfig::try_from_snapshot_projection(
+            iface_id,
+            destination.ok_or(SnapshotV2NetworkRestorePreparationError::MissingInterface)?,
+            interface.requested_guest_mac(),
+            interface.requested_mtu(),
+            limiter_config(interface.rx_limiter()),
+            limiter_config(interface.tx_limiter()),
+        )
+        .map_err(|_| SnapshotV2NetworkRestorePreparationError::Controller)?;
+        let public_id = SnapshotRestorePublicId::try_from(interface.iface_id())
+            .map_err(|source| SnapshotV2NetworkRestorePreparationError::ResourceId { source })?;
+        let instance = u32::try_from(index)
+            .map_err(|_| SnapshotV2NetworkRestorePreparationError::Controller)?;
+        resource_keys.push(SnapshotRestoreResourceKey::new(
+            SnapshotV2DeviceKey::network(instance),
+            public_id,
+            SnapshotRestoreResourceClass::NetworkPacketIo,
+        ));
+        controllers.push(controller);
+    }
+
+    check_cancelled(
+        &mut is_cancelled,
+        SnapshotV2NetworkRestorePreparationStage::Mmds,
+    )?;
+    let mmds_controller = state
+        .mmds()
+        .map(|mmds| {
+            let mut selected = Vec::new();
+            allocation.reserve(
+                &mut selected,
+                mmds.interfaces().len(),
+                AllocationFailure::MmdsInterfaceIds,
+            )?;
+            for selected_interface in mmds.interfaces() {
+                let interface = interfaces
+                    .get(usize::from(selected_interface.interface_index()))
+                    .ok_or(SnapshotV2NetworkRestorePreparationError::Mmds)?;
+                selected.push(
+                    allocation
+                        .copy_string(interface.iface_id(), AllocationFailure::MmdsInterfaceId)?,
+                );
+            }
+            let mut input = MmdsConfigInput::new(selected)
+                .with_version(mmds.version())
+                .with_imds_compat(mmds.imds_compat());
+            if let Some(address) = mmds.ipv4_address() {
+                input = input.with_ipv4_address(address);
+            }
+            input
+                .validate(&controllers)
+                .map_err(|_| SnapshotV2NetworkRestorePreparationError::Mmds)
+        })
+        .transpose()?;
+
+    let (portable_interfaces, mmds_state) = state.into_parts();
+    let mut prepared_interfaces = Vec::new();
+    allocation.reserve(
+        &mut prepared_interfaces,
+        portable_interfaces.len(),
+        AllocationFailure::PreparedInterfaces,
+    )?;
+    for (index, ((portable, controller), resource_key)) in portable_interfaces
+        .into_iter()
+        .zip(controllers)
+        .zip(resource_keys)
+        .enumerate()
+    {
+        let source_index = u16::try_from(index)
+            .map_err(|_| SnapshotV2NetworkRestorePreparationError::Controller)?;
+        let mmds_stack = mmds_state.as_ref().and_then(|mmds| {
+            mmds.interfaces()
+                .iter()
+                .copied()
+                .find(|entry| entry.interface_index() == source_index)
+        });
+        prepared_interfaces.push(PreparedSnapshotV2NetworkRestoreInterface {
+            source_index,
+            resource_key,
+            controller,
+            portable,
+            mmds_stack,
+        });
+    }
+
+    check_cancelled(
+        &mut is_cancelled,
+        SnapshotV2NetworkRestorePreparationStage::Completion,
+    )?;
+    Ok(PreparedSnapshotV2NetworkRestoreTopology {
+        interfaces: prepared_interfaces,
+        mmds_state,
+        mmds_controller,
+    })
+}
+
+fn check_cancelled<C>(
+    is_cancelled: &mut C,
+    stage: SnapshotV2NetworkRestorePreparationStage,
+) -> Result<(), SnapshotV2NetworkRestorePreparationError>
+where
+    C: FnMut(SnapshotV2NetworkRestorePreparationStage) -> bool,
+{
+    if is_cancelled(stage) {
+        Err(SnapshotV2NetworkRestorePreparationError::Cancelled { stage })
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_requested_interface_id(
+    iface_id: &str,
+) -> Result<(), SnapshotV2NetworkRestorePreparationError> {
+    if iface_id.is_empty()
+        || iface_id.len() > NATIVE_V2_NETWORK_MAX_INTERFACE_ID_BYTES
+        || !iface_id
+            .chars()
+            .all(|character| character == '_' || character.is_alphanumeric())
+    {
+        Err(SnapshotV2NetworkRestorePreparationError::InvalidInterfaceId)
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_destination_selector(
+    selector: &str,
+) -> Result<(), SnapshotV2NetworkRestorePreparationError> {
+    if selector.is_empty()
+        || selector.len() > NATIVE_V2_NETWORK_MAX_CAPTURED_SELECTOR_BYTES
+        || selector.chars().any(char::is_control)
+    {
+        Err(SnapshotV2NetworkRestorePreparationError::InvalidDestinationSelector)
+    } else {
+        Ok(())
+    }
+}
+
+fn limiter_config(limiter: SnapshotV2NetworkLimiterState) -> Option<NetworkRateLimiterConfig> {
+    let configured = NetworkRateLimiterConfig::new(
+        limiter.bandwidth().map(token_bucket_config),
+        limiter.ops().map(token_bucket_config),
+    );
+    configured.is_configured().then_some(configured)
+}
+
+fn token_bucket_config(bucket: SnapshotV2NetworkTokenBucketState) -> NetworkTokenBucketConfig {
+    NetworkTokenBucketConfig::new(
+        bucket.size(),
+        bucket.configured_burst(),
+        bucket.refill_time_millis(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interrupt::GuestInterruptLine;
+    use crate::memory::GuestAddress;
+    use crate::mmio::{MmioRegion, MmioRegionId};
+    use crate::network::{GuestMacAddress, NetworkDeviceProfile};
+    use crate::snapshot_device_v2::{SnapshotV2DeviceTransport, SnapshotV2MmioDeviceState};
+    use crate::snapshot_format::SnapshotFormatVersion;
+    use crate::snapshot_network_v2_11::{
+        SnapshotV2NetworkBackendClass, SnapshotV2NetworkInterfaceStateParts,
+    };
+    use crate::virtio_mmio::VIRTIO_MMIO_DEVICE_WINDOW_SIZE;
+
+    fn fixture_bytes(fixture: &str) -> Vec<u8> {
+        let compact = fixture.split_ascii_whitespace().collect::<String>();
+        compact
+            .as_bytes()
+            .chunks_exact(2)
+            .map(|pair| {
+                u8::from_str_radix(
+                    std::str::from_utf8(pair).expect("fixture should be ASCII"),
+                    16,
+                )
+                .expect("fixture should contain hexadecimal bytes")
+            })
+            .collect()
+    }
+
+    fn fixture(path: &str) -> SnapshotV2NetworkState {
+        let fixture = match path {
+            "inactive" => include_str!("snapshot_network_v2_11/fixtures/inactive-mmio.hex"),
+            "active" => include_str!("snapshot_network_v2_11/fixtures/active-pci-mmds.hex"),
+            _ => panic!("unknown fixture"),
+        };
+        SnapshotV2NetworkState::decode(
+            SnapshotFormatVersion::new(2, 11, 0),
+            &fixture_bytes(fixture),
+        )
+        .expect("network fixture should decode")
+    }
+
+    fn exact_overrides(state: &SnapshotV2NetworkState) -> Vec<SnapshotNetworkOverride> {
+        state
+            .interfaces()
+            .iter()
+            .map(|interface| SnapshotNetworkOverride::new(interface.iface_id(), "vmnet:shared"))
+            .collect()
+    }
+
+    fn inactive_state_with_interface_count(count: usize) -> SnapshotV2NetworkState {
+        let fixture = fixture("inactive");
+        let source = &fixture.interfaces()[0];
+        let SnapshotV2DeviceTransport::Mmio(mmio) = source.transport() else {
+            panic!("inactive fixture should use MMIO");
+        };
+        let interfaces = (0..count)
+            .map(|index| {
+                let index_u64 = u64::try_from(index).expect("test index should fit");
+                let region = MmioRegion::new(
+                    MmioRegionId::new(
+                        mmio.region()
+                            .id()
+                            .raw_value()
+                            .checked_add(index_u64)
+                            .expect("test region ID should fit"),
+                    ),
+                    GuestAddress::new(
+                        mmio.region()
+                            .range()
+                            .start()
+                            .raw_value()
+                            .checked_add(index_u64 * VIRTIO_MMIO_DEVICE_WINDOW_SIZE)
+                            .expect("test MMIO placement should fit"),
+                    ),
+                    VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+                )
+                .expect("test MMIO region should validate");
+                let guest_mac = GuestMacAddress::from_bytes([
+                    0x02,
+                    0,
+                    0,
+                    0,
+                    0x60,
+                    u8::try_from(index).expect("test MAC index should fit"),
+                ]);
+                SnapshotV2NetworkInterfaceState::try_from_parts(
+                    SnapshotV2NetworkInterfaceStateParts {
+                        iface_id: format!("eth{index}"),
+                        captured_selector: format!("captured{index}"),
+                        requested_guest_mac: Some(guest_mac),
+                        requested_mtu: source.requested_mtu(),
+                        profile: NetworkDeviceProfile::new(Some(guest_mac), source.requested_mtu()),
+                        backend: SnapshotV2NetworkBackendClass::Vmnet,
+                        local: source.local().clone(),
+                        virtio: source.virtio().clone(),
+                        rx_limiter: source.rx_limiter(),
+                        tx_limiter: source.tx_limiter(),
+                        transport: SnapshotV2DeviceTransport::Mmio(
+                            SnapshotV2MmioDeviceState::from_parts(
+                                mmio.device_feature_select(),
+                                mmio.driver_feature_select(),
+                                mmio.queue_select(),
+                                region,
+                                GuestInterruptLine::new(
+                                    mmio.interrupt_line()
+                                        .raw_value()
+                                        .checked_add(u32::try_from(index).unwrap())
+                                        .expect("test interrupt should fit"),
+                                )
+                                .expect("test interrupt should validate"),
+                            ),
+                        ),
+                    },
+                )
+                .expect("expanded test interface should validate")
+            })
+            .collect::<Vec<_>>();
+
+        SnapshotV2NetworkState::try_new(interfaces, None)
+            .expect("expanded network state should validate")
+    }
+
+    #[test]
+    fn complete_overrides_prepare_redacted_controller_and_resource_topology() {
+        let state = fixture("active");
+        let original = state.clone();
+        let overrides = exact_overrides(&state);
+        let prepared = PreparedSnapshotV2NetworkRestoreTopology::prepare(state, &overrides)
+            .expect("complete overrides should prepare");
+
+        assert_eq!(prepared.interfaces().len(), original.interfaces().len());
+        for (index, (entry, portable)) in prepared
+            .interfaces()
+            .iter()
+            .zip(original.interfaces())
+            .enumerate()
+        {
+            assert_eq!(entry.source_index(), u16::try_from(index).unwrap());
+            assert_eq!(entry.portable(), portable);
+            assert_eq!(entry.controller().iface_id(), portable.iface_id());
+            assert_eq!(entry.controller().host_dev_name(), "vmnet:shared");
+            assert_eq!(
+                entry.resource_key().resource_class(),
+                SnapshotRestoreResourceClass::NetworkPacketIo
+            );
+            assert_eq!(
+                entry.resource_key().device_key().kind(),
+                SnapshotV2DeviceKey::network(0).kind()
+            );
+            assert_eq!(
+                entry.resource_key().device_key().instance(),
+                u32::try_from(index).unwrap()
+            );
+            assert_eq!(
+                entry.resource_key().public_id().as_str(),
+                portable.iface_id()
+            );
+        }
+        assert_eq!(prepared.mmds_state(), original.mmds());
+        assert_eq!(
+            prepared
+                .mmds_controller()
+                .expect("active fixture has MMDS")
+                .network_interfaces(),
+            &["eth0".to_string()]
+        );
+        let debug = format!("{prepared:?}");
+        assert!(debug.contains(REDACTED));
+        assert!(!debug.contains("vmnet:shared"));
+        assert!(!debug.contains("eth0"));
+    }
+
+    #[test]
+    fn caller_order_and_same_string_destination_are_explicit_but_canonical() {
+        let state = fixture("active");
+        let mut overrides = exact_overrides(&state);
+        for (requested, interface) in overrides.iter_mut().zip(state.interfaces()) {
+            *requested =
+                SnapshotNetworkOverride::new(interface.iface_id(), interface.captured_selector());
+        }
+        overrides.reverse();
+        let prepared = PreparedSnapshotV2NetworkRestoreTopology::prepare(state.clone(), &overrides)
+            .expect("same-string explicit destinations should prepare");
+        assert!(
+            prepared
+                .interfaces()
+                .iter()
+                .zip(state.interfaces())
+                .all(|(entry, source)| {
+                    entry.controller().iface_id() == source.iface_id()
+                        && entry.controller().host_dev_name() == source.captured_selector()
+                })
+        );
+        assert_eq!(overrides, {
+            let mut copy = exact_overrides(&state);
+            for (requested, interface) in copy.iter_mut().zip(state.interfaces()) {
+                *requested = SnapshotNetworkOverride::new(
+                    interface.iface_id(),
+                    interface.captured_selector(),
+                );
+            }
+            copy.reverse();
+            copy
+        });
+    }
+
+    #[test]
+    fn one_and_sixteen_interface_permutations_remain_canonical_and_complete() {
+        for count in [1, NATIVE_V2_NETWORK_MAX_INTERFACES] {
+            let state = inactive_state_with_interface_count(count);
+            let original = state.clone();
+            let mut overrides = state
+                .interfaces()
+                .iter()
+                .map(|interface| {
+                    SnapshotNetworkOverride::new(
+                        interface.iface_id(),
+                        interface.captured_selector(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            overrides.reverse();
+            let caller_copy = overrides.clone();
+
+            let prepared =
+                PreparedSnapshotV2NetworkRestoreTopology::prepare(state.clone(), &overrides)
+                    .expect("complete reversed boundary set should prepare");
+            let retry = PreparedSnapshotV2NetworkRestoreTopology::prepare(state, &overrides)
+                .expect("unchanged boundary set should prepare repeatedly");
+            assert_eq!(prepared, retry);
+            assert_eq!(overrides, caller_copy);
+            assert_eq!(prepared.interfaces().len(), count);
+            for (index, (entry, source)) in prepared
+                .interfaces()
+                .iter()
+                .zip(original.interfaces())
+                .enumerate()
+            {
+                assert_eq!(entry.source_index(), u16::try_from(index).unwrap());
+                assert_eq!(entry.portable(), source);
+                assert_eq!(
+                    entry.controller().host_dev_name(),
+                    source.captured_selector()
+                );
+                assert_eq!(
+                    entry.resource_key().device_key().instance(),
+                    u32::try_from(index).unwrap()
+                );
+                assert_eq!(entry.resource_key().public_id().as_str(), source.iface_id());
+            }
+        }
+    }
+
+    #[test]
+    fn malformed_unknown_duplicate_missing_and_oversized_sets_fail() {
+        let state = fixture("active");
+        let iface = state.interfaces()[0].iface_id();
+        for (overrides, expected) in [
+            (
+                vec![],
+                SnapshotV2NetworkRestorePreparationError::MissingInterface,
+            ),
+            (
+                vec![SnapshotNetworkOverride::new("missing", "vmnet:shared")],
+                SnapshotV2NetworkRestorePreparationError::UnknownInterface,
+            ),
+            (
+                vec![
+                    SnapshotNetworkOverride::new(iface, "vmnet:shared"),
+                    SnapshotNetworkOverride::new(iface, "vmnet:host"),
+                ],
+                SnapshotV2NetworkRestorePreparationError::DuplicateInterface,
+            ),
+            (
+                vec![SnapshotNetworkOverride::new("", "vmnet:shared")],
+                SnapshotV2NetworkRestorePreparationError::InvalidInterfaceId,
+            ),
+            (
+                vec![SnapshotNetworkOverride::new(iface, "bad\nselector")],
+                SnapshotV2NetworkRestorePreparationError::InvalidDestinationSelector,
+            ),
+        ] {
+            let caller_copy = overrides.clone();
+            let error =
+                PreparedSnapshotV2NetworkRestoreTopology::prepare(state.clone(), &overrides)
+                    .expect_err("invalid override set should fail");
+            assert_eq!(overrides, caller_copy);
+            assert_eq!(format!("{error:?}"), format!("{expected:?}"));
+            let diagnostic = format!("{error:?} {error}");
+            assert!(!diagnostic.contains(iface));
+            assert!(!diagnostic.contains("bad"));
+            assert!(!diagnostic.contains("vmnet:"));
+        }
+
+        let too_many = (0..=NATIVE_V2_NETWORK_MAX_INTERFACES)
+            .map(|index| SnapshotNetworkOverride::new(format!("eth{index}"), "vmnet:shared"))
+            .collect::<Vec<_>>();
+        assert!(matches!(
+            PreparedSnapshotV2NetworkRestoreTopology::prepare(state, &too_many),
+            Err(SnapshotV2NetworkRestorePreparationError::TooManyOverrides)
+        ));
+    }
+
+    #[test]
+    fn overlong_and_type_invalid_override_values_fail_before_projection() {
+        let state = fixture("inactive");
+        let iface_id = state.interfaces()[0].iface_id();
+        for (overrides, expected) in [
+            (
+                vec![SnapshotNetworkOverride::new(
+                    "a".repeat(NATIVE_V2_NETWORK_MAX_INTERFACE_ID_BYTES + 1),
+                    "vmnet:shared",
+                )],
+                SnapshotV2NetworkRestorePreparationError::InvalidInterfaceId,
+            ),
+            (
+                vec![SnapshotNetworkOverride::new("eth-invalid", "vmnet:shared")],
+                SnapshotV2NetworkRestorePreparationError::InvalidInterfaceId,
+            ),
+            (
+                vec![SnapshotNetworkOverride::new(
+                    iface_id,
+                    "a".repeat(NATIVE_V2_NETWORK_MAX_CAPTURED_SELECTOR_BYTES + 1),
+                )],
+                SnapshotV2NetworkRestorePreparationError::InvalidDestinationSelector,
+            ),
+            (
+                vec![SnapshotNetworkOverride::new(iface_id, "")],
+                SnapshotV2NetworkRestorePreparationError::InvalidDestinationSelector,
+            ),
+        ] {
+            let caller_copy = overrides.clone();
+            let error =
+                PreparedSnapshotV2NetworkRestoreTopology::prepare(state.clone(), &overrides)
+                    .expect_err("invalid bounded override should fail");
+            assert_eq!(overrides, caller_copy);
+            assert_eq!(format!("{error:?}"), format!("{expected:?}"));
+        }
+    }
+
+    #[test]
+    fn every_stable_cancellation_checkpoint_prevents_publication() {
+        for target in [
+            SnapshotV2NetworkRestorePreparationStage::Start,
+            SnapshotV2NetworkRestorePreparationStage::Override,
+            SnapshotV2NetworkRestorePreparationStage::Controller,
+            SnapshotV2NetworkRestorePreparationStage::Mmds,
+            SnapshotV2NetworkRestorePreparationStage::Completion,
+        ] {
+            let state = fixture("active");
+            let source = state.clone();
+            let overrides = exact_overrides(&state);
+            let error = PreparedSnapshotV2NetworkRestoreTopology::prepare_with_cancel(
+                state,
+                &overrides,
+                |stage| stage == target,
+            )
+            .expect_err("targeted cancellation should fail");
+            assert!(matches!(
+                error,
+                SnapshotV2NetworkRestorePreparationError::Cancelled { stage } if stage == target
+            ));
+            assert_eq!(source, fixture("active"));
+        }
+    }
+
+    #[test]
+    fn every_injected_allocation_failure_is_redacted() {
+        for point in [
+            AllocationFailure::OverrideSlots,
+            AllocationFailure::DestinationSelector,
+            AllocationFailure::ControllerConfigs,
+            AllocationFailure::InterfaceId,
+            AllocationFailure::ResourceKeys,
+            AllocationFailure::MmdsInterfaceIds,
+            AllocationFailure::MmdsInterfaceId,
+            AllocationFailure::PreparedInterfaces,
+        ] {
+            let state = fixture("active");
+            let overrides = exact_overrides(&state);
+            let error = prepare_network_restore_topology(
+                state,
+                &overrides,
+                |_| false,
+                AllocationPolicy::Fail(point),
+            )
+            .expect_err("injected allocation failure should fail");
+            assert!(matches!(
+                error,
+                SnapshotV2NetworkRestorePreparationError::Allocation
+            ));
+            assert!(!format!("{error:?} {error}").contains("vmnet:shared"));
+        }
+    }
+
+    #[test]
+    fn controller_projection_preserves_requested_not_realized_configuration() {
+        let state = fixture("active");
+        let expected = state.interfaces()[0].clone();
+        let prepared = PreparedSnapshotV2NetworkRestoreTopology::prepare(
+            state.clone(),
+            &exact_overrides(&state),
+        )
+        .expect("fixture should prepare");
+        let controller = prepared.interfaces()[0].controller();
+        assert_eq!(controller.guest_mac(), expected.requested_guest_mac());
+        assert_eq!(controller.mtu(), expected.requested_mtu());
+        assert_eq!(
+            controller
+                .rx_rate_limiter()
+                .and_then(NetworkRateLimiterConfig::bandwidth),
+            expected.rx_limiter().bandwidth().map(token_bucket_config)
+        );
+        assert_eq!(
+            controller
+                .rx_rate_limiter()
+                .and_then(NetworkRateLimiterConfig::ops),
+            expected.rx_limiter().ops().map(token_bucket_config)
+        );
+        assert_eq!(
+            controller
+                .tx_rate_limiter()
+                .and_then(NetworkRateLimiterConfig::bandwidth),
+            expected.tx_limiter().bandwidth().map(token_bucket_config)
+        );
+        assert_eq!(
+            controller
+                .tx_rate_limiter()
+                .and_then(NetworkRateLimiterConfig::ops),
+            expected.tx_limiter().ops().map(token_bucket_config)
+        );
+        assert_eq!(prepared.interfaces()[0].portable(), &expected);
+    }
+}

--- a/crates/runtime/src/snapshot_network_v2_11.rs
+++ b/crates/runtime/src/snapshot_network_v2_11.rs
@@ -626,6 +626,12 @@ pub struct SnapshotV2NetworkState {
     mmds: Option<SnapshotV2MmdsState>,
 }
 
+/// Owned parts of one validated exact-2.11 network aggregate.
+pub type SnapshotV2NetworkStateParts = (
+    Vec<SnapshotV2NetworkInterfaceState>,
+    Option<SnapshotV2MmdsState>,
+);
+
 impl SnapshotV2NetworkState {
     /// Validates and retains one complete aggregate.
     pub fn try_new(
@@ -643,6 +649,11 @@ impl SnapshotV2NetworkState {
 
     pub const fn mmds(&self) -> Option<&SnapshotV2MmdsState> {
         self.mmds.as_ref()
+    }
+
+    /// Consumes the aggregate without changing interface or MMDS order.
+    pub fn into_parts(self) -> SnapshotV2NetworkStateParts {
+        (self.interfaces, self.mmds)
     }
 
     pub const fn compatibility_version(&self) -> SnapshotFormatVersion {

--- a/crates/runtime/src/snapshot_restore.rs
+++ b/crates/runtime/src/snapshot_restore.rs
@@ -9,6 +9,7 @@ use crate::snapshot_device_v2::{
     SnapshotV2DeviceGraph, SnapshotV2DeviceKey,
 };
 use crate::snapshot_device_v2_6::SnapshotV2StorageDeviceGraph;
+use crate::snapshot_network_v2_11::SnapshotV2NetworkState;
 use crate::snapshot_serial_v2_7::SnapshotV2SerialState;
 
 /// Maximum number of logical resources in one snapshot restore transaction.
@@ -129,6 +130,21 @@ fn validate_public_id(value: &str) -> Result<(), SnapshotRestorePublicIdError> {
     Ok(())
 }
 
+fn checked_native_v2_network_resource_count(
+    storage_count: usize,
+    serial_count: usize,
+    network_count: usize,
+) -> Result<usize, SnapshotRestoreManifestError> {
+    let resource_count = storage_count
+        .checked_add(serial_count)
+        .and_then(|count| count.checked_add(network_count))
+        .ok_or(SnapshotRestoreManifestError::TooManyResources)?;
+    if resource_count > MAX_SNAPSHOT_RESTORE_RESOURCES {
+        return Err(SnapshotRestoreManifestError::TooManyResources);
+    }
+    Ok(resource_count)
+}
+
 /// Closed logical class of one snapshot restore resource.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SnapshotRestoreResourceClass {
@@ -140,11 +156,13 @@ pub enum SnapshotRestoreResourceClass {
     VsockEndpoint,
     /// Destination output for the restored singleton serial device.
     SerialSink,
+    /// Fresh packet-I/O owner for one restored network interface.
+    NetworkPacketIo,
 }
 
 impl SnapshotRestoreResourceClass {
     const fn accepts_override(self) -> bool {
-        matches!(self, Self::VsockEndpoint)
+        matches!(self, Self::VsockEndpoint | Self::NetworkPacketIo)
     }
 }
 
@@ -227,9 +245,10 @@ pub struct SnapshotRestoreManifest {
 impl SnapshotRestoreManifest {
     /// Builds and validates one canonical logical manifest.
     ///
-    /// `overrides` contains value-free exact resource keys whose already
-    /// normalized destination differs from captured state. The final manifest
-    /// retains only canonical resource indices, never another public-ID copy.
+    /// `overrides` contains value-free exact resource keys with an explicit
+    /// destination binding. A binding may deliberately name the same logical
+    /// selector as captured state. The final manifest retains only canonical
+    /// resource indices, never another public-ID copy.
     pub fn try_new(
         resources: Vec<SnapshotRestoreResourceKey>,
         overrides: Vec<SnapshotRestoreResourceKey>,
@@ -350,6 +369,81 @@ impl SnapshotRestoreManifest {
             ));
         }
         Self::try_new(resources, Vec::new())
+    }
+
+    /// Derives the complete exact-2.11 storage, configured-serial, and network
+    /// resource set.
+    ///
+    /// Every network interface has one explicit destination binding even when
+    /// the caller deliberately selects the captured logical name. Network keys
+    /// use stable kind 4 and configuration-order instances. The unchanged
+    /// 64-entry limit applies to the aggregate rather than to each component's
+    /// independent maximum.
+    pub fn try_from_native_v2_network_state(
+        graph: Option<&SnapshotV2StorageDeviceGraph>,
+        serial: &SnapshotV2SerialState,
+        network: Option<&SnapshotV2NetworkState>,
+    ) -> Result<Self, SnapshotRestoreManifestError> {
+        let storage_count = graph.map_or(0, SnapshotV2StorageDeviceGraph::record_count);
+        let serial_count = usize::from(serial.endpoint_intent().configured_selector().is_some());
+        let network_count = network.map_or(0, |state| state.interfaces().len());
+        let resource_count =
+            checked_native_v2_network_resource_count(storage_count, serial_count, network_count)?;
+
+        let mut resources = Vec::new();
+        resources
+            .try_reserve_exact(resource_count)
+            .map_err(|source| SnapshotRestoreManifestError::AllocationFailed { source })?;
+        if let Some(graph) = graph {
+            for record in graph.block_records() {
+                let public_id = SnapshotRestorePublicId::try_from(record.config().drive_id())
+                    .map_err(|source| SnapshotRestoreManifestError::PublicId { source })?;
+                resources.push(SnapshotRestoreResourceKey::new(
+                    record.key(),
+                    public_id,
+                    SnapshotRestoreResourceClass::BlockBacking,
+                ));
+            }
+            for record in graph.pmem_records() {
+                let public_id = SnapshotRestorePublicId::try_from(record.config().pmem_id())
+                    .map_err(|source| SnapshotRestoreManifestError::PublicId { source })?;
+                resources.push(SnapshotRestoreResourceKey::new(
+                    record.key(),
+                    public_id,
+                    SnapshotRestoreResourceClass::PmemBacking,
+                ));
+            }
+        }
+        if serial_count == 1 {
+            let public_id = SnapshotRestorePublicId::try_from(NATIVE_V2_SERIAL_RESTORE_PUBLIC_ID)
+                .map_err(|source| SnapshotRestoreManifestError::PublicId { source })?;
+            resources.push(SnapshotRestoreResourceKey::new(
+                SnapshotV2DeviceKey::serial(),
+                public_id,
+                SnapshotRestoreResourceClass::SerialSink,
+            ));
+        }
+
+        let mut overrides = Vec::new();
+        overrides
+            .try_reserve_exact(network_count)
+            .map_err(|source| SnapshotRestoreManifestError::AllocationFailed { source })?;
+        if let Some(network) = network {
+            for (index, interface) in network.interfaces().iter().enumerate() {
+                let instance = u32::try_from(index)
+                    .map_err(|_| SnapshotRestoreManifestError::TooManyResources)?;
+                let public_id = SnapshotRestorePublicId::try_from(interface.iface_id())
+                    .map_err(|source| SnapshotRestoreManifestError::PublicId { source })?;
+                let key = SnapshotRestoreResourceKey::new(
+                    SnapshotV2DeviceKey::network(instance),
+                    public_id,
+                    SnapshotRestoreResourceClass::NetworkPacketIo,
+                );
+                overrides.push(key.clone());
+                resources.push(key);
+            }
+        }
+        Self::try_new(resources, overrides)
     }
 
     fn try_new_with_reserve(
@@ -934,6 +1028,7 @@ mod tests {
     use super::*;
     use crate::snapshot_device_v2::snapshot_v2_device_key_for_test;
     use crate::snapshot_device_v2_6::NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION;
+    use crate::snapshot_network_v2_11::NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION;
     use crate::snapshot_serial_v2_7::NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION;
 
     const DEFAULT_SERIAL_HEX: &str = include_str!("snapshot_serial_v2_7/fixtures/default.hex");
@@ -941,6 +1036,7 @@ mod tests {
         include_str!("snapshot_serial_v2_7/fixtures/configured.hex");
     const MIXED_STORAGE_HEX: &str =
         include_str!("snapshot_device_v2_6/fixtures/mixed-pmem-root-pci.hex");
+    const NETWORK_HEX: &str = include_str!("snapshot_network_v2_11/fixtures/inactive-mmio.hex");
 
     fn public_id(value: impl Into<String>) -> SnapshotRestorePublicId {
         SnapshotRestorePublicId::try_from(value.into())
@@ -967,7 +1063,7 @@ mod tests {
     }
 
     fn decode_hex(value: &str) -> Vec<u8> {
-        let value = value.trim();
+        let value = value.split_whitespace().collect::<String>();
         assert!(value.len().is_multiple_of(2));
         value
             .as_bytes()
@@ -1000,6 +1096,14 @@ mod tests {
             &decode_hex(MIXED_STORAGE_HEX),
         )
         .expect("storage fixture should decode")
+    }
+
+    fn network_state() -> SnapshotV2NetworkState {
+        SnapshotV2NetworkState::decode(
+            NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
+            &decode_hex(NETWORK_HEX),
+        )
+        .expect("network fixture should decode")
     }
 
     fn maximum_keys() -> Vec<SnapshotRestoreResourceKey> {
@@ -1224,6 +1328,188 @@ mod tests {
                 .resource_class(),
             SnapshotRestoreResourceClass::SerialSink
         );
+    }
+
+    #[test]
+    fn exact_2_11_manifest_closes_storage_serial_and_network_resources() {
+        let graph = storage_graph();
+        let serial = serial_state(true);
+        let network = network_state();
+        let manifest = SnapshotRestoreManifest::try_from_native_v2_network_state(
+            Some(&graph),
+            &serial,
+            Some(&network),
+        )
+        .expect("mixed exact-2.11 manifest should validate");
+
+        assert_eq!(
+            manifest.len(),
+            graph.record_count() + 1 + network.interfaces().len()
+        );
+        assert_eq!(
+            manifest
+                .resources()
+                .iter()
+                .filter(|resource| {
+                    matches!(
+                        resource.resource_class(),
+                        SnapshotRestoreResourceClass::BlockBacking
+                            | SnapshotRestoreResourceClass::PmemBacking
+                    )
+                })
+                .count(),
+            graph.record_count()
+        );
+        let serial_resource = manifest
+            .resources()
+            .iter()
+            .find(|resource| resource.resource_class() == SnapshotRestoreResourceClass::SerialSink)
+            .expect("configured serial resource should exist");
+        assert_eq!(
+            serial_resource.public_id().as_str(),
+            NATIVE_V2_SERIAL_RESTORE_PUBLIC_ID
+        );
+
+        let network_resources = manifest
+            .resources()
+            .iter()
+            .filter(|resource| {
+                resource.resource_class() == SnapshotRestoreResourceClass::NetworkPacketIo
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(network_resources.len(), network.interfaces().len());
+        assert_eq!(manifest.overrides().collect::<Vec<_>>(), network_resources);
+        for (index, (resource, interface)) in network_resources
+            .iter()
+            .zip(network.interfaces())
+            .enumerate()
+        {
+            assert_eq!(resource.device_key().kind(), 4);
+            assert_eq!(
+                resource.device_key().instance(),
+                u32::try_from(index).unwrap()
+            );
+            assert_eq!(resource.public_id().as_str(), interface.iface_id());
+            assert!(manifest.is_overridden(resource));
+        }
+
+        let without_network =
+            SnapshotRestoreManifest::try_from_native_v2_network_state(Some(&graph), &serial, None)
+                .expect("network-free exact-2.11 manifest should validate");
+        let exact_2_7 =
+            SnapshotRestoreManifest::try_from_native_v2_serial_state(Some(&graph), &serial)
+                .expect("equivalent exact-2.7 manifest should validate");
+        assert_eq!(without_network.resources(), exact_2_7.resources());
+        assert_eq!(without_network.overrides().count(), 0);
+    }
+
+    #[test]
+    fn exact_2_11_manifest_applies_one_aggregate_resource_ceiling() {
+        assert_eq!(
+            checked_native_v2_network_resource_count(48, 0, 16)
+                .expect("storage plus network at the aggregate ceiling should fit"),
+            MAX_SNAPSHOT_RESTORE_RESOURCES
+        );
+        assert_eq!(
+            checked_native_v2_network_resource_count(47, 1, 16)
+                .expect("storage, serial, and network at the aggregate ceiling should fit"),
+            MAX_SNAPSHOT_RESTORE_RESOURCES
+        );
+        assert!(matches!(
+            checked_native_v2_network_resource_count(48, 1, 16),
+            Err(SnapshotRestoreManifestError::TooManyResources)
+        ));
+        assert!(matches!(
+            checked_native_v2_network_resource_count(usize::MAX, 1, 1),
+            Err(SnapshotRestoreManifestError::TooManyResources)
+        ));
+    }
+
+    #[test]
+    fn network_override_membership_accepts_explicit_same_destination_identity() {
+        let network = key(
+            4,
+            0,
+            "network-secret",
+            SnapshotRestoreResourceClass::NetworkPacketIo,
+        );
+        let manifest =
+            SnapshotRestoreManifest::try_new(vec![network.clone()], vec![network.clone()])
+                .expect("explicit network binding should validate even when identity is unchanged");
+
+        assert!(manifest.is_overridden(&network));
+        assert_eq!(manifest.overrides().collect::<Vec<_>>(), [&network]);
+        let debug = format!("{manifest:?} {network:?}");
+        assert!(!debug.contains("network-secret"));
+    }
+
+    #[test]
+    fn network_bindings_reject_alias_class_extra_duplicate_missing_reuse_and_unconsumed() {
+        let network = key(4, 0, "eth0", SnapshotRestoreResourceClass::NetworkPacketIo);
+        let manifest =
+            SnapshotRestoreManifest::try_new(vec![network.clone()], vec![network.clone()])
+                .expect("network manifest should validate");
+        let mut bindings = manifest
+            .try_into_bindings()
+            .expect("network binding slots should allocate");
+
+        let alias = key(4, 1, "eth0", SnapshotRestoreResourceClass::NetworkPacketIo);
+        let alias_rejection = bindings
+            .bind(&alias, "alias")
+            .expect_err("same public ID under another device key must be extra");
+        assert_eq!(
+            alias_rejection.reason(),
+            SnapshotRestoreBindingRejectionReason::ExtraBinding
+        );
+        assert_eq!(alias_rejection.into_value(), "alias");
+
+        let wrong_class = SnapshotRestoreResourceKey::new(
+            network.device_key(),
+            network.public_id().clone(),
+            SnapshotRestoreResourceClass::VsockEndpoint,
+        );
+        let class_rejection = bindings
+            .bind(&wrong_class, "class")
+            .expect_err("network resource class swap must fail");
+        assert_eq!(
+            class_rejection.reason(),
+            SnapshotRestoreBindingRejectionReason::WrongClass
+        );
+        assert_eq!(class_rejection.into_value(), "class");
+
+        let incomplete = bindings
+            .complete()
+            .expect_err("missing network value must fail completion");
+        assert_eq!(incomplete.missing_count(), 1);
+        let mut bindings = incomplete.into_bindings();
+        bindings
+            .bind(&network, "owner")
+            .expect("exact network owner should bind");
+        let duplicate = bindings
+            .bind(&network, "duplicate")
+            .expect_err("duplicate network owner must fail");
+        assert_eq!(
+            duplicate.reason(),
+            SnapshotRestoreBindingRejectionReason::DuplicateBinding
+        );
+        assert_eq!(duplicate.into_value(), "duplicate");
+
+        let prepared = bindings
+            .complete()
+            .expect("complete network owner set should prepare");
+        let unconsumed = prepared
+            .finish()
+            .expect_err("unconsumed network owner must fail");
+        assert_eq!(unconsumed.unconsumed_count(), 1);
+        let mut prepared = unconsumed.into_bindings();
+        assert_eq!(prepared.take(&network), Ok("owner"));
+        assert_eq!(
+            prepared.take(&network),
+            Err(SnapshotRestoreTakeError::AlreadyTaken)
+        );
+        prepared
+            .finish()
+            .expect("consumed network owner set should finish");
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -1667,6 +1667,20 @@ config space, queue, common virtio, transport, and a compact plugged bitmap
 bound to exact memory extents while restoring one fresh shared aperture and
 destination-local mapping, dirty, notifier, interrupt, dispatcher, route,
 metrics, and cleanup owners. Network, vsock, and MMDS restore remain excluded.
+An internal exact native-v2 2.11 preparation seam now closes network destination
+values without activating that public restore path. It requires exactly one
+explicit `network_overrides` entry for every saved interface, including
+MMDS-only interfaces; validates and copies the complete set before macOS
+authority policy; canonicalizes it to saved interface order; and retains
+owner-free controller/MMDS projections plus exact packet-I/O resource keys.
+Captured host-device selectors remain inert source state and never select a
+destination. This is deliberately stricter than Firecracker v1.16.0, which
+updates the first matching decoded network record for each supplied override,
+allows partial and repeated override vectors, and otherwise falls back to the
+captured TAP name. Bangbang accepts an explicit replacement equal to the
+captured string, but still treats it as an explicit binding. Public native-v2
+create/load remains at exact 2.10 and continues to reject network restore until
+the later owner, platform, activation, and signed-evidence slices complete.
 Exact 2.9 retains optional balloon, exact 2.8 retains optional entropy, exact
 2.7 retains serial with optional profile-3 storage, exact 2.6 retains the storage-only profile-3
 graph, exact 2.5 retains its block-only profile-2 graph, exact 2.4 retains its singleton


### PR DESCRIPTION
## Summary

- add exact network packet-I/O restore resource identities and a complete
  storage/serial/network manifest
- require and canonicalize one explicit destination override per saved network
  interface, retaining an immutable owner-free controller/MMDS topology
- add a macOS value-only selector and direct/contained authority plan that
  stops before every provider or host-resource seam

## Scope exclusions

- public native-v2 create/load remains at exact 2.10
- live MMDS/vmnet owner preparation, HVF product construction, public
  activation, and capability-inventory promotion remain later slices

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- focused exact-2.11 runtime, manifest, and process tests
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all documented Apple-target Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- strict signed integration groups through `scripts/run-integration-tests.sh`;
  the production-bundle group was also rerun alone and passed 69/69 after an
  unrelated concurrent-run namespace collision

Closes #1710

Parent: #1539
