### PR TITLE
feat: prepare native-v2 vsock restore topology

### DIFF
--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -168,9 +168,10 @@ use bangbang_runtime::serial::{
     SerialStdioRestorationError, SharedSerialOutput, SharedSerialOutputBuffer,
 };
 use bangbang_runtime::snapshot::{
-    SnapshotCreateInput, SnapshotLoadInput, SnapshotMemoryBackendType, SnapshotV1ControllerCommit,
-    SnapshotV2ControllerCommit, SnapshotV2ControllerCommitProductConfigs,
-    SnapshotV2NetworkControllerCommitProductConfigs,
+    SnapshotCreateInput, SnapshotLoadInput, SnapshotMemoryBackendType, SnapshotNetworkOverride,
+    SnapshotV1ControllerCommit, SnapshotV2ControllerCommit,
+    SnapshotV2ControllerCommitProductConfigs, SnapshotV2NetworkControllerCommitProductConfigs,
+    SnapshotVsockOverride,
 };
 #[cfg(target_os = "macos")]
 use bangbang_runtime::snapshot_artifact::SnapshotStagingTracker;
@@ -184,7 +185,8 @@ use bangbang_runtime::snapshot_artifact::{
     NativeV2SerialSnapshotCandidateState, NativeV2SnapshotArtifactProfile,
     NativeV2SnapshotCandidateState, NativeV2SnapshotCandidateStateError,
     NativeV2StorageSnapshotCandidateState, NativeV2VsockSnapshotCandidateState,
-    PreparedNativeSnapshotState, PreparedNativeV2NetworkSnapshotCandidateState,
+    NativeV2VsockSnapshotPreparationError, PreparedNativeSnapshotState,
+    PreparedNativeV2NetworkSnapshotCandidateState, PreparedNativeV2VsockSnapshotCandidateState,
     SnapshotArtifactLoadError, SnapshotArtifactOutput, SnapshotArtifactOutputs,
     SnapshotArtifactPaths, SnapshotCommitDurability, SnapshotMemoryStagingWriter,
     SnapshotPublicationOutcome, SnapshotPublicationTransactionError,
@@ -20243,6 +20245,36 @@ const _: fn(
 ) -> PreparedProcessSnapshotV2NetworkRestorePlanParts =
     PreparedProcessSnapshotV2NetworkRestorePlan::into_parts;
 
+fn prepare_process_snapshot_v2_vsock_candidate(
+    candidate: NativeV2VsockSnapshotCandidateState,
+    destination_memory: &GuestMemory,
+    transport_kind: SnapshotV2DeviceTransportKind,
+    network_overrides: &[SnapshotNetworkOverride],
+    vsock_override: Option<&SnapshotVsockOverride>,
+) -> Result<PreparedNativeV2VsockSnapshotCandidateState, NativeV2VsockSnapshotPreparationError> {
+    candidate.prepare(
+        destination_memory,
+        transport_kind,
+        network_overrides,
+        vsock_override,
+    )
+}
+
+type ProcessSnapshotV2VsockCandidatePreparer = fn(
+    NativeV2VsockSnapshotCandidateState,
+    &GuestMemory,
+    SnapshotV2DeviceTransportKind,
+    &[SnapshotNetworkOverride],
+    Option<&SnapshotVsockOverride>,
+) -> Result<
+    PreparedNativeV2VsockSnapshotCandidateState,
+    NativeV2VsockSnapshotPreparationError,
+>;
+
+// Keep the exact-2.12 value-only pre-access gate type-checked without
+// activating public load/restore dispatch or acquiring host authority.
+const _: ProcessSnapshotV2VsockCandidatePreparer = prepare_process_snapshot_v2_vsock_candidate;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ProcessSnapshotV2NetworkRestoreResourceDisposition {
     Retryable,
@@ -29511,6 +29543,7 @@ fn default_hvf_boot_session_config(serial_output: SharedSerialOutput) -> HvfArm6
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
     use std::collections::VecDeque;
     use std::fmt;
     use std::fs::{self, File, OpenOptions, remove_file};
@@ -29603,7 +29636,8 @@ mod tests {
         SnapshotCreateInput, SnapshotLoadInput, SnapshotMemoryBackend, SnapshotMemoryBackendType,
         SnapshotNetworkOverride, SnapshotType, SnapshotV1ControllerCommit,
         SnapshotV2ControllerCommit, SnapshotV2ControllerCommitProductConfigs,
-        SnapshotV2NetworkControllerCommitProductConfigs,
+        SnapshotV2NetworkControllerCommitProductConfigs, SnapshotVsockOverride,
+        SnapshotVsockSelectorError,
     };
     use bangbang_runtime::snapshot_artifact::{
         LoadedNativeSnapshotArtifacts, NativeSnapshotPublicationOutcome,
@@ -29611,7 +29645,8 @@ mod tests {
         NativeV2MemoryHotplugSnapshotCandidateState, NativeV2MemoryHotplugSnapshotPreparation,
         NativeV2NetworkSnapshotCandidateState, NativeV2NetworkSnapshotPreparation,
         NativeV2SnapshotArtifactProfile, NativeV2VsockSnapshotCandidateState,
-        PreparedNativeSnapshotState, PreparedNativeV2NetworkSnapshotCandidateState,
+        NativeV2VsockSnapshotPreparationError, PreparedNativeSnapshotState,
+        PreparedNativeV2NetworkSnapshotCandidateState, PreparedNativeV2VsockSnapshotCandidateState,
         SnapshotArtifactOutputs, SnapshotArtifactPaths, SnapshotPublicationOutcome,
         publish_snapshot_artifacts_with,
     };
@@ -29660,6 +29695,7 @@ mod tests {
         SnapshotV2MemoryBinding, write_snapshot_v2_memory_image_with_cancel,
         write_snapshot_v2_memory_image_with_compatibility_version_and_cancel,
     };
+    use bangbang_runtime::snapshot_network_restore_v2_11::SnapshotV2NetworkRestorePreparationError;
     use bangbang_runtime::snapshot_network_v2_11::{
         NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION, SnapshotV2MmdsInterfaceState,
         SnapshotV2MmdsState, SnapshotV2NetworkBackendClass, SnapshotV2NetworkInterfaceState,
@@ -29670,6 +29706,7 @@ mod tests {
         NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION, SnapshotV2SerialEndpointIntent,
         SnapshotV2SerialState,
     };
+    use bangbang_runtime::snapshot_vsock_restore_v2_12::SnapshotV2VsockRestorePreparationError;
     use bangbang_runtime::snapshot_vsock_v2_12::{
         NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION, SnapshotV2VsockState,
     };
@@ -29769,8 +29806,8 @@ mod tests {
         SnapshotCreateSession, SnapshotV1LoadSuccess, SnapshotV2LoadSuccess,
         default_hvf_boot_run_loop_step_limit, default_hvf_boot_session_config,
         native_v2_platform_capture_is_terminal, prepare_process_snapshot_v2_network_restore_plan,
-        require_native_v1_composite_record, snapshot_destination_machine_config,
-        vsock_capture_error_from_boot_run_loop_command,
+        prepare_process_snapshot_v2_vsock_candidate, require_native_v1_composite_record,
+        snapshot_destination_machine_config, vsock_capture_error_from_boot_run_loop_command,
     };
     #[cfg(target_os = "macos")]
     use super::{
@@ -37048,6 +37085,171 @@ mod tests {
         .expect("fake native-v2 vsock fixture should decode")
     }
 
+    fn native_v2_vsock_pre_access_candidate(
+        network: Option<SnapshotV2NetworkState>,
+        vsock: Option<SnapshotV2VsockState>,
+    ) -> (NativeV2VsockSnapshotCandidateState, GuestMemory) {
+        let range = GuestMemoryRange::new(GuestAddress::new(0), 0x0040_0000)
+            .expect("exact-2.12 pre-access memory range should validate");
+        let layout = GuestMemoryLayout::new(vec![range])
+            .expect("exact-2.12 pre-access memory layout should validate");
+        let mut memory =
+            GuestMemory::allocate(&layout).expect("exact-2.12 pre-access memory should allocate");
+        if let Some(vsock) = vsock.as_ref()
+            && let Some(active) = vsock.active_queues()
+        {
+            for (queue, cursor) in
+                vsock
+                    .virtio()
+                    .queues()
+                    .iter()
+                    .zip([active.rx(), active.tx(), active.event()])
+            {
+                memory
+                    .write_slice(
+                        &cursor.next_available().to_le_bytes(),
+                        queue
+                            .driver_ring()
+                            .checked_add(2)
+                            .expect("available index should not overflow"),
+                    )
+                    .expect("available queue index should write");
+                memory
+                    .write_slice(
+                        &cursor.next_used().to_le_bytes(),
+                        queue
+                            .device_ring()
+                            .checked_add(2)
+                            .expect("used index should not overflow"),
+                    )
+                    .expect("used queue index should write");
+            }
+        }
+
+        let mut image = Cursor::new(Vec::new());
+        let binding = write_snapshot_v2_memory_image_with_compatibility_version_and_cancel(
+            &memory,
+            &mut image,
+            NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
+            |_| false,
+        )
+        .expect("exact-2.12 pre-access memory should encode")
+        .encode()
+        .expect("exact-2.12 pre-access binding should encode");
+        let serial_device = SerialMmioDevice::discarding()
+            .capture_state()
+            .expect("exact-2.12 pre-access serial device should capture");
+        let serial = SnapshotV2SerialState::try_from_capture_ready(CaptureReadySerialState::new(
+            SerialConfig::default(),
+            serial_device,
+        ))
+        .expect("exact-2.12 pre-access serial should validate")
+        .encode(NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION)
+        .expect("exact-2.12 pre-access serial should encode");
+        let network = network.as_ref().map(|state| {
+            state
+                .encode(NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION)
+                .expect("exact-2.12 pre-access network should encode")
+        });
+        let vsock = vsock.as_ref().map(|state| {
+            state
+                .encode(NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION)
+                .expect("exact-2.12 pre-access vsock should encode")
+        });
+        let mut components = vec![
+            SnapshotV2Component::new(
+                NATIVE_V2_MEMORY_COMPONENT_KEY,
+                SnapshotV2ComponentDisposition::Semantic,
+                &binding,
+            ),
+            SnapshotV2Component::new(
+                NATIVE_V2_SERIAL_COMPONENT_KEY,
+                SnapshotV2ComponentDisposition::Semantic,
+                &serial,
+            ),
+        ];
+        if let Some(network) = network.as_deref() {
+            components.push(SnapshotV2Component::new(
+                NATIVE_V2_NETWORK_COMPONENT_KEY,
+                SnapshotV2ComponentDisposition::Semantic,
+                network,
+            ));
+        }
+        if let Some(vsock) = vsock.as_deref() {
+            components.push(SnapshotV2Component::new(
+                NATIVE_V2_VSOCK_COMPONENT_KEY,
+                SnapshotV2ComponentDisposition::Semantic,
+                vsock,
+            ));
+        }
+        let encoded = encode_snapshot_v2_state_with_compatibility_version(
+            NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
+            &[],
+            &components,
+        )
+        .expect("exact-2.12 pre-access candidate should encode");
+        let candidate = NativeV2VsockSnapshotCandidateState::from_vsock_state_v2_12(encoded)
+            .expect("exact-2.12 pre-access candidate should close");
+        (candidate, memory)
+    }
+
+    #[derive(Default)]
+    struct NativeV2VsockPreAccessHostSpies {
+        filesystem: Cell<u32>,
+        grant: Cell<u32>,
+        broker: Cell<u32>,
+        listener: Cell<u32>,
+        connector: Cell<u32>,
+        vm: Cell<u32>,
+        vcpu: Cell<u32>,
+        hvf: Cell<u32>,
+    }
+
+    impl NativeV2VsockPreAccessHostSpies {
+        fn record_post_preflight_access(&self) {
+            for counter in [
+                &self.filesystem,
+                &self.grant,
+                &self.broker,
+                &self.listener,
+                &self.connector,
+                &self.vm,
+                &self.vcpu,
+                &self.hvf,
+            ] {
+                counter.set(counter.get() + 1);
+            }
+        }
+
+        fn counts(&self) -> [u32; 8] {
+            [
+                self.filesystem.get(),
+                self.grant.get(),
+                self.broker.get(),
+                self.listener.get(),
+                self.connector.get(),
+                self.vm.get(),
+                self.vcpu.get(),
+                self.hvf.get(),
+            ]
+        }
+    }
+
+    fn rejected_native_v2_vsock_pre_access(
+        result: Result<
+            PreparedNativeV2VsockSnapshotCandidateState,
+            NativeV2VsockSnapshotPreparationError,
+        >,
+    ) -> NativeV2VsockSnapshotPreparationError {
+        let spies = NativeV2VsockPreAccessHostSpies::default();
+        let result = result.inspect(|_| {
+            spies.record_post_preflight_access();
+        });
+        let error = result.expect_err("malformed exact-2.12 state must fail pre-access");
+        assert_eq!(spies.counts(), [0; 8]);
+        error
+    }
+
     #[cfg(target_os = "macos")]
     fn copied_inactive_mmio_network_interface(
         source: &SnapshotV2NetworkInterfaceState,
@@ -38985,6 +39187,172 @@ mod tests {
         assert_eq!(calls.load(Ordering::SeqCst), 0);
         assert_eq!(destination.instance_info().state, InstanceState::NotStarted);
         assert!(!format!("{error:?} {error}").contains("private-destination-selector"));
+    }
+
+    #[test]
+    fn native_v2_vsock_pre_access_gate_blocks_every_host_surface_on_rejection() {
+        let no_device_secret = "/private/no-device-vsock.sock";
+        let (candidate, memory) = native_v2_vsock_pre_access_candidate(None, None);
+        let no_device =
+            rejected_native_v2_vsock_pre_access(prepare_process_snapshot_v2_vsock_candidate(
+                candidate,
+                &memory,
+                SnapshotV2DeviceTransportKind::Mmio,
+                &[],
+                Some(&SnapshotVsockOverride::new(no_device_secret)),
+            ));
+        assert!(matches!(
+            no_device,
+            NativeV2VsockSnapshotPreparationError::Vsock(
+                SnapshotV2VsockRestorePreparationError::Selector(
+                    SnapshotVsockSelectorError::OverrideWithoutDevice
+                )
+            )
+        ));
+        assert!(!format!("{no_device:?} {no_device}").contains(no_device_secret));
+
+        let invalid_secret = "invalid\nprivate-vsock-selector";
+        let vsock = fake_native_v2_vsock_state(SnapshotV2DeviceTransportKind::Mmio);
+        let (candidate, memory) = native_v2_vsock_pre_access_candidate(None, Some(vsock));
+        let invalid_selector =
+            rejected_native_v2_vsock_pre_access(prepare_process_snapshot_v2_vsock_candidate(
+                candidate,
+                &memory,
+                SnapshotV2DeviceTransportKind::Mmio,
+                &[],
+                Some(&SnapshotVsockOverride::new(invalid_secret)),
+            ));
+        assert!(matches!(
+            invalid_selector,
+            NativeV2VsockSnapshotPreparationError::Vsock(
+                SnapshotV2VsockRestorePreparationError::Selector(
+                    SnapshotVsockSelectorError::InvalidOverride(_)
+                )
+            )
+        ));
+        assert!(!format!("{invalid_selector:?} {invalid_selector}").contains(invalid_secret));
+
+        let vsock = fake_native_v2_vsock_state(SnapshotV2DeviceTransportKind::Mmio);
+        let (candidate, memory) = native_v2_vsock_pre_access_candidate(None, Some(vsock));
+        let transport =
+            rejected_native_v2_vsock_pre_access(prepare_process_snapshot_v2_vsock_candidate(
+                candidate,
+                &memory,
+                SnapshotV2DeviceTransportKind::Pci,
+                &[],
+                None,
+            ));
+        assert!(matches!(
+            transport,
+            NativeV2VsockSnapshotPreparationError::Vsock(
+                SnapshotV2VsockRestorePreparationError::DestinationTransport
+            )
+        ));
+
+        let vsock = fake_native_v2_vsock_state(SnapshotV2DeviceTransportKind::Pci);
+        let (candidate, _) = native_v2_vsock_pre_access_candidate(None, Some(vsock.clone()));
+        let (_, blank_memory) = native_v2_vsock_pre_access_candidate(None, None);
+        let memory =
+            rejected_native_v2_vsock_pre_access(prepare_process_snapshot_v2_vsock_candidate(
+                candidate,
+                &blank_memory,
+                SnapshotV2DeviceTransportKind::Pci,
+                &[],
+                None,
+            ));
+        assert!(matches!(
+            memory,
+            NativeV2VsockSnapshotPreparationError::Vsock(
+                SnapshotV2VsockRestorePreparationError::Device(_)
+            )
+        ));
+
+        let (candidate, mut memory) =
+            native_v2_vsock_pre_access_candidate(None, Some(vsock.clone()));
+        let active = vsock
+            .active_queues()
+            .expect("active PCI fixture should retain queue cursors");
+        let queue = &vsock.virtio().queues()[0];
+        memory
+            .write_slice(
+                &active.rx().next_used().wrapping_add(1).to_le_bytes(),
+                queue
+                    .device_ring()
+                    .checked_add(2)
+                    .expect("used index should not overflow"),
+            )
+            .expect("hostile used index should write");
+        let queue =
+            rejected_native_v2_vsock_pre_access(prepare_process_snapshot_v2_vsock_candidate(
+                candidate,
+                &memory,
+                SnapshotV2DeviceTransportKind::Pci,
+                &[],
+                None,
+            ));
+        assert!(matches!(
+            queue,
+            NativeV2VsockSnapshotPreparationError::Vsock(
+                SnapshotV2VsockRestorePreparationError::Device(_)
+            )
+        ));
+
+        let network = fake_native_v2_network_state(SnapshotV2DeviceTransportKind::Mmio);
+        let (candidate, memory) = native_v2_vsock_pre_access_candidate(Some(network), None);
+        let manifest_and_network =
+            rejected_native_v2_vsock_pre_access(prepare_process_snapshot_v2_vsock_candidate(
+                candidate,
+                &memory,
+                SnapshotV2DeviceTransportKind::Mmio,
+                &[],
+                None,
+            ));
+        assert!(matches!(
+            manifest_and_network,
+            NativeV2VsockSnapshotPreparationError::Network(
+                SnapshotV2NetworkRestorePreparationError::MissingInterface
+            )
+        ));
+    }
+
+    #[test]
+    fn native_v2_vsock_pre_access_gate_reaches_only_value_handoff_when_valid() {
+        for transport in [
+            SnapshotV2DeviceTransportKind::Mmio,
+            SnapshotV2DeviceTransportKind::Pci,
+        ] {
+            let vsock = fake_native_v2_vsock_state(transport);
+            let (candidate, memory) = native_v2_vsock_pre_access_candidate(None, Some(vsock));
+            let host_spies = NativeV2VsockPreAccessHostSpies::default();
+            let handoff_count = Cell::new(0);
+            let prepared = prepare_process_snapshot_v2_vsock_candidate(
+                candidate,
+                &memory,
+                transport,
+                &[],
+                None,
+            )
+            .inspect(|_| {
+                handoff_count.set(handoff_count.get() + 1);
+            })
+            .unwrap_or_else(|error| {
+                panic!("valid {transport:?} pre-access candidate should prepare: {error}")
+            });
+
+            assert_eq!(handoff_count.get(), 1);
+            assert_eq!(host_spies.counts(), [0; 8]);
+            assert_eq!(
+                prepared.version(),
+                NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION
+            );
+            assert_eq!(
+                prepared
+                    .vsock_topology()
+                    .expect("valid fixture should retain vsock topology")
+                    .transport_kind(),
+                transport
+            );
+        }
     }
 
     #[test]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -51,6 +51,7 @@ pub mod snapshot_network_restore_v2_11;
 pub mod snapshot_network_v2_11;
 pub mod snapshot_restore;
 pub mod snapshot_serial_v2_7;
+pub mod snapshot_vsock_restore_v2_12;
 pub mod snapshot_vsock_v2_12;
 pub mod startup;
 pub mod storage_capture;

--- a/crates/runtime/src/snapshot_artifact.rs
+++ b/crates/runtime/src/snapshot_artifact.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::memory::GuestMemory;
-use crate::snapshot::SnapshotNetworkOverride;
+use crate::snapshot::{SnapshotNetworkOverride, SnapshotVsockOverride};
 use crate::snapshot_balloon_v2_9::{
     NATIVE_V2_BALLOON_STATE_COMPATIBILITY_VERSION, SnapshotV2BalloonState,
     SnapshotV2BalloonStateDecodeError,
@@ -86,6 +86,10 @@ use crate::snapshot_restore::{SnapshotRestoreManifest, SnapshotRestoreManifestEr
 use crate::snapshot_serial_v2_7::{
     NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION, SnapshotV2SerialState,
     SnapshotV2SerialStateDecodeError,
+};
+use crate::snapshot_vsock_restore_v2_12::{
+    PreparedSnapshotV2VsockRestoreTopology, SnapshotV2VsockRestorePreparationError,
+    SnapshotV2VsockRestorePreparationStage,
 };
 use crate::snapshot_vsock_v2_12::{
     NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION, SnapshotV2VsockState,
@@ -1876,6 +1880,191 @@ impl fmt::Debug for NativeV2NetworkSnapshotCandidateState {
     }
 }
 
+/// Stable exact-2.12 preparation checkpoints delegated to owner-free device
+/// topology producers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeV2VsockSnapshotPreparationStage {
+    /// One checkpoint in optional vsock topology preparation.
+    Vsock(SnapshotV2VsockRestorePreparationStage),
+    /// One checkpoint in optional network topology preparation.
+    Network(SnapshotV2NetworkRestorePreparationStage),
+}
+
+/// One prepared exact-2.12 candidate with complete owner-free topology.
+///
+/// This value owns no descriptor, provider, socket, packet-I/O owner, callback,
+/// metric, datastore, platform slot, VM, vCPU, or HVF authority.
+pub struct PreparedNativeV2VsockSnapshotCandidateState {
+    bytes: Vec<u8>,
+    binding: SnapshotV2MemoryBinding,
+    device_graph: Option<SnapshotV2StorageDeviceGraph>,
+    serial: SnapshotV2SerialState,
+    entropy: Option<SnapshotV2EntropyState>,
+    balloon: Option<SnapshotV2BalloonState>,
+    memory_hotplug: Option<SnapshotV2MemoryHotplugState>,
+    network_topology: PreparedSnapshotV2NetworkRestoreTopology,
+    vsock_topology: Option<PreparedSnapshotV2VsockRestoreTopology>,
+    manifest: SnapshotRestoreManifest,
+}
+
+/// Owned exact components of one prepared native-v2 2.12 candidate.
+pub type PreparedNativeV2VsockSnapshotCandidateParts = (
+    Vec<u8>,
+    SnapshotV2MemoryBinding,
+    Option<SnapshotV2StorageDeviceGraph>,
+    SnapshotV2SerialState,
+    Option<SnapshotV2EntropyState>,
+    Option<SnapshotV2BalloonState>,
+    Option<SnapshotV2MemoryHotplugState>,
+    PreparedSnapshotV2NetworkRestoreTopology,
+    Option<PreparedSnapshotV2VsockRestoreTopology>,
+    SnapshotRestoreManifest,
+);
+
+impl PreparedNativeV2VsockSnapshotCandidateState {
+    /// Returns the exact candidate compatibility version.
+    pub const fn version(&self) -> SnapshotFormatVersion {
+        NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION
+    }
+
+    /// Returns the unchanged immutable encoded state bytes.
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Returns the memory commitment derived from the same bytes.
+    pub const fn memory_binding(&self) -> &SnapshotV2MemoryBinding {
+        &self.binding
+    }
+
+    /// Returns optional unchanged exact-2.6 storage.
+    pub const fn device_graph(&self) -> Option<&SnapshotV2StorageDeviceGraph> {
+        self.device_graph.as_ref()
+    }
+
+    /// Returns required unchanged exact-2.7 serial state.
+    pub const fn serial(&self) -> &SnapshotV2SerialState {
+        &self.serial
+    }
+
+    /// Returns optional unchanged exact-2.8 entropy state.
+    pub const fn entropy(&self) -> Option<&SnapshotV2EntropyState> {
+        self.entropy.as_ref()
+    }
+
+    /// Returns optional unchanged exact-2.9 balloon state.
+    pub const fn balloon(&self) -> Option<&SnapshotV2BalloonState> {
+        self.balloon.as_ref()
+    }
+
+    /// Returns optional unchanged exact-2.10 virtio-mem state.
+    pub const fn memory_hotplug(&self) -> Option<&SnapshotV2MemoryHotplugState> {
+        self.memory_hotplug.as_ref()
+    }
+
+    /// Returns immutable exact-2.11 network/MMDS destination topology.
+    pub const fn network_topology(&self) -> &PreparedSnapshotV2NetworkRestoreTopology {
+        &self.network_topology
+    }
+
+    /// Returns optional immutable exact-2.12 vsock destination topology.
+    pub const fn vsock_topology(&self) -> Option<&PreparedSnapshotV2VsockRestoreTopology> {
+        self.vsock_topology.as_ref()
+    }
+
+    /// Returns the complete storage, serial, network, and vsock manifest.
+    pub const fn manifest(&self) -> &SnapshotRestoreManifest {
+        &self.manifest
+    }
+
+    /// Consumes the candidate into exact still-owner-free parts.
+    pub fn into_parts(self) -> PreparedNativeV2VsockSnapshotCandidateParts {
+        (
+            self.bytes,
+            self.binding,
+            self.device_graph,
+            self.serial,
+            self.entropy,
+            self.balloon,
+            self.memory_hotplug,
+            self.network_topology,
+            self.vsock_topology,
+            self.manifest,
+        )
+    }
+}
+
+impl fmt::Debug for PreparedNativeV2VsockSnapshotCandidateState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedNativeV2VsockSnapshotCandidateState")
+            .field("version", &self.version())
+            .field("has_storage", &self.device_graph.is_some())
+            .field("has_entropy", &self.entropy.is_some())
+            .field("has_balloon", &self.balloon.is_some())
+            .field("has_memory_hotplug", &self.memory_hotplug.is_some())
+            .field(
+                "network_interface_count",
+                &self.network_topology.interfaces().len(),
+            )
+            .field("has_vsock", &self.vsock_topology.is_some())
+            .field("state", &REDACTED)
+            .field("memory_binding", &REDACTED)
+            .field("serial", &REDACTED)
+            .field("network_topology", &REDACTED)
+            .field("vsock_topology", &REDACTED)
+            .field("manifest", &REDACTED)
+            .finish()
+    }
+}
+
+/// Failure while preparing one exact-2.12 artifact candidate.
+pub enum NativeV2VsockSnapshotPreparationError {
+    /// Caller network overrides were supplied without saved network state.
+    NetworkOverridesWithoutDevice,
+    /// Saved product placement and selected destination transport disagree.
+    DestinationTransport,
+    /// Owner-free vsock topology preparation failed.
+    Vsock(SnapshotV2VsockRestorePreparationError),
+    /// The complete restore resource manifest could not be derived.
+    Manifest(SnapshotRestoreManifestError),
+    /// Owner-free network topology preparation failed.
+    Network(SnapshotV2NetworkRestorePreparationError),
+}
+
+impl fmt::Debug for NativeV2VsockSnapshotPreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+impl fmt::Display for NativeV2VsockSnapshotPreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::NetworkOverridesWithoutDevice => {
+                "native-v2 network overrides require saved network state"
+            }
+            Self::DestinationTransport => {
+                "native-v2 vsock candidate destination transport is inconsistent"
+            }
+            Self::Vsock(_) => "native-v2 vsock restore topology is invalid",
+            Self::Manifest(_) => "native-v2 vsock restore manifest is invalid",
+            Self::Network(_) => "native-v2 network restore topology is invalid",
+        })
+    }
+}
+
+impl std::error::Error for NativeV2VsockSnapshotPreparationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Vsock(source) => Some(source),
+            Self::Manifest(source) => Some(source),
+            Self::Network(source) => Some(source),
+            Self::NetworkOverridesWithoutDevice | Self::DestinationTransport => None,
+        }
+    }
+}
+
 /// One closed explicit exact native-v2 2.12 vsock candidate.
 ///
 /// This owner-free value validates all unchanged earlier components and the
@@ -1975,6 +2164,107 @@ impl NativeV2VsockSnapshotCandidateState {
     /// Returns optional exact-2.12 vsock state.
     pub const fn vsock(&self) -> Option<&SnapshotV2VsockState> {
         self.vsock.as_ref()
+    }
+
+    /// Prepares the complete exact-2.12 owner-free restore candidate.
+    pub fn prepare(
+        self,
+        destination_memory: &GuestMemory,
+        transport_kind: SnapshotV2DeviceTransportKind,
+        network_overrides: &[SnapshotNetworkOverride],
+        requested_vsock_override: Option<&SnapshotVsockOverride>,
+    ) -> Result<PreparedNativeV2VsockSnapshotCandidateState, NativeV2VsockSnapshotPreparationError>
+    {
+        self.prepare_with_cancel(
+            destination_memory,
+            transport_kind,
+            network_overrides,
+            requested_vsock_override,
+            |_| false,
+        )
+    }
+
+    /// Prepares with stable owner-free device-topology cancellation.
+    ///
+    /// Vsock selectors resolve before this method invokes the caller callback
+    /// for either the vsock or network topology.
+    pub fn prepare_with_cancel<C>(
+        self,
+        destination_memory: &GuestMemory,
+        transport_kind: SnapshotV2DeviceTransportKind,
+        network_overrides: &[SnapshotNetworkOverride],
+        requested_vsock_override: Option<&SnapshotVsockOverride>,
+        mut is_cancelled: C,
+    ) -> Result<PreparedNativeV2VsockSnapshotCandidateState, NativeV2VsockSnapshotPreparationError>
+    where
+        C: FnMut(NativeV2VsockSnapshotPreparationStage) -> bool,
+    {
+        let Self {
+            bytes,
+            binding,
+            device_graph,
+            serial,
+            entropy,
+            balloon,
+            memory_hotplug,
+            network,
+            vsock,
+        } = self;
+        let vsock_topology = PreparedSnapshotV2VsockRestoreTopology::prepare_optional_with_cancel(
+            vsock,
+            requested_vsock_override,
+            transport_kind,
+            destination_memory,
+            |stage| is_cancelled(NativeV2VsockSnapshotPreparationStage::Vsock(stage)),
+        )
+        .map_err(NativeV2VsockSnapshotPreparationError::Vsock)?;
+        let manifest = SnapshotRestoreManifest::try_from_native_v2_vsock_state(
+            device_graph.as_ref(),
+            &serial,
+            network.as_ref(),
+            vsock_topology.as_ref().map(|topology| {
+                (
+                    topology.request().resource_key(),
+                    topology.request().is_overridden(),
+                )
+            }),
+        )
+        .map_err(NativeV2VsockSnapshotPreparationError::Manifest)?;
+        let network_topology = match network {
+            Some(network) => {
+                let topology = PreparedSnapshotV2NetworkRestoreTopology::prepare_with_cancel(
+                    network,
+                    network_overrides,
+                    |stage| is_cancelled(NativeV2VsockSnapshotPreparationStage::Network(stage)),
+                )
+                .map_err(NativeV2VsockSnapshotPreparationError::Network)?;
+                if topology.transport_kind() != transport_kind {
+                    return Err(NativeV2VsockSnapshotPreparationError::DestinationTransport);
+                }
+                topology
+            }
+            None => {
+                if !network_overrides.is_empty() {
+                    return Err(
+                        NativeV2VsockSnapshotPreparationError::NetworkOverridesWithoutDevice,
+                    );
+                }
+                PreparedSnapshotV2NetworkRestoreTopology::empty(transport_kind)
+            }
+        };
+
+        Ok(PreparedNativeV2VsockSnapshotCandidateState {
+            bytes,
+            binding,
+            device_graph,
+            serial,
+            entropy,
+            balloon,
+            memory_hotplug,
+            network_topology,
+            vsock_topology,
+            manifest,
+        })
     }
 
     /// Consumes the candidate into its inseparable exact components.

--- a/crates/runtime/src/snapshot_artifact/tests.rs
+++ b/crates/runtime/src/snapshot_artifact/tests.rs
@@ -2945,6 +2945,272 @@ fn exact_minor_eleven_candidate(
 }
 
 #[cfg(target_os = "macos")]
+fn exact_minor_twelve_candidate(
+    network_payload: Option<&[u8]>,
+    vsock_payload: Option<&[u8]>,
+) -> (NativeV2VsockSnapshotCandidateState, GuestMemory) {
+    let range = GuestMemoryRange::new(GuestAddress::new(0), 0x0040_0000)
+        .expect("exact-2.12 memory range should validate");
+    let layout =
+        GuestMemoryLayout::new(vec![range]).expect("exact-2.12 memory layout should validate");
+    let mut memory = GuestMemory::allocate(&layout).expect("exact-2.12 memory should allocate");
+    if let Some(vsock_payload) = vsock_payload {
+        let vsock = SnapshotV2VsockState::decode(
+            NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
+            vsock_payload,
+        )
+        .expect("exact-2.12 vsock fixture should decode");
+        if let Some(active) = vsock.active_queues() {
+            for (queue, cursor) in
+                vsock
+                    .virtio()
+                    .queues()
+                    .iter()
+                    .zip([active.rx(), active.tx(), active.event()])
+            {
+                let available_index = queue
+                    .driver_ring()
+                    .checked_add(2)
+                    .expect("available index should not overflow");
+                memory
+                    .write_slice(&cursor.next_available().to_le_bytes(), available_index)
+                    .expect("available index should write");
+                let used_index = queue
+                    .device_ring()
+                    .checked_add(2)
+                    .expect("used index should not overflow");
+                memory
+                    .write_slice(&cursor.next_used().to_le_bytes(), used_index)
+                    .expect("used index should write");
+            }
+        }
+    }
+
+    let mut image = Cursor::new(Vec::new());
+    let binding = write_snapshot_v2_memory_image_with_compatibility_version(
+        &memory,
+        &mut image,
+        NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
+    )
+    .expect("exact-2.12 memory should encode internally");
+    let binding_payload = binding.encode().expect("memory binding should encode");
+    let serial_device = SerialMmioDevice::discarding()
+        .capture_state()
+        .expect("fixture serial device should capture");
+    let serial_payload = SnapshotV2SerialState::try_from_capture_ready(
+        CaptureReadySerialState::new(SerialConfig::default(), serial_device),
+    )
+    .expect("fixture serial state should validate")
+    .encode(NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION)
+    .expect("fixture serial state should encode");
+
+    let mut components = vec![
+        SnapshotV2Component::new(
+            NATIVE_V2_MEMORY_COMPONENT_KEY,
+            SnapshotV2ComponentDisposition::Semantic,
+            &binding_payload,
+        ),
+        SnapshotV2Component::new(
+            NATIVE_V2_SERIAL_COMPONENT_KEY,
+            SnapshotV2ComponentDisposition::Semantic,
+            &serial_payload,
+        ),
+    ];
+    if let Some(network_payload) = network_payload {
+        components.push(SnapshotV2Component::new(
+            NATIVE_V2_NETWORK_COMPONENT_KEY,
+            SnapshotV2ComponentDisposition::Semantic,
+            network_payload,
+        ));
+    }
+    if let Some(vsock_payload) = vsock_payload {
+        components.push(SnapshotV2Component::new(
+            NATIVE_V2_VSOCK_COMPONENT_KEY,
+            SnapshotV2ComponentDisposition::Semantic,
+            vsock_payload,
+        ));
+    }
+    let bytes = encode_snapshot_v2_state_with_compatibility_version(
+        NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
+        &[],
+        &components,
+    )
+    .expect("exact-2.12 candidate should encode");
+    (
+        NativeV2VsockSnapshotCandidateState::from_vsock_state_v2_12(bytes)
+            .expect("exact-2.12 candidate should close"),
+        memory,
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn exact_minor_twelve_network_overrides(
+    candidate: &NativeV2VsockSnapshotCandidateState,
+) -> Vec<SnapshotNetworkOverride> {
+    candidate
+        .network()
+        .into_iter()
+        .flat_map(SnapshotV2NetworkState::interfaces)
+        .enumerate()
+        .map(|(index, interface)| {
+            SnapshotNetworkOverride::new(interface.iface_id(), format!("tap{index}"))
+        })
+        .collect()
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn exact_minor_twelve_preparation_closes_all_network_vsock_presence_products() {
+    let network_payload = fixture_bytes(include_str!(
+        "../snapshot_network_v2_11/fixtures/inactive-mmio.hex"
+    ));
+    let vsock_payload = fixture_bytes(include_str!(
+        "../snapshot_vsock_v2_12/fixtures/inactive-mmio.hex"
+    ));
+    for (network, vsock) in [(false, false), (true, false), (false, true), (true, true)] {
+        let (candidate, memory) = exact_minor_twelve_candidate(
+            network.then_some(network_payload.as_slice()),
+            vsock.then_some(vsock_payload.as_slice()),
+        );
+        let bytes = candidate.bytes().to_vec();
+        let overrides = exact_minor_twelve_network_overrides(&candidate);
+        let expected_network_count = candidate
+            .network()
+            .map_or(0, |state| state.interfaces().len());
+        let prepared = candidate
+            .prepare(
+                &memory,
+                SnapshotV2DeviceTransportKind::Mmio,
+                &overrides,
+                None,
+            )
+            .expect("complete exact-2.12 product should prepare");
+
+        assert_eq!(prepared.bytes(), bytes);
+        assert_eq!(
+            prepared.network_topology().interfaces().len(),
+            expected_network_count
+        );
+        assert_eq!(prepared.vsock_topology().is_some(), vsock);
+        assert_eq!(
+            prepared.manifest().len(),
+            expected_network_count + usize::from(vsock)
+        );
+        if let Some(topology) = prepared.vsock_topology() {
+            assert!(!topology.request().is_overridden());
+            assert!(
+                !prepared
+                    .manifest()
+                    .is_overridden(topology.request().resource_key())
+            );
+        }
+        let debug = format!("{prepared:?}");
+        assert!(debug.contains(REDACTED));
+        assert!(!debug.contains("bangbang-vsock"));
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn exact_minor_twelve_candidate_composes_vsock_override_and_manifest_membership() {
+    let vsock_payload = fixture_bytes(include_str!(
+        "../snapshot_vsock_v2_12/fixtures/inactive-mmio.hex"
+    ));
+    let (candidate, memory) = exact_minor_twelve_candidate(None, Some(&vsock_payload));
+    let destination = "/tmp/bangbang-candidate-private.sock";
+    let prepared = candidate
+        .prepare(
+            &memory,
+            SnapshotV2DeviceTransportKind::Mmio,
+            &[],
+            Some(&SnapshotVsockOverride::new(destination)),
+        )
+        .expect("overridden exact-2.12 candidate should prepare");
+    let topology = prepared
+        .vsock_topology()
+        .expect("saved vsock should produce topology");
+    assert!(topology.request().is_overridden());
+    assert_eq!(
+        topology.request().config().uds_path(),
+        Path::new(destination)
+    );
+    assert!(
+        prepared
+            .manifest()
+            .is_overridden(topology.request().resource_key())
+    );
+    assert!(!format!("{prepared:?}").contains(destination));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn exact_minor_twelve_candidate_rejects_before_later_topology_callbacks() {
+    let (candidate, memory) = exact_minor_twelve_candidate(None, None);
+    let callbacks = std::cell::Cell::new(0);
+    let secret = "/tmp/bangbang-no-device-private.sock";
+    let error = candidate
+        .prepare_with_cancel(
+            &memory,
+            SnapshotV2DeviceTransportKind::Mmio,
+            &[],
+            Some(&SnapshotVsockOverride::new(secret)),
+            |_| {
+                callbacks.set(callbacks.get() + 1);
+                false
+            },
+        )
+        .expect_err("vsock override without captured state should fail");
+    assert!(matches!(
+        error,
+        NativeV2VsockSnapshotPreparationError::Vsock(
+            SnapshotV2VsockRestorePreparationError::Selector(
+                crate::snapshot::SnapshotVsockSelectorError::OverrideWithoutDevice
+            )
+        )
+    ));
+    assert_eq!(callbacks.get(), 0);
+    assert!(!format!("{error:?} {error}").contains(secret));
+
+    let network_payload = fixture_bytes(include_str!(
+        "../snapshot_network_v2_11/fixtures/inactive-mmio.hex"
+    ));
+    let (candidate, memory) = exact_minor_twelve_candidate(Some(&network_payload), None);
+    assert!(matches!(
+        candidate.prepare(&memory, SnapshotV2DeviceTransportKind::Mmio, &[], None,),
+        Err(NativeV2VsockSnapshotPreparationError::Network(
+            SnapshotV2NetworkRestorePreparationError::MissingInterface
+        ))
+    ));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn exact_minor_twelve_candidate_checks_product_transport_and_active_memory() {
+    let mmio_payload = fixture_bytes(include_str!(
+        "../snapshot_vsock_v2_12/fixtures/inactive-mmio.hex"
+    ));
+    let (candidate, memory) = exact_minor_twelve_candidate(None, Some(&mmio_payload));
+    assert!(matches!(
+        candidate.prepare(&memory, SnapshotV2DeviceTransportKind::Pci, &[], None,),
+        Err(NativeV2VsockSnapshotPreparationError::Vsock(
+            SnapshotV2VsockRestorePreparationError::DestinationTransport
+        ))
+    ));
+
+    let pci_payload = fixture_bytes(include_str!(
+        "../snapshot_vsock_v2_12/fixtures/active-pci.hex"
+    ));
+    let (candidate, _) = exact_minor_twelve_candidate(None, Some(&pci_payload));
+    let (_, blank) = exact_minor_twelve_candidate(None, None);
+    assert!(matches!(
+        candidate.prepare(&blank, SnapshotV2DeviceTransportKind::Pci, &[], None,),
+        Err(NativeV2VsockSnapshotPreparationError::Vsock(
+            SnapshotV2VsockRestorePreparationError::Device(_)
+        ))
+    ));
+}
+
+#[cfg(target_os = "macos")]
 #[test]
 fn native_v1_adapter_preserves_legacy_publication_bytes_and_outcome() {
     let directory = TestDirectory::new("native-v1-adapter");

--- a/crates/runtime/src/snapshot_restore.rs
+++ b/crates/runtime/src/snapshot_restore.rs
@@ -144,19 +144,121 @@ fn validate_public_id(value: &str) -> Result<(), SnapshotRestorePublicIdError> {
     Ok(())
 }
 
-fn checked_native_v2_network_resource_count(
+fn checked_native_v2_restore_resource_count(
     storage_count: usize,
     serial_count: usize,
     network_count: usize,
+    vsock_count: usize,
 ) -> Result<usize, SnapshotRestoreManifestError> {
     let resource_count = storage_count
         .checked_add(serial_count)
         .and_then(|count| count.checked_add(network_count))
+        .and_then(|count| count.checked_add(vsock_count))
         .ok_or(SnapshotRestoreManifestError::TooManyResources)?;
     if resource_count > MAX_SNAPSHOT_RESTORE_RESOURCES {
         return Err(SnapshotRestoreManifestError::TooManyResources);
     }
     Ok(resource_count)
+}
+
+fn collect_native_v2_network_resources(
+    graph: Option<&SnapshotV2StorageDeviceGraph>,
+    serial: &SnapshotV2SerialState,
+    network: Option<&SnapshotV2NetworkState>,
+    additional_resource_count: usize,
+    additional_override_count: usize,
+) -> Result<
+    (
+        Vec<SnapshotRestoreResourceKey>,
+        Vec<SnapshotRestoreResourceKey>,
+    ),
+    SnapshotRestoreManifestError,
+> {
+    let storage_count = graph.map_or(0, SnapshotV2StorageDeviceGraph::record_count);
+    let serial_count = usize::from(serial.endpoint_intent().configured_selector().is_some());
+    let network_count = network.map_or(0, |state| state.interfaces().len());
+    let resource_count = checked_native_v2_restore_resource_count(
+        storage_count,
+        serial_count,
+        network_count,
+        additional_resource_count,
+    )?;
+    let override_count = network_count
+        .checked_add(additional_override_count)
+        .ok_or(SnapshotRestoreManifestError::TooManyOverrides)?;
+    if override_count > MAX_SNAPSHOT_RESTORE_RESOURCES {
+        return Err(SnapshotRestoreManifestError::TooManyOverrides);
+    }
+
+    let mut resources = Vec::new();
+    resources
+        .try_reserve_exact(resource_count)
+        .map_err(|source| SnapshotRestoreManifestError::AllocationFailed { source })?;
+    if let Some(graph) = graph {
+        for record in graph.block_records() {
+            let public_id = SnapshotRestorePublicId::try_from(record.config().drive_id())
+                .map_err(|source| SnapshotRestoreManifestError::PublicId { source })?;
+            resources.push(SnapshotRestoreResourceKey::new(
+                record.key(),
+                public_id,
+                SnapshotRestoreResourceClass::BlockBacking,
+            ));
+        }
+        for record in graph.pmem_records() {
+            let public_id = SnapshotRestorePublicId::try_from(record.config().pmem_id())
+                .map_err(|source| SnapshotRestoreManifestError::PublicId { source })?;
+            resources.push(SnapshotRestoreResourceKey::new(
+                record.key(),
+                public_id,
+                SnapshotRestoreResourceClass::PmemBacking,
+            ));
+        }
+    }
+    if serial_count == 1 {
+        let public_id = SnapshotRestorePublicId::try_from(NATIVE_V2_SERIAL_RESTORE_PUBLIC_ID)
+            .map_err(|source| SnapshotRestoreManifestError::PublicId { source })?;
+        resources.push(SnapshotRestoreResourceKey::new(
+            SnapshotV2DeviceKey::serial(),
+            public_id,
+            SnapshotRestoreResourceClass::SerialSink,
+        ));
+    }
+
+    let mut overrides = Vec::new();
+    overrides
+        .try_reserve_exact(override_count)
+        .map_err(|source| SnapshotRestoreManifestError::AllocationFailed { source })?;
+    if let Some(network) = network {
+        for (index, interface) in network.interfaces().iter().enumerate() {
+            let instance =
+                u32::try_from(index).map_err(|_| SnapshotRestoreManifestError::TooManyResources)?;
+            let public_id = SnapshotRestorePublicId::try_from(interface.iface_id())
+                .map_err(|source| SnapshotRestoreManifestError::PublicId { source })?;
+            let key = SnapshotRestoreResourceKey::new(
+                SnapshotV2DeviceKey::network(instance),
+                public_id,
+                SnapshotRestoreResourceClass::NetworkPacketIo,
+            );
+            overrides.push(key.clone());
+            resources.push(key);
+        }
+    }
+    Ok((resources, overrides))
+}
+
+pub(crate) fn validate_native_v2_vsock_resource_key(
+    key: &SnapshotRestoreResourceKey,
+) -> Result<(), SnapshotRestoreManifestError> {
+    if key.device_key() != SnapshotV2DeviceKey::vsock() {
+        return Err(SnapshotRestoreManifestError::InvalidVsockDeviceKey);
+    }
+    if key.resource_class() != SnapshotRestoreResourceClass::VsockEndpoint {
+        return Err(SnapshotRestoreManifestError::InvalidVsockResourceClass);
+    }
+    if key.public_id().as_str() != NATIVE_V2_VSOCK_RESTORE_PUBLIC_ID {
+        return Err(SnapshotRestoreManifestError::InvalidVsockPublicId);
+    }
+    Ok(())
 }
 
 /// Closed logical class of one snapshot restore resource.
@@ -407,64 +509,46 @@ impl SnapshotRestoreManifest {
         serial: &SnapshotV2SerialState,
         network: Option<&SnapshotV2NetworkState>,
     ) -> Result<Self, SnapshotRestoreManifestError> {
-        let storage_count = graph.map_or(0, SnapshotV2StorageDeviceGraph::record_count);
-        let serial_count = usize::from(serial.endpoint_intent().configured_selector().is_some());
-        let network_count = network.map_or(0, |state| state.interfaces().len());
-        let resource_count =
-            checked_native_v2_network_resource_count(storage_count, serial_count, network_count)?;
+        let (resources, overrides) =
+            collect_native_v2_network_resources(graph, serial, network, 0, 0)?;
+        Self::try_new(resources, overrides)
+    }
 
-        let mut resources = Vec::new();
-        resources
-            .try_reserve_exact(resource_count)
-            .map_err(|source| SnapshotRestoreManifestError::AllocationFailed { source })?;
-        if let Some(graph) = graph {
-            for record in graph.block_records() {
-                let public_id = SnapshotRestorePublicId::try_from(record.config().drive_id())
-                    .map_err(|source| SnapshotRestoreManifestError::PublicId { source })?;
-                resources.push(SnapshotRestoreResourceKey::new(
-                    record.key(),
-                    public_id,
-                    SnapshotRestoreResourceClass::BlockBacking,
-                ));
-            }
-            for record in graph.pmem_records() {
-                let public_id = SnapshotRestorePublicId::try_from(record.config().pmem_id())
-                    .map_err(|source| SnapshotRestoreManifestError::PublicId { source })?;
-                resources.push(SnapshotRestoreResourceKey::new(
-                    record.key(),
-                    public_id,
-                    SnapshotRestoreResourceClass::PmemBacking,
-                ));
-            }
-        }
-        if serial_count == 1 {
-            let public_id = SnapshotRestorePublicId::try_from(NATIVE_V2_SERIAL_RESTORE_PUBLIC_ID)
-                .map_err(|source| SnapshotRestoreManifestError::PublicId { source })?;
-            resources.push(SnapshotRestoreResourceKey::new(
-                SnapshotV2DeviceKey::serial(),
-                public_id,
-                SnapshotRestoreResourceClass::SerialSink,
-            ));
-        }
-
-        let mut overrides = Vec::new();
-        overrides
-            .try_reserve_exact(network_count)
-            .map_err(|source| SnapshotRestoreManifestError::AllocationFailed { source })?;
-        if let Some(network) = network {
-            for (index, interface) in network.interfaces().iter().enumerate() {
-                let instance = u32::try_from(index)
-                    .map_err(|_| SnapshotRestoreManifestError::TooManyResources)?;
-                let public_id = SnapshotRestorePublicId::try_from(interface.iface_id())
-                    .map_err(|source| SnapshotRestoreManifestError::PublicId { source })?;
-                let key = SnapshotRestoreResourceKey::new(
-                    SnapshotV2DeviceKey::network(instance),
-                    public_id,
-                    SnapshotRestoreResourceClass::NetworkPacketIo,
+    /// Derives the complete exact-2.12 storage, configured-serial, network, and
+    /// optional vsock resource set.
+    ///
+    /// The vsock request must use the validated singleton device key, endpoint
+    /// class, and private stable restore identity. It contributes an override
+    /// only when the caller explicitly selected a destination backend.
+    pub fn try_from_native_v2_vsock_state(
+        graph: Option<&SnapshotV2StorageDeviceGraph>,
+        serial: &SnapshotV2SerialState,
+        network: Option<&SnapshotV2NetworkState>,
+        vsock: Option<(&SnapshotRestoreResourceKey, bool)>,
+    ) -> Result<Self, SnapshotRestoreManifestError> {
+        let vsock_count = usize::from(vsock.is_some());
+        let vsock_override_count =
+            usize::from(vsock.is_some_and(|(_, is_overridden)| is_overridden));
+        let (mut resources, mut overrides) = collect_native_v2_network_resources(
+            graph,
+            serial,
+            network,
+            vsock_count,
+            vsock_override_count,
+        )?;
+        if let Some((key, is_overridden)) = vsock {
+            validate_native_v2_vsock_resource_key(key)?;
+            let retained = key
+                .try_clone()
+                .map_err(|source| SnapshotRestoreManifestError::AllocationFailed { source })?;
+            if is_overridden {
+                overrides.push(
+                    retained.try_clone().map_err(|source| {
+                        SnapshotRestoreManifestError::AllocationFailed { source }
+                    })?,
                 );
-                overrides.push(key.clone());
-                resources.push(key);
             }
+            resources.push(retained);
         }
         Self::try_new(resources, overrides)
     }
@@ -591,6 +675,12 @@ pub enum SnapshotRestoreManifestError {
     UnsupportedOverrideClass,
     /// The same exact override occurs more than once.
     DuplicateOverride,
+    /// The exact-2.12 vsock request uses the wrong device-graph key.
+    InvalidVsockDeviceKey,
+    /// The exact-2.12 vsock request uses the wrong resource class.
+    InvalidVsockResourceClass,
+    /// The exact-2.12 vsock request uses the wrong private restore identity.
+    InvalidVsockPublicId,
     /// A graph-derived public identifier could not be retained.
     PublicId {
         /// Public-ID validation or allocation failure.
@@ -616,6 +706,11 @@ impl fmt::Debug for SnapshotRestoreManifestError {
                 "SnapshotRestoreManifestError::UnsupportedOverrideClass"
             }
             Self::DuplicateOverride => "SnapshotRestoreManifestError::DuplicateOverride",
+            Self::InvalidVsockDeviceKey => "SnapshotRestoreManifestError::InvalidVsockDeviceKey",
+            Self::InvalidVsockResourceClass => {
+                "SnapshotRestoreManifestError::InvalidVsockResourceClass"
+            }
+            Self::InvalidVsockPublicId => "SnapshotRestoreManifestError::InvalidVsockPublicId",
             Self::PublicId { .. } => "SnapshotRestoreManifestError::PublicId",
             Self::AllocationFailed { .. } => "SnapshotRestoreManifestError::AllocationFailed",
         })
@@ -637,6 +732,15 @@ impl fmt::Display for SnapshotRestoreManifestError {
                 "snapshot restore resource class does not support an override"
             }
             Self::DuplicateOverride => "snapshot restore manifest contains a duplicate override",
+            Self::InvalidVsockDeviceKey => {
+                "snapshot restore vsock resource uses the wrong device identity"
+            }
+            Self::InvalidVsockResourceClass => {
+                "snapshot restore vsock resource uses the wrong class"
+            }
+            Self::InvalidVsockPublicId => {
+                "snapshot restore vsock resource uses the wrong private identity"
+            }
             Self::PublicId { .. } => "snapshot restore manifest has an invalid public identifier",
             Self::AllocationFailed { .. } => "failed to allocate snapshot restore manifest storage",
         })
@@ -655,7 +759,10 @@ impl std::error::Error for SnapshotRestoreManifestError {
             | Self::UnknownOverride
             | Self::OverrideClassMismatch
             | Self::UnsupportedOverrideClass
-            | Self::DuplicateOverride => None,
+            | Self::DuplicateOverride
+            | Self::InvalidVsockDeviceKey
+            | Self::InvalidVsockResourceClass
+            | Self::InvalidVsockPublicId => None,
         }
     }
 }
@@ -1429,21 +1536,152 @@ mod tests {
     #[test]
     fn exact_2_11_manifest_applies_one_aggregate_resource_ceiling() {
         assert_eq!(
-            checked_native_v2_network_resource_count(48, 0, 16)
+            checked_native_v2_restore_resource_count(48, 0, 16, 0)
                 .expect("storage plus network at the aggregate ceiling should fit"),
             MAX_SNAPSHOT_RESTORE_RESOURCES
         );
         assert_eq!(
-            checked_native_v2_network_resource_count(47, 1, 16)
+            checked_native_v2_restore_resource_count(47, 1, 16, 0)
                 .expect("storage, serial, and network at the aggregate ceiling should fit"),
             MAX_SNAPSHOT_RESTORE_RESOURCES
         );
         assert!(matches!(
-            checked_native_v2_network_resource_count(48, 1, 16),
+            checked_native_v2_restore_resource_count(48, 1, 16, 0),
             Err(SnapshotRestoreManifestError::TooManyResources)
         ));
         assert!(matches!(
-            checked_native_v2_network_resource_count(usize::MAX, 1, 1),
+            checked_native_v2_restore_resource_count(usize::MAX, 1, 1, 0),
+            Err(SnapshotRestoreManifestError::TooManyResources)
+        ));
+    }
+
+    #[test]
+    fn exact_2_12_manifest_adds_one_canonical_optional_vsock_request() {
+        let graph = storage_graph();
+        let serial = serial_state(true);
+        let network = network_state();
+        let vsock = key(
+            5,
+            0,
+            NATIVE_V2_VSOCK_RESTORE_PUBLIC_ID,
+            SnapshotRestoreResourceClass::VsockEndpoint,
+        );
+        let without_override = SnapshotRestoreManifest::try_from_native_v2_vsock_state(
+            Some(&graph),
+            &serial,
+            Some(&network),
+            Some((&vsock, false)),
+        )
+        .expect("captured-selector vsock manifest should validate");
+        assert_eq!(
+            without_override.len(),
+            graph.record_count() + 1 + network.interfaces().len() + 1
+        );
+        assert!(!without_override.is_overridden(&vsock));
+        assert_eq!(
+            without_override
+                .resources()
+                .iter()
+                .filter(|key| key.resource_class() == SnapshotRestoreResourceClass::VsockEndpoint)
+                .count(),
+            1
+        );
+
+        let overridden = SnapshotRestoreManifest::try_from_native_v2_vsock_state(
+            Some(&graph),
+            &serial,
+            Some(&network),
+            Some((&vsock, true)),
+        )
+        .expect("overridden vsock manifest should validate");
+        assert!(overridden.is_overridden(&vsock));
+        assert_eq!(
+            overridden.overrides().count(),
+            network.interfaces().len() + 1
+        );
+
+        let without_vsock = SnapshotRestoreManifest::try_from_native_v2_vsock_state(
+            Some(&graph),
+            &serial,
+            Some(&network),
+            None,
+        )
+        .expect("vsock-free exact-2.12 manifest should validate");
+        let exact_2_11 = SnapshotRestoreManifest::try_from_native_v2_network_state(
+            Some(&graph),
+            &serial,
+            Some(&network),
+        )
+        .expect("equivalent exact-2.11 manifest should validate");
+        assert_eq!(without_vsock.resources(), exact_2_11.resources());
+        assert_eq!(
+            without_vsock.overrides().collect::<Vec<_>>(),
+            exact_2_11.overrides().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn exact_2_12_manifest_rejects_wrong_vsock_identity_and_bounds_product() {
+        let serial = serial_state(false);
+        let wrong_device = key(
+            4,
+            0,
+            NATIVE_V2_VSOCK_RESTORE_PUBLIC_ID,
+            SnapshotRestoreResourceClass::VsockEndpoint,
+        );
+        assert!(matches!(
+            SnapshotRestoreManifest::try_from_native_v2_vsock_state(
+                None,
+                &serial,
+                None,
+                Some((&wrong_device, false)),
+            ),
+            Err(SnapshotRestoreManifestError::InvalidVsockDeviceKey)
+        ));
+
+        let wrong_class = key(
+            5,
+            0,
+            NATIVE_V2_VSOCK_RESTORE_PUBLIC_ID,
+            SnapshotRestoreResourceClass::NetworkPacketIo,
+        );
+        assert!(matches!(
+            SnapshotRestoreManifest::try_from_native_v2_vsock_state(
+                None,
+                &serial,
+                None,
+                Some((&wrong_class, false)),
+            ),
+            Err(SnapshotRestoreManifestError::InvalidVsockResourceClass)
+        ));
+
+        let wrong_public_id = key(
+            5,
+            0,
+            "private-vsock",
+            SnapshotRestoreResourceClass::VsockEndpoint,
+        );
+        assert!(matches!(
+            SnapshotRestoreManifest::try_from_native_v2_vsock_state(
+                None,
+                &serial,
+                None,
+                Some((&wrong_public_id, false)),
+            ),
+            Err(SnapshotRestoreManifestError::InvalidVsockPublicId)
+        ));
+
+        assert_eq!(
+            checked_native_v2_restore_resource_count(46, 1, 16, 1)
+                .expect("complete exact-2.12 product at the aggregate ceiling should fit"),
+            MAX_SNAPSHOT_RESTORE_RESOURCES
+        );
+        assert!(matches!(
+            checked_native_v2_restore_resource_count(47, 1, 16, 1),
+            Err(SnapshotRestoreManifestError::TooManyResources)
+        ));
+        assert!(matches!(
+            checked_native_v2_restore_resource_count(usize::MAX, 1, 1, 1),
             Err(SnapshotRestoreManifestError::TooManyResources)
         ));
     }

--- a/crates/runtime/src/snapshot_vsock_restore_v2_12.rs
+++ b/crates/runtime/src/snapshot_vsock_restore_v2_12.rs
@@ -1,0 +1,683 @@
+//! Owner-free exact native-v2 2.12 vsock restore preparation.
+//!
+//! This module resolves logical destination intent, validates the canonical
+//! restore resource identity, and reconstructs capture-compatible MMIO or PCI
+//! state against destination memory. It deliberately creates no socket,
+//! descriptor, grant, broker session, runtime device owner, metric, interrupt
+//! route, VM, vCPU, or platform authority.
+
+use std::fmt;
+
+use crate::interrupt::GuestInterruptLine;
+use crate::memory::{GuestMemory, GuestMemoryRange};
+use crate::mmio::MmioRegion;
+use crate::pci::PciSbdf;
+use crate::snapshot::{
+    SnapshotVsockOverride, SnapshotVsockSelectorError, SnapshotVsockSelectors,
+    resolve_snapshot_vsock_selectors,
+};
+use crate::snapshot_device_v2::{
+    SnapshotV2DeviceTransport, SnapshotV2DeviceTransportKind, SnapshotV2RootTransportRestoreError,
+    restore_mmio_transport_state_for_device_with_config_status_gate,
+};
+use crate::snapshot_restore::{
+    NATIVE_V2_VSOCK_RESTORE_PUBLIC_ID, SnapshotRestorePublicId, SnapshotRestorePublicIdError,
+    SnapshotRestoreResourceClass, SnapshotRestoreResourceKey,
+    validate_native_v2_vsock_resource_key,
+};
+use crate::snapshot_vsock_v2_12::{
+    SnapshotV2VsockQueueState, SnapshotV2VsockState, SnapshotV2VsockStateCaptureError,
+};
+use crate::storage_capture::StorageDeviceOrigin;
+use crate::virtio::{VirtioDeviceType, VirtioDeviceTypeError};
+use crate::virtio_pci::{VirtioPciEndpointError, VirtioPciIdentity, VirtioPciTransportState};
+use crate::vsock::{
+    VIRTIO_VSOCK_DEVICE_ID, VirtioVsockActiveQueuesCaptureState, VirtioVsockDeviceCaptureError,
+    VirtioVsockDeviceCaptureState, VirtioVsockMmioCaptureState, VirtioVsockPciCaptureState,
+    VirtioVsockQueueCaptureState, VsockConfig, VsockConfigInput,
+};
+
+const REDACTED: &str = "<redacted>";
+
+/// Stable checkpoints after all captured/destination selectors have resolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2VsockRestorePreparationStage {
+    /// Before projecting the canonical resource request and destination config.
+    Resource,
+    /// Before reconstructing checked capture-compatible device state.
+    Device,
+    /// Before normalizing reconstructed state back to the portable component.
+    Normalize,
+    /// After complete validation and before publishing the immutable topology.
+    Completion,
+}
+
+/// Host-operation-free request for one exact-2.12 vsock endpoint.
+#[derive(PartialEq, Eq)]
+pub struct SnapshotV2VsockRestoreResourceRequest {
+    resource_key: SnapshotRestoreResourceKey,
+    selectors: SnapshotVsockSelectors,
+    config: VsockConfig,
+    overridden: bool,
+}
+
+impl SnapshotV2VsockRestoreResourceRequest {
+    /// Returns the canonical singleton endpoint resource identity.
+    pub const fn resource_key(&self) -> &SnapshotRestoreResourceKey {
+        &self.resource_key
+    }
+
+    /// Returns the captured and selected destination logical selectors.
+    pub const fn selectors(&self) -> &SnapshotVsockSelectors {
+        &self.selectors
+    }
+
+    /// Returns destination configuration without proving access to its path.
+    pub const fn config(&self) -> &VsockConfig {
+        &self.config
+    }
+
+    /// Returns whether the API explicitly supplied the destination selector.
+    pub const fn is_overridden(&self) -> bool {
+        self.overridden
+    }
+
+    /// Consumes the request into still owner-free logical values.
+    pub fn into_parts(
+        self,
+    ) -> (
+        SnapshotRestoreResourceKey,
+        SnapshotVsockSelectors,
+        VsockConfig,
+        bool,
+    ) {
+        (
+            self.resource_key,
+            self.selectors,
+            self.config,
+            self.overridden,
+        )
+    }
+}
+
+impl fmt::Debug for SnapshotV2VsockRestoreResourceRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2VsockRestoreResourceRequest")
+            .field("overridden", &self.overridden)
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Checked owner-free MMIO vsock continuation and exact placement.
+#[derive(Clone, PartialEq, Eq)]
+pub struct PreparedSnapshotV2VsockMmioState {
+    region: MmioRegion,
+    interrupt_line: GuestInterruptLine,
+    capture: VirtioVsockMmioCaptureState,
+}
+
+impl PreparedSnapshotV2VsockMmioState {
+    /// Returns the exact retained MMIO region.
+    pub const fn region(&self) -> MmioRegion {
+        self.region
+    }
+
+    /// Returns the exact retained guest interrupt line.
+    pub const fn interrupt_line(&self) -> GuestInterruptLine {
+        self.interrupt_line
+    }
+
+    /// Returns checked capture-compatible device and transport state.
+    pub const fn capture(&self) -> &VirtioVsockMmioCaptureState {
+        &self.capture
+    }
+
+    /// Consumes the value into exact placement and checked capture state.
+    pub fn into_parts(self) -> (MmioRegion, GuestInterruptLine, VirtioVsockMmioCaptureState) {
+        (self.region, self.interrupt_line, self.capture)
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2VsockMmioState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2VsockMmioState")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Checked owner-free PCI vsock continuation and exact placement.
+#[derive(Clone, PartialEq, Eq)]
+pub struct PreparedSnapshotV2VsockPciState {
+    origin: StorageDeviceOrigin,
+    sbdf: PciSbdf,
+    bar_range: GuestMemoryRange,
+    capture: VirtioVsockPciCaptureState,
+}
+
+impl PreparedSnapshotV2VsockPciState {
+    /// Returns the captured source-family placement origin.
+    pub const fn origin(&self) -> StorageDeviceOrigin {
+        self.origin
+    }
+
+    /// Returns the exact retained PCI function.
+    pub const fn sbdf(&self) -> PciSbdf {
+        self.sbdf
+    }
+
+    /// Returns the exact retained PCI BAR range.
+    pub const fn bar_range(&self) -> GuestMemoryRange {
+        self.bar_range
+    }
+
+    /// Returns checked capture-compatible device and transport state.
+    pub const fn capture(&self) -> &VirtioVsockPciCaptureState {
+        &self.capture
+    }
+
+    /// Consumes the value into exact placement and checked capture state.
+    pub fn into_parts(
+        self,
+    ) -> (
+        StorageDeviceOrigin,
+        PciSbdf,
+        GuestMemoryRange,
+        VirtioVsockPciCaptureState,
+    ) {
+        (self.origin, self.sbdf, self.bar_range, self.capture)
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2VsockPciState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2VsockPciState")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Checked capture-compatible exact-2.12 vsock state.
+#[derive(Clone, PartialEq, Eq)]
+pub enum PreparedSnapshotV2VsockRestoreState {
+    /// Modern virtio-mmio continuation.
+    Mmio(PreparedSnapshotV2VsockMmioState),
+    /// Modern non-transitional virtio-pci continuation.
+    Pci(PreparedSnapshotV2VsockPciState),
+}
+
+impl PreparedSnapshotV2VsockRestoreState {
+    /// Returns the retained destination transport kind.
+    pub const fn transport_kind(&self) -> SnapshotV2DeviceTransportKind {
+        match self {
+            Self::Mmio(_) => SnapshotV2DeviceTransportKind::Mmio,
+            Self::Pci(_) => SnapshotV2DeviceTransportKind::Pci,
+        }
+    }
+
+    /// Consumes checked state and normalizes it to the portable component.
+    pub fn into_normalized_state(
+        self,
+    ) -> Result<SnapshotV2VsockState, SnapshotV2VsockStateCaptureError> {
+        match self {
+            Self::Mmio(prepared) => {
+                let (region, interrupt_line, capture) = prepared.into_parts();
+                SnapshotV2VsockState::try_from_mmio_capture(region, interrupt_line, capture)
+            }
+            Self::Pci(prepared) => {
+                let (origin, sbdf, bar_range, capture) = prepared.into_parts();
+                SnapshotV2VsockState::try_from_pci_capture(origin, sbdf, bar_range, capture)
+            }
+        }
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2VsockRestoreState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2VsockRestoreState")
+            .field("transport", &self.transport_kind())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Immutable owner-free exact-2.12 vsock destination topology.
+#[derive(PartialEq, Eq)]
+pub struct PreparedSnapshotV2VsockRestoreTopology {
+    request: SnapshotV2VsockRestoreResourceRequest,
+    state: PreparedSnapshotV2VsockRestoreState,
+}
+
+impl PreparedSnapshotV2VsockRestoreTopology {
+    /// Resolves and validates one present portable vsock component.
+    pub fn prepare(
+        state: SnapshotV2VsockState,
+        requested_override: Option<&SnapshotVsockOverride>,
+        expected_transport: SnapshotV2DeviceTransportKind,
+        destination_memory: &GuestMemory,
+    ) -> Result<Self, SnapshotV2VsockRestorePreparationError> {
+        Self::prepare_with_cancel(
+            state,
+            requested_override,
+            expected_transport,
+            destination_memory,
+            |_| false,
+        )
+    }
+
+    /// Resolves and validates one optional component before any host operation.
+    pub fn prepare_optional(
+        state: Option<SnapshotV2VsockState>,
+        requested_override: Option<&SnapshotVsockOverride>,
+        expected_transport: SnapshotV2DeviceTransportKind,
+        destination_memory: &GuestMemory,
+    ) -> Result<Option<Self>, SnapshotV2VsockRestorePreparationError> {
+        Self::prepare_optional_with_cancel(
+            state,
+            requested_override,
+            expected_transport,
+            destination_memory,
+            |_| false,
+        )
+    }
+
+    /// Resolves and validates one present component with stable cancellation.
+    pub fn prepare_with_cancel<C>(
+        state: SnapshotV2VsockState,
+        requested_override: Option<&SnapshotVsockOverride>,
+        expected_transport: SnapshotV2DeviceTransportKind,
+        destination_memory: &GuestMemory,
+        is_cancelled: C,
+    ) -> Result<Self, SnapshotV2VsockRestorePreparationError>
+    where
+        C: FnMut(SnapshotV2VsockRestorePreparationStage) -> bool,
+    {
+        Self::prepare_optional_with_cancel(
+            Some(state),
+            requested_override,
+            expected_transport,
+            destination_memory,
+            is_cancelled,
+        )?
+        .ok_or(SnapshotV2VsockRestorePreparationError::ResourceIdentity)
+    }
+
+    /// Resolves selectors before invoking any cancellation callback.
+    pub fn prepare_optional_with_cancel<C>(
+        state: Option<SnapshotV2VsockState>,
+        requested_override: Option<&SnapshotVsockOverride>,
+        expected_transport: SnapshotV2DeviceTransportKind,
+        destination_memory: &GuestMemory,
+        is_cancelled: C,
+    ) -> Result<Option<Self>, SnapshotV2VsockRestorePreparationError>
+    where
+        C: FnMut(SnapshotV2VsockRestorePreparationStage) -> bool,
+    {
+        prepare_optional_vsock_restore_topology(
+            state,
+            requested_override,
+            expected_transport,
+            destination_memory,
+            is_cancelled,
+            AllocationPolicy::System,
+            None,
+        )
+    }
+
+    /// Returns the canonical logical endpoint request.
+    pub const fn request(&self) -> &SnapshotV2VsockRestoreResourceRequest {
+        &self.request
+    }
+
+    /// Returns checked owner-free MMIO or PCI state.
+    pub const fn state(&self) -> &PreparedSnapshotV2VsockRestoreState {
+        &self.state
+    }
+
+    /// Returns the exact retained transport kind.
+    pub const fn transport_kind(&self) -> SnapshotV2DeviceTransportKind {
+        self.state.transport_kind()
+    }
+
+    /// Consumes the topology into request and checked state.
+    pub fn into_parts(
+        self,
+    ) -> (
+        SnapshotV2VsockRestoreResourceRequest,
+        PreparedSnapshotV2VsockRestoreState,
+    ) {
+        (self.request, self.state)
+    }
+
+    /// Consumes the topology and normalizes checked state back to portable form.
+    pub fn into_normalized_state(
+        self,
+    ) -> Result<SnapshotV2VsockState, SnapshotV2VsockStateCaptureError> {
+        self.state.into_normalized_state()
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2VsockRestoreTopology {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2VsockRestoreTopology")
+            .field("transport", &self.transport_kind())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Failure while preparing owner-free exact-2.12 vsock restore state.
+pub enum SnapshotV2VsockRestorePreparationError {
+    /// Captured and requested selectors could not be resolved.
+    Selector(SnapshotVsockSelectorError),
+    /// Destination `VsockConfig` could not be projected.
+    Config,
+    /// The stable private resource identifier could not be retained.
+    ResourceId(SnapshotRestorePublicIdError),
+    /// Resource key, class, or private public identity is inconsistent.
+    ResourceIdentity,
+    /// Portable and selected exact-product transports disagree.
+    DestinationTransport,
+    /// Encoding-independent vsock device state is invalid.
+    Device(VirtioVsockDeviceCaptureError),
+    /// Owner-free MMIO transport reconstruction failed.
+    Mmio(SnapshotV2RootTransportRestoreError),
+    /// The fixed modern PCI device type could not be represented.
+    PciDeviceType(VirtioDeviceTypeError),
+    /// Owner-free PCI transport reconstruction failed.
+    Pci(VirtioPciEndpointError),
+    /// Checked state could not normalize to portable exact-2.12 state.
+    Normalize(SnapshotV2VsockStateCaptureError),
+    /// Normalized state differs from the consumed portable component.
+    StateMismatch,
+    /// A bounded preparation allocation failed.
+    Allocation,
+    /// Preparation was cancelled at a stable post-selection checkpoint.
+    Cancelled {
+        /// The checkpoint that observed cancellation.
+        stage: SnapshotV2VsockRestorePreparationStage,
+    },
+}
+
+impl fmt::Debug for SnapshotV2VsockRestorePreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+impl fmt::Display for SnapshotV2VsockRestorePreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Selector(_) => "native-v2 vsock restore selector is invalid",
+            Self::Config => "native-v2 vsock restore configuration is invalid",
+            Self::ResourceId(_) | Self::ResourceIdentity => {
+                "native-v2 vsock restore resource identity is invalid"
+            }
+            Self::DestinationTransport => {
+                "native-v2 vsock restore destination transport is inconsistent"
+            }
+            Self::Device(_) => "native-v2 vsock restore device state is invalid",
+            Self::Mmio(_) => "native-v2 vsock MMIO restore state is invalid",
+            Self::PciDeviceType(_) | Self::Pci(_) => "native-v2 vsock PCI restore state is invalid",
+            Self::Normalize(_) | Self::StateMismatch => {
+                "native-v2 vsock restored state does not normalize"
+            }
+            Self::Allocation => "native-v2 vsock restore preparation allocation failed",
+            Self::Cancelled { .. } => "native-v2 vsock restore preparation was cancelled",
+        })
+    }
+}
+
+impl std::error::Error for SnapshotV2VsockRestorePreparationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Selector(source) => Some(source),
+            Self::ResourceId(source) => Some(source),
+            Self::Device(source) => Some(source),
+            Self::Mmio(source) => Some(source),
+            Self::PciDeviceType(source) => Some(source),
+            Self::Pci(source) => Some(source),
+            Self::Normalize(source) => Some(source),
+            Self::Config
+            | Self::ResourceIdentity
+            | Self::DestinationTransport
+            | Self::StateMismatch
+            | Self::Allocation
+            | Self::Cancelled { .. } => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AllocationFailure {
+    ResourceId,
+    DestinationConfig,
+    DeviceState,
+    TransportState,
+    Normalization,
+}
+
+#[derive(Clone, Copy)]
+enum AllocationPolicy {
+    System,
+    #[cfg(test)]
+    Fail(AllocationFailure),
+}
+
+impl AllocationPolicy {
+    fn check(self, point: AllocationFailure) -> Result<(), SnapshotV2VsockRestorePreparationError> {
+        #[cfg(test)]
+        if matches!(self, Self::Fail(failure) if failure == point) {
+            return Err(SnapshotV2VsockRestorePreparationError::Allocation);
+        }
+        #[cfg(not(test))]
+        let _ = (self, point);
+        Ok(())
+    }
+
+    fn copy_string(
+        self,
+        value: &str,
+        point: AllocationFailure,
+    ) -> Result<String, SnapshotV2VsockRestorePreparationError> {
+        self.check(point)?;
+        let mut copy = String::new();
+        copy.try_reserve_exact(value.len())
+            .map_err(|_| SnapshotV2VsockRestorePreparationError::Allocation)?;
+        copy.push_str(value);
+        Ok(copy)
+    }
+}
+
+fn prepare_optional_vsock_restore_topology<C>(
+    state: Option<SnapshotV2VsockState>,
+    requested_override: Option<&SnapshotVsockOverride>,
+    expected_transport: SnapshotV2DeviceTransportKind,
+    destination_memory: &GuestMemory,
+    mut is_cancelled: C,
+    allocation: AllocationPolicy,
+    injected_resource_key: Option<SnapshotRestoreResourceKey>,
+) -> Result<Option<PreparedSnapshotV2VsockRestoreTopology>, SnapshotV2VsockRestorePreparationError>
+where
+    C: FnMut(SnapshotV2VsockRestorePreparationStage) -> bool,
+{
+    let selectors = resolve_snapshot_vsock_selectors(
+        state.as_ref().map(SnapshotV2VsockState::backend_selector),
+        requested_override,
+    )
+    .map_err(SnapshotV2VsockRestorePreparationError::Selector)?;
+    let Some(state) = state else {
+        return Ok(None);
+    };
+    let selectors = selectors.ok_or(SnapshotV2VsockRestorePreparationError::ResourceIdentity)?;
+
+    check_cancelled(
+        &mut is_cancelled,
+        SnapshotV2VsockRestorePreparationStage::Resource,
+    )?;
+    if state.transport().kind() != expected_transport {
+        return Err(SnapshotV2VsockRestorePreparationError::DestinationTransport);
+    }
+    let resource_key = match injected_resource_key {
+        Some(resource_key) => resource_key,
+        None => {
+            allocation.check(AllocationFailure::ResourceId)?;
+            let public_id = SnapshotRestorePublicId::try_from(NATIVE_V2_VSOCK_RESTORE_PUBLIC_ID)
+                .map_err(SnapshotV2VsockRestorePreparationError::ResourceId)?;
+            SnapshotRestoreResourceKey::new(
+                state.device_key(),
+                public_id,
+                SnapshotRestoreResourceClass::VsockEndpoint,
+            )
+        }
+    };
+    validate_native_v2_vsock_resource_key(&resource_key)
+        .map_err(|_| SnapshotV2VsockRestorePreparationError::ResourceIdentity)?;
+    let guest_cid = u32::try_from(state.guest_cid())
+        .map_err(|_| SnapshotV2VsockRestorePreparationError::Config)?;
+    let destination = selectors
+        .destination()
+        .path()
+        .to_str()
+        .ok_or(SnapshotV2VsockRestorePreparationError::Config)?;
+    let destination = allocation.copy_string(destination, AllocationFailure::DestinationConfig)?;
+    let config = VsockConfigInput::new(guest_cid, destination)
+        .validate()
+        .map_err(|_| SnapshotV2VsockRestorePreparationError::Config)?;
+    let request = SnapshotV2VsockRestoreResourceRequest {
+        resource_key,
+        selectors,
+        config,
+        overridden: requested_override.is_some(),
+    };
+
+    check_cancelled(
+        &mut is_cancelled,
+        SnapshotV2VsockRestorePreparationStage::Device,
+    )?;
+    let checked = restore_checked_vsock_state(&state, destination_memory, allocation)?;
+
+    check_cancelled(
+        &mut is_cancelled,
+        SnapshotV2VsockRestorePreparationStage::Normalize,
+    )?;
+    allocation.check(AllocationFailure::Normalization)?;
+    let normalized = checked
+        .clone()
+        .into_normalized_state()
+        .map_err(SnapshotV2VsockRestorePreparationError::Normalize)?;
+    if normalized != state {
+        return Err(SnapshotV2VsockRestorePreparationError::StateMismatch);
+    }
+
+    check_cancelled(
+        &mut is_cancelled,
+        SnapshotV2VsockRestorePreparationStage::Completion,
+    )?;
+    Ok(Some(PreparedSnapshotV2VsockRestoreTopology {
+        request,
+        state: checked,
+    }))
+}
+
+fn restore_checked_vsock_state(
+    state: &SnapshotV2VsockState,
+    destination_memory: &GuestMemory,
+    allocation: AllocationPolicy,
+) -> Result<PreparedSnapshotV2VsockRestoreState, SnapshotV2VsockRestorePreparationError> {
+    allocation.check(AllocationFailure::DeviceState)?;
+    let active_queues = state.active_queues().map(|active| {
+        VirtioVsockActiveQueuesCaptureState::new(
+            capture_queue(active.rx()),
+            capture_queue(active.tx()),
+            capture_queue(active.event()),
+        )
+    });
+    let device = VirtioVsockDeviceCaptureState::try_from_parts(
+        state.guest_cid(),
+        state.virtio().available_features(),
+        state.virtio().driver_features(),
+        active_queues,
+        state.backend_selector().clone(),
+        state.host_local_port_cursor(),
+    )
+    .map_err(SnapshotV2VsockRestorePreparationError::Device)?;
+
+    allocation.check(AllocationFailure::TransportState)?;
+    match state.transport() {
+        SnapshotV2DeviceTransport::Mmio(mmio) => {
+            let retained = restore_mmio_transport_state_for_device_with_config_status_gate(
+                VIRTIO_VSOCK_DEVICE_ID,
+                state.virtio(),
+                mmio,
+                true,
+            )
+            .map_err(SnapshotV2VsockRestorePreparationError::Mmio)?;
+            let capture =
+                VirtioVsockMmioCaptureState::try_from_parts(device, retained, destination_memory)
+                    .map_err(SnapshotV2VsockRestorePreparationError::Device)?;
+            Ok(PreparedSnapshotV2VsockRestoreState::Mmio(
+                PreparedSnapshotV2VsockMmioState {
+                    region: mmio.region(),
+                    interrupt_line: mmio.interrupt_line(),
+                    capture,
+                },
+            ))
+        }
+        SnapshotV2DeviceTransport::Pci(pci) => {
+            let device_type = VirtioDeviceType::new(VIRTIO_VSOCK_DEVICE_ID)
+                .map_err(SnapshotV2VsockRestorePreparationError::PciDeviceType)?;
+            let identity = VirtioPciIdentity::new(device_type, state.virtio().available_features())
+                .with_config_generation(state.virtio().config_generation());
+            let retained = VirtioPciTransportState::from_snapshot_v2_parts(
+                identity,
+                state.virtio(),
+                pci,
+                false,
+            )
+            .map_err(SnapshotV2VsockRestorePreparationError::Pci)?;
+            let capture =
+                VirtioVsockPciCaptureState::try_from_parts(device, retained, destination_memory)
+                    .map_err(SnapshotV2VsockRestorePreparationError::Device)?;
+            Ok(PreparedSnapshotV2VsockRestoreState::Pci(
+                PreparedSnapshotV2VsockPciState {
+                    origin: pci.origin(),
+                    sbdf: pci.sbdf(),
+                    bar_range: pci.bar_range(),
+                    capture,
+                },
+            ))
+        }
+    }
+}
+
+fn capture_queue(state: SnapshotV2VsockQueueState) -> VirtioVsockQueueCaptureState {
+    VirtioVsockQueueCaptureState::new(
+        state.next_available(),
+        state.next_used(),
+        state.event_idx_enabled(),
+    )
+}
+
+fn check_cancelled<C>(
+    is_cancelled: &mut C,
+    stage: SnapshotV2VsockRestorePreparationStage,
+) -> Result<(), SnapshotV2VsockRestorePreparationError>
+where
+    C: FnMut(SnapshotV2VsockRestorePreparationStage) -> bool,
+{
+    if is_cancelled(stage) {
+        Err(SnapshotV2VsockRestorePreparationError::Cancelled { stage })
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/runtime/src/snapshot_vsock_restore_v2_12/tests.rs
+++ b/crates/runtime/src/snapshot_vsock_restore_v2_12/tests.rs
@@ -1,0 +1,359 @@
+use std::cell::Cell;
+
+use crate::memory::{GuestAddress, GuestMemoryLayout};
+use crate::snapshot::SnapshotVsockSelectorError;
+use crate::snapshot_device_v2::snapshot_v2_device_key_for_test;
+use crate::snapshot_restore::{SnapshotRestorePublicId, SnapshotRestoreResourceClass};
+use crate::snapshot_vsock_v2_12::NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION;
+
+use super::*;
+
+const INACTIVE_MMIO_HEX: &str = include_str!("../snapshot_vsock_v2_12/fixtures/inactive-mmio.hex");
+const ACTIVE_PCI_HEX: &str = include_str!("../snapshot_vsock_v2_12/fixtures/active-pci.hex");
+
+fn decode_hex(value: &str) -> Vec<u8> {
+    let value = value.split_whitespace().collect::<String>();
+    assert!(value.len().is_multiple_of(2));
+    value
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            u8::from_str_radix(
+                std::str::from_utf8(pair).expect("fixture pair should be UTF-8"),
+                16,
+            )
+            .expect("fixture pair should be hexadecimal")
+        })
+        .collect()
+}
+
+fn state(fixture: &str) -> SnapshotV2VsockState {
+    SnapshotV2VsockState::decode(
+        NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
+        &decode_hex(fixture),
+    )
+    .expect("exact-2.12 fixture should decode")
+}
+
+fn memory_for(state: &SnapshotV2VsockState) -> GuestMemory {
+    let range = GuestMemoryRange::new(GuestAddress::new(0), 0x0040_0000)
+        .expect("test memory range should validate");
+    let layout = GuestMemoryLayout::new(vec![range]).expect("test memory layout should validate");
+    let mut memory = GuestMemory::allocate(&layout).expect("test memory should allocate");
+    let Some(active) = state.active_queues() else {
+        return memory;
+    };
+    for (queue, cursor) in
+        state
+            .virtio()
+            .queues()
+            .iter()
+            .zip([active.rx(), active.tx(), active.event()])
+    {
+        let available_index = queue
+            .driver_ring()
+            .checked_add(2)
+            .expect("available index should not overflow");
+        memory
+            .write_slice(&cursor.next_available().to_le_bytes(), available_index)
+            .expect("available index should write");
+        let used_index = queue
+            .device_ring()
+            .checked_add(2)
+            .expect("used index should not overflow");
+        memory
+            .write_slice(&cursor.next_used().to_le_bytes(), used_index)
+            .expect("used index should write");
+    }
+    memory
+}
+
+fn blank_memory() -> GuestMemory {
+    let state = state(INACTIVE_MMIO_HEX);
+    memory_for(&state)
+}
+
+fn resource_key(
+    kind: u32,
+    instance: u32,
+    public_id: &str,
+    resource_class: SnapshotRestoreResourceClass,
+) -> SnapshotRestoreResourceKey {
+    SnapshotRestoreResourceKey::new(
+        snapshot_v2_device_key_for_test(kind, instance),
+        SnapshotRestorePublicId::try_from(public_id).expect("test public ID should validate"),
+        resource_class,
+    )
+}
+
+#[test]
+fn valid_mmio_and_pci_topologies_are_owner_free_and_normalize_exactly() {
+    for (portable, transport) in [
+        (
+            state(INACTIVE_MMIO_HEX),
+            SnapshotV2DeviceTransportKind::Mmio,
+        ),
+        (state(ACTIVE_PCI_HEX), SnapshotV2DeviceTransportKind::Pci),
+    ] {
+        let memory = memory_for(&portable);
+        let captured_selector = portable.backend_selector().path().to_path_buf();
+        let expected = portable.clone();
+        let topology =
+            PreparedSnapshotV2VsockRestoreTopology::prepare(portable, None, transport, &memory)
+                .expect("valid portable topology should prepare");
+
+        assert_eq!(topology.transport_kind(), transport);
+        assert_eq!(topology.request().resource_key().device_key().kind(), 5);
+        assert_eq!(topology.request().resource_key().device_key().instance(), 0);
+        assert_eq!(
+            topology.request().resource_key().resource_class(),
+            SnapshotRestoreResourceClass::VsockEndpoint
+        );
+        assert_eq!(
+            topology.request().resource_key().public_id().as_str(),
+            NATIVE_V2_VSOCK_RESTORE_PUBLIC_ID
+        );
+        assert_eq!(
+            topology.request().selectors().captured().path(),
+            captured_selector
+        );
+        assert_eq!(
+            topology.request().selectors().destination().path(),
+            captured_selector
+        );
+        assert_eq!(
+            topology.request().config().guest_cid(),
+            expected.guest_cid() as u32
+        );
+        assert_eq!(
+            topology.request().config().uds_path(),
+            captured_selector.as_path()
+        );
+        assert!(!topology.request().is_overridden());
+
+        let debug = format!("{topology:?} {:?}", topology.request());
+        assert!(!debug.contains(captured_selector.to_string_lossy().as_ref()));
+        assert_eq!(
+            topology
+                .into_normalized_state()
+                .expect("checked topology should normalize"),
+            expected
+        );
+    }
+}
+
+#[test]
+fn explicit_override_changes_only_destination_intent() {
+    let portable = state(INACTIVE_MMIO_HEX);
+    let captured = portable.backend_selector().path().to_path_buf();
+    let destination = "/tmp/bangbang-vsock-restored-private.sock";
+    let memory = memory_for(&portable);
+    let requested = SnapshotVsockOverride::new(destination);
+    let topology = PreparedSnapshotV2VsockRestoreTopology::prepare(
+        portable,
+        Some(&requested),
+        SnapshotV2DeviceTransportKind::Mmio,
+        &memory,
+    )
+    .expect("valid override should prepare");
+
+    assert_eq!(topology.request().selectors().captured().path(), captured);
+    assert_eq!(
+        topology.request().selectors().destination().path(),
+        std::path::Path::new(destination)
+    );
+    assert_eq!(
+        topology.request().config().uds_path(),
+        std::path::Path::new(destination)
+    );
+    assert!(topology.request().is_overridden());
+    let debug = format!("{topology:?} {:?}", topology.request());
+    assert!(!debug.contains(destination));
+    assert!(!debug.contains(captured.to_string_lossy().as_ref()));
+}
+
+#[test]
+fn absent_or_invalid_selector_policy_finishes_before_callbacks() {
+    let memory = blank_memory();
+    let calls = Cell::new(0);
+    let absent = PreparedSnapshotV2VsockRestoreTopology::prepare_optional_with_cancel(
+        None,
+        None,
+        SnapshotV2DeviceTransportKind::Mmio,
+        &memory,
+        |_| {
+            calls.set(calls.get() + 1);
+            false
+        },
+    )
+    .expect("absent state without override should remain absent");
+    assert!(absent.is_none());
+    assert_eq!(calls.get(), 0);
+
+    let secret = "/tmp/private-no-device.sock";
+    let error = PreparedSnapshotV2VsockRestoreTopology::prepare_optional_with_cancel(
+        None,
+        Some(&SnapshotVsockOverride::new(secret)),
+        SnapshotV2DeviceTransportKind::Mmio,
+        &memory,
+        |_| {
+            calls.set(calls.get() + 1);
+            false
+        },
+    )
+    .expect_err("override without a captured device should fail");
+    assert!(matches!(
+        error,
+        SnapshotV2VsockRestorePreparationError::Selector(
+            SnapshotVsockSelectorError::OverrideWithoutDevice
+        )
+    ));
+    assert_eq!(calls.get(), 0);
+    assert!(!format!("{error:?} {error}").contains(secret));
+
+    let portable = state(INACTIVE_MMIO_HEX);
+    let invalid = "invalid\nprivate";
+    let error = PreparedSnapshotV2VsockRestoreTopology::prepare_with_cancel(
+        portable,
+        Some(&SnapshotVsockOverride::new(invalid)),
+        SnapshotV2DeviceTransportKind::Mmio,
+        &memory,
+        |_| {
+            calls.set(calls.get() + 1);
+            false
+        },
+    )
+    .expect_err("invalid destination selector should fail");
+    assert!(matches!(
+        error,
+        SnapshotV2VsockRestorePreparationError::Selector(
+            SnapshotVsockSelectorError::InvalidOverride(_)
+        )
+    ));
+    assert_eq!(calls.get(), 0);
+    assert!(!format!("{error:?} {error}").contains(invalid));
+}
+
+#[test]
+fn product_transport_and_destination_memory_fail_before_publication() {
+    let mmio = state(INACTIVE_MMIO_HEX);
+    let memory = memory_for(&mmio);
+    assert!(matches!(
+        PreparedSnapshotV2VsockRestoreTopology::prepare(
+            mmio,
+            None,
+            SnapshotV2DeviceTransportKind::Pci,
+            &memory,
+        ),
+        Err(SnapshotV2VsockRestorePreparationError::DestinationTransport)
+    ));
+
+    let pci = state(ACTIVE_PCI_HEX);
+    let empty = blank_memory();
+    assert!(matches!(
+        PreparedSnapshotV2VsockRestoreTopology::prepare(
+            pci,
+            None,
+            SnapshotV2DeviceTransportKind::Pci,
+            &empty,
+        ),
+        Err(SnapshotV2VsockRestorePreparationError::Device(_))
+    ));
+}
+
+#[test]
+fn wrong_resource_key_class_and_private_identity_are_rejected() {
+    let portable = state(INACTIVE_MMIO_HEX);
+    let memory = memory_for(&portable);
+    let cases = [
+        resource_key(
+            4,
+            0,
+            NATIVE_V2_VSOCK_RESTORE_PUBLIC_ID,
+            SnapshotRestoreResourceClass::VsockEndpoint,
+        ),
+        resource_key(
+            5,
+            0,
+            NATIVE_V2_VSOCK_RESTORE_PUBLIC_ID,
+            SnapshotRestoreResourceClass::NetworkPacketIo,
+        ),
+        resource_key(
+            5,
+            0,
+            "private-vsock",
+            SnapshotRestoreResourceClass::VsockEndpoint,
+        ),
+    ];
+    for injected in cases {
+        let error = prepare_optional_vsock_restore_topology(
+            Some(portable.clone()),
+            None,
+            SnapshotV2DeviceTransportKind::Mmio,
+            &memory,
+            |_| false,
+            AllocationPolicy::System,
+            Some(injected),
+        )
+        .expect_err("wrong resource identity should fail");
+        assert!(matches!(
+            error,
+            SnapshotV2VsockRestorePreparationError::ResourceIdentity
+        ));
+    }
+}
+
+#[test]
+fn cancellation_and_allocation_checkpoints_are_deterministic() {
+    let portable = state(INACTIVE_MMIO_HEX);
+    let memory = memory_for(&portable);
+    for target in [
+        SnapshotV2VsockRestorePreparationStage::Resource,
+        SnapshotV2VsockRestorePreparationStage::Device,
+        SnapshotV2VsockRestorePreparationStage::Normalize,
+        SnapshotV2VsockRestorePreparationStage::Completion,
+    ] {
+        let observed = Cell::new(Vec::new());
+        let error = PreparedSnapshotV2VsockRestoreTopology::prepare_with_cancel(
+            portable.clone(),
+            None,
+            SnapshotV2DeviceTransportKind::Mmio,
+            &memory,
+            |stage| {
+                let mut stages = observed.take();
+                stages.push(stage);
+                observed.set(stages);
+                stage == target
+            },
+        )
+        .expect_err("selected cancellation stage should stop preparation");
+        assert!(matches!(
+            error,
+            SnapshotV2VsockRestorePreparationError::Cancelled { stage } if stage == target
+        ));
+        assert_eq!(observed.take().last().copied(), Some(target));
+    }
+
+    for point in [
+        AllocationFailure::ResourceId,
+        AllocationFailure::DestinationConfig,
+        AllocationFailure::DeviceState,
+        AllocationFailure::TransportState,
+        AllocationFailure::Normalization,
+    ] {
+        let error = prepare_optional_vsock_restore_topology(
+            Some(portable.clone()),
+            None,
+            SnapshotV2DeviceTransportKind::Mmio,
+            &memory,
+            |_| false,
+            AllocationPolicy::Fail(point),
+            None,
+        )
+        .expect_err("selected allocation point should fail");
+        assert!(matches!(
+            error,
+            SnapshotV2VsockRestorePreparationError::Allocation
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

- add an owner-free exact-2.12 vsock restore topology with selector resolution, canonical resource identity, MMIO/PCI reconstruction against destination memory, normalization, cancellation, allocation, and redacted errors
- extend the native-v2 restore manifest through optional vsock while preserving the aggregate 64-resource ceiling and exact-2.11 behavior
- compose complete exact-2.12 artifact candidates and add a dormant VMM pre-access gate with zero-host-access failure probes

## Scope exclusions

- exact-2.12 remains unavailable through public snapshot create/load/restore dispatch
- endpoint authority, socket publication, runtime owner construction, HVF planning, and signed exact-2.12 certification remain follow-up work

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

Closes #1730

Parent: #1540
