### PR TITLE
feat: write bounded native-v2 differential layers

### DIFF
--- a/crates/runtime/src/snapshot_diff_v2_13.rs
+++ b/crates/runtime/src/snapshot_diff_v2_13.rs
@@ -15,6 +15,14 @@ use crate::snapshot_memory_v2::{
 };
 
 mod codec;
+mod writer;
+
+pub use writer::{
+    SnapshotV2DiffSelection, SnapshotV2DiffSelectionError, SnapshotV2DiffVerifyError,
+    SnapshotV2DiffVerifyStage, SnapshotV2DiffWriteError, SnapshotV2DiffWriteStage,
+    verify_snapshot_v2_diff_layer_output, write_snapshot_v2_diff_layer,
+    write_snapshot_v2_diff_layer_with_cancel,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/runtime/src/snapshot_diff_v2_13/writer.rs
+++ b/crates/runtime/src/snapshot_diff_v2_13/writer.rs
@@ -518,25 +518,40 @@ where
         base,
         selection,
         is_cancelled,
-        |identity| getrandom::fill(identity).map_err(|_| ()),
-        |buffer, additional| buffer.try_reserve_exact(additional),
+        SnapshotV2DiffWritePolicy {
+            fill_identity: |identity: &mut [u8; IMAGE_ID_BYTES]| {
+                getrandom::fill(identity).map_err(|_| ())
+            },
+            reserve_copy_buffer: |buffer: &mut Vec<u8>, additional| {
+                buffer.try_reserve_exact(additional)
+            },
+            read_guest: |memory: &GuestMemory, destination: &mut [u8], address| {
+                memory.read_slice(destination, address).map_err(|_| ())
+            },
+        },
     )
 }
 
-fn write_snapshot_v2_diff_layer_with_policy<W, C, I, R>(
+struct SnapshotV2DiffWritePolicy<I, R, G> {
+    fill_identity: I,
+    reserve_copy_buffer: R,
+    read_guest: G,
+}
+
+fn write_snapshot_v2_diff_layer_with_policy<W, C, I, R, G>(
     memory: &GuestMemory,
     writer: &mut W,
     base: SnapshotV2DiffBase,
     selection: &SnapshotV2DiffSelection,
     mut is_cancelled: C,
-    mut fill_identity: I,
-    mut reserve_copy_buffer: R,
+    mut policy: SnapshotV2DiffWritePolicy<I, R, G>,
 ) -> Result<SnapshotV2DiffLayerBinding, SnapshotV2DiffWriteError>
 where
     W: Write + Seek,
     C: FnMut(SnapshotV2DiffWriteStage) -> bool,
     I: FnMut(&mut [u8; IMAGE_ID_BYTES]) -> Result<(), ()>,
     R: FnMut(&mut Vec<u8>, usize) -> Result<(), TryReserveError>,
+    G: FnMut(&GuestMemory, &mut [u8], GuestAddress) -> Result<(), ()>,
 {
     check_write_cancelled(&mut is_cancelled, SnapshotV2DiffWriteStage::InitialPosition)?;
     if !selection.matches_memory_topology(memory) {
@@ -545,7 +560,8 @@ where
     preflight_empty_output(writer)?;
 
     let mut identity = [0_u8; IMAGE_ID_BYTES];
-    fill_identity(&mut identity).map_err(|()| SnapshotV2DiffWriteError::IdentityUnavailable)?;
+    (policy.fill_identity)(&mut identity)
+        .map_err(|()| SnapshotV2DiffWriteError::IdentityUnavailable)?;
     let result = snapshot_v2_memory_binding_from_memory_with_version_and_id(
         memory,
         NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION,
@@ -570,7 +586,7 @@ where
             source: SnapshotV2DiffLayerBindingError::LengthOverflow,
         })?;
     let mut chunk = Vec::new();
-    reserve_copy_buffer(&mut chunk, copy_length)
+    (policy.reserve_copy_buffer)(&mut chunk, copy_length)
         .map_err(|source| SnapshotV2DiffWriteError::CopyBufferAllocationFailed { source })?;
     chunk.resize(copy_length, 0);
 
@@ -635,8 +651,7 @@ where
                     .ok_or(SnapshotV2DiffWriteError::LayerBinding {
                         source: SnapshotV2DiffLayerBindingError::LengthOverflow,
                     })?;
-            memory
-                .read_slice(destination, address)
+            (policy.read_guest)(memory, destination, address)
                 .map_err(|_| SnapshotV2DiffWriteError::GuestMemoryRead { stage })?;
             write_all_stage(writer, destination, stage)?;
             copied = copied.checked_add(length as u64).ok_or({

--- a/crates/runtime/src/snapshot_diff_v2_13/writer.rs
+++ b/crates/runtime/src/snapshot_diff_v2_13/writer.rs
@@ -1,0 +1,982 @@
+//! Checked page selection, streaming, and detached verification for Diff layers.
+
+use std::collections::TryReserveError;
+use std::fmt;
+use std::io::{self, Read, Seek, SeekFrom, Write};
+
+use crate::memory::{GuestAddress, GuestMemory, GuestMemoryRange, aarch64};
+use crate::snapshot_memory_v2::{
+    NATIVE_V2_MEMORY_GUEST_GRANULE, NATIVE_V2_MEMORY_MAX_EXTENTS, SnapshotV2MemoryBindingError,
+    SnapshotV2MemoryImageId, snapshot_v2_memory_binding_from_memory_with_version_and_id,
+};
+
+use super::{
+    NATIVE_V2_DIFF_MAX_EXTENTS, NATIVE_V2_DIFF_MAX_METADATA_BYTES,
+    NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION, SnapshotV2DiffBase, SnapshotV2DiffLayerBinding,
+    SnapshotV2DiffLayerBindingError,
+};
+
+const COPY_CHUNK_BYTES: usize = 1024 * 1024;
+const ZERO_CHUNK_BYTES: usize = 8192;
+const IMAGE_ID_BYTES: usize = 16;
+const REDACTED: &str = "<redacted>";
+
+/// A checked, canonical set of current guest-memory ranges for one Diff layer.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SnapshotV2DiffSelection {
+    topology: Vec<GuestMemoryRange>,
+    ranges: Vec<GuestMemoryRange>,
+}
+
+impl SnapshotV2DiffSelection {
+    /// Selects every byte in every current active guest-memory region.
+    pub fn all_current(memory: &GuestMemory) -> Result<Self, SnapshotV2DiffSelectionError> {
+        let topology = capture_topology(memory)?;
+        let mut ranges = Vec::new();
+        ranges
+            .try_reserve_exact(topology.len())
+            .map_err(|source| SnapshotV2DiffSelectionError::MetadataAllocationFailed { source })?;
+        ranges.extend(topology.iter().copied());
+        Ok(Self { topology, ranges })
+    }
+
+    /// Normalizes arbitrary mapped ranges outward to canonical 4-KiB guest pages.
+    pub fn try_from_ranges(
+        memory: &GuestMemory,
+        ranges: &[GuestMemoryRange],
+    ) -> Result<Self, SnapshotV2DiffSelectionError> {
+        Self::try_from_source_ranges(memory, ranges.iter().copied().map(Ok))
+    }
+
+    /// Normalizes host/source dirty-page starts to canonical 4-KiB guest pages.
+    pub fn try_from_dirty_pages(
+        memory: &GuestMemory,
+        source_page_size: u64,
+        dirty_pages: &[GuestAddress],
+    ) -> Result<Self, SnapshotV2DiffSelectionError> {
+        if source_page_size < NATIVE_V2_MEMORY_GUEST_GRANULE
+            || !source_page_size.is_power_of_two()
+            || !source_page_size.is_multiple_of(NATIVE_V2_MEMORY_GUEST_GRANULE)
+        {
+            return Err(SnapshotV2DiffSelectionError::InvalidSourcePageSize);
+        }
+        Self::try_from_source_ranges(
+            memory,
+            dirty_pages.iter().copied().map(|address| {
+                if !address.raw_value().is_multiple_of(source_page_size) {
+                    return Err(SnapshotV2DiffSelectionError::UnalignedDirtyPage);
+                }
+                GuestMemoryRange::new(address, source_page_size)
+                    .map_err(|_| SnapshotV2DiffSelectionError::AddressOverflow)
+            }),
+        )
+    }
+
+    /// Returns the final canonical ranges whose bytes will be written.
+    pub fn ranges(&self) -> &[GuestMemoryRange] {
+        &self.ranges
+    }
+
+    fn try_from_source_ranges<I>(
+        memory: &GuestMemory,
+        source_ranges: I,
+    ) -> Result<Self, SnapshotV2DiffSelectionError>
+    where
+        I: IntoIterator<Item = Result<GuestMemoryRange, SnapshotV2DiffSelectionError>>,
+    {
+        let topology = capture_topology(memory)?;
+        let mut touched = Vec::new();
+        touched
+            .try_reserve_exact(topology.len())
+            .map_err(|source| SnapshotV2DiffSelectionError::MetadataAllocationFailed { source })?;
+        touched.resize(topology.len(), false);
+
+        let mut fragments = Vec::new();
+        for source in source_ranges {
+            let normalized = normalize_outward(source?)?;
+            append_normalized_range(&topology, normalized, &mut touched, &mut fragments)?;
+        }
+        fragments.sort_unstable_by_key(|fragment| {
+            (fragment.region_index, fragment.range.start().raw_value())
+        });
+
+        let mut canonical: Vec<SelectedRange> = Vec::new();
+        canonical
+            .try_reserve_exact(fragments.len())
+            .map_err(|source| SnapshotV2DiffSelectionError::MetadataAllocationFailed { source })?;
+        for fragment in fragments {
+            if let Some(previous) = canonical.last_mut()
+                && previous.region_index == fragment.region_index
+                && fragment.range.start() <= previous.range.end_exclusive()
+            {
+                let end = previous
+                    .range
+                    .end_exclusive()
+                    .raw_value()
+                    .max(fragment.range.end_exclusive().raw_value());
+                previous.range = GuestMemoryRange::new(
+                    previous.range.start(),
+                    end.checked_sub(previous.range.start().raw_value())
+                        .ok_or(SnapshotV2DiffSelectionError::AddressOverflow)?,
+                )
+                .map_err(|_| SnapshotV2DiffSelectionError::AddressOverflow)?;
+                continue;
+            }
+            canonical.push(fragment);
+        }
+
+        let mut ranges = Vec::new();
+        if canonical.len() > NATIVE_V2_DIFF_MAX_EXTENTS {
+            let touched_count = touched.iter().filter(|selected| **selected).count();
+            ranges.try_reserve_exact(touched_count).map_err(|source| {
+                SnapshotV2DiffSelectionError::MetadataAllocationFailed { source }
+            })?;
+            for (range, selected) in topology.iter().copied().zip(touched.iter().copied()) {
+                if selected {
+                    ranges.push(range);
+                }
+            }
+        } else {
+            ranges
+                .try_reserve_exact(canonical.len())
+                .map_err(
+                    |source| SnapshotV2DiffSelectionError::MetadataAllocationFailed { source },
+                )?;
+            ranges.extend(canonical.into_iter().map(|selected| selected.range));
+        }
+
+        Ok(Self { topology, ranges })
+    }
+
+    fn matches_memory_topology(&self, memory: &GuestMemory) -> bool {
+        self.topology.len() == memory.regions().len()
+            && self
+                .topology
+                .iter()
+                .copied()
+                .zip(memory.regions().iter().map(|region| region.range()))
+                .all(|(selected, current)| selected == current)
+    }
+}
+
+impl fmt::Debug for SnapshotV2DiffSelection {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2DiffSelection")
+            .field("topology", &REDACTED)
+            .field("selected", &REDACTED)
+            .field("region_count", &self.topology.len())
+            .field("extent_count", &self.ranges.len())
+            .finish()
+    }
+}
+
+/// Failure while validating or normalizing a Diff page selection.
+pub enum SnapshotV2DiffSelectionError {
+    /// Current memory cannot form one exact native-v2 result topology.
+    InvalidTopology,
+    /// A source page size is not a supported multiple of the guest granule.
+    InvalidSourcePageSize,
+    /// A dirty-page start is not aligned to its declared source page size.
+    UnalignedDirtyPage,
+    /// Source or normalized guest-address arithmetic overflowed.
+    AddressOverflow,
+    /// A normalized byte is outside current active guest memory.
+    OutOfTopology,
+    /// Bounded selection metadata could not be allocated.
+    MetadataAllocationFailed {
+        /// The failed reservation.
+        source: TryReserveError,
+    },
+}
+
+impl fmt::Debug for SnapshotV2DiffSelectionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("SnapshotV2DiffSelectionError")
+            .field(&self.to_string())
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotV2DiffSelectionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidTopology => "native-v2 Diff selection topology is invalid",
+            Self::InvalidSourcePageSize => "native-v2 Diff source page size is invalid",
+            Self::UnalignedDirtyPage => "native-v2 Diff dirty page is unaligned",
+            Self::AddressOverflow => "native-v2 Diff selection address arithmetic overflowed",
+            Self::OutOfTopology => "native-v2 Diff selection is outside current memory",
+            Self::MetadataAllocationFailed { .. } => {
+                "native-v2 Diff selection metadata allocation failed"
+            }
+        })
+    }
+}
+
+impl std::error::Error for SnapshotV2DiffSelectionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::MetadataAllocationFailed { source } => Some(source),
+            Self::InvalidTopology
+            | Self::InvalidSourcePageSize
+            | Self::UnalignedDirtyPage
+            | Self::AddressOverflow
+            | Self::OutOfTopology => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SelectedRange {
+    range: GuestMemoryRange,
+    region_index: usize,
+}
+
+fn capture_topology(
+    memory: &GuestMemory,
+) -> Result<Vec<GuestMemoryRange>, SnapshotV2DiffSelectionError> {
+    let count = memory.regions().len();
+    if !(1..=NATIVE_V2_MEMORY_MAX_EXTENTS).contains(&count) {
+        return Err(SnapshotV2DiffSelectionError::InvalidTopology);
+    }
+    let mut topology = Vec::new();
+    topology
+        .try_reserve_exact(count)
+        .map_err(|source| SnapshotV2DiffSelectionError::MetadataAllocationFailed { source })?;
+    let mut previous = None;
+    let mut total = 0_u64;
+    for range in memory.regions().iter().map(|region| region.range()) {
+        if range
+            .validate_alignment(NATIVE_V2_MEMORY_GUEST_GRANULE)
+            .is_err()
+            || previous.is_some_and(|previous: GuestMemoryRange| {
+                range.start() <= previous.start() || previous.overlaps(range)
+            })
+        {
+            return Err(SnapshotV2DiffSelectionError::InvalidTopology);
+        }
+        total = total
+            .checked_add(range.size())
+            .ok_or(SnapshotV2DiffSelectionError::AddressOverflow)?;
+        if total > aarch64::DRAM_MEM_MAX_SIZE {
+            return Err(SnapshotV2DiffSelectionError::InvalidTopology);
+        }
+        topology.push(range);
+        previous = Some(range);
+    }
+    Ok(topology)
+}
+
+fn normalize_outward(
+    source: GuestMemoryRange,
+) -> Result<GuestMemoryRange, SnapshotV2DiffSelectionError> {
+    let mask = NATIVE_V2_MEMORY_GUEST_GRANULE - 1;
+    let start = source.start().raw_value() & !mask;
+    let end = source
+        .end_exclusive()
+        .raw_value()
+        .checked_add(mask)
+        .map(|value| value & !mask)
+        .ok_or(SnapshotV2DiffSelectionError::AddressOverflow)?;
+    let size = end
+        .checked_sub(start)
+        .ok_or(SnapshotV2DiffSelectionError::AddressOverflow)?;
+    GuestMemoryRange::new(GuestAddress::new(start), size)
+        .map_err(|_| SnapshotV2DiffSelectionError::AddressOverflow)
+}
+
+fn append_normalized_range(
+    topology: &[GuestMemoryRange],
+    normalized: GuestMemoryRange,
+    touched: &mut [bool],
+    fragments: &mut Vec<SelectedRange>,
+) -> Result<(), SnapshotV2DiffSelectionError> {
+    let mut current = normalized.start().raw_value();
+    let end = normalized.end_exclusive().raw_value();
+    let mut region_index =
+        topology.partition_point(|range| range.end_exclusive().raw_value() <= current);
+    while current < end {
+        let region = topology
+            .get(region_index)
+            .copied()
+            .ok_or(SnapshotV2DiffSelectionError::OutOfTopology)?;
+        if region.start().raw_value() > current {
+            return Err(SnapshotV2DiffSelectionError::OutOfTopology);
+        }
+        let fragment_end = end.min(region.end_exclusive().raw_value());
+        let range = GuestMemoryRange::new(
+            GuestAddress::new(current),
+            fragment_end
+                .checked_sub(current)
+                .ok_or(SnapshotV2DiffSelectionError::AddressOverflow)?,
+        )
+        .map_err(|_| SnapshotV2DiffSelectionError::AddressOverflow)?;
+        fragments
+            .try_reserve(1)
+            .map_err(|source| SnapshotV2DiffSelectionError::MetadataAllocationFailed { source })?;
+        fragments.push(SelectedRange {
+            range,
+            region_index,
+        });
+        let selected = touched
+            .get_mut(region_index)
+            .ok_or(SnapshotV2DiffSelectionError::InvalidTopology)?;
+        *selected = true;
+        current = fragment_end;
+        region_index = region_index
+            .checked_add(1)
+            .ok_or(SnapshotV2DiffSelectionError::AddressOverflow)?;
+    }
+    Ok(())
+}
+
+/// Stable stage for cooperative Diff layer writing and redacted diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2DiffWriteStage {
+    /// Output-position and emptiness preflight.
+    InitialPosition,
+    /// Canonical layer metadata.
+    Metadata,
+    /// Zero padding between metadata and packed data.
+    MetadataPadding,
+    /// One selected packed data extent.
+    Data {
+        /// Zero-based canonical extent index.
+        extent_index: usize,
+    },
+    /// Exact final output length.
+    FinalLength,
+}
+
+impl fmt::Display for SnapshotV2DiffWriteStage {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InitialPosition => formatter.write_str("initial output preflight"),
+            Self::Metadata => formatter.write_str("Diff layer metadata"),
+            Self::MetadataPadding => formatter.write_str("Diff layer metadata padding"),
+            Self::Data { extent_index } => write!(formatter, "Diff layer extent {extent_index}"),
+            Self::FinalLength => formatter.write_str("final Diff layer length"),
+        }
+    }
+}
+
+/// Failure while streaming one canonical exact-2.13 Diff layer.
+pub enum SnapshotV2DiffWriteError {
+    /// The checked selection no longer matches current memory topology.
+    TopologyChanged,
+    /// The complete result-memory binding could not be constructed.
+    ResultBinding {
+        /// The redacted binding failure.
+        source: SnapshotV2MemoryBindingError,
+    },
+    /// The exact layer binding or metadata could not be constructed.
+    LayerBinding {
+        /// The redacted layer failure.
+        source: SnapshotV2DiffLayerBindingError,
+    },
+    /// A fresh result identity could not be obtained.
+    IdentityUnavailable,
+    /// The bounded guest-copy buffer could not be allocated.
+    CopyBufferAllocationFailed {
+        /// The failed reservation.
+        source: TryReserveError,
+    },
+    /// The supplied output did not start at position zero.
+    InvalidInitialPosition,
+    /// The supplied output already contained bytes.
+    NonEmptyOutput,
+    /// A seek returned a different position than requested.
+    PositionMismatch {
+        /// The stable stage at which the mismatch occurred.
+        stage: SnapshotV2DiffWriteStage,
+    },
+    /// Cooperative cancellation was observed before a stable stage.
+    Cancelled {
+        /// The stage that did not begin or complete.
+        stage: SnapshotV2DiffWriteStage,
+    },
+    /// Output I/O failed without retaining a private error message.
+    Io {
+        /// The stable failing stage.
+        stage: SnapshotV2DiffWriteStage,
+        /// The public I/O classification.
+        kind: io::ErrorKind,
+    },
+    /// Current guest memory could not supply a selected range.
+    GuestMemoryRead {
+        /// The redacted selected-data stage.
+        stage: SnapshotV2DiffWriteStage,
+    },
+}
+
+impl fmt::Debug for SnapshotV2DiffWriteError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("SnapshotV2DiffWriteError")
+            .field(&self.to_string())
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotV2DiffWriteError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TopologyChanged => {
+                formatter.write_str("native-v2 Diff selection topology changed")
+            }
+            Self::ResultBinding { .. } => {
+                formatter.write_str("native-v2 Diff result binding is invalid")
+            }
+            Self::LayerBinding { .. } => {
+                formatter.write_str("native-v2 Diff layer binding is invalid")
+            }
+            Self::IdentityUnavailable => {
+                formatter.write_str("native-v2 Diff result identity is unavailable")
+            }
+            Self::CopyBufferAllocationFailed { .. } => {
+                formatter.write_str("native-v2 Diff copy-buffer allocation failed")
+            }
+            Self::InvalidInitialPosition => {
+                formatter.write_str("native-v2 Diff output is not positioned at zero")
+            }
+            Self::NonEmptyOutput => formatter.write_str("native-v2 Diff output is not empty"),
+            Self::PositionMismatch { stage } => {
+                write!(
+                    formatter,
+                    "native-v2 Diff output position is invalid at {stage}"
+                )
+            }
+            Self::Cancelled { stage } => {
+                write!(
+                    formatter,
+                    "native-v2 Diff writing was cancelled before {stage}"
+                )
+            }
+            Self::Io { stage, kind } => {
+                write!(formatter, "native-v2 Diff I/O failed at {stage}: {kind}")
+            }
+            Self::GuestMemoryRead { stage } => {
+                write!(
+                    formatter,
+                    "native-v2 Diff guest-memory read failed at {stage}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for SnapshotV2DiffWriteError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::ResultBinding { source } => Some(source),
+            Self::LayerBinding { source } => Some(source),
+            Self::CopyBufferAllocationFailed { source } => Some(source),
+            Self::TopologyChanged
+            | Self::IdentityUnavailable
+            | Self::InvalidInitialPosition
+            | Self::NonEmptyOutput
+            | Self::PositionMismatch { .. }
+            | Self::Cancelled { .. }
+            | Self::Io { .. }
+            | Self::GuestMemoryRead { .. } => None,
+        }
+    }
+}
+
+/// Streams one canonical exact-2.13 Diff layer into an empty transaction sink.
+///
+/// The caller owns the sink transaction. An error may leave only a prefix in
+/// that supplied sink; this function opens no path and publishes no output.
+pub fn write_snapshot_v2_diff_layer<W: Write + Seek>(
+    memory: &GuestMemory,
+    writer: &mut W,
+    base: SnapshotV2DiffBase,
+    selection: &SnapshotV2DiffSelection,
+) -> Result<SnapshotV2DiffLayerBinding, SnapshotV2DiffWriteError> {
+    write_snapshot_v2_diff_layer_with_cancel(memory, writer, base, selection, |_| false)
+}
+
+/// Streams one canonical Diff layer with cooperative bounded-stage cancellation.
+///
+/// Cancellation has the same transaction-owned partial-sink behavior as
+/// [`write_snapshot_v2_diff_layer`].
+pub fn write_snapshot_v2_diff_layer_with_cancel<W, C>(
+    memory: &GuestMemory,
+    writer: &mut W,
+    base: SnapshotV2DiffBase,
+    selection: &SnapshotV2DiffSelection,
+    is_cancelled: C,
+) -> Result<SnapshotV2DiffLayerBinding, SnapshotV2DiffWriteError>
+where
+    W: Write + Seek,
+    C: FnMut(SnapshotV2DiffWriteStage) -> bool,
+{
+    write_snapshot_v2_diff_layer_with_policy(
+        memory,
+        writer,
+        base,
+        selection,
+        is_cancelled,
+        |identity| getrandom::fill(identity).map_err(|_| ()),
+        |buffer, additional| buffer.try_reserve_exact(additional),
+    )
+}
+
+fn write_snapshot_v2_diff_layer_with_policy<W, C, I, R>(
+    memory: &GuestMemory,
+    writer: &mut W,
+    base: SnapshotV2DiffBase,
+    selection: &SnapshotV2DiffSelection,
+    mut is_cancelled: C,
+    mut fill_identity: I,
+    mut reserve_copy_buffer: R,
+) -> Result<SnapshotV2DiffLayerBinding, SnapshotV2DiffWriteError>
+where
+    W: Write + Seek,
+    C: FnMut(SnapshotV2DiffWriteStage) -> bool,
+    I: FnMut(&mut [u8; IMAGE_ID_BYTES]) -> Result<(), ()>,
+    R: FnMut(&mut Vec<u8>, usize) -> Result<(), TryReserveError>,
+{
+    check_write_cancelled(&mut is_cancelled, SnapshotV2DiffWriteStage::InitialPosition)?;
+    if !selection.matches_memory_topology(memory) {
+        return Err(SnapshotV2DiffWriteError::TopologyChanged);
+    }
+    preflight_empty_output(writer)?;
+
+    let mut identity = [0_u8; IMAGE_ID_BYTES];
+    fill_identity(&mut identity).map_err(|()| SnapshotV2DiffWriteError::IdentityUnavailable)?;
+    let result = snapshot_v2_memory_binding_from_memory_with_version_and_id(
+        memory,
+        NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION,
+        SnapshotV2MemoryImageId::from_bytes(identity),
+    )
+    .map_err(|source| SnapshotV2DiffWriteError::ResultBinding { source })?;
+    let binding = SnapshotV2DiffLayerBinding::try_from_ranges(base, result, selection.ranges())
+        .map_err(|source| SnapshotV2DiffWriteError::LayerBinding { source })?;
+    let metadata = binding
+        .encode()
+        .map_err(|source| SnapshotV2DiffWriteError::LayerBinding { source })?;
+
+    let copy_length = binding
+        .data_extents()
+        .iter()
+        .map(|extent| extent.range().size())
+        .max()
+        .unwrap_or(0)
+        .min(COPY_CHUNK_BYTES as u64);
+    let copy_length =
+        usize::try_from(copy_length).map_err(|_| SnapshotV2DiffWriteError::LayerBinding {
+            source: SnapshotV2DiffLayerBindingError::LengthOverflow,
+        })?;
+    let mut chunk = Vec::new();
+    reserve_copy_buffer(&mut chunk, copy_length)
+        .map_err(|source| SnapshotV2DiffWriteError::CopyBufferAllocationFailed { source })?;
+    chunk.resize(copy_length, 0);
+
+    check_write_cancelled(&mut is_cancelled, SnapshotV2DiffWriteStage::Metadata)?;
+    write_all_stage(writer, &metadata, SnapshotV2DiffWriteStage::Metadata)?;
+
+    let zeroes = [0_u8; ZERO_CHUNK_BYTES];
+    let metadata_length =
+        u64::try_from(metadata.len()).map_err(|_| SnapshotV2DiffWriteError::LayerBinding {
+            source: SnapshotV2DiffLayerBindingError::LengthOverflow,
+        })?;
+    let mut padding = binding.data_offset().checked_sub(metadata_length).ok_or(
+        SnapshotV2DiffWriteError::LayerBinding {
+            source: SnapshotV2DiffLayerBindingError::InvalidLength,
+        },
+    )?;
+    while padding != 0 {
+        check_write_cancelled(&mut is_cancelled, SnapshotV2DiffWriteStage::MetadataPadding)?;
+        let length = usize::try_from(padding.min(ZERO_CHUNK_BYTES as u64)).map_err(|_| {
+            SnapshotV2DiffWriteError::LayerBinding {
+                source: SnapshotV2DiffLayerBindingError::LengthOverflow,
+            }
+        })?;
+        let padding_chunk = zeroes
+            .get(..length)
+            .ok_or(SnapshotV2DiffWriteError::LayerBinding {
+                source: SnapshotV2DiffLayerBindingError::LengthOverflow,
+            })?;
+        write_all_stage(
+            writer,
+            padding_chunk,
+            SnapshotV2DiffWriteStage::MetadataPadding,
+        )?;
+        padding = padding.checked_sub(length as u64).ok_or({
+            SnapshotV2DiffWriteError::LayerBinding {
+                source: SnapshotV2DiffLayerBindingError::LengthOverflow,
+            }
+        })?;
+    }
+
+    for (extent_index, extent) in binding.data_extents().iter().copied().enumerate() {
+        let stage = SnapshotV2DiffWriteStage::Data { extent_index };
+        check_write_cancelled(&mut is_cancelled, stage)?;
+        seek_write_exact(writer, extent.file_offset(), stage)?;
+        let mut copied = 0_u64;
+        while copied < extent.range().size() {
+            check_write_cancelled(&mut is_cancelled, stage)?;
+            let remaining = extent.range().size() - copied;
+            let length = usize::try_from(remaining.min(COPY_CHUNK_BYTES as u64)).map_err(|_| {
+                SnapshotV2DiffWriteError::LayerBinding {
+                    source: SnapshotV2DiffLayerBindingError::LengthOverflow,
+                }
+            })?;
+            let address = extent.range().start().checked_add(copied).ok_or({
+                SnapshotV2DiffWriteError::LayerBinding {
+                    source: SnapshotV2DiffLayerBindingError::LengthOverflow,
+                }
+            })?;
+            let destination =
+                chunk
+                    .get_mut(..length)
+                    .ok_or(SnapshotV2DiffWriteError::LayerBinding {
+                        source: SnapshotV2DiffLayerBindingError::LengthOverflow,
+                    })?;
+            memory
+                .read_slice(destination, address)
+                .map_err(|_| SnapshotV2DiffWriteError::GuestMemoryRead { stage })?;
+            write_all_stage(writer, destination, stage)?;
+            copied = copied.checked_add(length as u64).ok_or({
+                SnapshotV2DiffWriteError::LayerBinding {
+                    source: SnapshotV2DiffLayerBindingError::LengthOverflow,
+                }
+            })?;
+        }
+    }
+
+    check_write_cancelled(&mut is_cancelled, SnapshotV2DiffWriteStage::FinalLength)?;
+    let position = writer
+        .stream_position()
+        .map_err(|source| SnapshotV2DiffWriteError::Io {
+            stage: SnapshotV2DiffWriteStage::FinalLength,
+            kind: source.kind(),
+        })?;
+    if position != binding.file_length() {
+        return Err(SnapshotV2DiffWriteError::PositionMismatch {
+            stage: SnapshotV2DiffWriteStage::FinalLength,
+        });
+    }
+    let end = writer
+        .seek(SeekFrom::End(0))
+        .map_err(|source| SnapshotV2DiffWriteError::Io {
+            stage: SnapshotV2DiffWriteStage::FinalLength,
+            kind: source.kind(),
+        })?;
+    if end != binding.file_length() {
+        return Err(SnapshotV2DiffWriteError::PositionMismatch {
+            stage: SnapshotV2DiffWriteStage::FinalLength,
+        });
+    }
+    Ok(binding)
+}
+
+fn preflight_empty_output<W: Seek>(writer: &mut W) -> Result<(), SnapshotV2DiffWriteError> {
+    let initial = writer
+        .stream_position()
+        .map_err(|source| SnapshotV2DiffWriteError::Io {
+            stage: SnapshotV2DiffWriteStage::InitialPosition,
+            kind: source.kind(),
+        })?;
+    if initial != 0 {
+        return Err(SnapshotV2DiffWriteError::InvalidInitialPosition);
+    }
+    let end = writer
+        .seek(SeekFrom::End(0))
+        .map_err(|source| SnapshotV2DiffWriteError::Io {
+            stage: SnapshotV2DiffWriteStage::InitialPosition,
+            kind: source.kind(),
+        })?;
+    let rewind =
+        writer
+            .seek(SeekFrom::Start(0))
+            .map_err(|source| SnapshotV2DiffWriteError::Io {
+                stage: SnapshotV2DiffWriteStage::InitialPosition,
+                kind: source.kind(),
+            })?;
+    if rewind != 0 {
+        return Err(SnapshotV2DiffWriteError::PositionMismatch {
+            stage: SnapshotV2DiffWriteStage::InitialPosition,
+        });
+    }
+    if end != 0 {
+        return Err(SnapshotV2DiffWriteError::NonEmptyOutput);
+    }
+    Ok(())
+}
+
+fn check_write_cancelled<C>(
+    is_cancelled: &mut C,
+    stage: SnapshotV2DiffWriteStage,
+) -> Result<(), SnapshotV2DiffWriteError>
+where
+    C: FnMut(SnapshotV2DiffWriteStage) -> bool,
+{
+    if is_cancelled(stage) {
+        Err(SnapshotV2DiffWriteError::Cancelled { stage })
+    } else {
+        Ok(())
+    }
+}
+
+fn seek_write_exact<W: Seek>(
+    writer: &mut W,
+    position: u64,
+    stage: SnapshotV2DiffWriteStage,
+) -> Result<(), SnapshotV2DiffWriteError> {
+    let actual =
+        writer
+            .seek(SeekFrom::Start(position))
+            .map_err(|source| SnapshotV2DiffWriteError::Io {
+                stage,
+                kind: source.kind(),
+            })?;
+    if actual != position {
+        return Err(SnapshotV2DiffWriteError::PositionMismatch { stage });
+    }
+    Ok(())
+}
+
+fn write_all_stage<W: Write>(
+    writer: &mut W,
+    bytes: &[u8],
+    stage: SnapshotV2DiffWriteStage,
+) -> Result<(), SnapshotV2DiffWriteError> {
+    writer
+        .write_all(bytes)
+        .map_err(|source| SnapshotV2DiffWriteError::Io {
+            stage,
+            kind: source.kind(),
+        })
+}
+
+/// Stable stage for detached Diff layer output verification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2DiffVerifyStage {
+    /// Exact complete file-length inspection.
+    FileLength,
+    /// Canonical metadata reading and decoding.
+    Metadata,
+    /// Zero metadata padding validation.
+    MetadataPadding,
+}
+
+impl fmt::Display for SnapshotV2DiffVerifyStage {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::FileLength => formatter.write_str("Diff layer file length"),
+            Self::Metadata => formatter.write_str("Diff layer metadata"),
+            Self::MetadataPadding => formatter.write_str("Diff layer metadata padding"),
+        }
+    }
+}
+
+/// Failure while verifying a Diff layer against one detached binding.
+pub enum SnapshotV2DiffVerifyError {
+    /// The detached or decoded binding is invalid.
+    Binding {
+        /// The redacted binding failure.
+        source: SnapshotV2DiffLayerBindingError,
+    },
+    /// The bounded metadata read buffer could not be allocated.
+    MetadataAllocationFailed {
+        /// The failed reservation.
+        source: TryReserveError,
+    },
+    /// Input I/O failed without retaining a private error message.
+    Io {
+        /// The stable failing stage.
+        stage: SnapshotV2DiffVerifyStage,
+        /// The public I/O classification.
+        kind: io::ErrorKind,
+    },
+    /// A seek returned a different position than requested.
+    PositionMismatch {
+        /// The stable failing stage.
+        stage: SnapshotV2DiffVerifyStage,
+    },
+    /// The complete file length differs from the detached binding.
+    FileLengthMismatch,
+    /// Canonical metadata names a different layer than the detached binding.
+    BindingMismatch,
+    /// Metadata padding contains a nonzero byte.
+    NonZeroPadding,
+}
+
+impl fmt::Debug for SnapshotV2DiffVerifyError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("SnapshotV2DiffVerifyError")
+            .field(&self.to_string())
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotV2DiffVerifyError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Binding { .. } => formatter.write_str("native-v2 Diff binding is invalid"),
+            Self::MetadataAllocationFailed { .. } => {
+                formatter.write_str("native-v2 Diff verification allocation failed")
+            }
+            Self::Io { stage, kind } => {
+                write!(
+                    formatter,
+                    "native-v2 Diff verification failed at {stage}: {kind}"
+                )
+            }
+            Self::PositionMismatch { stage } => {
+                write!(
+                    formatter,
+                    "native-v2 Diff input position is invalid at {stage}"
+                )
+            }
+            Self::FileLengthMismatch => {
+                formatter.write_str("native-v2 Diff file length does not match its binding")
+            }
+            Self::BindingMismatch => {
+                formatter.write_str("native-v2 Diff metadata does not match its binding")
+            }
+            Self::NonZeroPadding => {
+                formatter.write_str("native-v2 Diff metadata padding is noncanonical")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SnapshotV2DiffVerifyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Binding { source } => Some(source),
+            Self::MetadataAllocationFailed { source } => Some(source),
+            Self::Io { .. }
+            | Self::PositionMismatch { .. }
+            | Self::FileLengthMismatch
+            | Self::BindingMismatch
+            | Self::NonZeroPadding => None,
+        }
+    }
+}
+
+/// Verifies canonical metadata, zero padding, and length against a detached binding.
+pub fn verify_snapshot_v2_diff_layer_output<R: Read + Seek>(
+    binding: &SnapshotV2DiffLayerBinding,
+    reader: &mut R,
+) -> Result<(), SnapshotV2DiffVerifyError> {
+    verify_snapshot_v2_diff_layer_output_with_reserve(binding, reader, |buffer, additional| {
+        buffer.try_reserve_exact(additional)
+    })
+}
+
+fn verify_snapshot_v2_diff_layer_output_with_reserve<R, A>(
+    binding: &SnapshotV2DiffLayerBinding,
+    reader: &mut R,
+    mut reserve_metadata: A,
+) -> Result<(), SnapshotV2DiffVerifyError>
+where
+    R: Read + Seek,
+    A: FnMut(&mut Vec<u8>, usize) -> Result<(), TryReserveError>,
+{
+    let expected = binding
+        .encode()
+        .map_err(|source| SnapshotV2DiffVerifyError::Binding { source })?;
+    if expected.len() > NATIVE_V2_DIFF_MAX_METADATA_BYTES {
+        return Err(SnapshotV2DiffVerifyError::Binding {
+            source: SnapshotV2DiffLayerBindingError::MetadataTooLarge,
+        });
+    }
+    let end = reader
+        .seek(SeekFrom::End(0))
+        .map_err(|source| SnapshotV2DiffVerifyError::Io {
+            stage: SnapshotV2DiffVerifyStage::FileLength,
+            kind: source.kind(),
+        })?;
+    if end != binding.file_length() {
+        return Err(SnapshotV2DiffVerifyError::FileLengthMismatch);
+    }
+    seek_read_exact(reader, 0, SnapshotV2DiffVerifyStage::Metadata)?;
+
+    let mut metadata = Vec::new();
+    reserve_metadata(&mut metadata, expected.len())
+        .map_err(|source| SnapshotV2DiffVerifyError::MetadataAllocationFailed { source })?;
+    metadata.resize(expected.len(), 0);
+    read_exact_stage(reader, &mut metadata, SnapshotV2DiffVerifyStage::Metadata)?;
+    let decoded = SnapshotV2DiffLayerBinding::decode(&metadata)
+        .map_err(|source| SnapshotV2DiffVerifyError::Binding { source })?;
+    if metadata != expected || decoded != *binding {
+        return Err(SnapshotV2DiffVerifyError::BindingMismatch);
+    }
+
+    let metadata_length =
+        u64::try_from(metadata.len()).map_err(|_| SnapshotV2DiffVerifyError::Binding {
+            source: SnapshotV2DiffLayerBindingError::LengthOverflow,
+        })?;
+    let mut padding = binding.data_offset().checked_sub(metadata_length).ok_or(
+        SnapshotV2DiffVerifyError::Binding {
+            source: SnapshotV2DiffLayerBindingError::InvalidLength,
+        },
+    )?;
+    let mut buffer = [0_u8; ZERO_CHUNK_BYTES];
+    while padding != 0 {
+        let length = usize::try_from(padding.min(ZERO_CHUNK_BYTES as u64)).map_err(|_| {
+            SnapshotV2DiffVerifyError::Binding {
+                source: SnapshotV2DiffLayerBindingError::LengthOverflow,
+            }
+        })?;
+        let destination = buffer
+            .get_mut(..length)
+            .ok_or(SnapshotV2DiffVerifyError::Binding {
+                source: SnapshotV2DiffLayerBindingError::LengthOverflow,
+            })?;
+        read_exact_stage(
+            reader,
+            destination,
+            SnapshotV2DiffVerifyStage::MetadataPadding,
+        )?;
+        if destination.iter().any(|byte| *byte != 0) {
+            return Err(SnapshotV2DiffVerifyError::NonZeroPadding);
+        }
+        padding = padding.checked_sub(length as u64).ok_or({
+            SnapshotV2DiffVerifyError::Binding {
+                source: SnapshotV2DiffLayerBindingError::LengthOverflow,
+            }
+        })?;
+    }
+    Ok(())
+}
+
+fn seek_read_exact<R: Seek>(
+    reader: &mut R,
+    position: u64,
+    stage: SnapshotV2DiffVerifyStage,
+) -> Result<(), SnapshotV2DiffVerifyError> {
+    let actual =
+        reader
+            .seek(SeekFrom::Start(position))
+            .map_err(|source| SnapshotV2DiffVerifyError::Io {
+                stage,
+                kind: source.kind(),
+            })?;
+    if actual != position {
+        return Err(SnapshotV2DiffVerifyError::PositionMismatch { stage });
+    }
+    Ok(())
+}
+
+fn read_exact_stage<R: Read>(
+    reader: &mut R,
+    destination: &mut [u8],
+    stage: SnapshotV2DiffVerifyStage,
+) -> Result<(), SnapshotV2DiffVerifyError> {
+    reader
+        .read_exact(destination)
+        .map_err(|source| SnapshotV2DiffVerifyError::Io {
+            stage,
+            kind: source.kind(),
+        })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/runtime/src/snapshot_diff_v2_13/writer/tests.rs
+++ b/crates/runtime/src/snapshot_diff_v2_13/writer/tests.rs
@@ -55,11 +55,18 @@ where
         base,
         selection,
         is_cancelled,
-        |identity| {
-            *identity = RESULT_ID_BYTES;
-            Ok(())
+        SnapshotV2DiffWritePolicy {
+            fill_identity: |identity: &mut [u8; IMAGE_ID_BYTES]| {
+                *identity = RESULT_ID_BYTES;
+                Ok(())
+            },
+            reserve_copy_buffer: |buffer: &mut Vec<u8>, additional| {
+                buffer.try_reserve_exact(additional)
+            },
+            read_guest: |memory: &GuestMemory, destination: &mut [u8], address| {
+                memory.read_slice(destination, address).map_err(|_| ())
+            },
         },
-        |buffer, additional| buffer.try_reserve_exact(additional),
     )
 }
 
@@ -148,6 +155,15 @@ fn dirty_host_pages_expand_to_guest_pages_and_reject_invalid_inputs() {
             &[GuestAddress::new(start + 64 * 1024)]
         ),
         Err(SnapshotV2DiffSelectionError::OutOfTopology)
+    ));
+    let overflowing_page = GuestAddress::new(u64::MAX - (NATIVE_V2_MEMORY_GUEST_GRANULE - 1));
+    assert!(matches!(
+        SnapshotV2DiffSelection::try_from_dirty_pages(
+            &memory,
+            NATIVE_V2_MEMORY_GUEST_GRANULE,
+            &[overflowing_page],
+        ),
+        Err(SnapshotV2DiffSelectionError::AddressOverflow)
     ));
 }
 
@@ -436,8 +452,15 @@ fn writer_rejects_nonempty_nonzero_identity_and_copy_allocation_failures_before_
             SnapshotV2DiffBase::Zero,
             &selection,
             |_| false,
-            |_| Err(()),
-            |buffer, additional| buffer.try_reserve_exact(additional),
+            SnapshotV2DiffWritePolicy {
+                fill_identity: |_: &mut [u8; IMAGE_ID_BYTES]| Err(()),
+                reserve_copy_buffer: |buffer: &mut Vec<u8>, additional| {
+                    buffer.try_reserve_exact(additional)
+                },
+                read_guest: |memory: &GuestMemory, destination: &mut [u8], address| {
+                    memory.read_slice(destination, address).map_err(|_| ())
+                },
+            },
         ),
         Err(SnapshotV2DiffWriteError::IdentityUnavailable)
     ));
@@ -451,11 +474,16 @@ fn writer_rejects_nonempty_nonzero_identity_and_copy_allocation_failures_before_
             SnapshotV2DiffBase::Zero,
             &selection,
             |_| false,
-            |identity| {
-                *identity = RESULT_ID_BYTES;
-                Ok(())
+            SnapshotV2DiffWritePolicy {
+                fill_identity: |identity: &mut [u8; IMAGE_ID_BYTES]| {
+                    *identity = RESULT_ID_BYTES;
+                    Ok(())
+                },
+                reserve_copy_buffer: |_: &mut Vec<u8>, _: usize| Err(allocation_error()),
+                read_guest: |memory: &GuestMemory, destination: &mut [u8], address| {
+                    memory.read_slice(destination, address).map_err(|_| ())
+                },
             },
-            |_, _| Err(allocation_error()),
         ),
         Err(SnapshotV2DiffWriteError::CopyBufferAllocationFailed { .. })
     ));
@@ -685,6 +713,31 @@ fn writer_handles_short_io_and_redacts_failures_and_seek_mismatches() {
             stage: SnapshotV2DiffWriteStage::Data { extent_index: 0 },
         })
     ));
+
+    let mut inaccessible = Cursor::new(Vec::new());
+    assert!(matches!(
+        write_snapshot_v2_diff_layer_with_policy(
+            &memory,
+            &mut inaccessible,
+            SnapshotV2DiffBase::Zero,
+            &selection,
+            |_| false,
+            SnapshotV2DiffWritePolicy {
+                fill_identity: |identity: &mut [u8; IMAGE_ID_BYTES]| {
+                    *identity = RESULT_ID_BYTES;
+                    Ok(())
+                },
+                reserve_copy_buffer: |buffer: &mut Vec<u8>, additional| {
+                    buffer.try_reserve_exact(additional)
+                },
+                read_guest: |_: &GuestMemory, _: &mut [u8], _: GuestAddress| Err(()),
+            },
+        ),
+        Err(SnapshotV2DiffWriteError::GuestMemoryRead {
+            stage: SnapshotV2DiffWriteStage::Data { extent_index: 0 },
+        })
+    ));
+    assert!(!inaccessible.into_inner().is_empty());
 }
 
 #[test]

--- a/crates/runtime/src/snapshot_diff_v2_13/writer/tests.rs
+++ b/crates/runtime/src/snapshot_diff_v2_13/writer/tests.rs
@@ -1,0 +1,879 @@
+use std::collections::TryReserveError;
+use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
+
+use crate::memory::{GuestMemoryLayout, aarch64};
+use crate::snapshot_format_v2::NATIVE_V2_SNAPSHOT_VERSION;
+
+use super::*;
+
+const RESULT_ID_BYTES: [u8; IMAGE_ID_BYTES] = *b"result-image-id!";
+const BASE_ID: SnapshotV2MemoryImageId = SnapshotV2MemoryImageId::from_bytes(*b"base-image-id!!!");
+const OTHER_BASE_ID: SnapshotV2MemoryImageId =
+    SnapshotV2MemoryImageId::from_bytes(*b"other-base-id!!!");
+const ROOT_ZERO_FIXTURE: &str = include_str!("../fixtures/root-zero.hex");
+const PREDECESSOR_DYNAMIC_FIXTURE: &str = include_str!("../fixtures/predecessor-dynamic.hex");
+
+fn range(start: u64, size: u64) -> GuestMemoryRange {
+    GuestMemoryRange::new(GuestAddress::new(start), size).expect("test range should validate")
+}
+
+fn allocate_memory(ranges: &[GuestMemoryRange]) -> GuestMemory {
+    let layout = GuestMemoryLayout::new(ranges.to_vec()).expect("test layout should validate");
+    GuestMemory::allocate(&layout).expect("test guest memory should allocate")
+}
+
+fn patterned_memory(ranges: &[GuestMemoryRange]) -> GuestMemory {
+    let mut memory = allocate_memory(ranges);
+    for (region_index, range) in ranges.iter().copied().enumerate() {
+        let length = usize::try_from(range.size()).expect("test range should fit usize");
+        let mut bytes = vec![0_u8; length];
+        for (byte_index, byte) in bytes.iter_mut().enumerate() {
+            *byte = u8::try_from((region_index * 67 + byte_index) % 251)
+                .expect("test pattern should fit");
+        }
+        memory
+            .write_slice(&bytes, range.start())
+            .expect("test memory should write");
+    }
+    memory
+}
+
+fn write_with_identity<W, C>(
+    memory: &GuestMemory,
+    writer: &mut W,
+    base: SnapshotV2DiffBase,
+    selection: &SnapshotV2DiffSelection,
+    is_cancelled: C,
+) -> Result<SnapshotV2DiffLayerBinding, SnapshotV2DiffWriteError>
+where
+    W: Write + Seek,
+    C: FnMut(SnapshotV2DiffWriteStage) -> bool,
+{
+    write_snapshot_v2_diff_layer_with_policy(
+        memory,
+        writer,
+        base,
+        selection,
+        is_cancelled,
+        |identity| {
+            *identity = RESULT_ID_BYTES;
+            Ok(())
+        },
+        |buffer, additional| buffer.try_reserve_exact(additional),
+    )
+}
+
+fn read_guest(memory: &GuestMemory, range: GuestMemoryRange) -> Vec<u8> {
+    let mut bytes = vec![0_u8; usize::try_from(range.size()).expect("test size should fit")];
+    memory
+        .read_slice(&mut bytes, range.start())
+        .expect("test guest range should read");
+    bytes
+}
+
+fn contains_range(outer: GuestMemoryRange, inner: GuestMemoryRange) -> bool {
+    outer.start() <= inner.start() && outer.end_exclusive() >= inner.end_exclusive()
+}
+
+#[test]
+fn explicit_selection_normalizes_sorts_deduplicates_and_coalesces() {
+    let start = aarch64::DRAM_MEM_START;
+    let memory = allocate_memory(&[range(start, 64 * 1024)]);
+    let input = [
+        range(start + 12 * 1024 + 17, 64),
+        range(start + 1, 31),
+        range(start + 8192, 4096),
+        range(start + 4090, 5000),
+        range(start + 12 * 1024, 4096),
+    ];
+    let selection = SnapshotV2DiffSelection::try_from_ranges(&memory, &input)
+        .expect("mapped ranges should normalize");
+    assert_eq!(
+        selection.ranges(),
+        &[range(start, 16 * 1024)],
+        "overlapping and adjacent guest pages should form one canonical range"
+    );
+}
+
+#[test]
+fn selection_splits_adjacent_result_regions_and_rejects_gaps() {
+    let start = aarch64::DRAM_MEM_START;
+    let adjacent = allocate_memory(&[range(start, 16 * 1024), range(start + 16 * 1024, 16 * 1024)]);
+    let crossing = [range(start + 12 * 1024, 8192)];
+    let selection = SnapshotV2DiffSelection::try_from_ranges(&adjacent, &crossing)
+        .expect("adjacent regions should be fully covered");
+    assert_eq!(
+        selection.ranges(),
+        &[
+            range(start + 12 * 1024, 4096),
+            range(start + 16 * 1024, 4096),
+        ]
+    );
+
+    let gapped = allocate_memory(&[range(start, 16 * 1024), range(start + 32 * 1024, 16 * 1024)]);
+    assert!(matches!(
+        SnapshotV2DiffSelection::try_from_ranges(&gapped, &crossing),
+        Err(SnapshotV2DiffSelectionError::OutOfTopology)
+    ));
+}
+
+#[test]
+fn dirty_host_pages_expand_to_guest_pages_and_reject_invalid_inputs() {
+    let start = aarch64::DRAM_MEM_START;
+    let memory = allocate_memory(&[range(start, 64 * 1024)]);
+    let selection = SnapshotV2DiffSelection::try_from_dirty_pages(
+        &memory,
+        16 * 1024,
+        &[GuestAddress::new(start + 16 * 1024)],
+    )
+    .expect("one aligned host page should normalize");
+    assert_eq!(selection.ranges(), &[range(start + 16 * 1024, 16 * 1024)]);
+
+    assert!(matches!(
+        SnapshotV2DiffSelection::try_from_dirty_pages(&memory, 6000, &[GuestAddress::new(start)]),
+        Err(SnapshotV2DiffSelectionError::InvalidSourcePageSize)
+    ));
+    assert!(matches!(
+        SnapshotV2DiffSelection::try_from_dirty_pages(
+            &memory,
+            16 * 1024,
+            &[GuestAddress::new(start + 4096)]
+        ),
+        Err(SnapshotV2DiffSelectionError::UnalignedDirtyPage)
+    ));
+    assert!(matches!(
+        SnapshotV2DiffSelection::try_from_dirty_pages(
+            &memory,
+            16 * 1024,
+            &[GuestAddress::new(start + 64 * 1024)]
+        ),
+        Err(SnapshotV2DiffSelectionError::OutOfTopology)
+    ));
+}
+
+#[test]
+fn all_current_covers_every_region_and_stale_topology_fails_closed() {
+    let start = aarch64::DRAM_MEM_START;
+    let initial = [
+        range(start, 32 * 1024),
+        range(start + 128 * 1024, 16 * 1024),
+    ];
+    let mut memory = allocate_memory(&initial);
+    let selection = SnapshotV2DiffSelection::all_current(&memory)
+        .expect("all-current selection should validate");
+    assert_eq!(selection.ranges(), initial);
+
+    let added = range(start + 256 * 1024, 16 * 1024);
+    memory
+        .insert_region(added)
+        .expect("test region should insert");
+    let mut output = Cursor::new(Vec::new());
+    assert!(matches!(
+        write_with_identity(
+            &memory,
+            &mut output,
+            SnapshotV2DiffBase::Zero,
+            &selection,
+            |_| false,
+        ),
+        Err(SnapshotV2DiffWriteError::TopologyChanged)
+    ));
+    assert!(output.into_inner().is_empty());
+
+    let selection_after_add =
+        SnapshotV2DiffSelection::all_current(&memory).expect("expanded selection should validate");
+    memory
+        .remove_region(added)
+        .expect("test region should remove");
+    let mut output = Cursor::new(Vec::new());
+    assert!(matches!(
+        write_with_identity(
+            &memory,
+            &mut output,
+            SnapshotV2DiffBase::Zero,
+            &selection_after_add,
+            |_| false,
+        ),
+        Err(SnapshotV2DiffWriteError::TopologyChanged)
+    ));
+    assert!(output.into_inner().is_empty());
+}
+
+#[test]
+fn current_dynamic_add_and_remove_topologies_write_canonically() {
+    let start = aarch64::DRAM_MEM_START;
+    let original = range(start, 32 * 1024);
+    let added = range(start + 128 * 1024, 16 * 1024);
+    let mut memory = patterned_memory(&[original]);
+    memory
+        .insert_region(added)
+        .expect("test region should insert");
+    memory
+        .write_slice(&vec![0x5a; 16 * 1024], added.start())
+        .expect("inserted region should write");
+
+    let added_selection =
+        SnapshotV2DiffSelection::all_current(&memory).expect("added topology should select");
+    let mut added_output = Cursor::new(Vec::new());
+    let added_binding = write_with_identity(
+        &memory,
+        &mut added_output,
+        SnapshotV2DiffBase::Zero,
+        &added_selection,
+        |_| false,
+    )
+    .expect("added topology should write");
+    assert_eq!(
+        added_binding
+            .result()
+            .extents()
+            .iter()
+            .map(|extent| extent.range())
+            .collect::<Vec<_>>(),
+        [original, added]
+    );
+    assert_eq!(
+        added_binding
+            .data_extents()
+            .iter()
+            .map(|extent| extent.range())
+            .collect::<Vec<_>>(),
+        [original, added]
+    );
+    verify_snapshot_v2_diff_layer_output(&added_binding, &mut added_output)
+        .expect("added topology output should verify");
+
+    memory
+        .remove_region(original)
+        .expect("original region should remove");
+    let removed_selection =
+        SnapshotV2DiffSelection::all_current(&memory).expect("removed topology should select");
+    let mut removed_output = Cursor::new(Vec::new());
+    let removed_binding = write_with_identity(
+        &memory,
+        &mut removed_output,
+        SnapshotV2DiffBase::Image(BASE_ID),
+        &removed_selection,
+        |_| false,
+    )
+    .expect("removed topology should write");
+    assert_eq!(
+        removed_binding
+            .result()
+            .extents()
+            .iter()
+            .map(|extent| extent.range())
+            .collect::<Vec<_>>(),
+        [added]
+    );
+    assert_eq!(removed_binding.data_extents()[0].range(), added);
+    verify_snapshot_v2_diff_layer_output(&removed_binding, &mut removed_output)
+        .expect("removed topology output should verify");
+}
+
+#[test]
+fn fragmented_selection_falls_back_to_complete_touched_regions_without_omission() {
+    let start = aarch64::DRAM_MEM_START;
+    let selected_count = NATIVE_V2_DIFF_MAX_EXTENTS + 1;
+    let required_pages = selected_count
+        .checked_mul(2)
+        .and_then(|pages| pages.checked_sub(1))
+        .expect("test page count should fit");
+    let host_aligned_pages = required_pages.next_multiple_of(4);
+    let memory = allocate_memory(&[range(
+        start,
+        u64::try_from(host_aligned_pages).expect("test page count should fit")
+            * NATIVE_V2_MEMORY_GUEST_GRANULE,
+    )]);
+    let dirty_pages = (0..selected_count)
+        .map(|index| {
+            GuestAddress::new(
+                start
+                    + u64::try_from(index).expect("test index should fit")
+                        * 2
+                        * NATIVE_V2_MEMORY_GUEST_GRANULE,
+            )
+        })
+        .collect::<Vec<_>>();
+    let selection = SnapshotV2DiffSelection::try_from_dirty_pages(
+        &memory,
+        NATIVE_V2_MEMORY_GUEST_GRANULE,
+        &dirty_pages,
+    )
+    .expect("fragmented selection should widen safely");
+    assert_eq!(selection.ranges().len(), 1);
+    assert_eq!(selection.ranges()[0], memory.regions()[0].range());
+    for address in dirty_pages {
+        let page = range(address.raw_value(), NATIVE_V2_MEMORY_GUEST_GRANULE);
+        assert!(
+            selection
+                .ranges()
+                .iter()
+                .copied()
+                .any(|selected| contains_range(selected, page)),
+            "fallback omitted an input page"
+        );
+    }
+}
+
+#[test]
+fn root_empty_writer_matches_immutable_fixture_and_verifies() {
+    let start = aarch64::DRAM_MEM_START;
+    let memory = patterned_memory(&[range(start, 64 * 1024)]);
+    let selection = SnapshotV2DiffSelection::try_from_ranges(&memory, &[])
+        .expect("empty selection should validate");
+    let mut output = Cursor::new(Vec::new());
+    let binding = write_with_identity(
+        &memory,
+        &mut output,
+        SnapshotV2DiffBase::Zero,
+        &selection,
+        |_| false,
+    )
+    .expect("empty root layer should write");
+    assert!(binding.data_extents().is_empty());
+    assert_eq!(
+        binding.result().version(),
+        NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION
+    );
+    assert_eq!(NATIVE_V2_SNAPSHOT_VERSION.minor(), 12);
+    let bytes = output.into_inner();
+    let metadata_length =
+        usize::try_from(binding.metadata_length()).expect("metadata length should fit");
+    assert_eq!(&bytes[..metadata_length], decode_hex(ROOT_ZERO_FIXTURE));
+    assert!(bytes[metadata_length..].iter().all(|byte| *byte == 0));
+    verify_snapshot_v2_diff_layer_output(&binding, &mut Cursor::new(bytes))
+        .expect("detached root output should verify");
+}
+
+#[test]
+fn predecessor_writer_matches_fixture_and_packs_only_selected_bytes() {
+    let start = aarch64::DRAM_MEM_START;
+    let topology = [
+        range(start, 16 * 1024),
+        range(start + 128 * 1024, 32 * 1024),
+    ];
+    let memory = patterned_memory(&topology);
+    let selected = [
+        range(start + 4096, 4096),
+        range(start + 128 * 1024 + 8192, 8192),
+    ];
+    let selection = SnapshotV2DiffSelection::try_from_ranges(&memory, &selected)
+        .expect("selected ranges should validate");
+    let mut output = Cursor::new(Vec::new());
+    let binding = write_with_identity(
+        &memory,
+        &mut output,
+        SnapshotV2DiffBase::Image(BASE_ID),
+        &selection,
+        |_| false,
+    )
+    .expect("predecessor layer should write");
+    let bytes = output.into_inner();
+    let metadata_length =
+        usize::try_from(binding.metadata_length()).expect("metadata length should fit");
+    assert_eq!(
+        &bytes[..metadata_length],
+        decode_hex(PREDECESSOR_DYNAMIC_FIXTURE)
+    );
+    let data_offset = usize::try_from(binding.data_offset()).expect("data offset should fit");
+    assert!(
+        bytes[metadata_length..data_offset]
+            .iter()
+            .all(|byte| *byte == 0)
+    );
+    let first_end = data_offset + usize::try_from(selected[0].size()).expect("size should fit");
+    assert_eq!(
+        &bytes[data_offset..first_end],
+        read_guest(&memory, selected[0])
+    );
+    assert_eq!(&bytes[first_end..], read_guest(&memory, selected[1]));
+    assert_eq!(
+        u64::try_from(bytes.len()).expect("file length should fit"),
+        binding.file_length()
+    );
+    verify_snapshot_v2_diff_layer_output(&binding, &mut Cursor::new(bytes))
+        .expect("detached predecessor output should verify");
+}
+
+#[test]
+fn writer_rejects_nonempty_nonzero_identity_and_copy_allocation_failures_before_bytes() {
+    let start = aarch64::DRAM_MEM_START;
+    let memory = patterned_memory(&[range(start, 16 * 1024)]);
+    let selection =
+        SnapshotV2DiffSelection::all_current(&memory).expect("complete selection should validate");
+
+    let mut nonempty = Cursor::new(vec![1_u8]);
+    assert!(matches!(
+        write_with_identity(
+            &memory,
+            &mut nonempty,
+            SnapshotV2DiffBase::Zero,
+            &selection,
+            |_| false,
+        ),
+        Err(SnapshotV2DiffWriteError::NonEmptyOutput)
+    ));
+
+    let mut nonzero = Cursor::new(Vec::new());
+    nonzero.set_position(1);
+    assert!(matches!(
+        write_with_identity(
+            &memory,
+            &mut nonzero,
+            SnapshotV2DiffBase::Zero,
+            &selection,
+            |_| false,
+        ),
+        Err(SnapshotV2DiffWriteError::InvalidInitialPosition)
+    ));
+
+    let mut unavailable = Cursor::new(Vec::new());
+    assert!(matches!(
+        write_snapshot_v2_diff_layer_with_policy(
+            &memory,
+            &mut unavailable,
+            SnapshotV2DiffBase::Zero,
+            &selection,
+            |_| false,
+            |_| Err(()),
+            |buffer, additional| buffer.try_reserve_exact(additional),
+        ),
+        Err(SnapshotV2DiffWriteError::IdentityUnavailable)
+    ));
+    assert!(unavailable.into_inner().is_empty());
+
+    let mut allocation = Cursor::new(Vec::new());
+    assert!(matches!(
+        write_snapshot_v2_diff_layer_with_policy(
+            &memory,
+            &mut allocation,
+            SnapshotV2DiffBase::Zero,
+            &selection,
+            |_| false,
+            |identity| {
+                *identity = RESULT_ID_BYTES;
+                Ok(())
+            },
+            |_, _| Err(allocation_error()),
+        ),
+        Err(SnapshotV2DiffWriteError::CopyBufferAllocationFailed { .. })
+    ));
+    assert!(allocation.into_inner().is_empty());
+}
+
+#[test]
+fn cancellation_covers_every_observed_stage_and_fresh_retry() {
+    let start = aarch64::DRAM_MEM_START;
+    let memory = patterned_memory(&[
+        range(start, 32 * 1024),
+        range(start + 128 * 1024, 16 * 1024),
+    ]);
+    let selection =
+        SnapshotV2DiffSelection::all_current(&memory).expect("complete selection should validate");
+    let mut complete = Cursor::new(Vec::new());
+    let mut stages = Vec::new();
+    let complete_binding = write_with_identity(
+        &memory,
+        &mut complete,
+        SnapshotV2DiffBase::Zero,
+        &selection,
+        |stage| {
+            stages.push(stage);
+            false
+        },
+    )
+    .expect("observation write should complete");
+    assert!(stages.contains(&SnapshotV2DiffWriteStage::InitialPosition));
+    assert!(stages.contains(&SnapshotV2DiffWriteStage::Metadata));
+    assert!(stages.contains(&SnapshotV2DiffWriteStage::MetadataPadding));
+    assert!(stages.contains(&SnapshotV2DiffWriteStage::Data { extent_index: 0 }));
+    assert!(stages.contains(&SnapshotV2DiffWriteStage::Data { extent_index: 1 }));
+    assert!(stages.contains(&SnapshotV2DiffWriteStage::FinalLength));
+
+    for (cancel_index, expected_stage) in stages.iter().copied().enumerate() {
+        let mut output = Cursor::new(Vec::new());
+        let mut checkpoint = 0_usize;
+        let error = write_with_identity(
+            &memory,
+            &mut output,
+            SnapshotV2DiffBase::Zero,
+            &selection,
+            |stage| {
+                assert_eq!(stage, stages[checkpoint]);
+                let cancelled = checkpoint == cancel_index;
+                checkpoint += 1;
+                cancelled
+            },
+        )
+        .expect_err("selected checkpoint should cancel");
+        assert!(matches!(
+            error,
+            SnapshotV2DiffWriteError::Cancelled { stage } if stage == expected_stage
+        ));
+        assert_eq!(checkpoint, cancel_index + 1);
+    }
+
+    let mut fresh = Cursor::new(Vec::new());
+    let fresh_binding = write_with_identity(
+        &memory,
+        &mut fresh,
+        SnapshotV2DiffBase::Zero,
+        &selection,
+        |_| false,
+    )
+    .expect("fresh write should complete");
+    assert_eq!(fresh_binding, complete_binding);
+    assert_eq!(fresh.into_inner(), complete.into_inner());
+}
+
+struct ShortWriter {
+    inner: Cursor<Vec<u8>>,
+    maximum: usize,
+    interruptions_remaining: usize,
+}
+
+impl Write for ShortWriter {
+    fn write(&mut self, source: &[u8]) -> io::Result<usize> {
+        if self.interruptions_remaining != 0 {
+            self.interruptions_remaining -= 1;
+            return Err(io::Error::from(io::ErrorKind::Interrupted));
+        }
+        let length = source.len().min(self.maximum);
+        let source = source
+            .get(..length)
+            .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidInput))?;
+        self.inner.write(source)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Seek for ShortWriter {
+    fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
+        self.inner.seek(position)
+    }
+}
+
+struct ZeroOrFailWriter {
+    inner: Cursor<Vec<u8>>,
+    failure: Option<io::Error>,
+}
+
+impl Write for ZeroOrFailWriter {
+    fn write(&mut self, _source: &[u8]) -> io::Result<usize> {
+        match self.failure.take() {
+            Some(error) => Err(error),
+            None => Ok(0),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Seek for ZeroOrFailWriter {
+    fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
+        self.inner.seek(position)
+    }
+}
+
+struct MisreportingDataSeekWriter {
+    inner: Cursor<Vec<u8>>,
+}
+
+impl Write for MisreportingDataSeekWriter {
+    fn write(&mut self, source: &[u8]) -> io::Result<usize> {
+        self.inner.write(source)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Seek for MisreportingDataSeekWriter {
+    fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
+        let actual = self.inner.seek(position)?;
+        if matches!(position, SeekFrom::Start(requested) if requested != 0) {
+            Ok(actual.saturating_add(1))
+        } else {
+            Ok(actual)
+        }
+    }
+}
+
+#[test]
+fn writer_handles_short_io_and_redacts_failures_and_seek_mismatches() {
+    let start = aarch64::DRAM_MEM_START;
+    let memory = patterned_memory(&[range(start, 32 * 1024)]);
+    let selection =
+        SnapshotV2DiffSelection::all_current(&memory).expect("complete selection should validate");
+    let mut expected = Cursor::new(Vec::new());
+    let expected_binding = write_with_identity(
+        &memory,
+        &mut expected,
+        SnapshotV2DiffBase::Zero,
+        &selection,
+        |_| false,
+    )
+    .expect("reference write should complete");
+
+    let mut short = ShortWriter {
+        inner: Cursor::new(Vec::new()),
+        maximum: 13,
+        interruptions_remaining: 3,
+    };
+    let binding = write_with_identity(
+        &memory,
+        &mut short,
+        SnapshotV2DiffBase::Zero,
+        &selection,
+        |_| false,
+    )
+    .expect("short writes should complete");
+    assert_eq!(binding, expected_binding);
+    assert_eq!(short.inner.into_inner(), expected.into_inner());
+
+    let mut zero = ZeroOrFailWriter {
+        inner: Cursor::new(Vec::new()),
+        failure: None,
+    };
+    assert!(matches!(
+        write_with_identity(
+            &memory,
+            &mut zero,
+            SnapshotV2DiffBase::Zero,
+            &selection,
+            |_| false,
+        ),
+        Err(SnapshotV2DiffWriteError::Io {
+            stage: SnapshotV2DiffWriteStage::Metadata,
+            kind: io::ErrorKind::WriteZero,
+        })
+    ));
+
+    let mut private = ZeroOrFailWriter {
+        inner: Cursor::new(Vec::new()),
+        failure: Some(io::Error::other("private-output-name")),
+    };
+    let error = write_with_identity(
+        &memory,
+        &mut private,
+        SnapshotV2DiffBase::Zero,
+        &selection,
+        |_| false,
+    )
+    .expect_err("private I/O failure should propagate");
+    assert!(!format!("{error:?} {error}").contains("private-output-name"));
+
+    let mut mismatched = MisreportingDataSeekWriter {
+        inner: Cursor::new(Vec::new()),
+    };
+    assert!(matches!(
+        write_with_identity(
+            &memory,
+            &mut mismatched,
+            SnapshotV2DiffBase::Zero,
+            &selection,
+            |_| false,
+        ),
+        Err(SnapshotV2DiffWriteError::PositionMismatch {
+            stage: SnapshotV2DiffWriteStage::Data { extent_index: 0 },
+        })
+    ));
+}
+
+#[test]
+fn detached_verifier_rejects_mismatch_corruption_padding_and_length_changes() {
+    let start = aarch64::DRAM_MEM_START;
+    let memory = patterned_memory(&[range(start, 32 * 1024)]);
+    let selection = SnapshotV2DiffSelection::try_from_ranges(&memory, &[range(start + 4096, 4096)])
+        .expect("sparse selection should validate");
+    let mut output = Cursor::new(Vec::new());
+    let binding = write_with_identity(
+        &memory,
+        &mut output,
+        SnapshotV2DiffBase::Image(BASE_ID),
+        &selection,
+        |_| false,
+    )
+    .expect("fixture should write");
+    let bytes = output.into_inner();
+
+    let mismatched = SnapshotV2DiffLayerBinding::try_from_ranges(
+        SnapshotV2DiffBase::Image(OTHER_BASE_ID),
+        binding.result().clone(),
+        selection.ranges(),
+    )
+    .expect("mismatched detached binding should construct");
+    assert!(matches!(
+        verify_snapshot_v2_diff_layer_output(&mismatched, &mut Cursor::new(bytes.clone())),
+        Err(SnapshotV2DiffVerifyError::BindingMismatch)
+    ));
+
+    let mut corrupt = bytes.clone();
+    let checksum_byte = corrupt.get_mut(64).expect("checksum byte should exist");
+    *checksum_byte ^= 1;
+    assert!(matches!(
+        verify_snapshot_v2_diff_layer_output(&binding, &mut Cursor::new(corrupt)),
+        Err(SnapshotV2DiffVerifyError::Binding { .. })
+    ));
+
+    let mut padding = bytes.clone();
+    let padding_index =
+        usize::try_from(binding.metadata_length()).expect("metadata length should fit");
+    *padding
+        .get_mut(padding_index)
+        .expect("padding byte should exist") = 1;
+    assert!(matches!(
+        verify_snapshot_v2_diff_layer_output(&binding, &mut Cursor::new(padding)),
+        Err(SnapshotV2DiffVerifyError::NonZeroPadding)
+    ));
+
+    let mut truncated = bytes.clone();
+    truncated.pop();
+    assert!(matches!(
+        verify_snapshot_v2_diff_layer_output(&binding, &mut Cursor::new(truncated)),
+        Err(SnapshotV2DiffVerifyError::FileLengthMismatch)
+    ));
+    let mut trailing = bytes;
+    trailing.push(0);
+    assert!(matches!(
+        verify_snapshot_v2_diff_layer_output(&binding, &mut Cursor::new(trailing)),
+        Err(SnapshotV2DiffVerifyError::FileLengthMismatch)
+    ));
+}
+
+struct ShortReader {
+    inner: Cursor<Vec<u8>>,
+    maximum: usize,
+    interruptions_remaining: usize,
+}
+
+impl Read for ShortReader {
+    fn read(&mut self, destination: &mut [u8]) -> io::Result<usize> {
+        if self.interruptions_remaining != 0 {
+            self.interruptions_remaining -= 1;
+            return Err(io::Error::from(io::ErrorKind::Interrupted));
+        }
+        let length = destination.len().min(self.maximum);
+        let destination = destination
+            .get_mut(..length)
+            .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidInput))?;
+        self.inner.read(destination)
+    }
+}
+
+impl Seek for ShortReader {
+    fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
+        self.inner.seek(position)
+    }
+}
+
+struct MisreportingMetadataSeekReader {
+    inner: Cursor<Vec<u8>>,
+}
+
+impl Read for MisreportingMetadataSeekReader {
+    fn read(&mut self, destination: &mut [u8]) -> io::Result<usize> {
+        self.inner.read(destination)
+    }
+}
+
+impl Seek for MisreportingMetadataSeekReader {
+    fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
+        let actual = self.inner.seek(position)?;
+        if matches!(position, SeekFrom::Start(0)) {
+            Ok(actual.saturating_add(1))
+        } else {
+            Ok(actual)
+        }
+    }
+}
+
+#[test]
+fn detached_verifier_handles_short_reads_seek_mismatch_and_allocation_failure() {
+    let start = aarch64::DRAM_MEM_START;
+    let memory = patterned_memory(&[range(start, 16 * 1024)]);
+    let selection =
+        SnapshotV2DiffSelection::all_current(&memory).expect("complete selection should validate");
+    let mut output = Cursor::new(Vec::new());
+    let binding = write_with_identity(
+        &memory,
+        &mut output,
+        SnapshotV2DiffBase::Zero,
+        &selection,
+        |_| false,
+    )
+    .expect("fixture should write");
+    let bytes = output.into_inner();
+
+    let mut short = ShortReader {
+        inner: Cursor::new(bytes.clone()),
+        maximum: 11,
+        interruptions_remaining: 3,
+    };
+    verify_snapshot_v2_diff_layer_output(&binding, &mut short)
+        .expect("short and interrupted reads should complete");
+
+    let mut mismatched = MisreportingMetadataSeekReader {
+        inner: Cursor::new(bytes.clone()),
+    };
+    assert!(matches!(
+        verify_snapshot_v2_diff_layer_output(&binding, &mut mismatched),
+        Err(SnapshotV2DiffVerifyError::PositionMismatch {
+            stage: SnapshotV2DiffVerifyStage::Metadata,
+        })
+    ));
+
+    assert!(matches!(
+        verify_snapshot_v2_diff_layer_output_with_reserve(
+            &binding,
+            &mut Cursor::new(bytes),
+            |_, _| Err(allocation_error()),
+        ),
+        Err(SnapshotV2DiffVerifyError::MetadataAllocationFailed { .. })
+    ));
+}
+
+#[test]
+fn selection_and_error_diagnostics_redact_private_values() {
+    let start = aarch64::DRAM_MEM_START;
+    let memory = allocate_memory(&[range(start, 16 * 1024)]);
+    let selection = SnapshotV2DiffSelection::try_from_ranges(&memory, &[range(start + 4096, 4096)])
+        .expect("selection should validate");
+    let diagnostics = format!(
+        "{selection:?} {:?} {:?}",
+        SnapshotV2DiffSelectionError::OutOfTopology,
+        SnapshotV2DiffWriteError::GuestMemoryRead {
+            stage: SnapshotV2DiffWriteStage::Data { extent_index: 0 }
+        }
+    );
+    assert!(diagnostics.contains(REDACTED));
+    assert!(!diagnostics.contains("40001000"));
+    assert!(!diagnostics.contains("result-image-id!"));
+}
+
+fn allocation_error() -> TryReserveError {
+    let mut impossible = Vec::<u8>::new();
+    impossible
+        .try_reserve(usize::MAX)
+        .expect_err("impossible reservation should fail")
+}
+
+fn decode_hex(text: &str) -> Vec<u8> {
+    let text = text.trim();
+    let mut chunks = text.as_bytes().chunks_exact(2);
+    let mut bytes = Vec::new();
+    bytes.reserve_exact(chunks.len());
+    for chunk in &mut chunks {
+        let pair = std::str::from_utf8(chunk).expect("fixture hex should be UTF-8");
+        bytes.push(u8::from_str_radix(pair, 16).expect("fixture hex should decode"));
+    }
+    assert!(chunks.remainder().is_empty());
+    bytes
+}

--- a/crates/runtime/src/snapshot_memory_v2.rs
+++ b/crates/runtime/src/snapshot_memory_v2.rs
@@ -564,7 +564,8 @@ where
 {
     check_cancelled(&mut is_cancelled, SnapshotV2MemoryIoStage::InitialPosition)?;
     preflight_empty_output(writer)?;
-    let binding = binding_from_memory_with_version(memory, version, image_id)?;
+    let binding =
+        snapshot_v2_memory_binding_from_memory_with_version_and_id(memory, version, image_id)?;
     let header = binding.image_header()?;
 
     check_cancelled(&mut is_cancelled, SnapshotV2MemoryIoStage::Header)?;
@@ -1143,7 +1144,7 @@ fn open_regular_final(path: &Path) -> Result<File, SnapshotV2MemoryLoadError> {
     Ok(unsafe { File::from_raw_fd(descriptor) })
 }
 
-fn binding_from_memory_with_version(
+pub(crate) fn snapshot_v2_memory_binding_from_memory_with_version_and_id(
     memory: &GuestMemory,
     version: SnapshotFormatVersion,
     image_id: SnapshotV2MemoryImageId,


### PR DESCRIPTION
## Summary

- add opaque checked all-current, explicit-range, and dirty-page selection for exact native-v2 2.13 Diff layers
- normalize selections to 4-KiB guest pages, preserve result-region boundaries, and widen over-limit fragmentation to complete touched regions without omitting requested data
- stream canonical metadata, zero padding, and packed selected guest bytes through a bounded fallible buffer with typed cancellation and redacted failures
- add detached metadata/padding/length verification and immutable root/predecessor fixture coverage
- reuse the existing complete-memory binding constructor without changing the public exact-2.12 writer

## Scope exclusions

- public native-v2 remains `v2.12.0`, and every public/API/process Diff create path remains rejected
- descriptor/path materialization, publication, live HVF dirty epochs, lineage candidates, activation, rebase tools, documentation, and capability inventory remain in later #1541 children
- detached verification intentionally does not claim a guest-data digest because the exact-2.13 format does not bind one

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

Closes #1752

Parent context: #1541
