### PR TITLE
feat: expose snapshot rebase tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bangbang-snapshot-tools"
+version = "0.1.0"
+dependencies = [
+ "bangbang-runtime",
+ "clap",
+ "libc",
+ "signal-hook",
+]
+
+[[package]]
 name = "bangbang-vhost-user"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/bangbang",
     "tools/firecracker-capability-audit",
     "tools/seccompiler",
+    "tools/snapshot-tools",
 ]
 resolver = "3"
 

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -35651,6 +35651,8 @@ mod tests {
     #[cfg(target_os = "macos")]
     use std::os::unix::net::{UnixDatagram, UnixStream};
     use std::path::{Path, PathBuf};
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    use std::process::Command;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Arc, Condvar, Mutex, mpsc};
     use std::time::{Duration, Instant};
@@ -58918,9 +58920,6 @@ mod tests {
     #[ignore = "requires the signed native_v2_process integration group"]
     fn signed_native_v2_diff_process_loads_zero_root_and_rebased_products() {
         use bangbang_hvf::decode_hvf_snapshot_v2_diff_state;
-        use bangbang_runtime::snapshot_rebase::{
-            SnapshotV2DiffRebaseCommit, SnapshotV2DiffRebasePaths, rebase_snapshot_v2_diff_paths,
-        };
 
         const ARM64_IMAGE_HEADER_SIZE: usize = 64;
         const ARM64_IMAGE_SIZE_OFFSET: usize = 16;
@@ -58930,6 +58929,16 @@ mod tests {
         const STATE_REFERENCE: &str = "bangbang-grant:snapshot-state";
         const MEMORY_REFERENCE: &str = "bangbang-grant:snapshot-memory";
         const ROOT_REFERENCE: &str = "bangbang-grant:drive-ro";
+        const DEPRECATION_NOTICE: &str = "This tool is deprecated and will be removed in the future. Please use 'snapshot-editor' instead.\n";
+
+        let rebase_snap = PathBuf::from(
+            std::env::var_os("BANGBANG_REBASE_SNAP_PATH")
+                .expect("signed native-v2 process group should provide rebase-snap"),
+        );
+        let snapshot_editor = PathBuf::from(
+            std::env::var_os("BANGBANG_SNAPSHOT_EDITOR_PATH")
+                .expect("signed native-v2 process group should provide snapshot-editor"),
+        );
 
         let mut image = vec![0_u8; ARM64_IMAGE_HEADER_SIZE];
         image[..4].copy_from_slice(&ARM64_BRANCH_TO_SELF.to_le_bytes());
@@ -59090,26 +59099,88 @@ mod tests {
             drop(source);
 
             let memory_path = if let Some((full_directory, full_paths, _)) = &full {
-                let outcome = rebase_snapshot_v2_diff_paths(&SnapshotV2DiffRebasePaths::new(
-                    full_paths.memory(),
-                    diff_paths.memory(),
-                ))
-                .unwrap_or_else(|error| panic!("{case} rebase should commit: {error}"));
-                assert_eq!(outcome.commit(), SnapshotV2DiffRebaseCommit::Durable);
-                assert_eq!(outcome.binding(), &result_binding);
+                let deprecated_memory = full_paths
+                    .memory()
+                    .with_file_name(format!("{case}-deprecated-rebased.memory"));
+                let replacement_memory = full_paths
+                    .memory()
+                    .with_file_name(format!("{case}-replacement-rebased.memory"));
+                fs::copy(full_paths.memory(), &deprecated_memory)
+                    .expect("captured Full should copy for rebase-snap");
+                fs::copy(full_paths.memory(), &replacement_memory)
+                    .expect("captured Full should copy for snapshot-editor");
+                let diff_before =
+                    fs::read(diff_paths.memory()).expect("captured Diff memory should read");
+
+                let deprecated = Command::new(&rebase_snap)
+                    .arg("--base-file")
+                    .arg(&deprecated_memory)
+                    .arg("--diff-file")
+                    .arg(diff_paths.memory())
+                    .output()
+                    .expect("signed rebase-snap should start");
+                assert!(
+                    deprecated.status.success(),
+                    "{case} rebase-snap should succeed: {}",
+                    String::from_utf8_lossy(&deprecated.stderr)
+                );
+                assert_eq!(
+                    String::from_utf8(deprecated.stdout)
+                        .expect("rebase-snap output should be UTF-8"),
+                    DEPRECATION_NOTICE
+                );
+                assert!(deprecated.stderr.is_empty());
+
+                let replacement = Command::new(&snapshot_editor)
+                    .args(["edit-memory", "rebase"])
+                    .arg("--memory-path")
+                    .arg(&replacement_memory)
+                    .arg("--diff-path")
+                    .arg(diff_paths.memory())
+                    .output()
+                    .expect("signed snapshot-editor should start");
+                assert!(
+                    replacement.status.success(),
+                    "{case} snapshot-editor should succeed: {}",
+                    String::from_utf8_lossy(&replacement.stderr)
+                );
+                assert!(replacement.stdout.is_empty());
+                assert!(replacement.stderr.is_empty());
+
+                assert_eq!(
+                    fs::read(&deprecated_memory).expect("rebase-snap complete result should read"),
+                    fs::read(&replacement_memory)
+                        .expect("snapshot-editor complete result should read")
+                );
+                assert_eq!(
+                    fs::read(diff_paths.memory()).expect("captured Diff should remain readable"),
+                    diff_before
+                );
+                for tool_memory in [&deprecated_memory, &replacement_memory] {
+                    let tool_paths =
+                        SnapshotArtifactPaths::new(diff_paths.state(), tool_memory.clone());
+                    let loaded = load_native_snapshot_artifacts(&tool_paths)
+                        .unwrap_or_else(|error| panic!("{case} tool result should load: {error}"));
+                    assert_eq!(
+                        loaded
+                            .state()
+                            .v2_memory_binding()
+                            .expect("tool result state should retain its memory binding"),
+                        &result_binding
+                    );
+                }
                 full_directory.assert_no_staging();
-                full_paths.memory()
+                replacement_memory
             } else {
-                diff_paths.memory()
+                diff_paths.memory().to_path_buf()
             };
-            let closed_paths =
-                SnapshotArtifactPaths::new(diff_paths.state(), memory_path.to_path_buf());
+            let closed_paths = SnapshotArtifactPaths::new(diff_paths.state(), memory_path.clone());
             load_native_snapshot_artifacts(&closed_paths)
                 .unwrap_or_else(|error| panic!("{case} closed Diff pair should load: {error}"));
 
             let mut load = SnapshotLoadInput::new(
                 diff_paths.state(),
-                SnapshotMemoryBackend::new(memory_path, SnapshotMemoryBackendType::File),
+                SnapshotMemoryBackend::new(memory_path.clone(), SnapshotMemoryBackendType::File),
             )
             .with_track_dirty_pages(tracked);
             let mut destination = ProcessVmm::with_starter(
@@ -59121,7 +59192,7 @@ mod tests {
             if contained {
                 let authority = snapshot_root_file_grant_authority_for_test(
                     diff_paths.state(),
-                    memory_path,
+                    &memory_path,
                     root.path(),
                 );
                 let restore =

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -2642,7 +2642,7 @@ fn run_certified_production_vsock_missing_grant_rejection(
         "reject production vsock override without its exact grant",
     );
     assert!(
-        response.contains("vsock destination transaction failed (retryable)")
+        response.contains("current-product destination transaction failed (retryable)")
             && !response.contains(fixture.selector_ref)
             && !response.contains(path_text(&fixture.vsock_directory)),
         "missing-grant production retryable fault must remain stable and redacted: {response}"

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -337,6 +337,8 @@ build_executable_hvf_e2e() {
 build_native_v2_process_test() {
   local cargo_messages="$tmp_dir/cargo-test-native-v2-process.json"
   local test_bins_file="$tmp_dir/test-bins-native-v2-process"
+  local snapshot_tools_messages="$tmp_dir/cargo-build-snapshot-tools.json"
+  local snapshot_tools_bins_file="$tmp_dir/snapshot-tools-bins"
 
   cargo test \
     -p bangbang \
@@ -384,6 +386,81 @@ PY
 
   native_v2_process_bin="$tmp_dir/bangbang-native-v2-process-test"
   scripts/sign-hvf-binary.sh "${test_bins[0]}" "$native_v2_process_bin"
+
+  cargo build \
+    -p bangbang-snapshot-tools \
+    --bins \
+    --all-features \
+    --locked \
+    --target "$target_triple" \
+    --message-format=json \
+    > "$snapshot_tools_messages"
+
+  python3 - "$snapshot_tools_messages" > "$snapshot_tools_bins_file" <<'PY'
+import json
+import sys
+
+selected = {"rebase-snap", "snapshot-editor"}
+
+with open(sys.argv[1], encoding="utf-8") as messages:
+    for line in messages:
+        message = json.loads(line)
+        target = message.get("target", {})
+        executable = message.get("executable")
+        name = target.get("name")
+
+        if (
+            message.get("reason") == "compiler-artifact"
+            and executable is not None
+            and name in selected
+            and "bin" in target.get("kind", [])
+        ):
+            sys.stdout.write(name)
+            sys.stdout.write("\0")
+            sys.stdout.write(executable)
+            sys.stdout.write("\0")
+PY
+
+  local rebase_snap_source=""
+  local snapshot_editor_source=""
+  local tool_name
+  local tool_bin
+  while IFS= read -r -d "" tool_name && IFS= read -r -d "" tool_bin; do
+    case "$tool_name" in
+      rebase-snap)
+        if [[ -n "$rebase_snap_source" ]]; then
+          echo "found duplicate rebase-snap compiler artifacts" >&2
+          exit 1
+        fi
+        rebase_snap_source="$tool_bin"
+        ;;
+      snapshot-editor)
+        if [[ -n "$snapshot_editor_source" ]]; then
+          echo "found duplicate snapshot-editor compiler artifacts" >&2
+          exit 1
+        fi
+        snapshot_editor_source="$tool_bin"
+        ;;
+      *)
+        echo "found unexpected snapshot-tools compiler artifact: $tool_name" >&2
+        exit 1
+        ;;
+    esac
+  done < "$snapshot_tools_bins_file"
+
+  if [[ -z "$rebase_snap_source" || -z "$snapshot_editor_source" ]]; then
+    echo "failed to locate both snapshot-tools binary artifacts" >&2
+    exit 1
+  fi
+
+  snapshot_rebase_snap_bin="$tmp_dir/rebase-snap"
+  snapshot_editor_bin="$tmp_dir/snapshot-editor"
+  cp -p -- "$rebase_snap_source" "$snapshot_rebase_snap_bin"
+  cp -p -- "$snapshot_editor_source" "$snapshot_editor_bin"
+  codesign --force --sign - "$snapshot_rebase_snap_bin"
+  codesign --force --sign - "$snapshot_editor_bin"
+  codesign --verify --strict --verbose=2 "$snapshot_rebase_snap_bin"
+  codesign --verify --strict --verbose=2 "$snapshot_editor_bin"
 }
 
 host_os="$(uname -s)"
@@ -424,6 +501,8 @@ signed_test_names=()
 signed_test_bins=()
 executable_hvf_e2e_bangbang=""
 native_v2_process_bin=""
+snapshot_rebase_snap_bin=""
+snapshot_editor_bin=""
 app_sandbox_hvf_bin=""
 app_sandbox_bangbang_bin=""
 production_bundle_path=""
@@ -523,7 +602,27 @@ if contains native_v2_process "${selected_tests[@]}"; then
     vmm::tests::signed_native_v2_storage_destination_stays_private_and_paused_through_commit \
     vmm::tests::signed_native_v2_serial_destination_reconciles_and_recaptures_private_owner \
     vmm::tests::signed_native_v2_serial_storage_destination_preserves_mmio_and_pci_owners; do
-    if [[ "${#test_args[@]}" -eq 0 ]]; then
+    if [[ "$signed_snapshot_test" == \
+      "vmm::tests::signed_native_v2_diff_process_loads_zero_root_and_rebased_products" ]]; then
+      if [[ "${#test_args[@]}" -eq 0 ]]; then
+        BANGBANG_REBASE_SNAP_PATH="$snapshot_rebase_snap_bin" \
+          BANGBANG_SNAPSHOT_EDITOR_PATH="$snapshot_editor_bin" \
+          "$native_v2_process_bin" \
+          --test-threads=1 \
+          --ignored \
+          --exact \
+          "$signed_snapshot_test"
+      else
+        BANGBANG_REBASE_SNAP_PATH="$snapshot_rebase_snap_bin" \
+          BANGBANG_SNAPSHOT_EDITOR_PATH="$snapshot_editor_bin" \
+          "$native_v2_process_bin" \
+          --test-threads=1 \
+          --ignored \
+          --exact \
+          "$signed_snapshot_test" \
+          "${test_args[@]}"
+      fi
+    elif [[ "${#test_args[@]}" -eq 0 ]]; then
       "$native_v2_process_bin" \
         --test-threads=1 \
         --ignored \

--- a/tools/snapshot-tools/Cargo.toml
+++ b/tools/snapshot-tools/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "bangbang-snapshot-tools"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+clap = { version = "=4.6.1", features = ["derive"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+bangbang-runtime = { path = "../../crates/runtime" }
+signal-hook = "0.3"
+
+[dev-dependencies]
+libc = "0.2"
+
+[[bin]]
+name = "rebase-snap"
+path = "src/bin/rebase-snap.rs"
+
+[[bin]]
+name = "snapshot-editor"
+path = "src/bin/snapshot-editor.rs"
+
+[lints]
+workspace = true

--- a/tools/snapshot-tools/src/bin/rebase-snap.rs
+++ b/tools/snapshot-tools/src/bin/rebase-snap.rs
@@ -1,0 +1,59 @@
+//! Deprecated Firecracker-shaped memory snapshot rebase command.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use bangbang_snapshot_tools::{RebaseRequest, RebaseTool, execute_rebase};
+use clap::Parser;
+use clap::error::ErrorKind;
+
+const DEPRECATION_NOTICE: &str = "This tool is deprecated and will be removed in the future. Please use 'snapshot-editor' instead.";
+const INVOCATION_ERROR: &str =
+    "rebase-snap: invalid arguments; use --help for the supported interface";
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "rebase-snap",
+    about = "Apply a native-v2 differential memory snapshot to a base image",
+    version = concat!(
+        env!("CARGO_PKG_VERSION"),
+        " (bangbang; Firecracker v1.16.0-compatible command surface)"
+    )
+)]
+struct Cli {
+    /// File path of the base memory snapshot.
+    #[arg(long = "base-file", value_name = "PATH")]
+    base_file: PathBuf,
+
+    /// File path of the differential memory snapshot.
+    #[arg(long = "diff-file", value_name = "PATH")]
+    diff_file: PathBuf,
+}
+
+fn main() -> ExitCode {
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(error)
+            if matches!(
+                error.kind(),
+                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
+            ) =>
+        {
+            if error.print().is_err() {
+                return ExitCode::FAILURE;
+            }
+            println!("{DEPRECATION_NOTICE}");
+            return ExitCode::SUCCESS;
+        }
+        Err(_) => {
+            eprintln!("{INVOCATION_ERROR}");
+            return ExitCode::from(2);
+        }
+    };
+
+    println!("{DEPRECATION_NOTICE}");
+    execute_rebase(
+        RebaseTool::RebaseSnap,
+        RebaseRequest::new(cli.base_file, cli.diff_file),
+    )
+}

--- a/tools/snapshot-tools/src/bin/rebase-snap.rs
+++ b/tools/snapshot-tools/src/bin/rebase-snap.rs
@@ -11,7 +11,7 @@ const DEPRECATION_NOTICE: &str = "This tool is deprecated and will be removed in
 const INVOCATION_ERROR: &str =
     "rebase-snap: invalid arguments; use --help for the supported interface";
 
-#[derive(Debug, Parser)]
+#[derive(Parser)]
 #[command(
     name = "rebase-snap",
     about = "Apply a native-v2 differential memory snapshot to a base image",

--- a/tools/snapshot-tools/src/bin/snapshot-editor.rs
+++ b/tools/snapshot-tools/src/bin/snapshot-editor.rs
@@ -10,7 +10,7 @@ use clap::{Parser, Subcommand};
 const INVOCATION_ERROR: &str =
     "snapshot-editor: invalid arguments; use --help for the supported interface";
 
-#[derive(Debug, Parser)]
+#[derive(Parser)]
 #[command(
     name = "snapshot-editor",
     about = "Edit bangbang-native snapshot memory artifacts",
@@ -24,14 +24,14 @@ struct Cli {
     command: Command,
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Subcommand)]
 enum Command {
     /// Edit a snapshot memory artifact.
     #[command(subcommand)]
     EditMemory(EditMemoryCommand),
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Subcommand)]
 enum EditMemoryCommand {
     /// Apply a differential snapshot on top of a base memory image.
     Rebase {

--- a/tools/snapshot-tools/src/bin/snapshot-editor.rs
+++ b/tools/snapshot-tools/src/bin/snapshot-editor.rs
@@ -1,0 +1,77 @@
+//! Firecracker-shaped snapshot editor memory rebase command.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use bangbang_snapshot_tools::{RebaseRequest, RebaseTool, execute_rebase};
+use clap::error::ErrorKind;
+use clap::{Parser, Subcommand};
+
+const INVOCATION_ERROR: &str =
+    "snapshot-editor: invalid arguments; use --help for the supported interface";
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "snapshot-editor",
+    about = "Edit bangbang-native snapshot memory artifacts",
+    version = concat!(
+        env!("CARGO_PKG_VERSION"),
+        " (bangbang; Firecracker v1.16.0-compatible command surface)"
+    )
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Edit a snapshot memory artifact.
+    #[command(subcommand)]
+    EditMemory(EditMemoryCommand),
+}
+
+#[derive(Debug, Subcommand)]
+enum EditMemoryCommand {
+    /// Apply a differential snapshot on top of a base memory image.
+    Rebase {
+        /// Path to the memory file.
+        #[arg(short = 'm', long = "memory-path", value_name = "PATH")]
+        memory_path: PathBuf,
+
+        /// Path to the differential memory file.
+        #[arg(short = 'd', long = "diff-path", value_name = "PATH")]
+        diff_path: PathBuf,
+    },
+}
+
+fn main() -> ExitCode {
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(error)
+            if matches!(
+                error.kind(),
+                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
+            ) =>
+        {
+            return match error.print() {
+                Ok(()) => ExitCode::SUCCESS,
+                Err(_) => ExitCode::FAILURE,
+            };
+        }
+        Err(_) => {
+            eprintln!("{INVOCATION_ERROR}");
+            return ExitCode::from(2);
+        }
+    };
+
+    match cli.command {
+        Command::EditMemory(EditMemoryCommand::Rebase {
+            memory_path,
+            diff_path,
+        }) => execute_rebase(
+            RebaseTool::SnapshotEditor,
+            RebaseRequest::new(memory_path, diff_path),
+        ),
+    }
+}

--- a/tools/snapshot-tools/src/lib.rs
+++ b/tools/snapshot-tools/src/lib.rs
@@ -1,0 +1,407 @@
+//! Shared execution boundary for Firecracker-shaped snapshot rebase tools.
+
+use std::fmt;
+#[cfg(target_os = "macos")]
+use std::io;
+use std::path::PathBuf;
+use std::process::ExitCode;
+#[cfg(target_os = "macos")]
+use std::sync::Arc;
+#[cfg(target_os = "macos")]
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[cfg(target_os = "macos")]
+use bangbang_runtime::snapshot_rebase::{
+    SnapshotV2DiffRebaseCleanup, SnapshotV2DiffRebaseCommit, SnapshotV2DiffRebaseCommitFailure,
+    SnapshotV2DiffRebaseFailure, SnapshotV2DiffRebasePaths, SnapshotV2DiffRebaseStage,
+    rebase_snapshot_v2_diff_paths_with_cancel,
+};
+#[cfg(target_os = "macos")]
+use signal_hook::SigId;
+#[cfg(target_os = "macos")]
+use signal_hook::consts::signal::{SIGINT, SIGTERM};
+
+const REDACTED: &str = "<redacted>";
+const OPERATIONAL_EXIT: u8 = 1;
+#[cfg(target_os = "macos")]
+const COMMITTED_UNCERTAIN_EXIT: u8 = 3;
+#[cfg(target_os = "macos")]
+const SIGINT_EXIT: u8 = 128 + SIGINT as u8;
+#[cfg(target_os = "macos")]
+const SIGTERM_EXIT: u8 = 128 + SIGTERM as u8;
+
+/// The public command surface requesting a shared rebase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RebaseTool {
+    /// Firecracker's deprecated standalone command.
+    RebaseSnap,
+    /// Firecracker's replacement snapshot editor command.
+    SnapshotEditor,
+}
+
+impl fmt::Display for RebaseTool {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::RebaseSnap => "rebase-snap",
+            Self::SnapshotEditor => "snapshot-editor",
+        })
+    }
+}
+
+/// One owned base/diff request passed by either command frontend.
+#[derive(Clone, PartialEq, Eq)]
+pub struct RebaseRequest {
+    base: PathBuf,
+    diff: PathBuf,
+}
+
+impl RebaseRequest {
+    /// Creates a request without opening or canonicalizing either path.
+    pub fn new(base: impl Into<PathBuf>, diff: impl Into<PathBuf>) -> Self {
+        Self {
+            base: base.into(),
+            diff: diff.into(),
+        }
+    }
+}
+
+impl fmt::Debug for RebaseRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RebaseRequest")
+            .field("base", &REDACTED)
+            .field("diff", &REDACTED)
+            .finish()
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Debug)]
+struct CancellationState {
+    interrupt: Arc<AtomicBool>,
+    terminate: Arc<AtomicBool>,
+}
+
+#[cfg(target_os = "macos")]
+impl CancellationState {
+    fn is_cancelled(&self) -> bool {
+        self.interrupt.load(Ordering::Acquire) || self.terminate.load(Ordering::Acquire)
+    }
+
+    fn exit_code(&self) -> u8 {
+        if self.terminate.load(Ordering::Acquire) {
+            SIGTERM_EXIT
+        } else {
+            SIGINT_EXIT
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+struct CancellationSignals {
+    state: CancellationState,
+    registrations: [SigId; 2],
+}
+
+#[cfg(target_os = "macos")]
+impl CancellationSignals {
+    fn install() -> io::Result<Self> {
+        let (state, registrations) =
+            register_signal_flags_with(signal_hook::flag::register, |registration| {
+                signal_hook::low_level::unregister(registration);
+            })?;
+        Ok(Self {
+            state,
+            registrations,
+        })
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl fmt::Debug for CancellationSignals {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CancellationSignals")
+            .field("received", &self.state.is_cancelled())
+            .field("registrations", &self.registrations.len())
+            .finish()
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for CancellationSignals {
+    fn drop(&mut self) {
+        for registration in self.registrations {
+            signal_hook::low_level::unregister(registration);
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn register_signal_flags_with<T>(
+    mut register: impl FnMut(i32, Arc<AtomicBool>) -> io::Result<T>,
+    mut unregister: impl FnMut(T),
+) -> io::Result<(CancellationState, [T; 2])> {
+    let interrupt = Arc::new(AtomicBool::new(false));
+    let terminate = Arc::new(AtomicBool::new(false));
+    let interrupt_registration = register(SIGINT, Arc::clone(&interrupt))?;
+    let terminate_registration = match register(SIGTERM, Arc::clone(&terminate)) {
+        Ok(registration) => registration,
+        Err(error) => {
+            unregister(interrupt_registration);
+            return Err(error);
+        }
+    };
+    Ok((
+        CancellationState {
+            interrupt,
+            terminate,
+        },
+        [interrupt_registration, terminate_registration],
+    ))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ExecutionReport {
+    exit: u8,
+    diagnostic: Option<String>,
+}
+
+impl ExecutionReport {
+    #[cfg(target_os = "macos")]
+    const fn durable() -> Self {
+        Self {
+            exit: 0,
+            diagnostic: None,
+        }
+    }
+
+    fn operational(tool: RebaseTool, diagnostic: impl fmt::Display) -> Self {
+        Self {
+            exit: OPERATIONAL_EXIT,
+            diagnostic: Some(format!("{tool}: {diagnostic}")),
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn cancelled(tool: RebaseTool, signals: &CancellationState) -> Self {
+        Self {
+            exit: signals.exit_code(),
+            diagnostic: Some(format!(
+                "{tool}: native-v2 Diff rebase cancelled before commit"
+            )),
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn committed_uncertain(
+        tool: RebaseTool,
+        stage: SnapshotV2DiffRebaseStage,
+        failure: SnapshotV2DiffRebaseCommitFailure,
+        cleanup: SnapshotV2DiffRebaseCleanup,
+        directory_sync: Option<io::ErrorKind>,
+    ) -> Self {
+        Self {
+            exit: COMMITTED_UNCERTAIN_EXIT,
+            diagnostic: Some(format!(
+                "{tool}: native-v2 Diff rebase committed, but completion is uncertain during \
+                 {stage}: {}; displaced cleanup {}; directory synchronization {}",
+                commit_failure_message(failure),
+                cleanup_message(cleanup),
+                directory_sync_message(directory_sync),
+            )),
+        }
+    }
+
+    fn emit(self) -> ExitCode {
+        if let Some(diagnostic) = self.diagnostic {
+            eprintln!("{diagnostic}");
+        }
+        ExitCode::from(self.exit)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn report_for_commit(tool: RebaseTool, commit: SnapshotV2DiffRebaseCommit) -> ExecutionReport {
+    match commit {
+        SnapshotV2DiffRebaseCommit::Durable => ExecutionReport::durable(),
+        SnapshotV2DiffRebaseCommit::Uncertain {
+            stage,
+            failure,
+            cleanup,
+            directory_sync,
+        } => ExecutionReport::committed_uncertain(tool, stage, failure, cleanup, directory_sync),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn commit_failure_message(failure: SnapshotV2DiffRebaseCommitFailure) -> String {
+    match failure {
+        SnapshotV2DiffRebaseCommitFailure::DirectoryChanged { input } => {
+            format!("{input} directory identity changed")
+        }
+        SnapshotV2DiffRebaseCommitFailure::BaseEntryChanged => {
+            "committed base entry identity changed".to_string()
+        }
+        SnapshotV2DiffRebaseCommitFailure::DisplacedEntryChanged => {
+            "displaced base entry identity changed".to_string()
+        }
+        SnapshotV2DiffRebaseCommitFailure::DiffChanged => {
+            "immutable diff identity changed".to_string()
+        }
+        SnapshotV2DiffRebaseCommitFailure::BaseSourceChanged => {
+            "retained base identity changed".to_string()
+        }
+        SnapshotV2DiffRebaseCommitFailure::Cleanup => {
+            "displaced base cleanup was inconclusive".to_string()
+        }
+        SnapshotV2DiffRebaseCommitFailure::Io(kind) => {
+            format!("post-commit I/O failed with {kind:?}")
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn cleanup_message(cleanup: SnapshotV2DiffRebaseCleanup) -> String {
+    match cleanup {
+        SnapshotV2DiffRebaseCleanup::Removed => "removed".to_string(),
+        SnapshotV2DiffRebaseCleanup::AlreadyAbsent => "already absent".to_string(),
+        SnapshotV2DiffRebaseCleanup::ChangedRefused => "changed entry retained".to_string(),
+        SnapshotV2DiffRebaseCleanup::Failed(kind) => format!("failed with {kind:?}"),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn directory_sync_message(directory_sync: Option<io::ErrorKind>) -> String {
+    match directory_sync {
+        Some(kind) => format!("failed with {kind:?}"),
+        None => "completed".to_string(),
+    }
+}
+
+/// Executes one request through the shared path transaction.
+pub fn execute_rebase(tool: RebaseTool, request: RebaseRequest) -> ExitCode {
+    #[cfg(target_os = "macos")]
+    {
+        let signals = match CancellationSignals::install() {
+            Ok(signals) => signals,
+            Err(_) => {
+                return ExecutionReport::operational(
+                    tool,
+                    "failed to install cancellation handlers",
+                )
+                .emit();
+            }
+        };
+        let paths = SnapshotV2DiffRebasePaths::new(request.base, request.diff);
+        match rebase_snapshot_v2_diff_paths_with_cancel(&paths, |_| signals.state.is_cancelled()) {
+            Ok(outcome) => report_for_commit(tool, outcome.commit()).emit(),
+            Err(error) if matches!(error.failure(), SnapshotV2DiffRebaseFailure::Cancelled) => {
+                ExecutionReport::cancelled(tool, &signals.state).emit()
+            }
+            Err(error) => ExecutionReport::operational(tool, error).emit(),
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let RebaseRequest { base, diff } = request;
+        let _ = (base, diff);
+        ExecutionReport::operational(tool, "native-v2 Diff rebase is supported only on macOS")
+            .emit()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_os = "macos")]
+    use std::cell::RefCell;
+    #[cfg(target_os = "macos")]
+    use std::rc::Rc;
+
+    use super::*;
+
+    #[test]
+    fn request_debug_redacts_both_paths() {
+        let request = RebaseRequest::new("secret-base", "secret-diff");
+        let debug = format!("{request:?}");
+        assert_eq!(
+            debug,
+            "RebaseRequest { base: \"<redacted>\", diff: \"<redacted>\" }"
+        );
+        assert!(!debug.contains("secret-base"));
+        assert!(!debug.contains("secret-diff"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn partial_signal_registration_is_reversed() {
+        let attempts = Rc::new(RefCell::new(Vec::new()));
+        let unregistered = Rc::new(RefCell::new(Vec::new()));
+        let register_attempts = Rc::clone(&attempts);
+        let recorded_unregistrations = Rc::clone(&unregistered);
+        let error = register_signal_flags_with(
+            move |signal, _| {
+                register_attempts.borrow_mut().push(signal);
+                if signal == SIGTERM {
+                    Err(io::Error::other("test registration failure"))
+                } else {
+                    Ok(41_u8)
+                }
+            },
+            move |registration| recorded_unregistrations.borrow_mut().push(registration),
+        )
+        .expect_err("second registration should fail");
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert_eq!(*attempts.borrow(), vec![SIGINT, SIGTERM]);
+        assert_eq!(*unregistered.borrow(), vec![41]);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn cancellation_uses_conventional_signal_exits_with_termination_precedence() {
+        let state = CancellationState {
+            interrupt: Arc::new(AtomicBool::new(true)),
+            terminate: Arc::new(AtomicBool::new(false)),
+        };
+        assert_eq!(
+            ExecutionReport::cancelled(RebaseTool::RebaseSnap, &state).exit,
+            130
+        );
+        state.terminate.store(true, Ordering::Release);
+        assert_eq!(
+            ExecutionReport::cancelled(RebaseTool::SnapshotEditor, &state).exit,
+            143
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn durable_and_committed_uncertain_results_are_distinct_and_redacted() {
+        assert_eq!(
+            report_for_commit(
+                RebaseTool::SnapshotEditor,
+                SnapshotV2DiffRebaseCommit::Durable
+            ),
+            ExecutionReport::durable()
+        );
+        let report = report_for_commit(
+            RebaseTool::RebaseSnap,
+            SnapshotV2DiffRebaseCommit::Uncertain {
+                stage: SnapshotV2DiffRebaseStage::DisplacedCleanup,
+                failure: SnapshotV2DiffRebaseCommitFailure::DirectoryChanged {
+                    input: bangbang_runtime::snapshot_rebase::SnapshotV2DiffRebaseInput::Base,
+                },
+                cleanup: SnapshotV2DiffRebaseCleanup::Failed(io::ErrorKind::PermissionDenied),
+                directory_sync: Some(io::ErrorKind::Other),
+            },
+        );
+        assert_eq!(report.exit, 3);
+        let diagnostic = report
+            .diagnostic
+            .expect("uncertain outcome should have a diagnostic");
+        assert!(diagnostic.starts_with("rebase-snap: native-v2 Diff rebase committed"));
+        assert!(diagnostic.contains("displaced-base cleanup"));
+        assert!(diagnostic.contains("base directory identity changed"));
+        assert!(!diagnostic.contains('/'));
+    }
+}

--- a/tools/snapshot-tools/tests/cli.rs
+++ b/tools/snapshot-tools/tests/cli.rs
@@ -1,0 +1,704 @@
+#![allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unwrap_used
+)]
+
+use std::process::{Command, Output};
+
+const DEPRECATION_NOTICE: &str = "This tool is deprecated and will be removed in the future. Please use 'snapshot-editor' instead.";
+
+fn rebase_snap() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_rebase-snap"))
+}
+
+fn snapshot_editor() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_snapshot-editor"))
+}
+
+fn assert_invalid(mut command: Command, arguments: &[&str], tool: &str, sensitive: &str) {
+    let output = command
+        .args(arguments)
+        .output()
+        .expect("invalid command should start");
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8(output.stderr).expect("diagnostic should be UTF-8");
+    assert_eq!(
+        stderr,
+        format!("{tool}: invalid arguments; use --help for the supported interface\n")
+    );
+    assert!(!stderr.contains(sensitive));
+}
+
+#[cfg(target_os = "macos")]
+fn assert_operational_failure(output: &Output, tool: &str, sensitive: &[&str]) {
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if tool == "rebase-snap" {
+        assert_eq!(stdout, format!("{DEPRECATION_NOTICE}\n"));
+    } else {
+        assert!(stdout.is_empty());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.starts_with(&format!("{tool}: native-v2 Diff rebase failed during ")));
+    for value in sensitive {
+        assert!(!stderr.contains(value));
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn assert_unsupported_target(output: &Output, tool: &str, sensitive: &[&str]) {
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if tool == "rebase-snap" {
+        assert_eq!(stdout, format!("{DEPRECATION_NOTICE}\n"));
+    } else {
+        assert!(stdout.is_empty());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stderr,
+        format!("{tool}: native-v2 Diff rebase is supported only on macOS\n")
+    );
+    for value in sensitive {
+        assert!(!stderr.contains(value));
+    }
+}
+
+#[test]
+fn help_and_version_expose_only_the_two_selected_firecracker_surfaces() {
+    let help = rebase_snap()
+        .arg("--help")
+        .output()
+        .expect("deprecated help should run");
+    assert!(help.status.success());
+    assert!(help.stderr.is_empty());
+    let help = String::from_utf8(help.stdout).expect("help should be UTF-8");
+    assert!(help.contains("Usage: rebase-snap --base-file <PATH> --diff-file <PATH>"));
+    assert!(help.contains("--base-file <PATH>"));
+    assert!(help.contains("--diff-file <PATH>"));
+    assert!(help.ends_with(&format!("{DEPRECATION_NOTICE}\n")));
+
+    let version = rebase_snap()
+        .arg("--version")
+        .output()
+        .expect("deprecated version should run");
+    assert!(version.status.success());
+    assert!(version.stderr.is_empty());
+    assert_eq!(
+        String::from_utf8(version.stdout).unwrap(),
+        format!(
+            "rebase-snap {} (bangbang; Firecracker v1.16.0-compatible command surface)\n\
+             {DEPRECATION_NOTICE}\n",
+            env!("CARGO_PKG_VERSION")
+        )
+    );
+
+    let top_help = snapshot_editor()
+        .arg("--help")
+        .output()
+        .expect("editor help should run");
+    assert!(top_help.status.success());
+    assert!(top_help.stderr.is_empty());
+    let top_help = String::from_utf8(top_help.stdout).unwrap();
+    assert!(top_help.contains("Usage: snapshot-editor <COMMAND>"));
+    assert!(top_help.contains("edit-memory"));
+    assert!(!top_help.contains("edit-vmstate"));
+    assert!(!top_help.contains("info-vmstate"));
+
+    let edit_help = snapshot_editor()
+        .args(["edit-memory", "--help"])
+        .output()
+        .expect("edit-memory help should run");
+    assert!(edit_help.status.success());
+    assert!(edit_help.stderr.is_empty());
+    let edit_help = String::from_utf8(edit_help.stdout).unwrap();
+    assert!(edit_help.contains("Usage: snapshot-editor edit-memory <COMMAND>"));
+    assert!(edit_help.contains("rebase"));
+
+    let rebase_help = snapshot_editor()
+        .args(["edit-memory", "rebase", "--help"])
+        .output()
+        .expect("nested rebase help should run");
+    assert!(rebase_help.status.success());
+    assert!(rebase_help.stderr.is_empty());
+    let rebase_help = String::from_utf8(rebase_help.stdout).unwrap();
+    assert!(rebase_help.contains(
+        "Usage: snapshot-editor edit-memory rebase --memory-path <PATH> --diff-path <PATH>"
+    ));
+    assert!(rebase_help.contains("-m, --memory-path <PATH>"));
+    assert!(rebase_help.contains("-d, --diff-path <PATH>"));
+
+    let version = snapshot_editor()
+        .arg("--version")
+        .output()
+        .expect("editor version should run");
+    assert!(version.status.success());
+    assert!(version.stderr.is_empty());
+    assert_eq!(
+        String::from_utf8(version.stdout).unwrap(),
+        format!(
+            "snapshot-editor {} (bangbang; Firecracker v1.16.0-compatible command surface)\n",
+            env!("CARGO_PKG_VERSION")
+        )
+    );
+}
+
+#[test]
+fn invalid_invocations_are_deterministic_and_do_not_echo_values() {
+    let sensitive = "private-cli-value-9f6f";
+    for arguments in [
+        vec![],
+        vec!["--base-file", sensitive],
+        vec!["--base-file", sensitive, "--diff-file"],
+        vec![
+            "--base-file",
+            sensitive,
+            "--base-file",
+            "second",
+            "--diff-file",
+            "diff",
+        ],
+        vec!["--base-file", "base", "--diff-file", "diff", sensitive],
+        vec!["--unknown-private-option", sensitive],
+    ] {
+        assert_invalid(rebase_snap(), &arguments, "rebase-snap", sensitive);
+    }
+
+    for arguments in [
+        vec![],
+        vec!["edit-memory"],
+        vec!["edit-memory", "rebase", "--memory-path", sensitive],
+        vec![
+            "edit-memory",
+            "rebase",
+            "--memory-path",
+            sensitive,
+            "-m",
+            "second",
+            "--diff-path",
+            "diff",
+        ],
+        vec![
+            "edit-memory",
+            "rebase",
+            "-m",
+            "base",
+            "-d",
+            "diff",
+            sensitive,
+        ],
+        vec!["edit-vmstate", sensitive],
+        vec!["private-command", sensitive],
+    ] {
+        assert_invalid(snapshot_editor(), &arguments, "snapshot-editor", sensitive);
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn unsupported_target_rejects_before_accessing_or_echoing_paths() {
+    let base = "secret-missing-base-unsupported";
+    let diff = "secret-missing-diff-unsupported";
+    let deprecated = rebase_snap()
+        .args(["--base-file", base, "--diff-file", diff])
+        .output()
+        .expect("deprecated command should run");
+    assert_unsupported_target(&deprecated, "rebase-snap", &[base, diff]);
+
+    let replacement = snapshot_editor()
+        .args([
+            "edit-memory",
+            "rebase",
+            "--memory-path",
+            base,
+            "--diff-path",
+            diff,
+        ])
+        .output()
+        .expect("replacement command should run");
+    assert_unsupported_target(&replacement, "snapshot-editor", &[base, diff]);
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use std::fs::{self, File, OpenOptions};
+    use std::os::unix::fs::{FileExt, PermissionsExt};
+    use std::path::{Path, PathBuf};
+    use std::process::{Child, Stdio};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    use bangbang_runtime::memory::{
+        GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange, aarch64,
+    };
+    use bangbang_runtime::snapshot_diff_v2_13::{
+        NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION, SnapshotV2DiffBase, SnapshotV2DiffSelection,
+        write_snapshot_v2_diff_layer,
+    };
+    use bangbang_runtime::snapshot_memory_v2::{
+        SnapshotV2MemoryBinding, write_snapshot_v2_memory_image_with_compatibility_version,
+    };
+
+    use super::*;
+
+    static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+
+    #[derive(Debug)]
+    struct TestDirectory {
+        path: PathBuf,
+    }
+
+    impl TestDirectory {
+        fn new(label: &str) -> Self {
+            let serial = NEXT_TEST_DIRECTORY.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "bangbang-snapshot-tools-{label}-{}-{serial}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).expect("test directory should create");
+            Self { path }
+        }
+
+        fn child(&self, name: &str) -> PathBuf {
+            self.path.join(name)
+        }
+
+        fn staging_entries(&self) -> Vec<PathBuf> {
+            fs::read_dir(&self.path)
+                .expect("test directory should read")
+                .map(|entry| entry.expect("test entry should read"))
+                .filter(|entry| {
+                    entry
+                        .file_name()
+                        .as_encoded_bytes()
+                        .starts_with(b".bangbang-snapshot-rebase-")
+                })
+                .map(|entry| entry.path())
+                .collect()
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn page_range(first_page: u64, page_count: u64) -> GuestMemoryRange {
+        GuestMemoryRange::new(
+            GuestAddress::new(aarch64::DRAM_MEM_START + first_page * aarch64::GUEST_PAGE_SIZE),
+            page_count * aarch64::GUEST_PAGE_SIZE,
+        )
+        .expect("test range should validate")
+    }
+
+    fn memory_with_byte(range: GuestMemoryRange, byte: u8) -> GuestMemory {
+        let layout = GuestMemoryLayout::new(vec![range]).expect("test layout should validate");
+        let mut memory = GuestMemory::allocate(&layout).expect("test memory should allocate");
+        memory
+            .write_slice(
+                &vec![byte; usize::try_from(range.size()).expect("range should fit")],
+                range.start(),
+            )
+            .expect("test memory should populate");
+        memory
+    }
+
+    fn create_file(path: &Path) -> File {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(path)
+            .expect("test artifact should create")
+    }
+
+    fn write_complete(path: &Path, memory: &GuestMemory) -> SnapshotV2MemoryBinding {
+        write_snapshot_v2_memory_image_with_compatibility_version(
+            memory,
+            &mut create_file(path),
+            NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION,
+        )
+        .expect("complete image should write")
+    }
+
+    fn write_layer(
+        path: &Path,
+        memory: &GuestMemory,
+        base: SnapshotV2DiffBase,
+        selected: &[GuestMemoryRange],
+    ) -> SnapshotV2MemoryBinding {
+        let selection = SnapshotV2DiffSelection::try_from_ranges(memory, selected)
+            .expect("selection should validate");
+        write_snapshot_v2_diff_layer(memory, &mut create_file(path), base, &selection)
+            .expect("Diff layer should write")
+            .result()
+            .clone()
+    }
+
+    fn run_deprecated(base: &Path, diff: &Path) -> Output {
+        rebase_snap()
+            .arg("--base-file")
+            .arg(base)
+            .arg("--diff-file")
+            .arg(diff)
+            .output()
+            .expect("deprecated command should start")
+    }
+
+    fn run_replacement(base: &Path, diff: &Path, short: bool) -> Output {
+        let mut command = snapshot_editor();
+        command.args(["edit-memory", "rebase"]);
+        if short {
+            command.arg("-m").arg(base).arg("-d").arg(diff);
+        } else {
+            command
+                .arg("--memory-path")
+                .arg(base)
+                .arg("--diff-path")
+                .arg(diff);
+        }
+        command.output().expect("replacement command should start")
+    }
+
+    fn assert_deprecated_success(output: &Output) {
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            format!("{DEPRECATION_NOTICE}\n")
+        );
+        assert!(output.stderr.is_empty());
+    }
+
+    fn assert_replacement_success(output: &Output) {
+        assert!(output.status.success());
+        assert!(output.stdout.is_empty());
+        assert!(output.stderr.is_empty());
+    }
+
+    fn assert_result_payload(path: &Path, binding: &SnapshotV2MemoryBinding, expected_byte: u8) {
+        let file = File::open(path).expect("complete result should open");
+        for extent in binding.extents().iter().copied() {
+            let mut bytes =
+                vec![0_u8; usize::try_from(extent.range().size()).expect("extent should fit")];
+            file.read_exact_at(&mut bytes, extent.file_offset())
+                .expect("complete result should read");
+            assert!(bytes.iter().all(|byte| *byte == expected_byte));
+        }
+        assert_eq!(
+            fs::metadata(path)
+                .expect("result metadata should read")
+                .permissions()
+                .mode()
+                & 0o7777,
+            0o600
+        );
+    }
+
+    #[test]
+    fn both_commands_materialize_byte_identical_complete_images() {
+        let directory = TestDirectory::new("equivalent");
+        let original = directory.child("original.mem");
+        let deprecated_base = directory.child("deprecated.mem");
+        let replacement_base = directory.child("replacement.mem");
+        let diff = directory.child("next.diff");
+        let range = page_range(0, 4);
+        let base = write_complete(&original, &memory_with_byte(range, 0x21));
+        let result = write_layer(
+            &diff,
+            &memory_with_byte(range, 0xa4),
+            SnapshotV2DiffBase::Image(base),
+            &[range],
+        );
+        let diff_before = fs::read(&diff).expect("Diff should read");
+        fs::copy(&original, &deprecated_base).expect("deprecated base should copy");
+        fs::copy(&original, &replacement_base).expect("replacement base should copy");
+
+        assert_deprecated_success(&run_deprecated(&deprecated_base, &diff));
+        assert_replacement_success(&run_replacement(&replacement_base, &diff, true));
+
+        assert_eq!(
+            fs::read(&deprecated_base).expect("deprecated result should read"),
+            fs::read(&replacement_base).expect("replacement result should read")
+        );
+        assert_eq!(fs::read(&diff).expect("Diff should remain"), diff_before);
+        assert_result_payload(&deprecated_base, &result, 0xa4);
+        assert!(directory.staging_entries().is_empty());
+    }
+
+    #[test]
+    fn malformed_stale_and_alias_inputs_fail_without_mutation_or_leaks() {
+        let directory = TestDirectory::new("invalid");
+        let range = page_range(0, 4);
+        let good_base = directory.child("secret-good-base.mem");
+        let good_binding = write_complete(&good_base, &memory_with_byte(range, 0x31));
+        let diff = directory.child("secret-next.diff");
+        write_layer(
+            &diff,
+            &memory_with_byte(range, 0x72),
+            SnapshotV2DiffBase::Image(good_binding),
+            &[range],
+        );
+
+        let malformed = directory.child("secret-malformed-guest-bytes.mem");
+        fs::write(&malformed, b"private-guest-payload-7b4c").expect("malformed file should write");
+        let malformed_before = fs::read(&malformed).unwrap();
+        let diff_before = fs::read(&diff).unwrap();
+        let output = run_deprecated(&malformed, &diff);
+        assert_operational_failure(
+            &output,
+            "rebase-snap",
+            &["secret-malformed-guest-bytes", "private-guest-payload-7b4c"],
+        );
+        assert_eq!(fs::read(&malformed).unwrap(), malformed_before);
+        assert_eq!(fs::read(&diff).unwrap(), diff_before);
+
+        let stale_base = directory.child("secret-stale-base.mem");
+        write_complete(&stale_base, &memory_with_byte(range, 0x91));
+        let stale_before = fs::read(&stale_base).unwrap();
+        let output = run_replacement(&stale_base, &diff, false);
+        assert_operational_failure(
+            &output,
+            "snapshot-editor",
+            &["secret-stale-base", "secret-next"],
+        );
+        assert_eq!(fs::read(&stale_base).unwrap(), stale_before);
+        assert_eq!(fs::read(&diff).unwrap(), diff_before);
+
+        let exact_alias = run_deprecated(&good_base, &good_base);
+        assert_operational_failure(&exact_alias, "rebase-snap", &["secret-good-base"]);
+        assert!(String::from_utf8_lossy(&exact_alias.stderr).contains("source alias check"));
+
+        let alias = directory.child("secret-hard-link-alias.mem");
+        fs::hard_link(&good_base, &alias).expect("hard-link alias should create");
+        let output = run_replacement(&good_base, &alias, true);
+        assert_operational_failure(
+            &output,
+            "snapshot-editor",
+            &["secret-hard-link-alias", "secret-good-base"],
+        );
+        assert!(String::from_utf8_lossy(&output.stderr).contains("source alias check"));
+        assert_eq!(
+            fs::read(&good_base).expect("aliased base should remain"),
+            fs::read(&alias).expect("hard-link alias should remain")
+        );
+        assert_eq!(fs::read(&diff).unwrap(), diff_before);
+        assert!(directory.staging_entries().is_empty());
+    }
+
+    #[test]
+    fn sequential_commands_apply_repeated_lineage_exactly() {
+        let directory = TestDirectory::new("sequential");
+        let base_path = directory.child("base.mem");
+        let first_diff = directory.child("first.diff");
+        let second_diff = directory.child("second.diff");
+        let whole = page_range(0, 4);
+        let first_page = page_range(0, 1);
+        let second_page = page_range(1, 1);
+        let base_memory = memory_with_byte(whole, 0x18);
+        let base = write_complete(&base_path, &base_memory);
+
+        let mut first_memory = memory_with_byte(whole, 0x18);
+        first_memory
+            .write_slice(
+                &vec![0x41; usize::try_from(first_page.size()).unwrap()],
+                first_page.start(),
+            )
+            .expect("first page should update");
+        let first_result = write_layer(
+            &first_diff,
+            &first_memory,
+            SnapshotV2DiffBase::Image(base),
+            &[first_page],
+        );
+        let mut second_memory = first_memory;
+        second_memory
+            .write_slice(
+                &vec![0xb2; usize::try_from(second_page.size()).unwrap()],
+                second_page.start(),
+            )
+            .expect("second page should update");
+        let second_result = write_layer(
+            &second_diff,
+            &second_memory,
+            SnapshotV2DiffBase::Image(first_result),
+            &[second_page],
+        );
+        let first_before = fs::read(&first_diff).unwrap();
+        let second_before = fs::read(&second_diff).unwrap();
+
+        assert_deprecated_success(&run_deprecated(&base_path, &first_diff));
+        assert_replacement_success(&run_replacement(&base_path, &second_diff, false));
+        assert_eq!(fs::read(&first_diff).unwrap(), first_before);
+        assert_eq!(fs::read(&second_diff).unwrap(), second_before);
+
+        let file = File::open(&base_path).expect("final result should open");
+        for extent in second_result.extents().iter().copied() {
+            let length = usize::try_from(extent.range().size()).unwrap();
+            let mut actual = vec![0_u8; length];
+            let mut expected = vec![0_u8; length];
+            file.read_exact_at(&mut actual, extent.file_offset())
+                .expect("final payload should read");
+            second_memory
+                .read_slice(&mut expected, extent.range().start())
+                .expect("expected payload should read");
+            assert_eq!(actual, expected);
+        }
+        assert!(directory.staging_entries().is_empty());
+    }
+
+    fn spawn_deprecated(base: &Path, diff: &Path) -> Child {
+        rebase_snap()
+            .arg("--base-file")
+            .arg(base)
+            .arg("--diff-file")
+            .arg(diff)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("deprecated command should spawn")
+    }
+
+    fn spawn_replacement(base: &Path, diff: &Path) -> Child {
+        let mut command = snapshot_editor();
+        command
+            .args(["edit-memory", "rebase"])
+            .arg("--memory-path")
+            .arg(base)
+            .arg("--diff-path")
+            .arg(diff)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("replacement command should spawn")
+    }
+
+    fn wait_for_staging(directory: &TestDirectory, child: &mut Child) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if !directory.staging_entries().is_empty() {
+                return;
+            }
+            assert!(
+                child
+                    .try_wait()
+                    .expect("child status should be available")
+                    .is_none(),
+                "command exited before publishing a staging entry"
+            );
+            assert!(
+                Instant::now() < deadline,
+                "command did not publish a staging entry before timeout"
+            );
+            thread::sleep(Duration::from_millis(1));
+        }
+    }
+
+    fn signal_child(child: &Child, signal: i32) {
+        // SAFETY: the PID belongs to the live child process and signal is
+        // SIGINT or SIGTERM for this focused cancellation test.
+        assert_eq!(unsafe { libc::kill(child.id() as i32, signal) }, 0);
+    }
+
+    #[test]
+    fn process_signals_and_path_substitutions_preserve_precommit_inputs() {
+        const LARGE_PAGE_COUNT: u64 = 32 * 1024;
+
+        let directory = TestDirectory::new("races");
+        let original_base = directory.child("original-base.mem");
+        let original_diff = directory.child("original-next.diff");
+        let range = page_range(0, LARGE_PAGE_COUNT);
+        let base = write_complete(&original_base, &memory_with_byte(range, 0x28));
+        write_layer(
+            &original_diff,
+            &memory_with_byte(range, 0xc3),
+            SnapshotV2DiffBase::Image(base),
+            &[range],
+        );
+        let base_bytes = fs::read(&original_base).expect("large base should read");
+        let diff_bytes = fs::read(&original_diff).expect("large Diff should read");
+
+        for (case, signal, expected_exit, deprecated) in [
+            ("sigint", libc::SIGINT, 130, true),
+            ("sigterm", libc::SIGTERM, 143, false),
+        ] {
+            let base_path = directory.child(&format!("{case}-base.mem"));
+            let diff_path = directory.child(&format!("{case}-next.diff"));
+            fs::copy(&original_base, &base_path).expect("signal base should copy");
+            fs::copy(&original_diff, &diff_path).expect("signal Diff should copy");
+            let mut child = if deprecated {
+                spawn_deprecated(&base_path, &diff_path)
+            } else {
+                spawn_replacement(&base_path, &diff_path)
+            };
+            wait_for_staging(&directory, &mut child);
+            signal_child(&child, signal);
+            let output = child
+                .wait_with_output()
+                .expect("signalled child should exit");
+            assert_eq!(output.status.code(), Some(expected_exit));
+            assert_eq!(fs::read(&base_path).unwrap(), base_bytes);
+            assert_eq!(fs::read(&diff_path).unwrap(), diff_bytes);
+            assert!(directory.staging_entries().is_empty());
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(stderr.contains("cancelled before commit"));
+            assert!(!stderr.contains(case));
+        }
+
+        let base_path = directory.child("base-replacement-base.mem");
+        let diff_path = directory.child("base-replacement-next.diff");
+        let moved_base = directory.child("base-replacement-retained.mem");
+        fs::copy(&original_base, &base_path).expect("replacement base should copy");
+        fs::copy(&original_diff, &diff_path).expect("replacement Diff should copy");
+        let mut child = spawn_deprecated(&base_path, &diff_path);
+        wait_for_staging(&directory, &mut child);
+        fs::rename(&base_path, &moved_base).expect("retained base should move");
+        fs::write(&base_path, b"unrelated-private-base-replacement")
+            .expect("unrelated base replacement should write");
+        let output = child
+            .wait_with_output()
+            .expect("base replacement child should exit");
+        assert_operational_failure(
+            &output,
+            "rebase-snap",
+            &["base-replacement", "unrelated-private-base-replacement"],
+        );
+        assert_eq!(
+            fs::read(&base_path).unwrap(),
+            b"unrelated-private-base-replacement"
+        );
+        assert_eq!(fs::read(&moved_base).unwrap(), base_bytes);
+        assert_eq!(fs::read(&diff_path).unwrap(), diff_bytes);
+        assert!(directory.staging_entries().is_empty());
+
+        let base_path = directory.child("diff-replacement-base.mem");
+        let diff_path = directory.child("diff-replacement-next.diff");
+        let moved_diff = directory.child("diff-replacement-retained.diff");
+        fs::copy(&original_base, &base_path).expect("replacement base should copy");
+        fs::copy(&original_diff, &diff_path).expect("replacement Diff should copy");
+        let mut child = spawn_replacement(&base_path, &diff_path);
+        wait_for_staging(&directory, &mut child);
+        fs::rename(&diff_path, &moved_diff).expect("retained Diff should move");
+        fs::write(&diff_path, b"unrelated-private-diff-replacement")
+            .expect("unrelated Diff replacement should write");
+        let output = child
+            .wait_with_output()
+            .expect("Diff replacement child should exit");
+        assert_operational_failure(
+            &output,
+            "snapshot-editor",
+            &["diff-replacement", "unrelated-private-diff-replacement"],
+        );
+        assert_eq!(fs::read(&base_path).unwrap(), base_bytes);
+        assert_eq!(
+            fs::read(&diff_path).unwrap(),
+            b"unrelated-private-diff-replacement"
+        );
+        assert_eq!(fs::read(&moved_diff).unwrap(), diff_bytes);
+        assert!(directory.staging_entries().is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- add Firecracker-shaped rebase-snap and snapshot-editor edit-memory rebase commands over one shared native-v2 Diff transaction
- preserve redacted parse and operational diagnostics, signal cancellation exits, committed-uncertain classification, and explicit unsupported-target behavior
- run both independently signed tools against the same real HVF-captured Full-to-Diff chain and retain the existing contained restore evidence

## Scope exclusions

- snapshot inspection and VM/vCPU register editing remain in #1542
- documentation and capability-inventory reconciliation remain in #1759

## Verification

- cargo fmt --all -- --check
- cargo run -p bangbang-firecracker-capability-audit --locked -- validate
- cargo check --workspace --all-targets --all-features --locked
- cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl
- cargo check -p bangbang-snapshot-tools --all-targets --all-features --locked --target aarch64-unknown-linux-musl
- cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf
- cargo test -p bangbang-hvf --lib --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- all five Apple-target Clippy commands from AGENTS.md
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps --locked
- scripts/run-integration-tests.sh

Closes #1758