### PR TITLE
feat: plan native-v2 vsock restore platforms

### DIFF
--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -69,10 +69,11 @@ use bangbang_hvf::{
     HvfSnapshotV2StorageMmioPlatformPlan, HvfSnapshotV2StorageMmioProcessConfig,
     HvfSnapshotV2StorageMmioRestoreError, HvfSnapshotV2StoragePciPlatformPlan,
     HvfSnapshotV2StoragePciRestoreError, HvfSnapshotV2StorageState,
-    HvfSnapshotV2VsockPlatformState, HvfSnapshotV2VsockState, HvfVcpuRunControl,
-    HvfVcpuRunCoordinatorError, HvfVcpuRunStepOutcome, OwnedHvfArm64BootSession,
-    PrepareHvfSnapshotV1LoadError, PrepareHvfSnapshotV2BalloonPlatformPlanError,
-    PrepareHvfSnapshotV2EntropyPciPlatformPlanError,
+    HvfSnapshotV2VsockMmioPlatformPlan, HvfSnapshotV2VsockPciPlatformPlan,
+    HvfSnapshotV2VsockPlatformState, HvfSnapshotV2VsockProcessResourceIdentity,
+    HvfSnapshotV2VsockState, HvfVcpuRunControl, HvfVcpuRunCoordinatorError, HvfVcpuRunStepOutcome,
+    OwnedHvfArm64BootSession, PrepareHvfSnapshotV1LoadError,
+    PrepareHvfSnapshotV2BalloonPlatformPlanError, PrepareHvfSnapshotV2EntropyPciPlatformPlanError,
     PrepareHvfSnapshotV2MemoryHotplugPlatformPlanError,
     PrepareHvfSnapshotV2MultiBlockPlatformPlanError, PrepareHvfSnapshotV2NetworkPlatformPlanError,
     PrepareHvfSnapshotV2RootPlanError, PrepareHvfSnapshotV2StorageMmioPlatformPlanError,
@@ -20577,6 +20578,66 @@ impl PreparedProcessSnapshotV2VsockResourcePlan {
             && self.vsock_config.is_some() == self.files.vsock_key().is_some()
     }
 
+    fn vsock_identity(&self) -> Option<Option<HvfSnapshotV2VsockProcessResourceIdentity<'_>>> {
+        match (self.files.vsock_key(), self.vsock_config.as_ref()) {
+            (None, None) => Some(None),
+            (Some(key), Some(config)) => Some(Some(
+                HvfSnapshotV2VsockProcessResourceIdentity::new(key, config),
+            )),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn matches_mmio_platform_plan(
+        &self,
+        plan: &HvfSnapshotV2VsockMmioPlatformPlan,
+    ) -> bool {
+        let Some(vsock) = self.vsock_identity() else {
+            return false;
+        };
+        plan.preflight_process_resource_identity(
+            self.network.interfaces.iter().map(|interface| {
+                HvfSnapshotV2NetworkProcessResourceIdentity::new(
+                    interface.source_index,
+                    &interface.resource_key,
+                    &interface.controller,
+                    interface.profile,
+                    interface.backend,
+                    interface.mmds_stack,
+                )
+            }),
+            self.network.mmds_state.as_ref(),
+            self.network.mmds_controller.as_ref(),
+            vsock,
+            &self.binding_keys,
+        )
+    }
+
+    pub(crate) fn matches_pci_platform_plan(
+        &self,
+        plan: &HvfSnapshotV2VsockPciPlatformPlan,
+    ) -> bool {
+        let Some(vsock) = self.vsock_identity() else {
+            return false;
+        };
+        plan.preflight_process_resource_identity(
+            self.network.interfaces.iter().map(|interface| {
+                HvfSnapshotV2NetworkProcessResourceIdentity::new(
+                    interface.source_index,
+                    &interface.resource_key,
+                    &interface.controller,
+                    interface.profile,
+                    interface.backend,
+                    interface.mmds_stack,
+                )
+            }),
+            self.network.mmds_state.as_ref(),
+            self.network.mmds_controller.as_ref(),
+            vsock,
+            &self.binding_keys,
+        )
+    }
+
     #[cfg(all(test, target_os = "macos"))]
     fn drop_last_binding_key_for_test(&mut self) {
         self.binding_keys.pop();
@@ -20600,6 +20661,15 @@ impl PreparedProcessSnapshotV2VsockResourcePlan {
         }
     }
 }
+
+type ProcessSnapshotV2VsockMmioPlatformPreflight =
+    fn(&PreparedProcessSnapshotV2VsockResourcePlan, &HvfSnapshotV2VsockMmioPlatformPlan) -> bool;
+type ProcessSnapshotV2VsockPciPlatformPreflight =
+    fn(&PreparedProcessSnapshotV2VsockResourcePlan, &HvfSnapshotV2VsockPciPlatformPlan) -> bool;
+const _: ProcessSnapshotV2VsockMmioPlatformPreflight =
+    PreparedProcessSnapshotV2VsockResourcePlan::matches_mmio_platform_plan;
+const _: ProcessSnapshotV2VsockPciPlatformPreflight =
+    PreparedProcessSnapshotV2VsockResourcePlan::matches_pci_platform_plan;
 
 fn prepare_process_snapshot_v2_vsock_resource_plan(
     candidate: PreparedNativeV2VsockSnapshotCandidateState,

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -32,6 +32,7 @@ mod snapshot_v2_multi_block_platform;
 mod snapshot_v2_network_platform;
 mod snapshot_v2_platform;
 mod snapshot_v2_storage_platform;
+mod snapshot_v2_vsock_platform;
 mod startup;
 mod topology;
 mod vcpu;
@@ -228,6 +229,18 @@ pub use snapshot_v2_storage_platform::{
     prepare_hvf_snapshot_v2_storage_entropy_mmio_platform_plan,
     prepare_hvf_snapshot_v2_storage_mmio_platform_plan,
     prepare_hvf_snapshot_v2_storage_pci_platform_plan,
+};
+pub use snapshot_v2_vsock_platform::{
+    HvfSnapshotV2VsockMmioEndpointPlan, HvfSnapshotV2VsockMmioPlatformPlan,
+    HvfSnapshotV2VsockMmioProcessConfig, HvfSnapshotV2VsockPciEndpointPlan,
+    HvfSnapshotV2VsockPciPlatformPlan, HvfSnapshotV2VsockPlatformPlanStage,
+    HvfSnapshotV2VsockPreparedEndpoint, HvfSnapshotV2VsockPreparedMemory,
+    HvfSnapshotV2VsockPreparedProduct, HvfSnapshotV2VsockPreparedProductParts,
+    HvfSnapshotV2VsockProcessResourceIdentity, HvfSnapshotV2VsockProductKind,
+    PrepareHvfSnapshotV2VsockPlatformPlanError, prepare_hvf_snapshot_v2_vsock_mmio_platform_plan,
+    prepare_hvf_snapshot_v2_vsock_mmio_platform_plan_with_cancel,
+    prepare_hvf_snapshot_v2_vsock_pci_platform_plan,
+    prepare_hvf_snapshot_v2_vsock_pci_platform_plan_with_cancel,
 };
 pub use startup::{
     HvfArm64BootBalloonCaptureError, HvfArm64BootBalloonCaptureState,

--- a/crates/hvf/src/snapshot_v2_network_platform.rs
+++ b/crates/hvf/src/snapshot_v2_network_platform.rs
@@ -41,7 +41,7 @@ use bangbang_runtime::snapshot_restore::{
 };
 use bangbang_runtime::storage_capture::StorageDeviceOrigin;
 use bangbang_runtime::virtio_mmio::VIRTIO_MMIO_DEVICE_WINDOW_SIZE;
-use bangbang_runtime::virtio_pci::VirtioPciEndpointPhase;
+use bangbang_runtime::virtio_pci::{VirtioPciEndpointPhase, VirtioPciMsixState};
 
 use crate::gic::{HvfGicInterruptLineAllocator, HvfGicMsiMetadata};
 use crate::memory::{
@@ -78,7 +78,7 @@ use crate::snapshot_v2_storage_platform::{
 use crate::startup::{
     PCI_ENDPOINT_SLOT_COUNT, pci_balloon_restore_gic_msi_configuration,
     pci_entropy_restore_gic_msi_configuration, pci_memory_hotplug_restore_gic_msi_configuration,
-    pci_root_restore_gic_msi_configuration,
+    pci_root_restore_gic_msi_configuration, pci_vsock_restore_gic_msi_configuration,
 };
 
 const REDACTED: &str = "<redacted>";
@@ -531,21 +531,21 @@ impl HvfSnapshotV2NetworkPreparedProduct {
         self.memory_hotplug_topology().is_some()
     }
 
-    fn memory_binding(&self) -> &SnapshotV2MemoryBinding {
+    pub(crate) fn memory_binding(&self) -> &SnapshotV2MemoryBinding {
         match self.base() {
             NetworkProductBase::Static(base) => &base.binding,
             NetworkProductBase::MemoryHotplug(base) => base.topology.memory().binding(),
         }
     }
 
-    fn network(&self) -> &PreparedSnapshotV2NetworkRestoreTopology {
+    pub(crate) fn network(&self) -> &PreparedSnapshotV2NetworkRestoreTopology {
         match self.base() {
             NetworkProductBase::Static(base) => &base.network,
             NetworkProductBase::MemoryHotplug(base) => &base.network,
         }
     }
 
-    fn storage(&self) -> Option<&PreparedSnapshotV2StorageBundle> {
+    pub(crate) fn storage(&self) -> Option<&PreparedSnapshotV2StorageBundle> {
         match &self.parts {
             HvfSnapshotV2NetworkPreparedProductParts::StorageNetwork { storage, .. }
             | HvfSnapshotV2NetworkPreparedProductParts::StorageEntropyNetwork {
@@ -580,7 +580,7 @@ impl HvfSnapshotV2NetworkPreparedProduct {
         }
     }
 
-    fn entropy(&self) -> Option<&SnapshotV2EntropyRestorePlan> {
+    pub(crate) fn entropy(&self) -> Option<&SnapshotV2EntropyRestorePlan> {
         match &self.parts {
             HvfSnapshotV2NetworkPreparedProductParts::EntropyNetwork { entropy, .. }
             | HvfSnapshotV2NetworkPreparedProductParts::StorageEntropyNetwork {
@@ -615,7 +615,7 @@ impl HvfSnapshotV2NetworkPreparedProduct {
         }
     }
 
-    fn balloon(&self) -> Option<&SnapshotV2BalloonRestorePlan> {
+    pub(crate) fn balloon(&self) -> Option<&SnapshotV2BalloonRestorePlan> {
         match &self.parts {
             HvfSnapshotV2NetworkPreparedProductParts::BalloonNetwork { balloon, .. }
             | HvfSnapshotV2NetworkPreparedProductParts::BalloonStorageNetwork {
@@ -650,14 +650,16 @@ impl HvfSnapshotV2NetworkPreparedProduct {
         }
     }
 
-    fn memory_hotplug_topology(&self) -> Option<&PreparedSnapshotV2MemoryHotplugTopology> {
+    pub(crate) fn memory_hotplug_topology(
+        &self,
+    ) -> Option<&PreparedSnapshotV2MemoryHotplugTopology> {
         match self.base() {
             NetworkProductBase::Static(_) => None,
             NetworkProductBase::MemoryHotplug(base) => Some(&base.topology),
         }
     }
 
-    fn memory_hotplug_memory(&self) -> Option<&GuestMemory> {
+    pub(crate) fn memory_hotplug_memory(&self) -> Option<&GuestMemory> {
         match self.base() {
             NetworkProductBase::Static(_) => None,
             NetworkProductBase::MemoryHotplug(base) => Some(&base.memory),
@@ -1219,6 +1221,38 @@ impl fmt::Debug for HvfSnapshotV2NetworkAuxiliaryPciEndpointPlan {
     }
 }
 
+const FOLLOWING_ENDPOINT_QUEUE_COUNT: usize = 3;
+
+#[derive(Clone, Copy)]
+pub(crate) struct HvfSnapshotV2NetworkMmioFollowingEndpointInput {
+    pub(crate) region: MmioRegion,
+    pub(crate) interrupt_line: GuestInterruptLine,
+    pub(crate) queue_ranges: [Option<[GuestMemoryRange; 3]>; FOLLOWING_ENDPOINT_QUEUE_COUNT],
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct HvfSnapshotV2NetworkMmioFollowingEndpointPlan {
+    pub(crate) placement: HvfSnapshotV2NetworkAuxiliaryMmioEndpointPlan,
+    pub(crate) queue_ranges: [Option<[GuestMemoryRange; 3]>; FOLLOWING_ENDPOINT_QUEUE_COUNT],
+}
+
+pub(crate) struct HvfSnapshotV2NetworkPciFollowingEndpointInput<'a> {
+    pub(crate) origin: StorageDeviceOrigin,
+    pub(crate) phase: VirtioPciEndpointPhase,
+    pub(crate) sbdf: PciSbdf,
+    pub(crate) bar_range: GuestMemoryRange,
+    pub(crate) queue_ranges: [Option<[GuestMemoryRange; 3]>; FOLLOWING_ENDPOINT_QUEUE_COUNT],
+    pub(crate) msix: &'a VirtioPciMsixState,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct HvfSnapshotV2NetworkPciFollowingEndpointPlan {
+    pub(crate) placement: HvfSnapshotV2NetworkAuxiliaryPciEndpointPlan,
+    pub(crate) queue_ranges: [Option<[GuestMemoryRange; 3]>; FOLLOWING_ENDPOINT_QUEUE_COUNT],
+    pub(crate) queue_vectors: [u16; FOLLOWING_ENDPOINT_QUEUE_COUNT],
+    pub(crate) config_vector: u16,
+}
+
 /// Complete immutable exact-2.11 MMIO product proof.
 pub struct HvfSnapshotV2NetworkMmioPlatformPlan {
     product: HvfSnapshotV2NetworkPreparedProduct,
@@ -1637,7 +1671,7 @@ impl std::error::Error for PrepareHvfSnapshotV2NetworkPlatformPlanError {
     }
 }
 
-trait NetworkPlatformPlanReserve {
+pub(crate) trait NetworkPlatformPlanReserve {
     fn reserve<T>(
         &mut self,
         values: &mut Vec<T>,
@@ -1650,7 +1684,7 @@ trait NetworkPlatformPlanReserve {
     ) -> Result<SnapshotRestoreResourceKey, PrepareHvfSnapshotV2NetworkPlatformPlanError>;
 }
 
-struct SystemNetworkPlatformPlanReserve;
+pub(crate) struct SystemNetworkPlatformPlanReserve;
 
 impl NetworkPlatformPlanReserve for SystemNetworkPlatformPlanReserve {
     fn reserve<T>(
@@ -1683,7 +1717,7 @@ fn check_cancel(
     }
 }
 
-fn validate_product(
+pub(crate) fn validate_product(
     platform: &HvfSnapshotV2PlatformState,
     product: &HvfSnapshotV2NetworkPreparedProduct,
 ) -> Result<SnapshotV2DeviceTransportKind, PrepareHvfSnapshotV2NetworkPlatformPlanError> {
@@ -1915,6 +1949,27 @@ fn mmio_auxiliary_endpoint(
     })
 }
 
+fn prepare_mmio_following_endpoint(
+    platform: &HvfSnapshotV2PlatformState,
+    input: HvfSnapshotV2NetworkMmioFollowingEndpointInput,
+) -> Result<
+    HvfSnapshotV2NetworkMmioFollowingEndpointPlan,
+    PrepareHvfSnapshotV2NetworkPlatformPlanError,
+> {
+    let placement = mmio_auxiliary_endpoint(platform, input.region, input.interrupt_line, None)?;
+    for ranges in input.queue_ranges.iter().copied().flatten() {
+        if queue_ranges_conflict_with_platform(platform, Some(ranges))
+            .map_err(|_| PrepareHvfSnapshotV2NetworkPlatformPlanError::ResourcePlan)?
+        {
+            return Err(PrepareHvfSnapshotV2NetworkPlatformPlanError::RangeConflict);
+        }
+    }
+    Ok(HvfSnapshotV2NetworkMmioFollowingEndpointPlan {
+        placement,
+        queue_ranges: input.queue_ranges,
+    })
+}
+
 fn prepare_network_mmio_endpoint(
     platform: &HvfSnapshotV2PlatformState,
     interface: &PreparedSnapshotV2NetworkRestoreInterface,
@@ -2022,6 +2077,7 @@ fn validate_mmio_interrupt_sequence(
     balloon: Option<HvfSnapshotV2BalloonMmioEndpointPlan>,
     storage: Option<&HvfSnapshotV2StorageMmioPlatformPlan>,
     network: &[HvfSnapshotV2NetworkMmioEndpointPlan],
+    following: Option<HvfSnapshotV2NetworkMmioFollowingEndpointPlan>,
     entropy: Option<HvfSnapshotV2NetworkAuxiliaryMmioEndpointPlan>,
     memory_hotplug: Option<HvfSnapshotV2NetworkAuxiliaryMmioEndpointPlan>,
 ) -> Result<
@@ -2060,6 +2116,9 @@ fn validate_mmio_interrupt_sequence(
             validate(record.interrupt_line())?;
         }
     }
+    if let Some(following) = following {
+        validate(following.placement.interrupt_line())?;
+    }
     if let Some(entropy) = entropy {
         validate(entropy.interrupt_line())?;
     }
@@ -2097,9 +2156,14 @@ pub fn prepare_hvf_snapshot_v2_network_mmio_platform_plan(
         platform,
         product,
         process,
+        None,
         &mut SystemNetworkPlatformPlanReserve,
         &mut |_| false,
     )
+    .map(|(plan, following)| {
+        debug_assert!(following.is_none());
+        plan
+    })
 }
 
 /// Proves one MMIO product with stable owner-free cancellation checkpoints.
@@ -2116,18 +2180,30 @@ where
         platform,
         product,
         process,
+        None,
         &mut SystemNetworkPlatformPlanReserve,
         &mut is_cancelled,
     )
+    .map(|(plan, following)| {
+        debug_assert!(following.is_none());
+        plan
+    })
 }
 
-fn prepare_network_mmio_platform_plan(
+pub(crate) fn prepare_network_mmio_platform_plan(
     platform: &HvfSnapshotV2PlatformState,
     product: HvfSnapshotV2NetworkPreparedProduct,
     process: HvfSnapshotV2NetworkMmioProcessConfig,
+    following_input: Option<HvfSnapshotV2NetworkMmioFollowingEndpointInput>,
     reserve: &mut impl NetworkPlatformPlanReserve,
     is_cancelled: &mut impl FnMut(HvfSnapshotV2NetworkPlatformPlanStage) -> bool,
-) -> Result<HvfSnapshotV2NetworkMmioPlatformPlan, PrepareHvfSnapshotV2NetworkPlatformPlanError> {
+) -> Result<
+    (
+        HvfSnapshotV2NetworkMmioPlatformPlan,
+        Option<HvfSnapshotV2NetworkMmioFollowingEndpointPlan>,
+    ),
+    PrepareHvfSnapshotV2NetworkPlatformPlanError,
+> {
     check_cancel(is_cancelled, HvfSnapshotV2NetworkPlatformPlanStage::Start)?;
     if validate_product(platform, &product)? != SnapshotV2DeviceTransportKind::Mmio {
         return Err(PrepareHvfSnapshotV2NetworkPlatformPlanError::TransportPolicy);
@@ -2166,6 +2242,9 @@ fn prepare_network_mmio_platform_plan(
             )
         })
         .transpose()?;
+    let following = following_input
+        .map(|input| prepare_mmio_following_endpoint(platform, input))
+        .transpose()?;
 
     let interfaces = product.network().interfaces();
     let mut network = Vec::new();
@@ -2193,11 +2272,15 @@ fn prepare_network_mmio_platform_plan(
     inserted_endpoints.extend(network.iter().map(|endpoint| {
         HvfSnapshotV2StorageMmioInsertedEndpoint::new(endpoint.region(), endpoint.interrupt_line())
     }));
-    let following_count = usize::from(entropy.is_some())
-        .checked_add(usize::from(memory_hotplug.is_some()))
+    let following_count = usize::from(following.is_some())
+        .checked_add(usize::from(entropy.is_some()))
+        .and_then(|count| count.checked_add(usize::from(memory_hotplug.is_some())))
         .ok_or(PrepareHvfSnapshotV2NetworkPlatformPlanError::ResourcePlan)?;
     let mut following_interrupts = Vec::new();
     reserve.reserve(&mut following_interrupts, following_count)?;
+    if let Some(following) = following {
+        following_interrupts.push(following.placement.interrupt_line());
+    }
     if let Some(entropy) = entropy {
         following_interrupts.push(entropy.interrupt_line());
     }
@@ -2229,6 +2312,7 @@ fn prepare_network_mmio_platform_plan(
             balloon,
             storage.as_ref(),
             &network,
+            following,
             entropy,
             memory_hotplug,
         )?;
@@ -2243,6 +2327,7 @@ fn prepare_network_mmio_platform_plan(
         balloon,
         storage.as_ref(),
         &network,
+        following,
         entropy,
         memory_hotplug,
         reserve,
@@ -2251,18 +2336,21 @@ fn prepare_network_mmio_platform_plan(
         is_cancelled,
         HvfSnapshotV2NetworkPlatformPlanStage::Completion,
     )?;
-    Ok(HvfSnapshotV2NetworkMmioPlatformPlan {
-        product,
-        mapping,
-        balloon,
-        storage,
-        network,
-        entropy,
-        memory_hotplug,
-        serial_interrupt,
-        vmgenid_interrupt,
-        vmclock_interrupt,
-    })
+    Ok((
+        HvfSnapshotV2NetworkMmioPlatformPlan {
+            product,
+            mapping,
+            balloon,
+            storage,
+            network,
+            entropy,
+            memory_hotplug,
+            serial_interrupt,
+            vmgenid_interrupt,
+            vmclock_interrupt,
+        },
+        following,
+    ))
 }
 
 fn checked_queue_range_count(
@@ -2447,6 +2535,7 @@ fn validate_mmio_inventory(
     balloon: Option<HvfSnapshotV2BalloonMmioEndpointPlan>,
     storage: Option<&HvfSnapshotV2StorageMmioPlatformPlan>,
     network: &[HvfSnapshotV2NetworkMmioEndpointPlan],
+    following: Option<HvfSnapshotV2NetworkMmioFollowingEndpointPlan>,
     entropy: Option<HvfSnapshotV2NetworkAuxiliaryMmioEndpointPlan>,
     memory_hotplug: Option<HvfSnapshotV2NetworkAuxiliaryMmioEndpointPlan>,
     reserve: &mut impl NetworkPlatformPlanReserve,
@@ -2464,6 +2553,7 @@ fn validate_mmio_inventory(
     let region_count = usize::from(balloon.is_some())
         .checked_add(storage_region_count)
         .and_then(|count| count.checked_add(network.len()))
+        .and_then(|count| count.checked_add(usize::from(following.is_some())))
         .and_then(|count| count.checked_add(usize::from(entropy.is_some())))
         .and_then(|count| count.checked_add(usize::from(memory_hotplug.is_some())))
         .ok_or(PrepareHvfSnapshotV2NetworkPlatformPlanError::ResourcePlan)?;
@@ -2471,7 +2561,12 @@ fn validate_mmio_inventory(
         product,
         network
             .iter()
-            .flat_map(|endpoint| endpoint.queue_ranges().iter().copied()),
+            .flat_map(|endpoint| endpoint.queue_ranges().iter().copied())
+            .chain(
+                following
+                    .into_iter()
+                    .flat_map(|endpoint| endpoint.queue_ranges),
+            ),
     )?;
     let pmem_count = product
         .storage()
@@ -2498,6 +2593,9 @@ fn validate_mmio_inventory(
     if let Some(storage) = storage {
         regions.extend(storage.pmem_records().iter().map(|record| record.region()));
     }
+    if let Some(following) = following {
+        regions.push(following.placement.region());
+    }
     if let Some(entropy) = entropy {
         regions.push(entropy.region());
     }
@@ -2511,6 +2609,11 @@ fn validate_mmio_inventory(
         .flat_map(|endpoint| endpoint.queue_ranges().iter().copied().flatten())
     {
         queues.extend_from_slice(&ranges);
+    }
+    if let Some(following) = following {
+        for ranges in following.queue_ranges.into_iter().flatten() {
+            queues.extend_from_slice(&ranges);
+        }
     }
     if regions.len() != region_count
         || device_ranges.len() != region_count
@@ -2531,6 +2634,7 @@ fn validate_mmio_inventory(
 
 fn expected_pci_msi_interrupt_count(
     product: &HvfSnapshotV2NetworkPreparedProduct,
+    has_following_endpoint: bool,
 ) -> Result<u32, PrepareHvfSnapshotV2NetworkPlatformPlanError> {
     let balloon_queue_count = product
         .balloon()
@@ -2541,7 +2645,13 @@ fn expected_pci_msi_interrupt_count(
             Ok(transport.device().queue_layout().queue_count())
         })
         .transpose()?;
-    let configuration = if product.memory_hotplug_topology().is_some() {
+    let configuration = if has_following_endpoint {
+        pci_vsock_restore_gic_msi_configuration(
+            balloon_queue_count,
+            product.entropy().is_some(),
+            product.memory_hotplug_topology().is_some(),
+        )
+    } else if product.memory_hotplug_topology().is_some() {
         pci_memory_hotplug_restore_gic_msi_configuration(
             balloon_queue_count,
             product.entropy().is_some(),
@@ -2714,6 +2824,64 @@ fn prepare_memory_hotplug_pci_endpoint(
     })
 }
 
+fn prepare_pci_following_endpoint(
+    platform: &HvfSnapshotV2PlatformState,
+    input: &HvfSnapshotV2NetworkPciFollowingEndpointInput<'_>,
+    address_plan: Arm64PciAddressPlan,
+    msi: HvfGicMsiMetadata,
+    expected_msi_interrupt_count: u32,
+    slot: usize,
+) -> Result<
+    HvfSnapshotV2NetworkPciFollowingEndpointPlan,
+    PrepareHvfSnapshotV2NetworkPlatformPlanError,
+> {
+    let placement = snapshot_v2_pci_endpoint_placement(address_plan, slot)
+        .ok_or(PrepareHvfSnapshotV2NetworkPlatformPlanError::ResourcePlan)?;
+    let route_count = snapshot_v2_pci_endpoint_route_count(FOLLOWING_ENDPOINT_QUEUE_COUNT)
+        .filter(|count| *count == FOLLOWING_ENDPOINT_QUEUE_COUNT + 1)
+        .ok_or(PrepareHvfSnapshotV2NetworkPlatformPlanError::ResourcePlan)?;
+    let queue_vectors: [u16; FOLLOWING_ENDPOINT_QUEUE_COUNT] = input
+        .msix
+        .queue_vectors()
+        .try_into()
+        .map_err(|_| PrepareHvfSnapshotV2NetworkPlatformPlanError::ResourcePlan)?;
+    if msi.interrupt_range.count != expected_msi_interrupt_count
+        || input.origin != StorageDeviceOrigin::Startup
+        || input.phase != VirtioPciEndpointPhase::Active
+        || input.msix.vector_count() != route_count
+    {
+        return Err(PrepareHvfSnapshotV2NetworkPlatformPlanError::ResourcePlan);
+    }
+    if input.sbdf != placement.sbdf || input.bar_range != placement.bar_range {
+        return Err(PrepareHvfSnapshotV2NetworkPlatformPlanError::Placement);
+    }
+    for ranges in input.queue_ranges.iter().copied().flatten() {
+        if queue_ranges_conflict_with_pci_platform(
+            platform,
+            Some(ranges),
+            &platform.global().compatibility().gic_metadata(),
+            address_plan,
+        )
+        .map_err(|_| PrepareHvfSnapshotV2NetworkPlatformPlanError::ResourcePlan)?
+        {
+            return Err(PrepareHvfSnapshotV2NetworkPlatformPlanError::RangeConflict);
+        }
+    }
+    Ok(HvfSnapshotV2NetworkPciFollowingEndpointPlan {
+        placement: HvfSnapshotV2NetworkAuxiliaryPciEndpointPlan {
+            origin: input.origin,
+            sbdf: placement.sbdf,
+            bar_region_id: placement.bar_region_id,
+            bar_range: placement.bar_range,
+            route_count,
+            msi_interrupt_count: expected_msi_interrupt_count,
+        },
+        queue_ranges: input.queue_ranges,
+        queue_vectors,
+        config_vector: input.msix.config_vector(),
+    })
+}
+
 fn validate_pci_fixed_interrupts(
     platform: &HvfSnapshotV2PlatformState,
     storage: Option<&HvfSnapshotV2StoragePciPlatformPlan>,
@@ -2754,9 +2922,14 @@ pub fn prepare_hvf_snapshot_v2_network_pci_platform_plan(
     prepare_network_pci_platform_plan(
         platform,
         product,
+        None,
         &mut SystemNetworkPlatformPlanReserve,
         &mut |_| false,
     )
+    .map(|(plan, following)| {
+        debug_assert!(following.is_none());
+        plan
+    })
 }
 
 /// Proves one PCI product with stable owner-free cancellation checkpoints.
@@ -2771,17 +2944,29 @@ where
     prepare_network_pci_platform_plan(
         platform,
         product,
+        None,
         &mut SystemNetworkPlatformPlanReserve,
         &mut is_cancelled,
     )
+    .map(|(plan, following)| {
+        debug_assert!(following.is_none());
+        plan
+    })
 }
 
-fn prepare_network_pci_platform_plan(
+pub(crate) fn prepare_network_pci_platform_plan(
     platform: &HvfSnapshotV2PlatformState,
     product: HvfSnapshotV2NetworkPreparedProduct,
+    following_input: Option<HvfSnapshotV2NetworkPciFollowingEndpointInput<'_>>,
     reserve: &mut impl NetworkPlatformPlanReserve,
     is_cancelled: &mut impl FnMut(HvfSnapshotV2NetworkPlatformPlanStage) -> bool,
-) -> Result<HvfSnapshotV2NetworkPciPlatformPlan, PrepareHvfSnapshotV2NetworkPlatformPlanError> {
+) -> Result<
+    (
+        HvfSnapshotV2NetworkPciPlatformPlan,
+        Option<HvfSnapshotV2NetworkPciFollowingEndpointPlan>,
+    ),
+    PrepareHvfSnapshotV2NetworkPlatformPlanError,
+> {
     check_cancel(is_cancelled, HvfSnapshotV2NetworkPlatformPlanStage::Start)?;
     if validate_product(platform, &product)? != SnapshotV2DeviceTransportKind::Pci {
         return Err(PrepareHvfSnapshotV2NetworkPlatformPlanError::TransportPolicy);
@@ -2797,7 +2982,8 @@ fn prepare_network_pci_platform_plan(
         .gic_metadata()
         .msi
         .ok_or(PrepareHvfSnapshotV2NetworkPlatformPlanError::TransportPolicy)?;
-    let expected_msi_interrupt_count = expected_pci_msi_interrupt_count(&product)?;
+    let expected_msi_interrupt_count =
+        expected_pci_msi_interrupt_count(&product, following_input.is_some())?;
     if msi.interrupt_range.count != expected_msi_interrupt_count {
         return Err(PrepareHvfSnapshotV2NetworkPlatformPlanError::ResourcePlan);
     }
@@ -2837,8 +3023,11 @@ fn prepare_network_pci_platform_plan(
         .storage()
         .map_or(0, |storage| storage.pmem_records().len());
     let network_count = product.network().interfaces().len();
-    let reserved_following = usize::from(product.entropy().is_some())
-        .checked_add(usize::from(product.memory_hotplug_topology().is_some()))
+    let reserved_following = usize::from(following_input.is_some())
+        .checked_add(usize::from(product.entropy().is_some()))
+        .and_then(|count| {
+            count.checked_add(usize::from(product.memory_hotplug_topology().is_some()))
+        })
         .ok_or(PrepareHvfSnapshotV2NetworkPlatformPlanError::ResourcePlan)?;
 
     let storage = product
@@ -2888,9 +3077,25 @@ fn prepare_network_pci_platform_plan(
             reserve,
         )?);
     }
-    let entropy_slot = network_start
+    let following_slot = network_start
         .checked_add(network_count)
         .and_then(|slot| slot.checked_add(pmem_count))
+        .ok_or(PrepareHvfSnapshotV2NetworkPlatformPlanError::ResourcePlan)?;
+    let following = following_input
+        .as_ref()
+        .map(|input| {
+            prepare_pci_following_endpoint(
+                platform,
+                input,
+                address_plan,
+                msi,
+                expected_msi_interrupt_count,
+                following_slot,
+            )
+        })
+        .transpose()?;
+    let entropy_slot = following_slot
+        .checked_add(usize::from(following.is_some()))
         .ok_or(PrepareHvfSnapshotV2NetworkPlatformPlanError::ResourcePlan)?;
     let entropy = product
         .entropy()
@@ -2924,12 +3129,7 @@ fn prepare_network_pci_platform_plan(
     let endpoint_count = memory_hotplug_slot
         .checked_add(usize::from(memory_hotplug.is_some()))
         .ok_or(PrepareHvfSnapshotV2NetworkPlatformPlanError::ResourcePlan)?;
-    if endpoint_count > PCI_ENDPOINT_SLOT_COUNT {
-        return Err(PrepareHvfSnapshotV2NetworkPlatformPlanError::PciCapacity {
-            count: endpoint_count,
-            maximum: PCI_ENDPOINT_SLOT_COUNT,
-        });
-    }
+    validate_pci_endpoint_capacity(endpoint_count)?;
     check_cancel(
         is_cancelled,
         HvfSnapshotV2NetworkPlatformPlanStage::Components,
@@ -2948,6 +3148,9 @@ fn prepare_network_pci_platform_plan(
                 .and_then(|network| count.checked_add(network))
         })
         .and_then(|count| {
+            count.checked_add(following.map_or(0, |endpoint| endpoint.placement.route_count()))
+        })
+        .and_then(|count| {
             count.checked_add(
                 entropy.map_or(0, HvfSnapshotV2NetworkAuxiliaryPciEndpointPlan::route_count),
             )
@@ -2964,7 +3167,13 @@ fn prepare_network_pci_platform_plan(
     {
         return Err(PrepareHvfSnapshotV2NetworkPlatformPlanError::RouteConflict);
     }
-    validate_active_pci_routes(&product, msi, route_demand, reserve)?;
+    validate_active_pci_routes(
+        &product,
+        following_input.as_ref(),
+        msi,
+        route_demand,
+        reserve,
+    )?;
     let (serial_interrupt, vmgenid_interrupt, vmclock_interrupt) =
         validate_pci_fixed_interrupts(platform, storage.as_ref())?;
     check_cancel(
@@ -2977,6 +3186,7 @@ fn prepare_network_pci_platform_plan(
         balloon,
         storage.as_ref(),
         &network,
+        following,
         entropy,
         memory_hotplug,
         endpoint_count,
@@ -2986,26 +3196,30 @@ fn prepare_network_pci_platform_plan(
         is_cancelled,
         HvfSnapshotV2NetworkPlatformPlanStage::Completion,
     )?;
-    Ok(HvfSnapshotV2NetworkPciPlatformPlan {
-        product,
-        mapping,
-        balloon,
-        storage,
-        network,
-        entropy,
-        memory_hotplug,
-        host,
-        msi,
-        endpoint_count,
-        route_demand,
-        serial_interrupt,
-        vmgenid_interrupt,
-        vmclock_interrupt,
-    })
+    Ok((
+        HvfSnapshotV2NetworkPciPlatformPlan {
+            product,
+            mapping,
+            balloon,
+            storage,
+            network,
+            entropy,
+            memory_hotplug,
+            host,
+            msi,
+            endpoint_count,
+            route_demand,
+            serial_interrupt,
+            vmgenid_interrupt,
+            vmclock_interrupt,
+        },
+        following,
+    ))
 }
 
 fn validate_active_pci_routes(
     product: &HvfSnapshotV2NetworkPreparedProduct,
+    following: Option<&HvfSnapshotV2NetworkPciFollowingEndpointInput<'_>>,
     msi: HvfGicMsiMetadata,
     route_demand: usize,
     reserve: &mut impl NetworkPlatformPlanReserve,
@@ -3064,6 +3278,17 @@ fn validate_active_pci_routes(
             return Err(PrepareHvfSnapshotV2NetworkPlatformPlanError::RouteConflict);
         }
     }
+    if let Some(following) = following
+        && !register_active_retained_pci_routes(
+            following.msix,
+            msi,
+            FOLLOWING_ENDPOINT_QUEUE_COUNT,
+            FOLLOWING_ENDPOINT_QUEUE_COUNT + 1,
+            &mut active_routes,
+        )
+    {
+        return Err(PrepareHvfSnapshotV2NetworkPlatformPlanError::RouteConflict);
+    }
     if let Some(entropy) = product.entropy() {
         let PreparedSnapshotV2EntropyTransport::Pci(transport) = entropy.transport() else {
             return Err(PrepareHvfSnapshotV2NetworkPlatformPlanError::TransportPolicy);
@@ -3106,6 +3331,7 @@ fn validate_pci_inventory(
     balloon: Option<HvfSnapshotV2BalloonPciEndpointPlan>,
     storage: Option<&HvfSnapshotV2StoragePciPlatformPlan>,
     network: &[HvfSnapshotV2NetworkPciEndpointPlan],
+    following: Option<HvfSnapshotV2NetworkPciFollowingEndpointPlan>,
     entropy: Option<HvfSnapshotV2NetworkAuxiliaryPciEndpointPlan>,
     memory_hotplug: Option<HvfSnapshotV2NetworkAuxiliaryPciEndpointPlan>,
     endpoint_count: usize,
@@ -3115,7 +3341,12 @@ fn validate_pci_inventory(
         product,
         network
             .iter()
-            .flat_map(|endpoint| endpoint.queue_ranges().iter().copied()),
+            .flat_map(|endpoint| endpoint.queue_ranges().iter().copied())
+            .chain(
+                following
+                    .into_iter()
+                    .flat_map(|endpoint| endpoint.queue_ranges),
+            ),
     )?;
     let pmem_count = product
         .storage()
@@ -3160,6 +3391,10 @@ fn validate_pci_inventory(
             .iter()
             .map(HvfSnapshotV2NetworkPciEndpointPlan::bar_range),
     );
+    if let Some(following) = following {
+        bar_ids.push(following.placement.bar_region_id());
+        bars.push(following.placement.bar_range());
+    }
     if let Some(entropy) = entropy {
         bar_ids.push(entropy.bar_region_id());
         bars.push(entropy.bar_range());
@@ -3174,6 +3409,11 @@ fn validate_pci_inventory(
         .flat_map(|endpoint| endpoint.queue_ranges().iter().copied().flatten())
     {
         queues.extend_from_slice(&ranges);
+    }
+    if let Some(following) = following {
+        for ranges in following.queue_ranges.into_iter().flatten() {
+            queues.extend_from_slice(&ranges);
+        }
     }
     if bar_ids.len() != endpoint_count
         || bars.len() != endpoint_count
@@ -3250,6 +3490,19 @@ fn gic_region_range(
         .map_err(|_| PrepareHvfSnapshotV2NetworkPlatformPlanError::ResourcePlan)
 }
 
+fn validate_pci_endpoint_capacity(
+    endpoint_count: usize,
+) -> Result<(), PrepareHvfSnapshotV2NetworkPlatformPlanError> {
+    if endpoint_count > PCI_ENDPOINT_SLOT_COUNT {
+        Err(PrepareHvfSnapshotV2NetworkPlatformPlanError::PciCapacity {
+            count: endpoint_count,
+            maximum: PCI_ENDPOINT_SLOT_COUNT,
+        })
+    } else {
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod fixture_identity_tests {
     use bangbang_runtime::balloon::VIRTIO_BALLOON_MAX_QUEUE_COUNT;
@@ -3268,6 +3521,15 @@ mod fixture_identity_tests {
         SnapshotV2MmdsState, SnapshotV2NetworkBackendClass, SnapshotV2NetworkInterfaceState,
         SnapshotV2NetworkInterfaceStateParts, SnapshotV2NetworkState,
     };
+    use bangbang_runtime::snapshot_restore::{
+        SnapshotRestorePublicId, SnapshotRestoreResourceClass, SnapshotRestoreResourceKey,
+    };
+    use bangbang_runtime::snapshot_vsock_restore_v2_12::PreparedSnapshotV2VsockRestoreTopology;
+    use bangbang_runtime::snapshot_vsock_v2_12::{
+        NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION, SnapshotV2VsockState,
+        SnapshotV2VsockStateParts,
+    };
+    use bangbang_runtime::vsock::{VIRTIO_VSOCK_QUEUE_COUNT, VsockConfigInput, VsockMmioLayout};
 
     use super::*;
     use crate::gic::{HvfGicInterruptRange, HvfGicRegion};
@@ -3275,7 +3537,7 @@ mod fixture_identity_tests {
         HvfSnapshotV2MachineState, HvfSnapshotV2PlatformState, tests::product_storage_fixture,
     };
     use crate::snapshot_v2_memory_hotplug_platform::tests::{
-        MaterializedFixture, balloon_mmio_plan, balloon_pci_plan, entropy_mmio_plan,
+        MaterializedFixture, TestImage, balloon_mmio_plan, balloon_pci_plan, entropy_mmio_plan,
         entropy_pci_plan, materialized_fixture, memory_hotplug_mmio_state,
         memory_hotplug_pci_state, mmio_platform as memory_fixture_mmio_platform,
         pci_platform as memory_fixture_pci_platform, prepared_storage_bundle,
@@ -3284,6 +3546,18 @@ mod fixture_identity_tests {
     use crate::snapshot_v2_multi_block_platform::tests::{
         product_mmio_platform, product_pci_platform,
     };
+    use crate::snapshot_v2_vsock_platform::{
+        HvfSnapshotV2VsockMmioProcessConfig, HvfSnapshotV2VsockPlatformPlanStage,
+        HvfSnapshotV2VsockPreparedEndpoint, HvfSnapshotV2VsockPreparedMemory,
+        HvfSnapshotV2VsockPreparedProduct, HvfSnapshotV2VsockPreparedProductParts,
+        HvfSnapshotV2VsockProcessResourceIdentity, HvfSnapshotV2VsockProductKind,
+        PrepareHvfSnapshotV2VsockPlatformPlanError,
+        prepare_hvf_snapshot_v2_vsock_mmio_platform_plan,
+        prepare_hvf_snapshot_v2_vsock_mmio_platform_plan_with_cancel,
+        prepare_hvf_snapshot_v2_vsock_pci_platform_plan, prepare_vsock_mmio_platform_plan,
+        prepare_vsock_pci_platform_plan,
+    };
+    use crate::startup::pci_vsock_restore_gic_msi_configuration;
 
     const ACTIVE_PCI_MMDS_HEX: &str =
         include_str!("../../runtime/src/snapshot_network_v2_11/fixtures/active-pci-mmds.hex");
@@ -3296,6 +3570,16 @@ mod fixture_identity_tests {
     const NETWORK_QUEUE_STRIDE: u64 = 0x1_0000;
     const DRIVER_RING_OFFSET: u64 = 0x2000;
     const DEVICE_RING_OFFSET: u64 = 0x4000;
+    const VSOCK_QUEUE_BASE: u64 = 0x8030_0000;
+    const VSOCK_MMIO_BASE: GuestAddress = GuestAddress::new(0x7000_0000);
+    const VSOCK_MMIO_REGION_ID: MmioRegionId = MmioRegionId::new(2000);
+    const VSOCK_SECTION_DIRECTORY_OFFSET: usize = 64;
+    const VSOCK_SECTION_ENTRY_BYTES: usize = 32;
+    const VSOCK_LOCAL_QUEUE_CURSORS_OFFSET: usize = 20;
+    const VSOCK_LOCAL_QUEUE_CURSORS_BYTES: usize = VIRTIO_VSOCK_QUEUE_COUNT * 4;
+    const VSOCK_COMMON_FIXED_BYTES: usize = 32;
+    const VSOCK_COMMON_QUEUE_BYTES: usize = 32;
+    const VSOCK_COMMON_INTERRUPT_INTENT_BYTES: usize = 4;
     const PCI_FIXED_BYTES: usize = 72;
     const PCI_WRITABLE_ENTRY_BYTES: usize = 4;
     const PCI_BAR_PROBE_ENTRY_BYTES: usize = 4;
@@ -3343,6 +3627,10 @@ mod fixture_identity_tests {
 
     fn write_u32(bytes: &mut [u8], offset: usize, value: u32) {
         bytes[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+    }
+
+    fn write_u16(bytes: &mut [u8], offset: usize, value: u16) {
+        bytes[offset..offset + 2].copy_from_slice(&value.to_le_bytes());
     }
 
     fn write_u64(bytes: &mut [u8], offset: usize, value: u64) {
@@ -3429,6 +3717,452 @@ mod fixture_identity_tests {
             write_u32(bytes, entry_offset + 8, message_data);
             entry_offset += PCI_MSIX_ENTRY_BYTES;
         }
+    }
+
+    fn vsock_section_offset(bytes: &[u8], section_index: usize) -> usize {
+        let entry = VSOCK_SECTION_DIRECTORY_OFFSET + section_index * VSOCK_SECTION_ENTRY_BYTES;
+        usize::try_from(read_u64(bytes, entry + 8)).expect("vsock section offset should fit")
+    }
+
+    fn decode_vsock(bytes: &[u8]) -> SnapshotV2VsockState {
+        SnapshotV2VsockState::decode(NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION, bytes)
+            .expect("relocated vsock fixture should decode")
+    }
+
+    fn zero_active_vsock_queue_cursors(bytes: &mut [u8]) {
+        let local_offset = vsock_section_offset(bytes, 0);
+        bytes[local_offset + VSOCK_LOCAL_QUEUE_CURSORS_OFFSET
+            ..local_offset + VSOCK_LOCAL_QUEUE_CURSORS_OFFSET + VSOCK_LOCAL_QUEUE_CURSORS_BYTES]
+            .fill(0);
+    }
+
+    fn normalize_active_vsock_common_for_mmio(bytes: &mut Vec<u8>) {
+        let common_entry = VSOCK_SECTION_DIRECTORY_OFFSET + VSOCK_SECTION_ENTRY_BYTES;
+        let transport_entry = VSOCK_SECTION_DIRECTORY_OFFSET + 2 * VSOCK_SECTION_ENTRY_BYTES;
+        let common_offset = vsock_section_offset(bytes, 1);
+        let transport_offset = vsock_section_offset(bytes, 2);
+        let queue_count = usize::from(read_u16(bytes, common_offset + 26));
+        let notification_count = usize::from(read_u16(bytes, common_offset + 28));
+        let intent_count = usize::from(read_u16(bytes, common_offset + 30));
+        assert_eq!(queue_count, VIRTIO_VSOCK_QUEUE_COUNT);
+        assert_eq!(notification_count, VIRTIO_VSOCK_QUEUE_COUNT);
+        assert_eq!(intent_count, VIRTIO_VSOCK_QUEUE_COUNT + 1);
+
+        let intents_offset = common_offset
+            + VSOCK_COMMON_FIXED_BYTES
+            + queue_count * VSOCK_COMMON_QUEUE_BYTES
+            + notification_count * 2;
+        let configuration_intent_offset =
+            intents_offset + VIRTIO_VSOCK_QUEUE_COUNT * VSOCK_COMMON_INTERRUPT_INTENT_BYTES;
+        let removed_start = intents_offset + VSOCK_COMMON_INTERRUPT_INTENT_BYTES;
+        let removed_end = configuration_intent_offset;
+        bytes.drain(removed_start..removed_end);
+        write_u16(bytes, common_offset + 30, 2);
+
+        let removed_bytes = u64::try_from(removed_end - removed_start)
+            .expect("removed common intent bytes should fit");
+        let total_bytes = read_u64(bytes, 24)
+            .checked_sub(removed_bytes)
+            .expect("shortened vsock payload should fit");
+        let common_bytes = read_u64(bytes, common_entry + 16)
+            .checked_sub(removed_bytes)
+            .expect("shortened common section should fit");
+        let transport_offset = u64::try_from(transport_offset)
+            .expect("transport offset should fit")
+            .checked_sub(removed_bytes)
+            .expect("shortened transport offset should fit");
+        write_u64(bytes, 24, total_bytes);
+        write_u64(bytes, common_entry + 16, common_bytes);
+        write_u64(bytes, transport_entry + 8, transport_offset);
+    }
+
+    fn active_mmio_vsock_state(interrupt: u32) -> SnapshotV2VsockState {
+        let mut bytes = fixture_bytes(include_str!(
+            "../../runtime/src/snapshot_vsock_v2_12/fixtures/active-pci.hex"
+        ));
+        zero_active_vsock_queue_cursors(&mut bytes);
+        let common_offset = vsock_section_offset(&bytes, 1);
+        relocate_queues(&mut bytes, common_offset, VSOCK_QUEUE_BASE);
+        normalize_active_vsock_common_for_mmio(&mut bytes);
+        let source = decode_vsock(&bytes);
+        let SnapshotV2VsockStateParts {
+            guest_cid,
+            backend_selector,
+            host_local_port_cursor,
+            active_queues,
+            virtio,
+            transport,
+        } = source.into_parts();
+        let SnapshotV2DeviceTransport::Pci(pci) = transport else {
+            panic!("active vsock source should be PCI");
+        };
+        let region = MmioRegion::new(
+            VSOCK_MMIO_REGION_ID,
+            VSOCK_MMIO_BASE,
+            VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+        )
+        .expect("vsock MMIO region should validate");
+        SnapshotV2VsockState::try_from_parts(SnapshotV2VsockStateParts {
+            guest_cid,
+            backend_selector,
+            host_local_port_cursor,
+            active_queues,
+            virtio,
+            transport: SnapshotV2DeviceTransport::Mmio(SnapshotV2MmioDeviceState::from_parts(
+                pci.device_feature_select(),
+                pci.driver_feature_select(),
+                u32::from(pci.queue_select()),
+                region,
+                GuestInterruptLine::new(interrupt).expect("vsock interrupt should validate"),
+            )),
+        })
+        .expect("active MMIO vsock state should validate")
+    }
+
+    fn inactive_mmio_vsock_state(interrupt: u32) -> SnapshotV2VsockState {
+        let source = decode_vsock(&fixture_bytes(include_str!(
+            "../../runtime/src/snapshot_vsock_v2_12/fixtures/inactive-mmio.hex"
+        )));
+        let SnapshotV2VsockStateParts {
+            guest_cid,
+            backend_selector,
+            host_local_port_cursor,
+            active_queues,
+            virtio,
+            transport,
+        } = source.into_parts();
+        let SnapshotV2DeviceTransport::Mmio(mmio) = transport else {
+            panic!("inactive vsock source should be MMIO");
+        };
+        let region = MmioRegion::new(
+            VSOCK_MMIO_REGION_ID,
+            VSOCK_MMIO_BASE,
+            VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+        )
+        .expect("vsock MMIO region should validate");
+        SnapshotV2VsockState::try_from_parts(SnapshotV2VsockStateParts {
+            guest_cid,
+            backend_selector,
+            host_local_port_cursor,
+            active_queues,
+            virtio,
+            transport: SnapshotV2DeviceTransport::Mmio(SnapshotV2MmioDeviceState::from_parts(
+                mmio.device_feature_select(),
+                mmio.driver_feature_select(),
+                mmio.queue_select(),
+                region,
+                GuestInterruptLine::new(interrupt).expect("vsock interrupt should validate"),
+            )),
+        })
+        .expect("inactive MMIO vsock state should validate")
+    }
+
+    fn active_pci_vsock_state(
+        slot: usize,
+        msi: HvfGicMsiMetadata,
+        route_offset: u32,
+    ) -> SnapshotV2VsockState {
+        let mut bytes = fixture_bytes(include_str!(
+            "../../runtime/src/snapshot_vsock_v2_12/fixtures/active-pci.hex"
+        ));
+        zero_active_vsock_queue_cursors(&mut bytes);
+        let common_offset = vsock_section_offset(&bytes, 1);
+        relocate_queues(&mut bytes, common_offset, VSOCK_QUEUE_BASE);
+        let transport_offset = vsock_section_offset(&bytes, 2);
+        relocate_pci(&mut bytes, transport_offset, slot, msi, route_offset);
+        decode_vsock(&bytes)
+    }
+
+    fn prepared_vsock_endpoint(
+        state: SnapshotV2VsockState,
+        memory: &GuestMemory,
+    ) -> (
+        HvfSnapshotV2VsockPreparedEndpoint,
+        SnapshotRestoreResourceKey,
+    ) {
+        let transport = state.transport().kind();
+        let topology =
+            PreparedSnapshotV2VsockRestoreTopology::prepare(state, None, transport, memory)
+                .expect("vsock topology should prepare");
+        let (request, state) = topology.into_parts();
+        let (resource_key, _selectors, config, _overridden) = request.into_parts();
+        (
+            HvfSnapshotV2VsockPreparedEndpoint::new(state, config),
+            resource_key,
+        )
+    }
+
+    fn exact_vsock_binding_keys(
+        storage: Option<&bangbang_runtime::snapshot_device_v2_6::SnapshotV2StorageDeviceGraph>,
+        network: &PreparedSnapshotV2NetworkRestoreTopology,
+        vsock_key: Option<SnapshotRestoreResourceKey>,
+    ) -> Vec<SnapshotRestoreResourceKey> {
+        let mut keys = Vec::new();
+        if let Some(storage) = storage {
+            keys.extend(storage.block_records().iter().map(|record| {
+                SnapshotRestoreResourceKey::new(
+                    record.key(),
+                    SnapshotRestorePublicId::try_from(record.config().drive_id())
+                        .expect("block public ID should validate"),
+                    SnapshotRestoreResourceClass::BlockBacking,
+                )
+            }));
+            keys.extend(storage.pmem_records().iter().map(|record| {
+                SnapshotRestoreResourceKey::new(
+                    record.key(),
+                    SnapshotRestorePublicId::try_from(record.config().pmem_id())
+                        .expect("pmem public ID should validate"),
+                    SnapshotRestoreResourceClass::PmemBacking,
+                )
+            }));
+        }
+        keys.extend(network.interfaces().iter().map(|interface| {
+            interface
+                .resource_key()
+                .try_clone()
+                .expect("network resource key should copy")
+        }));
+        keys.extend(vsock_key);
+        keys.sort_unstable();
+        keys
+    }
+
+    fn vsock_mmio_process_config() -> HvfSnapshotV2VsockMmioProcessConfig {
+        HvfSnapshotV2VsockMmioProcessConfig::new(
+            mmio_process_config(),
+            VsockMmioLayout::new(VSOCK_MMIO_BASE, VSOCK_MMIO_REGION_ID),
+        )
+    }
+
+    fn vsock_kind(mask: u8) -> HvfSnapshotV2VsockProductKind {
+        HvfSnapshotV2VsockProductKind::from_presence(
+            mask & 1 != 0,
+            mask & 2 != 0,
+            mask & 4 != 0,
+            mask & 8 != 0,
+            mask & 16 != 0,
+            mask & 32 != 0,
+        )
+    }
+
+    fn mmio_vsock_only_parts(
+        active: bool,
+        interrupt_offset: u32,
+    ) -> (
+        HvfSnapshotV2PlatformState,
+        HvfSnapshotV2VsockPreparedProductParts,
+        HvfSnapshotV2VsockMmioProcessConfig,
+        TestImage,
+    ) {
+        let MaterializedFixture {
+            platform,
+            topology,
+            memory,
+            _image,
+        } = materialized_fixture(memory_hotplug_mmio_state(33));
+        let platform = memory_fixture_mmio_platform(platform, topology.state(), 1);
+        let first_interrupt = platform
+            .global()
+            .compatibility()
+            .gic_metadata()
+            .spi_interrupt_range
+            .base;
+        let interrupt = first_interrupt
+            .checked_add(interrupt_offset)
+            .expect("vsock interrupt should fit");
+        let state = if active {
+            active_mmio_vsock_state(interrupt)
+        } else {
+            inactive_mmio_vsock_state(interrupt)
+        };
+        let (vsock, key) = prepared_vsock_endpoint(state, &memory);
+        let network =
+            PreparedSnapshotV2NetworkRestoreTopology::empty(SnapshotV2DeviceTransportKind::Mmio);
+        (
+            platform.clone(),
+            HvfSnapshotV2VsockPreparedProductParts {
+                kind: vsock_kind(0b100000),
+                memory: HvfSnapshotV2VsockPreparedMemory::Static(platform.memory().clone()),
+                storage: None,
+                entropy: None,
+                balloon: None,
+                network,
+                vsock: Some(vsock),
+                serial_resource_present: false,
+                binding_keys: vec![key],
+            },
+            vsock_mmio_process_config(),
+            _image,
+        )
+    }
+
+    fn mmio_network_vsock_parts(
+        interface_count: usize,
+    ) -> (
+        HvfSnapshotV2PlatformState,
+        HvfSnapshotV2VsockPreparedProductParts,
+        HvfSnapshotV2VsockMmioProcessConfig,
+        SnapshotV2NetworkState,
+        TestImage,
+    ) {
+        let device_count = interface_count
+            .checked_add(1)
+            .expect("network and vsock device count should fit");
+        let MaterializedFixture {
+            platform,
+            topology,
+            memory,
+            _image,
+        } = materialized_fixture(memory_hotplug_mmio_state(
+            32_u32
+                .checked_add(u32::try_from(device_count).expect("device count should fit"))
+                .expect("following interrupt should fit"),
+        ));
+        let platform = memory_fixture_mmio_platform(platform, topology.state(), device_count);
+        let first_interrupt = platform
+            .global()
+            .compatibility()
+            .gic_metadata()
+            .spi_interrupt_range
+            .base;
+        let network_state = network_state(
+            SnapshotV2DeviceTransportKind::Mmio,
+            interface_count,
+            false,
+            MmdsSelection::None,
+            first_interrupt,
+            None,
+        );
+        let network = prepare_topology(network_state.clone());
+        let vsock_interrupt = first_interrupt
+            .checked_add(u32::try_from(interface_count).expect("interface count should fit"))
+            .expect("vsock interrupt should fit");
+        let (vsock, key) =
+            prepared_vsock_endpoint(active_mmio_vsock_state(vsock_interrupt), &memory);
+        let binding_keys = exact_vsock_binding_keys(None, &network, Some(key));
+        (
+            platform.clone(),
+            HvfSnapshotV2VsockPreparedProductParts {
+                kind: vsock_kind(0b110000),
+                memory: HvfSnapshotV2VsockPreparedMemory::Static(platform.memory().clone()),
+                storage: None,
+                entropy: None,
+                balloon: None,
+                network,
+                vsock: Some(vsock),
+                serial_resource_present: false,
+                binding_keys,
+            },
+            vsock_mmio_process_config(),
+            network_state,
+            _image,
+        )
+    }
+
+    fn pci_vsock_only_parts(
+        slot: usize,
+        route_offset: u32,
+        interrupt_count: Option<u32>,
+    ) -> (
+        HvfSnapshotV2PlatformState,
+        HvfSnapshotV2VsockPreparedProductParts,
+        HvfGicMsiMetadata,
+        TestImage,
+    ) {
+        let expected_interrupt_count = pci_vsock_restore_gic_msi_configuration(None, false, false)
+            .expect("vsock MSI configuration should validate")
+            .interrupt_count()
+            .get();
+        let msi = test_msi(interrupt_count.unwrap_or(expected_interrupt_count));
+        let MaterializedFixture {
+            platform,
+            topology,
+            memory,
+            _image,
+        } = materialized_fixture(memory_hotplug_pci_state(0, msi, 0));
+        let platform =
+            memory_fixture_pci_platform(platform, topology.state(), msi.interrupt_range.count);
+        let (vsock, key) =
+            prepared_vsock_endpoint(active_pci_vsock_state(slot, msi, route_offset), &memory);
+        let network =
+            PreparedSnapshotV2NetworkRestoreTopology::empty(SnapshotV2DeviceTransportKind::Pci);
+        (
+            platform.clone(),
+            HvfSnapshotV2VsockPreparedProductParts {
+                kind: vsock_kind(0b100000),
+                memory: HvfSnapshotV2VsockPreparedMemory::Static(platform.memory().clone()),
+                storage: None,
+                entropy: None,
+                balloon: None,
+                network,
+                vsock: Some(vsock),
+                serial_resource_present: false,
+                binding_keys: vec![key],
+            },
+            msi,
+            _image,
+        )
+    }
+
+    fn pci_network_vsock_parts(
+        interface_count: usize,
+        duplicate_vsock_routes: bool,
+    ) -> (
+        HvfSnapshotV2PlatformState,
+        HvfSnapshotV2VsockPreparedProductParts,
+        HvfGicMsiMetadata,
+        SnapshotV2NetworkState,
+        TestImage,
+    ) {
+        let interrupt_count = pci_vsock_restore_gic_msi_configuration(None, false, false)
+            .expect("network and vsock MSI configuration should validate")
+            .interrupt_count()
+            .get();
+        let msi = test_msi(interrupt_count);
+        let MaterializedFixture {
+            platform,
+            topology,
+            memory,
+            _image,
+        } = materialized_fixture(memory_hotplug_pci_state(0, msi, 0));
+        let platform = memory_fixture_pci_platform(platform, topology.state(), interrupt_count);
+        let network_state = network_state(
+            SnapshotV2DeviceTransportKind::Pci,
+            interface_count,
+            true,
+            MmdsSelection::None,
+            0,
+            Some((0, msi, 0, false)),
+        );
+        let network = prepare_topology(network_state.clone());
+        let route_offset = if duplicate_vsock_routes {
+            0
+        } else {
+            u32::try_from(interface_count * (VIRTIO_NET_QUEUE_COUNT + 1))
+                .expect("network route count should fit")
+        };
+        let (vsock, key) = prepared_vsock_endpoint(
+            active_pci_vsock_state(interface_count, msi, route_offset),
+            &memory,
+        );
+        let binding_keys = exact_vsock_binding_keys(None, &network, Some(key));
+        (
+            platform.clone(),
+            HvfSnapshotV2VsockPreparedProductParts {
+                kind: vsock_kind(0b110000),
+                memory: HvfSnapshotV2VsockPreparedMemory::Static(platform.memory().clone()),
+                storage: None,
+                entropy: None,
+                balloon: None,
+                network,
+                vsock: Some(vsock),
+                serial_resource_present: false,
+                binding_keys,
+            },
+            msi,
+            network_state,
+            _image,
+        )
     }
 
     fn decode_network(fixture: &str) -> SnapshotV2NetworkState {
@@ -4148,6 +4882,153 @@ mod fixture_identity_tests {
     }
 
     #[test]
+    fn all_sixty_four_mmio_vsock_products_close_presence_order_and_queue_ranges() {
+        let storage_shape = product_storage_fixture(SnapshotV2DeviceTransportKind::Mmio);
+        let storage_block_count = storage_shape.block_records().len();
+        let storage_pmem_count = storage_shape.pmem_records().len();
+        for mask in 0_u8..64 {
+            let has_storage = mask & 1 != 0;
+            let has_entropy = mask & 2 != 0;
+            let has_balloon = mask & 4 != 0;
+            let has_memory_hotplug = mask & 8 != 0;
+            let has_network = mask & 16 != 0;
+            let has_vsock = mask & 32 != 0;
+            let network_count = usize::from(has_network);
+            let block_count = usize::from(has_storage) * storage_block_count;
+            let pmem_count = usize::from(has_storage) * storage_pmem_count;
+            let first_interrupt = 32_u32;
+            let storage_interrupt = first_interrupt + u32::from(has_balloon);
+            let network_interrupt = storage_interrupt
+                + u32::try_from(block_count).expect("block interrupt count should fit");
+            let pmem_interrupt =
+                network_interrupt + u32::try_from(network_count).expect("network count should fit");
+            let vsock_interrupt = pmem_interrupt
+                + u32::try_from(pmem_count).expect("pmem interrupt count should fit");
+            let entropy_interrupt = vsock_interrupt + u32::from(has_vsock);
+            let memory_hotplug_interrupt = entropy_interrupt + u32::from(has_entropy);
+            let device_count = usize::from(has_balloon)
+                + block_count
+                + network_count
+                + pmem_count
+                + usize::from(has_vsock)
+                + usize::from(has_entropy)
+                + usize::from(has_memory_hotplug);
+
+            let MaterializedFixture {
+                platform,
+                topology,
+                memory,
+                _image,
+            } = materialized_fixture(memory_hotplug_mmio_state(memory_hotplug_interrupt));
+            let platform = memory_fixture_mmio_platform(platform, topology.state(), device_count);
+            let network = if has_network {
+                prepare_topology(network_state(
+                    SnapshotV2DeviceTransportKind::Mmio,
+                    1,
+                    false,
+                    MmdsSelection::None,
+                    network_interrupt,
+                    None,
+                ))
+            } else {
+                PreparedSnapshotV2NetworkRestoreTopology::empty(SnapshotV2DeviceTransportKind::Mmio)
+            };
+            let balloon = has_balloon.then(|| balloon_mmio_plan(&memory, first_interrupt));
+            let entropy = has_entropy.then(|| entropy_mmio_plan(&memory, entropy_interrupt));
+            let (storage_graph, storage, _backings) = if has_storage {
+                let graph = storage_mmio_graph_with_gap(storage_interrupt, network_count);
+                let (bundle, backings) = prepared_storage_bundle(graph.clone());
+                (Some(graph), Some(bundle), backings)
+            } else {
+                (None, None, Vec::new())
+            };
+            let (vsock, vsock_key) = if has_vsock {
+                let (endpoint, key) =
+                    prepared_vsock_endpoint(active_mmio_vsock_state(vsock_interrupt), &memory);
+                (Some(endpoint), Some(key))
+            } else {
+                (None, None)
+            };
+            let binding_keys =
+                exact_vsock_binding_keys(storage_graph.as_ref(), &network, vsock_key);
+            let prepared_memory = if has_memory_hotplug {
+                HvfSnapshotV2VsockPreparedMemory::MemoryHotplug {
+                    topology: Box::new(topology),
+                    memory,
+                }
+            } else {
+                HvfSnapshotV2VsockPreparedMemory::Static(platform.memory().clone())
+            };
+            let kind = HvfSnapshotV2VsockProductKind::from_presence(
+                has_storage,
+                has_entropy,
+                has_balloon,
+                has_memory_hotplug,
+                has_network,
+                has_vsock,
+            );
+            let product = HvfSnapshotV2VsockPreparedProduct::try_from_parts(
+                HvfSnapshotV2VsockPreparedProductParts {
+                    kind,
+                    memory: prepared_memory,
+                    storage,
+                    entropy,
+                    balloon,
+                    network,
+                    vsock,
+                    serial_resource_present: false,
+                    binding_keys,
+                },
+            )
+            .unwrap_or_else(|error| panic!("MMIO product mask {mask:#08b} failed: {error:?}"));
+            let plan = prepare_hvf_snapshot_v2_vsock_mmio_platform_plan(
+                &platform,
+                product,
+                vsock_mmio_process_config(),
+            )
+            .unwrap_or_else(|error| panic!("MMIO plan mask {mask:#08b} failed: {error:?}"));
+
+            assert_eq!(plan.kind(), kind);
+            assert_eq!(plan.balloon().is_some(), has_balloon);
+            assert_eq!(plan.storage().is_some(), has_storage);
+            assert_eq!(plan.network().len(), network_count);
+            assert_eq!(plan.vsock().is_some(), has_vsock);
+            assert_eq!(plan.entropy().is_some(), has_entropy);
+            assert_eq!(plan.memory_hotplug().is_some(), has_memory_hotplug);
+            assert_eq!(plan.mapping().is_some(), has_memory_hotplug);
+            if let Some(vsock) = plan.vsock() {
+                assert_eq!(vsock.region().range().start(), VSOCK_MMIO_BASE);
+                assert_eq!(vsock.region().id(), VSOCK_MMIO_REGION_ID);
+                assert_eq!(vsock.dispatcher_region_id(), VSOCK_MMIO_REGION_ID);
+                assert_eq!(vsock.interrupt_line().raw_value(), vsock_interrupt);
+                assert_eq!(vsock.fdt_device().region.base, VSOCK_MMIO_BASE.raw_value());
+                assert_eq!(
+                    vsock.fdt_device().region.size,
+                    VIRTIO_MMIO_DEVICE_WINDOW_SIZE
+                );
+                assert!(
+                    vsock.queue_ranges().iter().all(Option::is_some),
+                    "all active vsock queue ranges should be retained",
+                );
+            }
+            assert_eq!(
+                plan.entropy()
+                    .map(|endpoint| endpoint.interrupt_line().raw_value()),
+                has_entropy.then_some(entropy_interrupt),
+            );
+            assert_eq!(
+                plan.memory_hotplug()
+                    .map(|endpoint| endpoint.interrupt_line().raw_value()),
+                has_memory_hotplug.then_some(memory_hotplug_interrupt),
+            );
+            assert_eq!(
+                plan.serial_interrupt().raw_value(),
+                first_interrupt + u32::try_from(device_count).unwrap(),
+            );
+        }
+    }
+
+    #[test]
     fn all_sixteen_pci_product_tags_close_block_network_pmem_order_and_routes() {
         let storage_graph = product_storage_fixture(SnapshotV2DeviceTransportKind::Pci);
         let storage_record_count = storage_graph.record_count();
@@ -4320,6 +5201,696 @@ mod fixture_identity_tests {
     }
 
     #[test]
+    fn all_sixty_four_pci_vsock_products_close_presence_order_vectors_and_routes() {
+        let storage_shape = product_storage_fixture(SnapshotV2DeviceTransportKind::Pci);
+        let storage_record_count = storage_shape.record_count();
+        let storage_block_count = storage_shape.block_records().len();
+        let storage_pmem_count = storage_shape.pmem_records().len();
+        for mask in 0_u8..64 {
+            let has_storage = mask & 1 != 0;
+            let has_entropy = mask & 2 != 0;
+            let has_balloon = mask & 4 != 0;
+            let has_memory_hotplug = mask & 8 != 0;
+            let has_network = mask & 16 != 0;
+            let has_vsock = mask & 32 != 0;
+            let network_count = usize::from(has_network);
+            let block_count = usize::from(has_storage) * storage_block_count;
+            let pmem_count = usize::from(has_storage) * storage_pmem_count;
+            let storage_count = usize::from(has_storage) * storage_record_count;
+            let storage_slot = usize::from(has_balloon);
+            let network_slot = storage_slot + block_count;
+            let vsock_slot = network_slot + network_count + pmem_count;
+            let entropy_slot = vsock_slot + usize::from(has_vsock);
+            let memory_hotplug_slot = entropy_slot + usize::from(has_entropy);
+            let endpoint_count = memory_hotplug_slot + usize::from(has_memory_hotplug);
+
+            let balloon_routes = usize::from(has_balloon) * (VIRTIO_BALLOON_MAX_QUEUE_COUNT + 1);
+            let block_routes = block_count * 2;
+            let storage_routes = storage_count * 2;
+            let network_routes = network_count * (VIRTIO_NET_QUEUE_COUNT + 1);
+            let vsock_routes = usize::from(has_vsock) * (VIRTIO_VSOCK_QUEUE_COUNT + 1);
+            let entropy_routes = usize::from(has_entropy) * (VIRTIO_RNG_QUEUE_SIZES.len() + 1);
+            let memory_hotplug_routes =
+                usize::from(has_memory_hotplug) * (VIRTIO_MEM_QUEUE_SIZES.len() + 1);
+            let storage_route_offset =
+                u32::try_from(balloon_routes).expect("storage route offset should fit");
+            let network_route_offset = u32::try_from(balloon_routes + block_routes)
+                .expect("network route offset should fit");
+            let vsock_route_offset =
+                u32::try_from(balloon_routes + storage_routes + network_routes)
+                    .expect("vsock route offset should fit");
+            let entropy_route_offset =
+                u32::try_from(balloon_routes + storage_routes + network_routes + vsock_routes)
+                    .expect("entropy route offset should fit");
+            let memory_hotplug_route_offset = u32::try_from(
+                balloon_routes + storage_routes + network_routes + vsock_routes + entropy_routes,
+            )
+            .expect("memory-hotplug route offset should fit");
+            let route_demand = balloon_routes
+                + storage_routes
+                + network_routes
+                + vsock_routes
+                + entropy_routes
+                + memory_hotplug_routes;
+            let balloon_queue_count = has_balloon.then_some(VIRTIO_BALLOON_MAX_QUEUE_COUNT);
+            let expected_msi_interrupt_count = if has_vsock {
+                pci_vsock_restore_gic_msi_configuration(
+                    balloon_queue_count,
+                    has_entropy,
+                    has_memory_hotplug,
+                )
+            } else if has_memory_hotplug {
+                pci_memory_hotplug_restore_gic_msi_configuration(balloon_queue_count, has_entropy)
+            } else if has_balloon {
+                pci_balloon_restore_gic_msi_configuration(
+                    VIRTIO_BALLOON_MAX_QUEUE_COUNT,
+                    has_entropy,
+                )
+            } else if has_entropy {
+                pci_entropy_restore_gic_msi_configuration()
+            } else {
+                pci_root_restore_gic_msi_configuration()
+            }
+            .expect("PCI MSI configuration should validate")
+            .interrupt_count()
+            .get();
+            let msi = test_msi(expected_msi_interrupt_count);
+
+            let MaterializedFixture {
+                platform,
+                topology,
+                memory,
+                _image,
+            } = materialized_fixture(memory_hotplug_pci_state(
+                memory_hotplug_slot,
+                msi,
+                memory_hotplug_route_offset,
+            ));
+            let platform = memory_fixture_pci_platform(
+                platform,
+                topology.state(),
+                expected_msi_interrupt_count,
+            );
+            let network = if has_network {
+                prepare_topology(network_state(
+                    SnapshotV2DeviceTransportKind::Pci,
+                    1,
+                    true,
+                    MmdsSelection::All,
+                    0,
+                    Some((network_slot, msi, network_route_offset, false)),
+                ))
+            } else {
+                PreparedSnapshotV2NetworkRestoreTopology::empty(SnapshotV2DeviceTransportKind::Pci)
+            };
+            let balloon = has_balloon.then(|| balloon_pci_plan(0, msi, 0));
+            let entropy =
+                has_entropy.then(|| entropy_pci_plan(entropy_slot, msi, entropy_route_offset));
+            let (storage_graph, storage, _backings) = if has_storage {
+                let graph = storage_pci_graph_with_gap(
+                    storage_slot,
+                    network_count,
+                    msi,
+                    storage_route_offset,
+                );
+                let (bundle, backings) = prepared_storage_bundle(graph.clone());
+                (Some(graph), Some(bundle), backings)
+            } else {
+                (None, None, Vec::new())
+            };
+            let (vsock, vsock_key) = if has_vsock {
+                let (endpoint, key) = prepared_vsock_endpoint(
+                    active_pci_vsock_state(vsock_slot, msi, vsock_route_offset),
+                    &memory,
+                );
+                (Some(endpoint), Some(key))
+            } else {
+                (None, None)
+            };
+            let binding_keys =
+                exact_vsock_binding_keys(storage_graph.as_ref(), &network, vsock_key);
+            let prepared_memory = if has_memory_hotplug {
+                HvfSnapshotV2VsockPreparedMemory::MemoryHotplug {
+                    topology: Box::new(topology),
+                    memory,
+                }
+            } else {
+                HvfSnapshotV2VsockPreparedMemory::Static(platform.memory().clone())
+            };
+            let kind = HvfSnapshotV2VsockProductKind::from_presence(
+                has_storage,
+                has_entropy,
+                has_balloon,
+                has_memory_hotplug,
+                has_network,
+                has_vsock,
+            );
+            let product = HvfSnapshotV2VsockPreparedProduct::try_from_parts(
+                HvfSnapshotV2VsockPreparedProductParts {
+                    kind,
+                    memory: prepared_memory,
+                    storage,
+                    entropy,
+                    balloon,
+                    network,
+                    vsock,
+                    serial_resource_present: false,
+                    binding_keys,
+                },
+            )
+            .unwrap_or_else(|error| panic!("PCI product mask {mask:#08b} failed: {error:?}"));
+            let plan = prepare_hvf_snapshot_v2_vsock_pci_platform_plan(&platform, product)
+                .unwrap_or_else(|error| match error {
+                    PrepareHvfSnapshotV2VsockPlatformPlanError::Network(source) => {
+                        panic!("PCI plan mask {mask:#08b} failed: {source:?}")
+                    }
+                    error => panic!("PCI plan mask {mask:#08b} failed: {error:?}"),
+                });
+            let address_plan =
+                Arm64PciAddressPlan::firecracker_v1_16().expect("address plan should validate");
+
+            assert_eq!(plan.kind(), kind);
+            assert_eq!(plan.balloon().is_some(), has_balloon);
+            assert_eq!(plan.storage().is_some(), has_storage);
+            assert_eq!(plan.network().len(), network_count);
+            assert_eq!(plan.vsock().is_some(), has_vsock);
+            assert_eq!(plan.entropy().is_some(), has_entropy);
+            assert_eq!(plan.memory_hotplug().is_some(), has_memory_hotplug);
+            assert_eq!(plan.mapping().is_some(), has_memory_hotplug);
+            assert_eq!(plan.endpoint_count(), endpoint_count);
+            assert_eq!(plan.route_demand(), route_demand);
+            if let Some(vsock) = plan.vsock() {
+                let placement = snapshot_v2_pci_endpoint_placement(address_plan, vsock_slot)
+                    .expect("vsock placement should validate");
+                assert_eq!(vsock.origin(), StorageDeviceOrigin::Startup);
+                assert_eq!(vsock.sbdf(), placement.sbdf);
+                assert_eq!(vsock.bar_range(), placement.bar_range);
+                assert_eq!(vsock.bar_region_id(), placement.bar_region_id);
+                assert_eq!(vsock.dispatcher_region_id(), placement.bar_region_id);
+                assert_eq!(vsock.route_count(), VIRTIO_VSOCK_QUEUE_COUNT + 1);
+                assert_eq!(vsock.queue_vectors(), &[1, 2, 3]);
+                assert_eq!(vsock.config_vector(), 0);
+                assert_eq!(vsock.msi_interrupt_count(), expected_msi_interrupt_count);
+                assert!(vsock.queue_ranges().iter().all(Option::is_some));
+            }
+            assert_eq!(
+                plan.entropy().map(|endpoint| endpoint.sbdf()),
+                has_entropy.then(|| {
+                    snapshot_v2_pci_endpoint_placement(address_plan, entropy_slot)
+                        .expect("entropy placement should exist")
+                        .sbdf
+                }),
+            );
+            assert_eq!(
+                plan.memory_hotplug().map(|endpoint| endpoint.sbdf()),
+                has_memory_hotplug.then(|| {
+                    snapshot_v2_pci_endpoint_placement(address_plan, memory_hotplug_slot)
+                        .expect("memory-hotplug placement should exist")
+                        .sbdf
+                }),
+            );
+        }
+    }
+
+    #[test]
+    fn vsock_products_reject_presence_transport_config_and_manifest_substitution() {
+        for bit in 0..6 {
+            let (_platform, mut parts, _process, _image) = mmio_vsock_only_parts(false, 0);
+            parts.kind = vsock_kind(0b100000 ^ (1 << bit));
+            assert!(matches!(
+                HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts),
+                Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Product),
+            ));
+        }
+
+        let (_platform, mut parts, _process, _image) = mmio_vsock_only_parts(false, 0);
+        parts.vsock = None;
+        assert!(matches!(
+            HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts),
+            Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Product),
+        ));
+
+        let (_platform, mut parts, _process, _state, _image) = mmio_network_vsock_parts(1);
+        parts.kind = vsock_kind(0b100000);
+        assert!(matches!(
+            HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts),
+            Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Product),
+        ));
+
+        let (_platform, mut mmio, _process, _mmio_image) = mmio_vsock_only_parts(false, 0);
+        let (_platform, mut pci, _msi, _pci_image) = pci_vsock_only_parts(0, 0, None);
+        mmio.vsock = pci.vsock.take();
+        assert!(matches!(
+            HvfSnapshotV2VsockPreparedProduct::try_from_parts(mmio),
+            Err(PrepareHvfSnapshotV2VsockPlatformPlanError::TransportPolicy),
+        ));
+
+        let (_platform, mut parts, _process, _image) = mmio_vsock_only_parts(false, 0);
+        let endpoint = parts.vsock.take().expect("vsock endpoint should exist");
+        let (state, config) = endpoint.into_parts();
+        let wrong_config = VsockConfigInput::new(
+            config.guest_cid().saturating_add(1),
+            config.uds_path().to_string_lossy().into_owned(),
+        )
+        .validate()
+        .expect("substituted vsock config should validate");
+        parts.vsock = Some(HvfSnapshotV2VsockPreparedEndpoint::new(state, wrong_config));
+        assert!(matches!(
+            HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts),
+            Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Vsock),
+        ));
+
+        let (_platform, mut parts, _process, _image) = mmio_vsock_only_parts(false, 0);
+        let key = &parts.binding_keys[0];
+        parts.binding_keys[0] = SnapshotRestoreResourceKey::new(
+            key.device_key(),
+            SnapshotRestorePublicId::try_from(key.public_id().as_str())
+                .expect("vsock public ID should copy"),
+            SnapshotRestoreResourceClass::NetworkPacketIo,
+        );
+        assert!(matches!(
+            HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts),
+            Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest),
+        ));
+
+        let (_platform, mut parts, _process, _image) = mmio_vsock_only_parts(false, 0);
+        let key = &parts.binding_keys[0];
+        parts.binding_keys[0] = SnapshotRestoreResourceKey::new(
+            key.device_key(),
+            SnapshotRestorePublicId::try_from("not-vsock0")
+                .expect("substituted public ID should validate"),
+            key.resource_class(),
+        );
+        assert!(matches!(
+            HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts),
+            Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest),
+        ));
+
+        let (_platform, mut missing, _process, _state, _image) = mmio_network_vsock_parts(1);
+        missing.binding_keys.pop();
+        assert!(matches!(
+            HvfSnapshotV2VsockPreparedProduct::try_from_parts(missing),
+            Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest),
+        ));
+
+        let (_platform, mut extra, _process, _state, _image) = mmio_network_vsock_parts(1);
+        let duplicate = extra.binding_keys[1]
+            .try_clone()
+            .expect("resource key should copy");
+        extra.binding_keys.push(duplicate);
+        assert!(matches!(
+            HvfSnapshotV2VsockPreparedProduct::try_from_parts(extra),
+            Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest),
+        ));
+
+        let (_platform, mut reordered, _process, _state, _image) = mmio_network_vsock_parts(1);
+        reordered.binding_keys.swap(0, 1);
+        assert!(matches!(
+            HvfSnapshotV2VsockPreparedProduct::try_from_parts(reordered),
+            Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest),
+        ));
+
+        let (_platform, mut wrong_kind, _process, _state, _image) = mmio_network_vsock_parts(1);
+        wrong_kind.binding_keys[1] = wrong_kind.binding_keys[0]
+            .try_clone()
+            .expect("network key should copy");
+        assert!(matches!(
+            HvfSnapshotV2VsockPreparedProduct::try_from_parts(wrong_kind),
+            Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest),
+        ));
+    }
+
+    #[test]
+    fn mmio_vsock_plans_close_active_inactive_placement_ranges_and_host_exclusion() {
+        let (platform, parts, process, _image) = mmio_vsock_only_parts(true, 0);
+        let socket_path = parts
+            .vsock
+            .as_ref()
+            .expect("vsock endpoint should exist")
+            .config()
+            .uds_path()
+            .to_path_buf();
+        let existed_before = socket_path.exists();
+        let product = HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts)
+            .expect("active MMIO product should validate");
+        let plan = prepare_hvf_snapshot_v2_vsock_mmio_platform_plan(&platform, product, process)
+            .expect("active MMIO vsock should plan");
+        let endpoint = plan.vsock().expect("vsock endpoint should be present");
+        assert_eq!(endpoint.region().range().start(), VSOCK_MMIO_BASE);
+        assert_eq!(endpoint.region().id(), VSOCK_MMIO_REGION_ID);
+        assert_eq!(endpoint.dispatcher_region_id(), VSOCK_MMIO_REGION_ID);
+        assert_eq!(
+            endpoint.fdt_device().region.base,
+            VSOCK_MMIO_BASE.raw_value()
+        );
+        assert_eq!(
+            endpoint.fdt_device().region.size,
+            VIRTIO_MMIO_DEVICE_WINDOW_SIZE
+        );
+        for (index, ranges) in endpoint.queue_ranges().iter().enumerate() {
+            let base = VSOCK_QUEUE_BASE
+                + u64::try_from(index).expect("queue index should fit") * NETWORK_QUEUE_STRIDE;
+            assert_eq!(
+                *ranges,
+                Some([
+                    GuestMemoryRange::new(GuestAddress::new(base), 4096)
+                        .expect("descriptor range should validate"),
+                    GuestMemoryRange::new(GuestAddress::new(base + DRIVER_RING_OFFSET), 518)
+                        .expect("available range should validate"),
+                    GuestMemoryRange::new(GuestAddress::new(base + DEVICE_RING_OFFSET), 2054)
+                        .expect("used range should validate"),
+                ])
+            );
+        }
+        assert_eq!(socket_path.exists(), existed_before);
+
+        let (platform, parts, process, _image) = mmio_vsock_only_parts(false, 0);
+        let product = HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts)
+            .expect("inactive MMIO product should validate");
+        let plan = prepare_hvf_snapshot_v2_vsock_mmio_platform_plan(&platform, product, process)
+            .expect("inactive MMIO vsock should plan");
+        assert!(
+            plan.vsock()
+                .expect("inactive vsock endpoint should be present")
+                .queue_ranges()
+                .iter()
+                .all(Option::is_none)
+        );
+
+        let (platform, parts, process, _image) = mmio_vsock_only_parts(false, 0);
+        let wrong_process = HvfSnapshotV2VsockMmioProcessConfig::new(
+            process.network(),
+            VsockMmioLayout::new(
+                GuestAddress::new(
+                    VSOCK_MMIO_BASE
+                        .raw_value()
+                        .checked_add(VIRTIO_MMIO_DEVICE_WINDOW_SIZE)
+                        .expect("wrong placement should fit"),
+                ),
+                VSOCK_MMIO_REGION_ID,
+            ),
+        );
+        let product = HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts)
+            .expect("misplaced process product should validate");
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_vsock_mmio_platform_plan(&platform, product, wrong_process,),
+            Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Placement),
+        ));
+
+        let (platform, parts, process, _image) = mmio_vsock_only_parts(false, 1);
+        let product = HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts)
+            .expect("wrong-interrupt product should validate locally");
+        let error = prepare_hvf_snapshot_v2_vsock_mmio_platform_plan(&platform, product, process)
+            .expect_err("wrong MMIO interrupt should fail");
+        let detail = match &error {
+            PrepareHvfSnapshotV2VsockPlatformPlanError::Network(source) => {
+                format!("{source:?}")
+            }
+            _ => format!("{error:?}"),
+        };
+        assert!(
+            matches!(
+                error,
+                PrepareHvfSnapshotV2VsockPlatformPlanError::Network(source)
+                    if matches!(
+                        *source,
+                        PrepareHvfSnapshotV2NetworkPlatformPlanError::ResourcePlan
+                    )
+            ),
+            "unexpected wrong-interrupt failure: {detail}",
+        );
+    }
+
+    #[test]
+    fn mmio_vsock_suffix_queue_conflicts_share_the_aggregate_inventory_gate() {
+        let MaterializedFixture {
+            platform,
+            topology,
+            memory: _,
+            _image,
+        } = materialized_fixture(memory_hotplug_mmio_state(34));
+        let platform = memory_fixture_mmio_platform(platform, topology.state(), 2);
+        let first_interrupt = platform
+            .global()
+            .compatibility()
+            .gic_metadata()
+            .spi_interrupt_range
+            .base;
+        let network = prepare_topology(network_state(
+            SnapshotV2DeviceTransportKind::Mmio,
+            1,
+            true,
+            MmdsSelection::None,
+            first_interrupt,
+            None,
+        ));
+        let duplicate_queue = interface_queue_ranges(&network.interfaces()[0])
+            .expect("network queue ranges should project")[0];
+        assert!(duplicate_queue.is_some());
+        let product =
+            HvfSnapshotV2NetworkPreparedProduct::serial_network(platform.memory().clone(), network);
+        let following = HvfSnapshotV2NetworkMmioFollowingEndpointInput {
+            region: MmioRegion::new(
+                VSOCK_MMIO_REGION_ID,
+                VSOCK_MMIO_BASE,
+                VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+            )
+            .expect("vsock region should validate"),
+            interrupt_line: GuestInterruptLine::new(
+                first_interrupt
+                    .checked_add(1)
+                    .expect("vsock interrupt should fit"),
+            )
+            .expect("vsock interrupt should validate"),
+            queue_ranges: [duplicate_queue, None, None],
+        };
+        assert!(matches!(
+            prepare_network_mmio_platform_plan(
+                &platform,
+                product,
+                mmio_process_config(),
+                Some(following),
+                &mut SystemNetworkPlatformPlanReserve,
+                &mut |_| false,
+            ),
+            Err(PrepareHvfSnapshotV2NetworkPlatformPlanError::RangeConflict),
+        ));
+    }
+
+    #[test]
+    fn pci_vsock_plans_reject_wrong_slot_capacity_and_cross_family_routes() {
+        let (platform, parts, msi, _image) = pci_vsock_only_parts(0, 0, None);
+        let product = HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts)
+            .expect("PCI vsock product should validate");
+        let plan = prepare_hvf_snapshot_v2_vsock_pci_platform_plan(&platform, product)
+            .expect("PCI vsock should plan");
+        let endpoint = plan.vsock().expect("PCI vsock endpoint should be present");
+        assert_eq!(endpoint.origin(), StorageDeviceOrigin::Startup);
+        assert_eq!(endpoint.queue_vectors(), &[1, 2, 3]);
+        assert_eq!(endpoint.config_vector(), 0);
+        assert_eq!(endpoint.route_count(), VIRTIO_VSOCK_QUEUE_COUNT + 1);
+        assert_eq!(endpoint.msi_interrupt_count(), msi.interrupt_range.count);
+
+        let (platform, parts, _msi, _image) = pci_vsock_only_parts(1, 0, None);
+        let product = HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts)
+            .expect("misplaced PCI product should validate locally");
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_vsock_pci_platform_plan(&platform, product),
+            Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Network(source))
+                if matches!(
+                    *source,
+                    PrepareHvfSnapshotV2NetworkPlatformPlanError::Placement
+                )
+        ));
+
+        let expected_interrupt_count = pci_vsock_restore_gic_msi_configuration(None, false, false)
+            .expect("vsock MSI configuration should validate")
+            .interrupt_count()
+            .get();
+        let (platform, parts, _msi, _image) = pci_vsock_only_parts(
+            0,
+            0,
+            Some(
+                expected_interrupt_count
+                    .checked_sub(1)
+                    .expect("wrong MSI capacity should remain nonzero"),
+            ),
+        );
+        let product = HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts)
+            .expect("wrong-capacity product should validate locally");
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_vsock_pci_platform_plan(&platform, product),
+            Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Network(source))
+                if matches!(
+                    *source,
+                    PrepareHvfSnapshotV2NetworkPlatformPlanError::ResourcePlan
+                )
+        ));
+
+        let (platform, parts, _msi, _state, _image) = pci_network_vsock_parts(1, true);
+        let product = HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts)
+            .expect("duplicate-route product should validate locally");
+        assert!(matches!(
+            prepare_hvf_snapshot_v2_vsock_pci_platform_plan(&platform, product),
+            Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Network(source))
+                if matches!(
+                    *source,
+                    PrepareHvfSnapshotV2NetworkPlatformPlanError::RouteConflict
+                )
+        ));
+
+        let (platform, parts, _msi, _state, _image) = pci_network_vsock_parts(16, false);
+        let product = HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts)
+            .expect("maximum-network PCI product should validate");
+        let plan = prepare_hvf_snapshot_v2_vsock_pci_platform_plan(&platform, product)
+            .expect("maximum-network PCI vsock product should plan");
+        assert_eq!(plan.network().len(), 16);
+        assert_eq!(plan.endpoint_count(), 17);
+        assert_eq!(
+            plan.route_demand(),
+            16 * (VIRTIO_NET_QUEUE_COUNT + 1) + VIRTIO_VSOCK_QUEUE_COUNT + 1
+        );
+    }
+
+    #[test]
+    fn exact_pci_endpoint_capacity_accepts_thirty_one_and_rejects_thirty_two() {
+        assert_eq!(PCI_ENDPOINT_SLOT_COUNT, 31);
+        assert!(validate_pci_endpoint_capacity(PCI_ENDPOINT_SLOT_COUNT).is_ok());
+        assert!(matches!(
+            validate_pci_endpoint_capacity(
+                PCI_ENDPOINT_SLOT_COUNT
+                    .checked_add(1)
+                    .expect("one-over endpoint count should fit"),
+            ),
+            Err(PrepareHvfSnapshotV2NetworkPlatformPlanError::PciCapacity {
+                count,
+                maximum,
+            }) if count == 32 && maximum == 31
+        ));
+    }
+
+    #[test]
+    fn every_vsock_cancellation_stage_is_stable_and_redacted() {
+        for cancelled in [
+            HvfSnapshotV2VsockPlatformPlanStage::Start,
+            HvfSnapshotV2VsockPlatformPlanStage::Product,
+            HvfSnapshotV2VsockPlatformPlanStage::Interface,
+            HvfSnapshotV2VsockPlatformPlanStage::Vsock,
+            HvfSnapshotV2VsockPlatformPlanStage::Components,
+            HvfSnapshotV2VsockPlatformPlanStage::Inventory,
+            HvfSnapshotV2VsockPlatformPlanStage::Completion,
+        ] {
+            let (platform, parts, process, _state, _image) = mmio_network_vsock_parts(1);
+            let product = HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts)
+                .expect("cancellation product should validate");
+            let error = prepare_hvf_snapshot_v2_vsock_mmio_platform_plan_with_cancel(
+                &platform,
+                product,
+                process,
+                |stage| stage == cancelled,
+            )
+            .expect_err("injected exact-2.12 cancellation should fail");
+            assert!(matches!(
+                error,
+                PrepareHvfSnapshotV2VsockPlatformPlanError::Cancelled { stage }
+                    if stage == cancelled
+            ));
+            let diagnostics = format!("{error:?} {error}");
+            assert!(diagnostics.contains(REDACTED));
+            assert!(!diagnostics.contains("vmnet:shared"));
+        }
+    }
+
+    #[test]
+    fn vsock_process_preflight_closes_network_endpoint_and_complete_manifest_identity() {
+        let (platform, parts, process, state, _image) = mmio_network_vsock_parts(1);
+        let socket_path = parts
+            .vsock
+            .as_ref()
+            .expect("vsock endpoint should exist")
+            .config()
+            .uds_path()
+            .to_string_lossy()
+            .into_owned();
+        let product = HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts)
+            .expect("preflight product should validate");
+        let plan = prepare_hvf_snapshot_v2_vsock_mmio_platform_plan(&platform, product, process)
+            .expect("preflight product should plan");
+        let process_topology = prepare_topology(state);
+        let identities = || {
+            process_topology.interfaces().iter().map(|interface| {
+                HvfSnapshotV2NetworkProcessResourceIdentity::new(
+                    interface.source_index(),
+                    interface.resource_key(),
+                    interface.controller(),
+                    interface.portable().profile(),
+                    interface.portable().backend(),
+                    interface.mmds_stack(),
+                )
+            })
+        };
+        let endpoint = plan.vsock().expect("vsock endpoint should be present");
+        let vsock_identity = HvfSnapshotV2VsockProcessResourceIdentity::new(
+            endpoint.resource_key(),
+            endpoint.config(),
+        );
+        assert!(plan.preflight_process_resource_identity(
+            identities(),
+            process_topology.mmds_state(),
+            process_topology.mmds_controller(),
+            Some(vsock_identity),
+            plan.resource_keys(),
+        ));
+        assert!(!plan.preflight_process_resource_identity(
+            identities(),
+            process_topology.mmds_state(),
+            process_topology.mmds_controller(),
+            None,
+            plan.resource_keys(),
+        ));
+        assert!(!plan.preflight_process_resource_identity(
+            identities(),
+            process_topology.mmds_state(),
+            process_topology.mmds_controller(),
+            Some(vsock_identity),
+            &[],
+        ));
+        let wrong_order = process_topology.interfaces().iter().map(|interface| {
+            HvfSnapshotV2NetworkProcessResourceIdentity::new(
+                interface.source_index().saturating_add(1),
+                interface.resource_key(),
+                interface.controller(),
+                interface.portable().profile(),
+                interface.portable().backend(),
+                interface.mmds_stack(),
+            )
+        });
+        assert!(!plan.preflight_process_resource_identity(
+            wrong_order,
+            process_topology.mmds_state(),
+            process_topology.mmds_controller(),
+            Some(vsock_identity),
+            plan.resource_keys(),
+        ));
+
+        let plan_debug = format!("{plan:?}");
+        assert!(plan_debug.contains(REDACTED));
+        assert!(!plan_debug.contains(&socket_path));
+        let error = PrepareHvfSnapshotV2VsockPlatformPlanError::Network(Box::new(
+            PrepareHvfSnapshotV2NetworkPlatformPlanError::RangeConflict,
+        ));
+        let error_debug = format!("{error:?}");
+        let error_display = error.to_string();
+        let source_display = std::error::Error::source(&error)
+            .expect("nested network source should exist")
+            .to_string();
+        assert!(error_debug.contains(REDACTED));
+        assert!(!error_debug.contains(&socket_path));
+        assert!(!error_display.contains(&socket_path));
+        assert!(!source_display.contains(&socket_path));
+    }
+
+    #[test]
     fn placement_and_cross_interface_route_mismatches_fail_before_ownership() {
         let (platform, misplaced) = pci_product(1, true, MmdsSelection::All, false, 1);
         assert!(matches!(
@@ -4441,6 +6012,7 @@ mod fixture_identity_tests {
                     &platform,
                     product,
                     mmio_process_config(),
+                    None,
                     &mut FailingReserve { calls: 0, fail_at },
                     &mut |_| false,
                 ),
@@ -4453,12 +6025,63 @@ mod fixture_identity_tests {
                 prepare_network_pci_platform_plan(
                     &platform,
                     product,
+                    None,
                     &mut FailingReserve { calls: 0, fail_at },
                     &mut |_| false,
                 ),
                 Err(PrepareHvfSnapshotV2NetworkPlatformPlanError::Allocation),
             ));
         }
+    }
+
+    #[test]
+    fn every_exact_vsock_key_copy_and_inventory_allocation_failure_is_explicit() {
+        let mut mmio_failure_count = 0;
+        for fail_at in 0..32 {
+            let (platform, parts, process, _state, _image) = mmio_network_vsock_parts(1);
+            let product = HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts)
+                .expect("MMIO allocation product should validate");
+            match prepare_vsock_mmio_platform_plan(
+                &platform,
+                product,
+                process,
+                &mut FailingReserve { calls: 0, fail_at },
+                &mut |_| false,
+            ) {
+                Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Allocation) => {
+                    mmio_failure_count += 1;
+                }
+                Ok(_) => {
+                    assert_eq!(fail_at, mmio_failure_count);
+                    break;
+                }
+                Err(error) => panic!("unexpected MMIO allocation failure: {error:?}"),
+            }
+        }
+        assert!(mmio_failure_count > 1, "key copy and inventories must fail");
+
+        let mut pci_failure_count = 0;
+        for fail_at in 0..32 {
+            let (platform, parts, _msi, _state, _image) = pci_network_vsock_parts(1, false);
+            let product = HvfSnapshotV2VsockPreparedProduct::try_from_parts(parts)
+                .expect("PCI allocation product should validate");
+            match prepare_vsock_pci_platform_plan(
+                &platform,
+                product,
+                &mut FailingReserve { calls: 0, fail_at },
+                &mut |_| false,
+            ) {
+                Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Allocation) => {
+                    pci_failure_count += 1;
+                }
+                Ok(_) => {
+                    assert_eq!(fail_at, pci_failure_count);
+                    break;
+                }
+                Err(error) => panic!("unexpected PCI allocation failure: {error:?}"),
+            }
+        }
+        assert!(pci_failure_count > 1, "key copy and inventories must fail");
     }
 
     #[test]

--- a/crates/hvf/src/snapshot_v2_vsock_platform.rs
+++ b/crates/hvf/src/snapshot_v2_vsock_platform.rs
@@ -1,0 +1,1505 @@
+//! Host-free exact native-v2 2.12 vsock platform-product planning.
+
+use std::fmt;
+
+use bangbang_runtime::balloon::BalloonMmioLayout;
+use bangbang_runtime::entropy::EntropyMmioLayout;
+use bangbang_runtime::fdt::{Arm64FdtPciHost, Arm64FdtVirtioMmioDevice};
+use bangbang_runtime::interrupt::GuestInterruptLine;
+use bangbang_runtime::memory::{GuestMemory, GuestMemoryRange};
+use bangbang_runtime::memory_hotplug::VirtioMemMmioLayout;
+use bangbang_runtime::mmio::{MmioRegion, MmioRegionId};
+use bangbang_runtime::network::NetworkMmioLayout;
+use bangbang_runtime::snapshot_balloon_v2_9::SnapshotV2BalloonRestorePlan;
+use bangbang_runtime::snapshot_device_v2::SnapshotV2DeviceTransportKind;
+use bangbang_runtime::snapshot_device_v2_6::PreparedSnapshotV2StorageBundle;
+use bangbang_runtime::snapshot_entropy_v2_8::SnapshotV2EntropyRestorePlan;
+use bangbang_runtime::snapshot_memory_hotplug_v2_10::PreparedSnapshotV2MemoryHotplugTopology;
+use bangbang_runtime::snapshot_memory_v2::SnapshotV2MemoryBinding;
+use bangbang_runtime::snapshot_network_restore_v2_11::PreparedSnapshotV2NetworkRestoreTopology;
+use bangbang_runtime::snapshot_restore::{
+    MAX_SNAPSHOT_RESTORE_RESOURCES, NATIVE_V2_SERIAL_RESTORE_PUBLIC_ID,
+    NATIVE_V2_VSOCK_RESTORE_PUBLIC_ID, SnapshotRestoreResourceClass, SnapshotRestoreResourceKey,
+};
+use bangbang_runtime::snapshot_vsock_restore_v2_12::{
+    PreparedSnapshotV2VsockMmioState, PreparedSnapshotV2VsockPciState,
+    PreparedSnapshotV2VsockRestoreState,
+};
+use bangbang_runtime::storage_capture::StorageDeviceOrigin;
+use bangbang_runtime::virtio_mmio::{VIRTIO_MMIO_DEVICE_WINDOW_SIZE, VirtioMmioQueueState};
+use bangbang_runtime::vsock::{VIRTIO_VSOCK_QUEUE_COUNT, VsockConfig, VsockMmioLayout};
+
+use crate::gic::HvfGicMsiMetadata;
+use crate::memory::HvfSnapshotV2MemoryHotplugMappingPlan;
+use crate::snapshot_v2::HvfSnapshotV2PlatformState;
+use crate::snapshot_v2_balloon_platform::{
+    HvfSnapshotV2BalloonMmioEndpointPlan, HvfSnapshotV2BalloonPciEndpointPlan,
+};
+use crate::snapshot_v2_network_platform::{
+    HvfSnapshotV2NetworkAuxiliaryMmioEndpointPlan, HvfSnapshotV2NetworkAuxiliaryPciEndpointPlan,
+    HvfSnapshotV2NetworkMmioEndpointPlan, HvfSnapshotV2NetworkMmioFollowingEndpointInput,
+    HvfSnapshotV2NetworkMmioFollowingEndpointPlan, HvfSnapshotV2NetworkMmioPlatformPlan,
+    HvfSnapshotV2NetworkMmioProcessConfig, HvfSnapshotV2NetworkPciEndpointPlan,
+    HvfSnapshotV2NetworkPciFollowingEndpointInput, HvfSnapshotV2NetworkPciFollowingEndpointPlan,
+    HvfSnapshotV2NetworkPciPlatformPlan, HvfSnapshotV2NetworkPlatformPlanStage,
+    HvfSnapshotV2NetworkPreparedProduct, HvfSnapshotV2NetworkProcessResourceIdentity,
+    NetworkPlatformPlanReserve, PrepareHvfSnapshotV2NetworkPlatformPlanError,
+    SystemNetworkPlatformPlanReserve, prepare_network_mmio_platform_plan,
+    prepare_network_pci_platform_plan, validate_product,
+};
+use crate::snapshot_v2_storage_platform::{
+    HvfSnapshotV2StorageMmioPlatformPlan, HvfSnapshotV2StorageMmioProcessConfig,
+    HvfSnapshotV2StoragePciPlatformPlan,
+};
+
+const REDACTED: &str = "<redacted>";
+const STORAGE_MASK: u8 = 1 << 0;
+const ENTROPY_MASK: u8 = 1 << 1;
+const BALLOON_MASK: u8 = 1 << 2;
+const MEMORY_HOTPLUG_MASK: u8 = 1 << 3;
+const NETWORK_MASK: u8 = 1 << 4;
+const VSOCK_MASK: u8 = 1 << 5;
+const SERIAL_DEVICE_KIND: u32 = 3;
+const VSOCK_DEVICE_KIND: u32 = 5;
+
+/// One of the 64 admitted exact-2.12 optional-family presence products.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HvfSnapshotV2VsockProductKind {
+    mask: u8,
+}
+
+impl HvfSnapshotV2VsockProductKind {
+    #[allow(clippy::fn_params_excessive_bools)]
+    pub const fn from_presence(
+        has_storage: bool,
+        has_entropy: bool,
+        has_balloon: bool,
+        has_memory_hotplug: bool,
+        has_network: bool,
+        has_vsock: bool,
+    ) -> Self {
+        Self {
+            mask: ((has_storage as u8) * STORAGE_MASK)
+                | ((has_entropy as u8) * ENTROPY_MASK)
+                | ((has_balloon as u8) * BALLOON_MASK)
+                | ((has_memory_hotplug as u8) * MEMORY_HOTPLUG_MASK)
+                | ((has_network as u8) * NETWORK_MASK)
+                | ((has_vsock as u8) * VSOCK_MASK),
+        }
+    }
+
+    pub const fn has_storage(self) -> bool {
+        self.mask & STORAGE_MASK != 0
+    }
+
+    pub const fn has_entropy(self) -> bool {
+        self.mask & ENTROPY_MASK != 0
+    }
+
+    pub const fn has_balloon(self) -> bool {
+        self.mask & BALLOON_MASK != 0
+    }
+
+    pub const fn has_memory_hotplug(self) -> bool {
+        self.mask & MEMORY_HOTPLUG_MASK != 0
+    }
+
+    pub const fn has_network(self) -> bool {
+        self.mask & NETWORK_MASK != 0
+    }
+
+    pub const fn has_vsock(self) -> bool {
+        self.mask & VSOCK_MASK != 0
+    }
+
+    #[cfg(test)]
+    const fn mask(self) -> u8 {
+        self.mask
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2VsockProductKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2VsockProductKind")
+            .field("has_storage", &self.has_storage())
+            .field("has_entropy", &self.has_entropy())
+            .field("has_balloon", &self.has_balloon())
+            .field("has_memory_hotplug", &self.has_memory_hotplug())
+            .field("has_network", &self.has_network())
+            .field("has_vsock", &self.has_vsock())
+            .finish()
+    }
+}
+
+/// Static or virtio-mem destination ownership retained by one exact-2.12 product.
+pub enum HvfSnapshotV2VsockPreparedMemory {
+    Static(SnapshotV2MemoryBinding),
+    MemoryHotplug {
+        topology: Box<PreparedSnapshotV2MemoryHotplugTopology>,
+        memory: GuestMemory,
+    },
+}
+
+impl fmt::Debug for HvfSnapshotV2VsockPreparedMemory {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2VsockPreparedMemory")
+            .field(
+                "has_memory_hotplug",
+                &matches!(self, Self::MemoryHotplug { .. }),
+            )
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Checked singleton continuation before destination platform placement.
+pub struct HvfSnapshotV2VsockPreparedEndpoint {
+    state: PreparedSnapshotV2VsockRestoreState,
+    config: VsockConfig,
+}
+
+impl HvfSnapshotV2VsockPreparedEndpoint {
+    pub const fn new(state: PreparedSnapshotV2VsockRestoreState, config: VsockConfig) -> Self {
+        Self { state, config }
+    }
+
+    pub const fn state(&self) -> &PreparedSnapshotV2VsockRestoreState {
+        &self.state
+    }
+
+    pub const fn config(&self) -> &VsockConfig {
+        &self.config
+    }
+
+    #[doc(hidden)]
+    pub fn into_parts(self) -> (PreparedSnapshotV2VsockRestoreState, VsockConfig) {
+        (self.state, self.config)
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2VsockPreparedEndpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2VsockPreparedEndpoint")
+            .field("transport", &self.state.transport_kind())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Inputs consumed into one closed exact-2.12 platform product.
+pub struct HvfSnapshotV2VsockPreparedProductParts {
+    pub kind: HvfSnapshotV2VsockProductKind,
+    pub memory: HvfSnapshotV2VsockPreparedMemory,
+    pub storage: Option<PreparedSnapshotV2StorageBundle>,
+    pub entropy: Option<SnapshotV2EntropyRestorePlan>,
+    pub balloon: Option<SnapshotV2BalloonRestorePlan>,
+    pub network: PreparedSnapshotV2NetworkRestoreTopology,
+    pub vsock: Option<HvfSnapshotV2VsockPreparedEndpoint>,
+    pub serial_resource_present: bool,
+    pub binding_keys: Vec<SnapshotRestoreResourceKey>,
+}
+
+impl fmt::Debug for HvfSnapshotV2VsockPreparedProductParts {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2VsockPreparedProductParts")
+            .field("kind", &self.kind)
+            .field("interface_count", &self.network.interfaces().len())
+            .field("resource_count", &self.binding_keys.len())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Complete owner-free exact-2.12 component and resource-identity product.
+pub struct HvfSnapshotV2VsockPreparedProduct {
+    kind: HvfSnapshotV2VsockProductKind,
+    base: HvfSnapshotV2NetworkPreparedProduct,
+    vsock: Option<HvfSnapshotV2VsockPreparedEndpoint>,
+    serial_resource_present: bool,
+    binding_keys: Vec<SnapshotRestoreResourceKey>,
+    vsock_key_index: Option<usize>,
+}
+
+impl HvfSnapshotV2VsockPreparedProduct {
+    pub fn try_from_parts(
+        parts: HvfSnapshotV2VsockPreparedProductParts,
+    ) -> Result<Self, PrepareHvfSnapshotV2VsockPlatformPlanError> {
+        let HvfSnapshotV2VsockPreparedProductParts {
+            kind,
+            memory,
+            storage,
+            entropy,
+            balloon,
+            network,
+            vsock,
+            serial_resource_present,
+            binding_keys,
+        } = parts;
+        let has_memory_hotplug = matches!(
+            &memory,
+            HvfSnapshotV2VsockPreparedMemory::MemoryHotplug { .. }
+        );
+        let actual_kind = HvfSnapshotV2VsockProductKind::from_presence(
+            storage.is_some(),
+            entropy.is_some(),
+            balloon.is_some(),
+            has_memory_hotplug,
+            !network.interfaces().is_empty(),
+            vsock.is_some(),
+        );
+        if kind != actual_kind {
+            return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Product);
+        }
+        validate_prepared_vsock(vsock.as_ref(), network.transport_kind())?;
+        let vsock_key_index = validate_resource_manifest(
+            storage.as_ref(),
+            &network,
+            vsock.as_ref(),
+            serial_resource_present,
+            &binding_keys,
+        )?;
+        let base = build_base_product(memory, network, storage, entropy, balloon);
+        Ok(Self {
+            kind,
+            base,
+            vsock,
+            serial_resource_present,
+            binding_keys,
+            vsock_key_index,
+        })
+    }
+
+    pub const fn kind(&self) -> HvfSnapshotV2VsockProductKind {
+        self.kind
+    }
+
+    pub fn interface_count(&self) -> usize {
+        self.base.interface_count()
+    }
+
+    pub fn resource_keys(&self) -> &[SnapshotRestoreResourceKey] {
+        &self.binding_keys
+    }
+
+    pub const fn serial_resource_present(&self) -> bool {
+        self.serial_resource_present
+    }
+
+    fn validate(&self) -> Result<(), PrepareHvfSnapshotV2VsockPlatformPlanError> {
+        let actual = HvfSnapshotV2VsockProductKind::from_presence(
+            self.base.has_storage(),
+            self.base.has_entropy(),
+            self.base.has_balloon(),
+            self.base.has_memory_hotplug(),
+            self.base.interface_count() != 0,
+            self.vsock.is_some(),
+        );
+        if self.kind != actual {
+            return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Product);
+        }
+        validate_prepared_vsock(self.vsock.as_ref(), self.base.network().transport_kind())?;
+        let key_index = validate_resource_manifest(
+            self.base.storage(),
+            self.base.network(),
+            self.vsock.as_ref(),
+            self.serial_resource_present,
+            &self.binding_keys,
+        )?;
+        if key_index != self.vsock_key_index {
+            return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest);
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2VsockPreparedProduct {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2VsockPreparedProduct")
+            .field("kind", &self.kind)
+            .field("interface_count", &self.base.interface_count())
+            .field("resource_count", &self.binding_keys.len())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+fn validate_prepared_vsock(
+    endpoint: Option<&HvfSnapshotV2VsockPreparedEndpoint>,
+    expected_transport: SnapshotV2DeviceTransportKind,
+) -> Result<(), PrepareHvfSnapshotV2VsockPlatformPlanError> {
+    let Some(endpoint) = endpoint else {
+        return Ok(());
+    };
+    if endpoint.state.transport_kind() != expected_transport {
+        return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::TransportPolicy);
+    }
+    let device = match &endpoint.state {
+        PreparedSnapshotV2VsockRestoreState::Mmio(state) => state.capture().device(),
+        PreparedSnapshotV2VsockRestoreState::Pci(state) => state.capture().device(),
+    };
+    if device.guest_cid() != u64::from(endpoint.config.guest_cid())
+        || device.backend_selector().path() != endpoint.config.uds_path()
+    {
+        return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Vsock);
+    }
+    Ok(())
+}
+
+fn validate_resource_manifest(
+    storage: Option<&PreparedSnapshotV2StorageBundle>,
+    network: &PreparedSnapshotV2NetworkRestoreTopology,
+    vsock: Option<&HvfSnapshotV2VsockPreparedEndpoint>,
+    serial_resource_present: bool,
+    binding_keys: &[SnapshotRestoreResourceKey],
+) -> Result<Option<usize>, PrepareHvfSnapshotV2VsockPlatformPlanError> {
+    let block_count = storage
+        .and_then(PreparedSnapshotV2StorageBundle::block_bundle)
+        .map_or(0, |block| block.records().len());
+    let pmem_count = storage.map_or(0, |storage| storage.pmem_records().len());
+    let expected_count = block_count
+        .checked_add(pmem_count)
+        .and_then(|count| count.checked_add(usize::from(serial_resource_present)))
+        .and_then(|count| count.checked_add(network.interfaces().len()))
+        .and_then(|count| count.checked_add(usize::from(vsock.is_some())))
+        .ok_or(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest)?;
+    if expected_count != binding_keys.len()
+        || binding_keys.len() > MAX_SNAPSHOT_RESTORE_RESOURCES
+        || binding_keys.windows(2).any(|pair| match pair {
+            [left, right] => left >= right,
+            _ => false,
+        })
+    {
+        return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest);
+    }
+
+    let mut keys = binding_keys.iter().enumerate();
+    if let Some(block) = storage.and_then(PreparedSnapshotV2StorageBundle::block_bundle) {
+        for record in block.records() {
+            let Some((_, key)) = keys.next() else {
+                return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest);
+            };
+            if key.resource_class() != SnapshotRestoreResourceClass::BlockBacking
+                || key.device_key() != record.key()
+                || key.public_id().as_str() != record.drive_id()
+            {
+                return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest);
+            }
+        }
+    }
+    if let Some(storage) = storage {
+        for record in storage.pmem_records() {
+            let Some((_, key)) = keys.next() else {
+                return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest);
+            };
+            if key.resource_class() != SnapshotRestoreResourceClass::PmemBacking
+                || key.device_key() != record.key()
+                || key.public_id().as_str() != record.pmem_id()
+            {
+                return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest);
+            }
+        }
+    }
+    if serial_resource_present {
+        let Some((_, key)) = keys.next() else {
+            return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest);
+        };
+        if key.resource_class() != SnapshotRestoreResourceClass::SerialSink
+            || key.device_key().kind() != SERIAL_DEVICE_KIND
+            || key.device_key().instance() != 0
+            || key.public_id().as_str() != NATIVE_V2_SERIAL_RESTORE_PUBLIC_ID
+        {
+            return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest);
+        }
+    }
+    for interface in network.interfaces() {
+        let Some((_, key)) = keys.next() else {
+            return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest);
+        };
+        if key != interface.resource_key() {
+            return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest);
+        }
+    }
+    let vsock_key_index = if vsock.is_some() {
+        let Some((index, key)) = keys.next() else {
+            return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest);
+        };
+        if key.resource_class() != SnapshotRestoreResourceClass::VsockEndpoint
+            || key.device_key().kind() != VSOCK_DEVICE_KIND
+            || key.device_key().instance() != 0
+            || key.public_id().as_str() != NATIVE_V2_VSOCK_RESTORE_PUBLIC_ID
+        {
+            return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest);
+        }
+        Some(index)
+    } else {
+        None
+    };
+    if keys.next().is_some() {
+        return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest);
+    }
+    Ok(vsock_key_index)
+}
+
+fn build_base_product(
+    memory: HvfSnapshotV2VsockPreparedMemory,
+    network: PreparedSnapshotV2NetworkRestoreTopology,
+    storage: Option<PreparedSnapshotV2StorageBundle>,
+    entropy: Option<SnapshotV2EntropyRestorePlan>,
+    balloon: Option<SnapshotV2BalloonRestorePlan>,
+) -> HvfSnapshotV2NetworkPreparedProduct {
+    match (memory, balloon, storage, entropy) {
+        (HvfSnapshotV2VsockPreparedMemory::Static(binding), None, None, None) => {
+            HvfSnapshotV2NetworkPreparedProduct::serial_network(binding, network)
+        }
+        (HvfSnapshotV2VsockPreparedMemory::Static(binding), None, Some(storage), None) => {
+            HvfSnapshotV2NetworkPreparedProduct::serial_storage_network(
+                binding, network, storage,
+            )
+        }
+        (HvfSnapshotV2VsockPreparedMemory::Static(binding), None, None, Some(entropy)) => {
+            HvfSnapshotV2NetworkPreparedProduct::serial_entropy_network(
+                binding, network, entropy,
+            )
+        }
+        (
+            HvfSnapshotV2VsockPreparedMemory::Static(binding),
+            None,
+            Some(storage),
+            Some(entropy),
+        ) => HvfSnapshotV2NetworkPreparedProduct::serial_storage_entropy_network(
+            binding, network, storage, entropy,
+        ),
+        (HvfSnapshotV2VsockPreparedMemory::Static(binding), Some(balloon), None, None) => {
+            HvfSnapshotV2NetworkPreparedProduct::serial_balloon_network(
+                binding, network, balloon,
+            )
+        }
+        (
+            HvfSnapshotV2VsockPreparedMemory::Static(binding),
+            Some(balloon),
+            Some(storage),
+            None,
+        ) => HvfSnapshotV2NetworkPreparedProduct::serial_balloon_storage_network(
+            binding, network, balloon, storage,
+        ),
+        (
+            HvfSnapshotV2VsockPreparedMemory::Static(binding),
+            Some(balloon),
+            None,
+            Some(entropy),
+        ) => HvfSnapshotV2NetworkPreparedProduct::serial_balloon_entropy_network(
+            binding, network, balloon, entropy,
+        ),
+        (
+            HvfSnapshotV2VsockPreparedMemory::Static(binding),
+            Some(balloon),
+            Some(storage),
+            Some(entropy),
+        ) => HvfSnapshotV2NetworkPreparedProduct::serial_balloon_storage_entropy_network(
+            binding, network, balloon, storage, entropy,
+        ),
+        (
+            HvfSnapshotV2VsockPreparedMemory::MemoryHotplug { topology, memory },
+            None,
+            None,
+            None,
+        ) => HvfSnapshotV2NetworkPreparedProduct::serial_network_memory_hotplug(
+            *topology, memory, network,
+        ),
+        (
+            HvfSnapshotV2VsockPreparedMemory::MemoryHotplug { topology, memory },
+            None,
+            Some(storage),
+            None,
+        ) => HvfSnapshotV2NetworkPreparedProduct::serial_storage_network_memory_hotplug(
+            *topology, memory, network, storage,
+        ),
+        (
+            HvfSnapshotV2VsockPreparedMemory::MemoryHotplug { topology, memory },
+            None,
+            None,
+            Some(entropy),
+        ) => HvfSnapshotV2NetworkPreparedProduct::serial_entropy_network_memory_hotplug(
+            *topology, memory, network, entropy,
+        ),
+        (
+            HvfSnapshotV2VsockPreparedMemory::MemoryHotplug { topology, memory },
+            None,
+            Some(storage),
+            Some(entropy),
+        ) => HvfSnapshotV2NetworkPreparedProduct::serial_storage_entropy_network_memory_hotplug(
+            *topology, memory, network, storage, entropy,
+        ),
+        (
+            HvfSnapshotV2VsockPreparedMemory::MemoryHotplug { topology, memory },
+            Some(balloon),
+            None,
+            None,
+        ) => HvfSnapshotV2NetworkPreparedProduct::serial_balloon_network_memory_hotplug(
+            *topology, memory, network, balloon,
+        ),
+        (
+            HvfSnapshotV2VsockPreparedMemory::MemoryHotplug { topology, memory },
+            Some(balloon),
+            Some(storage),
+            None,
+        ) => HvfSnapshotV2NetworkPreparedProduct::serial_balloon_storage_network_memory_hotplug(
+            *topology, memory, network, balloon, storage,
+        ),
+        (
+            HvfSnapshotV2VsockPreparedMemory::MemoryHotplug { topology, memory },
+            Some(balloon),
+            None,
+            Some(entropy),
+        ) => HvfSnapshotV2NetworkPreparedProduct::serial_balloon_entropy_network_memory_hotplug(
+            *topology, memory, network, balloon, entropy,
+        ),
+        (
+            HvfSnapshotV2VsockPreparedMemory::MemoryHotplug { topology, memory },
+            Some(balloon),
+            Some(storage),
+            Some(entropy),
+        ) => HvfSnapshotV2NetworkPreparedProduct::
+            serial_balloon_storage_entropy_network_memory_hotplug(
+                *topology, memory, network, balloon, storage, entropy,
+            ),
+    }
+}
+
+/// Canonical destination layouts for one exact-2.12 MMIO process.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct HvfSnapshotV2VsockMmioProcessConfig {
+    network: HvfSnapshotV2NetworkMmioProcessConfig,
+    vsock_layout: VsockMmioLayout,
+}
+
+impl HvfSnapshotV2VsockMmioProcessConfig {
+    pub const fn new(
+        network: HvfSnapshotV2NetworkMmioProcessConfig,
+        vsock_layout: VsockMmioLayout,
+    ) -> Self {
+        Self {
+            network,
+            vsock_layout,
+        }
+    }
+
+    pub const fn from_layouts(
+        balloon_layout: BalloonMmioLayout,
+        storage: HvfSnapshotV2StorageMmioProcessConfig,
+        network_layout: NetworkMmioLayout,
+        vsock_layout: VsockMmioLayout,
+        entropy_layout: EntropyMmioLayout,
+        memory_hotplug_layout: VirtioMemMmioLayout,
+    ) -> Self {
+        Self::new(
+            HvfSnapshotV2NetworkMmioProcessConfig::new(
+                balloon_layout,
+                storage,
+                network_layout,
+                entropy_layout,
+                memory_hotplug_layout,
+            ),
+            vsock_layout,
+        )
+    }
+
+    pub const fn network(self) -> HvfSnapshotV2NetworkMmioProcessConfig {
+        self.network
+    }
+
+    pub const fn vsock_layout(self) -> VsockMmioLayout {
+        self.vsock_layout
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2VsockMmioProcessConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2VsockMmioProcessConfig")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Borrowed singleton process projection for value-only identity preflight.
+#[derive(Clone, Copy)]
+#[doc(hidden)]
+pub struct HvfSnapshotV2VsockProcessResourceIdentity<'a> {
+    resource_key: &'a SnapshotRestoreResourceKey,
+    config: &'a VsockConfig,
+}
+
+impl<'a> HvfSnapshotV2VsockProcessResourceIdentity<'a> {
+    pub const fn new(
+        resource_key: &'a SnapshotRestoreResourceKey,
+        config: &'a VsockConfig,
+    ) -> Self {
+        Self {
+            resource_key,
+            config,
+        }
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2VsockProcessResourceIdentity<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2VsockProcessResourceIdentity")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Complete fixed placement and continuation for one MMIO vsock endpoint.
+pub struct HvfSnapshotV2VsockMmioEndpointPlan {
+    resource_key: SnapshotRestoreResourceKey,
+    config: VsockConfig,
+    state: PreparedSnapshotV2VsockMmioState,
+    queue_ranges: [Option<[GuestMemoryRange; 3]>; VIRTIO_VSOCK_QUEUE_COUNT],
+    placement: HvfSnapshotV2NetworkAuxiliaryMmioEndpointPlan,
+}
+
+impl HvfSnapshotV2VsockMmioEndpointPlan {
+    pub const fn resource_key(&self) -> &SnapshotRestoreResourceKey {
+        &self.resource_key
+    }
+
+    pub const fn config(&self) -> &VsockConfig {
+        &self.config
+    }
+
+    pub const fn state(&self) -> &PreparedSnapshotV2VsockMmioState {
+        &self.state
+    }
+
+    pub const fn queue_ranges(&self) -> &[Option<[GuestMemoryRange; 3]>; VIRTIO_VSOCK_QUEUE_COUNT] {
+        &self.queue_ranges
+    }
+
+    pub const fn region(&self) -> MmioRegion {
+        self.placement.region()
+    }
+
+    pub const fn dispatcher_region_id(&self) -> MmioRegionId {
+        self.placement.dispatcher_region_id()
+    }
+
+    pub const fn interrupt_line(&self) -> GuestInterruptLine {
+        self.placement.interrupt_line()
+    }
+
+    pub const fn fdt_device(&self) -> Arm64FdtVirtioMmioDevice {
+        self.placement.fdt_device()
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2VsockMmioEndpointPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2VsockMmioEndpointPlan")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Complete fixed placement and continuation for one PCI vsock endpoint.
+pub struct HvfSnapshotV2VsockPciEndpointPlan {
+    resource_key: SnapshotRestoreResourceKey,
+    config: VsockConfig,
+    state: PreparedSnapshotV2VsockPciState,
+    queue_ranges: [Option<[GuestMemoryRange; 3]>; VIRTIO_VSOCK_QUEUE_COUNT],
+    placement: HvfSnapshotV2NetworkAuxiliaryPciEndpointPlan,
+    queue_vectors: [u16; VIRTIO_VSOCK_QUEUE_COUNT],
+    config_vector: u16,
+}
+
+impl HvfSnapshotV2VsockPciEndpointPlan {
+    pub const fn resource_key(&self) -> &SnapshotRestoreResourceKey {
+        &self.resource_key
+    }
+
+    pub const fn config(&self) -> &VsockConfig {
+        &self.config
+    }
+
+    pub const fn state(&self) -> &PreparedSnapshotV2VsockPciState {
+        &self.state
+    }
+
+    pub const fn queue_ranges(&self) -> &[Option<[GuestMemoryRange; 3]>; VIRTIO_VSOCK_QUEUE_COUNT] {
+        &self.queue_ranges
+    }
+
+    pub const fn origin(&self) -> StorageDeviceOrigin {
+        self.placement.origin()
+    }
+
+    pub const fn sbdf(&self) -> bangbang_runtime::pci::PciSbdf {
+        self.placement.sbdf()
+    }
+
+    pub const fn bar_region_id(&self) -> MmioRegionId {
+        self.placement.bar_region_id()
+    }
+
+    pub const fn dispatcher_region_id(&self) -> MmioRegionId {
+        self.placement.dispatcher_region_id()
+    }
+
+    pub const fn bar_range(&self) -> GuestMemoryRange {
+        self.placement.bar_range()
+    }
+
+    pub const fn route_count(&self) -> usize {
+        self.placement.route_count()
+    }
+
+    pub const fn queue_vectors(&self) -> &[u16; VIRTIO_VSOCK_QUEUE_COUNT] {
+        &self.queue_vectors
+    }
+
+    pub const fn config_vector(&self) -> u16 {
+        self.config_vector
+    }
+
+    pub const fn msi_interrupt_count(&self) -> u32 {
+        self.placement.msi_interrupt_count()
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2VsockPciEndpointPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2VsockPciEndpointPlan")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Complete immutable exact-2.12 MMIO product proof.
+pub struct HvfSnapshotV2VsockMmioPlatformPlan {
+    kind: HvfSnapshotV2VsockProductKind,
+    base: HvfSnapshotV2NetworkMmioPlatformPlan,
+    vsock: Option<HvfSnapshotV2VsockMmioEndpointPlan>,
+    serial_resource_present: bool,
+    binding_keys: Vec<SnapshotRestoreResourceKey>,
+}
+
+impl HvfSnapshotV2VsockMmioPlatformPlan {
+    pub const fn kind(&self) -> HvfSnapshotV2VsockProductKind {
+        self.kind
+    }
+
+    pub const fn mapping(&self) -> Option<&HvfSnapshotV2MemoryHotplugMappingPlan> {
+        self.base.mapping()
+    }
+
+    pub const fn balloon(&self) -> Option<HvfSnapshotV2BalloonMmioEndpointPlan> {
+        self.base.balloon()
+    }
+
+    pub const fn storage(&self) -> Option<&HvfSnapshotV2StorageMmioPlatformPlan> {
+        self.base.storage()
+    }
+
+    pub fn network(&self) -> &[HvfSnapshotV2NetworkMmioEndpointPlan] {
+        self.base.network()
+    }
+
+    pub const fn vsock(&self) -> Option<&HvfSnapshotV2VsockMmioEndpointPlan> {
+        self.vsock.as_ref()
+    }
+
+    pub const fn entropy(&self) -> Option<HvfSnapshotV2NetworkAuxiliaryMmioEndpointPlan> {
+        self.base.entropy()
+    }
+
+    pub const fn memory_hotplug(&self) -> Option<HvfSnapshotV2NetworkAuxiliaryMmioEndpointPlan> {
+        self.base.memory_hotplug()
+    }
+
+    pub const fn serial_interrupt(&self) -> GuestInterruptLine {
+        self.base.serial_interrupt()
+    }
+
+    pub const fn vmgenid_interrupt(&self) -> GuestInterruptLine {
+        self.base.vmgenid_interrupt()
+    }
+
+    pub const fn vmclock_interrupt(&self) -> GuestInterruptLine {
+        self.base.vmclock_interrupt()
+    }
+
+    pub fn resource_keys(&self) -> &[SnapshotRestoreResourceKey] {
+        &self.binding_keys
+    }
+
+    pub const fn serial_resource_present(&self) -> bool {
+        self.serial_resource_present
+    }
+
+    #[doc(hidden)]
+    pub fn preflight_process_resource_identity<'a>(
+        &self,
+        resources: impl ExactSizeIterator<Item = HvfSnapshotV2NetworkProcessResourceIdentity<'a>>,
+        mmds_state: Option<&bangbang_runtime::snapshot_network_v2_11::SnapshotV2MmdsState>,
+        mmds_controller: Option<&bangbang_runtime::mmds::MmdsConfig>,
+        vsock: Option<HvfSnapshotV2VsockProcessResourceIdentity<'a>>,
+        binding_keys: &[SnapshotRestoreResourceKey],
+    ) -> bool {
+        self.base
+            .preflight_process_resource_identity(resources, mmds_state, mmds_controller)
+            && matches_vsock_identity_mmio(self.vsock.as_ref(), vsock)
+            && self.binding_keys == binding_keys
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2VsockMmioPlatformPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2VsockMmioPlatformPlan")
+            .field("kind", &self.kind)
+            .field("interface_count", &self.base.network().len())
+            .field("resource_count", &self.binding_keys.len())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Complete immutable exact-2.12 PCI product proof.
+pub struct HvfSnapshotV2VsockPciPlatformPlan {
+    kind: HvfSnapshotV2VsockProductKind,
+    base: HvfSnapshotV2NetworkPciPlatformPlan,
+    vsock: Option<HvfSnapshotV2VsockPciEndpointPlan>,
+    serial_resource_present: bool,
+    binding_keys: Vec<SnapshotRestoreResourceKey>,
+}
+
+impl HvfSnapshotV2VsockPciPlatformPlan {
+    pub const fn kind(&self) -> HvfSnapshotV2VsockProductKind {
+        self.kind
+    }
+
+    pub const fn mapping(&self) -> Option<&HvfSnapshotV2MemoryHotplugMappingPlan> {
+        self.base.mapping()
+    }
+
+    pub const fn balloon(&self) -> Option<HvfSnapshotV2BalloonPciEndpointPlan> {
+        self.base.balloon()
+    }
+
+    pub const fn storage(&self) -> Option<&HvfSnapshotV2StoragePciPlatformPlan> {
+        self.base.storage()
+    }
+
+    pub fn network(&self) -> &[HvfSnapshotV2NetworkPciEndpointPlan] {
+        self.base.network()
+    }
+
+    pub const fn vsock(&self) -> Option<&HvfSnapshotV2VsockPciEndpointPlan> {
+        self.vsock.as_ref()
+    }
+
+    pub const fn entropy(&self) -> Option<HvfSnapshotV2NetworkAuxiliaryPciEndpointPlan> {
+        self.base.entropy()
+    }
+
+    pub const fn memory_hotplug(&self) -> Option<HvfSnapshotV2NetworkAuxiliaryPciEndpointPlan> {
+        self.base.memory_hotplug()
+    }
+
+    pub const fn host(&self) -> Arm64FdtPciHost {
+        self.base.host()
+    }
+
+    pub const fn msi(&self) -> HvfGicMsiMetadata {
+        self.base.msi()
+    }
+
+    pub const fn endpoint_count(&self) -> usize {
+        self.base.endpoint_count()
+    }
+
+    pub const fn route_demand(&self) -> usize {
+        self.base.route_demand()
+    }
+
+    pub const fn serial_interrupt(&self) -> GuestInterruptLine {
+        self.base.serial_interrupt()
+    }
+
+    pub const fn vmgenid_interrupt(&self) -> GuestInterruptLine {
+        self.base.vmgenid_interrupt()
+    }
+
+    pub const fn vmclock_interrupt(&self) -> GuestInterruptLine {
+        self.base.vmclock_interrupt()
+    }
+
+    pub fn resource_keys(&self) -> &[SnapshotRestoreResourceKey] {
+        &self.binding_keys
+    }
+
+    pub const fn serial_resource_present(&self) -> bool {
+        self.serial_resource_present
+    }
+
+    #[doc(hidden)]
+    pub fn preflight_process_resource_identity<'a>(
+        &self,
+        resources: impl ExactSizeIterator<Item = HvfSnapshotV2NetworkProcessResourceIdentity<'a>>,
+        mmds_state: Option<&bangbang_runtime::snapshot_network_v2_11::SnapshotV2MmdsState>,
+        mmds_controller: Option<&bangbang_runtime::mmds::MmdsConfig>,
+        vsock: Option<HvfSnapshotV2VsockProcessResourceIdentity<'a>>,
+        binding_keys: &[SnapshotRestoreResourceKey],
+    ) -> bool {
+        self.base
+            .preflight_process_resource_identity(resources, mmds_state, mmds_controller)
+            && matches_vsock_identity_pci(self.vsock.as_ref(), vsock)
+            && self.binding_keys == binding_keys
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2VsockPciPlatformPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2VsockPciPlatformPlan")
+            .field("kind", &self.kind)
+            .field("interface_count", &self.base.network().len())
+            .field("endpoint_count", &self.base.endpoint_count())
+            .field("resource_count", &self.binding_keys.len())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+fn matches_vsock_identity_mmio(
+    endpoint: Option<&HvfSnapshotV2VsockMmioEndpointPlan>,
+    identity: Option<HvfSnapshotV2VsockProcessResourceIdentity<'_>>,
+) -> bool {
+    match (endpoint, identity) {
+        (None, None) => true,
+        (Some(endpoint), Some(identity)) => {
+            endpoint.resource_key() == identity.resource_key && endpoint.config() == identity.config
+        }
+        _ => false,
+    }
+}
+
+fn matches_vsock_identity_pci(
+    endpoint: Option<&HvfSnapshotV2VsockPciEndpointPlan>,
+    identity: Option<HvfSnapshotV2VsockProcessResourceIdentity<'_>>,
+) -> bool {
+    match (endpoint, identity) {
+        (None, None) => true,
+        (Some(endpoint), Some(identity)) => {
+            endpoint.resource_key() == identity.resource_key && endpoint.config() == identity.config
+        }
+        _ => false,
+    }
+}
+
+/// Stable cancellation checkpoints before an exact-2.12 plan is published.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfSnapshotV2VsockPlatformPlanStage {
+    Start,
+    Product,
+    Interface,
+    Vsock,
+    Components,
+    Inventory,
+    Completion,
+}
+
+/// Redacted rejection from exact-2.12 vsock platform-product planning.
+pub enum PrepareHvfSnapshotV2VsockPlatformPlanError {
+    Product,
+    Manifest,
+    Vsock,
+    TransportPolicy,
+    Placement,
+    ResourcePlan,
+    Allocation,
+    Network(Box<PrepareHvfSnapshotV2NetworkPlatformPlanError>),
+    Cancelled {
+        stage: HvfSnapshotV2VsockPlatformPlanStage,
+    },
+}
+
+impl fmt::Debug for PrepareHvfSnapshotV2VsockPlatformPlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let category = match self {
+            Self::Product => "product",
+            Self::Manifest => "manifest",
+            Self::Vsock => "vsock",
+            Self::TransportPolicy => "transport-policy",
+            Self::Placement => "placement",
+            Self::ResourcePlan => "resource-plan",
+            Self::Allocation => "allocation",
+            Self::Network(_) => "network",
+            Self::Cancelled { .. } => "cancelled",
+        };
+        formatter
+            .debug_struct("PrepareHvfSnapshotV2VsockPlatformPlanError")
+            .field("category", &category)
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+impl fmt::Display for PrepareHvfSnapshotV2VsockPlatformPlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Product => "native-v2 vsock product presence is inconsistent",
+            Self::Manifest => "native-v2 vsock process resource manifest is inconsistent",
+            Self::Vsock => "native-v2 vsock endpoint projection is inconsistent",
+            Self::TransportPolicy => "native-v2 vsock product transport is inconsistent",
+            Self::Placement => "native-v2 vsock endpoint placement is inconsistent",
+            Self::ResourcePlan => "native-v2 vsock platform resources are inconsistent",
+            Self::Allocation => "native-v2 vsock temporary planning allocation failed",
+            Self::Network(_) => "native-v2 vsock aggregate platform planning failed",
+            Self::Cancelled { .. } => "native-v2 vsock platform planning was cancelled",
+        })
+    }
+}
+
+impl std::error::Error for PrepareHvfSnapshotV2VsockPlatformPlanError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Network(source) => Some(source),
+            Self::Product
+            | Self::Manifest
+            | Self::Vsock
+            | Self::TransportPolicy
+            | Self::Placement
+            | Self::ResourcePlan
+            | Self::Allocation
+            | Self::Cancelled { .. } => None,
+        }
+    }
+}
+
+fn check_cancelled(
+    is_cancelled: &mut impl FnMut(HvfSnapshotV2VsockPlatformPlanStage) -> bool,
+    stage: HvfSnapshotV2VsockPlatformPlanStage,
+) -> Result<(), PrepareHvfSnapshotV2VsockPlatformPlanError> {
+    if is_cancelled(stage) {
+        Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Cancelled { stage })
+    } else {
+        Ok(())
+    }
+}
+
+fn exact_stage(
+    stage: HvfSnapshotV2NetworkPlatformPlanStage,
+) -> Option<HvfSnapshotV2VsockPlatformPlanStage> {
+    match stage {
+        HvfSnapshotV2NetworkPlatformPlanStage::Start
+        | HvfSnapshotV2NetworkPlatformPlanStage::Product => None,
+        HvfSnapshotV2NetworkPlatformPlanStage::Interface => {
+            Some(HvfSnapshotV2VsockPlatformPlanStage::Interface)
+        }
+        HvfSnapshotV2NetworkPlatformPlanStage::Components => {
+            Some(HvfSnapshotV2VsockPlatformPlanStage::Components)
+        }
+        HvfSnapshotV2NetworkPlatformPlanStage::Inventory => {
+            Some(HvfSnapshotV2VsockPlatformPlanStage::Inventory)
+        }
+        HvfSnapshotV2NetworkPlatformPlanStage::Completion => {
+            Some(HvfSnapshotV2VsockPlatformPlanStage::Completion)
+        }
+    }
+}
+
+fn map_network_error(
+    error: PrepareHvfSnapshotV2NetworkPlatformPlanError,
+) -> PrepareHvfSnapshotV2VsockPlatformPlanError {
+    match error {
+        PrepareHvfSnapshotV2NetworkPlatformPlanError::Allocation => {
+            PrepareHvfSnapshotV2VsockPlatformPlanError::Allocation
+        }
+        PrepareHvfSnapshotV2NetworkPlatformPlanError::Cancelled { stage } => {
+            match exact_stage(stage) {
+                Some(stage) => PrepareHvfSnapshotV2VsockPlatformPlanError::Cancelled { stage },
+                None => PrepareHvfSnapshotV2VsockPlatformPlanError::Network(Box::new(
+                    PrepareHvfSnapshotV2NetworkPlatformPlanError::Cancelled { stage },
+                )),
+            }
+        }
+        error => PrepareHvfSnapshotV2VsockPlatformPlanError::Network(Box::new(error)),
+    }
+}
+
+fn queue_ranges(
+    queue: VirtioMmioQueueState,
+) -> Result<Option<[GuestMemoryRange; 3]>, PrepareHvfSnapshotV2VsockPlatformPlanError> {
+    if queue.size() == 0 {
+        return Ok(None);
+    }
+    let descriptor_size = u64::from(queue.size())
+        .checked_mul(16)
+        .ok_or(PrepareHvfSnapshotV2VsockPlatformPlanError::ResourcePlan)?;
+    let available_size = u64::from(queue.size())
+        .checked_mul(2)
+        .and_then(|size| size.checked_add(6))
+        .ok_or(PrepareHvfSnapshotV2VsockPlatformPlanError::ResourcePlan)?;
+    let used_size = u64::from(queue.size())
+        .checked_mul(8)
+        .and_then(|size| size.checked_add(6))
+        .ok_or(PrepareHvfSnapshotV2VsockPlatformPlanError::ResourcePlan)?;
+    Ok(Some([
+        GuestMemoryRange::new(queue.descriptor_table(), descriptor_size)
+            .map_err(|_| PrepareHvfSnapshotV2VsockPlatformPlanError::ResourcePlan)?,
+        GuestMemoryRange::new(queue.driver_ring(), available_size)
+            .map_err(|_| PrepareHvfSnapshotV2VsockPlatformPlanError::ResourcePlan)?,
+        GuestMemoryRange::new(queue.device_ring(), used_size)
+            .map_err(|_| PrepareHvfSnapshotV2VsockPlatformPlanError::ResourcePlan)?,
+    ]))
+}
+
+fn mmio_vsock_queue_ranges(
+    state: &PreparedSnapshotV2VsockMmioState,
+) -> Result<
+    [Option<[GuestMemoryRange; 3]>; VIRTIO_VSOCK_QUEUE_COUNT],
+    PrepareHvfSnapshotV2VsockPlatformPlanError,
+> {
+    let queues = state.capture().transport().queues();
+    let [rx, tx, event] = queues else {
+        return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Vsock);
+    };
+    Ok([
+        queue_ranges(*rx)?,
+        queue_ranges(*tx)?,
+        queue_ranges(*event)?,
+    ])
+}
+
+fn pci_vsock_queue_ranges(
+    state: &PreparedSnapshotV2VsockPciState,
+) -> Result<
+    [Option<[GuestMemoryRange; 3]>; VIRTIO_VSOCK_QUEUE_COUNT],
+    PrepareHvfSnapshotV2VsockPlatformPlanError,
+> {
+    let queues = state.capture().transport().queues();
+    if queues.queue_count() != VIRTIO_VSOCK_QUEUE_COUNT {
+        return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Vsock);
+    }
+    let queue = |index: u32| {
+        queues
+            .queue(index)
+            .copied()
+            .map_err(|_| PrepareHvfSnapshotV2VsockPlatformPlanError::Vsock)
+    };
+    Ok([
+        queue_ranges(queue(0)?)?,
+        queue_ranges(queue(1)?)?,
+        queue_ranges(queue(2)?)?,
+    ])
+}
+
+fn project_mmio_vsock(
+    endpoint: &HvfSnapshotV2VsockPreparedEndpoint,
+    layout: VsockMmioLayout,
+) -> Result<
+    HvfSnapshotV2NetworkMmioFollowingEndpointInput,
+    PrepareHvfSnapshotV2VsockPlatformPlanError,
+> {
+    let PreparedSnapshotV2VsockRestoreState::Mmio(state) = &endpoint.state else {
+        return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::TransportPolicy);
+    };
+    let region = MmioRegion::new(
+        layout.region_id(),
+        layout.address(),
+        VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+    )
+    .map_err(|_| PrepareHvfSnapshotV2VsockPlatformPlanError::ResourcePlan)?;
+    if state.region() != region {
+        return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Placement);
+    }
+    Ok(HvfSnapshotV2NetworkMmioFollowingEndpointInput {
+        region,
+        interrupt_line: state.interrupt_line(),
+        queue_ranges: mmio_vsock_queue_ranges(state)?,
+    })
+}
+
+fn project_pci_vsock(
+    endpoint: &HvfSnapshotV2VsockPreparedEndpoint,
+) -> Result<
+    HvfSnapshotV2NetworkPciFollowingEndpointInput<'_>,
+    PrepareHvfSnapshotV2VsockPlatformPlanError,
+> {
+    let PreparedSnapshotV2VsockRestoreState::Pci(state) = &endpoint.state else {
+        return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::TransportPolicy);
+    };
+    Ok(HvfSnapshotV2NetworkPciFollowingEndpointInput {
+        origin: state.origin(),
+        phase: state.capture().transport().phase(),
+        sbdf: state.sbdf(),
+        bar_range: state.bar_range(),
+        queue_ranges: pci_vsock_queue_ranges(state)?,
+        msix: state.capture().transport().msix_state(),
+    })
+}
+
+/// Proves one complete exact-2.12 MMIO product before live ownership.
+pub fn prepare_hvf_snapshot_v2_vsock_mmio_platform_plan(
+    platform: &HvfSnapshotV2PlatformState,
+    product: HvfSnapshotV2VsockPreparedProduct,
+    process: HvfSnapshotV2VsockMmioProcessConfig,
+) -> Result<HvfSnapshotV2VsockMmioPlatformPlan, PrepareHvfSnapshotV2VsockPlatformPlanError> {
+    prepare_vsock_mmio_platform_plan(
+        platform,
+        product,
+        process,
+        &mut SystemNetworkPlatformPlanReserve,
+        &mut |_| false,
+    )
+}
+
+/// Proves one exact-2.12 MMIO product with stable cancellation checkpoints.
+pub fn prepare_hvf_snapshot_v2_vsock_mmio_platform_plan_with_cancel<C>(
+    platform: &HvfSnapshotV2PlatformState,
+    product: HvfSnapshotV2VsockPreparedProduct,
+    process: HvfSnapshotV2VsockMmioProcessConfig,
+    mut is_cancelled: C,
+) -> Result<HvfSnapshotV2VsockMmioPlatformPlan, PrepareHvfSnapshotV2VsockPlatformPlanError>
+where
+    C: FnMut(HvfSnapshotV2VsockPlatformPlanStage) -> bool,
+{
+    prepare_vsock_mmio_platform_plan(
+        platform,
+        product,
+        process,
+        &mut SystemNetworkPlatformPlanReserve,
+        &mut is_cancelled,
+    )
+}
+
+pub(crate) fn prepare_vsock_mmio_platform_plan(
+    platform: &HvfSnapshotV2PlatformState,
+    product: HvfSnapshotV2VsockPreparedProduct,
+    process: HvfSnapshotV2VsockMmioProcessConfig,
+    reserve: &mut impl NetworkPlatformPlanReserve,
+    is_cancelled: &mut impl FnMut(HvfSnapshotV2VsockPlatformPlanStage) -> bool,
+) -> Result<HvfSnapshotV2VsockMmioPlatformPlan, PrepareHvfSnapshotV2VsockPlatformPlanError> {
+    check_cancelled(is_cancelled, HvfSnapshotV2VsockPlatformPlanStage::Start)?;
+    product.validate()?;
+    if validate_product(platform, &product.base).map_err(map_network_error)?
+        != SnapshotV2DeviceTransportKind::Mmio
+    {
+        return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::TransportPolicy);
+    }
+    check_cancelled(is_cancelled, HvfSnapshotV2VsockPlatformPlanStage::Product)?;
+
+    let following_input = product
+        .vsock
+        .as_ref()
+        .map(|endpoint| project_mmio_vsock(endpoint, process.vsock_layout()))
+        .transpose()?;
+    check_cancelled(is_cancelled, HvfSnapshotV2VsockPlatformPlanStage::Vsock)?;
+    let resource_key = product
+        .vsock_key_index
+        .map(|index| {
+            product
+                .binding_keys
+                .get(index)
+                .ok_or(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest)
+                .and_then(|key| reserve.clone_key(key).map_err(map_network_error))
+        })
+        .transpose()?;
+
+    let HvfSnapshotV2VsockPreparedProduct {
+        kind,
+        base,
+        vsock,
+        serial_resource_present,
+        binding_keys,
+        vsock_key_index: _,
+    } = product;
+    let mut mapped_cancel = |stage| exact_stage(stage).is_some_and(&mut *is_cancelled);
+    let (base, following) = prepare_network_mmio_platform_plan(
+        platform,
+        base,
+        process.network(),
+        following_input,
+        reserve,
+        &mut mapped_cancel,
+    )
+    .map_err(map_network_error)?;
+    let vsock = finish_mmio_vsock(vsock, resource_key, following)?;
+    Ok(HvfSnapshotV2VsockMmioPlatformPlan {
+        kind,
+        base,
+        vsock,
+        serial_resource_present,
+        binding_keys,
+    })
+}
+
+fn finish_mmio_vsock(
+    endpoint: Option<HvfSnapshotV2VsockPreparedEndpoint>,
+    resource_key: Option<SnapshotRestoreResourceKey>,
+    following: Option<HvfSnapshotV2NetworkMmioFollowingEndpointPlan>,
+) -> Result<Option<HvfSnapshotV2VsockMmioEndpointPlan>, PrepareHvfSnapshotV2VsockPlatformPlanError>
+{
+    match (endpoint, resource_key, following) {
+        (None, None, None) => Ok(None),
+        (Some(endpoint), Some(resource_key), Some(following)) => {
+            let PreparedSnapshotV2VsockRestoreState::Mmio(state) = endpoint.state else {
+                return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::TransportPolicy);
+            };
+            Ok(Some(HvfSnapshotV2VsockMmioEndpointPlan {
+                resource_key,
+                config: endpoint.config,
+                state,
+                queue_ranges: following.queue_ranges,
+                placement: following.placement,
+            }))
+        }
+        _ => Err(PrepareHvfSnapshotV2VsockPlatformPlanError::ResourcePlan),
+    }
+}
+
+/// Proves one complete exact-2.12 PCI product before live ownership.
+pub fn prepare_hvf_snapshot_v2_vsock_pci_platform_plan(
+    platform: &HvfSnapshotV2PlatformState,
+    product: HvfSnapshotV2VsockPreparedProduct,
+) -> Result<HvfSnapshotV2VsockPciPlatformPlan, PrepareHvfSnapshotV2VsockPlatformPlanError> {
+    prepare_vsock_pci_platform_plan(
+        platform,
+        product,
+        &mut SystemNetworkPlatformPlanReserve,
+        &mut |_| false,
+    )
+}
+
+/// Proves one exact-2.12 PCI product with stable cancellation checkpoints.
+pub fn prepare_hvf_snapshot_v2_vsock_pci_platform_plan_with_cancel<C>(
+    platform: &HvfSnapshotV2PlatformState,
+    product: HvfSnapshotV2VsockPreparedProduct,
+    mut is_cancelled: C,
+) -> Result<HvfSnapshotV2VsockPciPlatformPlan, PrepareHvfSnapshotV2VsockPlatformPlanError>
+where
+    C: FnMut(HvfSnapshotV2VsockPlatformPlanStage) -> bool,
+{
+    prepare_vsock_pci_platform_plan(
+        platform,
+        product,
+        &mut SystemNetworkPlatformPlanReserve,
+        &mut is_cancelled,
+    )
+}
+
+pub(crate) fn prepare_vsock_pci_platform_plan(
+    platform: &HvfSnapshotV2PlatformState,
+    product: HvfSnapshotV2VsockPreparedProduct,
+    reserve: &mut impl NetworkPlatformPlanReserve,
+    is_cancelled: &mut impl FnMut(HvfSnapshotV2VsockPlatformPlanStage) -> bool,
+) -> Result<HvfSnapshotV2VsockPciPlatformPlan, PrepareHvfSnapshotV2VsockPlatformPlanError> {
+    check_cancelled(is_cancelled, HvfSnapshotV2VsockPlatformPlanStage::Start)?;
+    product.validate()?;
+    if validate_product(platform, &product.base).map_err(map_network_error)?
+        != SnapshotV2DeviceTransportKind::Pci
+    {
+        return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::TransportPolicy);
+    }
+    check_cancelled(is_cancelled, HvfSnapshotV2VsockPlatformPlanStage::Product)?;
+
+    let HvfSnapshotV2VsockPreparedProduct {
+        kind,
+        base,
+        vsock,
+        serial_resource_present,
+        binding_keys,
+        vsock_key_index,
+    } = product;
+    let following_input = vsock.as_ref().map(project_pci_vsock).transpose()?;
+    check_cancelled(is_cancelled, HvfSnapshotV2VsockPlatformPlanStage::Vsock)?;
+    let resource_key = vsock_key_index
+        .map(|index| {
+            binding_keys
+                .get(index)
+                .ok_or(PrepareHvfSnapshotV2VsockPlatformPlanError::Manifest)
+                .and_then(|key| reserve.clone_key(key).map_err(map_network_error))
+        })
+        .transpose()?;
+    let mut mapped_cancel = |stage| exact_stage(stage).is_some_and(&mut *is_cancelled);
+    let (base, following) = prepare_network_pci_platform_plan(
+        platform,
+        base,
+        following_input,
+        reserve,
+        &mut mapped_cancel,
+    )
+    .map_err(map_network_error)?;
+    let vsock = finish_pci_vsock(vsock, resource_key, following)?;
+    Ok(HvfSnapshotV2VsockPciPlatformPlan {
+        kind,
+        base,
+        vsock,
+        serial_resource_present,
+        binding_keys,
+    })
+}
+
+fn finish_pci_vsock(
+    endpoint: Option<HvfSnapshotV2VsockPreparedEndpoint>,
+    resource_key: Option<SnapshotRestoreResourceKey>,
+    following: Option<HvfSnapshotV2NetworkPciFollowingEndpointPlan>,
+) -> Result<Option<HvfSnapshotV2VsockPciEndpointPlan>, PrepareHvfSnapshotV2VsockPlatformPlanError> {
+    match (endpoint, resource_key, following) {
+        (None, None, None) => Ok(None),
+        (Some(endpoint), Some(resource_key), Some(following)) => {
+            let PreparedSnapshotV2VsockRestoreState::Pci(state) = endpoint.state else {
+                return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::TransportPolicy);
+            };
+            Ok(Some(HvfSnapshotV2VsockPciEndpointPlan {
+                resource_key,
+                config: endpoint.config,
+                state,
+                queue_ranges: following.queue_ranges,
+                placement: following.placement,
+                queue_vectors: following.queue_vectors,
+                config_vector: following.config_vector,
+            }))
+        }
+        _ => Err(PrepareHvfSnapshotV2VsockPlatformPlanError::ResourcePlan),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_sixty_four_presence_kinds_are_distinct_and_exact() {
+        let mut seen = [false; 64];
+        for mask in 0_u8..64 {
+            let kind = HvfSnapshotV2VsockProductKind::from_presence(
+                mask & STORAGE_MASK != 0,
+                mask & ENTROPY_MASK != 0,
+                mask & BALLOON_MASK != 0,
+                mask & MEMORY_HOTPLUG_MASK != 0,
+                mask & NETWORK_MASK != 0,
+                mask & VSOCK_MASK != 0,
+            );
+            assert_eq!(kind.mask(), mask);
+            assert!(!seen[usize::from(kind.mask())]);
+            seen[usize::from(kind.mask())] = true;
+            assert_eq!(kind.has_storage(), mask & STORAGE_MASK != 0);
+            assert_eq!(kind.has_entropy(), mask & ENTROPY_MASK != 0);
+            assert_eq!(kind.has_balloon(), mask & BALLOON_MASK != 0);
+            assert_eq!(kind.has_memory_hotplug(), mask & MEMORY_HOTPLUG_MASK != 0);
+            assert_eq!(kind.has_network(), mask & NETWORK_MASK != 0);
+            assert_eq!(kind.has_vsock(), mask & VSOCK_MASK != 0);
+        }
+        assert!(seen.into_iter().all(|present| present));
+    }
+}

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -34516,6 +34516,23 @@ pub(crate) fn pci_memory_hotplug_restore_gic_msi_configuration(
     pci_all_virtio_gic_msi_configuration_for_fixed_demand(fixed_demand)
 }
 
+pub(crate) fn pci_vsock_restore_gic_msi_configuration(
+    balloon_queue_count: Option<usize>,
+    entropy_configured: bool,
+    memory_hotplug_configured: bool,
+) -> Result<HvfGicMsiConfiguration, HvfArm64BootPciDataError> {
+    let fixed_demand = pci_all_virtio_resource_demand(
+        0,
+        0,
+        0,
+        balloon_queue_count,
+        true,
+        entropy_configured,
+        memory_hotplug_configured,
+    )?;
+    pci_all_virtio_gic_msi_configuration_for_fixed_demand(fixed_demand)
+}
+
 pub(crate) fn pci_root_restore_bar_region_id() -> Result<MmioRegionId, HvfArm64BootPciDataError> {
     pci_data_region_id(0)
 }


### PR DESCRIPTION
## Summary

- add a checked exact native-v2 2.12 product and owner-free MMIO/PCI vsock
  platform plans for all 64 optional-family presence combinations
- extend the exact-2.11 network planner through one crate-private optional
  following-endpoint seam so vsock participates in canonical interrupt,
  endpoint, range, route, and capacity validation without changing the
  existing public 2.11 path
- retain complete network, vsock, and ordered process-resource identities for
  later owner adoption, with deterministic cancellation/allocation failures
  and redacted diagnostics

## Scope exclusions

- does not activate the exact-2.12 public reader, writer, or restore path
- does not construct or adopt a vsock listener, connector, dispatcher,
  interrupt route, VM, vCPU, or HVF owner
- does not change the current exact-2.11 writer version, public behavior,
  documentation claims, or capability inventory
- signed restored-guest adoption and certification remain in #1733 through
  #1736

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

Closes #1732

Parent context: #1540
