### PR TITLE
feat: reconstruct PCI network snapshot owners

### DIFF
--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -56,7 +56,9 @@ use bangbang_hvf::{
     HvfSnapshotV2MultiBlockPlatformPlan, HvfSnapshotV2MultiBlockProcessConfig,
     HvfSnapshotV2MultiBlockState, HvfSnapshotV2NativePath, HvfSnapshotV2NetworkMmioMemoryInput,
     HvfSnapshotV2NetworkMmioPlatformPlan, HvfSnapshotV2NetworkMmioRestoreDisposition,
-    HvfSnapshotV2NetworkMmioRestoreError, HvfSnapshotV2NetworkPlatformState,
+    HvfSnapshotV2NetworkMmioRestoreError, HvfSnapshotV2NetworkPciMemoryInput,
+    HvfSnapshotV2NetworkPciPlatformPlan, HvfSnapshotV2NetworkPciRestoreDisposition,
+    HvfSnapshotV2NetworkPciRestoreError, HvfSnapshotV2NetworkPlatformState,
     HvfSnapshotV2NetworkProcessResourceIdentity, HvfSnapshotV2NetworkState,
     HvfSnapshotV2PlatformRestoreError, HvfSnapshotV2PlatformState,
     HvfSnapshotV2RestoredSerialShell, HvfSnapshotV2RootProcessConfig,
@@ -74,15 +76,16 @@ use bangbang_hvf::{
     PrepareHvfSnapshotV2StorageMmioPlatformPlanError,
     PrepareHvfSnapshotV2StoragePciPlatformPlanError, PreparedHvfArm64BootPciNetworkRemoval,
     PreparedHvfSnapshotV1Load, PreparedHvfSnapshotV1State, RestoredHvfSnapshotV2NetworkMmioOwners,
-    RestoredHvfSnapshotV2Platform, decode_hvf_snapshot_v2_balloon_state,
-    decode_hvf_snapshot_v2_entropy_state, decode_hvf_snapshot_v2_memory_hotplug_state,
-    decode_hvf_snapshot_v2_multi_block_state, decode_hvf_snapshot_v2_platform_state,
-    decode_hvf_snapshot_v2_serial_state, decode_hvf_snapshot_v2_state,
-    decode_hvf_snapshot_v2_storage_state, encode_hvf_snapshot_v2_balloon_state,
-    encode_hvf_snapshot_v2_entropy_state, encode_hvf_snapshot_v2_memory_hotplug_state,
-    encode_hvf_snapshot_v2_multi_block_state, encode_hvf_snapshot_v2_network_state,
-    encode_hvf_snapshot_v2_serial_state, encode_hvf_snapshot_v2_state,
-    encode_hvf_snapshot_v2_storage_state, prepare_hvf_snapshot_v2_balloon_mmio_platform_plan,
+    RestoredHvfSnapshotV2NetworkPciOwners, RestoredHvfSnapshotV2Platform,
+    decode_hvf_snapshot_v2_balloon_state, decode_hvf_snapshot_v2_entropy_state,
+    decode_hvf_snapshot_v2_memory_hotplug_state, decode_hvf_snapshot_v2_multi_block_state,
+    decode_hvf_snapshot_v2_platform_state, decode_hvf_snapshot_v2_serial_state,
+    decode_hvf_snapshot_v2_state, decode_hvf_snapshot_v2_storage_state,
+    encode_hvf_snapshot_v2_balloon_state, encode_hvf_snapshot_v2_entropy_state,
+    encode_hvf_snapshot_v2_memory_hotplug_state, encode_hvf_snapshot_v2_multi_block_state,
+    encode_hvf_snapshot_v2_network_state, encode_hvf_snapshot_v2_serial_state,
+    encode_hvf_snapshot_v2_state, encode_hvf_snapshot_v2_storage_state,
+    prepare_hvf_snapshot_v2_balloon_mmio_platform_plan,
     prepare_hvf_snapshot_v2_balloon_pci_platform_plan,
     prepare_hvf_snapshot_v2_memory_hotplug_mmio_platform_plan,
     prepare_hvf_snapshot_v2_memory_hotplug_pci_platform_plan,
@@ -18659,6 +18662,23 @@ impl PreparedProcessSnapshotV2NetworkResourcePlan {
             self.mmds_controller.as_ref(),
         )
     }
+
+    fn matches_pci_platform_plan(&self, plan: &HvfSnapshotV2NetworkPciPlatformPlan) -> bool {
+        plan.preflight_process_resource_identity(
+            self.interfaces.iter().map(|interface| {
+                HvfSnapshotV2NetworkProcessResourceIdentity::new(
+                    interface.source_index,
+                    &interface.resource_key,
+                    &interface.controller,
+                    interface.profile,
+                    interface.backend,
+                    interface.mmds_stack,
+                )
+            }),
+            self.mmds_state.as_ref(),
+            self.mmds_controller.as_ref(),
+        )
+    }
 }
 
 impl fmt::Debug for PreparedProcessSnapshotV2NetworkResourcePlan {
@@ -19181,6 +19201,23 @@ where
     }
 
     fn matches_platform_plan(&self, plan: &HvfSnapshotV2NetworkMmioPlatformPlan) -> bool {
+        plan.preflight_process_resource_identity(
+            self.resource_interfaces.iter().map(|interface| {
+                HvfSnapshotV2NetworkProcessResourceIdentity::new(
+                    interface.source_index,
+                    &interface.resource_key,
+                    &interface.controller,
+                    interface.profile,
+                    interface.backend,
+                    interface.mmds_stack,
+                )
+            }),
+            self.expected_mmds_state(),
+            self.expected_mmds_controller(),
+        )
+    }
+
+    fn matches_pci_platform_plan(&self, plan: &HvfSnapshotV2NetworkPciPlatformPlan) -> bool {
         plan.preflight_process_resource_identity(
             self.resource_interfaces.iter().map(|interface| {
                 HvfSnapshotV2NetworkProcessResourceIdentity::new(
@@ -20676,6 +20713,308 @@ where
     Ok(())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProcessSnapshotV2NetworkPciRestoreStage {
+    ResourcePreparation,
+    ResourceTake { index: usize },
+    ProviderFinish,
+    HvfConstruction,
+    CompleteRecapture,
+    Assembly,
+    GateCommit,
+    Cleanup,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProcessSnapshotV2NetworkPciRestoreDisposition {
+    Retryable,
+    Terminal,
+    TerminalCleanup,
+}
+
+/// Bounded process-level failure for the still-private exact-2.11 PCI
+/// reconstruction transaction.
+struct ProcessSnapshotV2NetworkPciRestoreError {
+    stage: ProcessSnapshotV2NetworkPciRestoreStage,
+    disposition: ProcessSnapshotV2NetworkPciRestoreDisposition,
+}
+
+impl ProcessSnapshotV2NetworkPciRestoreError {
+    const fn retryable(stage: ProcessSnapshotV2NetworkPciRestoreStage) -> Self {
+        Self {
+            stage,
+            disposition: ProcessSnapshotV2NetworkPciRestoreDisposition::Retryable,
+        }
+    }
+
+    const fn terminal(
+        stage: ProcessSnapshotV2NetworkPciRestoreStage,
+        cleanup_uncertain: bool,
+    ) -> Self {
+        Self {
+            stage,
+            disposition: if cleanup_uncertain {
+                ProcessSnapshotV2NetworkPciRestoreDisposition::TerminalCleanup
+            } else {
+                ProcessSnapshotV2NetworkPciRestoreDisposition::Terminal
+            },
+        }
+    }
+
+    fn from_resource(
+        stage: ProcessSnapshotV2NetworkPciRestoreStage,
+        source: &ProcessSnapshotV2NetworkRestoreResourceError,
+    ) -> Self {
+        if source.cleanup_uncertain {
+            return Self::terminal(stage, true);
+        }
+        match source.disposition() {
+            ProcessSnapshotV2NetworkRestoreResourceDisposition::Retryable => Self::retryable(stage),
+            ProcessSnapshotV2NetworkRestoreResourceDisposition::Terminal => {
+                Self::terminal(stage, false)
+            }
+        }
+    }
+
+    fn from_hvf(
+        source: &HvfSnapshotV2NetworkPciRestoreError,
+        process_cleanup_uncertain: bool,
+    ) -> Self {
+        if source.has_incomplete_cleanup() || process_cleanup_uncertain {
+            return Self::terminal(
+                ProcessSnapshotV2NetworkPciRestoreStage::HvfConstruction,
+                true,
+            );
+        }
+        match source.disposition() {
+            HvfSnapshotV2NetworkPciRestoreDisposition::Retryable => {
+                Self::retryable(ProcessSnapshotV2NetworkPciRestoreStage::HvfConstruction)
+            }
+            HvfSnapshotV2NetworkPciRestoreDisposition::Terminal
+            | HvfSnapshotV2NetworkPciRestoreDisposition::TerminalCleanup => Self::terminal(
+                ProcessSnapshotV2NetworkPciRestoreStage::HvfConstruction,
+                false,
+            ),
+        }
+    }
+}
+
+impl fmt::Debug for ProcessSnapshotV2NetworkPciRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProcessSnapshotV2NetworkPciRestoreError")
+            .field("stage", &self.stage)
+            .field("disposition", &self.disposition)
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for ProcessSnapshotV2NetworkPciRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "exact-2.11 process PCI network reconstruction failed at {:?} ({:?})",
+            self.stage, self.disposition
+        )
+    }
+}
+
+impl std::error::Error for ProcessSnapshotV2NetworkPciRestoreError {}
+
+/// Complete unpublished process/HVF exact-2.11 PCI network owner graph.
+///
+/// Field order is the fallback cleanup order: HVF session and scheduler,
+/// provider/MMDS completion, then the saved-order publication receipts and
+/// metrics leases.
+struct RestoredProcessSnapshotV2NetworkPciOwners<B>
+where
+    B: ProcessVmnetBackend,
+{
+    hvf: Option<RestoredHvfSnapshotV2NetworkPciOwners>,
+    completion: Option<PreparedProcessSnapshotV2NetworkRestoreCompletion<B>>,
+    resources: Vec<PreparedProcessSnapshotV2NetworkRestoreResource>,
+}
+
+impl<B> RestoredProcessSnapshotV2NetworkPciOwners<B>
+where
+    B: ProcessVmnetBackend,
+{
+    fn shutdown(&mut self) -> Result<(), ProcessSnapshotV2NetworkPciRestoreError> {
+        let hvf_cleanup_uncertain = self
+            .hvf
+            .as_mut()
+            .is_some_and(|hvf| hvf.session_mut().shutdown().is_err());
+        self.hvf = None;
+        let process_cleanup_uncertain = self
+            .completion
+            .take()
+            .is_some_and(|completion| completion.abort().is_err());
+        self.resources.clear();
+        if hvf_cleanup_uncertain || process_cleanup_uncertain {
+            Err(ProcessSnapshotV2NetworkPciRestoreError::terminal(
+                ProcessSnapshotV2NetworkPciRestoreStage::Cleanup,
+                true,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<B> Drop for RestoredProcessSnapshotV2NetworkPciOwners<B>
+where
+    B: ProcessVmnetBackend,
+{
+    fn drop(&mut self) {
+        let _ = self.shutdown();
+    }
+}
+
+impl<B> fmt::Debug for RestoredProcessSnapshotV2NetworkPciOwners<B>
+where
+    B: ProcessVmnetBackend,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RestoredProcessSnapshotV2NetworkPciOwners")
+            .field("interface_count", &self.resources.len())
+            .field(
+                "retry_publication_committed",
+                &self.hvf.as_ref().is_some_and(
+                    RestoredHvfSnapshotV2NetworkPciOwners::retry_publication_is_committed,
+                ),
+            )
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+fn abort_staged_process_snapshot_v2_network_pci<B>(
+    mut hvf: RestoredHvfSnapshotV2NetworkPciOwners,
+    completion: PreparedProcessSnapshotV2NetworkRestoreCompletion<B>,
+    resources: Vec<PreparedProcessSnapshotV2NetworkRestoreResource>,
+) -> bool
+where
+    B: ProcessVmnetBackend,
+{
+    let hvf_cleanup_uncertain = hvf.session_mut().shutdown().is_err();
+    drop(hvf);
+    let process_cleanup_uncertain =
+        abort_completed_process_snapshot_v2_network_resources(completion, resources);
+    hvf_cleanup_uncertain || process_cleanup_uncertain
+}
+
+fn restored_process_snapshot_v2_network_pci_is_equivalent<B>(
+    hvf: &RestoredHvfSnapshotV2NetworkPciOwners,
+    completion: &PreparedProcessSnapshotV2NetworkRestoreCompletion<B>,
+    resources: &[PreparedProcessSnapshotV2NetworkRestoreResource],
+    now: Instant,
+) -> Result<(), ()>
+where
+    B: ProcessVmnetBackend,
+{
+    if !completion.configs_match(hvf.configs())
+        || !completion.resources_match(resources)
+        || completion.expected_mmds_state() != hvf.mmds_state()
+        || completion.expected_mmds_controller() != hvf.mmds_config()
+        || !completion
+            .network_metrics()
+            .shares_state_with(&hvf.session().shared_network_interface_metrics())
+    {
+        return Err(());
+    }
+
+    let Some(provider) = completion.provider() else {
+        return Err(());
+    };
+    if provider.readiness_wake.is_some() || provider.readiness_bridge.is_some() {
+        return Err(());
+    }
+    match (
+        completion.mmds_state(),
+        completion.mmds_metrics(),
+        hvf.mmds_config(),
+    ) {
+        (None, None, None) => {}
+        (Some(state), Some(metrics), Some(config)) => {
+            let state_is_fresh = state
+                .with(|state| {
+                    state.config() == Some(config)
+                        && state.data_store_present()
+                        && state.get_data().is_err()
+                })
+                .map_err(|_| ())?;
+            if !state_is_fresh || !metrics.snapshot().is_empty() {
+                return Err(());
+            }
+        }
+        _ => return Err(()),
+    }
+
+    let publication_guard = provider
+        .quiesce_capture_publication_for_owner(completion.authority())
+        .map_err(|_| ())?;
+    let limiter_guard = hvf
+        .session()
+        .quiesce_limiter_retry_wakeups()
+        .map_err(|_| ())?;
+    let prepared = provider
+        .prepare_capture_for_owner_with_optional_mmds(
+            completion.authority(),
+            hvf.configs(),
+            hvf.mmds_config(),
+            completion.mmds_state(),
+            completion.mmds_metrics(),
+            now,
+        )
+        .map_err(|_| ())?;
+    let metrics = hvf
+        .session()
+        .shared_network_interface_metrics()
+        .capture_state()
+        .map_err(|_| ())?;
+    let captured_hvf = hvf
+        .session()
+        .capture_ready_network_state_at(&prepared.hvf_configs, &limiter_guard, now)
+        .map_err(|_| ())?;
+    let captured =
+        compose_process_capture_ready_network_state(hvf.configs(), prepared, metrics, captured_hvf)
+            .map_err(|_| ())?;
+
+    if captured.interfaces().len() != resources.len()
+        || captured
+            .interfaces()
+            .iter()
+            .zip(resources)
+            .any(|(captured, resource)| {
+                captured.provider_generation() != resource.publication().generation
+                    || captured.metrics_generation() != resource._metrics_lease.generation()
+            })
+        || captured.source_work_normalized()
+        || !captured.aggregate_metrics().is_empty()
+        || captured
+            .interfaces()
+            .iter()
+            .any(|interface| !interface.metrics().is_empty())
+        || captured
+            .mmds()
+            .is_some_and(|mmds| !mmds.metrics().is_empty())
+    {
+        return Err(());
+    }
+    let portable =
+        convert_process_capture_ready_network_state(captured, SnapshotV2DeviceTransportKind::Pci)
+            .map_err(|_| ())?
+            .ok_or(())?;
+    if portable.interfaces() != hvf.expected() || portable.mmds() != hvf.mmds_state() {
+        return Err(());
+    }
+    drop(limiter_guard);
+    drop(publication_guard);
+    Ok(())
+}
+
 fn prepared_process_snapshot_v2_network_batch_is_fresh<B>(
     batch: &PreparedProcessSnapshotV2NetworkRestoreBatch<B>,
 ) -> bool
@@ -21029,6 +21368,318 @@ fn restore_process_snapshot_v2_network_mmio(
 > {
     let mut factory = SystemProcessVmnetPacketIoBackendFactory;
     restore_process_snapshot_v2_network_mmio_with_factory(
+        platform,
+        memory,
+        process_shell,
+        serial_input,
+        platform_plan,
+        resource_plan,
+        destination_instance_id,
+        mmds_data_store_limit_bytes,
+        &mut factory,
+        now,
+        cancelled,
+    )
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn restore_process_snapshot_v2_network_pci_with_factory<B, F, C>(
+    platform: HvfSnapshotV2PlatformState,
+    memory: HvfSnapshotV2NetworkPciMemoryInput,
+    process_shell: HvfSnapshotV2RestoredSerialShell,
+    serial_input: Option<SerialStdioInput>,
+    platform_plan: HvfSnapshotV2NetworkPciPlatformPlan,
+    resource_plan: PreparedProcessSnapshotV2NetworkResourcePlan,
+    destination_instance_id: &str,
+    mmds_data_store_limit_bytes: usize,
+    factory: &mut F,
+    now: Instant,
+    mut cancelled: C,
+) -> Result<RestoredProcessSnapshotV2NetworkPciOwners<B>, ProcessSnapshotV2NetworkPciRestoreError>
+where
+    B: ProcessVmnetBackend,
+    F: ProcessVmnetPacketIoBackendFactory<Backend = B>,
+    C: FnMut(ProcessSnapshotV2NetworkPciRestoreStage) -> bool,
+{
+    if cancelled(ProcessSnapshotV2NetworkPciRestoreStage::ResourcePreparation)
+        || !resource_plan.matches_pci_platform_plan(&platform_plan)
+    {
+        return Err(ProcessSnapshotV2NetworkPciRestoreError::retryable(
+            ProcessSnapshotV2NetworkPciRestoreStage::ResourcePreparation,
+        ));
+    }
+
+    let mut batch = {
+        let mut resource_cancelled =
+            |_| cancelled(ProcessSnapshotV2NetworkPciRestoreStage::ResourcePreparation);
+        prepare_process_snapshot_v2_network_restore_resources_with_factory(
+            resource_plan,
+            destination_instance_id,
+            mmds_data_store_limit_bytes,
+            factory,
+            &mut resource_cancelled,
+        )
+        .map_err(|source| {
+            ProcessSnapshotV2NetworkPciRestoreError::from_resource(
+                ProcessSnapshotV2NetworkPciRestoreStage::ResourcePreparation,
+                &source,
+            )
+        })?
+    };
+    if !batch.matches_pci_platform_plan(&platform_plan)
+        || !prepared_process_snapshot_v2_network_batch_is_fresh(&batch)
+    {
+        let cleanup_uncertain = batch.abort().is_err();
+        return Err(if cleanup_uncertain {
+            ProcessSnapshotV2NetworkPciRestoreError::terminal(
+                ProcessSnapshotV2NetworkPciRestoreStage::ResourcePreparation,
+                true,
+            )
+        } else {
+            ProcessSnapshotV2NetworkPciRestoreError::retryable(
+                ProcessSnapshotV2NetworkPciRestoreStage::ResourcePreparation,
+            )
+        });
+    }
+
+    let profiles = match batch.device_profiles() {
+        Ok(profiles) => profiles,
+        Err(source) => {
+            let cleanup_uncertain = batch.abort().is_err();
+            if cleanup_uncertain {
+                return Err(ProcessSnapshotV2NetworkPciRestoreError::terminal(
+                    ProcessSnapshotV2NetworkPciRestoreStage::ResourcePreparation,
+                    true,
+                ));
+            }
+            return Err(ProcessSnapshotV2NetworkPciRestoreError::from_resource(
+                ProcessSnapshotV2NetworkPciRestoreStage::ResourcePreparation,
+                &source,
+            ));
+        }
+    };
+    let mut resources = Vec::new();
+    if resources
+        .try_reserve_exact(batch.resource_interfaces().len())
+        .is_err()
+    {
+        let cleanup_uncertain = batch.abort().is_err();
+        return Err(if cleanup_uncertain {
+            ProcessSnapshotV2NetworkPciRestoreError::terminal(
+                ProcessSnapshotV2NetworkPciRestoreStage::ResourcePreparation,
+                true,
+            )
+        } else {
+            ProcessSnapshotV2NetworkPciRestoreError::retryable(
+                ProcessSnapshotV2NetworkPciRestoreStage::ResourcePreparation,
+            )
+        });
+    }
+    for index in 0..batch.resource_interfaces().len() {
+        let stage = ProcessSnapshotV2NetworkPciRestoreStage::ResourceTake { index };
+        if cancelled(stage) {
+            let cleanup_uncertain =
+                abort_unfinished_process_snapshot_v2_network_resources(batch, resources);
+            return Err(if cleanup_uncertain {
+                ProcessSnapshotV2NetworkPciRestoreError::terminal(stage, true)
+            } else {
+                ProcessSnapshotV2NetworkPciRestoreError::retryable(stage)
+            });
+        }
+        let Some(endpoint) = platform_plan.network().get(index) else {
+            let cleanup_uncertain =
+                abort_unfinished_process_snapshot_v2_network_resources(batch, resources);
+            return Err(if cleanup_uncertain {
+                ProcessSnapshotV2NetworkPciRestoreError::terminal(stage, true)
+            } else {
+                ProcessSnapshotV2NetworkPciRestoreError::retryable(stage)
+            });
+        };
+        let resource = match batch.take(endpoint.resource_key()) {
+            Ok(resource) => resource,
+            Err(_) => {
+                let cleanup_uncertain =
+                    abort_unfinished_process_snapshot_v2_network_resources(batch, resources);
+                return Err(if cleanup_uncertain {
+                    ProcessSnapshotV2NetworkPciRestoreError::terminal(stage, true)
+                } else {
+                    ProcessSnapshotV2NetworkPciRestoreError::retryable(stage)
+                });
+            }
+        };
+        if !batch.resource_matches(index, &resource) {
+            resources.push(resource);
+            let cleanup_uncertain =
+                abort_unfinished_process_snapshot_v2_network_resources(batch, resources);
+            return Err(if cleanup_uncertain {
+                ProcessSnapshotV2NetworkPciRestoreError::terminal(stage, true)
+            } else {
+                ProcessSnapshotV2NetworkPciRestoreError::retryable(stage)
+            });
+        }
+        resources.push(resource);
+    }
+    if cancelled(ProcessSnapshotV2NetworkPciRestoreStage::ProviderFinish) {
+        let cleanup_uncertain =
+            abort_unfinished_process_snapshot_v2_network_resources(batch, resources);
+        return Err(if cleanup_uncertain {
+            ProcessSnapshotV2NetworkPciRestoreError::terminal(
+                ProcessSnapshotV2NetworkPciRestoreStage::ProviderFinish,
+                true,
+            )
+        } else {
+            ProcessSnapshotV2NetworkPciRestoreError::retryable(
+                ProcessSnapshotV2NetworkPciRestoreStage::ProviderFinish,
+            )
+        });
+    }
+    let completion = match batch.finish() {
+        Ok(completion) => completion,
+        Err(source) => {
+            drop(resources);
+            return Err(ProcessSnapshotV2NetworkPciRestoreError::from_resource(
+                ProcessSnapshotV2NetworkPciRestoreStage::ProviderFinish,
+                &source,
+            ));
+        }
+    };
+    if !completion.resources_match(&resources) {
+        let cleanup_uncertain =
+            abort_completed_process_snapshot_v2_network_resources(completion, resources);
+        return Err(if cleanup_uncertain {
+            ProcessSnapshotV2NetworkPciRestoreError::terminal(
+                ProcessSnapshotV2NetworkPciRestoreStage::ProviderFinish,
+                true,
+            )
+        } else {
+            ProcessSnapshotV2NetworkPciRestoreError::retryable(
+                ProcessSnapshotV2NetworkPciRestoreStage::ProviderFinish,
+            )
+        });
+    }
+    if cancelled(ProcessSnapshotV2NetworkPciRestoreStage::HvfConstruction) {
+        let cleanup_uncertain =
+            abort_completed_process_snapshot_v2_network_resources(completion, resources);
+        return Err(if cleanup_uncertain {
+            ProcessSnapshotV2NetworkPciRestoreError::terminal(
+                ProcessSnapshotV2NetworkPciRestoreStage::HvfConstruction,
+                true,
+            )
+        } else {
+            ProcessSnapshotV2NetworkPciRestoreError::retryable(
+                ProcessSnapshotV2NetworkPciRestoreStage::HvfConstruction,
+            )
+        });
+    }
+
+    let staged_hvf = match OwnedHvfArm64BootSession::restore_snapshot_v2_network_pci(
+        platform,
+        memory,
+        process_shell,
+        serial_input,
+        platform_plan,
+        profiles,
+        completion.network_metrics().clone(),
+        now,
+    ) {
+        Ok(staged_hvf) => staged_hvf,
+        Err(source) => {
+            let cleanup_uncertain =
+                abort_completed_process_snapshot_v2_network_resources(completion, resources);
+            return Err(ProcessSnapshotV2NetworkPciRestoreError::from_hvf(
+                &source,
+                cleanup_uncertain,
+            ));
+        }
+    };
+
+    if cancelled(ProcessSnapshotV2NetworkPciRestoreStage::CompleteRecapture)
+        || restored_process_snapshot_v2_network_pci_is_equivalent(
+            &staged_hvf,
+            &completion,
+            &resources,
+            now,
+        )
+        .is_err()
+    {
+        let cleanup_uncertain =
+            abort_staged_process_snapshot_v2_network_pci(staged_hvf, completion, resources);
+        return Err(ProcessSnapshotV2NetworkPciRestoreError::terminal(
+            ProcessSnapshotV2NetworkPciRestoreStage::CompleteRecapture,
+            cleanup_uncertain,
+        ));
+    }
+
+    if cancelled(ProcessSnapshotV2NetworkPciRestoreStage::Assembly) {
+        let cleanup_uncertain =
+            abort_staged_process_snapshot_v2_network_pci(staged_hvf, completion, resources);
+        return Err(ProcessSnapshotV2NetworkPciRestoreError::terminal(
+            ProcessSnapshotV2NetworkPciRestoreStage::Assembly,
+            cleanup_uncertain,
+        ));
+    }
+    let mut owners = RestoredProcessSnapshotV2NetworkPciOwners {
+        hvf: Some(staged_hvf),
+        completion: Some(completion),
+        resources,
+    };
+    let owner_graph_is_complete = match (&owners.hvf, &owners.completion) {
+        (Some(hvf), Some(completion)) => {
+            !owners.resources.is_empty()
+                && hvf.configs().len() == owners.resources.len()
+                && completion.resource_interfaces().len() == owners.resources.len()
+        }
+        _ => false,
+    };
+    if !owner_graph_is_complete {
+        let cleanup_uncertain = owners.shutdown().is_err();
+        return Err(ProcessSnapshotV2NetworkPciRestoreError::terminal(
+            ProcessSnapshotV2NetworkPciRestoreStage::Assembly,
+            cleanup_uncertain,
+        ));
+    }
+
+    if cancelled(ProcessSnapshotV2NetworkPciRestoreStage::GateCommit) {
+        let cleanup_uncertain = owners.shutdown().is_err();
+        return Err(ProcessSnapshotV2NetworkPciRestoreError::terminal(
+            ProcessSnapshotV2NetworkPciRestoreStage::GateCommit,
+            cleanup_uncertain,
+        ));
+    }
+    let Some(staged_hvf) = owners.hvf.take() else {
+        let cleanup_uncertain = owners.shutdown().is_err();
+        return Err(ProcessSnapshotV2NetworkPciRestoreError::terminal(
+            ProcessSnapshotV2NetworkPciRestoreStage::GateCommit,
+            cleanup_uncertain,
+        ));
+    };
+    owners.hvf = Some(staged_hvf.commit_retry_publication());
+    Ok(owners)
+}
+
+type SystemRestoredProcessSnapshotV2NetworkPciOwners =
+    RestoredProcessSnapshotV2NetworkPciOwners<SystemVmnetInterfaceBackend>;
+
+#[expect(
+    dead_code,
+    reason = "public exact-2.11 load remains disabled until its activation slice"
+)]
+#[allow(clippy::too_many_arguments)]
+fn restore_process_snapshot_v2_network_pci(
+    platform: HvfSnapshotV2PlatformState,
+    memory: HvfSnapshotV2NetworkPciMemoryInput,
+    process_shell: HvfSnapshotV2RestoredSerialShell,
+    serial_input: Option<SerialStdioInput>,
+    platform_plan: HvfSnapshotV2NetworkPciPlatformPlan,
+    resource_plan: PreparedProcessSnapshotV2NetworkResourcePlan,
+    destination_instance_id: &str,
+    mmds_data_store_limit_bytes: usize,
+    now: Instant,
+    cancelled: impl FnMut(ProcessSnapshotV2NetworkPciRestoreStage) -> bool,
+) -> Result<SystemRestoredProcessSnapshotV2NetworkPciOwners, ProcessSnapshotV2NetworkPciRestoreError>
+{
+    let mut factory = SystemProcessVmnetPacketIoBackendFactory;
+    restore_process_snapshot_v2_network_pci_with_factory(
         platform,
         memory,
         process_shell,
@@ -45350,12 +46001,11 @@ mod tests {
     }
 
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    #[test]
-    #[ignore = "requires the signed native_v2_process integration group"]
-    fn signed_exact_minor_eleven_process_mmio_owner_transaction_is_atomic_and_retryable() {
+    fn verify_signed_exact_minor_eleven_process_network_owner_transaction(pci_enabled: bool) {
         use bangbang_hvf::{
             HvfSnapshotV2NetworkMmioProcessConfig, HvfSnapshotV2NetworkPreparedProduct,
             prepare_hvf_snapshot_v2_network_mmio_platform_plan,
+            prepare_hvf_snapshot_v2_network_pci_platform_plan,
         };
         use bangbang_runtime::balloon::BalloonMmioLayout;
         use bangbang_runtime::entropy::EntropyMmioLayout;
@@ -45404,13 +46054,16 @@ mod tests {
         let expected_mac = profiles[0]
             .guest_mac()
             .expect("saved vmnet profile should retain its requested MAC");
-        let mut source = super::OwnedHvfArm64BootSession::new(
-            &controller,
-            default_hvf_boot_session_config(SharedSerialOutput::from(
-                SharedSerialOutputBuffer::default(),
-            )),
-        )
-        .expect("signed exact-2.11 source should prepare");
+        let session_config = default_hvf_boot_session_config(SharedSerialOutput::from(
+            SharedSerialOutputBuffer::default(),
+        ));
+        let session_config = if pci_enabled {
+            session_config.with_pci_enabled()
+        } else {
+            session_config
+        };
+        let mut source = super::OwnedHvfArm64BootSession::new(&controller, session_config)
+            .expect("signed exact-2.11 source should prepare");
         let capture_configs = configs
             .iter()
             .zip(&profiles)
@@ -45441,23 +46094,44 @@ mod tests {
         let interfaces = captured
             .interfaces()
             .iter()
-            .map(|captured| {
-                let super::HvfArm64BootNetworkTransportCaptureState::Mmio {
+            .map(|captured| match captured.transport() {
+                super::HvfArm64BootNetworkTransportCaptureState::Mmio {
                     region,
                     interrupt_line,
                     state,
-                } = captured.transport()
-                else {
-                    panic!("network source should use MMIO");
-                };
-                SnapshotV2NetworkInterfaceState::try_from_mmio_capture(
+                } if !pci_enabled => SnapshotV2NetworkInterfaceState::try_from_mmio_capture(
                     captured.config(),
                     SnapshotV2NetworkBackendClass::Vmnet,
                     *region,
                     *interrupt_line,
                     state,
                 )
-                .expect("portable network interface should convert")
+                .expect("portable MMIO network interface should convert"),
+                super::HvfArm64BootNetworkTransportCaptureState::Pci {
+                    origin,
+                    sbdf,
+                    bar_range,
+                    state,
+                } if pci_enabled => {
+                    let origin = match origin {
+                        super::HvfArm64BootNetworkDeviceOrigin::Startup => {
+                            super::StorageDeviceOrigin::Startup
+                        }
+                        super::HvfArm64BootNetworkDeviceOrigin::Runtime => {
+                            super::StorageDeviceOrigin::Runtime
+                        }
+                    };
+                    SnapshotV2NetworkInterfaceState::try_from_pci_capture(
+                        captured.config(),
+                        SnapshotV2NetworkBackendClass::Vmnet,
+                        origin,
+                        *sbdf,
+                        *bar_range,
+                        state,
+                    )
+                    .expect("portable PCI network interface should convert")
+                }
+                _ => panic!("network source transport should match the test mode"),
             })
             .collect::<Vec<_>>();
         let network = SnapshotV2NetworkState::try_new(interfaces, None)
@@ -45504,6 +46178,196 @@ mod tests {
             "signed-exact-2-11-process-network-memory",
             &memory_output.into_inner(),
         );
+
+        if pci_enabled {
+            let make_restore_inputs = || {
+                let candidate = NativeV2NetworkSnapshotCandidateState::from_network_state_v2_11(
+                    encoded.clone(),
+                )
+                .expect("exact-2.11 PCI candidate should decode");
+                let prepared = match candidate
+                    .prepare(&overrides)
+                    .expect("exact-2.11 PCI destination topology should prepare")
+                {
+                    NativeV2NetworkSnapshotPreparation::Prepared(prepared) => prepared,
+                    NativeV2NetworkSnapshotPreparation::Compatible(_) => {
+                        panic!("PCI network-bearing candidate must not remain compatible")
+                    }
+                };
+                let plan = prepare_process_snapshot_v2_network_restore_plan(
+                    prepared,
+                    ProcessVmnetAuthority::Direct,
+                )
+                .expect("exact-2.11 PCI process value plan should prepare");
+                let (candidate, resource_plan) = plan.into_parts();
+                let (
+                    bytes,
+                    binding,
+                    storage,
+                    serial,
+                    entropy,
+                    balloon,
+                    memory_hotplug,
+                    topology,
+                    manifest,
+                ) = candidate.into_parts();
+                assert!(storage.is_none());
+                assert!(entropy.is_none());
+                assert!(balloon.is_none());
+                assert!(memory_hotplug.is_none());
+                assert_eq!(topology.interfaces().len(), 1);
+                let platform_plan = prepare_hvf_snapshot_v2_network_pci_platform_plan(
+                    &platform,
+                    HvfSnapshotV2NetworkPreparedProduct::serial_network(binding, topology),
+                )
+                .expect("exact-2.11 PCI platform plan should prepare");
+                let structural = decode_snapshot_v2_state_with_compatibility_version(
+                    &encoded,
+                    NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
+                )
+                .expect("exact-2.11 PCI state should decode structurally");
+                let memory = load_snapshot_v2_memory_path(&structural, memory_image.path())
+                    .expect("exact-2.11 PCI destination memory should map privately");
+                let shell = super::HvfSnapshotV2RestoredSerialShell::new(
+                    SerialMmioDevice::from_capture_state_with_shared_output(
+                        SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+                        serial.device().clone(),
+                    ),
+                );
+                drop((bytes, serial, manifest));
+                (memory, shell, platform_plan, resource_plan)
+            };
+
+            for (cancel_stage, expected_disposition) in [
+                (
+                    super::ProcessSnapshotV2NetworkPciRestoreStage::ResourcePreparation,
+                    super::ProcessSnapshotV2NetworkPciRestoreDisposition::Retryable,
+                ),
+                (
+                    super::ProcessSnapshotV2NetworkPciRestoreStage::ResourceTake { index: 0 },
+                    super::ProcessSnapshotV2NetworkPciRestoreDisposition::Retryable,
+                ),
+                (
+                    super::ProcessSnapshotV2NetworkPciRestoreStage::ProviderFinish,
+                    super::ProcessSnapshotV2NetworkPciRestoreDisposition::Retryable,
+                ),
+                (
+                    super::ProcessSnapshotV2NetworkPciRestoreStage::HvfConstruction,
+                    super::ProcessSnapshotV2NetworkPciRestoreDisposition::Retryable,
+                ),
+                (
+                    super::ProcessSnapshotV2NetworkPciRestoreStage::CompleteRecapture,
+                    super::ProcessSnapshotV2NetworkPciRestoreDisposition::Terminal,
+                ),
+                (
+                    super::ProcessSnapshotV2NetworkPciRestoreStage::Assembly,
+                    super::ProcessSnapshotV2NetworkPciRestoreDisposition::Terminal,
+                ),
+                (
+                    super::ProcessSnapshotV2NetworkPciRestoreStage::GateCommit,
+                    super::ProcessSnapshotV2NetworkPciRestoreDisposition::Terminal,
+                ),
+            ] {
+                let (memory, shell, platform_plan, resource_plan) = make_restore_inputs();
+                let mut factory = RecordingVmnetPacketIoBackendFactory::default()
+                    .with_next_realized_mac(expected_mac)
+                    .with_next_effective_mtu(1400);
+                let events = factory.events();
+                let error = super::restore_process_snapshot_v2_network_pci_with_factory(
+                    platform.clone(),
+                    super::HvfSnapshotV2NetworkPciMemoryInput::Static(memory),
+                    shell,
+                    None,
+                    platform_plan,
+                    resource_plan,
+                    "exact-2-11-pci-cancelled-destination",
+                    bangbang_runtime::mmds::MMDS_DATA_STORE_LIMIT_BYTES,
+                    &mut factory,
+                    Instant::now(),
+                    |stage| stage == cancel_stage,
+                )
+                .expect_err("injected PCI process owner cancellation should reject");
+                assert_eq!(error.stage, cancel_stage);
+                assert_eq!(error.disposition, expected_disposition);
+                let diagnostics = format!("{error:?} {error}");
+                assert!(diagnostics.contains("<redacted>"));
+                assert!(!diagnostics.contains("eth0"));
+                assert!(!diagnostics.contains("vmnet:shared"));
+                assert!(!diagnostics.contains("exact-2-11-pci-cancelled-destination"));
+                let events = recorded_events(&events);
+                if matches!(
+                    cancel_stage,
+                    super::ProcessSnapshotV2NetworkPciRestoreStage::ResourcePreparation
+                ) {
+                    assert!(events.is_empty());
+                } else {
+                    assert_eq!(
+                        events
+                            .iter()
+                            .filter(|event| event.starts_with("start:"))
+                            .count(),
+                        1
+                    );
+                    assert_eq!(
+                        events
+                            .iter()
+                            .filter(|event| event.starts_with("stop:"))
+                            .count(),
+                        1
+                    );
+                }
+            }
+
+            let (memory, shell, platform_plan, resource_plan) = make_restore_inputs();
+            let mut factory = RecordingVmnetPacketIoBackendFactory::default()
+                .with_next_realized_mac(expected_mac)
+                .with_next_effective_mtu(1400);
+            let events = factory.events();
+            let mut owners = super::restore_process_snapshot_v2_network_pci_with_factory(
+                platform,
+                super::HvfSnapshotV2NetworkPciMemoryInput::Static(memory),
+                shell,
+                None,
+                platform_plan,
+                resource_plan,
+                "exact-2-11-pci-committed-destination",
+                bangbang_runtime::mmds::MMDS_DATA_STORE_LIMIT_BYTES,
+                &mut factory,
+                Instant::now(),
+                |_| false,
+            )
+            .expect("complete PCI process/HVF owner graph should commit");
+            assert_eq!(owners.resources.len(), 1);
+            assert!(owners.completion.is_some());
+            assert!(owners.hvf.as_ref().is_some_and(
+                super::RestoredHvfSnapshotV2NetworkPciOwners::retry_publication_is_committed
+            ));
+            let diagnostics = format!("{owners:?}");
+            assert!(diagnostics.contains("<redacted>"));
+            assert!(!diagnostics.contains("eth0"));
+            assert!(!diagnostics.contains("vmnet:shared"));
+            assert_eq!(
+                recorded_events(&events)
+                    .iter()
+                    .filter(|event| event.starts_with("stop:"))
+                    .count(),
+                0
+            );
+            owners
+                .shutdown()
+                .expect("committed PCI process/HVF owner graph should shut down");
+            owners
+                .shutdown()
+                .expect("repeated PCI process/HVF shutdown should be idempotent");
+            assert_eq!(
+                recorded_events(&events)
+                    .iter()
+                    .filter(|event| event.starts_with("stop:"))
+                    .count(),
+                1
+            );
+            return;
+        }
 
         let process = HvfSnapshotV2NetworkMmioProcessConfig::new(
             BalloonMmioLayout::new(DEFAULT_BALLOON_MMIO_BASE, DEFAULT_BALLOON_MMIO_REGION_ID),
@@ -45704,6 +46568,20 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[test]
+    #[ignore = "requires the signed native_v2_process integration group"]
+    fn signed_exact_minor_eleven_process_mmio_owner_transaction_is_atomic_and_retryable() {
+        verify_signed_exact_minor_eleven_process_network_owner_transaction(false);
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[test]
+    #[ignore = "requires the signed native_v2_process integration group"]
+    fn signed_exact_minor_eleven_process_pci_owner_transaction_is_atomic_and_retryable() {
+        verify_signed_exact_minor_eleven_process_network_owner_transaction(true);
     }
 
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -20603,14 +20603,76 @@ where
     hvf_cleanup_uncertain || process_cleanup_uncertain
 }
 
-fn restored_process_snapshot_v2_network_mmio_is_equivalent<B>(
-    hvf: &RestoredHvfSnapshotV2NetworkMmioOwners,
+trait RestoredProcessSnapshotV2NetworkHvfOwners {
+    fn session(&self) -> &OwnedHvfArm64BootSession;
+    fn configs(&self) -> &[NetworkInterfaceConfig];
+    fn expected(&self) -> &[SnapshotV2NetworkInterfaceState];
+    fn mmds_state(&self) -> Option<&SnapshotV2MmdsState>;
+    fn mmds_config(&self) -> Option<&MmdsConfig>;
+    fn transport_kind(&self) -> SnapshotV2DeviceTransportKind;
+}
+
+impl RestoredProcessSnapshotV2NetworkHvfOwners for RestoredHvfSnapshotV2NetworkMmioOwners {
+    fn session(&self) -> &OwnedHvfArm64BootSession {
+        RestoredHvfSnapshotV2NetworkMmioOwners::session(self)
+    }
+
+    fn configs(&self) -> &[NetworkInterfaceConfig] {
+        RestoredHvfSnapshotV2NetworkMmioOwners::configs(self)
+    }
+
+    fn expected(&self) -> &[SnapshotV2NetworkInterfaceState] {
+        RestoredHvfSnapshotV2NetworkMmioOwners::expected(self)
+    }
+
+    fn mmds_state(&self) -> Option<&SnapshotV2MmdsState> {
+        RestoredHvfSnapshotV2NetworkMmioOwners::mmds_state(self)
+    }
+
+    fn mmds_config(&self) -> Option<&MmdsConfig> {
+        RestoredHvfSnapshotV2NetworkMmioOwners::mmds_config(self)
+    }
+
+    fn transport_kind(&self) -> SnapshotV2DeviceTransportKind {
+        SnapshotV2DeviceTransportKind::Mmio
+    }
+}
+
+impl RestoredProcessSnapshotV2NetworkHvfOwners for RestoredHvfSnapshotV2NetworkPciOwners {
+    fn session(&self) -> &OwnedHvfArm64BootSession {
+        RestoredHvfSnapshotV2NetworkPciOwners::session(self)
+    }
+
+    fn configs(&self) -> &[NetworkInterfaceConfig] {
+        RestoredHvfSnapshotV2NetworkPciOwners::configs(self)
+    }
+
+    fn expected(&self) -> &[SnapshotV2NetworkInterfaceState] {
+        RestoredHvfSnapshotV2NetworkPciOwners::expected(self)
+    }
+
+    fn mmds_state(&self) -> Option<&SnapshotV2MmdsState> {
+        RestoredHvfSnapshotV2NetworkPciOwners::mmds_state(self)
+    }
+
+    fn mmds_config(&self) -> Option<&MmdsConfig> {
+        RestoredHvfSnapshotV2NetworkPciOwners::mmds_config(self)
+    }
+
+    fn transport_kind(&self) -> SnapshotV2DeviceTransportKind {
+        SnapshotV2DeviceTransportKind::Pci
+    }
+}
+
+fn restored_process_snapshot_v2_network_is_equivalent<B, H>(
+    hvf: &H,
     completion: &PreparedProcessSnapshotV2NetworkRestoreCompletion<B>,
     resources: &[PreparedProcessSnapshotV2NetworkRestoreResource],
     now: Instant,
 ) -> Result<(), ()>
 where
     B: ProcessVmnetBackend,
+    H: RestoredProcessSnapshotV2NetworkHvfOwners,
 {
     if !completion.configs_match(hvf.configs())
         || !completion.resources_match(resources)
@@ -20701,10 +20763,9 @@ where
     {
         return Err(());
     }
-    let portable =
-        convert_process_capture_ready_network_state(captured, SnapshotV2DeviceTransportKind::Mmio)
-            .map_err(|_| ())?
-            .ok_or(())?;
+    let portable = convert_process_capture_ready_network_state(captured, hvf.transport_kind())
+        .map_err(|_| ())?
+        .ok_or(())?;
     if portable.interfaces() != hvf.expected() || portable.mmds() != hvf.mmds_state() {
         return Err(());
     }
@@ -20914,105 +20975,7 @@ fn restored_process_snapshot_v2_network_pci_is_equivalent<B>(
 where
     B: ProcessVmnetBackend,
 {
-    if !completion.configs_match(hvf.configs())
-        || !completion.resources_match(resources)
-        || completion.expected_mmds_state() != hvf.mmds_state()
-        || completion.expected_mmds_controller() != hvf.mmds_config()
-        || !completion
-            .network_metrics()
-            .shares_state_with(&hvf.session().shared_network_interface_metrics())
-    {
-        return Err(());
-    }
-
-    let Some(provider) = completion.provider() else {
-        return Err(());
-    };
-    if provider.readiness_wake.is_some() || provider.readiness_bridge.is_some() {
-        return Err(());
-    }
-    match (
-        completion.mmds_state(),
-        completion.mmds_metrics(),
-        hvf.mmds_config(),
-    ) {
-        (None, None, None) => {}
-        (Some(state), Some(metrics), Some(config)) => {
-            let state_is_fresh = state
-                .with(|state| {
-                    state.config() == Some(config)
-                        && state.data_store_present()
-                        && state.get_data().is_err()
-                })
-                .map_err(|_| ())?;
-            if !state_is_fresh || !metrics.snapshot().is_empty() {
-                return Err(());
-            }
-        }
-        _ => return Err(()),
-    }
-
-    let publication_guard = provider
-        .quiesce_capture_publication_for_owner(completion.authority())
-        .map_err(|_| ())?;
-    let limiter_guard = hvf
-        .session()
-        .quiesce_limiter_retry_wakeups()
-        .map_err(|_| ())?;
-    let prepared = provider
-        .prepare_capture_for_owner_with_optional_mmds(
-            completion.authority(),
-            hvf.configs(),
-            hvf.mmds_config(),
-            completion.mmds_state(),
-            completion.mmds_metrics(),
-            now,
-        )
-        .map_err(|_| ())?;
-    let metrics = hvf
-        .session()
-        .shared_network_interface_metrics()
-        .capture_state()
-        .map_err(|_| ())?;
-    let captured_hvf = hvf
-        .session()
-        .capture_ready_network_state_at(&prepared.hvf_configs, &limiter_guard, now)
-        .map_err(|_| ())?;
-    let captured =
-        compose_process_capture_ready_network_state(hvf.configs(), prepared, metrics, captured_hvf)
-            .map_err(|_| ())?;
-
-    if captured.interfaces().len() != resources.len()
-        || captured
-            .interfaces()
-            .iter()
-            .zip(resources)
-            .any(|(captured, resource)| {
-                captured.provider_generation() != resource.publication().generation
-                    || captured.metrics_generation() != resource._metrics_lease.generation()
-            })
-        || captured.source_work_normalized()
-        || !captured.aggregate_metrics().is_empty()
-        || captured
-            .interfaces()
-            .iter()
-            .any(|interface| !interface.metrics().is_empty())
-        || captured
-            .mmds()
-            .is_some_and(|mmds| !mmds.metrics().is_empty())
-    {
-        return Err(());
-    }
-    let portable =
-        convert_process_capture_ready_network_state(captured, SnapshotV2DeviceTransportKind::Pci)
-            .map_err(|_| ())?
-            .ok_or(())?;
-    if portable.interfaces() != hvf.expected() || portable.mmds() != hvf.mmds_state() {
-        return Err(());
-    }
-    drop(limiter_guard);
-    drop(publication_guard);
-    Ok(())
+    restored_process_snapshot_v2_network_is_equivalent(hvf, completion, resources, now)
 }
 
 fn prepared_process_snapshot_v2_network_batch_is_fresh<B>(
@@ -21280,7 +21243,7 @@ where
     };
 
     if cancelled(ProcessSnapshotV2NetworkMmioRestoreStage::CompleteRecapture)
-        || restored_process_snapshot_v2_network_mmio_is_equivalent(
+        || restored_process_snapshot_v2_network_is_equivalent(
             &staged_hvf,
             &completion,
             &resources,

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -278,7 +278,9 @@ pub use startup::{
     HvfSnapshotV2MultiBlockPciRestoreError, HvfSnapshotV2MultiBlockPciRestoreFailure,
     HvfSnapshotV2MultiBlockPciRestoreStage, HvfSnapshotV2NetworkMmioMemoryInput,
     HvfSnapshotV2NetworkMmioRestoreDisposition, HvfSnapshotV2NetworkMmioRestoreError,
-    HvfSnapshotV2NetworkMmioRestoreStage, HvfSnapshotV2RootRestoreCleanupFailure,
+    HvfSnapshotV2NetworkMmioRestoreStage, HvfSnapshotV2NetworkPciMemoryInput,
+    HvfSnapshotV2NetworkPciRestoreDisposition, HvfSnapshotV2NetworkPciRestoreError,
+    HvfSnapshotV2NetworkPciRestoreStage, HvfSnapshotV2RootRestoreCleanupFailure,
     HvfSnapshotV2RootRestoreError, HvfSnapshotV2RootRestoreFailure, HvfSnapshotV2RootRestoreStage,
     HvfSnapshotV2SerialOnlyRestoreError, HvfSnapshotV2StorageMmioRestoreCleanupFailure,
     HvfSnapshotV2StorageMmioRestoreError, HvfSnapshotV2StorageMmioRestoreFailure,
@@ -290,8 +292,8 @@ pub use startup::{
     RestoredHvfSnapshotV2EntropyMmioOwners, RestoredHvfSnapshotV2EntropyPciOwners,
     RestoredHvfSnapshotV2MemoryHotplugMmioOwners, RestoredHvfSnapshotV2MemoryHotplugPciOwners,
     RestoredHvfSnapshotV2MultiBlockMmioOwners, RestoredHvfSnapshotV2MultiBlockPciOwners,
-    RestoredHvfSnapshotV2NetworkMmioOwners, RestoredHvfSnapshotV2StorageMmioOwners,
-    RestoredHvfSnapshotV2StoragePciOwners,
+    RestoredHvfSnapshotV2NetworkMmioOwners, RestoredHvfSnapshotV2NetworkPciOwners,
+    RestoredHvfSnapshotV2StorageMmioOwners, RestoredHvfSnapshotV2StoragePciOwners,
 };
 pub use topology::{
     HvfVcpuTopology, HvfVcpuTopologyAllocation, HvfVcpuTopologyCreateStage, HvfVcpuTopologyError,

--- a/crates/hvf/src/snapshot_v2_entropy_platform.rs
+++ b/crates/hvf/src/snapshot_v2_entropy_platform.rs
@@ -52,6 +52,24 @@ pub struct HvfSnapshotV2EntropyPciEndpointPlan {
 }
 
 impl HvfSnapshotV2EntropyPciEndpointPlan {
+    pub(crate) const fn for_network_product(
+        preceding_endpoint_count: usize,
+        sbdf: PciSbdf,
+        bar_region_id: MmioRegionId,
+        bar_range: GuestMemoryRange,
+        route_count: usize,
+        msi_interrupt_count: u32,
+    ) -> Self {
+        Self {
+            preceding_endpoint_count,
+            sbdf,
+            bar_region_id,
+            bar_range,
+            route_count,
+            msi_interrupt_count,
+        }
+    }
+
     /// Returns how many storage endpoints must already be published.
     pub const fn preceding_endpoint_count(self) -> usize {
         self.preceding_endpoint_count

--- a/crates/hvf/src/snapshot_v2_memory_hotplug_platform.rs
+++ b/crates/hvf/src/snapshot_v2_memory_hotplug_platform.rs
@@ -502,6 +502,24 @@ pub struct HvfSnapshotV2MemoryHotplugPciEndpointPlan {
 }
 
 impl HvfSnapshotV2MemoryHotplugPciEndpointPlan {
+    pub(crate) const fn for_network_product(
+        origin: StorageDeviceOrigin,
+        sbdf: PciSbdf,
+        bar_region_id: MmioRegionId,
+        bar_range: GuestMemoryRange,
+        route_count: usize,
+        msi_interrupt_count: u32,
+    ) -> Self {
+        Self {
+            origin,
+            sbdf,
+            bar_region_id,
+            bar_range,
+            route_count,
+            msi_interrupt_count,
+        }
+    }
+
     pub const fn origin(self) -> StorageDeviceOrigin {
         self.origin
     }

--- a/crates/hvf/src/snapshot_v2_network_platform.rs
+++ b/crates/hvf/src/snapshot_v2_network_platform.rs
@@ -1433,6 +1433,41 @@ impl HvfSnapshotV2NetworkPciPlatformPlan {
     pub const fn vmclock_interrupt(&self) -> GuestInterruptLine {
         self.vmclock_interrupt
     }
+
+    /// Proves that a separately retained process resource blueprint still
+    /// describes this exact saved-order PCI product. This performs no host
+    /// operation and retains no caller borrow.
+    #[doc(hidden)]
+    pub fn preflight_process_resource_identity<'a>(
+        &self,
+        resources: impl ExactSizeIterator<Item = HvfSnapshotV2NetworkProcessResourceIdentity<'a>>,
+        mmds_state: Option<&bangbang_runtime::snapshot_network_v2_11::SnapshotV2MmdsState>,
+        mmds_controller: Option<&bangbang_runtime::mmds::MmdsConfig>,
+    ) -> bool {
+        let topology = self.product.network();
+        if resources.len() != self.network.len()
+            || topology.interfaces().len() != self.network.len()
+            || topology.mmds_state() != mmds_state
+            || topology.mmds_controller() != mmds_controller
+        {
+            return false;
+        }
+        resources.zip(topology.interfaces()).zip(&self.network).all(
+            |((resource, interface), endpoint)| {
+                resource.source_index == interface.source_index()
+                    && resource.source_index == endpoint.source_index()
+                    && resource.resource_key == interface.resource_key()
+                    && resource.resource_key == endpoint.resource_key()
+                    && resource.resource_key.resource_class()
+                        == SnapshotRestoreResourceClass::NetworkPacketIo
+                    && resource.controller == interface.controller()
+                    && resource.profile == interface.portable().profile()
+                    && resource.backend == interface.portable().backend()
+                    && resource.mmds_stack == interface.mmds_stack()
+                    && resource.mmds_stack == endpoint.mmds_stack()
+            },
+        )
+    }
 }
 
 impl fmt::Debug for HvfSnapshotV2NetworkPciPlatformPlan {
@@ -1443,6 +1478,44 @@ impl fmt::Debug for HvfSnapshotV2NetworkPciPlatformPlan {
             .field("interface_count", &self.network.len())
             .field("state", &REDACTED)
             .finish()
+    }
+}
+
+pub(crate) struct HvfSnapshotV2NetworkPciPlatformOwnerParts {
+    pub(crate) product: HvfSnapshotV2NetworkPreparedProduct,
+    pub(crate) mapping: Option<HvfSnapshotV2MemoryHotplugMappingPlan>,
+    pub(crate) balloon: Option<HvfSnapshotV2BalloonPciEndpointPlan>,
+    pub(crate) storage: Option<HvfSnapshotV2StoragePciPlatformPlan>,
+    pub(crate) network: Vec<HvfSnapshotV2NetworkPciEndpointPlan>,
+    pub(crate) entropy: Option<HvfSnapshotV2NetworkAuxiliaryPciEndpointPlan>,
+    pub(crate) memory_hotplug: Option<HvfSnapshotV2NetworkAuxiliaryPciEndpointPlan>,
+    pub(crate) host: Arm64FdtPciHost,
+    pub(crate) msi: HvfGicMsiMetadata,
+    pub(crate) endpoint_count: usize,
+    pub(crate) route_demand: usize,
+    pub(crate) serial_interrupt: GuestInterruptLine,
+    pub(crate) vmgenid_interrupt: GuestInterruptLine,
+    pub(crate) vmclock_interrupt: GuestInterruptLine,
+}
+
+impl HvfSnapshotV2NetworkPciPlatformPlan {
+    pub(crate) fn into_owner_parts(self) -> HvfSnapshotV2NetworkPciPlatformOwnerParts {
+        HvfSnapshotV2NetworkPciPlatformOwnerParts {
+            product: self.product,
+            mapping: self.mapping,
+            balloon: self.balloon,
+            storage: self.storage,
+            network: self.network,
+            entropy: self.entropy,
+            memory_hotplug: self.memory_hotplug,
+            host: self.host,
+            msi: self.msi,
+            endpoint_count: self.endpoint_count,
+            route_demand: self.route_demand,
+            serial_interrupt: self.serial_interrupt,
+            vmgenid_interrupt: self.vmgenid_interrupt,
+            vmclock_interrupt: self.vmclock_interrupt,
+        }
     }
 }
 
@@ -4794,6 +4867,50 @@ mod tests {
                 plan.msi().interrupt_range.count,
             );
         }
+    }
+
+    #[test]
+    fn pci_process_resource_preflight_closes_saved_order_identity() {
+        let (platform, state) = network_fixture(SnapshotV2DeviceTransportKind::Pci);
+        let process_topology = network_topology(state.clone());
+        let product = HvfSnapshotV2NetworkPreparedProduct::serial_network(
+            platform.memory().clone(),
+            network_topology(state),
+        );
+        let plan = prepare_hvf_snapshot_v2_network_pci_platform_plan(&platform, product)
+            .expect("network-only PCI product should plan");
+
+        let identities = process_topology.interfaces().iter().map(|interface| {
+            HvfSnapshotV2NetworkProcessResourceIdentity::new(
+                interface.source_index(),
+                interface.resource_key(),
+                interface.controller(),
+                interface.portable().profile(),
+                interface.portable().backend(),
+                interface.mmds_stack(),
+            )
+        });
+        assert!(plan.preflight_process_resource_identity(
+            identities,
+            process_topology.mmds_state(),
+            process_topology.mmds_controller(),
+        ));
+
+        let wrong_order = process_topology.interfaces().iter().map(|interface| {
+            HvfSnapshotV2NetworkProcessResourceIdentity::new(
+                interface.source_index().saturating_add(1),
+                interface.resource_key(),
+                interface.controller(),
+                interface.portable().profile(),
+                interface.portable().backend(),
+                interface.mmds_stack(),
+            )
+        });
+        assert!(!plan.preflight_process_resource_identity(
+            wrong_order,
+            process_topology.mmds_state(),
+            process_topology.mmds_controller(),
+        ));
     }
 
     #[test]

--- a/crates/hvf/src/snapshot_v2_platform.rs
+++ b/crates/hvf/src/snapshot_v2_platform.rs
@@ -10,7 +10,7 @@ use device_tree::{DeviceTree, Node};
 
 use bangbang_runtime::block::BlockMmioLayout;
 use bangbang_runtime::boot::canonical_process_root_block_command_line;
-use bangbang_runtime::fdt::ARM64_GICV2M_MSI_SET_SPI_NSR_OFFSET;
+use bangbang_runtime::fdt::{ARM64_GICV2M_MSI_SET_SPI_NSR_OFFSET, Arm64FdtPciHost};
 use bangbang_runtime::interrupt::GuestInterruptLine;
 use bangbang_runtime::memory::{
     GuestAddress, GuestMemory, GuestMemoryAccessError, GuestMemoryRange, aarch64,
@@ -55,7 +55,7 @@ use crate::cpu_template::HvfArm64CpuTemplateError;
 use crate::dirty::HvfDirtyWriteTrackerStartError;
 use crate::gic::{
     HvfGicError, HvfGicInterruptLineAllocator, HvfGicMetadata, HvfGicMsiConfiguration,
-    HvfGicSpiSignalError, HvfGicSpiSignaler, HvfInterruptLineAllocationError,
+    HvfGicMsiMetadata, HvfGicSpiSignalError, HvfGicSpiSignaler, HvfInterruptLineAllocationError,
 };
 use crate::memory::{
     HvfGuestMemoryMappingError, HvfMemoryPermissions, HvfSnapshotV2MemoryHotplugMappingPlan,
@@ -498,6 +498,18 @@ pub(crate) struct HvfSnapshotV2StoragePciShellPlan<'a> {
     pub(crate) vmclock_interrupt: GuestInterruptLine,
 }
 
+pub(crate) struct HvfSnapshotV2NetworkPciShellPlan<'a> {
+    pub(crate) storage: Option<HvfSnapshotV2StoragePciShellPlan<'a>>,
+    pub(crate) host: Arm64FdtPciHost,
+    pub(crate) msi: HvfGicMsiMetadata,
+    pub(crate) endpoint_count: usize,
+    pub(crate) route_demand: usize,
+    pub(crate) memory_hotplug: bool,
+    pub(crate) serial_interrupt: GuestInterruptLine,
+    pub(crate) vmgenid_interrupt: GuestInterruptLine,
+    pub(crate) vmclock_interrupt: GuestInterruptLine,
+}
+
 enum HvfSnapshotV2ProcessShellRestore<'a> {
     DeviceFree(HvfSnapshotV2ProcessSerialShell),
     SerialOnly {
@@ -541,6 +553,10 @@ enum HvfSnapshotV2ProcessShellRestore<'a> {
     NetworkMmio {
         shell: HvfSnapshotV2ProcessSerialShell,
         plan: HvfSnapshotV2NetworkMmioShellPlan<'a>,
+    },
+    NetworkPci {
+        shell: HvfSnapshotV2ProcessSerialShell,
+        plan: HvfSnapshotV2NetworkPciShellPlan<'a>,
     },
     StoragePci {
         shell: HvfSnapshotV2ProcessSerialShell,
@@ -1703,6 +1719,36 @@ pub(crate) fn restore_hvf_snapshot_v2_serial_network_mmio_process_platform(
         state,
         memory,
         Some(HvfSnapshotV2ProcessShellRestore::NetworkMmio {
+            shell: shell.into(),
+            plan,
+        }),
+        mapping.map_or(
+            HvfSnapshotV2MemoryMappingRestore::Ordinary,
+            HvfSnapshotV2MemoryMappingRestore::MemoryHotplug,
+        ),
+    )
+}
+
+pub(crate) fn restore_hvf_snapshot_v2_serial_network_pci_process_platform(
+    state: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    shell: HvfSnapshotV2RestoredSerialShell,
+    plan: HvfSnapshotV2NetworkPciShellPlan<'_>,
+    mapping: Option<&HvfSnapshotV2MemoryHotplugMappingPlan>,
+) -> Result<RestoredHvfSnapshotV2Platform, HvfSnapshotV2PlatformRestoreError> {
+    if mapping.is_some() != plan.memory_hotplug {
+        return Err(HvfSnapshotV2PlatformRestoreError::new(
+            HvfSnapshotV2PlatformRestoreStage::Preflight,
+            HvfSnapshotV2PlatformRestoreFailure::ProcessShellFdt {
+                mismatch: HvfSnapshotV2ProcessFdtMismatch::Profile,
+            },
+            Vec::new(),
+        ));
+    }
+    restore_hvf_snapshot_v2_platform_with_shell_and_mapping(
+        state,
+        memory,
+        Some(HvfSnapshotV2ProcessShellRestore::NetworkPci {
             shell: shell.into(),
             plan,
         }),
@@ -3128,6 +3174,55 @@ fn prepare_process_shell(
                         pmem_records: plan.pmem_records,
                     },
                     None => HvfSnapshotV2ProcessBlockFdtPlan::None,
+                };
+                (
+                    shell,
+                    block_plan,
+                    true,
+                    false,
+                    Some((
+                        plan.serial_interrupt,
+                        plan.vmgenid_interrupt,
+                        plan.vmclock_interrupt,
+                    )),
+                )
+            }
+            HvfSnapshotV2ProcessShellRestore::NetworkPci { shell, plan } => {
+                let canonical_host = Arm64PciAddressPlan::firecracker_v1_16()
+                    .map(Arm64FdtPciHost::from_address_plan)
+                    .ok();
+                if plan.endpoint_count == 0
+                    || plan.route_demand == 0
+                    || canonical_host != Some(plan.host)
+                    || gic.msi != Some(plan.msi)
+                    || !usize::try_from(plan.msi.interrupt_range.count)
+                        .is_ok_and(|count| plan.route_demand <= count)
+                {
+                    return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellFdt {
+                        mismatch: HvfSnapshotV2ProcessFdtMismatch::Profile,
+                    });
+                }
+                let block_plan = match plan.storage {
+                    Some(storage)
+                        if storage.pci.record_count() != 0
+                            && storage.pci.route_demand() != 0
+                            && storage.pci.host() == plan.host
+                            && storage.pci.msi() == plan.msi
+                            && storage.serial_interrupt == plan.serial_interrupt
+                            && storage.vmgenid_interrupt == plan.vmgenid_interrupt
+                            && storage.vmclock_interrupt == plan.vmclock_interrupt =>
+                    {
+                        HvfSnapshotV2ProcessBlockFdtPlan::StoragePci {
+                            command_line: storage.command_line,
+                            pci: storage.pci,
+                        }
+                    }
+                    None => HvfSnapshotV2ProcessBlockFdtPlan::None,
+                    Some(_) => {
+                        return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellFdt {
+                            mismatch: HvfSnapshotV2ProcessFdtMismatch::Profile,
+                        });
+                    }
                 };
                 (
                     shell,

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -44,8 +44,8 @@ use bangbang_runtime::entropy::{
     VirtioRngRetryCaptureState,
 };
 use bangbang_runtime::fdt::{
-    Arm64FdtCacheHierarchy, Arm64FdtError, Arm64FdtGuestMemoryWrite, Arm64FdtRegion,
-    Arm64FdtVirtioMmioDevice,
+    Arm64FdtCacheHierarchy, Arm64FdtError, Arm64FdtGuestMemoryWrite, Arm64FdtPciHost,
+    Arm64FdtRegion, Arm64FdtVirtioMmioDevice,
 };
 use bangbang_runtime::interrupt::{
     DeviceInterruptKind, DeviceInterruptTriggerError, GuestInterruptLine, InterruptSink,
@@ -150,6 +150,7 @@ use bangbang_runtime::snapshot_memory_v2::{
     SnapshotV2MemoryBinding, SnapshotV2MemoryIoStage, SnapshotV2MemoryWriteError,
     write_snapshot_v2_memory_image_with_compatibility_version_and_cancel,
 };
+use bangbang_runtime::snapshot_network_restore_v2_11::PreparedSnapshotV2NetworkRestoreInterface;
 use bangbang_runtime::snapshot_network_v2_11::{
     NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION, SnapshotV2MmdsState,
     SnapshotV2NetworkInterfaceState,
@@ -227,8 +228,8 @@ use crate::dirty::{HvfDirtyWriteEpochResetError, HvfDirtyWriteTrackerStartError}
 use crate::gic::{
     HvfArm64GicIccRegisterState, HvfGicDeviceState, HvfGicError, HvfGicInterruptLineAllocator,
     HvfGicMetadata, HvfGicMsiConfiguration, HvfGicMsiDeviceInterruptResourceError,
-    HvfGicMsiDeviceInterruptResources, HvfGicMsiSignaler, HvfGicSpiSignalError, HvfGicSpiSignaler,
-    HvfInterruptLineAllocationError,
+    HvfGicMsiDeviceInterruptResources, HvfGicMsiMetadata, HvfGicMsiSignaler, HvfGicSpiSignalError,
+    HvfGicSpiSignaler, HvfInterruptLineAllocationError,
 };
 use crate::memory::{
     HvfGuestMemoryMappingError, HvfMemoryPermissions, HvfPmemFlushExecutor,
@@ -285,17 +286,20 @@ use crate::snapshot_v2_multi_block_platform::{
 };
 use crate::snapshot_v2_network_platform::{
     HvfSnapshotV2NetworkMmioPlatformOwnerParts, HvfSnapshotV2NetworkMmioPlatformPlan,
-    HvfSnapshotV2NetworkPreparedMemoryProduct, HvfSnapshotV2NetworkPreparedOwnerParts,
+    HvfSnapshotV2NetworkPciEndpointPlan, HvfSnapshotV2NetworkPciPlatformOwnerParts,
+    HvfSnapshotV2NetworkPciPlatformPlan, HvfSnapshotV2NetworkPreparedMemoryProduct,
+    HvfSnapshotV2NetworkPreparedOwnerParts,
 };
 use crate::snapshot_v2_platform::{
     HvfSnapshotV2BalloonMmioShellPlan, HvfSnapshotV2DefaultProcessShell,
     HvfSnapshotV2MemoryHotplugMmioShellPlan, HvfSnapshotV2MultiBlockMmioShellPlan,
     HvfSnapshotV2MultiBlockPciShellPlan, HvfSnapshotV2NetworkMmioShellPlan,
-    HvfSnapshotV2PlatformRestoreError, HvfSnapshotV2PlatformShutdownError,
-    HvfSnapshotV2RestoredSerialShell, HvfSnapshotV2RootResourcePlan,
-    HvfSnapshotV2RootTransportPlan, HvfSnapshotV2SerialOnlyProcessConfig,
-    HvfSnapshotV2StorageMmioShellPlan, HvfSnapshotV2StoragePciShellPlan,
-    RestoredHvfSnapshotV2Platform, restore_hvf_snapshot_v2_multi_block_mmio_process_platform,
+    HvfSnapshotV2NetworkPciShellPlan, HvfSnapshotV2PlatformRestoreError,
+    HvfSnapshotV2PlatformShutdownError, HvfSnapshotV2RestoredSerialShell,
+    HvfSnapshotV2RootResourcePlan, HvfSnapshotV2RootTransportPlan,
+    HvfSnapshotV2SerialOnlyProcessConfig, HvfSnapshotV2StorageMmioShellPlan,
+    HvfSnapshotV2StoragePciShellPlan, RestoredHvfSnapshotV2Platform,
+    restore_hvf_snapshot_v2_multi_block_mmio_process_platform,
     restore_hvf_snapshot_v2_multi_block_pci_process_platform,
     restore_hvf_snapshot_v2_root_process_platform,
     restore_hvf_snapshot_v2_serial_balloon_mmio_process_platform,
@@ -303,6 +307,7 @@ use crate::snapshot_v2_platform::{
     restore_hvf_snapshot_v2_serial_memory_hotplug_mmio_process_platform,
     restore_hvf_snapshot_v2_serial_memory_hotplug_pci_process_platform,
     restore_hvf_snapshot_v2_serial_network_mmio_process_platform,
+    restore_hvf_snapshot_v2_serial_network_pci_process_platform,
     restore_hvf_snapshot_v2_serial_only_process_platform,
     restore_hvf_snapshot_v2_serial_storage_entropy_mmio_process_platform,
     restore_hvf_snapshot_v2_serial_storage_memory_hotplug_pci_process_platform,
@@ -3563,6 +3568,11 @@ enum HvfSnapshotV2StorageProcessShell {
         interrupts: HvfSnapshotV2NetworkMmioInterruptPlan,
         mapping: Option<HvfSnapshotV2MemoryHotplugMappingPlan>,
     },
+    RestoredNetworkPci {
+        shell: HvfSnapshotV2RestoredSerialShell,
+        process: HvfSnapshotV2NetworkPciProcessPlan,
+        mapping: Option<HvfSnapshotV2MemoryHotplugMappingPlan>,
+    },
     RestoredMemoryHotplugPci {
         shell: HvfSnapshotV2RestoredSerialShell,
         mapping: HvfSnapshotV2MemoryHotplugMappingPlan,
@@ -3590,6 +3600,11 @@ enum HvfSnapshotV2SerialProcessShell {
     NetworkMmio {
         shell: HvfSnapshotV2RestoredSerialShell,
         interrupts: HvfSnapshotV2NetworkMmioInterruptPlan,
+        mapping: Option<HvfSnapshotV2MemoryHotplugMappingPlan>,
+    },
+    NetworkPci {
+        shell: HvfSnapshotV2RestoredSerialShell,
+        process: HvfSnapshotV2NetworkPciProcessPlan,
         mapping: Option<HvfSnapshotV2MemoryHotplugMappingPlan>,
     },
     MemoryHotplugPci {
@@ -3628,10 +3643,23 @@ struct HvfSnapshotV2NetworkMmioInterruptPlan {
     vmclock: GuestInterruptLine,
 }
 
+#[derive(Clone, Copy)]
+struct HvfSnapshotV2NetworkPciProcessPlan {
+    host: Arm64FdtPciHost,
+    msi: HvfGicMsiMetadata,
+    endpoint_count: usize,
+    route_demand: usize,
+    memory_hotplug: bool,
+    serial: GuestInterruptLine,
+    vmgenid: GuestInterruptLine,
+    vmclock: GuestInterruptLine,
+}
+
 impl HvfSnapshotV2SerialProcessShell {
     const fn pci_enabled(&self) -> bool {
         match self {
             Self::SerialOnly { process, .. } => process.pci_enabled(),
+            Self::NetworkPci { .. } => true,
             Self::MemoryHotplugPci { process, .. } => process.pci_enabled(),
             Self::EntropyMmio { .. }
             | Self::BalloonMmio { .. }
@@ -3875,6 +3903,241 @@ impl fmt::Debug for RestoredHvfSnapshotV2NetworkMmioOwners {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("RestoredHvfSnapshotV2NetworkMmioOwners")
+            .field("interface_count", &self.configs.len())
+            .field(
+                "retry_publication_committed",
+                &self.retry_publication_is_committed(),
+            )
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Typed guest-memory handoff for one exact-2.11 PCI network product.
+#[doc(hidden)]
+pub enum HvfSnapshotV2NetworkPciMemoryInput {
+    /// The caller-owned image for a static-memory product.
+    Static(GuestMemory),
+    /// Selects the image retained by a mixed-memory virtio-mem product.
+    ProductOwned,
+}
+
+impl fmt::Debug for HvfSnapshotV2NetworkPciMemoryInput {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2NetworkPciMemoryInput")
+            .field(
+                "kind",
+                &match self {
+                    Self::Static(_) => "static",
+                    Self::ProductOwned => "product-owned",
+                },
+            )
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Stable aggregate stage for exact-2.11 PCI network reconstruction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[doc(hidden)]
+pub enum HvfSnapshotV2NetworkPciRestoreStage {
+    Product,
+    Platform,
+    EndpointPreparation { index: usize },
+    Publication { index: usize },
+    Entropy,
+    MemoryHotplug,
+    RetryScheduler,
+    RetryDeadline,
+    Recapture,
+    Assembly,
+}
+
+/// Whether an exact-2.11 PCI reconstruction failure may be retried.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[doc(hidden)]
+pub enum HvfSnapshotV2NetworkPciRestoreDisposition {
+    Retryable,
+    Terminal,
+    TerminalCleanup,
+}
+
+/// Bounded, redacted exact-2.11 PCI aggregate reconstruction error.
+#[doc(hidden)]
+pub struct HvfSnapshotV2NetworkPciRestoreError {
+    stage: HvfSnapshotV2NetworkPciRestoreStage,
+    disposition: HvfSnapshotV2NetworkPciRestoreDisposition,
+}
+
+impl HvfSnapshotV2NetworkPciRestoreError {
+    fn preflight(stage: HvfSnapshotV2NetworkPciRestoreStage) -> Self {
+        Self {
+            stage,
+            disposition: HvfSnapshotV2NetworkPciRestoreDisposition::Retryable,
+        }
+    }
+
+    fn committed(stage: HvfSnapshotV2NetworkPciRestoreStage, cleanup_failed: bool) -> Self {
+        Self {
+            stage,
+            disposition: if cleanup_failed {
+                HvfSnapshotV2NetworkPciRestoreDisposition::TerminalCleanup
+            } else {
+                HvfSnapshotV2NetworkPciRestoreDisposition::Terminal
+            },
+        }
+    }
+
+    fn after_session(
+        mut session: OwnedHvfArm64BootSession,
+        stage: HvfSnapshotV2NetworkPciRestoreStage,
+    ) -> Self {
+        Self::committed(stage, session.shutdown().is_err())
+    }
+
+    pub const fn stage(&self) -> HvfSnapshotV2NetworkPciRestoreStage {
+        self.stage
+    }
+
+    pub const fn disposition(&self) -> HvfSnapshotV2NetworkPciRestoreDisposition {
+        self.disposition
+    }
+
+    pub const fn is_terminal(&self) -> bool {
+        !matches!(
+            self.disposition,
+            HvfSnapshotV2NetworkPciRestoreDisposition::Retryable
+        )
+    }
+
+    pub const fn has_incomplete_cleanup(&self) -> bool {
+        matches!(
+            self.disposition,
+            HvfSnapshotV2NetworkPciRestoreDisposition::TerminalCleanup
+        )
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2NetworkPciRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2NetworkPciRestoreError")
+            .field("stage", &self.stage)
+            .field("disposition", &self.disposition)
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2NetworkPciRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "exact-2.11 PCI network reconstruction failed at {:?} ({:?})",
+            self.stage, self.disposition
+        )
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2NetworkPciRestoreError {}
+
+/// Complete exact-2.11 PCI owner graph with retry publication still gated.
+#[doc(hidden)]
+pub struct RestoredHvfSnapshotV2NetworkPciOwners {
+    session: OwnedHvfArm64BootSession,
+    configs: Vec<NetworkInterfaceConfig>,
+    expected: Vec<SnapshotV2NetworkInterfaceState>,
+    mmds_state: Option<SnapshotV2MmdsState>,
+    mmds_config: Option<MmdsConfig>,
+    storage_configs: Option<CaptureReadyStorageConfigs>,
+    entropy_config: Option<EntropyConfig>,
+    balloon_config: Option<BalloonConfig>,
+    memory_hotplug_state: Option<SnapshotV2MemoryHotplugState>,
+    memory_hotplug_controller: Option<SnapshotV2MemoryHotplugControllerProjection>,
+    retry_publication_gate: Option<HvfArm64BootLimiterRetryWakeupSchedulerPublicationGate>,
+}
+
+impl RestoredHvfSnapshotV2NetworkPciOwners {
+    pub const fn session(&self) -> &OwnedHvfArm64BootSession {
+        &self.session
+    }
+
+    pub fn session_mut(&mut self) -> &mut OwnedHvfArm64BootSession {
+        &mut self.session
+    }
+
+    pub fn configs(&self) -> &[NetworkInterfaceConfig] {
+        &self.configs
+    }
+
+    pub fn expected(&self) -> &[SnapshotV2NetworkInterfaceState] {
+        &self.expected
+    }
+
+    pub const fn mmds_state(&self) -> Option<&SnapshotV2MmdsState> {
+        self.mmds_state.as_ref()
+    }
+
+    pub const fn mmds_config(&self) -> Option<&MmdsConfig> {
+        self.mmds_config.as_ref()
+    }
+
+    pub const fn storage_configs(&self) -> Option<&CaptureReadyStorageConfigs> {
+        self.storage_configs.as_ref()
+    }
+
+    pub const fn entropy_config(&self) -> Option<EntropyConfig> {
+        self.entropy_config
+    }
+
+    pub const fn balloon_config(&self) -> Option<BalloonConfig> {
+        self.balloon_config
+    }
+
+    pub const fn memory_hotplug_state(&self) -> Option<&SnapshotV2MemoryHotplugState> {
+        self.memory_hotplug_state.as_ref()
+    }
+
+    pub const fn memory_hotplug_controller(
+        &self,
+    ) -> Option<&SnapshotV2MemoryHotplugControllerProjection> {
+        self.memory_hotplug_controller.as_ref()
+    }
+
+    pub const fn retry_publication_is_committed(&self) -> bool {
+        self.retry_publication_gate.is_none()
+    }
+
+    pub fn commit_retry_publication(mut self) -> Self {
+        if let Some(gate) = self.retry_publication_gate.take() {
+            gate.commit();
+        }
+        self
+    }
+
+    pub fn shutdown(mut self) -> Result<(), HvfArm64BootSessionShutdownError> {
+        self.session.shutdown()
+    }
+
+    pub fn into_session(
+        mut self,
+    ) -> Result<OwnedHvfArm64BootSession, HvfSnapshotV2NetworkPciRestoreError> {
+        if self.retry_publication_gate.is_some() {
+            let cleanup_failed = self.session.shutdown().is_err();
+            return Err(HvfSnapshotV2NetworkPciRestoreError::committed(
+                HvfSnapshotV2NetworkPciRestoreStage::Assembly,
+                cleanup_failed,
+            ));
+        }
+        Ok(self.session)
+    }
+}
+
+impl fmt::Debug for RestoredHvfSnapshotV2NetworkPciOwners {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RestoredHvfSnapshotV2NetworkPciOwners")
             .field("interface_count", &self.configs.len())
             .field(
                 "retry_publication_committed",
@@ -6632,9 +6895,17 @@ impl std::error::Error for HvfSnapshotV2StorageMmioRestoreError {
 
 /// One complete, still-private exact-2.6 PCI storage destination and ordered
 /// controller projection.
+struct RestoredHvfSnapshotV2NetworkPciBatch {
+    configs: Vec<NetworkInterfaceConfig>,
+    expected: Vec<SnapshotV2NetworkInterfaceState>,
+    capture_configs: Vec<HvfArm64BootNetworkCaptureConfig>,
+    earliest_retry_deadline: Option<Instant>,
+}
+
 pub struct RestoredHvfSnapshotV2StoragePciOwners {
     session: OwnedHvfArm64BootSession,
     configs: CaptureReadyStorageConfigs,
+    network: Option<RestoredHvfSnapshotV2NetworkPciBatch>,
 }
 
 impl RestoredHvfSnapshotV2StoragePciOwners {
@@ -6647,7 +6918,21 @@ impl RestoredHvfSnapshotV2StoragePciOwners {
     }
 
     pub fn into_parts(self) -> (OwnedHvfArm64BootSession, CaptureReadyStorageConfigs) {
+        debug_assert!(self.network.is_none());
         (self.session, self.configs)
+    }
+
+    fn into_network_parts(
+        self,
+    ) -> (
+        OwnedHvfArm64BootSession,
+        CaptureReadyStorageConfigs,
+        RestoredHvfSnapshotV2NetworkPciBatch,
+    ) {
+        let Some(network) = self.network else {
+            std::process::abort();
+        };
+        (self.session, self.configs, network)
     }
 }
 
@@ -16516,11 +16801,39 @@ struct PreparedHvfSnapshotV2BalloonPciPublication {
     interrupts: HvfGicMsiDeviceInterruptResources,
 }
 
+struct HvfSnapshotV2NetworkPciBatchInput {
+    interfaces: Vec<PreparedSnapshotV2NetworkRestoreInterface>,
+    endpoints: Vec<HvfSnapshotV2NetworkPciEndpointPlan>,
+    profiles: Vec<NetworkDeviceProfile>,
+    metrics: SharedNetworkInterfaceMetricsRegistry,
+    now: Instant,
+    fault: Option<HvfSnapshotV2NetworkPciBatchFault>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum HvfSnapshotV2NetworkPciBatchFault {
+    Preparation { index: usize },
+    Publication { index: usize },
+}
+
+#[derive(Clone, Copy)]
+struct HvfSnapshotV2EntropyPciPrecedingEndpointCounts {
+    balloon: usize,
+    network: usize,
+}
+
+impl HvfSnapshotV2EntropyPciPrecedingEndpointCounts {
+    const fn new(balloon: usize, network: usize) -> Self {
+        Self { balloon, network }
+    }
+}
+
 struct HvfSnapshotV2StoragePciPublicationInput {
     balloon: Option<(
         HvfSnapshotV2BalloonPciEndpointPlan,
         SnapshotV2BalloonRestorePlan,
     )>,
+    network: Option<HvfSnapshotV2NetworkPciBatchInput>,
     pmem_fault_index: Option<usize>,
     balloon_fault: Option<HvfSnapshotV2BalloonPciRestoreFault>,
 }
@@ -16529,6 +16842,7 @@ impl HvfSnapshotV2StoragePciPublicationInput {
     const fn empty() -> Self {
         Self {
             balloon: None,
+            network: None,
             pmem_fault_index: None,
             balloon_fault: None,
         }
@@ -16537,6 +16851,7 @@ impl HvfSnapshotV2StoragePciPublicationInput {
     const fn pmem_fault(index: usize) -> Self {
         Self {
             balloon: None,
+            network: None,
             pmem_fault_index: Some(index),
             balloon_fault: None,
         }
@@ -16549,9 +16864,15 @@ impl HvfSnapshotV2StoragePciPublicationInput {
     ) -> Self {
         Self {
             balloon: Some((endpoint, balloon)),
+            network: None,
             pmem_fault_index: None,
             balloon_fault: fault,
         }
+    }
+
+    fn with_network(mut self, network: HvfSnapshotV2NetworkPciBatchInput) -> Self {
+        self.network = Some(network);
+        self
     }
 }
 
@@ -16634,6 +16955,304 @@ fn release_unpublished_snapshot_v2_storage_pci_publication(
             release_unpublished_snapshot_v2_storage_pci_interrupts(index, &mut interrupts, cleanup);
         }
     }
+}
+
+#[derive(Clone, Copy)]
+enum HvfSnapshotV2NetworkPciBatchFailureKind {
+    Preparation,
+    Publication,
+}
+
+struct HvfSnapshotV2NetworkPciBatchFailure {
+    index: usize,
+    kind: HvfSnapshotV2NetworkPciBatchFailureKind,
+    cleanup_failed: bool,
+}
+
+fn release_snapshot_v2_network_pci_interrupts(
+    interrupts: &mut HvfGicMsiDeviceInterruptResources,
+) -> bool {
+    interrupts.release().is_err()
+}
+
+fn fallible_network_owner_string(value: &str) -> Result<String, ()> {
+    let mut owned = String::new();
+    owned.try_reserve_exact(value.len()).map_err(|_| ())?;
+    owned.push_str(value);
+    Ok(owned)
+}
+
+fn publish_snapshot_v2_network_pci_batch(
+    manager: &mut HvfArm64BootPciDataDevices,
+    memory: &GuestMemory,
+    input: HvfSnapshotV2NetworkPciBatchInput,
+) -> Result<
+    (
+        RestoredHvfSnapshotV2NetworkPciBatch,
+        SharedNetworkInterfaceMetricsRegistry,
+    ),
+    HvfSnapshotV2NetworkPciBatchFailure,
+> {
+    let HvfSnapshotV2NetworkPciBatchInput {
+        interfaces,
+        endpoints,
+        profiles,
+        metrics,
+        now,
+        fault,
+    } = input;
+    let interface_count = interfaces.len();
+    if interface_count == 0
+        || interface_count != endpoints.len()
+        || interface_count != profiles.len()
+        || manager
+            .network
+            .len()
+            .checked_add(interface_count)
+            .is_none_or(|count| count > manager.network.capacity())
+    {
+        return Err(HvfSnapshotV2NetworkPciBatchFailure {
+            index: 0,
+            kind: HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+            cleanup_failed: false,
+        });
+    }
+
+    let mut configs = Vec::new();
+    let mut expected = Vec::new();
+    let mut capture_configs = Vec::new();
+    if configs.try_reserve_exact(interface_count).is_err()
+        || expected.try_reserve_exact(interface_count).is_err()
+        || capture_configs.try_reserve_exact(interface_count).is_err()
+    {
+        return Err(HvfSnapshotV2NetworkPciBatchFailure {
+            index: 0,
+            kind: HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+            cleanup_failed: false,
+        });
+    }
+    let aggregate_metrics = metrics.aggregate();
+    let mut earliest_retry_deadline = None;
+
+    for (index, ((interface, endpoint_plan), profile)) in interfaces
+        .into_iter()
+        .zip(endpoints)
+        .zip(profiles)
+        .enumerate()
+    {
+        if fault == Some(HvfSnapshotV2NetworkPciBatchFault::Preparation { index }) {
+            return Err(HvfSnapshotV2NetworkPciBatchFailure {
+                index,
+                kind: HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+                cleanup_failed: false,
+            });
+        }
+        if interface.source_index() != endpoint_plan.source_index()
+            || interface.resource_key() != endpoint_plan.resource_key()
+            || interface.mmds_stack() != endpoint_plan.mmds_stack()
+            || endpoint_plan.route_count() != VIRTIO_NET_QUEUE_SIZES.len() + 1
+        {
+            return Err(HvfSnapshotV2NetworkPciBatchFailure {
+                index,
+                kind: HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+                cleanup_failed: false,
+            });
+        }
+        let Some(interface_metrics) = metrics.per_interface(interface.controller().iface_id())
+        else {
+            return Err(HvfSnapshotV2NetworkPciBatchFailure {
+                index,
+                kind: HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+                cleanup_failed: false,
+            });
+        };
+        let mut interrupts =
+            manager
+                .shared_msi_registry()
+                .map_err(|_| HvfSnapshotV2NetworkPciBatchFailure {
+                    index,
+                    kind: HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+                    cleanup_failed: false,
+                })?;
+        if interrupts.registry().route_count()
+            != usize::try_from(endpoint_plan.msi_interrupt_count()).unwrap_or(usize::MAX)
+        {
+            let cleanup_failed = release_snapshot_v2_network_pci_interrupts(&mut interrupts);
+            return Err(HvfSnapshotV2NetworkPciBatchFailure {
+                index,
+                kind: HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+                cleanup_failed,
+            });
+        }
+        let prepared = match interface.into_pci_endpoint(
+            memory,
+            profile,
+            interface_metrics,
+            aggregate_metrics.clone(),
+            endpoint_plan.bar_region_id(),
+            interrupts.registry(),
+            now,
+        ) {
+            Ok(prepared) => prepared,
+            Err(_) => {
+                let cleanup_failed = release_snapshot_v2_network_pci_interrupts(&mut interrupts);
+                return Err(HvfSnapshotV2NetworkPciBatchFailure {
+                    index,
+                    kind: HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+                    cleanup_failed,
+                });
+            }
+        };
+        let transport = prepared.endpoint().endpoint().transport_state();
+        let placement_matches = transport.as_ref().is_ok_and(|transport| {
+            transport.msix_vector_count() == endpoint_plan.route_count()
+                && transport.msix_state().queue_vectors() == endpoint_plan.queue_vectors()
+                && transport.msix_state().config_vector() == endpoint_plan.config_vector()
+        });
+        if prepared.source_index() != endpoint_plan.source_index()
+            || prepared.resource_key() != endpoint_plan.resource_key()
+            || prepared.mmds_stack() != endpoint_plan.mmds_stack()
+            || prepared.queue_ranges() != endpoint_plan.queue_ranges()
+            || prepared.origin() != endpoint_plan.origin()
+            || prepared.endpoint().sbdf() != endpoint_plan.sbdf()
+            || prepared.endpoint().bar_range() != endpoint_plan.bar_range()
+            || prepared.endpoint().region_id() != endpoint_plan.bar_region_id()
+            || !placement_matches
+        {
+            drop(prepared);
+            let cleanup_failed = release_snapshot_v2_network_pci_interrupts(&mut interrupts);
+            return Err(HvfSnapshotV2NetworkPciBatchFailure {
+                index,
+                kind: HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+                cleanup_failed,
+            });
+        }
+
+        let (
+            _source_index,
+            _resource_key,
+            controller,
+            expected_state,
+            _mmds_stack,
+            _queue_ranges,
+            _retry,
+            retry_deadline,
+            origin,
+            endpoint,
+        ) = prepared.into_parts();
+        if fault == Some(HvfSnapshotV2NetworkPciBatchFault::Publication { index }) {
+            drop(endpoint);
+            let cleanup_failed = release_snapshot_v2_network_pci_interrupts(&mut interrupts);
+            return Err(HvfSnapshotV2NetworkPciBatchFailure {
+                index,
+                kind: HvfSnapshotV2NetworkPciBatchFailureKind::Publication,
+                cleanup_failed,
+            });
+        }
+        let iface_id = match fallible_network_owner_string(controller.iface_id()) {
+            Ok(iface_id) => iface_id,
+            Err(()) => {
+                drop(endpoint);
+                let cleanup_failed = release_snapshot_v2_network_pci_interrupts(&mut interrupts);
+                return Err(HvfSnapshotV2NetworkPciBatchFailure {
+                    index,
+                    kind: HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+                    cleanup_failed,
+                });
+            }
+        };
+        let host_dev_name = match fallible_network_owner_string(controller.host_dev_name()) {
+            Ok(host_dev_name) => host_dev_name,
+            Err(()) => {
+                drop(endpoint);
+                let cleanup_failed = release_snapshot_v2_network_pci_interrupts(&mut interrupts);
+                return Err(HvfSnapshotV2NetworkPciBatchFailure {
+                    index,
+                    kind: HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+                    cleanup_failed,
+                });
+            }
+        };
+        let capture_controller = match controller.try_clone() {
+            Ok(controller) => controller,
+            Err(_) => {
+                drop(endpoint);
+                let cleanup_failed = release_snapshot_v2_network_pci_interrupts(&mut interrupts);
+                return Err(HvfSnapshotV2NetworkPciBatchFailure {
+                    index,
+                    kind: HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+                    cleanup_failed,
+                });
+            }
+        };
+        let live_origin = match origin {
+            StorageDeviceOrigin::Startup => HvfArm64BootNetworkDeviceOrigin::Startup,
+            StorageDeviceOrigin::Runtime => HvfArm64BootNetworkDeviceOrigin::Runtime,
+        };
+        let dispatcher_owner = Arc::clone(&manager.dispatcher);
+        let segment = manager.validation.segment().clone();
+        let mut dispatcher = match dispatcher_owner.lock() {
+            Ok(dispatcher) => dispatcher,
+            Err(_) => {
+                drop(endpoint);
+                let cleanup_failed = release_snapshot_v2_network_pci_interrupts(&mut interrupts);
+                return Err(HvfSnapshotV2NetworkPciBatchFailure {
+                    index,
+                    kind: HvfSnapshotV2NetworkPciBatchFailureKind::Publication,
+                    cleanup_failed,
+                });
+            }
+        };
+        let published = match endpoint.publish(
+            manager.validation.bar_allocator_mut(),
+            segment,
+            &mut dispatcher,
+            interrupts,
+        ) {
+            Ok(published) => published,
+            Err(source) => {
+                return Err(HvfSnapshotV2NetworkPciBatchFailure {
+                    index,
+                    kind: HvfSnapshotV2NetworkPciBatchFailureKind::Publication,
+                    cleanup_failed: matches!(source, VirtioPciPublicationError::Rollback { .. }),
+                });
+            }
+        };
+        drop(dispatcher);
+        manager.network.push(HvfArm64BootPciNetworkDevice {
+            iface_id,
+            host_dev_name,
+            origin: live_origin,
+            published,
+            queue_deliveries: 0,
+            retry_deadline,
+            _metrics_lease: None,
+        });
+        configs.push(controller);
+        expected.push(expected_state);
+        capture_configs.push(HvfArm64BootNetworkCaptureConfig::new(
+            capture_controller,
+            profile,
+            None,
+            None,
+            false,
+        ));
+        earliest_retry_deadline = match (earliest_retry_deadline, retry_deadline) {
+            (None, deadline) => deadline,
+            (deadline, None) => deadline,
+            (Some(current), Some(candidate)) => Some(current.min(candidate)),
+        };
+    }
+
+    Ok((
+        RestoredHvfSnapshotV2NetworkPciBatch {
+            configs,
+            expected,
+            capture_configs,
+            earliest_retry_deadline,
+        },
+        metrics,
+    ))
 }
 
 struct HvfSnapshotV2StoragePciCleanup<'a> {
@@ -17114,6 +17733,27 @@ impl OwnedHvfArm64BootSession {
                     serial_interrupt: interrupts.serial,
                     vmgenid_interrupt: interrupts.vmgenid,
                     vmclock_interrupt: interrupts.vmclock,
+                },
+                mapping.as_ref(),
+            ),
+            HvfSnapshotV2SerialProcessShell::NetworkPci {
+                shell,
+                process,
+                mapping,
+            } => restore_hvf_snapshot_v2_serial_network_pci_process_platform(
+                state,
+                memory,
+                shell,
+                HvfSnapshotV2NetworkPciShellPlan {
+                    storage: None,
+                    host: process.host,
+                    msi: process.msi,
+                    endpoint_count: process.endpoint_count,
+                    route_demand: process.route_demand,
+                    memory_hotplug: process.memory_hotplug,
+                    serial_interrupt: process.serial,
+                    vmgenid_interrupt: process.vmgenid,
+                    vmclock_interrupt: process.vmclock,
                 },
                 mapping.as_ref(),
             ),
@@ -18091,6 +18731,638 @@ impl OwnedHvfArm64BootSession {
             session,
             configs,
             expected,
+            mmds_state,
+            mmds_config,
+            storage_configs,
+            entropy_config,
+            balloon_config,
+            memory_hotplug_state,
+            memory_hotplug_controller,
+            retry_publication_gate: Some(retry_publication_gate),
+        })
+    }
+
+    /// Reconstructs one complete exact-2.11 PCI network owner graph while
+    /// keeping retry wake publication closed for the process-level check.
+    #[doc(hidden)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn restore_snapshot_v2_network_pci(
+        state: HvfSnapshotV2PlatformState,
+        memory_input: HvfSnapshotV2NetworkPciMemoryInput,
+        process_shell: HvfSnapshotV2RestoredSerialShell,
+        serial_input: Option<SerialStdioInput>,
+        plan: HvfSnapshotV2NetworkPciPlatformPlan,
+        profiles: Vec<NetworkDeviceProfile>,
+        network_metrics: SharedNetworkInterfaceMetricsRegistry,
+        now: Instant,
+    ) -> Result<RestoredHvfSnapshotV2NetworkPciOwners, HvfSnapshotV2NetworkPciRestoreError> {
+        Self::restore_snapshot_v2_network_pci_with_cancel(
+            state,
+            memory_input,
+            process_shell,
+            serial_input,
+            plan,
+            profiles,
+            network_metrics,
+            now,
+            |_| false,
+        )
+    }
+
+    /// Reconstructs with stable cancellation checkpoints for rollback
+    /// certification.
+    #[doc(hidden)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn restore_snapshot_v2_network_pci_with_cancel<C>(
+        state: HvfSnapshotV2PlatformState,
+        memory_input: HvfSnapshotV2NetworkPciMemoryInput,
+        process_shell: HvfSnapshotV2RestoredSerialShell,
+        serial_input: Option<SerialStdioInput>,
+        plan: HvfSnapshotV2NetworkPciPlatformPlan,
+        profiles: Vec<NetworkDeviceProfile>,
+        network_metrics: SharedNetworkInterfaceMetricsRegistry,
+        now: Instant,
+        cancelled: C,
+    ) -> Result<RestoredHvfSnapshotV2NetworkPciOwners, HvfSnapshotV2NetworkPciRestoreError>
+    where
+        C: FnMut(HvfSnapshotV2NetworkPciRestoreStage) -> bool,
+    {
+        Self::restore_snapshot_v2_network_pci_inner(
+            state,
+            memory_input,
+            process_shell,
+            serial_input,
+            plan,
+            profiles,
+            network_metrics,
+            now,
+            cancelled,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+    fn restore_snapshot_v2_network_pci_inner<C>(
+        state: HvfSnapshotV2PlatformState,
+        memory_input: HvfSnapshotV2NetworkPciMemoryInput,
+        process_shell: HvfSnapshotV2RestoredSerialShell,
+        serial_input: Option<SerialStdioInput>,
+        plan: HvfSnapshotV2NetworkPciPlatformPlan,
+        profiles: Vec<NetworkDeviceProfile>,
+        network_metrics: SharedNetworkInterfaceMetricsRegistry,
+        now: Instant,
+        mut cancelled: C,
+    ) -> Result<RestoredHvfSnapshotV2NetworkPciOwners, HvfSnapshotV2NetworkPciRestoreError>
+    where
+        C: FnMut(HvfSnapshotV2NetworkPciRestoreStage) -> bool,
+    {
+        if cancelled(HvfSnapshotV2NetworkPciRestoreStage::Product) {
+            return Err(HvfSnapshotV2NetworkPciRestoreError::preflight(
+                HvfSnapshotV2NetworkPciRestoreStage::Product,
+            ));
+        }
+        let HvfSnapshotV2NetworkPciPlatformOwnerParts {
+            product,
+            mapping,
+            balloon: balloon_endpoint,
+            storage: storage_platform,
+            network: network_endpoints,
+            entropy: entropy_endpoint,
+            memory_hotplug: memory_hotplug_endpoint,
+            host,
+            msi,
+            endpoint_count,
+            route_demand,
+            serial_interrupt,
+            vmgenid_interrupt,
+            vmclock_interrupt,
+        } = plan.into_owner_parts();
+        let HvfSnapshotV2NetworkPreparedOwnerParts {
+            kind: _kind,
+            memory: product_memory,
+            storage: storage_bundle,
+            entropy,
+            balloon,
+        } = product.into_owner_parts();
+        if balloon.is_some() != balloon_endpoint.is_some()
+            || storage_bundle.is_some() != storage_platform.is_some()
+            || entropy.is_some() != entropy_endpoint.is_some()
+            || mapping.is_some() != memory_hotplug_endpoint.is_some()
+            || network_endpoints.is_empty()
+            || network_endpoints.len() != profiles.len()
+            || endpoint_count == 0
+            || route_demand == 0
+            || !usize::try_from(msi.interrupt_range.count).is_ok_and(|count| route_demand <= count)
+        {
+            return Err(HvfSnapshotV2NetworkPciRestoreError::preflight(
+                HvfSnapshotV2NetworkPciRestoreStage::Product,
+            ));
+        }
+
+        let storage_block_count = storage_platform
+            .as_ref()
+            .map_or(0, |storage| storage.pci().block_records().len());
+        let storage_pmem_count = storage_platform
+            .as_ref()
+            .map_or(0, |storage| storage.pci().pmem_records().len());
+        let expected_balloon = balloon.is_some();
+        let expected_entropy = entropy.is_some();
+        let expected_memory_hotplug = memory_hotplug_endpoint.is_some();
+        let network_count = network_endpoints.len();
+        let mut network_placements = Vec::new();
+        if network_placements.try_reserve_exact(network_count).is_err() {
+            return Err(HvfSnapshotV2NetworkPciRestoreError::preflight(
+                HvfSnapshotV2NetworkPciRestoreStage::Product,
+            ));
+        }
+        for endpoint in &network_endpoints {
+            network_placements.push((endpoint.sbdf(), endpoint.bar_range(), endpoint.origin()));
+        }
+
+        let (memory, expected_binding, network, memory_hotplug) =
+            match (product_memory, memory_input) {
+                (
+                    HvfSnapshotV2NetworkPreparedMemoryProduct::Static { binding, network },
+                    HvfSnapshotV2NetworkPciMemoryInput::Static(memory),
+                ) if mapping.is_none() && memory_hotplug_endpoint.is_none() => {
+                    (memory, binding, network, None)
+                }
+                (
+                    HvfSnapshotV2NetworkPreparedMemoryProduct::MemoryHotplug {
+                        topology,
+                        memory,
+                        network,
+                    },
+                    HvfSnapshotV2NetworkPciMemoryInput::ProductOwned,
+                ) if mapping.is_some() && memory_hotplug_endpoint.is_some() => {
+                    let binding = topology.memory().binding().clone();
+                    (memory, binding, network, Some(*topology))
+                }
+                _ => {
+                    return Err(HvfSnapshotV2NetworkPciRestoreError::preflight(
+                        HvfSnapshotV2NetworkPciRestoreStage::Product,
+                    ));
+                }
+            };
+        let (interfaces, mmds_state, mmds_config) = network.into_parts();
+        if interfaces.len() != network_count {
+            return Err(HvfSnapshotV2NetworkPciRestoreError::preflight(
+                HvfSnapshotV2NetworkPciRestoreStage::Product,
+            ));
+        }
+        if cancelled(HvfSnapshotV2NetworkPciRestoreStage::Platform) {
+            return Err(HvfSnapshotV2NetworkPciRestoreError::preflight(
+                HvfSnapshotV2NetworkPciRestoreStage::Platform,
+            ));
+        }
+        let mut network_fault = None;
+        for index in 0..network_count {
+            if cancelled(HvfSnapshotV2NetworkPciRestoreStage::EndpointPreparation { index }) {
+                network_fault = Some(HvfSnapshotV2NetworkPciBatchFault::Preparation { index });
+                break;
+            }
+            if cancelled(HvfSnapshotV2NetworkPciRestoreStage::Publication { index }) {
+                network_fault = Some(HvfSnapshotV2NetworkPciBatchFault::Publication { index });
+                break;
+            }
+        }
+        let network_input = HvfSnapshotV2NetworkPciBatchInput {
+            interfaces,
+            endpoints: network_endpoints,
+            profiles,
+            metrics: network_metrics,
+            now,
+            fault: network_fault,
+        };
+        let balloon_config = balloon.as_ref().map(SnapshotV2BalloonRestorePlan::config);
+        let entropy_config = entropy.as_ref().map(SnapshotV2EntropyRestorePlan::config);
+        let process = HvfSnapshotV2NetworkPciProcessPlan {
+            host,
+            msi,
+            endpoint_count,
+            route_demand,
+            memory_hotplug: memory_hotplug_endpoint.is_some(),
+            serial: serial_interrupt,
+            vmgenid: vmgenid_interrupt,
+            vmclock: vmclock_interrupt,
+        };
+        let (mut session, mut storage_configs, network_batch) =
+            match (storage_bundle, storage_platform) {
+                (Some(bundle), Some(storage_plan)) => {
+                    let publication = match (balloon_endpoint, balloon) {
+                        (Some(endpoint), Some(balloon)) => {
+                            HvfSnapshotV2StoragePciPublicationInput::balloon(
+                                endpoint, balloon, None,
+                            )
+                        }
+                        (None, None) => HvfSnapshotV2StoragePciPublicationInput::empty(),
+                        _ => {
+                            return Err(HvfSnapshotV2NetworkPciRestoreError::preflight(
+                                HvfSnapshotV2NetworkPciRestoreStage::Product,
+                            ));
+                        }
+                    }
+                    .with_network(network_input);
+                    let restored = Self::restore_snapshot_v2_storage_pci_inner(
+                        state,
+                        memory,
+                        HvfSnapshotV2StorageProcessShell::RestoredNetworkPci {
+                            shell: process_shell,
+                            process,
+                            mapping: mapping.clone(),
+                        },
+                        serial_input,
+                        bundle,
+                        storage_plan,
+                        publication,
+                    )
+                    .map_err(|source| {
+                        let stage = match (network_fault, source.stage()) {
+                            (
+                                Some(HvfSnapshotV2NetworkPciBatchFault::Preparation { index }),
+                                HvfSnapshotV2StoragePciRestoreStage::EndpointPreparation {
+                                    index: actual,
+                                },
+                            ) if storage_block_count.checked_add(index) == Some(actual) => {
+                                HvfSnapshotV2NetworkPciRestoreStage::EndpointPreparation { index }
+                            }
+                            (
+                                Some(HvfSnapshotV2NetworkPciBatchFault::Publication { index }),
+                                HvfSnapshotV2StoragePciRestoreStage::Publication { index: actual },
+                            ) if storage_block_count.checked_add(index) == Some(actual) => {
+                                HvfSnapshotV2NetworkPciRestoreStage::Publication { index }
+                            }
+                            _ => HvfSnapshotV2NetworkPciRestoreStage::Platform,
+                        };
+                        HvfSnapshotV2NetworkPciRestoreError::committed(
+                            stage,
+                            source.has_incomplete_cleanup(),
+                        )
+                    })?;
+                    let (session, storage, network) = restored.into_network_parts();
+                    (session, Some(storage), network)
+                }
+                (None, None) => {
+                    let mut session = Self::restore_snapshot_v2_serial_only_inner(
+                        state,
+                        memory,
+                        HvfSnapshotV2SerialProcessShell::NetworkPci {
+                            shell: process_shell,
+                            process,
+                            mapping: mapping.clone(),
+                        },
+                        serial_input,
+                    )
+                    .map_err(|source| {
+                        HvfSnapshotV2NetworkPciRestoreError::committed(
+                            HvfSnapshotV2NetworkPciRestoreStage::Platform,
+                            source.has_incomplete_cleanup(),
+                        )
+                    })?;
+                    if let Some(balloon) = balloon {
+                        let Some(endpoint) = balloon_endpoint else {
+                            return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                                session,
+                                HvfSnapshotV2NetworkPciRestoreStage::Platform,
+                            ));
+                        };
+                        session =
+                            Self::attach_snapshot_v2_balloon_pci(session, endpoint, balloon, None)
+                                .map_err(|source| {
+                                    HvfSnapshotV2NetworkPciRestoreError::committed(
+                                        HvfSnapshotV2NetworkPciRestoreStage::Platform,
+                                        source.has_incomplete_cleanup(),
+                                    )
+                                })?;
+                    }
+                    let mut previous_scheduler = std::mem::replace(
+                        &mut session.network_retry_wakeup_scheduler,
+                        HvfArm64BootLimiterRetryWakeupScheduler::inactive(),
+                    );
+                    if previous_scheduler.stop_with_result().is_err() {
+                        drop(previous_scheduler);
+                        return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                            session,
+                            HvfSnapshotV2NetworkPciRestoreStage::Platform,
+                        ));
+                    }
+                    drop(previous_scheduler);
+                    let publication = {
+                        let Self {
+                            backend,
+                            pci_data_devices,
+                            ..
+                        } = &mut session;
+                        let memory = backend.mapped_guest_memory();
+                        match (memory, pci_data_devices.as_mut()) {
+                            (Ok(memory), Some(manager)) => publish_snapshot_v2_network_pci_batch(
+                                manager,
+                                memory,
+                                network_input,
+                            ),
+                            _ => Err(HvfSnapshotV2NetworkPciBatchFailure {
+                                index: 0,
+                                kind: HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+                                cleanup_failed: false,
+                            }),
+                        }
+                    };
+                    let (network, metrics) = match publication {
+                        Ok(restored) => restored,
+                        Err(failure) => {
+                            let stage = match failure.kind {
+                                HvfSnapshotV2NetworkPciBatchFailureKind::Preparation => {
+                                    HvfSnapshotV2NetworkPciRestoreStage::EndpointPreparation {
+                                        index: failure.index,
+                                    }
+                                }
+                                HvfSnapshotV2NetworkPciBatchFailureKind::Publication => {
+                                    HvfSnapshotV2NetworkPciRestoreStage::Publication {
+                                        index: failure.index,
+                                    }
+                                }
+                            };
+                            let cleanup_failed =
+                                failure.cleanup_failed || session.shutdown().is_err();
+                            return Err(HvfSnapshotV2NetworkPciRestoreError::committed(
+                                stage,
+                                cleanup_failed,
+                            ));
+                        }
+                    };
+                    session.network_interface_metrics = metrics;
+                    (session, None, network)
+                }
+                (None, Some(_)) | (Some(_), None) => {
+                    return Err(HvfSnapshotV2NetworkPciRestoreError::preflight(
+                        HvfSnapshotV2NetworkPciRestoreStage::Product,
+                    ));
+                }
+            };
+
+        if entropy.is_some() && cancelled(HvfSnapshotV2NetworkPciRestoreStage::Entropy) {
+            return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2NetworkPciRestoreStage::Entropy,
+            ));
+        }
+        if let Some(entropy) = entropy {
+            let Some(endpoint) = entropy_endpoint else {
+                return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2NetworkPciRestoreStage::Entropy,
+                ));
+            };
+            if endpoint.origin() != StorageDeviceOrigin::Startup {
+                return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2NetworkPciRestoreStage::Entropy,
+                ));
+            }
+            let preceding_endpoint_count = session
+                .pci_data_devices
+                .as_ref()
+                .map_or(0, HvfArm64BootPciDataDevices::endpoint_count);
+            let endpoint_plan = HvfSnapshotV2EntropyPciEndpointPlan::for_network_product(
+                preceding_endpoint_count,
+                endpoint.sbdf(),
+                endpoint.bar_region_id(),
+                endpoint.bar_range(),
+                endpoint.route_count(),
+                endpoint.msi_interrupt_count(),
+            );
+            if !snapshot_v2_entropy_pci_plan_matches(&entropy, endpoint_plan) {
+                return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2NetworkPciRestoreStage::Entropy,
+                ));
+            }
+            let restored = Self::attach_snapshot_v2_entropy_pci(
+                session,
+                endpoint_plan,
+                entropy,
+                storage_configs,
+                false,
+                VirtioRngOsEntropySource::new,
+                HvfSnapshotV2EntropyPciPrecedingEndpointCounts::new(
+                    usize::from(expected_balloon),
+                    network_count,
+                ),
+            )
+            .map_err(|source| {
+                HvfSnapshotV2NetworkPciRestoreError::committed(
+                    HvfSnapshotV2NetworkPciRestoreStage::Entropy,
+                    source.has_incomplete_cleanup(),
+                )
+            })?;
+            let (restored_session, restored_config, restored_storage_configs) =
+                restored.into_parts();
+            session = restored_session;
+            storage_configs = restored_storage_configs;
+            if Some(restored_config) != entropy_config {
+                return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2NetworkPciRestoreStage::Entropy,
+                ));
+            }
+        }
+
+        if memory_hotplug.is_some() && cancelled(HvfSnapshotV2NetworkPciRestoreStage::MemoryHotplug)
+        {
+            return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2NetworkPciRestoreStage::MemoryHotplug,
+            ));
+        }
+        let (memory_hotplug_state, memory_hotplug_controller) =
+            if let Some(memory_hotplug) = memory_hotplug {
+                let Some(endpoint) = memory_hotplug_endpoint else {
+                    return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                        session,
+                        HvfSnapshotV2NetworkPciRestoreStage::MemoryHotplug,
+                    ));
+                };
+                let endpoint_plan = HvfSnapshotV2MemoryHotplugPciEndpointPlan::for_network_product(
+                    endpoint.origin(),
+                    endpoint.sbdf(),
+                    endpoint.bar_region_id(),
+                    endpoint.bar_range(),
+                    endpoint.route_count(),
+                    endpoint.msi_interrupt_count(),
+                );
+                let preceding_endpoint_count = session
+                    .pci_data_devices
+                    .as_ref()
+                    .map_or(0, HvfArm64BootPciDataDevices::endpoint_count);
+                let (restored_session, expected_state, controller) =
+                    Self::attach_snapshot_v2_memory_hotplug_pci(
+                        session,
+                        endpoint_plan,
+                        memory_hotplug,
+                        preceding_endpoint_count,
+                        None,
+                    )
+                    .map_err(|source| {
+                        HvfSnapshotV2NetworkPciRestoreError::committed(
+                            HvfSnapshotV2NetworkPciRestoreStage::MemoryHotplug,
+                            source.has_incomplete_cleanup(),
+                        )
+                    })?;
+                session = restored_session;
+                (Some(expected_state), Some(controller))
+            } else {
+                (None, None)
+            };
+
+        let manager_matches = session.pci_data_devices.as_ref().is_some_and(|manager| {
+            manager.endpoint_count() == endpoint_count
+                && manager.balloon.is_some() == expected_balloon
+                && manager.block.len() == storage_block_count
+                && manager.network.len() == network_count
+                && manager.pmem.len() == storage_pmem_count
+                && manager.entropy.is_some() == expected_entropy
+                && manager.memory_hotplug.is_some() == expected_memory_hotplug
+                && manager.msi_interrupts.as_ref().is_some_and(|interrupts| {
+                    interrupts.lease_count()
+                        == usize::try_from(msi.interrupt_range.count).unwrap_or(usize::MAX)
+                })
+                && manager.network.iter().zip(&network_placements).all(
+                    |(device, (sbdf, bar_range, origin))| {
+                        device.published.sbdf() == Some(*sbdf)
+                            && device.published.bar_range() == Some(*bar_range)
+                            && device.origin
+                                == match origin {
+                                    StorageDeviceOrigin::Startup => {
+                                        HvfArm64BootNetworkDeviceOrigin::Startup
+                                    }
+                                    StorageDeviceOrigin::Runtime => {
+                                        HvfArm64BootNetworkDeviceOrigin::Runtime
+                                    }
+                                }
+                    },
+                )
+        });
+        if !manager_matches
+            || session.restored_snapshot_v2_memory_binding.as_ref() != Some(&expected_binding)
+        {
+            return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2NetworkPciRestoreStage::Assembly,
+            ));
+        }
+
+        if cancelled(HvfSnapshotV2NetworkPciRestoreStage::RetryScheduler) {
+            return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2NetworkPciRestoreStage::RetryScheduler,
+            ));
+        }
+        session.network_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        let vcpu_control = session.runner.control();
+        let scheduler_result =
+            HvfArm64BootLimiterRetryWakeupScheduler::start_with_cancellation_and_publication_gate(
+                NETWORK_RETRY_WAKEUP_SCHEDULER_THREAD_NAME,
+                session.network_retry_wakeup.clone(),
+                move || vcpu_control.request_wakeup(),
+            );
+        let (scheduler, retry_publication_gate) = match scheduler_result {
+            Ok(result) => result,
+            Err(_) => {
+                return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2NetworkPciRestoreStage::RetryScheduler,
+                ));
+            }
+        };
+        session.network_retry_wakeup_scheduler = scheduler;
+        if cancelled(HvfSnapshotV2NetworkPciRestoreStage::RetryDeadline) {
+            return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2NetworkPciRestoreStage::RetryDeadline,
+            ));
+        }
+        session
+            .network_retry_wakeup_scheduler
+            .schedule_deadline(network_batch.earliest_retry_deadline);
+
+        if cancelled(HvfSnapshotV2NetworkPciRestoreStage::Recapture) {
+            return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2NetworkPciRestoreStage::Recapture,
+            ));
+        }
+        let guard = match session.quiesce_limiter_retry_wakeups() {
+            Ok(guard) => guard,
+            Err(_) => {
+                return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2NetworkPciRestoreStage::Recapture,
+                ));
+            }
+        };
+        let captured = match session.capture_ready_network_state_at(
+            &network_batch.capture_configs,
+            &guard,
+            now,
+        ) {
+            Ok(captured) => captured,
+            Err(_) => {
+                drop(guard);
+                return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2NetworkPciRestoreStage::Recapture,
+                ));
+            }
+        };
+        if captured.source_work_normalized()
+            || captured.interfaces().len() != network_batch.expected.len()
+            || captured
+                .interfaces()
+                .iter()
+                .zip(network_batch.expected.iter())
+                .any(|(captured, expected)| {
+                    let HvfArm64BootNetworkTransportCaptureState::Pci {
+                        origin,
+                        sbdf,
+                        bar_range,
+                        state,
+                    } = captured.transport()
+                    else {
+                        return true;
+                    };
+                    let origin = match origin {
+                        HvfArm64BootNetworkDeviceOrigin::Startup => StorageDeviceOrigin::Startup,
+                        HvfArm64BootNetworkDeviceOrigin::Runtime => StorageDeviceOrigin::Runtime,
+                    };
+                    SnapshotV2NetworkInterfaceState::try_from_pci_capture(
+                        captured.config(),
+                        expected.backend(),
+                        origin,
+                        *sbdf,
+                        *bar_range,
+                        state,
+                    )
+                    .ok()
+                    .is_none_or(|actual| actual != *expected)
+                })
+        {
+            drop(guard);
+            return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2NetworkPciRestoreStage::Recapture,
+            ));
+        }
+        drop(guard);
+
+        if cancelled(HvfSnapshotV2NetworkPciRestoreStage::Assembly) {
+            return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2NetworkPciRestoreStage::Assembly,
+            ));
+        }
+        Ok(RestoredHvfSnapshotV2NetworkPciOwners {
+            session,
+            configs: network_batch.configs,
+            expected: network_batch.expected,
             mmds_state,
             mmds_config,
             storage_configs,
@@ -19452,7 +20724,7 @@ impl OwnedHvfArm64BootSession {
                 storage_configs,
                 fault == Some(HvfSnapshotV2BalloonPciRestoreFault::EntropyPublication),
                 VirtioRngOsEntropySource::new,
-                1,
+                HvfSnapshotV2EntropyPciPrecedingEndpointCounts::new(1, 0),
             )
             .map_err(HvfSnapshotV2BalloonPciRestoreError::entropy_platform)?;
             let (restored_session, restored_entropy_config, restored_storage_configs) =
@@ -20020,7 +21292,7 @@ impl OwnedHvfArm64BootSession {
                 storage_configs,
                 false,
                 VirtioRngOsEntropySource::new,
-                usize::from(has_balloon),
+                HvfSnapshotV2EntropyPciPrecedingEndpointCounts::new(usize::from(has_balloon), 0),
             )
             .map_err(HvfSnapshotV2MemoryHotplugPciRestoreError::entropy_platform)?;
             let (restored_session, restored_entropy_config, restored_storage_configs) =
@@ -20842,7 +22114,7 @@ impl OwnedHvfArm64BootSession {
             None,
             inject_scheduler_failure,
             source_factory,
-            0,
+            HvfSnapshotV2EntropyPciPrecedingEndpointCounts::new(0, 0),
         )
     }
 
@@ -20883,7 +22155,7 @@ impl OwnedHvfArm64BootSession {
             Some(storage_configs),
             false,
             VirtioRngOsEntropySource::new,
-            0,
+            HvfSnapshotV2EntropyPciPrecedingEndpointCounts::new(0, 0),
         )
     }
 
@@ -20894,11 +22166,12 @@ impl OwnedHvfArm64BootSession {
         storage_configs: Option<CaptureReadyStorageConfigs>,
         inject_scheduler_failure: bool,
         source_factory: impl FnOnce() -> VirtioRngOsEntropySource,
-        preceding_balloon_count: usize,
+        preceding: HvfSnapshotV2EntropyPciPrecedingEndpointCounts,
     ) -> Result<RestoredHvfSnapshotV2EntropyPciOwners, HvfSnapshotV2EntropyPciRestoreError> {
         let preceding_endpoint_count = endpoint_plan.preceding_endpoint_count();
-        let Some(preceding_storage_count) =
-            preceding_endpoint_count.checked_sub(preceding_balloon_count)
+        let Some(preceding_storage_count) = preceding_endpoint_count
+            .checked_sub(preceding.balloon)
+            .and_then(|count| count.checked_sub(preceding.network))
         else {
             return Err(HvfSnapshotV2EntropyPciRestoreError::after_platform(
                 session,
@@ -20912,9 +22185,9 @@ impl OwnedHvfArm64BootSession {
             && session.entropy_retry_wakeup_scheduler.thread.is_none()
             && session.pci_data_devices.as_ref().is_some_and(|manager| {
                 manager.entropy.is_none()
-                    && manager.network.is_empty()
-                    && manager.balloon.is_some() == (preceding_balloon_count == 1)
-                    && preceding_balloon_count <= 1
+                    && manager.network.len() == preceding.network
+                    && manager.balloon.is_some() == (preceding.balloon == 1)
+                    && preceding.balloon <= 1
                     && manager.vsock.is_none()
                     && manager.memory_hotplug.is_none()
                     && manager.endpoint_count() == preceding_endpoint_count
@@ -22064,7 +23337,8 @@ impl OwnedHvfArm64BootSession {
                 },
                 mapping.as_ref(),
             ),
-            HvfSnapshotV2StorageProcessShell::RestoredMemoryHotplugPci { .. } => {
+            HvfSnapshotV2StorageProcessShell::RestoredMemoryHotplugPci { .. }
+            | HvfSnapshotV2StorageProcessShell::RestoredNetworkPci { .. } => {
                 return Err(
                     HvfSnapshotV2StorageMmioRestoreError::with_prepared_bundle_abort(
                         HvfSnapshotV2StorageMmioRestoreStage::ResourcePlan,
@@ -22631,6 +23905,7 @@ impl OwnedHvfArm64BootSession {
     ) -> Result<RestoredHvfSnapshotV2StoragePciOwners, HvfSnapshotV2StoragePciRestoreError> {
         let HvfSnapshotV2StoragePciPublicationInput {
             balloon: balloon_publication,
+            network: mut network_publication,
             pmem_fault_index: publication_fault_pmem_index,
             balloon_fault,
         } = publication;
@@ -22853,6 +24128,27 @@ impl OwnedHvfArm64BootSession {
                     state, memory, shell, shell_plan, &mapping,
                 )
             }
+            HvfSnapshotV2StorageProcessShell::RestoredNetworkPci {
+                shell,
+                process,
+                mapping,
+            } => restore_hvf_snapshot_v2_serial_network_pci_process_platform(
+                state,
+                memory,
+                shell,
+                HvfSnapshotV2NetworkPciShellPlan {
+                    storage: Some(shell_plan),
+                    host: process.host,
+                    msi: process.msi,
+                    endpoint_count: process.endpoint_count,
+                    route_demand: process.route_demand,
+                    memory_hotplug: process.memory_hotplug,
+                    serial_interrupt: process.serial,
+                    vmgenid_interrupt: process.vmgenid,
+                    vmclock_interrupt: process.vmclock,
+                },
+                mapping.as_ref(),
+            ),
             HvfSnapshotV2StorageProcessShell::RestoredEntropyMmio { .. }
             | HvfSnapshotV2StorageProcessShell::RestoredBalloonMmio { .. }
             | HvfSnapshotV2StorageProcessShell::RestoredMemoryHotplugMmio { .. }
@@ -22897,6 +24193,8 @@ impl OwnedHvfArm64BootSession {
         let mut pmem_retry_wakeup_scheduler = None;
         let mut pci_data_devices = None;
         let mut prepared_balloon_publication = None;
+        let mut restored_network = None;
+        let mut restored_network_metrics = None;
         macro_rules! fail_after_platform {
             ($stage:expr, $failure:expr) => {{
                 release_unpublished_snapshot_v2_balloon_pci_publication(
@@ -23531,6 +24829,54 @@ impl OwnedHvfArm64BootSession {
             });
         }
 
+        if let Some(network) = network_publication.take() {
+            let memory = match platform.guest_memory() {
+                Ok(memory) => memory,
+                Err(_) => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::ResourcePlan,
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                ),
+            };
+            let manager = match pci_data_devices.as_mut() {
+                Some(manager) => manager,
+                None => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::PciHost,
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                ),
+            };
+            match publish_snapshot_v2_network_pci_batch(manager, memory, network) {
+                Ok((network, metrics)) => {
+                    restored_network = Some(network);
+                    restored_network_metrics = Some(metrics);
+                }
+                Err(failure) => {
+                    if failure.cleanup_failed {
+                        cleanup.push(HvfSnapshotV2StoragePciRestoreCleanupFailure::Pci(
+                            HvfArm64BootPciDataError::new(
+                                "exact-2.11 PCI network prefix cleanup was incomplete",
+                            ),
+                        ));
+                    }
+                    let stage = match failure.kind {
+                        HvfSnapshotV2NetworkPciBatchFailureKind::Preparation => {
+                            HvfSnapshotV2StoragePciRestoreStage::EndpointPreparation {
+                                index: block_count.saturating_add(failure.index),
+                            }
+                        }
+                        HvfSnapshotV2NetworkPciBatchFailureKind::Publication => {
+                            HvfSnapshotV2StoragePciRestoreStage::Publication {
+                                index: block_count.saturating_add(failure.index),
+                            }
+                        }
+                    };
+                    fail_after_platform!(
+                        stage,
+                        HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                    );
+                }
+            }
+        }
+
         for pmem_index in 0..pmem_count {
             let index = block_count.saturating_add(pmem_index);
             let planned = match pci_plan.pmem_records().get(pmem_index) {
@@ -23806,7 +25152,7 @@ impl OwnedHvfArm64BootSession {
             pmem_device_metrics,
             balloon_device_metrics: SharedBalloonDeviceMetrics::default(),
             memory_hotplug_device_metrics: None,
-            network_interface_metrics: SharedNetworkInterfaceMetricsRegistry::default(),
+            network_interface_metrics: restored_network_metrics.unwrap_or_default(),
             vsock_device_metrics: SharedVsockDeviceMetrics::default(),
             entropy_device_metrics: SharedEntropyDeviceMetrics::default(),
             gic,
@@ -23825,7 +25171,11 @@ impl OwnedHvfArm64BootSession {
         };
         let configs =
             CaptureReadyStorageConfigs::new(drive_configs.into_vec(), pmem_configs.into_vec());
-        Ok(RestoredHvfSnapshotV2StoragePciOwners { session, configs })
+        Ok(RestoredHvfSnapshotV2StoragePciOwners {
+            session,
+            configs,
+            network: restored_network,
+        })
     }
 
     /// Reconstructs one exact profile-2 PCI vector inside a private canonical

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -20101,6 +20101,1253 @@ fn restores_signed_exact_2_11_mmio_network_owner_graph_at_exact_capacity() {
     }
 }
 
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn restores_signed_exact_2_11_pci_network_owner_graph_at_exact_capacity() {
+    use std::io::Cursor;
+    use std::time::Instant;
+
+    use bangbang_hvf::{
+        HvfArm64BootNetworkCaptureConfig, HvfArm64BootNetworkDeviceOrigin,
+        HvfArm64BootNetworkTransportCaptureState, HvfArm64BootSerialDeviceConfig,
+        HvfArm64BootSessionConfig, HvfArm64BootSnapshotV2CaptureInput, HvfSnapshotV2BootState,
+        HvfSnapshotV2NativePath, HvfSnapshotV2NetworkPciMemoryInput,
+        HvfSnapshotV2NetworkPciRestoreDisposition, HvfSnapshotV2NetworkPciRestoreStage,
+        HvfSnapshotV2NetworkPreparedProduct, HvfSnapshotV2NetworkState,
+        HvfSnapshotV2RestoredSerialShell, OwnedHvfArm64BootSession,
+        encode_hvf_snapshot_v2_network_state, prepare_hvf_snapshot_v2_network_pci_platform_plan,
+    };
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::block::BlockMmioLayout;
+    use bangbang_runtime::boot::BootSourceConfigInput;
+    use bangbang_runtime::machine::MachineConfigInput;
+    use bangbang_runtime::memory::GuestAddress;
+    use bangbang_runtime::metrics::SharedNetworkInterfaceMetricsRegistry;
+    use bangbang_runtime::mmio::MmioRegionId;
+    use bangbang_runtime::network::{
+        NetworkDeviceProfile, NetworkInterfaceConfigInput, NetworkMmioLayout,
+        NetworkRateLimiterConfig, NetworkTokenBucketConfig, PreparedNetworkDevice,
+    };
+    use bangbang_runtime::pmem::PmemMmioLayout;
+    use bangbang_runtime::serial::{
+        SerialMmioDevice, SharedSerialOutput, SharedSerialOutputBuffer,
+    };
+    use bangbang_runtime::snapshot::SnapshotNetworkOverride;
+    use bangbang_runtime::snapshot_format_v2::decode_snapshot_v2_state_with_compatibility_version;
+    use bangbang_runtime::snapshot_memory_v2::load_snapshot_v2_memory_file;
+    use bangbang_runtime::snapshot_network_restore_v2_11::PreparedSnapshotV2NetworkRestoreTopology;
+    use bangbang_runtime::snapshot_network_v2_11::{
+        NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION, SnapshotV2NetworkBackendClass,
+        SnapshotV2NetworkInterfaceState, SnapshotV2NetworkState,
+    };
+    use bangbang_runtime::snapshot_serial_v2_7::SnapshotV2SerialState;
+    use bangbang_runtime::storage_capture::StorageDeviceOrigin;
+    use bangbang_runtime::vsock::VsockMmioLayout;
+
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let image = arm64_image().expect("test arm64 image should build");
+    let kernel = TempFile::new("restore-network-pci-kernel", &image)
+        .expect("network restore kernel should create");
+    let limiter = NetworkRateLimiterConfig::new(
+        Some(NetworkTokenBucketConfig::new(4096, Some(8192), 100)),
+        Some(NetworkTokenBucketConfig::new(64, None, 100)),
+    );
+    let block_layout = BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1));
+    let pmem_layout = PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500));
+    let network_layout =
+        NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000));
+
+    for interface_count in [1_usize, 16] {
+        let mut controller = bangbang_runtime::VmmController::new("test", "0.1.0", "bangbang");
+        controller
+            .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+                kernel.path(),
+            )))
+            .expect("network restore boot source should configure");
+        controller
+            .handle_action(VmmAction::PutMachineConfig(
+                MachineConfigInput::new(1, 128).with_track_dirty_pages(true),
+            ))
+            .expect("network restore dirty tracking should configure");
+        let startup_interface_count = if interface_count == 16 {
+            interface_count - 1
+        } else {
+            interface_count
+        };
+        for index in 0..startup_interface_count {
+            let iface_id = format!("eth{index}");
+            let selector = format!("private-network-backend-{index}");
+            let guest_mac = format!("02:00:00:00:02:{index:02x}");
+            controller
+                .handle_action(VmmAction::PutNetworkInterface(
+                    NetworkInterfaceConfigInput::new(iface_id.clone(), iface_id, selector)
+                        .with_guest_mac(guest_mac)
+                        .with_mtu(1400)
+                        .with_rx_rate_limiter(limiter)
+                        .with_tx_rate_limiter(limiter),
+                ))
+                .expect("network restore interface should configure");
+        }
+        let session_config = HvfArm64BootSessionConfig::new(
+            block_layout,
+            pmem_layout,
+            network_layout,
+            VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
+            bangbang_runtime::rtc::RtcMmioLayout::new(
+                GuestAddress::new(0x4000_1000),
+                MmioRegionId::new(10),
+            ),
+        )
+        .with_serial_device(HvfArm64BootSerialDeviceConfig::new(
+            MmioRegionId::new(20),
+            GuestAddress::new(0x4000_2000),
+            SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+        ))
+        .with_pci_enabled();
+        let mut source = OwnedHvfArm64BootSession::new(&controller, session_config)
+            .expect("signed PCI network source should prepare");
+        if startup_interface_count != interface_count {
+            let index = startup_interface_count;
+            let iface_id = format!("eth{index}");
+            controller
+                .handle_action(VmmAction::PutNetworkInterface(
+                    NetworkInterfaceConfigInput::new(
+                        iface_id.clone(),
+                        iface_id,
+                        format!("private-network-backend-{index}"),
+                    )
+                    .with_guest_mac(format!("02:00:00:00:02:{index:02x}"))
+                    .with_mtu(1400)
+                    .with_rx_rate_limiter(limiter)
+                    .with_tx_rate_limiter(limiter),
+                ))
+                .expect("runtime network restore interface should configure");
+            let runtime_config = controller.network_interface_configs()[index].clone();
+            source
+                .insert_runtime_network_device(PreparedNetworkDevice::from_config(&runtime_config))
+                .expect("runtime PCI network source should publish");
+        }
+        let configs = controller.network_interface_configs().to_vec();
+        let profiles = configs
+            .iter()
+            .map(NetworkDeviceProfile::from_config)
+            .collect::<Vec<_>>();
+        let capture_configs = configs
+            .iter()
+            .zip(&profiles)
+            .map(|(config, profile)| {
+                HvfArm64BootNetworkCaptureConfig::new(config.clone(), *profile, None, None, false)
+            })
+            .collect::<Vec<_>>();
+        let capture_now = Instant::now();
+        let guard = source
+            .quiesce_limiter_retry_wakeups()
+            .expect("network source publishers should quiesce");
+        let captured = source
+            .capture_ready_network_state_at(&capture_configs, &guard, capture_now)
+            .expect("PCI network source should capture");
+        let serial = SnapshotV2SerialState::try_from_capture_ready(
+            source
+                .capture_ready_serial_state(controller.serial_config().clone(), &guard)
+                .expect("network product serial should capture"),
+        )
+        .expect("network product serial capture should convert");
+        drop(guard);
+        let mut interfaces = Vec::new();
+        interfaces
+            .try_reserve_exact(interface_count)
+            .expect("portable network inventory should reserve");
+        for captured in captured.interfaces() {
+            let HvfArm64BootNetworkTransportCaptureState::Pci {
+                origin,
+                sbdf,
+                bar_range,
+                state,
+            } = captured.transport()
+            else {
+                panic!("network source should use PCI");
+            };
+            let origin = match origin {
+                HvfArm64BootNetworkDeviceOrigin::Startup => StorageDeviceOrigin::Startup,
+                HvfArm64BootNetworkDeviceOrigin::Runtime => StorageDeviceOrigin::Runtime,
+            };
+            interfaces.push(
+                SnapshotV2NetworkInterfaceState::try_from_pci_capture(
+                    captured.config(),
+                    SnapshotV2NetworkBackendClass::Vmnet,
+                    origin,
+                    *sbdf,
+                    *bar_range,
+                    state,
+                )
+                .expect("portable PCI network interface should convert"),
+            );
+        }
+        let network = SnapshotV2NetworkState::try_new(interfaces, None)
+            .expect("portable network aggregate should validate");
+        if interface_count == 16 {
+            assert!(matches!(
+                network.interfaces()[15].transport(),
+                bangbang_runtime::snapshot_device_v2::SnapshotV2DeviceTransport::Pci(pci)
+                    if pci.origin() == StorageDeviceOrigin::Runtime
+            ));
+        }
+        let overrides = network
+            .interfaces()
+            .iter()
+            .map(|interface| SnapshotNetworkOverride::new(interface.iface_id(), "vmnet:shared"))
+            .collect::<Vec<_>>();
+        source
+            .pause_for_snapshot_v2_capture()
+            .expect("network source should pause");
+        let boot = HvfSnapshotV2BootState::try_new(
+            HvfSnapshotV2NativePath::try_new(kernel.path().as_os_str())
+                .expect("network kernel path should validate"),
+            None,
+            None,
+        )
+        .expect("network boot metadata should validate");
+        let mut memory_writer = Cursor::new(Vec::new());
+        let network_platform = source
+            .capture_snapshot_v2_network_platform_with_cancel(
+                HvfArm64BootSnapshotV2CaptureInput::new(boot),
+                None,
+                &mut memory_writer,
+                |_| false,
+            )
+            .expect("exact-2.11 PCI network platform should capture");
+        let product = HvfSnapshotV2NetworkState::try_new(
+            network_platform.clone(),
+            None,
+            serial.clone(),
+            None,
+            None,
+            Some(network.clone()),
+        )
+        .expect("network-only exact-2.11 PCI product should compose");
+        let encoded = encode_hvf_snapshot_v2_network_state(&product)
+            .expect("network-only exact-2.11 PCI product should encode");
+        let structural = decode_snapshot_v2_state_with_compatibility_version(
+            &encoded,
+            NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
+        )
+        .expect("network-only exact-2.11 PCI product should decode structurally");
+        let memory_image = TempFile::new(
+            "restore-network-pci-cancellation-memory",
+            memory_writer.get_ref(),
+        )
+        .expect("network-only exact-2.11 PCI memory image should persist");
+        let platform = network_platform.platform().clone();
+        source
+            .shutdown()
+            .expect("signed PCI network source should shut down");
+        let cancellation_stages = if interface_count == 1 {
+            vec![
+                HvfSnapshotV2NetworkPciRestoreStage::Product,
+                HvfSnapshotV2NetworkPciRestoreStage::Platform,
+                HvfSnapshotV2NetworkPciRestoreStage::EndpointPreparation { index: 0 },
+                HvfSnapshotV2NetworkPciRestoreStage::Publication { index: 0 },
+                HvfSnapshotV2NetworkPciRestoreStage::RetryScheduler,
+                HvfSnapshotV2NetworkPciRestoreStage::RetryDeadline,
+                HvfSnapshotV2NetworkPciRestoreStage::Recapture,
+                HvfSnapshotV2NetworkPciRestoreStage::Assembly,
+            ]
+        } else {
+            let mut stages = Vec::new();
+            stages
+                .try_reserve_exact(interface_count * 2 + 1)
+                .expect("PCI network prefix stages should reserve");
+            for index in 0..interface_count {
+                stages.push(HvfSnapshotV2NetworkPciRestoreStage::EndpointPreparation { index });
+                stages.push(HvfSnapshotV2NetworkPciRestoreStage::Publication { index });
+            }
+            stages.push(HvfSnapshotV2NetworkPciRestoreStage::RetryScheduler);
+            stages
+        };
+
+        let prepare_plan = || {
+            let topology =
+                PreparedSnapshotV2NetworkRestoreTopology::prepare(network.clone(), &overrides)
+                    .expect("destination network topology should prepare");
+            prepare_hvf_snapshot_v2_network_pci_platform_plan(
+                &platform,
+                HvfSnapshotV2NetworkPreparedProduct::serial_network(
+                    platform.memory().clone(),
+                    topology,
+                ),
+            )
+            .expect("network PCI platform plan should prepare")
+        };
+        let restored_shell = || {
+            HvfSnapshotV2RestoredSerialShell::new(
+                SerialMmioDevice::from_capture_state_with_shared_output(
+                    SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+                    serial.device().clone(),
+                ),
+            )
+        };
+        let fresh_metrics = || {
+            SharedNetworkInterfaceMetricsRegistry::from_interface_ids(
+                configs.iter().map(|config| config.iface_id()),
+            )
+        };
+        let fresh_memory = || {
+            load_snapshot_v2_memory_file(
+                &structural,
+                std::fs::File::open(memory_image.path())
+                    .expect("network-only exact-2.11 PCI memory image should reopen"),
+            )
+            .expect("network-only exact-2.11 PCI memory should map privately")
+        };
+        let restore_now = Instant::now();
+        for cancel_stage in cancellation_stages {
+            let destination = fresh_memory();
+            let error = OwnedHvfArm64BootSession::restore_snapshot_v2_network_pci_with_cancel(
+                platform.clone(),
+                HvfSnapshotV2NetworkPciMemoryInput::Static(destination),
+                restored_shell(),
+                None,
+                prepare_plan(),
+                profiles.clone(),
+                fresh_metrics(),
+                restore_now,
+                |stage| stage == cancel_stage,
+            )
+            .expect_err("injected PCI network owner cancellation should reject");
+            assert_eq!(error.stage(), cancel_stage);
+            assert_eq!(
+                error.disposition(),
+                if matches!(
+                    cancel_stage,
+                    HvfSnapshotV2NetworkPciRestoreStage::Product
+                        | HvfSnapshotV2NetworkPciRestoreStage::Platform
+                ) {
+                    HvfSnapshotV2NetworkPciRestoreDisposition::Retryable
+                } else {
+                    HvfSnapshotV2NetworkPciRestoreDisposition::Terminal
+                }
+            );
+            assert!(!error.has_incomplete_cleanup());
+            let diagnostics = format!("{error:?} {error}");
+            assert!(diagnostics.contains("<redacted>"));
+            assert!(!diagnostics.contains("eth0"));
+            assert!(!diagnostics.contains("vmnet:shared"));
+        }
+
+        let premature_destination = fresh_memory();
+        let premature_owners = OwnedHvfArm64BootSession::restore_snapshot_v2_network_pci(
+            platform.clone(),
+            HvfSnapshotV2NetworkPciMemoryInput::Static(premature_destination),
+            restored_shell(),
+            None,
+            prepare_plan(),
+            profiles.clone(),
+            fresh_metrics(),
+            restore_now,
+        )
+        .expect("premature PCI extraction owner should restore");
+        let extraction_error = match premature_owners.into_session() {
+            Ok(mut session) => {
+                let _ = session.shutdown();
+                panic!("uncommitted PCI network owner must not release its session");
+            }
+            Err(error) => error,
+        };
+        assert_eq!(
+            extraction_error.stage(),
+            HvfSnapshotV2NetworkPciRestoreStage::Assembly
+        );
+        assert_eq!(
+            extraction_error.disposition(),
+            HvfSnapshotV2NetworkPciRestoreDisposition::Terminal
+        );
+        assert!(!extraction_error.has_incomplete_cleanup());
+
+        let destination = fresh_memory();
+        let owners = OwnedHvfArm64BootSession::restore_snapshot_v2_network_pci(
+            platform.clone(),
+            HvfSnapshotV2NetworkPciMemoryInput::Static(destination),
+            restored_shell(),
+            None,
+            prepare_plan(),
+            profiles.clone(),
+            fresh_metrics(),
+            restore_now,
+        )
+        .unwrap_or_else(|error| {
+            panic!("exact-capacity PCI network owners should restore: {error:?}")
+        });
+        assert_eq!(owners.configs().len(), interface_count);
+        assert_eq!(owners.expected().len(), interface_count);
+        assert!(!owners.retry_publication_is_committed());
+        assert!(owners.session().pci_network_device_updater().is_some());
+        let recapture_configs = owners
+            .configs()
+            .iter()
+            .zip(&profiles)
+            .map(|(config, profile)| {
+                HvfArm64BootNetworkCaptureConfig::new(config.clone(), *profile, None, None, false)
+            })
+            .collect::<Vec<_>>();
+        let guard = owners
+            .session()
+            .quiesce_limiter_retry_wakeups()
+            .expect("restored PCI network publishers should quiesce");
+        let recaptured = owners
+            .session()
+            .capture_ready_network_state_at(&recapture_configs, &guard, restore_now)
+            .expect("restored PCI network graph should recapture");
+        for (captured, expected) in recaptured.interfaces().iter().zip(owners.expected()) {
+            let HvfArm64BootNetworkTransportCaptureState::Pci {
+                origin,
+                sbdf,
+                bar_range,
+                state,
+            } = captured.transport()
+            else {
+                panic!("restored network should remain PCI");
+            };
+            let origin = match origin {
+                HvfArm64BootNetworkDeviceOrigin::Startup => StorageDeviceOrigin::Startup,
+                HvfArm64BootNetworkDeviceOrigin::Runtime => StorageDeviceOrigin::Runtime,
+            };
+            let portable = SnapshotV2NetworkInterfaceState::try_from_pci_capture(
+                captured.config(),
+                expected.backend(),
+                origin,
+                *sbdf,
+                *bar_range,
+                state,
+            )
+            .expect("restored PCI network recapture should convert");
+            assert_eq!(&portable, expected);
+        }
+        drop(guard);
+
+        let owners = owners.commit_retry_publication();
+        assert!(owners.retry_publication_is_committed());
+        let mut restored = owners
+            .into_session()
+            .expect("committed PCI network owner should release its session");
+        restored
+            .shutdown()
+            .expect("restored PCI network destination should shut down");
+        restored
+            .shutdown()
+            .expect("restored PCI network destination shutdown should be idempotent");
+    }
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn restores_signed_all_sixteen_network_pci_product_shapes() {
+    use std::io::Cursor;
+    use std::time::Instant;
+
+    use bangbang_hvf::{
+        HvfArm64BootBalloonDeviceConfig, HvfArm64BootEntropyDeviceConfig,
+        HvfArm64BootMemoryHotplugDeviceConfig, HvfArm64BootNetworkCaptureConfig,
+        HvfArm64BootNetworkDeviceOrigin, HvfArm64BootNetworkTransportCaptureState,
+        HvfArm64BootPciDataDeviceKind, HvfArm64BootSerialDeviceConfig, HvfArm64BootSessionConfig,
+        HvfArm64BootSnapshotV2CaptureInput, HvfSnapshotV2BootState, HvfSnapshotV2NativePath,
+        HvfSnapshotV2NetworkPciMemoryInput, HvfSnapshotV2NetworkPciRestoreDisposition,
+        HvfSnapshotV2NetworkPciRestoreStage, HvfSnapshotV2NetworkPreparedProduct,
+        HvfSnapshotV2NetworkState, HvfSnapshotV2RestoredSerialShell, OwnedHvfArm64BootSession,
+        prepare_hvf_snapshot_v2_network_pci_platform_plan,
+    };
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::balloon::{BalloonConfigInput, BalloonMmioLayout};
+    use bangbang_runtime::block::{
+        BlockFileBacking, BlockMmioLayout, DriveConfigInput, DriveIoEngine,
+    };
+    use bangbang_runtime::boot::BootSourceConfigInput;
+    use bangbang_runtime::entropy::{EntropyConfigInput, EntropyMmioLayout};
+    use bangbang_runtime::machine::MachineConfigInput;
+    use bangbang_runtime::memory::{GuestAddress, GuestMemory};
+    use bangbang_runtime::memory_hotplug::{MemoryHotplugConfigInput, VirtioMemMmioLayout};
+    use bangbang_runtime::metrics::SharedNetworkInterfaceMetricsRegistry;
+    use bangbang_runtime::mmio::MmioRegionId;
+    use bangbang_runtime::network::{
+        NetworkDeviceProfile, NetworkInterfaceConfigInput, NetworkMmioLayout,
+    };
+    use bangbang_runtime::pmem::PmemMmioLayout;
+    use bangbang_runtime::serial::{
+        SerialMmioDevice, SharedSerialOutput, SharedSerialOutputBuffer,
+    };
+    use bangbang_runtime::snapshot::SnapshotNetworkOverride;
+    use bangbang_runtime::snapshot_balloon_v2_9::SnapshotV2BalloonRestorePlan;
+    use bangbang_runtime::snapshot_device_v2_6::SnapshotV2StorageRestorePlan;
+    use bangbang_runtime::snapshot_entropy_v2_8::SnapshotV2EntropyRestorePlan;
+    use bangbang_runtime::snapshot_memory_hotplug_v2_10::PreparedSnapshotV2MemoryHotplugTopology;
+    use bangbang_runtime::snapshot_memory_v2::{
+        SnapshotV2MemoryBinding, materialize_snapshot_v2_memory_hotplug_file,
+    };
+    use bangbang_runtime::snapshot_network_restore_v2_11::PreparedSnapshotV2NetworkRestoreTopology;
+    use bangbang_runtime::snapshot_network_v2_11::{
+        NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION, SnapshotV2NetworkBackendClass,
+        SnapshotV2NetworkInterfaceState, SnapshotV2NetworkState,
+    };
+    use bangbang_runtime::snapshot_serial_v2_7::SnapshotV2SerialState;
+    use bangbang_runtime::storage_capture::{CaptureReadyStorageConfigs, StorageDeviceOrigin};
+    use bangbang_runtime::virtio_pci::VirtioPciEndpointPhase;
+    use bangbang_runtime::vsock::VsockMmioLayout;
+
+    enum PreparedMemory {
+        Static {
+            binding: SnapshotV2MemoryBinding,
+            memory: GuestMemory,
+        },
+        Hotplug {
+            topology: Box<PreparedSnapshotV2MemoryHotplugTopology>,
+            memory: GuestMemory,
+        },
+    }
+
+    #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+    fn run_case(
+        image: &[u8],
+        has_balloon: bool,
+        has_storage: bool,
+        has_entropy: bool,
+        has_memory_hotplug: bool,
+        network_count: usize,
+        cancel_stage: Option<HvfSnapshotV2NetworkPciRestoreStage>,
+    ) {
+        let kernel = TempFile::new("restore-network-pci-matrix-kernel", image)
+            .expect("network PCI matrix kernel should create");
+        let root = has_storage.then(|| {
+            TempFile::new_len("restore-network-pci-matrix-root", 4096)
+                .expect("network PCI matrix root should create")
+        });
+        let mut controller = bangbang_runtime::VmmController::new("test", "0.1.0", "bangbang");
+        controller
+            .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+                kernel.path(),
+            )))
+            .expect("network PCI matrix boot source should configure");
+        controller
+            .handle_action(VmmAction::PutMachineConfig(
+                MachineConfigInput::new(1, 128).with_track_dirty_pages(true),
+            ))
+            .expect("network PCI matrix dirty tracking should configure");
+        if let Some(root) = &root {
+            controller
+                .handle_action(VmmAction::PutDrive(
+                    DriveConfigInput::new("rootfs", "rootfs", root.path(), true)
+                        .with_is_read_only(true)
+                        .with_io_engine(DriveIoEngine::Sync),
+                ))
+                .expect("network PCI matrix root should configure");
+        }
+        if has_balloon {
+            controller
+                .handle_action(VmmAction::PutBalloon(BalloonConfigInput::new(8, false)))
+                .expect("network PCI matrix balloon should configure");
+        }
+        if has_entropy {
+            controller
+                .handle_action(VmmAction::PutEntropy(EntropyConfigInput::new()))
+                .expect("network PCI matrix entropy should configure");
+        }
+        if has_memory_hotplug {
+            controller
+                .handle_action(VmmAction::PutMemoryHotplug(MemoryHotplugConfigInput::new(
+                    128, 2, 128,
+                )))
+                .expect("network PCI matrix memory-hotplug should configure");
+        }
+        for index in 0..network_count {
+            let iface_id = format!("eth{index}");
+            controller
+                .handle_action(VmmAction::PutNetworkInterface(
+                    NetworkInterfaceConfigInput::new(
+                        iface_id.clone(),
+                        iface_id,
+                        format!("private-network-backend-{index}"),
+                    )
+                    .with_guest_mac(format!("02:00:00:00:03:{index:02x}"))
+                    .with_mtu(1400),
+                ))
+                .expect("network PCI matrix interface should configure");
+        }
+
+        let configs = controller.network_interface_configs().to_vec();
+        let profiles = configs
+            .iter()
+            .map(NetworkDeviceProfile::from_config)
+            .collect::<Vec<_>>();
+        let memory_hotplug_config = controller.memory_hotplug_config();
+        let requested_size_mib = controller
+            .memory_hotplug_status()
+            .map(|status| status.requested_size_mib());
+        let block_layout =
+            BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1));
+        let pmem_layout =
+            PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500));
+        let mut session_config = HvfArm64BootSessionConfig::new(
+            block_layout,
+            pmem_layout,
+            NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000)),
+            VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
+            bangbang_runtime::rtc::RtcMmioLayout::new(
+                GuestAddress::new(0x4000_1000),
+                MmioRegionId::new(10),
+            ),
+        )
+        .with_serial_device(HvfArm64BootSerialDeviceConfig::new(
+            MmioRegionId::new(20),
+            GuestAddress::new(0x4000_2000),
+            SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+        ))
+        .with_pci_enabled();
+        if has_balloon {
+            session_config =
+                session_config.with_balloon_device(HvfArm64BootBalloonDeviceConfig::new(
+                    BalloonMmioLayout::new(GuestAddress::new(0x4000_6000), MmioRegionId::new(3000)),
+                ));
+        }
+        if has_entropy {
+            session_config =
+                session_config.with_entropy_device(HvfArm64BootEntropyDeviceConfig::new(
+                    EntropyMmioLayout::new(GuestAddress::new(0x4000_7000), MmioRegionId::new(3001)),
+                ));
+        }
+        if has_memory_hotplug {
+            session_config = session_config.with_memory_hotplug_device(
+                HvfArm64BootMemoryHotplugDeviceConfig::new(VirtioMemMmioLayout::new(
+                    GuestAddress::new(0x4000_8000),
+                    MmioRegionId::new(4001),
+                )),
+            );
+        }
+
+        let mut source = OwnedHvfArm64BootSession::new(&controller, session_config)
+            .expect("signed network PCI matrix source should prepare");
+        let storage_configs = has_storage.then(|| {
+            CaptureReadyStorageConfigs::new(controller.drive_configs().to_vec(), Vec::new())
+        });
+        let capture_now = Instant::now();
+        let guard = source
+            .quiesce_limiter_retry_wakeups()
+            .expect("network PCI matrix source should quiesce");
+        let graph = storage_configs.as_ref().map(|configs| {
+            source
+                .capture_snapshot_v2_storage_device_graph_at(configs, &guard, capture_now)
+                .expect("network PCI matrix storage graph should capture")
+        });
+        let balloon = controller.balloon_config().map(|config| {
+            source
+                .capture_ready_balloon_state(Some(config), &guard)
+                .expect("network PCI matrix balloon should capture")
+                .expect("configured network PCI matrix balloon should exist")
+                .try_to_snapshot_v2()
+                .expect("network PCI matrix balloon capture should convert")
+        });
+        let entropy = controller.entropy_config().map(|config| {
+            source
+                .capture_ready_entropy_state_at(Some(config), &guard, capture_now)
+                .expect("network PCI matrix entropy should capture")
+                .expect("configured network PCI matrix entropy should exist")
+                .try_to_snapshot_v2()
+                .expect("network PCI matrix entropy capture should convert")
+        });
+        let memory_hotplug = memory_hotplug_config.map(|config| {
+            source
+                .capture_ready_memory_hotplug_state(Some(config), &guard)
+                .expect("network PCI matrix memory-hotplug should capture")
+                .expect("configured network PCI matrix memory-hotplug should exist")
+                .try_to_snapshot_v2(
+                    requested_size_mib.expect("requested memory-hotplug size should exist"),
+                )
+                .expect("network PCI matrix memory-hotplug capture should convert")
+        });
+        let captured_network = source
+            .capture_ready_network_state_at(
+                &configs
+                    .iter()
+                    .zip(&profiles)
+                    .map(|(config, profile)| {
+                        HvfArm64BootNetworkCaptureConfig::new(
+                            config.clone(),
+                            *profile,
+                            None,
+                            None,
+                            false,
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+                &guard,
+                capture_now,
+            )
+            .expect("network PCI matrix interfaces should capture");
+        let serial = SnapshotV2SerialState::try_from_capture_ready(
+            source
+                .capture_ready_serial_state(controller.serial_config().clone(), &guard)
+                .expect("network PCI matrix serial should capture"),
+        )
+        .expect("network PCI matrix serial capture should convert");
+        drop(guard);
+
+        let interfaces = captured_network
+            .interfaces()
+            .iter()
+            .map(|captured| {
+                let HvfArm64BootNetworkTransportCaptureState::Pci {
+                    origin,
+                    sbdf,
+                    bar_range,
+                    state,
+                } = captured.transport()
+                else {
+                    panic!("network PCI matrix source should use PCI");
+                };
+                let origin = match origin {
+                    HvfArm64BootNetworkDeviceOrigin::Startup => StorageDeviceOrigin::Startup,
+                    HvfArm64BootNetworkDeviceOrigin::Runtime => StorageDeviceOrigin::Runtime,
+                };
+                SnapshotV2NetworkInterfaceState::try_from_pci_capture(
+                    captured.config(),
+                    SnapshotV2NetworkBackendClass::Vmnet,
+                    origin,
+                    *sbdf,
+                    *bar_range,
+                    state,
+                )
+                .expect("network PCI matrix portable interface should convert")
+            })
+            .collect::<Vec<_>>();
+        let network = SnapshotV2NetworkState::try_new(interfaces, None)
+            .expect("network PCI matrix portable state should validate");
+        let overrides = network
+            .interfaces()
+            .iter()
+            .map(|interface| SnapshotNetworkOverride::new(interface.iface_id(), "vmnet:shared"))
+            .collect::<Vec<_>>();
+
+        source
+            .pause_for_snapshot_v2_capture()
+            .expect("network PCI matrix source should pause");
+        let boot = HvfSnapshotV2BootState::try_new(
+            HvfSnapshotV2NativePath::try_new(kernel.path().as_os_str())
+                .expect("network PCI matrix kernel path should validate"),
+            None,
+            None,
+        )
+        .expect("network PCI matrix boot metadata should validate");
+        let mut memory_writer = Cursor::new(Vec::new());
+        let platform = source
+            .capture_snapshot_v2_network_platform_with_cancel(
+                HvfArm64BootSnapshotV2CaptureInput::new(boot),
+                memory_hotplug,
+                &mut memory_writer,
+                |_| false,
+            )
+            .expect("network PCI matrix exact-2.11 platform should capture");
+        HvfSnapshotV2NetworkState::try_new(
+            platform.clone(),
+            graph.clone(),
+            serial.clone(),
+            entropy.clone(),
+            balloon.clone(),
+            Some(network.clone()),
+        )
+        .expect("network PCI matrix exact-2.11 product should compose");
+        let static_memory =
+            (!has_memory_hotplug).then(|| copy_signed_session_guest_memory(&source));
+        let memory_image = has_memory_hotplug.then(|| {
+            TempFile::new("restore-network-pci-matrix-memory", memory_writer.get_ref())
+                .expect("network PCI matrix memory image should persist")
+        });
+        source
+            .shutdown()
+            .expect("signed network PCI matrix source should shut down");
+
+        let platform_state = platform.platform().clone();
+        let prepared_memory = if has_memory_hotplug {
+            let portable = platform
+                .memory_hotplug()
+                .expect("network PCI matrix platform should retain memory-hotplug")
+                .clone();
+            let topology =
+                PreparedSnapshotV2MemoryHotplugTopology::prepare_for_compatibility_version(
+                    portable,
+                    platform_state.memory().clone(),
+                    NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
+                )
+                .expect("network PCI matrix memory-hotplug topology should prepare");
+            let memory = materialize_snapshot_v2_memory_hotplug_file(
+                &topology,
+                std::fs::File::open(
+                    memory_image
+                        .as_ref()
+                        .expect("network PCI matrix memory image should exist")
+                        .path(),
+                )
+                .expect("network PCI matrix memory image should reopen"),
+            )
+            .expect("network PCI matrix memory should materialize");
+            PreparedMemory::Hotplug {
+                topology: Box::new(topology),
+                memory,
+            }
+        } else {
+            PreparedMemory::Static {
+                binding: platform_state.memory().clone(),
+                memory: static_memory.expect("network PCI matrix static memory should exist"),
+            }
+        };
+        let memory = match &prepared_memory {
+            PreparedMemory::Static { memory, .. } | PreparedMemory::Hotplug { memory, .. } => {
+                memory
+            }
+        };
+        let restore_now = Instant::now();
+        let balloon_plan = balloon.map(|state| {
+            SnapshotV2BalloonRestorePlan::prepare(state, memory)
+                .expect("network PCI matrix balloon restore plan should prepare")
+        });
+        let entropy_plan = entropy.map(|state| {
+            SnapshotV2EntropyRestorePlan::prepare(state, memory, restore_now)
+                .expect("network PCI matrix entropy restore plan should prepare")
+        });
+        let storage_bundle = graph.map(|graph| {
+            let backing = BlockFileBacking::open_snapshot(
+                std::path::Path::new(graph.block_records()[0].config().selector()),
+                graph.block_records()[0].config().is_read_only(),
+            )
+            .expect("network PCI matrix block backing should reopen")
+            .0;
+            SnapshotV2StorageRestorePlan::prepare(graph, memory, restore_now)
+                .expect("network PCI matrix storage restore plan should prepare")
+                .prepare_backings(vec![backing], Vec::new(), || false)
+                .expect("network PCI matrix storage backing bundle should prepare")
+        });
+        let network_topology =
+            PreparedSnapshotV2NetworkRestoreTopology::prepare(network, &overrides)
+                .expect("network PCI matrix destination topology should prepare");
+
+        let (product, memory_input) =
+            match (prepared_memory, balloon_plan, storage_bundle, entropy_plan) {
+                (
+                    PreparedMemory::Static { binding, memory },
+                    None,
+                    None,
+                    None,
+                ) => (
+                    HvfSnapshotV2NetworkPreparedProduct::serial_network(
+                        binding,
+                        network_topology,
+                    ),
+                    HvfSnapshotV2NetworkPciMemoryInput::Static(memory),
+                ),
+                (
+                    PreparedMemory::Static { binding, memory },
+                    None,
+                    Some(storage),
+                    None,
+                ) => (
+                    HvfSnapshotV2NetworkPreparedProduct::serial_storage_network(
+                        binding,
+                        network_topology,
+                        storage,
+                    ),
+                    HvfSnapshotV2NetworkPciMemoryInput::Static(memory),
+                ),
+                (
+                    PreparedMemory::Static { binding, memory },
+                    None,
+                    None,
+                    Some(entropy),
+                ) => (
+                    HvfSnapshotV2NetworkPreparedProduct::serial_entropy_network(
+                        binding,
+                        network_topology,
+                        entropy,
+                    ),
+                    HvfSnapshotV2NetworkPciMemoryInput::Static(memory),
+                ),
+                (
+                    PreparedMemory::Static { binding, memory },
+                    None,
+                    Some(storage),
+                    Some(entropy),
+                ) => (
+                    HvfSnapshotV2NetworkPreparedProduct::serial_storage_entropy_network(
+                        binding,
+                        network_topology,
+                        storage,
+                        entropy,
+                    ),
+                    HvfSnapshotV2NetworkPciMemoryInput::Static(memory),
+                ),
+                (
+                    PreparedMemory::Static { binding, memory },
+                    Some(balloon),
+                    None,
+                    None,
+                ) => (
+                    HvfSnapshotV2NetworkPreparedProduct::serial_balloon_network(
+                        binding,
+                        network_topology,
+                        balloon,
+                    ),
+                    HvfSnapshotV2NetworkPciMemoryInput::Static(memory),
+                ),
+                (
+                    PreparedMemory::Static { binding, memory },
+                    Some(balloon),
+                    Some(storage),
+                    None,
+                ) => (
+                    HvfSnapshotV2NetworkPreparedProduct::serial_balloon_storage_network(
+                        binding,
+                        network_topology,
+                        balloon,
+                        storage,
+                    ),
+                    HvfSnapshotV2NetworkPciMemoryInput::Static(memory),
+                ),
+                (
+                    PreparedMemory::Static { binding, memory },
+                    Some(balloon),
+                    None,
+                    Some(entropy),
+                ) => (
+                    HvfSnapshotV2NetworkPreparedProduct::serial_balloon_entropy_network(
+                        binding,
+                        network_topology,
+                        balloon,
+                        entropy,
+                    ),
+                    HvfSnapshotV2NetworkPciMemoryInput::Static(memory),
+                ),
+                (
+                    PreparedMemory::Static { binding, memory },
+                    Some(balloon),
+                    Some(storage),
+                    Some(entropy),
+                ) => (
+                    HvfSnapshotV2NetworkPreparedProduct::serial_balloon_storage_entropy_network(
+                        binding,
+                        network_topology,
+                        balloon,
+                        storage,
+                        entropy,
+                    ),
+                    HvfSnapshotV2NetworkPciMemoryInput::Static(memory),
+                ),
+                (
+                    PreparedMemory::Hotplug { topology, memory },
+                    None,
+                    None,
+                    None,
+                ) => (
+                    HvfSnapshotV2NetworkPreparedProduct::serial_network_memory_hotplug(
+                        *topology,
+                        memory,
+                        network_topology,
+                    ),
+                    HvfSnapshotV2NetworkPciMemoryInput::ProductOwned,
+                ),
+                (
+                    PreparedMemory::Hotplug { topology, memory },
+                    None,
+                    Some(storage),
+                    None,
+                ) => (
+                    HvfSnapshotV2NetworkPreparedProduct::serial_storage_network_memory_hotplug(
+                        *topology,
+                        memory,
+                        network_topology,
+                        storage,
+                    ),
+                    HvfSnapshotV2NetworkPciMemoryInput::ProductOwned,
+                ),
+                (
+                    PreparedMemory::Hotplug { topology, memory },
+                    None,
+                    None,
+                    Some(entropy),
+                ) => (
+                    HvfSnapshotV2NetworkPreparedProduct::serial_entropy_network_memory_hotplug(
+                        *topology,
+                        memory,
+                        network_topology,
+                        entropy,
+                    ),
+                    HvfSnapshotV2NetworkPciMemoryInput::ProductOwned,
+                ),
+                (
+                    PreparedMemory::Hotplug { topology, memory },
+                    None,
+                    Some(storage),
+                    Some(entropy),
+                ) => (
+                    HvfSnapshotV2NetworkPreparedProduct::
+                        serial_storage_entropy_network_memory_hotplug(
+                            *topology,
+                            memory,
+                            network_topology,
+                            storage,
+                            entropy,
+                        ),
+                    HvfSnapshotV2NetworkPciMemoryInput::ProductOwned,
+                ),
+                (
+                    PreparedMemory::Hotplug { topology, memory },
+                    Some(balloon),
+                    None,
+                    None,
+                ) => (
+                    HvfSnapshotV2NetworkPreparedProduct::serial_balloon_network_memory_hotplug(
+                        *topology,
+                        memory,
+                        network_topology,
+                        balloon,
+                    ),
+                    HvfSnapshotV2NetworkPciMemoryInput::ProductOwned,
+                ),
+                (
+                    PreparedMemory::Hotplug { topology, memory },
+                    Some(balloon),
+                    Some(storage),
+                    None,
+                ) => (
+                    HvfSnapshotV2NetworkPreparedProduct::
+                        serial_balloon_storage_network_memory_hotplug(
+                            *topology,
+                            memory,
+                            network_topology,
+                            balloon,
+                            storage,
+                        ),
+                    HvfSnapshotV2NetworkPciMemoryInput::ProductOwned,
+                ),
+                (
+                    PreparedMemory::Hotplug { topology, memory },
+                    Some(balloon),
+                    None,
+                    Some(entropy),
+                ) => (
+                    HvfSnapshotV2NetworkPreparedProduct::
+                        serial_balloon_entropy_network_memory_hotplug(
+                            *topology,
+                            memory,
+                            network_topology,
+                            balloon,
+                            entropy,
+                        ),
+                    HvfSnapshotV2NetworkPciMemoryInput::ProductOwned,
+                ),
+                (
+                    PreparedMemory::Hotplug { topology, memory },
+                    Some(balloon),
+                    Some(storage),
+                    Some(entropy),
+                ) => (
+                    HvfSnapshotV2NetworkPreparedProduct::
+                        serial_balloon_storage_entropy_network_memory_hotplug(
+                            *topology,
+                            memory,
+                            network_topology,
+                            balloon,
+                            storage,
+                            entropy,
+                        ),
+                    HvfSnapshotV2NetworkPciMemoryInput::ProductOwned,
+                ),
+            };
+        let plan = prepare_hvf_snapshot_v2_network_pci_platform_plan(&platform_state, product)
+            .unwrap_or_else(|error| {
+                panic!(
+                    "network PCI matrix balloon={has_balloon} storage={has_storage} entropy={has_entropy} memory-hotplug={has_memory_hotplug} should plan: {error:?}"
+                )
+            });
+        assert_eq!(
+            plan.endpoint_count(),
+            network_count
+                + usize::from(has_balloon)
+                + usize::from(has_storage)
+                + usize::from(has_entropy)
+                + usize::from(has_memory_hotplug)
+        );
+        assert_eq!(plan.network().len(), network_count);
+
+        let restored_shell = HvfSnapshotV2RestoredSerialShell::new(
+            SerialMmioDevice::from_capture_state_with_shared_output(
+                SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+                serial.device().clone(),
+            ),
+        );
+        let metrics = SharedNetworkInterfaceMetricsRegistry::from_interface_ids(
+            configs.iter().map(|config| config.iface_id()),
+        );
+        let owners = if let Some(cancel_stage) = cancel_stage {
+            let error = OwnedHvfArm64BootSession::restore_snapshot_v2_network_pci_with_cancel(
+                platform_state,
+                memory_input,
+                restored_shell,
+                None,
+                plan,
+                profiles,
+                metrics,
+                restore_now,
+                |stage| stage == cancel_stage,
+            )
+            .expect_err("network PCI matrix aggregate cancellation should reject");
+            assert_eq!(error.stage(), cancel_stage);
+            assert_eq!(
+                error.disposition(),
+                HvfSnapshotV2NetworkPciRestoreDisposition::Terminal
+            );
+            assert!(!error.has_incomplete_cleanup());
+            return;
+        } else {
+            OwnedHvfArm64BootSession::restore_snapshot_v2_network_pci(
+                platform_state,
+                memory_input,
+                restored_shell,
+                None,
+                plan,
+                profiles.clone(),
+                metrics,
+                restore_now,
+            )
+            .unwrap_or_else(|error| {
+                panic!(
+                    "network PCI matrix balloon={has_balloon} storage={has_storage} entropy={has_entropy} memory-hotplug={has_memory_hotplug} should restore: {error:?}"
+                )
+            })
+        };
+        assert_eq!(owners.configs().len(), network_count);
+        assert_eq!(owners.expected().len(), network_count);
+        assert_eq!(owners.balloon_config().is_some(), has_balloon);
+        assert_eq!(owners.storage_configs().is_some(), has_storage);
+        assert_eq!(owners.entropy_config().is_some(), has_entropy);
+        assert_eq!(owners.memory_hotplug_state().is_some(), has_memory_hotplug);
+        assert_eq!(
+            owners.memory_hotplug_controller().is_some(),
+            has_memory_hotplug
+        );
+        assert!(!owners.retry_publication_is_committed());
+
+        let diagnostics = owners
+            .session()
+            .pci_data_device_diagnostics()
+            .expect("network PCI matrix manager should exist")
+            .expect("network PCI matrix diagnostics should inspect");
+        let mut expected_kinds = Vec::new();
+        if has_balloon {
+            expected_kinds.push(HvfArm64BootPciDataDeviceKind::Balloon);
+        }
+        if has_storage {
+            expected_kinds.push(HvfArm64BootPciDataDeviceKind::Block);
+        }
+        expected_kinds.extend(std::iter::repeat_n(
+            HvfArm64BootPciDataDeviceKind::Network,
+            network_count,
+        ));
+        if has_entropy {
+            expected_kinds.push(HvfArm64BootPciDataDeviceKind::Entropy);
+        }
+        if has_memory_hotplug {
+            expected_kinds.push(HvfArm64BootPciDataDeviceKind::MemoryHotplug);
+        }
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|entry| entry.kind)
+                .collect::<Vec<_>>(),
+            expected_kinds
+        );
+        assert!(diagnostics.iter().all(|entry| {
+            entry.transport.phase == VirtioPciEndpointPhase::Active
+                && !entry.transport.device_activated
+                && entry.queue_deliveries == 0
+        }));
+
+        let recapture_configs = owners
+            .configs()
+            .iter()
+            .zip(&profiles)
+            .map(|(config, profile)| {
+                HvfArm64BootNetworkCaptureConfig::new(config.clone(), *profile, None, None, false)
+            })
+            .collect::<Vec<_>>();
+        let guard = owners
+            .session()
+            .quiesce_limiter_retry_wakeups()
+            .expect("network PCI matrix destination should quiesce");
+        let recaptured = owners
+            .session()
+            .capture_ready_network_state_at(&recapture_configs, &guard, restore_now)
+            .expect("network PCI matrix destination should recapture");
+        for (captured, expected) in recaptured.interfaces().iter().zip(owners.expected()) {
+            let HvfArm64BootNetworkTransportCaptureState::Pci {
+                origin,
+                sbdf,
+                bar_range,
+                state,
+            } = captured.transport()
+            else {
+                panic!("network PCI matrix destination should remain PCI");
+            };
+            let origin = match origin {
+                HvfArm64BootNetworkDeviceOrigin::Startup => StorageDeviceOrigin::Startup,
+                HvfArm64BootNetworkDeviceOrigin::Runtime => StorageDeviceOrigin::Runtime,
+            };
+            let portable = SnapshotV2NetworkInterfaceState::try_from_pci_capture(
+                captured.config(),
+                expected.backend(),
+                origin,
+                *sbdf,
+                *bar_range,
+                state,
+            )
+            .expect("network PCI matrix destination recapture should convert");
+            assert_eq!(&portable, expected);
+        }
+        drop(guard);
+
+        let mut restored = owners
+            .commit_retry_publication()
+            .into_session()
+            .expect("network PCI matrix committed owner should release its session");
+        restored
+            .shutdown()
+            .expect("network PCI matrix destination should shut down");
+    }
+
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let image = arm64_image().expect("test arm64 image should build");
+    for mask in 0_u8..16 {
+        let has_storage = mask & 1 != 0;
+        let has_entropy = mask & 2 != 0;
+        let has_balloon = mask & 4 != 0;
+        let has_memory_hotplug = mask & 8 != 0;
+        run_case(
+            &image,
+            has_balloon,
+            has_storage,
+            has_entropy,
+            has_memory_hotplug,
+            if mask == 15 { 16 } else { 1 },
+            None,
+        );
+    }
+    for cancel_stage in [
+        HvfSnapshotV2NetworkPciRestoreStage::Publication { index: 0 },
+        HvfSnapshotV2NetworkPciRestoreStage::Entropy,
+        HvfSnapshotV2NetworkPciRestoreStage::MemoryHotplug,
+    ] {
+        run_case(&image, true, true, true, true, 1, Some(cancel_stage));
+    }
+}
+
 #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 #[test]
 fn requires_macos_apple_silicon() {

--- a/crates/runtime/src/network.rs
+++ b/crates/runtime/src/network.rs
@@ -1028,7 +1028,7 @@ impl VirtioNetworkConfigSpace {
         self.metrics = Some(VirtioNetworkTransportMetrics::for_interface(metrics));
     }
 
-    fn attach_metrics_with_aggregate(
+    pub(crate) fn attach_metrics_with_aggregate(
         &mut self,
         interface: SharedNetworkInterfaceMetrics,
         aggregate: SharedNetworkInterfaceMetrics,
@@ -3199,7 +3199,7 @@ impl VirtioNetworkDevice {
         self.metrics = Some(VirtioNetworkTransportMetrics::for_interface(metrics));
     }
 
-    fn attach_metrics_with_aggregate(
+    pub(crate) fn attach_metrics_with_aggregate(
         &mut self,
         interface: SharedNetworkInterfaceMetrics,
         aggregate: SharedNetworkInterfaceMetrics,

--- a/crates/runtime/src/snapshot_memory_hotplug_v2_10.rs
+++ b/crates/runtime/src/snapshot_memory_hotplug_v2_10.rs
@@ -424,7 +424,36 @@ impl PreparedSnapshotV2MemoryHotplugTopology {
         state: SnapshotV2MemoryHotplugState,
         binding: SnapshotV2MemoryBinding,
     ) -> Result<Self, SnapshotV2MemoryHotplugPreparationError> {
-        prepare_memory_hotplug_topology(state, binding, TopologyReservePolicy::System)
+        prepare_memory_hotplug_topology(
+            state,
+            binding,
+            NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+            TopologyReservePolicy::System,
+        )
+    }
+
+    /// Applies the unchanged exact-2.10 topology to a later closed container.
+    #[doc(hidden)]
+    pub fn prepare_for_compatibility_version(
+        state: SnapshotV2MemoryHotplugState,
+        binding: SnapshotV2MemoryBinding,
+        compatibility_version: SnapshotFormatVersion,
+    ) -> Result<Self, SnapshotV2MemoryHotplugPreparationError> {
+        let base = NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION;
+        if compatibility_version.major() != base.major()
+            || (compatibility_version.minor(), compatibility_version.patch())
+                < (base.minor(), base.patch())
+        {
+            return Err(SnapshotV2MemoryHotplugPreparationError::Binding(
+                SnapshotV2MemoryHotplugBindingError::Version,
+            ));
+        }
+        prepare_memory_hotplug_topology(
+            state,
+            binding,
+            compatibility_version,
+            TopologyReservePolicy::System,
+        )
     }
 
     #[cfg(test)]
@@ -432,7 +461,12 @@ impl PreparedSnapshotV2MemoryHotplugTopology {
         state: SnapshotV2MemoryHotplugState,
         binding: SnapshotV2MemoryBinding,
     ) -> Result<Self, SnapshotV2MemoryHotplugPreparationError> {
-        prepare_memory_hotplug_topology(state, binding, TopologyReservePolicy::FailExtentClasses)
+        prepare_memory_hotplug_topology(
+            state,
+            binding,
+            NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+            TopologyReservePolicy::FailExtentClasses,
+        )
     }
 
     #[cfg(test)]
@@ -440,7 +474,12 @@ impl PreparedSnapshotV2MemoryHotplugTopology {
         state: SnapshotV2MemoryHotplugState,
         binding: SnapshotV2MemoryBinding,
     ) -> Result<Self, SnapshotV2MemoryHotplugPreparationError> {
-        prepare_memory_hotplug_topology(state, binding, TopologyReservePolicy::FailPluggedRanges)
+        prepare_memory_hotplug_topology(
+            state,
+            binding,
+            NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+            TopologyReservePolicy::FailPluggedRanges,
+        )
     }
 
     /// Returns the exact binding and attached extent classification.
@@ -1513,12 +1552,13 @@ impl TopologyReservePolicy {
 fn prepare_memory_hotplug_topology(
     state: SnapshotV2MemoryHotplugState,
     binding: SnapshotV2MemoryBinding,
+    compatibility_version: SnapshotFormatVersion,
     reserve_policy: TopologyReservePolicy,
 ) -> Result<PreparedSnapshotV2MemoryHotplugTopology, SnapshotV2MemoryHotplugPreparationError> {
     validate_memory_hotplug_state(&state)
         .map_err(|_| SnapshotV2MemoryHotplugPreparationError::InvalidState)?;
     state
-        .validate_memory_binding(&binding)
+        .validate_memory_binding_for_compatibility_version(&binding, compatibility_version)
         .map_err(SnapshotV2MemoryHotplugPreparationError::Binding)?;
 
     let config_space = state.config_space();

--- a/crates/runtime/src/snapshot_memory_hotplug_v2_10/tests.rs
+++ b/crates/runtime/src/snapshot_memory_hotplug_v2_10/tests.rs
@@ -430,6 +430,71 @@ fn kind_one_binding_closes_fragmented_plugged_unions_and_rejects_hostile_coverag
     }
 }
 
+#[test]
+fn prepared_topology_accepts_an_exact_later_container_version_only_when_requested() {
+    let state = inactive_mmio_state();
+    let config_space = state.config_space();
+    let block_size = config_space.block_size();
+    let first_start = config_space.addr() + block_size;
+    let second_start = config_space.addr() + 5 * block_size;
+    let range = |start, length| {
+        GuestMemoryRange::new(GuestAddress::new(start), length)
+            .expect("later-container binding range should validate")
+    };
+    let version = crate::snapshot_network_v2_11::NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION;
+    let binding = binding_for_ranges(
+        version,
+        vec![
+            range(first_start, 2 * block_size),
+            range(second_start, 3 * block_size),
+        ],
+    );
+
+    assert!(matches!(
+        PreparedSnapshotV2MemoryHotplugTopology::prepare(state.clone(), binding.clone()),
+        Err(SnapshotV2MemoryHotplugPreparationError::Binding(
+            SnapshotV2MemoryHotplugBindingError::Version
+        ))
+    ));
+    let prepared = PreparedSnapshotV2MemoryHotplugTopology::prepare_for_compatibility_version(
+        state.clone(),
+        binding.clone(),
+        version,
+    )
+    .expect("unchanged exact-2.10 topology should close inside the exact-2.11 container");
+    assert_eq!(prepared.state(), &state);
+    assert_eq!(prepared.memory().binding(), &binding);
+    assert!(matches!(
+        PreparedSnapshotV2MemoryHotplugTopology::prepare_for_compatibility_version(
+            state,
+            binding,
+            NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        ),
+        Err(SnapshotV2MemoryHotplugPreparationError::Binding(
+            SnapshotV2MemoryHotplugBindingError::Version
+        ))
+    ));
+
+    let older_version = SnapshotFormatVersion::new(2, 9, 0);
+    let older_binding = binding_for_ranges(
+        older_version,
+        vec![
+            range(first_start, 2 * block_size),
+            range(second_start, 3 * block_size),
+        ],
+    );
+    assert!(matches!(
+        PreparedSnapshotV2MemoryHotplugTopology::prepare_for_compatibility_version(
+            inactive_mmio_state(),
+            older_binding,
+            older_version,
+        ),
+        Err(SnapshotV2MemoryHotplugPreparationError::Binding(
+            SnapshotV2MemoryHotplugBindingError::Version
+        ))
+    ));
+}
+
 fn test_range(start: u64, size: u64) -> GuestMemoryRange {
     GuestMemoryRange::new(GuestAddress::new(start), size)
         .expect("test guest-memory range should validate")

--- a/crates/runtime/src/snapshot_network_restore_v2_11.rs
+++ b/crates/runtime/src/snapshot_network_restore_v2_11.rs
@@ -5,9 +5,10 @@ use std::time::{Duration, Instant};
 
 use crate::interrupt::GuestInterruptLine;
 use crate::memory::{GuestMemory, GuestMemoryRange};
+use crate::message_interrupt::GuestMessageInterruptRegistry;
 use crate::metrics::SharedNetworkInterfaceMetrics;
 use crate::mmds::{MmdsConfig, MmdsConfigInput};
-use crate::mmio::MmioRegion;
+use crate::mmio::{MmioRegion, MmioRegionId};
 use crate::network::{
     NetworkDeviceProfile, NetworkInterfaceConfig, NetworkMmioDeviceRegistration,
     NetworkRateLimiterConfig, NetworkTokenBucketConfig, VIRTIO_NET_DEVICE_ID,
@@ -33,10 +34,31 @@ use crate::snapshot_restore::{
     SnapshotRestorePublicId, SnapshotRestorePublicIdError, SnapshotRestoreResourceClass,
     SnapshotRestoreResourceKey,
 };
-use crate::virtio::VirtioInterruptIntent;
+use crate::storage_capture::StorageDeviceOrigin;
+use crate::virtio::{VirtioDeviceType, VirtioInterruptIntent};
 use crate::virtio_mmio::VirtioMmioQueueState;
+use crate::virtio_pci::{
+    PreparedVirtioPciEndpoint, VirtioPciEndpointError, VirtioPciIdentity, VirtioPciTransportState,
+};
 
 const REDACTED: &str = "<redacted>";
+
+struct RestoredSnapshotV2NetworkDevice {
+    queue_ranges: [Option<[GuestMemoryRange; 3]>; 2],
+    retry_deadline: Option<Instant>,
+    config_space: VirtioNetworkConfigSpace,
+    device: VirtioNetworkDevice,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RestoreSnapshotV2NetworkDeviceError {
+    Profile,
+    Queue,
+    QueueMemory,
+    Limiter,
+    Retry,
+    Device,
+}
 
 /// Stable cancellation checkpoints before an owner-free topology is published.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -349,6 +371,145 @@ impl PreparedSnapshotV2NetworkRestoreInterface {
             handler,
         })
     }
+
+    /// Consumes one checked interface into a complete retained PCI endpoint
+    /// against destination memory and fresh metrics.
+    ///
+    /// The caller supplies the dispatcher region fixed by the platform plan and
+    /// a fresh destination message registry. The result still owns no message
+    /// resources, BAR/function/dispatcher lease, packet-I/O provider, callback,
+    /// scheduler, session, or VM authority.
+    #[doc(hidden)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn into_pci_endpoint(
+        self,
+        destination_memory: &GuestMemory,
+        realized_profile: NetworkDeviceProfile,
+        interface_metrics: SharedNetworkInterfaceMetrics,
+        aggregate_metrics: SharedNetworkInterfaceMetrics,
+        region_id: MmioRegionId,
+        messages: GuestMessageInterruptRegistry,
+        now: Instant,
+    ) -> Result<PreparedSnapshotV2NetworkPciEndpoint, SnapshotV2NetworkPciEndpointError> {
+        let restored = restore_snapshot_v2_network_device(
+            &self.controller,
+            &self.portable,
+            destination_memory,
+            realized_profile,
+            interface_metrics,
+            aggregate_metrics,
+            now,
+        )
+        .map_err(SnapshotV2NetworkPciEndpointError::from_device)?;
+        let Self {
+            source_index,
+            resource_key,
+            controller,
+            portable,
+            mmds_stack,
+        } = self;
+        let SnapshotV2NetworkInterfaceStateParts {
+            iface_id,
+            captured_selector: _,
+            requested_guest_mac,
+            requested_mtu,
+            profile,
+            backend,
+            local,
+            virtio,
+            rx_limiter,
+            tx_limiter,
+            transport,
+        } = portable.into_parts();
+        let SnapshotV2DeviceTransport::Pci(pci) = &transport else {
+            return Err(SnapshotV2NetworkPciEndpointError::WrongTransport);
+        };
+        let origin = pci.origin();
+        let sbdf = pci.sbdf();
+        let bar_range = pci.bar_range();
+        let mut captured_selector = String::new();
+        captured_selector
+            .try_reserve_exact(controller.host_dev_name().len())
+            .map_err(|_| SnapshotV2NetworkPciEndpointError::Allocation)?;
+        captured_selector.push_str(controller.host_dev_name());
+        let expected_state =
+            SnapshotV2NetworkInterfaceState::try_from_parts(SnapshotV2NetworkInterfaceStateParts {
+                iface_id,
+                captured_selector,
+                requested_guest_mac,
+                requested_mtu,
+                profile,
+                backend,
+                local,
+                virtio,
+                rx_limiter,
+                tx_limiter,
+                transport,
+            })
+            .map_err(|_| SnapshotV2NetworkPciEndpointError::ExpectedState)?;
+        let device_type = VirtioDeviceType::new(VIRTIO_NET_DEVICE_ID)
+            .map_err(|_| SnapshotV2NetworkPciEndpointError::DeviceType)?;
+        let identity =
+            VirtioPciIdentity::new(device_type, expected_state.virtio().available_features())
+                .with_config_generation(expected_state.virtio().config_generation());
+        let SnapshotV2DeviceTransport::Pci(pci) = expected_state.transport() else {
+            return Err(SnapshotV2NetworkPciEndpointError::WrongTransport);
+        };
+        let retained = VirtioPciTransportState::from_snapshot_v2_parts(
+            identity,
+            expected_state.virtio(),
+            pci,
+            false,
+        )
+        .map_err(|_| SnapshotV2NetworkPciEndpointError::RetainedTransport)?;
+        let activation_is_active = restored.device.is_activated();
+        let endpoint = PreparedVirtioPciEndpoint::new(
+            identity,
+            &VIRTIO_NET_QUEUE_SIZES,
+            restored.config_space,
+            restored.device,
+            activation_is_active,
+            false,
+            &retained,
+            sbdf,
+            bar_range,
+            region_id,
+            messages,
+        )
+        .map_err(SnapshotV2NetworkPciEndpointError::Endpoint)?;
+        let (captured, validation) = endpoint
+            .endpoint()
+            .capture_network_state_at(&controller, realized_profile, destination_memory, None, now)
+            .map_err(|_| SnapshotV2NetworkPciEndpointError::Capture)?;
+        if validation.source_rx_retry().is_some() {
+            return Err(SnapshotV2NetworkPciEndpointError::Capture);
+        }
+        let normalized = SnapshotV2NetworkInterfaceState::try_from_pci_capture(
+            &controller,
+            backend,
+            origin,
+            sbdf,
+            bar_range,
+            &captured,
+        )
+        .map_err(|_| SnapshotV2NetworkPciEndpointError::Normalize)?;
+        if normalized != expected_state {
+            return Err(SnapshotV2NetworkPciEndpointError::StateMismatch);
+        }
+
+        Ok(PreparedSnapshotV2NetworkPciEndpoint {
+            source_index,
+            resource_key,
+            controller,
+            expected_state,
+            mmds_stack,
+            queue_ranges: restored.queue_ranges,
+            retry: normalized.local().tx_retry(),
+            retry_deadline: restored.retry_deadline,
+            origin,
+            endpoint,
+        })
+    }
 }
 
 impl fmt::Debug for PreparedSnapshotV2NetworkRestoreInterface {
@@ -526,6 +687,212 @@ impl fmt::Display for SnapshotV2NetworkMmioHandlerError {
 }
 
 impl std::error::Error for SnapshotV2NetworkMmioHandlerError {}
+
+/// One checked exact-2.11 network endpoint awaiting destination PCI
+/// publication.
+#[doc(hidden)]
+pub struct PreparedSnapshotV2NetworkPciEndpoint {
+    source_index: u16,
+    resource_key: SnapshotRestoreResourceKey,
+    controller: NetworkInterfaceConfig,
+    expected_state: SnapshotV2NetworkInterfaceState,
+    mmds_stack: Option<SnapshotV2MmdsInterfaceState>,
+    queue_ranges: [Option<[GuestMemoryRange; 3]>; 2],
+    retry: SnapshotV2NetworkRetryState,
+    retry_deadline: Option<Instant>,
+    origin: StorageDeviceOrigin,
+    endpoint: PreparedVirtioPciEndpoint<VirtioNetworkConfigSpace, VirtioNetworkDevice>,
+}
+
+/// Consumed checked network continuation and retained PCI endpoint.
+#[doc(hidden)]
+pub type PreparedSnapshotV2NetworkPciEndpointParts = (
+    u16,
+    SnapshotRestoreResourceKey,
+    NetworkInterfaceConfig,
+    SnapshotV2NetworkInterfaceState,
+    Option<SnapshotV2MmdsInterfaceState>,
+    [Option<[GuestMemoryRange; 3]>; 2],
+    SnapshotV2NetworkRetryState,
+    Option<Instant>,
+    StorageDeviceOrigin,
+    PreparedVirtioPciEndpoint<VirtioNetworkConfigSpace, VirtioNetworkDevice>,
+);
+
+impl PreparedSnapshotV2NetworkPciEndpoint {
+    pub const fn source_index(&self) -> u16 {
+        self.source_index
+    }
+
+    pub const fn resource_key(&self) -> &SnapshotRestoreResourceKey {
+        &self.resource_key
+    }
+
+    pub const fn controller(&self) -> &NetworkInterfaceConfig {
+        &self.controller
+    }
+
+    pub const fn expected_state(&self) -> &SnapshotV2NetworkInterfaceState {
+        &self.expected_state
+    }
+
+    pub const fn mmds_stack(&self) -> Option<SnapshotV2MmdsInterfaceState> {
+        self.mmds_stack
+    }
+
+    pub const fn queue_ranges(&self) -> &[Option<[GuestMemoryRange; 3]>; 2] {
+        &self.queue_ranges
+    }
+
+    pub const fn retry(&self) -> SnapshotV2NetworkRetryState {
+        self.retry
+    }
+
+    pub const fn retry_deadline(&self) -> Option<Instant> {
+        self.retry_deadline
+    }
+
+    pub const fn origin(&self) -> StorageDeviceOrigin {
+        self.origin
+    }
+
+    pub const fn endpoint(
+        &self,
+    ) -> &PreparedVirtioPciEndpoint<VirtioNetworkConfigSpace, VirtioNetworkDevice> {
+        &self.endpoint
+    }
+
+    pub fn into_parts(self) -> PreparedSnapshotV2NetworkPciEndpointParts {
+        (
+            self.source_index,
+            self.resource_key,
+            self.controller,
+            self.expected_state,
+            self.mmds_stack,
+            self.queue_ranges,
+            self.retry,
+            self.retry_deadline,
+            self.origin,
+            self.endpoint,
+        )
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2NetworkPciEndpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2NetworkPciEndpoint")
+            .field("source_index", &self.source_index)
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Redacted failure while materializing one checked network PCI endpoint.
+#[doc(hidden)]
+pub enum SnapshotV2NetworkPciEndpointError {
+    Profile,
+    WrongTransport,
+    Queue,
+    QueueMemory,
+    Limiter,
+    Retry,
+    Device,
+    DeviceType,
+    RetainedTransport,
+    Endpoint(VirtioPciEndpointError),
+    ExpectedState,
+    Capture,
+    Normalize,
+    StateMismatch,
+    Allocation,
+}
+
+impl SnapshotV2NetworkPciEndpointError {
+    const fn from_device(source: RestoreSnapshotV2NetworkDeviceError) -> Self {
+        match source {
+            RestoreSnapshotV2NetworkDeviceError::Profile => Self::Profile,
+            RestoreSnapshotV2NetworkDeviceError::Queue => Self::Queue,
+            RestoreSnapshotV2NetworkDeviceError::QueueMemory => Self::QueueMemory,
+            RestoreSnapshotV2NetworkDeviceError::Limiter => Self::Limiter,
+            RestoreSnapshotV2NetworkDeviceError::Retry => Self::Retry,
+            RestoreSnapshotV2NetworkDeviceError::Device => Self::Device,
+        }
+    }
+}
+
+impl fmt::Debug for SnapshotV2NetworkPciEndpointError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2NetworkPciEndpointError")
+            .field(
+                "kind",
+                &match self {
+                    Self::Profile => "Profile",
+                    Self::WrongTransport => "WrongTransport",
+                    Self::Queue => "Queue",
+                    Self::QueueMemory => "QueueMemory",
+                    Self::Limiter => "Limiter",
+                    Self::Retry => "Retry",
+                    Self::Device => "Device",
+                    Self::DeviceType => "DeviceType",
+                    Self::RetainedTransport => "RetainedTransport",
+                    Self::Endpoint(_) => "Endpoint",
+                    Self::ExpectedState => "ExpectedState",
+                    Self::Capture => "Capture",
+                    Self::Normalize => "Normalize",
+                    Self::StateMismatch => "StateMismatch",
+                    Self::Allocation => "Allocation",
+                },
+            )
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotV2NetworkPciEndpointError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Profile => "native-v2 network destination profile is invalid",
+            Self::WrongTransport => "native-v2 network restore interface is not PCI",
+            Self::Queue => "native-v2 network queue reconstruction failed",
+            Self::QueueMemory => "native-v2 network queue memory is invalid",
+            Self::Limiter => "native-v2 network limiter reconstruction failed",
+            Self::Retry => "native-v2 network retry reconstruction failed",
+            Self::Device => "native-v2 network device reconstruction failed",
+            Self::DeviceType => "native-v2 network PCI device type is invalid",
+            Self::RetainedTransport => "native-v2 network retained PCI state is invalid",
+            Self::Endpoint(_) => "native-v2 network PCI endpoint construction failed",
+            Self::ExpectedState => "native-v2 network normalized state is invalid",
+            Self::Capture => "native-v2 network immediate PCI capture failed",
+            Self::Normalize => "native-v2 network immediate PCI normalization failed",
+            Self::StateMismatch => "native-v2 network immediate PCI state does not match",
+            Self::Allocation => "native-v2 network PCI preparation allocation failed",
+        })
+    }
+}
+
+impl std::error::Error for SnapshotV2NetworkPciEndpointError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Endpoint(source) => Some(source),
+            Self::Profile
+            | Self::WrongTransport
+            | Self::Queue
+            | Self::QueueMemory
+            | Self::Limiter
+            | Self::Retry
+            | Self::Device
+            | Self::DeviceType
+            | Self::RetainedTransport
+            | Self::ExpectedState
+            | Self::Capture
+            | Self::Normalize
+            | Self::StateMismatch
+            | Self::Allocation => None,
+        }
+    }
+}
 
 /// Immutable exact-2.11 network/controller/MMDS destination topology.
 ///
@@ -963,6 +1330,151 @@ fn validate_destination_selector(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+fn restore_snapshot_v2_network_device(
+    controller: &NetworkInterfaceConfig,
+    portable: &SnapshotV2NetworkInterfaceState,
+    destination_memory: &GuestMemory,
+    realized_profile: NetworkDeviceProfile,
+    interface_metrics: SharedNetworkInterfaceMetrics,
+    aggregate_metrics: SharedNetworkInterfaceMetrics,
+    now: Instant,
+) -> Result<RestoredSnapshotV2NetworkDevice, RestoreSnapshotV2NetworkDeviceError> {
+    if realized_profile != portable.profile()
+        || controller
+            .guest_mac()
+            .is_some_and(|mac| realized_profile.guest_mac() != Some(mac))
+        || controller
+            .mtu()
+            .is_some_and(|mtu| realized_profile.mtu() != Some(mtu))
+        || !realized_profile
+            .feature_capabilities()
+            .is_dependency_complete()
+    {
+        return Err(RestoreSnapshotV2NetworkDeviceError::Profile);
+    }
+
+    let virtio = portable.virtio();
+    let local = portable.local();
+    let rx_transport = virtio
+        .queues()
+        .first()
+        .copied()
+        .ok_or(RestoreSnapshotV2NetworkDeviceError::Queue)?;
+    let tx_transport = virtio
+        .queues()
+        .get(1)
+        .copied()
+        .ok_or(RestoreSnapshotV2NetworkDeviceError::Queue)?;
+    if virtio.queues().len() != VIRTIO_NET_QUEUE_SIZES.len() {
+        return Err(RestoreSnapshotV2NetworkDeviceError::Queue);
+    }
+    let queue_ranges = [
+        queue_ranges(&rx_transport).map_err(|_| RestoreSnapshotV2NetworkDeviceError::Queue)?,
+        queue_ranges(&tx_transport).map_err(|_| RestoreSnapshotV2NetworkDeviceError::Queue)?,
+    ];
+    if queue_ranges
+        .iter()
+        .flatten()
+        .flatten()
+        .copied()
+        .any(|range| !range_is_wholly_contained(destination_memory, range))
+    {
+        return Err(RestoreSnapshotV2NetworkDeviceError::QueueMemory);
+    }
+
+    let negotiated_features = virtio.driver_features();
+    let rx_queue = local
+        .active_rx_queue()
+        .map(|cursor| {
+            VirtioNetworkRxQueue::from_snapshot_state(
+                restore_queue_state(rx_transport),
+                cursor.next_available(),
+                cursor.next_used(),
+                negotiated_features,
+            )
+            .map_err(|_| RestoreSnapshotV2NetworkDeviceError::Queue)
+        })
+        .transpose()?;
+    let tx_queue = local
+        .active_tx_queue()
+        .map(|cursor| {
+            VirtioNetworkTxQueue::from_snapshot_state(
+                restore_queue_state(tx_transport),
+                cursor.next_available(),
+                cursor.next_used(),
+                negotiated_features,
+            )
+            .map_err(|_| RestoreSnapshotV2NetworkDeviceError::Queue)
+        })
+        .transpose()?;
+    if rx_queue.is_some() != virtio.is_activated() || tx_queue.is_some() != virtio.is_activated() {
+        return Err(RestoreSnapshotV2NetworkDeviceError::Queue);
+    }
+    if let Some(queue) = rx_queue.as_ref() {
+        queue
+            .validate_snapshot_state(destination_memory)
+            .map_err(|_| RestoreSnapshotV2NetworkDeviceError::Queue)?;
+    }
+    let has_tx_retry = local.tx_retry().has_retry();
+    if let Some(queue) = tx_queue.as_ref() {
+        queue
+            .validate_snapshot_state(destination_memory, has_tx_retry)
+            .map_err(|_| RestoreSnapshotV2NetworkDeviceError::Queue)?;
+    }
+    if let (Some(rx), Some(tx)) = (rx_queue.as_ref(), tx_queue.as_ref()) {
+        validate_network_queue_pair_ranges(rx, tx)
+            .map_err(|_| RestoreSnapshotV2NetworkDeviceError::Queue)?;
+    }
+
+    let rx_rate_limiter = VirtioNetworkRateLimiter::from_persisted_state_at(
+        controller.rx_rate_limiter(),
+        restore_limiter_state(portable.rx_limiter()),
+        now,
+    )
+    .map_err(|_| RestoreSnapshotV2NetworkDeviceError::Limiter)?;
+    let tx_rate_limiter = VirtioNetworkRateLimiter::from_persisted_state_at(
+        controller.tx_rate_limiter(),
+        restore_limiter_state(portable.tx_limiter()),
+        now,
+    )
+    .map_err(|_| RestoreSnapshotV2NetworkDeviceError::Limiter)?;
+    let retry_deadline = match local.tx_retry() {
+        SnapshotV2NetworkRetryState::None => None,
+        SnapshotV2NetworkRetryState::Immediate => Some(now),
+        SnapshotV2NetworkRetryState::After { remaining_nanos } => Some(
+            now.checked_add(Duration::from_nanos(remaining_nanos))
+                .ok_or(RestoreSnapshotV2NetworkDeviceError::Retry)?,
+        ),
+    };
+    let mut device = VirtioNetworkDevice::from_snapshot_parts(
+        rx_queue,
+        tx_queue,
+        rx_rate_limiter,
+        tx_rate_limiter,
+        has_tx_retry,
+    )
+    .map_err(|_| RestoreSnapshotV2NetworkDeviceError::Device)?;
+    let mut config_space = VirtioNetworkConfigSpace::with_feature_capabilities(
+        realized_profile.guest_mac(),
+        realized_profile.mtu(),
+        realized_profile.feature_capabilities(),
+    );
+    if config_space.available_features() != virtio.available_features() {
+        return Err(RestoreSnapshotV2NetworkDeviceError::Profile);
+    }
+    config_space
+        .attach_metrics_with_aggregate(interface_metrics.clone(), aggregate_metrics.clone());
+    device.attach_metrics_with_aggregate(interface_metrics, aggregate_metrics);
+
+    Ok(RestoredSnapshotV2NetworkDevice {
+        queue_ranges,
+        retry_deadline,
+        config_space,
+        device,
+    })
+}
+
 fn limiter_config(limiter: SnapshotV2NetworkLimiterState) -> Option<NetworkRateLimiterConfig> {
     let configured = NetworkRateLimiterConfig::new(
         limiter.bandwidth().map(token_bucket_config),
@@ -1028,9 +1540,14 @@ fn token_bucket_config(bucket: SnapshotV2NetworkTokenBucketState) -> NetworkToke
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::interrupt::GuestInterruptLine;
     use crate::memory::{GuestAddress, GuestMemoryLayout};
+    use crate::message_interrupt::{
+        GuestMessage, GuestMessageInterrupt, GuestMessageInterruptSignalError,
+    };
     use crate::mmio::{MmioRegion, MmioRegionId};
     use crate::network::{
         GuestMacAddress, NetworkDeviceProfile, VIRTIO_NET_QUEUE_SIZE, VirtioNetworkConfigSpace,
@@ -1063,6 +1580,49 @@ mod tests {
     const AVAILABLE_INDEX_OFFSET: u64 = 2;
     const AVAILABLE_RING_OFFSET: u64 = 4;
     const USED_INDEX_OFFSET: u64 = 2;
+
+    #[derive(Debug)]
+    struct TestMessageRoute(GuestMessage);
+
+    impl GuestMessageInterrupt for TestMessageRoute {
+        fn matches(&self, message: GuestMessage) -> bool {
+            self.0 == message
+        }
+
+        fn signal(&self, message: GuestMessage) -> Result<(), GuestMessageInterruptSignalError> {
+            if self.matches(message) {
+                Ok(())
+            } else {
+                Err(GuestMessageInterruptSignalError::new(
+                    "test route rejected an unknown message",
+                    false,
+                ))
+            }
+        }
+    }
+
+    fn network_message_registry(
+        interface: &SnapshotV2NetworkInterfaceState,
+    ) -> GuestMessageInterruptRegistry {
+        let SnapshotV2DeviceTransport::Pci(pci) = interface.transport() else {
+            panic!("test interface should use PCI");
+        };
+        let routes: Vec<Arc<dyn GuestMessageInterrupt>> = pci
+            .msix()
+            .entries()
+            .iter()
+            .map(|entry| {
+                let address = (u64::from(entry.message_address_high()) << 32)
+                    | u64::from(entry.message_address_low());
+                Arc::new(TestMessageRoute(GuestMessage::new(
+                    address,
+                    entry.message_data(),
+                ))) as Arc<dyn GuestMessageInterrupt>
+            })
+            .collect();
+        GuestMessageInterruptRegistry::new(routes)
+            .expect("network message registry should validate")
+    }
 
     fn fixture_bytes(fixture: &str) -> Vec<u8> {
         let compact = fixture.split_ascii_whitespace().collect::<String>();
@@ -1251,6 +1811,32 @@ mod tests {
             .expect("active retry interface should validate");
         SnapshotV2NetworkState::try_new(vec![interface], None)
             .expect("active retry network state should validate")
+    }
+
+    fn active_pci_state_with_immediate_retry() -> SnapshotV2NetworkState {
+        let fixture = fixture("active");
+        let source = &fixture.interfaces()[0];
+        let interface =
+            SnapshotV2NetworkInterfaceState::try_from_parts(SnapshotV2NetworkInterfaceStateParts {
+                iface_id: source.iface_id().to_owned(),
+                captured_selector: source.captured_selector().to_owned(),
+                requested_guest_mac: source.requested_guest_mac(),
+                requested_mtu: source.requested_mtu(),
+                profile: source.profile(),
+                backend: source.backend(),
+                local: SnapshotV2NetworkLocalState::new(
+                    source.local().active_rx_queue(),
+                    source.local().active_tx_queue(),
+                    SnapshotV2NetworkRetryState::Immediate,
+                ),
+                virtio: source.virtio().clone(),
+                rx_limiter: source.rx_limiter(),
+                tx_limiter: source.tx_limiter(),
+                transport: source.transport().clone(),
+            })
+            .expect("active PCI immediate-retry state should validate");
+        SnapshotV2NetworkState::try_new(vec![interface], fixture.mmds().cloned())
+            .expect("active PCI immediate-retry aggregate should validate")
     }
 
     fn restore_memory_with_pending_tx() -> GuestMemory {
@@ -1685,6 +2271,123 @@ mod tests {
             prepared.expected_state().captured_selector(),
             "vmnet:shared"
         );
+    }
+
+    #[test]
+    fn active_pci_endpoint_rebinds_selector_and_recaptures_exactly() {
+        let state = active_pci_state_with_immediate_retry();
+        let topology = PreparedSnapshotV2NetworkRestoreTopology::prepare(
+            state.clone(),
+            &exact_overrides(&state),
+        )
+        .expect("active PCI topology should prepare");
+        let (mut interfaces, _, _) = topology.into_parts();
+        let interface = interfaces.pop().expect("one interface should be prepared");
+        let profile = interface.portable().profile();
+        let messages = network_message_registry(interface.portable());
+        let now = Instant::now();
+        let prepared = interface
+            .into_pci_endpoint(
+                &restore_memory_with_pending_tx(),
+                profile,
+                SharedNetworkInterfaceMetrics::default(),
+                SharedNetworkInterfaceMetrics::default(),
+                MmioRegionId::new(44),
+                messages,
+                now,
+            )
+            .expect("active PCI endpoint should materialize");
+
+        let SnapshotV2DeviceTransport::Pci(expected_pci) = state.interfaces()[0].transport() else {
+            panic!("active fixture should use PCI");
+        };
+        assert_eq!(prepared.source_index(), 0);
+        assert_eq!(prepared.controller().host_dev_name(), "vmnet:shared");
+        assert_eq!(
+            prepared.expected_state().captured_selector(),
+            "vmnet:shared"
+        );
+        assert_eq!(prepared.origin(), expected_pci.origin());
+        assert_eq!(prepared.endpoint().sbdf(), expected_pci.sbdf());
+        assert_eq!(prepared.endpoint().bar_range(), expected_pci.bar_range());
+        assert_eq!(prepared.endpoint().region_id(), MmioRegionId::new(44));
+        assert_eq!(
+            prepared.expected_state().virtio(),
+            state.interfaces()[0].virtio()
+        );
+        assert!(prepared.queue_ranges().iter().all(Option::is_some));
+        let debug = format!("{prepared:?}");
+        assert!(debug.contains(REDACTED));
+        assert!(!debug.contains("vmnet:shared"));
+    }
+
+    #[test]
+    fn pci_endpoint_rejects_mmio_transport_and_unmapped_queue_memory_redacted() {
+        let state = fixture("inactive");
+        let topology = PreparedSnapshotV2NetworkRestoreTopology::prepare(
+            state.clone(),
+            &exact_overrides(&state),
+        )
+        .expect("inactive MMIO topology should prepare");
+        let (mut interfaces, _, _) = topology.into_parts();
+        let interface = interfaces.pop().expect("one interface should be prepared");
+        let profile = interface.portable().profile();
+        let dummy_messages = GuestMessageInterruptRegistry::new(vec![Arc::new(TestMessageRoute(
+            GuestMessage::new(0x0800_0040, 64),
+        ))
+            as Arc<dyn GuestMessageInterrupt>])
+        .expect("dummy registry should validate");
+        let error = interface
+            .into_pci_endpoint(
+                &restore_memory_with_pending_tx(),
+                profile,
+                SharedNetworkInterfaceMetrics::default(),
+                SharedNetworkInterfaceMetrics::default(),
+                MmioRegionId::new(44),
+                dummy_messages,
+                Instant::now(),
+            )
+            .expect_err("MMIO continuation must not materialize as PCI");
+        assert!(matches!(
+            error,
+            SnapshotV2NetworkPciEndpointError::WrongTransport
+        ));
+
+        let state = active_pci_state_with_immediate_retry();
+        let topology = PreparedSnapshotV2NetworkRestoreTopology::prepare(
+            state.clone(),
+            &exact_overrides(&state),
+        )
+        .expect("active PCI topology should prepare");
+        let (mut interfaces, _, _) = topology.into_parts();
+        let interface = interfaces.pop().expect("one interface should be prepared");
+        let profile = interface.portable().profile();
+        let messages = network_message_registry(interface.portable());
+        let tiny_layout = GuestMemoryLayout::new(vec![
+            GuestMemoryRange::new(GuestAddress::new(0), 0x4000)
+                .expect("tiny range should validate"),
+        ])
+        .expect("tiny layout should validate");
+        let tiny_memory = GuestMemory::allocate(&tiny_layout).expect("tiny memory should allocate");
+        let error = interface
+            .into_pci_endpoint(
+                &tiny_memory,
+                profile,
+                SharedNetworkInterfaceMetrics::default(),
+                SharedNetworkInterfaceMetrics::default(),
+                MmioRegionId::new(44),
+                messages,
+                Instant::now(),
+            )
+            .expect_err("unmapped PCI queue memory should fail");
+        assert!(matches!(
+            error,
+            SnapshotV2NetworkPciEndpointError::QueueMemory
+        ));
+        let diagnostic = format!("{error:?} {error}");
+        assert!(diagnostic.contains(REDACTED));
+        assert!(!diagnostic.contains("eth0"));
+        assert!(!diagnostic.contains("vmnet:"));
     }
 
     #[test]

--- a/crates/runtime/src/snapshot_network_restore_v2_11.rs
+++ b/crates/runtime/src/snapshot_network_restore_v2_11.rs
@@ -129,19 +129,27 @@ impl PreparedSnapshotV2NetworkRestoreInterface {
             portable,
             mmds_stack,
         } = self;
-        if realized_profile != portable.profile()
-            || controller
-                .guest_mac()
-                .is_some_and(|mac| realized_profile.guest_mac() != Some(mac))
-            || controller
-                .mtu()
-                .is_some_and(|mtu| realized_profile.mtu() != Some(mtu))
-            || !realized_profile
-                .feature_capabilities()
-                .is_dependency_complete()
-        {
-            return Err(SnapshotV2NetworkMmioHandlerError::Profile);
+        validate_snapshot_v2_network_destination_profile(&controller, &portable, realized_profile)
+            .map_err(SnapshotV2NetworkMmioHandlerError::from_device)?;
+        if !matches!(portable.transport(), SnapshotV2DeviceTransport::Mmio(_)) {
+            return Err(SnapshotV2NetworkMmioHandlerError::WrongTransport);
         }
+        let RestoredSnapshotV2NetworkDevice {
+            queue_ranges,
+            retry_deadline,
+            config_space,
+            device,
+        } = restore_snapshot_v2_network_device(
+            &controller,
+            &portable,
+            destination_memory,
+            realized_profile,
+            interface_metrics,
+            aggregate_metrics,
+            now,
+        )
+        .map_err(SnapshotV2NetworkMmioHandlerError::from_device)?;
+        let activation_is_active = device.is_activated();
 
         let SnapshotV2NetworkInterfaceStateParts {
             iface_id,
@@ -161,111 +169,6 @@ impl PreparedSnapshotV2NetworkRestoreInterface {
         };
         let region = mmio.region();
         let interrupt_line = mmio.interrupt_line();
-
-        let rx_transport = virtio
-            .queues()
-            .first()
-            .copied()
-            .ok_or(SnapshotV2NetworkMmioHandlerError::Queue)?;
-        let tx_transport = virtio
-            .queues()
-            .get(1)
-            .copied()
-            .ok_or(SnapshotV2NetworkMmioHandlerError::Queue)?;
-        if virtio.queues().len() != VIRTIO_NET_QUEUE_SIZES.len() {
-            return Err(SnapshotV2NetworkMmioHandlerError::Queue);
-        }
-        let queue_ranges = [
-            queue_ranges(&rx_transport).map_err(|_| SnapshotV2NetworkMmioHandlerError::Queue)?,
-            queue_ranges(&tx_transport).map_err(|_| SnapshotV2NetworkMmioHandlerError::Queue)?,
-        ];
-        if queue_ranges
-            .iter()
-            .flatten()
-            .flatten()
-            .copied()
-            .any(|range| !range_is_wholly_contained(destination_memory, range))
-        {
-            return Err(SnapshotV2NetworkMmioHandlerError::QueueMemory);
-        }
-
-        let negotiated_features = virtio.driver_features();
-        let rx_queue = local
-            .active_rx_queue()
-            .map(|cursor| {
-                VirtioNetworkRxQueue::from_snapshot_state(
-                    restore_queue_state(rx_transport),
-                    cursor.next_available(),
-                    cursor.next_used(),
-                    negotiated_features,
-                )
-                .map_err(|_| SnapshotV2NetworkMmioHandlerError::Queue)
-            })
-            .transpose()?;
-        let tx_queue = local
-            .active_tx_queue()
-            .map(|cursor| {
-                VirtioNetworkTxQueue::from_snapshot_state(
-                    restore_queue_state(tx_transport),
-                    cursor.next_available(),
-                    cursor.next_used(),
-                    negotiated_features,
-                )
-                .map_err(|_| SnapshotV2NetworkMmioHandlerError::Queue)
-            })
-            .transpose()?;
-        if rx_queue.is_some() != virtio.is_activated()
-            || tx_queue.is_some() != virtio.is_activated()
-        {
-            return Err(SnapshotV2NetworkMmioHandlerError::Queue);
-        }
-        if let Some(queue) = rx_queue.as_ref() {
-            queue
-                .validate_snapshot_state(destination_memory)
-                .map_err(|_| SnapshotV2NetworkMmioHandlerError::Queue)?;
-        }
-        let has_tx_retry = local.tx_retry().has_retry();
-        if let Some(queue) = tx_queue.as_ref() {
-            queue
-                .validate_snapshot_state(destination_memory, has_tx_retry)
-                .map_err(|_| SnapshotV2NetworkMmioHandlerError::Queue)?;
-        }
-        if let (Some(rx), Some(tx)) = (rx_queue.as_ref(), tx_queue.as_ref()) {
-            validate_network_queue_pair_ranges(rx, tx)
-                .map_err(|_| SnapshotV2NetworkMmioHandlerError::Queue)?;
-        }
-
-        let rx_rate_limiter = VirtioNetworkRateLimiter::from_persisted_state_at(
-            controller.rx_rate_limiter(),
-            restore_limiter_state(rx_limiter),
-            now,
-        )
-        .map_err(|_| SnapshotV2NetworkMmioHandlerError::Limiter)?;
-        let tx_rate_limiter = VirtioNetworkRateLimiter::from_persisted_state_at(
-            controller.tx_rate_limiter(),
-            restore_limiter_state(tx_limiter),
-            now,
-        )
-        .map_err(|_| SnapshotV2NetworkMmioHandlerError::Limiter)?;
-        let retry_deadline = restored_retry_deadline_at(local.tx_retry(), now)?;
-        let device = VirtioNetworkDevice::from_snapshot_parts(
-            rx_queue,
-            tx_queue,
-            rx_rate_limiter,
-            tx_rate_limiter,
-            has_tx_retry,
-        )
-        .map_err(|_| SnapshotV2NetworkMmioHandlerError::Device)?;
-        let activation_is_active = device.is_activated();
-
-        let config_space = VirtioNetworkConfigSpace::with_feature_capabilities(
-            realized_profile.guest_mac(),
-            realized_profile.mtu(),
-            realized_profile.feature_capabilities(),
-        );
-        if config_space.available_features() != virtio.available_features() {
-            return Err(SnapshotV2NetworkMmioHandlerError::Profile);
-        }
         let retained = restore_mmio_transport_state_for_device_with_config_status_gate(
             VIRTIO_NET_DEVICE_ID,
             &virtio,
@@ -310,7 +213,6 @@ impl PreparedSnapshotV2NetworkRestoreInterface {
         handler
             .restore_network_interrupt_intents(&interrupt_intents)
             .map_err(|_| SnapshotV2NetworkMmioHandlerError::Allocation)?;
-        handler.attach_network_metrics_with_aggregate(interface_metrics, aggregate_metrics);
 
         let mut captured_selector = String::new();
         captured_selector
@@ -656,6 +558,19 @@ pub enum SnapshotV2NetworkMmioHandlerError {
     Normalize,
     StateMismatch,
     Allocation,
+}
+
+impl SnapshotV2NetworkMmioHandlerError {
+    const fn from_device(source: RestoreSnapshotV2NetworkDeviceError) -> Self {
+        match source {
+            RestoreSnapshotV2NetworkDeviceError::Profile => Self::Profile,
+            RestoreSnapshotV2NetworkDeviceError::Queue => Self::Queue,
+            RestoreSnapshotV2NetworkDeviceError::QueueMemory => Self::QueueMemory,
+            RestoreSnapshotV2NetworkDeviceError::Limiter => Self::Limiter,
+            RestoreSnapshotV2NetworkDeviceError::Retry => Self::Retry,
+            RestoreSnapshotV2NetworkDeviceError::Device => Self::Device,
+        }
+    }
 }
 
 impl fmt::Debug for SnapshotV2NetworkMmioHandlerError {
@@ -1330,16 +1245,11 @@ fn validate_destination_selector(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn restore_snapshot_v2_network_device(
+fn validate_snapshot_v2_network_destination_profile(
     controller: &NetworkInterfaceConfig,
     portable: &SnapshotV2NetworkInterfaceState,
-    destination_memory: &GuestMemory,
     realized_profile: NetworkDeviceProfile,
-    interface_metrics: SharedNetworkInterfaceMetrics,
-    aggregate_metrics: SharedNetworkInterfaceMetrics,
-    now: Instant,
-) -> Result<RestoredSnapshotV2NetworkDevice, RestoreSnapshotV2NetworkDeviceError> {
+) -> Result<(), RestoreSnapshotV2NetworkDeviceError> {
     if realized_profile != portable.profile()
         || controller
             .guest_mac()
@@ -1351,8 +1261,23 @@ fn restore_snapshot_v2_network_device(
             .feature_capabilities()
             .is_dependency_complete()
     {
-        return Err(RestoreSnapshotV2NetworkDeviceError::Profile);
+        Err(RestoreSnapshotV2NetworkDeviceError::Profile)
+    } else {
+        Ok(())
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn restore_snapshot_v2_network_device(
+    controller: &NetworkInterfaceConfig,
+    portable: &SnapshotV2NetworkInterfaceState,
+    destination_memory: &GuestMemory,
+    realized_profile: NetworkDeviceProfile,
+    interface_metrics: SharedNetworkInterfaceMetrics,
+    aggregate_metrics: SharedNetworkInterfaceMetrics,
+    now: Instant,
+) -> Result<RestoredSnapshotV2NetworkDevice, RestoreSnapshotV2NetworkDeviceError> {
+    validate_snapshot_v2_network_destination_profile(controller, portable, realized_profile)?;
 
     let virtio = portable.virtio();
     let local = portable.local();
@@ -1514,20 +1439,6 @@ fn restore_queue_state(
         queue.driver_ring(),
         queue.device_ring(),
     )
-}
-
-fn restored_retry_deadline_at(
-    retry: SnapshotV2NetworkRetryState,
-    now: Instant,
-) -> Result<Option<Instant>, SnapshotV2NetworkMmioHandlerError> {
-    match retry {
-        SnapshotV2NetworkRetryState::None => Ok(None),
-        SnapshotV2NetworkRetryState::Immediate => Ok(Some(now)),
-        SnapshotV2NetworkRetryState::After { remaining_nanos } => now
-            .checked_add(Duration::from_nanos(remaining_nanos))
-            .map(Some)
-            .ok_or(SnapshotV2NetworkMmioHandlerError::Retry),
-    }
 }
 
 fn token_bucket_config(bucket: SnapshotV2NetworkTokenBucketState) -> NetworkTokenBucketConfig {

--- a/crates/runtime/src/virtio_pci.rs
+++ b/crates/runtime/src/virtio_pci.rs
@@ -1178,6 +1178,11 @@ impl<C: VirtioDeviceConfigHandler, A: VirtioDeviceActivationHandler>
         })
     }
 
+    /// Returns the reconstructed endpoint before exact resource publication.
+    pub const fn endpoint(&self) -> &VirtioPciEndpoint<C, A> {
+        &self.endpoint
+    }
+
     pub const fn sbdf(&self) -> PciSbdf {
         self.sbdf
     }

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -514,6 +514,7 @@ if contains native_v2_process "${selected_tests[@]}"; then
   for signed_snapshot_test in \
     vmm::tests::signed_native_v1_public_dispatch_restores_frozen_file_pair \
     vmm::tests::signed_exact_minor_eleven_process_mmio_owner_transaction_is_atomic_and_retryable \
+    vmm::tests::signed_exact_minor_eleven_process_pci_owner_transaction_is_atomic_and_retryable \
     vmm::tests::signed_native_v2_process_publishes_recaptures_and_resumes_private_pair \
     vmm::tests::signed_native_v2_root_process_commits_complete_mmio_and_pci_owners_atomically \
     vmm::tests::signed_native_v2_storage_destination_stays_private_and_paused_through_commit \


### PR DESCRIPTION
## Summary

- reconstruct exact-2.11 PCI virtio-net owners with canonical SBDF/BAR/MSI-X placement, packet-I/O, metrics, MMDS, limiter retry, and reverse cleanup ownership
- compose every coherent balloon/storage/entropy/virtio-mem product while retaining exact saved order and immediate portable recapture
- add the private process-level PCI owner transaction plus signed one/16-interface, 16-product, cancellation, rollback, and teardown coverage

## Scope exclusions

- public exact-2.11 create/load activation remains disabled for the follow-up activation slice
- signed guest continuation, documentation, and capability inventory updates remain follow-up work

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all documented Apple Silicon signed-target Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

Closes #1714
