### PR TITLE
fix: preserve Firecracker MMIO network ordering

### DIFF
--- a/crates/hvf/src/snapshot_v2_memory_hotplug_platform.rs
+++ b/crates/hvf/src/snapshot_v2_memory_hotplug_platform.rs
@@ -2331,13 +2331,31 @@ pub(crate) mod tests {
     }
 
     pub(crate) fn storage_mmio_graph(first_interrupt: u32) -> SnapshotV2StorageDeviceGraph {
+        storage_mmio_graph_with_gap(first_interrupt, 0)
+    }
+
+    pub(crate) fn storage_mmio_graph_with_gap(
+        first_interrupt: u32,
+        inserted_interrupt_count: usize,
+    ) -> SnapshotV2StorageDeviceGraph {
         let graph = product_storage_fixture(SnapshotV2DeviceTransportKind::Mmio);
+        let block_count = graph.block_records().len();
         let mut bytes = graph
             .encode(NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION)
             .expect("MMIO storage graph should encode");
         for (index, transport_offset) in storage_transport_offsets(&bytes).into_iter().enumerate() {
+            let inserted = usize::from(index >= block_count)
+                .checked_mul(inserted_interrupt_count)
+                .expect("inserted interrupt count should fit");
             let interrupt = first_interrupt
-                .checked_add(u32::try_from(index).expect("storage index should fit"))
+                .checked_add(
+                    u32::try_from(
+                        index
+                            .checked_add(inserted)
+                            .expect("storage interrupt index should fit"),
+                    )
+                    .expect("storage interrupt index should fit"),
+                )
                 .expect("storage interrupt should fit");
             relocate_mmio_interrupt(&mut bytes, transport_offset, interrupt);
         }

--- a/crates/hvf/src/snapshot_v2_network_platform.rs
+++ b/crates/hvf/src/snapshot_v2_network_platform.rs
@@ -65,11 +65,12 @@ use crate::snapshot_v2_platform::{
     PROCESS_RTC_MMIO_BASE, PROCESS_RTC_MMIO_REGION_ID, PROCESS_SERIAL_MMIO_BASE,
 };
 use crate::snapshot_v2_storage_platform::{
-    HvfSnapshotV2StorageMmioPlatformPlan, HvfSnapshotV2StorageMmioPlatformPrefix,
-    HvfSnapshotV2StorageMmioProcessConfig, HvfSnapshotV2StoragePciPlatformPlan,
-    HvfSnapshotV2StoragePciPlatformPrefix, PrepareHvfSnapshotV2StorageMmioPlatformPlanError,
+    HvfSnapshotV2StorageMmioInsertedEndpoint, HvfSnapshotV2StorageMmioPlatformPlan,
+    HvfSnapshotV2StorageMmioPlatformPrefix, HvfSnapshotV2StorageMmioProcessConfig,
+    HvfSnapshotV2StoragePciPlatformPlan, HvfSnapshotV2StoragePciPlatformPrefix,
+    PrepareHvfSnapshotV2StorageMmioPlatformPlanError,
     PrepareHvfSnapshotV2StoragePciPlatformPlanError, mmio_region_conflicts_with_platform,
-    prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix,
+    prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix_and_insertion,
     prepare_hvf_snapshot_v2_storage_pci_platform_plan_with_prefix,
     queue_ranges_conflict_with_pci_platform, queue_ranges_conflict_with_platform,
     register_active_pci_routes,
@@ -1708,12 +1709,17 @@ fn validate_mmio_interrupt_sequence(
         validate(balloon.interrupt_line())?;
     }
     if let Some(storage) = storage {
-        for record in storage.block_records().iter().chain(storage.pmem_records()) {
+        for record in storage.block_records() {
             validate(record.interrupt_line())?;
         }
     }
     for endpoint in network {
         validate(endpoint.interrupt_line())?;
+    }
+    if let Some(storage) = storage {
+        for record in storage.pmem_records() {
+            validate(record.interrupt_line())?;
+        }
     }
     if let Some(entropy) = entropy {
         validate(entropy.interrupt_line())?;
@@ -1843,14 +1849,16 @@ fn prepare_network_mmio_platform_plan(
         HvfSnapshotV2NetworkPlatformPlanStage::Components,
     )?;
 
-    let following_count = network
-        .len()
-        .checked_add(usize::from(entropy.is_some()))
-        .and_then(|count| count.checked_add(usize::from(memory_hotplug.is_some())))
+    let mut inserted_endpoints = Vec::new();
+    reserve.reserve(&mut inserted_endpoints, network.len())?;
+    inserted_endpoints.extend(network.iter().map(|endpoint| {
+        HvfSnapshotV2StorageMmioInsertedEndpoint::new(endpoint.region(), endpoint.interrupt_line())
+    }));
+    let following_count = usize::from(entropy.is_some())
+        .checked_add(usize::from(memory_hotplug.is_some()))
         .ok_or(PrepareHvfSnapshotV2NetworkPlatformPlanError::ResourcePlan)?;
     let mut following_interrupts = Vec::new();
     reserve.reserve(&mut following_interrupts, following_count)?;
-    following_interrupts.extend(network.iter().map(|endpoint| endpoint.interrupt_line()));
     if let Some(entropy) = entropy {
         following_interrupts.push(entropy.interrupt_line());
     }
@@ -1863,11 +1871,12 @@ fn prepare_network_mmio_platform_plan(
     let storage = product
         .storage()
         .map(|storage| {
-            prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix(
+            prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix_and_insertion(
                 platform,
                 storage,
                 process.storage(),
                 prefix,
+                &inserted_endpoints,
                 &following_interrupts,
             )
             .map_err(|source| {
@@ -2140,19 +2149,16 @@ fn validate_mmio_inventory(
         regions.push(balloon.region());
     }
     if let Some(storage) = storage {
-        regions.extend(
-            storage
-                .block_records()
-                .iter()
-                .chain(storage.pmem_records())
-                .map(|record| record.region()),
-        );
+        regions.extend(storage.block_records().iter().map(|record| record.region()));
     }
     regions.extend(
         network
             .iter()
             .map(HvfSnapshotV2NetworkMmioEndpointPlan::region),
     );
+    if let Some(storage) = storage {
+        regions.extend(storage.pmem_records().iter().map(|record| record.region()));
+    }
     if let Some(entropy) = entropy {
         regions.push(entropy.region());
     }
@@ -2933,8 +2939,8 @@ mod fixture_identity_tests {
         MaterializedFixture, balloon_mmio_plan, balloon_pci_plan, entropy_mmio_plan,
         entropy_pci_plan, materialized_fixture, memory_hotplug_mmio_state,
         memory_hotplug_pci_state, mmio_platform as memory_fixture_mmio_platform,
-        pci_platform as memory_fixture_pci_platform, prepared_storage_bundle, storage_mmio_graph,
-        storage_pci_graph_with_gap,
+        pci_platform as memory_fixture_pci_platform, prepared_storage_bundle,
+        storage_mmio_graph_with_gap, storage_pci_graph_with_gap,
     };
     use crate::snapshot_v2_multi_block_platform::tests::{
         product_mmio_platform, product_pci_platform,
@@ -3666,24 +3672,30 @@ mod fixture_identity_tests {
 
     #[test]
     fn all_sixteen_mmio_product_tags_close_canonical_component_order() {
-        let storage_record_count =
-            product_storage_fixture(SnapshotV2DeviceTransportKind::Mmio).record_count();
+        let storage_graph = product_storage_fixture(SnapshotV2DeviceTransportKind::Mmio);
+        let storage_block_count = storage_graph.block_records().len();
+        let storage_pmem_count = storage_graph.pmem_records().len();
         for mask in 0_u8..16 {
             let has_storage = mask & 1 != 0;
             let has_entropy = mask & 2 != 0;
             let has_balloon = mask & 4 != 0;
             let has_memory_hotplug = mask & 8 != 0;
             let network_count = if mask == 15 { 16 } else { 1 };
-            let storage_count = usize::from(has_storage) * storage_record_count;
+            let block_count = usize::from(has_storage) * storage_block_count;
+            let pmem_count = usize::from(has_storage) * storage_pmem_count;
             let first_interrupt = 32_u32;
             let storage_interrupt = first_interrupt + u32::from(has_balloon);
             let network_interrupt = storage_interrupt
-                + u32::try_from(storage_count).expect("storage interrupt count should fit");
-            let entropy_interrupt = network_interrupt + u32::try_from(network_count).unwrap();
+                + u32::try_from(block_count).expect("block interrupt count should fit");
+            let pmem_interrupt =
+                network_interrupt + u32::try_from(network_count).expect("network count should fit");
+            let entropy_interrupt = pmem_interrupt
+                + u32::try_from(pmem_count).expect("pmem interrupt count should fit");
             let memory_hotplug_interrupt = entropy_interrupt + u32::from(has_entropy);
             let device_count = usize::from(has_balloon)
-                + storage_count
+                + block_count
                 + network_count
+                + pmem_count
                 + usize::from(has_entropy)
                 + usize::from(has_memory_hotplug);
 
@@ -3715,7 +3727,7 @@ mod fixture_identity_tests {
             let balloon = has_balloon.then(|| balloon_mmio_plan(&memory, first_interrupt));
             let entropy = has_entropy.then(|| entropy_mmio_plan(&memory, entropy_interrupt));
             let (storage, _backings) = if has_storage {
-                let graph = storage_mmio_graph(storage_interrupt);
+                let graph = storage_mmio_graph_with_gap(storage_interrupt, network_count);
                 let (bundle, backings) = prepared_storage_bundle(graph);
                 (Some(bundle), backings)
             } else {
@@ -3751,15 +3763,16 @@ mod fixture_identity_tests {
                 network_interrupt,
             );
             if let Some(storage) = plan.storage() {
-                for (index, record) in storage
-                    .block_records()
-                    .iter()
-                    .chain(storage.pmem_records())
-                    .enumerate()
-                {
+                for (index, record) in storage.block_records().iter().enumerate() {
                     assert_eq!(
                         record.interrupt_line().raw_value(),
                         storage_interrupt + u32::try_from(index).unwrap(),
+                    );
+                }
+                for (index, record) in storage.pmem_records().iter().enumerate() {
+                    assert_eq!(
+                        record.interrupt_line().raw_value(),
+                        pmem_interrupt + u32::try_from(index).unwrap(),
                     );
                 }
             }
@@ -4064,7 +4077,7 @@ mod fixture_identity_tests {
 
     #[test]
     fn every_network_identity_and_inventory_allocation_failure_is_explicit() {
-        for fail_at in 0..7 {
+        for fail_at in 0..8 {
             let (platform, product) = mmio_product(1, true, MmdsSelection::All);
             assert!(matches!(
                 prepare_network_mmio_platform_plan(

--- a/crates/hvf/src/snapshot_v2_storage_platform.rs
+++ b/crates/hvf/src/snapshot_v2_storage_platform.rs
@@ -666,6 +666,26 @@ impl HvfSnapshotV2StorageMmioPlatformPrefix {
 }
 
 #[derive(Clone, Copy)]
+pub(crate) struct HvfSnapshotV2StorageMmioInsertedEndpoint {
+    region: MmioRegion,
+    interrupt: GuestInterruptLine,
+}
+
+impl HvfSnapshotV2StorageMmioInsertedEndpoint {
+    pub(crate) const fn new(region: MmioRegion, interrupt: GuestInterruptLine) -> Self {
+        Self { region, interrupt }
+    }
+
+    const fn region(self) -> MmioRegion {
+        self.region
+    }
+
+    const fn interrupt(self) -> GuestInterruptLine {
+        self.interrupt
+    }
+}
+
+#[derive(Clone, Copy)]
 pub(crate) enum HvfSnapshotV2StoragePciMsiProfile {
     Root,
     RootOrEntropy,
@@ -795,6 +815,7 @@ pub fn prepare_hvf_snapshot_v2_storage_mmio_platform_plan(
         process,
         HvfSnapshotV2StorageMmioPlatformPrefix::EMPTY,
         &[],
+        &[],
         &mut SystemStoragePlatformPlanReserve,
     )
 }
@@ -814,6 +835,7 @@ pub fn prepare_hvf_snapshot_v2_storage_entropy_mmio_platform_plan(
         bundle,
         process,
         HvfSnapshotV2StorageMmioPlatformPrefix::EMPTY,
+        &[],
         std::slice::from_ref(&entropy_interrupt),
         &mut SystemStoragePlatformPlanReserve,
     )
@@ -827,11 +849,31 @@ pub(crate) fn prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix(
     following_interrupts: &[GuestInterruptLine],
 ) -> Result<HvfSnapshotV2StorageMmioPlatformPlan, PrepareHvfSnapshotV2StorageMmioPlatformPlanError>
 {
+    prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix_and_insertion(
+        platform,
+        bundle,
+        process,
+        prefix,
+        &[],
+        following_interrupts,
+    )
+}
+
+pub(crate) fn prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix_and_insertion(
+    platform: &HvfSnapshotV2PlatformState,
+    bundle: &PreparedSnapshotV2StorageBundle,
+    process: HvfSnapshotV2StorageMmioProcessConfig,
+    prefix: HvfSnapshotV2StorageMmioPlatformPrefix,
+    inserted_endpoints: &[HvfSnapshotV2StorageMmioInsertedEndpoint],
+    following_interrupts: &[GuestInterruptLine],
+) -> Result<HvfSnapshotV2StorageMmioPlatformPlan, PrepareHvfSnapshotV2StorageMmioPlatformPlanError>
+{
     prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with(
         platform,
         bundle,
         process,
         prefix,
+        inserted_endpoints,
         following_interrupts,
         &mut SystemStoragePlatformPlanReserve,
     )
@@ -842,6 +884,7 @@ fn prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with(
     bundle: &PreparedSnapshotV2StorageBundle,
     process: HvfSnapshotV2StorageMmioProcessConfig,
     prefix: HvfSnapshotV2StorageMmioPlatformPrefix,
+    inserted_endpoints: &[HvfSnapshotV2StorageMmioInsertedEndpoint],
     following_interrupts: &[GuestInterruptLine],
     reserve: &mut impl StoragePlatformPlanReserve,
 ) -> Result<HvfSnapshotV2StorageMmioPlatformPlan, PrepareHvfSnapshotV2StorageMmioPlatformPlanError>
@@ -888,10 +931,11 @@ fn prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with(
     reserve.reserve(&mut pmem_retries, pmem_records.len())?;
     reserve.reserve(&mut planned_block, block_records.len())?;
     reserve.reserve(&mut planned_pmem, pmem_records.len())?;
-    reserve.reserve(
-        &mut planned_regions,
-        record_count + usize::from(prefix.region.is_some()),
-    )?;
+    let planned_region_count = record_count
+        .checked_add(usize::from(prefix.region.is_some()))
+        .and_then(|count| count.checked_add(inserted_endpoints.len()))
+        .ok_or(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan)?;
+    reserve.reserve(&mut planned_regions, planned_region_count)?;
 
     if prefix.region.is_some() != prefix.interrupt.is_some() {
         return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan);
@@ -984,6 +1028,24 @@ fn prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with(
             .allocate()
             .map_err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::Interrupt)?;
         validate_and_set_interrupt(record.transport(), interrupt, planned)?;
+    }
+
+    for endpoint in inserted_endpoints.iter().copied() {
+        let region = endpoint.region();
+        if mmio_region_conflicts_with_platform(platform, region, &gic)?
+            || planned_regions.iter().any(|planned| {
+                planned.id() == region.id() || planned.range().overlaps(region.range())
+            })
+        {
+            return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan);
+        }
+        let interrupt = interrupt_allocator
+            .allocate()
+            .map_err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::Interrupt)?;
+        if interrupt != endpoint.interrupt() {
+            return Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan);
+        }
+        planned_regions.push(region);
     }
 
     for (index, (record, config)) in pmem_records.iter().zip(pmem_configs).enumerate() {
@@ -2052,6 +2114,14 @@ pub(crate) mod tests {
         graph: SnapshotV2StorageDeviceGraph,
         first_interrupt: u32,
     ) -> SnapshotV2StorageDeviceGraph {
+        canonicalize_pmem_placement_with_gap(graph, first_interrupt, 0)
+    }
+
+    fn canonicalize_pmem_placement_with_gap(
+        graph: SnapshotV2StorageDeviceGraph,
+        first_interrupt: u32,
+        inserted_interrupt_count: usize,
+    ) -> SnapshotV2StorageDeviceGraph {
         let root_key = graph.root_key();
         let block_records = graph.block_records().to_vec();
         for (index, record) in block_records.iter().enumerate() {
@@ -2078,8 +2148,13 @@ pub(crate) mod tests {
                     .expect("canonical pmem region should validate");
                 let interrupt = GuestInterruptLine::new(
                     first_interrupt
-                        + u32::try_from(block_count + index)
-                            .expect("storage interrupt index should fit"),
+                        + u32::try_from(
+                            block_count
+                                .checked_add(inserted_interrupt_count)
+                                .and_then(|count| count.checked_add(index))
+                                .expect("storage interrupt index should fit"),
+                        )
+                        .expect("storage interrupt index should fit"),
                 )
                 .expect("canonical pmem interrupt should validate");
                 let transport =
@@ -2218,6 +2293,72 @@ pub(crate) mod tests {
             bundle,
             _files: files,
         }
+    }
+
+    fn fixture_with_mmio_insertion(
+        inserted_endpoint_count: usize,
+    ) -> (
+        StorageFixture,
+        Vec<HvfSnapshotV2StorageMmioInsertedEndpoint>,
+    ) {
+        let base = base_graph(FixtureShape::MixedBlockRoot);
+        let platform = crate::snapshot_v2_multi_block_platform::tests::product_mmio_platform(
+            base.record_count()
+                .checked_add(inserted_endpoint_count)
+                .expect("inserted endpoint count should fit"),
+        );
+        let first_interrupt = platform
+            .global()
+            .compatibility()
+            .gic_metadata()
+            .spi_interrupt_range
+            .base;
+        let block_count = base.block_records().len();
+        let graph =
+            canonicalize_pmem_placement_with_gap(base, first_interrupt, inserted_endpoint_count);
+        let (bundle, files) = bundle_from_graph(graph);
+        let mut inserted = Vec::new();
+        inserted
+            .try_reserve_exact(inserted_endpoint_count)
+            .expect("inserted endpoint fixture should reserve");
+        for index in 0..inserted_endpoint_count {
+            let index_u64 = u64::try_from(index).expect("inserted endpoint index should fit");
+            let region = MmioRegion::new(
+                bangbang_runtime::mmio::MmioRegionId::new(
+                    300_u64
+                        .checked_add(index_u64)
+                        .expect("inserted region ID should fit"),
+                ),
+                GuestAddress::new(
+                    0xd200_0000_u64
+                        .checked_add(
+                            index_u64
+                                .checked_mul(VIRTIO_MMIO_DEVICE_WINDOW_SIZE)
+                                .expect("inserted region offset should fit"),
+                        )
+                        .expect("inserted region address should fit"),
+                ),
+                VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+            )
+            .expect("inserted endpoint region should validate");
+            let interrupt = GuestInterruptLine::new(
+                first_interrupt
+                    .checked_add(u32::try_from(block_count + index).expect("index should fit"))
+                    .expect("inserted endpoint interrupt should fit"),
+            )
+            .expect("inserted endpoint interrupt should validate");
+            inserted.push(HvfSnapshotV2StorageMmioInsertedEndpoint::new(
+                region, interrupt,
+            ));
+        }
+        (
+            StorageFixture {
+                platform,
+                bundle,
+                _files: files,
+            },
+            inserted,
+        )
     }
 
     fn pci_fixture(hex: &str) -> StorageFixture {
@@ -2439,6 +2580,216 @@ pub(crate) mod tests {
                 .abort()
                 .expect("planned storage bundle should abort cleanly");
         }
+    }
+
+    #[test]
+    fn mmio_insertion_places_one_and_sixteen_endpoints_between_block_and_pmem() {
+        for inserted_endpoint_count in [1, 16] {
+            let (fixture, inserted) = fixture_with_mmio_insertion(inserted_endpoint_count);
+            let first_interrupt = fixture
+                .platform
+                .global()
+                .compatibility()
+                .gic_metadata()
+                .spi_interrupt_range
+                .base;
+            let block_count = fixture
+                .bundle
+                .block_bundle()
+                .map_or(0, |bundle| bundle.records().len());
+            let pmem_count = fixture.bundle.pmem_records().len();
+            let plan =
+                prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix_and_insertion(
+                    &fixture.platform,
+                    &fixture.bundle,
+                    process_config(),
+                    HvfSnapshotV2StorageMmioPlatformPrefix::EMPTY,
+                    &inserted,
+                    &[],
+                )
+                .expect("block/network/pmem insertion should plan");
+
+            for (index, record) in plan.block_records().iter().enumerate() {
+                assert_eq!(
+                    record.interrupt_line().raw_value(),
+                    first_interrupt + u32::try_from(index).expect("block index should fit"),
+                );
+            }
+            for (index, endpoint) in inserted.iter().copied().enumerate() {
+                assert_eq!(
+                    endpoint.interrupt().raw_value(),
+                    first_interrupt
+                        + u32::try_from(block_count + index)
+                            .expect("inserted endpoint index should fit"),
+                );
+            }
+            for (index, record) in plan.pmem_records().iter().enumerate() {
+                assert_eq!(
+                    record.interrupt_line().raw_value(),
+                    first_interrupt
+                        + u32::try_from(block_count + inserted_endpoint_count + index)
+                            .expect("pmem index should fit"),
+                );
+            }
+            assert_eq!(
+                plan.serial_interrupt().raw_value(),
+                first_interrupt
+                    + u32::try_from(block_count + inserted_endpoint_count + pmem_count)
+                        .expect("serial interrupt index should fit"),
+            );
+            fixture
+                .bundle
+                .abort()
+                .expect("inserted storage fixture should abort cleanly");
+        }
+    }
+
+    #[test]
+    fn mmio_insertion_rejects_interrupt_and_region_conflicts_before_pmem() {
+        let (fixture, inserted) = fixture_with_mmio_insertion(1);
+        let endpoint = inserted[0];
+        let wrong_interrupt = GuestInterruptLine::new(
+            endpoint
+                .interrupt()
+                .raw_value()
+                .checked_add(1)
+                .expect("wrong interrupt should fit"),
+        )
+        .expect("wrong interrupt should validate");
+        let wrong_interrupt = [HvfSnapshotV2StorageMmioInsertedEndpoint::new(
+            endpoint.region(),
+            wrong_interrupt,
+        )];
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix_and_insertion(
+                &fixture.platform,
+                &fixture.bundle,
+                process_config(),
+                HvfSnapshotV2StorageMmioPlatformPrefix::EMPTY,
+                &wrong_interrupt,
+                &[],
+            ),
+            Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan),
+        ));
+
+        let block_region = process_config()
+            .block_layout()
+            .region_at(0)
+            .expect("block region should project");
+        let duplicate_block = [HvfSnapshotV2StorageMmioInsertedEndpoint::new(
+            block_region,
+            endpoint.interrupt(),
+        )];
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix_and_insertion(
+                &fixture.platform,
+                &fixture.bundle,
+                process_config(),
+                HvfSnapshotV2StorageMmioPlatformPrefix::EMPTY,
+                &duplicate_block,
+                &[],
+            ),
+            Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan),
+        ));
+
+        let fixed_region = MmioRegion::new(
+            bangbang_runtime::mmio::MmioRegionId::new(999),
+            PROCESS_SERIAL_MMIO_BASE,
+            VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+        )
+        .expect("fixed-overlap region should validate");
+        let fixed = [HvfSnapshotV2StorageMmioInsertedEndpoint::new(
+            fixed_region,
+            endpoint.interrupt(),
+        )];
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix_and_insertion(
+                &fixture.platform,
+                &fixture.bundle,
+                process_config(),
+                HvfSnapshotV2StorageMmioPlatformPrefix::EMPTY,
+                &fixed,
+                &[],
+            ),
+            Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan),
+        ));
+
+        let pmem_region = process_config()
+            .pmem_layout()
+            .region_at(0)
+            .expect("pmem region should project");
+        let duplicate_pmem = [HvfSnapshotV2StorageMmioInsertedEndpoint::new(
+            pmem_region,
+            endpoint.interrupt(),
+        )];
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix_and_insertion(
+                &fixture.platform,
+                &fixture.bundle,
+                process_config(),
+                HvfSnapshotV2StorageMmioPlatformPrefix::EMPTY,
+                &duplicate_pmem,
+                &[],
+            ),
+            Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan),
+        ));
+
+        let pmem_mapping = fixture.bundle.pmem_records()[0]
+            .prepared_device()
+            .guest_range();
+        let mapping_region = MmioRegion::new(
+            bangbang_runtime::mmio::MmioRegionId::new(998),
+            pmem_mapping.start(),
+            VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+        )
+        .expect("pmem-mapping overlap region should validate");
+        let mapping = [HvfSnapshotV2StorageMmioInsertedEndpoint::new(
+            mapping_region,
+            endpoint.interrupt(),
+        )];
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix_and_insertion(
+                &fixture.platform,
+                &fixture.bundle,
+                process_config(),
+                HvfSnapshotV2StorageMmioPlatformPrefix::EMPTY,
+                &mapping,
+                &[],
+            ),
+            Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::PmemRangeConflict),
+        ));
+
+        fixture
+            .bundle
+            .abort()
+            .expect("hostile insertion fixture should abort cleanly");
+    }
+
+    #[test]
+    fn mmio_insertion_rejects_duplicate_inserted_endpoint_identity() {
+        let (fixture, inserted) = fixture_with_mmio_insertion(2);
+        let duplicate = [
+            inserted[0],
+            HvfSnapshotV2StorageMmioInsertedEndpoint::new(
+                inserted[0].region(),
+                inserted[1].interrupt(),
+            ),
+        ];
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix_and_insertion(
+                &fixture.platform,
+                &fixture.bundle,
+                process_config(),
+                HvfSnapshotV2StorageMmioPlatformPrefix::EMPTY,
+                &duplicate,
+                &[],
+            ),
+            Err(PrepareHvfSnapshotV2StorageMmioPlatformPlanError::ResourcePlan),
+        ));
+        fixture
+            .bundle
+            .abort()
+            .expect("duplicate insertion fixture should abort cleanly");
     }
 
     #[test]
@@ -2822,14 +3173,16 @@ pub(crate) mod tests {
             process_config(),
         )
         .expect("legacy MMIO storage plan should validate");
-        let prefixed = prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix(
-            &fixture.platform,
-            &fixture.bundle,
-            process_config(),
-            HvfSnapshotV2StorageMmioPlatformPrefix::EMPTY,
-            &[],
-        )
-        .expect("zero-prefix MMIO storage plan should validate");
+        let prefixed =
+            prepare_hvf_snapshot_v2_storage_mmio_platform_plan_with_prefix_and_insertion(
+                &fixture.platform,
+                &fixture.bundle,
+                process_config(),
+                HvfSnapshotV2StorageMmioPlatformPrefix::EMPTY,
+                &[],
+                &[],
+            )
+            .expect("zero-insertion MMIO storage plan should validate");
         assert_eq!(legacy.root_key(), prefixed.root_key());
         assert_eq!(legacy.command_line(), prefixed.command_line());
         assert_eq!(legacy.block_metrics_ids(), prefixed.block_metrics_ids());
@@ -2927,6 +3280,7 @@ pub(crate) mod tests {
                     &fixture.bundle,
                     process_config(),
                     HvfSnapshotV2StorageMmioPlatformPrefix::EMPTY,
+                    &[],
                     &[],
                     &mut FailingReserve { calls: 0, fail_at },
                 ),

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -32605,19 +32605,6 @@ fn allocate_interrupt_lines(
         })?);
     }
 
-    let mut pmem = Vec::new();
-    pmem.try_reserve_exact(request.pmem_device_count)
-        .map_err(|source| HvfArm64BootSessionError::InterruptLineStorage { source })?;
-
-    for _ in 0..request.pmem_device_count {
-        pmem.push(allocator.allocate().map_err(|source| {
-            HvfArm64BootSessionError::AllocateInterruptLine {
-                purpose: HvfArm64BootInterruptLinePurpose::PmemDevice,
-                source,
-            }
-        })?);
-    }
-
     let mut network = Vec::new();
     network
         .try_reserve_exact(request.network_device_count)
@@ -32627,6 +32614,19 @@ fn allocate_interrupt_lines(
         network.push(allocator.allocate().map_err(|source| {
             HvfArm64BootSessionError::AllocateInterruptLine {
                 purpose: HvfArm64BootInterruptLinePurpose::NetworkDevice,
+                source,
+            }
+        })?);
+    }
+
+    let mut pmem = Vec::new();
+    pmem.try_reserve_exact(request.pmem_device_count)
+        .map_err(|source| HvfArm64BootSessionError::InterruptLineStorage { source })?;
+
+    for _ in 0..request.pmem_device_count {
+        pmem.push(allocator.allocate().map_err(|source| {
+            HvfArm64BootSessionError::AllocateInterruptLine {
+                purpose: HvfArm64BootInterruptLinePurpose::PmemDevice,
                 source,
             }
         })?);
@@ -43926,8 +43926,8 @@ mod tests {
 
         assert_eq!(lines.balloon.map(|line| line.raw_value()), Some(32));
         assert_eq!(line_values(&lines.block), vec![33, 34]);
-        assert_eq!(line_values(&lines.pmem), vec![35, 36]);
-        assert_eq!(line_values(&lines.network), vec![37, 38]);
+        assert_eq!(line_values(&lines.network), vec![35, 36]);
+        assert_eq!(line_values(&lines.pmem), vec![37, 38]);
         assert_eq!(lines.vsock.map(|line| line.raw_value()), Some(39));
         assert_eq!(lines.entropy.map(|line| line.raw_value()), Some(40));
         assert_eq!(lines.memory_hotplug.map(|line| line.raw_value()), Some(41));
@@ -44000,14 +44000,15 @@ mod tests {
     #[test]
     fn interrupt_lines_report_pmem_exhaustion_with_purpose() {
         let err = allocate_interrupt_lines(
-            &gic_with_spi_range(32, 1),
+            &gic_with_spi_range(32, 2),
             HvfArm64BootInterruptRequest {
                 block_device_count: 1,
                 pmem_device_count: 1,
+                network_device_count: 1,
                 ..HvfArm64BootInterruptRequest::default()
             },
         )
-        .expect_err("pmem allocation should exhaust range");
+        .expect_err("pmem allocation should exhaust range after block and network");
 
         assert!(matches!(
             err,


### PR DESCRIPTION
## Summary

- allocate fresh-start MMIO SPIs in pinned Firecracker order, with network devices between block and pmem devices
- validate exact-2.11 network MMIO region/SPI insertions through the storage planner before pmem
- cover 1/16-interface products, hostile resource insertions, allocation failures, startup exhaustion, and zero-insertion compatibility

## Scope exclusions

- no change to fixed per-class MMIO layouts or address-sorted bus/FDT publication
- no change to runtime owner assembly, PCI placement/routes, wire formats, or public exact-2.11 enablement

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh` (all signed groups before production passed; an initial transient wrong-worker selection in the production group did not reproduce)
- `scripts/run-integration-tests.sh --test production_bundle -- --exact signed_grants_authorize_only_typed_read_write_and_directory_operations`
- `scripts/run-integration-tests.sh --test production_bundle` (69 passed)

Closes #1722

Parent delivery: #1539
