### PR TITLE
feat: materialize native-v2 differential chains

### DIFF
--- a/crates/runtime/src/snapshot_diff_v2_13.rs
+++ b/crates/runtime/src/snapshot_diff_v2_13.rs
@@ -16,7 +16,15 @@ use crate::snapshot_memory_v2::{
 };
 
 mod codec;
+mod materialize;
 mod writer;
+
+pub use materialize::{
+    SnapshotV2DiffMaterializationBaseFile, SnapshotV2DiffMaterializationError,
+    SnapshotV2DiffMaterializationStage, apply_snapshot_v2_diff_layer_file,
+    apply_snapshot_v2_diff_layer_file_with_cancel, promote_snapshot_v2_diff_zero_root_file,
+    promote_snapshot_v2_diff_zero_root_file_with_cancel,
+};
 
 pub use writer::{
     SnapshotV2DiffSelection, SnapshotV2DiffSelectionError, SnapshotV2DiffVerifyError,

--- a/crates/runtime/src/snapshot_diff_v2_13/codec.rs
+++ b/crates/runtime/src/snapshot_diff_v2_13/codec.rs
@@ -170,6 +170,73 @@ pub(super) fn decode(
     decode_with_reserve(bytes, &mut reserve)
 }
 
+pub(super) fn preflight_metadata_length(
+    header: &[u8],
+) -> Result<usize, SnapshotV2DiffLayerBindingError> {
+    if header.len() != NATIVE_V2_DIFF_HEADER_BYTES {
+        return Err(SnapshotV2DiffLayerBindingError::InvalidLength);
+    }
+    if read_array::<8>(header, MAGIC_OFFSET)? != NATIVE_V2_DIFF_MAGIC {
+        return Err(SnapshotV2DiffLayerBindingError::InvalidMagic);
+    }
+    let version = SnapshotFormatVersion::new(
+        read_u16(header, VERSION_MAJOR_OFFSET)?,
+        read_u16(header, VERSION_MINOR_OFFSET)?,
+        read_u16(header, VERSION_PATCH_OFFSET)?,
+    );
+    if version != NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION {
+        return Err(SnapshotV2DiffLayerBindingError::UnsupportedVersion);
+    }
+    if usize::from(read_u16(header, HEADER_BYTES_OFFSET)?) != NATIVE_V2_DIFF_HEADER_BYTES
+        || read_u16(header, PROFILE_OFFSET)? != NATIVE_V2_DIFF_PROFILE
+        || read_u32(header, FLAGS_OFFSET)? != FLAGS
+        || u64::from(read_u32(header, GUEST_GRANULE_OFFSET)?) != NATIVE_V2_MEMORY_GUEST_GRANULE
+        || usize::try_from(read_u32(header, EXTENT_BYTES_OFFSET)?)
+            .map_err(|_| SnapshotV2DiffLayerBindingError::LengthOverflow)?
+            != NATIVE_V2_DIFF_EXTENT_BYTES
+        || header
+            .get(RESERVED_OFFSET..RESERVED_OFFSET + RESERVED_BYTES)
+            .is_none_or(|reserved| reserved.iter().any(|byte| *byte != 0))
+    {
+        return Err(SnapshotV2DiffLayerBindingError::InvalidHeader);
+    }
+
+    let base_bytes = read_array::<BASE_IMAGE_ID_BYTES>(header, BASE_IMAGE_ID_OFFSET)?;
+    let predecessor_length = usize::try_from(read_u32(header, PREDECESSOR_BINDING_LENGTH_OFFSET)?)
+        .map_err(|_| SnapshotV2DiffLayerBindingError::LengthOverflow)?;
+    match read_u16(header, BASE_KIND_OFFSET)? {
+        BASE_ZERO if base_bytes == [0_u8; BASE_IMAGE_ID_BYTES] && predecessor_length == 0 => {}
+        BASE_IMAGE if predecessor_length != 0 => {}
+        _ => return Err(SnapshotV2DiffLayerBindingError::InvalidBase),
+    }
+
+    let count = usize::try_from(read_u32(header, EXTENT_COUNT_OFFSET)?)
+        .map_err(|_| SnapshotV2DiffLayerBindingError::LengthOverflow)?;
+    if count > NATIVE_V2_DIFF_MAX_EXTENTS {
+        return Err(SnapshotV2DiffLayerBindingError::CountOutOfBounds);
+    }
+    let result_length = usize::try_from(read_u32(header, RESULT_BINDING_LENGTH_OFFSET)?)
+        .map_err(|_| SnapshotV2DiffLayerBindingError::LengthOverflow)?;
+    let expected = NATIVE_V2_DIFF_HEADER_BYTES
+        .checked_add(result_length)
+        .and_then(|length| length.checked_add(predecessor_length))
+        .and_then(|length| {
+            count
+                .checked_mul(NATIVE_V2_DIFF_EXTENT_BYTES)
+                .and_then(|extent_bytes| length.checked_add(extent_bytes))
+        })
+        .ok_or(SnapshotV2DiffLayerBindingError::LengthOverflow)?;
+    if expected > NATIVE_V2_DIFF_MAX_METADATA_BYTES {
+        return Err(SnapshotV2DiffLayerBindingError::MetadataTooLarge);
+    }
+    let encoded = usize::try_from(read_u64(header, METADATA_LENGTH_OFFSET)?)
+        .map_err(|_| SnapshotV2DiffLayerBindingError::LengthOverflow)?;
+    if encoded != expected {
+        return Err(SnapshotV2DiffLayerBindingError::InvalidLength);
+    }
+    Ok(encoded)
+}
+
 pub(super) fn decode_with_reserve<R: ReservePolicy>(
     bytes: &[u8],
     reserve: &mut R,
@@ -177,30 +244,10 @@ pub(super) fn decode_with_reserve<R: ReservePolicy>(
     if bytes.len() < NATIVE_V2_DIFF_HEADER_BYTES {
         return Err(SnapshotV2DiffLayerBindingError::InvalidLength);
     }
-    if read_array::<8>(bytes, MAGIC_OFFSET)? != NATIVE_V2_DIFF_MAGIC {
-        return Err(SnapshotV2DiffLayerBindingError::InvalidMagic);
-    }
-    let version = SnapshotFormatVersion::new(
-        read_u16(bytes, VERSION_MAJOR_OFFSET)?,
-        read_u16(bytes, VERSION_MINOR_OFFSET)?,
-        read_u16(bytes, VERSION_PATCH_OFFSET)?,
-    );
-    if version != NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION {
-        return Err(SnapshotV2DiffLayerBindingError::UnsupportedVersion);
-    }
-    if usize::from(read_u16(bytes, HEADER_BYTES_OFFSET)?) != NATIVE_V2_DIFF_HEADER_BYTES
-        || read_u16(bytes, PROFILE_OFFSET)? != NATIVE_V2_DIFF_PROFILE
-        || read_u32(bytes, FLAGS_OFFSET)? != FLAGS
-        || u64::from(read_u32(bytes, GUEST_GRANULE_OFFSET)?) != NATIVE_V2_MEMORY_GUEST_GRANULE
-        || usize::try_from(read_u32(bytes, EXTENT_BYTES_OFFSET)?)
-            .map_err(|_| SnapshotV2DiffLayerBindingError::LengthOverflow)?
-            != NATIVE_V2_DIFF_EXTENT_BYTES
-        || bytes
-            .get(RESERVED_OFFSET..RESERVED_OFFSET + RESERVED_BYTES)
-            .is_none_or(|reserved| reserved.iter().any(|byte| *byte != 0))
-    {
-        return Err(SnapshotV2DiffLayerBindingError::InvalidHeader);
-    }
+    let header = bytes
+        .get(..NATIVE_V2_DIFF_HEADER_BYTES)
+        .ok_or(SnapshotV2DiffLayerBindingError::InvalidLength)?;
+    let metadata_length = preflight_metadata_length(header)?;
     let base_bytes = read_array::<BASE_IMAGE_ID_BYTES>(bytes, BASE_IMAGE_ID_OFFSET)?;
     let predecessor_length = usize::try_from(read_u32(bytes, PREDECESSOR_BINDING_LENGTH_OFFSET)?)
         .map_err(|_| SnapshotV2DiffLayerBindingError::LengthOverflow)?;
@@ -211,26 +258,9 @@ pub(super) fn decode_with_reserve<R: ReservePolicy>(
     };
     let count = usize::try_from(read_u32(bytes, EXTENT_COUNT_OFFSET)?)
         .map_err(|_| SnapshotV2DiffLayerBindingError::LengthOverflow)?;
-    if count > NATIVE_V2_DIFF_MAX_EXTENTS {
-        return Err(SnapshotV2DiffLayerBindingError::CountOutOfBounds);
-    }
     let result_length = usize::try_from(read_u32(bytes, RESULT_BINDING_LENGTH_OFFSET)?)
         .map_err(|_| SnapshotV2DiffLayerBindingError::LengthOverflow)?;
-    let expected_metadata_length = NATIVE_V2_DIFF_HEADER_BYTES
-        .checked_add(result_length)
-        .and_then(|length| length.checked_add(predecessor_length))
-        .and_then(|length| {
-            count
-                .checked_mul(NATIVE_V2_DIFF_EXTENT_BYTES)
-                .and_then(|extent_bytes| length.checked_add(extent_bytes))
-        })
-        .ok_or(SnapshotV2DiffLayerBindingError::LengthOverflow)?;
-    if expected_metadata_length > NATIVE_V2_DIFF_MAX_METADATA_BYTES {
-        return Err(SnapshotV2DiffLayerBindingError::MetadataTooLarge);
-    }
-    let metadata_length = usize::try_from(read_u64(bytes, METADATA_LENGTH_OFFSET)?)
-        .map_err(|_| SnapshotV2DiffLayerBindingError::LengthOverflow)?;
-    if metadata_length != expected_metadata_length || bytes.len() != metadata_length {
+    if bytes.len() != metadata_length {
         return Err(SnapshotV2DiffLayerBindingError::InvalidLength);
     }
     let data_offset = read_u64(bytes, DATA_OFFSET_OFFSET)?;

--- a/crates/runtime/src/snapshot_diff_v2_13/materialize.rs
+++ b/crates/runtime/src/snapshot_diff_v2_13/materialize.rs
@@ -170,6 +170,11 @@ pub enum SnapshotV2DiffMaterializationError {
         /// Output-preflight checkpoint.
         stage: SnapshotV2DiffMaterializationStage,
     },
+    /// The adopted base and next layer name the same source object.
+    SourceAlias {
+        /// Source-validation checkpoint.
+        stage: SnapshotV2DiffMaterializationStage,
+    },
     /// The staged complete result failed detached output verification.
     ResultVerification {
         /// Result-verification checkpoint.
@@ -198,6 +203,7 @@ impl SnapshotV2DiffMaterializationError {
             | Self::InvalidRoute { stage }
             | Self::InvalidOutput { stage }
             | Self::SourceOutputAlias { stage }
+            | Self::SourceAlias { stage }
             | Self::ResultVerification { stage, .. } => *stage,
         }
     }
@@ -221,6 +227,7 @@ impl fmt::Debug for SnapshotV2DiffMaterializationError {
             Self::InvalidRoute { .. } => "route",
             Self::InvalidOutput { .. } => "output",
             Self::SourceOutputAlias { .. } => "alias",
+            Self::SourceAlias { .. } => "source alias",
             Self::ResultVerification { .. } => "verification",
         };
         formatter
@@ -250,6 +257,7 @@ impl fmt::Display for SnapshotV2DiffMaterializationError {
             Self::InvalidRoute { .. } => "found invalid route arithmetic",
             Self::InvalidOutput { .. } => "rejected the staging descriptor",
             Self::SourceOutputAlias { .. } => "rejected a source/output alias",
+            Self::SourceAlias { .. } => "rejected a source alias",
             Self::ResultVerification { .. } => "result verification failed",
         };
         write!(
@@ -278,7 +286,8 @@ impl std::error::Error for SnapshotV2DiffMaterializationError {
             | Self::MissingCoverage { .. }
             | Self::InvalidRoute { .. }
             | Self::InvalidOutput { .. }
-            | Self::SourceOutputAlias { .. } => None,
+            | Self::SourceOutputAlias { .. }
+            | Self::SourceAlias { .. } => None,
         }
     }
 }
@@ -421,8 +430,12 @@ where
 }
 
 struct ValidatedLayerSource {
-    file: File,
+    source: ValidatedLayerFile,
     binding: SnapshotV2DiffLayerBinding,
+}
+
+struct ValidatedLayerFile {
+    file: File,
     facts: FileFacts,
     role: SourceRole,
 }
@@ -503,13 +516,19 @@ impl ValidatedLayerSource {
             });
         }
         Ok(Self {
-            file,
+            source: ValidatedLayerFile { file, facts, role },
             binding,
-            facts,
-            role,
         })
     }
 
+    fn into_file_and_result(self) -> (ValidatedLayerFile, SnapshotV2MemoryBinding) {
+        let Self { source, binding } = self;
+        let SnapshotV2DiffLayerBinding { result, .. } = binding;
+        (source, result)
+    }
+}
+
+impl ValidatedLayerFile {
     fn verify_unchanged(
         &self,
         observation: SourceObservation,
@@ -539,7 +558,7 @@ impl ValidatedBase {
     fn facts(&self) -> FileFacts {
         match self {
             Self::Complete(source) => source.facts(),
-            Self::ZeroRoot(source) => source.facts,
+            Self::ZeroRoot(source) => source.source.facts,
         }
     }
 
@@ -560,7 +579,7 @@ impl ValidatedBase {
                     .verify_unchanged()
                     .map_err(|source| SnapshotV2DiffMaterializationError::Source { stage, source })
             }
-            Self::ZeroRoot(source) => source.verify_unchanged(observation, policy),
+            Self::ZeroRoot(source) => source.source.verify_unchanged(observation, policy),
         }
     }
 }
@@ -603,8 +622,13 @@ fn promote_with_policy(
     }
 
     policy.checkpoint(Stage::LineagePlanning)?;
-    let target = root.binding.result().clone();
-    let routes = build_routes(&target, &root.binding, Inheritance::Zero, policy)?;
+    let routes = build_routes(
+        root.binding.result(),
+        &root.binding,
+        Inheritance::Zero,
+        policy,
+    )?;
+    let (root, target) = root.into_file_and_result();
     execute(target, routes, &root, None, staging, policy)
 }
 
@@ -626,6 +650,7 @@ fn apply_with_policy(
 
     let base = match base {
         SnapshotV2DiffMaterializationBaseFile::Complete(file) => {
+            reject_source_alias(&next.source, &file)?;
             let source =
                 ValidatedSnapshotV2MemorySource::new_with_hook(predecessor, file, |_, file| {
                     policy.source_hook(
@@ -641,6 +666,7 @@ fn apply_with_policy(
             ValidatedBase::Complete(source)
         }
         SnapshotV2DiffMaterializationBaseFile::ZeroRoot(file) => {
+            reject_source_alias(&next.source, &file)?;
             let root = ValidatedLayerSource::new(file, SourceRole::ZeroRoot, policy)?;
             if !matches!(root.binding.base(), SnapshotV2DiffBase::Zero) {
                 return Err(SnapshotV2DiffMaterializationError::InvalidZeroRoot {
@@ -657,13 +683,27 @@ fn apply_with_policy(
     };
 
     policy.checkpoint(Stage::LineagePlanning)?;
-    let target = next.binding.result().clone();
     let inheritance = match &base {
         ValidatedBase::Complete(_) => Inheritance::Complete(predecessor),
         ValidatedBase::ZeroRoot(root) => Inheritance::ZeroRoot(&root.binding),
     };
-    let routes = build_routes(&target, &next.binding, inheritance, policy)?;
+    let routes = build_routes(next.binding.result(), &next.binding, inheritance, policy)?;
+    let (next, target) = next.into_file_and_result();
     execute(target, routes, &next, Some(&base), staging, policy)
+}
+
+fn reject_source_alias(
+    next: &ValidatedLayerFile,
+    base: &File,
+) -> Result<(), SnapshotV2DiffMaterializationError> {
+    let stage = SnapshotV2DiffMaterializationStage::SourceValidation;
+    let base_facts = inspect_file(base)
+        .map_err(|source| SnapshotV2DiffMaterializationError::Source { stage, source })?;
+    if next.facts.same_object(base_facts) {
+        Err(SnapshotV2DiffMaterializationError::SourceAlias { stage })
+    } else {
+        Ok(())
+    }
 }
 
 fn build_routes(
@@ -944,7 +984,7 @@ fn append_route(
 fn execute(
     target: SnapshotV2MemoryBinding,
     routes: Vec<Route>,
-    next: &ValidatedLayerSource,
+    next: &ValidatedLayerFile,
     base: Option<&ValidatedBase>,
     staging: &mut File,
     policy: &mut impl MaterializationPolicy,
@@ -1140,7 +1180,7 @@ fn execute(
 
 fn source_file<'a>(
     source: RouteSource,
-    next: &'a ValidatedLayerSource,
+    next: &'a ValidatedLayerFile,
     base: Option<&'a ValidatedBase>,
 ) -> Option<&'a File> {
     match source {
@@ -1150,7 +1190,7 @@ fn source_file<'a>(
             Some(ValidatedBase::ZeroRoot(_)) | None => None,
         },
         RouteSource::ZeroRoot => match base {
-            Some(ValidatedBase::ZeroRoot(source)) => Some(&source.file),
+            Some(ValidatedBase::ZeroRoot(source)) => Some(&source.source.file),
             Some(ValidatedBase::Complete(_)) | None => None,
         },
         RouteSource::Zero => None,
@@ -1158,7 +1198,7 @@ fn source_file<'a>(
 }
 
 fn verify_sources(
-    next: &ValidatedLayerSource,
+    next: &ValidatedLayerFile,
     base: Option<&ValidatedBase>,
     observation: SourceObservation,
     policy: &mut impl MaterializationPolicy,

--- a/crates/runtime/src/snapshot_diff_v2_13/materialize.rs
+++ b/crates/runtime/src/snapshot_diff_v2_13/materialize.rs
@@ -1,0 +1,1254 @@
+//! Immutable descriptor adoption and GPA-correct Diff materialization.
+
+use std::collections::TryReserveError;
+use std::fmt;
+use std::fs::File;
+use std::io::{self, Seek, SeekFrom};
+use std::os::unix::fs::FileExt;
+
+use crate::snapshot_memory_v2::{
+    FileFacts, NATIVE_V2_MEMORY_ALIGNMENT, NATIVE_V2_MEMORY_HEADER_BYTES, SnapshotV2MemoryBinding,
+    SnapshotV2MemoryBindingError, SnapshotV2MemoryLoadError, ValidatedSnapshotV2MemorySource,
+    inspect_file, inspect_file_facts, verify_snapshot_v2_memory_image_output,
+};
+
+use super::{
+    NATIVE_V2_DIFF_HEADER_BYTES, NATIVE_V2_DIFF_MAX_METADATA_BYTES, SnapshotV2DiffBase,
+    SnapshotV2DiffDataExtent, SnapshotV2DiffLayerBinding, SnapshotV2DiffLayerBindingError, codec,
+};
+
+const COPY_CHUNK_BYTES: usize = 1024 * 1024;
+const ZERO_CHUNK_BYTES: usize = 8192;
+
+/// One adopted base file accepted by next-layer materialization.
+pub enum SnapshotV2DiffMaterializationBaseFile {
+    /// A canonical complete `BANGM2A` predecessor image.
+    Complete(File),
+    /// A canonical exact-2.13 layer whose provenance is the zero root.
+    ZeroRoot(File),
+}
+
+impl fmt::Debug for SnapshotV2DiffMaterializationBaseFile {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2DiffMaterializationBaseFile")
+            .field(
+                "kind",
+                &match self {
+                    Self::Complete(_) => "complete",
+                    Self::ZeroRoot(_) => "zero root",
+                },
+            )
+            .field("descriptor", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Stable, value-redacted checkpoint in exact-2.13 Diff materialization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2DiffMaterializationStage {
+    /// Validate immutable adopted source descriptors and their metadata.
+    SourceValidation,
+    /// Validate lineage and precompute every target GPA route.
+    LineagePlanning,
+    /// Validate the caller-owned empty read-write staging descriptor.
+    OutputPreflight,
+    /// Write the complete result image header.
+    OutputHeader,
+    /// Write canonical metadata padding and establish the result length.
+    OutputPadding,
+    /// Copy one bounded explicit or inherited data chunk.
+    DataStreaming,
+    /// Recheck all immutable source facts.
+    SourceStability,
+    /// Verify the complete staged result against its detached binding.
+    ResultVerification,
+    /// Complete without another fallible ownership transition.
+    Complete,
+}
+
+impl fmt::Display for SnapshotV2DiffMaterializationStage {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::SourceValidation => "source validation",
+            Self::LineagePlanning => "lineage and route planning",
+            Self::OutputPreflight => "output preflight",
+            Self::OutputHeader => "output header",
+            Self::OutputPadding => "output padding",
+            Self::DataStreaming => "data streaming",
+            Self::SourceStability => "source stability",
+            Self::ResultVerification => "result verification",
+            Self::Complete => "completion",
+        })
+    }
+}
+
+/// Failure while producing an unpublished complete image from Diff inputs.
+pub enum SnapshotV2DiffMaterializationError {
+    /// The caller cancelled at a stable, value-redacted checkpoint.
+    Cancelled {
+        /// Checkpoint at which cancellation was observed.
+        stage: SnapshotV2DiffMaterializationStage,
+    },
+    /// A source descriptor failed immutable complete-image or file inspection.
+    Source {
+        /// Checkpoint at which source validation failed.
+        stage: SnapshotV2DiffMaterializationStage,
+        /// Existing native-v2 descriptor validation failure.
+        source: SnapshotV2MemoryLoadError,
+    },
+    /// A layer's bounded canonical metadata failed validation.
+    Layer {
+        /// Checkpoint at which layer validation failed.
+        stage: SnapshotV2DiffMaterializationStage,
+        /// Exact-2.13 layer binding failure.
+        source: SnapshotV2DiffLayerBindingError,
+    },
+    /// Bounded transaction metadata could not be reserved.
+    MetadataAllocation {
+        /// Checkpoint at which allocation failed.
+        stage: SnapshotV2DiffMaterializationStage,
+        /// Failed fallible reservation.
+        source: TryReserveError,
+    },
+    /// Target complete-binding encoding failed before output began.
+    ResultBinding {
+        /// Checkpoint at which binding preparation failed.
+        stage: SnapshotV2DiffMaterializationStage,
+        /// Complete memory-binding failure.
+        source: SnapshotV2MemoryBindingError,
+    },
+    /// A positional descriptor operation failed or made no progress.
+    Io {
+        /// Checkpoint at which I/O failed.
+        stage: SnapshotV2DiffMaterializationStage,
+        /// Stable I/O class without a path or descriptor number.
+        kind: io::ErrorKind,
+    },
+    /// The layer descriptor length differs from its canonical binding.
+    LayerFileLengthMismatch {
+        /// Source-validation checkpoint.
+        stage: SnapshotV2DiffMaterializationStage,
+    },
+    /// Layer metadata-to-data padding contains a nonzero byte.
+    NonZeroLayerPadding {
+        /// Source-validation checkpoint.
+        stage: SnapshotV2DiffMaterializationStage,
+    },
+    /// Root promotion or a zero-root base used nonzero provenance.
+    InvalidZeroRoot {
+        /// Lineage checkpoint.
+        stage: SnapshotV2DiffMaterializationStage,
+    },
+    /// A next layer did not name one complete image predecessor.
+    InvalidNextLayer {
+        /// Lineage checkpoint.
+        stage: SnapshotV2DiffMaterializationStage,
+    },
+    /// The supplied base does not equal the next layer's embedded predecessor.
+    PredecessorMismatch {
+        /// Lineage checkpoint.
+        stage: SnapshotV2DiffMaterializationStage,
+    },
+    /// At least one target GPA has no explicit, inherited, or proven-zero source.
+    MissingCoverage {
+        /// Lineage checkpoint.
+        stage: SnapshotV2DiffMaterializationStage,
+    },
+    /// Checked route arithmetic or an internal canonical bound was inconsistent.
+    InvalidRoute {
+        /// Lineage checkpoint.
+        stage: SnapshotV2DiffMaterializationStage,
+    },
+    /// Staging is not an empty position-zero read-write CLOEXEC regular file.
+    InvalidOutput {
+        /// Output-preflight or final-position checkpoint.
+        stage: SnapshotV2DiffMaterializationStage,
+    },
+    /// Staging aliases one immutable source object.
+    SourceOutputAlias {
+        /// Output-preflight checkpoint.
+        stage: SnapshotV2DiffMaterializationStage,
+    },
+    /// The staged complete result failed detached output verification.
+    ResultVerification {
+        /// Result-verification checkpoint.
+        stage: SnapshotV2DiffMaterializationStage,
+        /// Complete image verification failure.
+        source: SnapshotV2MemoryLoadError,
+    },
+}
+
+impl SnapshotV2DiffMaterializationError {
+    /// Returns the stable materialization checkpoint associated with the error.
+    pub const fn stage(&self) -> SnapshotV2DiffMaterializationStage {
+        match self {
+            Self::Cancelled { stage }
+            | Self::Source { stage, .. }
+            | Self::Layer { stage, .. }
+            | Self::MetadataAllocation { stage, .. }
+            | Self::ResultBinding { stage, .. }
+            | Self::Io { stage, .. }
+            | Self::LayerFileLengthMismatch { stage }
+            | Self::NonZeroLayerPadding { stage }
+            | Self::InvalidZeroRoot { stage }
+            | Self::InvalidNextLayer { stage }
+            | Self::PredecessorMismatch { stage }
+            | Self::MissingCoverage { stage }
+            | Self::InvalidRoute { stage }
+            | Self::InvalidOutput { stage }
+            | Self::SourceOutputAlias { stage }
+            | Self::ResultVerification { stage, .. } => *stage,
+        }
+    }
+}
+
+impl fmt::Debug for SnapshotV2DiffMaterializationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::Cancelled { .. } => "cancelled",
+            Self::Source { .. } => "source",
+            Self::Layer { .. } => "layer",
+            Self::MetadataAllocation { .. } => "metadata allocation",
+            Self::ResultBinding { .. } => "result binding",
+            Self::Io { .. } => "I/O",
+            Self::LayerFileLengthMismatch { .. } => "layer length",
+            Self::NonZeroLayerPadding { .. } => "layer padding",
+            Self::InvalidZeroRoot { .. } => "zero-root provenance",
+            Self::InvalidNextLayer { .. } => "next-layer provenance",
+            Self::PredecessorMismatch { .. } => "predecessor",
+            Self::MissingCoverage { .. } => "coverage",
+            Self::InvalidRoute { .. } => "route",
+            Self::InvalidOutput { .. } => "output",
+            Self::SourceOutputAlias { .. } => "alias",
+            Self::ResultVerification { .. } => "verification",
+        };
+        formatter
+            .debug_struct("SnapshotV2DiffMaterializationError")
+            .field("stage", &self.stage())
+            .field("kind", &kind)
+            .field("details", &"<redacted>")
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotV2DiffMaterializationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let action = match self {
+            Self::Cancelled { .. } => "was cancelled",
+            Self::Source { .. } => "source validation failed",
+            Self::Layer { .. } => "layer validation failed",
+            Self::MetadataAllocation { .. } => "metadata allocation failed",
+            Self::ResultBinding { .. } => "result binding preparation failed",
+            Self::Io { .. } => "descriptor I/O failed",
+            Self::LayerFileLengthMismatch { .. } => "found an invalid layer length",
+            Self::NonZeroLayerPadding { .. } => "found noncanonical layer padding",
+            Self::InvalidZeroRoot { .. } => "rejected zero-root provenance",
+            Self::InvalidNextLayer { .. } => "rejected next-layer provenance",
+            Self::PredecessorMismatch { .. } => "rejected a stale predecessor",
+            Self::MissingCoverage { .. } => "found an uncovered target range",
+            Self::InvalidRoute { .. } => "found invalid route arithmetic",
+            Self::InvalidOutput { .. } => "rejected the staging descriptor",
+            Self::SourceOutputAlias { .. } => "rejected a source/output alias",
+            Self::ResultVerification { .. } => "result verification failed",
+        };
+        write!(
+            formatter,
+            "native-v2 Diff materialization {action} during {}",
+            self.stage()
+        )
+    }
+}
+
+impl std::error::Error for SnapshotV2DiffMaterializationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Source { source, .. } => Some(source),
+            Self::Layer { source, .. } => Some(source),
+            Self::MetadataAllocation { source, .. } => Some(source),
+            Self::ResultBinding { source, .. } => Some(source),
+            Self::ResultVerification { source, .. } => Some(source),
+            Self::Cancelled { .. }
+            | Self::Io { .. }
+            | Self::LayerFileLengthMismatch { .. }
+            | Self::NonZeroLayerPadding { .. }
+            | Self::InvalidZeroRoot { .. }
+            | Self::InvalidNextLayer { .. }
+            | Self::PredecessorMismatch { .. }
+            | Self::MissingCoverage { .. }
+            | Self::InvalidRoute { .. }
+            | Self::InvalidOutput { .. }
+            | Self::SourceOutputAlias { .. } => None,
+        }
+    }
+}
+
+/// Promotes one immutable zero-root layer into a complete memory image.
+pub fn promote_snapshot_v2_diff_zero_root_file(
+    root: File,
+    staging: &mut File,
+) -> Result<SnapshotV2MemoryBinding, SnapshotV2DiffMaterializationError> {
+    promote_snapshot_v2_diff_zero_root_file_with_cancel(root, staging, |_| false)
+}
+
+/// Promotes one zero-root layer with bounded cooperative cancellation.
+pub fn promote_snapshot_v2_diff_zero_root_file_with_cancel<C>(
+    root: File,
+    staging: &mut File,
+    is_cancelled: C,
+) -> Result<SnapshotV2MemoryBinding, SnapshotV2DiffMaterializationError>
+where
+    C: FnMut(SnapshotV2DiffMaterializationStage) -> bool,
+{
+    promote_with_policy(
+        root,
+        staging,
+        &mut SystemMaterializationPolicy { is_cancelled },
+    )
+}
+
+/// Applies one immutable next layer to a complete or proven zero-root base.
+pub fn apply_snapshot_v2_diff_layer_file(
+    base: SnapshotV2DiffMaterializationBaseFile,
+    next: File,
+    staging: &mut File,
+) -> Result<SnapshotV2MemoryBinding, SnapshotV2DiffMaterializationError> {
+    apply_snapshot_v2_diff_layer_file_with_cancel(base, next, staging, |_| false)
+}
+
+/// Applies one next layer with bounded cooperative cancellation.
+pub fn apply_snapshot_v2_diff_layer_file_with_cancel<C>(
+    base: SnapshotV2DiffMaterializationBaseFile,
+    next: File,
+    staging: &mut File,
+    is_cancelled: C,
+) -> Result<SnapshotV2MemoryBinding, SnapshotV2DiffMaterializationError>
+where
+    C: FnMut(SnapshotV2DiffMaterializationStage) -> bool,
+{
+    apply_with_policy(
+        base,
+        next,
+        staging,
+        &mut SystemMaterializationPolicy { is_cancelled },
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SourceRole {
+    CompleteBase,
+    ZeroRoot,
+    NextLayer,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SourceObservation {
+    DuringValidation,
+    BeforeOutput,
+    AfterStreaming,
+    Final,
+}
+
+trait MaterializationPolicy {
+    fn checkpoint(
+        &mut self,
+        stage: SnapshotV2DiffMaterializationStage,
+    ) -> Result<(), SnapshotV2DiffMaterializationError>;
+
+    fn reserve_layer_metadata(
+        &mut self,
+        metadata: &mut Vec<u8>,
+        count: usize,
+    ) -> Result<(), TryReserveError> {
+        metadata.try_reserve_exact(count)
+    }
+
+    fn reserve_routes(
+        &mut self,
+        routes: &mut Vec<Route>,
+        count: usize,
+    ) -> Result<(), TryReserveError> {
+        routes.try_reserve_exact(count)
+    }
+
+    fn reserve_copy_buffer(
+        &mut self,
+        buffer: &mut Vec<u8>,
+        count: usize,
+    ) -> Result<(), TryReserveError> {
+        buffer.try_reserve_exact(count)
+    }
+
+    fn read_at(&mut self, file: &File, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
+        file.read_at(buffer, offset)
+    }
+
+    fn write_at(&mut self, file: &File, buffer: &[u8], offset: u64) -> io::Result<usize> {
+        file.write_at(buffer, offset)
+    }
+
+    fn set_len(&mut self, file: &File, length: u64) -> io::Result<()> {
+        file.set_len(length)
+    }
+
+    fn seek_output(&mut self, file: &mut File, position: u64) -> io::Result<u64> {
+        file.seek(SeekFrom::Start(position))
+    }
+
+    fn source_hook(&mut self, _role: SourceRole, _observation: SourceObservation, _file: &File) {}
+
+    fn result_verification_hook(&mut self, _file: &mut File) {}
+}
+
+struct SystemMaterializationPolicy<C> {
+    is_cancelled: C,
+}
+
+impl<C> MaterializationPolicy for SystemMaterializationPolicy<C>
+where
+    C: FnMut(SnapshotV2DiffMaterializationStage) -> bool,
+{
+    fn checkpoint(
+        &mut self,
+        stage: SnapshotV2DiffMaterializationStage,
+    ) -> Result<(), SnapshotV2DiffMaterializationError> {
+        if (self.is_cancelled)(stage) {
+            Err(SnapshotV2DiffMaterializationError::Cancelled { stage })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+struct ValidatedLayerSource {
+    file: File,
+    binding: SnapshotV2DiffLayerBinding,
+    facts: FileFacts,
+    role: SourceRole,
+}
+
+impl ValidatedLayerSource {
+    fn new(
+        file: File,
+        role: SourceRole,
+        policy: &mut impl MaterializationPolicy,
+    ) -> Result<Self, SnapshotV2DiffMaterializationError> {
+        let stage = SnapshotV2DiffMaterializationStage::SourceValidation;
+        let facts = inspect_file(&file)
+            .map_err(|source| SnapshotV2DiffMaterializationError::Source { stage, source })?;
+        if facts.length()
+            < u64::try_from(NATIVE_V2_DIFF_HEADER_BYTES)
+                .map_err(|_| SnapshotV2DiffMaterializationError::InvalidRoute { stage })?
+        {
+            return Err(SnapshotV2DiffMaterializationError::LayerFileLengthMismatch { stage });
+        }
+
+        let mut header = [0_u8; NATIVE_V2_DIFF_HEADER_BYTES];
+        read_exact_at(&file, &mut header, 0, stage, policy)?;
+        let metadata_length = codec::preflight_metadata_length(&header)
+            .map_err(|source| SnapshotV2DiffMaterializationError::Layer { stage, source })?;
+        if metadata_length > NATIVE_V2_DIFF_MAX_METADATA_BYTES
+            || u64::try_from(metadata_length)
+                .ok()
+                .is_none_or(|length| length > facts.length())
+        {
+            return Err(SnapshotV2DiffMaterializationError::LayerFileLengthMismatch { stage });
+        }
+
+        let mut metadata = Vec::new();
+        policy
+            .reserve_layer_metadata(&mut metadata, metadata_length)
+            .map_err(
+                |source| SnapshotV2DiffMaterializationError::MetadataAllocation { stage, source },
+            )?;
+        metadata.resize(metadata_length, 0);
+        read_exact_at(&file, &mut metadata, 0, stage, policy)?;
+        let binding = SnapshotV2DiffLayerBinding::decode(&metadata)
+            .map_err(|source| SnapshotV2DiffMaterializationError::Layer { stage, source })?;
+        if binding.file_length() != facts.length() {
+            return Err(SnapshotV2DiffMaterializationError::LayerFileLengthMismatch { stage });
+        }
+
+        let mut offset = binding.metadata_length();
+        let mut zeroes = [0_u8; ZERO_CHUNK_BYTES];
+        while offset < binding.data_offset() {
+            let remaining = binding
+                .data_offset()
+                .checked_sub(offset)
+                .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute { stage })?;
+            let length = usize::try_from(remaining.min(ZERO_CHUNK_BYTES as u64))
+                .map_err(|_| SnapshotV2DiffMaterializationError::InvalidRoute { stage })?;
+            let chunk = zeroes
+                .get_mut(..length)
+                .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute { stage })?;
+            read_exact_at(&file, chunk, offset, stage, policy)?;
+            if chunk.iter().any(|byte| *byte != 0) {
+                return Err(SnapshotV2DiffMaterializationError::NonZeroLayerPadding { stage });
+            }
+            offset = offset
+                .checked_add(
+                    u64::try_from(length)
+                        .map_err(|_| SnapshotV2DiffMaterializationError::InvalidRoute { stage })?,
+                )
+                .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute { stage })?;
+        }
+
+        policy.source_hook(role, SourceObservation::DuringValidation, &file);
+        let after = inspect_file(&file)
+            .map_err(|source| SnapshotV2DiffMaterializationError::Source { stage, source })?;
+        if after != facts {
+            return Err(SnapshotV2DiffMaterializationError::Source {
+                stage,
+                source: SnapshotV2MemoryLoadError::SourceChanged,
+            });
+        }
+        Ok(Self {
+            file,
+            binding,
+            facts,
+            role,
+        })
+    }
+
+    fn verify_unchanged(
+        &self,
+        observation: SourceObservation,
+        policy: &mut impl MaterializationPolicy,
+    ) -> Result<(), SnapshotV2DiffMaterializationError> {
+        let stage = SnapshotV2DiffMaterializationStage::SourceStability;
+        policy.source_hook(self.role, observation, &self.file);
+        let current = inspect_file(&self.file)
+            .map_err(|source| SnapshotV2DiffMaterializationError::Source { stage, source })?;
+        if current == self.facts {
+            Ok(())
+        } else {
+            Err(SnapshotV2DiffMaterializationError::Source {
+                stage,
+                source: SnapshotV2MemoryLoadError::SourceChanged,
+            })
+        }
+    }
+}
+
+enum ValidatedBase {
+    Complete(ValidatedSnapshotV2MemorySource),
+    ZeroRoot(ValidatedLayerSource),
+}
+
+impl ValidatedBase {
+    fn facts(&self) -> FileFacts {
+        match self {
+            Self::Complete(source) => source.facts(),
+            Self::ZeroRoot(source) => source.facts,
+        }
+    }
+
+    fn verify_unchanged(
+        &self,
+        observation: SourceObservation,
+        policy: &mut impl MaterializationPolicy,
+    ) -> Result<(), SnapshotV2DiffMaterializationError> {
+        let stage = SnapshotV2DiffMaterializationStage::SourceStability;
+        match self {
+            Self::Complete(source) => {
+                policy.source_hook(
+                    SourceRole::CompleteBase,
+                    observation,
+                    source.file().as_ref(),
+                );
+                source
+                    .verify_unchanged()
+                    .map_err(|source| SnapshotV2DiffMaterializationError::Source { stage, source })
+            }
+            Self::ZeroRoot(source) => source.verify_unchanged(observation, policy),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RouteSource {
+    Zero,
+    CompleteBase,
+    ZeroRoot,
+    NextLayer,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Route {
+    source: RouteSource,
+    source_offset: u64,
+    target_offset: u64,
+    length: u64,
+}
+
+enum Inheritance<'a> {
+    Zero,
+    Complete(&'a SnapshotV2MemoryBinding),
+    ZeroRoot(&'a SnapshotV2DiffLayerBinding),
+}
+
+fn promote_with_policy(
+    root: File,
+    staging: &mut File,
+    policy: &mut impl MaterializationPolicy,
+) -> Result<SnapshotV2MemoryBinding, SnapshotV2DiffMaterializationError> {
+    use SnapshotV2DiffMaterializationStage as Stage;
+
+    policy.checkpoint(Stage::SourceValidation)?;
+    let root = ValidatedLayerSource::new(root, SourceRole::ZeroRoot, policy)?;
+    if !matches!(root.binding.base(), SnapshotV2DiffBase::Zero) {
+        return Err(SnapshotV2DiffMaterializationError::InvalidZeroRoot {
+            stage: Stage::LineagePlanning,
+        });
+    }
+
+    policy.checkpoint(Stage::LineagePlanning)?;
+    let target = root.binding.result().clone();
+    let routes = build_routes(&target, &root.binding, Inheritance::Zero, policy)?;
+    execute(target, routes, &root, None, staging, policy)
+}
+
+fn apply_with_policy(
+    base: SnapshotV2DiffMaterializationBaseFile,
+    next: File,
+    staging: &mut File,
+    policy: &mut impl MaterializationPolicy,
+) -> Result<SnapshotV2MemoryBinding, SnapshotV2DiffMaterializationError> {
+    use SnapshotV2DiffMaterializationStage as Stage;
+
+    policy.checkpoint(Stage::SourceValidation)?;
+    let next = ValidatedLayerSource::new(next, SourceRole::NextLayer, policy)?;
+    let predecessor = next.binding.base().binding().ok_or(
+        SnapshotV2DiffMaterializationError::InvalidNextLayer {
+            stage: Stage::LineagePlanning,
+        },
+    )?;
+
+    let base = match base {
+        SnapshotV2DiffMaterializationBaseFile::Complete(file) => {
+            let source =
+                ValidatedSnapshotV2MemorySource::new_with_hook(predecessor, file, |_, file| {
+                    policy.source_hook(
+                        SourceRole::CompleteBase,
+                        SourceObservation::DuringValidation,
+                        file,
+                    );
+                })
+                .map_err(|source| SnapshotV2DiffMaterializationError::Source {
+                    stage: Stage::SourceValidation,
+                    source,
+                })?;
+            ValidatedBase::Complete(source)
+        }
+        SnapshotV2DiffMaterializationBaseFile::ZeroRoot(file) => {
+            let root = ValidatedLayerSource::new(file, SourceRole::ZeroRoot, policy)?;
+            if !matches!(root.binding.base(), SnapshotV2DiffBase::Zero) {
+                return Err(SnapshotV2DiffMaterializationError::InvalidZeroRoot {
+                    stage: Stage::LineagePlanning,
+                });
+            }
+            if root.binding.result() != predecessor {
+                return Err(SnapshotV2DiffMaterializationError::PredecessorMismatch {
+                    stage: Stage::LineagePlanning,
+                });
+            }
+            ValidatedBase::ZeroRoot(root)
+        }
+    };
+
+    policy.checkpoint(Stage::LineagePlanning)?;
+    let target = next.binding.result().clone();
+    let inheritance = match &base {
+        ValidatedBase::Complete(_) => Inheritance::Complete(predecessor),
+        ValidatedBase::ZeroRoot(root) => Inheritance::ZeroRoot(&root.binding),
+    };
+    let routes = build_routes(&target, &next.binding, inheritance, policy)?;
+    execute(target, routes, &next, Some(&base), staging, policy)
+}
+
+fn build_routes(
+    target: &SnapshotV2MemoryBinding,
+    explicit: &SnapshotV2DiffLayerBinding,
+    inheritance: Inheritance<'_>,
+    policy: &mut impl MaterializationPolicy,
+) -> Result<Vec<Route>, SnapshotV2DiffMaterializationError> {
+    let stage = SnapshotV2DiffMaterializationStage::LineagePlanning;
+    let predecessor_count = match &inheritance {
+        Inheritance::Zero => 0,
+        Inheritance::Complete(binding) => binding.extents().len(),
+        Inheritance::ZeroRoot(root) => root.result().extents().len(),
+    };
+    let root_data_count = match &inheritance {
+        Inheritance::ZeroRoot(root) => root.data_extents().len(),
+        Inheritance::Zero | Inheritance::Complete(_) => 0,
+    };
+    let route_bound = target
+        .extents()
+        .len()
+        .checked_add(explicit.data_extents().len())
+        .and_then(|count| count.checked_add(predecessor_count))
+        .and_then(|count| count.checked_add(root_data_count))
+        .and_then(|count| count.checked_mul(2))
+        .and_then(|count| count.checked_add(1))
+        .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute { stage })?;
+    let mut routes = Vec::new();
+    policy
+        .reserve_routes(&mut routes, route_bound)
+        .map_err(
+            |source| SnapshotV2DiffMaterializationError::MetadataAllocation { stage, source },
+        )?;
+
+    let mut explicit_index = 0_usize;
+    let mut predecessor_index = 0_usize;
+    let mut root_data_index = 0_usize;
+    for target_extent in target.extents().iter().copied() {
+        let mut gpa = target_extent.range().start().raw_value();
+        let target_end = target_extent.range().end_exclusive().raw_value();
+        while gpa < target_end {
+            advance_diff_extent(explicit.data_extents(), &mut explicit_index, gpa, stage)?;
+            let explicit_extent = explicit.data_extents().get(explicit_index).copied();
+            if explicit_extent.is_some_and(|extent| contains_diff(extent, gpa)) {
+                let extent = explicit_extent
+                    .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute { stage })?;
+                let end = target_end.min(extent.range().end_exclusive().raw_value());
+                append_route(
+                    &mut routes,
+                    route_bound,
+                    RouteSource::NextLayer,
+                    diff_source_offset(extent, gpa, stage)?,
+                    target_offset(target_extent, gpa, stage)?,
+                    checked_length(gpa, end, stage)?,
+                    stage,
+                )?;
+                gpa = end;
+                continue;
+            }
+
+            let explicit_start = explicit_extent
+                .map(|extent| extent.range().start().raw_value())
+                .unwrap_or(target_end)
+                .min(target_end);
+            match &inheritance {
+                Inheritance::Zero => {
+                    append_route(
+                        &mut routes,
+                        route_bound,
+                        RouteSource::Zero,
+                        0,
+                        target_offset(target_extent, gpa, stage)?,
+                        checked_length(gpa, explicit_start, stage)?,
+                        stage,
+                    )?;
+                    gpa = explicit_start;
+                }
+                Inheritance::Complete(binding) => {
+                    advance_memory_extent(binding, &mut predecessor_index, gpa, stage)?;
+                    let predecessor = binding
+                        .extents()
+                        .get(predecessor_index)
+                        .copied()
+                        .ok_or(SnapshotV2DiffMaterializationError::MissingCoverage { stage })?;
+                    if !contains_memory(predecessor, gpa) {
+                        return Err(SnapshotV2DiffMaterializationError::MissingCoverage { stage });
+                    }
+                    let end = target_end
+                        .min(explicit_start)
+                        .min(predecessor.range().end_exclusive().raw_value());
+                    append_route(
+                        &mut routes,
+                        route_bound,
+                        RouteSource::CompleteBase,
+                        memory_source_offset(predecessor, gpa, stage)?,
+                        target_offset(target_extent, gpa, stage)?,
+                        checked_length(gpa, end, stage)?,
+                        stage,
+                    )?;
+                    gpa = end;
+                }
+                Inheritance::ZeroRoot(root) => {
+                    advance_memory_extent(root.result(), &mut predecessor_index, gpa, stage)?;
+                    let predecessor = root
+                        .result()
+                        .extents()
+                        .get(predecessor_index)
+                        .copied()
+                        .ok_or(SnapshotV2DiffMaterializationError::MissingCoverage { stage })?;
+                    if !contains_memory(predecessor, gpa) {
+                        return Err(SnapshotV2DiffMaterializationError::MissingCoverage { stage });
+                    }
+                    advance_diff_extent(root.data_extents(), &mut root_data_index, gpa, stage)?;
+                    let root_data = root.data_extents().get(root_data_index).copied();
+                    if root_data.is_some_and(|extent| contains_diff(extent, gpa)) {
+                        let extent = root_data
+                            .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute { stage })?;
+                        let end = target_end
+                            .min(explicit_start)
+                            .min(predecessor.range().end_exclusive().raw_value())
+                            .min(extent.range().end_exclusive().raw_value());
+                        append_route(
+                            &mut routes,
+                            route_bound,
+                            RouteSource::ZeroRoot,
+                            diff_source_offset(extent, gpa, stage)?,
+                            target_offset(target_extent, gpa, stage)?,
+                            checked_length(gpa, end, stage)?,
+                            stage,
+                        )?;
+                        gpa = end;
+                    } else {
+                        let root_data_start = root_data
+                            .map(|extent| extent.range().start().raw_value())
+                            .unwrap_or(target_end);
+                        let end = target_end
+                            .min(explicit_start)
+                            .min(predecessor.range().end_exclusive().raw_value())
+                            .min(root_data_start);
+                        append_route(
+                            &mut routes,
+                            route_bound,
+                            RouteSource::Zero,
+                            0,
+                            target_offset(target_extent, gpa, stage)?,
+                            checked_length(gpa, end, stage)?,
+                            stage,
+                        )?;
+                        gpa = end;
+                    }
+                }
+            }
+        }
+    }
+    Ok(routes)
+}
+
+fn advance_memory_extent(
+    binding: &SnapshotV2MemoryBinding,
+    index: &mut usize,
+    gpa: u64,
+    stage: SnapshotV2DiffMaterializationStage,
+) -> Result<(), SnapshotV2DiffMaterializationError> {
+    while binding
+        .extents()
+        .get(*index)
+        .is_some_and(|extent| extent.range().end_exclusive().raw_value() <= gpa)
+    {
+        *index = index
+            .checked_add(1)
+            .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute { stage })?;
+    }
+    Ok(())
+}
+
+fn advance_diff_extent(
+    extents: &[SnapshotV2DiffDataExtent],
+    index: &mut usize,
+    gpa: u64,
+    stage: SnapshotV2DiffMaterializationStage,
+) -> Result<(), SnapshotV2DiffMaterializationError> {
+    while extents
+        .get(*index)
+        .is_some_and(|extent| extent.range().end_exclusive().raw_value() <= gpa)
+    {
+        *index = index
+            .checked_add(1)
+            .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute { stage })?;
+    }
+    Ok(())
+}
+
+fn contains_memory(extent: crate::snapshot_memory_v2::SnapshotV2MemoryExtent, gpa: u64) -> bool {
+    extent.range().start().raw_value() <= gpa && gpa < extent.range().end_exclusive().raw_value()
+}
+
+fn contains_diff(extent: SnapshotV2DiffDataExtent, gpa: u64) -> bool {
+    extent.range().start().raw_value() <= gpa && gpa < extent.range().end_exclusive().raw_value()
+}
+
+fn memory_source_offset(
+    extent: crate::snapshot_memory_v2::SnapshotV2MemoryExtent,
+    gpa: u64,
+    stage: SnapshotV2DiffMaterializationStage,
+) -> Result<u64, SnapshotV2DiffMaterializationError> {
+    gpa.checked_sub(extent.range().start().raw_value())
+        .and_then(|delta| extent.file_offset().checked_add(delta))
+        .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute { stage })
+}
+
+fn diff_source_offset(
+    extent: SnapshotV2DiffDataExtent,
+    gpa: u64,
+    stage: SnapshotV2DiffMaterializationStage,
+) -> Result<u64, SnapshotV2DiffMaterializationError> {
+    gpa.checked_sub(extent.range().start().raw_value())
+        .and_then(|delta| extent.file_offset().checked_add(delta))
+        .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute { stage })
+}
+
+fn target_offset(
+    extent: crate::snapshot_memory_v2::SnapshotV2MemoryExtent,
+    gpa: u64,
+    stage: SnapshotV2DiffMaterializationStage,
+) -> Result<u64, SnapshotV2DiffMaterializationError> {
+    memory_source_offset(extent, gpa, stage)
+}
+
+fn checked_length(
+    start: u64,
+    end: u64,
+    stage: SnapshotV2DiffMaterializationStage,
+) -> Result<u64, SnapshotV2DiffMaterializationError> {
+    end.checked_sub(start)
+        .filter(|length| *length != 0)
+        .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute { stage })
+}
+
+fn append_route(
+    routes: &mut Vec<Route>,
+    route_bound: usize,
+    source: RouteSource,
+    source_offset: u64,
+    target_offset: u64,
+    length: u64,
+    stage: SnapshotV2DiffMaterializationStage,
+) -> Result<(), SnapshotV2DiffMaterializationError> {
+    if let Some(previous) = routes.last_mut() {
+        let target_contiguous = previous
+            .target_offset
+            .checked_add(previous.length)
+            .is_some_and(|end| end == target_offset);
+        let source_contiguous = source == RouteSource::Zero
+            || previous
+                .source_offset
+                .checked_add(previous.length)
+                .is_some_and(|end| end == source_offset);
+        if previous.source == source && target_contiguous && source_contiguous {
+            previous.length = previous
+                .length
+                .checked_add(length)
+                .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute { stage })?;
+            return Ok(());
+        }
+    }
+    if routes.len() >= route_bound {
+        return Err(SnapshotV2DiffMaterializationError::InvalidRoute { stage });
+    }
+    routes.push(Route {
+        source,
+        source_offset,
+        target_offset,
+        length,
+    });
+    Ok(())
+}
+
+fn execute(
+    target: SnapshotV2MemoryBinding,
+    routes: Vec<Route>,
+    next: &ValidatedLayerSource,
+    base: Option<&ValidatedBase>,
+    staging: &mut File,
+    policy: &mut impl MaterializationPolicy,
+) -> Result<SnapshotV2MemoryBinding, SnapshotV2DiffMaterializationError> {
+    use SnapshotV2DiffMaterializationStage as Stage;
+
+    policy.checkpoint(Stage::OutputPreflight)?;
+    let output_facts = inspect_file_facts(staging).map_err(|source| {
+        SnapshotV2DiffMaterializationError::Source {
+            stage: Stage::OutputPreflight,
+            source,
+        }
+    })?;
+    let position =
+        staging
+            .stream_position()
+            .map_err(|source| SnapshotV2DiffMaterializationError::Io {
+                stage: Stage::OutputPreflight,
+                kind: source.kind(),
+            })?;
+    if output_facts.same_object(next.facts)
+        || base.is_some_and(|source| output_facts.same_object(source.facts()))
+    {
+        return Err(SnapshotV2DiffMaterializationError::SourceOutputAlias {
+            stage: Stage::OutputPreflight,
+        });
+    }
+    if !output_facts.is_regular()
+        || !output_facts.is_read_write()
+        || output_facts.is_append()
+        || !output_facts.is_close_on_exec()
+        || output_facts.length() != 0
+        || position != 0
+    {
+        return Err(SnapshotV2DiffMaterializationError::InvalidOutput {
+            stage: Stage::OutputPreflight,
+        });
+    }
+    let copy_length = routes
+        .iter()
+        .filter(|route| route.source != RouteSource::Zero)
+        .map(|route| route.length)
+        .max()
+        .unwrap_or(0)
+        .min(COPY_CHUNK_BYTES as u64);
+    let copy_length = usize::try_from(copy_length).map_err(|_| {
+        SnapshotV2DiffMaterializationError::InvalidRoute {
+            stage: Stage::LineagePlanning,
+        }
+    })?;
+    let mut buffer = Vec::new();
+    policy
+        .reserve_copy_buffer(&mut buffer, copy_length)
+        .map_err(
+            |source| SnapshotV2DiffMaterializationError::MetadataAllocation {
+                stage: Stage::LineagePlanning,
+                source,
+            },
+        )?;
+    buffer.resize(copy_length, 0);
+    let header = target.image_header().map_err(|source| {
+        SnapshotV2DiffMaterializationError::ResultBinding {
+            stage: Stage::LineagePlanning,
+            source,
+        }
+    })?;
+
+    verify_sources(next, base, SourceObservation::BeforeOutput, policy)?;
+
+    policy.checkpoint(Stage::OutputHeader)?;
+    write_exact_at(staging, &header, 0, Stage::OutputHeader, policy)?;
+
+    let zeroes = [0_u8; ZERO_CHUNK_BYTES];
+    let mut offset = u64::try_from(NATIVE_V2_MEMORY_HEADER_BYTES).map_err(|_| {
+        SnapshotV2DiffMaterializationError::InvalidRoute {
+            stage: Stage::OutputPadding,
+        }
+    })?;
+    while offset < NATIVE_V2_MEMORY_ALIGNMENT {
+        policy.checkpoint(Stage::OutputPadding)?;
+        let remaining = NATIVE_V2_MEMORY_ALIGNMENT.checked_sub(offset).ok_or(
+            SnapshotV2DiffMaterializationError::InvalidRoute {
+                stage: Stage::OutputPadding,
+            },
+        )?;
+        let length = usize::try_from(remaining.min(ZERO_CHUNK_BYTES as u64)).map_err(|_| {
+            SnapshotV2DiffMaterializationError::InvalidRoute {
+                stage: Stage::OutputPadding,
+            }
+        })?;
+        let chunk =
+            zeroes
+                .get(..length)
+                .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute {
+                    stage: Stage::OutputPadding,
+                })?;
+        write_exact_at(staging, chunk, offset, Stage::OutputPadding, policy)?;
+        offset = offset
+            .checked_add(u64::try_from(length).map_err(|_| {
+                SnapshotV2DiffMaterializationError::InvalidRoute {
+                    stage: Stage::OutputPadding,
+                }
+            })?)
+            .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute {
+                stage: Stage::OutputPadding,
+            })?;
+    }
+    policy
+        .set_len(staging, target.file_length())
+        .map_err(|source| SnapshotV2DiffMaterializationError::Io {
+            stage: Stage::OutputPadding,
+            kind: source.kind(),
+        })?;
+
+    for route in routes {
+        if route.source == RouteSource::Zero {
+            policy.checkpoint(Stage::DataStreaming)?;
+            continue;
+        }
+        let mut copied = 0_u64;
+        while copied < route.length {
+            policy.checkpoint(Stage::DataStreaming)?;
+            let remaining = route.length.checked_sub(copied).ok_or(
+                SnapshotV2DiffMaterializationError::InvalidRoute {
+                    stage: Stage::DataStreaming,
+                },
+            )?;
+            let length = usize::try_from(remaining.min(COPY_CHUNK_BYTES as u64)).map_err(|_| {
+                SnapshotV2DiffMaterializationError::InvalidRoute {
+                    stage: Stage::DataStreaming,
+                }
+            })?;
+            let chunk = buffer.get_mut(..length).ok_or(
+                SnapshotV2DiffMaterializationError::InvalidRoute {
+                    stage: Stage::DataStreaming,
+                },
+            )?;
+            let source = source_file(route.source, next, base).ok_or(
+                SnapshotV2DiffMaterializationError::InvalidRoute {
+                    stage: Stage::DataStreaming,
+                },
+            )?;
+            let source_offset = route.source_offset.checked_add(copied).ok_or(
+                SnapshotV2DiffMaterializationError::InvalidRoute {
+                    stage: Stage::DataStreaming,
+                },
+            )?;
+            read_exact_at(source, chunk, source_offset, Stage::DataStreaming, policy)?;
+            let target_offset = route.target_offset.checked_add(copied).ok_or(
+                SnapshotV2DiffMaterializationError::InvalidRoute {
+                    stage: Stage::DataStreaming,
+                },
+            )?;
+            write_exact_at(staging, chunk, target_offset, Stage::DataStreaming, policy)?;
+            copied = copied
+                .checked_add(u64::try_from(length).map_err(|_| {
+                    SnapshotV2DiffMaterializationError::InvalidRoute {
+                        stage: Stage::DataStreaming,
+                    }
+                })?)
+                .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute {
+                    stage: Stage::DataStreaming,
+                })?;
+        }
+    }
+
+    verify_sources(next, base, SourceObservation::AfterStreaming, policy)?;
+    let position = policy
+        .seek_output(staging, target.file_length())
+        .map_err(|source| SnapshotV2DiffMaterializationError::Io {
+            stage: Stage::ResultVerification,
+            kind: source.kind(),
+        })?;
+    if position != target.file_length() {
+        return Err(SnapshotV2DiffMaterializationError::InvalidOutput {
+            stage: Stage::ResultVerification,
+        });
+    }
+
+    policy.checkpoint(Stage::ResultVerification)?;
+    policy.result_verification_hook(staging);
+    verify_snapshot_v2_memory_image_output(&target, staging).map_err(|source| {
+        SnapshotV2DiffMaterializationError::ResultVerification {
+            stage: Stage::ResultVerification,
+            source,
+        }
+    })?;
+
+    verify_sources(next, base, SourceObservation::Final, policy)?;
+    policy.checkpoint(Stage::Complete)?;
+    Ok(target)
+}
+
+fn source_file<'a>(
+    source: RouteSource,
+    next: &'a ValidatedLayerSource,
+    base: Option<&'a ValidatedBase>,
+) -> Option<&'a File> {
+    match source {
+        RouteSource::NextLayer => Some(&next.file),
+        RouteSource::CompleteBase => match base {
+            Some(ValidatedBase::Complete(source)) => Some(source.file().as_ref()),
+            Some(ValidatedBase::ZeroRoot(_)) | None => None,
+        },
+        RouteSource::ZeroRoot => match base {
+            Some(ValidatedBase::ZeroRoot(source)) => Some(&source.file),
+            Some(ValidatedBase::Complete(_)) | None => None,
+        },
+        RouteSource::Zero => None,
+    }
+}
+
+fn verify_sources(
+    next: &ValidatedLayerSource,
+    base: Option<&ValidatedBase>,
+    observation: SourceObservation,
+    policy: &mut impl MaterializationPolicy,
+) -> Result<(), SnapshotV2DiffMaterializationError> {
+    let stage = SnapshotV2DiffMaterializationStage::SourceStability;
+    policy.checkpoint(stage)?;
+    next.verify_unchanged(observation, policy)?;
+    if let Some(base) = base {
+        base.verify_unchanged(observation, policy)?;
+    }
+    Ok(())
+}
+
+fn read_exact_at(
+    file: &File,
+    mut buffer: &mut [u8],
+    mut offset: u64,
+    stage: SnapshotV2DiffMaterializationStage,
+    policy: &mut impl MaterializationPolicy,
+) -> Result<(), SnapshotV2DiffMaterializationError> {
+    while !buffer.is_empty() {
+        match policy.read_at(file, buffer, offset) {
+            Ok(0) => {
+                return Err(SnapshotV2DiffMaterializationError::Io {
+                    stage,
+                    kind: io::ErrorKind::UnexpectedEof,
+                });
+            }
+            Ok(count) => {
+                let count = u64::try_from(count)
+                    .map_err(|_| SnapshotV2DiffMaterializationError::InvalidRoute { stage })?;
+                offset = offset
+                    .checked_add(count)
+                    .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute { stage })?;
+                let count = usize::try_from(count)
+                    .map_err(|_| SnapshotV2DiffMaterializationError::InvalidRoute { stage })?;
+                buffer = buffer
+                    .get_mut(count..)
+                    .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute { stage })?;
+            }
+            Err(source) if source.kind() == io::ErrorKind::Interrupted => {}
+            Err(source) => {
+                return Err(SnapshotV2DiffMaterializationError::Io {
+                    stage,
+                    kind: source.kind(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn write_exact_at(
+    file: &File,
+    mut buffer: &[u8],
+    mut offset: u64,
+    stage: SnapshotV2DiffMaterializationStage,
+    policy: &mut impl MaterializationPolicy,
+) -> Result<(), SnapshotV2DiffMaterializationError> {
+    while !buffer.is_empty() {
+        match policy.write_at(file, buffer, offset) {
+            Ok(0) => {
+                return Err(SnapshotV2DiffMaterializationError::Io {
+                    stage,
+                    kind: io::ErrorKind::WriteZero,
+                });
+            }
+            Ok(count) => {
+                let count = u64::try_from(count)
+                    .map_err(|_| SnapshotV2DiffMaterializationError::InvalidRoute { stage })?;
+                offset = offset
+                    .checked_add(count)
+                    .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute { stage })?;
+                let count = usize::try_from(count)
+                    .map_err(|_| SnapshotV2DiffMaterializationError::InvalidRoute { stage })?;
+                buffer = buffer
+                    .get(count..)
+                    .ok_or(SnapshotV2DiffMaterializationError::InvalidRoute { stage })?;
+            }
+            Err(source) if source.kind() == io::ErrorKind::Interrupted => {}
+            Err(source) => {
+                return Err(SnapshotV2DiffMaterializationError::Io {
+                    stage,
+                    kind: source.kind(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/runtime/src/snapshot_diff_v2_13/materialize/tests.rs
+++ b/crates/runtime/src/snapshot_diff_v2_13/materialize/tests.rs
@@ -631,6 +631,25 @@ fn descriptor_policy_rejects_mutable_special_aliasing_and_invalid_output_files()
         Err(SnapshotV2DiffMaterializationError::SourceOutputAlias { .. })
     ));
 
+    let complete = write_complete(&memory, "source-alias-complete");
+    let next = write_layer(
+        &memory,
+        SnapshotV2DiffBase::Image(complete.binding.clone()),
+        &[],
+        "source-alias-next",
+    );
+    let (_source_alias_output, mut staging) = TestFile::create_empty("source-alias-output");
+    assert!(matches!(
+        apply_snapshot_v2_diff_layer_file(
+            SnapshotV2DiffMaterializationBaseFile::Complete(next.file.open_read()),
+            next.file.open_read(),
+            &mut staging,
+        ),
+        Err(SnapshotV2DiffMaterializationError::SourceAlias {
+            stage: SnapshotV2DiffMaterializationStage::SourceValidation
+        })
+    ));
+
     let (nonempty_file, mut nonempty) = TestFile::create_empty("nonempty-output");
     nonempty
         .write_all(&[1])

--- a/crates/runtime/src/snapshot_diff_v2_13/materialize/tests.rs
+++ b/crates/runtime/src/snapshot_diff_v2_13/materialize/tests.rs
@@ -1,0 +1,1479 @@
+use std::cell::RefCell;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Seek, SeekFrom, Write};
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::FileExt;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::memory::{GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange, aarch64};
+use crate::snapshot_diff_v2_13::{
+    NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION, SnapshotV2DiffSelection,
+    write_snapshot_v2_diff_layer,
+};
+use crate::snapshot_memory_v2::write_snapshot_v2_memory_image_with_compatibility_version;
+
+use super::*;
+
+static NEXT_TEST_FILE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug)]
+struct TestFile {
+    path: PathBuf,
+}
+
+impl TestFile {
+    fn create_empty(label: &str) -> (Self, File) {
+        let sequence = NEXT_TEST_FILE.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "bangbang-diff-materialize-{label}-{}-{sequence}.snap",
+            std::process::id()
+        ));
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .expect("test file should create");
+        (Self { path }, file)
+    }
+
+    fn open_read(&self) -> File {
+        File::open(&self.path).expect("test file should open read-only")
+    }
+
+    fn open_read_write(&self) -> File {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&self.path)
+            .expect("test file should open read-write")
+    }
+
+    fn bytes(&self) -> Vec<u8> {
+        fs::read(&self.path).expect("test file should read")
+    }
+
+    fn length(&self) -> u64 {
+        fs::metadata(&self.path)
+            .expect("test file metadata should read")
+            .len()
+    }
+}
+
+impl Drop for TestFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+struct LayerFixture {
+    file: TestFile,
+    binding: SnapshotV2DiffLayerBinding,
+}
+
+struct CompleteFixture {
+    file: TestFile,
+    binding: SnapshotV2MemoryBinding,
+}
+
+fn page_range(first_page: u64, page_count: u64) -> GuestMemoryRange {
+    GuestMemoryRange::new(
+        GuestAddress::new(aarch64::DRAM_MEM_START + first_page * aarch64::GUEST_PAGE_SIZE),
+        page_count * aarch64::GUEST_PAGE_SIZE,
+    )
+    .expect("test range should validate")
+}
+
+fn memory_with_bytes(ranges: &[(GuestMemoryRange, u8)]) -> GuestMemory {
+    let layout = GuestMemoryLayout::new(ranges.iter().map(|(range, _)| *range).collect())
+        .expect("test layout should validate");
+    let mut memory = GuestMemory::allocate(&layout).expect("test memory should allocate");
+    for (range, byte) in ranges.iter().copied() {
+        let length = usize::try_from(range.size()).expect("test range should fit usize");
+        memory
+            .write_slice(&vec![byte; length], range.start())
+            .expect("test memory should populate");
+    }
+    memory
+}
+
+fn write_layer(
+    memory: &GuestMemory,
+    base: SnapshotV2DiffBase,
+    selected: &[GuestMemoryRange],
+    label: &str,
+) -> LayerFixture {
+    let selection = SnapshotV2DiffSelection::try_from_ranges(memory, selected)
+        .expect("test selection should validate");
+    let (file, mut writer) = TestFile::create_empty(label);
+    let binding = write_snapshot_v2_diff_layer(memory, &mut writer, base, &selection)
+        .expect("test layer should write");
+    drop(writer);
+    LayerFixture { file, binding }
+}
+
+fn write_complete(memory: &GuestMemory, label: &str) -> CompleteFixture {
+    let (file, mut writer) = TestFile::create_empty(label);
+    let binding = write_snapshot_v2_memory_image_with_compatibility_version(
+        memory,
+        &mut writer,
+        NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION,
+    )
+    .expect("test complete image should write");
+    drop(writer);
+    CompleteFixture { file, binding }
+}
+
+fn read_exact_file(file: &File, mut bytes: &mut [u8], mut offset: u64) {
+    while !bytes.is_empty() {
+        let count = file
+            .read_at(bytes, offset)
+            .expect("test positional read should succeed");
+        assert_ne!(count, 0, "test positional read should make progress");
+        offset += u64::try_from(count).expect("test read length should fit");
+        bytes = bytes
+            .get_mut(count..)
+            .expect("test read count should fit destination");
+    }
+}
+
+fn assert_complete_matches(expected: &GuestMemory, binding: &SnapshotV2MemoryBinding, file: &File) {
+    assert_eq!(
+        file.metadata().expect("result metadata should read").len(),
+        binding.file_length()
+    );
+    let mut previous_end = NATIVE_V2_MEMORY_ALIGNMENT;
+    for extent in binding.extents().iter().copied() {
+        let gap_length = usize::try_from(
+            extent
+                .file_offset()
+                .checked_sub(previous_end)
+                .expect("canonical gap should not underflow"),
+        )
+        .expect("test gap should fit usize");
+        let mut gap = vec![0_u8; gap_length];
+        read_exact_file(file, &mut gap, previous_end);
+        assert!(gap.iter().all(|byte| *byte == 0));
+
+        let length = usize::try_from(extent.range().size()).expect("extent should fit usize");
+        let mut actual = vec![0_u8; length];
+        let mut wanted = vec![0_u8; length];
+        read_exact_file(file, &mut actual, extent.file_offset());
+        expected
+            .read_slice(&mut wanted, extent.range().start())
+            .expect("expected memory should read");
+        assert_eq!(actual, wanted);
+        previous_end = extent.file_offset() + extent.range().size();
+    }
+}
+
+fn zero_memory_like(ranges: &[GuestMemoryRange]) -> GuestMemory {
+    memory_with_bytes(
+        &ranges
+            .iter()
+            .copied()
+            .map(|range| (range, 0))
+            .collect::<Vec<_>>(),
+    )
+}
+
+#[test]
+fn promotes_empty_partial_and_full_zero_root_layers() {
+    let whole = page_range(0, 4);
+    let first = page_range(0, 1);
+    let source = memory_with_bytes(&[(whole, 0x3c)]);
+
+    for (label, selected) in [
+        ("empty-root", Vec::new()),
+        ("partial-root", vec![first]),
+        ("full-root", vec![whole]),
+    ] {
+        let root = write_layer(&source, SnapshotV2DiffBase::Zero, &selected, label);
+        let mut expected = zero_memory_like(&[whole]);
+        for range in selected.iter().copied() {
+            let length = usize::try_from(range.size()).expect("selected range should fit");
+            let mut bytes = vec![0_u8; length];
+            source
+                .read_slice(&mut bytes, range.start())
+                .expect("selected bytes should read");
+            expected
+                .write_slice(&bytes, range.start())
+                .expect("selected bytes should populate expected memory");
+        }
+
+        let source_before = root.file.bytes();
+        let (result_file, mut staging) = TestFile::create_empty("promoted");
+        let result = promote_snapshot_v2_diff_zero_root_file(root.file.open_read(), &mut staging)
+            .expect("zero-root layer should promote");
+        assert_eq!(result, *root.binding.result());
+        assert_eq!(source_before, root.file.bytes());
+        assert_complete_matches(&expected, &result, &staging);
+        assert_eq!(
+            staging
+                .stream_position()
+                .expect("result position should query"),
+            result.file_length()
+        );
+        drop(result_file);
+    }
+}
+
+#[test]
+fn zero_root_and_complete_bases_produce_the_same_next_result() {
+    let first = page_range(0, 4);
+    let second = page_range(8, 4);
+    let root_memory = memory_with_bytes(&[(first, 0x11), (second, 0x22)]);
+    let root = write_layer(
+        &root_memory,
+        SnapshotV2DiffBase::Zero,
+        &[first],
+        "chain-root",
+    );
+
+    let next_memory = memory_with_bytes(&[(first, 0x11), (second, 0x77)]);
+    let next = write_layer(
+        &next_memory,
+        SnapshotV2DiffBase::Image(root.binding.result().clone()),
+        &[second],
+        "chain-next",
+    );
+    let expected = memory_with_bytes(&[(first, 0x11), (second, 0x77)]);
+
+    let (from_root_file, mut from_root) = TestFile::create_empty("from-root");
+    let root_result = apply_snapshot_v2_diff_layer_file(
+        SnapshotV2DiffMaterializationBaseFile::ZeroRoot(root.file.open_read()),
+        next.file.open_read(),
+        &mut from_root,
+    )
+    .expect("next layer should apply to a proven root");
+    assert_eq!(root_result, *next.binding.result());
+    assert_complete_matches(&expected, &root_result, &from_root);
+
+    let (promoted_file, mut promoted) = TestFile::create_empty("root-complete");
+    let promoted_binding =
+        promote_snapshot_v2_diff_zero_root_file(root.file.open_read(), &mut promoted)
+            .expect("root should promote for complete-base comparison");
+    assert_eq!(promoted_binding, *root.binding.result());
+    drop(promoted);
+
+    let (from_complete_file, mut from_complete) = TestFile::create_empty("from-complete");
+    let complete_result = apply_snapshot_v2_diff_layer_file(
+        SnapshotV2DiffMaterializationBaseFile::Complete(promoted_file.open_read()),
+        next.file.open_read(),
+        &mut from_complete,
+    )
+    .expect("next layer should apply to a complete base");
+    assert_eq!(complete_result, root_result);
+    assert_eq!(from_complete_file.bytes(), from_root_file.bytes());
+    assert_complete_matches(&expected, &complete_result, &from_complete);
+}
+
+#[test]
+fn dynamic_removal_inherits_by_gpa_after_the_target_offset_moves() {
+    let removed = page_range(0, 4);
+    let retained = page_range(32, 4);
+    let base_memory = memory_with_bytes(&[(removed, 0x19), (retained, 0xa7)]);
+    let base = write_complete(&base_memory, "remove-base");
+
+    let target_memory = memory_with_bytes(&[(retained, 0xff)]);
+    let next = write_layer(
+        &target_memory,
+        SnapshotV2DiffBase::Image(base.binding.clone()),
+        &[],
+        "remove-next",
+    );
+    assert_ne!(
+        base.binding
+            .extents()
+            .iter()
+            .find(|extent| extent.range() == retained)
+            .expect("retained base extent should exist")
+            .file_offset(),
+        next.binding.result().extents()[0].file_offset()
+    );
+
+    let expected = memory_with_bytes(&[(retained, 0xa7)]);
+    let (_result_file, mut staging) = TestFile::create_empty("remove-result");
+    let result = apply_snapshot_v2_diff_layer_file(
+        SnapshotV2DiffMaterializationBaseFile::Complete(base.file.open_read()),
+        next.file.open_read(),
+        &mut staging,
+    )
+    .expect("removed topology should inherit the retained GPA");
+    assert_complete_matches(&expected, &result, &staging);
+}
+
+#[test]
+fn simultaneous_add_remove_preserves_distinct_adjacent_result_regions() {
+    let removed = page_range(0, 4);
+    let retained = page_range(32, 4);
+    let added_adjacent = page_range(36, 4);
+    let base_memory = memory_with_bytes(&[(removed, 0x10), (retained, 0x20)]);
+    let base = write_complete(&base_memory, "replace-base");
+    let target_memory = memory_with_bytes(&[(retained, 0x20), (added_adjacent, 0x30)]);
+    let next = write_layer(
+        &target_memory,
+        SnapshotV2DiffBase::Image(base.binding.clone()),
+        &[added_adjacent],
+        "replace-next",
+    );
+    assert_eq!(next.binding.result().extents().len(), 2);
+
+    let (_output, mut staging) = TestFile::create_empty("replace-output");
+    let result = apply_snapshot_v2_diff_layer_file(
+        SnapshotV2DiffMaterializationBaseFile::Complete(base.file.open_read()),
+        next.file.open_read(),
+        &mut staging,
+    )
+    .expect("simultaneous add/remove should materialize by GPA");
+    assert_complete_matches(&target_memory, &result, &staging);
+}
+
+#[test]
+fn dynamic_addition_requires_complete_explicit_coverage_for_both_base_kinds() {
+    let existing = page_range(0, 4);
+    let added = page_range(64, 4);
+    let base_memory = memory_with_bytes(&[(existing, 0x2a)]);
+    let base = write_complete(&base_memory, "add-base");
+    let target_memory = memory_with_bytes(&[(existing, 0x2a), (added, 0x6d)]);
+
+    for selected in [Vec::new(), vec![page_range(64, 1)]] {
+        let next = write_layer(
+            &target_memory,
+            SnapshotV2DiffBase::Image(base.binding.clone()),
+            &selected,
+            "add-incomplete",
+        );
+        let (staging_file, mut staging) = TestFile::create_empty("add-rejected");
+        let error = apply_snapshot_v2_diff_layer_file(
+            SnapshotV2DiffMaterializationBaseFile::Complete(base.file.open_read()),
+            next.file.open_read(),
+            &mut staging,
+        )
+        .expect_err("an omitted added page must reject");
+        assert!(matches!(
+            error,
+            SnapshotV2DiffMaterializationError::MissingCoverage {
+                stage: SnapshotV2DiffMaterializationStage::LineagePlanning
+            }
+        ));
+        assert_eq!(staging_file.length(), 0);
+    }
+
+    let next = write_layer(
+        &target_memory,
+        SnapshotV2DiffBase::Image(base.binding.clone()),
+        &[added],
+        "add-complete",
+    );
+    let (_staging_file, mut staging) = TestFile::create_empty("add-result");
+    let result = apply_snapshot_v2_diff_layer_file(
+        SnapshotV2DiffMaterializationBaseFile::Complete(base.file.open_read()),
+        next.file.open_read(),
+        &mut staging,
+    )
+    .expect("fully explicit added topology should materialize");
+    assert_complete_matches(&target_memory, &result, &staging);
+
+    let root = write_layer(
+        &base_memory,
+        SnapshotV2DiffBase::Zero,
+        &[existing],
+        "add-root",
+    );
+    for selected in [Vec::new(), vec![page_range(64, 1)]] {
+        let next = write_layer(
+            &target_memory,
+            SnapshotV2DiffBase::Image(root.binding.result().clone()),
+            &selected,
+            "add-root-incomplete",
+        );
+        let (staging_file, mut staging) = TestFile::create_empty("add-root-rejected");
+        let error = apply_snapshot_v2_diff_layer_file(
+            SnapshotV2DiffMaterializationBaseFile::ZeroRoot(root.file.open_read()),
+            next.file.open_read(),
+            &mut staging,
+        )
+        .expect_err("a root base cannot prove zero outside its predecessor topology");
+        assert!(matches!(
+            error,
+            SnapshotV2DiffMaterializationError::MissingCoverage { .. }
+        ));
+        assert_eq!(staging_file.length(), 0);
+    }
+
+    let next = write_layer(
+        &target_memory,
+        SnapshotV2DiffBase::Image(root.binding.result().clone()),
+        &[added],
+        "add-root-complete",
+    );
+    let (_staging_file, mut staging) = TestFile::create_empty("add-root-result");
+    let result = apply_snapshot_v2_diff_layer_file(
+        SnapshotV2DiffMaterializationBaseFile::ZeroRoot(root.file.open_read()),
+        next.file.open_read(),
+        &mut staging,
+    )
+    .expect("a fully explicit addition should apply to a zero-root base");
+    assert_complete_matches(&target_memory, &result, &staging);
+}
+
+#[test]
+fn repeated_complete_application_handles_add_then_remove() {
+    let original = page_range(0, 4);
+    let added = page_range(48, 4);
+    let root_memory = memory_with_bytes(&[(original, 0x31)]);
+    let root = write_layer(
+        &root_memory,
+        SnapshotV2DiffBase::Zero,
+        &[original],
+        "repeat-root",
+    );
+    let (first_file, mut first) = TestFile::create_empty("repeat-first");
+    let first_binding = promote_snapshot_v2_diff_zero_root_file(root.file.open_read(), &mut first)
+        .expect("first result should promote");
+    drop(first);
+
+    let added_memory = memory_with_bytes(&[(original, 0x31), (added, 0x42)]);
+    let add_layer = write_layer(
+        &added_memory,
+        SnapshotV2DiffBase::Image(first_binding),
+        &[added],
+        "repeat-add",
+    );
+    let (second_file, mut second) = TestFile::create_empty("repeat-second");
+    let second_binding = apply_snapshot_v2_diff_layer_file(
+        SnapshotV2DiffMaterializationBaseFile::Complete(first_file.open_read()),
+        add_layer.file.open_read(),
+        &mut second,
+    )
+    .expect("added result should apply");
+    drop(second);
+
+    let removed_memory = memory_with_bytes(&[(added, 0xff)]);
+    let remove_layer = write_layer(
+        &removed_memory,
+        SnapshotV2DiffBase::Image(second_binding),
+        &[],
+        "repeat-remove",
+    );
+    let (_third_file, mut third) = TestFile::create_empty("repeat-third");
+    let third_binding = apply_snapshot_v2_diff_layer_file(
+        SnapshotV2DiffMaterializationBaseFile::Complete(second_file.open_read()),
+        remove_layer.file.open_read(),
+        &mut third,
+    )
+    .expect("removed result should apply");
+    let expected = memory_with_bytes(&[(added, 0x42)]);
+    assert_complete_matches(&expected, &third_binding, &third);
+}
+
+#[test]
+fn malformed_layer_files_and_lineage_fail_closed() {
+    let range = page_range(0, 4);
+    let memory = memory_with_bytes(&[(range, 0x55)]);
+    let root = write_layer(
+        &memory,
+        SnapshotV2DiffBase::Zero,
+        &[range],
+        "malformed-root",
+    );
+
+    let trailing = write_layer(&memory, SnapshotV2DiffBase::Zero, &[range], "trailing-root");
+    trailing
+        .file
+        .open_read_write()
+        .set_len(trailing.binding.file_length() + 1)
+        .expect("trailing byte should append");
+    let (_trailing_output, mut staging) = TestFile::create_empty("trailing-output");
+    assert!(matches!(
+        promote_snapshot_v2_diff_zero_root_file(trailing.file.open_read(), &mut staging),
+        Err(SnapshotV2DiffMaterializationError::LayerFileLengthMismatch { .. })
+    ));
+
+    let padded = write_layer(&memory, SnapshotV2DiffBase::Zero, &[range], "padded-root");
+    padded
+        .file
+        .open_read_write()
+        .write_at(&[1], padded.binding.metadata_length())
+        .expect("padding byte should mutate");
+    let (_padding_output, mut staging) = TestFile::create_empty("padding-output");
+    assert!(matches!(
+        promote_snapshot_v2_diff_zero_root_file(padded.file.open_read(), &mut staging),
+        Err(SnapshotV2DiffMaterializationError::NonZeroLayerPadding { .. })
+    ));
+
+    let truncated = write_layer(
+        &memory,
+        SnapshotV2DiffBase::Zero,
+        &[range],
+        "truncated-root",
+    );
+    truncated
+        .file
+        .open_read_write()
+        .set_len(
+            u64::try_from(NATIVE_V2_DIFF_HEADER_BYTES - 1).expect("test header length should fit"),
+        )
+        .expect("layer header should truncate");
+    let (_truncated_output, mut staging) = TestFile::create_empty("truncated-output");
+    assert!(matches!(
+        promote_snapshot_v2_diff_zero_root_file(truncated.file.open_read(), &mut staging),
+        Err(SnapshotV2DiffMaterializationError::LayerFileLengthMismatch { .. })
+    ));
+
+    let corrupt = write_layer(&memory, SnapshotV2DiffBase::Zero, &[range], "corrupt-root");
+    let corrupt_writer = corrupt.file.open_read_write();
+    let mut checksum_byte = [0_u8; 1];
+    read_exact_file(&corrupt_writer, &mut checksum_byte, 64);
+    checksum_byte[0] ^= 1;
+    corrupt_writer
+        .write_at(&checksum_byte, 64)
+        .expect("layer checksum should corrupt");
+    let (_corrupt_output, mut staging) = TestFile::create_empty("corrupt-output");
+    assert!(matches!(
+        promote_snapshot_v2_diff_zero_root_file(corrupt.file.open_read(), &mut staging),
+        Err(SnapshotV2DiffMaterializationError::Layer {
+            source: SnapshotV2DiffLayerBindingError::IntegrityMismatch,
+            ..
+        })
+    ));
+
+    let complete = write_complete(&memory, "lineage-complete");
+    let next = write_layer(
+        &memory,
+        SnapshotV2DiffBase::Image(complete.binding.clone()),
+        &[],
+        "image-layer",
+    );
+    let (_root_output, mut staging) = TestFile::create_empty("image-as-root");
+    assert!(matches!(
+        promote_snapshot_v2_diff_zero_root_file(next.file.open_read(), &mut staging),
+        Err(SnapshotV2DiffMaterializationError::InvalidZeroRoot { .. })
+    ));
+
+    let (_next_output, mut staging) = TestFile::create_empty("zero-as-next");
+    assert!(matches!(
+        apply_snapshot_v2_diff_layer_file(
+            SnapshotV2DiffMaterializationBaseFile::Complete(complete.file.open_read()),
+            root.file.open_read(),
+            &mut staging,
+        ),
+        Err(SnapshotV2DiffMaterializationError::InvalidNextLayer { .. })
+    ));
+
+    let other_root = write_layer(&memory, SnapshotV2DiffBase::Zero, &[range], "other-root");
+    let (_mismatch_output, mut staging) = TestFile::create_empty("mismatch-output");
+    assert!(matches!(
+        apply_snapshot_v2_diff_layer_file(
+            SnapshotV2DiffMaterializationBaseFile::ZeroRoot(other_root.file.open_read()),
+            next.file.open_read(),
+            &mut staging,
+        ),
+        Err(SnapshotV2DiffMaterializationError::PredecessorMismatch { .. })
+    ));
+}
+
+fn clear_cloexec(file: &File) {
+    // SAFETY: `file` owns a live descriptor and `F_SETFD` receives no pointer.
+    let result = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETFD, 0) };
+    assert_eq!(result, 0, "test should clear close-on-exec");
+}
+
+#[test]
+fn descriptor_policy_rejects_mutable_special_aliasing_and_invalid_output_files() {
+    let range = page_range(0, 4);
+    let memory = memory_with_bytes(&[(range, 0x61)]);
+    let root = write_layer(
+        &memory,
+        SnapshotV2DiffBase::Zero,
+        &[range],
+        "descriptor-root",
+    );
+
+    let (_writable_output, mut staging) = TestFile::create_empty("writable-source-output");
+    assert!(matches!(
+        promote_snapshot_v2_diff_zero_root_file(root.file.open_read_write(), &mut staging),
+        Err(SnapshotV2DiffMaterializationError::Source {
+            source: SnapshotV2MemoryLoadError::DescriptorNotReadOnly,
+            ..
+        })
+    ));
+
+    let source = root.file.open_read();
+    clear_cloexec(&source);
+    let (_cloexec_output, mut staging) = TestFile::create_empty("cloexec-source-output");
+    assert!(matches!(
+        promote_snapshot_v2_diff_zero_root_file(source, &mut staging),
+        Err(SnapshotV2DiffMaterializationError::Source {
+            source: SnapshotV2MemoryLoadError::DescriptorNotCloseOnExec,
+            ..
+        })
+    ));
+
+    let (_special_output, mut staging) = TestFile::create_empty("special-output");
+    assert!(matches!(
+        promote_snapshot_v2_diff_zero_root_file(
+            File::open("/dev/null").expect("null device should open"),
+            &mut staging,
+        ),
+        Err(SnapshotV2DiffMaterializationError::Source {
+            source: SnapshotV2MemoryLoadError::NotRegularFile,
+            ..
+        })
+    ));
+
+    let mut alias = root.file.open_read_write();
+    assert!(matches!(
+        promote_snapshot_v2_diff_zero_root_file(root.file.open_read(), &mut alias),
+        Err(SnapshotV2DiffMaterializationError::SourceOutputAlias { .. })
+    ));
+
+    let (nonempty_file, mut nonempty) = TestFile::create_empty("nonempty-output");
+    nonempty
+        .write_all(&[1])
+        .expect("nonempty output should write");
+    nonempty
+        .seek(SeekFrom::Start(0))
+        .expect("nonempty output should rewind");
+    assert!(matches!(
+        promote_snapshot_v2_diff_zero_root_file(root.file.open_read(), &mut nonempty),
+        Err(SnapshotV2DiffMaterializationError::InvalidOutput { .. })
+    ));
+    assert_eq!(nonempty_file.bytes(), vec![1]);
+
+    let (_position_file, mut positioned) = TestFile::create_empty("position-output");
+    positioned
+        .seek(SeekFrom::Start(1))
+        .expect("empty output position should move");
+    assert!(matches!(
+        promote_snapshot_v2_diff_zero_root_file(root.file.open_read(), &mut positioned),
+        Err(SnapshotV2DiffMaterializationError::InvalidOutput { .. })
+    ));
+
+    let (_cloexec_file, mut no_cloexec) = TestFile::create_empty("no-cloexec-output");
+    clear_cloexec(&no_cloexec);
+    assert!(matches!(
+        promote_snapshot_v2_diff_zero_root_file(root.file.open_read(), &mut no_cloexec),
+        Err(SnapshotV2DiffMaterializationError::InvalidOutput { .. })
+    ));
+
+    let (write_only_file, read_write) = TestFile::create_empty("write-only-output");
+    drop(read_write);
+    let mut write_only = OpenOptions::new()
+        .write(true)
+        .open(&write_only_file.path)
+        .expect("write-only staging should open");
+    assert!(matches!(
+        promote_snapshot_v2_diff_zero_root_file(root.file.open_read(), &mut write_only),
+        Err(SnapshotV2DiffMaterializationError::InvalidOutput { .. })
+    ));
+
+    let (append_file, read_write) = TestFile::create_empty("append-output");
+    drop(read_write);
+    let mut append = OpenOptions::new()
+        .read(true)
+        .append(true)
+        .open(&append_file.path)
+        .expect("append staging should open");
+    assert!(matches!(
+        promote_snapshot_v2_diff_zero_root_file(root.file.open_read(), &mut append),
+        Err(SnapshotV2DiffMaterializationError::InvalidOutput { .. })
+    ));
+
+    let mut special_output = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/null")
+        .expect("null device should open read-write");
+    assert!(matches!(
+        promote_snapshot_v2_diff_zero_root_file(root.file.open_read(), &mut special_output),
+        Err(SnapshotV2DiffMaterializationError::InvalidOutput { .. })
+    ));
+
+    let complete = write_complete(&memory, "mutable-complete-base");
+    let next = write_layer(
+        &memory,
+        SnapshotV2DiffBase::Image(complete.binding.clone()),
+        &[],
+        "mutable-complete-next",
+    );
+    let (_complete_output, mut staging) = TestFile::create_empty("mutable-complete-output");
+    assert!(matches!(
+        apply_snapshot_v2_diff_layer_file(
+            SnapshotV2DiffMaterializationBaseFile::Complete(complete.file.open_read_write()),
+            next.file.open_read(),
+            &mut staging,
+        ),
+        Err(SnapshotV2DiffMaterializationError::Source {
+            source: SnapshotV2MemoryLoadError::DescriptorNotReadOnly,
+            ..
+        })
+    ));
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AllocationFailure {
+    LayerMetadata,
+    Routes,
+    CopyBuffer,
+}
+
+struct MetadataReserveObservation {
+    called: bool,
+}
+
+impl MaterializationPolicy for MetadataReserveObservation {
+    fn checkpoint(
+        &mut self,
+        _stage: SnapshotV2DiffMaterializationStage,
+    ) -> Result<(), SnapshotV2DiffMaterializationError> {
+        Ok(())
+    }
+
+    fn reserve_layer_metadata(
+        &mut self,
+        metadata: &mut Vec<u8>,
+        count: usize,
+    ) -> Result<(), TryReserveError> {
+        self.called = true;
+        metadata.try_reserve_exact(count)
+    }
+}
+
+#[test]
+fn hostile_fixed_prefix_rejects_oversized_metadata_before_allocation() {
+    let range = page_range(0, 4);
+    let memory = memory_with_bytes(&[(range, 0x18)]);
+    let root = write_layer(
+        &memory,
+        SnapshotV2DiffBase::Zero,
+        &[range],
+        "oversized-prefix-root",
+    );
+    root.file
+        .open_read_write()
+        .write_at(&u32::MAX.to_le_bytes(), 32)
+        .expect("result-binding length should mutate");
+    let (output, mut staging) = TestFile::create_empty("oversized-prefix-output");
+    let mut policy = MetadataReserveObservation { called: false };
+    let error = promote_with_policy(root.file.open_read(), &mut staging, &mut policy)
+        .expect_err("oversized fixed prefix should reject");
+    assert!(matches!(
+        error,
+        SnapshotV2DiffMaterializationError::Layer {
+            source: SnapshotV2DiffLayerBindingError::MetadataTooLarge,
+            ..
+        }
+    ));
+    assert!(!policy.called);
+    assert_eq!(output.length(), 0);
+}
+
+struct AllocationFailurePolicy {
+    target: AllocationFailure,
+}
+
+impl MaterializationPolicy for AllocationFailurePolicy {
+    fn checkpoint(
+        &mut self,
+        _stage: SnapshotV2DiffMaterializationStage,
+    ) -> Result<(), SnapshotV2DiffMaterializationError> {
+        Ok(())
+    }
+
+    fn reserve_layer_metadata(
+        &mut self,
+        metadata: &mut Vec<u8>,
+        count: usize,
+    ) -> Result<(), TryReserveError> {
+        if self.target == AllocationFailure::LayerMetadata {
+            metadata.try_reserve_exact(usize::MAX)
+        } else {
+            metadata.try_reserve_exact(count)
+        }
+    }
+
+    fn reserve_routes(
+        &mut self,
+        routes: &mut Vec<Route>,
+        count: usize,
+    ) -> Result<(), TryReserveError> {
+        if self.target == AllocationFailure::Routes {
+            routes.try_reserve_exact(usize::MAX)
+        } else {
+            routes.try_reserve_exact(count)
+        }
+    }
+
+    fn reserve_copy_buffer(
+        &mut self,
+        buffer: &mut Vec<u8>,
+        count: usize,
+    ) -> Result<(), TryReserveError> {
+        if self.target == AllocationFailure::CopyBuffer {
+            buffer.try_reserve_exact(usize::MAX)
+        } else {
+            buffer.try_reserve_exact(count)
+        }
+    }
+}
+
+#[test]
+fn bounded_allocation_failures_happen_before_the_first_output_byte() {
+    let range = page_range(0, 4);
+    let memory = memory_with_bytes(&[(range, 0x8c)]);
+    let root = write_layer(
+        &memory,
+        SnapshotV2DiffBase::Zero,
+        &[range],
+        "allocation-root",
+    );
+    for target in [
+        AllocationFailure::LayerMetadata,
+        AllocationFailure::Routes,
+        AllocationFailure::CopyBuffer,
+    ] {
+        let (output, mut staging) = TestFile::create_empty("allocation-output");
+        let error = promote_with_policy(
+            root.file.open_read(),
+            &mut staging,
+            &mut AllocationFailurePolicy { target },
+        )
+        .expect_err("injected allocation should fail");
+        assert!(matches!(
+            error,
+            SnapshotV2DiffMaterializationError::MetadataAllocation { .. }
+        ));
+        assert_eq!(output.length(), 0);
+    }
+}
+
+struct ShortIoPolicy {
+    interrupted_read: bool,
+    interrupted_write: bool,
+}
+
+impl MaterializationPolicy for ShortIoPolicy {
+    fn checkpoint(
+        &mut self,
+        _stage: SnapshotV2DiffMaterializationStage,
+    ) -> Result<(), SnapshotV2DiffMaterializationError> {
+        Ok(())
+    }
+
+    fn read_at(&mut self, file: &File, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
+        if !self.interrupted_read {
+            self.interrupted_read = true;
+            return Err(io::Error::from(io::ErrorKind::Interrupted));
+        }
+        let length = buffer.len().min(17);
+        file.read_at(
+            buffer
+                .get_mut(..length)
+                .expect("short read slice should fit"),
+            offset,
+        )
+    }
+
+    fn write_at(&mut self, file: &File, buffer: &[u8], offset: u64) -> io::Result<usize> {
+        if !self.interrupted_write {
+            self.interrupted_write = true;
+            return Err(io::Error::from(io::ErrorKind::Interrupted));
+        }
+        let length = buffer.len().min(19);
+        file.write_at(
+            buffer.get(..length).expect("short write slice should fit"),
+            offset,
+        )
+    }
+}
+
+#[test]
+fn interrupted_and_short_positional_io_retries_to_the_exact_result() {
+    let range = page_range(0, 4);
+    let memory = memory_with_bytes(&[(range, 0xd2)]);
+    let root = write_layer(&memory, SnapshotV2DiffBase::Zero, &[range], "short-io-root");
+    let (_output, mut staging) = TestFile::create_empty("short-io-output");
+    let mut policy = ShortIoPolicy {
+        interrupted_read: false,
+        interrupted_write: false,
+    };
+    let result = promote_with_policy(root.file.open_read(), &mut staging, &mut policy)
+        .expect("short interrupted I/O should retry");
+    assert!(policy.interrupted_read);
+    assert!(policy.interrupted_write);
+    assert_complete_matches(&memory, &result, &staging);
+}
+
+struct ZeroProgressPolicy {
+    streaming: bool,
+    fail_read: bool,
+}
+
+impl MaterializationPolicy for ZeroProgressPolicy {
+    fn checkpoint(
+        &mut self,
+        stage: SnapshotV2DiffMaterializationStage,
+    ) -> Result<(), SnapshotV2DiffMaterializationError> {
+        if stage == SnapshotV2DiffMaterializationStage::DataStreaming {
+            self.streaming = true;
+        }
+        Ok(())
+    }
+
+    fn read_at(&mut self, file: &File, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
+        if self.streaming && self.fail_read {
+            Ok(0)
+        } else {
+            file.read_at(buffer, offset)
+        }
+    }
+
+    fn write_at(&mut self, file: &File, buffer: &[u8], offset: u64) -> io::Result<usize> {
+        if self.streaming && !self.fail_read {
+            Ok(0)
+        } else {
+            file.write_at(buffer, offset)
+        }
+    }
+}
+
+#[test]
+fn zero_progress_reads_and_writes_fail_with_stable_redacted_io_classes() {
+    let range = page_range(0, 4);
+    let memory = memory_with_bytes(&[(range, 0xe4)]);
+    let root = write_layer(
+        &memory,
+        SnapshotV2DiffBase::Zero,
+        &[range],
+        "zero-progress-root",
+    );
+    for (fail_read, expected) in [
+        (true, io::ErrorKind::UnexpectedEof),
+        (false, io::ErrorKind::WriteZero),
+    ] {
+        let (_output, mut staging) = TestFile::create_empty("zero-progress-output");
+        let error = promote_with_policy(
+            root.file.open_read(),
+            &mut staging,
+            &mut ZeroProgressPolicy {
+                streaming: false,
+                fail_read,
+            },
+        )
+        .expect_err("zero-progress I/O should fail");
+        assert!(matches!(
+            error,
+            SnapshotV2DiffMaterializationError::Io {
+                stage: SnapshotV2DiffMaterializationStage::DataStreaming,
+                kind,
+            } if kind == expected
+        ));
+    }
+}
+
+struct FailingStreamingIoPolicy {
+    streaming: bool,
+    fail_read: bool,
+    operation_count: usize,
+}
+
+impl MaterializationPolicy for FailingStreamingIoPolicy {
+    fn checkpoint(
+        &mut self,
+        stage: SnapshotV2DiffMaterializationStage,
+    ) -> Result<(), SnapshotV2DiffMaterializationError> {
+        if stage == SnapshotV2DiffMaterializationStage::DataStreaming {
+            self.streaming = true;
+        }
+        Ok(())
+    }
+
+    fn read_at(&mut self, file: &File, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
+        if self.streaming && self.fail_read {
+            self.operation_count += 1;
+            if self.operation_count == 2 {
+                return Err(io::Error::from(io::ErrorKind::PermissionDenied));
+            }
+            let length = buffer.len().min(23);
+            return file.read_at(
+                buffer
+                    .get_mut(..length)
+                    .expect("partial failing read should fit"),
+                offset,
+            );
+        }
+        file.read_at(buffer, offset)
+    }
+
+    fn write_at(&mut self, file: &File, buffer: &[u8], offset: u64) -> io::Result<usize> {
+        if self.streaming && !self.fail_read {
+            self.operation_count += 1;
+            if self.operation_count == 2 {
+                return Err(io::Error::from(io::ErrorKind::PermissionDenied));
+            }
+            let length = buffer.len().min(29);
+            return file.write_at(
+                buffer
+                    .get(..length)
+                    .expect("partial failing write should fit"),
+                offset,
+            );
+        }
+        file.write_at(buffer, offset)
+    }
+}
+
+#[test]
+fn positional_errors_after_partial_streaming_leave_only_caller_staging_changed() {
+    let range = page_range(0, 4);
+    let memory = memory_with_bytes(&[(range, 0x6a)]);
+    let root = write_layer(
+        &memory,
+        SnapshotV2DiffBase::Zero,
+        &[range],
+        "failing-io-root",
+    );
+    let source_before = root.file.bytes();
+    for fail_read in [true, false] {
+        let (output, mut staging) = TestFile::create_empty("failing-io-output");
+        let error = promote_with_policy(
+            root.file.open_read(),
+            &mut staging,
+            &mut FailingStreamingIoPolicy {
+                streaming: false,
+                fail_read,
+                operation_count: 0,
+            },
+        )
+        .expect_err("injected positional failure should reject");
+        assert!(matches!(
+            error,
+            SnapshotV2DiffMaterializationError::Io {
+                stage: SnapshotV2DiffMaterializationStage::DataStreaming,
+                kind: io::ErrorKind::PermissionDenied,
+            }
+        ));
+        assert_eq!(output.length(), root.binding.result().file_length());
+        assert_eq!(source_before, root.file.bytes());
+    }
+}
+
+struct TruncatingReadPolicy {
+    streaming: bool,
+    truncated: bool,
+    writer: File,
+}
+
+impl MaterializationPolicy for TruncatingReadPolicy {
+    fn checkpoint(
+        &mut self,
+        stage: SnapshotV2DiffMaterializationStage,
+    ) -> Result<(), SnapshotV2DiffMaterializationError> {
+        if stage == SnapshotV2DiffMaterializationStage::DataStreaming {
+            self.streaming = true;
+        }
+        Ok(())
+    }
+
+    fn read_at(&mut self, file: &File, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
+        if self.streaming && !self.truncated {
+            self.writer.set_len(offset)?;
+            self.truncated = true;
+        }
+        file.read_at(buffer, offset)
+    }
+}
+
+#[test]
+fn truncation_during_copy_fails_at_the_bounded_read() {
+    let range = page_range(0, 4);
+    let memory = memory_with_bytes(&[(range, 0x44)]);
+    let root = write_layer(
+        &memory,
+        SnapshotV2DiffBase::Zero,
+        &[range],
+        "truncate-copy-root",
+    );
+    let (_output, mut staging) = TestFile::create_empty("truncate-copy-output");
+    let error = promote_with_policy(
+        root.file.open_read(),
+        &mut staging,
+        &mut TruncatingReadPolicy {
+            streaming: false,
+            truncated: false,
+            writer: root.file.open_read_write(),
+        },
+    )
+    .expect_err("source truncation should stop copy");
+    assert!(matches!(
+        error,
+        SnapshotV2DiffMaterializationError::Io {
+            stage: SnapshotV2DiffMaterializationStage::DataStreaming,
+            kind: io::ErrorKind::UnexpectedEof,
+        }
+    ));
+}
+
+struct MutationPolicy {
+    role: SourceRole,
+    target: SourceObservation,
+    writer: File,
+    changed: bool,
+}
+
+impl MaterializationPolicy for MutationPolicy {
+    fn checkpoint(
+        &mut self,
+        _stage: SnapshotV2DiffMaterializationStage,
+    ) -> Result<(), SnapshotV2DiffMaterializationError> {
+        Ok(())
+    }
+
+    fn source_hook(&mut self, role: SourceRole, observation: SourceObservation, _file: &File) {
+        if role == self.role && observation == self.target && !self.changed {
+            self.writer
+                .write_at(&[0x5a], NATIVE_V2_MEMORY_ALIGNMENT)
+                .expect("test source mutation should write");
+            self.changed = true;
+        }
+    }
+}
+
+#[test]
+fn source_fact_changes_at_every_observation_fail_without_committing_authority() {
+    let range = page_range(0, 4);
+    let memory = memory_with_bytes(&[(range, 0x93)]);
+    for target in [
+        SourceObservation::DuringValidation,
+        SourceObservation::BeforeOutput,
+        SourceObservation::AfterStreaming,
+        SourceObservation::Final,
+    ] {
+        let root = write_layer(&memory, SnapshotV2DiffBase::Zero, &[range], "mutation-root");
+        let (output, mut staging) = TestFile::create_empty("mutation-output");
+        let error = promote_with_policy(
+            root.file.open_read(),
+            &mut staging,
+            &mut MutationPolicy {
+                role: SourceRole::ZeroRoot,
+                target,
+                writer: root.file.open_read_write(),
+                changed: false,
+            },
+        )
+        .expect_err("source mutation should fail closed");
+        let expected_stage = if target == SourceObservation::DuringValidation {
+            SnapshotV2DiffMaterializationStage::SourceValidation
+        } else {
+            SnapshotV2DiffMaterializationStage::SourceStability
+        };
+        assert_eq!(error.stage(), expected_stage);
+        if matches!(
+            target,
+            SourceObservation::DuringValidation | SourceObservation::BeforeOutput
+        ) {
+            assert_eq!(output.length(), 0);
+        }
+    }
+}
+
+#[test]
+fn complete_base_changes_after_inherited_copy_fail_the_source_recheck() {
+    let range = page_range(0, 4);
+    let memory = memory_with_bytes(&[(range, 0x81)]);
+    let complete = write_complete(&memory, "mutation-complete");
+    let next = write_layer(
+        &memory,
+        SnapshotV2DiffBase::Image(complete.binding.clone()),
+        &[],
+        "mutation-complete-next",
+    );
+    let (output, mut staging) = TestFile::create_empty("mutation-complete-output");
+    let error = apply_with_policy(
+        SnapshotV2DiffMaterializationBaseFile::Complete(complete.file.open_read()),
+        next.file.open_read(),
+        &mut staging,
+        &mut MutationPolicy {
+            role: SourceRole::CompleteBase,
+            target: SourceObservation::AfterStreaming,
+            writer: complete.file.open_read_write(),
+            changed: false,
+        },
+    )
+    .expect_err("a changed complete predecessor should fail closed");
+    assert!(matches!(
+        error,
+        SnapshotV2DiffMaterializationError::Source {
+            stage: SnapshotV2DiffMaterializationStage::SourceStability,
+            source: SnapshotV2MemoryLoadError::SourceChanged,
+        }
+    ));
+    assert_eq!(output.length(), next.binding.result().file_length());
+}
+
+struct VerificationFailurePolicy;
+
+impl MaterializationPolicy for VerificationFailurePolicy {
+    fn checkpoint(
+        &mut self,
+        _stage: SnapshotV2DiffMaterializationStage,
+    ) -> Result<(), SnapshotV2DiffMaterializationError> {
+        Ok(())
+    }
+
+    fn result_verification_hook(&mut self, file: &mut File) {
+        file.write_at(&[0], 0)
+            .expect("test result header should corrupt");
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OutputFailure {
+    HeaderWrite,
+    SetLength,
+    FinalSeek,
+}
+
+struct OutputFailurePolicy {
+    target: OutputFailure,
+    stage: SnapshotV2DiffMaterializationStage,
+}
+
+impl MaterializationPolicy for OutputFailurePolicy {
+    fn checkpoint(
+        &mut self,
+        stage: SnapshotV2DiffMaterializationStage,
+    ) -> Result<(), SnapshotV2DiffMaterializationError> {
+        self.stage = stage;
+        Ok(())
+    }
+
+    fn write_at(&mut self, file: &File, buffer: &[u8], offset: u64) -> io::Result<usize> {
+        if self.target == OutputFailure::HeaderWrite
+            && self.stage == SnapshotV2DiffMaterializationStage::OutputHeader
+        {
+            Err(io::Error::from(io::ErrorKind::PermissionDenied))
+        } else {
+            file.write_at(buffer, offset)
+        }
+    }
+
+    fn set_len(&mut self, file: &File, length: u64) -> io::Result<()> {
+        if self.target == OutputFailure::SetLength {
+            Err(io::Error::from(io::ErrorKind::PermissionDenied))
+        } else {
+            file.set_len(length)
+        }
+    }
+
+    fn seek_output(&mut self, file: &mut File, position: u64) -> io::Result<u64> {
+        if self.target == OutputFailure::FinalSeek {
+            Err(io::Error::from(io::ErrorKind::PermissionDenied))
+        } else {
+            file.seek(SeekFrom::Start(position))
+        }
+    }
+}
+
+#[test]
+fn output_operation_failures_are_staged_and_leave_sources_immutable() {
+    let range = page_range(0, 4);
+    let memory = memory_with_bytes(&[(range, 0x72)]);
+    let root = write_layer(
+        &memory,
+        SnapshotV2DiffBase::Zero,
+        &[range],
+        "output-failure-root",
+    );
+    let source_before = root.file.bytes();
+    for (target, expected_stage) in [
+        (
+            OutputFailure::HeaderWrite,
+            SnapshotV2DiffMaterializationStage::OutputHeader,
+        ),
+        (
+            OutputFailure::SetLength,
+            SnapshotV2DiffMaterializationStage::OutputPadding,
+        ),
+        (
+            OutputFailure::FinalSeek,
+            SnapshotV2DiffMaterializationStage::ResultVerification,
+        ),
+    ] {
+        let (_output, mut staging) = TestFile::create_empty("output-failure-result");
+        let error = promote_with_policy(
+            root.file.open_read(),
+            &mut staging,
+            &mut OutputFailurePolicy {
+                target,
+                stage: SnapshotV2DiffMaterializationStage::SourceValidation,
+            },
+        )
+        .expect_err("injected output operation should fail");
+        assert!(matches!(
+            error,
+            SnapshotV2DiffMaterializationError::Io {
+                stage,
+                kind: io::ErrorKind::PermissionDenied,
+            } if stage == expected_stage
+        ));
+        assert_eq!(source_before, root.file.bytes());
+    }
+}
+
+#[test]
+fn detached_result_verification_failure_is_staged_after_streaming() {
+    let range = page_range(0, 4);
+    let memory = memory_with_bytes(&[(range, 0xab)]);
+    let root = write_layer(
+        &memory,
+        SnapshotV2DiffBase::Zero,
+        &[range],
+        "verification-root",
+    );
+    let source_before = root.file.bytes();
+    let (output, mut staging) = TestFile::create_empty("verification-output");
+    let error = promote_with_policy(
+        root.file.open_read(),
+        &mut staging,
+        &mut VerificationFailurePolicy,
+    )
+    .expect_err("corrupt result should fail verification");
+    assert!(matches!(
+        error,
+        SnapshotV2DiffMaterializationError::ResultVerification {
+            stage: SnapshotV2DiffMaterializationStage::ResultVerification,
+            ..
+        }
+    ));
+    assert_eq!(output.length(), root.binding.result().file_length());
+    assert_eq!(source_before, root.file.bytes());
+}
+
+#[test]
+fn cancellation_at_every_observed_checkpoint_preserves_sources_and_allows_retry() {
+    let range = page_range(0, 512);
+    let memory = memory_with_bytes(&[(range, 0xc3)]);
+    let root = write_layer(&memory, SnapshotV2DiffBase::Zero, &[range], "cancel-root");
+    let source_before = root.file.bytes();
+    let observed = Rc::new(RefCell::new(Vec::new()));
+    let captured = Rc::clone(&observed);
+    let (_success_file, mut success) = TestFile::create_empty("cancel-observe");
+    promote_snapshot_v2_diff_zero_root_file_with_cancel(
+        root.file.open_read(),
+        &mut success,
+        move |stage| {
+            captured.borrow_mut().push(stage);
+            false
+        },
+    )
+    .expect("checkpoint observation run should succeed");
+    let checkpoints = observed.borrow().clone();
+    assert!(checkpoints.len() > 8);
+    assert!(
+        checkpoints
+            .iter()
+            .filter(|stage| **stage == SnapshotV2DiffMaterializationStage::DataStreaming)
+            .count()
+            > 1
+    );
+
+    for (cancellation_index, expected_stage) in checkpoints.iter().copied().enumerate() {
+        let (_output, mut staging) = TestFile::create_empty("cancel-output");
+        let mut index = 0_usize;
+        let error = promote_snapshot_v2_diff_zero_root_file_with_cancel(
+            root.file.open_read(),
+            &mut staging,
+            |_| {
+                let cancelled = index == cancellation_index;
+                index += 1;
+                cancelled
+            },
+        )
+        .expect_err("selected checkpoint should cancel");
+        assert!(matches!(
+            error,
+            SnapshotV2DiffMaterializationError::Cancelled { stage }
+                if stage == expected_stage
+        ));
+        assert_eq!(source_before, root.file.bytes());
+    }
+
+    let (_retry_file, mut retry) = TestFile::create_empty("cancel-retry");
+    let result = promote_snapshot_v2_diff_zero_root_file(root.file.open_read(), &mut retry)
+        .expect("fresh retry should succeed");
+    assert_complete_matches(&memory, &result, &retry);
+}
+
+#[test]
+fn source_positions_and_error_diagnostics_do_not_disclose_private_values() {
+    let range = page_range(0, 4);
+    let memory = memory_with_bytes(&[(range, 0x7e)]);
+    let root = write_layer(
+        &memory,
+        SnapshotV2DiffBase::Zero,
+        &[range],
+        "redacted-private-marker",
+    );
+    let mut source = root.file.open_read();
+    source
+        .seek(SeekFrom::Start(13))
+        .expect("source position should set");
+    let mut position_probe = source
+        .try_clone()
+        .expect("source position probe should clone");
+    let (_output, mut staging) = TestFile::create_empty("position-result");
+    promote_snapshot_v2_diff_zero_root_file(source, &mut staging)
+        .expect("nonzero source position should remain irrelevant");
+    assert_eq!(
+        position_probe
+            .stream_position()
+            .expect("source position should query"),
+        13
+    );
+
+    let (_bad_output, mut bad) = TestFile::create_empty("redaction-output");
+    bad.write_all(&[1])
+        .expect("bad output should become nonempty");
+    bad.seek(SeekFrom::Start(0))
+        .expect("bad output should rewind");
+    let error = promote_snapshot_v2_diff_zero_root_file(root.file.open_read(), &mut bad)
+        .expect_err("bad output should reject");
+    let debug = format!("{error:?}");
+    let display = error.to_string();
+    assert!(debug.contains("<redacted>"));
+    for private in [
+        root.file.path.to_string_lossy().as_ref(),
+        "redacted-private-marker",
+        "2147483648",
+        "65536",
+        "0x7e",
+    ] {
+        assert!(!debug.contains(private));
+        assert!(!display.contains(private));
+    }
+}
+
+#[test]
+fn checked_route_overflow_is_rejected_without_panicking() {
+    let stage = SnapshotV2DiffMaterializationStage::LineagePlanning;
+    assert!(matches!(
+        checked_length(u64::MAX, 0, stage),
+        Err(SnapshotV2DiffMaterializationError::InvalidRoute { .. })
+    ));
+
+    let mut routes = vec![Route {
+        source: RouteSource::CompleteBase,
+        source_offset: 0,
+        target_offset: 0,
+        length: 1,
+    }];
+    assert!(matches!(
+        append_route(&mut routes, 1, RouteSource::NextLayer, 0, 2, 1, stage),
+        Err(SnapshotV2DiffMaterializationError::InvalidRoute { .. })
+    ));
+}

--- a/crates/runtime/src/snapshot_memory_v2.rs
+++ b/crates/runtime/src/snapshot_memory_v2.rs
@@ -162,7 +162,7 @@ impl SnapshotV2MemoryBinding {
         encode_binding(self)
     }
 
-    fn image_header(
+    pub(crate) fn image_header(
         &self,
     ) -> Result<[u8; NATIVE_V2_MEMORY_HEADER_BYTES], SnapshotV2MemoryBindingError> {
         let encoded = self.encode()?;
@@ -849,7 +849,7 @@ fn load_snapshot_v2_memory_binding_from_file(
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SnapshotV2MemoryLoadStage {
+pub(crate) enum SnapshotV2MemoryLoadStage {
     Preflight,
     Metadata,
     Mapping,
@@ -885,13 +885,13 @@ fn load_snapshot_v2_memory_binding_from_file_with_hook(
     Ok(memory)
 }
 
-struct ValidatedSnapshotV2MemorySource {
+pub(crate) struct ValidatedSnapshotV2MemorySource {
     file: Arc<File>,
     facts: FileFacts,
 }
 
 impl ValidatedSnapshotV2MemorySource {
-    fn new_with_hook(
+    pub(crate) fn new_with_hook(
         binding: &SnapshotV2MemoryBinding,
         file: File,
         mut hook: impl FnMut(SnapshotV2MemoryLoadStage, &File),
@@ -915,11 +915,15 @@ impl ValidatedSnapshotV2MemorySource {
         })
     }
 
-    fn file(&self) -> &Arc<File> {
+    pub(crate) fn file(&self) -> &Arc<File> {
         &self.file
     }
 
-    fn verify_unchanged(&self) -> Result<(), SnapshotV2MemoryLoadError> {
+    pub(crate) const fn facts(&self) -> FileFacts {
+        self.facts
+    }
+
+    pub(crate) fn verify_unchanged(&self) -> Result<(), SnapshotV2MemoryLoadError> {
         if inspect_file(self.file.as_ref())? == self.facts {
             Ok(())
         } else {
@@ -934,7 +938,6 @@ impl ValidatedSnapshotV2MemorySource {
 /// loader. This verifier therefore checks the exact output position, length,
 /// regular-file identity, header, zero padding, and source stability without
 /// applying the final loader's read-only policy.
-#[cfg(any(target_os = "macos", test))]
 pub(crate) fn verify_snapshot_v2_memory_image_output(
     binding: &SnapshotV2MemoryBinding,
     file: &mut File,
@@ -999,7 +1002,7 @@ fn verify_memory_metadata(
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct FileFacts {
+pub(crate) struct FileFacts {
     device: u64,
     inode: u64,
     mode: u32,
@@ -1012,7 +1015,33 @@ struct FileFacts {
     descriptor_flags: i32,
 }
 
-fn inspect_file(file: &File) -> Result<FileFacts, SnapshotV2MemoryLoadError> {
+impl FileFacts {
+    pub(crate) const fn length(self) -> u64 {
+        self.length
+    }
+
+    pub(crate) const fn is_read_write(self) -> bool {
+        self.status_flags & libc::O_ACCMODE == libc::O_RDWR
+    }
+
+    pub(crate) const fn is_append(self) -> bool {
+        self.status_flags & libc::O_APPEND != 0
+    }
+
+    pub(crate) const fn is_close_on_exec(self) -> bool {
+        self.descriptor_flags & libc::FD_CLOEXEC != 0
+    }
+
+    pub(crate) const fn is_regular(self) -> bool {
+        self.mode & libc::S_IFMT as u32 == libc::S_IFREG as u32
+    }
+
+    pub(crate) const fn same_object(self, other: Self) -> bool {
+        self.device == other.device && self.inode == other.inode
+    }
+}
+
+pub(crate) fn inspect_file(file: &File) -> Result<FileFacts, SnapshotV2MemoryLoadError> {
     let facts = inspect_file_facts(file)?;
     if facts.status_flags & libc::O_ACCMODE != libc::O_RDONLY {
         return Err(SnapshotV2MemoryLoadError::DescriptorNotReadOnly);
@@ -1024,7 +1053,7 @@ fn inspect_file(file: &File) -> Result<FileFacts, SnapshotV2MemoryLoadError> {
     Ok(facts)
 }
 
-fn inspect_file_facts(file: &File) -> Result<FileFacts, SnapshotV2MemoryLoadError> {
+pub(crate) fn inspect_file_facts(file: &File) -> Result<FileFacts, SnapshotV2MemoryLoadError> {
     // SAFETY: `file` owns a live descriptor and these commands have no pointer
     // arguments.
     let status_flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFL) };


### PR DESCRIPTION
Closes #1753.

## Summary

- add descriptor-only promotion of exact-2.13 zero-root Diff layers into canonical complete `BANGM2A` images
- add one-layer application over complete or proven zero-root bases, with fallible GPA route precomputation for explicit, inherited, and proven-zero bytes
- enforce immutable read-only/CLOEXEC sources, distinct empty read-write staging, source fact rechecks, bounded positional I/O, cooperative cancellation, and detached result verification
- share low-level complete-image descriptor facts and add fixed-prefix Diff metadata preflight before the one-MiB allocation boundary
- cover repeated chains, dynamic add/remove and offset movement, lineage gaps, hostile descriptors/metadata/I/O/allocation/races, cancellation, and redacted diagnostics

## Scope exclusions

- no path opening, fsync, rename/exchange, cleanup, or publication; #1754 owns failure-atomic base-path replacement
- no live dirty-epoch transition, state merge, public exact-2.13 activation, API route, CLI, docs, or inventory change

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five required Apple-target Clippy commands from `AGENTS.md`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
