### PR TITLE
feat: reconstruct PCI vsock snapshot owners

### DIFF
--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -71,7 +71,8 @@ use bangbang_hvf::{
     HvfSnapshotV2StoragePciRestoreError, HvfSnapshotV2StorageState,
     HvfSnapshotV2VsockMmioPlatformPlan, HvfSnapshotV2VsockMmioProcessConfig,
     HvfSnapshotV2VsockMmioRestoreError, HvfSnapshotV2VsockMmioRestoreStage,
-    HvfSnapshotV2VsockPciPlatformPlan, HvfSnapshotV2VsockPlatformState,
+    HvfSnapshotV2VsockPciPlatformPlan, HvfSnapshotV2VsockPciRestoreError,
+    HvfSnapshotV2VsockPciRestoreStage, HvfSnapshotV2VsockPlatformState,
     HvfSnapshotV2VsockPreparedEndpoint, HvfSnapshotV2VsockPreparedMemory,
     HvfSnapshotV2VsockPreparedProduct, HvfSnapshotV2VsockPreparedProductParts,
     HvfSnapshotV2VsockProcessResourceIdentity, HvfSnapshotV2VsockProductKind,
@@ -84,16 +85,17 @@ use bangbang_hvf::{
     PrepareHvfSnapshotV2StoragePciPlatformPlanError, PreparedHvfArm64BootPciNetworkRemoval,
     PreparedHvfSnapshotV1Load, PreparedHvfSnapshotV1State, RestoredHvfSnapshotV2NetworkMmioOwners,
     RestoredHvfSnapshotV2NetworkPciOwners, RestoredHvfSnapshotV2Platform,
-    RestoredHvfSnapshotV2VsockMmioOwners, decode_hvf_snapshot_v2_balloon_state,
-    decode_hvf_snapshot_v2_entropy_state, decode_hvf_snapshot_v2_memory_hotplug_state,
-    decode_hvf_snapshot_v2_multi_block_state, decode_hvf_snapshot_v2_network_state,
-    decode_hvf_snapshot_v2_platform_state, decode_hvf_snapshot_v2_serial_state,
-    decode_hvf_snapshot_v2_state, decode_hvf_snapshot_v2_storage_state,
-    encode_hvf_snapshot_v2_balloon_state, encode_hvf_snapshot_v2_entropy_state,
-    encode_hvf_snapshot_v2_memory_hotplug_state, encode_hvf_snapshot_v2_multi_block_state,
-    encode_hvf_snapshot_v2_network_state, encode_hvf_snapshot_v2_serial_state,
-    encode_hvf_snapshot_v2_state, encode_hvf_snapshot_v2_storage_state,
-    encode_hvf_snapshot_v2_vsock_state, prepare_hvf_snapshot_v2_balloon_mmio_platform_plan,
+    RestoredHvfSnapshotV2VsockMmioOwners, RestoredHvfSnapshotV2VsockPciOwners,
+    decode_hvf_snapshot_v2_balloon_state, decode_hvf_snapshot_v2_entropy_state,
+    decode_hvf_snapshot_v2_memory_hotplug_state, decode_hvf_snapshot_v2_multi_block_state,
+    decode_hvf_snapshot_v2_network_state, decode_hvf_snapshot_v2_platform_state,
+    decode_hvf_snapshot_v2_serial_state, decode_hvf_snapshot_v2_state,
+    decode_hvf_snapshot_v2_storage_state, encode_hvf_snapshot_v2_balloon_state,
+    encode_hvf_snapshot_v2_entropy_state, encode_hvf_snapshot_v2_memory_hotplug_state,
+    encode_hvf_snapshot_v2_multi_block_state, encode_hvf_snapshot_v2_network_state,
+    encode_hvf_snapshot_v2_serial_state, encode_hvf_snapshot_v2_state,
+    encode_hvf_snapshot_v2_storage_state, encode_hvf_snapshot_v2_vsock_state,
+    prepare_hvf_snapshot_v2_balloon_mmio_platform_plan,
     prepare_hvf_snapshot_v2_balloon_pci_platform_plan,
     prepare_hvf_snapshot_v2_memory_hotplug_mmio_platform_plan,
     prepare_hvf_snapshot_v2_memory_hotplug_pci_platform_plan,
@@ -105,7 +107,8 @@ use bangbang_hvf::{
     prepare_hvf_snapshot_v2_storage_entropy_pci_platform_plan,
     prepare_hvf_snapshot_v2_storage_mmio_platform_plan,
     prepare_hvf_snapshot_v2_storage_pci_platform_plan,
-    prepare_hvf_snapshot_v2_vsock_mmio_platform_plan, restore_hvf_snapshot_v2_process_platform,
+    prepare_hvf_snapshot_v2_vsock_mmio_platform_plan,
+    prepare_hvf_snapshot_v2_vsock_pci_platform_plan, restore_hvf_snapshot_v2_process_platform,
 };
 use bangbang_runtime::balloon::BalloonMmioLayout;
 use bangbang_runtime::balloon::{
@@ -22756,6 +22759,43 @@ where
         )
     }
 
+    fn matches_pci_platform_plan(&self, plan: &HvfSnapshotV2VsockPciPlatformPlan) -> bool {
+        let mut vsock_keys = self
+            .binding_keys
+            .iter()
+            .filter(|key| key.resource_class() == SnapshotRestoreResourceClass::VsockEndpoint);
+        let vsock = match (
+            vsock_keys.next(),
+            vsock_keys.next(),
+            self.vsock_config.as_ref(),
+        ) {
+            (None, None, None) => None,
+            (Some(key), None, Some(config)) => {
+                Some(HvfSnapshotV2VsockProcessResourceIdentity::new(key, config))
+            }
+            _ => return false,
+        };
+        plan.preflight_process_resource_identity(
+            self.network_completion
+                .resource_interfaces
+                .iter()
+                .map(|interface| {
+                    HvfSnapshotV2NetworkProcessResourceIdentity::new(
+                        interface.source_index,
+                        &interface.resource_key,
+                        &interface.controller,
+                        interface.profile,
+                        interface.backend,
+                        interface.mmds_stack,
+                    )
+                }),
+            self.network_completion.expected_mmds_state(),
+            self.network_completion.expected_mmds_controller(),
+            vsock,
+            &self.binding_keys,
+        )
+    }
+
     pub(crate) fn remaining_count(&self) -> usize {
         self.bindings.remaining_count()
     }
@@ -23659,6 +23699,356 @@ where
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProcessSnapshotV2VsockPciRestoreStage {
+    ResourcePreparation,
+    ProductPreparation,
+    ResourceTake { index: usize },
+    Serial,
+    HvfConstruction,
+    Hvf(HvfSnapshotV2VsockPciRestoreStage),
+    BatchFinish,
+    CompleteRecapture,
+    Assembly,
+    GateCommit,
+    Cleanup,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProcessSnapshotV2VsockPciRestoreDisposition {
+    Retryable,
+    Terminal,
+    TerminalCleanup,
+}
+
+/// Bounded process-level failure for one exact-2.12 PCI owner transaction.
+struct ProcessSnapshotV2VsockPciRestoreError {
+    stage: ProcessSnapshotV2VsockPciRestoreStage,
+    disposition: ProcessSnapshotV2VsockPciRestoreDisposition,
+}
+
+impl ProcessSnapshotV2VsockPciRestoreError {
+    const fn retryable(stage: ProcessSnapshotV2VsockPciRestoreStage) -> Self {
+        Self {
+            stage,
+            disposition: ProcessSnapshotV2VsockPciRestoreDisposition::Retryable,
+        }
+    }
+
+    const fn terminal(
+        stage: ProcessSnapshotV2VsockPciRestoreStage,
+        cleanup_uncertain: bool,
+    ) -> Self {
+        Self {
+            stage,
+            disposition: if cleanup_uncertain {
+                ProcessSnapshotV2VsockPciRestoreDisposition::TerminalCleanup
+            } else {
+                ProcessSnapshotV2VsockPciRestoreDisposition::Terminal
+            },
+        }
+    }
+
+    fn from_resource(
+        stage: ProcessSnapshotV2VsockPciRestoreStage,
+        source: &ProcessSnapshotV2VsockRestoreResourceError,
+    ) -> Self {
+        if source.cleanup_uncertain() {
+            return Self::terminal(stage, true);
+        }
+        match source.disposition() {
+            ProcessSnapshotV2NetworkRestoreResourceDisposition::Retryable => Self::retryable(stage),
+            ProcessSnapshotV2NetworkRestoreResourceDisposition::Terminal => {
+                Self::terminal(stage, false)
+            }
+        }
+    }
+
+    fn from_hvf(source: &HvfSnapshotV2VsockPciRestoreError, cleanup_uncertain: bool) -> Self {
+        let stage = ProcessSnapshotV2VsockPciRestoreStage::Hvf(source.stage());
+        if source.has_incomplete_cleanup() || cleanup_uncertain {
+            return Self::terminal(stage, true);
+        }
+        match source.disposition() {
+            HvfSnapshotV2NetworkPciRestoreDisposition::Retryable => Self::retryable(stage),
+            HvfSnapshotV2NetworkPciRestoreDisposition::Terminal
+            | HvfSnapshotV2NetworkPciRestoreDisposition::TerminalCleanup => {
+                Self::terminal(stage, false)
+            }
+        }
+    }
+
+    fn from_adoption(
+        source: &ProcessSnapshotV2VsockAdoptionError<HvfSnapshotV2VsockPciRestoreError>,
+        cleanup_uncertain: bool,
+    ) -> Self {
+        match source {
+            ProcessSnapshotV2VsockAdoptionError::Resources(source) => {
+                let mapped = Self::from_resource(
+                    ProcessSnapshotV2VsockPciRestoreStage::HvfConstruction,
+                    source,
+                );
+                if cleanup_uncertain {
+                    Self::terminal(mapped.stage, true)
+                } else {
+                    mapped
+                }
+            }
+            ProcessSnapshotV2VsockAdoptionError::Adoption(
+                VsockRestoreAdoptionError::Reconstruction {
+                    source,
+                    disposition,
+                },
+            ) => {
+                let mapped = Self::from_hvf(source, cleanup_uncertain);
+                if matches!(disposition, VsockRestoreDisposition::Terminal)
+                    && matches!(
+                        mapped.disposition,
+                        ProcessSnapshotV2VsockPciRestoreDisposition::Retryable
+                    )
+                {
+                    Self::terminal(mapped.stage, cleanup_uncertain)
+                } else {
+                    mapped
+                }
+            }
+            ProcessSnapshotV2VsockAdoptionError::Adoption(VsockRestoreAdoptionError::Contract(
+                source,
+            )) => match (source.disposition(), cleanup_uncertain) {
+                (_, true) => {
+                    Self::terminal(ProcessSnapshotV2VsockPciRestoreStage::HvfConstruction, true)
+                }
+                (VsockRestoreDisposition::Retryable, false) => {
+                    Self::retryable(ProcessSnapshotV2VsockPciRestoreStage::HvfConstruction)
+                }
+                (VsockRestoreDisposition::Terminal, false) => Self::terminal(
+                    ProcessSnapshotV2VsockPciRestoreStage::HvfConstruction,
+                    false,
+                ),
+            },
+        }
+    }
+}
+
+impl fmt::Debug for ProcessSnapshotV2VsockPciRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProcessSnapshotV2VsockPciRestoreError")
+            .field("stage", &self.stage)
+            .field("disposition", &self.disposition)
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for ProcessSnapshotV2VsockPciRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "exact-2.12 process PCI vsock reconstruction failed at {:?} ({:?})",
+            self.stage, self.disposition
+        )
+    }
+}
+
+impl std::error::Error for ProcessSnapshotV2VsockPciRestoreError {}
+
+/// Complete unpublished process/HVF exact-2.12 PCI owner graph.
+///
+/// Explicit shutdown preserves the irreversible lifetime order: HVF/session,
+/// active socket publication, network provider and metrics leases, file and
+/// contained authority, then process-stdio restoration.
+struct RestoredProcessSnapshotV2VsockPciOwners<B>
+where
+    B: ProcessVmnetBackend,
+{
+    hvf: Option<RestoredHvfSnapshotV2VsockPciOwners>,
+    active_vsock: Option<ActiveVsockRestoreGuard>,
+    completion: Option<PreparedProcessSnapshotV2VsockRestoreCompletion<B>>,
+    network_resources: Vec<PreparedProcessSnapshotV2NetworkRestoreResource>,
+    serial_output: Option<SharedSerialOutput>,
+    serial_config: Option<SerialConfig>,
+    serial_restoration: Option<SerialStdioRestoration>,
+}
+
+impl<B> RestoredProcessSnapshotV2VsockPciOwners<B>
+where
+    B: ProcessVmnetBackend,
+{
+    fn shutdown(&mut self) -> Result<(), ProcessSnapshotV2VsockPciRestoreError> {
+        let mut cleanup_uncertain = self.hvf.take().is_some_and(|hvf| hvf.shutdown().is_err());
+        cleanup_uncertain |= self
+            .active_vsock
+            .take()
+            .is_some_and(|guard| guard.cleanup().is_err());
+        if let Some(completion) = self.completion.take() {
+            cleanup_uncertain |= abort_completed_process_snapshot_v2_vsock_resources(
+                completion,
+                &mut self.network_resources,
+            );
+        } else {
+            self.network_resources.clear();
+        }
+        cleanup_uncertain |= finish_process_snapshot_v2_serial_restoration(
+            &mut self.serial_output,
+            &mut self.serial_config,
+            &mut self.serial_restoration,
+        );
+        if cleanup_uncertain {
+            Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                ProcessSnapshotV2VsockPciRestoreStage::Cleanup,
+                true,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<B> Drop for RestoredProcessSnapshotV2VsockPciOwners<B>
+where
+    B: ProcessVmnetBackend,
+{
+    fn drop(&mut self) {
+        let _ = self.shutdown();
+    }
+}
+
+impl<B> fmt::Debug for RestoredProcessSnapshotV2VsockPciOwners<B>
+where
+    B: ProcessVmnetBackend,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RestoredProcessSnapshotV2VsockPciOwners")
+            .field("interface_count", &self.network_resources.len())
+            .field("has_vsock", &self.active_vsock.is_some())
+            .field(
+                "retry_publication_committed",
+                &self.hvf.as_ref().is_some_and(
+                    RestoredHvfSnapshotV2VsockPciOwners::retry_publication_is_committed,
+                ),
+            )
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+struct StagedProcessSnapshotV2VsockPciOwners<B>
+where
+    B: ProcessVmnetBackend,
+{
+    batch: Option<PreparedProcessSnapshotV2VsockRestoreBatch<B>>,
+    hvf: Option<RestoredHvfSnapshotV2VsockPciOwners>,
+    active_vsock: Option<ActiveVsockRestoreGuard>,
+    completion: Option<PreparedProcessSnapshotV2VsockRestoreCompletion<B>>,
+    network_resources: Vec<PreparedProcessSnapshotV2NetworkRestoreResource>,
+    serial_endpoint: Option<PreparedSnapshotV2SerialEndpoint>,
+    serial_output: Option<SharedSerialOutput>,
+    serial_config: Option<SerialConfig>,
+    serial_restoration: Option<SerialStdioRestoration>,
+}
+
+impl<B> StagedProcessSnapshotV2VsockPciOwners<B>
+where
+    B: ProcessVmnetBackend,
+{
+    fn new(batch: PreparedProcessSnapshotV2VsockRestoreBatch<B>) -> Self {
+        Self {
+            batch: Some(batch),
+            hvf: None,
+            active_vsock: None,
+            completion: None,
+            network_resources: Vec::new(),
+            serial_endpoint: None,
+            serial_output: None,
+            serial_config: None,
+            serial_restoration: None,
+        }
+    }
+
+    fn shutdown_evidence(&mut self) -> ProcessSnapshotV2VsockAbortEvidence {
+        let mut evidence = ProcessSnapshotV2VsockAbortEvidence::clean();
+        if self.hvf.take().is_some_and(|hvf| hvf.shutdown().is_err()) {
+            evidence = evidence.merge(ProcessSnapshotV2VsockAbortEvidence::terminal(true));
+        }
+        if self
+            .active_vsock
+            .take()
+            .is_some_and(|guard| guard.cleanup().is_err())
+        {
+            evidence = evidence.merge(ProcessSnapshotV2VsockAbortEvidence::terminal(true));
+        }
+        if let Some(completion) = self.completion.take() {
+            if abort_completed_process_snapshot_v2_vsock_resources(
+                completion,
+                &mut self.network_resources,
+            ) {
+                evidence = evidence.merge(ProcessSnapshotV2VsockAbortEvidence::terminal(true));
+            }
+        } else if let Some(batch) = self.batch.take() {
+            if let Err(source) = batch.abort() {
+                evidence = evidence.merge(ProcessSnapshotV2VsockAbortEvidence::terminal(
+                    source.cleanup_uncertain(),
+                ));
+            }
+            self.network_resources.clear();
+        } else {
+            self.network_resources.clear();
+        }
+        if self
+            .serial_endpoint
+            .take()
+            .is_some_and(|endpoint| endpoint.abort().is_err())
+        {
+            evidence = evidence.merge(ProcessSnapshotV2VsockAbortEvidence::terminal(true));
+        }
+        if finish_process_snapshot_v2_serial_restoration(
+            &mut self.serial_output,
+            &mut self.serial_config,
+            &mut self.serial_restoration,
+        ) {
+            evidence = evidence.merge(ProcessSnapshotV2VsockAbortEvidence::terminal(true));
+        }
+        evidence
+    }
+
+    fn shutdown(&mut self) -> bool {
+        self.shutdown_evidence().cleanup_uncertain
+    }
+
+    fn into_owners(
+        mut self,
+    ) -> Result<RestoredProcessSnapshotV2VsockPciOwners<B>, ProcessSnapshotV2VsockPciRestoreError>
+    {
+        let (Some(hvf), Some(completion)) = (self.hvf.take(), self.completion.take()) else {
+            let cleanup_uncertain = self.shutdown();
+            return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                ProcessSnapshotV2VsockPciRestoreStage::Assembly,
+                cleanup_uncertain,
+            ));
+        };
+        Ok(RestoredProcessSnapshotV2VsockPciOwners {
+            hvf: Some(hvf),
+            active_vsock: self.active_vsock.take(),
+            completion: Some(completion),
+            network_resources: std::mem::take(&mut self.network_resources),
+            serial_output: self.serial_output.take(),
+            serial_config: self.serial_config.take(),
+            serial_restoration: self.serial_restoration.take(),
+        })
+    }
+}
+
+impl<B> Drop for StagedProcessSnapshotV2VsockPciOwners<B>
+where
+    B: ProcessVmnetBackend,
+{
+    fn drop(&mut self) {
+        let _ = self.shutdown();
+    }
+}
+
 trait ProcessSnapshotV2NetworkResourcePlanInput {
     fn into_resource_plan(self) -> PreparedProcessSnapshotV2NetworkResourcePlan;
 }
@@ -24166,6 +24556,93 @@ impl RestoredProcessSnapshotV2NetworkHvfOwners for RestoredHvfSnapshotV2VsockMmi
     }
 }
 
+impl RestoredProcessSnapshotV2NetworkHvfOwners for RestoredHvfSnapshotV2VsockPciOwners {
+    fn session(&self) -> &OwnedHvfArm64BootSession {
+        RestoredHvfSnapshotV2VsockPciOwners::session(self)
+    }
+
+    fn configs(&self) -> &[NetworkInterfaceConfig] {
+        RestoredHvfSnapshotV2VsockPciOwners::configs(self)
+    }
+
+    fn expected(&self) -> &[SnapshotV2NetworkInterfaceState] {
+        RestoredHvfSnapshotV2VsockPciOwners::expected_network(self)
+    }
+
+    fn mmds_state(&self) -> Option<&SnapshotV2MmdsState> {
+        RestoredHvfSnapshotV2VsockPciOwners::mmds_state(self)
+    }
+
+    fn mmds_config(&self) -> Option<&MmdsConfig> {
+        RestoredHvfSnapshotV2VsockPciOwners::mmds_config(self)
+    }
+
+    fn transport_kind(&self) -> SnapshotV2DeviceTransportKind {
+        SnapshotV2DeviceTransportKind::Pci
+    }
+}
+
+trait RestoredProcessSnapshotV2VsockHvfOwners: RestoredProcessSnapshotV2NetworkHvfOwners {
+    fn resource_keys(&self) -> &[SnapshotRestoreResourceKey];
+    fn serial_resource_present(&self) -> bool;
+    fn kind(&self) -> HvfSnapshotV2VsockProductKind;
+    fn vsock_config(&self) -> Option<&VsockConfig>;
+    fn expected_vsock(&self) -> Option<&SnapshotV2VsockState>;
+    fn vsock_metrics(&self) -> Option<&SharedVsockDeviceMetrics>;
+}
+
+impl RestoredProcessSnapshotV2VsockHvfOwners for RestoredHvfSnapshotV2VsockMmioOwners {
+    fn resource_keys(&self) -> &[SnapshotRestoreResourceKey] {
+        RestoredHvfSnapshotV2VsockMmioOwners::resource_keys(self)
+    }
+
+    fn serial_resource_present(&self) -> bool {
+        RestoredHvfSnapshotV2VsockMmioOwners::serial_resource_present(self)
+    }
+
+    fn kind(&self) -> HvfSnapshotV2VsockProductKind {
+        RestoredHvfSnapshotV2VsockMmioOwners::kind(self)
+    }
+
+    fn vsock_config(&self) -> Option<&VsockConfig> {
+        RestoredHvfSnapshotV2VsockMmioOwners::vsock_config(self)
+    }
+
+    fn expected_vsock(&self) -> Option<&SnapshotV2VsockState> {
+        RestoredHvfSnapshotV2VsockMmioOwners::expected_vsock(self)
+    }
+
+    fn vsock_metrics(&self) -> Option<&SharedVsockDeviceMetrics> {
+        RestoredHvfSnapshotV2VsockMmioOwners::vsock_metrics(self)
+    }
+}
+
+impl RestoredProcessSnapshotV2VsockHvfOwners for RestoredHvfSnapshotV2VsockPciOwners {
+    fn resource_keys(&self) -> &[SnapshotRestoreResourceKey] {
+        RestoredHvfSnapshotV2VsockPciOwners::resource_keys(self)
+    }
+
+    fn serial_resource_present(&self) -> bool {
+        RestoredHvfSnapshotV2VsockPciOwners::serial_resource_present(self)
+    }
+
+    fn kind(&self) -> HvfSnapshotV2VsockProductKind {
+        RestoredHvfSnapshotV2VsockPciOwners::kind(self)
+    }
+
+    fn vsock_config(&self) -> Option<&VsockConfig> {
+        RestoredHvfSnapshotV2VsockPciOwners::vsock_config(self)
+    }
+
+    fn expected_vsock(&self) -> Option<&SnapshotV2VsockState> {
+        RestoredHvfSnapshotV2VsockPciOwners::expected_vsock(self)
+    }
+
+    fn vsock_metrics(&self) -> Option<&SharedVsockDeviceMetrics> {
+        RestoredHvfSnapshotV2VsockPciOwners::vsock_metrics(self)
+    }
+}
+
 fn restored_process_snapshot_v2_network_is_equivalent<B, H>(
     hvf: &H,
     completion: &PreparedProcessSnapshotV2NetworkRestoreCompletion<B>,
@@ -24278,14 +24755,15 @@ where
     Ok(())
 }
 
-fn restored_process_snapshot_v2_vsock_mmio_is_equivalent<B>(
-    hvf: &RestoredHvfSnapshotV2VsockMmioOwners,
+fn restored_process_snapshot_v2_vsock_is_equivalent<B, H>(
+    hvf: &H,
     completion: &PreparedProcessSnapshotV2VsockRestoreCompletion<B>,
     resources: &[PreparedProcessSnapshotV2NetworkRestoreResource],
     now: Instant,
 ) -> Result<(), ()>
 where
     B: ProcessVmnetBackend,
+    H: RestoredProcessSnapshotV2VsockHvfOwners,
 {
     restored_process_snapshot_v2_network_is_equivalent(
         hvf,
@@ -24333,6 +24811,30 @@ where
         Some(_) | None => return Err(()),
     }
     Ok(())
+}
+
+fn restored_process_snapshot_v2_vsock_mmio_is_equivalent<B>(
+    hvf: &RestoredHvfSnapshotV2VsockMmioOwners,
+    completion: &PreparedProcessSnapshotV2VsockRestoreCompletion<B>,
+    resources: &[PreparedProcessSnapshotV2NetworkRestoreResource],
+    now: Instant,
+) -> Result<(), ()>
+where
+    B: ProcessVmnetBackend,
+{
+    restored_process_snapshot_v2_vsock_is_equivalent(hvf, completion, resources, now)
+}
+
+fn restored_process_snapshot_v2_vsock_pci_is_equivalent<B>(
+    hvf: &RestoredHvfSnapshotV2VsockPciOwners,
+    completion: &PreparedProcessSnapshotV2VsockRestoreCompletion<B>,
+    resources: &[PreparedProcessSnapshotV2NetworkRestoreResource],
+    now: Instant,
+) -> Result<(), ()>
+where
+    B: ProcessVmnetBackend,
+{
+    restored_process_snapshot_v2_vsock_is_equivalent(hvf, completion, resources, now)
 }
 
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
@@ -24989,6 +25491,646 @@ type SystemRestoreProcessSnapshotV2VsockMmioFn = fn(
 
 const _: SystemRestoreProcessSnapshotV2VsockMmioFn =
     restore_process_snapshot_v2_vsock_mmio::<fn(ProcessSnapshotV2VsockMmioRestoreStage) -> bool>;
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn restore_process_snapshot_v2_vsock_pci_with_factory<B, F, C>(
+    platform: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    resource_plan: PreparedProcessSnapshotV2VsockResourcePlan,
+    contained_authority: Option<&ContainedSnapshotRestoreAuthority>,
+    destination_instance_id: &str,
+    mmds_data_store_limit_bytes: usize,
+    factory: &mut F,
+    now: Instant,
+    cancelled: C,
+) -> Result<RestoredProcessSnapshotV2VsockPciOwners<B>, ProcessSnapshotV2VsockPciRestoreError>
+where
+    B: ProcessVmnetBackend,
+    F: ProcessVmnetPacketIoBackendFactory<Backend = B>,
+    C: Fn(ProcessSnapshotV2VsockPciRestoreStage) -> bool,
+{
+    if cancelled(ProcessSnapshotV2VsockPciRestoreStage::ResourcePreparation) {
+        return Err(ProcessSnapshotV2VsockPciRestoreError::retryable(
+            ProcessSnapshotV2VsockPciRestoreStage::ResourcePreparation,
+        ));
+    }
+    let batch = {
+        let resource_cancelled =
+            |_| cancelled(ProcessSnapshotV2VsockPciRestoreStage::ResourcePreparation);
+        prepare_process_snapshot_v2_vsock_restore_resources_with_factory(
+            resource_plan,
+            contained_authority,
+            destination_instance_id,
+            mmds_data_store_limit_bytes,
+            factory,
+            resource_cancelled,
+        )
+        .map_err(|source| {
+            ProcessSnapshotV2VsockPciRestoreError::from_resource(
+                ProcessSnapshotV2VsockPciRestoreStage::ResourcePreparation,
+                &source,
+            )
+        })?
+    };
+    let mut staged = StagedProcessSnapshotV2VsockPciOwners::new(batch);
+
+    if cancelled(ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation) {
+        let evidence = staged.shutdown_evidence();
+        return Err(if evidence.terminal {
+            ProcessSnapshotV2VsockPciRestoreError::terminal(
+                ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
+                evidence.cleanup_uncertain,
+            )
+        } else {
+            ProcessSnapshotV2VsockPciRestoreError::retryable(
+                ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
+            )
+        });
+    }
+
+    let (
+        binding,
+        graph,
+        serial_state,
+        entropy_state,
+        balloon_state,
+        memory_hotplug_state,
+        network_topology,
+        vsock_state,
+        vsock_config,
+        binding_keys,
+    ) = {
+        let Some(batch) = staged.batch.as_ref() else {
+            return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
+                false,
+            ));
+        };
+        (
+            batch.binding.clone(),
+            batch.device_graph.clone(),
+            batch.serial.clone(),
+            batch.entropy.clone(),
+            batch.balloon.clone(),
+            batch.memory_hotplug.clone(),
+            batch.network_topology.clone(),
+            batch.vsock_state.clone(),
+            batch.vsock_config.clone(),
+            batch.binding_keys.clone(),
+        )
+    };
+    let product_transport_is_pci = graph
+        .as_ref()
+        .is_none_or(|graph| graph.transport_kind() == SnapshotV2DeviceTransportKind::Pci)
+        && entropy_state
+            .as_ref()
+            .is_none_or(|state| state.transport().kind() == SnapshotV2DeviceTransportKind::Pci)
+        && balloon_state
+            .as_ref()
+            .is_none_or(|state| state.transport().kind() == SnapshotV2DeviceTransportKind::Pci)
+        && memory_hotplug_state
+            .as_ref()
+            .is_none_or(|state| state.transport().kind() == SnapshotV2DeviceTransportKind::Pci)
+        && network_topology.transport_kind() == SnapshotV2DeviceTransportKind::Pci
+        && vsock_state
+            .as_ref()
+            .is_none_or(|state| state.transport_kind() == SnapshotV2DeviceTransportKind::Pci);
+    if platform.memory() != &binding || !product_transport_is_pci {
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+            ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
+            cleanup_uncertain,
+        ));
+    }
+
+    let storage_plan = match graph.clone() {
+        Some(graph) => match SnapshotV2StorageRestorePlan::prepare(graph, &memory, now) {
+            Ok(plan) => Some(plan),
+            Err(_) => {
+                let cleanup_uncertain = staged.shutdown();
+                return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                    ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
+                    cleanup_uncertain,
+                ));
+            }
+        },
+        None => None,
+    };
+    let entropy = match entropy_state
+        .clone()
+        .map(|state| SnapshotV2EntropyRestorePlan::prepare(state, &memory, now))
+        .transpose()
+    {
+        Ok(entropy) => entropy,
+        Err(_) => {
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
+                cleanup_uncertain,
+            ));
+        }
+    };
+    let balloon = match balloon_state
+        .clone()
+        .map(|state| SnapshotV2BalloonRestorePlan::prepare(state, &memory))
+        .transpose()
+    {
+        Ok(balloon) => balloon,
+        Err(_) => {
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
+                cleanup_uncertain,
+            ));
+        }
+    };
+    let memory_hotplug = match memory_hotplug_state
+        .clone()
+        .map(|state| {
+            PreparedSnapshotV2MemoryHotplugTopology::prepare_for_compatibility_version(
+                state,
+                binding.clone(),
+                NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
+            )
+        })
+        .transpose()
+    {
+        Ok(memory_hotplug) => memory_hotplug,
+        Err(_) => {
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
+                cleanup_uncertain,
+            ));
+        }
+    };
+
+    let block_count = binding_keys
+        .iter()
+        .filter(|key| key.resource_class() == SnapshotRestoreResourceClass::BlockBacking)
+        .count();
+    let pmem_count = binding_keys
+        .iter()
+        .filter(|key| key.resource_class() == SnapshotRestoreResourceClass::PmemBacking)
+        .count();
+    let network_count = binding_keys
+        .iter()
+        .filter(|key| key.resource_class() == SnapshotRestoreResourceClass::NetworkPacketIo)
+        .count();
+    let mut block_backings = Vec::new();
+    let mut pmem_backings = Vec::new();
+    if block_backings.try_reserve_exact(block_count).is_err()
+        || pmem_backings.try_reserve_exact(pmem_count).is_err()
+        || staged
+            .network_resources
+            .try_reserve_exact(network_count)
+            .is_err()
+    {
+        let evidence = staged.shutdown_evidence();
+        return Err(if evidence.terminal {
+            ProcessSnapshotV2VsockPciRestoreError::terminal(
+                ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
+                evidence.cleanup_uncertain,
+            )
+        } else {
+            ProcessSnapshotV2VsockPciRestoreError::retryable(
+                ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
+            )
+        });
+    }
+    let mut serial_output = None;
+    for (index, key) in binding_keys.iter().enumerate() {
+        if key.resource_class() == SnapshotRestoreResourceClass::VsockEndpoint {
+            continue;
+        }
+        let stage = ProcessSnapshotV2VsockPciRestoreStage::ResourceTake { index };
+        if cancelled(stage) {
+            drop((block_backings, pmem_backings, serial_output));
+            let already_consumed = staged
+                .batch
+                .as_ref()
+                .is_some_and(|batch| batch.taken_count != 0);
+            let evidence = staged.shutdown_evidence();
+            return Err(if already_consumed || evidence.terminal {
+                ProcessSnapshotV2VsockPciRestoreError::terminal(stage, evidence.cleanup_uncertain)
+            } else {
+                ProcessSnapshotV2VsockPciRestoreError::retryable(stage)
+            });
+        }
+        let Some(batch) = staged.batch.as_mut() else {
+            drop((block_backings, pmem_backings, serial_output));
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                stage,
+                cleanup_uncertain,
+            ));
+        };
+        let result = match key.resource_class() {
+            SnapshotRestoreResourceClass::BlockBacking => batch
+                .take_block(key)
+                .map(|backing| block_backings.push(backing)),
+            SnapshotRestoreResourceClass::PmemBacking => batch
+                .take_pmem(key)
+                .map(|backing| pmem_backings.push(backing)),
+            SnapshotRestoreResourceClass::SerialSink => batch
+                .take_serial(key)
+                .map(|output| serial_output = Some(output)),
+            SnapshotRestoreResourceClass::NetworkPacketIo => batch
+                .take_network(key)
+                .map(|resource| staged.network_resources.push(resource)),
+            SnapshotRestoreResourceClass::VsockEndpoint => Ok(()),
+        };
+        if result.is_err() {
+            drop((block_backings, pmem_backings, serial_output));
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                stage,
+                cleanup_uncertain,
+            ));
+        }
+    }
+
+    let storage = match storage_plan {
+        Some(plan) => match plan.prepare_backings(block_backings, pmem_backings, || false) {
+            Ok(storage) => Some(storage),
+            Err(_) => {
+                let cleanup_uncertain = staged.shutdown();
+                return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                    ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
+                    cleanup_uncertain,
+                ));
+            }
+        },
+        None if block_backings.is_empty() && pmem_backings.is_empty() => None,
+        None => {
+            drop((block_backings, pmem_backings));
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
+                cleanup_uncertain,
+            ));
+        }
+    };
+    let serial_endpoint =
+        match prepare_native_v2_serial_restore_endpoint(serial_state.clone(), serial_output) {
+            Ok(endpoint) => endpoint,
+            Err(_) => {
+                drop(storage);
+                let cleanup_uncertain = staged.shutdown();
+                return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                    ProcessSnapshotV2VsockPciRestoreStage::Serial,
+                    cleanup_uncertain,
+                ));
+            }
+        };
+    staged.serial_endpoint = Some(serial_endpoint);
+
+    let serial_resource_present = !serial_state.endpoint_intent().is_default_process_stdio();
+    let kind = HvfSnapshotV2VsockProductKind::from_presence(
+        storage.is_some(),
+        entropy.is_some(),
+        balloon.is_some(),
+        memory_hotplug.is_some(),
+        !network_topology.interfaces().is_empty(),
+        vsock_state.is_some(),
+    );
+    let (prepared_memory, static_memory) = match memory_hotplug {
+        Some(topology) => (
+            HvfSnapshotV2VsockPreparedMemory::MemoryHotplug {
+                topology: Box::new(topology),
+                memory,
+            },
+            None,
+        ),
+        None => (
+            HvfSnapshotV2VsockPreparedMemory::Static(binding),
+            Some(memory),
+        ),
+    };
+    let vsock = match (vsock_state, vsock_config) {
+        (Some(state), Some(config)) => Some(HvfSnapshotV2VsockPreparedEndpoint::new(state, config)),
+        (None, None) => None,
+        _ => {
+            drop((prepared_memory, storage, entropy, balloon, network_topology));
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
+                cleanup_uncertain,
+            ));
+        }
+    };
+    let product = match HvfSnapshotV2VsockPreparedProduct::try_from_parts(
+        HvfSnapshotV2VsockPreparedProductParts {
+            kind,
+            memory: prepared_memory,
+            storage,
+            entropy,
+            balloon,
+            network: network_topology,
+            vsock,
+            serial_resource_present,
+            binding_keys,
+        },
+    ) {
+        Ok(product) => product,
+        Err(_) => {
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
+                cleanup_uncertain,
+            ));
+        }
+    };
+    let platform_plan = match prepare_hvf_snapshot_v2_vsock_pci_platform_plan(&platform, product) {
+        Ok(plan) => plan,
+        Err(_) => {
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
+                cleanup_uncertain,
+            ));
+        }
+    };
+    if !staged
+        .batch
+        .as_ref()
+        .is_some_and(|batch| batch.matches_pci_platform_plan(&platform_plan))
+        || platform_plan.network().len() != staged.network_resources.len()
+    {
+        drop(platform_plan);
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+            ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
+            cleanup_uncertain,
+        ));
+    }
+
+    if cancelled(ProcessSnapshotV2VsockPciRestoreStage::HvfConstruction) {
+        drop(platform_plan);
+        let already_consumed = staged
+            .batch
+            .as_ref()
+            .is_some_and(|batch| batch.taken_count != 0);
+        let evidence = staged.shutdown_evidence();
+        return Err(if already_consumed || evidence.terminal {
+            ProcessSnapshotV2VsockPciRestoreError::terminal(
+                ProcessSnapshotV2VsockPciRestoreStage::HvfConstruction,
+                evidence.cleanup_uncertain,
+            )
+        } else {
+            ProcessSnapshotV2VsockPciRestoreError::retryable(
+                ProcessSnapshotV2VsockPciRestoreStage::HvfConstruction,
+            )
+        });
+    }
+    let Some(endpoint) = staged.serial_endpoint.take() else {
+        drop(platform_plan);
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+            ProcessSnapshotV2VsockPciRestoreStage::Serial,
+            cleanup_uncertain,
+        ));
+    };
+    let (serial, serial_input, serial_restoration, serial_config) = match endpoint.into_parts() {
+        Ok(parts) => parts,
+        Err(_) => {
+            drop(platform_plan);
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                ProcessSnapshotV2VsockPciRestoreStage::Serial,
+                cleanup_uncertain,
+            ));
+        }
+    };
+    staged.serial_output = Some(serial.output().clone());
+    staged.serial_config = Some(serial_config);
+    staged.serial_restoration = serial_restoration;
+    let process_shell = HvfSnapshotV2RestoredSerialShell::new(serial);
+    let profiles = staged
+        .network_resources
+        .iter()
+        .map(PreparedProcessSnapshotV2NetworkRestoreResource::device_profile)
+        .collect::<Vec<_>>();
+    let Some(network_metrics) = staged
+        .batch
+        .as_ref()
+        .map(|batch| batch.network_completion.network_metrics().clone())
+    else {
+        drop((platform_plan, process_shell, profiles));
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+            ProcessSnapshotV2VsockPciRestoreStage::HvfConstruction,
+            cleanup_uncertain,
+        ));
+    };
+    let vsock_key = platform_plan
+        .vsock()
+        .map(|endpoint| endpoint.resource_key().clone());
+    let memory_input = static_memory
+        .map(HvfSnapshotV2NetworkPciMemoryInput::Static)
+        .unwrap_or(HvfSnapshotV2NetworkPciMemoryInput::ProductOwned);
+    let vsock_metrics = SharedVsockDeviceMetrics::default();
+
+    let restored = match vsock_key {
+        Some(key) => {
+            let Some(batch) = staged.batch.as_mut() else {
+                let cleanup_uncertain = staged.shutdown();
+                return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                    ProcessSnapshotV2VsockPciRestoreStage::HvfConstruction,
+                    cleanup_uncertain,
+                ));
+            };
+            match batch.adopt_vsock(&key, |resource| {
+                OwnedHvfArm64BootSession::restore_snapshot_v2_vsock_pci_with_cancel(
+                    platform,
+                    memory_input,
+                    process_shell,
+                    serial_input,
+                    platform_plan,
+                    profiles,
+                    network_metrics,
+                    Some(resource),
+                    vsock_metrics,
+                    now,
+                    |stage| cancelled(ProcessSnapshotV2VsockPciRestoreStage::Hvf(stage)),
+                )
+            }) {
+                Ok((hvf, guard)) => {
+                    staged.active_vsock = Some(guard);
+                    hvf
+                }
+                Err(source) => {
+                    let cleanup_uncertain = staged.shutdown();
+                    return Err(ProcessSnapshotV2VsockPciRestoreError::from_adoption(
+                        &source,
+                        cleanup_uncertain,
+                    ));
+                }
+            }
+        }
+        None => {
+            match OwnedHvfArm64BootSession::restore_snapshot_v2_vsock_pci_with_cancel(
+                platform,
+                memory_input,
+                process_shell,
+                serial_input,
+                platform_plan,
+                profiles,
+                network_metrics,
+                None,
+                vsock_metrics,
+                now,
+                |stage| cancelled(ProcessSnapshotV2VsockPciRestoreStage::Hvf(stage)),
+            ) {
+                Ok(hvf) => hvf,
+                Err(source) => {
+                    let cleanup_uncertain = staged.shutdown();
+                    return Err(ProcessSnapshotV2VsockPciRestoreError::from_hvf(
+                        &source,
+                        cleanup_uncertain,
+                    ));
+                }
+            }
+        }
+    };
+    staged.hvf = Some(restored);
+
+    if cancelled(ProcessSnapshotV2VsockPciRestoreStage::BatchFinish) {
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+            ProcessSnapshotV2VsockPciRestoreStage::BatchFinish,
+            cleanup_uncertain,
+        ));
+    }
+    let Some(batch) = staged.batch.take() else {
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+            ProcessSnapshotV2VsockPciRestoreStage::BatchFinish,
+            cleanup_uncertain,
+        ));
+    };
+    let completion = match batch.finish() {
+        Ok(completion) => completion,
+        Err(_) => {
+            let cleanup_uncertain = staged.shutdown();
+            return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                ProcessSnapshotV2VsockPciRestoreStage::BatchFinish,
+                cleanup_uncertain,
+            ));
+        }
+    };
+    staged.completion = Some(completion);
+
+    let equivalent = match (&staged.hvf, &staged.completion) {
+        (Some(hvf), Some(completion)) => restored_process_snapshot_v2_vsock_pci_is_equivalent(
+            hvf,
+            completion,
+            &staged.network_resources,
+            now,
+        )
+        .is_ok(),
+        _ => false,
+    };
+    if cancelled(ProcessSnapshotV2VsockPciRestoreStage::CompleteRecapture) || !equivalent {
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+            ProcessSnapshotV2VsockPciRestoreStage::CompleteRecapture,
+            cleanup_uncertain,
+        ));
+    }
+
+    if cancelled(ProcessSnapshotV2VsockPciRestoreStage::Assembly) {
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+            ProcessSnapshotV2VsockPciRestoreStage::Assembly,
+            cleanup_uncertain,
+        ));
+    }
+    let owner_graph_is_complete = match (&staged.hvf, &staged.completion) {
+        (Some(hvf), Some(completion)) => {
+            hvf.configs().len() == staged.network_resources.len()
+                && completion
+                    .network_completion
+                    .resources_match(&staged.network_resources)
+                && staged.serial_output.is_some()
+                && staged.serial_config.is_some()
+                && hvf.expected_vsock().is_some() == staged.active_vsock.is_some()
+        }
+        _ => false,
+    };
+    if !owner_graph_is_complete {
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+            ProcessSnapshotV2VsockPciRestoreStage::Assembly,
+            cleanup_uncertain,
+        ));
+    }
+
+    if cancelled(ProcessSnapshotV2VsockPciRestoreStage::GateCommit) {
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+            ProcessSnapshotV2VsockPciRestoreStage::GateCommit,
+            cleanup_uncertain,
+        ));
+    }
+    let Some(hvf) = staged.hvf.take() else {
+        let cleanup_uncertain = staged.shutdown();
+        return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+            ProcessSnapshotV2VsockPciRestoreStage::GateCommit,
+            cleanup_uncertain,
+        ));
+    };
+    staged.hvf = Some(hvf.commit_retry_publication());
+    staged.into_owners()
+}
+
+type SystemRestoredProcessSnapshotV2VsockPciOwners =
+    RestoredProcessSnapshotV2VsockPciOwners<SystemVmnetInterfaceBackend>;
+
+#[allow(clippy::too_many_arguments)]
+fn restore_process_snapshot_v2_vsock_pci<C>(
+    platform: HvfSnapshotV2PlatformState,
+    memory: GuestMemory,
+    resource_plan: PreparedProcessSnapshotV2VsockResourcePlan,
+    contained_authority: Option<&ContainedSnapshotRestoreAuthority>,
+    destination_instance_id: &str,
+    mmds_data_store_limit_bytes: usize,
+    now: Instant,
+    cancelled: C,
+) -> Result<SystemRestoredProcessSnapshotV2VsockPciOwners, ProcessSnapshotV2VsockPciRestoreError>
+where
+    C: Fn(ProcessSnapshotV2VsockPciRestoreStage) -> bool,
+{
+    let mut factory = SystemProcessVmnetPacketIoBackendFactory;
+    restore_process_snapshot_v2_vsock_pci_with_factory(
+        platform,
+        memory,
+        resource_plan,
+        contained_authority,
+        destination_instance_id,
+        mmds_data_store_limit_bytes,
+        &mut factory,
+        now,
+        cancelled,
+    )
+}
+
+type SystemRestoreProcessSnapshotV2VsockPciFn = fn(
+    HvfSnapshotV2PlatformState,
+    GuestMemory,
+    PreparedProcessSnapshotV2VsockResourcePlan,
+    Option<&ContainedSnapshotRestoreAuthority>,
+    &str,
+    usize,
+    Instant,
+    fn(ProcessSnapshotV2VsockPciRestoreStage) -> bool,
+) -> Result<
+    SystemRestoredProcessSnapshotV2VsockPciOwners,
+    ProcessSnapshotV2VsockPciRestoreError,
+>;
+
+const _: SystemRestoreProcessSnapshotV2VsockPciFn =
+    restore_process_snapshot_v2_vsock_pci::<fn(ProcessSnapshotV2VsockPciRestoreStage) -> bool>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ProcessSnapshotV2NetworkPciRestoreStage {
@@ -53722,9 +54864,9 @@ mod tests {
     }
 
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    #[test]
-    #[ignore = "requires the signed native_v2_process integration group"]
-    fn signed_exact_minor_twelve_process_mmio_vsock_owner_transaction_is_atomic() {
+    fn verify_signed_exact_minor_twelve_process_vsock_owner_transaction_is_atomic(
+        pci_enabled: bool,
+    ) {
         use bangbang_runtime::snapshot_memory_v2::load_snapshot_v2_memory_path;
         use bangbang_runtime::vsock::VsockBackendSelector;
 
@@ -53767,13 +54909,16 @@ mod tests {
             .cloned()
             .expect("vsock source config should exist");
 
-        let mut source = super::OwnedHvfArm64BootSession::new(
-            &controller,
-            default_hvf_boot_session_config(SharedSerialOutput::from(
-                SharedSerialOutputBuffer::default(),
-            )),
-        )
-        .expect("signed exact-2.12 source should prepare");
+        let session_config = default_hvf_boot_session_config(SharedSerialOutput::from(
+            SharedSerialOutputBuffer::default(),
+        ));
+        let session_config = if pci_enabled {
+            session_config.with_pci_enabled()
+        } else {
+            session_config
+        };
+        let mut source = super::OwnedHvfArm64BootSession::new(&controller, session_config)
+            .expect("signed exact-2.12 source should prepare");
         assert!(source_socket.path().exists());
         let source_metrics = source.shared_vsock_device_metrics();
         let guard = source
@@ -53854,10 +54999,15 @@ mod tests {
             let candidate =
                 NativeV2VsockSnapshotCandidateState::from_vsock_state_v2_12(encoded.clone())
                     .expect("exact-2.12 candidate should decode");
+            let transport_kind = if pci_enabled {
+                SnapshotV2DeviceTransportKind::Pci
+            } else {
+                SnapshotV2DeviceTransportKind::Mmio
+            };
             let prepared = prepare_process_snapshot_v2_vsock_candidate(
                 candidate,
                 &memory,
-                SnapshotV2DeviceTransportKind::Mmio,
+                transport_kind,
                 &[],
                 Some(&SnapshotVsockOverride::new(destination_socket.path())),
             )
@@ -53869,6 +55019,168 @@ mod tests {
             .expect("exact-2.12 process resource plan should prepare");
             (memory, resource_plan)
         };
+
+        if pci_enabled {
+            for (cancel_stage, expected_disposition) in [
+                (
+                    super::ProcessSnapshotV2VsockPciRestoreStage::ResourcePreparation,
+                    super::ProcessSnapshotV2VsockPciRestoreDisposition::Retryable,
+                ),
+                (
+                    super::ProcessSnapshotV2VsockPciRestoreStage::ProductPreparation,
+                    super::ProcessSnapshotV2VsockPciRestoreDisposition::Retryable,
+                ),
+                (
+                    super::ProcessSnapshotV2VsockPciRestoreStage::HvfConstruction,
+                    super::ProcessSnapshotV2VsockPciRestoreDisposition::Retryable,
+                ),
+                (
+                    super::ProcessSnapshotV2VsockPciRestoreStage::Hvf(
+                        super::HvfSnapshotV2VsockPciRestoreStage::Product,
+                    ),
+                    super::ProcessSnapshotV2VsockPciRestoreDisposition::Retryable,
+                ),
+                (
+                    super::ProcessSnapshotV2VsockPciRestoreStage::Hvf(
+                        super::HvfSnapshotV2VsockPciRestoreStage::Platform,
+                    ),
+                    super::ProcessSnapshotV2VsockPciRestoreDisposition::Retryable,
+                ),
+                (
+                    super::ProcessSnapshotV2VsockPciRestoreStage::Hvf(
+                        super::HvfSnapshotV2VsockPciRestoreStage::VsockPreparation,
+                    ),
+                    super::ProcessSnapshotV2VsockPciRestoreDisposition::Terminal,
+                ),
+                (
+                    super::ProcessSnapshotV2VsockPciRestoreStage::Hvf(
+                        super::HvfSnapshotV2VsockPciRestoreStage::VsockPublication,
+                    ),
+                    super::ProcessSnapshotV2VsockPciRestoreDisposition::Terminal,
+                ),
+                (
+                    super::ProcessSnapshotV2VsockPciRestoreStage::Hvf(
+                        super::HvfSnapshotV2VsockPciRestoreStage::RetryScheduler,
+                    ),
+                    super::ProcessSnapshotV2VsockPciRestoreDisposition::Terminal,
+                ),
+                (
+                    super::ProcessSnapshotV2VsockPciRestoreStage::Hvf(
+                        super::HvfSnapshotV2VsockPciRestoreStage::RetryDeadline,
+                    ),
+                    super::ProcessSnapshotV2VsockPciRestoreDisposition::Terminal,
+                ),
+                (
+                    super::ProcessSnapshotV2VsockPciRestoreStage::Hvf(
+                        super::HvfSnapshotV2VsockPciRestoreStage::Recapture,
+                    ),
+                    super::ProcessSnapshotV2VsockPciRestoreDisposition::Terminal,
+                ),
+                (
+                    super::ProcessSnapshotV2VsockPciRestoreStage::Hvf(
+                        super::HvfSnapshotV2VsockPciRestoreStage::Assembly,
+                    ),
+                    super::ProcessSnapshotV2VsockPciRestoreDisposition::Terminal,
+                ),
+                (
+                    super::ProcessSnapshotV2VsockPciRestoreStage::BatchFinish,
+                    super::ProcessSnapshotV2VsockPciRestoreDisposition::Terminal,
+                ),
+                (
+                    super::ProcessSnapshotV2VsockPciRestoreStage::CompleteRecapture,
+                    super::ProcessSnapshotV2VsockPciRestoreDisposition::Terminal,
+                ),
+                (
+                    super::ProcessSnapshotV2VsockPciRestoreStage::Assembly,
+                    super::ProcessSnapshotV2VsockPciRestoreDisposition::Terminal,
+                ),
+                (
+                    super::ProcessSnapshotV2VsockPciRestoreStage::GateCommit,
+                    super::ProcessSnapshotV2VsockPciRestoreDisposition::Terminal,
+                ),
+            ] {
+                let (memory, resource_plan) = make_restore_inputs();
+                let mut factory = RecordingVmnetPacketIoBackendFactory::default();
+                let events = factory.events();
+                let error = super::restore_process_snapshot_v2_vsock_pci_with_factory(
+                    platform.clone(),
+                    memory,
+                    resource_plan,
+                    None,
+                    "exact-2-12-pci-cancelled-destination",
+                    bangbang_runtime::mmds::MMDS_DATA_STORE_LIMIT_BYTES,
+                    &mut factory,
+                    Instant::now(),
+                    |stage| stage == cancel_stage,
+                )
+                .expect_err("injected exact-2.12 PCI owner cancellation should reject");
+                assert_eq!(error.stage, cancel_stage);
+                assert_eq!(error.disposition, expected_disposition);
+                let diagnostics = format!("{error:?} {error}");
+                assert!(diagnostics.contains("<redacted>"));
+                assert!(
+                    !diagnostics.contains(destination_socket.path().to_string_lossy().as_ref())
+                );
+                assert!(!diagnostics.contains("exact-2-12-pci-cancelled-destination"));
+                assert!(!destination_socket.path().exists());
+                assert!(recorded_events(&events).is_empty());
+            }
+
+            let (memory, resource_plan) = make_restore_inputs();
+            let mut factory = RecordingVmnetPacketIoBackendFactory::default();
+            let events = factory.events();
+            let mut owners = super::restore_process_snapshot_v2_vsock_pci_with_factory(
+                platform,
+                memory,
+                resource_plan,
+                None,
+                "exact-2-12-pci-committed-destination",
+                bangbang_runtime::mmds::MMDS_DATA_STORE_LIMIT_BYTES,
+                &mut factory,
+                Instant::now(),
+                |_| false,
+            )
+            .expect("complete exact-2.12 PCI process/HVF owner graph should commit");
+            assert!(destination_socket.path().exists());
+            assert!(owners.active_vsock.is_some());
+            assert!(owners.completion.is_some());
+            assert!(owners.network_resources.is_empty());
+            let hvf = owners
+                .hvf
+                .as_ref()
+                .expect("committed exact-2.12 PCI graph should retain HVF");
+            assert!(hvf.retry_publication_is_committed());
+            assert_eq!(hvf.expected_vsock(), Some(&expected_destination_vsock));
+            let restored_config = hvf
+                .vsock_config()
+                .expect("committed exact-2.12 PCI graph should retain vsock config");
+            assert_eq!(restored_config.guest_cid(), source_config.guest_cid());
+            assert_eq!(restored_config.uds_path(), destination_socket.path());
+            let destination_metrics = hvf
+                .vsock_metrics()
+                .expect("committed exact-2.12 PCI graph should retain fresh metrics");
+            assert!(
+                destination_metrics.shares_state_with(&hvf.session().shared_vsock_device_metrics())
+            );
+            assert!(!source_metrics.shares_state_with(destination_metrics));
+            assert!(destination_metrics.snapshot().is_empty());
+            assert!(source_metrics.snapshot().is_empty());
+            assert_eq!(controller.vsock_config(), Some(&source_config));
+            let diagnostics = format!("{owners:?}");
+            assert!(diagnostics.contains("<redacted>"));
+            assert!(!diagnostics.contains(destination_socket.path().to_string_lossy().as_ref()));
+            assert!(!diagnostics.contains("exact-2-12-pci-committed-destination"));
+            assert!(recorded_events(&events).is_empty());
+
+            owners
+                .shutdown()
+                .expect("committed exact-2.12 PCI process/HVF owner graph should shut down");
+            owners
+                .shutdown()
+                .expect("repeated exact-2.12 PCI process/HVF shutdown should be idempotent");
+            assert!(!destination_socket.path().exists());
+            return;
+        }
 
         for (cancel_stage, expected_disposition) in [
             (
@@ -54026,6 +55338,20 @@ mod tests {
             .shutdown()
             .expect("repeated exact-2.12 process/HVF shutdown should be idempotent");
         assert!(!destination_socket.path().exists());
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[test]
+    #[ignore = "requires the signed native_v2_process integration group"]
+    fn signed_exact_minor_twelve_process_mmio_vsock_owner_transaction_is_atomic() {
+        verify_signed_exact_minor_twelve_process_vsock_owner_transaction_is_atomic(false);
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[test]
+    #[ignore = "requires the signed native_v2_process integration group"]
+    fn signed_exact_minor_twelve_process_pci_vsock_owner_transaction_is_atomic() {
+        verify_signed_exact_minor_twelve_process_vsock_owner_transaction_is_atomic(true);
     }
 
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -303,7 +303,8 @@ pub use startup::{
     HvfSnapshotV2StorageMmioRestoreStage, HvfSnapshotV2StoragePciRestoreCleanupFailure,
     HvfSnapshotV2StoragePciRestoreError, HvfSnapshotV2StoragePciRestoreFailure,
     HvfSnapshotV2StoragePciRestoreStage, HvfSnapshotV2VsockMmioRestoreError,
-    HvfSnapshotV2VsockMmioRestoreStage, OwnedHvfArm64BootSession,
+    HvfSnapshotV2VsockMmioRestoreStage, HvfSnapshotV2VsockPciRestoreError,
+    HvfSnapshotV2VsockPciRestoreStage, OwnedHvfArm64BootSession,
     PreparedHvfArm64BootPciNetworkRemoval, RestoredHvfArm64BootSession,
     RestoredHvfSnapshotV2BalloonMmioOwners, RestoredHvfSnapshotV2BalloonPciOwners,
     RestoredHvfSnapshotV2EntropyMmioOwners, RestoredHvfSnapshotV2EntropyPciOwners,
@@ -311,7 +312,7 @@ pub use startup::{
     RestoredHvfSnapshotV2MultiBlockMmioOwners, RestoredHvfSnapshotV2MultiBlockPciOwners,
     RestoredHvfSnapshotV2NetworkMmioOwners, RestoredHvfSnapshotV2NetworkPciOwners,
     RestoredHvfSnapshotV2StorageMmioOwners, RestoredHvfSnapshotV2StoragePciOwners,
-    RestoredHvfSnapshotV2VsockMmioOwners,
+    RestoredHvfSnapshotV2VsockMmioOwners, RestoredHvfSnapshotV2VsockPciOwners,
 };
 pub use topology::{
     HvfVcpuTopology, HvfVcpuTopologyAllocation, HvfVcpuTopologyCreateStage, HvfVcpuTopologyError,

--- a/crates/hvf/src/snapshot_v2_vsock_platform.rs
+++ b/crates/hvf/src/snapshot_v2_vsock_platform.rs
@@ -986,6 +986,24 @@ impl HvfSnapshotV2VsockPciPlatformPlan {
             && matches_vsock_identity_pci(self.vsock.as_ref(), vsock)
             && self.binding_keys == binding_keys
     }
+
+    pub(crate) fn into_owner_parts(self) -> HvfSnapshotV2VsockPciPlatformOwnerParts {
+        HvfSnapshotV2VsockPciPlatformOwnerParts {
+            kind: self.kind,
+            base: self.base,
+            vsock: self.vsock,
+            serial_resource_present: self.serial_resource_present,
+            binding_keys: self.binding_keys,
+        }
+    }
+}
+
+pub(crate) struct HvfSnapshotV2VsockPciPlatformOwnerParts {
+    pub(crate) kind: HvfSnapshotV2VsockProductKind,
+    pub(crate) base: HvfSnapshotV2NetworkPciPlatformPlan,
+    pub(crate) vsock: Option<HvfSnapshotV2VsockPciEndpointPlan>,
+    pub(crate) serial_resource_present: bool,
+    pub(crate) binding_keys: Vec<SnapshotRestoreResourceKey>,
 }
 
 impl fmt::Debug for HvfSnapshotV2VsockPciPlatformPlan {

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -329,7 +329,9 @@ use crate::snapshot_v2_storage_platform::{
 };
 use crate::snapshot_v2_vsock_platform::{
     HvfSnapshotV2VsockMmioEndpointPlan, HvfSnapshotV2VsockMmioPlatformOwnerParts,
-    HvfSnapshotV2VsockMmioPlatformPlan, HvfSnapshotV2VsockProductKind,
+    HvfSnapshotV2VsockMmioPlatformPlan, HvfSnapshotV2VsockPciEndpointPlan,
+    HvfSnapshotV2VsockPciPlatformOwnerParts, HvfSnapshotV2VsockPciPlatformPlan,
+    HvfSnapshotV2VsockProductKind,
 };
 use crate::topology::{HvfVcpuTopologyError, prepare_ordered_mpidrs};
 use crate::vcpu::{
@@ -4352,6 +4354,134 @@ impl fmt::Display for HvfSnapshotV2NetworkPciRestoreError {
 
 impl std::error::Error for HvfSnapshotV2NetworkPciRestoreError {}
 
+/// Stable aggregate stage for exact-2.12 PCI vsock reconstruction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[doc(hidden)]
+pub enum HvfSnapshotV2VsockPciRestoreStage {
+    Product,
+    Platform,
+    EndpointPreparation { index: usize },
+    Publication { index: usize },
+    VsockPreparation,
+    VsockPublication,
+    Entropy,
+    MemoryHotplug,
+    RetryScheduler,
+    RetryDeadline,
+    Recapture,
+    Assembly,
+}
+
+/// Bounded, redacted exact-2.12 PCI aggregate reconstruction error.
+#[doc(hidden)]
+pub struct HvfSnapshotV2VsockPciRestoreError {
+    stage: HvfSnapshotV2VsockPciRestoreStage,
+    disposition: HvfSnapshotV2NetworkPciRestoreDisposition,
+}
+
+fn network_pci_stage_to_vsock(
+    stage: HvfSnapshotV2NetworkPciRestoreStage,
+    interface_count: usize,
+) -> HvfSnapshotV2VsockPciRestoreStage {
+    match stage {
+        HvfSnapshotV2NetworkPciRestoreStage::Product => HvfSnapshotV2VsockPciRestoreStage::Product,
+        HvfSnapshotV2NetworkPciRestoreStage::Platform => {
+            HvfSnapshotV2VsockPciRestoreStage::Platform
+        }
+        HvfSnapshotV2NetworkPciRestoreStage::EndpointPreparation { index }
+            if index == interface_count =>
+        {
+            HvfSnapshotV2VsockPciRestoreStage::VsockPreparation
+        }
+        HvfSnapshotV2NetworkPciRestoreStage::EndpointPreparation { index } => {
+            HvfSnapshotV2VsockPciRestoreStage::EndpointPreparation { index }
+        }
+        HvfSnapshotV2NetworkPciRestoreStage::Publication { index } if index == interface_count => {
+            HvfSnapshotV2VsockPciRestoreStage::VsockPublication
+        }
+        HvfSnapshotV2NetworkPciRestoreStage::Publication { index } => {
+            HvfSnapshotV2VsockPciRestoreStage::Publication { index }
+        }
+        HvfSnapshotV2NetworkPciRestoreStage::Entropy => HvfSnapshotV2VsockPciRestoreStage::Entropy,
+        HvfSnapshotV2NetworkPciRestoreStage::MemoryHotplug => {
+            HvfSnapshotV2VsockPciRestoreStage::MemoryHotplug
+        }
+        HvfSnapshotV2NetworkPciRestoreStage::RetryScheduler => {
+            HvfSnapshotV2VsockPciRestoreStage::RetryScheduler
+        }
+        HvfSnapshotV2NetworkPciRestoreStage::RetryDeadline => {
+            HvfSnapshotV2VsockPciRestoreStage::RetryDeadline
+        }
+        HvfSnapshotV2NetworkPciRestoreStage::Recapture => {
+            HvfSnapshotV2VsockPciRestoreStage::Recapture
+        }
+        HvfSnapshotV2NetworkPciRestoreStage::Assembly => {
+            HvfSnapshotV2VsockPciRestoreStage::Assembly
+        }
+    }
+}
+
+impl HvfSnapshotV2VsockPciRestoreError {
+    fn preflight(stage: HvfSnapshotV2VsockPciRestoreStage) -> Self {
+        Self {
+            stage,
+            disposition: HvfSnapshotV2NetworkPciRestoreDisposition::Retryable,
+        }
+    }
+
+    fn from_network(source: HvfSnapshotV2NetworkPciRestoreError, interface_count: usize) -> Self {
+        Self {
+            stage: network_pci_stage_to_vsock(source.stage(), interface_count),
+            disposition: source.disposition(),
+        }
+    }
+
+    pub const fn stage(&self) -> HvfSnapshotV2VsockPciRestoreStage {
+        self.stage
+    }
+
+    pub const fn disposition(&self) -> HvfSnapshotV2NetworkPciRestoreDisposition {
+        self.disposition
+    }
+
+    pub const fn is_terminal(&self) -> bool {
+        !matches!(
+            self.disposition,
+            HvfSnapshotV2NetworkPciRestoreDisposition::Retryable
+        )
+    }
+
+    pub const fn has_incomplete_cleanup(&self) -> bool {
+        matches!(
+            self.disposition,
+            HvfSnapshotV2NetworkPciRestoreDisposition::TerminalCleanup
+        )
+    }
+}
+
+impl fmt::Debug for HvfSnapshotV2VsockPciRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfSnapshotV2VsockPciRestoreError")
+            .field("stage", &self.stage)
+            .field("disposition", &self.disposition)
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for HvfSnapshotV2VsockPciRestoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "exact-2.12 PCI vsock reconstruction failed at {:?} ({:?})",
+            self.stage, self.disposition
+        )
+    }
+}
+
+impl std::error::Error for HvfSnapshotV2VsockPciRestoreError {}
+
 /// Complete exact-2.11 PCI owner graph with retry publication still gated.
 #[doc(hidden)]
 pub struct RestoredHvfSnapshotV2NetworkPciOwners {
@@ -4483,6 +4613,130 @@ impl fmt::Debug for RestoredHvfSnapshotV2NetworkPciOwners {
         formatter
             .debug_struct("RestoredHvfSnapshotV2NetworkPciOwners")
             .field("interface_count", &self.configs.len())
+            .field(
+                "retry_publication_committed",
+                &self.retry_publication_is_committed(),
+            )
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+struct RestoredHvfSnapshotV2VsockPciMetadata {
+    config: VsockConfig,
+    expected: SnapshotV2VsockState,
+    metrics: SharedVsockDeviceMetrics,
+}
+
+struct RestoredHvfSnapshotV2NetworkPciInnerOwners {
+    network: RestoredHvfSnapshotV2NetworkPciOwners,
+    vsock: Option<RestoredHvfSnapshotV2VsockPciMetadata>,
+}
+
+/// Complete exact-2.12 PCI owner graph with retry publication still gated.
+#[doc(hidden)]
+pub struct RestoredHvfSnapshotV2VsockPciOwners {
+    base: RestoredHvfSnapshotV2NetworkPciOwners,
+    kind: HvfSnapshotV2VsockProductKind,
+    serial_resource_present: bool,
+    binding_keys: Vec<bangbang_runtime::snapshot_restore::SnapshotRestoreResourceKey>,
+    vsock: Option<RestoredHvfSnapshotV2VsockPciMetadata>,
+}
+
+impl RestoredHvfSnapshotV2VsockPciOwners {
+    pub const fn session(&self) -> &OwnedHvfArm64BootSession {
+        self.base.session()
+    }
+
+    pub fn session_mut(&mut self) -> &mut OwnedHvfArm64BootSession {
+        self.base.session_mut()
+    }
+
+    pub fn configs(&self) -> &[NetworkInterfaceConfig] {
+        self.base.configs()
+    }
+
+    pub fn expected_network(&self) -> &[SnapshotV2NetworkInterfaceState] {
+        self.base.expected()
+    }
+
+    pub const fn mmds_state(&self) -> Option<&SnapshotV2MmdsState> {
+        self.base.mmds_state()
+    }
+
+    pub const fn mmds_config(&self) -> Option<&MmdsConfig> {
+        self.base.mmds_config()
+    }
+
+    pub const fn storage_configs(&self) -> Option<&CaptureReadyStorageConfigs> {
+        self.base.storage_configs()
+    }
+
+    pub const fn entropy_config(&self) -> Option<EntropyConfig> {
+        self.base.entropy_config()
+    }
+
+    pub const fn balloon_config(&self) -> Option<BalloonConfig> {
+        self.base.balloon_config()
+    }
+
+    pub const fn memory_hotplug_state(&self) -> Option<&SnapshotV2MemoryHotplugState> {
+        self.base.memory_hotplug_state()
+    }
+
+    pub const fn memory_hotplug_controller(
+        &self,
+    ) -> Option<&SnapshotV2MemoryHotplugControllerProjection> {
+        self.base.memory_hotplug_controller()
+    }
+
+    pub const fn kind(&self) -> HvfSnapshotV2VsockProductKind {
+        self.kind
+    }
+
+    pub const fn serial_resource_present(&self) -> bool {
+        self.serial_resource_present
+    }
+
+    pub fn resource_keys(
+        &self,
+    ) -> &[bangbang_runtime::snapshot_restore::SnapshotRestoreResourceKey] {
+        &self.binding_keys
+    }
+
+    pub fn vsock_config(&self) -> Option<&VsockConfig> {
+        self.vsock.as_ref().map(|vsock| &vsock.config)
+    }
+
+    pub fn expected_vsock(&self) -> Option<&SnapshotV2VsockState> {
+        self.vsock.as_ref().map(|vsock| &vsock.expected)
+    }
+
+    pub fn vsock_metrics(&self) -> Option<&SharedVsockDeviceMetrics> {
+        self.vsock.as_ref().map(|vsock| &vsock.metrics)
+    }
+
+    pub const fn retry_publication_is_committed(&self) -> bool {
+        self.base.retry_publication_is_committed()
+    }
+
+    pub fn commit_retry_publication(mut self) -> Self {
+        self.base = self.base.commit_retry_publication();
+        self
+    }
+
+    pub fn shutdown(self) -> Result<(), HvfArm64BootSessionShutdownError> {
+        self.base.shutdown()
+    }
+}
+
+impl fmt::Debug for RestoredHvfSnapshotV2VsockPciOwners {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RestoredHvfSnapshotV2VsockPciOwners")
+            .field("kind", &self.kind)
+            .field("interface_count", &self.base.configs().len())
+            .field("has_vsock", &self.vsock.is_some())
             .field(
                 "retry_publication_committed",
                 &self.retry_publication_is_committed(),
@@ -7244,6 +7498,7 @@ struct RestoredHvfSnapshotV2NetworkPciBatch {
     expected: Vec<SnapshotV2NetworkInterfaceState>,
     capture_configs: Vec<HvfArm64BootNetworkCaptureConfig>,
     earliest_retry_deadline: Option<Instant>,
+    vsock: Option<RestoredHvfSnapshotV2VsockPciMetadata>,
 }
 
 pub struct RestoredHvfSnapshotV2StoragePciOwners {
@@ -7302,9 +7557,19 @@ pub enum HvfSnapshotV2StoragePciRestoreStage {
     Platform,
     PciHost,
     PciRoutes,
-    EndpointPreparation { index: usize },
-    Mapping { index: usize },
-    Publication { index: usize },
+    EndpointPreparation {
+        index: usize,
+    },
+    Mapping {
+        index: usize,
+    },
+    Publication {
+        index: usize,
+    },
+    #[doc(hidden)]
+    FollowingEndpointPreparation,
+    #[doc(hidden)]
+    FollowingEndpointPublication,
     BlockRetryScheduler,
     PmemRetryScheduler,
 }
@@ -17211,6 +17476,13 @@ struct PreparedHvfSnapshotV2BalloonPciPublication {
     interrupts: HvfGicMsiDeviceInterruptResources,
 }
 
+struct HvfSnapshotV2VsockPciRestoreInput<'a> {
+    endpoint: HvfSnapshotV2VsockPciEndpointPlan,
+    resource: &'a mut VirtioVsockReconstructionResource,
+    metrics: SharedVsockDeviceMetrics,
+    fault: Option<HvfSnapshotV2NetworkPciBatchFault>,
+}
+
 struct HvfSnapshotV2NetworkPciBatchInput {
     interfaces: Vec<PreparedSnapshotV2NetworkRestoreInterface>,
     endpoints: Vec<HvfSnapshotV2NetworkPciEndpointPlan>,
@@ -17230,29 +17502,41 @@ enum HvfSnapshotV2NetworkPciBatchFault {
 struct HvfSnapshotV2EntropyPciPrecedingEndpointCounts {
     balloon: usize,
     network: usize,
+    vsock: usize,
 }
 
 impl HvfSnapshotV2EntropyPciPrecedingEndpointCounts {
     const fn new(balloon: usize, network: usize) -> Self {
-        Self { balloon, network }
+        Self {
+            balloon,
+            network,
+            vsock: 0,
+        }
+    }
+
+    const fn with_vsock(mut self, present: bool) -> Self {
+        self.vsock = present as usize;
+        self
     }
 }
 
-struct HvfSnapshotV2StoragePciPublicationInput {
+struct HvfSnapshotV2StoragePciPublicationInput<'a> {
     balloon: Option<(
         HvfSnapshotV2BalloonPciEndpointPlan,
         SnapshotV2BalloonRestorePlan,
     )>,
     network: Option<HvfSnapshotV2NetworkPciBatchInput>,
+    vsock: Option<HvfSnapshotV2VsockPciRestoreInput<'a>>,
     pmem_fault_index: Option<usize>,
     balloon_fault: Option<HvfSnapshotV2BalloonPciRestoreFault>,
 }
 
-impl HvfSnapshotV2StoragePciPublicationInput {
+impl<'a> HvfSnapshotV2StoragePciPublicationInput<'a> {
     const fn empty() -> Self {
         Self {
             balloon: None,
             network: None,
+            vsock: None,
             pmem_fault_index: None,
             balloon_fault: None,
         }
@@ -17262,6 +17546,7 @@ impl HvfSnapshotV2StoragePciPublicationInput {
         Self {
             balloon: None,
             network: None,
+            vsock: None,
             pmem_fault_index: Some(index),
             balloon_fault: None,
         }
@@ -17275,6 +17560,7 @@ impl HvfSnapshotV2StoragePciPublicationInput {
         Self {
             balloon: Some((endpoint, balloon)),
             network: None,
+            vsock: None,
             pmem_fault_index: None,
             balloon_fault: fault,
         }
@@ -17282,6 +17568,11 @@ impl HvfSnapshotV2StoragePciPublicationInput {
 
     fn with_network(mut self, network: HvfSnapshotV2NetworkPciBatchInput) -> Self {
         self.network = Some(network);
+        self
+    }
+
+    fn with_vsock(mut self, vsock: Option<HvfSnapshotV2VsockPciRestoreInput<'a>>) -> Self {
+        self.vsock = vsock;
         self
     }
 }
@@ -17659,9 +17950,167 @@ fn publish_snapshot_v2_network_pci_batch(
             expected,
             capture_configs,
             earliest_retry_deadline,
+            vsock: None,
         },
         metrics,
     ))
+}
+
+fn publish_snapshot_v2_vsock_pci(
+    manager: &mut HvfArm64BootPciDataDevices,
+    memory: &GuestMemory,
+    input: HvfSnapshotV2VsockPciRestoreInput<'_>,
+    failure_index: usize,
+) -> Result<RestoredHvfSnapshotV2VsockPciMetadata, HvfSnapshotV2NetworkPciBatchFailure> {
+    let HvfSnapshotV2VsockPciRestoreInput {
+        endpoint,
+        resource,
+        metrics,
+        fault,
+    } = input;
+    let failure = |kind, cleanup_failed| HvfSnapshotV2NetworkPciBatchFailure {
+        index: failure_index,
+        kind,
+        cleanup_failed,
+    };
+    if manager.vsock.is_some()
+        || endpoint.state().origin() != endpoint.origin()
+        || endpoint.state().sbdf() != endpoint.sbdf()
+        || endpoint.state().bar_range() != endpoint.bar_range()
+        || endpoint.route_count() != VIRTIO_VSOCK_QUEUE_SIZES.len() + 1
+        || endpoint.state().capture().device().guest_cid()
+            != u64::from(endpoint.config().guest_cid())
+        || fault
+            == Some(HvfSnapshotV2NetworkPciBatchFault::Preparation {
+                index: failure_index,
+            })
+    {
+        return Err(failure(
+            HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+            false,
+        ));
+    }
+    let mut interrupts = manager
+        .shared_msi_registry()
+        .map_err(|_| failure(HvfSnapshotV2NetworkPciBatchFailureKind::Preparation, false))?;
+    if interrupts.registry().route_count()
+        != usize::try_from(endpoint.msi_interrupt_count()).unwrap_or(usize::MAX)
+    {
+        let cleanup_failed = release_snapshot_v2_network_pci_interrupts(&mut interrupts);
+        return Err(failure(
+            HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+            cleanup_failed,
+        ));
+    }
+    let config = endpoint.config().clone();
+    let queue_vectors = *endpoint.queue_vectors();
+    let config_vector = endpoint.config_vector();
+    let sbdf = endpoint.sbdf();
+    let bar_range = endpoint.bar_range();
+    let bar_region_id = endpoint.bar_region_id();
+    let prepared = match endpoint.state().clone().into_pci_endpoint(
+        &config,
+        memory,
+        resource,
+        bar_region_id,
+        interrupts.registry(),
+    ) {
+        Ok(prepared) => prepared,
+        Err(_) => {
+            let cleanup_failed = release_snapshot_v2_network_pci_interrupts(&mut interrupts);
+            return Err(failure(
+                HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+                cleanup_failed,
+            ));
+        }
+    };
+    let transport = prepared.endpoint().endpoint().transport_state();
+    let placement_matches = transport.as_ref().is_ok_and(|transport| {
+        transport.msix_vector_count() == VIRTIO_VSOCK_QUEUE_SIZES.len() + 1
+            && transport.msix_state().queue_vectors() == queue_vectors
+            && transport.msix_state().config_vector() == config_vector
+    });
+    if prepared.origin() != StorageDeviceOrigin::Startup
+        || prepared.guest_cid() != config.guest_cid()
+        || prepared.uds_path() != config.uds_path()
+        || prepared.endpoint().sbdf() != sbdf
+        || prepared.endpoint().bar_range() != bar_range
+        || prepared.endpoint().region_id() != bar_region_id
+        || !placement_matches
+    {
+        drop(prepared);
+        let cleanup_failed = release_snapshot_v2_network_pci_interrupts(&mut interrupts);
+        return Err(failure(
+            HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+            cleanup_failed,
+        ));
+    }
+    if prepared
+        .endpoint()
+        .endpoint()
+        .signal_restored_vsock_transport_reset(&metrics)
+        .is_err()
+    {
+        drop(prepared);
+        let cleanup_failed = release_snapshot_v2_network_pci_interrupts(&mut interrupts);
+        return Err(failure(
+            HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+            cleanup_failed,
+        ));
+    }
+    let (guest_cid, uds_path, expected, origin, endpoint) = prepared.into_parts();
+    if origin != StorageDeviceOrigin::Startup
+        || fault
+            == Some(HvfSnapshotV2NetworkPciBatchFault::Publication {
+                index: failure_index,
+            })
+    {
+        drop(endpoint);
+        let cleanup_failed = release_snapshot_v2_network_pci_interrupts(&mut interrupts);
+        return Err(failure(
+            HvfSnapshotV2NetworkPciBatchFailureKind::Publication,
+            cleanup_failed,
+        ));
+    }
+    let dispatcher_owner = Arc::clone(&manager.dispatcher);
+    let segment = manager.validation.segment().clone();
+    let mut dispatcher = match dispatcher_owner.lock() {
+        Ok(dispatcher) => dispatcher,
+        Err(_) => {
+            drop(endpoint);
+            let cleanup_failed = release_snapshot_v2_network_pci_interrupts(&mut interrupts);
+            return Err(failure(
+                HvfSnapshotV2NetworkPciBatchFailureKind::Publication,
+                cleanup_failed,
+            ));
+        }
+    };
+    let published = match endpoint.publish(
+        manager.validation.bar_allocator_mut(),
+        segment,
+        &mut dispatcher,
+        interrupts,
+    ) {
+        Ok(published) => published,
+        Err(source) => {
+            return Err(failure(
+                HvfSnapshotV2NetworkPciBatchFailureKind::Publication,
+                matches!(source, VirtioPciPublicationError::Rollback { .. }),
+            ));
+        }
+    };
+    drop(dispatcher);
+    manager.vsock = Some(HvfArm64BootPciVsockDevice {
+        guest_cid,
+        uds_path,
+        published,
+        queue_deliveries: 0,
+    });
+    Ok(RestoredHvfSnapshotV2VsockPciMetadata {
+        config,
+        expected,
+        metrics,
+    })
 }
 
 struct HvfSnapshotV2StoragePciCleanup<'a> {
@@ -19525,13 +19974,126 @@ impl OwnedHvfArm64BootSession {
             plan,
             profiles,
             network_metrics,
+            None,
             now,
             cancelled,
         )
+        .map(|owners| owners.network)
+    }
+
+    /// Reconstructs one complete exact-2.12 PCI vsock owner graph while
+    /// keeping retry wake publication closed for the process-level check.
+    #[doc(hidden)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn restore_snapshot_v2_vsock_pci(
+        state: HvfSnapshotV2PlatformState,
+        memory_input: HvfSnapshotV2NetworkPciMemoryInput,
+        process_shell: HvfSnapshotV2RestoredSerialShell,
+        serial_input: Option<SerialStdioInput>,
+        plan: HvfSnapshotV2VsockPciPlatformPlan,
+        profiles: Vec<NetworkDeviceProfile>,
+        network_metrics: SharedNetworkInterfaceMetricsRegistry,
+        vsock_resource: Option<&mut VirtioVsockReconstructionResource>,
+        vsock_metrics: SharedVsockDeviceMetrics,
+        now: Instant,
+    ) -> Result<RestoredHvfSnapshotV2VsockPciOwners, HvfSnapshotV2VsockPciRestoreError> {
+        Self::restore_snapshot_v2_vsock_pci_with_cancel(
+            state,
+            memory_input,
+            process_shell,
+            serial_input,
+            plan,
+            profiles,
+            network_metrics,
+            vsock_resource,
+            vsock_metrics,
+            now,
+            |_| false,
+        )
+    }
+
+    /// Reconstructs exact-2.12 PCI vsock ownership with stable cancellation
+    /// checkpoints.
+    #[doc(hidden)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn restore_snapshot_v2_vsock_pci_with_cancel<C>(
+        state: HvfSnapshotV2PlatformState,
+        memory_input: HvfSnapshotV2NetworkPciMemoryInput,
+        process_shell: HvfSnapshotV2RestoredSerialShell,
+        serial_input: Option<SerialStdioInput>,
+        plan: HvfSnapshotV2VsockPciPlatformPlan,
+        profiles: Vec<NetworkDeviceProfile>,
+        network_metrics: SharedNetworkInterfaceMetricsRegistry,
+        vsock_resource: Option<&mut VirtioVsockReconstructionResource>,
+        vsock_metrics: SharedVsockDeviceMetrics,
+        now: Instant,
+        mut cancelled: C,
+    ) -> Result<RestoredHvfSnapshotV2VsockPciOwners, HvfSnapshotV2VsockPciRestoreError>
+    where
+        C: FnMut(HvfSnapshotV2VsockPciRestoreStage) -> bool,
+    {
+        let interface_count = plan.network().len();
+        let HvfSnapshotV2VsockPciPlatformOwnerParts {
+            kind,
+            base,
+            vsock,
+            serial_resource_present,
+            binding_keys,
+        } = plan.into_owner_parts();
+        let input = match (vsock, vsock_resource) {
+            (None, None) => None,
+            (Some(endpoint), Some(resource)) => Some(HvfSnapshotV2VsockPciRestoreInput {
+                endpoint,
+                resource,
+                metrics: vsock_metrics,
+                fault: None,
+            }),
+            (None, Some(_)) | (Some(_), None) => {
+                return Err(HvfSnapshotV2VsockPciRestoreError::preflight(
+                    HvfSnapshotV2VsockPciRestoreStage::Product,
+                ));
+            }
+        };
+        let mut mapped_cancelled =
+            |stage| cancelled(network_pci_stage_to_vsock(stage, interface_count));
+        let owners = Self::restore_snapshot_v2_network_pci_inner(
+            state,
+            memory_input,
+            process_shell,
+            serial_input,
+            base,
+            profiles,
+            network_metrics,
+            input,
+            now,
+            &mut mapped_cancelled,
+        )
+        .map_err(|source| {
+            HvfSnapshotV2VsockPciRestoreError::from_network(source, interface_count)
+        })?;
+        if owners.vsock.is_some() != kind.has_vsock() {
+            let RestoredHvfSnapshotV2NetworkPciInnerOwners { network, vsock: _ } = owners;
+            let cleanup_failed = network.shutdown().is_err();
+            return Err(HvfSnapshotV2VsockPciRestoreError {
+                stage: HvfSnapshotV2VsockPciRestoreStage::Assembly,
+                disposition: if cleanup_failed {
+                    HvfSnapshotV2NetworkPciRestoreDisposition::TerminalCleanup
+                } else {
+                    HvfSnapshotV2NetworkPciRestoreDisposition::Terminal
+                },
+            });
+        }
+        Ok(RestoredHvfSnapshotV2VsockPciOwners {
+            base: owners.network,
+            kind,
+            serial_resource_present,
+            binding_keys,
+            vsock: owners.vsock,
+        })
     }
 
     #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
-    fn restore_snapshot_v2_network_pci_inner<C>(
+    fn restore_snapshot_v2_network_pci_inner<'a, C>(
         state: HvfSnapshotV2PlatformState,
         memory_input: HvfSnapshotV2NetworkPciMemoryInput,
         process_shell: HvfSnapshotV2RestoredSerialShell,
@@ -19539,9 +20101,10 @@ impl OwnedHvfArm64BootSession {
         plan: HvfSnapshotV2NetworkPciPlatformPlan,
         profiles: Vec<NetworkDeviceProfile>,
         network_metrics: SharedNetworkInterfaceMetricsRegistry,
+        mut vsock_input: Option<HvfSnapshotV2VsockPciRestoreInput<'a>>,
         now: Instant,
         mut cancelled: C,
-    ) -> Result<RestoredHvfSnapshotV2NetworkPciOwners, HvfSnapshotV2NetworkPciRestoreError>
+    ) -> Result<RestoredHvfSnapshotV2NetworkPciInnerOwners, HvfSnapshotV2NetworkPciRestoreError>
     where
         C: FnMut(HvfSnapshotV2NetworkPciRestoreStage) -> bool,
     {
@@ -19566,6 +20129,34 @@ impl OwnedHvfArm64BootSession {
             vmgenid_interrupt,
             vmclock_interrupt,
         } = plan.into_owner_parts();
+        let expected_vsock_state = vsock_input
+            .as_ref()
+            .map(|input| {
+                let endpoint = &input.endpoint;
+                if endpoint.state().origin() != endpoint.origin()
+                    || endpoint.state().sbdf() != endpoint.sbdf()
+                    || endpoint.state().bar_range() != endpoint.bar_range()
+                    || endpoint.state().capture().device().guest_cid()
+                        != u64::from(endpoint.config().guest_cid())
+                    || endpoint.dispatcher_region_id() != endpoint.bar_region_id()
+                    || endpoint.origin() != StorageDeviceOrigin::Startup
+                {
+                    return Err(HvfSnapshotV2NetworkPciRestoreError::preflight(
+                        HvfSnapshotV2NetworkPciRestoreStage::Product,
+                    ));
+                }
+                PreparedSnapshotV2VsockRestoreState::Pci(endpoint.state().clone())
+                    .into_destination_normalized_state(endpoint.config())
+                    .map_err(|_| {
+                        HvfSnapshotV2NetworkPciRestoreError::preflight(
+                            HvfSnapshotV2NetworkPciRestoreStage::Product,
+                        )
+                    })
+            })
+            .transpose()?;
+        let expected_vsock_placement = vsock_input
+            .as_ref()
+            .map(|input| (input.endpoint.sbdf(), input.endpoint.bar_range()));
         let HvfSnapshotV2NetworkPreparedOwnerParts {
             kind: _kind,
             memory: product_memory,
@@ -19595,6 +20186,7 @@ impl OwnedHvfArm64BootSession {
         let expected_balloon = balloon.is_some();
         let expected_entropy = entropy.is_some();
         let expected_memory_hotplug = memory_hotplug_endpoint.is_some();
+        let expected_vsock = vsock_input.is_some();
         let network_count = network_endpoints.len();
         let mut network_placements = Vec::new();
         if network_placements.try_reserve_exact(network_count).is_err() {
@@ -19653,6 +20245,23 @@ impl OwnedHvfArm64BootSession {
                 break;
             }
         }
+        if network_fault.is_none()
+            && let Some(vsock) = vsock_input.as_mut()
+        {
+            if cancelled(HvfSnapshotV2NetworkPciRestoreStage::EndpointPreparation {
+                index: network_count,
+            }) {
+                vsock.fault = Some(HvfSnapshotV2NetworkPciBatchFault::Preparation {
+                    index: network_count,
+                });
+            } else if cancelled(HvfSnapshotV2NetworkPciRestoreStage::Publication {
+                index: network_count,
+            }) {
+                vsock.fault = Some(HvfSnapshotV2NetworkPciBatchFault::Publication {
+                    index: network_count,
+                });
+            }
+        }
         let network_input = HvfSnapshotV2NetworkPciBatchInput {
             interfaces,
             endpoints: network_endpoints,
@@ -19689,7 +20298,8 @@ impl OwnedHvfArm64BootSession {
                             ));
                         }
                     }
-                    .with_network(network_input);
+                    .with_network(network_input)
+                    .with_vsock(vsock_input);
                     let restored = Self::restore_snapshot_v2_storage_pci_inner(
                         state,
                         memory,
@@ -19718,6 +20328,22 @@ impl OwnedHvfArm64BootSession {
                                 HvfSnapshotV2StoragePciRestoreStage::Publication { index: actual },
                             ) if storage_block_count.checked_add(index) == Some(actual) => {
                                 HvfSnapshotV2NetworkPciRestoreStage::Publication { index }
+                            }
+                            (
+                                _,
+                                HvfSnapshotV2StoragePciRestoreStage::FollowingEndpointPreparation,
+                            ) if expected_vsock => {
+                                HvfSnapshotV2NetworkPciRestoreStage::EndpointPreparation {
+                                    index: network_count,
+                                }
+                            }
+                            (
+                                _,
+                                HvfSnapshotV2StoragePciRestoreStage::FollowingEndpointPublication,
+                            ) if expected_vsock => {
+                                HvfSnapshotV2NetworkPciRestoreStage::Publication {
+                                    index: network_count,
+                                }
                             }
                             _ => HvfSnapshotV2NetworkPciRestoreStage::Platform,
                         };
@@ -19794,7 +20420,7 @@ impl OwnedHvfArm64BootSession {
                             }),
                         }
                     };
-                    let (network, metrics) = match publication {
+                    let (mut network, metrics) = match publication {
                         Ok(restored) => restored,
                         Err(failure) => {
                             let stage = match failure.kind {
@@ -19818,6 +20444,55 @@ impl OwnedHvfArm64BootSession {
                         }
                     };
                     session.network_interface_metrics = metrics;
+                    if let Some(vsock) = vsock_input {
+                        let publication = {
+                            let Self {
+                                backend,
+                                pci_data_devices,
+                                ..
+                            } = &mut session;
+                            let memory = backend.mapped_guest_memory();
+                            match (memory, pci_data_devices.as_mut()) {
+                                (Ok(memory), Some(manager)) => publish_snapshot_v2_vsock_pci(
+                                    manager,
+                                    memory,
+                                    vsock,
+                                    network_count,
+                                ),
+                                _ => Err(HvfSnapshotV2NetworkPciBatchFailure {
+                                    index: network_count,
+                                    kind: HvfSnapshotV2NetworkPciBatchFailureKind::Preparation,
+                                    cleanup_failed: false,
+                                }),
+                            }
+                        };
+                        match publication {
+                            Ok(vsock) => {
+                                session.vsock_device_metrics = vsock.metrics.clone();
+                                network.vsock = Some(vsock);
+                            }
+                            Err(failure) => {
+                                let stage = match failure.kind {
+                                    HvfSnapshotV2NetworkPciBatchFailureKind::Preparation => {
+                                        HvfSnapshotV2NetworkPciRestoreStage::EndpointPreparation {
+                                            index: failure.index,
+                                        }
+                                    }
+                                    HvfSnapshotV2NetworkPciBatchFailureKind::Publication => {
+                                        HvfSnapshotV2NetworkPciRestoreStage::Publication {
+                                            index: failure.index,
+                                        }
+                                    }
+                                };
+                                let cleanup_failed =
+                                    failure.cleanup_failed || session.shutdown().is_err();
+                                return Err(HvfSnapshotV2NetworkPciRestoreError::committed(
+                                    stage,
+                                    cleanup_failed,
+                                ));
+                            }
+                        }
+                    }
                     (session, None, network)
                 }
                 (None, Some(_)) | (Some(_), None) => {
@@ -19826,6 +20501,24 @@ impl OwnedHvfArm64BootSession {
                     ));
                 }
             };
+
+        let vsock_batch_matches =
+            match (network_batch.vsock.as_ref(), expected_vsock_state.as_ref()) {
+                (None, None) => true,
+                (Some(vsock), Some(expected)) => {
+                    &vsock.expected == expected
+                        && session
+                            .shared_vsock_device_metrics()
+                            .shares_state_with(&vsock.metrics)
+                }
+                (None, Some(_)) | (Some(_), None) => false,
+            };
+        if !vsock_batch_matches {
+            return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2NetworkPciRestoreStage::Assembly,
+            ));
+        }
 
         if entropy.is_some() && cancelled(HvfSnapshotV2NetworkPciRestoreStage::Entropy) {
             return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
@@ -19874,7 +20567,8 @@ impl OwnedHvfArm64BootSession {
                 HvfSnapshotV2EntropyPciPrecedingEndpointCounts::new(
                     usize::from(expected_balloon),
                     network_count,
-                ),
+                )
+                .with_vsock(expected_vsock),
             )
             .map_err(|source| {
                 HvfSnapshotV2NetworkPciRestoreError::committed(
@@ -19942,11 +20636,27 @@ impl OwnedHvfArm64BootSession {
             };
 
         let manager_matches = session.pci_data_devices.as_ref().is_some_and(|manager| {
+            let vsock_matches = match (
+                manager.vsock.as_ref(),
+                expected_vsock_placement,
+                network_batch.vsock.as_ref(),
+            ) {
+                (None, None, None) => true,
+                (Some(device), Some((sbdf, bar_range)), Some(vsock)) => {
+                    device.guest_cid == vsock.config.guest_cid()
+                        && device.uds_path.as_path() == vsock.config.uds_path()
+                        && device.published.sbdf() == Some(sbdf)
+                        && device.published.bar_range() == Some(bar_range)
+                }
+                _ => false,
+            };
             manager.endpoint_count() == endpoint_count
                 && manager.balloon.is_some() == expected_balloon
                 && manager.block.len() == storage_block_count
                 && manager.network.len() == network_count
                 && manager.pmem.len() == storage_pmem_count
+                && manager.vsock.is_some() == expected_vsock
+                && vsock_matches
                 && manager.entropy.is_some() == expected_entropy
                 && manager.memory_hotplug.is_some() == expected_memory_hotplug
                 && manager.msi_interrupts.as_ref().is_some_and(|interrupts| {
@@ -20079,6 +20789,46 @@ impl OwnedHvfArm64BootSession {
                 HvfSnapshotV2NetworkPciRestoreStage::Recapture,
             ));
         }
+        let recapture_metrics = network_batch.vsock.as_ref().map_or_else(
+            || session.shared_vsock_device_metrics(),
+            |vsock| vsock.metrics.clone(),
+        );
+        let recaptured_vsock = match session.capture_ready_vsock_state(
+            network_batch
+                .vsock
+                .as_ref()
+                .map(|vsock| vsock.config.clone()),
+            &recapture_metrics,
+            &guard,
+        ) {
+            Ok(captured) => match captured
+                .map(HvfArm64BootVsockCaptureState::try_into_snapshot_v2)
+                .transpose()
+            {
+                Ok(captured) => captured,
+                Err(_) => {
+                    drop(guard);
+                    return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                        session,
+                        HvfSnapshotV2NetworkPciRestoreStage::Recapture,
+                    ));
+                }
+            },
+            Err(_) => {
+                drop(guard);
+                return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                    session,
+                    HvfSnapshotV2NetworkPciRestoreStage::Recapture,
+                ));
+            }
+        };
+        if recaptured_vsock.as_ref() != network_batch.vsock.as_ref().map(|vsock| &vsock.expected) {
+            drop(guard);
+            return Err(HvfSnapshotV2NetworkPciRestoreError::after_session(
+                session,
+                HvfSnapshotV2NetworkPciRestoreStage::Recapture,
+            ));
+        }
         drop(guard);
 
         if cancelled(HvfSnapshotV2NetworkPciRestoreStage::Assembly) {
@@ -20087,18 +20837,28 @@ impl OwnedHvfArm64BootSession {
                 HvfSnapshotV2NetworkPciRestoreStage::Assembly,
             ));
         }
-        Ok(RestoredHvfSnapshotV2NetworkPciOwners {
-            session,
-            configs: network_batch.configs,
-            expected: network_batch.expected,
-            mmds_state,
-            mmds_config,
-            storage_configs,
-            entropy_config,
-            balloon_config,
-            memory_hotplug_state,
-            memory_hotplug_controller,
-            retry_publication_gate: Some(retry_publication_gate),
+        let RestoredHvfSnapshotV2NetworkPciBatch {
+            configs,
+            expected,
+            capture_configs: _,
+            earliest_retry_deadline: _,
+            vsock,
+        } = network_batch;
+        Ok(RestoredHvfSnapshotV2NetworkPciInnerOwners {
+            network: RestoredHvfSnapshotV2NetworkPciOwners {
+                session,
+                configs,
+                expected,
+                mmds_state,
+                mmds_config,
+                storage_configs,
+                entropy_config,
+                balloon_config,
+                memory_hotplug_state,
+                memory_hotplug_controller,
+                retry_publication_gate: Some(retry_publication_gate),
+            },
+            vsock,
         })
     }
 
@@ -22900,6 +23660,7 @@ impl OwnedHvfArm64BootSession {
         let Some(preceding_storage_count) = preceding_endpoint_count
             .checked_sub(preceding.balloon)
             .and_then(|count| count.checked_sub(preceding.network))
+            .and_then(|count| count.checked_sub(preceding.vsock))
         else {
             return Err(HvfSnapshotV2EntropyPciRestoreError::after_platform(
                 session,
@@ -22916,7 +23677,8 @@ impl OwnedHvfArm64BootSession {
                     && manager.network.len() == preceding.network
                     && manager.balloon.is_some() == (preceding.balloon == 1)
                     && preceding.balloon <= 1
-                    && manager.vsock.is_none()
+                    && manager.vsock.is_some() == (preceding.vsock == 1)
+                    && preceding.vsock <= 1
                     && manager.memory_hotplug.is_none()
                     && manager.endpoint_count() == preceding_endpoint_count
                     && manager.block.len().saturating_add(manager.pmem.len())
@@ -24630,14 +25392,18 @@ impl OwnedHvfArm64BootSession {
         serial_input: Option<SerialStdioInput>,
         bundle: PreparedSnapshotV2StorageBundle,
         plan: HvfSnapshotV2StoragePciPlatformPlan,
-        publication: HvfSnapshotV2StoragePciPublicationInput,
+        publication: HvfSnapshotV2StoragePciPublicationInput<'_>,
     ) -> Result<RestoredHvfSnapshotV2StoragePciOwners, HvfSnapshotV2StoragePciRestoreError> {
         let HvfSnapshotV2StoragePciPublicationInput {
             balloon: balloon_publication,
             network: mut network_publication,
+            vsock: mut vsock_publication,
             pmem_fault_index: publication_fault_pmem_index,
             balloon_fault,
         } = publication;
+        let following_vsock_index = network_publication
+            .as_ref()
+            .map_or(0, |network| network.interfaces.len());
         if balloon_publication.is_none() && balloon_fault.is_some()
             || balloon_fault.is_some_and(|fault| {
                 !matches!(
@@ -25785,6 +26551,53 @@ impl OwnedHvfArm64BootSession {
             });
         }
 
+        if let Some(vsock) = vsock_publication.take() {
+            let memory = match platform.guest_memory() {
+                Ok(memory) => memory,
+                Err(_) => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::ResourcePlan,
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                ),
+            };
+            let manager = match pci_data_devices.as_mut() {
+                Some(manager) => manager,
+                None => fail_after_platform!(
+                    HvfSnapshotV2StoragePciRestoreStage::PciHost,
+                    HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                ),
+            };
+            match publish_snapshot_v2_vsock_pci(manager, memory, vsock, following_vsock_index) {
+                Ok(vsock) => match restored_network.as_mut() {
+                    Some(network) if network.vsock.is_none() => network.vsock = Some(vsock),
+                    _ => fail_after_platform!(
+                        HvfSnapshotV2StoragePciRestoreStage::ResourcePlan,
+                        HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                    ),
+                },
+                Err(failure) => {
+                    if failure.cleanup_failed {
+                        cleanup.push(HvfSnapshotV2StoragePciRestoreCleanupFailure::Pci(
+                            HvfArm64BootPciDataError::new(
+                                "exact-2.12 PCI vsock cleanup was incomplete",
+                            ),
+                        ));
+                    }
+                    let stage = match failure.kind {
+                        HvfSnapshotV2NetworkPciBatchFailureKind::Preparation => {
+                            HvfSnapshotV2StoragePciRestoreStage::FollowingEndpointPreparation
+                        }
+                        HvfSnapshotV2NetworkPciBatchFailureKind::Publication => {
+                            HvfSnapshotV2StoragePciRestoreStage::FollowingEndpointPublication
+                        }
+                    };
+                    fail_after_platform!(
+                        stage,
+                        HvfSnapshotV2StoragePciRestoreFailure::ResourcePlan
+                    );
+                }
+            }
+        }
+
         release_unpublished_snapshot_v2_balloon_pci_publication(
             &mut prepared_balloon_publication,
             &mut cleanup,
@@ -25852,6 +26665,12 @@ impl OwnedHvfArm64BootSession {
         };
         let network_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
         let entropy_retry_wakeup = HvfArm64BootLimiterRetryWakeupToken::default();
+        let vsock_device_metrics = restored_network
+            .as_ref()
+            .and_then(|network| network.vsock.as_ref())
+            .map_or_else(SharedVsockDeviceMetrics::default, |vsock| {
+                vsock.metrics.clone()
+            });
         let session = Self {
             runner: parts.runner,
             backend: parts.backend,
@@ -25882,7 +26701,7 @@ impl OwnedHvfArm64BootSession {
             balloon_device_metrics: SharedBalloonDeviceMetrics::default(),
             memory_hotplug_device_metrics: None,
             network_interface_metrics: restored_network_metrics.unwrap_or_default(),
-            vsock_device_metrics: SharedVsockDeviceMetrics::default(),
+            vsock_device_metrics,
             entropy_device_metrics: SharedEntropyDeviceMetrics::default(),
             gic,
             block_interrupt_lines: Vec::new(),

--- a/crates/hvf/tests/hvf_lifecycle.rs
+++ b/crates/hvf/tests/hvf_lifecycle.rs
@@ -11462,7 +11462,9 @@ fn notify_vsock_capture_event_queue(
     pci: bool,
 ) {
     use bangbang_runtime::virtio_mmio::VirtioMmioRegister;
-    use bangbang_runtime::virtio_pci::VIRTIO_PCI_NOTIFICATION_OFFSET;
+    use bangbang_runtime::virtio_pci::{
+        VIRTIO_PCI_NOTIFICATION_MULTIPLIER, VIRTIO_PCI_NOTIFICATION_OFFSET,
+    };
     use bangbang_runtime::vsock::VIRTIO_VSOCK_EVENT_QUEUE_INDEX;
 
     let dispatcher = session.mmio_dispatcher();
@@ -11471,7 +11473,14 @@ fn notify_vsock_capture_event_queue(
         .expect("signed vsock MMIO dispatcher should not be poisoned");
     let (offset, bytes) = if pci {
         (
-            VIRTIO_PCI_NOTIFICATION_OFFSET,
+            VIRTIO_PCI_NOTIFICATION_OFFSET
+                .checked_add(
+                    u64::try_from(VIRTIO_VSOCK_EVENT_QUEUE_INDEX)
+                        .unwrap()
+                        .checked_mul(u64::from(VIRTIO_PCI_NOTIFICATION_MULTIPLIER))
+                        .unwrap(),
+                )
+                .unwrap(),
             u16::try_from(VIRTIO_VSOCK_EVENT_QUEUE_INDEX)
                 .unwrap()
                 .to_le_bytes()
@@ -11759,6 +11768,361 @@ fn capture_ready_vsock_resets_signed_mmio_and_pci_owners() {
         .expect("signed PCI vsock session should shut down");
     drop(pci_session);
     assert!(!socket_path.exists());
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn restores_signed_active_exact_2_12_pci_vsock_owner_graph() {
+    use std::io::Cursor;
+    use std::os::unix::net::{UnixListener, UnixStream};
+
+    use bangbang_hvf::{
+        HvfArm64BootSerialDeviceConfig, HvfArm64BootSessionConfig,
+        HvfArm64BootSnapshotV2CaptureInput, HvfArm64BootVsockTransportState,
+        HvfSnapshotV2BootState, HvfSnapshotV2NativePath, HvfSnapshotV2NetworkPciMemoryInput,
+        HvfSnapshotV2RestoredSerialShell, HvfSnapshotV2VsockPreparedEndpoint,
+        HvfSnapshotV2VsockPreparedMemory, HvfSnapshotV2VsockPreparedProduct,
+        HvfSnapshotV2VsockPreparedProductParts, HvfSnapshotV2VsockProductKind,
+        HvfSnapshotV2VsockState, OwnedHvfArm64BootSession, encode_hvf_snapshot_v2_vsock_state,
+        prepare_hvf_snapshot_v2_vsock_pci_platform_plan,
+    };
+    use bangbang_runtime::VmmAction;
+    use bangbang_runtime::block::BlockMmioLayout;
+    use bangbang_runtime::boot::BootSourceConfigInput;
+    use bangbang_runtime::machine::MachineConfigInput;
+    use bangbang_runtime::memory::GuestAddress;
+    use bangbang_runtime::metrics::{
+        SharedNetworkInterfaceMetricsRegistry, SharedVsockDeviceMetrics,
+    };
+    use bangbang_runtime::mmio::MmioRegionId;
+    use bangbang_runtime::network::NetworkMmioLayout;
+    use bangbang_runtime::pmem::PmemMmioLayout;
+    use bangbang_runtime::serial::{
+        SerialMmioDevice, SharedSerialOutput, SharedSerialOutputBuffer,
+    };
+    use bangbang_runtime::snapshot::SnapshotVsockOverride;
+    use bangbang_runtime::snapshot_device_v2::{
+        SnapshotV2DeviceTransport, SnapshotV2DeviceTransportKind,
+    };
+    use bangbang_runtime::snapshot_format_v2::decode_snapshot_v2_state_with_compatibility_version;
+    use bangbang_runtime::snapshot_memory_v2::load_snapshot_v2_memory_file;
+    use bangbang_runtime::snapshot_network_restore_v2_11::PreparedSnapshotV2NetworkRestoreTopology;
+    use bangbang_runtime::snapshot_restore::NATIVE_V2_VSOCK_RESTORE_PUBLIC_ID;
+    use bangbang_runtime::snapshot_serial_v2_7::SnapshotV2SerialState;
+    use bangbang_runtime::snapshot_vsock_restore_v2_12::PreparedSnapshotV2VsockRestoreTopology;
+    use bangbang_runtime::snapshot_vsock_v2_12::NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION;
+    use bangbang_runtime::vsock::{
+        SuppliedVsockListener, VirtioVsockReconstructionResource, VsockBackendSelector,
+        VsockConfigInput, VsockGuestConnector, VsockMmioLayout,
+    };
+
+    // Direct listener creation is unavailable in the App Sandbox lifecycle
+    // replay. Supplied-listener containment is covered by the signed process
+    // transaction test in the same integration wrapper.
+    if is_app_sandbox_hvf_lifecycle_replay() {
+        return;
+    }
+
+    #[derive(Debug)]
+    struct RejectingGuestConnector;
+
+    impl VsockGuestConnector for RejectingGuestConnector {
+        fn connect(&mut self, _host_port: u32) -> std::io::Result<UnixStream> {
+            Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+        }
+    }
+
+    let _test_lock = HVF_LIFECYCLE_TEST_LOCK
+        .lock()
+        .expect("HVF lifecycle test lock should not be poisoned");
+    let image = arm64_image().expect("test arm64 image should build");
+    let kernel = TempFile::new("restore-vsock-pci-kernel", &image)
+        .expect("vsock restore kernel should create");
+    let socket_id = NEXT_HVF_TEST_FILE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let source_socket = std::env::temp_dir().join(format!(
+        "bb-vsock-source-{}-{socket_id}.sock",
+        std::process::id()
+    ));
+    let destination_socket = std::env::temp_dir().join(format!(
+        "bb-vsock-destination-{}-{socket_id}.sock",
+        std::process::id()
+    ));
+    let mut controller = bangbang_runtime::VmmController::new("test", "0.1.0", "bangbang");
+    controller
+        .handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            kernel.path(),
+        )))
+        .expect("vsock restore boot source should configure");
+    controller
+        .handle_action(VmmAction::PutMachineConfig(
+            MachineConfigInput::new(1, 128).with_track_dirty_pages(true),
+        ))
+        .expect("vsock restore machine should configure");
+    controller
+        .handle_action(VmmAction::PutVsock(VsockConfigInput::new(
+            42,
+            path_text(&source_socket),
+        )))
+        .expect("vsock restore source should configure");
+    let source_config = controller
+        .vsock_config()
+        .cloned()
+        .expect("vsock restore source config should exist");
+    let session_config = HvfArm64BootSessionConfig::new(
+        BlockMmioLayout::new(GuestAddress::new(0x5000_0000), MmioRegionId::new(1)),
+        PmemMmioLayout::new(GuestAddress::new(0x5800_0000), MmioRegionId::new(500)),
+        NetworkMmioLayout::new(GuestAddress::new(0x6000_0000), MmioRegionId::new(1000)),
+        VsockMmioLayout::new(GuestAddress::new(0x7000_0000), MmioRegionId::new(2000)),
+        bangbang_runtime::rtc::RtcMmioLayout::new(
+            GuestAddress::new(0x4000_1000),
+            MmioRegionId::new(10),
+        ),
+    )
+    .with_serial_device(HvfArm64BootSerialDeviceConfig::new(
+        MmioRegionId::new(20),
+        GuestAddress::new(0x4000_2000),
+        SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+    ))
+    .with_pci_enabled();
+    let mut source = OwnedHvfArm64BootSession::new(&controller, session_config)
+        .expect("signed active PCI vsock source should prepare");
+    let source_metrics = source.shared_vsock_device_metrics();
+    let idle_guard = source
+        .quiesce_limiter_retry_wakeups()
+        .expect("PCI vsock source publishers should quiesce");
+    let idle = source
+        .capture_ready_vsock_state(Some(source_config.clone()), &source_metrics, &idle_guard)
+        .expect("inactive PCI vsock source should capture")
+        .expect("configured PCI vsock source should exist");
+    let HvfArm64BootVsockTransportState::Pci { bar_range, .. } = idle.transport() else {
+        panic!("vsock source should use PCI");
+    };
+    let transport_base = bar_range.start();
+    drop(idle_guard);
+    activate_vsock_capture_queues(&mut source, transport_base, true);
+    {
+        let dispatcher = source.mmio_dispatcher();
+        let mut dispatcher = dispatcher
+            .lock()
+            .expect("signed PCI vsock dispatcher should not be poisoned");
+        write_vsock_capture_mmio(
+            &mut dispatcher,
+            transport_base.checked_add(0x10).unwrap(),
+            &3_u16.to_le_bytes(),
+        );
+        for (queue_index, vector) in [(0_u16, 0_u16), (1, 1), (2, 2)] {
+            write_vsock_capture_mmio(
+                &mut dispatcher,
+                transport_base.checked_add(0x16).unwrap(),
+                &queue_index.to_le_bytes(),
+            );
+            write_vsock_capture_mmio(
+                &mut dispatcher,
+                transport_base.checked_add(0x1a).unwrap(),
+                &vector.to_le_bytes(),
+            );
+        }
+    }
+
+    let active_guard = source
+        .quiesce_limiter_retry_wakeups()
+        .expect("active PCI vsock source publishers should quiesce");
+    let captured_vsock = source
+        .capture_ready_vsock_state(Some(source_config.clone()), &source_metrics, &active_guard)
+        .expect("active PCI vsock source should capture")
+        .expect("configured active PCI vsock source should exist")
+        .try_into_snapshot_v2()
+        .expect("active PCI vsock source should convert");
+    assert!(captured_vsock.active_queues().is_some());
+    assert!(matches!(
+        captured_vsock.transport(),
+        SnapshotV2DeviceTransport::Pci(_)
+    ));
+    let serial = SnapshotV2SerialState::try_from_capture_ready(
+        source
+            .capture_ready_serial_state(controller.serial_config().clone(), &active_guard)
+            .expect("vsock product serial should capture"),
+    )
+    .expect("vsock product serial should convert");
+    drop(active_guard);
+
+    source
+        .pause_for_snapshot_v2_capture()
+        .expect("active PCI vsock source should pause");
+    let boot = HvfSnapshotV2BootState::try_new(
+        HvfSnapshotV2NativePath::try_new(kernel.path().as_os_str())
+            .expect("vsock restore kernel path should validate"),
+        None,
+        None,
+    )
+    .expect("vsock restore boot metadata should validate");
+    let mut memory_writer = Cursor::new(Vec::new());
+    let platform = source
+        .capture_snapshot_v2_vsock_platform_with_cancel(
+            HvfArm64BootSnapshotV2CaptureInput::new(boot),
+            None,
+            &mut memory_writer,
+            |_| false,
+        )
+        .expect("active PCI vsock platform should capture");
+    let encoded = encode_hvf_snapshot_v2_vsock_state(
+        &HvfSnapshotV2VsockState::try_new(
+            platform.clone(),
+            None,
+            serial.clone(),
+            None,
+            None,
+            None,
+            Some(captured_vsock.clone()),
+        )
+        .expect("active PCI vsock product should compose"),
+    )
+    .expect("active PCI vsock product should encode");
+    let structural = decode_snapshot_v2_state_with_compatibility_version(
+        &encoded,
+        NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
+    )
+    .expect("active PCI vsock product should decode structurally");
+    let memory_image = TempFile::new("restore-vsock-pci-memory", memory_writer.get_ref())
+        .expect("active PCI vsock memory should persist");
+    let platform_state = platform.platform().clone();
+    source
+        .shutdown()
+        .expect("active PCI vsock source should shut down");
+    drop(source);
+    assert!(!source_socket.exists());
+
+    let destination_memory = load_snapshot_v2_memory_file(
+        &structural,
+        std::fs::File::open(memory_image.path()).expect("active PCI vsock memory should reopen"),
+    )
+    .expect("active PCI vsock memory should map privately");
+    let topology = PreparedSnapshotV2VsockRestoreTopology::prepare(
+        captured_vsock,
+        Some(&SnapshotVsockOverride::new(&destination_socket)),
+        SnapshotV2DeviceTransportKind::Pci,
+        &destination_memory,
+    )
+    .expect("active PCI vsock destination should prepare");
+    let (request, state) = topology.into_parts();
+    let (resource_key, selectors, destination_config, overridden) = request.into_parts();
+    assert_eq!(
+        resource_key.public_id().as_str(),
+        NATIVE_V2_VSOCK_RESTORE_PUBLIC_ID
+    );
+    assert!(overridden);
+    let expected = state
+        .clone()
+        .into_destination_normalized_state(&destination_config)
+        .expect("active PCI vsock expected state should normalize");
+    let product =
+        HvfSnapshotV2VsockPreparedProduct::try_from_parts(HvfSnapshotV2VsockPreparedProductParts {
+            kind: HvfSnapshotV2VsockProductKind::from_presence(
+                false, false, false, false, false, true,
+            ),
+            memory: HvfSnapshotV2VsockPreparedMemory::Static(platform_state.memory().clone()),
+            storage: None,
+            entropy: None,
+            balloon: None,
+            network: PreparedSnapshotV2NetworkRestoreTopology::empty(
+                SnapshotV2DeviceTransportKind::Pci,
+            ),
+            vsock: Some(HvfSnapshotV2VsockPreparedEndpoint::new(
+                state,
+                destination_config.clone(),
+            )),
+            serial_resource_present: false,
+            binding_keys: vec![resource_key],
+        })
+        .expect("active PCI vsock prepared product should validate");
+    let plan = prepare_hvf_snapshot_v2_vsock_pci_platform_plan(&platform_state, product)
+        .unwrap_or_else(|error| {
+            panic!(
+                "active PCI vsock platform plan should prepare: {error:?}; source={:?}",
+                std::error::Error::source(&error)
+            )
+        });
+    let listener = UnixListener::bind(&destination_socket)
+        .expect("active PCI vsock destination listener should bind");
+    let mut resource = VirtioVsockReconstructionResource::with_destination_selector(
+        selectors.captured().clone(),
+        VsockBackendSelector::try_from_path(&destination_socket)
+            .expect("active PCI vsock destination selector should validate"),
+        SuppliedVsockListener::new(listener).with_guest_connector(RejectingGuestConnector),
+    );
+    let destination_metrics = SharedVsockDeviceMetrics::default();
+    let shell = HvfSnapshotV2RestoredSerialShell::new(
+        SerialMmioDevice::from_capture_state_with_shared_output(
+            SharedSerialOutput::from(SharedSerialOutputBuffer::default()),
+            serial.device().clone(),
+        ),
+    );
+    let mut owners = OwnedHvfArm64BootSession::restore_snapshot_v2_vsock_pci_with_cancel(
+        platform_state,
+        HvfSnapshotV2NetworkPciMemoryInput::Static(destination_memory),
+        shell,
+        None,
+        plan,
+        Vec::new(),
+        SharedNetworkInterfaceMetricsRegistry::default(),
+        Some(&mut resource),
+        destination_metrics.clone(),
+        std::time::Instant::now(),
+        |_| false,
+    )
+    .unwrap_or_else(|error| {
+        panic!(
+            "active exact-2.12 PCI vsock owner graph should restore at {:?}: {error:?}",
+            error.stage()
+        )
+    });
+
+    assert!(resource.is_consumed());
+    assert!(!owners.retry_publication_is_committed());
+    assert!(owners.configs().is_empty());
+    assert_eq!(owners.expected_vsock(), Some(&expected));
+    assert_eq!(owners.vsock_config(), Some(&destination_config));
+    assert!(owners.resource_keys().len() == 1);
+    assert!(
+        owners
+            .vsock_metrics()
+            .is_some_and(|metrics| metrics.shares_state_with(&destination_metrics))
+    );
+    assert!(!source_metrics.shares_state_with(&destination_metrics));
+    let destination_metric_snapshot = destination_metrics.snapshot();
+    assert!(
+        destination_metric_snapshot.is_empty(),
+        "fresh destination metrics should be empty: {destination_metric_snapshot:?}"
+    );
+    let guard = owners
+        .session()
+        .quiesce_limiter_retry_wakeups()
+        .expect("restored PCI vsock publishers should quiesce");
+    let recaptured = owners
+        .session_mut()
+        .capture_ready_vsock_state(
+            Some(destination_config.clone()),
+            &destination_metrics,
+            &guard,
+        )
+        .expect("restored active PCI vsock should recapture")
+        .expect("restored active PCI vsock should remain present")
+        .try_into_snapshot_v2()
+        .expect("restored active PCI vsock should convert");
+    drop(guard);
+    assert_eq!(recaptured, expected);
+    let diagnostics = format!("{owners:?}");
+    assert!(diagnostics.contains("<redacted>"));
+    assert!(!diagnostics.contains(destination_socket.to_string_lossy().as_ref()));
+
+    let owners = owners.commit_retry_publication();
+    assert!(owners.retry_publication_is_committed());
+    owners
+        .shutdown()
+        .expect("restored active PCI vsock owner graph should shut down");
+    assert!(destination_socket.exists());
+    std::fs::remove_file(&destination_socket)
+        .expect("restored active PCI vsock socket should unlink after shutdown");
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]

--- a/crates/runtime/src/snapshot_vsock_restore_v2_12.rs
+++ b/crates/runtime/src/snapshot_vsock_restore_v2_12.rs
@@ -7,10 +7,12 @@
 //! route, VM, vCPU, or platform authority.
 
 use std::fmt;
+use std::path::{Path, PathBuf};
 
 use crate::interrupt::GuestInterruptLine;
 use crate::memory::{GuestMemory, GuestMemoryRange};
-use crate::mmio::MmioRegion;
+use crate::message_interrupt::GuestMessageInterruptRegistry;
+use crate::mmio::{MmioRegion, MmioRegionId};
 use crate::pci::PciSbdf;
 use crate::snapshot::{
     SnapshotVsockOverride, SnapshotVsockSelectorError, SnapshotVsockSelectors,
@@ -30,11 +32,15 @@ use crate::snapshot_vsock_v2_12::{
 };
 use crate::storage_capture::StorageDeviceOrigin;
 use crate::virtio::{VirtioDeviceType, VirtioDeviceTypeError};
-use crate::virtio_pci::{VirtioPciEndpointError, VirtioPciIdentity, VirtioPciTransportState};
+use crate::virtio_pci::{
+    PreparedVirtioPciEndpoint, VirtioPciEndpointError, VirtioPciIdentity, VirtioPciTransportState,
+};
 use crate::vsock::{
-    VIRTIO_VSOCK_DEVICE_ID, VirtioVsockActiveQueuesCaptureState, VirtioVsockDeviceCaptureError,
+    VIRTIO_VSOCK_DEVICE_ID, VIRTIO_VSOCK_QUEUE_SIZES, VirtioVsockActiveQueuesCaptureState,
+    VirtioVsockConfigSpace, VirtioVsockDevice, VirtioVsockDeviceCaptureError,
     VirtioVsockDeviceCaptureState, VirtioVsockMmioCaptureState, VirtioVsockPciCaptureState,
-    VirtioVsockQueueCaptureState, VsockConfig, VsockConfigInput,
+    VirtioVsockQueueCaptureState, VirtioVsockReconstructionError,
+    VirtioVsockReconstructionResource, VsockConfig, VsockConfigInput,
 };
 
 const REDACTED: &str = "<redacted>";
@@ -190,6 +196,77 @@ impl PreparedSnapshotV2VsockPciState {
     ) {
         (self.origin, self.sbdf, self.bar_range, self.capture)
     }
+
+    /// Consumes checked PCI state into one complete retained endpoint.
+    ///
+    /// The caller supplies the destination endpoint resource, fixed dispatcher
+    /// region, and fresh message registry. Function, BAR, dispatcher,
+    /// interrupt-resource, run-loop, session, and VM ownership remain outside
+    /// this value.
+    #[doc(hidden)]
+    pub fn into_pci_endpoint(
+        self,
+        config: &VsockConfig,
+        destination_memory: &GuestMemory,
+        resource: &mut VirtioVsockReconstructionResource,
+        region_id: MmioRegionId,
+        messages: GuestMessageInterruptRegistry,
+    ) -> Result<PreparedSnapshotV2VsockPciEndpoint, SnapshotV2VsockPciEndpointError> {
+        if resource.captured_selector() != self.capture.device().backend_selector()
+            || resource.destination_selector().path() != config.uds_path()
+            || self.capture.device().guest_cid() != u64::from(config.guest_cid())
+        {
+            return Err(SnapshotV2VsockPciEndpointError::ResourceIdentity);
+        }
+        let expected = PreparedSnapshotV2VsockRestoreState::Pci(self.clone())
+            .into_destination_normalized_state(config)
+            .map_err(|_| SnapshotV2VsockPciEndpointError::ExpectedState)?;
+        let Self {
+            origin,
+            sbdf,
+            bar_range,
+            capture,
+        } = self;
+        let retained = capture.transport().clone();
+        let prepared = capture
+            .reconstruct_snapshot_device(destination_memory, resource)
+            .map_err(SnapshotV2VsockPciEndpointError::Device)?;
+        let activation_is_active = prepared.device().is_activated();
+        let (guest_cid, uds_path, config_space, device) = prepared.into_parts();
+        let device_type = VirtioDeviceType::new(VIRTIO_VSOCK_DEVICE_ID)
+            .map_err(SnapshotV2VsockPciEndpointError::DeviceType)?;
+        let identity = VirtioPciIdentity::new(device_type, config_space.available_features())
+            .with_config_generation(retained.device_registers().config_generation());
+        let endpoint = PreparedVirtioPciEndpoint::new(
+            identity,
+            &VIRTIO_VSOCK_QUEUE_SIZES,
+            config_space,
+            device,
+            activation_is_active,
+            false,
+            &retained,
+            sbdf,
+            bar_range,
+            region_id,
+            messages,
+        )
+        .map_err(SnapshotV2VsockPciEndpointError::Endpoint)?;
+        let recaptured = endpoint
+            .endpoint()
+            .transport_state()
+            .map_err(SnapshotV2VsockPciEndpointError::Endpoint)?;
+        if recaptured != retained {
+            return Err(SnapshotV2VsockPciEndpointError::StateMismatch);
+        }
+
+        Ok(PreparedSnapshotV2VsockPciEndpoint {
+            guest_cid,
+            uds_path,
+            expected,
+            origin,
+            endpoint,
+        })
+    }
 }
 
 impl fmt::Debug for PreparedSnapshotV2VsockPciState {
@@ -198,6 +275,110 @@ impl fmt::Debug for PreparedSnapshotV2VsockPciState {
             .debug_struct("PreparedSnapshotV2VsockPciState")
             .field("state", &REDACTED)
             .finish()
+    }
+}
+
+/// One checked exact-2.12 vsock endpoint awaiting PCI publication.
+#[doc(hidden)]
+pub struct PreparedSnapshotV2VsockPciEndpoint {
+    guest_cid: u32,
+    uds_path: PathBuf,
+    expected: SnapshotV2VsockState,
+    origin: StorageDeviceOrigin,
+    endpoint: PreparedVirtioPciEndpoint<VirtioVsockConfigSpace, VirtioVsockDevice>,
+}
+
+/// Consumed exact-2.12 vsock continuation and retained PCI endpoint.
+#[doc(hidden)]
+pub type PreparedSnapshotV2VsockPciEndpointParts = (
+    u32,
+    PathBuf,
+    SnapshotV2VsockState,
+    StorageDeviceOrigin,
+    PreparedVirtioPciEndpoint<VirtioVsockConfigSpace, VirtioVsockDevice>,
+);
+
+impl PreparedSnapshotV2VsockPciEndpoint {
+    pub const fn guest_cid(&self) -> u32 {
+        self.guest_cid
+    }
+
+    pub fn uds_path(&self) -> &Path {
+        &self.uds_path
+    }
+
+    pub const fn expected_state(&self) -> &SnapshotV2VsockState {
+        &self.expected
+    }
+
+    pub const fn origin(&self) -> StorageDeviceOrigin {
+        self.origin
+    }
+
+    pub const fn endpoint(
+        &self,
+    ) -> &PreparedVirtioPciEndpoint<VirtioVsockConfigSpace, VirtioVsockDevice> {
+        &self.endpoint
+    }
+
+    pub fn into_parts(self) -> PreparedSnapshotV2VsockPciEndpointParts {
+        (
+            self.guest_cid,
+            self.uds_path,
+            self.expected,
+            self.origin,
+            self.endpoint,
+        )
+    }
+}
+
+impl fmt::Debug for PreparedSnapshotV2VsockPciEndpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedSnapshotV2VsockPciEndpoint")
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Redacted failure while materializing one checked vsock PCI endpoint.
+#[doc(hidden)]
+pub enum SnapshotV2VsockPciEndpointError {
+    ResourceIdentity,
+    ExpectedState,
+    Device(VirtioVsockReconstructionError),
+    DeviceType(VirtioDeviceTypeError),
+    Endpoint(VirtioPciEndpointError),
+    StateMismatch,
+}
+
+impl fmt::Debug for SnapshotV2VsockPciEndpointError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+impl fmt::Display for SnapshotV2VsockPciEndpointError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::ResourceIdentity => "native-v2 vsock PCI resource identity is invalid",
+            Self::ExpectedState => "native-v2 vsock PCI destination state is invalid",
+            Self::Device(_) => "native-v2 vsock PCI device reconstruction failed",
+            Self::DeviceType(_) => "native-v2 vsock PCI device type is invalid",
+            Self::Endpoint(_) => "native-v2 vsock PCI endpoint construction failed",
+            Self::StateMismatch => "native-v2 vsock PCI endpoint state does not match",
+        })
+    }
+}
+
+impl std::error::Error for SnapshotV2VsockPciEndpointError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Device(source) => Some(source),
+            Self::DeviceType(source) => Some(source),
+            Self::Endpoint(source) => Some(source),
+            Self::ResourceIdentity | Self::ExpectedState | Self::StateMismatch => None,
+        }
     }
 }
 

--- a/crates/runtime/src/snapshot_vsock_restore_v2_12/tests.rs
+++ b/crates/runtime/src/snapshot_vsock_restore_v2_12/tests.rs
@@ -1,15 +1,99 @@
 use std::cell::Cell;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::memory::{GuestAddress, GuestMemoryLayout};
+use crate::message_interrupt::{
+    GuestMessage, GuestMessageInterrupt, GuestMessageInterruptRegistry,
+    GuestMessageInterruptSignalError,
+};
+use crate::mmio::MmioRegionId;
 use crate::snapshot::SnapshotVsockSelectorError;
+use crate::snapshot_device_v2::SnapshotV2DeviceTransport;
 use crate::snapshot_device_v2::snapshot_v2_device_key_for_test;
 use crate::snapshot_restore::{SnapshotRestorePublicId, SnapshotRestoreResourceClass};
 use crate::snapshot_vsock_v2_12::NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION;
+use crate::vsock::{
+    SuppliedVsockListener, VirtioVsockReconstructionResource, VsockBackendSelector,
+    VsockGuestConnector,
+};
 
 use super::*;
 
 const INACTIVE_MMIO_HEX: &str = include_str!("../snapshot_vsock_v2_12/fixtures/inactive-mmio.hex");
 const ACTIVE_PCI_HEX: &str = include_str!("../snapshot_vsock_v2_12/fixtures/active-pci.hex");
+static NEXT_LISTENER_ID: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug)]
+struct RejectingGuestConnector;
+
+impl VsockGuestConnector for RejectingGuestConnector {
+    fn connect(&mut self, _host_port: u32) -> std::io::Result<UnixStream> {
+        Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+    }
+}
+
+#[derive(Debug)]
+struct TestMessageRoute(GuestMessage);
+
+impl GuestMessageInterrupt for TestMessageRoute {
+    fn matches(&self, message: GuestMessage) -> bool {
+        self.0 == message
+    }
+
+    fn signal(&self, message: GuestMessage) -> Result<(), GuestMessageInterruptSignalError> {
+        if self.matches(message) {
+            Ok(())
+        } else {
+            Err(GuestMessageInterruptSignalError::new(
+                "test route rejected an unknown message",
+                false,
+            ))
+        }
+    }
+}
+
+fn vsock_message_registry(state: &SnapshotV2VsockState) -> GuestMessageInterruptRegistry {
+    let SnapshotV2DeviceTransport::Pci(pci) = state.transport() else {
+        panic!("test vsock should use PCI");
+    };
+    let routes: Vec<Arc<dyn GuestMessageInterrupt>> = pci
+        .msix()
+        .entries()
+        .iter()
+        .map(|entry| {
+            let address = (u64::from(entry.message_address_high()) << 32)
+                | u64::from(entry.message_address_low());
+            Arc::new(TestMessageRoute(GuestMessage::new(
+                address,
+                entry.message_data(),
+            ))) as Arc<dyn GuestMessageInterrupt>
+        })
+        .collect();
+    GuestMessageInterruptRegistry::new(routes)
+        .expect("vsock message registry should contain every retained vector")
+}
+
+fn supplied_vsock_resource(
+    captured: VsockBackendSelector,
+    destination: VsockBackendSelector,
+) -> VirtioVsockReconstructionResource {
+    let listener_path = std::path::Path::new("/tmp").join(format!(
+        "bb-vsock-{}-{}.sock",
+        std::process::id(),
+        NEXT_LISTENER_ID.fetch_add(1, Ordering::Relaxed)
+    ));
+    let listener = UnixListener::bind(&listener_path)
+        .expect("test reconstruction listener should bind before handoff");
+    std::fs::remove_file(&listener_path)
+        .expect("test reconstruction listener should unlink after bind");
+    VirtioVsockReconstructionResource::with_destination_selector(
+        captured,
+        destination,
+        SuppliedVsockListener::new(listener).with_guest_connector(RejectingGuestConnector),
+    )
+}
 
 fn decode_hex(value: &str) -> Vec<u8> {
     let value = value.split_whitespace().collect::<String>();
@@ -183,6 +267,114 @@ fn explicit_override_changes_only_destination_intent() {
     let debug = format!("{topology:?} {:?}", topology.request());
     assert!(!debug.contains(destination));
     assert!(!debug.contains(captured.to_string_lossy().as_ref()));
+}
+
+#[test]
+fn active_pci_state_materializes_one_exact_destination_endpoint() {
+    let portable = state(ACTIVE_PCI_HEX);
+    let memory = memory_for(&portable);
+    let destination = std::path::Path::new("/tmp").join(format!(
+        "bangbang-vsock-restored-pci-{}.sock",
+        std::process::id()
+    ));
+    let requested = SnapshotVsockOverride::new(&destination);
+    let topology = PreparedSnapshotV2VsockRestoreTopology::prepare(
+        portable.clone(),
+        Some(&requested),
+        SnapshotV2DeviceTransportKind::Pci,
+        &memory,
+    )
+    .expect("active PCI topology should prepare");
+    let expected = topology
+        .state()
+        .clone()
+        .into_destination_normalized_state(topology.request().config())
+        .expect("checked PCI state should normalize to the destination");
+    let config = topology.request().config().clone();
+    let captured_selector = portable.backend_selector().clone();
+    let destination_selector = VsockBackendSelector::try_from_path(&destination)
+        .expect("destination selector should validate");
+    let messages = vsock_message_registry(&portable);
+    let (_, prepared) = topology.into_parts();
+    let PreparedSnapshotV2VsockRestoreState::Pci(prepared) = prepared else {
+        panic!("prepared state should retain PCI transport");
+    };
+    let origin = prepared.origin();
+    let sbdf = prepared.sbdf();
+    let bar_range = prepared.bar_range();
+    let mut resource = supplied_vsock_resource(captured_selector, destination_selector);
+    let endpoint = prepared
+        .into_pci_endpoint(
+            &config,
+            &memory,
+            &mut resource,
+            MmioRegionId::new(700),
+            messages,
+        )
+        .expect("checked PCI state should materialize");
+
+    assert!(resource.is_consumed());
+    assert_eq!(endpoint.guest_cid(), config.guest_cid());
+    assert_eq!(endpoint.uds_path(), destination);
+    assert_eq!(endpoint.expected_state(), &expected);
+    assert_eq!(endpoint.origin(), origin);
+    assert_eq!(endpoint.endpoint().sbdf(), sbdf);
+    assert_eq!(endpoint.endpoint().bar_range(), bar_range);
+    assert_eq!(endpoint.endpoint().region_id(), MmioRegionId::new(700));
+    assert!(
+        endpoint
+            .endpoint()
+            .endpoint()
+            .transport_state()
+            .expect("reconstructed transport should recapture")
+            .is_device_activated()
+    );
+    let debug = format!("{endpoint:?}");
+    assert!(debug.contains(REDACTED));
+    assert!(!debug.contains(destination.to_string_lossy().as_ref()));
+}
+
+#[test]
+fn pci_endpoint_rejects_mismatched_destination_without_consuming_resource() {
+    let portable = state(ACTIVE_PCI_HEX);
+    let memory = memory_for(&portable);
+    let destination = "/tmp/bangbang-vsock-expected-pci.sock";
+    let topology = PreparedSnapshotV2VsockRestoreTopology::prepare(
+        portable.clone(),
+        Some(&SnapshotVsockOverride::new(destination)),
+        SnapshotV2DeviceTransportKind::Pci,
+        &memory,
+    )
+    .expect("active PCI topology should prepare");
+    let config = topology.request().config().clone();
+    let messages = vsock_message_registry(&portable);
+    let (_, prepared) = topology.into_parts();
+    let PreparedSnapshotV2VsockRestoreState::Pci(prepared) = prepared else {
+        panic!("prepared state should retain PCI transport");
+    };
+    let wrong_destination =
+        VsockBackendSelector::try_from_path("/tmp/bangbang-vsock-wrong-pci.sock")
+            .expect("wrong test selector should still validate");
+    let mut resource =
+        supplied_vsock_resource(portable.backend_selector().clone(), wrong_destination);
+    let error = prepared
+        .into_pci_endpoint(
+            &config,
+            &memory,
+            &mut resource,
+            MmioRegionId::new(700),
+            messages,
+        )
+        .expect_err("mismatched destination selector should reject");
+
+    assert!(matches!(
+        error,
+        SnapshotV2VsockPciEndpointError::ResourceIdentity
+    ));
+    assert!(!resource.is_consumed());
+    let diagnostic = format!("{error:?} {error}");
+    assert!(!diagnostic.contains(destination));
+    assert!(!diagnostic.contains("bangbang-vsock-wrong-pci"));
 }
 
 #[test]

--- a/crates/runtime/src/vsock.rs
+++ b/crates/runtime/src/vsock.rs
@@ -7112,6 +7112,7 @@ impl VirtioVsockTransportResetPublication {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VirtioVsockTransportResetAttempt {
     Inactive,
+    AlreadyPending,
     QueueEmpty,
     Published(VirtioVsockTransportResetPublication),
 }
@@ -7120,7 +7121,7 @@ impl VirtioVsockTransportResetAttempt {
     pub const fn publication(self) -> Option<VirtioVsockTransportResetPublication> {
         match self {
             Self::Published(publication) => Some(publication),
-            Self::Inactive | Self::QueueEmpty => None,
+            Self::Inactive | Self::AlreadyPending | Self::QueueEmpty => None,
         }
     }
 
@@ -7738,6 +7739,7 @@ pub enum VirtioVsockDeviceCaptureError {
     InactiveResetAttemptMismatch,
     ActiveResetAttemptMissing,
     PublishedResetWithoutGate,
+    PendingResetWithoutGate,
     EmptyResetAttemptWithPendingDescriptor,
 }
 
@@ -7810,6 +7812,8 @@ impl fmt::Display for VirtioVsockDeviceCaptureError {
             }
             Self::PublishedResetWithoutGate => formatter
                 .write_str("published vsock reset capture does not have the source RX gate armed"),
+            Self::PendingResetWithoutGate => formatter
+                .write_str("pending vsock reset capture does not have the source RX gate armed"),
             Self::EmptyResetAttemptWithPendingDescriptor => formatter
                 .write_str("empty vsock reset capture still has an available event descriptor"),
         }
@@ -8774,6 +8778,9 @@ impl VirtioVsockDevice {
             (true, VirtioVsockTransportResetAttempt::Published(_)) if !self.pending_event_ack => {
                 return Err(VirtioVsockDeviceCaptureError::PublishedResetWithoutGate);
             }
+            (true, VirtioVsockTransportResetAttempt::AlreadyPending) if !self.pending_event_ack => {
+                return Err(VirtioVsockDeviceCaptureError::PendingResetWithoutGate);
+            }
             (true, VirtioVsockTransportResetAttempt::QueueEmpty)
                 if event_available_count != Some(0) =>
             {
@@ -8972,6 +8979,9 @@ impl VirtioVsockDevice {
     ) -> Result<VirtioVsockTransportResetAttempt, VirtioVsockTransportResetError> {
         if !self.is_activated() {
             return Ok(VirtioVsockTransportResetAttempt::Inactive);
+        }
+        if self.pending_event_ack {
+            return Ok(VirtioVsockTransportResetAttempt::AlreadyPending);
         }
         let Some(event_queue) = self.active_event_queue.as_mut() else {
             return Ok(VirtioVsockTransportResetAttempt::Inactive);
@@ -18392,7 +18402,7 @@ mod tests {
     }
 
     #[test]
-    fn virtio_vsock_repeated_transport_reset_preserves_existing_ack_gate_when_queue_is_empty() {
+    fn virtio_vsock_repeated_transport_reset_preserves_existing_ack_gate_and_descriptors() {
         let mut memory = vsock_tx_memory();
         let mut handler = virtio_vsock_mmio_handler(42).expect("vsock handler should build");
         let metrics = SharedVsockDeviceMetrics::default();
@@ -18403,7 +18413,18 @@ mod tests {
             0,
             TestDescriptor::writable(TEST_VSOCK_EVENT_PAYLOAD, 4, None),
         );
-        write_vsock_event_available_heads(&mut memory, &[0]);
+        write_vsock_event_descriptor(
+            &mut memory,
+            1,
+            TestDescriptor::writable(
+                TEST_VSOCK_EVENT_PAYLOAD
+                    .checked_add(0x100)
+                    .expect("second event payload should fit"),
+                4,
+                None,
+            ),
+        );
+        write_vsock_event_available_heads(&mut memory, &[0, 1]);
         write_guest_u16(
             &mut memory,
             vsock_event_used_ring_avail_event_address(),
@@ -18426,12 +18447,22 @@ mod tests {
 
         let repeated = handler
             .prepare_vsock_transport_reset(&mut memory, &metrics)
-            .expect("empty repeated reset should remain nonfatal");
+            .expect("pending repeated reset should remain nonfatal");
 
-        assert_eq!(repeated, VirtioVsockTransportResetAttempt::QueueEmpty);
+        assert_eq!(repeated, VirtioVsockTransportResetAttempt::AlreadyPending);
         assert!(handler.activation_handler().pending_event_ack());
         assert_eq!(read_vsock_event_used_index(&memory), 1);
-        assert_eq!(metrics.snapshot().ev_queue_event_fails(), 1);
+        assert_eq!(
+            handler
+                .activation_handler()
+                .active_event_dispatch_queue()
+                .expect("event queue should remain active")
+                .available_ring()
+                .next_avail(),
+            1,
+            "repeated reset must not consume another guest descriptor"
+        );
+        assert!(metrics.snapshot().is_empty());
     }
 
     #[test]
@@ -26484,6 +26515,14 @@ mod tests {
                 VirtioVsockTransportResetAttempt::Inactive
             ),
             Err(VirtioVsockDeviceCaptureError::ActiveResetAttemptMissing)
+        ));
+        assert!(matches!(
+            handler.capture_vsock_state(
+                &config,
+                &memory,
+                VirtioVsockTransportResetAttempt::AlreadyPending
+            ),
+            Err(VirtioVsockDeviceCaptureError::PendingResetWithoutGate)
         ));
 
         let publisher_path = unique_socket_path("capture-publisher");

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -687,9 +687,11 @@ UART/metrics state, explicitly resumes and repauses it, then shuts it down. A
 second fresh process restores the same pair with resume intent through
 already-opened contained state/memory/root descriptors after both artifact
 paths are replaced, uses the ordinary action gate to reach `Running`, pauses,
-and shuts down. The replacements remain untouched. The second ignored test
-exercises complete MMIO and PCI root-owner commit/rollback boundaries. This
-group is part of the default integration set and must run without
+and shuts down. The replacements remain untouched. Additional ignored seams
+exercise complete MMIO and PCI root-owner commit/rollback boundaries,
+exact-2.11 network owner transactions, and exact-2.12 vsock owner transactions
+over both MMIO and PCI. This group is part of the default integration set and
+must run without
 `--allow-unsupported` on supported Apple Silicon. It adds no API, CLI,
 config-file, or environment activation for native-v2.
 

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -516,6 +516,7 @@ if contains native_v2_process "${selected_tests[@]}"; then
     vmm::tests::signed_exact_minor_eleven_process_mmio_owner_transaction_is_atomic_and_retryable \
     vmm::tests::signed_exact_minor_eleven_process_pci_owner_transaction_is_atomic_and_retryable \
     vmm::tests::signed_exact_minor_twelve_process_mmio_vsock_owner_transaction_is_atomic \
+    vmm::tests::signed_exact_minor_twelve_process_pci_vsock_owner_transaction_is_atomic \
     vmm::tests::signed_native_v2_process_publishes_recaptures_and_resumes_private_pair \
     vmm::tests::signed_native_v2_root_process_commits_complete_mmio_and_pci_owners_atomically \
     vmm::tests::signed_native_v2_storage_destination_stays_private_and_paused_through_commit \


### PR DESCRIPTION
## Summary

- reconstruct exact-2.12 PCI vsock endpoints from destination-normalized snapshot state with single-use listener adoption, exact retained transport recapture, and explicit already-pending reset semantics
- insert PCI vsock into the canonical balloon, block, network, pmem, vsock, entropy, memory-hotplug owner order with exact MSI-X/BAR ownership, rollback stages, fresh metrics, and retry-publication gating
- add the private process transaction and signed inactive/active coverage, including all cancellation boundaries, reset acknowledgement, redaction, cleanup, and the native-v2 integration group

## Scope exclusions

- does not activate the public exact-2.12 PCI load path; that remains tracked by #1735
- does not complete the parent capability inventory and user-facing documentation gate; that remains tracked by #1736

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

Closes #1734

Parent delivery context: #1540
