### PR TITLE
feat: publish snapshot rebases failure-atomically

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -50,6 +50,7 @@ pub mod snapshot_memory_hotplug_v2_10;
 pub mod snapshot_memory_v2;
 pub mod snapshot_network_restore_v2_11;
 pub mod snapshot_network_v2_11;
+pub mod snapshot_rebase;
 pub mod snapshot_restore;
 pub mod snapshot_serial_v2_7;
 pub mod snapshot_vsock_restore_v2_12;

--- a/crates/runtime/src/snapshot_memory_v2.rs
+++ b/crates/runtime/src/snapshot_memory_v2.rs
@@ -1036,6 +1036,11 @@ impl FileFacts {
         self.mode & libc::S_IFMT as u32 == libc::S_IFREG as u32
     }
 
+    #[cfg(target_os = "macos")]
+    pub(crate) const fn permissions(self) -> u32 {
+        self.mode & 0o7777
+    }
+
     pub(crate) const fn same_object(self, other: Self) -> bool {
         self.device == other.device && self.inode == other.inode
     }

--- a/crates/runtime/src/snapshot_memory_v2.rs
+++ b/crates/runtime/src/snapshot_memory_v2.rs
@@ -1039,6 +1039,11 @@ impl FileFacts {
     pub(crate) const fn same_object(self, other: Self) -> bool {
         self.device == other.device && self.inode == other.inode
     }
+
+    #[cfg(target_os = "macos")]
+    pub(crate) const fn same_identity(self, device: u64, inode: u64) -> bool {
+        self.device == device && self.inode == inode
+    }
 }
 
 pub(crate) fn inspect_file(file: &File) -> Result<FileFacts, SnapshotV2MemoryLoadError> {

--- a/crates/runtime/src/snapshot_rebase.rs
+++ b/crates/runtime/src/snapshot_rebase.rs
@@ -1,0 +1,503 @@
+//! Failure-atomic path transaction for dormant native-v2 Diff rebases.
+//!
+//! Mutation is anchored to retained directory descriptors and every stable
+//! identity is rechecked before the atomic exchange. Darwin does not expose an
+//! identity-conditioned rename or unlink, so callers must retain trusted
+//! authority over the base directory during the transaction. These checks
+//! narrow the residual race; they do not make an uncooperative writer with the
+//! same directory authority safe. Callers must likewise prevent concurrent
+//! mutation of the already-open source inodes; repeated fact checks are
+//! detection boundaries, not filesystem seals.
+//!
+//! Ordinary errors and panic unwinding clean only an identity-matching private
+//! staging entry. Abrupt process termination such as `SIGKILL` can leave a
+//! random staging or displaced-base entry because this dormant transaction has
+//! no selected persistent supervisor or recovery ledger.
+
+use std::fmt;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::snapshot_diff_v2_13::SnapshotV2DiffMaterializationError;
+use crate::snapshot_memory_v2::{SnapshotV2MemoryBinding, SnapshotV2MemoryLoadError};
+
+const REDACTED: &str = "<redacted>";
+
+/// The two Firecracker-shaped memory paths used by one Diff rebase.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SnapshotV2DiffRebasePaths {
+    base: PathBuf,
+    diff: PathBuf,
+}
+
+impl SnapshotV2DiffRebasePaths {
+    /// Creates one base/diff path pair.
+    pub fn new(base: impl Into<PathBuf>, diff: impl Into<PathBuf>) -> Self {
+        Self {
+            base: base.into(),
+            diff: diff.into(),
+        }
+    }
+
+    /// Returns the base path to a trusted caller.
+    pub fn base(&self) -> &Path {
+        &self.base
+    }
+
+    /// Returns the differential-layer path to a trusted caller.
+    pub fn diff(&self) -> &Path {
+        &self.diff
+    }
+}
+
+impl fmt::Debug for SnapshotV2DiffRebasePaths {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2DiffRebasePaths")
+            .field("base", &REDACTED)
+            .field("diff", &REDACTED)
+            .finish()
+    }
+}
+
+/// Stable role of one path in a Diff rebase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2DiffRebaseInput {
+    /// Complete-image or proven zero-root base replaced on commit.
+    Base,
+    /// Immutable next layer that is never mutated.
+    Diff,
+}
+
+impl fmt::Display for SnapshotV2DiffRebaseInput {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Base => "base",
+            Self::Diff => "diff",
+        })
+    }
+}
+
+/// Stable, value-redacted checkpoint in the rebase transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2DiffRebaseStage {
+    /// Reject unsupported compile targets before inspecting either path.
+    PlatformCheck,
+    /// Validate the base path syntax.
+    BasePathValidation,
+    /// Open and retain the base parent directory.
+    BaseDirectoryOpen,
+    /// Open the base final component without following it.
+    BaseFileOpen,
+    /// Validate and classify the immutable base descriptor.
+    BaseValidation,
+    /// Validate the diff path syntax.
+    DiffPathValidation,
+    /// Open and retain the diff parent directory.
+    DiffDirectoryOpen,
+    /// Open the diff final component without following it.
+    DiffFileOpen,
+    /// Validate the immutable diff descriptor.
+    DiffValidation,
+    /// Reject base/diff object aliases.
+    SourceAliasCheck,
+    /// Duplicate immutable descriptors for the consuming materializer.
+    SourceDuplication,
+    /// Create and validate private result staging.
+    StagingCreate,
+    /// Materialize and verify the complete result.
+    Materialization,
+    /// Synchronize and reverify the staged result.
+    ResultFileSync,
+    /// Recheck immutable source facts.
+    SourceStability,
+    /// Recheck retained and path-resolved directory identities.
+    DirectoryStability,
+    /// Recheck source and staging component identities.
+    EntryStability,
+    /// Atomically exchange result staging with the base.
+    AtomicExchange,
+    /// Verify the identities observed after the commit point.
+    CommitVerification,
+    /// Remove the exact displaced old base.
+    DisplacedCleanup,
+    /// Synchronize the committed base directory.
+    BaseDirectorySync,
+    /// Finish without another fallible transition.
+    Complete,
+}
+
+impl fmt::Display for SnapshotV2DiffRebaseStage {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::PlatformCheck => "platform check",
+            Self::BasePathValidation => "base path validation",
+            Self::BaseDirectoryOpen => "base directory open",
+            Self::BaseFileOpen => "base file open",
+            Self::BaseValidation => "base validation",
+            Self::DiffPathValidation => "diff path validation",
+            Self::DiffDirectoryOpen => "diff directory open",
+            Self::DiffFileOpen => "diff file open",
+            Self::DiffValidation => "diff validation",
+            Self::SourceAliasCheck => "source alias check",
+            Self::SourceDuplication => "source duplication",
+            Self::StagingCreate => "staging creation",
+            Self::Materialization => "materialization",
+            Self::ResultFileSync => "result file synchronization",
+            Self::SourceStability => "source stability",
+            Self::DirectoryStability => "directory stability",
+            Self::EntryStability => "entry stability",
+            Self::AtomicExchange => "atomic exchange",
+            Self::CommitVerification => "committed identity verification",
+            Self::DisplacedCleanup => "displaced-base cleanup",
+            Self::BaseDirectorySync => "base directory synchronization",
+            Self::Complete => "completion",
+        })
+    }
+}
+
+/// Disposition of a private staging or displaced-base entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2DiffRebaseCleanup {
+    /// The exact owned entry was removed.
+    Removed,
+    /// The owned entry was already absent.
+    AlreadyAbsent,
+    /// A changed entry was deliberately retained.
+    ChangedRefused,
+    /// Inspection or removal failed.
+    Failed(io::ErrorKind),
+}
+
+/// Redacted reason for a failure before the exchange commit point.
+pub enum SnapshotV2DiffRebaseFailure {
+    /// The caller cancelled at a stable checkpoint.
+    Cancelled,
+    /// The compile target cannot provide the required atomic exchange.
+    UnsupportedPlatform,
+    /// One submitted path has no valid final component.
+    InvalidPath {
+        /// Path role, without its value.
+        input: SnapshotV2DiffRebaseInput,
+    },
+    /// One immutable source descriptor failed validation.
+    Source {
+        /// Source role, without its value.
+        input: SnapshotV2DiffRebaseInput,
+        /// Existing redacted descriptor-validation failure.
+        source: SnapshotV2MemoryLoadError,
+    },
+    /// The base magic is neither a complete image nor a Diff layer.
+    InvalidBaseKind,
+    /// Base and diff name the same filesystem object.
+    SourceAlias,
+    /// Private staging-name randomness is unavailable.
+    RandomnessUnavailable,
+    /// A retained source changed before commit.
+    SourceChanged {
+        /// Changed source role.
+        input: SnapshotV2DiffRebaseInput,
+    },
+    /// A parent path no longer resolves to its retained directory.
+    DirectoryChanged {
+        /// Changed input's directory role.
+        input: SnapshotV2DiffRebaseInput,
+    },
+    /// A final input component no longer names its retained object.
+    EntryChanged {
+        /// Changed input role.
+        input: SnapshotV2DiffRebaseInput,
+    },
+    /// The private staging component no longer names the result object.
+    StagingChanged,
+    /// The newly created staging descriptor failed validation.
+    StagingValidation {
+        /// Existing redacted descriptor-inspection failure.
+        source: SnapshotV2MemoryLoadError,
+    },
+    /// GPA-correct descriptor materialization failed.
+    Materialization {
+        /// Existing redacted materialization failure.
+        source: SnapshotV2DiffMaterializationError,
+    },
+    /// The synchronized staged complete image failed detached verification.
+    ResultVerification {
+        /// Existing redacted complete-image verification failure.
+        source: SnapshotV2MemoryLoadError,
+    },
+    /// The filesystem rejected the required atomic exchange.
+    AtomicExchangeUnavailable {
+        /// Stable OS error class.
+        kind: io::ErrorKind,
+    },
+    /// Another filesystem operation failed.
+    Io {
+        /// Stable OS error class.
+        kind: io::ErrorKind,
+    },
+}
+
+impl fmt::Debug for SnapshotV2DiffRebaseFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (kind, input) = match self {
+            Self::Cancelled => ("cancelled", None),
+            Self::UnsupportedPlatform => ("unsupported platform", None),
+            Self::InvalidPath { input } => ("invalid path", Some(*input)),
+            Self::Source { input, .. } => ("source", Some(*input)),
+            Self::InvalidBaseKind => ("base kind", Some(SnapshotV2DiffRebaseInput::Base)),
+            Self::SourceAlias => ("source alias", None),
+            Self::RandomnessUnavailable => ("randomness", None),
+            Self::SourceChanged { input } => ("source changed", Some(*input)),
+            Self::DirectoryChanged { input } => ("directory changed", Some(*input)),
+            Self::EntryChanged { input } => ("entry changed", Some(*input)),
+            Self::StagingChanged => ("staging changed", None),
+            Self::StagingValidation { .. } => ("staging validation", None),
+            Self::Materialization { .. } => ("materialization", None),
+            Self::ResultVerification { .. } => ("result verification", None),
+            Self::AtomicExchangeUnavailable { .. } => ("atomic exchange", None),
+            Self::Io { .. } => ("I/O", None),
+        };
+        formatter
+            .debug_struct("SnapshotV2DiffRebaseFailure")
+            .field("kind", &kind)
+            .field("input", &input)
+            .field("details", &REDACTED)
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotV2DiffRebaseFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cancelled => formatter.write_str("the caller cancelled the rebase"),
+            Self::UnsupportedPlatform => {
+                formatter.write_str("atomic snapshot rebase is supported only on macOS")
+            }
+            Self::InvalidPath { input } => write!(formatter, "the {input} path is invalid"),
+            Self::Source { input, .. } => {
+                write!(formatter, "the {input} source descriptor is invalid")
+            }
+            Self::InvalidBaseKind => formatter.write_str("the base artifact kind is invalid"),
+            Self::SourceAlias => formatter.write_str("the base and diff sources alias"),
+            Self::RandomnessUnavailable => {
+                formatter.write_str("private staging-name randomness is unavailable")
+            }
+            Self::SourceChanged { input } => {
+                write!(formatter, "the {input} source changed")
+            }
+            Self::DirectoryChanged { input } => {
+                write!(formatter, "the {input} directory changed")
+            }
+            Self::EntryChanged { input } => {
+                write!(formatter, "the {input} entry changed")
+            }
+            Self::StagingChanged => formatter.write_str("the private staging entry changed"),
+            Self::StagingValidation { .. } => {
+                formatter.write_str("the private staging descriptor is invalid")
+            }
+            Self::Materialization { .. } => {
+                formatter.write_str("differential materialization failed")
+            }
+            Self::ResultVerification { .. } => {
+                formatter.write_str("the synchronized result failed verification")
+            }
+            Self::AtomicExchangeUnavailable { kind } => {
+                write!(formatter, "atomic exchange failed with {kind:?}")
+            }
+            Self::Io { kind } => write!(formatter, "filesystem operation failed with {kind:?}"),
+        }
+    }
+}
+
+impl std::error::Error for SnapshotV2DiffRebaseFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Source { source, .. } => Some(source),
+            Self::StagingValidation { source } => Some(source),
+            Self::Materialization { source } => Some(source),
+            Self::ResultVerification { source } => Some(source),
+            Self::Cancelled
+            | Self::UnsupportedPlatform
+            | Self::InvalidPath { .. }
+            | Self::InvalidBaseKind
+            | Self::SourceAlias
+            | Self::RandomnessUnavailable
+            | Self::SourceChanged { .. }
+            | Self::DirectoryChanged { .. }
+            | Self::EntryChanged { .. }
+            | Self::StagingChanged
+            | Self::AtomicExchangeUnavailable { .. }
+            | Self::Io { .. } => None,
+        }
+    }
+}
+
+/// A failed rebase whose `Err` contract proves no exchange committed.
+pub struct SnapshotV2DiffRebaseError {
+    stage: SnapshotV2DiffRebaseStage,
+    failure: SnapshotV2DiffRebaseFailure,
+    staging_cleanup: Option<SnapshotV2DiffRebaseCleanup>,
+}
+
+impl SnapshotV2DiffRebaseError {
+    /// Returns the pre-commit stage that failed.
+    pub const fn stage(&self) -> SnapshotV2DiffRebaseStage {
+        self.stage
+    }
+
+    /// Returns the redacted primary failure.
+    pub const fn failure(&self) -> &SnapshotV2DiffRebaseFailure {
+        &self.failure
+    }
+
+    /// Returns the explicit private-staging cleanup disposition, when present.
+    pub const fn staging_cleanup(&self) -> Option<SnapshotV2DiffRebaseCleanup> {
+        self.staging_cleanup
+    }
+}
+
+impl fmt::Debug for SnapshotV2DiffRebaseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2DiffRebaseError")
+            .field("stage", &self.stage)
+            .field("failure", &self.failure)
+            .field("staging_cleanup", &self.staging_cleanup)
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotV2DiffRebaseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "native-v2 Diff rebase failed during {}: {}",
+            self.stage, self.failure
+        )
+    }
+}
+
+impl std::error::Error for SnapshotV2DiffRebaseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.failure)
+    }
+}
+
+/// Redacted reason that a committed rebase is not proven durable and clean.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2DiffRebaseCommitFailure {
+    /// A retained or path-resolved parent directory changed.
+    DirectoryChanged {
+        /// Directory role, without its path.
+        input: SnapshotV2DiffRebaseInput,
+    },
+    /// The committed base entry did not retain the result identity.
+    BaseEntryChanged,
+    /// The displaced staging entry did not retain the old-base identity.
+    DisplacedEntryChanged,
+    /// The immutable diff changed across the commit.
+    DiffChanged,
+    /// The retained old-base descriptor no longer names its original object.
+    BaseSourceChanged,
+    /// Displaced-base cleanup was not conclusive.
+    Cleanup,
+    /// Another post-commit filesystem operation failed.
+    Io(io::ErrorKind),
+}
+
+/// Durability and cleanup classification after a successful exchange.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotV2DiffRebaseCommit {
+    /// Result identity, displaced cleanup, and directory synchronization succeeded.
+    Durable,
+    /// The result was exchanged into the base, but later proof is incomplete.
+    Uncertain {
+        /// First post-commit stage that became uncertain.
+        stage: SnapshotV2DiffRebaseStage,
+        /// Stable value-redacted first uncertainty.
+        failure: SnapshotV2DiffRebaseCommitFailure,
+        /// Best-effort displaced-entry cleanup disposition.
+        cleanup: SnapshotV2DiffRebaseCleanup,
+        /// Directory synchronization failure, or `None` when the barrier succeeded.
+        directory_sync: Option<io::ErrorKind>,
+    },
+}
+
+/// Binding and commit classification returned after an atomic base exchange.
+pub struct SnapshotV2DiffRebaseOutcome {
+    binding: SnapshotV2MemoryBinding,
+    commit: SnapshotV2DiffRebaseCommit,
+}
+
+impl SnapshotV2DiffRebaseOutcome {
+    /// Returns the complete canonical result binding.
+    pub const fn binding(&self) -> &SnapshotV2MemoryBinding {
+        &self.binding
+    }
+
+    /// Returns the durable or committed-uncertain classification.
+    pub const fn commit(&self) -> SnapshotV2DiffRebaseCommit {
+        self.commit
+    }
+}
+
+impl fmt::Debug for SnapshotV2DiffRebaseOutcome {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotV2DiffRebaseOutcome")
+            .field("binding", &REDACTED)
+            .field("commit", &self.commit)
+            .finish()
+    }
+}
+
+/// Applies one next Diff layer and failure-atomically replaces the named base.
+pub fn rebase_snapshot_v2_diff_paths(
+    paths: &SnapshotV2DiffRebasePaths,
+) -> Result<SnapshotV2DiffRebaseOutcome, SnapshotV2DiffRebaseError> {
+    rebase_snapshot_v2_diff_paths_with_cancel(paths, |_| false)
+}
+
+/// Applies one next Diff layer with bounded pre-commit cancellation.
+///
+/// A successful atomic exchange disables cancellation while mandatory
+/// committed verification, cleanup, and directory synchronization finish.
+/// A pre-exchange `Err` means no exchange committed; after exchange the return
+/// value always carries a durable or committed-uncertain classification.
+pub fn rebase_snapshot_v2_diff_paths_with_cancel<C>(
+    paths: &SnapshotV2DiffRebasePaths,
+    is_cancelled: C,
+) -> Result<SnapshotV2DiffRebaseOutcome, SnapshotV2DiffRebaseError>
+where
+    C: FnMut(SnapshotV2DiffRebaseStage) -> bool,
+{
+    #[cfg(target_os = "macos")]
+    {
+        macos::rebase_snapshot_v2_diff_paths_macos(paths, is_cancelled)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (paths, is_cancelled);
+        Err(precommit_error(
+            SnapshotV2DiffRebaseStage::PlatformCheck,
+            SnapshotV2DiffRebaseFailure::UnsupportedPlatform,
+        ))
+    }
+}
+
+fn precommit_error(
+    stage: SnapshotV2DiffRebaseStage,
+    failure: SnapshotV2DiffRebaseFailure,
+) -> SnapshotV2DiffRebaseError {
+    SnapshotV2DiffRebaseError {
+        stage,
+        failure,
+        staging_cleanup: None,
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos;
+
+#[cfg(test)]
+mod tests;

--- a/crates/runtime/src/snapshot_rebase/macos.rs
+++ b/crates/runtime/src/snapshot_rebase/macos.rs
@@ -532,12 +532,25 @@ where
             SnapshotV2DiffRebaseFailure::StagingChanged,
         ));
     }
-    staging.verified_facts = Some(inspect_file_facts(&staging.file).map_err(|source| {
+    let verified_facts = inspect_file_facts(&staging.file).map_err(|source| {
         precommit_error(
             stage,
             SnapshotV2DiffRebaseFailure::StagingValidation { source },
         )
-    })?);
+    })?;
+    if verified_facts.permissions() != 0o600
+        || !verified_facts.is_regular()
+        || !verified_facts.is_read_write()
+        || !verified_facts.is_close_on_exec()
+        || verified_facts.is_append()
+        || verified_facts.length() != binding.file_length()
+    {
+        return Err(precommit_error(
+            stage,
+            SnapshotV2DiffRebaseFailure::StagingChanged,
+        ));
+    }
+    staging.verified_facts = Some(verified_facts);
     Ok(())
 }
 
@@ -829,7 +842,7 @@ fn open_staging(directory: &File, name: &CString) -> Result<File, io::ErrorKind>
             directory.as_raw_fd(),
             name.as_ptr(),
             libc::O_RDWR | libc::O_CREAT | libc::O_EXCL | libc::O_CLOEXEC | libc::O_NOFOLLOW,
-            libc::c_uint::from(mode),
+            libc::c_int::from(mode),
         )
     };
     if descriptor < 0 {
@@ -899,7 +912,7 @@ fn entry_identity(directory: &File, name: &CString) -> Result<Option<FileIdentit
         // SAFETY: successful `fstatat` initialized the complete structure.
         let stat = unsafe { stat.assume_init() };
         return Ok(Some(FileIdentity {
-            device: u64::from(u32::from_ne_bytes(stat.st_dev.to_ne_bytes())),
+            device: raw_device_identity(stat.st_dev),
             inode: stat.st_ino,
         }));
     }
@@ -909,6 +922,10 @@ fn entry_identity(directory: &File, name: &CString) -> Result<Option<FileIdentit
     } else {
         Err(error.kind())
     }
+}
+
+fn raw_device_identity(device: libc::dev_t) -> u64 {
+    u64::from_ne_bytes(i64::from(device).to_ne_bytes())
 }
 
 fn atomic_exchange(

--- a/crates/runtime/src/snapshot_rebase/macos.rs
+++ b/crates/runtime/src/snapshot_rebase/macos.rs
@@ -1,0 +1,1322 @@
+#[cfg(test)]
+use std::collections::VecDeque;
+use std::ffi::CString;
+use std::fs::{File, OpenOptions, Permissions};
+use std::io::{self, Seek};
+use std::mem::MaybeUninit;
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::{FileExt, MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Component, Path, PathBuf};
+
+use crate::snapshot_diff_v2_13::{
+    NATIVE_V2_DIFF_MAGIC, SnapshotV2DiffMaterializationBaseFile,
+    SnapshotV2DiffMaterializationError, apply_snapshot_v2_diff_layer_file_with_cancel,
+};
+use crate::snapshot_memory_v2::{
+    FileFacts, NATIVE_V2_MEMORY_MAGIC, inspect_file, inspect_file_facts,
+    verify_snapshot_v2_memory_image_output,
+};
+
+use super::*;
+
+const STAGING_PREFIX: &[u8] = b".bangbang-snapshot-rebase-";
+const STAGING_RANDOM_BYTES: usize = 16;
+const STAGING_CREATE_ATTEMPTS: usize = 16;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct FileIdentity {
+    device: u64,
+    inode: u64,
+}
+
+struct SplitInputPath {
+    parent: PathBuf,
+    component: CString,
+}
+
+struct AdoptedInput {
+    role: SnapshotV2DiffRebaseInput,
+    parent: PathBuf,
+    directory: File,
+    directory_identity: FileIdentity,
+    component: CString,
+    file: File,
+    facts: FileFacts,
+    identity: FileIdentity,
+}
+
+impl fmt::Debug for AdoptedInput {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AdoptedInput")
+            .field("role", &self.role)
+            .field("parent", &REDACTED)
+            .field("component", &REDACTED)
+            .field("identity", &REDACTED)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BaseKind {
+    Complete,
+    ZeroRoot,
+}
+
+struct StagingFile<'directory> {
+    directory: &'directory File,
+    name: CString,
+    file: File,
+    result_identity: FileIdentity,
+    verified_facts: Option<FileFacts>,
+    cleanup_identity: FileIdentity,
+    active: bool,
+    cleanup_on_drop: bool,
+}
+
+impl fmt::Debug for StagingFile<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StagingFile")
+            .field("name", &REDACTED)
+            .field("identity", &REDACTED)
+            .field("active", &self.active)
+            .finish()
+    }
+}
+
+impl StagingFile<'_> {
+    fn cleanup(&mut self) -> Option<SnapshotV2DiffRebaseCleanup> {
+        if !self.active {
+            return None;
+        }
+        self.cleanup_on_drop = false;
+        let cleanup = clean_owned_entry(self.directory, &self.name, self.cleanup_identity);
+        self.active = false;
+        Some(cleanup)
+    }
+
+    fn committed(&mut self, displaced_identity: FileIdentity) {
+        self.cleanup_identity = displaced_identity;
+    }
+}
+
+impl Drop for StagingFile<'_> {
+    fn drop(&mut self) {
+        if self.active && self.cleanup_on_drop {
+            let _ = clean_owned_entry(self.directory, &self.name, self.cleanup_identity);
+        }
+    }
+}
+
+struct SystemRebasePolicy<C> {
+    is_cancelled: C,
+}
+
+impl<C> SystemRebasePolicy<C>
+where
+    C: FnMut(SnapshotV2DiffRebaseStage) -> bool,
+{
+    fn checkpoint(
+        &mut self,
+        stage: SnapshotV2DiffRebaseStage,
+    ) -> Result<(), SnapshotV2DiffRebaseError> {
+        enter_rebase_stage(stage)
+            .map_err(|kind| precommit_error(stage, SnapshotV2DiffRebaseFailure::Io { kind }))?;
+        if (self.is_cancelled)(stage) {
+            Err(precommit_error(
+                stage,
+                SnapshotV2DiffRebaseFailure::Cancelled,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+pub(super) fn rebase_snapshot_v2_diff_paths_macos<C>(
+    paths: &SnapshotV2DiffRebasePaths,
+    is_cancelled: C,
+) -> Result<SnapshotV2DiffRebaseOutcome, SnapshotV2DiffRebaseError>
+where
+    C: FnMut(SnapshotV2DiffRebaseStage) -> bool,
+{
+    let mut policy = SystemRebasePolicy { is_cancelled };
+    policy.checkpoint(SnapshotV2DiffRebaseStage::PlatformCheck)?;
+
+    let base = adopt_input(paths.base(), SnapshotV2DiffRebaseInput::Base, &mut policy)?;
+    let base_kind = classify_base(&base.file)?;
+    let diff = adopt_input(paths.diff(), SnapshotV2DiffRebaseInput::Diff, &mut policy)?;
+
+    policy.checkpoint(SnapshotV2DiffRebaseStage::SourceAliasCheck)?;
+    if base.facts.same_object(diff.facts) {
+        return Err(precommit_error(
+            SnapshotV2DiffRebaseStage::SourceAliasCheck,
+            SnapshotV2DiffRebaseFailure::SourceAlias,
+        ));
+    }
+
+    policy.checkpoint(SnapshotV2DiffRebaseStage::SourceDuplication)?;
+    let base_copy = duplicate_source(&base)?;
+    let diff_copy = duplicate_source(&diff)?;
+
+    policy.checkpoint(SnapshotV2DiffRebaseStage::StagingCreate)?;
+    let mut staging = create_staging(&base.directory)?;
+    let materialization_base = match base_kind {
+        BaseKind::Complete => SnapshotV2DiffMaterializationBaseFile::Complete(base_copy),
+        BaseKind::ZeroRoot => SnapshotV2DiffMaterializationBaseFile::ZeroRoot(base_copy),
+    };
+
+    if let Err(mut error) = policy.checkpoint(SnapshotV2DiffRebaseStage::Materialization) {
+        error.staging_cleanup = staging.cleanup();
+        return Err(error);
+    }
+    let materialization = apply_snapshot_v2_diff_layer_file_with_cancel(
+        materialization_base,
+        diff_copy,
+        &mut staging.file,
+        |_| (policy.is_cancelled)(SnapshotV2DiffRebaseStage::Materialization),
+    );
+    let binding = match materialization {
+        Ok(binding) => binding,
+        Err(SnapshotV2DiffMaterializationError::Cancelled { .. }) => {
+            return Err(cleanup_precommit_error(
+                &mut staging,
+                precommit_error(
+                    SnapshotV2DiffRebaseStage::Materialization,
+                    SnapshotV2DiffRebaseFailure::Cancelled,
+                ),
+            ));
+        }
+        Err(source) => {
+            return Err(cleanup_precommit_error(
+                &mut staging,
+                precommit_error(
+                    SnapshotV2DiffRebaseStage::Materialization,
+                    SnapshotV2DiffRebaseFailure::Materialization { source },
+                ),
+            ));
+        }
+    };
+
+    if let Err(error) = sync_and_verify_result(&binding, &mut staging, &mut policy) {
+        return Err(cleanup_precommit_error(&mut staging, error));
+    }
+
+    if let Err(error) = policy
+        .checkpoint(SnapshotV2DiffRebaseStage::SourceStability)
+        .and_then(|()| verify_sources(&base, &diff))
+    {
+        return Err(cleanup_precommit_error(&mut staging, error));
+    }
+    if let Err(error) = policy
+        .checkpoint(SnapshotV2DiffRebaseStage::DirectoryStability)
+        .and_then(|()| verify_directories(&base, &diff))
+    {
+        return Err(cleanup_precommit_error(&mut staging, error));
+    }
+    if let Err(error) = policy
+        .checkpoint(SnapshotV2DiffRebaseStage::EntryStability)
+        .and_then(|()| verify_entries(&base, &diff, &staging))
+    {
+        return Err(cleanup_precommit_error(&mut staging, error));
+    }
+
+    // This is the final caller-controlled checkpoint. Every identity check is
+    // repeated after it and no callback, allocator, or test action runs between
+    // those checks and the exchange syscall.
+    if let Err(error) = policy.checkpoint(SnapshotV2DiffRebaseStage::AtomicExchange) {
+        return Err(cleanup_precommit_error(&mut staging, error));
+    }
+    if let Err(error) = verify_sources(&base, &diff)
+        .and_then(|()| verify_directories(&base, &diff))
+        .and_then(|()| verify_entries(&base, &diff, &staging))
+    {
+        return Err(cleanup_precommit_error(&mut staging, error));
+    }
+
+    atomic_exchange(&base.directory, &staging.name, &base.component).map_err(|kind| {
+        cleanup_precommit_error(
+            &mut staging,
+            precommit_error(
+                SnapshotV2DiffRebaseStage::AtomicExchange,
+                SnapshotV2DiffRebaseFailure::AtomicExchangeUnavailable { kind },
+            ),
+        )
+    })?;
+
+    // `RENAME_SWAP` is the commit point. From here onward this function cannot
+    // return `Err`, attempt a compensating swap, or invoke caller code.
+    staging.committed(base.identity);
+    Ok(finish_committed_rebase(binding, &base, &diff, &mut staging))
+}
+
+fn adopt_input<C>(
+    path: &Path,
+    role: SnapshotV2DiffRebaseInput,
+    policy: &mut SystemRebasePolicy<C>,
+) -> Result<AdoptedInput, SnapshotV2DiffRebaseError>
+where
+    C: FnMut(SnapshotV2DiffRebaseStage) -> bool,
+{
+    let (path_stage, directory_stage, file_stage, validation_stage) = match role {
+        SnapshotV2DiffRebaseInput::Base => (
+            SnapshotV2DiffRebaseStage::BasePathValidation,
+            SnapshotV2DiffRebaseStage::BaseDirectoryOpen,
+            SnapshotV2DiffRebaseStage::BaseFileOpen,
+            SnapshotV2DiffRebaseStage::BaseValidation,
+        ),
+        SnapshotV2DiffRebaseInput::Diff => (
+            SnapshotV2DiffRebaseStage::DiffPathValidation,
+            SnapshotV2DiffRebaseStage::DiffDirectoryOpen,
+            SnapshotV2DiffRebaseStage::DiffFileOpen,
+            SnapshotV2DiffRebaseStage::DiffValidation,
+        ),
+    };
+
+    policy.checkpoint(path_stage)?;
+    let split = split_input_path(path).ok_or_else(|| {
+        precommit_error(
+            path_stage,
+            SnapshotV2DiffRebaseFailure::InvalidPath { input: role },
+        )
+    })?;
+
+    policy.checkpoint(directory_stage)?;
+    let directory = open_directory(&split.parent).map_err(|kind| {
+        precommit_error(directory_stage, SnapshotV2DiffRebaseFailure::Io { kind })
+    })?;
+    let directory_identity = file_identity(&directory).map_err(|kind| {
+        precommit_error(directory_stage, SnapshotV2DiffRebaseFailure::Io { kind })
+    })?;
+
+    policy.checkpoint(file_stage)?;
+    let file = open_source(&directory, &split.component)
+        .map_err(|kind| precommit_error(file_stage, SnapshotV2DiffRebaseFailure::Io { kind }))?;
+    let identity = file_identity(&file)
+        .map_err(|kind| precommit_error(file_stage, SnapshotV2DiffRebaseFailure::Io { kind }))?;
+
+    policy.checkpoint(validation_stage)?;
+    let facts = inspect_file(&file).map_err(|source| {
+        precommit_error(
+            validation_stage,
+            SnapshotV2DiffRebaseFailure::Source {
+                input: role,
+                source,
+            },
+        )
+    })?;
+    if !facts.same_identity(identity.device, identity.inode) {
+        return Err(precommit_error(
+            validation_stage,
+            SnapshotV2DiffRebaseFailure::SourceChanged { input: role },
+        ));
+    }
+    if entry_identity(&directory, &split.component).map_err(|kind| {
+        precommit_error(validation_stage, SnapshotV2DiffRebaseFailure::Io { kind })
+    })? != Some(identity)
+    {
+        return Err(precommit_error(
+            validation_stage,
+            SnapshotV2DiffRebaseFailure::EntryChanged { input: role },
+        ));
+    }
+    let after = inspect_file(&file).map_err(|source| {
+        precommit_error(
+            validation_stage,
+            SnapshotV2DiffRebaseFailure::Source {
+                input: role,
+                source,
+            },
+        )
+    })?;
+    if after != facts {
+        return Err(precommit_error(
+            validation_stage,
+            SnapshotV2DiffRebaseFailure::SourceChanged { input: role },
+        ));
+    }
+
+    Ok(AdoptedInput {
+        role,
+        parent: split.parent,
+        directory,
+        directory_identity,
+        component: split.component,
+        file,
+        facts,
+        identity,
+    })
+}
+
+fn classify_base(file: &File) -> Result<BaseKind, SnapshotV2DiffRebaseError> {
+    let stage = SnapshotV2DiffRebaseStage::BaseValidation;
+    let mut magic = [0_u8; 8];
+    if read_exact_at(file, &mut magic, 0).is_err() {
+        return Err(precommit_error(
+            stage,
+            SnapshotV2DiffRebaseFailure::InvalidBaseKind,
+        ));
+    }
+    if magic == NATIVE_V2_MEMORY_MAGIC {
+        Ok(BaseKind::Complete)
+    } else if magic == NATIVE_V2_DIFF_MAGIC {
+        Ok(BaseKind::ZeroRoot)
+    } else {
+        Err(precommit_error(
+            stage,
+            SnapshotV2DiffRebaseFailure::InvalidBaseKind,
+        ))
+    }
+}
+
+fn duplicate_source(input: &AdoptedInput) -> Result<File, SnapshotV2DiffRebaseError> {
+    let stage = SnapshotV2DiffRebaseStage::SourceDuplication;
+    let copy = input.file.try_clone().map_err(|source| {
+        precommit_error(
+            stage,
+            SnapshotV2DiffRebaseFailure::Io {
+                kind: source.kind(),
+            },
+        )
+    })?;
+    let facts = inspect_file(&copy).map_err(|source| {
+        precommit_error(
+            stage,
+            SnapshotV2DiffRebaseFailure::Source {
+                input: input.role,
+                source,
+            },
+        )
+    })?;
+    if facts != input.facts {
+        return Err(precommit_error(
+            stage,
+            SnapshotV2DiffRebaseFailure::SourceChanged { input: input.role },
+        ));
+    }
+    Ok(copy)
+}
+
+fn create_staging(directory: &File) -> Result<StagingFile<'_>, SnapshotV2DiffRebaseError> {
+    let stage = SnapshotV2DiffRebaseStage::StagingCreate;
+    for _ in 0..STAGING_CREATE_ATTEMPTS {
+        let name = staging_name()?;
+        match open_staging(directory, &name) {
+            Ok(file) => {
+                let identity = match file_identity(&file) {
+                    Ok(identity) => identity,
+                    Err(kind) => {
+                        let mut error =
+                            precommit_error(stage, SnapshotV2DiffRebaseFailure::Io { kind });
+                        error.staging_cleanup = Some(SnapshotV2DiffRebaseCleanup::Failed(kind));
+                        return Err(error);
+                    }
+                };
+                let mut staging = StagingFile {
+                    directory,
+                    name,
+                    file,
+                    result_identity: identity,
+                    verified_facts: None,
+                    cleanup_identity: identity,
+                    active: true,
+                    cleanup_on_drop: true,
+                };
+                if let Err(source) = staging.file.set_permissions(Permissions::from_mode(0o600)) {
+                    let error = precommit_error(
+                        stage,
+                        SnapshotV2DiffRebaseFailure::Io {
+                            kind: source.kind(),
+                        },
+                    );
+                    return Err(cleanup_precommit_error(&mut staging, error));
+                }
+                let permissions = staging.file.metadata().map_err(|source| {
+                    cleanup_precommit_error(
+                        &mut staging,
+                        precommit_error(
+                            stage,
+                            SnapshotV2DiffRebaseFailure::Io {
+                                kind: source.kind(),
+                            },
+                        ),
+                    )
+                })?;
+                let facts = inspect_file_facts(&staging.file).map_err(|source| {
+                    cleanup_precommit_error(
+                        &mut staging,
+                        precommit_error(
+                            stage,
+                            SnapshotV2DiffRebaseFailure::StagingValidation { source },
+                        ),
+                    )
+                })?;
+                let position = staging.file.stream_position().map_err(|source| {
+                    cleanup_precommit_error(
+                        &mut staging,
+                        precommit_error(
+                            stage,
+                            SnapshotV2DiffRebaseFailure::Io {
+                                kind: source.kind(),
+                            },
+                        ),
+                    )
+                })?;
+                if permissions.mode() & 0o7777 != 0o600
+                    || !facts.is_regular()
+                    || !facts.is_read_write()
+                    || !facts.is_close_on_exec()
+                    || facts.is_append()
+                    || facts.length() != 0
+                    || position != 0
+                {
+                    let error = precommit_error(
+                        stage,
+                        SnapshotV2DiffRebaseFailure::Io {
+                            kind: io::ErrorKind::InvalidData,
+                        },
+                    );
+                    return Err(cleanup_precommit_error(&mut staging, error));
+                }
+                return Ok(staging);
+            }
+            Err(io::ErrorKind::AlreadyExists) => {}
+            Err(kind) => {
+                return Err(precommit_error(
+                    stage,
+                    SnapshotV2DiffRebaseFailure::Io { kind },
+                ));
+            }
+        }
+    }
+    Err(precommit_error(
+        stage,
+        SnapshotV2DiffRebaseFailure::Io {
+            kind: io::ErrorKind::AlreadyExists,
+        },
+    ))
+}
+
+fn sync_and_verify_result<C>(
+    binding: &SnapshotV2MemoryBinding,
+    staging: &mut StagingFile<'_>,
+    policy: &mut SystemRebasePolicy<C>,
+) -> Result<(), SnapshotV2DiffRebaseError>
+where
+    C: FnMut(SnapshotV2DiffRebaseStage) -> bool,
+{
+    let stage = SnapshotV2DiffRebaseStage::ResultFileSync;
+    policy.checkpoint(stage)?;
+    staging.file.sync_all().map_err(|source| {
+        precommit_error(
+            stage,
+            SnapshotV2DiffRebaseFailure::Io {
+                kind: source.kind(),
+            },
+        )
+    })?;
+    verify_snapshot_v2_memory_image_output(binding, &mut staging.file).map_err(|source| {
+        precommit_error(
+            stage,
+            SnapshotV2DiffRebaseFailure::ResultVerification { source },
+        )
+    })?;
+    if file_identity(&staging.file)
+        .map_err(|kind| precommit_error(stage, SnapshotV2DiffRebaseFailure::Io { kind }))?
+        != staging.result_identity
+    {
+        return Err(precommit_error(
+            stage,
+            SnapshotV2DiffRebaseFailure::StagingChanged,
+        ));
+    }
+    staging.verified_facts = Some(inspect_file_facts(&staging.file).map_err(|source| {
+        precommit_error(
+            stage,
+            SnapshotV2DiffRebaseFailure::StagingValidation { source },
+        )
+    })?);
+    Ok(())
+}
+
+fn verify_sources(
+    base: &AdoptedInput,
+    diff: &AdoptedInput,
+) -> Result<(), SnapshotV2DiffRebaseError> {
+    for input in [base, diff] {
+        if inspect_file(&input.file).ok() != Some(input.facts) {
+            return Err(precommit_error(
+                SnapshotV2DiffRebaseStage::SourceStability,
+                SnapshotV2DiffRebaseFailure::SourceChanged { input: input.role },
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn verify_directories(
+    base: &AdoptedInput,
+    diff: &AdoptedInput,
+) -> Result<(), SnapshotV2DiffRebaseError> {
+    for input in [base, diff] {
+        let retained = file_identity(&input.directory).ok();
+        let reopened = open_directory(&input.parent)
+            .ok()
+            .and_then(|directory| file_identity(&directory).ok());
+        if retained != Some(input.directory_identity) || reopened != Some(input.directory_identity)
+        {
+            return Err(precommit_error(
+                SnapshotV2DiffRebaseStage::DirectoryStability,
+                SnapshotV2DiffRebaseFailure::DirectoryChanged { input: input.role },
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn verify_entries(
+    base: &AdoptedInput,
+    diff: &AdoptedInput,
+    staging: &StagingFile<'_>,
+) -> Result<(), SnapshotV2DiffRebaseError> {
+    if base.identity == diff.identity {
+        return Err(precommit_error(
+            SnapshotV2DiffRebaseStage::EntryStability,
+            SnapshotV2DiffRebaseFailure::SourceAlias,
+        ));
+    }
+    if staging.result_identity == base.identity || staging.result_identity == diff.identity {
+        return Err(precommit_error(
+            SnapshotV2DiffRebaseStage::EntryStability,
+            SnapshotV2DiffRebaseFailure::StagingChanged,
+        ));
+    }
+    for input in [base, diff] {
+        if entry_identity(&input.directory, &input.component)
+            .ok()
+            .flatten()
+            != Some(input.identity)
+        {
+            return Err(precommit_error(
+                SnapshotV2DiffRebaseStage::EntryStability,
+                SnapshotV2DiffRebaseFailure::EntryChanged { input: input.role },
+            ));
+        }
+    }
+    if entry_identity(staging.directory, &staging.name)
+        .ok()
+        .flatten()
+        != Some(staging.result_identity)
+    {
+        return Err(precommit_error(
+            SnapshotV2DiffRebaseStage::EntryStability,
+            SnapshotV2DiffRebaseFailure::StagingChanged,
+        ));
+    }
+    if staging.verified_facts.is_none()
+        || inspect_file_facts(&staging.file).ok() != staging.verified_facts
+    {
+        return Err(precommit_error(
+            SnapshotV2DiffRebaseStage::EntryStability,
+            SnapshotV2DiffRebaseFailure::StagingChanged,
+        ));
+    }
+    Ok(())
+}
+
+fn cleanup_precommit_error(
+    staging: &mut StagingFile<'_>,
+    mut error: SnapshotV2DiffRebaseError,
+) -> SnapshotV2DiffRebaseError {
+    error.staging_cleanup = staging.cleanup();
+    error
+}
+
+fn finish_committed_rebase(
+    binding: SnapshotV2MemoryBinding,
+    base: &AdoptedInput,
+    diff: &AdoptedInput,
+    staging: &mut StagingFile<'_>,
+) -> SnapshotV2DiffRebaseOutcome {
+    let mut first_uncertainty = None;
+
+    if let Err(kind) = enter_rebase_stage(SnapshotV2DiffRebaseStage::CommitVerification) {
+        record_uncertainty(
+            &mut first_uncertainty,
+            SnapshotV2DiffRebaseStage::CommitVerification,
+            SnapshotV2DiffRebaseCommitFailure::Io(kind),
+        );
+    }
+    for input in [base, diff] {
+        let retained = file_identity(&input.directory).ok();
+        let reopened = open_directory(&input.parent)
+            .ok()
+            .and_then(|directory| file_identity(&directory).ok());
+        if retained != Some(input.directory_identity) || reopened != Some(input.directory_identity)
+        {
+            record_uncertainty(
+                &mut first_uncertainty,
+                SnapshotV2DiffRebaseStage::CommitVerification,
+                SnapshotV2DiffRebaseCommitFailure::DirectoryChanged { input: input.role },
+            );
+        }
+    }
+    if entry_identity(&base.directory, &base.component)
+        .ok()
+        .flatten()
+        != Some(staging.result_identity)
+    {
+        record_uncertainty(
+            &mut first_uncertainty,
+            SnapshotV2DiffRebaseStage::CommitVerification,
+            SnapshotV2DiffRebaseCommitFailure::BaseEntryChanged,
+        );
+    }
+    if entry_identity(staging.directory, &staging.name)
+        .ok()
+        .flatten()
+        != Some(base.identity)
+    {
+        record_uncertainty(
+            &mut first_uncertainty,
+            SnapshotV2DiffRebaseStage::CommitVerification,
+            SnapshotV2DiffRebaseCommitFailure::DisplacedEntryChanged,
+        );
+    }
+    if inspect_file(&diff.file).ok() != Some(diff.facts)
+        || entry_identity(&diff.directory, &diff.component)
+            .ok()
+            .flatten()
+            != Some(diff.identity)
+    {
+        record_uncertainty(
+            &mut first_uncertainty,
+            SnapshotV2DiffRebaseStage::CommitVerification,
+            SnapshotV2DiffRebaseCommitFailure::DiffChanged,
+        );
+    }
+    if file_identity(&base.file).ok() != Some(base.identity) {
+        record_uncertainty(
+            &mut first_uncertainty,
+            SnapshotV2DiffRebaseStage::CommitVerification,
+            SnapshotV2DiffRebaseCommitFailure::BaseSourceChanged,
+        );
+    }
+
+    let cleanup = match enter_rebase_stage(SnapshotV2DiffRebaseStage::DisplacedCleanup) {
+        Ok(()) => staging
+            .cleanup()
+            .unwrap_or(SnapshotV2DiffRebaseCleanup::AlreadyAbsent),
+        Err(kind) => {
+            staging.cleanup_on_drop = false;
+            staging.active = false;
+            SnapshotV2DiffRebaseCleanup::Failed(kind)
+        }
+    };
+    if matches!(
+        cleanup,
+        SnapshotV2DiffRebaseCleanup::ChangedRefused | SnapshotV2DiffRebaseCleanup::Failed(_)
+    ) {
+        record_uncertainty(
+            &mut first_uncertainty,
+            SnapshotV2DiffRebaseStage::DisplacedCleanup,
+            SnapshotV2DiffRebaseCommitFailure::Cleanup,
+        );
+    }
+
+    let directory_sync = match enter_rebase_stage(SnapshotV2DiffRebaseStage::BaseDirectorySync) {
+        Ok(()) => base.directory.sync_all().err().map(|source| source.kind()),
+        Err(kind) => Some(kind),
+    };
+    if let Some(kind) = directory_sync {
+        record_uncertainty(
+            &mut first_uncertainty,
+            SnapshotV2DiffRebaseStage::BaseDirectorySync,
+            SnapshotV2DiffRebaseCommitFailure::Io(kind),
+        );
+    }
+
+    let _ = enter_rebase_stage(SnapshotV2DiffRebaseStage::Complete);
+    let commit = match first_uncertainty {
+        None => SnapshotV2DiffRebaseCommit::Durable,
+        Some((stage, failure)) => SnapshotV2DiffRebaseCommit::Uncertain {
+            stage,
+            failure,
+            cleanup,
+            directory_sync,
+        },
+    };
+    SnapshotV2DiffRebaseOutcome { binding, commit }
+}
+
+fn record_uncertainty(
+    first: &mut Option<(SnapshotV2DiffRebaseStage, SnapshotV2DiffRebaseCommitFailure)>,
+    stage: SnapshotV2DiffRebaseStage,
+    failure: SnapshotV2DiffRebaseCommitFailure,
+) {
+    if first.is_none() {
+        *first = Some((stage, failure));
+    }
+}
+
+fn split_input_path(path: &Path) -> Option<SplitInputPath> {
+    let raw_path = path.as_os_str().as_bytes();
+    if raw_path.contains(&0) {
+        return None;
+    }
+    let raw_component = raw_path.rsplit(|byte| *byte == b'/').next()?;
+    if raw_component.is_empty() || raw_component == b"." || raw_component == b".." {
+        return None;
+    }
+    let Component::Normal(component) = path.components().next_back()? else {
+        return None;
+    };
+    if component.as_bytes() != raw_component {
+        return None;
+    }
+    let component = CString::new(raw_component).ok()?;
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let parent = if parent.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        parent.to_path_buf()
+    };
+    Some(SplitInputPath { parent, component })
+}
+
+fn open_directory(path: &Path) -> Result<File, io::ErrorKind> {
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY)
+        .open(path)
+        .map_err(|source| source.kind())
+}
+
+fn open_source(directory: &File, component: &CString) -> Result<File, io::ErrorKind> {
+    // SAFETY: `directory` is live and `component` is one NUL-terminated final
+    // component. `O_NOFOLLOW` rejects a final symlink, and success returns a
+    // fresh descriptor owned by this function.
+    let descriptor = unsafe {
+        libc::openat(
+            directory.as_raw_fd(),
+            component.as_ptr(),
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
+        )
+    };
+    if descriptor < 0 {
+        Err(io::Error::last_os_error().kind())
+    } else {
+        // SAFETY: successful `openat` returned a fresh owned descriptor.
+        Ok(unsafe { File::from_raw_fd(descriptor) })
+    }
+}
+
+fn open_staging(directory: &File, name: &CString) -> Result<File, io::ErrorKind> {
+    // SAFETY: `directory` is live and `name` is a generated NUL-terminated
+    // component. The flags create one private, exclusive regular file and a
+    // successful call returns a fresh owned descriptor.
+    #[cfg(test)]
+    let mode: libc::mode_t =
+        REBASE_TEST_HOOK.with(|hook| hook.borrow().staging_mode.unwrap_or(0o600));
+    #[cfg(not(test))]
+    let mode: libc::mode_t = 0o600;
+    // SAFETY: the descriptor, component, and flag invariants are stated above;
+    // `mode_t` is explicitly promoted for the variadic mode argument.
+    let descriptor = unsafe {
+        libc::openat(
+            directory.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDWR | libc::O_CREAT | libc::O_EXCL | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            libc::c_uint::from(mode),
+        )
+    };
+    if descriptor < 0 {
+        Err(io::Error::last_os_error().kind())
+    } else {
+        // SAFETY: successful `openat` returned a fresh owned descriptor.
+        Ok(unsafe { File::from_raw_fd(descriptor) })
+    }
+}
+
+fn staging_name() -> Result<CString, SnapshotV2DiffRebaseError> {
+    let stage = SnapshotV2DiffRebaseStage::StagingCreate;
+    let mut random = [0_u8; STAGING_RANDOM_BYTES];
+    fill_staging_random(&mut random)
+        .map_err(|()| precommit_error(stage, SnapshotV2DiffRebaseFailure::RandomnessUnavailable))?;
+    let mut bytes = Vec::with_capacity(STAGING_PREFIX.len() + STAGING_RANDOM_BYTES * 2);
+    bytes.extend_from_slice(STAGING_PREFIX);
+    for byte in random {
+        bytes.push(hex_digit(byte >> 4));
+        bytes.push(hex_digit(byte & 0x0f));
+    }
+    CString::new(bytes)
+        .map_err(|_| precommit_error(stage, SnapshotV2DiffRebaseFailure::RandomnessUnavailable))
+}
+
+fn fill_staging_random(destination: &mut [u8; STAGING_RANDOM_BYTES]) -> Result<(), ()> {
+    #[cfg(test)]
+    if REBASE_TEST_HOOK.with(|hook| hook.borrow().random_failure) {
+        return Err(());
+    }
+    #[cfg(test)]
+    if let Some(random) = REBASE_TEST_HOOK.with(|hook| hook.borrow_mut().random_names.pop_front()) {
+        *destination = random;
+        return Ok(());
+    }
+    getrandom::fill(destination).map_err(|_| ())
+}
+
+const fn hex_digit(nibble: u8) -> u8 {
+    match nibble {
+        0..=9 => b'0' + nibble,
+        _ => b'a' + (nibble - 10),
+    }
+}
+
+fn file_identity(file: &File) -> Result<FileIdentity, io::ErrorKind> {
+    let metadata = file.metadata().map_err(|source| source.kind())?;
+    Ok(FileIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    })
+}
+
+fn entry_identity(directory: &File, name: &CString) -> Result<Option<FileIdentity>, io::ErrorKind> {
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: all descriptors and pointers are live for the call, and
+    // `AT_SYMLINK_NOFOLLOW` observes the entry rather than a symlink target.
+    let result = unsafe {
+        libc::fstatat(
+            directory.as_raw_fd(),
+            name.as_ptr(),
+            stat.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    if result == 0 {
+        // SAFETY: successful `fstatat` initialized the complete structure.
+        let stat = unsafe { stat.assume_init() };
+        return Ok(Some(FileIdentity {
+            device: u64::from(u32::from_ne_bytes(stat.st_dev.to_ne_bytes())),
+            inode: stat.st_ino,
+        }));
+    }
+    let error = io::Error::last_os_error();
+    if error.kind() == io::ErrorKind::NotFound {
+        Ok(None)
+    } else {
+        Err(error.kind())
+    }
+}
+
+fn atomic_exchange(
+    directory: &File,
+    staging: &CString,
+    base: &CString,
+) -> Result<(), io::ErrorKind> {
+    #[cfg(test)]
+    if REBASE_TEST_HOOK.with(|hook| hook.borrow().exchange_failure) {
+        return Err(io::ErrorKind::Other);
+    }
+    // SAFETY: both names are retained NUL-terminated single components in the
+    // same retained directory. `RENAME_SWAP` performs one atomic exchange.
+    let result = unsafe {
+        libc::renameatx_np(
+            directory.as_raw_fd(),
+            staging.as_ptr(),
+            directory.as_raw_fd(),
+            base.as_ptr(),
+            libc::RENAME_SWAP,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error().kind())
+    }
+}
+
+fn clean_owned_entry(
+    directory: &File,
+    name: &CString,
+    expected: FileIdentity,
+) -> SnapshotV2DiffRebaseCleanup {
+    match entry_identity(directory, name) {
+        Ok(None) => SnapshotV2DiffRebaseCleanup::AlreadyAbsent,
+        Ok(Some(actual)) if actual != expected => SnapshotV2DiffRebaseCleanup::ChangedRefused,
+        Ok(Some(_)) => {
+            // SAFETY: the immediately preceding identity check matched the
+            // retained expected inode. Darwin has no identity-conditioned
+            // unlink, so the documented trusted-directory boundary applies.
+            let result = unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) };
+            if result == 0 {
+                SnapshotV2DiffRebaseCleanup::Removed
+            } else {
+                let kind = io::Error::last_os_error().kind();
+                if kind == io::ErrorKind::NotFound {
+                    SnapshotV2DiffRebaseCleanup::AlreadyAbsent
+                } else {
+                    SnapshotV2DiffRebaseCleanup::Failed(kind)
+                }
+            }
+        }
+        Err(kind) => SnapshotV2DiffRebaseCleanup::Failed(kind),
+    }
+}
+
+fn read_exact_at(file: &File, mut bytes: &mut [u8], mut offset: u64) -> io::Result<()> {
+    while !bytes.is_empty() {
+        let count = file.read_at(bytes, offset)?;
+        if count == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "descriptor read made no progress",
+            ));
+        }
+        offset = offset
+            .checked_add(u64::try_from(count).map_err(|_| io::ErrorKind::InvalidData)?)
+            .ok_or(io::ErrorKind::InvalidData)?;
+        bytes = bytes.get_mut(count..).ok_or(io::ErrorKind::InvalidData)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+enum RebaseTestAction {
+    ReplacePath {
+        stage: SnapshotV2DiffRebaseStage,
+        path: PathBuf,
+        moved: PathBuf,
+        replacement: Vec<u8>,
+    },
+    MovePath {
+        stage: SnapshotV2DiffRebaseStage,
+        path: PathBuf,
+        moved: PathBuf,
+    },
+    ReplaceParent {
+        stage: SnapshotV2DiffRebaseStage,
+        parent: PathBuf,
+        moved: PathBuf,
+    },
+    ReplaceStaging {
+        stage: SnapshotV2DiffRebaseStage,
+        directory: PathBuf,
+        moved: PathBuf,
+        replacement: Vec<u8>,
+    },
+    MoveStaging {
+        stage: SnapshotV2DiffRebaseStage,
+        directory: PathBuf,
+        moved: PathBuf,
+    },
+    CorruptStaging {
+        stage: SnapshotV2DiffRebaseStage,
+        directory: PathBuf,
+        bytes: Vec<u8>,
+    },
+}
+
+#[cfg(test)]
+impl RebaseTestAction {
+    fn stage(&self) -> SnapshotV2DiffRebaseStage {
+        match self {
+            Self::ReplacePath { stage, .. }
+            | Self::MovePath { stage, .. }
+            | Self::ReplaceParent { stage, .. }
+            | Self::ReplaceStaging { stage, .. }
+            | Self::MoveStaging { stage, .. }
+            | Self::CorruptStaging { stage, .. } => *stage,
+        }
+    }
+
+    fn perform(self) -> Result<(), io::ErrorKind> {
+        match self {
+            Self::ReplacePath {
+                path,
+                moved,
+                replacement,
+                ..
+            } => {
+                std::fs::rename(&path, moved).map_err(|source| source.kind())?;
+                std::fs::write(path, replacement).map_err(|source| source.kind())
+            }
+            Self::MovePath { path, moved, .. } => {
+                std::fs::rename(path, moved).map_err(|source| source.kind())
+            }
+            Self::ReplaceParent { parent, moved, .. } => {
+                std::fs::rename(&parent, moved).map_err(|source| source.kind())?;
+                std::fs::create_dir(parent).map_err(|source| source.kind())
+            }
+            Self::ReplaceStaging {
+                directory,
+                moved,
+                replacement,
+                ..
+            } => {
+                let staging = find_staging_path(&directory)?;
+                std::fs::rename(&staging, moved).map_err(|source| source.kind())?;
+                std::fs::write(staging, replacement).map_err(|source| source.kind())
+            }
+            Self::MoveStaging {
+                directory, moved, ..
+            } => std::fs::rename(find_staging_path(&directory)?, moved)
+                .map_err(|source| source.kind()),
+            Self::CorruptStaging {
+                directory, bytes, ..
+            } => std::fs::write(find_staging_path(&directory)?, bytes)
+                .map_err(|source| source.kind()),
+        }
+    }
+}
+
+#[cfg(test)]
+fn find_staging_path(directory: &Path) -> Result<PathBuf, io::ErrorKind> {
+    std::fs::read_dir(directory)
+        .map_err(|source| source.kind())?
+        .filter_map(Result::ok)
+        .find(|entry| entry.file_name().as_bytes().starts_with(STAGING_PREFIX))
+        .map(|entry| entry.path())
+        .ok_or(io::ErrorKind::NotFound)
+}
+
+#[cfg(test)]
+#[derive(Debug, Default)]
+struct RebaseTestHook {
+    failures: Vec<SnapshotV2DiffRebaseStage>,
+    action: Option<RebaseTestAction>,
+    random_names: VecDeque<[u8; STAGING_RANDOM_BYTES]>,
+    random_failure: bool,
+    exchange_failure: bool,
+    staging_mode: Option<libc::mode_t>,
+    order: Vec<SnapshotV2DiffRebaseStage>,
+}
+
+#[cfg(test)]
+thread_local! {
+    static REBASE_TEST_HOOK: std::cell::RefCell<RebaseTestHook> =
+        std::cell::RefCell::new(RebaseTestHook::default());
+}
+
+fn enter_rebase_stage(stage: SnapshotV2DiffRebaseStage) -> Result<(), io::ErrorKind> {
+    #[cfg(test)]
+    {
+        let action = REBASE_TEST_HOOK.with(|hook| {
+            let mut hook = hook.borrow_mut();
+            hook.order.push(stage);
+            if hook.failures.contains(&stage) {
+                return Err(io::ErrorKind::Other);
+            }
+            if hook.action.as_ref().map(RebaseTestAction::stage) == Some(stage) {
+                Ok(hook.action.take())
+            } else {
+                Ok(None)
+            }
+        })?;
+        action.map_or(Ok(()), RebaseTestAction::perform)
+    }
+    #[cfg(not(test))]
+    {
+        let _ = stage;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(super) fn with_rebase_failures<T>(
+    failures: Vec<SnapshotV2DiffRebaseStage>,
+    operation: impl FnOnce() -> T,
+) -> (T, Vec<SnapshotV2DiffRebaseStage>) {
+    REBASE_TEST_HOOK.with(|hook| {
+        *hook.borrow_mut() = RebaseTestHook {
+            failures,
+            ..RebaseTestHook::default()
+        };
+    });
+    let result = operation();
+    let order = REBASE_TEST_HOOK.with(|hook| {
+        let mut hook = hook.borrow_mut();
+        let order = std::mem::take(&mut hook.order);
+        *hook = RebaseTestHook::default();
+        order
+    });
+    (result, order)
+}
+
+#[cfg(test)]
+pub(super) fn with_staging_random_failure<T>(operation: impl FnOnce() -> T) -> T {
+    REBASE_TEST_HOOK.with(|hook| {
+        *hook.borrow_mut() = RebaseTestHook {
+            random_failure: true,
+            ..RebaseTestHook::default()
+        };
+    });
+    let result = operation();
+    REBASE_TEST_HOOK.with(|hook| *hook.borrow_mut() = RebaseTestHook::default());
+    result
+}
+
+#[cfg(test)]
+pub(super) fn with_staging_random_names<T>(
+    names: Vec<[u8; STAGING_RANDOM_BYTES]>,
+    operation: impl FnOnce() -> T,
+) -> T {
+    REBASE_TEST_HOOK.with(|hook| {
+        *hook.borrow_mut() = RebaseTestHook {
+            random_names: names.into(),
+            ..RebaseTestHook::default()
+        };
+    });
+    let result = operation();
+    REBASE_TEST_HOOK.with(|hook| *hook.borrow_mut() = RebaseTestHook::default());
+    result
+}
+
+#[cfg(test)]
+pub(super) fn with_exchange_failure<T>(operation: impl FnOnce() -> T) -> T {
+    REBASE_TEST_HOOK.with(|hook| {
+        *hook.borrow_mut() = RebaseTestHook {
+            exchange_failure: true,
+            ..RebaseTestHook::default()
+        };
+    });
+    let result = operation();
+    REBASE_TEST_HOOK.with(|hook| *hook.borrow_mut() = RebaseTestHook::default());
+    result
+}
+
+#[cfg(test)]
+pub(super) fn with_path_replacement<T>(
+    stage: SnapshotV2DiffRebaseStage,
+    path: PathBuf,
+    moved: PathBuf,
+    replacement: Vec<u8>,
+    operation: impl FnOnce() -> T,
+) -> (T, Vec<SnapshotV2DiffRebaseStage>) {
+    with_rebase_action(
+        RebaseTestAction::ReplacePath {
+            stage,
+            path,
+            moved,
+            replacement,
+        },
+        operation,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn with_path_removal<T>(
+    stage: SnapshotV2DiffRebaseStage,
+    path: PathBuf,
+    moved: PathBuf,
+    operation: impl FnOnce() -> T,
+) -> (T, Vec<SnapshotV2DiffRebaseStage>) {
+    with_rebase_action(RebaseTestAction::MovePath { stage, path, moved }, operation)
+}
+
+#[cfg(test)]
+pub(super) fn with_parent_replacement<T>(
+    stage: SnapshotV2DiffRebaseStage,
+    parent: PathBuf,
+    moved: PathBuf,
+    operation: impl FnOnce() -> T,
+) -> (T, Vec<SnapshotV2DiffRebaseStage>) {
+    with_rebase_action(
+        RebaseTestAction::ReplaceParent {
+            stage,
+            parent,
+            moved,
+        },
+        operation,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn with_staging_replacement<T>(
+    stage: SnapshotV2DiffRebaseStage,
+    directory: PathBuf,
+    moved: PathBuf,
+    replacement: Vec<u8>,
+    operation: impl FnOnce() -> T,
+) -> (T, Vec<SnapshotV2DiffRebaseStage>) {
+    with_rebase_action(
+        RebaseTestAction::ReplaceStaging {
+            stage,
+            directory,
+            moved,
+            replacement,
+        },
+        operation,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn with_staging_removal<T>(
+    stage: SnapshotV2DiffRebaseStage,
+    directory: PathBuf,
+    moved: PathBuf,
+    operation: impl FnOnce() -> T,
+) -> (T, Vec<SnapshotV2DiffRebaseStage>) {
+    with_rebase_action(
+        RebaseTestAction::MoveStaging {
+            stage,
+            directory,
+            moved,
+        },
+        operation,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn with_staging_corruption<T>(
+    stage: SnapshotV2DiffRebaseStage,
+    directory: PathBuf,
+    bytes: Vec<u8>,
+    operation: impl FnOnce() -> T,
+) -> (T, Vec<SnapshotV2DiffRebaseStage>) {
+    with_rebase_action(
+        RebaseTestAction::CorruptStaging {
+            stage,
+            directory,
+            bytes,
+        },
+        operation,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn with_staging_mode<T>(mode: libc::mode_t, operation: impl FnOnce() -> T) -> T {
+    REBASE_TEST_HOOK.with(|hook| {
+        *hook.borrow_mut() = RebaseTestHook {
+            staging_mode: Some(mode),
+            ..RebaseTestHook::default()
+        };
+    });
+    let result = operation();
+    REBASE_TEST_HOOK.with(|hook| *hook.borrow_mut() = RebaseTestHook::default());
+    result
+}
+
+#[cfg(test)]
+fn with_rebase_action<T>(
+    action: RebaseTestAction,
+    operation: impl FnOnce() -> T,
+) -> (T, Vec<SnapshotV2DiffRebaseStage>) {
+    REBASE_TEST_HOOK.with(|hook| {
+        *hook.borrow_mut() = RebaseTestHook {
+            action: Some(action),
+            ..RebaseTestHook::default()
+        };
+    });
+    let result = operation();
+    let order = REBASE_TEST_HOOK.with(|hook| {
+        let mut hook = hook.borrow_mut();
+        let order = std::mem::take(&mut hook.order);
+        *hook = RebaseTestHook::default();
+        order
+    });
+    (result, order)
+}

--- a/crates/runtime/src/snapshot_rebase/tests.rs
+++ b/crates/runtime/src/snapshot_rebase/tests.rs
@@ -362,6 +362,31 @@ mod macos_tests {
     }
 
     #[test]
+    fn result_sync_rejects_staging_permission_drift() {
+        let fixture = RebaseFixture::complete("result-mode-drift");
+        let error = rebase_snapshot_v2_diff_paths_with_cancel(&fixture.paths, |stage| {
+            if stage == SnapshotV2DiffRebaseStage::ResultFileSync {
+                let staging = fixture.directory.staging_entries();
+                assert_eq!(staging.len(), 1);
+                fs::set_permissions(&staging[0], fs::Permissions::from_mode(0o644))
+                    .expect("staging permissions should drift during the callback");
+            }
+            false
+        })
+        .expect_err("result verification should reject permission drift");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::ResultFileSync);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::StagingChanged
+        ));
+        assert_eq!(
+            error.staging_cleanup(),
+            Some(SnapshotV2DiffRebaseCleanup::Removed)
+        );
+        fixture.assert_uncommitted_and_clean();
+    }
+
+    #[test]
     fn stable_parent_symlink_resolves_to_one_retained_anchor() {
         let fixture = RebaseFixture::complete("parent-symlink");
         let parent_alias = fixture.directory.child("parent-alias");

--- a/crates/runtime/src/snapshot_rebase/tests.rs
+++ b/crates/runtime/src/snapshot_rebase/tests.rs
@@ -1,0 +1,1360 @@
+use super::*;
+
+#[test]
+fn paths_debug_redacts_both_values() {
+    let paths = SnapshotV2DiffRebasePaths::new("secret-base", "secret-diff");
+    let debug = format!("{paths:?}");
+    assert!(!debug.contains("secret-base"));
+    assert!(!debug.contains("secret-diff"));
+    assert_eq!(paths.base(), Path::new("secret-base"));
+    assert_eq!(paths.diff(), Path::new("secret-diff"));
+}
+
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn unsupported_platform_fails_before_callback_or_path_access() {
+    let paths = SnapshotV2DiffRebasePaths::new("", "");
+    let mut callbacks = 0;
+    let error = rebase_snapshot_v2_diff_paths_with_cancel(&paths, |_| {
+        callbacks += 1;
+        false
+    })
+    .expect_err("unsupported target must reject the operation");
+    assert_eq!(callbacks, 0);
+    assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::PlatformCheck);
+    assert!(matches!(
+        error.failure(),
+        SnapshotV2DiffRebaseFailure::UnsupportedPlatform
+    ));
+    assert_eq!(error.staging_cleanup(), None);
+}
+
+#[cfg(target_os = "macos")]
+mod macos_tests {
+    use std::ffi::CString;
+    use std::fs::{self, File, OpenOptions};
+    use std::io;
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+    use std::os::unix::fs::{FileExt, MetadataExt, PermissionsExt};
+    use std::os::unix::net::UnixListener;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use crate::memory::{GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange, aarch64};
+    use crate::snapshot_diff_v2_13::{
+        NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION, SnapshotV2DiffBase, SnapshotV2DiffSelection,
+        write_snapshot_v2_diff_layer,
+    };
+    use crate::snapshot_memory_v2::{
+        SnapshotV2MemoryBinding, write_snapshot_v2_memory_image_with_compatibility_version,
+    };
+
+    use super::super::macos::{
+        with_exchange_failure, with_parent_replacement, with_path_removal, with_path_replacement,
+        with_rebase_failures, with_staging_corruption, with_staging_mode,
+        with_staging_random_failure, with_staging_random_names, with_staging_removal,
+        with_staging_replacement,
+    };
+    use super::*;
+
+    static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+
+    #[derive(Debug)]
+    struct TestDirectory {
+        path: PathBuf,
+    }
+
+    impl TestDirectory {
+        fn new(label: &str) -> Self {
+            let sequence = NEXT_TEST_DIRECTORY.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir()
+                .join(format!("bb-rb-{label}-{}-{sequence}", std::process::id()));
+            fs::create_dir(&path).expect("test directory should create");
+            Self { path }
+        }
+
+        fn child(&self, name: &str) -> PathBuf {
+            self.path.join(name)
+        }
+
+        fn staging_entries(&self) -> Vec<PathBuf> {
+            fs::read_dir(&self.path)
+                .expect("test directory should enumerate")
+                .map(|entry| entry.expect("test entry should read"))
+                .filter(|entry| {
+                    entry
+                        .file_name()
+                        .as_encoded_bytes()
+                        .starts_with(b".bangbang-snapshot-rebase-")
+                })
+                .map(|entry| entry.path())
+                .collect()
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    struct RebaseFixture {
+        directory: TestDirectory,
+        paths: SnapshotV2DiffRebasePaths,
+        base_before: Vec<u8>,
+        base_before_facts: TestFileFacts,
+        diff_before: Vec<u8>,
+        diff_before_facts: TestFileFacts,
+        result: SnapshotV2MemoryBinding,
+        expected_byte: u8,
+    }
+
+    type TestFileFacts = (u64, u64, u32, u64, i64, i64, i64, i64);
+
+    impl RebaseFixture {
+        fn complete(label: &str) -> Self {
+            let directory = TestDirectory::new(label);
+            let base_path = directory.child("base.mem");
+            let diff_path = directory.child("next.diff");
+            let range = page_range(0, 4);
+            let base_memory = memory_with_byte(range, 0x19);
+            let base = write_complete(&base_path, &base_memory);
+            let result_memory = memory_with_byte(range, 0xa7);
+            let result = write_layer(
+                &diff_path,
+                &result_memory,
+                SnapshotV2DiffBase::Image(base),
+                &[range],
+            );
+            Self::from_parts(directory, base_path, diff_path, result, 0xa7)
+        }
+
+        fn zero_root(label: &str) -> Self {
+            let directory = TestDirectory::new(label);
+            let base_path = directory.child("base.diff");
+            let diff_path = directory.child("next.diff");
+            let range = page_range(0, 4);
+            let root_memory = memory_with_byte(range, 0x31);
+            let root = write_layer(&base_path, &root_memory, SnapshotV2DiffBase::Zero, &[range]);
+            let result_memory = memory_with_byte(range, 0xc4);
+            let result = write_layer(
+                &diff_path,
+                &result_memory,
+                SnapshotV2DiffBase::Image(root),
+                &[range],
+            );
+            Self::from_parts(directory, base_path, diff_path, result, 0xc4)
+        }
+
+        fn from_parts(
+            directory: TestDirectory,
+            base_path: PathBuf,
+            diff_path: PathBuf,
+            result: SnapshotV2MemoryBinding,
+            expected_byte: u8,
+        ) -> Self {
+            let base_before = fs::read(&base_path).expect("base should read");
+            let base_before_facts = test_file_facts(&base_path);
+            let diff_before = fs::read(&diff_path).expect("diff should read");
+            let diff_before_facts = test_file_facts(&diff_path);
+            Self {
+                directory,
+                paths: SnapshotV2DiffRebasePaths::new(base_path, diff_path),
+                base_before,
+                base_before_facts,
+                diff_before,
+                diff_before_facts,
+                result,
+                expected_byte,
+            }
+        }
+
+        fn assert_uncommitted_and_clean(&self) {
+            self.assert_uncommitted_bytes_and_clean();
+            assert_eq!(test_file_facts(self.paths.base()), self.base_before_facts);
+            assert_eq!(test_file_facts(self.paths.diff()), self.diff_before_facts);
+        }
+
+        fn assert_uncommitted_bytes_and_clean(&self) {
+            assert_eq!(
+                fs::read(self.paths.base()).expect("base should remain readable"),
+                self.base_before
+            );
+            assert_eq!(
+                fs::read(self.paths.diff()).expect("diff should remain readable"),
+                self.diff_before
+            );
+            assert!(self.directory.staging_entries().is_empty());
+        }
+
+        fn assert_committed(&self, outcome: &SnapshotV2DiffRebaseOutcome) {
+            assert_eq!(outcome.binding(), &self.result);
+            assert_ne!(
+                fs::read(self.paths.base()).expect("committed base should read"),
+                self.base_before
+            );
+            assert_eq!(
+                fs::read(self.paths.diff()).expect("diff should remain readable"),
+                self.diff_before
+            );
+            assert_eq!(test_file_facts(self.paths.diff()), self.diff_before_facts);
+            let file = File::open(self.paths.base()).expect("committed base should open");
+            for extent in self.result.extents().iter().copied() {
+                let mut bytes = vec![
+                    0_u8;
+                    usize::try_from(extent.range().size())
+                        .expect("extent should fit test memory")
+                ];
+                file.read_exact_at(&mut bytes, extent.file_offset())
+                    .expect("committed payload should read");
+                assert!(bytes.iter().all(|byte| *byte == self.expected_byte));
+            }
+            assert_eq!(
+                fs::metadata(self.paths.base())
+                    .expect("committed mode should read")
+                    .mode()
+                    & 0o7777,
+                0o600
+            );
+        }
+    }
+
+    fn page_range(first_page: u64, page_count: u64) -> GuestMemoryRange {
+        GuestMemoryRange::new(
+            GuestAddress::new(aarch64::DRAM_MEM_START + first_page * aarch64::GUEST_PAGE_SIZE),
+            page_count * aarch64::GUEST_PAGE_SIZE,
+        )
+        .expect("test range should validate")
+    }
+
+    fn test_file_facts(path: &Path) -> TestFileFacts {
+        let metadata = fs::metadata(path).expect("test file facts should read");
+        (
+            metadata.dev(),
+            metadata.ino(),
+            metadata.mode(),
+            metadata.size(),
+            metadata.mtime(),
+            metadata.mtime_nsec(),
+            metadata.ctime(),
+            metadata.ctime_nsec(),
+        )
+    }
+
+    fn memory_with_byte(range: GuestMemoryRange, byte: u8) -> GuestMemory {
+        let layout = GuestMemoryLayout::new(vec![range]).expect("test layout should validate");
+        let mut memory = GuestMemory::allocate(&layout).expect("test memory should allocate");
+        memory
+            .write_slice(
+                &vec![byte; usize::try_from(range.size()).expect("range should fit")],
+                range.start(),
+            )
+            .expect("test memory should populate");
+        memory
+    }
+
+    fn writable_file(path: &Path) -> File {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(path)
+            .expect("test artifact should create")
+    }
+
+    fn write_complete(path: &Path, memory: &GuestMemory) -> SnapshotV2MemoryBinding {
+        let mut file = writable_file(path);
+        write_snapshot_v2_memory_image_with_compatibility_version(
+            memory,
+            &mut file,
+            NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION,
+        )
+        .expect("complete image should write")
+    }
+
+    fn write_layer(
+        path: &Path,
+        memory: &GuestMemory,
+        base: SnapshotV2DiffBase,
+        selected: &[GuestMemoryRange],
+    ) -> SnapshotV2MemoryBinding {
+        let selection = SnapshotV2DiffSelection::try_from_ranges(memory, selected)
+            .expect("selection should validate");
+        let mut file = writable_file(path);
+        write_snapshot_v2_diff_layer(memory, &mut file, base, &selection)
+            .expect("Diff layer should write")
+            .result()
+            .clone()
+    }
+
+    fn assert_file_matches_memory(
+        path: &Path,
+        binding: &SnapshotV2MemoryBinding,
+        expected: &GuestMemory,
+    ) {
+        let file = File::open(path).expect("complete result should open");
+        for extent in binding.extents().iter().copied() {
+            let length = usize::try_from(extent.range().size()).expect("extent should fit usize");
+            let mut actual = vec![0_u8; length];
+            let mut wanted = vec![0_u8; length];
+            file.read_exact_at(&mut actual, extent.file_offset())
+                .expect("result extent should read");
+            expected
+                .read_slice(&mut wanted, extent.range().start())
+                .expect("expected extent should read");
+            assert_eq!(actual, wanted);
+        }
+    }
+
+    fn expect_materialization_failure(
+        directory: &TestDirectory,
+        paths: &SnapshotV2DiffRebasePaths,
+    ) -> SnapshotV2DiffRebaseError {
+        let base_before = fs::read(paths.base()).expect("rejected base should read");
+        let diff_before = fs::read(paths.diff()).expect("rejected diff should read");
+        let error = rebase_snapshot_v2_diff_paths(paths)
+            .expect_err("invalid materialization inputs should fail");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::Materialization);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::Materialization { .. }
+        ));
+        assert_eq!(
+            error.staging_cleanup(),
+            Some(SnapshotV2DiffRebaseCleanup::Removed)
+        );
+        assert_eq!(
+            fs::read(paths.base()).expect("base should remain"),
+            base_before
+        );
+        assert_eq!(
+            fs::read(paths.diff()).expect("diff should remain"),
+            diff_before
+        );
+        assert!(directory.staging_entries().is_empty());
+        error
+    }
+
+    #[test]
+    fn complete_and_zero_root_bases_exchange_durably() {
+        for fixture in [
+            RebaseFixture::complete("durable-complete"),
+            RebaseFixture::zero_root("durable-zero-root"),
+        ] {
+            let outcome =
+                rebase_snapshot_v2_diff_paths(&fixture.paths).expect("valid pair should commit");
+            assert_eq!(outcome.commit(), SnapshotV2DiffRebaseCommit::Durable);
+            fixture.assert_committed(&outcome);
+            assert!(fixture.directory.staging_entries().is_empty());
+        }
+    }
+
+    #[test]
+    fn explicit_mode_fixup_does_not_depend_on_creation_mode() {
+        let fixture = RebaseFixture::complete("explicit-mode");
+        let outcome = with_staging_mode(0o000, || {
+            rebase_snapshot_v2_diff_paths(&fixture.paths)
+                .expect("explicit chmod should recover a zero creation mode")
+        });
+        assert_eq!(outcome.commit(), SnapshotV2DiffRebaseCommit::Durable);
+        fixture.assert_committed(&outcome);
+        assert!(fixture.directory.staging_entries().is_empty());
+    }
+
+    #[test]
+    fn stable_parent_symlink_resolves_to_one_retained_anchor() {
+        let fixture = RebaseFixture::complete("parent-symlink");
+        let parent_alias = fixture.directory.child("parent-alias");
+        std::os::unix::fs::symlink(&fixture.directory.path, &parent_alias)
+            .expect("parent alias should create");
+        let paths =
+            SnapshotV2DiffRebasePaths::new(parent_alias.join("base.mem"), fixture.paths.diff());
+        let outcome = rebase_snapshot_v2_diff_paths(&paths)
+            .expect("stable parent alias should retain the same directory");
+        assert_eq!(outcome.commit(), SnapshotV2DiffRebaseCommit::Durable);
+        fixture.assert_committed(&outcome);
+        assert!(fixture.directory.staging_entries().is_empty());
+    }
+
+    #[test]
+    fn sparse_cross_directory_and_repeated_rebases_are_exact() {
+        let directory = TestDirectory::new("sparse-repeated");
+        let diff_directory = TestDirectory::new("cross-directory-diff");
+        let base_path = directory.child("base.mem");
+        let first_diff = diff_directory.child("first.diff");
+        let whole = page_range(0, 4);
+        let changed = page_range(0, 1);
+        let base_memory = memory_with_byte(whole, 0x21);
+        let base = write_complete(&base_path, &base_memory);
+
+        let mut first_memory = memory_with_byte(whole, 0x21);
+        first_memory
+            .write_slice(
+                &vec![0x72; usize::try_from(changed.size()).expect("page should fit")],
+                changed.start(),
+            )
+            .expect("selected page should update");
+        let first_result = write_layer(
+            &first_diff,
+            &first_memory,
+            SnapshotV2DiffBase::Image(base),
+            &[changed],
+        );
+        let first_diff_before = fs::read(&first_diff).expect("first diff should read");
+        let first_paths = SnapshotV2DiffRebasePaths::new(&base_path, &first_diff);
+        let first = rebase_snapshot_v2_diff_paths(&first_paths)
+            .expect("cross-directory sparse rebase should commit");
+        assert_eq!(first.commit(), SnapshotV2DiffRebaseCommit::Durable);
+        assert_eq!(first.binding(), &first_result);
+        assert_file_matches_memory(&base_path, &first_result, &first_memory);
+        assert_eq!(
+            fs::read(&first_diff).expect("first diff should remain"),
+            first_diff_before
+        );
+
+        let second_diff = directory.child("second.diff");
+        let second_memory = memory_with_byte(whole, 0xe3);
+        let second_result = write_layer(
+            &second_diff,
+            &second_memory,
+            SnapshotV2DiffBase::Image(first_result),
+            &[whole],
+        );
+        let second_diff_before = fs::read(&second_diff).expect("second diff should read");
+        let second_paths = SnapshotV2DiffRebasePaths::new(&base_path, &second_diff);
+        let second =
+            rebase_snapshot_v2_diff_paths(&second_paths).expect("sequential rebase should commit");
+        assert_eq!(second.commit(), SnapshotV2DiffRebaseCommit::Durable);
+        assert_eq!(second.binding(), &second_result);
+        assert_file_matches_memory(&base_path, &second_result, &second_memory);
+        assert_eq!(
+            fs::read(&second_diff).expect("second diff should remain"),
+            second_diff_before
+        );
+        assert!(directory.staging_entries().is_empty());
+        assert!(diff_directory.staging_entries().is_empty());
+    }
+
+    #[test]
+    fn cancellation_before_exchange_preserves_base_and_cleans_staging() {
+        let fixture = RebaseFixture::complete("cancel-exchange");
+        let error = rebase_snapshot_v2_diff_paths_with_cancel(&fixture.paths, |stage| {
+            stage == SnapshotV2DiffRebaseStage::AtomicExchange
+        })
+        .expect_err("exchange checkpoint cancellation should fail");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::AtomicExchange);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::Cancelled
+        ));
+        assert_eq!(
+            error.staging_cleanup(),
+            Some(SnapshotV2DiffRebaseCleanup::Removed)
+        );
+        fixture.assert_uncommitted_and_clean();
+    }
+
+    #[test]
+    fn every_outer_precommit_checkpoint_can_cancel_without_committing() {
+        for stage in [
+            SnapshotV2DiffRebaseStage::PlatformCheck,
+            SnapshotV2DiffRebaseStage::BasePathValidation,
+            SnapshotV2DiffRebaseStage::BaseDirectoryOpen,
+            SnapshotV2DiffRebaseStage::BaseFileOpen,
+            SnapshotV2DiffRebaseStage::BaseValidation,
+            SnapshotV2DiffRebaseStage::DiffPathValidation,
+            SnapshotV2DiffRebaseStage::DiffDirectoryOpen,
+            SnapshotV2DiffRebaseStage::DiffFileOpen,
+            SnapshotV2DiffRebaseStage::DiffValidation,
+            SnapshotV2DiffRebaseStage::SourceAliasCheck,
+            SnapshotV2DiffRebaseStage::SourceDuplication,
+            SnapshotV2DiffRebaseStage::StagingCreate,
+            SnapshotV2DiffRebaseStage::Materialization,
+            SnapshotV2DiffRebaseStage::ResultFileSync,
+            SnapshotV2DiffRebaseStage::SourceStability,
+            SnapshotV2DiffRebaseStage::DirectoryStability,
+            SnapshotV2DiffRebaseStage::EntryStability,
+            SnapshotV2DiffRebaseStage::AtomicExchange,
+        ] {
+            let fixture = RebaseFixture::complete(&format!("cancel-{stage:?}"));
+            let error = rebase_snapshot_v2_diff_paths_with_cancel(&fixture.paths, |current| {
+                current == stage
+            })
+            .expect_err("precommit checkpoint should cancel");
+            assert_eq!(error.stage(), stage);
+            assert!(matches!(
+                error.failure(),
+                SnapshotV2DiffRebaseFailure::Cancelled
+            ));
+            fixture.assert_uncommitted_and_clean();
+        }
+    }
+
+    #[test]
+    fn every_outer_precommit_stage_failure_preserves_inputs() {
+        for stage in [
+            SnapshotV2DiffRebaseStage::PlatformCheck,
+            SnapshotV2DiffRebaseStage::BasePathValidation,
+            SnapshotV2DiffRebaseStage::BaseDirectoryOpen,
+            SnapshotV2DiffRebaseStage::BaseFileOpen,
+            SnapshotV2DiffRebaseStage::BaseValidation,
+            SnapshotV2DiffRebaseStage::DiffPathValidation,
+            SnapshotV2DiffRebaseStage::DiffDirectoryOpen,
+            SnapshotV2DiffRebaseStage::DiffFileOpen,
+            SnapshotV2DiffRebaseStage::DiffValidation,
+            SnapshotV2DiffRebaseStage::SourceAliasCheck,
+            SnapshotV2DiffRebaseStage::SourceDuplication,
+            SnapshotV2DiffRebaseStage::StagingCreate,
+            SnapshotV2DiffRebaseStage::Materialization,
+            SnapshotV2DiffRebaseStage::ResultFileSync,
+            SnapshotV2DiffRebaseStage::SourceStability,
+            SnapshotV2DiffRebaseStage::DirectoryStability,
+            SnapshotV2DiffRebaseStage::EntryStability,
+            SnapshotV2DiffRebaseStage::AtomicExchange,
+        ] {
+            let fixture = RebaseFixture::complete(&format!("failure-{stage:?}"));
+            let (result, order) = with_rebase_failures(vec![stage], || {
+                rebase_snapshot_v2_diff_paths(&fixture.paths)
+            });
+            let error = result.expect_err("injected precommit stage should fail");
+            assert_eq!(error.stage(), stage);
+            assert!(matches!(
+                error.failure(),
+                SnapshotV2DiffRebaseFailure::Io {
+                    kind: io::ErrorKind::Other
+                }
+            ));
+            assert!(order.contains(&stage));
+            fixture.assert_uncommitted_and_clean();
+        }
+    }
+
+    #[test]
+    fn nested_materialization_cancellation_is_a_precommit_cancel() {
+        let fixture = RebaseFixture::complete("cancel-materialization");
+        let mut materialization_callbacks = 0;
+        let error = rebase_snapshot_v2_diff_paths_with_cancel(&fixture.paths, |stage| {
+            if stage == SnapshotV2DiffRebaseStage::Materialization {
+                materialization_callbacks += 1;
+                materialization_callbacks == 2
+            } else {
+                false
+            }
+        })
+        .expect_err("nested materialization should cancel");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::Materialization);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::Cancelled
+        ));
+        assert_eq!(
+            error.staging_cleanup(),
+            Some(SnapshotV2DiffRebaseCleanup::Removed)
+        );
+        fixture.assert_uncommitted_and_clean();
+    }
+
+    #[test]
+    fn final_callback_mutation_is_detected_before_swap() {
+        let fixture = RebaseFixture::complete("final-race");
+        let moved = fixture.directory.child("old-base.mem");
+        let base = fixture.paths.base().to_path_buf();
+        let error = rebase_snapshot_v2_diff_paths_with_cancel(&fixture.paths, |stage| {
+            if stage == SnapshotV2DiffRebaseStage::AtomicExchange {
+                fs::rename(&base, &moved).expect("base should move during test callback");
+                fs::write(&base, b"replacement").expect("replacement should create");
+            }
+            false
+        })
+        .expect_err("final identity checks should reject the replacement");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::SourceStability);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::SourceChanged {
+                input: SnapshotV2DiffRebaseInput::Base
+            }
+        ));
+        assert_eq!(
+            error.staging_cleanup(),
+            Some(SnapshotV2DiffRebaseCleanup::Removed)
+        );
+        assert_eq!(
+            fs::read(&base).expect("replacement should read"),
+            b"replacement"
+        );
+        assert!(fixture.directory.staging_entries().is_empty());
+    }
+
+    #[test]
+    fn final_callback_same_inode_staging_mutation_is_detected() {
+        let fixture = RebaseFixture::complete("final-staging-mutation");
+        let error = rebase_snapshot_v2_diff_paths_with_cancel(&fixture.paths, |stage| {
+            if stage == SnapshotV2DiffRebaseStage::AtomicExchange {
+                let staging = fixture.directory.staging_entries();
+                assert_eq!(staging.len(), 1);
+                fs::write(&staging[0], b"same-inode-corruption")
+                    .expect("staging should corrupt through its name");
+            }
+            false
+        })
+        .expect_err("final full-facts gate should reject same-inode mutation");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::EntryStability);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::StagingChanged
+        ));
+        assert_eq!(
+            error.staging_cleanup(),
+            Some(SnapshotV2DiffRebaseCleanup::Removed)
+        );
+        fixture.assert_uncommitted_and_clean();
+    }
+
+    #[test]
+    fn panic_unwind_removes_only_owned_staging() {
+        let fixture = RebaseFixture::complete("panic-cleanup");
+        let mut callbacks = 0;
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = rebase_snapshot_v2_diff_paths_with_cancel(&fixture.paths, |stage| {
+                if stage == SnapshotV2DiffRebaseStage::Materialization {
+                    callbacks += 1;
+                    if callbacks == 2 {
+                        panic!("injected caller panic");
+                    }
+                }
+                false
+            });
+        }));
+        assert!(panic.is_err());
+        fixture.assert_uncommitted_and_clean();
+    }
+
+    #[test]
+    fn injected_precommit_failure_keeps_primary_error_and_cleanup() {
+        let fixture = RebaseFixture::complete("precommit-failure");
+        let (result, order) =
+            with_rebase_failures(vec![SnapshotV2DiffRebaseStage::ResultFileSync], || {
+                rebase_snapshot_v2_diff_paths(&fixture.paths)
+            });
+        let error = result.expect_err("injected sync failure should abort");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::ResultFileSync);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::Io {
+                kind: io::ErrorKind::Other
+            }
+        ));
+        assert_eq!(
+            error.staging_cleanup(),
+            Some(SnapshotV2DiffRebaseCleanup::Removed)
+        );
+        assert!(order.contains(&SnapshotV2DiffRebaseStage::ResultFileSync));
+        fixture.assert_uncommitted_and_clean();
+    }
+
+    #[test]
+    fn precommit_cleanup_failure_does_not_mask_the_primary_cancel() {
+        let fixture = RebaseFixture::complete("precommit-cleanup-failure");
+        let parent = fixture.directory.path.clone();
+        let error = rebase_snapshot_v2_diff_paths_with_cancel(&fixture.paths, |stage| {
+            if stage == SnapshotV2DiffRebaseStage::ResultFileSync {
+                fs::set_permissions(&parent, fs::Permissions::from_mode(0o500))
+                    .expect("test parent should become unwritable");
+                true
+            } else {
+                false
+            }
+        })
+        .expect_err("result-sync cancellation should remain primary");
+        fs::set_permissions(&parent, fs::Permissions::from_mode(0o700))
+            .expect("test parent permissions should restore");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::ResultFileSync);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::Cancelled
+        ));
+        assert_eq!(
+            error.staging_cleanup(),
+            Some(SnapshotV2DiffRebaseCleanup::Failed(
+                io::ErrorKind::PermissionDenied
+            ))
+        );
+        assert_eq!(fixture.directory.staging_entries().len(), 1);
+        assert_eq!(
+            fs::read(fixture.paths.base()).expect("base should remain"),
+            fixture.base_before
+        );
+        assert_eq!(
+            fs::read(fixture.paths.diff()).expect("diff should remain"),
+            fixture.diff_before
+        );
+    }
+
+    #[test]
+    fn exchange_syscall_failure_is_precommit_and_retryable() {
+        let fixture = RebaseFixture::complete("exchange-failure");
+        let error = with_exchange_failure(|| {
+            rebase_snapshot_v2_diff_paths(&fixture.paths)
+                .expect_err("injected exchange failure should abort")
+        });
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::AtomicExchange);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::AtomicExchangeUnavailable {
+                kind: io::ErrorKind::Other
+            }
+        ));
+        assert_eq!(
+            error.staging_cleanup(),
+            Some(SnapshotV2DiffRebaseCleanup::Removed)
+        );
+        fixture.assert_uncommitted_and_clean();
+
+        let outcome = rebase_snapshot_v2_diff_paths(&fixture.paths)
+            .expect("fresh retry should commit unchanged inputs");
+        assert_eq!(outcome.commit(), SnapshotV2DiffRebaseCommit::Durable);
+        fixture.assert_committed(&outcome);
+    }
+
+    #[test]
+    fn observed_component_and_parent_replacements_abort_safely() {
+        let fixture = RebaseFixture::complete("diff-removal");
+        let moved_diff = fixture.directory.child("moved-next.diff");
+        let (result, _) = with_path_removal(
+            SnapshotV2DiffRebaseStage::EntryStability,
+            fixture.paths.diff().to_path_buf(),
+            moved_diff.clone(),
+            || rebase_snapshot_v2_diff_paths(&fixture.paths),
+        );
+        let error = result.expect_err("missing diff entry should abort");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::EntryStability);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::EntryChanged {
+                input: SnapshotV2DiffRebaseInput::Diff
+            }
+        ));
+        fs::rename(moved_diff, fixture.paths.diff()).expect("diff should restore");
+        fixture.assert_uncommitted_bytes_and_clean();
+
+        let fixture = RebaseFixture::complete("parent-replacement");
+        let parent = fixture.directory.path.clone();
+        let moved_parent = parent.with_extension("moved");
+        let (result, _) = with_parent_replacement(
+            SnapshotV2DiffRebaseStage::AtomicExchange,
+            parent.clone(),
+            moved_parent.clone(),
+            || rebase_snapshot_v2_diff_paths(&fixture.paths),
+        );
+        let error = result.expect_err("replaced parent path should abort");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::DirectoryStability);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::DirectoryChanged {
+                input: SnapshotV2DiffRebaseInput::Base
+            }
+        ));
+        assert_eq!(
+            error.staging_cleanup(),
+            Some(SnapshotV2DiffRebaseCleanup::Removed)
+        );
+        fs::remove_dir(&parent).expect("replacement parent should be empty");
+        fs::rename(moved_parent, &parent).expect("original parent should restore");
+        fixture.assert_uncommitted_bytes_and_clean();
+    }
+
+    #[test]
+    fn observed_staging_replacement_is_retained_and_classified() {
+        let fixture = RebaseFixture::complete("staging-replacement");
+        let moved = fixture.directory.child("owned-result.moved");
+        let (result, _) = with_staging_replacement(
+            SnapshotV2DiffRebaseStage::EntryStability,
+            fixture.directory.path.clone(),
+            moved,
+            b"foreign-staging".to_vec(),
+            || rebase_snapshot_v2_diff_paths(&fixture.paths),
+        );
+        let error = result.expect_err("staging substitution should abort");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::EntryStability);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::StagingChanged
+        ));
+        assert_eq!(
+            error.staging_cleanup(),
+            Some(SnapshotV2DiffRebaseCleanup::ChangedRefused)
+        );
+        assert_eq!(fixture.directory.staging_entries().len(), 1);
+        assert_eq!(
+            fs::read(&fixture.directory.staging_entries()[0])
+                .expect("foreign staging should survive"),
+            b"foreign-staging"
+        );
+        assert_eq!(
+            fs::read(fixture.paths.base()).expect("base should remain"),
+            fixture.base_before
+        );
+        assert_eq!(
+            fs::read(fixture.paths.diff()).expect("diff should remain"),
+            fixture.diff_before
+        );
+    }
+
+    #[test]
+    fn observed_staging_removal_is_not_retried_against_another_name() {
+        let fixture = RebaseFixture::complete("staging-removal");
+        let moved = fixture.directory.child("moved-owned-result");
+        let (result, _) = with_staging_removal(
+            SnapshotV2DiffRebaseStage::EntryStability,
+            fixture.directory.path.clone(),
+            moved.clone(),
+            || rebase_snapshot_v2_diff_paths(&fixture.paths),
+        );
+        let error = result.expect_err("missing staging name should abort");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::EntryStability);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::StagingChanged
+        ));
+        assert_eq!(
+            error.staging_cleanup(),
+            Some(SnapshotV2DiffRebaseCleanup::AlreadyAbsent)
+        );
+        assert!(moved.is_file());
+        assert!(fixture.directory.staging_entries().is_empty());
+        assert_eq!(
+            fs::read(fixture.paths.base()).expect("base should remain"),
+            fixture.base_before
+        );
+        assert_eq!(
+            fs::read(fixture.paths.diff()).expect("diff should remain"),
+            fixture.diff_before
+        );
+    }
+
+    #[test]
+    fn synchronized_result_corruption_fails_before_exchange() {
+        let fixture = RebaseFixture::complete("result-corruption");
+        let (result, _) = with_staging_corruption(
+            SnapshotV2DiffRebaseStage::ResultFileSync,
+            fixture.directory.path.clone(),
+            b"corrupt-result".to_vec(),
+            || rebase_snapshot_v2_diff_paths(&fixture.paths),
+        );
+        let error = result.expect_err("outer result verification should reject corruption");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::ResultFileSync);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::ResultVerification { .. }
+        ));
+        assert_eq!(
+            error.staging_cleanup(),
+            Some(SnapshotV2DiffRebaseCleanup::Removed)
+        );
+        fixture.assert_uncommitted_and_clean();
+    }
+
+    #[test]
+    fn postcommit_cleanup_failure_still_runs_directory_sync() {
+        let fixture = RebaseFixture::complete("cleanup-failure");
+        let (result, order) =
+            with_rebase_failures(vec![SnapshotV2DiffRebaseStage::DisplacedCleanup], || {
+                rebase_snapshot_v2_diff_paths(&fixture.paths)
+            });
+        let outcome = result.expect("postcommit failure must return an outcome");
+        assert_eq!(
+            outcome.commit(),
+            SnapshotV2DiffRebaseCommit::Uncertain {
+                stage: SnapshotV2DiffRebaseStage::DisplacedCleanup,
+                failure: SnapshotV2DiffRebaseCommitFailure::Cleanup,
+                cleanup: SnapshotV2DiffRebaseCleanup::Failed(io::ErrorKind::Other),
+                directory_sync: None,
+            }
+        );
+        fixture.assert_committed(&outcome);
+        let cleanup_index = order
+            .iter()
+            .position(|stage| *stage == SnapshotV2DiffRebaseStage::DisplacedCleanup)
+            .expect("cleanup stage should run");
+        let sync_index = order
+            .iter()
+            .position(|stage| *stage == SnapshotV2DiffRebaseStage::BaseDirectorySync)
+            .expect("directory sync stage should run");
+        assert!(cleanup_index < sync_index);
+        assert_eq!(fixture.directory.staging_entries().len(), 1);
+    }
+
+    #[test]
+    fn postcommit_preserves_first_uncertainty_and_records_later_sync() {
+        let fixture = RebaseFixture::complete("postcommit-first-error");
+        let (result, order) = with_rebase_failures(
+            vec![
+                SnapshotV2DiffRebaseStage::CommitVerification,
+                SnapshotV2DiffRebaseStage::BaseDirectorySync,
+            ],
+            || rebase_snapshot_v2_diff_paths(&fixture.paths),
+        );
+        let outcome = result.expect("committed failures must return an outcome");
+        assert_eq!(
+            outcome.commit(),
+            SnapshotV2DiffRebaseCommit::Uncertain {
+                stage: SnapshotV2DiffRebaseStage::CommitVerification,
+                failure: SnapshotV2DiffRebaseCommitFailure::Io(io::ErrorKind::Other),
+                cleanup: SnapshotV2DiffRebaseCleanup::Removed,
+                directory_sync: Some(io::ErrorKind::Other),
+            }
+        );
+        fixture.assert_committed(&outcome);
+        assert!(fixture.directory.staging_entries().is_empty());
+        assert!(order.ends_with(&[
+            SnapshotV2DiffRebaseStage::DisplacedCleanup,
+            SnapshotV2DiffRebaseStage::BaseDirectorySync,
+            SnapshotV2DiffRebaseStage::Complete,
+        ]));
+    }
+
+    #[test]
+    fn postcommit_base_replacement_is_reported_without_rollback() {
+        let fixture = RebaseFixture::complete("committed-base-replacement");
+        let committed_result = fixture.directory.child("committed-result.moved");
+        let (result, order) = with_path_replacement(
+            SnapshotV2DiffRebaseStage::CommitVerification,
+            fixture.paths.base().to_path_buf(),
+            committed_result.clone(),
+            b"foreign-base".to_vec(),
+            || rebase_snapshot_v2_diff_paths(&fixture.paths),
+        );
+        let outcome = result.expect("postcommit substitution must return an outcome");
+        assert_eq!(
+            outcome.commit(),
+            SnapshotV2DiffRebaseCommit::Uncertain {
+                stage: SnapshotV2DiffRebaseStage::CommitVerification,
+                failure: SnapshotV2DiffRebaseCommitFailure::BaseEntryChanged,
+                cleanup: SnapshotV2DiffRebaseCleanup::Removed,
+                directory_sync: None,
+            }
+        );
+        assert_eq!(
+            fs::read(fixture.paths.base()).expect("replacement base should survive"),
+            b"foreign-base"
+        );
+        assert_ne!(
+            fs::read(committed_result).expect("committed result should remain reachable"),
+            fixture.base_before
+        );
+        assert!(fixture.directory.staging_entries().is_empty());
+        assert!(order.contains(&SnapshotV2DiffRebaseStage::BaseDirectorySync));
+    }
+
+    #[test]
+    fn postcommit_displaced_replacement_is_refused_and_synced() {
+        let fixture = RebaseFixture::complete("displaced-replacement");
+        let displaced = fixture.directory.child("displaced-base.moved");
+        let (result, order) = with_staging_replacement(
+            SnapshotV2DiffRebaseStage::DisplacedCleanup,
+            fixture.directory.path.clone(),
+            displaced,
+            b"foreign-displaced".to_vec(),
+            || rebase_snapshot_v2_diff_paths(&fixture.paths),
+        );
+        let outcome = result.expect("committed cleanup mismatch must return an outcome");
+        assert_eq!(
+            outcome.commit(),
+            SnapshotV2DiffRebaseCommit::Uncertain {
+                stage: SnapshotV2DiffRebaseStage::DisplacedCleanup,
+                failure: SnapshotV2DiffRebaseCommitFailure::Cleanup,
+                cleanup: SnapshotV2DiffRebaseCleanup::ChangedRefused,
+                directory_sync: None,
+            }
+        );
+        fixture.assert_committed(&outcome);
+        assert_eq!(fixture.directory.staging_entries().len(), 1);
+        assert_eq!(
+            fs::read(&fixture.directory.staging_entries()[0])
+                .expect("foreign displaced entry should survive"),
+            b"foreign-displaced"
+        );
+        assert!(order.contains(&SnapshotV2DiffRebaseStage::BaseDirectorySync));
+    }
+
+    #[test]
+    fn randomness_failure_happens_before_any_staging_ownership() {
+        let fixture = RebaseFixture::complete("random-failure");
+        let error = with_staging_random_failure(|| {
+            rebase_snapshot_v2_diff_paths(&fixture.paths)
+                .expect_err("randomness failure should abort")
+        });
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::StagingCreate);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::RandomnessUnavailable
+        ));
+        assert_eq!(error.staging_cleanup(), None);
+        fixture.assert_uncommitted_and_clean();
+    }
+
+    #[test]
+    fn random_name_collision_retries_without_claiming_foreign_entry() {
+        let fixture = RebaseFixture::complete("random-collision");
+        let collision = fixture
+            .directory
+            .child(".bangbang-snapshot-rebase-00000000000000000000000000000000");
+        fs::write(&collision, b"foreign").expect("collision entry should create");
+        let outcome = with_staging_random_names(vec![[0_u8; 16], [1_u8; 16]], || {
+            rebase_snapshot_v2_diff_paths(&fixture.paths).expect("second name should succeed")
+        });
+        assert_eq!(outcome.commit(), SnapshotV2DiffRebaseCommit::Durable);
+        fixture.assert_committed(&outcome);
+        assert_eq!(
+            fs::read(&collision).expect("foreign collision should remain"),
+            b"foreign"
+        );
+        assert_eq!(fixture.directory.staging_entries(), vec![collision]);
+    }
+
+    #[test]
+    fn random_name_collisions_exhaust_at_the_fixed_bound() {
+        let fixture = RebaseFixture::complete("random-collision-bound");
+        let collision = fixture
+            .directory
+            .child(".bangbang-snapshot-rebase-00000000000000000000000000000000");
+        fs::write(&collision, b"foreign").expect("collision entry should create");
+        let error = with_staging_random_names(vec![[0_u8; 16]; 16], || {
+            rebase_snapshot_v2_diff_paths(&fixture.paths)
+                .expect_err("sixteen collisions should exhaust the bound")
+        });
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::StagingCreate);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::Io {
+                kind: io::ErrorKind::AlreadyExists
+            }
+        ));
+        assert_eq!(error.staging_cleanup(), None);
+        assert_eq!(
+            fs::read(&collision).expect("collision should remain"),
+            b"foreign"
+        );
+        assert_eq!(
+            fs::read(fixture.paths.base()).expect("base should remain"),
+            fixture.base_before
+        );
+        assert_eq!(
+            fs::read(fixture.paths.diff()).expect("diff should remain"),
+            fixture.diff_before
+        );
+        assert_eq!(fixture.directory.staging_entries(), vec![collision]);
+    }
+
+    #[test]
+    fn hard_link_alias_is_rejected_before_materialization() {
+        let fixture = RebaseFixture::complete("source-alias");
+        for alias in [
+            fixture.paths.base().to_path_buf(),
+            fixture.directory.path.join(".").join("base.mem"),
+        ] {
+            let paths = SnapshotV2DiffRebasePaths::new(fixture.paths.base(), alias);
+            let error = rebase_snapshot_v2_diff_paths(&paths)
+                .expect_err("exact and syntactic aliases should be rejected");
+            assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::SourceAliasCheck);
+            assert!(matches!(
+                error.failure(),
+                SnapshotV2DiffRebaseFailure::SourceAlias
+            ));
+            assert_eq!(error.staging_cleanup(), None);
+        }
+        let original_diff = fixture.directory.child("original-next.diff");
+        fs::rename(fixture.paths.diff(), &original_diff).expect("diff should move aside");
+        fs::hard_link(fixture.paths.base(), fixture.paths.diff()).expect("alias should create");
+        let error = rebase_snapshot_v2_diff_paths(&fixture.paths)
+            .expect_err("source alias should be rejected");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::SourceAliasCheck);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::SourceAlias
+        ));
+        assert_eq!(error.staging_cleanup(), None);
+        assert_eq!(
+            fs::read(fixture.paths.base()).expect("base should remain"),
+            fixture.base_before
+        );
+    }
+
+    #[test]
+    fn final_symlink_and_invalid_component_are_rejected() {
+        let fixture = RebaseFixture::complete("invalid-paths");
+        let link = fixture.directory.child("base-link.mem");
+        std::os::unix::fs::symlink(fixture.paths.base(), &link)
+            .expect("test symlink should create");
+        let symlink_paths = SnapshotV2DiffRebasePaths::new(link, fixture.paths.diff());
+        let symlink_error = rebase_snapshot_v2_diff_paths(&symlink_paths)
+            .expect_err("final symlink should be rejected");
+        assert_eq!(
+            symlink_error.stage(),
+            SnapshotV2DiffRebaseStage::BaseFileOpen
+        );
+
+        let invalid = SnapshotV2DiffRebasePaths::new("secret-base/..", fixture.paths.diff());
+        let invalid_error = rebase_snapshot_v2_diff_paths(&invalid)
+            .expect_err("invalid final component should be rejected");
+        assert_eq!(
+            invalid_error.stage(),
+            SnapshotV2DiffRebaseStage::BasePathValidation
+        );
+        assert!(matches!(
+            invalid_error.failure(),
+            SnapshotV2DiffRebaseFailure::InvalidPath {
+                input: SnapshotV2DiffRebaseInput::Base
+            }
+        ));
+        assert!(!format!("{invalid_error:?}").contains("secret-base"));
+    }
+
+    #[test]
+    fn path_validation_rejects_all_non_components_without_disclosure() {
+        let fixture = RebaseFixture::complete("path-validation");
+        let mut invalid = vec![
+            PathBuf::from(""),
+            PathBuf::from("/"),
+            PathBuf::from("trailing/"),
+            PathBuf::from("."),
+            PathBuf::from(".."),
+        ];
+        invalid.push(PathBuf::from(std::ffi::OsString::from_vec(
+            b"secret\0base".to_vec(),
+        )));
+        for base in invalid {
+            let paths = SnapshotV2DiffRebasePaths::new(base, fixture.paths.diff());
+            let error =
+                rebase_snapshot_v2_diff_paths(&paths).expect_err("invalid base syntax should fail");
+            assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::BasePathValidation);
+            assert!(matches!(
+                error.failure(),
+                SnapshotV2DiffRebaseFailure::InvalidPath {
+                    input: SnapshotV2DiffRebaseInput::Base
+                }
+            ));
+            assert_eq!(error.staging_cleanup(), None);
+            assert!(!format!("{error:?}").contains("secret"));
+        }
+
+        let paths = SnapshotV2DiffRebasePaths::new(fixture.paths.base(), "bad-diff/");
+        let error = rebase_snapshot_v2_diff_paths(&paths)
+            .expect_err("invalid diff syntax should fail after base adoption");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::DiffPathValidation);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::InvalidPath {
+                input: SnapshotV2DiffRebaseInput::Diff
+            }
+        ));
+        fixture.assert_uncommitted_and_clean();
+    }
+
+    #[test]
+    fn formatted_error_source_chain_redacts_host_and_snapshot_values() {
+        let fixture = RebaseFixture::complete("secret-host-directory");
+        OpenOptions::new()
+            .write(true)
+            .open(fixture.paths.diff())
+            .expect("diff should open for malformed diagnostic")
+            .set_len(8)
+            .expect("diff should truncate");
+        let error =
+            rebase_snapshot_v2_diff_paths(&fixture.paths).expect_err("malformed layer should fail");
+        let mut diagnostics = format!("{error:?}\n{error}");
+        let mut source = std::error::Error::source(&error);
+        while let Some(current) = source {
+            diagnostics.push_str(&format!("\n{current:?}\n{current}"));
+            source = current.source();
+        }
+        let directory = fixture.directory.path.to_string_lossy().into_owned();
+        let base = fixture.paths.base().to_string_lossy().into_owned();
+        let diff = fixture.paths.diff().to_string_lossy().into_owned();
+        for private in [
+            directory.as_str(),
+            base.as_str(),
+            diff.as_str(),
+            ".bangbang-snapshot-rebase-",
+            "BANGM2A",
+            "BANGD2A",
+        ] {
+            assert!(!diagnostics.contains(private));
+        }
+        assert!(!diagnostics.contains("secret-host-directory"));
+        assert!(!diagnostics.contains("0xa7"));
+    }
+
+    #[test]
+    fn missing_and_special_inputs_fail_before_staging_without_blocking() {
+        let fixture = RebaseFixture::complete("special-inputs");
+
+        let missing_parent = fixture.directory.child("missing/base.mem");
+        let paths = SnapshotV2DiffRebasePaths::new(missing_parent, fixture.paths.diff());
+        let error = rebase_snapshot_v2_diff_paths(&paths).expect_err("missing parent should fail");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::BaseDirectoryOpen);
+
+        let missing_file = fixture.directory.child("missing.mem");
+        let paths = SnapshotV2DiffRebasePaths::new(missing_file, fixture.paths.diff());
+        let error = rebase_snapshot_v2_diff_paths(&paths).expect_err("missing file should fail");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::BaseFileOpen);
+
+        let directory_source = fixture.directory.child("source-directory");
+        fs::create_dir(&directory_source).expect("source directory should create");
+        let paths = SnapshotV2DiffRebasePaths::new(&directory_source, fixture.paths.diff());
+        let error = rebase_snapshot_v2_diff_paths(&paths)
+            .expect_err("directory source should fail validation");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::BaseValidation);
+
+        let fifo = fixture.directory.child("source-fifo");
+        let fifo_name = CString::new(fifo.as_os_str().as_bytes()).expect("FIFO path should encode");
+        // SAFETY: `fifo_name` is a live NUL-terminated path and the mode is valid.
+        assert_eq!(unsafe { libc::mkfifo(fifo_name.as_ptr(), 0o600) }, 0);
+        let paths = SnapshotV2DiffRebasePaths::new(&fifo, fixture.paths.diff());
+        let error = rebase_snapshot_v2_diff_paths(&paths)
+            .expect_err("nonblocking FIFO adoption should reject the type");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::BaseValidation);
+
+        let socket = fixture.directory.child("source.sock");
+        let _listener = UnixListener::bind(&socket).expect("test socket should bind");
+        let paths = SnapshotV2DiffRebasePaths::new(&socket, fixture.paths.diff());
+        let error = rebase_snapshot_v2_diff_paths(&paths)
+            .expect_err("socket source should fail without staging");
+        assert!(matches!(
+            error.stage(),
+            SnapshotV2DiffRebaseStage::BaseFileOpen | SnapshotV2DiffRebaseStage::BaseValidation
+        ));
+
+        assert!(fixture.directory.staging_entries().is_empty());
+        assert_eq!(
+            fs::read(fixture.paths.base()).expect("base should remain"),
+            fixture.base_before
+        );
+        assert_eq!(
+            fs::read(fixture.paths.diff()).expect("diff should remain"),
+            fixture.diff_before
+        );
+    }
+
+    #[test]
+    fn unwritable_base_parent_fails_before_staging_creation() {
+        let fixture = RebaseFixture::complete("unwritable-parent");
+        fs::set_permissions(&fixture.directory.path, fs::Permissions::from_mode(0o500))
+            .expect("parent permissions should tighten");
+        let result = rebase_snapshot_v2_diff_paths(&fixture.paths);
+        fs::set_permissions(&fixture.directory.path, fs::Permissions::from_mode(0o700))
+            .expect("parent permissions should restore");
+        let error = result.expect_err("unwritable parent should reject staging");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::StagingCreate);
+        assert_eq!(error.staging_cleanup(), None);
+        fixture.assert_uncommitted_and_clean();
+    }
+
+    #[test]
+    fn invalid_base_magic_and_layer_semantics_preserve_both_inputs() {
+        let fixture = RebaseFixture::complete("invalid-base-magic");
+        let base = OpenOptions::new()
+            .write(true)
+            .open(fixture.paths.base())
+            .expect("base should open for corruption");
+        base.write_all_at(b"NOTBASE!", 0)
+            .expect("base magic should corrupt");
+        let corrupted = fs::read(fixture.paths.base()).expect("corrupt base should read");
+        let error = rebase_snapshot_v2_diff_paths(&fixture.paths)
+            .expect_err("invalid base magic should fail");
+        assert_eq!(error.stage(), SnapshotV2DiffRebaseStage::BaseValidation);
+        assert!(matches!(
+            error.failure(),
+            SnapshotV2DiffRebaseFailure::InvalidBaseKind
+        ));
+        assert_eq!(
+            fs::read(fixture.paths.base()).expect("corrupt base should remain"),
+            corrupted
+        );
+        assert!(fixture.directory.staging_entries().is_empty());
+
+        let fixture = RebaseFixture::complete("truncated-layer");
+        OpenOptions::new()
+            .write(true)
+            .open(fixture.paths.diff())
+            .expect("diff should open for truncation")
+            .set_len(8)
+            .expect("diff should truncate");
+        let _ = expect_materialization_failure(&fixture.directory, &fixture.paths);
+
+        let directory = TestDirectory::new("zero-root-next");
+        let range = page_range(0, 4);
+        let base_path = directory.child("base.mem");
+        let diff_path = directory.child("next.diff");
+        let base_memory = memory_with_byte(range, 0x10);
+        let _base = write_complete(&base_path, &base_memory);
+        let next_memory = memory_with_byte(range, 0x20);
+        let _next = write_layer(&diff_path, &next_memory, SnapshotV2DiffBase::Zero, &[range]);
+        let paths = SnapshotV2DiffRebasePaths::new(base_path, diff_path);
+        let _ = expect_materialization_failure(&directory, &paths);
+
+        let directory = TestDirectory::new("image-based-root");
+        let predecessor_path = directory.child("predecessor.mem");
+        let base_path = directory.child("base.diff");
+        let diff_path = directory.child("next.diff");
+        let predecessor_memory = memory_with_byte(range, 0x30);
+        let predecessor = write_complete(&predecessor_path, &predecessor_memory);
+        let base_memory = memory_with_byte(range, 0x40);
+        let base_result = write_layer(
+            &base_path,
+            &base_memory,
+            SnapshotV2DiffBase::Image(predecessor),
+            &[range],
+        );
+        let next_memory = memory_with_byte(range, 0x50);
+        let _next = write_layer(
+            &diff_path,
+            &next_memory,
+            SnapshotV2DiffBase::Image(base_result),
+            &[range],
+        );
+        let paths = SnapshotV2DiffRebasePaths::new(base_path, diff_path);
+        let _ = expect_materialization_failure(&directory, &paths);
+    }
+
+    #[test]
+    fn stale_lineage_and_missing_coverage_are_retry_safe() {
+        let range = page_range(0, 4);
+        let directory = TestDirectory::new("stale-lineage");
+        let base_path = directory.child("base.mem");
+        let unrelated_path = directory.child("unrelated.mem");
+        let diff_path = directory.child("next.diff");
+        let base = write_complete(&base_path, &memory_with_byte(range, 0x11));
+        let unrelated = write_complete(&unrelated_path, &memory_with_byte(range, 0x22));
+        assert_ne!(base.image_id(), unrelated.image_id());
+        let _next = write_layer(
+            &diff_path,
+            &memory_with_byte(range, 0x33),
+            SnapshotV2DiffBase::Image(unrelated),
+            &[range],
+        );
+        let paths = SnapshotV2DiffRebasePaths::new(base_path, diff_path);
+        let _ = expect_materialization_failure(&directory, &paths);
+
+        let directory = TestDirectory::new("missing-coverage");
+        let base_path = directory.child("base.mem");
+        let diff_path = directory.child("next.diff");
+        let inherited = page_range(0, 4);
+        let added = page_range(8, 4);
+        let base = write_complete(&base_path, &memory_with_byte(inherited, 0x44));
+        let layout = GuestMemoryLayout::new(vec![inherited, added])
+            .expect("expanded layout should validate");
+        let mut target = GuestMemory::allocate(&layout).expect("expanded memory should allocate");
+        for (range, byte) in [(inherited, 0x44), (added, 0x55)] {
+            target
+                .write_slice(
+                    &vec![byte; usize::try_from(range.size()).expect("range should fit")],
+                    range.start(),
+                )
+                .expect("expanded memory should populate");
+        }
+        let _next = write_layer(&diff_path, &target, SnapshotV2DiffBase::Image(base), &[]);
+        let paths = SnapshotV2DiffRebasePaths::new(base_path, diff_path);
+        let _ = expect_materialization_failure(&directory, &paths);
+    }
+}


### PR DESCRIPTION
## Summary

- add a dormant runtime API for rebasing a native-v2 Diff snapshot onto a complete or proven zero-root base
- materialize and verify the replacement through descriptor-anchored sources, then publish it atomically on macOS with `RENAME_SWAP`
- distinguish retry-safe pre-commit failures from post-commit durability or cleanup uncertainty, with redacted diagnostics throughout
- cover cancellation, source and namespace races, staging corruption, exchange failures, cleanup uncertainty, alias rejection, and complete/zero-root success paths with real-filesystem tests

## Scope

- this PR adds the runtime primitive only; it does not expose a CLI/API route or promote the compatibility inventory and user documentation
- public documentation and capability promotion remain tracked by #1759
- the primitive documents its trusted parent-directory and retained source-inode boundary, plus the lack of crash-recovery cleanup after `SIGKILL`

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
- `cargo test -p bangbang-runtime snapshot_rebase --all-features --locked`
- `cargo test -p bangbang-runtime snapshot_diff_v2_13 --all-features --locked`
- `cargo test -p bangbang-runtime snapshot_artifact --all-features --locked`

Closes #1754

Parent: #1541
