### PR TITLE
feat: add exact native snapshot documents

### DIFF
--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -23,6 +23,7 @@ mod session_vcpu;
 mod sme;
 mod snapshot;
 mod snapshot_bundle;
+mod snapshot_document;
 mod snapshot_restore;
 mod snapshot_v2;
 mod snapshot_v2_balloon_platform;
@@ -133,6 +134,12 @@ pub use snapshot_bundle::{
     HvfSnapshotV1CompatibilityState, HvfSnapshotV1DecodeError, HvfSnapshotV1EncodeError,
     HvfSnapshotV1InterruptState, HvfSnapshotV1State, HvfSnapshotV1VcpuState,
     decode_hvf_snapshot_v1_state, encode_hvf_snapshot_v1_state,
+};
+pub use snapshot_document::{
+    HvfNativeSnapshotDocument, HvfNativeSnapshotDocumentDecodeError,
+    HvfNativeSnapshotDocumentEncodeError, HvfNativeSnapshotDocumentProfile,
+    HvfNativeSnapshotDocumentReplaceError, HvfNativeSnapshotPlatformRef, HvfNativeSnapshotVcpuRef,
+    HvfNativeSnapshotVcpuState, HvfNativeSnapshotVcpus,
 };
 pub use snapshot_restore::{
     HvfSnapshotV1PlatformError, HvfSnapshotV1RestoreCleanup, HvfSnapshotV1RestoreDisposition,

--- a/crates/hvf/src/snapshot_bundle.rs
+++ b/crates/hvf/src/snapshot_bundle.rs
@@ -1558,7 +1558,7 @@ pub(crate) mod tests {
         }
     }
 
-    fn memory_binding(memory_mib: u64) -> SnapshotMemoryBinding {
+    pub(crate) fn memory_binding(memory_mib: u64) -> SnapshotMemoryBinding {
         let size = memory_mib * MIB;
         memory_binding_for_ranges(vec![
             GuestMemoryRange::new(GuestAddress::new(aarch64::DRAM_MEM_START), size)

--- a/crates/hvf/src/snapshot_document.rs
+++ b/crates/hvf/src/snapshot_document.rs
@@ -1,0 +1,926 @@
+//! Pure owned documents for exact Bangbang-native HVF snapshot state.
+
+use std::collections::TryReserveError;
+use std::fmt;
+use std::iter::FusedIterator;
+use std::slice;
+
+use bangbang_runtime::snapshot_artifact::{
+    NativeSnapshotArtifactFamily, NativeV2SnapshotArtifactProfile,
+};
+use bangbang_runtime::snapshot_balloon_v2_9::NATIVE_V2_BALLOON_STATE_COMPATIBILITY_VERSION;
+use bangbang_runtime::snapshot_commit::{
+    SnapshotCommitError, decode_snapshot_commit_envelope, encode_snapshot_commit_envelope,
+};
+use bangbang_runtime::snapshot_device_v2::NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION;
+use bangbang_runtime::snapshot_device_v2_5::NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION;
+use bangbang_runtime::snapshot_device_v2_6::NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION;
+use bangbang_runtime::snapshot_diff_v2_13::NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION;
+use bangbang_runtime::snapshot_entropy_v2_8::NATIVE_V2_ENTROPY_STATE_COMPATIBILITY_VERSION;
+use bangbang_runtime::snapshot_format::{
+    NATIVE_V1_SNAPSHOT_VERSION, NativeSnapshotFormatError, NativeSnapshotState,
+    SnapshotFormatVersion, decode_native_snapshot_state,
+};
+use bangbang_runtime::snapshot_format_v2::NATIVE_V2_LEGACY_PLATFORM_VERSION;
+use bangbang_runtime::snapshot_memory::SnapshotMemoryBinding;
+use bangbang_runtime::snapshot_memory_hotplug_v2_10::NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION;
+use bangbang_runtime::snapshot_network_v2_11::NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION;
+use bangbang_runtime::snapshot_serial_v2_7::NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION;
+use bangbang_runtime::snapshot_vsock_v2_12::NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION;
+
+use crate::snapshot_bundle::{
+    HvfSnapshotV1Bundle, HvfSnapshotV1BundleError, HvfSnapshotV1State, HvfSnapshotV1VcpuState,
+};
+use crate::snapshot_v2::{
+    HvfSnapshotV2BalloonState, HvfSnapshotV2BuildError, HvfSnapshotV2DecodeError,
+    HvfSnapshotV2DiffState, HvfSnapshotV2EncodeError, HvfSnapshotV2EntropyState,
+    HvfSnapshotV2MemoryHotplugState, HvfSnapshotV2MultiBlockState, HvfSnapshotV2NetworkState,
+    HvfSnapshotV2PlatformState, HvfSnapshotV2SerialState, HvfSnapshotV2State,
+    HvfSnapshotV2StorageState, HvfSnapshotV2VcpuState, HvfSnapshotV2VsockState,
+    decode_hvf_snapshot_v2_balloon_state, decode_hvf_snapshot_v2_diff_state,
+    decode_hvf_snapshot_v2_entropy_state, decode_hvf_snapshot_v2_memory_hotplug_state,
+    decode_hvf_snapshot_v2_multi_block_state, decode_hvf_snapshot_v2_network_state,
+    decode_hvf_snapshot_v2_platform_state, decode_hvf_snapshot_v2_serial_state,
+    decode_hvf_snapshot_v2_state, decode_hvf_snapshot_v2_storage_state,
+    decode_hvf_snapshot_v2_vsock_state, encode_hvf_snapshot_v2_balloon_state,
+    encode_hvf_snapshot_v2_diff_state, encode_hvf_snapshot_v2_entropy_state,
+    encode_hvf_snapshot_v2_memory_hotplug_state, encode_hvf_snapshot_v2_multi_block_state,
+    encode_hvf_snapshot_v2_network_state, encode_hvf_snapshot_v2_platform_state,
+    encode_hvf_snapshot_v2_serial_state, encode_hvf_snapshot_v2_state,
+    encode_hvf_snapshot_v2_storage_state, encode_hvf_snapshot_v2_vsock_state,
+};
+
+const REDACTED: &str = "<redacted>";
+
+/// Exact semantic profile owned by one native HVF snapshot document.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfNativeSnapshotDocumentProfile {
+    /// Native-v1 `1.0.0` composite commit envelope.
+    V1,
+    /// One exact native-v2 profile.
+    V2(NativeV2SnapshotArtifactProfile),
+}
+
+impl fmt::Display for HvfNativeSnapshotDocumentProfile {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::V1 => formatter.write_str("native-v1 1.0.0"),
+            Self::V2(NativeV2SnapshotArtifactProfile::LegacyPlatformV2_3) => {
+                formatter.write_str("native-v2 2.3.0 legacy-platform")
+            }
+            Self::V2(NativeV2SnapshotArtifactProfile::DeviceGraphV2_4) => {
+                formatter.write_str("native-v2 2.4.0 device-graph")
+            }
+            Self::V2(NativeV2SnapshotArtifactProfile::MultiBlockDeviceGraphV2_5) => {
+                formatter.write_str("native-v2 2.5.0 multi-block-device-graph")
+            }
+            Self::V2(NativeV2SnapshotArtifactProfile::StorageDeviceGraphV2_6) => {
+                formatter.write_str("native-v2 2.6.0 storage-device-graph")
+            }
+            Self::V2(NativeV2SnapshotArtifactProfile::SerialStateV2_7) => {
+                formatter.write_str("native-v2 2.7.0 serial-state")
+            }
+            Self::V2(NativeV2SnapshotArtifactProfile::EntropyStateV2_8) => {
+                formatter.write_str("native-v2 2.8.0 entropy-state")
+            }
+            Self::V2(NativeV2SnapshotArtifactProfile::BalloonStateV2_9) => {
+                formatter.write_str("native-v2 2.9.0 balloon-state")
+            }
+            Self::V2(NativeV2SnapshotArtifactProfile::MemoryHotplugStateV2_10) => {
+                formatter.write_str("native-v2 2.10.0 memory-hotplug-state")
+            }
+            Self::V2(NativeV2SnapshotArtifactProfile::NetworkStateV2_11) => {
+                formatter.write_str("native-v2 2.11.0 network-state")
+            }
+            Self::V2(NativeV2SnapshotArtifactProfile::VsockStateV2_12) => {
+                formatter.write_str("native-v2 2.12.0 vsock-state")
+            }
+            Self::V2(NativeV2SnapshotArtifactProfile::DiffStateV2_13) => {
+                formatter.write_str("native-v2 2.13.0 diff-state")
+            }
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+enum HvfNativeSnapshotDocumentState {
+    V1(HvfSnapshotV1Bundle),
+    V2LegacyPlatform(HvfSnapshotV2PlatformState),
+    V2DeviceGraph(HvfSnapshotV2State),
+    V2MultiBlock(HvfSnapshotV2MultiBlockState),
+    V2Storage(HvfSnapshotV2StorageState),
+    V2Serial(HvfSnapshotV2SerialState),
+    V2Entropy(HvfSnapshotV2EntropyState),
+    V2Balloon(HvfSnapshotV2BalloonState),
+    V2MemoryHotplug(HvfSnapshotV2MemoryHotplugState),
+    V2Network(HvfSnapshotV2NetworkState),
+    V2Vsock(HvfSnapshotV2VsockState),
+    V2Diff(HvfSnapshotV2DiffState),
+}
+
+/// One complete, owned, exact-profile Bangbang-native HVF state document.
+#[derive(Clone, PartialEq, Eq)]
+pub struct HvfNativeSnapshotDocument {
+    state: HvfNativeSnapshotDocumentState,
+}
+
+impl HvfNativeSnapshotDocument {
+    /// Decodes one bounded native state file into its exact typed profile.
+    pub fn decode(bytes: &[u8]) -> Result<Self, HvfNativeSnapshotDocumentDecodeError> {
+        match decode_native_snapshot_state(bytes)
+            .map_err(HvfNativeSnapshotDocumentDecodeError::Format)?
+        {
+            NativeSnapshotState::V1(_) => {
+                let record = decode_snapshot_commit_envelope(bytes)
+                    .map_err(HvfNativeSnapshotDocumentDecodeError::Commit)?;
+                let bundle = HvfSnapshotV1Bundle::try_from_commit_record(record)
+                    .map_err(HvfNativeSnapshotDocumentDecodeError::NativeV1)?;
+                Ok(Self {
+                    state: HvfNativeSnapshotDocumentState::V1(bundle),
+                })
+            }
+            NativeSnapshotState::V2(structural) => {
+                let version = structural.metadata().version();
+                let state = match version {
+                    NATIVE_V2_LEGACY_PLATFORM_VERSION => {
+                        HvfNativeSnapshotDocumentState::V2LegacyPlatform(
+                            decode_hvf_snapshot_v2_platform_state(&structural)
+                                .map_err(HvfNativeSnapshotDocumentDecodeError::NativeV2)?,
+                        )
+                    }
+                    NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION => {
+                        HvfNativeSnapshotDocumentState::V2DeviceGraph(
+                            decode_hvf_snapshot_v2_state(&structural)
+                                .map_err(HvfNativeSnapshotDocumentDecodeError::NativeV2)?,
+                        )
+                    }
+                    NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION => {
+                        HvfNativeSnapshotDocumentState::V2MultiBlock(
+                            decode_hvf_snapshot_v2_multi_block_state(&structural)
+                                .map_err(HvfNativeSnapshotDocumentDecodeError::NativeV2)?,
+                        )
+                    }
+                    NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION => {
+                        HvfNativeSnapshotDocumentState::V2Storage(
+                            decode_hvf_snapshot_v2_storage_state(&structural)
+                                .map_err(HvfNativeSnapshotDocumentDecodeError::NativeV2)?,
+                        )
+                    }
+                    NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION => {
+                        HvfNativeSnapshotDocumentState::V2Serial(
+                            decode_hvf_snapshot_v2_serial_state(&structural)
+                                .map_err(HvfNativeSnapshotDocumentDecodeError::NativeV2)?,
+                        )
+                    }
+                    NATIVE_V2_ENTROPY_STATE_COMPATIBILITY_VERSION => {
+                        HvfNativeSnapshotDocumentState::V2Entropy(
+                            decode_hvf_snapshot_v2_entropy_state(&structural)
+                                .map_err(HvfNativeSnapshotDocumentDecodeError::NativeV2)?,
+                        )
+                    }
+                    NATIVE_V2_BALLOON_STATE_COMPATIBILITY_VERSION => {
+                        HvfNativeSnapshotDocumentState::V2Balloon(
+                            decode_hvf_snapshot_v2_balloon_state(&structural)
+                                .map_err(HvfNativeSnapshotDocumentDecodeError::NativeV2)?,
+                        )
+                    }
+                    NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION => {
+                        HvfNativeSnapshotDocumentState::V2MemoryHotplug(
+                            decode_hvf_snapshot_v2_memory_hotplug_state(&structural)
+                                .map_err(HvfNativeSnapshotDocumentDecodeError::NativeV2)?,
+                        )
+                    }
+                    NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION => {
+                        HvfNativeSnapshotDocumentState::V2Network(
+                            decode_hvf_snapshot_v2_network_state(&structural)
+                                .map_err(HvfNativeSnapshotDocumentDecodeError::NativeV2)?,
+                        )
+                    }
+                    NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION => {
+                        HvfNativeSnapshotDocumentState::V2Vsock(
+                            decode_hvf_snapshot_v2_vsock_state(&structural)
+                                .map_err(HvfNativeSnapshotDocumentDecodeError::NativeV2)?,
+                        )
+                    }
+                    NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION => {
+                        HvfNativeSnapshotDocumentState::V2Diff(
+                            decode_hvf_snapshot_v2_diff_state(&structural)
+                                .map_err(HvfNativeSnapshotDocumentDecodeError::NativeV2)?,
+                        )
+                    }
+                    _ => {
+                        return Err(
+                            HvfNativeSnapshotDocumentDecodeError::UnsupportedExactProfile(version),
+                        );
+                    }
+                };
+                Ok(Self { state })
+            }
+        }
+    }
+
+    /// Encodes the document through its original exact family/profile codec.
+    pub fn encode(&self) -> Result<Vec<u8>, HvfNativeSnapshotDocumentEncodeError> {
+        match &self.state {
+            HvfNativeSnapshotDocumentState::V1(bundle) => {
+                encode_snapshot_commit_envelope(bundle.commit_record())
+                    .map_err(HvfNativeSnapshotDocumentEncodeError::NativeV1)
+            }
+            HvfNativeSnapshotDocumentState::V2LegacyPlatform(state) => {
+                encode_hvf_snapshot_v2_platform_state(state)
+                    .map_err(HvfNativeSnapshotDocumentEncodeError::NativeV2)
+            }
+            HvfNativeSnapshotDocumentState::V2DeviceGraph(state) => {
+                encode_hvf_snapshot_v2_state(state)
+                    .map_err(HvfNativeSnapshotDocumentEncodeError::NativeV2)
+            }
+            HvfNativeSnapshotDocumentState::V2MultiBlock(state) => {
+                encode_hvf_snapshot_v2_multi_block_state(state)
+                    .map_err(HvfNativeSnapshotDocumentEncodeError::NativeV2)
+            }
+            HvfNativeSnapshotDocumentState::V2Storage(state) => {
+                encode_hvf_snapshot_v2_storage_state(state)
+                    .map_err(HvfNativeSnapshotDocumentEncodeError::NativeV2)
+            }
+            HvfNativeSnapshotDocumentState::V2Serial(state) => {
+                encode_hvf_snapshot_v2_serial_state(state)
+                    .map_err(HvfNativeSnapshotDocumentEncodeError::NativeV2)
+            }
+            HvfNativeSnapshotDocumentState::V2Entropy(state) => {
+                encode_hvf_snapshot_v2_entropy_state(state)
+                    .map_err(HvfNativeSnapshotDocumentEncodeError::NativeV2)
+            }
+            HvfNativeSnapshotDocumentState::V2Balloon(state) => {
+                encode_hvf_snapshot_v2_balloon_state(state)
+                    .map_err(HvfNativeSnapshotDocumentEncodeError::NativeV2)
+            }
+            HvfNativeSnapshotDocumentState::V2MemoryHotplug(state) => {
+                encode_hvf_snapshot_v2_memory_hotplug_state(state)
+                    .map_err(HvfNativeSnapshotDocumentEncodeError::NativeV2)
+            }
+            HvfNativeSnapshotDocumentState::V2Network(state) => {
+                encode_hvf_snapshot_v2_network_state(state)
+                    .map_err(HvfNativeSnapshotDocumentEncodeError::NativeV2)
+            }
+            HvfNativeSnapshotDocumentState::V2Vsock(state) => {
+                encode_hvf_snapshot_v2_vsock_state(state)
+                    .map_err(HvfNativeSnapshotDocumentEncodeError::NativeV2)
+            }
+            HvfNativeSnapshotDocumentState::V2Diff(state) => {
+                encode_hvf_snapshot_v2_diff_state(state)
+                    .map_err(HvfNativeSnapshotDocumentEncodeError::NativeV2)
+            }
+        }
+    }
+
+    /// Returns the native artifact family.
+    pub const fn family(&self) -> NativeSnapshotArtifactFamily {
+        match self.state {
+            HvfNativeSnapshotDocumentState::V1(_) => NativeSnapshotArtifactFamily::V1,
+            HvfNativeSnapshotDocumentState::V2LegacyPlatform(_)
+            | HvfNativeSnapshotDocumentState::V2DeviceGraph(_)
+            | HvfNativeSnapshotDocumentState::V2MultiBlock(_)
+            | HvfNativeSnapshotDocumentState::V2Storage(_)
+            | HvfNativeSnapshotDocumentState::V2Serial(_)
+            | HvfNativeSnapshotDocumentState::V2Entropy(_)
+            | HvfNativeSnapshotDocumentState::V2Balloon(_)
+            | HvfNativeSnapshotDocumentState::V2MemoryHotplug(_)
+            | HvfNativeSnapshotDocumentState::V2Network(_)
+            | HvfNativeSnapshotDocumentState::V2Vsock(_)
+            | HvfNativeSnapshotDocumentState::V2Diff(_) => NativeSnapshotArtifactFamily::V2,
+        }
+    }
+
+    /// Returns the complete exact semantic version.
+    pub const fn version(&self) -> SnapshotFormatVersion {
+        match self.state {
+            HvfNativeSnapshotDocumentState::V1(_) => NATIVE_V1_SNAPSHOT_VERSION,
+            HvfNativeSnapshotDocumentState::V2LegacyPlatform(_) => {
+                NATIVE_V2_LEGACY_PLATFORM_VERSION
+            }
+            HvfNativeSnapshotDocumentState::V2DeviceGraph(_) => {
+                NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION
+            }
+            HvfNativeSnapshotDocumentState::V2MultiBlock(_) => {
+                NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION
+            }
+            HvfNativeSnapshotDocumentState::V2Storage(_) => {
+                NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION
+            }
+            HvfNativeSnapshotDocumentState::V2Serial(_) => {
+                NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION
+            }
+            HvfNativeSnapshotDocumentState::V2Entropy(_) => {
+                NATIVE_V2_ENTROPY_STATE_COMPATIBILITY_VERSION
+            }
+            HvfNativeSnapshotDocumentState::V2Balloon(_) => {
+                NATIVE_V2_BALLOON_STATE_COMPATIBILITY_VERSION
+            }
+            HvfNativeSnapshotDocumentState::V2MemoryHotplug(_) => {
+                NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION
+            }
+            HvfNativeSnapshotDocumentState::V2Network(_) => {
+                NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION
+            }
+            HvfNativeSnapshotDocumentState::V2Vsock(_) => {
+                NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION
+            }
+            HvfNativeSnapshotDocumentState::V2Diff(_) => NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION,
+        }
+    }
+
+    /// Returns the exact semantic document profile.
+    pub const fn profile(&self) -> HvfNativeSnapshotDocumentProfile {
+        let profile = match self.state {
+            HvfNativeSnapshotDocumentState::V1(_) => {
+                return HvfNativeSnapshotDocumentProfile::V1;
+            }
+            HvfNativeSnapshotDocumentState::V2LegacyPlatform(_) => {
+                NativeV2SnapshotArtifactProfile::LegacyPlatformV2_3
+            }
+            HvfNativeSnapshotDocumentState::V2DeviceGraph(_) => {
+                NativeV2SnapshotArtifactProfile::DeviceGraphV2_4
+            }
+            HvfNativeSnapshotDocumentState::V2MultiBlock(_) => {
+                NativeV2SnapshotArtifactProfile::MultiBlockDeviceGraphV2_5
+            }
+            HvfNativeSnapshotDocumentState::V2Storage(_) => {
+                NativeV2SnapshotArtifactProfile::StorageDeviceGraphV2_6
+            }
+            HvfNativeSnapshotDocumentState::V2Serial(_) => {
+                NativeV2SnapshotArtifactProfile::SerialStateV2_7
+            }
+            HvfNativeSnapshotDocumentState::V2Entropy(_) => {
+                NativeV2SnapshotArtifactProfile::EntropyStateV2_8
+            }
+            HvfNativeSnapshotDocumentState::V2Balloon(_) => {
+                NativeV2SnapshotArtifactProfile::BalloonStateV2_9
+            }
+            HvfNativeSnapshotDocumentState::V2MemoryHotplug(_) => {
+                NativeV2SnapshotArtifactProfile::MemoryHotplugStateV2_10
+            }
+            HvfNativeSnapshotDocumentState::V2Network(_) => {
+                NativeV2SnapshotArtifactProfile::NetworkStateV2_11
+            }
+            HvfNativeSnapshotDocumentState::V2Vsock(_) => {
+                NativeV2SnapshotArtifactProfile::VsockStateV2_12
+            }
+            HvfNativeSnapshotDocumentState::V2Diff(_) => {
+                NativeV2SnapshotArtifactProfile::DiffStateV2_13
+            }
+        };
+        HvfNativeSnapshotDocumentProfile::V2(profile)
+    }
+
+    /// Returns a borrowed checked platform view without exposing outer devices.
+    pub const fn platform(&self) -> HvfNativeSnapshotPlatformRef<'_> {
+        match &self.state {
+            HvfNativeSnapshotDocumentState::V1(bundle) => HvfNativeSnapshotPlatformRef::V1 {
+                memory_binding: bundle.commit_record().memory_binding(),
+                state: bundle.state(),
+            },
+            HvfNativeSnapshotDocumentState::V2LegacyPlatform(state) => {
+                HvfNativeSnapshotPlatformRef::V2(state)
+            }
+            HvfNativeSnapshotDocumentState::V2DeviceGraph(state) => {
+                HvfNativeSnapshotPlatformRef::V2(state.platform())
+            }
+            HvfNativeSnapshotDocumentState::V2MultiBlock(state) => {
+                HvfNativeSnapshotPlatformRef::V2(state.platform())
+            }
+            HvfNativeSnapshotDocumentState::V2Storage(state) => {
+                HvfNativeSnapshotPlatformRef::V2(state.platform())
+            }
+            HvfNativeSnapshotDocumentState::V2Serial(state) => {
+                HvfNativeSnapshotPlatformRef::V2(state.platform())
+            }
+            HvfNativeSnapshotDocumentState::V2Entropy(state) => {
+                HvfNativeSnapshotPlatformRef::V2(state.platform())
+            }
+            HvfNativeSnapshotDocumentState::V2Balloon(state) => {
+                HvfNativeSnapshotPlatformRef::V2(state.platform())
+            }
+            HvfNativeSnapshotDocumentState::V2MemoryHotplug(state) => {
+                HvfNativeSnapshotPlatformRef::V2(state.platform())
+            }
+            HvfNativeSnapshotDocumentState::V2Network(state) => {
+                HvfNativeSnapshotPlatformRef::V2(state.platform())
+            }
+            HvfNativeSnapshotDocumentState::V2Vsock(state) => {
+                HvfNativeSnapshotPlatformRef::V2(state.platform())
+            }
+            HvfNativeSnapshotDocumentState::V2Diff(state) => {
+                HvfNativeSnapshotPlatformRef::V2(state.platform())
+            }
+        }
+    }
+
+    /// Returns complete vCPU states in canonical instance order.
+    pub fn vcpus(&self) -> HvfNativeSnapshotVcpus<'_> {
+        let inner = match &self.state {
+            HvfNativeSnapshotDocumentState::V1(bundle) => {
+                HvfNativeSnapshotVcpuIterator::V1(Some(bundle.state().vcpu()))
+            }
+            HvfNativeSnapshotDocumentState::V2LegacyPlatform(state) => {
+                HvfNativeSnapshotVcpuIterator::V2(state.vcpus().iter())
+            }
+            HvfNativeSnapshotDocumentState::V2DeviceGraph(state) => {
+                HvfNativeSnapshotVcpuIterator::V2(state.platform().vcpus().iter())
+            }
+            HvfNativeSnapshotDocumentState::V2MultiBlock(state) => {
+                HvfNativeSnapshotVcpuIterator::V2(state.platform().vcpus().iter())
+            }
+            HvfNativeSnapshotDocumentState::V2Storage(state) => {
+                HvfNativeSnapshotVcpuIterator::V2(state.platform().vcpus().iter())
+            }
+            HvfNativeSnapshotDocumentState::V2Serial(state) => {
+                HvfNativeSnapshotVcpuIterator::V2(state.platform().vcpus().iter())
+            }
+            HvfNativeSnapshotDocumentState::V2Entropy(state) => {
+                HvfNativeSnapshotVcpuIterator::V2(state.platform().vcpus().iter())
+            }
+            HvfNativeSnapshotDocumentState::V2Balloon(state) => {
+                HvfNativeSnapshotVcpuIterator::V2(state.platform().vcpus().iter())
+            }
+            HvfNativeSnapshotDocumentState::V2MemoryHotplug(state) => {
+                HvfNativeSnapshotVcpuIterator::V2(state.platform().vcpus().iter())
+            }
+            HvfNativeSnapshotDocumentState::V2Network(state) => {
+                HvfNativeSnapshotVcpuIterator::V2(state.platform().vcpus().iter())
+            }
+            HvfNativeSnapshotDocumentState::V2Vsock(state) => {
+                HvfNativeSnapshotVcpuIterator::V2(state.platform().vcpus().iter())
+            }
+            HvfNativeSnapshotDocumentState::V2Diff(state) => {
+                HvfNativeSnapshotVcpuIterator::V2(state.platform().vcpus().iter())
+            }
+        };
+        HvfNativeSnapshotVcpus { inner }
+    }
+
+    /// Returns the exact number of complete vCPU states.
+    pub fn vcpu_count(&self) -> usize {
+        match self.platform() {
+            HvfNativeSnapshotPlatformRef::V1 { .. } => 1,
+            HvfNativeSnapshotPlatformRef::V2(platform) => platform.vcpus().len(),
+        }
+    }
+
+    /// Replaces the complete ordered vCPU set and rebuilds the same profile.
+    pub fn try_replace_vcpus(
+        self,
+        replacements: Vec<HvfNativeSnapshotVcpuState>,
+    ) -> Result<Self, HvfNativeSnapshotDocumentReplaceError> {
+        let expected = self.vcpu_count();
+        let actual = replacements.len();
+        if actual != expected {
+            return Err(HvfNativeSnapshotDocumentReplaceError::VcpuCount { expected, actual });
+        }
+
+        let state = match self.state {
+            HvfNativeSnapshotDocumentState::V1(bundle) => {
+                let replacement = replacements
+                    .into_iter()
+                    .next()
+                    .ok_or(HvfNativeSnapshotDocumentReplaceError::VcpuCount { expected, actual })?;
+                let HvfNativeSnapshotVcpuState::V1(vcpu) = replacement else {
+                    return Err(HvfNativeSnapshotDocumentReplaceError::VcpuFamily);
+                };
+                let memory_binding = bundle.commit_record().memory_binding().clone();
+                let (machine, compatibility, _, interrupts, device) =
+                    bundle.into_state().into_parts();
+                let state =
+                    HvfSnapshotV1State::new(machine, compatibility, *vcpu, interrupts, device);
+                HvfNativeSnapshotDocumentState::V1(
+                    HvfSnapshotV1Bundle::try_new(memory_binding, state)
+                        .map_err(HvfNativeSnapshotDocumentReplaceError::NativeV1)?,
+                )
+            }
+            HvfNativeSnapshotDocumentState::V2LegacyPlatform(state) => {
+                HvfNativeSnapshotDocumentState::V2LegacyPlatform(
+                    state
+                        .try_replace_vcpus(into_v2_vcpus(replacements)?)
+                        .map_err(HvfNativeSnapshotDocumentReplaceError::NativeV2)?,
+                )
+            }
+            HvfNativeSnapshotDocumentState::V2DeviceGraph(state) => {
+                HvfNativeSnapshotDocumentState::V2DeviceGraph(
+                    state
+                        .try_replace_vcpus(into_v2_vcpus(replacements)?)
+                        .map_err(HvfNativeSnapshotDocumentReplaceError::NativeV2)?,
+                )
+            }
+            HvfNativeSnapshotDocumentState::V2MultiBlock(state) => {
+                HvfNativeSnapshotDocumentState::V2MultiBlock(
+                    state
+                        .try_replace_vcpus(into_v2_vcpus(replacements)?)
+                        .map_err(HvfNativeSnapshotDocumentReplaceError::NativeV2)?,
+                )
+            }
+            HvfNativeSnapshotDocumentState::V2Storage(state) => {
+                HvfNativeSnapshotDocumentState::V2Storage(
+                    state
+                        .try_replace_vcpus(into_v2_vcpus(replacements)?)
+                        .map_err(HvfNativeSnapshotDocumentReplaceError::NativeV2)?,
+                )
+            }
+            HvfNativeSnapshotDocumentState::V2Serial(state) => {
+                HvfNativeSnapshotDocumentState::V2Serial(
+                    state
+                        .try_replace_vcpus(into_v2_vcpus(replacements)?)
+                        .map_err(HvfNativeSnapshotDocumentReplaceError::NativeV2)?,
+                )
+            }
+            HvfNativeSnapshotDocumentState::V2Entropy(state) => {
+                HvfNativeSnapshotDocumentState::V2Entropy(
+                    state
+                        .try_replace_vcpus(into_v2_vcpus(replacements)?)
+                        .map_err(HvfNativeSnapshotDocumentReplaceError::NativeV2)?,
+                )
+            }
+            HvfNativeSnapshotDocumentState::V2Balloon(state) => {
+                HvfNativeSnapshotDocumentState::V2Balloon(
+                    state
+                        .try_replace_vcpus(into_v2_vcpus(replacements)?)
+                        .map_err(HvfNativeSnapshotDocumentReplaceError::NativeV2)?,
+                )
+            }
+            HvfNativeSnapshotDocumentState::V2MemoryHotplug(state) => {
+                HvfNativeSnapshotDocumentState::V2MemoryHotplug(
+                    state
+                        .try_replace_vcpus(into_v2_vcpus(replacements)?)
+                        .map_err(HvfNativeSnapshotDocumentReplaceError::NativeV2)?,
+                )
+            }
+            HvfNativeSnapshotDocumentState::V2Network(state) => {
+                HvfNativeSnapshotDocumentState::V2Network(
+                    state
+                        .try_replace_vcpus(into_v2_vcpus(replacements)?)
+                        .map_err(HvfNativeSnapshotDocumentReplaceError::NativeV2)?,
+                )
+            }
+            HvfNativeSnapshotDocumentState::V2Vsock(state) => {
+                HvfNativeSnapshotDocumentState::V2Vsock(
+                    state
+                        .try_replace_vcpus(into_v2_vcpus(replacements)?)
+                        .map_err(HvfNativeSnapshotDocumentReplaceError::NativeV2)?,
+                )
+            }
+            HvfNativeSnapshotDocumentState::V2Diff(state) => {
+                HvfNativeSnapshotDocumentState::V2Diff(
+                    state
+                        .try_replace_vcpus(into_v2_vcpus(replacements)?)
+                        .map_err(HvfNativeSnapshotDocumentReplaceError::NativeV2)?,
+                )
+            }
+        };
+        Ok(Self { state })
+    }
+}
+
+impl fmt::Debug for HvfNativeSnapshotDocument {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfNativeSnapshotDocument")
+            .field("profile", &self.profile())
+            .field("vcpu_count", &self.vcpu_count())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+fn into_v2_vcpus(
+    replacements: Vec<HvfNativeSnapshotVcpuState>,
+) -> Result<Vec<HvfSnapshotV2VcpuState>, HvfNativeSnapshotDocumentReplaceError> {
+    let mut vcpus = Vec::new();
+    vcpus
+        .try_reserve_exact(replacements.len())
+        .map_err(HvfNativeSnapshotDocumentReplaceError::Allocation)?;
+    for replacement in replacements {
+        let HvfNativeSnapshotVcpuState::V2(vcpu) = replacement else {
+            return Err(HvfNativeSnapshotDocumentReplaceError::VcpuFamily);
+        };
+        vcpus.push(*vcpu);
+    }
+    Ok(vcpus)
+}
+
+/// Borrowed checked platform semantics for one native document.
+#[derive(Clone, Copy)]
+pub enum HvfNativeSnapshotPlatformRef<'state> {
+    /// Native-v1 typed state and its retained memory commitment.
+    V1 {
+        /// Exact state-to-memory commitment from the complete envelope.
+        memory_binding: &'state SnapshotMemoryBinding,
+        /// Complete fixed-profile HVF state.
+        state: &'state HvfSnapshotV1State,
+    },
+    /// Common checked native-v2 platform graph.
+    V2(&'state HvfSnapshotV2PlatformState),
+}
+
+impl fmt::Debug for HvfNativeSnapshotPlatformRef<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (family, vcpu_count) = match self {
+            Self::V1 { .. } => ("native-v1", 1),
+            Self::V2(platform) => ("native-v2", platform.vcpus().len()),
+        };
+        formatter
+            .debug_struct("HvfNativeSnapshotPlatformRef")
+            .field("family", &family)
+            .field("vcpu_count", &vcpu_count)
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Borrowed complete vCPU state from one native document.
+#[derive(Clone, Copy)]
+pub enum HvfNativeSnapshotVcpuRef<'state> {
+    /// Native-v1's single mandatory vCPU state.
+    V1(&'state HvfSnapshotV1VcpuState),
+    /// One ordered native-v2 complete vCPU state.
+    V2(&'state HvfSnapshotV2VcpuState),
+}
+
+impl HvfNativeSnapshotVcpuRef<'_> {
+    /// Returns the canonical zero-based vCPU index.
+    pub const fn index(self) -> u32 {
+        match self {
+            Self::V1(_) => 0,
+            Self::V2(state) => state.index(),
+        }
+    }
+}
+
+impl fmt::Debug for HvfNativeSnapshotVcpuRef<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let family = match self {
+            Self::V1(_) => "native-v1",
+            Self::V2(_) => "native-v2",
+        };
+        formatter
+            .debug_struct("HvfNativeSnapshotVcpuRef")
+            .field("family", &family)
+            .field("index", &self.index())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Owned complete vCPU replacement for one native document.
+#[derive(Clone, PartialEq, Eq)]
+pub enum HvfNativeSnapshotVcpuState {
+    /// Native-v1's single mandatory vCPU state.
+    V1(Box<HvfSnapshotV1VcpuState>),
+    /// One native-v2 complete vCPU state.
+    V2(Box<HvfSnapshotV2VcpuState>),
+}
+
+impl HvfNativeSnapshotVcpuState {
+    /// Returns a borrowed view of this owned state.
+    pub const fn as_ref(&self) -> HvfNativeSnapshotVcpuRef<'_> {
+        match self {
+            Self::V1(state) => HvfNativeSnapshotVcpuRef::V1(state),
+            Self::V2(state) => HvfNativeSnapshotVcpuRef::V2(state),
+        }
+    }
+
+    /// Returns the canonical zero-based vCPU index.
+    pub const fn index(&self) -> u32 {
+        self.as_ref().index()
+    }
+}
+
+impl From<HvfNativeSnapshotVcpuRef<'_>> for HvfNativeSnapshotVcpuState {
+    fn from(state: HvfNativeSnapshotVcpuRef<'_>) -> Self {
+        match state {
+            HvfNativeSnapshotVcpuRef::V1(state) => Self::V1(Box::new(state.clone())),
+            HvfNativeSnapshotVcpuRef::V2(state) => Self::V2(Box::new(state.clone())),
+        }
+    }
+}
+
+impl fmt::Debug for HvfNativeSnapshotVcpuState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let family = match self {
+            Self::V1(_) => "native-v1",
+            Self::V2(_) => "native-v2",
+        };
+        formatter
+            .debug_struct("HvfNativeSnapshotVcpuState")
+            .field("family", &family)
+            .field("index", &self.index())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+enum HvfNativeSnapshotVcpuIterator<'state> {
+    V1(Option<&'state HvfSnapshotV1VcpuState>),
+    V2(slice::Iter<'state, HvfSnapshotV2VcpuState>),
+}
+
+/// Exact-size ordered iterator over complete native vCPU state.
+pub struct HvfNativeSnapshotVcpus<'state> {
+    inner: HvfNativeSnapshotVcpuIterator<'state>,
+}
+
+impl<'state> Iterator for HvfNativeSnapshotVcpus<'state> {
+    type Item = HvfNativeSnapshotVcpuRef<'state>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.inner {
+            HvfNativeSnapshotVcpuIterator::V1(state) => {
+                state.take().map(HvfNativeSnapshotVcpuRef::V1)
+            }
+            HvfNativeSnapshotVcpuIterator::V2(states) => {
+                states.next().map(HvfNativeSnapshotVcpuRef::V2)
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let length = self.len();
+        (length, Some(length))
+    }
+}
+
+impl ExactSizeIterator for HvfNativeSnapshotVcpus<'_> {
+    fn len(&self) -> usize {
+        match &self.inner {
+            HvfNativeSnapshotVcpuIterator::V1(state) => usize::from(state.is_some()),
+            HvfNativeSnapshotVcpuIterator::V2(states) => states.len(),
+        }
+    }
+}
+
+impl FusedIterator for HvfNativeSnapshotVcpus<'_> {}
+
+impl fmt::Debug for HvfNativeSnapshotVcpus<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfNativeSnapshotVcpus")
+            .field("remaining", &self.len())
+            .field("state", &REDACTED)
+            .finish()
+    }
+}
+
+/// Failure to decode one exact native HVF snapshot document.
+pub enum HvfNativeSnapshotDocumentDecodeError {
+    /// Native-family structural classification or bounds failed.
+    Format(NativeSnapshotFormatError),
+    /// A native-v1 envelope did not contain a valid commit payload.
+    Commit(SnapshotCommitError),
+    /// A native-v1 commit did not form a complete checked HVF bundle.
+    NativeV1(HvfSnapshotV1BundleError),
+    /// The container version is structurally admitted but has no exact profile.
+    UnsupportedExactProfile(SnapshotFormatVersion),
+    /// The selected exact native-v2 typed decoder rejected the state.
+    NativeV2(HvfSnapshotV2DecodeError),
+}
+
+impl fmt::Display for HvfNativeSnapshotDocumentDecodeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Format(source) => write!(formatter, "invalid native snapshot state: {source}"),
+            Self::Commit(source) => write!(formatter, "invalid native-v1 commit: {source}"),
+            Self::NativeV1(source) => write!(formatter, "invalid native-v1 HVF state: {source}"),
+            Self::UnsupportedExactProfile(version) => {
+                write!(
+                    formatter,
+                    "native snapshot profile {version} is unsupported"
+                )
+            }
+            Self::NativeV2(source) => {
+                write!(formatter, "invalid exact native-v2 HVF state: {source}")
+            }
+        }
+    }
+}
+
+impl fmt::Debug for HvfNativeSnapshotDocumentDecodeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "HvfNativeSnapshotDocumentDecodeError({self})")
+    }
+}
+
+impl std::error::Error for HvfNativeSnapshotDocumentDecodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Format(source) => Some(source),
+            Self::Commit(source) => Some(source),
+            Self::NativeV1(source) => Some(source),
+            Self::NativeV2(source) => Some(source),
+            Self::UnsupportedExactProfile(_) => None,
+        }
+    }
+}
+
+/// Failure to encode one already-checked exact native document.
+pub enum HvfNativeSnapshotDocumentEncodeError {
+    /// Native-v1 commit-envelope encoding failed.
+    NativeV1(SnapshotCommitError),
+    /// Exact native-v2 typed encoding failed.
+    NativeV2(HvfSnapshotV2EncodeError),
+}
+
+impl fmt::Display for HvfNativeSnapshotDocumentEncodeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NativeV1(source) => {
+                write!(formatter, "failed to encode native-v1 document: {source}")
+            }
+            Self::NativeV2(source) => {
+                write!(
+                    formatter,
+                    "failed to encode exact native-v2 document: {source}"
+                )
+            }
+        }
+    }
+}
+
+impl fmt::Debug for HvfNativeSnapshotDocumentEncodeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "HvfNativeSnapshotDocumentEncodeError({self})")
+    }
+}
+
+impl std::error::Error for HvfNativeSnapshotDocumentEncodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::NativeV1(source) => Some(source),
+            Self::NativeV2(source) => Some(source),
+        }
+    }
+}
+
+/// Failure to rebuild the same exact document with replacement vCPU state.
+pub enum HvfNativeSnapshotDocumentReplaceError {
+    /// Replacement cardinality differs from the original platform.
+    VcpuCount {
+        /// Original exact vCPU count.
+        expected: usize,
+        /// Supplied replacement count.
+        actual: usize,
+    },
+    /// At least one replacement belongs to the wrong native family.
+    VcpuFamily,
+    /// Allocation for family-checked v2 replacements failed.
+    Allocation(TryReserveError),
+    /// Rebuilding the native-v1 bundle failed validation.
+    NativeV1(HvfSnapshotV1BundleError),
+    /// Rebuilding the exact native-v2 platform/profile failed validation.
+    NativeV2(HvfSnapshotV2BuildError),
+}
+
+impl fmt::Display for HvfNativeSnapshotDocumentReplaceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::VcpuCount { expected, actual } => write!(
+                formatter,
+                "replacement vCPU count {actual} does not match document count {expected}"
+            ),
+            Self::VcpuFamily => {
+                formatter.write_str("replacement vCPU belongs to the wrong native family")
+            }
+            Self::Allocation(_) => {
+                formatter.write_str("failed to allocate checked replacement vCPU state")
+            }
+            Self::NativeV1(source) => {
+                write!(
+                    formatter,
+                    "replacement native-v1 state is invalid: {source}"
+                )
+            }
+            Self::NativeV2(source) => {
+                write!(
+                    formatter,
+                    "replacement native-v2 state is invalid: {source}"
+                )
+            }
+        }
+    }
+}
+
+impl fmt::Debug for HvfNativeSnapshotDocumentReplaceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "HvfNativeSnapshotDocumentReplaceError({self})")
+    }
+}
+
+impl std::error::Error for HvfNativeSnapshotDocumentReplaceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Allocation(source) => Some(source),
+            Self::NativeV1(source) => Some(source),
+            Self::NativeV2(source) => Some(source),
+            Self::VcpuCount { .. } | Self::VcpuFamily => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/hvf/src/snapshot_document/tests.rs
+++ b/crates/hvf/src/snapshot_document/tests.rs
@@ -1,0 +1,515 @@
+use bangbang_runtime::memory::{GuestAddress, GuestMemoryRange, aarch64};
+use bangbang_runtime::snapshot_artifact::{
+    NativeSnapshotArtifactFamily, NativeV2SnapshotArtifactProfile,
+};
+use bangbang_runtime::snapshot_commit::{SnapshotCommitKind, SnapshotCommitRecord};
+use bangbang_runtime::snapshot_device_v2::SnapshotV2DeviceTransportKind;
+use bangbang_runtime::snapshot_diff_v2_13::SnapshotV2DiffBase;
+use bangbang_runtime::snapshot_format::NativeSnapshotFormatError;
+use bangbang_runtime::snapshot_format_v2::{
+    NATIVE_V2_SNAPSHOT_INTEGRITY_BYTES, SnapshotV2DecodeError,
+};
+
+use super::*;
+use crate::snapshot_bundle::tests::{fixture as native_v1_fixture, memory_binding};
+use crate::snapshot_v2::tests::{
+    ENTROPY_INACTIVE_MMIO_FIXTURE_HEX, MMIO_GRAPH_FIXTURE_HEX, MULTI_BLOCK_MMIO_GRAPH_FIXTURE_HEX,
+    SERIAL_CONFIGURED_FIXTURE_HEX, STORAGE_MMIO_GRAPH_FIXTURE_HEX, complete_balloon_state_fixture,
+    complete_diff_state_fixture, complete_entropy_state_fixture,
+    complete_memory_hotplug_state_fixture, complete_multi_block_state_fixture,
+    complete_network_state_fixture, complete_serial_state_fixture, complete_state_fixture,
+    complete_storage_state_fixture, complete_vsock_state_fixture,
+    exact_minor_twelve_memory_binding, platform_fixture, product_memory_hotplug_fixture,
+};
+
+fn assert_document(
+    bytes: &[u8],
+    expected_profile: HvfNativeSnapshotDocumentProfile,
+    expected_version: SnapshotFormatVersion,
+    expected_vcpus: usize,
+) -> HvfNativeSnapshotDocument {
+    let document = HvfNativeSnapshotDocument::decode(bytes)
+        .expect("complete exact-profile fixture should decode as a document");
+    let expected_family = match expected_profile {
+        HvfNativeSnapshotDocumentProfile::V1 => NativeSnapshotArtifactFamily::V1,
+        HvfNativeSnapshotDocumentProfile::V2(_) => NativeSnapshotArtifactFamily::V2,
+    };
+    assert_eq!(document.family(), expected_family);
+    assert_eq!(document.version(), expected_version);
+    assert_eq!(document.profile(), expected_profile);
+    assert_eq!(document.vcpu_count(), expected_vcpus);
+
+    let mut vcpus = document.vcpus();
+    assert_eq!(vcpus.len(), expected_vcpus);
+    let indexes = vcpus
+        .by_ref()
+        .map(HvfNativeSnapshotVcpuRef::index)
+        .collect::<Vec<_>>();
+    assert_eq!(vcpus.len(), 0);
+    assert_eq!(
+        indexes,
+        (0..u32::try_from(expected_vcpus).expect("fixture vCPU count should fit u32"))
+            .collect::<Vec<_>>()
+    );
+
+    assert_eq!(
+        document
+            .encode()
+            .expect("checked document should encode canonically"),
+        bytes
+    );
+    let replacements = document
+        .vcpus()
+        .map(HvfNativeSnapshotVcpuState::from)
+        .collect::<Vec<_>>();
+    let replaced = document
+        .clone()
+        .try_replace_vcpus(replacements)
+        .expect("same-value replacement should revalidate");
+    assert_eq!(replaced, document);
+    assert_eq!(
+        replaced
+            .encode()
+            .expect("rebuilt document should encode canonically"),
+        bytes
+    );
+    document
+}
+
+fn native_v1_document_fixture() -> (HvfSnapshotV1Bundle, Vec<u8>) {
+    let bundle = HvfSnapshotV1Bundle::try_new(memory_binding(1), native_v1_fixture())
+        .expect("native-v1 fixture bundle should validate");
+    let bytes = encode_snapshot_commit_envelope(bundle.commit_record())
+        .expect("native-v1 fixture envelope should encode");
+    (bundle, bytes)
+}
+
+#[test]
+fn native_v1_document_preserves_commit_memory_state_and_replacement() {
+    let (bundle, bytes) = native_v1_document_fixture();
+    let document = assert_document(
+        &bytes,
+        HvfNativeSnapshotDocumentProfile::V1,
+        NATIVE_V1_SNAPSHOT_VERSION,
+        1,
+    );
+
+    let HvfNativeSnapshotDocumentState::V1(decoded) = &document.state else {
+        panic!("native-v1 fixture should retain the native-v1 variant");
+    };
+    assert_eq!(decoded, &bundle);
+    assert_eq!(
+        decoded.commit_record().kind(),
+        SnapshotCommitKind::Composite
+    );
+    assert_eq!(
+        decoded.commit_record().memory_binding(),
+        bundle.commit_record().memory_binding()
+    );
+    assert_eq!(decoded.state(), bundle.state());
+
+    let HvfNativeSnapshotPlatformRef::V1 {
+        memory_binding,
+        state,
+    } = document.platform()
+    else {
+        panic!("native-v1 fixture should expose a native-v1 platform");
+    };
+    assert_eq!(memory_binding, bundle.commit_record().memory_binding());
+    assert_eq!(state, bundle.state());
+}
+
+#[test]
+fn exact_native_v2_profiles_round_trip_without_outer_state_loss() {
+    let legacy = platform_fixture(false);
+    let bytes =
+        encode_hvf_snapshot_v2_platform_state(&legacy).expect("exact-2.3 fixture should encode");
+    let document = assert_document(
+        &bytes,
+        HvfNativeSnapshotDocumentProfile::V2(NativeV2SnapshotArtifactProfile::LegacyPlatformV2_3),
+        NATIVE_V2_LEGACY_PLATFORM_VERSION,
+        2,
+    );
+    assert!(matches!(
+        &document.state,
+        HvfNativeSnapshotDocumentState::V2LegacyPlatform(state) if state == &legacy
+    ));
+
+    let device_graph = complete_state_fixture(MMIO_GRAPH_FIXTURE_HEX);
+    let bytes =
+        encode_hvf_snapshot_v2_state(&device_graph).expect("exact-2.4 fixture should encode");
+    let document = assert_document(
+        &bytes,
+        HvfNativeSnapshotDocumentProfile::V2(NativeV2SnapshotArtifactProfile::DeviceGraphV2_4),
+        NATIVE_V2_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+        2,
+    );
+    assert!(matches!(
+        &document.state,
+        HvfNativeSnapshotDocumentState::V2DeviceGraph(state) if state == &device_graph
+    ));
+
+    let multi_block = complete_multi_block_state_fixture(MULTI_BLOCK_MMIO_GRAPH_FIXTURE_HEX);
+    let bytes = encode_hvf_snapshot_v2_multi_block_state(&multi_block)
+        .expect("exact-2.5 fixture should encode");
+    let document = assert_document(
+        &bytes,
+        HvfNativeSnapshotDocumentProfile::V2(
+            NativeV2SnapshotArtifactProfile::MultiBlockDeviceGraphV2_5,
+        ),
+        NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+        2,
+    );
+    assert!(matches!(
+        &document.state,
+        HvfNativeSnapshotDocumentState::V2MultiBlock(state) if state == &multi_block
+    ));
+
+    let storage = complete_storage_state_fixture(STORAGE_MMIO_GRAPH_FIXTURE_HEX);
+    let bytes =
+        encode_hvf_snapshot_v2_storage_state(&storage).expect("exact-2.6 fixture should encode");
+    let document = assert_document(
+        &bytes,
+        HvfNativeSnapshotDocumentProfile::V2(
+            NativeV2SnapshotArtifactProfile::StorageDeviceGraphV2_6,
+        ),
+        NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+        2,
+    );
+    assert!(matches!(
+        &document.state,
+        HvfNativeSnapshotDocumentState::V2Storage(state) if state == &storage
+    ));
+
+    let serial = complete_serial_state_fixture(
+        Some(STORAGE_MMIO_GRAPH_FIXTURE_HEX),
+        SERIAL_CONFIGURED_FIXTURE_HEX,
+    );
+    let bytes =
+        encode_hvf_snapshot_v2_serial_state(&serial).expect("exact-2.7 fixture should encode");
+    let document = assert_document(
+        &bytes,
+        HvfNativeSnapshotDocumentProfile::V2(NativeV2SnapshotArtifactProfile::SerialStateV2_7),
+        NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION,
+        2,
+    );
+    assert!(matches!(
+        &document.state,
+        HvfNativeSnapshotDocumentState::V2Serial(state) if state == &serial
+    ));
+
+    let entropy = complete_entropy_state_fixture(
+        None,
+        SERIAL_CONFIGURED_FIXTURE_HEX,
+        Some(ENTROPY_INACTIVE_MMIO_FIXTURE_HEX),
+        false,
+    );
+    let bytes =
+        encode_hvf_snapshot_v2_entropy_state(&entropy).expect("exact-2.8 fixture should encode");
+    let document = assert_document(
+        &bytes,
+        HvfNativeSnapshotDocumentProfile::V2(NativeV2SnapshotArtifactProfile::EntropyStateV2_8),
+        NATIVE_V2_ENTROPY_STATE_COMPATIBILITY_VERSION,
+        2,
+    );
+    assert!(matches!(
+        &document.state,
+        HvfNativeSnapshotDocumentState::V2Entropy(state) if state == &entropy
+    ));
+
+    let balloon =
+        complete_balloon_state_fixture(SnapshotV2DeviceTransportKind::Mmio, true, true, true);
+    let bytes =
+        encode_hvf_snapshot_v2_balloon_state(&balloon).expect("exact-2.9 fixture should encode");
+    let document = assert_document(
+        &bytes,
+        HvfNativeSnapshotDocumentProfile::V2(NativeV2SnapshotArtifactProfile::BalloonStateV2_9),
+        NATIVE_V2_BALLOON_STATE_COMPATIBILITY_VERSION,
+        2,
+    );
+    assert!(matches!(
+        &document.state,
+        HvfNativeSnapshotDocumentState::V2Balloon(state) if state == &balloon
+    ));
+
+    let memory_hotplug = complete_memory_hotplug_state_fixture(
+        SnapshotV2DeviceTransportKind::Mmio,
+        true,
+        true,
+        true,
+        true,
+    );
+    let bytes = encode_hvf_snapshot_v2_memory_hotplug_state(&memory_hotplug)
+        .expect("exact-2.10 fixture should encode");
+    let document = assert_document(
+        &bytes,
+        HvfNativeSnapshotDocumentProfile::V2(
+            NativeV2SnapshotArtifactProfile::MemoryHotplugStateV2_10,
+        ),
+        NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
+        2,
+    );
+    assert!(matches!(
+        &document.state,
+        HvfNativeSnapshotDocumentState::V2MemoryHotplug(state) if state == &memory_hotplug
+    ));
+
+    let network = complete_network_state_fixture(
+        SnapshotV2DeviceTransportKind::Mmio,
+        true,
+        true,
+        true,
+        true,
+        true,
+    );
+    let bytes =
+        encode_hvf_snapshot_v2_network_state(&network).expect("exact-2.11 fixture should encode");
+    let document = assert_document(
+        &bytes,
+        HvfNativeSnapshotDocumentProfile::V2(NativeV2SnapshotArtifactProfile::NetworkStateV2_11),
+        NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
+        2,
+    );
+    assert!(matches!(
+        &document.state,
+        HvfNativeSnapshotDocumentState::V2Network(state) if state == &network
+    ));
+
+    let vsock = complete_vsock_state_fixture(
+        SnapshotV2DeviceTransportKind::Mmio,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+    );
+    let bytes =
+        encode_hvf_snapshot_v2_vsock_state(&vsock).expect("exact-2.12 fixture should encode");
+    let document = assert_document(
+        &bytes,
+        HvfNativeSnapshotDocumentProfile::V2(NativeV2SnapshotArtifactProfile::VsockStateV2_12),
+        NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION,
+        2,
+    );
+    assert!(matches!(
+        &document.state,
+        HvfNativeSnapshotDocumentState::V2Vsock(state) if state == &vsock
+    ));
+
+    let predecessor_memory_hotplug =
+        product_memory_hotplug_fixture(SnapshotV2DeviceTransportKind::Mmio);
+    let predecessor = exact_minor_twelve_memory_binding(Some(&predecessor_memory_hotplug));
+    let extent = GuestMemoryRange::new(GuestAddress::new(aarch64::DRAM_MEM_START), 4096)
+        .expect("Diff fixture extent should validate");
+    let diff = complete_diff_state_fixture(
+        SnapshotV2DeviceTransportKind::Mmio,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        SnapshotV2DiffBase::Image(predecessor.clone()),
+        &[extent],
+    );
+    assert_eq!(diff.layer().base().binding(), Some(&predecessor));
+    assert_eq!(diff.layer().data_extents().len(), 1);
+    let layer = diff.layer().clone();
+    let bytes = encode_hvf_snapshot_v2_diff_state(&diff).expect("exact-2.13 fixture should encode");
+    let document = assert_document(
+        &bytes,
+        HvfNativeSnapshotDocumentProfile::V2(NativeV2SnapshotArtifactProfile::DiffStateV2_13),
+        NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION,
+        2,
+    );
+    let HvfNativeSnapshotDocumentState::V2Diff(decoded) = &document.state else {
+        panic!("exact-2.13 fixture should retain the Diff variant");
+    };
+    assert_eq!(decoded, &diff);
+    assert_eq!(decoded.layer(), &layer);
+    assert_eq!(decoded.layer().base().binding(), Some(&predecessor));
+    assert_eq!(decoded.layer().data_extents(), layer.data_extents());
+    assert_eq!(decoded.layer().result(), diff.platform().memory());
+}
+
+#[test]
+fn replacement_rejects_count_family_and_invalid_vcpu_order() {
+    let (_, v1_bytes) = native_v1_document_fixture();
+    let v1 = HvfNativeSnapshotDocument::decode(&v1_bytes)
+        .expect("native-v1 fixture should decode as a document");
+    assert!(matches!(
+        v1.clone().try_replace_vcpus(Vec::new()),
+        Err(HvfNativeSnapshotDocumentReplaceError::VcpuCount {
+            expected: 1,
+            actual: 0
+        })
+    ));
+
+    let v2_bytes = encode_hvf_snapshot_v2_platform_state(&platform_fixture(false))
+        .expect("native-v2 fixture should encode");
+    let v2 = HvfNativeSnapshotDocument::decode(&v2_bytes)
+        .expect("native-v2 fixture should decode as a document");
+    let v2_replacement = v2
+        .vcpus()
+        .next()
+        .map(HvfNativeSnapshotVcpuState::from)
+        .expect("native-v2 fixture should contain vCPUs");
+    assert!(matches!(
+        v1.try_replace_vcpus(vec![v2_replacement]),
+        Err(HvfNativeSnapshotDocumentReplaceError::VcpuFamily)
+    ));
+
+    let v1_state = HvfNativeSnapshotVcpuState::V1(Box::new(native_v1_fixture().vcpu().clone()));
+    assert!(matches!(
+        v2.clone()
+            .try_replace_vcpus(vec![v1_state.clone(), v1_state]),
+        Err(HvfNativeSnapshotDocumentReplaceError::VcpuFamily)
+    ));
+
+    let mut reversed = v2
+        .vcpus()
+        .map(HvfNativeSnapshotVcpuState::from)
+        .collect::<Vec<_>>();
+    reversed.reverse();
+    assert!(matches!(
+        v2.try_replace_vcpus(reversed),
+        Err(HvfNativeSnapshotDocumentReplaceError::NativeV2(_))
+    ));
+}
+
+#[test]
+fn decode_rejects_malformed_incompatible_nonexact_and_mismatched_profiles() {
+    let (_, mut malformed_v1) = native_v1_document_fixture();
+    *malformed_v1
+        .last_mut()
+        .expect("native-v1 envelope should contain an integrity trailer") ^= 1;
+    assert!(matches!(
+        HvfNativeSnapshotDocument::decode(&malformed_v1),
+        Err(HvfNativeSnapshotDocumentDecodeError::Format(
+            NativeSnapshotFormatError::NativeV1(_)
+        ))
+    ));
+
+    let mut malformed_v2 = encode_hvf_snapshot_v2_platform_state(&platform_fixture(false))
+        .expect("native-v2 fixture should encode");
+    *malformed_v2
+        .last_mut()
+        .expect("native-v2 state should contain an integrity trailer") ^= 1;
+    assert!(matches!(
+        HvfNativeSnapshotDocument::decode(&malformed_v2),
+        Err(HvfNativeSnapshotDocumentDecodeError::Format(
+            NativeSnapshotFormatError::NativeV2(_)
+        ))
+    ));
+
+    let firecracker_aarch64 = [0x00, 0x00, 0x00, 0xaa, 0xaa, 0x84, 0x19, 0x10, 0x07];
+    assert!(matches!(
+        HvfNativeSnapshotDocument::decode(&firecracker_aarch64),
+        Err(HvfNativeSnapshotDocumentDecodeError::Format(
+            NativeSnapshotFormatError::IncompatibleFirecrackerFormat
+        ))
+    ));
+
+    let memory_only = SnapshotCommitRecord::new(memory_binding(1));
+    let memory_only = encode_snapshot_commit_envelope(&memory_only)
+        .expect("memory-only native-v1 fixture should encode");
+    assert!(matches!(
+        HvfNativeSnapshotDocument::decode(&memory_only),
+        Err(HvfNativeSnapshotDocumentDecodeError::NativeV1(
+            HvfSnapshotV1BundleError::MemoryOnlyCommit
+        ))
+    ));
+
+    let mut nonexact = encode_hvf_snapshot_v2_platform_state(&platform_fixture(false))
+        .expect("native-v2 fixture should encode");
+    rewrite_v2_version(&mut nonexact, 3, 1);
+    let error = HvfNativeSnapshotDocument::decode(&nonexact)
+        .expect_err("structurally admitted 2.3.1 must not select exact 2.3.0");
+    let HvfNativeSnapshotDocumentDecodeError::UnsupportedExactProfile(version) = error else {
+        panic!("2.3.1 should fail as an unsupported exact profile");
+    };
+    assert_eq!(version.major(), 2);
+    assert_eq!(version.minor(), 3);
+    assert_eq!(version.patch(), 1);
+
+    let mut future = encode_hvf_snapshot_v2_platform_state(&platform_fixture(false))
+        .expect("native-v2 fixture should encode");
+    rewrite_v2_version(&mut future, 14, 0);
+    assert!(matches!(
+        HvfNativeSnapshotDocument::decode(&future),
+        Err(HvfNativeSnapshotDocumentDecodeError::Format(
+            NativeSnapshotFormatError::NativeV2(SnapshotV2DecodeError::UnsupportedVersion { .. })
+        ))
+    ));
+
+    let mut mismatched =
+        encode_hvf_snapshot_v2_state(&complete_state_fixture(MMIO_GRAPH_FIXTURE_HEX))
+            .expect("exact-2.4 fixture should encode");
+    rewrite_v2_version(&mut mismatched, 5, 0);
+    assert!(matches!(
+        HvfNativeSnapshotDocument::decode(&mismatched),
+        Err(HvfNativeSnapshotDocumentDecodeError::NativeV2(_))
+    ));
+}
+
+#[test]
+fn document_views_owned_state_and_errors_redact_values_and_paths() {
+    let network = complete_network_state_fixture(
+        SnapshotV2DeviceTransportKind::Mmio,
+        true,
+        true,
+        true,
+        true,
+        true,
+    );
+    let bytes =
+        encode_hvf_snapshot_v2_network_state(&network).expect("exact-2.11 fixture should encode");
+    let document = HvfNativeSnapshotDocument::decode(&bytes)
+        .expect("exact-2.11 fixture should decode as a document");
+    let owned = document
+        .vcpus()
+        .next()
+        .map(HvfNativeSnapshotVcpuState::from)
+        .expect("exact-2.11 fixture should contain a vCPU");
+    let replace_error = document
+        .clone()
+        .try_replace_vcpus(Vec::new())
+        .expect_err("empty replacement should fail");
+    let decode_error = HvfNativeSnapshotDocument::decode(b"/tmp/sensitive-snapshot.state")
+        .expect_err("path bytes are not a native state");
+    let encode_error =
+        HvfNativeSnapshotDocumentEncodeError::NativeV2(HvfSnapshotV2EncodeError::LengthOverflow);
+    let rendered = format!(
+        "{document:?}\n{:?}\n{:?}\n{owned:?}\n{replace_error}\n{replace_error:?}\n{decode_error}\n{decode_error:?}\n{encode_error}\n{encode_error:?}",
+        document.platform(),
+        document.vcpus(),
+    );
+    assert!(rendered.contains("<redacted>"));
+    for sensitive in [
+        "rootfs.img",
+        "serial-log",
+        "vmnet:",
+        "sensitive-snapshot.state",
+        "/tmp/",
+    ] {
+        assert!(!rendered.contains(sensitive));
+    }
+}
+
+fn rewrite_v2_version(bytes: &mut [u8], minor: u16, patch: u16) {
+    bytes
+        .get_mut(10..12)
+        .expect("native-v2 header should contain a minor version")
+        .copy_from_slice(&minor.to_le_bytes());
+    bytes
+        .get_mut(12..14)
+        .expect("native-v2 header should contain a patch version")
+        .copy_from_slice(&patch.to_le_bytes());
+    let checksum_offset = bytes
+        .len()
+        .checked_sub(NATIVE_V2_SNAPSHOT_INTEGRITY_BYTES)
+        .expect("native-v2 fixture should contain an integrity trailer");
+    let (contents, checksum) = bytes.split_at_mut(checksum_offset);
+    checksum.copy_from_slice(&crc64::crc64(0, contents).to_le_bytes());
+}

--- a/crates/hvf/src/snapshot_v2.rs
+++ b/crates/hvf/src/snapshot_v2.rs
@@ -833,6 +833,31 @@ impl HvfSnapshotV2PlatformState {
             self.time,
         )
     }
+
+    pub(crate) fn try_replace_vcpus(
+        self,
+        vcpus: Vec<HvfSnapshotV2VcpuState>,
+    ) -> Result<Self, HvfSnapshotV2BuildError> {
+        self.try_replace_vcpus_with_memory_hotplug(vcpus, None)
+    }
+
+    fn try_replace_vcpus_with_memory_hotplug(
+        self,
+        vcpus: Vec<HvfSnapshotV2VcpuState>,
+        memory_hotplug: Option<&SnapshotV2MemoryHotplugState>,
+    ) -> Result<Self, HvfSnapshotV2BuildError> {
+        let (memory, machine, global, topology, _, time) = self.into_parts();
+        let state = Self {
+            memory,
+            machine,
+            global,
+            topology,
+            vcpus,
+            time,
+        };
+        validate_platform_with_memory_hotplug(&state, memory_hotplug)?;
+        Ok(state)
+    }
 }
 
 impl fmt::Debug for HvfSnapshotV2PlatformState {
@@ -888,6 +913,14 @@ impl HvfSnapshotV2State {
     pub fn into_parts(self) -> (HvfSnapshotV2PlatformState, SnapshotV2DeviceGraph) {
         (self.platform, self.device_graph)
     }
+
+    pub(crate) fn try_replace_vcpus(
+        self,
+        vcpus: Vec<HvfSnapshotV2VcpuState>,
+    ) -> Result<Self, HvfSnapshotV2BuildError> {
+        let (platform, device_graph) = self.into_parts();
+        Self::try_new(platform.try_replace_vcpus(vcpus)?, device_graph)
+    }
 }
 
 impl fmt::Debug for HvfSnapshotV2State {
@@ -938,6 +971,14 @@ impl HvfSnapshotV2MultiBlockState {
     /// Consumes the complete state without discarding either owned graph.
     pub fn into_parts(self) -> (HvfSnapshotV2PlatformState, SnapshotV2MultiBlockDeviceGraph) {
         (self.platform, self.device_graph)
+    }
+
+    pub(crate) fn try_replace_vcpus(
+        self,
+        vcpus: Vec<HvfSnapshotV2VcpuState>,
+    ) -> Result<Self, HvfSnapshotV2BuildError> {
+        let (platform, device_graph) = self.into_parts();
+        Self::try_new(platform.try_replace_vcpus(vcpus)?, device_graph)
     }
 }
 
@@ -994,6 +1035,14 @@ impl HvfSnapshotV2StorageState {
     /// Consumes the complete state without discarding either owned graph.
     pub fn into_parts(self) -> (HvfSnapshotV2PlatformState, SnapshotV2StorageDeviceGraph) {
         (self.platform, self.device_graph)
+    }
+
+    pub(crate) fn try_replace_vcpus(
+        self,
+        vcpus: Vec<HvfSnapshotV2VcpuState>,
+    ) -> Result<Self, HvfSnapshotV2BuildError> {
+        let (platform, device_graph) = self.into_parts();
+        Self::try_new(platform.try_replace_vcpus(vcpus)?, device_graph)
     }
 }
 
@@ -1072,6 +1121,14 @@ impl HvfSnapshotV2SerialState {
         SnapshotV2SerialState,
     ) {
         (self.platform, self.device_graph, self.serial)
+    }
+
+    pub(crate) fn try_replace_vcpus(
+        self,
+        vcpus: Vec<HvfSnapshotV2VcpuState>,
+    ) -> Result<Self, HvfSnapshotV2BuildError> {
+        let (platform, device_graph, serial) = self.into_parts();
+        Self::try_new(platform.try_replace_vcpus(vcpus)?, device_graph, serial)
     }
 }
 
@@ -1160,6 +1217,19 @@ impl HvfSnapshotV2EntropyState {
         Option<SnapshotV2EntropyState>,
     ) {
         (self.platform, self.device_graph, self.serial, self.entropy)
+    }
+
+    pub(crate) fn try_replace_vcpus(
+        self,
+        vcpus: Vec<HvfSnapshotV2VcpuState>,
+    ) -> Result<Self, HvfSnapshotV2BuildError> {
+        let (platform, device_graph, serial, entropy) = self.into_parts();
+        Self::try_new(
+            platform.try_replace_vcpus(vcpus)?,
+            device_graph,
+            serial,
+            entropy,
+        )
     }
 }
 
@@ -1324,6 +1394,20 @@ impl HvfSnapshotV2BalloonState {
             self.serial,
             self.entropy,
             self.balloon,
+        )
+    }
+
+    pub(crate) fn try_replace_vcpus(
+        self,
+        vcpus: Vec<HvfSnapshotV2VcpuState>,
+    ) -> Result<Self, HvfSnapshotV2BuildError> {
+        let (platform, device_graph, serial, entropy, balloon) = self.into_parts();
+        Self::try_new(
+            platform.try_replace_vcpus(vcpus)?,
+            device_graph,
+            serial,
+            entropy,
+            balloon,
         )
     }
 }
@@ -1642,6 +1726,19 @@ impl HvfSnapshotV2MemoryHotplugState {
             self.memory_hotplug,
         )
     }
+
+    pub(crate) fn try_replace_vcpus(
+        self,
+        vcpus: Vec<HvfSnapshotV2VcpuState>,
+    ) -> Result<Self, HvfSnapshotV2BuildError> {
+        let (platform, device_graph, serial, entropy, balloon, memory_hotplug) = self.into_parts();
+        let platform = HvfSnapshotV2MemoryHotplugPlatformState {
+            platform: platform
+                .try_replace_vcpus_with_memory_hotplug(vcpus, memory_hotplug.as_ref())?,
+            memory_hotplug,
+        };
+        Self::try_new(platform, device_graph, serial, entropy, balloon)
+    }
 }
 
 impl fmt::Debug for HvfSnapshotV2MemoryHotplugState {
@@ -1853,6 +1950,20 @@ impl HvfSnapshotV2NetworkState {
             self.memory_hotplug,
             self.network,
         )
+    }
+
+    pub(crate) fn try_replace_vcpus(
+        self,
+        vcpus: Vec<HvfSnapshotV2VcpuState>,
+    ) -> Result<Self, HvfSnapshotV2BuildError> {
+        let (platform, device_graph, serial, entropy, balloon, memory_hotplug, network) =
+            self.into_parts();
+        let platform = HvfSnapshotV2NetworkPlatformState {
+            platform: platform
+                .try_replace_vcpus_with_memory_hotplug(vcpus, memory_hotplug.as_ref())?,
+            memory_hotplug,
+        };
+        Self::try_new(platform, device_graph, serial, entropy, balloon, network)
     }
 }
 
@@ -2085,6 +2196,28 @@ impl HvfSnapshotV2VsockState {
             self.memory_hotplug,
             self.network,
             self.vsock,
+        )
+    }
+
+    pub(crate) fn try_replace_vcpus(
+        self,
+        vcpus: Vec<HvfSnapshotV2VcpuState>,
+    ) -> Result<Self, HvfSnapshotV2BuildError> {
+        let (platform, device_graph, serial, entropy, balloon, memory_hotplug, network, vsock) =
+            self.into_parts();
+        let platform = HvfSnapshotV2VsockPlatformState {
+            platform: platform
+                .try_replace_vcpus_with_memory_hotplug(vcpus, memory_hotplug.as_ref())?,
+            memory_hotplug,
+        };
+        Self::try_new(
+            platform,
+            device_graph,
+            serial,
+            entropy,
+            balloon,
+            network,
+            vsock,
         )
     }
 }
@@ -2346,6 +2479,38 @@ impl HvfSnapshotV2DiffState {
             self.network,
             self.vsock,
             self.layer,
+        )
+    }
+
+    pub(crate) fn try_replace_vcpus(
+        self,
+        vcpus: Vec<HvfSnapshotV2VcpuState>,
+    ) -> Result<Self, HvfSnapshotV2BuildError> {
+        let (
+            platform,
+            device_graph,
+            serial,
+            entropy,
+            balloon,
+            memory_hotplug,
+            network,
+            vsock,
+            layer,
+        ) = self.into_parts();
+        let platform = HvfSnapshotV2DiffPlatformState {
+            platform: platform
+                .try_replace_vcpus_with_memory_hotplug(vcpus, memory_hotplug.as_ref())?,
+            memory_hotplug,
+            layer,
+        };
+        Self::try_new(
+            platform,
+            device_graph,
+            serial,
+            entropy,
+            balloon,
+            network,
+            vsock,
         )
     }
 }

--- a/crates/hvf/src/snapshot_v2/tests.rs
+++ b/crates/hvf/src/snapshot_v2/tests.rs
@@ -67,19 +67,19 @@ pub(crate) const MMIO_GRAPH_FIXTURE_HEX: &str =
     include_str!("../../../runtime/src/snapshot_device_v2/fixtures/mmio.hex");
 pub(crate) const PCI_GRAPH_FIXTURE_HEX: &str =
     include_str!("../../../runtime/src/snapshot_device_v2/fixtures/pci.hex");
-const MULTI_BLOCK_MMIO_GRAPH_FIXTURE_HEX: &str =
+pub(crate) const MULTI_BLOCK_MMIO_GRAPH_FIXTURE_HEX: &str =
     include_str!("../../../runtime/src/snapshot_device_v2_5/fixtures/root-mmio.hex");
 const MULTI_BLOCK_PCI_GRAPH_FIXTURE_HEX: &str =
     include_str!("../../../runtime/src/snapshot_device_v2_5/fixtures/rootless-pci.hex");
-const STORAGE_MMIO_GRAPH_FIXTURE_HEX: &str =
+pub(crate) const STORAGE_MMIO_GRAPH_FIXTURE_HEX: &str =
     include_str!("../../../runtime/src/snapshot_device_v2_6/fixtures/pmem-root-mmio.hex");
 const STORAGE_PCI_GRAPH_FIXTURE_HEX: &str =
     include_str!("../../../runtime/src/snapshot_device_v2_6/fixtures/mixed-pmem-root-pci.hex");
 const SERIAL_DEFAULT_FIXTURE_HEX: &str =
     include_str!("../../../runtime/src/snapshot_serial_v2_7/fixtures/default.hex");
-const SERIAL_CONFIGURED_FIXTURE_HEX: &str =
+pub(crate) const SERIAL_CONFIGURED_FIXTURE_HEX: &str =
     include_str!("../../../runtime/src/snapshot_serial_v2_7/fixtures/configured.hex");
-const ENTROPY_INACTIVE_MMIO_FIXTURE_HEX: &str =
+pub(crate) const ENTROPY_INACTIVE_MMIO_FIXTURE_HEX: &str =
     include_str!("../../../runtime/src/snapshot_entropy_v2_8/fixtures/inactive-mmio.hex");
 const ENTROPY_ACTIVE_PCI_FIXTURE_HEX: &str =
     include_str!("../../../runtime/src/snapshot_entropy_v2_8/fixtures/active-pci.hex");
@@ -474,7 +474,7 @@ pub(crate) fn complete_state_fixture(graph_hex: &str) -> HvfSnapshotV2State {
         .expect("complete minor-four fixture should validate")
 }
 
-fn complete_multi_block_state_fixture(graph_hex: &str) -> HvfSnapshotV2MultiBlockState {
+pub(crate) fn complete_multi_block_state_fixture(graph_hex: &str) -> HvfSnapshotV2MultiBlockState {
     let graph = SnapshotV2MultiBlockDeviceGraph::decode(
         NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_COMPATIBILITY_VERSION,
         &fixture_bytes(graph_hex),
@@ -484,7 +484,7 @@ fn complete_multi_block_state_fixture(graph_hex: &str) -> HvfSnapshotV2MultiBloc
         .expect("complete minor-five fixture should validate")
 }
 
-fn complete_storage_state_fixture(graph_hex: &str) -> HvfSnapshotV2StorageState {
+pub(crate) fn complete_storage_state_fixture(graph_hex: &str) -> HvfSnapshotV2StorageState {
     let graph = SnapshotV2StorageDeviceGraph::decode(
         NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
         &fixture_bytes(graph_hex),
@@ -494,7 +494,7 @@ fn complete_storage_state_fixture(graph_hex: &str) -> HvfSnapshotV2StorageState 
         .expect("complete minor-six fixture should validate")
 }
 
-fn complete_serial_state_fixture(
+pub(crate) fn complete_serial_state_fixture(
     graph_hex: Option<&str>,
     serial_hex: &str,
 ) -> HvfSnapshotV2SerialState {
@@ -518,7 +518,7 @@ fn complete_serial_state_fixture(
     .expect("complete minor-seven fixture should validate")
 }
 
-fn complete_entropy_state_fixture(
+pub(crate) fn complete_entropy_state_fixture(
     graph_hex: Option<&str>,
     serial_hex: &str,
     entropy_hex: Option<&str>,
@@ -945,7 +945,7 @@ pub(crate) fn product_serial_fixture() -> SnapshotV2SerialState {
     .expect("serial fixture should decode")
 }
 
-fn complete_balloon_state_fixture(
+pub(crate) fn complete_balloon_state_fixture(
     transport: SnapshotV2DeviceTransportKind,
     has_storage: bool,
     has_entropy: bool,
@@ -1068,7 +1068,7 @@ pub(crate) fn try_exact_minor_ten_platform(
     )
 }
 
-fn complete_memory_hotplug_state_fixture(
+pub(crate) fn complete_memory_hotplug_state_fixture(
     transport: SnapshotV2DeviceTransportKind,
     has_storage: bool,
     has_entropy: bool,
@@ -1166,7 +1166,7 @@ pub(crate) fn complete_network_state_fixture(
     })
 }
 
-fn exact_minor_twelve_memory_binding(
+pub(crate) fn exact_minor_twelve_memory_binding(
     state: Option<&SnapshotV2MemoryHotplugState>,
 ) -> SnapshotV2MemoryBinding {
     let mut ranges = aarch64::dram_layout(FIXTURE_MEMORY_MIB * MIB)
@@ -1269,6 +1269,7 @@ fn exact_minor_thirteen_memory_binding(
 fn exact_minor_thirteen_platform_fixture(
     state: Option<SnapshotV2MemoryHotplugState>,
     base: SnapshotV2DiffBase,
+    ranges: &[GuestMemoryRange],
 ) -> HvfSnapshotV2DiffPlatformState {
     let capture = state.map(memory_hotplug_capture_fixture);
     let result = exact_minor_thirteen_memory_binding(
@@ -1276,7 +1277,7 @@ fn exact_minor_thirteen_platform_fixture(
             .as_ref()
             .map(HvfSnapshotV2MemoryHotplugCaptureState::state),
     );
-    let layer = SnapshotV2DiffLayerBinding::try_from_ranges(base, result, &[])
+    let layer = SnapshotV2DiffLayerBinding::try_from_ranges(base, result, ranges)
         .expect("exact-2.13 layer should validate");
     let (_, machine, global, topology, vcpus, time) = deterministic_device_graph_platform_fixture(
         NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION,
@@ -1288,7 +1289,7 @@ fn exact_minor_thirteen_platform_fixture(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn complete_diff_state_fixture(
+pub(crate) fn complete_diff_state_fixture(
     transport: SnapshotV2DeviceTransportKind,
     has_storage: bool,
     has_entropy: bool,
@@ -1297,6 +1298,7 @@ fn complete_diff_state_fixture(
     has_network: bool,
     has_vsock: bool,
     base: SnapshotV2DiffBase,
+    ranges: &[GuestMemoryRange],
 ) -> HvfSnapshotV2DiffState {
     let memory_hotplug = has_memory_hotplug.then(|| product_memory_hotplug_fixture(transport));
     let graph = has_storage.then(|| product_storage_fixture_with_network(transport, has_network));
@@ -1313,7 +1315,7 @@ fn complete_diff_state_fixture(
     let network = has_network.then(|| product_network_fixture(transport, network_device));
     let vsock = has_vsock.then(|| product_vsock_fixture(transport));
     HvfSnapshotV2DiffState::try_new(
-        exact_minor_thirteen_platform_fixture(memory_hotplug, base),
+        exact_minor_thirteen_platform_fixture(memory_hotplug, base, ranges),
         graph,
         product_serial_fixture(),
         has_entropy.then(|| memory_hotplug_product_entropy_fixture(transport)),
@@ -2699,6 +2701,7 @@ fn exact_minor_thirteen_diff_closes_all_sixty_four_mmio_and_pci_products() {
                 has_network,
                 has_vsock,
                 SnapshotV2DiffBase::Zero,
+                &[],
             );
             let encoded = encode_hvf_snapshot_v2_diff_state(&original)
                 .expect("complete exact-2.13 state should encode");
@@ -2786,6 +2789,7 @@ fn exact_minor_thirteen_diff_accepts_predecessor_and_rejects_detached_layer_subs
         true,
         true,
         SnapshotV2DiffBase::Image(predecessor.clone()),
+        &[],
     );
     let encoded = encode_hvf_snapshot_v2_diff_state(&original)
         .expect("predecessor-root exact-2.13 state should encode");
@@ -2808,6 +2812,7 @@ fn exact_minor_thirteen_diff_accepts_predecessor_and_rejects_detached_layer_subs
         true,
         true,
         SnapshotV2DiffBase::Zero,
+        &[],
     );
     assert!(matches!(
         NativeV2DiffSnapshotCandidateState::from_diff_state_v2_13(


### PR DESCRIPTION
## Summary

- add an opaque `HvfNativeSnapshotDocument` that decodes and re-encodes exact native v1 and v2.3-v2.13 snapshot state without erasing version-specific data
- expose stable family/profile metadata plus redacted platform and vCPU inspection, and add consuming checked whole-vector vCPU replacement
- preserve native-v1 memory commitment and revalidate every exact v2 outer state, including dynamic-memory and diff-layer invariants
- cover the full native version/profile matrix, optional device products, canonical round trips, replacement failures, malformed inputs, and version rejection boundaries

## Scope

This PR implements the exact native state-document foundation only. Canonical inspection, reviewed KVM-register removal, atomic file publication, commands, and certification remain in the follow-up children of #1542. It closes only #1771; #1542 remains open.

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker ../firecracker`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo check -p bangbang-snapshot-tools --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked` (1495 passed)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented Apple-target signed-test Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh --test production_bundle` (73 passed)

The complete signed integration wrapper also passed every test group; one vsock stream timing case initially observed a transient EOF after the guest reset marker, then passed both its exact rerun and the clean 73-test production-bundle rerun above.

Closes #1771
