### PR TITLE
feat: reconstruct MMIO vsock snapshot owners

### DIFF
--- a/crates/bangbang/src/snapshot_serial_restore.rs
+++ b/crates/bangbang/src/snapshot_serial_restore.rs
@@ -6,9 +6,9 @@ use std::time::Instant;
 
 use bangbang_runtime::memory::GuestMemory;
 use bangbang_runtime::serial::{
-    SerialConfig, SerialConfigError, SerialConfigInput, SerialMmioDevice, SerialStdio,
-    SerialStdioError, SerialStdioInput, SerialStdioRestoration, SerialStdioRestorationError,
-    SharedSerialOutput,
+    SerialConfig, SerialConfigError, SerialConfigInput, SerialMmioDevice, SerialOutputFile,
+    SerialStdio, SerialStdioError, SerialStdioInput, SerialStdioRestoration,
+    SerialStdioRestorationError, SharedSerialOutput,
 };
 use bangbang_runtime::snapshot_device_v2_5::SnapshotV2MultiBlockRestorePlanError;
 use bangbang_runtime::snapshot_device_v2_6::{
@@ -49,6 +49,219 @@ pub(crate) type PreparedSnapshotV2SerialRestoreOwnerParts = (
     Option<SerialStdioRestoration>,
     Option<SerialConfig>,
 );
+
+/// One fresh serial endpoint whose process-stdio restoration authority remains
+/// provisional until its enclosing destination shuts down.
+pub(crate) struct PreparedSnapshotV2SerialEndpoint {
+    serial: Option<SerialMmioDevice<SharedSerialOutput>>,
+    input: Option<SerialStdioInput>,
+    restoration: Option<SerialStdioRestoration>,
+    config: Option<SerialConfig>,
+}
+
+pub(crate) type PreparedSnapshotV2SerialEndpointParts = (
+    SerialMmioDevice<SharedSerialOutput>,
+    Option<SerialStdioInput>,
+    Option<SerialStdioRestoration>,
+    SerialConfig,
+);
+
+impl PreparedSnapshotV2SerialEndpoint {
+    pub(crate) fn into_parts(
+        mut self,
+    ) -> Result<PreparedSnapshotV2SerialEndpointParts, PreparedSnapshotV2SerialEndpointCleanupError>
+    {
+        match (self.serial.take(), self.config.take()) {
+            (Some(serial), Some(config)) => {
+                Ok((serial, self.input.take(), self.restoration.take(), config))
+            }
+            (serial, config) => {
+                self.serial = serial;
+                self.config = config;
+                Err(PreparedSnapshotV2SerialEndpointCleanupError {
+                    restoration: self.cleanup(),
+                })
+            }
+        }
+    }
+
+    pub(crate) fn abort(mut self) -> Result<(), PreparedSnapshotV2SerialEndpointCleanupError> {
+        match self.cleanup() {
+            Some(restoration) => Err(PreparedSnapshotV2SerialEndpointCleanupError {
+                restoration: Some(restoration),
+            }),
+            None => Ok(()),
+        }
+    }
+
+    fn cleanup(&mut self) -> Option<SerialStdioRestorationError> {
+        {
+            let _input = self.input.take();
+        }
+        {
+            let _serial = self.serial.take();
+        }
+        {
+            let _config = self.config.take();
+        }
+        self.restoration
+            .take()
+            .and_then(|restoration| restoration.finish().err())
+    }
+}
+
+impl Drop for PreparedSnapshotV2SerialEndpoint {
+    fn drop(&mut self) {
+        let _ = self.cleanup();
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2SerialEndpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2SerialEndpoint")
+            .field("has_input", &self.input.is_some())
+            .field("state", &"<private-provisional>")
+            .finish()
+    }
+}
+
+pub(crate) struct PreparedSnapshotV2SerialEndpointCleanupError {
+    restoration: Option<SerialStdioRestorationError>,
+}
+
+impl fmt::Debug for PreparedSnapshotV2SerialEndpointCleanupError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2SerialEndpointCleanupError")
+            .field("restoration_failed", &self.restoration.is_some())
+            .finish()
+    }
+}
+
+impl fmt::Display for PreparedSnapshotV2SerialEndpointCleanupError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("snapshot serial endpoint cleanup failed")
+    }
+}
+
+impl std::error::Error for PreparedSnapshotV2SerialEndpointCleanupError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.restoration
+            .as_ref()
+            .map(|source| source as &(dyn std::error::Error + 'static))
+    }
+}
+
+pub(crate) enum SnapshotV2SerialEndpointPreparationError {
+    Stdio(SerialStdioError),
+    SerialConfig(SerialConfigError),
+    InvalidResourceSet,
+}
+
+impl fmt::Debug for SnapshotV2SerialEndpointPreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2SerialEndpointPreparationError")
+            .field(
+                "stage",
+                &match self {
+                    Self::Stdio(_) => "stdio",
+                    Self::SerialConfig(_) => "serial-config",
+                    Self::InvalidResourceSet => "resource-set",
+                },
+            )
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotV2SerialEndpointPreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("snapshot serial endpoint preparation failed")
+    }
+}
+
+impl std::error::Error for SnapshotV2SerialEndpointPreparationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Stdio(source) => Some(source),
+            Self::SerialConfig(source) => Some(source),
+            Self::InvalidResourceSet => None,
+        }
+    }
+}
+
+/// Constructs only the fresh serial endpoint. File/grant completion remains
+/// owned by the caller's aggregate transaction.
+pub(crate) fn prepare_native_v2_serial_restore_endpoint(
+    state: SnapshotV2SerialState,
+    configured_output: Option<SerialOutputFile>,
+) -> Result<PreparedSnapshotV2SerialEndpoint, SnapshotV2SerialEndpointPreparationError> {
+    prepare_native_v2_serial_restore_endpoint_with(
+        state,
+        configured_output,
+        SerialStdio::from_process_standard_streams,
+    )
+}
+
+fn prepare_native_v2_serial_restore_endpoint_with<S>(
+    state: SnapshotV2SerialState,
+    configured_output: Option<SerialOutputFile>,
+    prepare_stdio: S,
+) -> Result<PreparedSnapshotV2SerialEndpoint, SnapshotV2SerialEndpointPreparationError>
+where
+    S: FnOnce() -> Result<SerialStdio, SerialStdioError>,
+{
+    let (endpoint_intent, rate_limiter, device_state) = state.into_parts();
+    let (output, input, restoration, config) = match endpoint_intent {
+        SnapshotV2SerialEndpointIntent::DefaultProcessStdio => {
+            if configured_output.is_some() {
+                return Err(SnapshotV2SerialEndpointPreparationError::InvalidResourceSet);
+            }
+            let mut config = SerialConfigInput::new();
+            if let Some(rate_limiter) = rate_limiter {
+                config = config.with_rate_limiter(rate_limiter);
+            }
+            let config = config
+                .validate()
+                .map_err(SnapshotV2SerialEndpointPreparationError::SerialConfig)?;
+            let stdio = prepare_stdio().map_err(SnapshotV2SerialEndpointPreparationError::Stdio)?;
+            let (output, input, restoration) = stdio.into_restorable_parts();
+            (
+                SharedSerialOutput::with_rate_limiter(output, rate_limiter),
+                input,
+                Some(restoration),
+                config,
+            )
+        }
+        SnapshotV2SerialEndpointIntent::ConfiguredOutput { selector } => {
+            let Some(output) = configured_output else {
+                return Err(SnapshotV2SerialEndpointPreparationError::InvalidResourceSet);
+            };
+            let mut config = SerialConfigInput::new().with_serial_out_path(selector);
+            if let Some(rate_limiter) = rate_limiter {
+                config = config.with_rate_limiter(rate_limiter);
+            }
+            let config = config
+                .validate()
+                .map_err(SnapshotV2SerialEndpointPreparationError::SerialConfig)?;
+            (
+                SharedSerialOutput::with_rate_limiter(output, rate_limiter),
+                None,
+                None,
+                config,
+            )
+        }
+    };
+    let serial = SerialMmioDevice::from_capture_state_with_shared_output(output, device_state);
+    Ok(PreparedSnapshotV2SerialEndpoint {
+        serial: Some(serial),
+        input,
+        restoration,
+        config: Some(config),
+    })
+}
 
 impl PreparedSnapshotV2SerialRestoreOwners {
     pub(crate) fn block_count(&self) -> usize {
@@ -896,67 +1109,9 @@ where
         });
     }
 
-    let (endpoint_intent, rate_limiter, device_state) = state.into_parts();
-    let (output, input, restoration, serial_config) = match endpoint_intent {
-        SnapshotV2SerialEndpointIntent::DefaultProcessStdio => {
-            let mut config = SerialConfigInput::new();
-            if let Some(rate_limiter) = rate_limiter {
-                config = config.with_rate_limiter(rate_limiter);
-            }
-            let serial_config = match config.validate() {
-                Ok(config) => config,
-                Err(source) => {
-                    let completion_abort =
-                        abort_unassembled(blocks, pmems, prepared_serial, completion);
-                    return Err(SnapshotV2SerialRestoreBundleError::SerialConfig {
-                        source,
-                        completion_abort,
-                    });
-                }
-            };
-            if prepared_serial.is_some() {
-                let completion_abort =
-                    abort_unassembled(blocks, pmems, prepared_serial, completion);
-                return Err(SnapshotV2SerialRestoreBundleError::InvalidResourceSet {
-                    owners_cleanup: None,
-                    completion_abort,
-                });
-            }
-            let stdio = match prepare_stdio() {
-                Ok(stdio) => stdio,
-                Err(source) => {
-                    let completion_abort =
-                        abort_unassembled(blocks, pmems, prepared_serial, completion);
-                    return Err(SnapshotV2SerialRestoreBundleError::Stdio {
-                        source,
-                        completion_abort,
-                    });
-                }
-            };
-            let (output, input, restoration) = stdio.into_restorable_parts();
-            (
-                SharedSerialOutput::with_rate_limiter(output, rate_limiter),
-                input,
-                Some(restoration),
-                serial_config,
-            )
-        }
-        SnapshotV2SerialEndpointIntent::ConfiguredOutput { selector } => {
-            let mut config = SerialConfigInput::new().with_serial_out_path(selector);
-            if let Some(rate_limiter) = rate_limiter {
-                config = config.with_rate_limiter(rate_limiter);
-            }
-            let serial_config = match config.validate() {
-                Ok(config) => config,
-                Err(source) => {
-                    let completion_abort =
-                        abort_unassembled(blocks, pmems, prepared_serial, completion);
-                    return Err(SnapshotV2SerialRestoreBundleError::SerialConfig {
-                        source,
-                        completion_abort,
-                    });
-                }
-            };
+    let configured_output = match state.endpoint_intent() {
+        SnapshotV2SerialEndpointIntent::DefaultProcessStdio if prepared_serial.is_none() => None,
+        SnapshotV2SerialEndpointIntent::ConfiguredOutput { .. } => {
             let Some(serial) = prepared_serial.as_ref() else {
                 let completion_abort =
                     abort_unassembled(blocks, pmems, prepared_serial, completion);
@@ -978,24 +1133,59 @@ where
                     completion_abort,
                 });
             }
-            let Some(serial) = prepared_serial.take() else {
-                let completion_abort =
-                    abort_unassembled(blocks, pmems, prepared_serial, completion);
-                return Err(SnapshotV2SerialRestoreBundleError::InvalidResourceSet {
-                    owners_cleanup: None,
-                    completion_abort,
-                });
-            };
-            let (_, output) = serial.into_parts();
-            (
-                SharedSerialOutput::with_rate_limiter(output, rate_limiter),
-                None,
-                None,
-                serial_config,
-            )
+            prepared_serial
+                .take()
+                .map(PreparedSnapshotSerialRestoreOutput::into_parts)
+                .map(|(_, output)| output)
+        }
+        SnapshotV2SerialEndpointIntent::DefaultProcessStdio => {
+            let completion_abort = abort_unassembled(blocks, pmems, prepared_serial, completion);
+            return Err(SnapshotV2SerialRestoreBundleError::InvalidResourceSet {
+                owners_cleanup: None,
+                completion_abort,
+            });
         }
     };
-    let serial = SerialMmioDevice::from_capture_state_with_shared_output(output, device_state);
+    let endpoint = match prepare_native_v2_serial_restore_endpoint_with(
+        state,
+        configured_output,
+        prepare_stdio,
+    ) {
+        Ok(endpoint) => endpoint,
+        Err(source) => {
+            let completion_abort = abort_unassembled(blocks, pmems, prepared_serial, completion);
+            return Err(match source {
+                SnapshotV2SerialEndpointPreparationError::Stdio(source) => {
+                    SnapshotV2SerialRestoreBundleError::Stdio {
+                        source,
+                        completion_abort,
+                    }
+                }
+                SnapshotV2SerialEndpointPreparationError::SerialConfig(source) => {
+                    SnapshotV2SerialRestoreBundleError::SerialConfig {
+                        source,
+                        completion_abort,
+                    }
+                }
+                SnapshotV2SerialEndpointPreparationError::InvalidResourceSet => {
+                    SnapshotV2SerialRestoreBundleError::InvalidResourceSet {
+                        owners_cleanup: None,
+                        completion_abort,
+                    }
+                }
+            });
+        }
+    };
+    let (serial, input, restoration, serial_config) = match endpoint.into_parts() {
+        Ok(parts) => parts,
+        Err(_) => {
+            let completion_abort = abort_unassembled(blocks, pmems, prepared_serial, completion);
+            return Err(SnapshotV2SerialRestoreBundleError::InvalidResourceSet {
+                owners_cleanup: None,
+                completion_abort,
+            });
+        }
+    };
     let owners = PreparedSnapshotV2SerialRestoreOwners {
         blocks,
         pmems,

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -69,8 +69,12 @@ use bangbang_hvf::{
     HvfSnapshotV2StorageMmioPlatformPlan, HvfSnapshotV2StorageMmioProcessConfig,
     HvfSnapshotV2StorageMmioRestoreError, HvfSnapshotV2StoragePciPlatformPlan,
     HvfSnapshotV2StoragePciRestoreError, HvfSnapshotV2StorageState,
-    HvfSnapshotV2VsockMmioPlatformPlan, HvfSnapshotV2VsockPciPlatformPlan,
-    HvfSnapshotV2VsockPlatformState, HvfSnapshotV2VsockProcessResourceIdentity,
+    HvfSnapshotV2VsockMmioPlatformPlan, HvfSnapshotV2VsockMmioProcessConfig,
+    HvfSnapshotV2VsockMmioRestoreError, HvfSnapshotV2VsockMmioRestoreStage,
+    HvfSnapshotV2VsockPciPlatformPlan, HvfSnapshotV2VsockPlatformState,
+    HvfSnapshotV2VsockPreparedEndpoint, HvfSnapshotV2VsockPreparedMemory,
+    HvfSnapshotV2VsockPreparedProduct, HvfSnapshotV2VsockPreparedProductParts,
+    HvfSnapshotV2VsockProcessResourceIdentity, HvfSnapshotV2VsockProductKind,
     HvfSnapshotV2VsockState, HvfVcpuRunControl, HvfVcpuRunCoordinatorError, HvfVcpuRunStepOutcome,
     OwnedHvfArm64BootSession, PrepareHvfSnapshotV1LoadError,
     PrepareHvfSnapshotV2BalloonPlatformPlanError, PrepareHvfSnapshotV2EntropyPciPlatformPlanError,
@@ -80,16 +84,16 @@ use bangbang_hvf::{
     PrepareHvfSnapshotV2StoragePciPlatformPlanError, PreparedHvfArm64BootPciNetworkRemoval,
     PreparedHvfSnapshotV1Load, PreparedHvfSnapshotV1State, RestoredHvfSnapshotV2NetworkMmioOwners,
     RestoredHvfSnapshotV2NetworkPciOwners, RestoredHvfSnapshotV2Platform,
-    decode_hvf_snapshot_v2_balloon_state, decode_hvf_snapshot_v2_entropy_state,
-    decode_hvf_snapshot_v2_memory_hotplug_state, decode_hvf_snapshot_v2_multi_block_state,
-    decode_hvf_snapshot_v2_network_state, decode_hvf_snapshot_v2_platform_state,
-    decode_hvf_snapshot_v2_serial_state, decode_hvf_snapshot_v2_state,
-    decode_hvf_snapshot_v2_storage_state, encode_hvf_snapshot_v2_balloon_state,
-    encode_hvf_snapshot_v2_entropy_state, encode_hvf_snapshot_v2_memory_hotplug_state,
-    encode_hvf_snapshot_v2_multi_block_state, encode_hvf_snapshot_v2_network_state,
-    encode_hvf_snapshot_v2_serial_state, encode_hvf_snapshot_v2_state,
-    encode_hvf_snapshot_v2_storage_state, encode_hvf_snapshot_v2_vsock_state,
-    prepare_hvf_snapshot_v2_balloon_mmio_platform_plan,
+    RestoredHvfSnapshotV2VsockMmioOwners, decode_hvf_snapshot_v2_balloon_state,
+    decode_hvf_snapshot_v2_entropy_state, decode_hvf_snapshot_v2_memory_hotplug_state,
+    decode_hvf_snapshot_v2_multi_block_state, decode_hvf_snapshot_v2_network_state,
+    decode_hvf_snapshot_v2_platform_state, decode_hvf_snapshot_v2_serial_state,
+    decode_hvf_snapshot_v2_state, decode_hvf_snapshot_v2_storage_state,
+    encode_hvf_snapshot_v2_balloon_state, encode_hvf_snapshot_v2_entropy_state,
+    encode_hvf_snapshot_v2_memory_hotplug_state, encode_hvf_snapshot_v2_multi_block_state,
+    encode_hvf_snapshot_v2_network_state, encode_hvf_snapshot_v2_serial_state,
+    encode_hvf_snapshot_v2_state, encode_hvf_snapshot_v2_storage_state,
+    encode_hvf_snapshot_v2_vsock_state, prepare_hvf_snapshot_v2_balloon_mmio_platform_plan,
     prepare_hvf_snapshot_v2_balloon_pci_platform_plan,
     prepare_hvf_snapshot_v2_memory_hotplug_mmio_platform_plan,
     prepare_hvf_snapshot_v2_memory_hotplug_pci_platform_plan,
@@ -100,7 +104,8 @@ use bangbang_hvf::{
     prepare_hvf_snapshot_v2_storage_entropy_mmio_platform_plan,
     prepare_hvf_snapshot_v2_storage_entropy_pci_platform_plan,
     prepare_hvf_snapshot_v2_storage_mmio_platform_plan,
-    prepare_hvf_snapshot_v2_storage_pci_platform_plan, restore_hvf_snapshot_v2_process_platform,
+    prepare_hvf_snapshot_v2_storage_pci_platform_plan,
+    prepare_hvf_snapshot_v2_vsock_mmio_platform_plan, restore_hvf_snapshot_v2_process_platform,
 };
 use bangbang_runtime::balloon::BalloonMmioLayout;
 use bangbang_runtime::balloon::{
@@ -215,6 +220,7 @@ use bangbang_runtime::snapshot_device_v2_5::{
 use bangbang_runtime::snapshot_device_v2_6::{
     NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION, SnapshotV2StorageCleanupError,
     SnapshotV2StorageDeviceGraph, SnapshotV2StorageDeviceGraphCaptureError,
+    SnapshotV2StorageRestorePlan,
 };
 use bangbang_runtime::snapshot_entropy_v2_8::{
     NATIVE_V2_ENTROPY_STATE_COMPATIBILITY_VERSION, PreparedSnapshotV2EntropyTransport,
@@ -256,7 +262,8 @@ use bangbang_runtime::snapshot_serial_v2_7::{
 };
 use bangbang_runtime::snapshot_vsock_restore_v2_12::PreparedSnapshotV2VsockRestoreState;
 use bangbang_runtime::snapshot_vsock_v2_12::{
-    SnapshotV2VsockState, SnapshotV2VsockStateCaptureError,
+    NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION, SnapshotV2VsockState,
+    SnapshotV2VsockStateCaptureError,
 };
 use bangbang_runtime::startup::{
     Arm64BootBalloonDevice, Arm64BootBlockDevice, Arm64BootNetworkDevice,
@@ -328,9 +335,10 @@ use crate::snapshot_restore_resources::{
 #[cfg(target_os = "macos")]
 use crate::snapshot_serial_restore::{
     PreparedSnapshotV2SerialDestinationCommitError,
-    PreparedSnapshotV2SerialDestinationConstructionError, PreparedSnapshotV2SerialRestoreBundle,
-    PreparedSnapshotV2SerialRestoreOwners, SnapshotV2SerialRestoreBundleError,
-    SnapshotV2SerialStorageAdoptionError, prepare_native_v2_serial_restore_bundle,
+    PreparedSnapshotV2SerialDestinationConstructionError, PreparedSnapshotV2SerialEndpoint,
+    PreparedSnapshotV2SerialRestoreBundle, PreparedSnapshotV2SerialRestoreOwners,
+    SnapshotV2SerialRestoreBundleError, SnapshotV2SerialStorageAdoptionError,
+    prepare_native_v2_serial_restore_bundle, prepare_native_v2_serial_restore_endpoint,
 };
 #[cfg(target_os = "macos")]
 use crate::vsock_restore::{
@@ -22208,7 +22216,7 @@ impl fmt::Debug for PreparedProcessSnapshotV2VsockRestoreResource {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ProcessSnapshotV2VsockAbortEvidence {
     terminal: bool,
     cleanup_uncertain: bool,
@@ -22709,6 +22717,43 @@ where
 
     pub(crate) const fn vsock_config(&self) -> Option<&VsockConfig> {
         self.vsock_config.as_ref()
+    }
+
+    fn matches_mmio_platform_plan(&self, plan: &HvfSnapshotV2VsockMmioPlatformPlan) -> bool {
+        let mut vsock_keys = self
+            .binding_keys
+            .iter()
+            .filter(|key| key.resource_class() == SnapshotRestoreResourceClass::VsockEndpoint);
+        let vsock = match (
+            vsock_keys.next(),
+            vsock_keys.next(),
+            self.vsock_config.as_ref(),
+        ) {
+            (None, None, None) => None,
+            (Some(key), None, Some(config)) => {
+                Some(HvfSnapshotV2VsockProcessResourceIdentity::new(key, config))
+            }
+            _ => return false,
+        };
+        plan.preflight_process_resource_identity(
+            self.network_completion
+                .resource_interfaces
+                .iter()
+                .map(|interface| {
+                    HvfSnapshotV2NetworkProcessResourceIdentity::new(
+                        interface.source_index,
+                        &interface.resource_key,
+                        &interface.controller,
+                        interface.profile,
+                        interface.backend,
+                        interface.mmds_stack,
+                    )
+                }),
+            self.network_completion.expected_mmds_state(),
+            self.network_completion.expected_mmds_controller(),
+            vsock,
+            &self.binding_keys,
+        )
     }
 
     pub(crate) fn remaining_count(&self) -> usize {
@@ -23219,6 +23264,401 @@ fn typecheck_process_snapshot_v2_vsock_adoption(
 const _: fn(&mut SystemPreparedProcessSnapshotV2VsockRestoreBatch, &SnapshotRestoreResourceKey) =
     typecheck_process_snapshot_v2_vsock_adoption;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProcessSnapshotV2VsockMmioRestoreStage {
+    ResourcePreparation,
+    ProductPreparation,
+    ResourceTake { index: usize },
+    Serial,
+    HvfConstruction,
+    Hvf(HvfSnapshotV2VsockMmioRestoreStage),
+    BatchFinish,
+    CompleteRecapture,
+    Assembly,
+    GateCommit,
+    Cleanup,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProcessSnapshotV2VsockMmioRestoreDisposition {
+    Retryable,
+    Terminal,
+    TerminalCleanup,
+}
+
+/// Bounded process-level failure for one exact-2.12 MMIO owner transaction.
+struct ProcessSnapshotV2VsockMmioRestoreError {
+    stage: ProcessSnapshotV2VsockMmioRestoreStage,
+    disposition: ProcessSnapshotV2VsockMmioRestoreDisposition,
+}
+
+impl ProcessSnapshotV2VsockMmioRestoreError {
+    const fn retryable(stage: ProcessSnapshotV2VsockMmioRestoreStage) -> Self {
+        Self {
+            stage,
+            disposition: ProcessSnapshotV2VsockMmioRestoreDisposition::Retryable,
+        }
+    }
+
+    const fn terminal(
+        stage: ProcessSnapshotV2VsockMmioRestoreStage,
+        cleanup_uncertain: bool,
+    ) -> Self {
+        Self {
+            stage,
+            disposition: if cleanup_uncertain {
+                ProcessSnapshotV2VsockMmioRestoreDisposition::TerminalCleanup
+            } else {
+                ProcessSnapshotV2VsockMmioRestoreDisposition::Terminal
+            },
+        }
+    }
+
+    fn from_resource(
+        stage: ProcessSnapshotV2VsockMmioRestoreStage,
+        source: &ProcessSnapshotV2VsockRestoreResourceError,
+    ) -> Self {
+        if source.cleanup_uncertain() {
+            return Self::terminal(stage, true);
+        }
+        match source.disposition() {
+            ProcessSnapshotV2NetworkRestoreResourceDisposition::Retryable => Self::retryable(stage),
+            ProcessSnapshotV2NetworkRestoreResourceDisposition::Terminal => {
+                Self::terminal(stage, false)
+            }
+        }
+    }
+
+    fn from_hvf(source: &HvfSnapshotV2VsockMmioRestoreError, cleanup_uncertain: bool) -> Self {
+        let stage = ProcessSnapshotV2VsockMmioRestoreStage::Hvf(source.stage());
+        if source.has_incomplete_cleanup() || cleanup_uncertain {
+            return Self::terminal(stage, true);
+        }
+        match source.disposition() {
+            HvfSnapshotV2NetworkMmioRestoreDisposition::Retryable => Self::retryable(stage),
+            HvfSnapshotV2NetworkMmioRestoreDisposition::Terminal
+            | HvfSnapshotV2NetworkMmioRestoreDisposition::TerminalCleanup => {
+                Self::terminal(stage, false)
+            }
+        }
+    }
+
+    fn from_adoption(
+        source: &ProcessSnapshotV2VsockAdoptionError<HvfSnapshotV2VsockMmioRestoreError>,
+        cleanup_uncertain: bool,
+    ) -> Self {
+        match source {
+            ProcessSnapshotV2VsockAdoptionError::Resources(source) => {
+                let mapped = Self::from_resource(
+                    ProcessSnapshotV2VsockMmioRestoreStage::HvfConstruction,
+                    source,
+                );
+                if cleanup_uncertain {
+                    Self::terminal(mapped.stage, true)
+                } else {
+                    mapped
+                }
+            }
+            ProcessSnapshotV2VsockAdoptionError::Adoption(
+                VsockRestoreAdoptionError::Reconstruction {
+                    source,
+                    disposition,
+                },
+            ) => {
+                let mapped = Self::from_hvf(source, cleanup_uncertain);
+                if matches!(disposition, VsockRestoreDisposition::Terminal)
+                    && matches!(
+                        mapped.disposition,
+                        ProcessSnapshotV2VsockMmioRestoreDisposition::Retryable
+                    )
+                {
+                    Self::terminal(mapped.stage, cleanup_uncertain)
+                } else {
+                    mapped
+                }
+            }
+            ProcessSnapshotV2VsockAdoptionError::Adoption(VsockRestoreAdoptionError::Contract(
+                source,
+            )) => match (source.disposition(), cleanup_uncertain) {
+                (_, true) => Self::terminal(
+                    ProcessSnapshotV2VsockMmioRestoreStage::HvfConstruction,
+                    true,
+                ),
+                (VsockRestoreDisposition::Retryable, false) => {
+                    Self::retryable(ProcessSnapshotV2VsockMmioRestoreStage::HvfConstruction)
+                }
+                (VsockRestoreDisposition::Terminal, false) => Self::terminal(
+                    ProcessSnapshotV2VsockMmioRestoreStage::HvfConstruction,
+                    false,
+                ),
+            },
+        }
+    }
+}
+
+impl fmt::Debug for ProcessSnapshotV2VsockMmioRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProcessSnapshotV2VsockMmioRestoreError")
+            .field("stage", &self.stage)
+            .field("disposition", &self.disposition)
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for ProcessSnapshotV2VsockMmioRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "exact-2.12 process MMIO vsock reconstruction failed at {:?} ({:?})",
+            self.stage, self.disposition
+        )
+    }
+}
+
+impl std::error::Error for ProcessSnapshotV2VsockMmioRestoreError {}
+
+/// Complete unpublished process/HVF exact-2.12 MMIO owner graph.
+///
+/// Explicit shutdown preserves the irreversible lifetime order: HVF/session,
+/// active socket publication, network provider and metrics leases, file and
+/// contained authority, then process-stdio restoration.
+struct RestoredProcessSnapshotV2VsockMmioOwners<B>
+where
+    B: ProcessVmnetBackend,
+{
+    hvf: Option<RestoredHvfSnapshotV2VsockMmioOwners>,
+    active_vsock: Option<ActiveVsockRestoreGuard>,
+    completion: Option<PreparedProcessSnapshotV2VsockRestoreCompletion<B>>,
+    network_resources: Vec<PreparedProcessSnapshotV2NetworkRestoreResource>,
+    serial_output: Option<SharedSerialOutput>,
+    serial_config: Option<SerialConfig>,
+    serial_restoration: Option<SerialStdioRestoration>,
+}
+
+fn abort_completed_process_snapshot_v2_vsock_resources<B>(
+    completion: PreparedProcessSnapshotV2VsockRestoreCompletion<B>,
+    network_resources: &mut Vec<PreparedProcessSnapshotV2NetworkRestoreResource>,
+) -> bool
+where
+    B: ProcessVmnetBackend,
+{
+    let PreparedProcessSnapshotV2VsockRestoreCompletion {
+        bytes: _,
+        binding: _,
+        device_graph: _,
+        serial: _,
+        entropy: _,
+        balloon: _,
+        memory_hotplug: _,
+        network_topology: _,
+        vsock_state: _,
+        vsock_config: _,
+        binding_keys: _,
+        file_completion,
+        network_completion,
+    } = completion;
+    let mut cleanup_uncertain = network_completion.abort().is_err();
+    network_resources.clear();
+    cleanup_uncertain |= file_completion.abort().is_err();
+    cleanup_uncertain
+}
+
+fn finish_process_snapshot_v2_serial_restoration(
+    serial_output: &mut Option<SharedSerialOutput>,
+    serial_config: &mut Option<SerialConfig>,
+    serial_restoration: &mut Option<SerialStdioRestoration>,
+) -> bool {
+    {
+        let _output = serial_output.take();
+    }
+    {
+        let _config = serial_config.take();
+    }
+    serial_restoration
+        .take()
+        .is_some_and(|restoration| restoration.finish().is_err())
+}
+
+impl<B> RestoredProcessSnapshotV2VsockMmioOwners<B>
+where
+    B: ProcessVmnetBackend,
+{
+    fn shutdown(&mut self) -> Result<(), ProcessSnapshotV2VsockMmioRestoreError> {
+        let mut cleanup_uncertain = self.hvf.take().is_some_and(|hvf| hvf.shutdown().is_err());
+        cleanup_uncertain |= self
+            .active_vsock
+            .take()
+            .is_some_and(|guard| guard.cleanup().is_err());
+        if let Some(completion) = self.completion.take() {
+            cleanup_uncertain |= abort_completed_process_snapshot_v2_vsock_resources(
+                completion,
+                &mut self.network_resources,
+            );
+        } else {
+            self.network_resources.clear();
+        }
+        cleanup_uncertain |= finish_process_snapshot_v2_serial_restoration(
+            &mut self.serial_output,
+            &mut self.serial_config,
+            &mut self.serial_restoration,
+        );
+        if cleanup_uncertain {
+            Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                ProcessSnapshotV2VsockMmioRestoreStage::Cleanup,
+                true,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<B> Drop for RestoredProcessSnapshotV2VsockMmioOwners<B>
+where
+    B: ProcessVmnetBackend,
+{
+    fn drop(&mut self) {
+        let _ = self.shutdown();
+    }
+}
+
+impl<B> fmt::Debug for RestoredProcessSnapshotV2VsockMmioOwners<B>
+where
+    B: ProcessVmnetBackend,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RestoredProcessSnapshotV2VsockMmioOwners")
+            .field("interface_count", &self.network_resources.len())
+            .field("has_vsock", &self.active_vsock.is_some())
+            .field(
+                "retry_publication_committed",
+                &self.hvf.as_ref().is_some_and(
+                    RestoredHvfSnapshotV2VsockMmioOwners::retry_publication_is_committed,
+                ),
+            )
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+struct StagedProcessSnapshotV2VsockMmioOwners<B>
+where
+    B: ProcessVmnetBackend,
+{
+    batch: Option<PreparedProcessSnapshotV2VsockRestoreBatch<B>>,
+    hvf: Option<RestoredHvfSnapshotV2VsockMmioOwners>,
+    active_vsock: Option<ActiveVsockRestoreGuard>,
+    completion: Option<PreparedProcessSnapshotV2VsockRestoreCompletion<B>>,
+    network_resources: Vec<PreparedProcessSnapshotV2NetworkRestoreResource>,
+    serial_endpoint: Option<PreparedSnapshotV2SerialEndpoint>,
+    serial_output: Option<SharedSerialOutput>,
+    serial_config: Option<SerialConfig>,
+    serial_restoration: Option<SerialStdioRestoration>,
+}
+
+impl<B> StagedProcessSnapshotV2VsockMmioOwners<B>
+where
+    B: ProcessVmnetBackend,
+{
+    fn new(batch: PreparedProcessSnapshotV2VsockRestoreBatch<B>) -> Self {
+        Self {
+            batch: Some(batch),
+            hvf: None,
+            active_vsock: None,
+            completion: None,
+            network_resources: Vec::new(),
+            serial_endpoint: None,
+            serial_output: None,
+            serial_config: None,
+            serial_restoration: None,
+        }
+    }
+
+    fn shutdown_evidence(&mut self) -> ProcessSnapshotV2VsockAbortEvidence {
+        let mut evidence = ProcessSnapshotV2VsockAbortEvidence::clean();
+        if self.hvf.take().is_some_and(|hvf| hvf.shutdown().is_err()) {
+            evidence = evidence.merge(ProcessSnapshotV2VsockAbortEvidence::terminal(true));
+        }
+        if self
+            .active_vsock
+            .take()
+            .is_some_and(|guard| guard.cleanup().is_err())
+        {
+            evidence = evidence.merge(ProcessSnapshotV2VsockAbortEvidence::terminal(true));
+        }
+        if let Some(completion) = self.completion.take() {
+            if abort_completed_process_snapshot_v2_vsock_resources(
+                completion,
+                &mut self.network_resources,
+            ) {
+                evidence = evidence.merge(ProcessSnapshotV2VsockAbortEvidence::terminal(true));
+            }
+        } else if let Some(batch) = self.batch.take() {
+            if let Err(source) = batch.abort() {
+                evidence = evidence.merge(ProcessSnapshotV2VsockAbortEvidence::terminal(
+                    source.cleanup_uncertain(),
+                ));
+            }
+            self.network_resources.clear();
+        } else {
+            self.network_resources.clear();
+        }
+        if self
+            .serial_endpoint
+            .take()
+            .is_some_and(|endpoint| endpoint.abort().is_err())
+        {
+            evidence = evidence.merge(ProcessSnapshotV2VsockAbortEvidence::terminal(true));
+        }
+        if finish_process_snapshot_v2_serial_restoration(
+            &mut self.serial_output,
+            &mut self.serial_config,
+            &mut self.serial_restoration,
+        ) {
+            evidence = evidence.merge(ProcessSnapshotV2VsockAbortEvidence::terminal(true));
+        }
+        evidence
+    }
+
+    fn shutdown(&mut self) -> bool {
+        self.shutdown_evidence().cleanup_uncertain
+    }
+
+    fn into_owners(
+        mut self,
+    ) -> Result<RestoredProcessSnapshotV2VsockMmioOwners<B>, ProcessSnapshotV2VsockMmioRestoreError>
+    {
+        let (Some(hvf), Some(completion)) = (self.hvf.take(), self.completion.take()) else {
+            let cleanup_uncertain = self.shutdown();
+            return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                ProcessSnapshotV2VsockMmioRestoreStage::Assembly,
+                cleanup_uncertain,
+            ));
+        };
+        Ok(RestoredProcessSnapshotV2VsockMmioOwners {
+            hvf: Some(hvf),
+            active_vsock: self.active_vsock.take(),
+            completion: Some(completion),
+            network_resources: std::mem::take(&mut self.network_resources),
+            serial_output: self.serial_output.take(),
+            serial_config: self.serial_config.take(),
+            serial_restoration: self.serial_restoration.take(),
+        })
+    }
+}
+
+impl<B> Drop for StagedProcessSnapshotV2VsockMmioOwners<B>
+where
+    B: ProcessVmnetBackend,
+{
+    fn drop(&mut self) {
+        let _ = self.shutdown();
+    }
+}
+
 trait ProcessSnapshotV2NetworkResourcePlanInput {
     fn into_resource_plan(self) -> PreparedProcessSnapshotV2NetworkResourcePlan;
 }
@@ -23700,6 +24140,32 @@ impl RestoredProcessSnapshotV2NetworkHvfOwners for RestoredHvfSnapshotV2NetworkP
     }
 }
 
+impl RestoredProcessSnapshotV2NetworkHvfOwners for RestoredHvfSnapshotV2VsockMmioOwners {
+    fn session(&self) -> &OwnedHvfArm64BootSession {
+        RestoredHvfSnapshotV2VsockMmioOwners::session(self)
+    }
+
+    fn configs(&self) -> &[NetworkInterfaceConfig] {
+        RestoredHvfSnapshotV2VsockMmioOwners::configs(self)
+    }
+
+    fn expected(&self) -> &[SnapshotV2NetworkInterfaceState] {
+        RestoredHvfSnapshotV2VsockMmioOwners::expected_network(self)
+    }
+
+    fn mmds_state(&self) -> Option<&SnapshotV2MmdsState> {
+        RestoredHvfSnapshotV2VsockMmioOwners::mmds_state(self)
+    }
+
+    fn mmds_config(&self) -> Option<&MmdsConfig> {
+        RestoredHvfSnapshotV2VsockMmioOwners::mmds_config(self)
+    }
+
+    fn transport_kind(&self) -> SnapshotV2DeviceTransportKind {
+        SnapshotV2DeviceTransportKind::Mmio
+    }
+}
+
 fn restored_process_snapshot_v2_network_is_equivalent<B, H>(
     hvf: &H,
     completion: &PreparedProcessSnapshotV2NetworkRestoreCompletion<B>,
@@ -23811,6 +24277,718 @@ where
     drop(publication_guard);
     Ok(())
 }
+
+fn restored_process_snapshot_v2_vsock_mmio_is_equivalent<B>(
+    hvf: &RestoredHvfSnapshotV2VsockMmioOwners,
+    completion: &PreparedProcessSnapshotV2VsockRestoreCompletion<B>,
+    resources: &[PreparedProcessSnapshotV2NetworkRestoreResource],
+    now: Instant,
+) -> Result<(), ()>
+where
+    B: ProcessVmnetBackend,
+{
+    restored_process_snapshot_v2_network_is_equivalent(
+        hvf,
+        &completion.network_completion,
+        resources,
+        now,
+    )?;
+    if hvf.resource_keys() != completion.binding_keys
+        || hvf.serial_resource_present()
+            == completion
+                .serial
+                .endpoint_intent()
+                .is_default_process_stdio()
+        || hvf.kind()
+            != HvfSnapshotV2VsockProductKind::from_presence(
+                completion.device_graph.is_some(),
+                completion.entropy.is_some(),
+                completion.balloon.is_some(),
+                completion.memory_hotplug.is_some(),
+                !completion.network_topology.interfaces().is_empty(),
+                completion.vsock_state.is_some(),
+            )
+        || hvf.vsock_config() != completion.vsock_config.as_ref()
+    {
+        return Err(());
+    }
+    let expected = match (&completion.vsock_state, &completion.vsock_config) {
+        (Some(state), Some(config)) => Some(
+            state
+                .clone()
+                .into_destination_normalized_state(config)
+                .map_err(|_| ())?,
+        ),
+        (None, None) => None,
+        (Some(_), None) | (None, Some(_)) => return Err(()),
+    };
+    if hvf.expected_vsock() != expected.as_ref() {
+        return Err(());
+    }
+    match hvf.vsock_metrics() {
+        Some(metrics)
+            if metrics.shares_state_with(&hvf.session().shared_vsock_device_metrics())
+                && metrics.snapshot().is_empty() => {}
+        None if expected.is_none() => {}
+        Some(_) | None => return Err(()),
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn restore_process_snapshot_v2_vsock_mmio_with_factory<B, F, C>(
+    platform: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    resource_plan: PreparedProcessSnapshotV2VsockResourcePlan,
+    contained_authority: Option<&ContainedSnapshotRestoreAuthority>,
+    destination_instance_id: &str,
+    mmds_data_store_limit_bytes: usize,
+    factory: &mut F,
+    now: Instant,
+    cancelled: C,
+) -> Result<RestoredProcessSnapshotV2VsockMmioOwners<B>, ProcessSnapshotV2VsockMmioRestoreError>
+where
+    B: ProcessVmnetBackend,
+    F: ProcessVmnetPacketIoBackendFactory<Backend = B>,
+    C: Fn(ProcessSnapshotV2VsockMmioRestoreStage) -> bool,
+{
+    if cancelled(ProcessSnapshotV2VsockMmioRestoreStage::ResourcePreparation) {
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::retryable(
+            ProcessSnapshotV2VsockMmioRestoreStage::ResourcePreparation,
+        ));
+    }
+    let batch = {
+        let resource_cancelled =
+            |_| cancelled(ProcessSnapshotV2VsockMmioRestoreStage::ResourcePreparation);
+        prepare_process_snapshot_v2_vsock_restore_resources_with_factory(
+            resource_plan,
+            contained_authority,
+            destination_instance_id,
+            mmds_data_store_limit_bytes,
+            factory,
+            resource_cancelled,
+        )
+        .map_err(|source| {
+            ProcessSnapshotV2VsockMmioRestoreError::from_resource(
+                ProcessSnapshotV2VsockMmioRestoreStage::ResourcePreparation,
+                &source,
+            )
+        })?
+    };
+    let mut staged = StagedProcessSnapshotV2VsockMmioOwners::new(batch);
+
+    if cancelled(ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation) {
+        let evidence = staged.shutdown_evidence();
+        return Err(if evidence.terminal {
+            ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
+                evidence.cleanup_uncertain,
+            )
+        } else {
+            ProcessSnapshotV2VsockMmioRestoreError::retryable(
+                ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
+            )
+        });
+    }
+
+    let (
+        binding,
+        graph,
+        serial_state,
+        entropy_state,
+        balloon_state,
+        memory_hotplug_state,
+        network_topology,
+        vsock_state,
+        vsock_config,
+        binding_keys,
+    ) = {
+        let Some(batch) = staged.batch.as_ref() else {
+            return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
+                false,
+            ));
+        };
+        (
+            batch.binding.clone(),
+            batch.device_graph.clone(),
+            batch.serial.clone(),
+            batch.entropy.clone(),
+            batch.balloon.clone(),
+            batch.memory_hotplug.clone(),
+            batch.network_topology.clone(),
+            batch.vsock_state.clone(),
+            batch.vsock_config.clone(),
+            batch.binding_keys.clone(),
+        )
+    };
+    let product_transport_is_mmio = graph
+        .as_ref()
+        .is_none_or(|graph| graph.transport_kind() == SnapshotV2DeviceTransportKind::Mmio)
+        && entropy_state
+            .as_ref()
+            .is_none_or(|state| state.transport().kind() == SnapshotV2DeviceTransportKind::Mmio)
+        && balloon_state
+            .as_ref()
+            .is_none_or(|state| state.transport().kind() == SnapshotV2DeviceTransportKind::Mmio)
+        && memory_hotplug_state
+            .as_ref()
+            .is_none_or(|state| state.transport().kind() == SnapshotV2DeviceTransportKind::Mmio)
+        && network_topology.transport_kind() == SnapshotV2DeviceTransportKind::Mmio
+        && vsock_state
+            .as_ref()
+            .is_none_or(|state| state.transport_kind() == SnapshotV2DeviceTransportKind::Mmio);
+    if platform.memory() != &binding || !product_transport_is_mmio {
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+            ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
+            cleanup_uncertain,
+        ));
+    }
+
+    let storage_plan = match graph.clone() {
+        Some(graph) => match SnapshotV2StorageRestorePlan::prepare(graph, &memory, now) {
+            Ok(plan) => Some(plan),
+            Err(_) => {
+                let cleanup_uncertain = staged.shutdown();
+                return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                    ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
+                    cleanup_uncertain,
+                ));
+            }
+        },
+        None => None,
+    };
+    let entropy = match entropy_state
+        .clone()
+        .map(|state| SnapshotV2EntropyRestorePlan::prepare(state, &memory, now))
+        .transpose()
+    {
+        Ok(entropy) => entropy,
+        Err(_) => {
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
+                cleanup_uncertain,
+            ));
+        }
+    };
+    let balloon = match balloon_state
+        .clone()
+        .map(|state| SnapshotV2BalloonRestorePlan::prepare(state, &memory))
+        .transpose()
+    {
+        Ok(balloon) => balloon,
+        Err(_) => {
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
+                cleanup_uncertain,
+            ));
+        }
+    };
+    let memory_hotplug = match memory_hotplug_state
+        .clone()
+        .map(|state| {
+            PreparedSnapshotV2MemoryHotplugTopology::prepare_for_compatibility_version(
+                state,
+                binding.clone(),
+                NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
+            )
+        })
+        .transpose()
+    {
+        Ok(memory_hotplug) => memory_hotplug,
+        Err(_) => {
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
+                cleanup_uncertain,
+            ));
+        }
+    };
+
+    let block_count = binding_keys
+        .iter()
+        .filter(|key| key.resource_class() == SnapshotRestoreResourceClass::BlockBacking)
+        .count();
+    let pmem_count = binding_keys
+        .iter()
+        .filter(|key| key.resource_class() == SnapshotRestoreResourceClass::PmemBacking)
+        .count();
+    let network_count = binding_keys
+        .iter()
+        .filter(|key| key.resource_class() == SnapshotRestoreResourceClass::NetworkPacketIo)
+        .count();
+    let mut block_backings = Vec::new();
+    let mut pmem_backings = Vec::new();
+    if block_backings.try_reserve_exact(block_count).is_err()
+        || pmem_backings.try_reserve_exact(pmem_count).is_err()
+        || staged
+            .network_resources
+            .try_reserve_exact(network_count)
+            .is_err()
+    {
+        let evidence = staged.shutdown_evidence();
+        return Err(if evidence.terminal {
+            ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
+                evidence.cleanup_uncertain,
+            )
+        } else {
+            ProcessSnapshotV2VsockMmioRestoreError::retryable(
+                ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
+            )
+        });
+    }
+    let mut serial_output = None;
+    for (index, key) in binding_keys.iter().enumerate() {
+        if key.resource_class() == SnapshotRestoreResourceClass::VsockEndpoint {
+            continue;
+        }
+        let stage = ProcessSnapshotV2VsockMmioRestoreStage::ResourceTake { index };
+        if cancelled(stage) {
+            drop((block_backings, pmem_backings, serial_output));
+            let already_consumed = staged
+                .batch
+                .as_ref()
+                .is_some_and(|batch| batch.taken_count != 0);
+            let evidence = staged.shutdown_evidence();
+            return Err(if already_consumed || evidence.terminal {
+                ProcessSnapshotV2VsockMmioRestoreError::terminal(stage, evidence.cleanup_uncertain)
+            } else {
+                ProcessSnapshotV2VsockMmioRestoreError::retryable(stage)
+            });
+        }
+        let Some(batch) = staged.batch.as_mut() else {
+            drop((block_backings, pmem_backings, serial_output));
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                stage,
+                cleanup_uncertain,
+            ));
+        };
+        let result = match key.resource_class() {
+            SnapshotRestoreResourceClass::BlockBacking => batch
+                .take_block(key)
+                .map(|backing| block_backings.push(backing)),
+            SnapshotRestoreResourceClass::PmemBacking => batch
+                .take_pmem(key)
+                .map(|backing| pmem_backings.push(backing)),
+            SnapshotRestoreResourceClass::SerialSink => batch
+                .take_serial(key)
+                .map(|output| serial_output = Some(output)),
+            SnapshotRestoreResourceClass::NetworkPacketIo => batch
+                .take_network(key)
+                .map(|resource| staged.network_resources.push(resource)),
+            SnapshotRestoreResourceClass::VsockEndpoint => Ok(()),
+        };
+        if result.is_err() {
+            drop((block_backings, pmem_backings, serial_output));
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                stage,
+                cleanup_uncertain,
+            ));
+        }
+    }
+
+    let storage = match storage_plan {
+        Some(plan) => match plan.prepare_backings(block_backings, pmem_backings, || false) {
+            Ok(storage) => Some(storage),
+            Err(_) => {
+                let cleanup_uncertain = staged.shutdown();
+                return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                    ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
+                    cleanup_uncertain,
+                ));
+            }
+        },
+        None if block_backings.is_empty() && pmem_backings.is_empty() => None,
+        None => {
+            drop((block_backings, pmem_backings));
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
+                cleanup_uncertain,
+            ));
+        }
+    };
+    let serial_endpoint =
+        match prepare_native_v2_serial_restore_endpoint(serial_state.clone(), serial_output) {
+            Ok(endpoint) => endpoint,
+            Err(_) => {
+                drop(storage);
+                let cleanup_uncertain = staged.shutdown();
+                return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                    ProcessSnapshotV2VsockMmioRestoreStage::Serial,
+                    cleanup_uncertain,
+                ));
+            }
+        };
+    staged.serial_endpoint = Some(serial_endpoint);
+
+    let serial_resource_present = !serial_state.endpoint_intent().is_default_process_stdio();
+    let kind = HvfSnapshotV2VsockProductKind::from_presence(
+        storage.is_some(),
+        entropy.is_some(),
+        balloon.is_some(),
+        memory_hotplug.is_some(),
+        !network_topology.interfaces().is_empty(),
+        vsock_state.is_some(),
+    );
+    let (prepared_memory, static_memory) = match memory_hotplug {
+        Some(topology) => (
+            HvfSnapshotV2VsockPreparedMemory::MemoryHotplug {
+                topology: Box::new(topology),
+                memory,
+            },
+            None,
+        ),
+        None => (
+            HvfSnapshotV2VsockPreparedMemory::Static(binding),
+            Some(memory),
+        ),
+    };
+    let vsock = match (vsock_state, vsock_config) {
+        (Some(state), Some(config)) => Some(HvfSnapshotV2VsockPreparedEndpoint::new(state, config)),
+        (None, None) => None,
+        _ => {
+            drop((prepared_memory, storage, entropy, balloon, network_topology));
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
+                cleanup_uncertain,
+            ));
+        }
+    };
+    let product = match HvfSnapshotV2VsockPreparedProduct::try_from_parts(
+        HvfSnapshotV2VsockPreparedProductParts {
+            kind,
+            memory: prepared_memory,
+            storage,
+            entropy,
+            balloon,
+            network: network_topology,
+            vsock,
+            serial_resource_present,
+            binding_keys,
+        },
+    ) {
+        Ok(product) => product,
+        Err(_) => {
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
+                cleanup_uncertain,
+            ));
+        }
+    };
+    let process = HvfSnapshotV2VsockMmioProcessConfig::from_layouts(
+        BalloonMmioLayout::new(DEFAULT_BALLOON_MMIO_BASE, DEFAULT_BALLOON_MMIO_REGION_ID),
+        HvfSnapshotV2StorageMmioProcessConfig::new(
+            BlockMmioLayout::new(DEFAULT_BLOCK_MMIO_BASE, DEFAULT_BLOCK_MMIO_REGION_ID),
+            PmemMmioLayout::new(DEFAULT_PMEM_MMIO_BASE, DEFAULT_PMEM_MMIO_REGION_ID),
+        ),
+        NetworkMmioLayout::new(DEFAULT_NETWORK_MMIO_BASE, DEFAULT_NETWORK_MMIO_REGION_ID),
+        VsockMmioLayout::new(DEFAULT_VSOCK_MMIO_BASE, DEFAULT_VSOCK_MMIO_REGION_ID),
+        EntropyMmioLayout::new(DEFAULT_ENTROPY_MMIO_BASE, DEFAULT_ENTROPY_MMIO_REGION_ID),
+        VirtioMemMmioLayout::new(
+            DEFAULT_MEMORY_HOTPLUG_MMIO_BASE,
+            DEFAULT_MEMORY_HOTPLUG_MMIO_REGION_ID,
+        ),
+    );
+    let platform_plan =
+        match prepare_hvf_snapshot_v2_vsock_mmio_platform_plan(&platform, product, process) {
+            Ok(plan) => plan,
+            Err(_) => {
+                let cleanup_uncertain = staged.shutdown();
+                return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                    ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
+                    cleanup_uncertain,
+                ));
+            }
+        };
+    if !staged
+        .batch
+        .as_ref()
+        .is_some_and(|batch| batch.matches_mmio_platform_plan(&platform_plan))
+        || platform_plan.network().len() != staged.network_resources.len()
+    {
+        drop(platform_plan);
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+            ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
+            cleanup_uncertain,
+        ));
+    }
+
+    if cancelled(ProcessSnapshotV2VsockMmioRestoreStage::HvfConstruction) {
+        drop(platform_plan);
+        let already_consumed = staged
+            .batch
+            .as_ref()
+            .is_some_and(|batch| batch.taken_count != 0);
+        let evidence = staged.shutdown_evidence();
+        return Err(if already_consumed || evidence.terminal {
+            ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                ProcessSnapshotV2VsockMmioRestoreStage::HvfConstruction,
+                evidence.cleanup_uncertain,
+            )
+        } else {
+            ProcessSnapshotV2VsockMmioRestoreError::retryable(
+                ProcessSnapshotV2VsockMmioRestoreStage::HvfConstruction,
+            )
+        });
+    }
+    let Some(endpoint) = staged.serial_endpoint.take() else {
+        drop(platform_plan);
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+            ProcessSnapshotV2VsockMmioRestoreStage::Serial,
+            cleanup_uncertain,
+        ));
+    };
+    let (serial, serial_input, serial_restoration, serial_config) = match endpoint.into_parts() {
+        Ok(parts) => parts,
+        Err(_) => {
+            drop(platform_plan);
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                ProcessSnapshotV2VsockMmioRestoreStage::Serial,
+                cleanup_uncertain,
+            ));
+        }
+    };
+    staged.serial_output = Some(serial.output().clone());
+    staged.serial_config = Some(serial_config);
+    staged.serial_restoration = serial_restoration;
+    let process_shell = HvfSnapshotV2RestoredSerialShell::new(serial);
+    let profiles = staged
+        .network_resources
+        .iter()
+        .map(PreparedProcessSnapshotV2NetworkRestoreResource::device_profile)
+        .collect::<Vec<_>>();
+    let Some(network_metrics) = staged
+        .batch
+        .as_ref()
+        .map(|batch| batch.network_completion.network_metrics().clone())
+    else {
+        drop((platform_plan, process_shell, profiles));
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+            ProcessSnapshotV2VsockMmioRestoreStage::HvfConstruction,
+            cleanup_uncertain,
+        ));
+    };
+    let vsock_key = platform_plan
+        .vsock()
+        .map(|endpoint| endpoint.resource_key().clone());
+    let memory_input = static_memory
+        .map(HvfSnapshotV2NetworkMmioMemoryInput::Static)
+        .unwrap_or(HvfSnapshotV2NetworkMmioMemoryInput::ProductOwned);
+    let vsock_metrics = SharedVsockDeviceMetrics::default();
+
+    let restored = match vsock_key {
+        Some(key) => {
+            let Some(batch) = staged.batch.as_mut() else {
+                let cleanup_uncertain = staged.shutdown();
+                return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                    ProcessSnapshotV2VsockMmioRestoreStage::HvfConstruction,
+                    cleanup_uncertain,
+                ));
+            };
+            match batch.adopt_vsock(&key, |resource| {
+                OwnedHvfArm64BootSession::restore_snapshot_v2_vsock_mmio_with_cancel(
+                    platform,
+                    memory_input,
+                    process_shell,
+                    serial_input,
+                    platform_plan,
+                    profiles,
+                    network_metrics,
+                    Some(resource),
+                    vsock_metrics,
+                    now,
+                    |stage| cancelled(ProcessSnapshotV2VsockMmioRestoreStage::Hvf(stage)),
+                )
+            }) {
+                Ok((hvf, guard)) => {
+                    staged.active_vsock = Some(guard);
+                    hvf
+                }
+                Err(source) => {
+                    let cleanup_uncertain = staged.shutdown();
+                    return Err(ProcessSnapshotV2VsockMmioRestoreError::from_adoption(
+                        &source,
+                        cleanup_uncertain,
+                    ));
+                }
+            }
+        }
+        None => {
+            match OwnedHvfArm64BootSession::restore_snapshot_v2_vsock_mmio_with_cancel(
+                platform,
+                memory_input,
+                process_shell,
+                serial_input,
+                platform_plan,
+                profiles,
+                network_metrics,
+                None,
+                vsock_metrics,
+                now,
+                |stage| cancelled(ProcessSnapshotV2VsockMmioRestoreStage::Hvf(stage)),
+            ) {
+                Ok(hvf) => hvf,
+                Err(source) => {
+                    let cleanup_uncertain = staged.shutdown();
+                    return Err(ProcessSnapshotV2VsockMmioRestoreError::from_hvf(
+                        &source,
+                        cleanup_uncertain,
+                    ));
+                }
+            }
+        }
+    };
+    staged.hvf = Some(restored);
+
+    if cancelled(ProcessSnapshotV2VsockMmioRestoreStage::BatchFinish) {
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+            ProcessSnapshotV2VsockMmioRestoreStage::BatchFinish,
+            cleanup_uncertain,
+        ));
+    }
+    let Some(batch) = staged.batch.take() else {
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+            ProcessSnapshotV2VsockMmioRestoreStage::BatchFinish,
+            cleanup_uncertain,
+        ));
+    };
+    let completion = match batch.finish() {
+        Ok(completion) => completion,
+        Err(_) => {
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                ProcessSnapshotV2VsockMmioRestoreStage::BatchFinish,
+                cleanup_uncertain,
+            ));
+        }
+    };
+    staged.completion = Some(completion);
+
+    let equivalent = match (&staged.hvf, &staged.completion) {
+        (Some(hvf), Some(completion)) => restored_process_snapshot_v2_vsock_mmio_is_equivalent(
+            hvf,
+            completion,
+            &staged.network_resources,
+            now,
+        )
+        .is_ok(),
+        _ => false,
+    };
+    if cancelled(ProcessSnapshotV2VsockMmioRestoreStage::CompleteRecapture) || !equivalent {
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+            ProcessSnapshotV2VsockMmioRestoreStage::CompleteRecapture,
+            cleanup_uncertain,
+        ));
+    }
+
+    if cancelled(ProcessSnapshotV2VsockMmioRestoreStage::Assembly) {
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+            ProcessSnapshotV2VsockMmioRestoreStage::Assembly,
+            cleanup_uncertain,
+        ));
+    }
+    let owner_graph_is_complete = match (&staged.hvf, &staged.completion) {
+        (Some(hvf), Some(completion)) => {
+            hvf.configs().len() == staged.network_resources.len()
+                && completion
+                    .network_completion
+                    .resources_match(&staged.network_resources)
+                && staged.serial_output.is_some()
+                && staged.serial_config.is_some()
+                && hvf.expected_vsock().is_some() == staged.active_vsock.is_some()
+        }
+        _ => false,
+    };
+    if !owner_graph_is_complete {
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+            ProcessSnapshotV2VsockMmioRestoreStage::Assembly,
+            cleanup_uncertain,
+        ));
+    }
+
+    if cancelled(ProcessSnapshotV2VsockMmioRestoreStage::GateCommit) {
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+            ProcessSnapshotV2VsockMmioRestoreStage::GateCommit,
+            cleanup_uncertain,
+        ));
+    }
+    let Some(hvf) = staged.hvf.take() else {
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+            ProcessSnapshotV2VsockMmioRestoreStage::GateCommit,
+            cleanup_uncertain,
+        ));
+    };
+    staged.hvf = Some(hvf.commit_retry_publication());
+    staged.into_owners()
+}
+
+type SystemRestoredProcessSnapshotV2VsockMmioOwners =
+    RestoredProcessSnapshotV2VsockMmioOwners<SystemVmnetInterfaceBackend>;
+
+#[allow(clippy::too_many_arguments)]
+fn restore_process_snapshot_v2_vsock_mmio<C>(
+    platform: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    resource_plan: PreparedProcessSnapshotV2VsockResourcePlan,
+    contained_authority: Option<&ContainedSnapshotRestoreAuthority>,
+    destination_instance_id: &str,
+    mmds_data_store_limit_bytes: usize,
+    now: Instant,
+    cancelled: C,
+) -> Result<SystemRestoredProcessSnapshotV2VsockMmioOwners, ProcessSnapshotV2VsockMmioRestoreError>
+where
+    C: Fn(ProcessSnapshotV2VsockMmioRestoreStage) -> bool,
+{
+    let mut factory = SystemProcessVmnetPacketIoBackendFactory;
+    restore_process_snapshot_v2_vsock_mmio_with_factory(
+        platform,
+        memory,
+        resource_plan,
+        contained_authority,
+        destination_instance_id,
+        mmds_data_store_limit_bytes,
+        &mut factory,
+        now,
+        cancelled,
+    )
+}
+
+type SystemRestoreProcessSnapshotV2VsockMmioFn = fn(
+    HvfSnapshotV2PlatformState,
+    GuestMemory,
+    PreparedProcessSnapshotV2VsockResourcePlan,
+    Option<&ContainedSnapshotRestoreAuthority>,
+    &str,
+    usize,
+    Instant,
+    fn(ProcessSnapshotV2VsockMmioRestoreStage) -> bool,
+) -> Result<
+    SystemRestoredProcessSnapshotV2VsockMmioOwners,
+    ProcessSnapshotV2VsockMmioRestoreError,
+>;
+
+const _: SystemRestoreProcessSnapshotV2VsockMmioFn =
+    restore_process_snapshot_v2_vsock_mmio::<fn(ProcessSnapshotV2VsockMmioRestoreStage) -> bool>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ProcessSnapshotV2NetworkPciRestoreStage {
@@ -41876,6 +43054,84 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
+    fn exact_minor_twelve_contained_staged_abort_retains_terminal_evidence() {
+        let root = TempFilePath::create("v2-contained-staged-abort-unused-root");
+        let fixture = contained_restore_authority_for_test(root.path(), true);
+        let destination_reference = Path::new("bangbang-grant:vsock-directory/staged-abort.sock");
+        let published = fixture
+            .vsock_directory_path_for_test()
+            .join("staged-abort.sock");
+        let (plan, _) = prepared_native_v2_vsock_resource_plan(destination_reference, false);
+        let launcher = fixture.socket_broker_for_test();
+        let session = fixture.session_for_test();
+        let broker = std::thread::spawn(move || {
+            let activation = receive_socket_broker_message(&launcher)
+                .expect("contained staged-abort broker should receive activation");
+            assert!(activation.descriptor.is_none());
+            assert!(matches!(
+                activation.message,
+                SocketBrokerMessage::Activate {
+                    session: observed,
+                    sequence: 1,
+                    ..
+                } if observed == session
+            ));
+            send_socket_broker_message(
+                &launcher,
+                &SocketBrokerMessage::Ready {
+                    session,
+                    sequence: 1,
+                },
+                None,
+            )
+            .expect("contained staged-abort broker should confirm activation");
+
+            let shutdown = receive_socket_broker_message(&launcher)
+                .expect("contained staged-abort broker should receive shutdown");
+            let sequence = match shutdown.message {
+                SocketBrokerMessage::Shutdown {
+                    session: observed,
+                    sequence,
+                } if observed == session => sequence,
+                message => panic!("unexpected contained staged-abort shutdown: {message:?}"),
+            };
+            assert!(shutdown.descriptor.is_none());
+            send_socket_broker_message(
+                &launcher,
+                &SocketBrokerMessage::Complete { session, sequence },
+                None,
+            )
+            .expect("contained staged-abort broker should confirm shutdown");
+        });
+        let mut factory = RecordingVmnetPacketIoBackendFactory::default();
+        let batch = super::prepare_process_snapshot_v2_vsock_restore_resources_with_factory(
+            plan,
+            Some(fixture.authority()),
+            "private-contained-vsock-staged-abort",
+            bangbang_runtime::mmds::MMDS_DATA_STORE_LIMIT_BYTES,
+            &mut factory,
+            |_| false,
+        )
+        .expect("contained staged-abort resources should prepare");
+        assert!(published.exists());
+
+        let mut staged = super::StagedProcessSnapshotV2VsockMmioOwners::new(batch);
+        let evidence = staged.shutdown_evidence();
+        broker
+            .join()
+            .expect("contained staged-abort broker should finish cleanly");
+
+        assert!(evidence.terminal);
+        assert!(!evidence.cleanup_uncertain);
+        assert!(!published.exists());
+        assert_eq!(
+            staged.shutdown_evidence(),
+            super::ProcessSnapshotV2VsockAbortEvidence::clean()
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
     fn exact_minor_twelve_unconsumed_finish_cleans_and_allows_retry() {
         let socket = TempFilePath::absent("v2-unconsumed.sock");
         let destination = socket.path().to_path_buf();
@@ -52463,6 +53719,313 @@ mod tests {
     #[ignore = "requires the signed native_v2_process integration group"]
     fn signed_exact_minor_eleven_process_pci_owner_transaction_is_atomic_and_retryable() {
         verify_signed_exact_minor_eleven_process_network_owner_transaction(true);
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[test]
+    #[ignore = "requires the signed native_v2_process integration group"]
+    fn signed_exact_minor_twelve_process_mmio_vsock_owner_transaction_is_atomic() {
+        use bangbang_runtime::snapshot_memory_v2::load_snapshot_v2_memory_path;
+        use bangbang_runtime::vsock::VsockBackendSelector;
+
+        const ARM64_IMAGE_HEADER_SIZE: usize = 64;
+        const ARM64_IMAGE_SIZE_OFFSET: usize = 16;
+        const ARM64_IMAGE_MAGIC_OFFSET: usize = 56;
+        const ARM64_IMAGE_MAGIC: u32 = 0x644d_5241;
+        const ARM64_BRANCH_TO_SELF: u32 = 0x1400_0000;
+
+        let mut image = vec![0_u8; ARM64_IMAGE_HEADER_SIZE];
+        image[..4].copy_from_slice(&ARM64_BRANCH_TO_SELF.to_le_bytes());
+        image[ARM64_IMAGE_SIZE_OFFSET..ARM64_IMAGE_SIZE_OFFSET + 8]
+            .copy_from_slice(&(ARM64_IMAGE_HEADER_SIZE as u64).to_le_bytes());
+        image[ARM64_IMAGE_MAGIC_OFFSET..ARM64_IMAGE_MAGIC_OFFSET + 4]
+            .copy_from_slice(&ARM64_IMAGE_MAGIC.to_le_bytes());
+        let kernel =
+            TempFilePath::create_with_bytes("signed-exact-2-12-process-vsock-kernel", &image);
+        let source_socket = TempFilePath::absent("signed-exact-2-12-source-vsock.sock");
+        let destination_socket = TempFilePath::absent("signed-exact-2-12-destination-vsock.sock");
+
+        let mut controller = VmmController::new("exact-2-12-process-source", "0.1.0", "bangbang");
+        controller
+            .handle_action(VmmAction::PutMachineConfig(
+                MachineConfigInput::new(1, 16).with_track_dirty_pages(true),
+            ))
+            .expect("vsock source machine should configure");
+        controller
+            .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+                kernel.path(),
+            )))
+            .expect("vsock source boot metadata should configure");
+        controller
+            .handle_action(VmmAction::PutVsock(VsockConfigInput::new(
+                42,
+                source_socket.path().to_string_lossy(),
+            )))
+            .expect("vsock source endpoint should configure");
+        let source_config = controller
+            .vsock_config()
+            .cloned()
+            .expect("vsock source config should exist");
+
+        let mut source = super::OwnedHvfArm64BootSession::new(
+            &controller,
+            default_hvf_boot_session_config(SharedSerialOutput::from(
+                SharedSerialOutputBuffer::default(),
+            )),
+        )
+        .expect("signed exact-2.12 source should prepare");
+        assert!(source_socket.path().exists());
+        let source_metrics = source.shared_vsock_device_metrics();
+        let guard = source
+            .quiesce_limiter_retry_wakeups()
+            .expect("vsock source publishers should quiesce");
+        let serial = SnapshotV2SerialState::try_from_capture_ready(
+            source
+                .capture_ready_serial_state(controller.serial_config().clone(), &guard)
+                .expect("vsock source serial should capture"),
+        )
+        .expect("vsock source serial should convert");
+        let expected_vsock = source
+            .capture_ready_vsock_state(Some(source_config.clone()), &source_metrics, &guard)
+            .expect("vsock source should capture")
+            .expect("configured vsock source should remain present")
+            .try_into_snapshot_v2()
+            .expect("vsock source should convert to exact-2.12");
+        let expected_destination_vsock = {
+            let mut parts = expected_vsock.clone().into_parts();
+            parts.backend_selector = VsockBackendSelector::try_from_path(destination_socket.path())
+                .expect("vsock destination selector should validate");
+            SnapshotV2VsockState::try_from_parts(parts)
+                .expect("vsock destination-normalized state should validate")
+        };
+        drop(guard);
+
+        source
+            .pause_for_snapshot_v2_capture()
+            .expect("vsock source should pause");
+        let boot = super::HvfSnapshotV2BootState::try_new(
+            super::HvfSnapshotV2NativePath::try_new(kernel.path().as_os_str())
+                .expect("vsock source kernel path should validate"),
+            None,
+            None,
+        )
+        .expect("vsock source boot state should validate");
+        let mut memory_output = Cursor::new(Vec::new());
+        let vsock_platform = source
+            .capture_snapshot_v2_vsock_platform_with_cancel(
+                super::HvfArm64BootSnapshotV2CaptureInput::new(boot),
+                None,
+                &mut memory_output,
+                |_| false,
+            )
+            .expect("vsock source platform should capture");
+        let platform = vsock_platform.platform().clone();
+        let encoded = super::encode_hvf_snapshot_v2_vsock_state(
+            &super::HvfSnapshotV2VsockState::try_new(
+                vsock_platform,
+                None,
+                serial,
+                None,
+                None,
+                None,
+                Some(expected_vsock.clone()),
+            )
+            .expect("vsock-only exact-2.12 product should compose"),
+        )
+        .expect("vsock-only exact-2.12 product should encode");
+        source
+            .shutdown()
+            .expect("signed exact-2.12 source should shut down");
+        drop(source);
+        assert!(!source_socket.path().exists());
+        let memory_image = TempFilePath::create_with_bytes(
+            "signed-exact-2-12-process-vsock-memory",
+            &memory_output.into_inner(),
+        );
+
+        let make_restore_inputs = || {
+            let structural = decode_snapshot_v2_state_with_compatibility_version(
+                &encoded,
+                NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
+            )
+            .expect("exact-2.12 state should decode structurally");
+            let memory = load_snapshot_v2_memory_path(&structural, memory_image.path())
+                .expect("exact-2.12 destination memory should map privately");
+            let candidate =
+                NativeV2VsockSnapshotCandidateState::from_vsock_state_v2_12(encoded.clone())
+                    .expect("exact-2.12 candidate should decode");
+            let prepared = prepare_process_snapshot_v2_vsock_candidate(
+                candidate,
+                &memory,
+                SnapshotV2DeviceTransportKind::Mmio,
+                &[],
+                Some(&SnapshotVsockOverride::new(destination_socket.path())),
+            )
+            .expect("exact-2.12 destination vsock should prepare");
+            let resource_plan = super::prepare_process_snapshot_v2_vsock_resource_plan(
+                prepared,
+                ProcessVmnetAuthority::Direct,
+            )
+            .expect("exact-2.12 process resource plan should prepare");
+            (memory, resource_plan)
+        };
+
+        for (cancel_stage, expected_disposition) in [
+            (
+                super::ProcessSnapshotV2VsockMmioRestoreStage::ResourcePreparation,
+                super::ProcessSnapshotV2VsockMmioRestoreDisposition::Retryable,
+            ),
+            (
+                super::ProcessSnapshotV2VsockMmioRestoreStage::ProductPreparation,
+                super::ProcessSnapshotV2VsockMmioRestoreDisposition::Retryable,
+            ),
+            (
+                super::ProcessSnapshotV2VsockMmioRestoreStage::HvfConstruction,
+                super::ProcessSnapshotV2VsockMmioRestoreDisposition::Retryable,
+            ),
+            (
+                super::ProcessSnapshotV2VsockMmioRestoreStage::Hvf(
+                    super::HvfSnapshotV2VsockMmioRestoreStage::Product,
+                ),
+                super::ProcessSnapshotV2VsockMmioRestoreDisposition::Retryable,
+            ),
+            (
+                super::ProcessSnapshotV2VsockMmioRestoreStage::Hvf(
+                    super::HvfSnapshotV2VsockMmioRestoreStage::InterruptSetup,
+                ),
+                super::ProcessSnapshotV2VsockMmioRestoreDisposition::Retryable,
+            ),
+            (
+                super::ProcessSnapshotV2VsockMmioRestoreStage::Hvf(
+                    super::HvfSnapshotV2VsockMmioRestoreStage::Platform,
+                ),
+                super::ProcessSnapshotV2VsockMmioRestoreDisposition::Retryable,
+            ),
+            (
+                super::ProcessSnapshotV2VsockMmioRestoreStage::Hvf(
+                    super::HvfSnapshotV2VsockMmioRestoreStage::Vsock,
+                ),
+                super::ProcessSnapshotV2VsockMmioRestoreDisposition::Terminal,
+            ),
+            (
+                super::ProcessSnapshotV2VsockMmioRestoreStage::Hvf(
+                    super::HvfSnapshotV2VsockMmioRestoreStage::RetryScheduler,
+                ),
+                super::ProcessSnapshotV2VsockMmioRestoreDisposition::Terminal,
+            ),
+            (
+                super::ProcessSnapshotV2VsockMmioRestoreStage::Hvf(
+                    super::HvfSnapshotV2VsockMmioRestoreStage::RetryDeadline,
+                ),
+                super::ProcessSnapshotV2VsockMmioRestoreDisposition::Terminal,
+            ),
+            (
+                super::ProcessSnapshotV2VsockMmioRestoreStage::Hvf(
+                    super::HvfSnapshotV2VsockMmioRestoreStage::Recapture,
+                ),
+                super::ProcessSnapshotV2VsockMmioRestoreDisposition::Terminal,
+            ),
+            (
+                super::ProcessSnapshotV2VsockMmioRestoreStage::Hvf(
+                    super::HvfSnapshotV2VsockMmioRestoreStage::Assembly,
+                ),
+                super::ProcessSnapshotV2VsockMmioRestoreDisposition::Terminal,
+            ),
+            (
+                super::ProcessSnapshotV2VsockMmioRestoreStage::BatchFinish,
+                super::ProcessSnapshotV2VsockMmioRestoreDisposition::Terminal,
+            ),
+            (
+                super::ProcessSnapshotV2VsockMmioRestoreStage::CompleteRecapture,
+                super::ProcessSnapshotV2VsockMmioRestoreDisposition::Terminal,
+            ),
+            (
+                super::ProcessSnapshotV2VsockMmioRestoreStage::Assembly,
+                super::ProcessSnapshotV2VsockMmioRestoreDisposition::Terminal,
+            ),
+            (
+                super::ProcessSnapshotV2VsockMmioRestoreStage::GateCommit,
+                super::ProcessSnapshotV2VsockMmioRestoreDisposition::Terminal,
+            ),
+        ] {
+            let (memory, resource_plan) = make_restore_inputs();
+            let mut factory = RecordingVmnetPacketIoBackendFactory::default();
+            let events = factory.events();
+            let error = super::restore_process_snapshot_v2_vsock_mmio_with_factory(
+                platform.clone(),
+                memory,
+                resource_plan,
+                None,
+                "exact-2-12-cancelled-destination",
+                bangbang_runtime::mmds::MMDS_DATA_STORE_LIMIT_BYTES,
+                &mut factory,
+                Instant::now(),
+                |stage| stage == cancel_stage,
+            )
+            .expect_err("injected exact-2.12 owner cancellation should reject");
+            assert_eq!(error.stage, cancel_stage);
+            assert_eq!(error.disposition, expected_disposition);
+            let diagnostics = format!("{error:?} {error}");
+            assert!(diagnostics.contains("<redacted>"));
+            assert!(!diagnostics.contains(destination_socket.path().to_string_lossy().as_ref()));
+            assert!(!diagnostics.contains("exact-2-12-cancelled-destination"));
+            assert!(!destination_socket.path().exists());
+            assert!(recorded_events(&events).is_empty());
+        }
+
+        let (memory, resource_plan) = make_restore_inputs();
+        let mut factory = RecordingVmnetPacketIoBackendFactory::default();
+        let events = factory.events();
+        let mut owners = super::restore_process_snapshot_v2_vsock_mmio_with_factory(
+            platform,
+            memory,
+            resource_plan,
+            None,
+            "exact-2-12-committed-destination",
+            bangbang_runtime::mmds::MMDS_DATA_STORE_LIMIT_BYTES,
+            &mut factory,
+            Instant::now(),
+            |_| false,
+        )
+        .expect("complete exact-2.12 process/HVF owner graph should commit");
+        assert!(destination_socket.path().exists());
+        assert!(owners.active_vsock.is_some());
+        assert!(owners.completion.is_some());
+        assert!(owners.network_resources.is_empty());
+        let hvf = owners
+            .hvf
+            .as_ref()
+            .expect("committed exact-2.12 graph should retain HVF");
+        assert!(hvf.retry_publication_is_committed());
+        assert_eq!(hvf.expected_vsock(), Some(&expected_destination_vsock));
+        let restored_config = hvf
+            .vsock_config()
+            .expect("committed exact-2.12 graph should retain vsock config");
+        assert_eq!(restored_config.guest_cid(), source_config.guest_cid());
+        assert_eq!(restored_config.uds_path(), destination_socket.path());
+        let destination_metrics = hvf
+            .vsock_metrics()
+            .expect("committed exact-2.12 graph should retain fresh metrics");
+        assert!(
+            destination_metrics.shares_state_with(&hvf.session().shared_vsock_device_metrics())
+        );
+        assert!(!source_metrics.shares_state_with(destination_metrics));
+        assert!(destination_metrics.snapshot().is_empty());
+        assert!(source_metrics.snapshot().is_empty());
+        assert_eq!(controller.vsock_config(), Some(&source_config));
+        let diagnostics = format!("{owners:?}");
+        assert!(diagnostics.contains("<redacted>"));
+        assert!(!diagnostics.contains(destination_socket.path().to_string_lossy().as_ref()));
+        assert!(!diagnostics.contains("exact-2-12-committed-destination"));
+        assert!(recorded_events(&events).is_empty());
+
+        owners
+            .shutdown()
+            .expect("committed exact-2.12 process/HVF owner graph should shut down");
+        owners
+            .shutdown()
+            .expect("repeated exact-2.12 process/HVF shutdown should be idempotent");
+        assert!(!destination_socket.path().exists());
     }
 
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/crates/bangbang/src/vsock_restore.rs
+++ b/crates/bangbang/src/vsock_restore.rs
@@ -118,6 +118,18 @@ pub(crate) enum ActiveVsockRestoreGuard {
     Contained(AnchoredSocketGuard),
 }
 
+impl ActiveVsockRestoreGuard {
+    pub(crate) fn cleanup(self) -> Result<(), ()> {
+        match self {
+            Self::Direct(guard) => guard.cleanup().map_err(|_| ()),
+            Self::Contained(guard) => {
+                drop(guard);
+                Ok(())
+            }
+        }
+    }
+}
+
 impl fmt::Debug for ActiveVsockRestoreGuard {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -302,7 +302,8 @@ pub use startup::{
     HvfSnapshotV2StorageMmioRestoreError, HvfSnapshotV2StorageMmioRestoreFailure,
     HvfSnapshotV2StorageMmioRestoreStage, HvfSnapshotV2StoragePciRestoreCleanupFailure,
     HvfSnapshotV2StoragePciRestoreError, HvfSnapshotV2StoragePciRestoreFailure,
-    HvfSnapshotV2StoragePciRestoreStage, OwnedHvfArm64BootSession,
+    HvfSnapshotV2StoragePciRestoreStage, HvfSnapshotV2VsockMmioRestoreError,
+    HvfSnapshotV2VsockMmioRestoreStage, OwnedHvfArm64BootSession,
     PreparedHvfArm64BootPciNetworkRemoval, RestoredHvfArm64BootSession,
     RestoredHvfSnapshotV2BalloonMmioOwners, RestoredHvfSnapshotV2BalloonPciOwners,
     RestoredHvfSnapshotV2EntropyMmioOwners, RestoredHvfSnapshotV2EntropyPciOwners,
@@ -310,6 +311,7 @@ pub use startup::{
     RestoredHvfSnapshotV2MultiBlockMmioOwners, RestoredHvfSnapshotV2MultiBlockPciOwners,
     RestoredHvfSnapshotV2NetworkMmioOwners, RestoredHvfSnapshotV2NetworkPciOwners,
     RestoredHvfSnapshotV2StorageMmioOwners, RestoredHvfSnapshotV2StoragePciOwners,
+    RestoredHvfSnapshotV2VsockMmioOwners,
 };
 pub use topology::{
     HvfVcpuTopology, HvfVcpuTopologyAllocation, HvfVcpuTopologyCreateStage, HvfVcpuTopologyError,

--- a/crates/hvf/src/snapshot_v2_platform.rs
+++ b/crates/hvf/src/snapshot_v2_platform.rs
@@ -483,6 +483,7 @@ pub(crate) struct HvfSnapshotV2NetworkMmioShellPlan<'a> {
     pub(crate) block_records: &'a [HvfSnapshotV2StorageMmioRecordPlan],
     pub(crate) network_interrupts: &'a [GuestInterruptLine],
     pub(crate) pmem_records: &'a [HvfSnapshotV2StorageMmioRecordPlan],
+    pub(crate) following_interrupt: Option<GuestInterruptLine>,
     pub(crate) entropy_interrupt: Option<GuestInterruptLine>,
     pub(crate) memory_hotplug_interrupt: Option<GuestInterruptLine>,
     pub(crate) serial_interrupt: GuestInterruptLine,
@@ -3148,6 +3149,14 @@ fn prepare_process_shell(
                         );
                     }
                 }
+                if let Some(following_interrupt) = plan.following_interrupt
+                    && allocator
+                        .allocate()
+                        .map_err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterrupt)?
+                        != following_interrupt
+                {
+                    return Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterruptIdentity);
+                }
                 if let Some(entropy_interrupt) = plan.entropy_interrupt
                     && allocator
                         .allocate()
@@ -5685,6 +5694,7 @@ pub(crate) mod tests {
             block_records: &[],
             network_interrupts: &[],
             pmem_records: &[],
+            following_interrupt: None,
             entropy_interrupt: None,
             memory_hotplug_interrupt: None,
             serial_interrupt: serial.interrupt_line,
@@ -5708,6 +5718,63 @@ pub(crate) mod tests {
                 .interrupt_line,
             serial.interrupt_line,
         );
+    }
+
+    #[test]
+    fn network_mmio_shell_replays_a_following_endpoint_before_fixed_interrupts() {
+        let (state, following_interrupt, serial_interrupt, vmgenid_interrupt, vmclock_interrupt) =
+            product_entropy_interrupt_platform_fixture(product_process_platform_fixture(), &[]);
+        let shell_plan = HvfSnapshotV2NetworkMmioShellPlan {
+            balloon_interrupt: None,
+            command_line: None,
+            block_records: &[],
+            network_interrupts: &[],
+            pmem_records: &[],
+            following_interrupt: Some(following_interrupt),
+            entropy_interrupt: None,
+            memory_hotplug_interrupt: None,
+            serial_interrupt,
+            vmgenid_interrupt,
+            vmclock_interrupt,
+        };
+
+        prepare_process_shell(
+            Some(HvfSnapshotV2ProcessShellRestore::NetworkMmio {
+                shell: restored_serial_shell().into(),
+                plan: shell_plan,
+            }),
+            &state,
+            b"authenticated product FDT bytes are not reparsed",
+        )
+        .expect("a following exact-2.12 endpoint should preserve product interrupt order");
+
+        let wrong_interrupt =
+            GuestInterruptLine::new(following_interrupt.raw_value().saturating_add(1))
+                .expect("wrong following interrupt should validate structurally");
+        let shell_plan = HvfSnapshotV2NetworkMmioShellPlan {
+            balloon_interrupt: None,
+            command_line: None,
+            block_records: &[],
+            network_interrupts: &[],
+            pmem_records: &[],
+            following_interrupt: Some(wrong_interrupt),
+            entropy_interrupt: None,
+            memory_hotplug_interrupt: None,
+            serial_interrupt,
+            vmgenid_interrupt,
+            vmclock_interrupt,
+        };
+        assert!(matches!(
+            prepare_process_shell(
+                Some(HvfSnapshotV2ProcessShellRestore::NetworkMmio {
+                    shell: restored_serial_shell().into(),
+                    plan: shell_plan,
+                }),
+                &state,
+                b"authenticated product FDT bytes are not reparsed",
+            ),
+            Err(HvfSnapshotV2PlatformRestoreFailure::ProcessShellInterruptIdentity)
+        ));
     }
 
     #[test]

--- a/crates/hvf/src/snapshot_v2_vsock_platform.rs
+++ b/crates/hvf/src/snapshot_v2_vsock_platform.rs
@@ -343,7 +343,11 @@ fn validate_prepared_vsock(
         PreparedSnapshotV2VsockRestoreState::Pci(state) => state.capture().device(),
     };
     if device.guest_cid() != u64::from(endpoint.config.guest_cid())
-        || device.backend_selector().path() != endpoint.config.uds_path()
+        || endpoint
+            .state
+            .clone()
+            .into_destination_normalized_state(&endpoint.config)
+            .is_err()
     {
         return Err(PrepareHvfSnapshotV2VsockPlatformPlanError::Vsock);
     }
@@ -858,6 +862,24 @@ impl HvfSnapshotV2VsockMmioPlatformPlan {
             && matches_vsock_identity_mmio(self.vsock.as_ref(), vsock)
             && self.binding_keys == binding_keys
     }
+
+    pub(crate) fn into_owner_parts(self) -> HvfSnapshotV2VsockMmioPlatformOwnerParts {
+        HvfSnapshotV2VsockMmioPlatformOwnerParts {
+            kind: self.kind,
+            base: self.base,
+            vsock: self.vsock,
+            serial_resource_present: self.serial_resource_present,
+            binding_keys: self.binding_keys,
+        }
+    }
+}
+
+pub(crate) struct HvfSnapshotV2VsockMmioPlatformOwnerParts {
+    pub(crate) kind: HvfSnapshotV2VsockProductKind,
+    pub(crate) base: HvfSnapshotV2NetworkMmioPlatformPlan,
+    pub(crate) vsock: Option<HvfSnapshotV2VsockMmioEndpointPlan>,
+    pub(crate) serial_resource_present: bool,
+    pub(crate) binding_keys: Vec<SnapshotRestoreResourceKey>,
 }
 
 impl fmt::Debug for HvfSnapshotV2VsockMmioPlatformPlan {

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -156,6 +156,7 @@ use bangbang_runtime::snapshot_network_v2_11::{
     SnapshotV2NetworkInterfaceState,
 };
 use bangbang_runtime::snapshot_serial_v2_7::NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION;
+use bangbang_runtime::snapshot_vsock_restore_v2_12::PreparedSnapshotV2VsockRestoreState;
 use bangbang_runtime::snapshot_vsock_v2_12::{
     NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION, SnapshotV2VsockState,
     SnapshotV2VsockStateCaptureError,
@@ -219,7 +220,8 @@ use bangbang_runtime::vmclock::{VMCLOCK_ABI_SIZE, VmClockAbi, VmClockRestoreUpda
 use bangbang_runtime::vsock::{
     VIRTIO_VSOCK_DEVICE_ID, VIRTIO_VSOCK_QUEUE_SIZES, VirtioVsockCaptureValidation,
     VirtioVsockConfigSpace, VirtioVsockDevice, VirtioVsockMmioCaptureState,
-    VirtioVsockPciCaptureState, VsockConfig, VsockHostWakeup, VsockMmioLayout,
+    VirtioVsockPciCaptureState, VirtioVsockReconstructionResource, VsockConfig, VsockHostWakeup,
+    VsockMmioDeviceRegistration, VsockMmioLayout,
 };
 use bangbang_runtime::{BackendError, VmBackend, VmmController};
 use crc64::crc64;
@@ -324,6 +326,10 @@ use crate::snapshot_v2_platform::{
 use crate::snapshot_v2_storage_platform::{
     HvfSnapshotV2StorageMmioPlatformPlan, HvfSnapshotV2StorageMmioPlatformPlanParts,
     HvfSnapshotV2StoragePciPlatformPlan, HvfSnapshotV2StoragePciPlatformPlanParts,
+};
+use crate::snapshot_v2_vsock_platform::{
+    HvfSnapshotV2VsockMmioEndpointPlan, HvfSnapshotV2VsockMmioPlatformOwnerParts,
+    HvfSnapshotV2VsockMmioPlatformPlan, HvfSnapshotV2VsockProductKind,
 };
 use crate::topology::{HvfVcpuTopologyError, prepare_ordered_mpidrs};
 use crate::vcpu::{
@@ -3640,6 +3646,7 @@ struct HvfSnapshotV2MemoryHotplugMmioInterruptPlan {
 struct HvfSnapshotV2NetworkMmioInterruptPlan {
     balloon: Option<GuestInterruptLine>,
     network: Vec<GuestInterruptLine>,
+    following: Option<GuestInterruptLine>,
     entropy: Option<GuestInterruptLine>,
     memory_hotplug: Option<GuestInterruptLine>,
     serial: GuestInterruptLine,
@@ -3803,6 +3810,139 @@ impl fmt::Display for HvfSnapshotV2NetworkMmioRestoreError {
 
 impl std::error::Error for HvfSnapshotV2NetworkMmioRestoreError {}
 
+/// Stable aggregate stage for exact-2.12 MMIO vsock reconstruction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[doc(hidden)]
+pub enum HvfSnapshotV2VsockMmioRestoreStage {
+    Product,
+    Handler { index: usize },
+    InterruptSetup,
+    Platform,
+    Registration { index: usize },
+    Vsock,
+    Entropy,
+    MemoryHotplug,
+    RetryScheduler,
+    RetryDeadline,
+    Recapture,
+    Assembly,
+}
+
+/// Bounded, redacted exact-2.12 MMIO aggregate reconstruction error.
+#[doc(hidden)]
+pub struct HvfSnapshotV2VsockMmioRestoreError {
+    stage: HvfSnapshotV2VsockMmioRestoreStage,
+    disposition: HvfSnapshotV2NetworkMmioRestoreDisposition,
+}
+
+fn network_mmio_stage_to_vsock(
+    stage: HvfSnapshotV2NetworkMmioRestoreStage,
+    interface_count: usize,
+) -> HvfSnapshotV2VsockMmioRestoreStage {
+    match stage {
+        HvfSnapshotV2NetworkMmioRestoreStage::Product => {
+            HvfSnapshotV2VsockMmioRestoreStage::Product
+        }
+        HvfSnapshotV2NetworkMmioRestoreStage::Handler { index } => {
+            HvfSnapshotV2VsockMmioRestoreStage::Handler { index }
+        }
+        HvfSnapshotV2NetworkMmioRestoreStage::InterruptSetup => {
+            HvfSnapshotV2VsockMmioRestoreStage::InterruptSetup
+        }
+        HvfSnapshotV2NetworkMmioRestoreStage::Platform => {
+            HvfSnapshotV2VsockMmioRestoreStage::Platform
+        }
+        HvfSnapshotV2NetworkMmioRestoreStage::Registration { index }
+            if index == interface_count =>
+        {
+            HvfSnapshotV2VsockMmioRestoreStage::Vsock
+        }
+        HvfSnapshotV2NetworkMmioRestoreStage::Registration { index } => {
+            HvfSnapshotV2VsockMmioRestoreStage::Registration { index }
+        }
+        HvfSnapshotV2NetworkMmioRestoreStage::Entropy => {
+            HvfSnapshotV2VsockMmioRestoreStage::Entropy
+        }
+        HvfSnapshotV2NetworkMmioRestoreStage::MemoryHotplug => {
+            HvfSnapshotV2VsockMmioRestoreStage::MemoryHotplug
+        }
+        HvfSnapshotV2NetworkMmioRestoreStage::RetryScheduler => {
+            HvfSnapshotV2VsockMmioRestoreStage::RetryScheduler
+        }
+        HvfSnapshotV2NetworkMmioRestoreStage::RetryDeadline => {
+            HvfSnapshotV2VsockMmioRestoreStage::RetryDeadline
+        }
+        HvfSnapshotV2NetworkMmioRestoreStage::Recapture => {
+            HvfSnapshotV2VsockMmioRestoreStage::Recapture
+        }
+        HvfSnapshotV2NetworkMmioRestoreStage::Assembly => {
+            HvfSnapshotV2VsockMmioRestoreStage::Assembly
+        }
+    }
+}
+
+impl HvfSnapshotV2VsockMmioRestoreError {
+    fn preflight(stage: HvfSnapshotV2VsockMmioRestoreStage) -> Self {
+        Self {
+            stage,
+            disposition: HvfSnapshotV2NetworkMmioRestoreDisposition::Retryable,
+        }
+    }
+
+    fn from_network(source: HvfSnapshotV2NetworkMmioRestoreError, interface_count: usize) -> Self {
+        let stage = network_mmio_stage_to_vsock(source.stage(), interface_count);
+        Self {
+            stage,
+            disposition: source.disposition(),
+        }
+    }
+
+    pub const fn stage(&self) -> HvfSnapshotV2VsockMmioRestoreStage {
+        self.stage
+    }
+
+    pub const fn disposition(&self) -> HvfSnapshotV2NetworkMmioRestoreDisposition {
+        self.disposition
+    }
+
+    pub const fn is_terminal(&self) -> bool {
+        !matches!(
+            self.disposition,
+            HvfSnapshotV2NetworkMmioRestoreDisposition::Retryable
+        )
+    }
+
+    pub const fn has_incomplete_cleanup(&self) -> bool {
+        matches!(
+            self.disposition,
+            HvfSnapshotV2NetworkMmioRestoreDisposition::TerminalCleanup
+        )
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2VsockMmioRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2VsockMmioRestoreError")
+            .field("stage", &self.stage)
+            .field("disposition", &self.disposition)
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2VsockMmioRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "exact-2.12 MMIO vsock reconstruction failed at {:?} ({:?})",
+            self.stage, self.disposition
+        )
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2VsockMmioRestoreError {}
+
 /// Complete exact-2.11 MMIO owner graph with retry publication still gated.
 #[doc(hidden)]
 pub struct RestoredHvfSnapshotV2NetworkMmioOwners {
@@ -3951,6 +4091,136 @@ impl fmt::Debug for RestoredHvfSnapshotV2NetworkMmioOwners {
             .field("state", &"<redacted>")
             .finish()
     }
+}
+
+struct RestoredHvfSnapshotV2VsockMmioMetadata {
+    config: VsockConfig,
+    expected: SnapshotV2VsockState,
+    metrics: SharedVsockDeviceMetrics,
+}
+
+struct RestoredHvfSnapshotV2NetworkMmioInnerOwners {
+    network: RestoredHvfSnapshotV2NetworkMmioOwners,
+    vsock: Option<RestoredHvfSnapshotV2VsockMmioMetadata>,
+}
+
+/// Complete exact-2.12 MMIO owner graph with retry publication still gated.
+#[doc(hidden)]
+pub struct RestoredHvfSnapshotV2VsockMmioOwners {
+    base: RestoredHvfSnapshotV2NetworkMmioOwners,
+    kind: HvfSnapshotV2VsockProductKind,
+    serial_resource_present: bool,
+    binding_keys: Vec<bangbang_runtime::snapshot_restore::SnapshotRestoreResourceKey>,
+    vsock: Option<RestoredHvfSnapshotV2VsockMmioMetadata>,
+}
+
+impl RestoredHvfSnapshotV2VsockMmioOwners {
+    pub const fn session(&self) -> &OwnedHvfArm64BootSession {
+        self.base.session()
+    }
+
+    pub fn session_mut(&mut self) -> &mut OwnedHvfArm64BootSession {
+        self.base.session_mut()
+    }
+
+    pub fn configs(&self) -> &[NetworkInterfaceConfig] {
+        self.base.configs()
+    }
+
+    pub fn expected_network(&self) -> &[SnapshotV2NetworkInterfaceState] {
+        self.base.expected()
+    }
+
+    pub const fn mmds_state(&self) -> Option<&SnapshotV2MmdsState> {
+        self.base.mmds_state()
+    }
+
+    pub const fn mmds_config(&self) -> Option<&MmdsConfig> {
+        self.base.mmds_config()
+    }
+
+    pub const fn storage_configs(&self) -> Option<&CaptureReadyStorageConfigs> {
+        self.base.storage_configs()
+    }
+
+    pub const fn entropy_config(&self) -> Option<EntropyConfig> {
+        self.base.entropy_config()
+    }
+
+    pub const fn balloon_config(&self) -> Option<BalloonConfig> {
+        self.base.balloon_config()
+    }
+
+    pub const fn memory_hotplug_state(&self) -> Option<&SnapshotV2MemoryHotplugState> {
+        self.base.memory_hotplug_state()
+    }
+
+    pub const fn memory_hotplug_controller(
+        &self,
+    ) -> Option<&SnapshotV2MemoryHotplugControllerProjection> {
+        self.base.memory_hotplug_controller()
+    }
+
+    pub const fn kind(&self) -> HvfSnapshotV2VsockProductKind {
+        self.kind
+    }
+
+    pub const fn serial_resource_present(&self) -> bool {
+        self.serial_resource_present
+    }
+
+    pub fn resource_keys(
+        &self,
+    ) -> &[bangbang_runtime::snapshot_restore::SnapshotRestoreResourceKey] {
+        &self.binding_keys
+    }
+
+    pub fn vsock_config(&self) -> Option<&VsockConfig> {
+        self.vsock.as_ref().map(|vsock| &vsock.config)
+    }
+
+    pub fn expected_vsock(&self) -> Option<&SnapshotV2VsockState> {
+        self.vsock.as_ref().map(|vsock| &vsock.expected)
+    }
+
+    pub fn vsock_metrics(&self) -> Option<&SharedVsockDeviceMetrics> {
+        self.vsock.as_ref().map(|vsock| &vsock.metrics)
+    }
+
+    pub const fn retry_publication_is_committed(&self) -> bool {
+        self.base.retry_publication_is_committed()
+    }
+
+    pub fn commit_retry_publication(mut self) -> Self {
+        self.base = self.base.commit_retry_publication();
+        self
+    }
+
+    pub fn shutdown(self) -> Result<(), HvfArm64BootSessionShutdownError> {
+        self.base.shutdown()
+    }
+}
+
+impl fmt::Debug for RestoredHvfSnapshotV2VsockMmioOwners {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RestoredHvfSnapshotV2VsockMmioOwners")
+            .field("kind", &self.kind)
+            .field("interface_count", &self.base.configs().len())
+            .field("has_vsock", &self.vsock.is_some())
+            .field(
+                "retry_publication_committed",
+                &self.retry_publication_is_committed(),
+            )
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+struct HvfSnapshotV2VsockMmioRestoreInput<'a> {
+    endpoint: HvfSnapshotV2VsockMmioEndpointPlan,
+    resource: &'a mut VirtioVsockReconstructionResource,
+    metrics: SharedVsockDeviceMetrics,
 }
 
 /// Typed guest-memory handoff for one exact-2.11 PCI network product.
@@ -17867,6 +18137,7 @@ impl OwnedHvfArm64BootSession {
                     block_records: &[],
                     network_interrupts: &interrupts.network,
                     pmem_records: &[],
+                    following_interrupt: interrupts.following,
                     entropy_interrupt: interrupts.entropy,
                     memory_hotplug_interrupt: interrupts.memory_hotplug,
                     serial_interrupt: interrupts.serial,
@@ -18166,13 +18437,125 @@ impl OwnedHvfArm64BootSession {
             plan,
             profiles,
             network_metrics,
+            None,
             now,
             cancelled,
         )
+        .map(|owners| owners.network)
+    }
+
+    /// Reconstructs one complete exact-2.12 MMIO vsock owner graph while
+    /// keeping retry wake publication closed for the process-level check.
+    #[doc(hidden)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn restore_snapshot_v2_vsock_mmio(
+        state: HvfSnapshotV2PlatformState,
+        memory_input: HvfSnapshotV2NetworkMmioMemoryInput,
+        process_shell: HvfSnapshotV2RestoredSerialShell,
+        serial_input: Option<SerialStdioInput>,
+        plan: HvfSnapshotV2VsockMmioPlatformPlan,
+        profiles: Vec<NetworkDeviceProfile>,
+        network_metrics: SharedNetworkInterfaceMetricsRegistry,
+        vsock_resource: Option<&mut VirtioVsockReconstructionResource>,
+        vsock_metrics: SharedVsockDeviceMetrics,
+        now: Instant,
+    ) -> Result<RestoredHvfSnapshotV2VsockMmioOwners, HvfSnapshotV2VsockMmioRestoreError> {
+        Self::restore_snapshot_v2_vsock_mmio_with_cancel(
+            state,
+            memory_input,
+            process_shell,
+            serial_input,
+            plan,
+            profiles,
+            network_metrics,
+            vsock_resource,
+            vsock_metrics,
+            now,
+            |_| false,
+        )
+    }
+
+    /// Reconstructs exact-2.12 MMIO vsock ownership with stable cancellation
+    /// checkpoints.
+    #[doc(hidden)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn restore_snapshot_v2_vsock_mmio_with_cancel<C>(
+        state: HvfSnapshotV2PlatformState,
+        memory_input: HvfSnapshotV2NetworkMmioMemoryInput,
+        process_shell: HvfSnapshotV2RestoredSerialShell,
+        serial_input: Option<SerialStdioInput>,
+        plan: HvfSnapshotV2VsockMmioPlatformPlan,
+        profiles: Vec<NetworkDeviceProfile>,
+        network_metrics: SharedNetworkInterfaceMetricsRegistry,
+        vsock_resource: Option<&mut VirtioVsockReconstructionResource>,
+        vsock_metrics: SharedVsockDeviceMetrics,
+        now: Instant,
+        mut cancelled: C,
+    ) -> Result<RestoredHvfSnapshotV2VsockMmioOwners, HvfSnapshotV2VsockMmioRestoreError>
+    where
+        C: FnMut(HvfSnapshotV2VsockMmioRestoreStage) -> bool,
+    {
+        let interface_count = plan.network().len();
+        let HvfSnapshotV2VsockMmioPlatformOwnerParts {
+            kind,
+            base,
+            vsock,
+            serial_resource_present,
+            binding_keys,
+        } = plan.into_owner_parts();
+        let input = match (vsock, vsock_resource) {
+            (None, None) => None,
+            (Some(endpoint), Some(resource)) => Some(HvfSnapshotV2VsockMmioRestoreInput {
+                endpoint,
+                resource,
+                metrics: vsock_metrics,
+            }),
+            (None, Some(_)) | (Some(_), None) => {
+                return Err(HvfSnapshotV2VsockMmioRestoreError::preflight(
+                    HvfSnapshotV2VsockMmioRestoreStage::Product,
+                ));
+            }
+        };
+        let mut mapped_cancelled =
+            |stage| cancelled(network_mmio_stage_to_vsock(stage, interface_count));
+        let owners = Self::restore_snapshot_v2_network_mmio_inner(
+            state,
+            memory_input,
+            process_shell,
+            serial_input,
+            base,
+            profiles,
+            network_metrics,
+            input,
+            now,
+            &mut mapped_cancelled,
+        )
+        .map_err(|source| {
+            HvfSnapshotV2VsockMmioRestoreError::from_network(source, interface_count)
+        })?;
+        if owners.vsock.is_some() != kind.has_vsock() {
+            let RestoredHvfSnapshotV2NetworkMmioInnerOwners { network, vsock: _ } = owners;
+            let cleanup_failed = network.shutdown().is_err();
+            return Err(HvfSnapshotV2VsockMmioRestoreError {
+                stage: HvfSnapshotV2VsockMmioRestoreStage::Assembly,
+                disposition: if cleanup_failed {
+                    HvfSnapshotV2NetworkMmioRestoreDisposition::TerminalCleanup
+                } else {
+                    HvfSnapshotV2NetworkMmioRestoreDisposition::Terminal
+                },
+            });
+        }
+        Ok(RestoredHvfSnapshotV2VsockMmioOwners {
+            base: owners.network,
+            kind,
+            serial_resource_present,
+            binding_keys,
+            vsock: owners.vsock,
+        })
     }
 
     #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
-    fn restore_snapshot_v2_network_mmio_inner<C>(
+    fn restore_snapshot_v2_network_mmio_inner<'a, C>(
         state: HvfSnapshotV2PlatformState,
         memory_input: HvfSnapshotV2NetworkMmioMemoryInput,
         process_shell: HvfSnapshotV2RestoredSerialShell,
@@ -18180,9 +18563,10 @@ impl OwnedHvfArm64BootSession {
         plan: HvfSnapshotV2NetworkMmioPlatformPlan,
         profiles: Vec<NetworkDeviceProfile>,
         network_metrics: SharedNetworkInterfaceMetricsRegistry,
+        vsock_input: Option<HvfSnapshotV2VsockMmioRestoreInput<'a>>,
         now: Instant,
         mut cancelled: C,
-    ) -> Result<RestoredHvfSnapshotV2NetworkMmioOwners, HvfSnapshotV2NetworkMmioRestoreError>
+    ) -> Result<RestoredHvfSnapshotV2NetworkMmioInnerOwners, HvfSnapshotV2NetworkMmioRestoreError>
     where
         C: FnMut(HvfSnapshotV2NetworkMmioRestoreStage) -> bool,
     {
@@ -18203,6 +18587,36 @@ impl OwnedHvfArm64BootSession {
             vmgenid_interrupt,
             vmclock_interrupt,
         } = plan.into_owner_parts();
+        let expected_vsock = vsock_input
+            .as_ref()
+            .map(|input| {
+                let endpoint = &input.endpoint;
+                if endpoint.state().region() != endpoint.region()
+                    || endpoint.state().interrupt_line() != endpoint.interrupt_line()
+                    || endpoint.dispatcher_region_id() != endpoint.region().id()
+                    || endpoint.fdt_device().region.base
+                        != endpoint.region().range().start().raw_value()
+                    || endpoint.fdt_device().region.size != endpoint.region().range().size()
+                    || endpoint.fdt_device().interrupt_line != endpoint.interrupt_line()
+                    || endpoint.state().capture().device().guest_cid()
+                        != u64::from(endpoint.config().guest_cid())
+                {
+                    return Err(HvfSnapshotV2NetworkMmioRestoreError::preflight(
+                        HvfSnapshotV2NetworkMmioRestoreStage::Product,
+                    ));
+                }
+                PreparedSnapshotV2VsockRestoreState::Mmio(endpoint.state().clone())
+                    .into_destination_normalized_state(endpoint.config())
+                    .map_err(|_| {
+                        HvfSnapshotV2NetworkMmioRestoreError::preflight(
+                            HvfSnapshotV2NetworkMmioRestoreStage::Product,
+                        )
+                    })
+            })
+            .transpose()?;
+        let vsock_interrupt = vsock_input
+            .as_ref()
+            .map(|input| input.endpoint.interrupt_line());
         let HvfSnapshotV2NetworkPreparedOwnerParts {
             kind: _kind,
             memory: product_memory,
@@ -18429,6 +18843,7 @@ impl OwnedHvfArm64BootSession {
         let mut validated_interrupts = Vec::new();
         let interrupt_count = usize::from(balloon_endpoint.is_some())
             .checked_add(network_interrupts.len())
+            .and_then(|count| count.checked_add(usize::from(vsock_interrupt.is_some())))
             .and_then(|count| count.checked_add(usize::from(entropy_endpoint.is_some())))
             .and_then(|count| count.checked_add(usize::from(memory_hotplug_endpoint.is_some())))
             .ok_or_else(|| {
@@ -18447,6 +18862,7 @@ impl OwnedHvfArm64BootSession {
             .map(|endpoint| endpoint.interrupt_line())
             .into_iter()
             .chain(network_interrupts.iter().copied())
+            .chain(vsock_interrupt)
             .chain(entropy_endpoint.map(|endpoint| endpoint.interrupt_line()))
             .chain(memory_hotplug_endpoint.map(|endpoint| endpoint.interrupt_line()))
         {
@@ -18464,7 +18880,8 @@ impl OwnedHvfArm64BootSession {
         }
 
         let additional_registration_capacity = interface_count
-            .checked_add(usize::from(entropy.is_some()))
+            .checked_add(usize::from(vsock_input.is_some()))
+            .and_then(|count| count.checked_add(usize::from(entropy.is_some())))
             .and_then(|count| count.checked_add(usize::from(memory_hotplug.is_some())))
             .ok_or_else(|| {
                 HvfSnapshotV2NetworkMmioRestoreError::preflight(
@@ -18474,6 +18891,7 @@ impl OwnedHvfArm64BootSession {
         let interrupts = HvfSnapshotV2NetworkMmioInterruptPlan {
             balloon: balloon_endpoint.map(|endpoint| endpoint.interrupt_line()),
             network: network_interrupts.clone(),
+            following: vsock_interrupt,
             entropy: entropy_endpoint.map(|endpoint| endpoint.interrupt_line()),
             memory_hotplug: memory_hotplug_endpoint.map(|endpoint| endpoint.interrupt_line()),
             serial: serial_interrupt,
@@ -18595,7 +19013,10 @@ impl OwnedHvfArm64BootSession {
         if session.restored_snapshot_v2_memory_binding.as_ref() != Some(&expected_binding)
             || !session.runtime_resources.network_devices.is_empty()
             || !session.runtime_resources.pci_network_devices.is_empty()
+            || session.runtime_resources.vsock_device.is_some()
+            || session.runtime_resources.pci_vsock_device.is_some()
             || !session.network_interrupt_lines.is_empty()
+            || session.vsock_interrupt_line.is_some()
             || session.network_retry_wakeup_scheduler.thread.is_some()
             || session
                 .restored_snapshot_v2_mmio_registrations
@@ -18605,6 +19026,9 @@ impl OwnedHvfArm64BootSession {
                         .leases
                         .len()
                         .checked_add(interface_count)
+                        .and_then(|required| {
+                            required.checked_add(usize::from(vsock_input.is_some()))
+                        })
                         .is_none_or(|required| required > registrations.leases.capacity())
                 })
         {
@@ -18689,6 +19113,133 @@ impl OwnedHvfArm64BootSession {
         }
         session.runtime_resources.network_devices = runtime_devices;
         session.network_interrupt_lines = network_interrupts;
+
+        let vsock_metadata = if let Some(vsock_input) = vsock_input {
+            let stage = HvfSnapshotV2NetworkMmioRestoreStage::Registration {
+                index: interface_count,
+            };
+            if cancelled(stage) {
+                return Err(HvfSnapshotV2NetworkMmioRestoreError::after_session(
+                    session, stage,
+                ));
+            }
+            let HvfSnapshotV2VsockMmioRestoreInput {
+                endpoint,
+                resource,
+                metrics,
+            } = vsock_input;
+            let region = endpoint.region();
+            let interrupt_line = endpoint.interrupt_line();
+            let fdt_device = endpoint.fdt_device();
+            let config = endpoint.config().clone();
+            let capture = endpoint.state().capture().clone();
+            if resource.captured_selector() != capture.device().backend_selector()
+                || resource.destination_selector().path() != config.uds_path()
+            {
+                return Err(HvfSnapshotV2NetworkMmioRestoreError::after_session(
+                    session, stage,
+                ));
+            }
+            let expected = match expected_vsock {
+                Some(expected) => expected,
+                None => {
+                    return Err(HvfSnapshotV2NetworkMmioRestoreError::after_session(
+                        session, stage,
+                    ));
+                }
+            };
+            let request = [MmioRegionRequest::new(
+                region.range().start(),
+                region.range().size(),
+            )];
+            let registration = VsockMmioDeviceRegistration::from_restored(
+                config.guest_cid(),
+                config.uds_path().to_path_buf(),
+                region,
+            );
+            let dispatcher_preflight = session
+                .restored_snapshot_v2_mmio_registrations
+                .as_ref()
+                .is_some_and(|_| {
+                    session
+                        .mmio_dispatcher
+                        .lock()
+                        .ok()
+                        .is_some_and(|dispatcher| {
+                            dispatcher
+                                .validate_owned_handler(region.id(), &request)
+                                .is_ok()
+                        })
+                });
+            if !dispatcher_preflight {
+                return Err(HvfSnapshotV2NetworkMmioRestoreError::after_session(
+                    session, stage,
+                ));
+            }
+            let reconstruction = session
+                .backend
+                .mapped_guest_memory()
+                .ok()
+                .and_then(|memory| capture.reconstruct_snapshot_handler(memory, resource).ok());
+            let Some(handler) = reconstruction else {
+                return Err(HvfSnapshotV2NetworkMmioRestoreError::after_session(
+                    session, stage,
+                ));
+            };
+            let registration_result = {
+                let registrations = session.restored_snapshot_v2_mmio_registrations.as_ref();
+                match (registrations, session.mmio_dispatcher.lock()) {
+                    (Some(registrations), Ok(mut dispatcher)) => dispatcher
+                        .register_owned_handler(
+                            &registrations.owner,
+                            region.id(),
+                            &request,
+                            handler,
+                        )
+                        .ok(),
+                    (None, _) | (_, Err(_)) => None,
+                }
+            };
+            let Some(lease) = registration_result else {
+                return Err(HvfSnapshotV2NetworkMmioRestoreError::after_session(
+                    session, stage,
+                ));
+            };
+            let retained = session
+                .restored_snapshot_v2_mmio_registrations
+                .as_mut()
+                .is_some_and(|registrations| {
+                    registrations.leases.push(lease);
+                    registrations.leases.last().is_some_and(|lease| {
+                        lease.region_id() == region.id() && lease.regions() == [region]
+                    })
+                });
+            if !retained {
+                return Err(HvfSnapshotV2NetworkMmioRestoreError::after_session(
+                    session, stage,
+                ));
+            }
+            let retained_metrics = metrics.clone();
+            session.runtime_resources.vsock_device = Some(Arm64BootVsockDevice {
+                registration,
+                fdt_device,
+            });
+            session.vsock_interrupt_line = Some(interrupt_line);
+            session.vsock_device_metrics = metrics;
+            Some(RestoredHvfSnapshotV2VsockMmioMetadata {
+                config,
+                expected,
+                metrics: retained_metrics,
+            })
+        } else {
+            if expected_vsock.is_some() {
+                return Err(HvfSnapshotV2NetworkMmioRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2NetworkMmioRestoreStage::Assembly,
+                ));
+            }
+            None
+        };
 
         if entropy.is_some() && cancelled(HvfSnapshotV2NetworkMmioRestoreStage::Entropy) {
             return Err(HvfSnapshotV2NetworkMmioRestoreError::after_session(
@@ -18857,6 +19408,44 @@ impl OwnedHvfArm64BootSession {
                 HvfSnapshotV2NetworkMmioRestoreStage::Recapture,
             ));
         }
+        let recapture_metrics = vsock_metadata.as_ref().map_or_else(
+            || session.shared_vsock_device_metrics(),
+            |vsock| vsock.metrics.clone(),
+        );
+        let recaptured_vsock = match session.capture_ready_vsock_state(
+            vsock_metadata.as_ref().map(|vsock| vsock.config.clone()),
+            &recapture_metrics,
+            &guard,
+        ) {
+            Ok(captured) => match captured
+                .map(HvfArm64BootVsockCaptureState::try_into_snapshot_v2)
+                .transpose()
+            {
+                Ok(captured) => captured,
+                Err(_) => {
+                    drop(guard);
+                    return Err(HvfSnapshotV2NetworkMmioRestoreError::after_session(
+                        session,
+                        HvfSnapshotV2NetworkMmioRestoreStage::Recapture,
+                    ));
+                }
+            },
+            Err(_) => {
+                drop(guard);
+                return Err(HvfSnapshotV2NetworkMmioRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2NetworkMmioRestoreStage::Recapture,
+                ));
+            }
+        };
+        let expected_recapture = vsock_metadata.as_ref().map(|vsock| &vsock.expected);
+        if recaptured_vsock.as_ref() != expected_recapture {
+            drop(guard);
+            return Err(HvfSnapshotV2NetworkMmioRestoreError::after_session(
+                session,
+                HvfSnapshotV2NetworkMmioRestoreStage::Recapture,
+            ));
+        }
         drop(guard);
 
         if cancelled(HvfSnapshotV2NetworkMmioRestoreStage::Assembly) {
@@ -18865,18 +19454,21 @@ impl OwnedHvfArm64BootSession {
                 HvfSnapshotV2NetworkMmioRestoreStage::Assembly,
             ));
         }
-        Ok(RestoredHvfSnapshotV2NetworkMmioOwners {
-            session,
-            configs,
-            expected,
-            mmds_state,
-            mmds_config,
-            storage_configs,
-            entropy_config,
-            balloon_config,
-            memory_hotplug_state,
-            memory_hotplug_controller,
-            retry_publication_gate: Some(retry_publication_gate),
+        Ok(RestoredHvfSnapshotV2NetworkMmioInnerOwners {
+            network: RestoredHvfSnapshotV2NetworkMmioOwners {
+                session,
+                configs,
+                expected,
+                mmds_state,
+                mmds_config,
+                storage_configs,
+                entropy_config,
+                balloon_config,
+                memory_hotplug_state,
+                memory_hotplug_controller,
+                retry_publication_gate: Some(retry_publication_gate),
+            },
+            vsock: vsock_metadata,
         })
     }
 
@@ -23465,6 +24057,7 @@ impl OwnedHvfArm64BootSession {
                     block_records: &prepared_owner.planned_block_records,
                     network_interrupts: &interrupts.network,
                     pmem_records: &prepared_owner.planned_pmem_records,
+                    following_interrupt: interrupts.following,
                     entropy_interrupt: interrupts.entropy,
                     memory_hotplug_interrupt: interrupts.memory_hotplug,
                     serial_interrupt: interrupts.serial,
@@ -26739,6 +27332,7 @@ impl OwnedHvfArm64BootSession {
         let had_entropy = self.runtime_resources.entropy_device.is_some();
         let had_memory_hotplug = self.runtime_resources.memory_hotplug_device.is_some();
         let had_network = !self.runtime_resources.network_devices.is_empty();
+        let had_vsock = self.runtime_resources.vsock_device.is_some();
         let Some(registrations) = self.restored_snapshot_v2_mmio_registrations.as_mut() else {
             return Ok(());
         };
@@ -26779,6 +27373,8 @@ impl OwnedHvfArm64BootSession {
         self.runtime_resources.pmem_devices.clear();
         self.runtime_resources.network_devices.clear();
         self.network_interrupt_lines.clear();
+        self.runtime_resources.vsock_device = None;
+        self.vsock_interrupt_line = None;
         self.runtime_resources.balloon_device = None;
         self.balloon_interrupt_line = None;
         self.runtime_resources.entropy_device = None;
@@ -26799,6 +27395,9 @@ impl OwnedHvfArm64BootSession {
         }
         if had_network {
             self.network_interface_metrics = SharedNetworkInterfaceMetricsRegistry::default();
+        }
+        if had_vsock {
+            self.vsock_device_metrics = SharedVsockDeviceMetrics::default();
         }
         self.restored_snapshot_v2_mmio_registrations = None;
         Ok(())

--- a/crates/runtime/src/snapshot_network_restore_v2_11.rs
+++ b/crates/runtime/src/snapshot_network_restore_v2_11.rs
@@ -76,7 +76,7 @@ pub enum SnapshotV2NetworkRestorePreparationStage {
 }
 
 /// One exact destination entry paired with its portable continuation.
-#[derive(PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct PreparedSnapshotV2NetworkRestoreInterface {
     source_index: u16,
     resource_key: SnapshotRestoreResourceKey,
@@ -813,7 +813,7 @@ impl std::error::Error for SnapshotV2NetworkPciEndpointError {
 ///
 /// The value owns no descriptor, provider, packet owner, callback, metric,
 /// datastore, token, session, device, platform slot, or VM authority.
-#[derive(PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct PreparedSnapshotV2NetworkRestoreTopology {
     transport_kind: SnapshotV2DeviceTransportKind,
     interfaces: Vec<PreparedSnapshotV2NetworkRestoreInterface>,

--- a/crates/runtime/src/snapshot_vsock_restore_v2_12.rs
+++ b/crates/runtime/src/snapshot_vsock_restore_v2_12.rs
@@ -234,6 +234,27 @@ impl PreparedSnapshotV2VsockRestoreState {
             }
         }
     }
+
+    /// Consumes checked source state and projects the exact state expected
+    /// from a live destination using the already-validated destination
+    /// configuration.
+    pub fn into_destination_normalized_state(
+        self,
+        config: &VsockConfig,
+    ) -> Result<SnapshotV2VsockState, SnapshotV2VsockRestorePreparationError> {
+        let normalized = self
+            .into_normalized_state()
+            .map_err(SnapshotV2VsockRestorePreparationError::Normalize)?;
+        if normalized.guest_cid() != u64::from(config.guest_cid()) {
+            return Err(SnapshotV2VsockRestorePreparationError::Config);
+        }
+        let mut parts = normalized.into_parts();
+        parts.backend_selector =
+            crate::vsock::VsockBackendSelector::try_from_path(config.uds_path())
+                .map_err(|_| SnapshotV2VsockRestorePreparationError::Config)?;
+        SnapshotV2VsockState::try_from_parts(parts)
+            .map_err(|_| SnapshotV2VsockRestorePreparationError::StateMismatch)
+    }
 }
 
 impl fmt::Debug for PreparedSnapshotV2VsockRestoreState {

--- a/crates/runtime/src/snapshot_vsock_restore_v2_12/tests.rs
+++ b/crates/runtime/src/snapshot_vsock_restore_v2_12/tests.rs
@@ -167,6 +167,19 @@ fn explicit_override_changes_only_destination_intent() {
         std::path::Path::new(destination)
     );
     assert!(topology.request().is_overridden());
+    let destination_state = topology
+        .state()
+        .clone()
+        .into_destination_normalized_state(topology.request().config())
+        .expect("override should normalize to the selected destination");
+    assert_eq!(
+        destination_state.backend_selector().path(),
+        std::path::Path::new(destination)
+    );
+    assert_eq!(
+        destination_state.guest_cid(),
+        u64::from(topology.request().config().guest_cid())
+    );
     let debug = format!("{topology:?} {:?}", topology.request());
     assert!(!debug.contains(destination));
     assert!(!debug.contains(captured.to_string_lossy().as_ref()));

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -11295,6 +11295,16 @@ pub struct VsockMmioDeviceRegistration {
 }
 
 impl VsockMmioDeviceRegistration {
+    /// Reconstructs registration metadata from an already-validated restore
+    /// plan.
+    pub fn from_restored(guest_cid: u32, uds_path: PathBuf, region: MmioRegion) -> Self {
+        Self {
+            guest_cid,
+            uds_path,
+            region,
+        }
+    }
+
     pub const fn guest_cid(&self) -> u32 {
         self.guest_cid
     }
@@ -11585,7 +11595,7 @@ mod tests {
         VsockHostLocalPort, VsockHostLocalPortAllocator, VsockHostLocalPortAllocatorError,
         VsockHostLocalPortCursor, VsockHostLocalPortCursorError, VsockHostLocalPortError,
         VsockHostSocketAcceptError, VsockHostSocketOwner, VsockHostSocketOwnerError,
-        VsockMmioDevice, VsockMmioLayout, VsockMmioRegistrationError,
+        VsockMmioDevice, VsockMmioDeviceRegistration, VsockMmioLayout, VsockMmioRegistrationError,
         is_transient_host_socket_accept_error, is_transient_host_socket_read_error,
         parse_vsock_host_connect_request, prepare_direct_vsock_restore, virtio_vsock_mmio_handler,
     };
@@ -16170,6 +16180,27 @@ mod tests {
             .expect("registered vsock handler should be present");
         assert!(!handler.is_device_activated());
         assert!(!handler.activation_handler().is_activated());
+    }
+
+    #[test]
+    fn restored_vsock_mmio_registration_retains_exact_independent_metadata() {
+        let region = vsock_mmio_layout()
+            .region()
+            .expect("fixture MMIO region should validate");
+        let registration = VsockMmioDeviceRegistration::from_restored(
+            42,
+            PathBuf::from("restored-vsock.sock"),
+            region,
+        );
+        let mut clone = registration.clone();
+
+        assert_eq!(registration.guest_cid(), 42);
+        assert_eq!(registration.uds_path(), Path::new("restored-vsock.sock"));
+        assert_eq!(registration.region(), region);
+        assert_eq!(clone, registration);
+        clone.uds_path.push("independent");
+        assert_eq!(registration.uds_path(), Path::new("restored-vsock.sock"));
+        assert_ne!(clone, registration);
     }
 
     #[test]

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -515,6 +515,7 @@ if contains native_v2_process "${selected_tests[@]}"; then
     vmm::tests::signed_native_v1_public_dispatch_restores_frozen_file_pair \
     vmm::tests::signed_exact_minor_eleven_process_mmio_owner_transaction_is_atomic_and_retryable \
     vmm::tests::signed_exact_minor_eleven_process_pci_owner_transaction_is_atomic_and_retryable \
+    vmm::tests::signed_exact_minor_twelve_process_mmio_vsock_owner_transaction_is_atomic \
     vmm::tests::signed_native_v2_process_publishes_recaptures_and_resumes_private_pair \
     vmm::tests::signed_native_v2_root_process_commits_complete_mmio_and_pci_owners_atomically \
     vmm::tests::signed_native_v2_storage_destination_stays_private_and_paused_through_commit \


### PR DESCRIPTION
## Summary

- reconstruct exact native-v2 2.12 MMIO vsock owners from one checked,
  single-use destination endpoint
- retain exact transport, queue, interrupt, FDT, runtime, metrics, reset,
  RX-gate, TX-continuation, rollback, cancellation, and recapture behavior
- preserve exact-2.11 and older restore paths while extending the shared MMIO
  aggregate with a private optional vsock endpoint
- add focused and signed transaction coverage for inactive/active products,
  fault boundaries, cleanup evidence, authority misuse, and clone isolation

## Scope exclusions

- PCI vsock owner reconstruction remains in #1734
- public exact-2.12 activation and first signed active restored-guest traffic
  remain in #1735
- exhaustive signed certification, documentation, and capability inventory
  promotion remain in #1736

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented Apple-target integration-test Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- focused exact-2.12 tests: 14 passed, plus the signed exact-2.12 MMIO
  transaction
- strict signed HVF lifecycle: 100 passed
- strict guest boot: 30 passed
- strict App Sandbox HVF lifecycle: 100 passed
- strict App Sandbox process: 7 passed
- `scripts/run-integration-tests.sh --test executable_hvf_e2e`: 74 passed
- production bundle full runs reached 69/70 and 68/70 under repeated real
  guest execution; each rotating timeout/broken-pipe/EOF failure passed when
  rerun alone with the same strict signed wrapper
- `git diff --check`

Closes #1733

Parent delivery context: #1540
