### PR TITLE
feat: activate native-v2 vsock snapshot restore

### DIFF
--- a/crates/bangbang/src/api_server.rs
+++ b/crates/bangbang/src/api_server.rs
@@ -2301,6 +2301,7 @@ mod tests {
     use bangbang_runtime::metrics::{
         BootRunLoopMetricStatus, MetricsConfigInput, MetricsDiagnostics,
     };
+    use bangbang_runtime::mmds::MmdsStateHandle;
     use bangbang_runtime::network::{NetworkInterfaceConfigs, NetworkRuntimeMutationError};
     use bangbang_runtime::serial::{
         CaptureReadySerialState, SerialConfig, SerialConfigInput, SerialMmioDevice,
@@ -2308,13 +2309,14 @@ mod tests {
     use bangbang_runtime::snapshot::{
         SnapshotLoadInput, SnapshotV1ControllerCommit, SnapshotV2ControllerCommit,
         SnapshotV2ControllerCommitProductConfigs, SnapshotV2NetworkControllerCommitProductConfigs,
+        SnapshotV2VsockControllerCommitProductConfigs,
     };
     #[cfg(target_os = "macos")]
     use bangbang_runtime::snapshot_artifact::load_native_snapshot_artifacts;
     use bangbang_runtime::snapshot_artifact::{
         LoadedNativeSnapshotArtifacts, NativeSnapshotArtifactState,
         NativeSnapshotPublicationOutcome, NativeV2MemoryHotplugSnapshotPreparation,
-        NativeV2NetworkSnapshotCandidateState, SnapshotArtifactPaths, SnapshotPublicationOutcome,
+        NativeV2VsockSnapshotCandidateState, SnapshotArtifactPaths, SnapshotPublicationOutcome,
         publish_native_snapshot_artifacts_with, publish_snapshot_artifacts_with,
     };
     use bangbang_runtime::snapshot_balloon_v2_9::{
@@ -2343,6 +2345,7 @@ mod tests {
     use bangbang_runtime::snapshot_serial_v2_7::{
         NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION, SnapshotV2SerialState,
     };
+    use bangbang_runtime::snapshot_vsock_v2_12::NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION;
     use bangbang_runtime::startup::Arm64BootResources;
     use bangbang_runtime::{BackendError, VmmActionError, VmmController};
 
@@ -2359,8 +2362,8 @@ mod tests {
         ProcessSnapshotV2NetworkLoadRequest, ProcessSnapshotV2RootLoadCompletion,
         ProcessSnapshotV2RootLoadRequest, ProcessSnapshotV2RootLoadSuccess,
         ProcessSnapshotV2SerialLoadRequest, ProcessSnapshotV2StorageLoadRequest,
-        ProcessSnapshotV2StorageLoadSuccess, ProcessVmm, ProcessVmnetAuthority,
-        SnapshotV1LoadSuccess, SnapshotV2LoadSuccess,
+        ProcessSnapshotV2StorageLoadSuccess, ProcessSnapshotV2VsockLoadRequest, ProcessVmm,
+        ProcessVmnetAuthority, SnapshotV1LoadSuccess, SnapshotV2LoadSuccess,
     };
     use bangbang_runtime::storage_capture::CaptureReadyStorageConfigs;
 
@@ -3751,6 +3754,174 @@ mod tests {
                 commit,
             ))
         }
+
+        fn load_prepared_snapshot_v2_vsock(
+            &mut self,
+            request: ProcessSnapshotV2VsockLoadRequest<'_>,
+        ) -> Result<SnapshotV2LoadSuccess<Self::Session>, NativeV2SnapshotLoadError> {
+            let ProcessSnapshotV2VsockLoadRequest {
+                controller: _,
+                vmnet_authority: _,
+                #[cfg(target_os = "macos")]
+                    contained_restore_authority: _,
+                pci_enabled,
+                input,
+                candidate,
+                memory,
+                cancellation,
+            } = request;
+            if !self.snapshot_operations_succeed {
+                return Err(NativeV2SnapshotLoadError::ProcessPreparation(
+                    BackendError::InvalidState("test snapshot load failed"),
+                ));
+            }
+            let expected_transport = if pci_enabled {
+                SnapshotV2DeviceTransportKind::Pci
+            } else {
+                SnapshotV2DeviceTransportKind::Mmio
+            };
+            let candidate = candidate
+                .prepare(
+                    &memory,
+                    expected_transport,
+                    input.network_overrides(),
+                    input.vsock_override(),
+                )
+                .map_err(NativeV2SnapshotLoadError::VsockPreparation)?;
+            let drives = candidate
+                .device_graph()
+                .into_iter()
+                .flat_map(SnapshotV2StorageDeviceGraph::block_records)
+                .map(|record| {
+                    let config = record.config();
+                    let mut input = DriveConfigInput::new(
+                        config.drive_id(),
+                        config.drive_id(),
+                        config.selector(),
+                        config.is_root(),
+                    )
+                    .with_is_read_only(config.is_read_only())
+                    .with_cache_type(config.cache_type())
+                    .with_io_engine(config.io_engine());
+                    if let Some(partuuid) = config.partuuid() {
+                        input = input.with_partuuid(partuuid);
+                    }
+                    if let Some(rate_limiter) = config.rate_limiter() {
+                        input = input.with_rate_limiter(rate_limiter);
+                    }
+                    input.validate()
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| NativeV2SnapshotLoadError::CandidateMismatch)?;
+            let pmem = candidate
+                .device_graph()
+                .into_iter()
+                .flat_map(SnapshotV2StorageDeviceGraph::pmem_records)
+                .map(|record| {
+                    let config = record.config();
+                    let mut input = PmemConfigInput::new(config.pmem_id(), config.selector())
+                        .with_root_device(config.is_root())
+                        .with_read_only(config.is_read_only());
+                    if let Some(rate_limiter) = config.rate_limiter() {
+                        input = input.with_rate_limiter(rate_limiter);
+                    }
+                    PmemConfig::try_from(input)
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| NativeV2SnapshotLoadError::CandidateMismatch)?;
+            let storage_configs = candidate
+                .device_graph()
+                .map(|_| CaptureReadyStorageConfigs::new(drives, pmem));
+            let mut serial_input = SerialConfigInput::new();
+            if let Some(selector) = candidate.serial().endpoint_intent().configured_selector() {
+                serial_input = serial_input.with_serial_out_path(selector);
+            }
+            if let Some(rate_limiter) = candidate.serial().rate_limiter() {
+                serial_input = serial_input.with_rate_limiter(rate_limiter);
+            }
+            let serial_config = serial_input
+                .validate()
+                .map_err(|_| NativeV2SnapshotLoadError::CandidateMismatch)?;
+            let entropy_config = candidate.entropy().map(|state| state.config());
+            let balloon_config = candidate.balloon().map(|state| state.config());
+            let memory_hotplug = candidate
+                .memory_hotplug()
+                .cloned()
+                .map(|state| {
+                    PreparedSnapshotV2MemoryHotplugTopology::prepare_for_compatibility_version(
+                        state,
+                        candidate.memory_binding().clone(),
+                        NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
+                    )
+                })
+                .transpose()
+                .map_err(|_| NativeV2SnapshotLoadError::CandidateMismatch)?
+                .map(|topology| topology.controller());
+            let network_configs = NetworkInterfaceConfigs::from_validated(
+                candidate
+                    .network_topology()
+                    .interfaces()
+                    .iter()
+                    .map(|interface| interface.controller().clone())
+                    .collect(),
+            );
+            let mmds_state = candidate
+                .network_topology()
+                .mmds_controller()
+                .map(|config| {
+                    let mut input = MmdsConfigInput::new(config.network_interfaces().to_vec())
+                        .with_version(config.version())
+                        .with_imds_compat(config.imds_compat());
+                    if let Some(address) = config.ipv4_address() {
+                        input = input.with_ipv4_address(address);
+                    }
+                    let state = MmdsStateHandle::default();
+                    state
+                        .with_mut(|state| state.put_config(input, network_configs.as_slice()))
+                        .map_err(|_| NativeV2SnapshotLoadError::CandidateMismatch)?
+                        .map_err(|_| NativeV2SnapshotLoadError::CandidateMismatch)?;
+                    Ok::<_, NativeV2SnapshotLoadError>(state)
+                })
+                .transpose()?;
+            let vsock_config = candidate
+                .vsock_topology()
+                .map(|topology| topology.request().config().clone());
+            if !cancellation.try_seal_commit() {
+                return Err(NativeV2SnapshotLoadError::Cancelled);
+            }
+            let boot_source = BootSourceConfigInput::new("/private/fake-api-restored-vmlinux")
+                .validate()
+                .map_err(|_| {
+                    NativeV2SnapshotLoadError::ProcessPreparation(BackendError::InvalidState(
+                        "fake snapshot boot configuration failed",
+                    ))
+                })?;
+            let machine =
+                MachineConfig::default().with_track_dirty_pages(input.track_dirty_pages());
+            let commit = SnapshotV2ControllerCommit::with_vsock_product_configs(
+                machine,
+                boot_source,
+                SnapshotV2VsockControllerCommitProductConfigs::new(
+                    SnapshotV2NetworkControllerCommitProductConfigs::new(
+                        SnapshotV2ControllerCommitProductConfigs::new(
+                            storage_configs,
+                            serial_config,
+                            entropy_config,
+                            balloon_config,
+                            memory_hotplug,
+                        ),
+                        network_configs,
+                        mmds_state,
+                    ),
+                    vsock_config,
+                ),
+                input.resume_vm(),
+            );
+            Ok(SnapshotV2LoadSuccess::new(
+                TestSession::without_boot_run_loop_status(),
+                commit,
+            ))
+        }
     }
 
     fn test_controller() -> ProcessVmm<TestInstanceStarter> {
@@ -3911,12 +4082,12 @@ mod tests {
             ));
         }
         let encoded = encode_snapshot_v2_state_with_compatibility_version(
-            NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
+            NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
             &[],
             &components,
         )
         .expect("native-v2 fixture state should encode");
-        NativeV2NetworkSnapshotCandidateState::from_network_state_v2_11(encoded)
+        NativeV2VsockSnapshotCandidateState::from_vsock_state_v2_12(encoded)
             .expect("native-v2 fixture candidate should close")
             .into_current_artifact_state()
     }
@@ -8611,12 +8782,12 @@ mod tests {
         let memory_before = fs::read(&memory_path).expect("committed memory should read");
         let (candidate, _) =
             load_native_snapshot_artifacts(&SnapshotArtifactPaths::new(&state_path, &memory_path))
-                .expect("public exact-2.11 virtio-mem pair should load")
+                .expect("public exact-2.12 virtio-mem pair should load")
                 .into_current_v2_candidate()
                 .expect("public pair should retain its exact current candidate");
         let memory_hotplug = candidate
             .memory_hotplug()
-            .expect("public exact-2.11 pair should contain kind 11");
+            .expect("public exact-2.12 pair should contain kind 11");
         assert_eq!(memory_hotplug.config().total_size_mib(), 1024);
         assert_eq!(
             memory_hotplug.config_space().requested_size(),
@@ -8625,9 +8796,9 @@ mod tests {
         PreparedSnapshotV2MemoryHotplugTopology::prepare_for_compatibility_version(
             memory_hotplug.clone(),
             candidate.memory_binding().clone(),
-            NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
+            NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
         )
-        .expect("public exact-2.11 virtio-mem binding should close");
+        .expect("public exact-2.12 virtio-mem binding should close");
 
         let flush = put_action_over_socket(&mut vmm, "spf", "FlushMetrics");
         assert!(flush.starts_with("HTTP/1.1 204 No Content\r\n"));

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -90,12 +90,12 @@ use bangbang_hvf::{
     decode_hvf_snapshot_v2_memory_hotplug_state, decode_hvf_snapshot_v2_multi_block_state,
     decode_hvf_snapshot_v2_network_state, decode_hvf_snapshot_v2_platform_state,
     decode_hvf_snapshot_v2_serial_state, decode_hvf_snapshot_v2_state,
-    decode_hvf_snapshot_v2_storage_state, encode_hvf_snapshot_v2_balloon_state,
-    encode_hvf_snapshot_v2_entropy_state, encode_hvf_snapshot_v2_memory_hotplug_state,
-    encode_hvf_snapshot_v2_multi_block_state, encode_hvf_snapshot_v2_network_state,
-    encode_hvf_snapshot_v2_serial_state, encode_hvf_snapshot_v2_state,
-    encode_hvf_snapshot_v2_storage_state, encode_hvf_snapshot_v2_vsock_state,
-    prepare_hvf_snapshot_v2_balloon_mmio_platform_plan,
+    decode_hvf_snapshot_v2_storage_state, decode_hvf_snapshot_v2_vsock_state,
+    encode_hvf_snapshot_v2_balloon_state, encode_hvf_snapshot_v2_entropy_state,
+    encode_hvf_snapshot_v2_memory_hotplug_state, encode_hvf_snapshot_v2_multi_block_state,
+    encode_hvf_snapshot_v2_network_state, encode_hvf_snapshot_v2_serial_state,
+    encode_hvf_snapshot_v2_state, encode_hvf_snapshot_v2_storage_state,
+    encode_hvf_snapshot_v2_vsock_state, prepare_hvf_snapshot_v2_balloon_mmio_platform_plan,
     prepare_hvf_snapshot_v2_balloon_pci_platform_plan,
     prepare_hvf_snapshot_v2_memory_hotplug_mmio_platform_plan,
     prepare_hvf_snapshot_v2_memory_hotplug_pci_platform_plan,
@@ -180,7 +180,7 @@ use bangbang_runtime::snapshot::{
     SnapshotCreateInput, SnapshotLoadInput, SnapshotMemoryBackendType, SnapshotNetworkOverride,
     SnapshotV1ControllerCommit, SnapshotV2ControllerCommit,
     SnapshotV2ControllerCommitProductConfigs, SnapshotV2NetworkControllerCommitProductConfigs,
-    SnapshotVsockOverride,
+    SnapshotV2VsockControllerCommitProductConfigs, SnapshotVsockOverride,
 };
 #[cfg(target_os = "macos")]
 use bangbang_runtime::snapshot_artifact::SnapshotStagingTracker;
@@ -437,6 +437,7 @@ pub(crate) struct NativeV2SnapshotPublicationRequest {
     pub(crate) network_configs: Vec<NetworkInterfaceConfig>,
     pub(crate) mmds_config: Option<MmdsConfig>,
     pub(crate) mmds_state: MmdsStateHandle,
+    pub(crate) vsock_config: Option<VsockConfig>,
     pub(crate) expected_transport: SnapshotV2DeviceTransportKind,
     pub(crate) cancellation: NativeV2SnapshotCaptureCancellation,
 }
@@ -533,6 +534,18 @@ pub(crate) struct ProcessSnapshotV2NetworkLoadRequest<'a> {
     pub(crate) pci_enabled: bool,
     pub(crate) input: &'a SnapshotLoadInput,
     pub(crate) candidate: NativeV2NetworkSnapshotCandidateState,
+    pub(crate) memory: GuestMemory,
+    pub(crate) cancellation: NativeV2SnapshotCaptureCancellation,
+}
+
+pub(crate) struct ProcessSnapshotV2VsockLoadRequest<'a> {
+    pub(crate) controller: &'a VmmController,
+    pub(crate) vmnet_authority: ProcessVmnetAuthority,
+    #[cfg(target_os = "macos")]
+    pub(crate) contained_restore_authority: Option<&'a ContainedSnapshotRestoreAuthority>,
+    pub(crate) pci_enabled: bool,
+    pub(crate) input: &'a SnapshotLoadInput,
+    pub(crate) candidate: NativeV2VsockSnapshotCandidateState,
     pub(crate) memory: GuestMemory,
     pub(crate) cancellation: NativeV2SnapshotCaptureCancellation,
 }
@@ -776,6 +789,15 @@ pub(crate) trait InstanceStartExecutor {
         ))
     }
 
+    fn load_prepared_snapshot_v2_vsock(
+        &mut self,
+        _request: ProcessSnapshotV2VsockLoadRequest<'_>,
+    ) -> Result<SnapshotV2LoadSuccess<Self::Session>, NativeV2SnapshotLoadError> {
+        Err(NativeV2SnapshotLoadError::ProcessPreparation(
+            BackendError::InvalidState("native-v2 vsock snapshot loading is unavailable"),
+        ))
+    }
+
     fn commit_prepared_snapshot_v2_root_load(
         &mut self,
         _completion: ProcessSnapshotV2RootLoadCompletion,
@@ -909,7 +931,7 @@ enum NativeV2SnapshotCaptureProfile {
         mmds_config: Option<MmdsConfig>,
         mmds_state: MmdsStateHandle,
         vsock_config: Option<VsockConfig>,
-        expected_vsock_metrics: SharedVsockDeviceMetrics,
+        expected_vsock_metrics: Option<SharedVsockDeviceMetrics>,
         expected_transport: SnapshotV2DeviceTransportKind,
     },
 }
@@ -2358,7 +2380,7 @@ pub(crate) enum NativeV1SnapshotPublicationProducerError {
 pub(crate) enum NativeV2SnapshotPublicationError {
     Preflight(VmmActionError),
     CaptureReadyPreflight(SnapshotCaptureReadyPreflightError),
-    Profile(NativeV2NetworkCandidateProfileError),
+    Profile(NativeV2VsockCandidateProfileError),
     Resource(GrantClaimError),
     SessionUnavailable,
     ConfigurationUnavailable,
@@ -3326,6 +3348,65 @@ impl fmt::Display for NativeV2NetworkDestinationLoadError {
 #[cfg(target_os = "macos")]
 impl std::error::Error for NativeV2NetworkDestinationLoadError {}
 
+#[cfg(target_os = "macos")]
+pub(crate) struct NativeV2VsockDestinationLoadError {
+    transport: SnapshotV2DeviceTransportKind,
+    terminal: bool,
+}
+
+#[cfg(target_os = "macos")]
+impl NativeV2VsockDestinationLoadError {
+    const fn new(transport: SnapshotV2DeviceTransportKind, terminal: bool) -> Self {
+        Self {
+            transport,
+            terminal,
+        }
+    }
+
+    fn with_source(
+        transport: SnapshotV2DeviceTransportKind,
+        terminal: bool,
+        _source: &(dyn std::error::Error + 'static),
+    ) -> Self {
+        Self::new(transport, terminal)
+    }
+
+    const fn is_terminal(&self) -> bool {
+        self.terminal
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl fmt::Debug for NativeV2VsockDestinationLoadError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("NativeV2VsockDestinationLoadError")
+            .field("transport", &self.transport)
+            .field("terminal", &self.terminal)
+            .field("state", &"<redacted>")
+            .finish()
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl fmt::Display for NativeV2VsockDestinationLoadError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "native-v2 2.12 {:?} vsock destination transaction failed ({})",
+            self.transport,
+            if self.terminal {
+                "terminal"
+            } else {
+                "retryable"
+            }
+        )
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl std::error::Error for NativeV2VsockDestinationLoadError {}
+
 #[allow(
     dead_code,
     reason = "native-v2 process restore is target-gated and exercised by signed integration coverage"
@@ -3389,6 +3470,11 @@ pub(crate) enum NativeV2SnapshotLoadError {
     NetworkBundle(SnapshotV2SerialRestoreBundleError),
     #[cfg(target_os = "macos")]
     NetworkDestination(NativeV2NetworkDestinationLoadError),
+    VsockPreparation(NativeV2VsockSnapshotPreparationError),
+    #[cfg(target_os = "macos")]
+    VsockRestoreResources(ProcessSnapshotV2VsockRestoreResourceError),
+    #[cfg(target_os = "macos")]
+    VsockDestination(NativeV2VsockDestinationLoadError),
     AfterResourceAdoption {
         source: Box<NativeV2SnapshotLoadError>,
     },
@@ -3489,6 +3575,12 @@ impl NativeV2SnapshotLoadError {
             }
             #[cfg(target_os = "macos")]
             Self::NetworkDestination(source) => source.is_terminal(),
+            #[cfg(target_os = "macos")]
+            Self::VsockRestoreResources(source) => {
+                source.disposition() == ProcessSnapshotV2NetworkRestoreResourceDisposition::Terminal
+            }
+            #[cfg(target_os = "macos")]
+            Self::VsockDestination(source) => source.is_terminal(),
             Self::Restore(source) => source.is_committed() || !source.cleanup_failures().is_empty(),
             Self::RootRestore(source) => source.is_terminal(),
             Self::Preflight(_)
@@ -3502,6 +3594,7 @@ impl NativeV2SnapshotLoadError {
             | Self::CandidateMismatch
             | Self::MemoryHotplugPreparation(_)
             | Self::NetworkPreparation(_)
+            | Self::VsockPreparation(_)
             | Self::Decode(_)
             | Self::RootPlan(_)
             | Self::RootConfiguration(_)
@@ -3675,6 +3768,21 @@ impl fmt::Display for NativeV2SnapshotLoadError {
             }
             #[cfg(target_os = "macos")]
             Self::NetworkDestination(source) => source.fmt(formatter),
+            Self::VsockPreparation(source) => {
+                write!(
+                    formatter,
+                    "native-v2 2.12 vsock topology preparation failed: {source}"
+                )
+            }
+            #[cfg(target_os = "macos")]
+            Self::VsockRestoreResources(source) => {
+                write!(
+                    formatter,
+                    "native-v2 2.12 process resource preparation failed: {source}"
+                )
+            }
+            #[cfg(target_os = "macos")]
+            Self::VsockDestination(source) => source.fmt(formatter),
             Self::AfterResourceAdoption { source } => {
                 write!(
                     formatter,
@@ -3839,6 +3947,11 @@ impl std::error::Error for NativeV2SnapshotLoadError {
             Self::NetworkDestination(source) => Some(source),
             #[cfg(target_os = "macos")]
             Self::NetworkRestorePlan => None,
+            Self::VsockPreparation(source) => Some(source),
+            #[cfg(target_os = "macos")]
+            Self::VsockRestoreResources(source) => Some(source),
+            #[cfg(target_os = "macos")]
+            Self::VsockDestination(source) => Some(source),
             Self::AfterResourceAdoption { source } => Some(source.as_ref()),
             #[cfg(target_os = "macos")]
             Self::RootResourceCleanup { source, .. } => Some(source.as_ref()),
@@ -7403,11 +7516,21 @@ where
             .state
             .v2_profile()
             .map_err(NativeV2SnapshotLoadError::ArtifactState)?;
-        if !matches!(profile, NativeV2SnapshotArtifactProfile::NetworkStateV2_11)
-            && !input.network_overrides().is_empty()
+        if !matches!(
+            profile,
+            NativeV2SnapshotArtifactProfile::NetworkStateV2_11
+                | NativeV2SnapshotArtifactProfile::VsockStateV2_12
+        ) && !input.network_overrides().is_empty()
         {
             return Err(NativeV2SnapshotLoadError::NetworkPreparation(
                 NativeV2NetworkSnapshotPreparationError::OverridesWithoutNetwork,
+            ));
+        }
+        if !matches!(profile, NativeV2SnapshotArtifactProfile::VsockStateV2_12)
+            && input.vsock_override().is_some()
+        {
+            return Err(NativeV2SnapshotLoadError::Preflight(
+                VmmActionError::SnapshotUnsupported,
             ));
         }
         self.starter
@@ -7425,18 +7548,14 @@ where
             | NativeV2SnapshotArtifactProfile::EntropyStateV2_8
             | NativeV2SnapshotArtifactProfile::BalloonStateV2_9
             | NativeV2SnapshotArtifactProfile::MemoryHotplugStateV2_10
-            | NativeV2SnapshotArtifactProfile::NetworkStateV2_11 => {
+            | NativeV2SnapshotArtifactProfile::NetworkStateV2_11
+            | NativeV2SnapshotArtifactProfile::VsockStateV2_12 => {
                 self.starter
                     .preflight_snapshot_v2_root_process(self.pci_enabled)
                     .map_err(NativeV2SnapshotLoadError::Preflight)?;
                 if !self.snapshot_capture_cancellation.begin_operation() {
                     return Err(NativeV2SnapshotLoadError::Cancelled);
                 }
-            }
-            NativeV2SnapshotArtifactProfile::VsockStateV2_12 => {
-                return Err(NativeV2SnapshotLoadError::Preflight(
-                    VmmActionError::SnapshotUnsupported,
-                ));
             }
         }
 
@@ -7798,7 +7917,7 @@ where
             }
             NativeV2SnapshotArtifactProfile::NetworkStateV2_11 => {
                 let (candidate, memory) = artifacts
-                    .into_current_v2_candidate()
+                    .into_v2_11_candidate()
                     .map_err(NativeV2SnapshotLoadError::ArtifactState)
                     .map_err(|source| {
                         if resource_adopted {
@@ -7835,9 +7954,45 @@ where
                 self.started_session = Some(session);
                 Ok(self.controller.commit_snapshot_v2_load(controller_commit))
             }
-            NativeV2SnapshotArtifactProfile::VsockStateV2_12 => Err(
-                NativeV2SnapshotLoadError::Preflight(VmmActionError::SnapshotUnsupported),
-            ),
+            NativeV2SnapshotArtifactProfile::VsockStateV2_12 => {
+                let (candidate, memory) = artifacts
+                    .into_current_v2_candidate()
+                    .map_err(NativeV2SnapshotLoadError::ArtifactState)
+                    .map_err(|source| {
+                        if resource_adopted {
+                            NativeV2SnapshotLoadError::AfterResourceAdoption {
+                                source: Box::new(source),
+                            }
+                        } else {
+                            source
+                        }
+                    })?;
+                let restored = self
+                    .starter
+                    .load_prepared_snapshot_v2_vsock(ProcessSnapshotV2VsockLoadRequest {
+                        controller: &self.controller,
+                        vmnet_authority: self.vmnet_authority,
+                        #[cfg(target_os = "macos")]
+                        contained_restore_authority: self.contained_restore_authority.as_ref(),
+                        pci_enabled: self.pci_enabled,
+                        input,
+                        candidate,
+                        memory,
+                        cancellation: self.snapshot_capture_cancellation.clone(),
+                    })
+                    .map_err(|source| {
+                        if resource_adopted {
+                            NativeV2SnapshotLoadError::AfterResourceAdoption {
+                                source: Box::new(source),
+                            }
+                        } else {
+                            source
+                        }
+                    })?;
+                let (session, controller_commit) = restored.into_parts();
+                self.started_session = Some(session);
+                Ok(self.controller.commit_snapshot_v2_load(controller_commit))
+            }
         }
     }
 
@@ -9312,7 +9467,7 @@ where
     }
 
     /// Publishes one strictly admitted paused source as a current native-v2
-    /// 2.11 pair, including the network-free case.
+    /// 2.12 pair, including the vsock-free case.
     ///
     /// The public create action reaches this seam after request normalization.
     pub(crate) fn publish_native_v2_snapshot(
@@ -9322,13 +9477,7 @@ where
         self.controller
             .preflight_create_snapshot_v2_request(input)
             .map_err(NativeV2SnapshotPublicationError::Preflight)?;
-        if self.controller.vsock_config().is_some() {
-            let cancellation = self.snapshot_capture_cancellation.clone();
-            let _serial = self
-                .preflight_snapshot_capture_ready(cancellation)
-                .map_err(SnapshotCaptureReadyPreflightError::into_native_v2)?;
-        }
-        let NativeV2NetworkCandidateProductProfile {
+        let NativeV2VsockCandidateProductProfile {
             input: capture_input,
             serial_config,
             entropy_config,
@@ -9339,9 +9488,10 @@ where
             network_configs,
             mmds_config,
             mmds_state,
+            vsock_config,
             expected_transport,
         } = self
-            .native_v2_network_candidate_product_profile()
+            .native_v2_vsock_candidate_product_profile()
             .map_err(NativeV2SnapshotPublicationError::Profile)?;
         let cancellation = self.snapshot_capture_cancellation.clone();
         let _serial = self
@@ -9370,6 +9520,7 @@ where
             network_configs,
             mmds_config,
             mmds_state,
+            vsock_config,
             expected_transport,
             cancellation,
         };
@@ -9680,8 +9831,8 @@ const _: fn(
     -> Result<NativeV2NetworkSnapshotCandidateState, NativeV2NetworkCandidateProcessError> =
     ProcessVmm::<HvfInstanceStartExecutor>::capture_native_v2_network_candidate;
 
-// Keep the exact-2.12 vsock candidate seam type-checked while public create,
-// load, and artifact authority remain pinned to exact 2.11.
+// Keep the current exact-2.12 vsock candidate seam type-checked alongside the
+// public create, load, and artifact-authority transaction.
 const _: fn(
     &mut ProcessVmm<HvfInstanceStartExecutor>,
     BoxedNativeV2SnapshotMemoryOutput,
@@ -9876,9 +10027,7 @@ impl HvfInstanceStartExecutor {
                 NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION
             }
             NativeV2SnapshotArtifactProfile::VsockStateV2_12 => {
-                return Err(NativeV2SnapshotLoadError::Preflight(
-                    VmmActionError::SnapshotUnsupported,
-                ));
+                NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION
             }
         };
         let structural = decode_snapshot_v2_state_with_compatibility_version(bytes, version)
@@ -9921,9 +10070,8 @@ impl HvfInstanceStartExecutor {
                     .map_err(NativeV2SnapshotLoadError::Decode)?;
             }
             NativeV2SnapshotArtifactProfile::VsockStateV2_12 => {
-                return Err(NativeV2SnapshotLoadError::Preflight(
-                    VmmActionError::SnapshotUnsupported,
-                ));
+                decode_hvf_snapshot_v2_vsock_state(&structural)
+                    .map_err(NativeV2SnapshotLoadError::Decode)?;
             }
         }
         Ok(())
@@ -11207,13 +11355,18 @@ impl std::error::Error for HvfSnapshotV2SerialConstructionError {
 #[derive(Debug)]
 struct HvfSnapshotV2SerialDestinationCleanupError {
     session: Option<BackendError>,
+    vsock: bool,
     restoration: Option<SerialStdioRestorationError>,
 }
 
 #[cfg(target_os = "macos")]
 impl fmt::Display for HvfSnapshotV2SerialDestinationCleanupError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("native-v2 serial-bearing destination cleanup failed")
+        formatter.write_str("native-v2 serial-bearing destination cleanup failed")?;
+        if self.vsock {
+            formatter.write_str("; vsock publication cleanup is uncertain")?;
+        }
+        Ok(())
     }
 }
 
@@ -11246,12 +11399,20 @@ enum HvfSnapshotV2SerialControllerProfile {
         balloon_config: Option<BalloonConfig>,
         memory_hotplug: Option<SnapshotV2MemoryHotplugControllerProjection>,
     },
-    CurrentV2_11 {
+    RetainedV2_11 {
         entropy_config: Option<EntropyConfig>,
         balloon_config: Option<BalloonConfig>,
         memory_hotplug: Option<SnapshotV2MemoryHotplugControllerProjection>,
         network_configs: NetworkInterfaceConfigs,
         mmds_state: Option<MmdsStateHandle>,
+    },
+    CurrentV2_12 {
+        entropy_config: Option<EntropyConfig>,
+        balloon_config: Option<BalloonConfig>,
+        memory_hotplug: Option<SnapshotV2MemoryHotplugControllerProjection>,
+        network_configs: NetworkInterfaceConfigs,
+        mmds_state: Option<MmdsStateHandle>,
+        vsock_config: Option<VsockConfig>,
     },
 }
 
@@ -11267,7 +11428,8 @@ impl fmt::Debug for HvfSnapshotV2SerialControllerProfile {
                     Self::RetainedV2_8 { .. } => "2.8",
                     Self::CurrentV2_9 { .. } => "2.9",
                     Self::CurrentV2_10 { .. } => "2.10",
-                    Self::CurrentV2_11 { .. } => "2.11",
+                    Self::RetainedV2_11 { .. } => "2.11",
+                    Self::CurrentV2_12 { .. } => "2.12",
                 },
             )
             .field(
@@ -11282,7 +11444,10 @@ impl fmt::Debug for HvfSnapshotV2SerialControllerProfile {
                     } | Self::CurrentV2_10 {
                         entropy_config: Some(_),
                         ..
-                    } | Self::CurrentV2_11 {
+                    } | Self::RetainedV2_11 {
+                        entropy_config: Some(_),
+                        ..
+                    } | Self::CurrentV2_12 {
                         entropy_config: Some(_),
                         ..
                     }
@@ -11298,7 +11463,10 @@ impl fmt::Debug for HvfSnapshotV2SerialControllerProfile {
                     } | Self::CurrentV2_10 {
                         balloon_config: Some(_),
                         ..
-                    } | Self::CurrentV2_11 {
+                    } | Self::RetainedV2_11 {
+                        balloon_config: Some(_),
+                        ..
+                    } | Self::CurrentV2_12 {
                         balloon_config: Some(_),
                         ..
                     }
@@ -11311,7 +11479,10 @@ impl fmt::Debug for HvfSnapshotV2SerialControllerProfile {
                     Self::CurrentV2_10 {
                         memory_hotplug: Some(_),
                         ..
-                    } | Self::CurrentV2_11 {
+                    } | Self::RetainedV2_11 {
+                        memory_hotplug: Some(_),
+                        ..
+                    } | Self::CurrentV2_12 {
                         memory_hotplug: Some(_),
                         ..
                     }
@@ -11320,19 +11491,33 @@ impl fmt::Debug for HvfSnapshotV2SerialControllerProfile {
             .field(
                 "network_interface_count",
                 &match self {
-                    Self::CurrentV2_11 {
+                    Self::RetainedV2_11 {
+                        network_configs, ..
+                    }
+                    | Self::CurrentV2_12 {
                         network_configs, ..
                     } => network_configs.as_slice().len(),
                     _ => 0,
                 },
             )
+            .field(
+                "has_vsock",
+                &matches!(
+                    self,
+                    Self::CurrentV2_12 {
+                        vsock_config: Some(_),
+                        ..
+                    }
+                ),
+            )
             .finish()
     }
 }
 
-/// Complete exact-2.7 through exact-2.11 serial-bearing process owner. The stdio
+/// Complete exact-2.7 through exact-2.12 serial-bearing process owner. The stdio
 /// restoration receipt remains outside the worker and is finished only after
-/// worker, UART, input, active-output, and network-resource teardown.
+/// worker, UART, input, active-output, vsock publication, and network-resource
+/// teardown.
 #[cfg(target_os = "macos")]
 pub(crate) struct HvfSnapshotV2SerialDestination {
     session: Option<Box<HvfProcessSession>>,
@@ -11340,6 +11525,7 @@ pub(crate) struct HvfSnapshotV2SerialDestination {
     has_storage: bool,
     serial_config: Option<SerialConfig>,
     controller_profile: HvfSnapshotV2SerialControllerProfile,
+    active_vsock: Option<ActiveVsockRestoreGuard>,
     network_resources: Vec<PreparedProcessSnapshotV2NetworkRestoreResource>,
     serial_output: Option<SharedSerialOutput>,
     restoration: Option<SerialStdioRestoration>,
@@ -11437,7 +11623,7 @@ impl HvfSnapshotV2SerialDestination {
                     resume_requested,
                 )
             }
-            HvfSnapshotV2SerialControllerProfile::CurrentV2_11 {
+            HvfSnapshotV2SerialControllerProfile::RetainedV2_11 {
                 entropy_config,
                 balloon_config,
                 memory_hotplug,
@@ -11456,6 +11642,32 @@ impl HvfSnapshotV2SerialDestination {
                     ),
                     network_configs,
                     mmds_state,
+                ),
+                resume_requested,
+            ),
+            HvfSnapshotV2SerialControllerProfile::CurrentV2_12 {
+                entropy_config,
+                balloon_config,
+                memory_hotplug,
+                network_configs,
+                mmds_state,
+                vsock_config,
+            } => SnapshotV2ControllerCommit::with_vsock_product_configs(
+                machine,
+                boot,
+                SnapshotV2VsockControllerCommitProductConfigs::new(
+                    SnapshotV2NetworkControllerCommitProductConfigs::new(
+                        SnapshotV2ControllerCommitProductConfigs::new(
+                            storage_configs,
+                            serial_config,
+                            entropy_config,
+                            balloon_config,
+                            memory_hotplug,
+                        ),
+                        network_configs,
+                        mmds_state,
+                    ),
+                    vsock_config,
                 ),
                 resume_requested,
             ),
@@ -11515,6 +11727,10 @@ impl HvfSnapshotV2SerialDestination {
             )),
             None => None,
         };
+        let vsock = self
+            .active_vsock
+            .take()
+            .is_some_and(|guard| guard.cleanup().is_err());
         {
             let _session = self.session.take();
         }
@@ -11526,9 +11742,10 @@ impl HvfSnapshotV2SerialDestination {
             .restoration
             .take()
             .and_then(|restoration| restoration.finish().err());
-        if session.is_some() || restoration.is_some() {
+        if session.is_some() || vsock || restoration.is_some() {
             Err(HvfSnapshotV2SerialDestinationCleanupError {
                 session,
+                vsock,
                 restoration,
             })
         } else {
@@ -11966,6 +12183,7 @@ fn prepare_hvf_native_v2_serial_destination(
                 has_storage,
                 serial_config: Some(serial_config),
                 controller_profile: HvfSnapshotV2SerialControllerProfile::RetainedV2_7,
+                active_vsock: None,
                 network_resources: Vec::new(),
                 serial_output: Some(serial_output),
                 restoration,
@@ -12495,6 +12713,7 @@ fn prepare_hvf_native_v2_entropy_destination(
                         }
                     }
                 },
+                active_vsock: None,
                 network_resources: Vec::new(),
                 serial_output: Some(serial_output),
                 restoration,
@@ -12782,6 +13001,7 @@ fn prepare_hvf_native_v2_balloon_destination(
                     entropy_config,
                     balloon_config: Some(balloon_config),
                 },
+                active_vsock: None,
                 network_resources: Vec::new(),
                 serial_output: Some(serial_output),
                 restoration,
@@ -13116,6 +13336,7 @@ fn prepare_hvf_native_v2_memory_hotplug_destination(
                     balloon_config,
                     memory_hotplug: Some(memory_hotplug),
                 },
+                active_vsock: None,
                 network_resources: Vec::new(),
                 serial_output: Some(serial_output),
                 restoration,
@@ -13278,7 +13499,7 @@ struct PrepareHvfSnapshotV2NetworkDestinationInput<'a> {
     cancellation: NativeV2SnapshotCaptureCancellation,
 }
 
-/// Reconstructs and atomically commits one current exact-2.11 destination,
+/// Reconstructs and atomically commits one retained exact-2.11 destination,
 /// retaining provider, MMDS, and per-interface metric owners for its complete
 /// process lifetime.
 #[cfg(target_os = "macos")]
@@ -13553,13 +13774,14 @@ fn prepare_hvf_native_v2_network_destination(
                 storage_configs,
                 has_storage,
                 serial_config: Some(serial_config),
-                controller_profile: HvfSnapshotV2SerialControllerProfile::CurrentV2_11 {
+                controller_profile: HvfSnapshotV2SerialControllerProfile::RetainedV2_11 {
                     entropy_config,
                     balloon_config,
                     memory_hotplug,
                     network_configs: NetworkInterfaceConfigs::from_validated(configs),
                     mmds_state,
                 },
+                active_vsock: None,
                 network_resources: resources,
                 serial_output: Some(serial_output),
                 restoration,
@@ -13582,6 +13804,186 @@ fn prepare_hvf_native_v2_network_destination(
         )
         .map_err(PrepareHvfSnapshotV2SerialDestinationError::Commit)?;
     Ok((destination, controller))
+}
+
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+fn cleanup_unpublished_native_v2_vsock_destination(
+    mut session: OwnedHvfArm64BootSession,
+    provider: ProcessNetworkPacketIoProvider,
+    mmds_state: Option<MmdsStateHandle>,
+    mmds_metrics: Option<SharedMmdsMetrics>,
+    mut resources: Vec<PreparedProcessSnapshotV2NetworkRestoreResource>,
+    active_vsock: Option<ActiveVsockRestoreGuard>,
+    serial_output: SharedSerialOutput,
+    serial_config: SerialConfig,
+    restoration: Option<SerialStdioRestoration>,
+) -> bool {
+    let mut cleanup_uncertain = session.shutdown().is_err();
+    cleanup_uncertain |= active_vsock.is_some_and(|guard| guard.cleanup().is_err());
+    drop((provider, mmds_state, mmds_metrics));
+    resources.clear();
+    let mut serial_output = Some(serial_output);
+    let mut serial_config = Some(serial_config);
+    let mut restoration = restoration;
+    cleanup_uncertain |= finish_process_snapshot_v2_serial_restoration(
+        &mut serial_output,
+        &mut serial_config,
+        &mut restoration,
+    );
+    cleanup_uncertain
+}
+
+#[cfg(target_os = "macos")]
+struct PrepareHvfSnapshotV2VsockDestinationInput {
+    parts: RestoredProcessSnapshotV2VsockDestinationParts,
+    machine: bangbang_runtime::machine::MachineConfig,
+    boot: bangbang_runtime::boot::BootSourceConfig,
+    resume_requested: bool,
+    expected_transport: SnapshotV2DeviceTransportKind,
+    cancellation: NativeV2SnapshotCaptureCancellation,
+}
+
+/// Publishes one completely reconstructed exact-2.12 process graph as a
+/// Paused worker and closes its controller projection at the commit seal.
+#[cfg(target_os = "macos")]
+fn prepare_hvf_native_v2_vsock_destination(
+    input: PrepareHvfSnapshotV2VsockDestinationInput,
+) -> Result<
+    (HvfSnapshotV2SerialDestination, SnapshotV2ControllerCommit),
+    NativeV2VsockDestinationLoadError,
+> {
+    let PrepareHvfSnapshotV2VsockDestinationInput {
+        parts:
+            RestoredProcessSnapshotV2VsockDestinationParts {
+                mut session,
+                configs,
+                storage_configs,
+                entropy_config,
+                balloon_config,
+                memory_hotplug,
+                vsock_config,
+                provider,
+                mmds_state,
+                mmds_metrics,
+                authority,
+                resources,
+                active_vsock,
+                serial_output,
+                serial_config,
+                restoration,
+            },
+        machine,
+        boot,
+        resume_requested,
+        expected_transport,
+        cancellation,
+    } = input;
+
+    if let Err(_source) = session.prepare_restored_serial_continuation() {
+        let _cleanup_uncertain = cleanup_unpublished_native_v2_vsock_destination(
+            session,
+            provider,
+            mmds_state,
+            mmds_metrics,
+            resources,
+            active_vsock,
+            serial_output,
+            serial_config,
+            restoration,
+        );
+        return Err(NativeV2VsockDestinationLoadError::new(
+            expected_transport,
+            true,
+        ));
+    }
+    if let Err(_source) = session.resume_after_snapshot_v2_capture() {
+        let _cleanup_uncertain = cleanup_unpublished_native_v2_vsock_destination(
+            session,
+            provider,
+            mmds_state,
+            mmds_metrics,
+            resources,
+            active_vsock,
+            serial_output,
+            serial_config,
+            restoration,
+        );
+        return Err(NativeV2VsockDestinationLoadError::new(
+            expected_transport,
+            true,
+        ));
+    }
+
+    let process_session =
+        ProcessHvfBootSession::new_with_vmnet_authority(session, provider, mmds_metrics, authority);
+    let supervisor = match HvfBootRunLoopSupervisor::start_paused(
+        process_session,
+        default_hvf_boot_run_loop_step_limit(),
+    ) {
+        Ok(supervisor) => supervisor,
+        Err(error) => {
+            let (_source, failed_session) = error.into_parts();
+            let ProcessHvfBootSession {
+                packet_io,
+                session,
+                mmds_metrics,
+                vmnet_authority: _,
+            } = failed_session;
+            let _cleanup_uncertain = cleanup_unpublished_native_v2_vsock_destination(
+                session,
+                packet_io,
+                mmds_state,
+                mmds_metrics,
+                resources,
+                active_vsock,
+                serial_output,
+                serial_config,
+                restoration,
+            );
+            return Err(NativeV2VsockDestinationLoadError::new(
+                expected_transport,
+                true,
+            ));
+        }
+    };
+    let has_storage = storage_configs.is_some();
+    let destination = HvfSnapshotV2SerialDestination {
+        session: Some(Box::new(HvfProcessSession::Boot(supervisor))),
+        storage_configs,
+        has_storage,
+        serial_config: Some(serial_config),
+        controller_profile: HvfSnapshotV2SerialControllerProfile::CurrentV2_12 {
+            entropy_config,
+            balloon_config,
+            memory_hotplug,
+            network_configs: NetworkInterfaceConfigs::from_validated(configs),
+            mmds_state,
+            vsock_config,
+        },
+        active_vsock,
+        network_resources: resources,
+        serial_output: Some(serial_output),
+        restoration,
+        unavailable_diagnostics: (),
+    };
+    if !cancellation.try_seal_commit() {
+        let _ = destination.shutdown();
+        return Err(NativeV2VsockDestinationLoadError::new(
+            expected_transport,
+            true,
+        ));
+    }
+    match destination.prepare_controller(machine, boot, resume_requested) {
+        Ok(committed) => Ok(committed),
+        Err((destination, _source)) => {
+            let _ = (*destination).shutdown();
+            Err(NativeV2VsockDestinationLoadError::new(
+                expected_transport,
+                true,
+            ))
+        }
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -15465,6 +15867,180 @@ impl InstanceStartExecutor for HvfInstanceStartExecutor {
         let (destination, controller_commit) = result?;
         let serial_output = destination.serial_output_clone().ok_or_else(|| {
             NativeV2SnapshotLoadError::NetworkDestination(NativeV2NetworkDestinationLoadError::new(
+                expected_transport,
+                true,
+            ))
+        })?;
+        self.active_serial_output = Some(serial_output);
+        Ok(SnapshotV2LoadSuccess::new(
+            HvfProcessSession::SerialSnapshotV2(Box::new(destination)),
+            controller_commit,
+        ))
+    }
+
+    #[cfg(target_os = "macos")]
+    fn load_prepared_snapshot_v2_vsock(
+        &mut self,
+        request: ProcessSnapshotV2VsockLoadRequest<'_>,
+    ) -> Result<SnapshotV2LoadSuccess<Self::Session>, NativeV2SnapshotLoadError> {
+        let ProcessSnapshotV2VsockLoadRequest {
+            controller,
+            vmnet_authority,
+            contained_restore_authority,
+            pci_enabled,
+            input,
+            candidate,
+            memory,
+            cancellation,
+        } = request;
+        self.preflight_snapshot_v2_root_process(pci_enabled)
+            .map_err(NativeV2SnapshotLoadError::Preflight)?;
+        let expected_transport = if pci_enabled {
+            SnapshotV2DeviceTransportKind::Pci
+        } else {
+            SnapshotV2DeviceTransportKind::Mmio
+        };
+
+        let structural = decode_snapshot_v2_state_with_compatibility_version(
+            candidate.bytes(),
+            NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
+        )
+        .map_err(NativeV2SnapshotLoadError::CandidateFormat)?;
+        let decoded = decode_hvf_snapshot_v2_vsock_state(&structural)
+            .map_err(NativeV2SnapshotLoadError::Decode)?;
+        if decoded.platform().memory() != candidate.memory_binding()
+            || decoded.device_graph() != candidate.device_graph()
+            || decoded.serial() != candidate.serial()
+            || decoded.entropy() != candidate.entropy()
+            || decoded.balloon() != candidate.balloon()
+            || decoded.memory_hotplug() != candidate.memory_hotplug()
+            || decoded.network() != candidate.network()
+            || decoded.vsock() != candidate.vsock()
+        {
+            return Err(NativeV2SnapshotLoadError::CandidateMismatch);
+        }
+        let (platform, graph, serial, entropy, balloon, memory_hotplug, network, vsock) =
+            decoded.into_parts();
+        if graph
+            .as_ref()
+            .is_some_and(|graph| graph.transport_kind() != expected_transport)
+            || entropy
+                .as_ref()
+                .is_some_and(|state| state.transport().kind() != expected_transport)
+            || balloon
+                .as_ref()
+                .is_some_and(|state| state.transport().kind() != expected_transport)
+            || memory_hotplug
+                .as_ref()
+                .is_some_and(|state| state.transport().kind() != expected_transport)
+            || network.as_ref().is_some_and(|state| {
+                state
+                    .interfaces()
+                    .iter()
+                    .any(|interface| interface.transport().kind() != expected_transport)
+            })
+            || vsock
+                .as_ref()
+                .is_some_and(|state| state.transport().kind() != expected_transport)
+        {
+            return Err(NativeV2SnapshotLoadError::Preflight(
+                VmmActionError::SnapshotUnsupported,
+            ));
+        }
+        let boot = native_v2_boot_source_config(platform.machine().boot())
+            .map_err(NativeV2SnapshotLoadError::BootMetadata)?;
+        let machine = snapshot_destination_machine_config(
+            platform.machine().machine(),
+            input.track_dirty_pages(),
+        );
+        drop((
+            graph,
+            serial,
+            entropy,
+            balloon,
+            memory_hotplug,
+            network,
+            vsock,
+        ));
+
+        // Selector resolution, override validation, destination-memory checks,
+        // and resource planning remain owner-free and precede all host access.
+        let candidate = candidate
+            .prepare_with_cancel(
+                &memory,
+                expected_transport,
+                input.network_overrides(),
+                input.vsock_override(),
+                |_| cancellation.is_cancelled(),
+            )
+            .map_err(NativeV2SnapshotLoadError::VsockPreparation)?;
+        let resource_plan =
+            prepare_process_snapshot_v2_vsock_resource_plan(candidate, vmnet_authority)
+                .map_err(NativeV2SnapshotLoadError::VsockRestoreResources)?;
+        let mmds_data_store_limit_bytes = controller
+            .mmds_state_handle()
+            .with(MmdsState::data_store_limit_bytes)
+            .map_err(|_| {
+                NativeV2SnapshotLoadError::ProcessPreparation(BackendError::InvalidState(
+                    "native-v2 destination MMDS state is unavailable",
+                ))
+            })?;
+        let now = Instant::now();
+        let parts = if pci_enabled {
+            restore_process_snapshot_v2_vsock_pci(
+                platform,
+                memory,
+                resource_plan,
+                contained_restore_authority,
+                &controller.instance_info().id,
+                mmds_data_store_limit_bytes,
+                now,
+                |_| cancellation.is_cancelled(),
+            )
+            .and_then(SystemRestoredProcessSnapshotV2VsockPciOwners::into_destination_parts)
+            .map_err(|source| {
+                NativeV2SnapshotLoadError::VsockDestination(
+                    NativeV2VsockDestinationLoadError::with_source(
+                        expected_transport,
+                        source.is_terminal(),
+                        &source,
+                    ),
+                )
+            })?
+        } else {
+            restore_process_snapshot_v2_vsock_mmio(
+                platform,
+                memory,
+                resource_plan,
+                contained_restore_authority,
+                &controller.instance_info().id,
+                mmds_data_store_limit_bytes,
+                now,
+                |_| cancellation.is_cancelled(),
+            )
+            .and_then(SystemRestoredProcessSnapshotV2VsockMmioOwners::into_destination_parts)
+            .map_err(|source| {
+                NativeV2SnapshotLoadError::VsockDestination(
+                    NativeV2VsockDestinationLoadError::with_source(
+                        expected_transport,
+                        source.is_terminal(),
+                        &source,
+                    ),
+                )
+            })?
+        };
+        let (destination, controller_commit) =
+            prepare_hvf_native_v2_vsock_destination(PrepareHvfSnapshotV2VsockDestinationInput {
+                parts,
+                machine,
+                boot,
+                resume_requested: input.resume_vm(),
+                expected_transport,
+                cancellation,
+            })
+            .map_err(NativeV2SnapshotLoadError::VsockDestination)?;
+        let serial_output = destination.serial_output_clone().ok_or_else(|| {
+            NativeV2SnapshotLoadError::VsockDestination(NativeV2VsockDestinationLoadError::new(
                 expected_transport,
                 true,
             ))
@@ -23434,6 +24010,13 @@ impl ProcessSnapshotV2VsockMmioRestoreError {
             },
         }
     }
+
+    const fn is_terminal(&self) -> bool {
+        !matches!(
+            self.disposition,
+            ProcessSnapshotV2VsockMmioRestoreDisposition::Retryable
+        )
+    }
 }
 
 impl fmt::Debug for ProcessSnapshotV2VsockMmioRestoreError {
@@ -23475,6 +24058,26 @@ where
     serial_output: Option<SharedSerialOutput>,
     serial_config: Option<SerialConfig>,
     serial_restoration: Option<SerialStdioRestoration>,
+}
+
+#[cfg(target_os = "macos")]
+struct RestoredProcessSnapshotV2VsockDestinationParts {
+    session: OwnedHvfArm64BootSession,
+    configs: Vec<NetworkInterfaceConfig>,
+    storage_configs: Option<CaptureReadyStorageConfigs>,
+    entropy_config: Option<EntropyConfig>,
+    balloon_config: Option<BalloonConfig>,
+    memory_hotplug: Option<SnapshotV2MemoryHotplugControllerProjection>,
+    vsock_config: Option<VsockConfig>,
+    provider: ProcessNetworkPacketIoProvider,
+    mmds_state: Option<MmdsStateHandle>,
+    mmds_metrics: Option<SharedMmdsMetrics>,
+    authority: ProcessVmnetAuthority,
+    resources: Vec<PreparedProcessSnapshotV2NetworkRestoreResource>,
+    active_vsock: Option<ActiveVsockRestoreGuard>,
+    serial_output: SharedSerialOutput,
+    serial_config: SerialConfig,
+    restoration: Option<SerialStdioRestoration>,
 }
 
 fn abort_completed_process_snapshot_v2_vsock_resources<B>(
@@ -23827,6 +24430,13 @@ impl ProcessSnapshotV2VsockPciRestoreError {
                 ),
             },
         }
+    }
+
+    const fn is_terminal(&self) -> bool {
+        !matches!(
+            self.disposition,
+            ProcessSnapshotV2VsockPciRestoreDisposition::Retryable
+        )
     }
 }
 
@@ -25447,6 +26057,189 @@ where
 type SystemRestoredProcessSnapshotV2VsockMmioOwners =
     RestoredProcessSnapshotV2VsockMmioOwners<SystemVmnetInterfaceBackend>;
 
+#[cfg(target_os = "macos")]
+impl SystemRestoredProcessSnapshotV2VsockMmioOwners {
+    fn into_destination_parts(
+        mut self,
+    ) -> Result<
+        RestoredProcessSnapshotV2VsockDestinationParts,
+        ProcessSnapshotV2VsockMmioRestoreError,
+    > {
+        let graph_is_complete = match (&self.hvf, &self.completion) {
+            (Some(hvf), Some(completion)) => {
+                self.serial_output.is_some()
+                    && self.serial_config.is_some()
+                    && completion.network_completion.configs_match(hvf.configs())
+                    && completion
+                        .network_completion
+                        .resources_match(&self.network_resources)
+                    && completion.vsock_config.as_ref() == hvf.vsock_config()
+                    && self.active_vsock.is_some() == completion.vsock_config.is_some()
+            }
+            _ => false,
+        };
+        if !graph_is_complete {
+            let cleanup_uncertain = self.shutdown().is_err();
+            return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                ProcessSnapshotV2VsockMmioRestoreStage::Assembly,
+                cleanup_uncertain,
+            ));
+        }
+
+        let (hvf, completion) = match (self.hvf.take(), self.completion.take()) {
+            (Some(hvf), Some(completion)) => (hvf, completion),
+            (hvf, completion) => {
+                self.hvf = hvf;
+                self.completion = completion;
+                let cleanup_uncertain = self.shutdown().is_err();
+                return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                    ProcessSnapshotV2VsockMmioRestoreStage::Assembly,
+                    cleanup_uncertain,
+                ));
+            }
+        };
+        let (
+            mut session,
+            configs,
+            storage_configs,
+            entropy_config,
+            balloon_config,
+            memory_hotplug,
+            hvf_vsock_config,
+        ) = match hvf.into_destination_parts() {
+            Ok(parts) => parts,
+            Err(source) => {
+                self.completion = Some(completion);
+                let mut cleanup_uncertain = source.has_incomplete_cleanup();
+                cleanup_uncertain |= self.shutdown().is_err();
+                return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                    ProcessSnapshotV2VsockMmioRestoreStage::Assembly,
+                    cleanup_uncertain,
+                ));
+            }
+        };
+        let (
+            bytes,
+            binding,
+            device_graph,
+            serial,
+            entropy,
+            balloon,
+            memory_hotplug_state,
+            network_topology,
+            vsock_state,
+            vsock_config,
+            binding_keys,
+            network_completion,
+        ) = match completion.commit() {
+            Ok(parts) => parts,
+            Err(source) => {
+                let mut cleanup_uncertain = source.cleanup_uncertain();
+                cleanup_uncertain |= session.shutdown().is_err();
+                cleanup_uncertain |= self.shutdown().is_err();
+                return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                    ProcessSnapshotV2VsockMmioRestoreStage::Assembly,
+                    cleanup_uncertain,
+                ));
+            }
+        };
+        if hvf_vsock_config != vsock_config {
+            let mut cleanup_uncertain = session.shutdown().is_err();
+            cleanup_uncertain |= self
+                .active_vsock
+                .take()
+                .is_some_and(|guard| guard.cleanup().is_err());
+            cleanup_uncertain |= network_completion.abort().is_err();
+            self.network_resources.clear();
+            cleanup_uncertain |= self.shutdown().is_err();
+            return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                ProcessSnapshotV2VsockMmioRestoreStage::Assembly,
+                cleanup_uncertain,
+            ));
+        }
+        let (
+            resource_interfaces,
+            mut provider,
+            mmds_state,
+            mmds_metrics,
+            expected_mmds_state,
+            expected_mmds_controller,
+            network_metrics,
+            authority,
+        ) = match network_completion.into_parts() {
+            Ok(parts) => parts,
+            Err(_) => {
+                let mut cleanup_uncertain = session.shutdown().is_err();
+                cleanup_uncertain |= self
+                    .active_vsock
+                    .take()
+                    .is_some_and(|guard| guard.cleanup().is_err());
+                self.network_resources.clear();
+                cleanup_uncertain |= self.shutdown().is_err();
+                return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                    ProcessSnapshotV2VsockMmioRestoreStage::Assembly,
+                    cleanup_uncertain,
+                ));
+            }
+        };
+        drop((
+            bytes,
+            binding,
+            device_graph,
+            serial,
+            entropy,
+            balloon,
+            memory_hotplug_state,
+            network_topology,
+            vsock_state,
+            binding_keys,
+            resource_interfaces,
+            expected_mmds_state,
+            expected_mmds_controller,
+            network_metrics,
+        ));
+        let (serial_output, serial_config) =
+            match (self.serial_output.take(), self.serial_config.take()) {
+                (Some(serial_output), Some(serial_config)) => (serial_output, serial_config),
+                (serial_output, serial_config) => {
+                    self.serial_output = serial_output;
+                    self.serial_config = serial_config;
+                    let mut cleanup_uncertain = session.shutdown().is_err();
+                    cleanup_uncertain |= self
+                        .active_vsock
+                        .take()
+                        .is_some_and(|guard| guard.cleanup().is_err());
+                    cleanup_uncertain |= provider.shutdown_packet_io().is_err();
+                    drop((provider, mmds_state, mmds_metrics));
+                    self.network_resources.clear();
+                    cleanup_uncertain |= self.shutdown().is_err();
+                    return Err(ProcessSnapshotV2VsockMmioRestoreError::terminal(
+                        ProcessSnapshotV2VsockMmioRestoreStage::Assembly,
+                        cleanup_uncertain,
+                    ));
+                }
+            };
+        Ok(RestoredProcessSnapshotV2VsockDestinationParts {
+            session,
+            configs,
+            storage_configs,
+            entropy_config,
+            balloon_config,
+            memory_hotplug,
+            vsock_config,
+            provider,
+            mmds_state,
+            mmds_metrics,
+            authority,
+            resources: std::mem::take(&mut self.network_resources),
+            active_vsock: self.active_vsock.take(),
+            serial_output,
+            serial_config,
+            restoration: self.serial_restoration.take(),
+        })
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn restore_process_snapshot_v2_vsock_mmio<C>(
     platform: HvfSnapshotV2PlatformState,
@@ -26086,6 +26879,187 @@ where
 
 type SystemRestoredProcessSnapshotV2VsockPciOwners =
     RestoredProcessSnapshotV2VsockPciOwners<SystemVmnetInterfaceBackend>;
+
+#[cfg(target_os = "macos")]
+impl SystemRestoredProcessSnapshotV2VsockPciOwners {
+    fn into_destination_parts(
+        mut self,
+    ) -> Result<RestoredProcessSnapshotV2VsockDestinationParts, ProcessSnapshotV2VsockPciRestoreError>
+    {
+        let graph_is_complete = match (&self.hvf, &self.completion) {
+            (Some(hvf), Some(completion)) => {
+                self.serial_output.is_some()
+                    && self.serial_config.is_some()
+                    && completion.network_completion.configs_match(hvf.configs())
+                    && completion
+                        .network_completion
+                        .resources_match(&self.network_resources)
+                    && completion.vsock_config.as_ref() == hvf.vsock_config()
+                    && self.active_vsock.is_some() == completion.vsock_config.is_some()
+            }
+            _ => false,
+        };
+        if !graph_is_complete {
+            let cleanup_uncertain = self.shutdown().is_err();
+            return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                ProcessSnapshotV2VsockPciRestoreStage::Assembly,
+                cleanup_uncertain,
+            ));
+        }
+
+        let (hvf, completion) = match (self.hvf.take(), self.completion.take()) {
+            (Some(hvf), Some(completion)) => (hvf, completion),
+            (hvf, completion) => {
+                self.hvf = hvf;
+                self.completion = completion;
+                let cleanup_uncertain = self.shutdown().is_err();
+                return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                    ProcessSnapshotV2VsockPciRestoreStage::Assembly,
+                    cleanup_uncertain,
+                ));
+            }
+        };
+        let (
+            mut session,
+            configs,
+            storage_configs,
+            entropy_config,
+            balloon_config,
+            memory_hotplug,
+            hvf_vsock_config,
+        ) = match hvf.into_destination_parts() {
+            Ok(parts) => parts,
+            Err(source) => {
+                self.completion = Some(completion);
+                let mut cleanup_uncertain = source.has_incomplete_cleanup();
+                cleanup_uncertain |= self.shutdown().is_err();
+                return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                    ProcessSnapshotV2VsockPciRestoreStage::Assembly,
+                    cleanup_uncertain,
+                ));
+            }
+        };
+        let (
+            bytes,
+            binding,
+            device_graph,
+            serial,
+            entropy,
+            balloon,
+            memory_hotplug_state,
+            network_topology,
+            vsock_state,
+            vsock_config,
+            binding_keys,
+            network_completion,
+        ) = match completion.commit() {
+            Ok(parts) => parts,
+            Err(source) => {
+                let mut cleanup_uncertain = source.cleanup_uncertain();
+                cleanup_uncertain |= session.shutdown().is_err();
+                cleanup_uncertain |= self.shutdown().is_err();
+                return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                    ProcessSnapshotV2VsockPciRestoreStage::Assembly,
+                    cleanup_uncertain,
+                ));
+            }
+        };
+        if hvf_vsock_config != vsock_config {
+            let mut cleanup_uncertain = session.shutdown().is_err();
+            cleanup_uncertain |= self
+                .active_vsock
+                .take()
+                .is_some_and(|guard| guard.cleanup().is_err());
+            cleanup_uncertain |= network_completion.abort().is_err();
+            self.network_resources.clear();
+            cleanup_uncertain |= self.shutdown().is_err();
+            return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                ProcessSnapshotV2VsockPciRestoreStage::Assembly,
+                cleanup_uncertain,
+            ));
+        }
+        let (
+            resource_interfaces,
+            mut provider,
+            mmds_state,
+            mmds_metrics,
+            expected_mmds_state,
+            expected_mmds_controller,
+            network_metrics,
+            authority,
+        ) = match network_completion.into_parts() {
+            Ok(parts) => parts,
+            Err(_) => {
+                let mut cleanup_uncertain = session.shutdown().is_err();
+                cleanup_uncertain |= self
+                    .active_vsock
+                    .take()
+                    .is_some_and(|guard| guard.cleanup().is_err());
+                self.network_resources.clear();
+                cleanup_uncertain |= self.shutdown().is_err();
+                return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                    ProcessSnapshotV2VsockPciRestoreStage::Assembly,
+                    cleanup_uncertain,
+                ));
+            }
+        };
+        drop((
+            bytes,
+            binding,
+            device_graph,
+            serial,
+            entropy,
+            balloon,
+            memory_hotplug_state,
+            network_topology,
+            vsock_state,
+            binding_keys,
+            resource_interfaces,
+            expected_mmds_state,
+            expected_mmds_controller,
+            network_metrics,
+        ));
+        let (serial_output, serial_config) =
+            match (self.serial_output.take(), self.serial_config.take()) {
+                (Some(serial_output), Some(serial_config)) => (serial_output, serial_config),
+                (serial_output, serial_config) => {
+                    self.serial_output = serial_output;
+                    self.serial_config = serial_config;
+                    let mut cleanup_uncertain = session.shutdown().is_err();
+                    cleanup_uncertain |= self
+                        .active_vsock
+                        .take()
+                        .is_some_and(|guard| guard.cleanup().is_err());
+                    cleanup_uncertain |= provider.shutdown_packet_io().is_err();
+                    drop((provider, mmds_state, mmds_metrics));
+                    self.network_resources.clear();
+                    cleanup_uncertain |= self.shutdown().is_err();
+                    return Err(ProcessSnapshotV2VsockPciRestoreError::terminal(
+                        ProcessSnapshotV2VsockPciRestoreStage::Assembly,
+                        cleanup_uncertain,
+                    ));
+                }
+            };
+        Ok(RestoredProcessSnapshotV2VsockDestinationParts {
+            session,
+            configs,
+            storage_configs,
+            entropy_config,
+            balloon_config,
+            memory_hotplug,
+            vsock_config,
+            provider,
+            mmds_state,
+            mmds_metrics,
+            authority,
+            resources: std::mem::take(&mut self.network_resources),
+            active_vsock: self.active_vsock.take(),
+            serial_output,
+            serial_config,
+            restoration: self.serial_restoration.take(),
+        })
+    }
+}
 
 #[allow(clippy::too_many_arguments)]
 fn restore_process_snapshot_v2_vsock_pci<C>(
@@ -31206,15 +32180,30 @@ where
                         NativeV2SnapshotCaptureStage::Vsock,
                     ));
                 }
-                let vsock = session
-                    .capture_native_v2_vsock(
-                        vsock_config,
-                        &expected_vsock_metrics,
-                        expected_transport,
-                        guard,
-                        cancellation,
-                    )
-                    .map_err(|source| NativeV2SnapshotCaptureError::Vsock { source })?;
+                let vsock = match vsock_config {
+                    Some(config) => {
+                        let expected_vsock_metrics =
+                            expected_vsock_metrics.as_ref().ok_or_else(|| {
+                                NativeV2SnapshotCaptureError::Vsock {
+                                    source: NativeV2SnapshotVsockCaptureError::Live {
+                                        source: HvfArm64BootVsockCaptureError::owner_unavailable(
+                                            HvfArm64BootVsockCaptureDisposition::Terminal,
+                                        ),
+                                    },
+                                }
+                            })?;
+                        session
+                            .capture_native_v2_vsock(
+                                Some(config),
+                                expected_vsock_metrics,
+                                expected_transport,
+                                guard,
+                                cancellation,
+                            )
+                            .map_err(|source| NativeV2SnapshotCaptureError::Vsock { source })?
+                    }
+                    None => None,
+                };
                 if cancellation.is_cancelled() {
                     return Err(native_v2_snapshot_cancelled(
                         NativeV2SnapshotCaptureStage::Vsock,
@@ -32078,17 +33067,22 @@ where
             expected_transport,
         )
         .map_err(native_v2_snapshot_transaction_error_before_staging)?;
-        let expected_vsock_metrics = self.vsock_device_metrics.clone().ok_or_else(|| {
-            native_v2_snapshot_transaction_error_before_staging(
-                NativeV2SnapshotCaptureError::Vsock {
-                    source: NativeV2SnapshotVsockCaptureError::Live {
-                        source: HvfArm64BootVsockCaptureError::owner_unavailable(
-                            HvfArm64BootVsockCaptureDisposition::Terminal,
-                        ),
-                    },
-                },
-            )
-        })?;
+        let expected_vsock_metrics = vsock_config
+            .as_ref()
+            .map(|_| {
+                self.vsock_device_metrics.clone().ok_or_else(|| {
+                    native_v2_snapshot_transaction_error_before_staging(
+                        NativeV2SnapshotCaptureError::Vsock {
+                            source: NativeV2SnapshotVsockCaptureError::Live {
+                                source: HvfArm64BootVsockCaptureError::owner_unavailable(
+                                    HvfArm64BootVsockCaptureDisposition::Terminal,
+                                ),
+                            },
+                        },
+                    )
+                })
+            })
+            .transpose()?;
         let active_capture = self
             .register_snapshot_capture_raw(cancellation.clone())
             .map_err(|source| {
@@ -32219,10 +33213,11 @@ where
             network_configs,
             mmds_config,
             mmds_state,
+            vsock_config,
             expected_transport,
             cancellation,
         } = request;
-        preflight_native_v2_network_capture(
+        preflight_native_v2_vsock_capture(
             &serial_config,
             balloon_config,
             entropy_config,
@@ -32232,9 +33227,26 @@ where
             &network_configs,
             mmds_config.as_ref(),
             &mmds_state,
+            vsock_config.as_ref(),
             expected_transport,
         )
         .map_err(native_v2_snapshot_transaction_error_before_staging)?;
+        let expected_vsock_metrics = vsock_config
+            .as_ref()
+            .map(|_| {
+                self.vsock_device_metrics.clone().ok_or_else(|| {
+                    native_v2_snapshot_transaction_error_before_staging(
+                        NativeV2SnapshotCaptureError::Vsock {
+                            source: NativeV2SnapshotVsockCaptureError::Live {
+                                source: HvfArm64BootVsockCaptureError::owner_unavailable(
+                                    HvfArm64BootVsockCaptureDisposition::Terminal,
+                                ),
+                            },
+                        },
+                    )
+                })
+            })
+            .transpose()?;
         let active_capture = self
             .register_snapshot_capture_raw(cancellation.clone())
             .map_err(|source| {
@@ -32289,7 +33301,7 @@ where
                     let state = capture_and_recover_native_v2_state(
                         session,
                         input,
-                        NativeV2SnapshotCaptureProfile::Network {
+                        NativeV2SnapshotCaptureProfile::Vsock {
                             serial,
                             memory_hotplug_config,
                             memory_hotplug_requested_size_mib,
@@ -32299,14 +33311,16 @@ where
                             network_configs,
                             mmds_config,
                             mmds_state,
+                            vsock_config,
+                            expected_vsock_metrics,
                             expected_transport,
                         },
                         &guard,
                         Box::new(writer),
                         &cancellation,
                         |encoded| {
-                            NativeV2NetworkSnapshotCandidateState::from_network_state_v2_11(encoded)
-                                .map(NativeV2NetworkSnapshotCandidateState::into_current_artifact_state)
+                            NativeV2VsockSnapshotCandidateState::from_vsock_state_v2_12(encoded)
+                                .map(NativeV2VsockSnapshotCandidateState::into_current_artifact_state)
                                 .map_err(|source| {
                                     NativeV2SnapshotCaptureError::CandidateState { source }
                                 })
@@ -33596,7 +34610,8 @@ mod tests {
         SnapshotCreateInput, SnapshotLoadInput, SnapshotMemoryBackend, SnapshotMemoryBackendType,
         SnapshotNetworkOverride, SnapshotType, SnapshotV1ControllerCommit,
         SnapshotV2ControllerCommit, SnapshotV2ControllerCommitProductConfigs,
-        SnapshotV2NetworkControllerCommitProductConfigs, SnapshotVsockOverride,
+        SnapshotV2NetworkControllerCommitProductConfigs,
+        SnapshotV2VsockControllerCommitProductConfigs, SnapshotVsockOverride,
         SnapshotVsockSelectorError,
     };
     use bangbang_runtime::snapshot_artifact::{
@@ -33765,11 +34780,12 @@ mod tests {
         ProcessSnapshotV2NetworkLoadRequest, ProcessSnapshotV2NetworkRestorePlanError,
         ProcessSnapshotV2RootLoadCompletion, ProcessSnapshotV2RootLoadRequest,
         ProcessSnapshotV2RootLoadSuccess, ProcessSnapshotV2SerialLoadRequest,
-        ProcessSnapshotV2StorageLoadRequest, ProcessSnapshotV2StorageLoadSuccess, ProcessVmm,
-        ProcessVmnetAuthority, ProcessVmnetPacketIoBackendFactory, SerialGrantState,
-        SnapshotCreateSession, SnapshotV1LoadSuccess, SnapshotV2LoadSuccess,
-        default_hvf_boot_run_loop_step_limit, default_hvf_boot_session_config,
-        native_v2_platform_capture_is_terminal, prepare_process_snapshot_v2_network_restore_plan,
+        ProcessSnapshotV2StorageLoadRequest, ProcessSnapshotV2StorageLoadSuccess,
+        ProcessSnapshotV2VsockLoadRequest, ProcessVmm, ProcessVmnetAuthority,
+        ProcessVmnetPacketIoBackendFactory, SerialGrantState, SnapshotCreateSession,
+        SnapshotV1LoadSuccess, SnapshotV2LoadSuccess, default_hvf_boot_run_loop_step_limit,
+        default_hvf_boot_session_config, native_v2_platform_capture_is_terminal,
+        prepare_process_snapshot_v2_network_restore_plan,
         prepare_process_snapshot_v2_vsock_candidate, require_native_v1_composite_record,
         snapshot_destination_machine_config, vsock_capture_error_from_boot_run_loop_command,
     };
@@ -34925,12 +35941,14 @@ mod tests {
             storage_configs,
             network_configs,
             mmds_config,
+            vsock_config,
             expected_transport: transport,
             ..
         } = request;
         let has_block = !storage_configs.drives().is_empty();
         let has_pmem = !storage_configs.pmem().is_empty();
         let has_network = !network_configs.is_empty();
+        let has_vsock = vsock_config.is_some();
         session.native_snapshot_publication_count += 1;
         let memory_hotplug = memory_hotplug_config.map(|config| {
             fake_native_v2_memory_hotplug_state_for_request(
@@ -34976,7 +35994,7 @@ mod tests {
                 .expect("fake serial state should capture")
                 .encode(NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION)
                 .expect("fake serial state should encode");
-                let mut components = Vec::with_capacity(7);
+                let mut components = Vec::with_capacity(8);
                 components.push(SnapshotV2Component::new(
                     NATIVE_V2_MEMORY_COMPONENT_KEY,
                     SnapshotV2ComponentDisposition::Semantic,
@@ -35063,8 +36081,20 @@ mod tests {
                         network,
                     ));
                 }
+                let vsock = has_vsock.then(|| {
+                    fake_native_v2_vsock_state(transport)
+                        .encode(NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION)
+                        .expect("fake vsock state should encode")
+                });
+                if let Some(vsock) = &vsock {
+                    components.push(SnapshotV2Component::new(
+                        NATIVE_V2_VSOCK_COMPONENT_KEY,
+                        SnapshotV2ComponentDisposition::Semantic,
+                        vsock,
+                    ));
+                }
                 let encoded = encode_snapshot_v2_state_with_compatibility_version(
-                    NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
+                    NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
                     &[],
                     &components,
                 )
@@ -35075,8 +36105,8 @@ mod tests {
                         },
                     )
                 })?;
-                NativeV2NetworkSnapshotCandidateState::from_network_state_v2_11(encoded)
-                    .map(NativeV2NetworkSnapshotCandidateState::into_current_artifact_state)
+                NativeV2VsockSnapshotCandidateState::from_vsock_state_v2_12(encoded)
+                    .map(NativeV2VsockSnapshotCandidateState::into_current_artifact_state)
                     .map_err(|source| {
                         NativeV2SnapshotPublicationProducerError::Capture(
                             NativeV2SnapshotCaptureError::CandidateState { source },
@@ -36611,6 +37641,196 @@ mod tests {
                     ),
                     network_configs,
                     mmds_state,
+                ),
+                input.resume_vm(),
+            );
+            let session = match self.result {
+                FakeSnapshotLoadResult::ResumeFailure => FakeSession::with_resume_result(
+                    77,
+                    BackendError::Hypervisor("private-resume-sentinel".to_owned()),
+                ),
+                FakeSnapshotLoadResult::Success | FakeSnapshotLoadResult::Terminal => {
+                    FakeSession::new(77)
+                }
+            };
+            Ok(SnapshotV2LoadSuccess::new(session, commit))
+        }
+
+        fn load_prepared_snapshot_v2_vsock(
+            &mut self,
+            request: ProcessSnapshotV2VsockLoadRequest<'_>,
+        ) -> Result<SnapshotV2LoadSuccess<Self::Session>, NativeV2SnapshotLoadError> {
+            let ProcessSnapshotV2VsockLoadRequest {
+                controller,
+                vmnet_authority,
+                #[cfg(target_os = "macos")]
+                    contained_restore_authority: _,
+                pci_enabled,
+                input,
+                candidate,
+                memory,
+                cancellation,
+            } = request;
+            let expected_transport = if pci_enabled {
+                SnapshotV2DeviceTransportKind::Pci
+            } else {
+                SnapshotV2DeviceTransportKind::Mmio
+            };
+            if candidate
+                .device_graph()
+                .is_some_and(|graph| graph.transport_kind() != expected_transport)
+                || candidate
+                    .entropy()
+                    .is_some_and(|state| state.transport().kind() != expected_transport)
+                || candidate
+                    .balloon()
+                    .is_some_and(|state| state.transport().kind() != expected_transport)
+                || candidate
+                    .memory_hotplug()
+                    .is_some_and(|state| state.transport().kind() != expected_transport)
+            {
+                return Err(NativeV2SnapshotLoadError::CandidateMismatch);
+            }
+            let candidate = candidate
+                .prepare(
+                    &memory,
+                    expected_transport,
+                    input.network_overrides(),
+                    input.vsock_override(),
+                )
+                .map_err(NativeV2SnapshotLoadError::VsockPreparation)?;
+            let drive_configs = candidate
+                .device_graph()
+                .into_iter()
+                .flat_map(SnapshotV2StorageDeviceGraph::block_records)
+                .map(|record| {
+                    let config = record.config();
+                    let mut input = DriveConfigInput::new(
+                        config.drive_id(),
+                        config.drive_id(),
+                        config.selector(),
+                        config.is_root(),
+                    )
+                    .with_is_read_only(config.is_read_only())
+                    .with_cache_type(config.cache_type())
+                    .with_io_engine(config.io_engine());
+                    if let Some(partuuid) = config.partuuid() {
+                        input = input.with_partuuid(partuuid);
+                    }
+                    if let Some(rate_limiter) = config.rate_limiter() {
+                        input = input.with_rate_limiter(rate_limiter);
+                    }
+                    input.validate()
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| NativeV2SnapshotLoadError::CandidateMismatch)?;
+            let pmem_configs = candidate
+                .device_graph()
+                .into_iter()
+                .flat_map(SnapshotV2StorageDeviceGraph::pmem_records)
+                .map(|record| {
+                    let config = record.config();
+                    let mut input = PmemConfigInput::new(config.pmem_id(), config.selector())
+                        .with_root_device(config.is_root())
+                        .with_read_only(config.is_read_only());
+                    if let Some(rate_limiter) = config.rate_limiter() {
+                        input = input.with_rate_limiter(rate_limiter);
+                    }
+                    PmemConfig::try_from(input)
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| NativeV2SnapshotLoadError::CandidateMismatch)?;
+            let storage_configs = candidate
+                .device_graph()
+                .map(|_| CaptureReadyStorageConfigs::new(drive_configs, pmem_configs));
+            let mut serial_input = SerialConfigInput::new();
+            if let Some(selector) = candidate.serial().endpoint_intent().configured_selector() {
+                serial_input = serial_input.with_serial_out_path(selector);
+            }
+            if let Some(rate_limiter) = candidate.serial().rate_limiter() {
+                serial_input = serial_input.with_rate_limiter(rate_limiter);
+            }
+            let serial_config = serial_input
+                .validate()
+                .map_err(|_| NativeV2SnapshotLoadError::CandidateMismatch)?;
+            let entropy_config = candidate.entropy().map(SnapshotV2EntropyState::config);
+            let balloon_config = candidate.balloon().map(SnapshotV2BalloonState::config);
+            let memory_hotplug = candidate
+                .memory_hotplug()
+                .cloned()
+                .map(|state| {
+                    PreparedSnapshotV2MemoryHotplugTopology::prepare_for_compatibility_version(
+                        state,
+                        candidate.memory_binding().clone(),
+                        NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
+                    )
+                })
+                .transpose()
+                .map_err(|_| NativeV2SnapshotLoadError::CandidateMismatch)?
+                .map(|topology| topology.controller());
+            let network_configs = NetworkInterfaceConfigs::from_validated(
+                candidate
+                    .network_topology()
+                    .interfaces()
+                    .iter()
+                    .map(|interface| interface.controller().clone())
+                    .collect(),
+            );
+            let mmds_state = candidate
+                .network_topology()
+                .mmds_controller()
+                .map(|config| {
+                    let mut config_input =
+                        MmdsConfigInput::new(config.network_interfaces().to_vec())
+                            .with_version(config.version())
+                            .with_imds_compat(config.imds_compat());
+                    if let Some(address) = config.ipv4_address() {
+                        config_input = config_input.with_ipv4_address(address);
+                    }
+                    let state = MmdsStateHandle::default();
+                    state
+                        .with_mut(|state| {
+                            state.put_config(config_input, network_configs.as_slice())
+                        })
+                        .map_err(|_| NativeV2SnapshotLoadError::CandidateMismatch)?
+                        .map_err(|_| NativeV2SnapshotLoadError::CandidateMismatch)?;
+                    Ok::<_, NativeV2SnapshotLoadError>(state)
+                })
+                .transpose()?;
+            let vsock_config = candidate
+                .vsock_topology()
+                .map(|topology| topology.request().config().clone());
+            if !cancellation.try_seal_commit() {
+                return Err(NativeV2SnapshotLoadError::Cancelled);
+            }
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.last_vmnet_authority = Some(vmnet_authority);
+            assert_eq!(controller.instance_info().state, InstanceState::NotStarted);
+            if self.result == FakeSnapshotLoadResult::Terminal {
+                return Err(NativeV2SnapshotLoadError::ProcessTerminal);
+            }
+
+            let boot_source = BootSourceConfigInput::new("/private/restored-vmlinux")
+                .validate()
+                .expect("fake restored boot source should validate");
+            let machine =
+                MachineConfig::default().with_track_dirty_pages(input.track_dirty_pages());
+            let commit = SnapshotV2ControllerCommit::with_vsock_product_configs(
+                machine,
+                boot_source,
+                SnapshotV2VsockControllerCommitProductConfigs::new(
+                    SnapshotV2NetworkControllerCommitProductConfigs::new(
+                        SnapshotV2ControllerCommitProductConfigs::new(
+                            storage_configs,
+                            serial_config,
+                            entropy_config,
+                            balloon_config,
+                            memory_hotplug,
+                        ),
+                        network_configs,
+                        mmds_state,
+                    ),
+                    vsock_config,
                 ),
                 input.resume_vm(),
             );
@@ -41862,6 +43082,7 @@ mod tests {
             mmds_state: MmdsStateHandle::new(bangbang_runtime::mmds::MmdsState::new(
                 bangbang_runtime::mmds::MMDS_DATA_STORE_LIMIT_BYTES,
             )),
+            vsock_config: None,
             expected_transport,
             cancellation,
         }
@@ -42027,6 +43248,7 @@ mod tests {
                 mmds_state: MmdsStateHandle::new(bangbang_runtime::mmds::MmdsState::new(
                     bangbang_runtime::mmds::MMDS_DATA_STORE_LIMIT_BYTES,
                 )),
+                vsock_config: None,
                 expected_transport: transport,
                 cancellation: NativeV2SnapshotCaptureCancellation::default(),
             },
@@ -42069,6 +43291,7 @@ mod tests {
                 mmds_state: MmdsStateHandle::new(bangbang_runtime::mmds::MmdsState::new(
                     bangbang_runtime::mmds::MMDS_DATA_STORE_LIMIT_BYTES,
                 )),
+                vsock_config: None,
                 expected_transport: transport,
                 cancellation: NativeV2SnapshotCaptureCancellation::default(),
             },
@@ -44595,7 +45818,7 @@ mod tests {
     }
 
     #[test]
-    fn native_v2_process_preflight_validates_exact_minor_eleven_profile() {
+    fn native_v2_process_preflight_validates_exact_minor_profiles() {
         let range = GuestMemoryRange::new(GuestAddress::new(0x8000_0000), 16 * 1024)
             .expect("exact minor-eleven fixture range should validate");
         let layout = GuestMemoryLayout::new(vec![range])
@@ -44642,7 +45865,7 @@ mod tests {
         .expect("network-free exact minor-eleven state should encode internally");
         let state = NativeV2NetworkSnapshotCandidateState::from_network_state_v2_11(encoded)
             .expect("network-free exact minor-eleven candidate should validate")
-            .into_current_artifact_state();
+            .into_v2_11_artifact_state();
         assert_eq!(
             state
                 .v2_profile()
@@ -44663,9 +45886,7 @@ mod tests {
                 &prepared,
                 NativeV2SnapshotArtifactProfile::VsockStateV2_12,
             ),
-            Err(NativeV2SnapshotLoadError::Preflight(
-                VmmActionError::SnapshotUnsupported
-            ))
+            Err(NativeV2SnapshotLoadError::Decode(_))
         ));
     }
 
@@ -52844,7 +54065,7 @@ mod tests {
         let (candidate, _) = load_native_snapshot_artifacts(&paths)
             .expect("published network snapshot should load")
             .into_current_v2_candidate()
-            .expect("published network snapshot should retain exact 2.11");
+            .expect("published network snapshot should retain exact 2.12");
         assert!(candidate.network().is_some());
         directory.assert_no_staging();
     }
@@ -52880,7 +54101,7 @@ mod tests {
         let (candidate, _) = load_native_snapshot_artifacts(&paths)
             .expect("published memory-hotplug snapshot should load")
             .into_current_v2_candidate()
-            .expect("published memory-hotplug snapshot should retain exact 2.11");
+            .expect("published memory-hotplug snapshot should retain exact 2.12");
         let memory_hotplug = candidate
             .memory_hotplug()
             .expect("published memory-hotplug snapshot should contain kind 11");
@@ -52889,9 +54110,9 @@ mod tests {
         PreparedSnapshotV2MemoryHotplugTopology::prepare_for_compatibility_version(
             memory_hotplug.clone(),
             candidate.memory_binding().clone(),
-            NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
+            NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
         )
-        .expect("published memory-hotplug binding should close at exact 2.11");
+        .expect("published memory-hotplug binding should close at exact 2.12");
         directory.assert_no_staging();
     }
 
@@ -53042,13 +54263,11 @@ mod tests {
         assert!(!parent.exists());
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
-    fn public_exact_minor_eleven_configured_vsock_captures_before_unchanged_rejection() {
-        let state_path = missing_temp_child_path("public-vsock.state");
-        let memory_path = state_path.with_file_name("public-vsock.memory");
-        let parent = state_path
-            .parent()
-            .expect("missing public-vsock path should have a parent");
+    fn public_exact_minor_twelve_configured_vsock_publishes_current_pair() {
+        let directory = TempSnapshotDirectory::new("public-vsock");
+        let paths = directory.paths();
         let mut vmm = configured_vmm(FakeStarter::success(161));
         vmm.handle_action(VmmAction::PutVsock(VsockConfigInput::new(
             42,
@@ -53060,15 +54279,15 @@ mod tests {
         vmm.handle_action(VmmAction::Pause)
             .expect("public vsock fake session should pause");
 
-        let error = vmm
-            .handle_action(VmmAction::CreateSnapshot(SnapshotCreateInput::new(
+        assert_eq!(
+            vmm.handle_action(VmmAction::CreateSnapshot(SnapshotCreateInput::new(
                 SnapshotType::Full,
-                &state_path,
-                &memory_path,
-            )))
-            .expect_err("public exact-2.11 should reject configured vsock after capture");
+                paths.state(),
+                paths.memory(),
+            ))),
+            Ok(VmmData::Empty)
+        );
 
-        assert_eq!(error, VmmActionError::SnapshotUnsupported);
         assert_eq!(
             vmm.starter.snapshot_preflight_trace,
             [
@@ -53089,12 +54308,19 @@ mod tests {
         let session = vmm
             .started_session
             .as_ref()
-            .expect("rejected public vsock snapshot should retain its paused session");
-        assert_eq!(session.native_snapshot_publication_count, 0);
-        assert_eq!(session.native_snapshot_producer_count, 0);
-        assert!(!state_path.exists());
-        assert!(!memory_path.exists());
-        assert!(!parent.exists());
+            .expect("published public vsock snapshot should retain its paused session");
+        assert_eq!(session.native_snapshot_publication_count, 1);
+        assert_eq!(session.native_snapshot_producer_count, 1);
+        let (candidate, _) = load_native_snapshot_artifacts(&paths)
+            .expect("public exact-2.12 vsock pair should load")
+            .into_current_v2_candidate()
+            .expect("public exact-2.12 vsock pair should retain the current candidate");
+        assert_eq!(
+            candidate.version(),
+            NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION
+        );
+        assert!(candidate.vsock().is_some());
+        directory.assert_no_staging();
     }
 
     #[test]
@@ -53778,7 +55004,7 @@ mod tests {
                             }
                             source
                                 .handle_action(VmmAction::InstanceStart)
-                                .expect("public exact-2.11 source should start");
+                                .expect("public exact-2.12 source should start");
                             if has_memory_hotplug {
                                 source
                                     .handle_action(VmmAction::PatchMemoryHotplug(
@@ -53788,7 +55014,7 @@ mod tests {
                             }
                             source
                                 .handle_action(VmmAction::Pause)
-                                .expect("public exact-2.11 source should pause");
+                                .expect("public exact-2.12 source should pause");
                             source
                             .handle_action(VmmAction::CreateSnapshot(SnapshotCreateInput::new(
                                 SnapshotType::Full,
@@ -53802,13 +55028,13 @@ mod tests {
                             });
 
                             let loaded = load_native_snapshot_artifacts(&paths)
-                                .expect("public exact-2.11 pair should load");
+                                .expect("public exact-2.12 pair should load");
                             let (candidate, _) = loaded
                                 .into_current_v2_candidate()
                                 .expect("public pair should retain the exact current candidate");
                             assert_eq!(
                                 candidate.version(),
-                                NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION
+                                NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION
                             );
                             assert_eq!(candidate.entropy().is_some(), has_entropy);
                             if let Some(entropy) = candidate.entropy() {
@@ -53829,9 +55055,9 @@ mod tests {
                                 PreparedSnapshotV2MemoryHotplugTopology::prepare_for_compatibility_version(
                                     memory_hotplug.clone(),
                                     candidate.memory_binding().clone(),
-                                    NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
+                                    NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
                                 )
-                                .expect("public exact-2.11 virtio-mem memory binding should close");
+                                .expect("public exact-2.12 virtio-mem memory binding should close");
                             }
                             match candidate.device_graph() {
                                 Some(graph) => {
@@ -55445,7 +56671,7 @@ mod tests {
     #[test]
     #[ignore = "requires the signed native_v2_process integration group"]
     fn signed_native_v2_process_publishes_recaptures_and_resumes_private_pair() {
-        use bangbang_hvf::{HvfArm64StableVcpuDisposition, decode_hvf_snapshot_v2_network_state};
+        use bangbang_hvf::{HvfArm64StableVcpuDisposition, decode_hvf_snapshot_v2_vsock_state};
         use bangbang_runtime::snapshot_format_v2::decode_snapshot_v2_state;
 
         const ARM64_IMAGE_HEADER_SIZE: usize = 64;
@@ -55515,7 +56741,7 @@ mod tests {
                 .expect("native-v2 load should retain structural bytes"),
         )
         .expect("real process native-v2 state should decode structurally");
-        let first_state = decode_hvf_snapshot_v2_network_state(&first_structural)
+        let first_state = decode_hvf_snapshot_v2_vsock_state(&first_structural)
             .expect("real process native-v2 current state should cross-validate");
         let first_platform = first_state.platform();
         assert_eq!(first_platform.topology().members().len(), 2);
@@ -55659,13 +56885,13 @@ mod tests {
             Ok(VmmData::Empty)
         );
         let recaptured = load_native_snapshot_artifacts(&recaptured_paths)
-            .expect("restored destination should publish current exact-2.11 state");
+            .expect("restored destination should publish current exact-2.12 state");
         assert_eq!(
             recaptured
                 .state()
                 .v2_profile()
                 .expect("recaptured destination should retain a closed profile"),
-            NativeV2SnapshotArtifactProfile::NetworkStateV2_11
+            NativeV2SnapshotArtifactProfile::VsockStateV2_12
         );
         recaptured_directory.assert_no_staging();
         drop(paused_destination);
@@ -57028,7 +58254,7 @@ mod tests {
             .expect("empty-drive source should pause");
         drive
             .publish_native_v2_snapshot(&drive_input)
-            .expect("serial-only source should publish current exact-2.11 state");
+            .expect("serial-only source should publish current exact-2.12 state");
         assert_eq!(
             drive
                 .started_session
@@ -57044,7 +58270,7 @@ mod tests {
         let (candidate, _) = load_native_snapshot_artifacts(&drive_paths)
             .expect("serial-only pair should load")
             .into_current_v2_candidate()
-            .expect("serial-only pair should close as current exact 2.11");
+            .expect("serial-only pair should close as current exact 2.12");
         assert!(candidate.device_graph().is_none());
         drive_directory.assert_no_staging();
 
@@ -57104,7 +58330,7 @@ mod tests {
                 optional_paths.state(),
                 optional_paths.memory(),
             ))
-            .expect("balloon source should publish current exact-2.11 state");
+            .expect("balloon source should publish current exact-2.12 state");
         assert_eq!(
             optional.starter.snapshot_storage_preflight_calls, 1,
             "balloon publication should preflight the storage owner set"
@@ -57112,7 +58338,7 @@ mod tests {
         let (candidate, _) = load_native_snapshot_artifacts(&optional_paths)
             .expect("balloon publication should load")
             .into_current_v2_candidate()
-            .expect("balloon publication should close as current exact 2.11");
+            .expect("balloon publication should close as current exact 2.12");
         assert!(candidate.balloon().is_some());
         optional_directory.assert_no_staging();
 
@@ -57140,7 +58366,7 @@ mod tests {
             .expect("custom serial source should pause");
         serial
             .publish_native_v2_snapshot(&serial_input)
-            .expect("configured serial state should publish in current exact 2.11");
+            .expect("configured serial state should publish in current exact 2.12");
         assert_eq!(
             serial
                 .started_session
@@ -57156,7 +58382,7 @@ mod tests {
         let (candidate, _) = load_native_snapshot_artifacts(&serial_paths)
             .expect("configured serial snapshot should load")
             .into_current_v2_candidate()
-            .expect("configured serial snapshot should close as current exact 2.11");
+            .expect("configured serial snapshot should close as current exact 2.12");
         assert_eq!(
             candidate.serial().rate_limiter(),
             Some(SerialRateLimiterConfig::new(1, None, 1_000))
@@ -62915,27 +64141,32 @@ mod tests {
                 assert!(!format!("{candidate:?}").contains("captured-vsock"));
                 assert_eq!(auxiliary.acquire_count.load(Ordering::SeqCst), 1);
                 assert_eq!(auxiliary.drop_count.load(Ordering::SeqCst), 1);
+                let mut expected_events = vec![
+                    "aux-acquire",
+                    "v2-serial",
+                    "v2-pause",
+                    "v2-balloon",
+                    "v2-entropy",
+                    "v2-memory-hotplug",
+                    "v2-network",
+                ];
+                if has_vsock {
+                    expected_events.push("v2-vsock");
+                }
+                expected_events.extend([
+                    "v2-vsock-platform",
+                    "v2-vsock-compose",
+                    "v2-vsock-encode",
+                    "v2-recover",
+                    "v2-candidate-sealed",
+                    "aux-drop",
+                ]);
                 assert_eq!(
                     events
                         .lock()
                         .expect("vsock candidate events should lock")
                         .as_slice(),
-                    [
-                        "aux-acquire",
-                        "v2-serial",
-                        "v2-pause",
-                        "v2-balloon",
-                        "v2-entropy",
-                        "v2-memory-hotplug",
-                        "v2-network",
-                        "v2-vsock",
-                        "v2-vsock-platform",
-                        "v2-vsock-compose",
-                        "v2-vsock-encode",
-                        "v2-recover",
-                        "v2-candidate-sealed",
-                        "aux-drop",
-                    ]
+                    expected_events.as_slice()
                 );
                 assert_eq!(supervisor.status(), BootRunLoopWorkerStatus::Paused);
                 drop(supervisor);
@@ -64840,9 +66071,9 @@ mod tests {
                 "v2-entropy",
                 "v2-memory-hotplug",
                 "v2-network",
-                "v2-network-platform",
-                "v2-network-compose",
-                "v2-network-encode",
+                "v2-vsock-platform",
+                "v2-vsock-compose",
+                "v2-vsock-encode",
                 "v2-recover",
                 "v2-published",
                 "aux-drop",
@@ -64916,12 +66147,12 @@ mod tests {
                 ),
                 &paths,
             )
-            .expect("mutated UART state should publish as complete exact-2.11 state");
+            .expect("mutated UART state should publish as complete exact-2.12 state");
         assert_eq!(outcome.family(), NativeSnapshotArtifactFamily::V2);
         let (candidate, _) = load_native_snapshot_artifacts(&paths)
             .expect("mutated UART pair should load")
             .into_current_v2_candidate()
-            .expect("mutated UART pair should close as exact 2.11");
+            .expect("mutated UART pair should close as exact 2.12");
         assert_eq!(candidate.serial().device().receive_bytes(), b"x");
         assert_eq!(
             events
@@ -64938,9 +66169,9 @@ mod tests {
                 "v2-entropy",
                 "v2-memory-hotplug",
                 "v2-network",
-                "v2-network-platform",
-                "v2-network-compose",
-                "v2-network-encode",
+                "v2-vsock-platform",
+                "v2-vsock-compose",
+                "v2-vsock-encode",
                 "v2-recover",
                 "v2-published",
                 "aux-drop",

--- a/crates/bangbang/tests/app_sandbox_process_e2e.rs
+++ b/crates/bangbang/tests/app_sandbox_process_e2e.rs
@@ -104,7 +104,7 @@ fn sandboxed_bundle_reports_current_native_v2_snapshot_version() {
         output.stdout,
         output.stderr
     );
-    assert_eq!(output.stdout.trim(), "v2.11.0");
+    assert_eq!(output.stdout.trim(), "v2.12.0");
     assert_eq!(output.stderr, "");
 }
 

--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -29,14 +29,17 @@ mod macos_arm64 {
     use std::process::{Command, Stdio};
     use std::time::{Duration, Instant};
 
-    use bangbang_hvf::decode_hvf_snapshot_v2_network_state;
+    use bangbang_hvf::decode_hvf_snapshot_v2_vsock_state;
     use bangbang_runtime::balloon::VIRTIO_BALLOON_FREE_PAGE_HINT_DONE;
     use bangbang_runtime::block::{DriveCacheType, DriveIoEngine};
     use bangbang_runtime::mmds::MmdsVersion;
     use bangbang_runtime::snapshot_balloon_v2_9::SnapshotV2BalloonState;
     use bangbang_runtime::snapshot_device_v2::SnapshotV2DeviceTransportKind;
     use bangbang_runtime::snapshot_device_v2_6::SnapshotV2StorageDeviceGraph;
-    use bangbang_runtime::snapshot_format_v2::decode_snapshot_v2_state;
+    use bangbang_runtime::snapshot_format_v2::{
+        NATIVE_V2_VSOCK_COMPONENT_KEY, SnapshotV2Component, decode_snapshot_v2_state,
+        encode_snapshot_v2_state_with_compatibility_version,
+    };
     use bangbang_runtime::snapshot_memory_hotplug_v2_10::SnapshotV2MemoryHotplugState;
     use bangbang_runtime::snapshot_network_v2_11::{
         SnapshotV2NetworkBackendClass, SnapshotV2NetworkLimiterState, SnapshotV2NetworkState,
@@ -678,10 +681,11 @@ mod macos_arm64 {
             r#""state":"Paused""#,
             "GET / after idempotent duplicate PATCH /vm Paused",
         );
-        assert_capture_ready_snapshot_rejected_without_artifacts(
+        assert_capture_ready_snapshot_succeeds(
             &socket_path,
             test_dir.path(),
-            "paused MMIO Async storage preflight",
+            "paused MMIO Async storage and vsock exact-2.12 publication",
+            ExpectedSnapshotOptionalProducts::STORAGE_AND_VSOCK,
         );
 
         let resume_response = http_json(&socket_path, "PATCH", "/vm", r#"{"state":"Resumed"}"#);
@@ -3774,8 +3778,8 @@ mod macos_arm64 {
         });
         let structural =
             decode_snapshot_v2_state(&bytes).expect("balloon state should decode structurally");
-        let state = decode_hvf_snapshot_v2_network_state(&structural)
-            .expect("balloon state should decode as exact native-v2 2.11");
+        let state = decode_hvf_snapshot_v2_vsock_state(&structural)
+            .expect("balloon state should decode as exact native-v2 2.12");
         assert_eq!(
             state.device_graph().is_some(),
             expect_storage,
@@ -4497,8 +4501,8 @@ mod macos_arm64 {
         });
         let structural =
             decode_snapshot_v2_state(&bytes).expect("memory-hotplug state should decode");
-        let state = decode_hvf_snapshot_v2_network_state(&structural)
-            .expect("memory-hotplug state should be exact native-v2 2.11");
+        let state = decode_hvf_snapshot_v2_vsock_state(&structural)
+            .expect("memory-hotplug state should be exact native-v2 2.12");
         let graph = state
             .device_graph()
             .expect("memory-hotplug certification artifact should retain root and data");
@@ -6215,8 +6219,8 @@ mod macos_arm64 {
         });
         let structural =
             decode_snapshot_v2_state(&bytes).expect("entropy state should decode structurally");
-        let state = decode_hvf_snapshot_v2_network_state(&structural)
-            .expect("entropy state should decode as exact native-v2 2.11");
+        let state = decode_hvf_snapshot_v2_vsock_state(&structural)
+            .expect("entropy state should decode as exact native-v2 2.12");
         assert_eq!(
             state.device_graph().is_some(),
             with_storage,
@@ -7231,10 +7235,15 @@ mod macos_arm64 {
             &http_json(&socket_path, "PATCH", "/vm", r#"{"state":"Paused"}"#),
             "pause before product PCI memory-hotplug capture-ready preflight",
         );
-        assert_capture_ready_snapshot_rejected_without_artifacts(
+        let memory_hotplug_snapshot_directory =
+            test_dir.path().join("all-virtio-memory-hotplug-snapshot");
+        fs::create_dir(&memory_hotplug_snapshot_directory)
+            .expect("product PCI memory-hotplug snapshot directory should create");
+        assert_capture_ready_snapshot_succeeds(
             &socket_path,
-            test_dir.path(),
-            "paused product PCI memory-hotplug capture-ready preflight",
+            &memory_hotplug_snapshot_directory,
+            "paused product PCI all-device memory-hotplug exact-2.12 publication",
+            ExpectedSnapshotOptionalProducts::ALL_WITH_VSOCK,
         );
         assert_no_content_response(
             &http_json(&socket_path, "PATCH", "/vm", r#"{"state":"Resumed"}"#),
@@ -7300,10 +7309,14 @@ mod macos_arm64 {
             &http_json(&socket_path, "PATCH", "/vm", r#"{"state":"Paused"}"#),
             "pause before product PCI balloon capture-ready preflight",
         );
-        assert_capture_ready_snapshot_rejected_without_artifacts(
+        let balloon_snapshot_directory = test_dir.path().join("all-virtio-balloon-snapshot");
+        fs::create_dir(&balloon_snapshot_directory)
+            .expect("product PCI balloon snapshot directory should create");
+        assert_capture_ready_snapshot_succeeds(
             &socket_path,
-            test_dir.path(),
-            "paused product PCI balloon capture-ready preflight",
+            &balloon_snapshot_directory,
+            "paused product PCI all-device balloon exact-2.12 publication",
+            ExpectedSnapshotOptionalProducts::ALL_WITH_VSOCK,
         );
         assert_no_content_response(
             &http_json(&socket_path, "PATCH", "/vm", r#"{"state":"Resumed"}"#),
@@ -10519,23 +10532,29 @@ mod macos_arm64 {
     }
 
     #[test]
-    fn signed_executable_resets_optional_vsock_before_unchanged_rejection_over_mmio() {
-        run_signed_vsock_snapshot_preflight_rejection(false);
+    fn signed_executable_restores_native_v2_vsock_snapshot_over_mmio() {
+        run_signed_vsock_snapshot_activation(false);
     }
 
     #[test]
-    fn signed_executable_resets_optional_vsock_before_unchanged_rejection_over_product_pci() {
-        run_signed_vsock_snapshot_preflight_rejection(true);
+    fn signed_executable_restores_native_v2_vsock_snapshot_over_product_pci() {
+        run_signed_vsock_snapshot_activation(true);
     }
 
-    fn run_signed_vsock_snapshot_preflight_rejection(enable_pci: bool) {
+    fn run_signed_vsock_snapshot_activation(enable_pci: bool) {
         let transport = if enable_pci { "product PCI" } else { "MMIO" };
         let test_dir = TestDir::new();
         let socket_path = test_dir.path().join("api.socket");
         let data_backing_path = test_dir.path().join("vsock-reset.img");
         let uds_path = test_dir.path().join("vs.sock");
+        let override_uds_path = test_dir.path().join("override-vs.sock");
+        let rejected_uds_path = test_dir.path().join("rejected-vs.sock");
+        let state_path = test_dir.path().join("vsock.state");
+        let memory_path = test_dir.path().join("vsock.memory");
+        let no_vsock_state_path = test_dir.path().join("without-vsock.state");
+        let recaptured_state_path = test_dir.path().join("recaptured-vsock.state");
+        let recaptured_memory_path = test_dir.path().join("recaptured-vsock.memory");
         let old_port_path = vsock_port_path(&uds_path, DIRECT_ROOTFS_VSOCK_SNAPSHOT_OLD_PORT);
-        let fresh_port_path = vsock_port_path(&uds_path, DIRECT_ROOTFS_VSOCK_SNAPSHOT_FRESH_PORT);
         let kernel_path = env_path(BANGBANG_GUEST_KERNEL_PATH_ENV);
         let rootfs_path = env_path(BANGBANG_GUEST_EXT4_ROOTFS_PATH_ENV);
         let instance_id = test_dir.instance_id();
@@ -10544,12 +10563,6 @@ mod macos_arm64 {
         let old_listener = UnixListener::bind(&old_port_path).unwrap_or_else(|err| {
             panic!(
                 "{transport} old vsock listener should bind before startup: {:?}",
-                err.kind()
-            )
-        });
-        let fresh_listener = UnixListener::bind(&fresh_port_path).unwrap_or_else(|err| {
-            panic!(
-                "{transport} fresh vsock listener should bind before startup: {:?}",
                 err.kind()
             )
         });
@@ -10677,44 +10690,220 @@ mod macos_arm64 {
             .set_nonblocking(false)
             .expect("old vsock stream should return to blocking I/O");
 
-        assert_capture_ready_snapshot_rejected_without_artifacts(
-            &socket_path,
-            test_dir.path(),
-            &format!("paused {transport} vsock capture-preflight rejection"),
-        );
-        old_stream
-            .set_nonblocking(true)
-            .expect("rejected snapshot should leave the reset old vsock stream probeable");
-        match old_stream.read(&mut unexpected) {
-            Ok(0) => {}
-            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => panic!(
-                "{transport} snapshot rejection returned before capture preflight reset the old vsock stream"
-            ),
-            Ok(bytes) => panic!(
-                "{transport} reset old vsock stream produced {bytes} unexpected byte(s) after snapshot rejection"
-            ),
-            Err(err) => panic!(
-                "{transport} reset old vsock stream probe failed after snapshot rejection: {:?}",
-                err.kind()
-            ),
-        }
+        let create_body = serde_json::json!({
+            "snapshot_type": "Full",
+            "snapshot_path": state_path,
+            "mem_file_path": memory_path,
+        })
+        .to_string();
         assert_no_content_response(
-            &http_json(&socket_path, "PATCH", "/vm", r#"{"state":"Resumed"}"#),
-            &format!("resume after vsock snapshot capture-preflight rejection {transport}"),
+            &http_put_json(&socket_path, "/snapshot/create", &create_body),
+            &format!("create paused {transport} exact-2.12 vsock snapshot"),
         );
+        assert!(state_path.is_file());
+        assert!(memory_path.is_file());
+        assert_native_v2_vsock_snapshot(&state_path, enable_pci, transport);
+        let state_before = fs::read(&state_path).expect("vsock snapshot state should read");
+        let memory_before = fs::read(&memory_path).expect("vsock snapshot memory should read");
+
+        if let Err(err) = read_unix_stream_eof(&mut old_stream) {
+            let output = bangbang.force_stop_and_collect();
+            panic!(
+                "{transport} snapshot capture did not reset the source-only old stream: {err}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                output.status, output.stdout, output.stderr
+            );
+        }
         drop(old_stream);
+
+        assert_clean_shutdown(
+            bangbang.terminate(),
+            &socket_path,
+            &format!("bangbang {transport} vsock snapshot source"),
+        );
+        assert!(
+            !uds_path.exists(),
+            "{transport} source shutdown should remove its process-owned listener"
+        );
+
+        write_native_v2_snapshot_without_vsock(&state_path, &no_vsock_state_path, transport);
+        let rejected_socket_path = test_dir.path().join("rejected-api.socket");
+        let rejected_instance_id = format!("{instance_id}-rejected");
+        let rejected = if enable_pci {
+            BangbangProcess::start_with_extra_args(
+                &rejected_socket_path,
+                &rejected_instance_id,
+                &["--enable-pci"],
+            )
+        } else {
+            BangbangProcess::start(&rejected_socket_path, &rejected_instance_id)
+        };
+        let rejected_body = signed_vsock_snapshot_load_body(
+            &no_vsock_state_path,
+            &memory_path,
+            false,
+            Some(&rejected_uds_path),
+        );
+        let rejected_response =
+            http_put_json(&rejected_socket_path, "/snapshot/load", &rejected_body);
+        assert_bad_request_response(
+            &rejected_response,
+            &format!("{transport} override without snapshot vsock"),
+        );
+        assert!(
+            !rejected_response.contains(path_text(&rejected_uds_path))
+                && !rejected_response.contains(path_text(&no_vsock_state_path))
+                && !rejected_response.contains(path_text(&memory_path)),
+            "{transport} override-without-device diagnostics must redact selectors and artifacts"
+        );
+        assert!(
+            http_get(&rejected_socket_path, "/").contains(r#""state":"Not started""#),
+            "{transport} rejected destination must remain Not started"
+        );
+        assert!(
+            !rejected_uds_path.exists(),
+            "{transport} rejected override must not publish a socket"
+        );
+        assert_clean_shutdown(
+            rejected.terminate(),
+            &rejected_socket_path,
+            &format!("bangbang {transport} rejected vsock snapshot destination"),
+        );
+
+        run_signed_vsock_snapshot_destination(SignedVsockSnapshotDestination {
+            enable_pci,
+            transport,
+            instance_id: &format!("{instance_id}-paused"),
+            api_socket: &test_dir.path().join("paused-api.socket"),
+            state: &state_path,
+            memory: &memory_path,
+            data_backing: &data_backing_path,
+            saved_uds_path: &uds_path,
+            destination_uds_path: &uds_path,
+            requested_override: None,
+            resume_vm: false,
+            recapture: Some((&recaptured_state_path, &recaptured_memory_path)),
+        });
+        assert_native_v2_vsock_snapshot(&recaptured_state_path, enable_pci, transport);
+
+        run_signed_vsock_snapshot_destination(SignedVsockSnapshotDestination {
+            enable_pci,
+            transport,
+            instance_id: &format!("{instance_id}-automatic"),
+            api_socket: &test_dir.path().join("automatic-api.socket"),
+            state: &state_path,
+            memory: &memory_path,
+            data_backing: &data_backing_path,
+            saved_uds_path: &uds_path,
+            destination_uds_path: &override_uds_path,
+            requested_override: Some(&override_uds_path),
+            resume_vm: true,
+            recapture: None,
+        });
+
+        assert_eq!(
+            fs::read(&state_path).expect("immutable vsock snapshot state should read"),
+            state_before,
+            "{transport} repeated loads must not mutate the state artifact"
+        );
+        assert_eq!(
+            fs::read(&memory_path).expect("immutable vsock snapshot memory should read"),
+            memory_before,
+            "{transport} repeated loads must not mutate the memory artifact"
+        );
+        assert_no_snapshot_staging(test_dir.path());
+    }
+
+    struct SignedVsockSnapshotDestination<'a> {
+        enable_pci: bool,
+        transport: &'a str,
+        instance_id: &'a str,
+        api_socket: &'a Path,
+        state: &'a Path,
+        memory: &'a Path,
+        data_backing: &'a Path,
+        saved_uds_path: &'a Path,
+        destination_uds_path: &'a Path,
+        requested_override: Option<&'a Path>,
+        resume_vm: bool,
+        recapture: Option<(&'a Path, &'a Path)>,
+    }
+
+    fn run_signed_vsock_snapshot_destination(case: SignedVsockSnapshotDestination<'_>) {
+        let SignedVsockSnapshotDestination {
+            enable_pci,
+            transport,
+            instance_id,
+            api_socket,
+            state,
+            memory,
+            data_backing,
+            saved_uds_path,
+            destination_uds_path,
+            requested_override,
+            resume_vm,
+            recapture,
+        } = case;
+        reset_zeroed_block_backing(data_backing, 1);
+        let fresh_port_path = vsock_port_path(
+            destination_uds_path,
+            DIRECT_ROOTFS_VSOCK_SNAPSHOT_FRESH_PORT,
+        );
+        let fresh_listener = UnixListener::bind(&fresh_port_path).unwrap_or_else(|err| {
+            panic!(
+                "{transport} destination fresh listener should bind before load: {:?}",
+                err.kind()
+            )
+        });
+        let mut destination = if enable_pci {
+            BangbangProcess::start_with_extra_args(api_socket, instance_id, &["--enable-pci"])
+        } else {
+            BangbangProcess::start(api_socket, instance_id)
+        };
+        let body = signed_vsock_snapshot_load_body(state, memory, resume_vm, requested_override);
+        let load_response = http_put_json(api_socket, "/snapshot/load", &body);
+        assert_no_content_response(
+            &load_response,
+            &format!("{transport} exact-2.12 vsock snapshot load"),
+        );
+        let expected_state = if resume_vm { "Running" } else { "Paused" };
+        assert!(
+            http_get(api_socket, "/").contains(&format!(r#""state":"{expected_state}""#)),
+            "{transport} destination should commit {expected_state}"
+        );
+        assert!(
+            destination_uds_path.exists(),
+            "{transport} destination should own its selected main listener"
+        );
+        if destination_uds_path != saved_uds_path {
+            assert!(
+                !saved_uds_path.exists(),
+                "{transport} override load must not republish the saved selector"
+            );
+        }
+        if !resume_vm {
+            assert_no_content_response(
+                &http_json(api_socket, "PATCH", "/vm", r#"{"state":"Resumed"}"#),
+                &format!("resume paused {transport} exact-2.12 vsock destination"),
+            );
+        }
 
         let mut fresh_stream =
             wait_for_unix_listener_accept(&fresh_listener, GUEST_EXECUTION_TIMEOUT)
                 .unwrap_or_else(|err| {
-                    let prefix = file_prefix_lossy(&data_backing_path, 128);
-                    let output = bangbang.force_stop_and_collect();
+                    let prefix = file_prefix_lossy(data_backing, 128);
+                    let output = destination.force_stop_and_collect();
                     panic!(
-                        "{transport} guest did not establish a fresh vsock connection after the host closed the preserved old stream: {err}; control prefix: {prefix:?}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                        "{transport} restored guest did not establish a fresh vsock connection: {err}; control prefix: {prefix:?}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
                         output.status, output.stdout, output.stderr
                     );
                 });
         drop(fresh_listener);
+        fs::remove_file(&fresh_port_path).unwrap_or_else(|err| {
+            panic!(
+                "{transport} host-owned fresh listener path should clean up: {:?}",
+                err.kind()
+            )
+        });
         fresh_stream
             .set_nonblocking(false)
             .expect("fresh vsock stream should use blocking I/O");
@@ -10726,61 +10915,155 @@ mod macos_arm64 {
             .expect("fresh vsock stream write timeout should set");
         let mut fresh_ready = vec![0; DIRECT_ROOTFS_VSOCK_SNAPSHOT_FRESH_READY.len()];
         fresh_stream.read_exact(&mut fresh_ready).unwrap_or_else(|err| {
-            let output = bangbang.force_stop_and_collect();
+            let output = destination.force_stop_and_collect();
             panic!(
-                "{transport} fresh vsock connection did not publish readiness: {err}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                "{transport} fresh restored vsock connection did not publish readiness: {err}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
                 output.status, output.stdout, output.stderr
             );
         });
         assert_eq!(
             fresh_ready, DIRECT_ROOTFS_VSOCK_SNAPSHOT_FRESH_READY,
-            "{transport} fresh vsock readiness payload should match"
+            "{transport} restored fresh readiness payload should match"
         );
         fresh_stream
             .write_all(DIRECT_ROOTFS_VSOCK_SNAPSHOT_FRESH_ACK)
             .unwrap_or_else(|err| {
-                let output = bangbang.force_stop_and_collect();
+                let output = destination.force_stop_and_collect();
                 panic!(
-                    "{transport} host did not acknowledge the fresh vsock connection: {err}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                    "{transport} host did not acknowledge the restored fresh connection: {err}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
                     output.status, output.stdout, output.stderr
                 );
             });
         shutdown_unix_stream_write(&fresh_stream).unwrap_or_else(|err| {
-            let output = bangbang.force_stop_and_collect();
+            let output = destination.force_stop_and_collect();
             panic!(
-                "{transport} host did not half-close the fresh vsock connection: {err}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                "{transport} host did not half-close the restored fresh connection: {err}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
                 output.status, output.stdout, output.stderr
             );
         });
         if let Err(err) = read_unix_stream_eof(&mut fresh_stream) {
-            let output = bangbang.force_stop_and_collect();
+            let output = destination.force_stop_and_collect();
             panic!(
-                "{transport} host did not observe EOF on the fresh vsock connection: {err}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                "{transport} host did not observe restored fresh connection EOF: {err}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
                 output.status, output.stdout, output.stderr
             );
         }
 
         if let Err(err) = wait_for_file_prefix_marker(
-            &data_backing_path,
+            data_backing,
             DIRECT_ROOTFS_VSOCK_SNAPSHOT_SUCCESS,
             GUEST_EXECUTION_TIMEOUT,
         ) {
-            let prefix = file_prefix_lossy(&data_backing_path, 128);
-            let output = bangbang.force_stop_and_collect();
+            let prefix = file_prefix_lossy(data_backing, 128);
+            let output = destination.force_stop_and_collect();
             panic!(
-                "{transport} guest did not confirm reset and fresh reconnection: {err}; control prefix: {prefix:?}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
+                "{transport} restored guest did not confirm reset and fresh traffic: {err}; control prefix: {prefix:?}; status: {:?}\nstdout:\n{}\nstderr:\n{}",
                 output.status, output.stdout, output.stderr
             );
         }
 
+        if let Some((recaptured_state, recaptured_memory)) = recapture {
+            assert_no_content_response(
+                &http_json(api_socket, "PATCH", "/vm", r#"{"state":"Paused"}"#),
+                &format!("pause restored {transport} vsock destination before recapture"),
+            );
+            let recapture_body = serde_json::json!({
+                "snapshot_type": "Full",
+                "snapshot_path": recaptured_state,
+                "mem_file_path": recaptured_memory,
+            })
+            .to_string();
+            assert_no_content_response(
+                &http_put_json(api_socket, "/snapshot/create", &recapture_body),
+                &format!("recapture restored {transport} exact-2.12 vsock destination"),
+            );
+        }
+
         assert_clean_shutdown(
-            bangbang.terminate(),
-            &socket_path,
-            &format!("bangbang vsock snapshot reset {transport}"),
+            destination.terminate(),
+            api_socket,
+            &format!("bangbang restored {transport} vsock snapshot destination"),
         );
         assert!(
-            !uds_path.exists(),
-            "{transport} shutdown should remove the process-owned main vsock listener"
+            !destination_uds_path.exists(),
+            "{transport} destination shutdown should remove its selected main listener"
+        );
+    }
+
+    fn signed_vsock_snapshot_load_body(
+        state: &Path,
+        memory: &Path,
+        resume_vm: bool,
+        requested_override: Option<&Path>,
+    ) -> String {
+        let mut body = serde_json::json!({
+            "snapshot_path": state,
+            "mem_backend": {
+                "backend_path": memory,
+                "backend_type": "File",
+            },
+            "resume_vm": resume_vm,
+        });
+        if let Some(requested_override) = requested_override {
+            body["vsock_override"] = serde_json::json!({
+                "uds_path": requested_override,
+            });
+        }
+        body.to_string()
+    }
+
+    fn assert_native_v2_vsock_snapshot(path: &Path, enable_pci: bool, context: &str) {
+        let bytes = fs::read(path).expect("exact-2.12 vsock snapshot state should read");
+        let structural =
+            decode_snapshot_v2_state(&bytes).expect("exact-2.12 vsock state should decode");
+        let state = decode_hvf_snapshot_v2_vsock_state(&structural)
+            .expect("exact-2.12 vsock state should decode semantically");
+        let vsock = state
+            .vsock()
+            .expect("exact-2.12 activation artifact should contain kind 13");
+        assert_eq!(vsock.guest_cid(), 3, "{context} guest CID should persist");
+        assert_eq!(
+            vsock.transport().kind(),
+            if enable_pci {
+                SnapshotV2DeviceTransportKind::Pci
+            } else {
+                SnapshotV2DeviceTransportKind::Mmio
+            },
+            "{context} vsock transport should persist"
+        );
+    }
+
+    fn write_native_v2_snapshot_without_vsock(source: &Path, destination: &Path, context: &str) {
+        let bytes = fs::read(source).expect("source exact-2.12 state should read");
+        let structural =
+            decode_snapshot_v2_state(&bytes).expect("source exact-2.12 state should decode");
+        let required_features = structural.required_features().collect::<Vec<_>>();
+        let mut removed = 0;
+        let components = structural
+            .components()
+            .filter(|component| {
+                let retain = component.key() != NATIVE_V2_VSOCK_COMPONENT_KEY;
+                removed += usize::from(!retain);
+                retain
+            })
+            .collect::<Vec<SnapshotV2Component<'_>>>();
+        assert_eq!(removed, 1, "{context} fixture should remove one kind 13");
+        let encoded = encode_snapshot_v2_state_with_compatibility_version(
+            structural.metadata().version(),
+            &required_features,
+            &components,
+        )
+        .expect("exact-2.12 state without vsock should encode");
+        fs::write(destination, encoded).expect("exact-2.12 no-vsock fixture should write");
+        let rewritten =
+            fs::read(destination).expect("rewritten exact-2.12 no-vsock state should read");
+        let structural =
+            decode_snapshot_v2_state(&rewritten).expect("rewritten exact-2.12 state should decode");
+        let state = decode_hvf_snapshot_v2_vsock_state(&structural)
+            .expect("rewritten exact-2.12 no-vsock state should decode semantically");
+        assert!(
+            state.vsock().is_none(),
+            "{context} rewritten fixture should omit kind 13"
         );
     }
 
@@ -11784,8 +12067,8 @@ mod macos_arm64 {
         });
         let structural =
             decode_snapshot_v2_state(&bytes).expect("network state should decode structurally");
-        let state = decode_hvf_snapshot_v2_network_state(&structural)
-            .expect("network state should decode as exact native-v2 2.11");
+        let state = decode_hvf_snapshot_v2_vsock_state(&structural)
+            .expect("network state should decode as exact native-v2 2.12");
         let graph = state
             .device_graph()
             .expect("network certification source should retain root and data");
@@ -13964,7 +14247,7 @@ mod macos_arm64 {
         let bytes = fs::read(path).expect("configured serial snapshot state should read");
         let structural = decode_snapshot_v2_state(&bytes)
             .expect("configured serial snapshot state should decode");
-        let decoded = decode_hvf_snapshot_v2_network_state(&structural)
+        let decoded = decode_hvf_snapshot_v2_vsock_state(&structural)
             .expect("configured serial snapshot state should decode semantically");
         assert!(decoded.device_graph().is_none());
         assert_eq!(
@@ -14016,7 +14299,7 @@ mod macos_arm64 {
         let bytes = fs::read(path).expect("serial snapshot state should read");
         let structural =
             decode_snapshot_v2_state(&bytes).expect("serial snapshot state should decode");
-        let decoded = decode_hvf_snapshot_v2_network_state(&structural)
+        let decoded = decode_hvf_snapshot_v2_vsock_state(&structural)
             .expect("serial snapshot state should decode semantically");
         assert!(
             decoded
@@ -14204,7 +14487,7 @@ mod macos_arm64 {
             "native-v2 description should succeed; stderr:\n{}",
             described.stderr
         );
-        assert_eq!(described.stdout.trim(), "v2.11.0");
+        assert_eq!(described.stdout.trim(), "v2.12.0");
 
         let collision = http_json_with_io_timeout(
             &source_socket,
@@ -14727,7 +15010,7 @@ mod macos_arm64 {
             "{transport} native-v2 root description should succeed; stderr:\n{}",
             described.stderr
         );
-        assert_eq!(described.stdout.trim(), "v2.11.0");
+        assert_eq!(described.stdout.trim(), "v2.12.0");
         let source_output = source.terminate();
         assert_clean_shutdown(
             source_output,
@@ -15841,7 +16124,7 @@ mod macos_arm64 {
         });
         let structural =
             decode_snapshot_v2_state(&bytes).expect("native-v2 state should decode structurally");
-        decode_hvf_snapshot_v2_network_state(&structural)
+        decode_hvf_snapshot_v2_vsock_state(&structural)
             .expect("native-v2 state should decode semantically")
             .device_graph()
             .expect("storage-bearing native-v2 state should contain a device graph")
@@ -16085,19 +16368,6 @@ mod macos_arm64 {
         );
     }
 
-    fn assert_capture_ready_snapshot_rejected_without_artifacts(
-        socket_path: &Path,
-        directory: &Path,
-        context: &str,
-    ) {
-        assert_snapshot_rejected_without_artifacts(
-            socket_path,
-            directory,
-            context,
-            "Snapshot and restore are not supported.",
-        );
-    }
-
     #[derive(Clone, Copy)]
     struct ExpectedSnapshotOptionalProducts {
         storage: bool,
@@ -16105,6 +16375,7 @@ mod macos_arm64 {
         balloon: bool,
         memory_hotplug: bool,
         network: bool,
+        vsock: bool,
     }
 
     impl ExpectedSnapshotOptionalProducts {
@@ -16114,10 +16385,15 @@ mod macos_arm64 {
             balloon: false,
             memory_hotplug: false,
             network: false,
+            vsock: false,
         };
         const STORAGE: Self = Self {
             storage: true,
             ..Self::NONE
+        };
+        const STORAGE_AND_VSOCK: Self = Self {
+            vsock: true,
+            ..Self::STORAGE
         };
         const STORAGE_AND_ENTROPY: Self = Self {
             entropy: true,
@@ -16139,6 +16415,14 @@ mod macos_arm64 {
             entropy: true,
             balloon: true,
             memory_hotplug: true,
+            ..Self::STORAGE
+        };
+        const ALL_WITH_VSOCK: Self = Self {
+            entropy: true,
+            balloon: true,
+            memory_hotplug: true,
+            network: true,
+            vsock: true,
             ..Self::STORAGE
         };
     }
@@ -16169,8 +16453,8 @@ mod macos_arm64 {
         let bytes = fs::read(&state_path).expect("capture-ready state should read");
         let structural =
             decode_snapshot_v2_state(&bytes).expect("capture-ready state should be exact current");
-        let state = decode_hvf_snapshot_v2_network_state(&structural)
-            .expect("capture-ready state should use the exact-2.11 network profile");
+        let state = decode_hvf_snapshot_v2_vsock_state(&structural)
+            .expect("capture-ready state should use the exact-2.12 vsock profile");
         assert_eq!(
             state.device_graph().is_some(),
             expected.storage,
@@ -16196,35 +16480,11 @@ mod macos_arm64 {
             expected.network,
             "{context} network profile presence should match"
         );
-        assert_no_snapshot_staging(directory);
-    }
-
-    fn assert_snapshot_rejected_without_artifacts(
-        socket_path: &Path,
-        directory: &Path,
-        context: &str,
-        expected_error: &str,
-    ) {
-        let state_path = directory.join("capture-ready-rejected.state");
-        let memory_path = directory.join("capture-ready-rejected.memory");
-        let response = http_json_with_io_timeout(
-            socket_path,
-            "PUT",
-            "/snapshot/create",
-            &format!(
-                r#"{{"snapshot_type":"Full","snapshot_path":{},"mem_file_path":{}}}"#,
-                json_string(path_text(&state_path)),
-                json_string(path_text(&memory_path))
-            ),
-            GUEST_EXECUTION_TIMEOUT,
+        assert_eq!(
+            state.vsock().is_some(),
+            expected.vsock,
+            "{context} vsock profile presence should match"
         );
-
-        assert_bad_request_response(&response, context);
-        assert_response_contains(&response, expected_error, context);
-        assert!(!response.contains(path_text(&state_path)));
-        assert!(!response.contains(path_text(&memory_path)));
-        assert!(!state_path.exists());
-        assert!(!memory_path.exists());
         assert_no_snapshot_staging(directory);
     }
 

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -1229,7 +1229,7 @@ fn executable_rejects_invalid_logger_level_as_bad_configuration() {
 }
 
 #[test]
-fn executable_rejects_snapshot_requests_without_mutating() {
+fn executable_snapshot_request_failures_do_not_mutate() {
     let test_dir = TestDir::new();
     let socket_path = test_dir.path().join("api.socket");
     let logger_path = test_dir.path().join("snapshot-requests.log");
@@ -1277,7 +1277,7 @@ fn executable_rejects_snapshot_requests_without_mutating() {
         (
             "/snapshot/load",
             load_body,
-            r#"{"fault_message":"Snapshot and restore are not supported."}"#,
+            "snapshot artifact load failed during state final open",
             vec![
                 path_text(&load_state_path),
                 path_text(&load_memory_path),

--- a/crates/hvf/src/startup.rs
+++ b/crates/hvf/src/startup.rs
@@ -4106,6 +4106,18 @@ struct RestoredHvfSnapshotV2NetworkMmioInnerOwners {
     vsock: Option<RestoredHvfSnapshotV2VsockMmioMetadata>,
 }
 
+/// Live exact-2.12 MMIO destination parts after retry publication commits.
+#[doc(hidden)]
+pub type RestoredHvfSnapshotV2VsockMmioDestinationParts = (
+    OwnedHvfArm64BootSession,
+    Vec<NetworkInterfaceConfig>,
+    Option<CaptureReadyStorageConfigs>,
+    Option<EntropyConfig>,
+    Option<BalloonConfig>,
+    Option<SnapshotV2MemoryHotplugControllerProjection>,
+    Option<VsockConfig>,
+);
+
 /// Complete exact-2.12 MMIO owner graph with retry publication still gated.
 #[doc(hidden)]
 pub struct RestoredHvfSnapshotV2VsockMmioOwners {
@@ -4200,6 +4212,26 @@ impl RestoredHvfSnapshotV2VsockMmioOwners {
 
     pub fn shutdown(self) -> Result<(), HvfArm64BootSessionShutdownError> {
         self.base.shutdown()
+    }
+
+    /// Extracts the complete live destination projection only after the
+    /// process-level retry-publication gate has committed.
+    pub fn into_destination_parts(
+        mut self,
+    ) -> Result<RestoredHvfSnapshotV2VsockMmioDestinationParts, HvfSnapshotV2NetworkMmioRestoreError>
+    {
+        let vsock_config = self.vsock.take().map(|metadata| metadata.config);
+        let (session, configs, storage, entropy, balloon, memory_hotplug) =
+            self.base.into_destination_parts()?;
+        Ok((
+            session,
+            configs,
+            storage,
+            entropy,
+            balloon,
+            memory_hotplug,
+            vsock_config,
+        ))
     }
 }
 
@@ -4633,6 +4665,18 @@ struct RestoredHvfSnapshotV2NetworkPciInnerOwners {
     vsock: Option<RestoredHvfSnapshotV2VsockPciMetadata>,
 }
 
+/// Live exact-2.12 PCI destination parts after retry publication commits.
+#[doc(hidden)]
+pub type RestoredHvfSnapshotV2VsockPciDestinationParts = (
+    OwnedHvfArm64BootSession,
+    Vec<NetworkInterfaceConfig>,
+    Option<CaptureReadyStorageConfigs>,
+    Option<EntropyConfig>,
+    Option<BalloonConfig>,
+    Option<SnapshotV2MemoryHotplugControllerProjection>,
+    Option<VsockConfig>,
+);
+
 /// Complete exact-2.12 PCI owner graph with retry publication still gated.
 #[doc(hidden)]
 pub struct RestoredHvfSnapshotV2VsockPciOwners {
@@ -4727,6 +4771,26 @@ impl RestoredHvfSnapshotV2VsockPciOwners {
 
     pub fn shutdown(self) -> Result<(), HvfArm64BootSessionShutdownError> {
         self.base.shutdown()
+    }
+
+    /// Extracts the complete live destination projection only after the
+    /// process-level retry-publication gate has committed.
+    pub fn into_destination_parts(
+        mut self,
+    ) -> Result<RestoredHvfSnapshotV2VsockPciDestinationParts, HvfSnapshotV2NetworkPciRestoreError>
+    {
+        let vsock_config = self.vsock.take().map(|metadata| metadata.config);
+        let (session, configs, storage, entropy, balloon, memory_hotplug) =
+            self.base.into_destination_parts()?;
+        Ok((
+            session,
+            configs,
+            storage,
+            entropy,
+            balloon,
+            memory_hotplug,
+            vsock_config,
+        ))
     }
 }
 

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -29,7 +29,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
-use bangbang_hvf::decode_hvf_snapshot_v2_network_state;
+use bangbang_hvf::decode_hvf_snapshot_v2_vsock_state;
 use bangbang_launcher::{
     JailerIsolationArgument, LAUNCHER_BUNDLE_IDENTIFIER, LAUNCHER_EXECUTABLE_NAME,
     OUTER_BUNDLE_NAME, WORKER_BUNDLE_IDENTIFIER, WORKER_BUNDLE_NAME, WORKER_EXECUTABLE_NAME,
@@ -268,6 +268,21 @@ const SNAPSHOT_NETWORK_MMDS_CONNECTION_OFFSET: u64 = 2 * VIRTIO_BLOCK_SECTOR_BYT
 const SNAPSHOT_NETWORK_MMDS_TOKEN_RESULT_OFFSET: u64 = 3 * VIRTIO_BLOCK_SECTOR_BYTES;
 const SNAPSHOT_NETWORK_MMDS_FRESH_OFFSET: u64 = 4 * VIRTIO_BLOCK_SECTOR_BYTES;
 const SNAPSHOT_NETWORK_MMDS_TIMEOUT: Duration = Duration::from_secs(120);
+const SNAPSHOT_VSOCK_SOURCE_DIRECTORY_ID: &str = "grant-snapshot-vsock-source-1735";
+const SNAPSHOT_VSOCK_OVERRIDE_DIRECTORY_ID: &str = "grant-snapshot-vsock-override-1735";
+const SNAPSHOT_VSOCK_SOURCE_CHILD: &str = "snapshot-vsock-source.sock";
+const SNAPSHOT_VSOCK_OVERRIDE_CHILD: &str = "snapshot-vsock-override.sock";
+const SNAPSHOT_VSOCK_SOURCE_REF: &str =
+    "bangbang-grant:grant-snapshot-vsock-source-1735/snapshot-vsock-source.sock";
+const SNAPSHOT_VSOCK_OVERRIDE_REF: &str =
+    "bangbang-grant:grant-snapshot-vsock-override-1735/snapshot-vsock-override.sock";
+const SNAPSHOT_VSOCK_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 quiet loglevel=1 rootwait init=/bangbang-direct-rootfs-init bangbang.vsock-snapshot-reset=1";
+const SNAPSHOT_VSOCK_OLD_PORT: u32 = 5011;
+const SNAPSHOT_VSOCK_FRESH_PORT: u32 = 5012;
+const SNAPSHOT_VSOCK_OLD_READY: &[u8] = b"BANGBANG_VSOCK_SNAPSHOT_OLD_READY";
+const SNAPSHOT_VSOCK_FRESH_READY: &[u8] = b"BANGBANG_VSOCK_SNAPSHOT_FRESH_READY";
+const SNAPSHOT_VSOCK_FRESH_ACK: &[u8] = b"BANGBANG_VSOCK_SNAPSHOT_FRESH_ACK";
+const SNAPSHOT_VSOCK_SUCCESS: &[u8] = b"BANGBANG_VSOCK_SNAPSHOT_RESET_OK";
 const SNAPSHOT_BLOCK_SECTOR_SIZE: usize = 512;
 const SNAPSHOT_BLOCK_DRIVE_A_INITIAL_BYTE: u8 = 0x11;
 const SNAPSHOT_BLOCK_DRIVE_A_PRE_CAPTURE_BYTE: u8 = 0x12;
@@ -1714,6 +1729,436 @@ fn run_production_configured_serial_snapshot_continuation(bundle: &Path, enable_
 }
 
 #[test]
+fn normal_bundle_certifies_native_v2_vsock_snapshot_continuation_and_containment() {
+    let bundle = production_bundle();
+    let baseline_sessions = session_entries();
+    for enable_pci in [false, true] {
+        run_production_vsock_snapshot_continuation(&bundle, enable_pci, &baseline_sessions);
+    }
+    assert_eq!(
+        session_entries(),
+        baseline_sessions,
+        "vsock snapshot launcher and worker teardown must restore the session namespace"
+    );
+}
+
+fn run_production_vsock_snapshot_continuation(
+    bundle: &Path,
+    enable_pci: bool,
+    baseline_sessions: &[PathBuf],
+) {
+    let transport = if enable_pci { "pci" } else { "mmio" };
+    let source_fixture = SnapshotVsockSourceGrantFixture::new(&format!("{transport}-vsock-source"));
+    reset_zeroed_file(
+        &source_fixture.snapshot.data_backing,
+        8 * VIRTIO_BLOCK_SECTOR_BYTES,
+    );
+    let old_port_path = source_fixture.port_path(SNAPSHOT_VSOCK_OLD_PORT);
+    let old_listener = UnixListener::bind(&old_port_path)
+        .expect("production snapshot-vsock old listener should bind");
+    old_listener
+        .set_nonblocking(true)
+        .expect("production snapshot-vsock old listener should be nonblocking");
+    let mut source = spawn_ready_snapshot_grant_api_launcher(
+        bundle,
+        &source_fixture.snapshot.manifest,
+        source_fixture.sensitive_strings(),
+        &format!("vsock-snapshot-{transport}-source"),
+        false,
+        enable_pci,
+    );
+    source_fixture.snapshot.replace_source_file_pathnames();
+    configure_and_start_production_vsock_snapshot_source(&source.socket, transport);
+    assert!(
+        source_fixture.socket().exists(),
+        "production {transport} source should publish its granted main vsock listener"
+    );
+    let worker = only_worker_pid(&source.child);
+    assert!(
+        child_pids(worker).is_empty(),
+        "production {transport} source vsock must not retain a helper"
+    );
+    let mut old_stream = wait_for_unix_listener_accept(&old_listener, PROCESS_TIMEOUT)
+        .unwrap_or_else(|error| {
+            panic!("production {transport} old snapshot-vsock connection should arrive: {error}")
+        });
+    drop(old_listener);
+    fs::remove_file(&old_port_path)
+        .expect("production snapshot-vsock old listener path should clean up");
+    old_stream
+        .set_nonblocking(true)
+        .expect("production old snapshot-vsock stream should be nonblocking");
+    let mut old_ready = vec![0_u8; SNAPSHOT_VSOCK_OLD_READY.len()];
+    read_exact_nonblocking(&mut old_stream, &mut old_ready, PROCESS_TIMEOUT)
+        .expect("production snapshot-vsock old readiness should arrive");
+    assert_eq!(
+        old_ready, SNAPSHOT_VSOCK_OLD_READY,
+        "production {transport} old readiness should match"
+    );
+
+    assert_http_status(
+        &http_request(&source.socket, "PATCH", "/vm", r#"{"state":"Paused"}"#),
+        204,
+        &format!("pause production {transport} vsock snapshot source"),
+    );
+    assert_http_status(
+        &http_put(&source.socket, "/snapshot/create", &snapshot_create_body()),
+        204,
+        &format!("create production {transport} vsock snapshot"),
+    );
+    let artifacts = source_fixture.snapshot.artifacts();
+    assert_production_vsock_snapshot(&artifacts.state, enable_pci, &format!("{transport} source"));
+    let state_before =
+        fs::read(&artifacts.state).expect("production vsock source state should read");
+    let memory_before =
+        fs::read(&artifacts.memory).expect("production vsock source memory should read");
+    wait_for_stream_eof_nonblocking(&mut old_stream, PROCESS_TIMEOUT)
+        .expect("production snapshot capture should reset the source-only old stream");
+    drop(old_stream);
+    assert_no_snapshot_staging(&source_fixture.snapshot.state_directory);
+    assert_no_snapshot_staging(&source_fixture.snapshot.memory_directory);
+    stop_running_launcher(
+        &mut source,
+        &format!("production {transport} vsock snapshot source"),
+    );
+    assert!(
+        !source_fixture.socket().exists(),
+        "production {transport} source shutdown should clean its granted listener"
+    );
+    assert_session_entries_eventually_restored(
+        baseline_sessions,
+        &format!("production {transport} vsock snapshot source"),
+    );
+    source_fixture
+        .snapshot
+        .assert_replacement_pathnames_unused(&format!(
+            "production {transport} vsock snapshot source"
+        ));
+
+    let explicit_case = format!("{transport}-vsock-explicit");
+    let current = run_production_vsock_snapshot_destination(ProductionVsockSnapshotDestination {
+        bundle,
+        artifacts,
+        enable_pci,
+        resume_vm: false,
+        use_override: false,
+        recapture: true,
+        case: &explicit_case,
+        baseline_sessions,
+    });
+    assert_eq!(
+        fs::read(&current.state).expect("production repeated vsock state should read"),
+        state_before,
+        "production {transport} first load must not mutate state"
+    );
+    assert_eq!(
+        fs::read(&current.memory).expect("production repeated vsock memory should read"),
+        memory_before,
+        "production {transport} first load must not mutate memory"
+    );
+
+    let automatic_case = format!("{transport}-vsock-automatic");
+    let final_artifacts =
+        run_production_vsock_snapshot_destination(ProductionVsockSnapshotDestination {
+            bundle,
+            artifacts: current,
+            enable_pci,
+            resume_vm: true,
+            use_override: true,
+            recapture: false,
+            case: &automatic_case,
+            baseline_sessions,
+        });
+    assert_eq!(
+        fs::read(&final_artifacts.state).expect("final production vsock state should read"),
+        state_before,
+        "production {transport} repeated loads must keep state immutable"
+    );
+    assert_eq!(
+        fs::read(&final_artifacts.memory).expect("final production vsock memory should read"),
+        memory_before,
+        "production {transport} repeated loads must keep memory immutable"
+    );
+}
+
+fn configure_and_start_production_vsock_snapshot_source(socket: &Path, context: &str) {
+    for (path, body, request) in [
+        (
+            "/machine-config",
+            serde_json::json!({"vcpu_count": 1, "mem_size_mib": 256}),
+            "machine config",
+        ),
+        (
+            "/metrics",
+            serde_json::json!({"metrics_path": SNAPSHOT_METRICS_REF}),
+            "metrics",
+        ),
+        (
+            "/boot-source",
+            serde_json::json!({
+                "kernel_image_path": SNAPSHOT_KERNEL_REF,
+                "boot_args": SNAPSHOT_VSOCK_BOOT_ARGS,
+            }),
+            "boot source",
+        ),
+        (
+            "/drives/rootfs",
+            serde_json::json!({
+                "drive_id": "rootfs",
+                "path_on_host": SNAPSHOT_ROOT_REF,
+                "is_root_device": true,
+                "is_read_only": false,
+                "cache_type": "Unsafe",
+                "io_engine": "Async",
+            }),
+            "rootfs",
+        ),
+        (
+            "/drives/data",
+            serde_json::json!({
+                "drive_id": "data",
+                "path_on_host": SNAPSHOT_DATA_REF,
+                "is_root_device": false,
+                "is_read_only": false,
+                "io_engine": "Sync",
+            }),
+            "data drive",
+        ),
+        (
+            "/vsock",
+            serde_json::json!({
+                "guest_cid": 3,
+                "uds_path": SNAPSHOT_VSOCK_SOURCE_REF,
+            }),
+            "vsock",
+        ),
+    ] {
+        assert_http_status(
+            &http_put(
+                socket,
+                path,
+                &serde_json::to_string(&body)
+                    .expect("production snapshot-vsock request should serialize"),
+            ),
+            204,
+            &format!("PUT production {context} snapshot-vsock {request}"),
+        );
+    }
+    assert_http_status(
+        &http_put(socket, "/actions", r#"{"action_type":"InstanceStart"}"#),
+        204,
+        &format!("start production {context} snapshot-vsock source"),
+    );
+}
+
+struct ProductionVsockSnapshotDestination<'a> {
+    bundle: &'a Path,
+    artifacts: SnapshotArtifactSet,
+    enable_pci: bool,
+    resume_vm: bool,
+    use_override: bool,
+    recapture: bool,
+    case: &'a str,
+    baseline_sessions: &'a [PathBuf],
+}
+
+fn run_production_vsock_snapshot_destination(
+    destination: ProductionVsockSnapshotDestination<'_>,
+) -> SnapshotArtifactSet {
+    let ProductionVsockSnapshotDestination {
+        bundle,
+        artifacts,
+        enable_pci,
+        resume_vm,
+        use_override,
+        recapture,
+        case,
+        baseline_sessions,
+    } = destination;
+    let fixture =
+        SnapshotVsockContinuationInputGrantFixture::new(case, artifacts, recapture, use_override);
+    let fresh_port_path = fixture.port_path(SNAPSHOT_VSOCK_FRESH_PORT);
+    let fresh_listener = UnixListener::bind(&fresh_port_path)
+        .expect("production restored snapshot-vsock fresh listener should bind");
+    fresh_listener
+        .set_nonblocking(true)
+        .expect("production restored snapshot-vsock listener should be nonblocking");
+    let mut running = spawn_ready_snapshot_epoch_grant_api_launcher(
+        bundle,
+        &fixture.snapshot.manifest,
+        &fixture.snapshot.api_socket(),
+        fixture.sensitive_strings(),
+        &format!("vsock-snapshot-{case}"),
+        enable_pci,
+    );
+    let worker = only_worker_pid(&running.child);
+    let opened = fixture.snapshot.replace_source_pathnames();
+    let state_before =
+        fs::read(&opened.state).expect("production destination vsock state should read");
+    let memory_before =
+        fs::read(&opened.memory).expect("production destination vsock memory should read");
+    reset_zeroed_file(&opened.data, 8 * VIRTIO_BLOCK_SECTOR_BYTES);
+    let load_body = production_vsock_snapshot_load_body(
+        resume_vm,
+        use_override.then_some(fixture.selector_ref),
+    );
+    assert_http_status(
+        &http_put(&running.socket, "/snapshot/load", &load_body),
+        204,
+        &format!("load production {case} vsock snapshot"),
+    );
+    assert!(
+        http_get(&running.socket, "/").contains(if resume_vm {
+            r#""state":"Running""#
+        } else {
+            r#""state":"Paused""#
+        }),
+        "production {case} destination should publish the requested resume state"
+    );
+    let config = http_get(&running.socket, "/vm/config");
+    assert_http_status(
+        &config,
+        200,
+        &format!("read production {case} restored vsock config"),
+    );
+    assert!(
+        config.contains(fixture.selector_ref),
+        "production {case} controller commit should retain the selected vsock reference"
+    );
+    assert!(
+        fixture.socket().exists(),
+        "production {case} destination should own its selected granted listener"
+    );
+    assert!(
+        child_pids(worker).is_empty(),
+        "production {case} restored vsock must not retain a helper"
+    );
+    if !resume_vm {
+        assert_http_status(
+            &http_request(&running.socket, "PATCH", "/vm", r#"{"state":"Resumed"}"#),
+            204,
+            &format!("resume production {case} vsock destination"),
+        );
+    }
+
+    let mut fresh_stream = wait_for_unix_listener_accept(&fresh_listener, PROCESS_TIMEOUT)
+        .unwrap_or_else(|error| {
+            panic!("production {case} restored fresh vsock connection should arrive: {error}")
+        });
+    drop(fresh_listener);
+    fs::remove_file(&fresh_port_path)
+        .expect("production restored snapshot-vsock listener path should clean up");
+    fresh_stream
+        .set_nonblocking(true)
+        .expect("production restored fresh vsock stream should be nonblocking");
+    let mut fresh_ready = vec![0_u8; SNAPSHOT_VSOCK_FRESH_READY.len()];
+    read_exact_nonblocking(&mut fresh_stream, &mut fresh_ready, PROCESS_TIMEOUT)
+        .expect("production restored fresh vsock readiness should arrive");
+    assert_eq!(
+        fresh_ready, SNAPSHOT_VSOCK_FRESH_READY,
+        "production {case} fresh readiness should match"
+    );
+    write_all_nonblocking(&mut fresh_stream, SNAPSHOT_VSOCK_FRESH_ACK, PROCESS_TIMEOUT)
+        .expect("production restored fresh vsock acknowledgement should write");
+    wait_for_stream_eof_nonblocking(&mut fresh_stream, PROCESS_TIMEOUT)
+        .expect("production restored fresh vsock stream should close cleanly");
+    wait_for_file_contains(&opened.data, SNAPSHOT_VSOCK_SUCCESS, PROCESS_TIMEOUT).unwrap_or_else(
+        |error| {
+            panic!("production {case} restored guest should confirm fresh vsock traffic: {error}")
+        },
+    );
+
+    if recapture {
+        assert_http_status(
+            &http_request(&running.socket, "PATCH", "/vm", r#"{"state":"Paused"}"#),
+            204,
+            &format!("pause production {case} vsock destination before recapture"),
+        );
+        assert_http_status(
+            &http_put(&running.socket, "/snapshot/create", &snapshot_create_body()),
+            204,
+            &format!("recapture production {case} vsock snapshot"),
+        );
+        let recaptured = fixture.snapshot.recaptured_artifacts();
+        assert_production_vsock_snapshot(
+            &recaptured.state,
+            enable_pci,
+            &format!("{case} recapture"),
+        );
+        fixture.snapshot.assert_no_recapture_staging();
+    }
+
+    stop_running_launcher(
+        &mut running,
+        &format!("production {case} restored vsock destination"),
+    );
+    assert!(
+        !fixture.socket().exists(),
+        "production {case} shutdown should clean its selected listener"
+    );
+    assert_session_entries_eventually_restored(
+        baseline_sessions,
+        &format!("production {case} restored vsock destination"),
+    );
+    assert_eq!(
+        fs::read(&opened.state).expect("production destination vsock state should remain"),
+        state_before,
+        "production {case} load must not mutate state"
+    );
+    assert_eq!(
+        fs::read(&opened.memory).expect("production destination vsock memory should remain"),
+        memory_before,
+        "production {case} load must not mutate memory"
+    );
+    fixture
+        .snapshot
+        .assert_replacement_pathnames_unused(&format!(
+            "production {case} restored vsock destination"
+        ));
+    opened
+}
+
+fn production_vsock_snapshot_load_body(resume_vm: bool, selector: Option<&str>) -> String {
+    let mut body = serde_json::json!({
+        "snapshot_path": SNAPSHOT_STATE_INPUT_REF,
+        "mem_backend": {
+            "backend_path": SNAPSHOT_MEMORY_INPUT_REF,
+            "backend_type": "File",
+        },
+        "resume_vm": resume_vm,
+    });
+    if let Some(selector) = selector {
+        body["vsock_override"] = serde_json::json!({"uds_path": selector});
+    }
+    body.to_string()
+}
+
+fn assert_production_vsock_snapshot(path: &Path, enable_pci: bool, context: &str) {
+    let bytes = fs::read(path).expect("production exact-2.12 vsock state should read");
+    let structural =
+        decode_snapshot_v2_state(&bytes).expect("production exact-2.12 vsock state should decode");
+    let state = decode_hvf_snapshot_v2_vsock_state(&structural)
+        .expect("production exact-2.12 vsock state should decode semantically");
+    let vsock = state
+        .vsock()
+        .expect("production exact-2.12 activation state should contain kind 13");
+    assert_eq!(
+        vsock.guest_cid(),
+        3,
+        "production {context} guest CID should persist"
+    );
+    assert_eq!(
+        vsock.transport().kind(),
+        if enable_pci {
+            SnapshotV2DeviceTransportKind::Pci
+        } else {
+            SnapshotV2DeviceTransportKind::Mmio
+        },
+        "production {context} vsock transport should persist"
+    );
+}
+
+#[test]
 fn normal_bundle_certifies_native_v2_network_mmds_snapshot_continuation_and_containment() {
     let bundle = production_bundle();
     let baseline_sessions = session_entries();
@@ -2027,8 +2472,8 @@ fn assert_production_network_mmds_snapshot(
     });
     let structural =
         decode_snapshot_v2_state(&bytes).expect("production network/MMDS state should decode");
-    let state = decode_hvf_snapshot_v2_network_state(&structural)
-        .expect("production network/MMDS state should be exact native-v2 2.11");
+    let state = decode_hvf_snapshot_v2_vsock_state(&structural)
+        .expect("production network/MMDS state should be exact native-v2 2.12");
     let graph = state
         .device_graph()
         .expect("production network/MMDS artifact should retain root and data");
@@ -3192,8 +3637,8 @@ fn assert_production_memory_hotplug_snapshot(
     });
     let structural =
         decode_snapshot_v2_state(&bytes).expect("production memory-hotplug state should decode");
-    let state = decode_hvf_snapshot_v2_network_state(&structural)
-        .expect("production memory-hotplug state should be exact native-v2 2.11");
+    let state = decode_hvf_snapshot_v2_vsock_state(&structural)
+        .expect("production memory-hotplug state should be exact native-v2 2.12");
     let graph = state
         .device_graph()
         .expect("production memory-hotplug artifact should retain root and data");
@@ -5225,7 +5670,7 @@ fn run_native_v2_snapshot_grant_case(bundle: &Path, enable_pci: bool) {
     assert_output_success(&describe_output, "granted snapshot description");
     assert_eq!(
         String::from_utf8_lossy(&describe_output.stdout).trim(),
-        "v2.11.0"
+        "v2.12.0"
     );
     assert_snapshot_output_redacted(&describe_output, &describe.sensitive_strings());
 
@@ -11786,6 +12231,84 @@ impl SnapshotSourceGrantFixture {
 }
 
 #[derive(Debug)]
+struct SnapshotVsockSourceGrantFixture {
+    snapshot: SnapshotSourceGrantFixture,
+    _socket_root: TestDir,
+    vsock_directory: PathBuf,
+}
+
+impl SnapshotVsockSourceGrantFixture {
+    fn new(case: &str) -> Self {
+        let snapshot = SnapshotSourceGrantFixture::new(case);
+        let socket_id = NEXT_TEST_ID.fetch_add(1, Ordering::SeqCst);
+        let socket_root = TestDir(
+            PathBuf::from("/private/tmp").join(format!("bbvss-{}-{socket_id}", std::process::id())),
+        );
+        fs::create_dir(socket_root.path()).expect("short snapshot-vsock source root should create");
+        let vsock_directory = socket_root.path().join("v");
+        fs::create_dir(&vsock_directory).expect("snapshot-vsock source directory should create");
+        append_snapshot_vsock_grant(
+            &snapshot.manifest,
+            SNAPSHOT_VSOCK_SOURCE_DIRECTORY_ID,
+            &vsock_directory,
+        );
+        Self {
+            snapshot,
+            _socket_root: socket_root,
+            vsock_directory,
+        }
+    }
+
+    fn socket(&self) -> PathBuf {
+        self.vsock_directory.join(SNAPSHOT_VSOCK_SOURCE_CHILD)
+    }
+
+    fn port_path(&self, port: u32) -> PathBuf {
+        snapshot_vsock_port_path(&self.socket(), port)
+    }
+
+    fn sensitive_strings(&self) -> Vec<String> {
+        let mut sensitive = self.snapshot.sensitive_strings();
+        sensitive.extend([
+            path_text(&self.vsock_directory).to_owned(),
+            path_text(&self.socket()).to_owned(),
+            SNAPSHOT_VSOCK_SOURCE_DIRECTORY_ID.to_owned(),
+            SNAPSHOT_VSOCK_SOURCE_REF.to_owned(),
+            SNAPSHOT_VSOCK_SOURCE_CHILD.to_owned(),
+        ]);
+        sensitive
+    }
+}
+
+fn append_snapshot_vsock_grant(manifest_path: &Path, id: &str, directory: &Path) {
+    let mut manifest: serde_json::Value = serde_json::from_slice(
+        &fs::read(manifest_path).expect("snapshot-vsock manifest should read"),
+    )
+    .expect("snapshot-vsock manifest should parse");
+    manifest
+        .get_mut("grants")
+        .and_then(serde_json::Value::as_array_mut)
+        .expect("snapshot-vsock manifest should contain grants")
+        .push(serde_json::json!({
+            "id": id,
+            "role": "vsock-socket-directory",
+            "access": "create-children",
+            "source": path_text(directory),
+        }));
+    fs::write(
+        manifest_path,
+        serde_json::to_vec(&manifest).expect("snapshot-vsock manifest should serialize"),
+    )
+    .expect("snapshot-vsock manifest should update");
+}
+
+fn snapshot_vsock_port_path(socket: &Path, port: u32) -> PathBuf {
+    let mut path = socket.as_os_str().to_os_string();
+    path.push(format!("_{port}"));
+    PathBuf::from(path)
+}
+
+#[derive(Debug)]
 struct SnapshotEpochSourceGrantFixture {
     _root: TestDir,
     _socket_root: TestDir,
@@ -12389,6 +12912,78 @@ impl SnapshotContinuationInputGrantFixture {
                 .map(str::to_owned),
             );
         }
+        sensitive
+    }
+}
+
+#[derive(Debug)]
+struct SnapshotVsockContinuationInputGrantFixture {
+    snapshot: SnapshotContinuationInputGrantFixture,
+    _vsock_root: TestDir,
+    vsock_directory: PathBuf,
+    selector_id: &'static str,
+    selector_ref: &'static str,
+    selector_child: &'static str,
+}
+
+impl SnapshotVsockContinuationInputGrantFixture {
+    fn new(
+        case: &str,
+        sources: SnapshotArtifactSet,
+        with_recapture: bool,
+        use_override: bool,
+    ) -> Self {
+        let snapshot = SnapshotContinuationInputGrantFixture::new(case, sources, with_recapture);
+        let socket_id = NEXT_TEST_ID.fetch_add(1, Ordering::SeqCst);
+        let vsock_root = TestDir(
+            PathBuf::from("/private/tmp").join(format!("bbvsd-{}-{socket_id}", std::process::id())),
+        );
+        fs::create_dir(vsock_root.path())
+            .expect("short snapshot-vsock destination root should create");
+        let vsock_directory = vsock_root.path().join("v");
+        fs::create_dir(&vsock_directory)
+            .expect("snapshot-vsock destination directory should create");
+        let (selector_id, selector_ref, selector_child) = if use_override {
+            (
+                SNAPSHOT_VSOCK_OVERRIDE_DIRECTORY_ID,
+                SNAPSHOT_VSOCK_OVERRIDE_REF,
+                SNAPSHOT_VSOCK_OVERRIDE_CHILD,
+            )
+        } else {
+            (
+                SNAPSHOT_VSOCK_SOURCE_DIRECTORY_ID,
+                SNAPSHOT_VSOCK_SOURCE_REF,
+                SNAPSHOT_VSOCK_SOURCE_CHILD,
+            )
+        };
+        append_snapshot_vsock_grant(&snapshot.manifest, selector_id, &vsock_directory);
+        Self {
+            snapshot,
+            _vsock_root: vsock_root,
+            vsock_directory,
+            selector_id,
+            selector_ref,
+            selector_child,
+        }
+    }
+
+    fn socket(&self) -> PathBuf {
+        self.vsock_directory.join(self.selector_child)
+    }
+
+    fn port_path(&self, port: u32) -> PathBuf {
+        snapshot_vsock_port_path(&self.socket(), port)
+    }
+
+    fn sensitive_strings(&self) -> Vec<String> {
+        let mut sensitive = self.snapshot.sensitive_strings();
+        sensitive.extend([
+            path_text(&self.vsock_directory).to_owned(),
+            path_text(&self.socket()).to_owned(),
+            self.selector_id.to_owned(),
+            self.selector_ref.to_owned(),
+            self.selector_child.to_owned(),
+        ]);
         sensitive
     }
 }
@@ -16065,8 +16660,8 @@ fn assert_production_balloon_snapshot(
     });
     let structural =
         decode_snapshot_v2_state(&bytes).expect("production balloon state should decode");
-    let state = decode_hvf_snapshot_v2_network_state(&structural)
-        .expect("production balloon state should be exact native-v2 2.11");
+    let state = decode_hvf_snapshot_v2_vsock_state(&structural)
+        .expect("production balloon state should be exact native-v2 2.12");
     let graph = state
         .device_graph()
         .expect("production balloon artifact should retain storage");
@@ -16284,8 +16879,8 @@ fn assert_production_pending_entropy_snapshot(
     });
     let structural =
         decode_snapshot_v2_state(&bytes).expect("production entropy state should decode");
-    let state = decode_hvf_snapshot_v2_network_state(&structural)
-        .expect("production entropy state should be exact native-v2 2.11");
+    let state = decode_hvf_snapshot_v2_vsock_state(&structural)
+        .expect("production entropy state should be exact native-v2 2.12");
     assert_eq!(
         state.device_graph().is_some(),
         with_storage,
@@ -17999,6 +18594,28 @@ fn read_exact_nonblocking(
         }
     }
     Ok(())
+}
+
+fn wait_for_stream_eof_nonblocking(
+    stream: &mut UnixStream,
+    timeout: Duration,
+) -> std::io::Result<()> {
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .expect("stream EOF deadline should fit Instant");
+    let mut byte = [0_u8; 1];
+    loop {
+        match stream.read(&mut byte) {
+            Ok(0) => return Ok(()),
+            Ok(_) => return Err(std::io::ErrorKind::InvalidData.into()),
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                wait_for_socket_event(stream.as_raw_fd(), libc::POLLIN, deadline)?;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::ConnectionReset => return Ok(()),
+            Err(error) => return Err(error),
+        }
+    }
 }
 
 fn write_all_nonblocking(

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1495,7 +1495,7 @@ impl VmmController {
                 state: self.instance_info.state,
             });
         }
-        if input.clock_realtime() || input.vsock_override().is_some() {
+        if input.clock_realtime() {
             return Err(VmmActionError::SnapshotUnsupported);
         }
 
@@ -1555,6 +1555,7 @@ impl VmmController {
             memory_hotplug,
             network_configs,
             mmds_state,
+            vsock_config,
             resume_requested,
         ) = commit.into_parts();
         self.machine_config = machine_config;
@@ -1570,6 +1571,7 @@ impl VmmController {
             .map(|projection| projection.requested_size_mib())
             .unwrap_or(0);
         self.network_interface_configs = network_configs;
+        self.vsock_config = vsock_config;
         self.mmds_state = mmds_state.unwrap_or_else(|| {
             let data_store_limit_bytes = self
                 .mmds_state
@@ -3465,6 +3467,15 @@ mod tests {
             controller.preflight_load_snapshot(&network),
             Err(VmmActionError::SnapshotUnsupported),
             "native-v1 compatibility must retain its override rejection"
+        );
+        let vsock = snapshot_load_input().with_vsock_override(
+            super::snapshot::SnapshotVsockOverride::new("destination-vsock"),
+        );
+        assert_eq!(controller.preflight_load_snapshot_v2(&vsock), Ok(()));
+        assert_eq!(
+            controller.preflight_load_snapshot(&vsock),
+            Err(VmmActionError::SnapshotUnsupported),
+            "native-v1 compatibility must retain its vsock override rejection"
         );
 
         let uffd = SnapshotLoadInput::new(

--- a/crates/runtime/src/snapshot.rs
+++ b/crates/runtime/src/snapshot.rs
@@ -15,7 +15,7 @@ use crate::pmem::PmemConfigs;
 use crate::serial::SerialConfig;
 use crate::snapshot_memory_hotplug_v2_10::SnapshotV2MemoryHotplugControllerProjection;
 use crate::storage_capture::CaptureReadyStorageConfigs;
-use crate::vsock::{VsockBackendSelector, VsockBackendSelectorError};
+use crate::vsock::{VsockBackendSelector, VsockBackendSelectorError, VsockConfig};
 
 const REDACTED: &str = "<redacted>";
 
@@ -30,6 +30,7 @@ type SnapshotV2ControllerCommitParts = (
     Option<SnapshotV2MemoryHotplugControllerProjection>,
     NetworkInterfaceConfigs,
     Option<MmdsStateHandle>,
+    Option<VsockConfig>,
     bool,
 );
 
@@ -44,13 +45,43 @@ pub struct SnapshotV2ControllerCommitProductConfigs {
     memory_hotplug: Option<SnapshotV2MemoryHotplugControllerProjection>,
 }
 
-/// Complete current exact-2.11 controller product, including destination-only
+/// Complete retained exact-2.11 controller product, including destination-only
 /// network selectors and the optional fresh MMDS owner.
 #[doc(hidden)]
 pub struct SnapshotV2NetworkControllerCommitProductConfigs {
     product: SnapshotV2ControllerCommitProductConfigs,
     network_configs: NetworkInterfaceConfigs,
     mmds_state: Option<MmdsStateHandle>,
+}
+
+/// Complete current exact-2.12 controller product, including destination-only
+/// vsock configuration and every retained exact-2.11 projection.
+#[doc(hidden)]
+pub struct SnapshotV2VsockControllerCommitProductConfigs {
+    product: SnapshotV2NetworkControllerCommitProductConfigs,
+    vsock_config: Option<VsockConfig>,
+}
+
+impl SnapshotV2VsockControllerCommitProductConfigs {
+    /// Closes every exact-2.12 controller projection before publication.
+    pub fn new(
+        product: SnapshotV2NetworkControllerCommitProductConfigs,
+        vsock_config: Option<VsockConfig>,
+    ) -> Self {
+        Self {
+            product,
+            vsock_config,
+        }
+    }
+}
+
+impl fmt::Debug for SnapshotV2VsockControllerCommitProductConfigs {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2VsockControllerCommitProductConfigs")
+            .field("configuration", &REDACTED)
+            .finish()
+    }
 }
 
 impl SnapshotV2NetworkControllerCommitProductConfigs {
@@ -163,6 +194,7 @@ pub struct SnapshotV2ControllerCommit {
     memory_hotplug: Option<SnapshotV2MemoryHotplugControllerProjection>,
     network_configs: NetworkInterfaceConfigs,
     mmds_state: Option<MmdsStateHandle>,
+    vsock_config: Option<VsockConfig>,
     resume_requested: bool,
 }
 
@@ -184,6 +216,7 @@ impl SnapshotV2ControllerCommit {
             memory_hotplug: None,
             network_configs: NetworkInterfaceConfigs::new(),
             mmds_state: None,
+            vsock_config: None,
             resume_requested,
         }
     }
@@ -207,6 +240,7 @@ impl SnapshotV2ControllerCommit {
             memory_hotplug: None,
             network_configs: NetworkInterfaceConfigs::new(),
             mmds_state: None,
+            vsock_config: None,
             resume_requested,
         })
     }
@@ -231,6 +265,7 @@ impl SnapshotV2ControllerCommit {
             memory_hotplug: None,
             network_configs: NetworkInterfaceConfigs::new(),
             mmds_state: None,
+            vsock_config: None,
             resume_requested,
         }
     }
@@ -256,6 +291,7 @@ impl SnapshotV2ControllerCommit {
             memory_hotplug: None,
             network_configs: NetworkInterfaceConfigs::new(),
             mmds_state: None,
+            vsock_config: None,
             resume_requested,
         }
     }
@@ -279,6 +315,7 @@ impl SnapshotV2ControllerCommit {
             memory_hotplug: None,
             network_configs: NetworkInterfaceConfigs::new(),
             mmds_state: None,
+            vsock_config: None,
             resume_requested,
         }
     }
@@ -305,6 +342,7 @@ impl SnapshotV2ControllerCommit {
             memory_hotplug: None,
             network_configs: NetworkInterfaceConfigs::new(),
             mmds_state: None,
+            vsock_config: None,
             resume_requested,
         }
     }
@@ -334,6 +372,7 @@ impl SnapshotV2ControllerCommit {
             memory_hotplug: None,
             network_configs: NetworkInterfaceConfigs::new(),
             mmds_state: None,
+            vsock_config: None,
             resume_requested,
         }
     }
@@ -364,6 +403,7 @@ impl SnapshotV2ControllerCommit {
             memory_hotplug: None,
             network_configs: NetworkInterfaceConfigs::new(),
             mmds_state: None,
+            vsock_config: None,
             resume_requested,
         }
     }
@@ -398,11 +438,12 @@ impl SnapshotV2ControllerCommit {
             memory_hotplug,
             network_configs: NetworkInterfaceConfigs::new(),
             mmds_state: None,
+            vsock_config: None,
             resume_requested,
         }
     }
 
-    /// Retains current exact-2.11 serial, optional prior products, complete
+    /// Retains exact-2.11 serial, optional prior products, complete
     /// override-resolved network configuration, and a fresh optional MMDS
     /// handle as one atomic destination value.
     #[doc(hidden)]
@@ -438,6 +479,52 @@ impl SnapshotV2ControllerCommit {
             memory_hotplug,
             network_configs,
             mmds_state,
+            vsock_config: None,
+            resume_requested,
+        }
+    }
+
+    /// Retains current exact-2.12 serial, optional prior products, complete
+    /// override-resolved network/MMDS state, and optional destination vsock
+    /// configuration as one atomic destination value.
+    #[doc(hidden)]
+    pub fn with_vsock_product_configs(
+        machine_config: MachineConfig,
+        boot_source_config: BootSourceConfig,
+        configs: SnapshotV2VsockControllerCommitProductConfigs,
+        resume_requested: bool,
+    ) -> Self {
+        let SnapshotV2VsockControllerCommitProductConfigs {
+            product:
+                SnapshotV2NetworkControllerCommitProductConfigs {
+                    product:
+                        SnapshotV2ControllerCommitProductConfigs {
+                            storage_configs,
+                            serial_config,
+                            entropy_config,
+                            balloon_config,
+                            memory_hotplug,
+                        },
+                    network_configs,
+                    mmds_state,
+                },
+            vsock_config,
+        } = configs;
+        let (drive_configs, pmem_configs) = storage_configs
+            .map(CaptureReadyStorageConfigs::into_parts)
+            .unwrap_or_default();
+        Self {
+            machine_config,
+            boot_source_config,
+            drive_configs: DriveConfigs::from_validated(drive_configs),
+            pmem_configs: PmemConfigs::from_validated(pmem_configs),
+            serial_config,
+            entropy_config,
+            balloon_config,
+            memory_hotplug,
+            network_configs,
+            mmds_state,
+            vsock_config,
             resume_requested,
         }
     }
@@ -458,6 +545,7 @@ impl SnapshotV2ControllerCommit {
             self.memory_hotplug,
             self.network_configs,
             self.mmds_state,
+            self.vsock_config,
             self.resume_requested,
         )
     }
@@ -896,7 +984,6 @@ pub(crate) enum SnapshotV2CreateRejection {
 pub(crate) enum SnapshotV2LoadRejection {
     MemoryBackend,
     LoadClockRealtime,
-    LoadVsockOverride,
     DeprecatedFields,
     MachineProfile,
     BootSource,
@@ -1170,9 +1257,6 @@ pub(crate) fn classify_v2_load_request(
     }
     if input.clock_realtime {
         return Err(SnapshotV2LoadRejection::LoadClockRealtime);
-    }
-    if input.vsock_override.is_some() {
-        return Err(SnapshotV2LoadRejection::LoadVsockOverride);
     }
     if input.deprecated_fields_used {
         return Err(SnapshotV2LoadRejection::DeprecatedFields);
@@ -1755,6 +1839,14 @@ mod tests {
             ),
             Ok(())
         );
+        assert_eq!(
+            classify_v2_load(
+                &file_load().with_vsock_override(SnapshotVsockOverride::new("vsock")),
+                true,
+                clean_v2_load_profile(),
+            ),
+            Ok(())
+        );
 
         let request_cases = [
             (
@@ -1767,10 +1859,6 @@ mod tests {
             (
                 file_load().with_clock_realtime(true),
                 SnapshotV2LoadRejection::LoadClockRealtime,
-            ),
-            (
-                file_load().with_vsock_override(SnapshotVsockOverride::new("vsock")),
-                SnapshotV2LoadRejection::LoadVsockOverride,
             ),
             (
                 file_load().with_deprecated_fields_used(true),

--- a/crates/runtime/src/snapshot_artifact.rs
+++ b/crates/runtime/src/snapshot_artifact.rs
@@ -243,8 +243,8 @@ impl NativeSnapshotArtifactState {
 
     /// Validates exact current-version native-v2 bytes for publication.
     pub fn from_current_v2(bytes: Vec<u8>) -> Result<Self, NativeSnapshotArtifactStateError> {
-        NativeV2NetworkSnapshotCandidateState::from_network_state_v2_11(bytes)
-            .map(NativeV2NetworkSnapshotCandidateState::into_current_artifact_state)
+        NativeV2VsockSnapshotCandidateState::from_vsock_state_v2_12(bytes)
+            .map(NativeV2VsockSnapshotCandidateState::into_current_artifact_state)
             .map_err(NativeSnapshotArtifactStateError::CurrentV2Profile)
     }
 
@@ -376,7 +376,7 @@ impl NativeSnapshotArtifactState {
         };
         if *version == NATIVE_V2_SNAPSHOT_VERSION && binding.version() == NATIVE_V2_SNAPSHOT_VERSION
         {
-            let (actual_binding, _, _, _, _, _, _) = decode_network_state_v2_11(bytes)
+            let (actual_binding, _, _, _, _, _, _, _) = decode_vsock_state_v2_12(bytes)
                 .map_err(NativeSnapshotArtifactStateError::CurrentV2Profile)?;
             if &actual_binding == binding {
                 Ok(())
@@ -1850,8 +1850,8 @@ impl NativeV2NetworkSnapshotCandidateState {
         )
     }
 
-    /// Consumes this exact current candidate into artifact authority.
-    pub fn into_current_artifact_state(self) -> NativeSnapshotArtifactState {
+    /// Consumes this exact-2.11 compatibility candidate into artifact authority.
+    pub fn into_v2_11_artifact_state(self) -> NativeSnapshotArtifactState {
         let (bytes, binding, _, _, _, _, _, _) = self.into_parts();
         NativeSnapshotArtifactState {
             inner: NativeSnapshotArtifactStateInner::V2 {
@@ -2069,8 +2069,8 @@ impl std::error::Error for NativeV2VsockSnapshotPreparationError {
 ///
 /// This owner-free value validates all unchanged earlier components and the
 /// optional kind-13 vsock singleton from one immutable byte vector. It
-/// deliberately has no conversion into current artifact publication
-/// authority.
+/// becomes current artifact publication authority only through a consuming
+/// checked conversion.
 pub struct NativeV2VsockSnapshotCandidateState {
     bytes: Vec<u8>,
     binding: SnapshotV2MemoryBinding,
@@ -2280,6 +2280,18 @@ impl NativeV2VsockSnapshotCandidateState {
             self.network,
             self.vsock,
         )
+    }
+
+    /// Consumes this exact current candidate into artifact authority.
+    pub fn into_current_artifact_state(self) -> NativeSnapshotArtifactState {
+        let (bytes, binding, _, _, _, _, _, _, _) = self.into_parts();
+        NativeSnapshotArtifactState {
+            inner: NativeSnapshotArtifactStateInner::V2 {
+                bytes,
+                version: NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
+                binding,
+            },
+        }
     }
 }
 
@@ -4442,17 +4454,26 @@ impl LoadedNativeSnapshotArtifacts {
         Ok((candidate, memory))
     }
 
-    /// Consumes one exact current 2.11 pair into the network load handoff.
+    /// Consumes one exact current 2.12 pair into the vsock load handoff.
     ///
     /// The state bytes are neither reopened nor re-encoded, and the already
     /// loaded guest memory remains bound to the candidate derived from them.
     pub fn into_current_v2_candidate(
         self,
-    ) -> Result<
-        (NativeV2NetworkSnapshotCandidateState, GuestMemory),
-        NativeSnapshotArtifactStateError,
-    > {
-        self.into_v2_11_candidate()
+    ) -> Result<(NativeV2VsockSnapshotCandidateState, GuestMemory), NativeSnapshotArtifactStateError>
+    {
+        let actual = self.family();
+        let (state, memory) = self.into_parts();
+        let (bytes, binding) = state.into_v2_parts().map_err(|_| {
+            NativeSnapshotArtifactStateError::UnexpectedFamily {
+                expected: NativeSnapshotArtifactFamily::V2,
+                actual,
+            }
+        })?;
+        let candidate = NativeV2VsockSnapshotCandidateState::from_vsock_state_v2_12(bytes)
+            .map_err(NativeSnapshotArtifactStateError::CurrentV2Profile)?;
+        debug_assert_eq!(candidate.memory_binding(), &binding);
+        Ok((candidate, memory))
     }
 
     /// Consumes one exact 2.11 pair into the network load handoff.

--- a/crates/runtime/src/snapshot_artifact/macos.rs
+++ b/crates/runtime/src/snapshot_artifact/macos.rs
@@ -1461,16 +1461,54 @@ pub(super) fn load_prepared_native_snapshot_memory_file_macos(
                     }
                 }
                 NativeV2SnapshotArtifactProfile::VsockStateV2_12 => {
-                    return Err(load_error(
-                        SnapshotArtifactLoadStage::StateDecode,
-                        SnapshotArtifactLoadFailure::NativeState(
-                            NativeSnapshotArtifactStateError::CurrentV2Profile(
-                                NativeV2SnapshotCandidateStateError::UnexpectedVersion {
-                                    found: NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
-                                },
-                            ),
-                        ),
-                    ));
+                    let candidate =
+                        NativeV2VsockSnapshotCandidateState::from_vsock_state_v2_12(bytes.clone())
+                            .map_err(|source| {
+                                load_error(
+                                    SnapshotArtifactLoadStage::StateDecode,
+                                    SnapshotArtifactLoadFailure::NativeState(
+                                        NativeSnapshotArtifactStateError::CurrentV2Profile(source),
+                                    ),
+                                )
+                            })?;
+                    let (_, binding, _, _, _, _, memory_hotplug, _, _) = candidate.into_parts();
+                    match memory_hotplug {
+                        Some(memory_hotplug) => {
+                            let topology =
+                                PreparedSnapshotV2MemoryHotplugTopology::prepare_for_compatibility_version(
+                                    memory_hotplug,
+                                    binding,
+                                    NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
+                                )
+                                .map_err(|source| {
+                                    load_error(
+                                        SnapshotArtifactLoadStage::StateDecode,
+                                        SnapshotArtifactLoadFailure::MemoryHotplugPreparation(
+                                            NativeV2MemoryHotplugSnapshotPreparationError::Topology(
+                                                source,
+                                            ),
+                                        ),
+                                    )
+                                })?;
+                            materialize_snapshot_v2_memory_hotplug_file(&topology, memory_file)
+                                .map_err(|source| {
+                                    load_error(
+                                        SnapshotArtifactLoadStage::MemoryLoad,
+                                        SnapshotArtifactLoadFailure::MemoryHotplugMaterialization(
+                                            source,
+                                        ),
+                                    )
+                                })?
+                        }
+                        None => load_snapshot_v2_memory_file(&decoded, memory_file).map_err(
+                            |source| {
+                                load_error(
+                                    SnapshotArtifactLoadStage::MemoryLoad,
+                                    SnapshotArtifactLoadFailure::MemoryV2(source),
+                                )
+                            },
+                        )?,
+                    }
                 }
                 _ => load_snapshot_v2_memory_file(&decoded, memory_file).map_err(|source| {
                     load_error(

--- a/crates/runtime/src/snapshot_artifact/tests.rs
+++ b/crates/runtime/src/snapshot_artifact/tests.rs
@@ -150,8 +150,8 @@ fn closed_native_state_derives_v2_binding_and_redacts_owned_bytes() {
     assert_eq!(
         state
             .v2_profile()
-            .expect("current state should classify as exact network profile"),
-        NativeV2SnapshotArtifactProfile::NetworkStateV2_11
+            .expect("current state should classify as exact vsock profile"),
+        NativeV2SnapshotArtifactProfile::VsockStateV2_12
     );
     assert!(state.v1_record().is_none());
     let debug = format!("{state:?}");
@@ -309,7 +309,7 @@ fn current_v2_artifact_boundary_rejects_missing_serial_state() {
 
 #[cfg(target_os = "macos")]
 #[test]
-fn exact_minor_twelve_vsock_pair_remains_outside_artifact_and_family_activation() {
+fn exact_minor_twelve_vsock_pair_has_current_artifact_and_family_authority() {
     let memory = test_v2_memory();
     let mut image = Cursor::new(Vec::new());
     let binding = write_snapshot_v2_memory_image_with_compatibility_version(
@@ -494,14 +494,16 @@ fn exact_minor_twelve_vsock_pair_remains_outside_artifact_and_family_activation(
         Err(NativeV2SnapshotCandidateStateError::InvalidVsockComponent)
     ));
 
-    assert!(matches!(
-        NativeSnapshotArtifactState::from_current_v2(bytes.clone()),
-        Err(NativeSnapshotArtifactStateError::CurrentV2Profile(_))
-    ));
-    assert!(matches!(
-        NativeSnapshotArtifactState::from_compatible_bytes(bytes.clone()),
-        Err(NativeSnapshotArtifactStateError::Format(_))
-    ));
+    let artifact = NativeSnapshotArtifactState::from_current_v2(bytes.clone())
+        .expect("exact-2.12 should have current artifact authority");
+    assert_eq!(
+        artifact
+            .v2_profile()
+            .expect("current exact-2.12 artifact should classify"),
+        NativeV2SnapshotArtifactProfile::VsockStateV2_12
+    );
+    NativeSnapshotArtifactState::from_compatible_bytes(bytes.clone())
+        .expect("the compatible family decoder should admit current exact-2.12");
     assert_eq!(
         classify_native_v2_profile(&bytes, &binding)
             .expect("the explicit classifier should recognize exact 2.12"),
@@ -509,13 +511,15 @@ fn exact_minor_twelve_vsock_pair_remains_outside_artifact_and_family_activation(
     );
     assert!(matches!(
         crate::snapshot_format::decode_native_snapshot_state(&bytes),
-        Err(crate::snapshot_format::NativeSnapshotFormatError::NativeV2(
-            SnapshotV2DecodeError::UnsupportedVersion { .. }
-        ))
+        Ok(crate::snapshot_format::NativeSnapshotState::V2(_))
     ));
     assert_eq!(
         NATIVE_V2_SNAPSHOT_VERSION,
-        NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION
+        NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION
+    );
+    assert_eq!(
+        NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION.minor() + 1,
+        NATIVE_V2_SNAPSHOT_VERSION.minor()
     );
 
     let (owned_bytes, owned_binding, _, _, _, _, _, _, owned_vsock) = candidate.into_parts();
@@ -1138,18 +1142,28 @@ fn exact_minor_eleven_candidate_closes_every_optional_component_product() {
         assert!(!debug.contains("BANGNW2"));
         assert!(!debug.contains("vmnet:host"));
 
-        let artifact = candidate.into_current_artifact_state();
+        let artifact = candidate.into_v2_11_artifact_state();
         assert_eq!(
             artifact
                 .v2_profile()
                 .expect("exact-2.11 optional product should classify"),
             NativeV2SnapshotArtifactProfile::NetworkStateV2_11
         );
-        artifact
-            .validate_for_publication()
-            .expect("exact-2.11 should have current publication authority");
-        NativeSnapshotArtifactState::from_current_v2(bytes)
-            .expect("the public exact-2.11 constructor must admit product");
+        assert!(matches!(
+            artifact.validate_for_publication(),
+            Err(NativeSnapshotArtifactStateError::NonCurrentV2Publication {
+                state: NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
+                memory: NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
+            })
+        ));
+        assert!(matches!(
+            NativeSnapshotArtifactState::from_current_v2(bytes),
+            Err(NativeSnapshotArtifactStateError::CurrentV2Profile(
+                NativeV2SnapshotCandidateStateError::UnexpectedVersion {
+                    found: NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
+                }
+            ))
+        ));
     }
 }
 

--- a/crates/runtime/src/snapshot_format_v2.rs
+++ b/crates/runtime/src/snapshot_format_v2.rs
@@ -46,7 +46,7 @@ pub const NATIVE_V2_SNAPSHOT_FOUNDATION_VERSION: SnapshotFormatVersion =
     SnapshotFormatVersion::new(2, 0, 0);
 
 /// Semantic version emitted by the current native-v2 writer.
-pub const NATIVE_V2_SNAPSHOT_VERSION: SnapshotFormatVersion = SnapshotFormatVersion::new(2, 11, 0);
+pub const NATIVE_V2_SNAPSHOT_VERSION: SnapshotFormatVersion = SnapshotFormatVersion::new(2, 12, 0);
 
 /// Newest compatibility version understood through an explicit internal seam.
 const NATIVE_V2_LATEST_KNOWN_COMPATIBILITY_VERSION: SnapshotFormatVersion =
@@ -67,27 +67,27 @@ const _: () = assert!(
 const _: () = assert!(
     NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION.major()
         == NATIVE_V2_SNAPSHOT_VERSION.major()
-        && NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION.minor() + 5
+        && NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION.minor() + 6
             == NATIVE_V2_SNAPSHOT_VERSION.minor()
         && NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION.patch() == 0
 );
 const _: () = assert!(
     NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION.major() == NATIVE_V2_SNAPSHOT_VERSION.major()
-        && NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION.minor() + 4
+        && NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION.minor() + 5
             == NATIVE_V2_SNAPSHOT_VERSION.minor()
         && NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION.patch()
             == NATIVE_V2_SNAPSHOT_VERSION.patch()
 );
 const _: () = assert!(
     NATIVE_V2_ENTROPY_STATE_COMPATIBILITY_VERSION.major() == NATIVE_V2_SNAPSHOT_VERSION.major()
-        && NATIVE_V2_ENTROPY_STATE_COMPATIBILITY_VERSION.minor() + 3
+        && NATIVE_V2_ENTROPY_STATE_COMPATIBILITY_VERSION.minor() + 4
             == NATIVE_V2_SNAPSHOT_VERSION.minor()
         && NATIVE_V2_ENTROPY_STATE_COMPATIBILITY_VERSION.patch()
             == NATIVE_V2_SNAPSHOT_VERSION.patch()
 );
 const _: () = assert!(
     NATIVE_V2_BALLOON_STATE_COMPATIBILITY_VERSION.major() == NATIVE_V2_SNAPSHOT_VERSION.major()
-        && NATIVE_V2_BALLOON_STATE_COMPATIBILITY_VERSION.minor() + 2
+        && NATIVE_V2_BALLOON_STATE_COMPATIBILITY_VERSION.minor() + 3
             == NATIVE_V2_SNAPSHOT_VERSION.minor()
         && NATIVE_V2_BALLOON_STATE_COMPATIBILITY_VERSION.patch()
             == NATIVE_V2_SNAPSHOT_VERSION.patch()
@@ -95,14 +95,14 @@ const _: () = assert!(
 const _: () = assert!(
     NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION.major()
         == NATIVE_V2_SNAPSHOT_VERSION.major()
-        && NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION.minor() + 1
+        && NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION.minor() + 2
             == NATIVE_V2_SNAPSHOT_VERSION.minor()
         && NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION.patch()
             == NATIVE_V2_SNAPSHOT_VERSION.patch()
 );
 const _: () = assert!(
     NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION.major() == NATIVE_V2_SNAPSHOT_VERSION.major()
-        && NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION.minor()
+        && NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION.minor() + 1
             == NATIVE_V2_SNAPSHOT_VERSION.minor()
         && NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION.patch()
             == NATIVE_V2_SNAPSHOT_VERSION.patch()
@@ -110,7 +110,7 @@ const _: () = assert!(
 const _: () = assert!(
     NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION.major() == NATIVE_V2_SNAPSHOT_VERSION.major()
         && NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION.minor()
-            == NATIVE_V2_SNAPSHOT_VERSION.minor() + 1
+            == NATIVE_V2_SNAPSHOT_VERSION.minor()
         && NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION.patch()
             == NATIVE_V2_SNAPSHOT_VERSION.patch()
 );

--- a/crates/runtime/src/snapshot_format_v2/tests.rs
+++ b/crates/runtime/src/snapshot_format_v2/tests.rs
@@ -209,7 +209,7 @@ fn production_catalog_accepts_all_current_semantic_kinds_and_nonsemantic_extensi
 }
 
 #[test]
-fn public_writer_stays_network_eleven_while_internal_vsock_twelve_is_dormant() {
+fn public_writer_is_vsock_twelve_and_retains_network_eleven_compatibility() {
     assert_eq!(NATIVE_V2_DEVICE_GRAPH_COMPONENT_KEY.kind(), 7);
     assert_eq!(NATIVE_V2_DEVICE_GRAPH_COMPONENT_KEY.instance(), 0);
     assert_eq!(
@@ -218,7 +218,7 @@ fn public_writer_stays_network_eleven_while_internal_vsock_twelve_is_dormant() {
     );
     assert_eq!(
         NATIVE_V2_SNAPSHOT_VERSION,
-        NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION
+        NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION
     );
     assert_eq!(NATIVE_V2_MEMORY_HOTPLUG_COMPONENT_KEY.kind(), 11);
     assert_eq!(NATIVE_V2_MEMORY_HOTPLUG_COMPONENT_KEY.instance(), 0);
@@ -573,8 +573,8 @@ fn public_writer_stays_network_eleven_while_internal_vsock_twelve_is_dormant() {
         decoded_network.component(NATIVE_V2_NETWORK_COMPONENT_KEY),
         Some(network)
     );
-    let decoded_current =
-        decode_snapshot_v2_state(&network_state).expect("exact 2.11 is the public current profile");
+    let decoded_current = decode_snapshot_v2_state(&network_state)
+        .expect("the compatible public decoder should retain exact 2.11");
     assert_eq!(
         decoded_current.metadata().version(),
         NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION
@@ -612,12 +612,12 @@ fn public_writer_stays_network_eleven_while_internal_vsock_twelve_is_dormant() {
         &[],
         &[network, vsock],
     )
-    .expect("explicit exact 2.12 should admit dormant vsock state");
+    .expect("current exact 2.12 should admit vsock state");
     let decoded_vsock = decode_snapshot_v2_state_with_compatibility_version(
         &vsock_state,
         NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
     )
-    .expect("explicit exact 2.12 should decode dormant vsock state");
+    .expect("current exact 2.12 should decode vsock state");
     assert_eq!(
         decoded_vsock.metadata().version(),
         NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION
@@ -626,15 +626,10 @@ fn public_writer_stays_network_eleven_while_internal_vsock_twelve_is_dormant() {
         decoded_vsock.component(NATIVE_V2_VSOCK_COMPONENT_KEY),
         Some(vsock)
     );
-    assert!(matches!(
-        decode_snapshot_v2_state(&vsock_state),
-        Err(SnapshotV2DecodeError::UnsupportedVersion { .. })
-    ));
+    assert!(decode_snapshot_v2_state(&vsock_state).is_ok());
     assert!(matches!(
         decode_native_snapshot_state(&vsock_state),
-        Err(NativeSnapshotFormatError::NativeV2(
-            SnapshotV2DecodeError::UnsupportedVersion { .. }
-        ))
+        Ok(NativeSnapshotState::V2(_))
     ));
     let downgraded_vsock = with_u16_field_and_checksum(&vsock_state, VERSION_MINOR_OFFSET, 11);
     assert_eq!(
@@ -718,11 +713,11 @@ fn version_policy_rejects_major_and_newer_minor_but_accepts_patch() {
         })
     );
 
-    let minor = with_u16_field(&EMPTY_V2_FIXTURE, VERSION_MINOR_OFFSET, 12);
+    let minor = with_u16_field(&EMPTY_V2_FIXTURE, VERSION_MINOR_OFFSET, 13);
     assert_eq!(
         decode_snapshot_v2_state(&minor),
         Err(SnapshotV2DecodeError::UnsupportedVersion {
-            found: SnapshotFormatVersion::new(2, 12, 0),
+            found: SnapshotFormatVersion::new(2, 13, 0),
             supported: NATIVE_V2_SNAPSHOT_VERSION,
         })
     );

--- a/crates/runtime/src/snapshot_memory_v2/tests.rs
+++ b/crates/runtime/src/snapshot_memory_v2/tests.rs
@@ -151,7 +151,7 @@ fn canonical_binding_state_and_image_round_trip() {
 }
 
 #[test]
-fn explicit_minor_four_through_internal_twelve_memory_images_round_trip() {
+fn explicit_minor_four_through_current_twelve_memory_images_round_trip() {
     let memory = test_memory();
     let mut output = Cursor::new(Vec::new());
     let binding = write_snapshot_v2_memory_image_with_compatibility_version(
@@ -508,10 +508,13 @@ fn explicit_minor_four_through_internal_twelve_memory_images_round_trip() {
             &[component],
         )
         .expect("minor-twelve memory state should encode internally");
-    assert!(matches!(
-        crate::snapshot_format_v2::decode_snapshot_v2_state(&state_bytes),
-        Err(crate::snapshot_format_v2::SnapshotV2DecodeError::UnsupportedVersion { .. })
-    ));
+    assert_eq!(
+        crate::snapshot_format_v2::decode_snapshot_v2_state(&state_bytes)
+            .expect("current minor-twelve memory state should decode")
+            .metadata()
+            .version(),
+        crate::snapshot_vsock_v2_12::NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION
+    );
     let state = crate::snapshot_format_v2::decode_snapshot_v2_state_with_compatibility_version(
         &state_bytes,
         crate::snapshot_vsock_v2_12::NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,

--- a/crates/runtime/src/snapshot_network_restore_v2_11.rs
+++ b/crates/runtime/src/snapshot_network_restore_v2_11.rs
@@ -822,7 +822,7 @@ pub struct PreparedSnapshotV2NetworkRestoreTopology {
 }
 
 impl PreparedSnapshotV2NetworkRestoreTopology {
-    /// Constructs the internal network-free form for one current exact-2.11
+    /// Constructs the internal network-free form for one retained exact-2.11
     /// destination. Portable kind-12 state itself remains non-empty.
     #[doc(hidden)]
     pub fn empty(transport_kind: SnapshotV2DeviceTransportKind) -> Self {

--- a/crates/runtime/src/snapshot_vsock_v2_12/tests.rs
+++ b/crates/runtime/src/snapshot_vsock_v2_12/tests.rs
@@ -366,7 +366,7 @@ fn public_debug_and_error_text_redact_private_values() {
 fn exact_version_is_required_for_component_codec() {
     let state = inactive_mmio_state();
     assert!(matches!(
-        state.encode(crate::snapshot_format_v2::NATIVE_V2_SNAPSHOT_VERSION),
+        state.encode(crate::snapshot_network_v2_11::NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION),
         Err(SnapshotV2VsockStateEncodeError::UnsupportedVersion)
     ));
     let encoded = state
@@ -374,7 +374,7 @@ fn exact_version_is_required_for_component_codec() {
         .expect("state should encode");
     assert!(matches!(
         SnapshotV2VsockState::decode(
-            crate::snapshot_format_v2::NATIVE_V2_SNAPSHOT_VERSION,
+            crate::snapshot_network_v2_11::NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
             &encoded,
         ),
         Err(SnapshotV2VsockStateDecodeError::UnsupportedVersion)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -563,13 +563,14 @@ Native-v2 structural state tests pin an independent exact 72-byte empty
 private catalog-aware test codec exercises multiple required features,
 semantic components, instances, and an ignorable nonsemantic extension. The
 production catalog admits semantic memory kind 1 introduced in minor 1; the
-current `2.11.0` writer additionally admits machine/global/topology kinds 2–4
+current `2.12.0` writer additionally admits machine/global/topology kinds 2–4
 and per-vCPU kind 5 introduced in minor 2, singleton time kind 6 introduced in
 minor 3, optional singleton device-graph kind 7 introduced in minor 4, and
 mandatory singleton serial kind 8 introduced in minor 7, plus optional entropy
 kind 9 introduced in minor 8, optional balloon kind 10 introduced in minor 9,
 optional virtio-mem kind 11 introduced in minor 10, and optional network/MMDS
-kind 12 introduced in minor 11.
+kind 12 introduced in minor 11, plus optional vsock kind 13 introduced in minor
+12.
 Exact `2.4.0` retains device-graph profile 1's singleton root, while `2.5.0`
 uses profile 2's bounded ordered block vector and `2.6.0` uses profile 3's
 bounded ordered block-and-pmem vector. Exact `2.7.0` requires kind 8 and
@@ -586,7 +587,11 @@ kind 12 with ordered interface configuration, inert selector identity,
 requested/realized MAC/MTU, backend class, queue/common-virtio state,
 limiter/retry, MMIO/PCI placement, and MMDS protocol configuration while
 excluding source owners, packets, connections, data, tokens, metrics, and
-clocks. Exact `2.3.0` remains the
+clocks. Exact `2.12.0` retains those rules and optionally appends kind 13 with
+the guest CID, inert backend selector, host-local port cursor, active
+queue/common-virtio continuation, and MMIO/PCI placement while excluding
+listeners, connections, callbacks, metrics, and other host authority. Exact
+`2.3.0` remains the
 legacy device-free platform profile. The mutation corpus
 covers every fixed header field, both count caps, exact/trailing/oversized
 lengths, all three offsets, CRC and every truncation, feature
@@ -599,7 +604,7 @@ resource action. Run the focused surface with
 `cargo test -p bangbang-runtime snapshot_format --locked`.
 
 Native-v2 lazy-memory tests retain exact multi-extent binding and complete
-`2.1.0` compatibility fixtures while proving that new output uses `2.11.0`.
+`2.1.0` compatibility fixtures while proving that new output uses `2.12.0`.
 They cover canonical 64-KiB metadata/data offsets and sparse gaps, every
 binding/header/topology/length mutation, exact admitted-version retention,
 typed state profiles,
@@ -677,7 +682,7 @@ The wrapper builds the `bangbang` binary unit-test harness, locates and signs
 that exact test executable, and runs only the ignored private-seam proof. Its
 minimal two-vCPU guest does not touch serial or optional devices beyond the
 required read-only root. The first test starts and pauses the real
-process-owned HVF supervisor, publishes one current 2.11
+process-owned HVF supervisor, publishes one current 2.12
 serial-plus-profile-3 MMIO-root pair without entropy, resumes and repauses the
 source, publishes a fresh recapture,
 and drops the source. It
@@ -1698,7 +1703,7 @@ may skip execution. On supported Apple Silicon it proves:
   registries, apply mutually exclusive logger module filters, start real guests,
   and write logger/metrics/serial output only to their own opened objects while
   planted replacement paths remain unchanged;
-- exact external snapshot grants creating current native-v2 2.11
+- exact external snapshot grants creating current native-v2 2.12
   serial-plus-profile-3 rooted three-drive MMIO and PCI pairs without entropy
   into separate output directories, reusing both retained
   directories for a second successful pair, preserving all finals on
@@ -1903,9 +1908,10 @@ punctuation, exact UTF-8 byte boundaries, and ignored non-UTF-8 bytes after the
 separator as a bangbang robustness extension.
 
 The process suite covers native snapshot inspection without starting HVF. It
-checks exact `v2.11.0` output for `--snapshot-version`, exact description of
+checks exact `v2.12.0` output for `--snapshot-version`, exact description of
 native-v1, legacy `2.3.0`, `2.4.0`, `2.5.0`, `2.6.0`, `2.7.0`, `2.8.0`, and
-`2.9.0`, `2.10.0`, and current native-v2 fixtures, plus explicit pinned
+`2.9.0`, `2.10.0`, `2.11.0`, and current `2.12.0` native-v2 fixtures, plus
+explicit pinned
 Firecracker/unknown incompatibility. It also
 covers missing, non-regular,
 oversized, malformed, truncated, trailing/inconsistent-length, corrupt,
@@ -1960,7 +1966,7 @@ pausing, proving the source has already followed live MMIO or PCI root I/O.
 The source UART must remain canonical, while its Linux-consumed FDT bytes are
 captured and CRC-bound without being reparsed as trusted post-boot topology.
 Creation through `/snapshot/create` then verifies the real CLI reports
-`v2.11.0`. Fresh signed processes repeatedly load the same immutable pair: one
+`v2.12.0`. Fresh signed processes repeatedly load the same immutable pair: one
 remains paused until public `PATCH /vm`, and one uses `resume_vm: true`. The
 paused destination is also publicly recaptured and its decoded root graph must
 equal the source graph. After resume Linux reads the known root marker through
@@ -2629,14 +2635,17 @@ guest payloads on both streams, waits for distinct host replies, and writes
 `BANGBANG_VSOCK_GUEST_MULTISTREAM_OK` only after both streams complete. When
 the boot args include `bangbang.vsock-snapshot-reset=1`, Python instead keeps
 one guest-initiated connection blocked while the harness proves pause alone
-does not close it. The harness invokes public snapshot creation while paused;
-the request still receives the supported-profile rejection and leaves no state,
-memory, or staging artifact, but only after the production vsock preflight has
-published `TRANSPORT_RESET`, captured state, and detached source-only work.
-After resume, the guest must observe non-timeout termination of the old socket,
-connect to a distinct host port, and complete a fresh marker/ack exchange before
-writing `BANGBANG_VSOCK_SNAPSHOT_RESET_OK`. Separate signed MMIO and product-PCI
-cases exercise this sequence.
+does not close it. The harness invokes public exact-2.12 snapshot creation while
+paused and requires durable state and memory artifacts after the production
+vsock capture has published `TRANSPORT_RESET`, captured state, and detached
+source-only work. A fresh signed process then loads the immutable pair, first
+through a Paused commit with the original selector and then through automatic
+resume with an overridden selector. The restored guest must acknowledge
+termination of the old socket, connect to a distinct host port, and complete a
+fresh marker/ack exchange before writing
+`BANGBANG_VSOCK_SNAPSHOT_RESET_OK`. The Paused destination is recaptured, and
+separate signed MMIO and product-PCI plus normal production/App Sandbox cases
+exercise the sequence and listener cleanup.
 When
 the boot args include `bangbang.vsock-host-connect=1`, Python instead binds and
 listens on the test AF_VSOCK port, writes


### PR DESCRIPTION
## Summary

- advance the current native-v2 writer and public artifact authority to exact 2.12 while retaining exact 2.11 and older readers
- activate optional vsock create/load with destination selector overrides, fresh MMIO/PCI owners, atomic Paused controller publication, recapture, resume, cancellation, and ordered cleanup
- cover all 64 product profiles plus direct signed and production/App Sandbox guest continuation and containment

## Scope exclusions

- exhaustive compatibility, security, capability-inventory, and lifecycle documentation promotion remains in #1736
- native-v2 Diff/Uffd, Firecracker artifact bytes, and cross-host portability remain outside this issue

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five repository Apple-target Clippy commands from `AGENTS.md`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test native_v2_process`
- exact signed executable MMIO and product-PCI vsock restore filters
- exact signed production-bundle vsock continuation and containment filter

Closes #1735

Part of #1540