### PR TITLE
feat: add canonical snapshot state inspection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   rust:
     name: rust
     runs-on: macos-26
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Checkout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,9 @@ dependencies = [
  "device_tree",
  "libc",
  "plist",
+ "serde",
  "serde_json",
+ "sha2",
 ]
 
 [[package]]
@@ -363,6 +365,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "cpubits"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +429,17 @@ name = "device_tree"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f18f717c5c7c2e3483feb64cccebd077245ad6d19007c2db0fd341d38595353c"
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+]
 
 [[package]]
 name = "dispatch2"
@@ -715,6 +734,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/crates/hvf/Cargo.toml
+++ b/crates/hvf/Cargo.toml
@@ -10,13 +10,15 @@ bangbang-runtime = { path = "../runtime" }
 crc64 = "2.0.0"
 device_tree = "1.1.0"
 libc = "0.2"
+serde = "1.0.228"
+serde_json = "1.0.140"
+sha2 = "0.11.0"
 
 [build-dependencies]
 cc = "1"
 
 [dev-dependencies]
 plist = "1"
-serde_json = "1.0.140"
 
 [[test]]
 name = "guest_boot"

--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -136,10 +136,12 @@ pub use snapshot_bundle::{
     decode_hvf_snapshot_v1_state, encode_hvf_snapshot_v1_state,
 };
 pub use snapshot_document::{
-    HvfNativeSnapshotDocument, HvfNativeSnapshotDocumentDecodeError,
-    HvfNativeSnapshotDocumentEncodeError, HvfNativeSnapshotDocumentProfile,
-    HvfNativeSnapshotDocumentReplaceError, HvfNativeSnapshotPlatformRef, HvfNativeSnapshotVcpuRef,
-    HvfNativeSnapshotVcpuState, HvfNativeSnapshotVcpus,
+    HVF_NATIVE_SNAPSHOT_INSPECTION_MAX_JSON_BYTES, HvfNativeSnapshotDocument,
+    HvfNativeSnapshotDocumentDecodeError, HvfNativeSnapshotDocumentEncodeError,
+    HvfNativeSnapshotDocumentProfile, HvfNativeSnapshotDocumentReplaceError,
+    HvfNativeSnapshotInspectionError, HvfNativeSnapshotPlatformRef, HvfNativeSnapshotVcpuRef,
+    HvfNativeSnapshotVcpuState, HvfNativeSnapshotVcpuStatesInspection, HvfNativeSnapshotVcpus,
+    HvfNativeSnapshotVmStateInspection,
 };
 pub use snapshot_restore::{
     HvfSnapshotV1PlatformError, HvfSnapshotV1RestoreCleanup, HvfSnapshotV1RestoreDisposition,

--- a/crates/hvf/src/snapshot_document.rs
+++ b/crates/hvf/src/snapshot_document.rs
@@ -52,6 +52,13 @@ use crate::snapshot_v2::{
 
 const REDACTED: &str = "<redacted>";
 
+mod inspection;
+
+pub use inspection::{
+    HVF_NATIVE_SNAPSHOT_INSPECTION_MAX_JSON_BYTES, HvfNativeSnapshotInspectionError,
+    HvfNativeSnapshotVcpuStatesInspection, HvfNativeSnapshotVmStateInspection,
+};
+
 /// Exact semantic profile owned by one native HVF snapshot document.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HvfNativeSnapshotDocumentProfile {

--- a/crates/hvf/src/snapshot_document/inspection.rs
+++ b/crates/hvf/src/snapshot_document/inspection.rs
@@ -1,0 +1,417 @@
+//! Canonical, confidentiality-aware native snapshot inspection.
+//!
+//! The public views in this module borrow an already decoded
+//! [`HvfNativeSnapshotDocument`](super::HvfNativeSnapshotDocument). They never
+//! open paths, acquire restore resources, mutate state, or publish artifacts.
+//!
+//! Both views use schema `bangbang.snapshot-editor.info.v1`. Object fields are
+//! emitted in declaration order and retained collections preserve their checked
+//! semantic order. Counts and lengths are decimal JSON integers. Bit-pattern
+//! values use type-width-fixed lowercase hexadecimal strings.
+//!
+//! Ordinary portable semantics—including machine configuration, identification
+//! and cache registers, CPU-template values, topology, time policy, queue
+//! cursors, transport placement, and device configuration—remain explicit.
+//! Confidential high-entropy state—including pointer-authentication keys,
+//! vector/debug/SME state, opaque GIC/device buffers, memory identities, and
+//! integrity values—is represented only by a domain-separated SHA-256 equality
+//! fingerprint plus its byte length.
+//!
+//! Host authority and low-entropy host choices—including paths, boot arguments,
+//! backing/backend selectors, descriptors, inode-derived identities,
+//! process/session/grant state, and the FDT checksum derived from boot choices—
+//! are represented only by the literal `<redacted>`; they never enter a
+//! fingerprint. Internal snapshot types
+//! deliberately do not implement `Serialize`, and this module never uses their
+//! `Debug` output.
+
+use std::collections::TryReserveError;
+use std::error::Error;
+use std::fmt;
+use std::io::{self, Write};
+
+use bangbang_runtime::machine::MAX_SUPPORTED_VCPUS;
+use bangbang_runtime::snapshot_balloon_v2_9::NATIVE_V2_BALLOON_STATE_MAX_ACCOUNTING_RANGES;
+use bangbang_runtime::snapshot_device_v2_6::NATIVE_V2_STORAGE_DEVICE_GRAPH_MAX_RECORDS;
+use bangbang_runtime::snapshot_diff_v2_13::NATIVE_V2_DIFF_MAX_EXTENTS;
+use bangbang_runtime::snapshot_format::NATIVE_V1_SNAPSHOT_MAX_FILE_BYTES;
+use bangbang_runtime::snapshot_format_v2::{
+    NATIVE_V2_SNAPSHOT_MAX_COMPONENTS, NATIVE_V2_SNAPSHOT_MAX_FILE_BYTES,
+};
+use bangbang_runtime::snapshot_memory_hotplug_v2_10::NATIVE_V2_MEMORY_HOTPLUG_MAX_BLOCKS;
+use bangbang_runtime::snapshot_memory_v2::NATIVE_V2_MEMORY_MAX_EXTENTS;
+use bangbang_runtime::snapshot_network_v2_11::NATIVE_V2_NETWORK_MAX_INTERFACES;
+use serde::Serialize;
+use serde::ser::SerializeStruct;
+
+use super::{HvfNativeSnapshotDocument, HvfNativeSnapshotDocumentState};
+
+mod common;
+mod devices;
+mod fingerprint;
+
+#[cfg(test)]
+mod tests;
+
+const SCHEMA: &str = "bangbang.snapshot-editor.info.v1";
+const VCPU_VIEW: &str = "vcpu-states";
+const VM_VIEW: &str = "vm-state";
+
+// The input-derived term covers worst-case JSON escaping for every byte of a
+// maximum native document. The remaining terms cover schema labels and the
+// expansion of compact binary collections into explicit semantic objects.
+const MAX_NATIVE_SNAPSHOT_FILE_BYTES: usize =
+    if NATIVE_V1_SNAPSHOT_MAX_FILE_BYTES > NATIVE_V2_SNAPSHOT_MAX_FILE_BYTES {
+        NATIVE_V1_SNAPSHOT_MAX_FILE_BYTES
+    } else {
+        NATIVE_V2_SNAPSHOT_MAX_FILE_BYTES
+    };
+const MAX_ESCAPED_INPUT_BYTES: usize = MAX_NATIVE_SNAPSHOT_FILE_BYTES * 6;
+const MAX_SCHEMA_FIXED_BYTES: usize = 8 * 1024 * 1024;
+const MAX_JSON_BYTES_PER_VCPU: usize = 128 * 1024;
+const MAX_JSON_BYTES_PER_COMPONENT: usize = 1024;
+const MAX_JSON_BYTES_PER_MEMORY_EXTENT: usize = 256;
+const MAX_JSON_BYTES_PER_STORAGE_RECORD: usize = 64 * 1024;
+const MAX_JSON_BYTES_PER_NETWORK_INTERFACE: usize = 64 * 1024;
+const MAX_JSON_BYTES_PER_BALLOON_RANGE: usize = 128;
+const MAX_JSON_BYTES_PER_MEMORY_HOTPLUG_RANGE: usize = 128;
+const MAX_JSON_BYTES_PER_DIFF_EXTENT: usize = 256;
+
+/// Maximum pretty-JSON bytes returned by either native snapshot inspection view.
+///
+/// This ceiling is a conservative sum of existing native-file, vCPU,
+/// component, memory-extent, storage, network, balloon, virtio-mem range, and
+/// Diff bounds. The formatter measures under this limit before allocating its
+/// result.
+pub const HVF_NATIVE_SNAPSHOT_INSPECTION_MAX_JSON_BYTES: usize = MAX_ESCAPED_INPUT_BYTES
+    + MAX_SCHEMA_FIXED_BYTES
+    + MAX_SUPPORTED_VCPUS as usize * MAX_JSON_BYTES_PER_VCPU
+    + NATIVE_V2_SNAPSHOT_MAX_COMPONENTS * MAX_JSON_BYTES_PER_COMPONENT
+    + NATIVE_V2_MEMORY_MAX_EXTENTS * MAX_JSON_BYTES_PER_MEMORY_EXTENT
+    + NATIVE_V2_STORAGE_DEVICE_GRAPH_MAX_RECORDS as usize * MAX_JSON_BYTES_PER_STORAGE_RECORD
+    + NATIVE_V2_NETWORK_MAX_INTERFACES * MAX_JSON_BYTES_PER_NETWORK_INTERFACE
+    + NATIVE_V2_BALLOON_STATE_MAX_ACCOUNTING_RANGES * MAX_JSON_BYTES_PER_BALLOON_RANGE
+    + NATIVE_V2_MEMORY_HOTPLUG_MAX_BLOCKS.div_ceil(2) * MAX_JSON_BYTES_PER_MEMORY_HOTPLUG_RANGE
+    + NATIVE_V2_DIFF_MAX_EXTENTS * MAX_JSON_BYTES_PER_DIFF_EXTENT;
+
+const _: () = assert!(HVF_NATIVE_SNAPSHOT_INSPECTION_MAX_JSON_BYTES > 0);
+
+/// Borrowed canonical `vcpu-states` inspection DTO.
+pub struct HvfNativeSnapshotVcpuStatesInspection<'a> {
+    document: &'a HvfNativeSnapshotDocument,
+}
+
+impl HvfNativeSnapshotVcpuStatesInspection<'_> {
+    /// Serializes this view as bounded deterministic pretty JSON.
+    pub fn to_pretty_json(&self) -> Result<String, HvfNativeSnapshotInspectionError> {
+        format_pretty_json(
+            &VcpuStatesRoot {
+                document: self.document,
+            },
+            HVF_NATIVE_SNAPSHOT_INSPECTION_MAX_JSON_BYTES,
+        )
+    }
+}
+
+impl fmt::Debug for HvfNativeSnapshotVcpuStatesInspection<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfNativeSnapshotVcpuStatesInspection")
+            .field("schema", &SCHEMA)
+            .field("profile", &self.document.profile())
+            .field("vcpu_count", &self.document.vcpu_count())
+            .finish()
+    }
+}
+
+/// Borrowed canonical full `vm-state` inspection DTO.
+pub struct HvfNativeSnapshotVmStateInspection<'a> {
+    document: &'a HvfNativeSnapshotDocument,
+}
+
+impl HvfNativeSnapshotVmStateInspection<'_> {
+    /// Serializes this view as bounded deterministic pretty JSON.
+    pub fn to_pretty_json(&self) -> Result<String, HvfNativeSnapshotInspectionError> {
+        format_pretty_json(
+            &VmStateRoot {
+                document: self.document,
+            },
+            HVF_NATIVE_SNAPSHOT_INSPECTION_MAX_JSON_BYTES,
+        )
+    }
+}
+
+impl fmt::Debug for HvfNativeSnapshotVmStateInspection<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfNativeSnapshotVmStateInspection")
+            .field("schema", &SCHEMA)
+            .field("profile", &self.document.profile())
+            .field("vcpu_count", &self.document.vcpu_count())
+            .finish()
+    }
+}
+
+impl HvfNativeSnapshotDocument {
+    /// Returns the canonical borrowed vCPU-state inspection DTO.
+    pub const fn inspect_vcpu_states(&self) -> HvfNativeSnapshotVcpuStatesInspection<'_> {
+        HvfNativeSnapshotVcpuStatesInspection { document: self }
+    }
+
+    /// Returns the canonical borrowed full-VM inspection DTO.
+    pub const fn inspect_vm_state(&self) -> HvfNativeSnapshotVmStateInspection<'_> {
+        HvfNativeSnapshotVmStateInspection { document: self }
+    }
+}
+
+struct VcpuStatesRoot<'a> {
+    document: &'a HvfNativeSnapshotDocument,
+}
+
+impl Serialize for VcpuStatesRoot<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("VcpuStatesInspection", 6)?;
+        state.serialize_field("schema", SCHEMA)?;
+        state.serialize_field("view", VCPU_VIEW)?;
+        state.serialize_field("family", &common::Family(self.document.family()))?;
+        state.serialize_field("profile", &common::Profile(self.document.profile()))?;
+        state.serialize_field("version", &common::Version(self.document.version()))?;
+        state.serialize_field("vcpus", &common::Vcpus(self.document))?;
+        state.end()
+    }
+}
+
+struct VmStateRoot<'a> {
+    document: &'a HvfNativeSnapshotDocument,
+}
+
+impl Serialize for VmStateRoot<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("VmStateInspection", 13)?;
+        state.serialize_field("schema", SCHEMA)?;
+        state.serialize_field("view", VM_VIEW)?;
+        state.serialize_field("family", &common::Family(self.document.family()))?;
+        state.serialize_field("profile", &common::Profile(self.document.profile()))?;
+        state.serialize_field("version", &common::Version(self.document.version()))?;
+        state.serialize_field("memory", &common::Memory(self.document))?;
+        state.serialize_field("machine", &common::Machine(self.document))?;
+        state.serialize_field("global", &common::Global(self.document))?;
+        state.serialize_field("topology", &common::Topology(self.document))?;
+        state.serialize_field("time", &common::Time(self.document))?;
+        state.serialize_field("vcpus", &common::Vcpus(self.document))?;
+        state.serialize_field("devices", &devices::Devices(self.document))?;
+        state.serialize_field("diff", &devices::Diff(self.document))?;
+        state.end()
+    }
+}
+
+/// Canonical native snapshot inspection failure.
+pub enum HvfNativeSnapshotInspectionError {
+    /// Pretty JSON exceeded the published deterministic ceiling.
+    OutputTooLarge { maximum: usize },
+    /// The exactly measured output allocation failed.
+    Allocation { source: TryReserveError },
+    /// Serde JSON rejected the explicit schema or its bounded writer.
+    Serialization { source: serde_json::Error },
+    /// The immutable two-pass serialization produced different byte counts.
+    NonDeterministic,
+    /// Serde JSON unexpectedly produced non-UTF-8 bytes.
+    InvalidUtf8,
+}
+
+impl fmt::Debug for HvfNativeSnapshotInspectionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OutputTooLarge { maximum } => formatter
+                .debug_struct("HvfNativeSnapshotInspectionError::OutputTooLarge")
+                .field("maximum", maximum)
+                .finish(),
+            Self::Allocation { .. } => {
+                formatter.write_str("HvfNativeSnapshotInspectionError::Allocation(<redacted>)")
+            }
+            Self::Serialization { .. } => {
+                formatter.write_str("HvfNativeSnapshotInspectionError::Serialization(<redacted>)")
+            }
+            Self::NonDeterministic => {
+                formatter.write_str("HvfNativeSnapshotInspectionError::NonDeterministic")
+            }
+            Self::InvalidUtf8 => {
+                formatter.write_str("HvfNativeSnapshotInspectionError::InvalidUtf8")
+            }
+        }
+    }
+}
+
+impl fmt::Display for HvfNativeSnapshotInspectionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OutputTooLarge { maximum } => {
+                write!(formatter, "snapshot inspection exceeds {maximum} bytes")
+            }
+            Self::Allocation { .. } => {
+                formatter.write_str("snapshot inspection output allocation failed")
+            }
+            Self::Serialization { .. } => {
+                formatter.write_str("snapshot inspection JSON serialization failed")
+            }
+            Self::NonDeterministic => {
+                formatter.write_str("snapshot inspection serialization was not deterministic")
+            }
+            Self::InvalidUtf8 => {
+                formatter.write_str("snapshot inspection serialization was not UTF-8")
+            }
+        }
+    }
+}
+
+impl Error for HvfNativeSnapshotInspectionError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Allocation { source } => Some(source),
+            Self::Serialization { source } => Some(source),
+            Self::OutputTooLarge { .. } | Self::NonDeterministic | Self::InvalidUtf8 => None,
+        }
+    }
+}
+
+struct CountingWriter {
+    count: usize,
+    limit: usize,
+    exceeded: bool,
+}
+
+impl CountingWriter {
+    const fn new(limit: usize) -> Self {
+        Self {
+            count: 0,
+            limit,
+            exceeded: false,
+        }
+    }
+}
+
+impl Write for CountingWriter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        let Some(next) = self.count.checked_add(bytes.len()) else {
+            self.exceeded = true;
+            return Err(io::Error::other(
+                "snapshot inspection output limit exceeded",
+            ));
+        };
+        if next > self.limit {
+            self.exceeded = true;
+            return Err(io::Error::other(
+                "snapshot inspection output limit exceeded",
+            ));
+        }
+        self.count = next;
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+struct BoundedVecWriter {
+    bytes: Vec<u8>,
+    limit: usize,
+    exceeded: bool,
+}
+
+impl BoundedVecWriter {
+    fn try_new(capacity: usize) -> Result<Self, TryReserveError> {
+        let mut bytes = Vec::new();
+        bytes.try_reserve_exact(capacity)?;
+        Ok(Self {
+            bytes,
+            limit: capacity,
+            exceeded: false,
+        })
+    }
+}
+
+impl Write for BoundedVecWriter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        let Some(next) = self.bytes.len().checked_add(bytes.len()) else {
+            self.exceeded = true;
+            return Err(io::Error::other(
+                "snapshot inspection output limit exceeded",
+            ));
+        };
+        if next > self.limit {
+            self.exceeded = true;
+            return Err(io::Error::other(
+                "snapshot inspection output limit exceeded",
+            ));
+        }
+        self.bytes.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn format_pretty_json<T: Serialize>(
+    value: &T,
+    limit: usize,
+) -> Result<String, HvfNativeSnapshotInspectionError> {
+    let mut counter = CountingWriter::new(limit);
+    if let Err(source) = serde_json::to_writer_pretty(&mut counter, value) {
+        return if counter.exceeded {
+            Err(HvfNativeSnapshotInspectionError::OutputTooLarge { maximum: limit })
+        } else {
+            Err(HvfNativeSnapshotInspectionError::Serialization { source })
+        };
+    }
+
+    let measured = counter.count;
+    let mut output = BoundedVecWriter::try_new(measured)
+        .map_err(|source| HvfNativeSnapshotInspectionError::Allocation { source })?;
+    if let Err(source) = serde_json::to_writer_pretty(&mut output, value) {
+        return if output.exceeded {
+            Err(HvfNativeSnapshotInspectionError::NonDeterministic)
+        } else {
+            Err(HvfNativeSnapshotInspectionError::Serialization { source })
+        };
+    }
+    if output.bytes.len() != measured {
+        return Err(HvfNativeSnapshotInspectionError::NonDeterministic);
+    }
+    String::from_utf8(output.bytes).map_err(|_| HvfNativeSnapshotInspectionError::InvalidUtf8)
+}
+
+#[cfg(test)]
+fn format_pretty_json_with_limit<T: Serialize>(
+    value: &T,
+    limit: usize,
+) -> Result<String, HvfNativeSnapshotInspectionError> {
+    format_pretty_json(value, limit)
+}
+
+fn platform_v2(
+    state: &HvfNativeSnapshotDocumentState,
+) -> Option<&crate::HvfSnapshotV2PlatformState> {
+    match state {
+        HvfNativeSnapshotDocumentState::V1(_) => None,
+        HvfNativeSnapshotDocumentState::V2LegacyPlatform(state) => Some(state),
+        HvfNativeSnapshotDocumentState::V2DeviceGraph(state) => Some(state.platform()),
+        HvfNativeSnapshotDocumentState::V2MultiBlock(state) => Some(state.platform()),
+        HvfNativeSnapshotDocumentState::V2Storage(state) => Some(state.platform()),
+        HvfNativeSnapshotDocumentState::V2Serial(state) => Some(state.platform()),
+        HvfNativeSnapshotDocumentState::V2Entropy(state) => Some(state.platform()),
+        HvfNativeSnapshotDocumentState::V2Balloon(state) => Some(state.platform()),
+        HvfNativeSnapshotDocumentState::V2MemoryHotplug(state) => Some(state.platform()),
+        HvfNativeSnapshotDocumentState::V2Network(state) => Some(state.platform()),
+        HvfNativeSnapshotDocumentState::V2Vsock(state) => Some(state.platform()),
+        HvfNativeSnapshotDocumentState::V2Diff(state) => Some(state.platform()),
+    }
+}

--- a/crates/hvf/src/snapshot_document/inspection/common.rs
+++ b/crates/hvf/src/snapshot_document/inspection/common.rs
@@ -1,0 +1,1585 @@
+use bangbang_runtime::machine::{MachineConfig, MachineConfigCpuTemplate, MachineConfigHugePages};
+use bangbang_runtime::memory::GuestMemoryRange;
+use bangbang_runtime::snapshot_artifact::{
+    NativeSnapshotArtifactFamily, NativeV2SnapshotArtifactProfile,
+};
+use bangbang_runtime::snapshot_format::{SnapshotArchitecture, SnapshotFormatVersion};
+use bangbang_runtime::snapshot_memory::{SnapshotMemoryBinding, SnapshotMemoryRangeBinding};
+use bangbang_runtime::snapshot_memory_v2::{SnapshotV2MemoryBinding, SnapshotV2MemoryExtent};
+use serde::Serialize;
+use serde::ser::{Error as _, SerializeSeq, SerializeStruct};
+
+use crate::gic::{HvfArm64GicIccRegisterState, HvfGicDeviceState};
+use crate::optional_state::{
+    HvfArm64DebugRegisterRestoreState, HvfArm64OptionalStateValue,
+    HvfArm64ReviewedOptionalStateRestore, HvfArm64SmeRestoreState,
+};
+use crate::snapshot::HvfArm64SnapshotTimerState;
+use crate::snapshot_bundle::{
+    HvfSnapshotV1CompatibilityState, HvfSnapshotV1InterruptState, HvfSnapshotV1VcpuState,
+};
+use crate::snapshot_v2::{
+    HvfSnapshotV2MachineState, HvfSnapshotV2PlatformState, HvfSnapshotV2PvTimeRestorePolicy,
+    HvfSnapshotV2PvTimeVcpuState, HvfSnapshotV2RtcRestorePolicy, HvfSnapshotV2VcpuState,
+    HvfSnapshotV2VmClockRestorePolicy, HvfSnapshotV2VmGenIdRestorePolicy,
+};
+use crate::vcpu::{
+    HvfArm64VcpuCacheSelectionRegisterState, HvfArm64VcpuCoreSystemRegisterState,
+    HvfArm64VcpuDebugControlRegisterState, HvfArm64VcpuDebugTrapState,
+    HvfArm64VcpuExceptionRegisterState, HvfArm64VcpuExecutionControlRegisterState,
+    HvfArm64VcpuGeneralRegisterState, HvfArm64VcpuPendingInterruptState,
+    HvfArm64VcpuPointerAuthenticationKeyState, HvfArm64VcpuSimdFpState,
+    HvfArm64VcpuSystemContextRegisterState, HvfArm64VcpuThreadContextRegisterState,
+    HvfArm64VcpuTranslationRegisterState,
+};
+
+use super::fingerprint::{
+    Fingerprint, FingerprintBuilder, HexU16, HexU32, HexU64, HexU128, Redacted, RedactedOption,
+    confidential_bytes,
+};
+use super::{HvfNativeSnapshotDocument, HvfNativeSnapshotDocumentState, platform_v2};
+use crate::snapshot_document::HvfNativeSnapshotDocumentProfile;
+
+pub(super) struct Family(pub(super) NativeSnapshotArtifactFamily);
+
+impl Serialize for Family {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(match self.0 {
+            NativeSnapshotArtifactFamily::V1 => "native-v1",
+            NativeSnapshotArtifactFamily::V2 => "native-v2",
+        })
+    }
+}
+
+pub(super) struct Profile(pub(super) HvfNativeSnapshotDocumentProfile);
+
+impl Serialize for Profile {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = match self.0 {
+            HvfNativeSnapshotDocumentProfile::V1 => "v1",
+            HvfNativeSnapshotDocumentProfile::V2(
+                NativeV2SnapshotArtifactProfile::LegacyPlatformV2_3,
+            ) => "legacy-platform-v2.3",
+            HvfNativeSnapshotDocumentProfile::V2(
+                NativeV2SnapshotArtifactProfile::DeviceGraphV2_4,
+            ) => "device-graph-v2.4",
+            HvfNativeSnapshotDocumentProfile::V2(
+                NativeV2SnapshotArtifactProfile::MultiBlockDeviceGraphV2_5,
+            ) => "multi-block-device-graph-v2.5",
+            HvfNativeSnapshotDocumentProfile::V2(
+                NativeV2SnapshotArtifactProfile::StorageDeviceGraphV2_6,
+            ) => "storage-device-graph-v2.6",
+            HvfNativeSnapshotDocumentProfile::V2(
+                NativeV2SnapshotArtifactProfile::SerialStateV2_7,
+            ) => "serial-state-v2.7",
+            HvfNativeSnapshotDocumentProfile::V2(
+                NativeV2SnapshotArtifactProfile::EntropyStateV2_8,
+            ) => "entropy-state-v2.8",
+            HvfNativeSnapshotDocumentProfile::V2(
+                NativeV2SnapshotArtifactProfile::BalloonStateV2_9,
+            ) => "balloon-state-v2.9",
+            HvfNativeSnapshotDocumentProfile::V2(
+                NativeV2SnapshotArtifactProfile::MemoryHotplugStateV2_10,
+            ) => "memory-hotplug-state-v2.10",
+            HvfNativeSnapshotDocumentProfile::V2(
+                NativeV2SnapshotArtifactProfile::NetworkStateV2_11,
+            ) => "network-state-v2.11",
+            HvfNativeSnapshotDocumentProfile::V2(
+                NativeV2SnapshotArtifactProfile::VsockStateV2_12,
+            ) => "vsock-state-v2.12",
+            HvfNativeSnapshotDocumentProfile::V2(
+                NativeV2SnapshotArtifactProfile::DiffStateV2_13,
+            ) => "diff-state-v2.13",
+        };
+        serializer.serialize_str(value)
+    }
+}
+
+pub(super) struct Version(pub(super) SnapshotFormatVersion);
+
+impl Serialize for Version {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("SnapshotVersion", 3)?;
+        state.serialize_field("major", &self.0.major())?;
+        state.serialize_field("minor", &self.0.minor())?;
+        state.serialize_field("patch", &self.0.patch())?;
+        state.end()
+    }
+}
+
+pub(super) struct Memory<'a>(pub(super) &'a HvfNativeSnapshotDocument);
+
+impl Serialize for Memory<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match &self.0.state {
+            HvfNativeSnapshotDocumentState::V1(bundle) => {
+                V1Memory(bundle.commit_record().memory_binding()).serialize(serializer)
+            }
+            state => platform_v2(state)
+                .ok_or_else(|| S::Error::custom("native-v2 inspection platform is missing"))
+                .and_then(|platform| V2Memory(platform.memory()).serialize(serializer)),
+        }
+    }
+}
+
+struct V1Memory<'a>(&'a SnapshotMemoryBinding);
+
+impl Serialize for V1Memory<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let binding = self.0;
+        let mut identity = FingerprintBuilder::new("memory.v1.binding-identity");
+        identity.bytes(binding.image_id().as_bytes());
+        identity.u64(binding.checksum());
+
+        let mut state = serializer.serialize_struct("NativeV1Memory", 10)?;
+        state.serialize_field("version", &Version(binding.version()))?;
+        state.serialize_field(
+            "architecture",
+            match binding.architecture() {
+                SnapshotArchitecture::Arm64 => "arm64",
+            },
+        )?;
+        state.serialize_field("guest_page_size", &binding.guest_page_size())?;
+        state.serialize_field("data_length", &binding.data_length())?;
+        state.serialize_field("file_length", &binding.file_length())?;
+        state.serialize_field("integrity", "crc64-jones")?;
+        state.serialize_field("binding_identity", &identity.finish())?;
+        state.serialize_field("range_count", &binding.ranges().len())?;
+        state.serialize_field("ranges", &V1MemoryRanges(binding.ranges()))?;
+        state.serialize_field("sparse", &false)?;
+        state.end()
+    }
+}
+
+struct V1MemoryRanges<'a>(&'a [SnapshotMemoryRangeBinding]);
+
+impl Serialize for V1MemoryRanges<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for binding in self.0 {
+            sequence.serialize_element(&MemoryRange {
+                range: binding.range(),
+                file_offset: binding.file_offset(),
+            })?;
+        }
+        sequence.end()
+    }
+}
+
+pub(super) struct V2Memory<'a>(pub(super) &'a SnapshotV2MemoryBinding);
+
+impl Serialize for V2Memory<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let binding = self.0;
+        let mut identity = FingerprintBuilder::new("memory.v2.binding-identity");
+        identity.bytes(binding.image_id().as_bytes());
+        identity.u64(binding.metadata_checksum());
+
+        let mut state = serializer.serialize_struct("NativeV2Memory", 8)?;
+        state.serialize_field("version", &Version(binding.version()))?;
+        state.serialize_field(
+            "guest_granule",
+            &bangbang_runtime::snapshot_memory_v2::NATIVE_V2_MEMORY_GUEST_GRANULE,
+        )?;
+        state.serialize_field("file_length", &binding.file_length())?;
+        state.serialize_field("binding_identity", &identity.finish())?;
+        state.serialize_field("extent_count", &binding.extents().len())?;
+        state.serialize_field("extents", &V2MemoryExtents(binding.extents()))?;
+        state.serialize_field(
+            "alignment",
+            &bangbang_runtime::snapshot_memory_v2::NATIVE_V2_MEMORY_ALIGNMENT,
+        )?;
+        state.serialize_field("sparse", &true)?;
+        state.end()
+    }
+}
+
+struct V2MemoryExtents<'a>(&'a [SnapshotV2MemoryExtent]);
+
+impl Serialize for V2MemoryExtents<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for extent in self.0 {
+            sequence.serialize_element(&MemoryRange {
+                range: extent.range(),
+                file_offset: extent.file_offset(),
+            })?;
+        }
+        sequence.end()
+    }
+}
+
+pub(super) struct MemoryRange {
+    pub(super) range: GuestMemoryRange,
+    pub(super) file_offset: u64,
+}
+
+impl Serialize for MemoryRange {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("MemoryRange", 3)?;
+        state.serialize_field("start", &HexU64(self.range.start().raw_value()))?;
+        state.serialize_field("size", &self.range.size())?;
+        state.serialize_field("file_offset", &self.file_offset)?;
+        state.end()
+    }
+}
+
+pub(super) struct Machine<'a>(pub(super) &'a HvfNativeSnapshotDocument);
+
+impl Serialize for Machine<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match &self.0.state {
+            HvfNativeSnapshotDocumentState::V1(bundle) => {
+                V1Machine(bundle.state().machine()).serialize(serializer)
+            }
+            state => platform_v2(state)
+                .ok_or_else(|| S::Error::custom("native-v2 inspection platform is missing"))
+                .and_then(|platform| V2Machine(platform.machine()).serialize(serializer)),
+        }
+    }
+}
+
+struct V1Machine(MachineConfig);
+
+impl Serialize for V1Machine {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("NativeV1Machine", 5)?;
+        state.serialize_field("config", &MachineConfigView(self.0))?;
+        state.serialize_field("boot", &Option::<()>::None)?;
+        state.serialize_field("fdt", &Option::<()>::None)?;
+        state.serialize_field("cpu_template_application", &Option::<()>::None)?;
+        state.serialize_field("profile", "native-v1")?;
+        state.end()
+    }
+}
+
+struct V2Machine<'a>(&'a HvfSnapshotV2MachineState);
+
+impl Serialize for V2Machine<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let machine = self.0;
+        let boot = machine.boot();
+        let fdt = machine.fdt();
+        let mut state = serializer.serialize_struct("NativeV2Machine", 5)?;
+        state.serialize_field("config", &MachineConfigView(machine.machine()))?;
+        state.serialize_field(
+            "boot",
+            &Boot {
+                has_initrd: boot.initrd_path().is_some(),
+                has_arguments: boot.boot_arguments().is_some(),
+            },
+        )?;
+        state.serialize_field(
+            "fdt",
+            &Fdt {
+                address: fdt.address().raw_value(),
+                size: fdt.size(),
+                product_process_profile: fdt.is_product_process_profile(),
+            },
+        )?;
+        state.serialize_field(
+            "cpu_template_application",
+            &machine.cpu_template().map(CpuTemplateApplication),
+        )?;
+        state.serialize_field("profile", "native-v2")?;
+        state.end()
+    }
+}
+
+struct MachineConfigView(MachineConfig);
+
+impl Serialize for MachineConfigView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let machine = self.0;
+        let mut state = serializer.serialize_struct("MachineConfig", 6)?;
+        state.serialize_field("vcpu_count", &machine.vcpu_count())?;
+        state.serialize_field("mem_size_mib", &machine.mem_size_mib())?;
+        state.serialize_field("smt", &machine.smt())?;
+        state.serialize_field("cpu_template", &machine.cpu_template().map(CpuTemplate))?;
+        state.serialize_field("track_dirty_pages", &machine.track_dirty_pages())?;
+        state.serialize_field("huge_pages", &HugePages(machine.huge_pages()))?;
+        state.end()
+    }
+}
+
+struct CpuTemplate(MachineConfigCpuTemplate);
+
+impl Serialize for CpuTemplate {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(match self.0 {
+            MachineConfigCpuTemplate::C3 => "c3",
+            MachineConfigCpuTemplate::T2 => "t2",
+            MachineConfigCpuTemplate::T2S => "t2s",
+            MachineConfigCpuTemplate::T2CL => "t2cl",
+            MachineConfigCpuTemplate::T2A => "t2a",
+            MachineConfigCpuTemplate::V1N1 => "v1n1",
+            MachineConfigCpuTemplate::None => "none",
+        })
+    }
+}
+
+struct HugePages(MachineConfigHugePages);
+
+impl Serialize for HugePages {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(match self.0 {
+            MachineConfigHugePages::None => "none",
+            MachineConfigHugePages::TwoM => "2m",
+        })
+    }
+}
+
+struct Boot {
+    has_initrd: bool,
+    has_arguments: bool,
+}
+
+impl Serialize for Boot {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("Boot", 3)?;
+        state.serialize_field("kernel_path", &Redacted)?;
+        state.serialize_field("initrd_path", &RedactedOption(self.has_initrd))?;
+        state.serialize_field("arguments", &RedactedOption(self.has_arguments))?;
+        state.end()
+    }
+}
+
+struct Fdt {
+    address: u64,
+    size: u32,
+    product_process_profile: bool,
+}
+
+impl Serialize for Fdt {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("Fdt", 4)?;
+        state.serialize_field("address", &HexU64(self.address))?;
+        state.serialize_field("size", &self.size)?;
+        // The checksum covers low-entropy boot choices, including arguments;
+        // exposing it raw or hashing it would create a guessable oracle.
+        state.serialize_field("checksum", &Redacted)?;
+        state.serialize_field("product_process_profile", &self.product_process_profile)?;
+        state.end()
+    }
+}
+
+struct CpuTemplateApplication<'a>(&'a crate::HvfArm64CpuTemplateApplicationState);
+
+impl Serialize for CpuTemplateApplication<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("CpuTemplateApplication", 2)?;
+        state.serialize_field("entry_count", &self.0.entries().len())?;
+        state.serialize_field("entries", &CpuTemplateEntries(self.0.entries()))?;
+        state.end()
+    }
+}
+
+struct CpuTemplateEntries<'a>(&'a [crate::HvfArm64CpuTemplateApplicationEntry]);
+
+impl Serialize for CpuTemplateEntries<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for entry in self.0 {
+            sequence.serialize_element(&CpuTemplateEntry(entry))?;
+        }
+        sequence.end()
+    }
+}
+
+struct CpuTemplateEntry<'a>(&'a crate::HvfArm64CpuTemplateApplicationEntry);
+
+impl Serialize for CpuTemplateEntry<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use crate::HvfArm64CpuTemplateValueWidth;
+
+        let entry = self.0;
+        let mut state = serializer.serialize_struct("CpuTemplateEntry", 6)?;
+        state.serialize_field("tag", &HexU16(entry.tag().raw()))?;
+        state.serialize_field(
+            "width",
+            match entry.width() {
+                HvfArm64CpuTemplateValueWidth::U32 => "u32",
+                HvfArm64CpuTemplateValueWidth::U64 => "u64",
+                HvfArm64CpuTemplateValueWidth::U128 => "u128",
+            },
+        )?;
+        state.serialize_field("filter", &CpuTemplateValue(entry.filter()))?;
+        state.serialize_field("logical_value", &CpuTemplateValue(entry.logical_value()))?;
+        state.serialize_field(
+            "common_baseline",
+            &CpuTemplateValue(entry.common_baseline()),
+        )?;
+        state.serialize_field(
+            "effective_value",
+            &CpuTemplateValue(entry.effective_value()),
+        )?;
+        state.end()
+    }
+}
+
+struct CpuTemplateValue(crate::HvfArm64CpuTemplateValue);
+
+impl Serialize for CpuTemplateValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.0 {
+            crate::HvfArm64CpuTemplateValue::U32(value) => HexU32(value).serialize(serializer),
+            crate::HvfArm64CpuTemplateValue::U64(value) => HexU64(value).serialize(serializer),
+            crate::HvfArm64CpuTemplateValue::U128(value) => HexU128(value).serialize(serializer),
+        }
+    }
+}
+
+pub(super) struct Vcpus<'a>(pub(super) &'a HvfNativeSnapshotDocument);
+
+impl Serialize for Vcpus<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match &self.0.state {
+            HvfNativeSnapshotDocumentState::V1(bundle) => {
+                let mut sequence = serializer.serialize_seq(Some(1))?;
+                sequence.serialize_element(&Vcpu::V1 {
+                    index: 0,
+                    mpidr: bundle.state().compatibility().primary_mpidr(),
+                    state: bundle.state().vcpu(),
+                    interrupts: bundle.state().interrupts(),
+                })?;
+                sequence.end()
+            }
+            state => {
+                let platform = platform_v2(state)
+                    .ok_or_else(|| S::Error::custom("native-v2 inspection platform is missing"))?;
+                let mut sequence = serializer.serialize_seq(Some(platform.vcpus().len()))?;
+                for vcpu in platform.vcpus() {
+                    sequence.serialize_element(&Vcpu::V2(vcpu))?;
+                }
+                sequence.end()
+            }
+        }
+    }
+}
+
+enum Vcpu<'a> {
+    V1 {
+        index: u32,
+        mpidr: u64,
+        state: &'a HvfSnapshotV1VcpuState,
+        interrupts: &'a HvfSnapshotV1InterruptState,
+    },
+    V2(&'a HvfSnapshotV2VcpuState),
+}
+
+impl Serialize for Vcpu<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let (index, mpidr, mandatory, timer, pending, gic_icc, reviewed) = match self {
+            Self::V1 {
+                index,
+                mpidr,
+                state,
+                interrupts,
+            } => (
+                *index,
+                *mpidr,
+                *state,
+                interrupts.timer,
+                interrupts.pending_interrupts,
+                interrupts.gic_icc,
+                None,
+            ),
+            Self::V2(state) => (
+                state.index(),
+                state.mpidr(),
+                state.mandatory(),
+                *state.timer(),
+                state.pending_interrupts(),
+                state.gic_icc(),
+                Some(state.reviewed_optional()),
+            ),
+        };
+
+        let mut output = serializer.serialize_struct("Vcpu", 17)?;
+        output.serialize_field("index", &index)?;
+        output.serialize_field("mpidr", &HexU64(mpidr))?;
+        output.serialize_field("general", &General(&mandatory.general))?;
+        output.serialize_field("core", &Core(mandatory.core))?;
+        output.serialize_field("exception", &Exception(mandatory.exception))?;
+        output.serialize_field("execution", &Execution(mandatory.execution))?;
+        output.serialize_field(
+            "cache_selection",
+            &CacheSelection(mandatory.cache_selection),
+        )?;
+        output.serialize_field(
+            "debug",
+            &DebugState {
+                control: mandatory.debug_control,
+                trap: mandatory.debug_trap,
+                reviewed,
+            },
+        )?;
+        output.serialize_field("system_context", &SystemContext(mandatory.system_context))?;
+        output.serialize_field("translation", &Translation(mandatory.translation))?;
+        output.serialize_field(
+            "pointer_authentication",
+            &pointer_authentication_fingerprint(&mandatory.pointer_authentication),
+        )?;
+        output.serialize_field("thread_context", &ThreadContext(mandatory.thread_context))?;
+        output.serialize_field("simd_fp", &simd_fp_fingerprint(&mandatory.simd_fp))?;
+        output.serialize_field("timer", &Timer(timer))?;
+        output.serialize_field("pending_interrupts", &PendingInterrupts(pending))?;
+        output.serialize_field("gic_icc", &gic_icc_fingerprint(gic_icc))?;
+        output.serialize_field(
+            "reviewed_sme",
+            &reviewed.and_then(|value| value.sme()).map(Sme),
+        )?;
+        output.end()
+    }
+}
+
+struct HexU64Slice<'a>(&'a [u64]);
+
+impl Serialize for HexU64Slice<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for value in self.0 {
+            sequence.serialize_element(&HexU64(*value))?;
+        }
+        sequence.end()
+    }
+}
+
+struct General<'a>(&'a HvfArm64VcpuGeneralRegisterState);
+
+impl Serialize for General<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("GeneralRegisters", 3)?;
+        state.serialize_field("x", &HexU64Slice(self.0.general_purpose_registers()))?;
+        state.serialize_field("pc", &HexU64(self.0.pc()))?;
+        state.serialize_field("cpsr", &HexU64(self.0.cpsr()))?;
+        state.end()
+    }
+}
+
+struct Core(HvfArm64VcpuCoreSystemRegisterState);
+
+impl Serialize for Core {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("CoreRegisters", 4)?;
+        state.serialize_field("sp_el0", &HexU64(self.0.sp_el0()))?;
+        state.serialize_field("sp_el1", &HexU64(self.0.sp_el1()))?;
+        state.serialize_field("elr_el1", &HexU64(self.0.elr_el1()))?;
+        state.serialize_field("spsr_el1", &HexU64(self.0.spsr_el1()))?;
+        state.end()
+    }
+}
+
+struct Exception(HvfArm64VcpuExceptionRegisterState);
+
+impl Serialize for Exception {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("ExceptionRegisters", 6)?;
+        state.serialize_field("afsr0_el1", &HexU64(self.0.afsr0_el1()))?;
+        state.serialize_field("afsr1_el1", &HexU64(self.0.afsr1_el1()))?;
+        state.serialize_field("esr_el1", &HexU64(self.0.esr_el1()))?;
+        state.serialize_field("far_el1", &HexU64(self.0.far_el1()))?;
+        state.serialize_field("par_el1", &HexU64(self.0.par_el1()))?;
+        state.serialize_field("vbar_el1", &HexU64(self.0.vbar_el1()))?;
+        state.end()
+    }
+}
+
+struct Execution(HvfArm64VcpuExecutionControlRegisterState);
+
+impl Serialize for Execution {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("ExecutionRegisters", 2)?;
+        state.serialize_field("actlr_el1", &HexU64(self.0.actlr_el1()))?;
+        state.serialize_field("cpacr_el1", &HexU64(self.0.cpacr_el1()))?;
+        state.end()
+    }
+}
+
+struct CacheSelection(HvfArm64VcpuCacheSelectionRegisterState);
+
+impl Serialize for CacheSelection {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("CacheSelection", 1)?;
+        state.serialize_field("csselr_el1", &HexU64(self.0.csselr_el1()))?;
+        state.end()
+    }
+}
+
+struct SystemContext(HvfArm64VcpuSystemContextRegisterState);
+
+impl Serialize for SystemContext {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("SystemContext", 2)?;
+        state.serialize_field("scxtnum_el0", &HexU64(self.0.scxtnum_el0()))?;
+        state.serialize_field("scxtnum_el1", &HexU64(self.0.scxtnum_el1()))?;
+        state.end()
+    }
+}
+
+struct Translation(HvfArm64VcpuTranslationRegisterState);
+
+impl Serialize for Translation {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("TranslationRegisters", 7)?;
+        state.serialize_field("sctlr_el1", &HexU64(self.0.sctlr_el1()))?;
+        state.serialize_field("ttbr0_el1", &HexU64(self.0.ttbr0_el1()))?;
+        state.serialize_field("ttbr1_el1", &HexU64(self.0.ttbr1_el1()))?;
+        state.serialize_field("tcr_el1", &HexU64(self.0.tcr_el1()))?;
+        state.serialize_field("mair_el1", &HexU64(self.0.mair_el1()))?;
+        state.serialize_field("amair_el1", &HexU64(self.0.amair_el1()))?;
+        state.serialize_field("contextidr_el1", &HexU64(self.0.contextidr_el1()))?;
+        state.end()
+    }
+}
+
+struct ThreadContext(HvfArm64VcpuThreadContextRegisterState);
+
+impl Serialize for ThreadContext {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("ThreadContext", 3)?;
+        state.serialize_field("tpidr_el0", &HexU64(self.0.tpidr_el0()))?;
+        state.serialize_field("tpidrro_el0", &HexU64(self.0.tpidrro_el0()))?;
+        state.serialize_field("tpidr_el1", &HexU64(self.0.tpidr_el1()))?;
+        state.end()
+    }
+}
+
+struct Timer(HvfArm64SnapshotTimerState);
+
+impl Serialize for Timer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("Timer", 7)?;
+        state.serialize_field(
+            "virtual_timer_exit_masked",
+            &self.0.virtual_timer_exit_masked(),
+        )?;
+        state.serialize_field("cntkctl_el1", &HexU64(self.0.cntkctl_el1()))?;
+        state.serialize_field("virtual_count", &HexU64(self.0.virtual_count()))?;
+        state.serialize_field("virtual_control", &HexU64(self.0.virtual_control()))?;
+        state.serialize_field(
+            "virtual_compare_value",
+            &HexU64(self.0.virtual_compare_value()),
+        )?;
+        state.serialize_field("physical_control", &HexU64(self.0.physical_control()))?;
+        state.serialize_field(
+            "physical_compare_delta",
+            &HexU64(self.0.physical_compare_delta()),
+        )?;
+        state.end()
+    }
+}
+
+struct PendingInterrupts(HvfArm64VcpuPendingInterruptState);
+
+impl Serialize for PendingInterrupts {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("PendingInterrupts", 2)?;
+        state.serialize_field("irq", &self.0.irq_pending())?;
+        state.serialize_field("fiq", &self.0.fiq_pending())?;
+        state.end()
+    }
+}
+
+struct DebugState<'a> {
+    control: HvfArm64VcpuDebugControlRegisterState,
+    trap: HvfArm64VcpuDebugTrapState,
+    reviewed: Option<&'a HvfArm64ReviewedOptionalStateRestore>,
+}
+
+impl Serialize for DebugState<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut mandatory = FingerprintBuilder::new("vcpu.debug.mandatory");
+        mandatory.u64(self.control.mdccint_el1());
+        mandatory.u64(self.control.mdscr_el1());
+        mandatory.bool(self.trap.trap_debug_exceptions());
+        mandatory.bool(self.trap.trap_debug_reg_accesses());
+
+        let (breakpoint_count, watchpoint_count, reviewed) =
+            self.reviewed.map_or((None, None, None), |value| {
+                (
+                    Some(value.breakpoints().implemented_count()),
+                    Some(value.watchpoints().implemented_count()),
+                    Some(reviewed_debug_fingerprint(value)),
+                )
+            });
+
+        let mut state = serializer.serialize_struct("DebugState", 5)?;
+        state.serialize_field("mandatory", &mandatory.finish())?;
+        state.serialize_field("breakpoint_count", &breakpoint_count)?;
+        state.serialize_field("watchpoint_count", &watchpoint_count)?;
+        state.serialize_field("reviewed", &reviewed)?;
+        state.serialize_field("policy", "confidential-equality-only")?;
+        state.end()
+    }
+}
+
+struct Sme<'a>(&'a HvfArm64SmeRestoreState);
+
+impl Serialize for Sme<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let sme = self.0;
+        let pstate_source = optional_source(&sme.pstate());
+        let system_sources = OptionalSources(sme.system_registers());
+        let z_count = sme
+            .z_registers()
+            .map(<[HvfArm64OptionalStateValue<Box<[u8]>>]>::len);
+        let p_count = sme
+            .p_registers()
+            .map(<[HvfArm64OptionalStateValue<Box<[u8]>>]>::len);
+        let mut state = serializer.serialize_struct("SmeState", 10)?;
+        state.serialize_field("version", &sme.version())?;
+        state.serialize_field("maximum_svl_bytes", &sme.maximum_svl_bytes())?;
+        state.serialize_field("pstate_source", pstate_source)?;
+        state.serialize_field("system_register_sources", &system_sources)?;
+        state.serialize_field("z_register_count", &z_count)?;
+        state.serialize_field("p_register_count", &p_count)?;
+        state.serialize_field("za_present", &sme.za_register().is_some())?;
+        state.serialize_field("zt0_present", &sme.zt0_register().is_some())?;
+        state.serialize_field("state", &sme_fingerprint(sme))?;
+        state.serialize_field("policy", "confidential-equality-only")?;
+        state.end()
+    }
+}
+
+struct OptionalSources<'a>(&'a [HvfArm64OptionalStateValue<u64>]);
+
+impl Serialize for OptionalSources<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for value in self.0 {
+            sequence.serialize_element(optional_source(value))?;
+        }
+        sequence.end()
+    }
+}
+
+fn optional_source<T>(value: &HvfArm64OptionalStateValue<T>) -> &'static str {
+    match value {
+        HvfArm64OptionalStateValue::Explicit(_) => "explicit",
+        HvfArm64OptionalStateValue::DestinationDefault => "destination-default",
+    }
+}
+
+fn pointer_authentication_fingerprint(
+    state: &HvfArm64VcpuPointerAuthenticationKeyState,
+) -> Fingerprint {
+    let mut builder = FingerprintBuilder::new("vcpu.pointer-authentication");
+    builder.u128(state.apia_key());
+    builder.u128(state.apib_key());
+    builder.u128(state.apda_key());
+    builder.u128(state.apdb_key());
+    builder.u128(state.apga_key());
+    builder.finish()
+}
+
+fn simd_fp_fingerprint(state: &HvfArm64VcpuSimdFpState) -> Fingerprint {
+    let mut builder = FingerprintBuilder::new("vcpu.simd-fp");
+    builder.sequence_len(state.q_registers().len());
+    for register in state.q_registers() {
+        builder.bytes(register);
+    }
+    builder.u64(state.fpcr());
+    builder.u64(state.fpsr());
+    builder.finish()
+}
+
+fn gic_icc_fingerprint(state: HvfArm64GicIccRegisterState) -> Fingerprint {
+    let mut builder = FingerprintBuilder::new("vcpu.gic-icc");
+    builder.u64(state.pmr_el1());
+    builder.u64(state.bpr0_el1());
+    builder.u64(state.ap0r0_el1());
+    builder.u64(state.ap1r0_el1());
+    builder.u64(state.rpr_el1());
+    builder.u64(state.bpr1_el1());
+    builder.u64(state.ctlr_el1());
+    builder.u64(state.sre_el1());
+    builder.u64(state.igrpen0_el1());
+    builder.u64(state.igrpen1_el1());
+    builder.finish()
+}
+
+fn reviewed_debug_fingerprint(state: &HvfArm64ReviewedOptionalStateRestore) -> Fingerprint {
+    let mut builder = FingerprintBuilder::new("vcpu.debug.reviewed");
+    builder.u64(state.expected_id_aa64dfr0_el1());
+    append_debug_inventory(&mut builder, state.breakpoints());
+    append_debug_inventory(&mut builder, state.watchpoints());
+    builder.finish()
+}
+
+fn append_debug_inventory(
+    builder: &mut FingerprintBuilder,
+    state: &HvfArm64DebugRegisterRestoreState,
+) {
+    builder.u8(state.implemented_count());
+    for value in state.values().iter().chain(state.controls()) {
+        append_optional_u64(builder, value);
+    }
+}
+
+fn append_optional_u64(builder: &mut FingerprintBuilder, value: &HvfArm64OptionalStateValue<u64>) {
+    match value {
+        HvfArm64OptionalStateValue::Explicit(value) => {
+            builder.tag(1);
+            builder.u64(*value);
+        }
+        HvfArm64OptionalStateValue::DestinationDefault => builder.tag(0),
+    }
+}
+
+fn sme_fingerprint(state: &HvfArm64SmeRestoreState) -> Fingerprint {
+    let mut builder = FingerprintBuilder::new("vcpu.sme");
+    builder.u8(state.version());
+    let identification = state.identification();
+    builder.u64(identification.id_aa64zfr0_el1());
+    builder.u64(identification.id_aa64smfr0_el1());
+    builder.u64(state.maximum_svl_bytes() as u64);
+    match state.pstate() {
+        HvfArm64OptionalStateValue::Explicit(value) => {
+            builder.tag(1);
+            builder.bool(value.streaming_sve_mode_enabled());
+            builder.bool(value.za_storage_enabled());
+        }
+        HvfArm64OptionalStateValue::DestinationDefault => builder.tag(0),
+    }
+    for value in state.system_registers() {
+        append_optional_u64(&mut builder, value);
+    }
+    append_optional_byte_inventory(&mut builder, state.z_registers());
+    append_optional_byte_inventory(&mut builder, state.p_registers());
+    append_optional_bytes(
+        &mut builder,
+        state.za_register().map(|value| match value {
+            HvfArm64OptionalStateValue::Explicit(bytes) => {
+                HvfArm64OptionalStateValue::Explicit(bytes.as_ref())
+            }
+            HvfArm64OptionalStateValue::DestinationDefault => {
+                HvfArm64OptionalStateValue::DestinationDefault
+            }
+        }),
+    );
+    append_optional_bytes(
+        &mut builder,
+        state.zt0_register().map(|value| match value {
+            HvfArm64OptionalStateValue::Explicit(bytes) => {
+                HvfArm64OptionalStateValue::Explicit(bytes.as_slice())
+            }
+            HvfArm64OptionalStateValue::DestinationDefault => {
+                HvfArm64OptionalStateValue::DestinationDefault
+            }
+        }),
+    );
+    builder.finish()
+}
+
+fn append_optional_byte_inventory(
+    builder: &mut FingerprintBuilder,
+    inventory: Option<&[HvfArm64OptionalStateValue<Box<[u8]>>]>,
+) {
+    match inventory {
+        Some(values) => {
+            builder.tag(1);
+            builder.sequence_len(values.len());
+            for value in values {
+                match value {
+                    HvfArm64OptionalStateValue::Explicit(bytes) => {
+                        builder.tag(1);
+                        builder.bytes(bytes);
+                    }
+                    HvfArm64OptionalStateValue::DestinationDefault => builder.tag(0),
+                }
+            }
+        }
+        None => builder.tag(0),
+    }
+}
+
+fn append_optional_bytes(
+    builder: &mut FingerprintBuilder,
+    value: Option<HvfArm64OptionalStateValue<&[u8]>>,
+) {
+    match value {
+        Some(HvfArm64OptionalStateValue::Explicit(bytes)) => {
+            builder.tag(2);
+            builder.bytes(bytes);
+        }
+        Some(HvfArm64OptionalStateValue::DestinationDefault) => builder.tag(1),
+        None => builder.tag(0),
+    }
+}
+
+pub(super) fn gic_device_fingerprint(state: &HvfGicDeviceState) -> Fingerprint {
+    confidential_bytes("global.gic-device", state.as_bytes())
+}
+
+// Implemented below in the platform section.
+pub(super) struct Global<'a>(pub(super) &'a HvfNativeSnapshotDocument);
+pub(super) struct Topology<'a>(pub(super) &'a HvfNativeSnapshotDocument);
+pub(super) struct Time<'a>(pub(super) &'a HvfNativeSnapshotDocument);
+
+impl Serialize for Global<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        GlobalState(self.0).serialize(serializer)
+    }
+}
+
+impl Serialize for Topology<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        TopologyState(self.0).serialize(serializer)
+    }
+}
+
+impl Serialize for Time<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        TimeState(self.0).serialize(serializer)
+    }
+}
+
+struct GlobalState<'a>(&'a HvfNativeSnapshotDocument);
+struct TopologyState<'a>(&'a HvfNativeSnapshotDocument);
+struct TimeState<'a>(&'a HvfNativeSnapshotDocument);
+
+impl Serialize for GlobalState<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match &self.0.state {
+            HvfNativeSnapshotDocumentState::V1(bundle) => GlobalParts {
+                compatibility: bundle.state().compatibility(),
+                gic_device: &bundle.state().interrupts().gic_device,
+            }
+            .serialize(serializer),
+            state => platform_v2(state)
+                .ok_or_else(|| S::Error::custom("native-v2 inspection platform is missing"))
+                .and_then(|platform| {
+                    GlobalParts {
+                        compatibility: platform.global().compatibility(),
+                        gic_device: platform.global().gic_device(),
+                    }
+                    .serialize(serializer)
+                }),
+        }
+    }
+}
+
+struct GlobalParts<'a> {
+    compatibility: &'a HvfSnapshotV1CompatibilityState,
+    gic_device: &'a HvfGicDeviceState,
+}
+
+impl Serialize for GlobalParts<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("Global", 2)?;
+        state.serialize_field("compatibility", &Compatibility(self.compatibility))?;
+        state.serialize_field("gic_device", &gic_device_fingerprint(self.gic_device))?;
+        state.end()
+    }
+}
+
+struct Compatibility<'a>(&'a HvfSnapshotV1CompatibilityState);
+
+impl Serialize for Compatibility<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let compatibility = self.0;
+        let identification = compatibility.identification();
+        let cache = compatibility.cache_manifest();
+
+        let mut state = serializer.serialize_struct("Compatibility", 6)?;
+        state.serialize_field("identification", &Identification(identification))?;
+        state.serialize_field(
+            "sve_sme_identification",
+            &compatibility
+                .optional_sve_sme_identification()
+                .map(SveSmeIdentification),
+        )?;
+        state.serialize_field("cache_manifest", &CacheManifest(cache))?;
+        state.serialize_field("primary_mpidr", &HexU64(compatibility.primary_mpidr()))?;
+        state.serialize_field("gic_metadata", &GicMetadata(compatibility.gic_metadata()))?;
+        state.serialize_field("rtc_layout", &RtcLayout(compatibility.rtc_mmio_layout()))?;
+        state.end()
+    }
+}
+
+struct SveSmeIdentification(crate::HvfArm64VcpuSveSmeIdentificationRegisterState);
+
+impl Serialize for SveSmeIdentification {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("SveSmeIdentification", 2)?;
+        state.serialize_field("id_aa64zfr0_el1", &HexU64(self.0.id_aa64zfr0_el1()))?;
+        state.serialize_field("id_aa64smfr0_el1", &HexU64(self.0.id_aa64smfr0_el1()))?;
+        state.end()
+    }
+}
+
+struct CacheManifest(crate::HvfArm64VcpuCacheManifest);
+
+impl Serialize for CacheManifest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let configuration = self.0.configuration();
+        let geometry = self.0.geometry();
+        let mut state = serializer.serialize_struct("CacheManifest", 5)?;
+        state.serialize_field("ctr_el0", &HexU64(configuration.ctr_el0()))?;
+        state.serialize_field("clidr_el1", &HexU64(configuration.clidr_el1()))?;
+        state.serialize_field("dczid_el0", &HexU64(configuration.dczid_el0()))?;
+        state.serialize_field(
+            "data_or_unified_ccsidr_el1",
+            &HexU64Slice(geometry.data_or_unified_ccsidr_el1()),
+        )?;
+        state.serialize_field(
+            "instruction_ccsidr_el1",
+            &HexU64Slice(geometry.instruction_ccsidr_el1()),
+        )?;
+        state.end()
+    }
+}
+
+struct Identification(crate::HvfArm64VcpuIdentificationRegisterState);
+
+impl Serialize for Identification {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("Identification", 11)?;
+        state.serialize_field("midr_el1", &HexU64(value.midr_el1()))?;
+        state.serialize_field("mpidr_el1", &HexU64(value.mpidr_el1()))?;
+        state.serialize_field("id_aa64pfr0_el1", &HexU64(value.id_aa64pfr0_el1()))?;
+        state.serialize_field("id_aa64pfr1_el1", &HexU64(value.id_aa64pfr1_el1()))?;
+        state.serialize_field("id_aa64dfr0_el1", &HexU64(value.id_aa64dfr0_el1()))?;
+        state.serialize_field("id_aa64dfr1_el1", &HexU64(value.id_aa64dfr1_el1()))?;
+        state.serialize_field("id_aa64isar0_el1", &HexU64(value.id_aa64isar0_el1()))?;
+        state.serialize_field("id_aa64isar1_el1", &HexU64(value.id_aa64isar1_el1()))?;
+        state.serialize_field("id_aa64mmfr0_el1", &HexU64(value.id_aa64mmfr0_el1()))?;
+        state.serialize_field("id_aa64mmfr1_el1", &HexU64(value.id_aa64mmfr1_el1()))?;
+        state.serialize_field("id_aa64mmfr2_el1", &HexU64(value.id_aa64mmfr2_el1()))?;
+        state.end()
+    }
+}
+
+struct GicMetadata(crate::HvfGicMetadata);
+
+impl Serialize for GicMetadata {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("GicMetadata", 5)?;
+        state.serialize_field("distributor", &GicRegion(value.distributor))?;
+        state.serialize_field("redistributor", &GicRedistributor(value.redistributor))?;
+        state.serialize_field(
+            "spi_interrupt_range",
+            &GicInterruptRange(value.spi_interrupt_range),
+        )?;
+        state.serialize_field(
+            "timer_interrupts",
+            &GicTimerInterrupts(value.timer_interrupts),
+        )?;
+        state.serialize_field("msi", &value.msi.map(GicMsi))?;
+        state.end()
+    }
+}
+
+struct GicRegion(crate::HvfGicRegion);
+
+impl Serialize for GicRegion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("GicRegion", 2)?;
+        state.serialize_field("base", &HexU64(self.0.base))?;
+        state.serialize_field("size", &self.0.size)?;
+        state.end()
+    }
+}
+
+struct GicRedistributor(crate::HvfGicRedistributor);
+
+impl Serialize for GicRedistributor {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("GicRedistributor", 2)?;
+        state.serialize_field("region", &GicRegion(self.0.region))?;
+        state.serialize_field(
+            "single_redistributor_size",
+            &self.0.single_redistributor_size,
+        )?;
+        state.end()
+    }
+}
+
+struct GicInterruptRange(crate::HvfGicInterruptRange);
+
+impl Serialize for GicInterruptRange {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("GicInterruptRange", 2)?;
+        state.serialize_field("base", &self.0.base)?;
+        state.serialize_field("count", &self.0.count)?;
+        state.end()
+    }
+}
+
+struct GicTimerInterrupts(crate::HvfGicTimerInterrupts);
+
+impl Serialize for GicTimerInterrupts {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("GicTimerInterrupts", 2)?;
+        state.serialize_field("el1_virtual_timer_intid", &self.0.el1_virtual_timer_intid)?;
+        state.serialize_field("el1_physical_timer_intid", &self.0.el1_physical_timer_intid)?;
+        state.end()
+    }
+}
+
+struct GicMsi(crate::HvfGicMsiMetadata);
+
+impl Serialize for GicMsi {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("GicMsi", 2)?;
+        state.serialize_field("region", &GicRegion(self.0.region))?;
+        state.serialize_field(
+            "interrupt_range",
+            &GicInterruptRange(self.0.interrupt_range),
+        )?;
+        state.end()
+    }
+}
+
+struct RtcLayout(bangbang_runtime::rtc::RtcMmioLayout);
+
+impl Serialize for RtcLayout {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("RtcLayout", 2)?;
+        state.serialize_field("base", &HexU64(self.0.base().raw_value()))?;
+        state.serialize_field("region_id", &self.0.region_id().raw_value())?;
+        state.end()
+    }
+}
+
+impl Serialize for TopologyState<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match &self.0.state {
+            HvfNativeSnapshotDocumentState::V1(_) => serializer.serialize_none(),
+            state => platform_v2(state)
+                .ok_or_else(|| S::Error::custom("native-v2 inspection platform is missing"))
+                .and_then(|platform| PausedTopology(platform).serialize(serializer)),
+        }
+    }
+}
+
+struct PausedTopology<'a>(&'a HvfSnapshotV2PlatformState);
+
+impl Serialize for PausedTopology<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let topology = self.0.topology();
+        let mut state = serializer.serialize_struct("PausedTopology", 3)?;
+        state.serialize_field("virtual_timer_intid", &topology.virtual_timer_intid())?;
+        state.serialize_field("member_count", &topology.members().len())?;
+        state.serialize_field("members", &TopologyMembers(topology.members()))?;
+        state.end()
+    }
+}
+
+struct TopologyMembers<'a>(&'a [crate::HvfArm64StablePausedTopologyMember]);
+
+impl Serialize for TopologyMembers<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for member in self.0 {
+            sequence.serialize_element(&TopologyMember(member))?;
+        }
+        sequence.end()
+    }
+}
+
+struct TopologyMember<'a>(&'a crate::HvfArm64StablePausedTopologyMember);
+
+impl Serialize for TopologyMember<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use crate::HvfArm64StableVcpuDisposition;
+
+        let member = self.0;
+        let mut state = serializer.serialize_struct("TopologyMember", 4)?;
+        state.serialize_field("index", &member.index())?;
+        state.serialize_field("mpidr", &HexU64(member.mpidr()))?;
+        match member.disposition() {
+            HvfArm64StableVcpuDisposition::Runnable => {
+                state.serialize_field("disposition", "runnable")?;
+                state.serialize_field("suspend", &Option::<()>::None)?;
+            }
+            HvfArm64StableVcpuDisposition::Offline => {
+                state.serialize_field("disposition", "offline")?;
+                state.serialize_field("suspend", &Option::<()>::None)?;
+            }
+            HvfArm64StableVcpuDisposition::Suspended(suspend) => {
+                state.serialize_field("disposition", "suspended")?;
+                state.serialize_field("suspend", &Some(Suspend(suspend)))?;
+            }
+        }
+        state.end()
+    }
+}
+
+struct Suspend<'a>(&'a crate::HvfArm64StableCpuSuspendState);
+
+impl Serialize for Suspend<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use crate::HvfArm64CpuSuspendConvention;
+
+        let arguments = self.0.arguments();
+        let mut state = serializer.serialize_struct("CpuSuspend", 3)?;
+        state.serialize_field(
+            "convention",
+            match self.0.convention() {
+                HvfArm64CpuSuspendConvention::Call32 => "call32",
+                HvfArm64CpuSuspendConvention::Call64 => "call64",
+            },
+        )?;
+        state.serialize_field("arguments", &HexU64Slice(&arguments))?;
+        state.serialize_field("return_pc", &HexU64(self.0.return_pc()))?;
+        state.end()
+    }
+}
+
+impl Serialize for TimeState<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match &self.0.state {
+            HvfNativeSnapshotDocumentState::V1(bundle) => {
+                V1Time(bundle.state().interrupts()).serialize(serializer)
+            }
+            state => platform_v2(state)
+                .ok_or_else(|| S::Error::custom("native-v2 inspection platform is missing"))
+                .and_then(|platform| V2Time(platform).serialize(serializer)),
+        }
+    }
+}
+
+struct V1Time<'a>(&'a HvfSnapshotV1InterruptState);
+
+impl Serialize for V1Time<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("NativeV1Time", 2)?;
+        state.serialize_field("vcpu_timer", &Timer(self.0.timer))?;
+        state.serialize_field("restore_policy", "native-v1-retained")?;
+        state.end()
+    }
+}
+
+struct V2Time<'a>(&'a HvfSnapshotV2PlatformState);
+
+impl Serialize for V2Time<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let time = self.0.time();
+        let mut state = serializer.serialize_struct("NativeV2Time", 9)?;
+        state.serialize_field("rtc_layout", &RtcLayout(time.rtc_layout()))?;
+        state.serialize_field("rtc_restore_policy", &RtcPolicy(time.rtc_restore_policy()))?;
+        state.serialize_field("vmgenid", &PlatformDeviceMetadata(time.vmgenid()))?;
+        state.serialize_field(
+            "vmgenid_restore_policy",
+            &VmGenIdPolicy(time.vmgenid_restore_policy()),
+        )?;
+        state.serialize_field("vmclock", &PlatformDeviceMetadata(time.vmclock()))?;
+        state.serialize_field("vmclock_abi", &VmClockAbiFingerprint(time.vmclock_abi()))?;
+        state.serialize_field(
+            "vmclock_restore_policy",
+            &VmClockPolicy(time.vmclock_restore_policy()),
+        )?;
+        state.serialize_field("pvtime_vcpus", &PvTimeVcpus(time.pvtime_vcpus()))?;
+        state.serialize_field(
+            "pvtime_restore_policy",
+            &PvTimePolicy(time.pvtime_restore_policy()),
+        )?;
+        state.end()
+    }
+}
+
+struct PlatformDeviceMetadata(bangbang_runtime::snapshot_device::SnapshotV1PlatformDeviceMetadata);
+
+impl Serialize for PlatformDeviceMetadata {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let metadata = self.0;
+        let mut state = serializer.serialize_struct("PlatformDeviceMetadata", 3)?;
+        state.serialize_field("range", &GuestRange(metadata.range()))?;
+        state.serialize_field("fdt_region", &FdtRegion(metadata.fdt_region()))?;
+        state.serialize_field("interrupt_line", &metadata.interrupt_line().raw_value())?;
+        state.end()
+    }
+}
+
+pub(super) struct GuestRange(pub(super) GuestMemoryRange);
+
+impl Serialize for GuestRange {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("GuestRange", 2)?;
+        state.serialize_field("start", &HexU64(self.0.start().raw_value()))?;
+        state.serialize_field("size", &self.0.size())?;
+        state.end()
+    }
+}
+
+struct FdtRegion(bangbang_runtime::fdt::Arm64FdtRegion);
+
+impl Serialize for FdtRegion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("FdtRegion", 2)?;
+        state.serialize_field("base", &HexU64(self.0.base))?;
+        state.serialize_field("size", &self.0.size)?;
+        state.end()
+    }
+}
+
+struct VmClockAbiFingerprint(bangbang_runtime::vmclock::VmClockAbi);
+
+impl Serialize for VmClockAbiFingerprint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        confidential_bytes("time.vmclock-abi", &self.0.to_bytes()).serialize(serializer)
+    }
+}
+
+struct PvTimeVcpus<'a>(&'a [HvfSnapshotV2PvTimeVcpuState]);
+
+impl Serialize for PvTimeVcpus<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for vcpu in self.0 {
+            sequence.serialize_element(&PvTimeVcpu(vcpu))?;
+        }
+        sequence.end()
+    }
+}
+
+struct PvTimeVcpu<'a>(&'a HvfSnapshotV2PvTimeVcpuState);
+
+impl Serialize for PvTimeVcpu<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("PvTimeVcpu", 3)?;
+        state.serialize_field("index", &self.0.index())?;
+        state.serialize_field("record_ipa", &HexU64(self.0.record_ipa().raw_value()))?;
+        state.serialize_field("stolen_time_ns", &self.0.stolen_time_ns())?;
+        state.end()
+    }
+}
+
+struct RtcPolicy(HvfSnapshotV2RtcRestorePolicy);
+struct PvTimePolicy(HvfSnapshotV2PvTimeRestorePolicy);
+struct VmGenIdPolicy(HvfSnapshotV2VmGenIdRestorePolicy);
+struct VmClockPolicy(HvfSnapshotV2VmClockRestorePolicy);
+
+macro_rules! policy_serialize {
+    ($wrapper:ident, $type:ty, { $($variant:path => $token:literal),+ $(,)? }) => {
+        impl Serialize for $wrapper {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                let token = match self.0 {
+                    $($variant => $token),+
+                };
+                serializer.serialize_str(token)
+            }
+        }
+    };
+}
+
+policy_serialize!(RtcPolicy, HvfSnapshotV2RtcRestorePolicy, {
+    HvfSnapshotV2RtcRestorePolicy::DestinationSystemTimeReset => "destination-system-time-reset"
+});
+policy_serialize!(PvTimePolicy, HvfSnapshotV2PvTimeRestorePolicy, {
+    HvfSnapshotV2PvTimeRestorePolicy::PreserveCumulativeExcludeDowntime => "preserve-cumulative-exclude-downtime"
+});
+policy_serialize!(VmGenIdPolicy, HvfSnapshotV2VmGenIdRestorePolicy, {
+    HvfSnapshotV2VmGenIdRestorePolicy::RegenerateAndNotify => "regenerate-and-notify"
+});
+policy_serialize!(VmClockPolicy, HvfSnapshotV2VmClockRestorePolicy, {
+    HvfSnapshotV2VmClockRestorePolicy::IncrementAndNotify => "increment-and-notify"
+});

--- a/crates/hvf/src/snapshot_document/inspection/devices.rs
+++ b/crates/hvf/src/snapshot_document/inspection/devices.rs
@@ -1,0 +1,248 @@
+use serde::Serialize;
+use serde::ser::SerializeStruct;
+
+use super::{HvfNativeSnapshotDocument, HvfNativeSnapshotDocumentState};
+
+mod diff;
+mod product;
+mod shared;
+mod storage;
+
+pub(super) struct Devices<'a>(pub(super) &'a HvfNativeSnapshotDocument);
+
+#[cfg(test)]
+pub(super) struct StorageGraphForTest<'a>(
+    pub(super) &'a bangbang_runtime::snapshot_device_v2_6::SnapshotV2StorageDeviceGraph,
+);
+
+#[cfg(test)]
+impl Serialize for StorageGraphForTest<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        storage::StorageGraph(self.0).serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+pub(super) struct BalloonForTest<'a>(
+    pub(super) &'a bangbang_runtime::snapshot_balloon_v2_9::SnapshotV2BalloonState,
+);
+
+#[cfg(test)]
+impl Serialize for BalloonForTest<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        product::Balloon(self.0).serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+pub(super) struct MemoryHotplugForTest<'a>(
+    pub(super) &'a bangbang_runtime::snapshot_memory_hotplug_v2_10::SnapshotV2MemoryHotplugState,
+);
+
+#[cfg(test)]
+impl Serialize for MemoryHotplugForTest<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        product::MemoryHotplug(self.0).serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+pub(super) struct NetworkForTest<'a>(
+    pub(super) &'a bangbang_runtime::snapshot_network_v2_11::SnapshotV2NetworkState,
+);
+
+#[cfg(test)]
+impl Serialize for NetworkForTest<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        product::Network(self.0).serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+pub(super) struct DiffLayerForTest<'a>(
+    pub(super) &'a bangbang_runtime::snapshot_diff_v2_13::SnapshotV2DiffLayerBinding,
+);
+
+#[cfg(test)]
+impl Serialize for DiffLayerForTest<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        diff::DiffLayer(self.0).serialize(serializer)
+    }
+}
+
+impl Serialize for Devices<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let parts = DeviceParts::from_document(self.0);
+        let mut state = serializer.serialize_struct("Devices", 10)?;
+        state.serialize_field("profile", &super::common::Profile(self.0.profile()))?;
+        state.serialize_field("legacy", &parts.legacy)?;
+        state.serialize_field("root_block", &parts.root_block)?;
+        state.serialize_field("storage", &parts.storage)?;
+        state.serialize_field("serial", &parts.serial)?;
+        state.serialize_field("entropy", &parts.entropy)?;
+        state.serialize_field("balloon", &parts.balloon)?;
+        state.serialize_field("memory_hotplug", &parts.memory_hotplug)?;
+        state.serialize_field("network", &parts.network)?;
+        state.serialize_field("vsock", &parts.vsock)?;
+        state.end()
+    }
+}
+
+struct DeviceParts<'a> {
+    legacy: Option<storage::LegacyDevices<'a>>,
+    root_block: Option<storage::SingletonBlockGraph<'a>>,
+    storage: Option<Storage<'a>>,
+    serial: Option<product::Serial<'a>>,
+    entropy: Option<product::Entropy<'a>>,
+    balloon: Option<product::Balloon<'a>>,
+    memory_hotplug: Option<product::MemoryHotplug<'a>>,
+    network: Option<product::Network<'a>>,
+    vsock: Option<product::Vsock<'a>>,
+}
+
+impl DeviceParts<'_> {
+    const fn empty() -> Self {
+        Self {
+            legacy: None,
+            root_block: None,
+            storage: None,
+            serial: None,
+            entropy: None,
+            balloon: None,
+            memory_hotplug: None,
+            network: None,
+            vsock: None,
+        }
+    }
+}
+
+impl<'a> DeviceParts<'a> {
+    fn from_document(document: &'a HvfNativeSnapshotDocument) -> Self {
+        let mut parts = Self::empty();
+        match &document.state {
+            HvfNativeSnapshotDocumentState::V1(bundle) => {
+                parts.legacy = Some(storage::LegacyDevices(bundle.state().device()));
+            }
+            HvfNativeSnapshotDocumentState::V2LegacyPlatform(_) => {}
+            HvfNativeSnapshotDocumentState::V2DeviceGraph(state) => {
+                parts.root_block = Some(storage::SingletonBlockGraph(state.device_graph()));
+            }
+            HvfNativeSnapshotDocumentState::V2MultiBlock(state) => {
+                parts.storage = Some(Storage::MultiBlock(state.device_graph()));
+            }
+            HvfNativeSnapshotDocumentState::V2Storage(state) => {
+                parts.storage = Some(Storage::Storage(state.device_graph()));
+            }
+            HvfNativeSnapshotDocumentState::V2Serial(state) => {
+                parts.storage = state.device_graph().map(Storage::Storage);
+                parts.serial = Some(product::Serial(state.serial()));
+            }
+            HvfNativeSnapshotDocumentState::V2Entropy(state) => {
+                parts.storage = state.device_graph().map(Storage::Storage);
+                parts.serial = Some(product::Serial(state.serial()));
+                parts.entropy = state.entropy().map(product::Entropy);
+            }
+            HvfNativeSnapshotDocumentState::V2Balloon(state) => {
+                parts.storage = state.device_graph().map(Storage::Storage);
+                parts.serial = Some(product::Serial(state.serial()));
+                parts.entropy = state.entropy().map(product::Entropy);
+                parts.balloon = state.balloon().map(product::Balloon);
+            }
+            HvfNativeSnapshotDocumentState::V2MemoryHotplug(state) => {
+                parts.storage = state.device_graph().map(Storage::Storage);
+                parts.serial = Some(product::Serial(state.serial()));
+                parts.entropy = state.entropy().map(product::Entropy);
+                parts.balloon = state.balloon().map(product::Balloon);
+                parts.memory_hotplug = state.memory_hotplug().map(product::MemoryHotplug);
+            }
+            HvfNativeSnapshotDocumentState::V2Network(state) => {
+                parts.storage = state.device_graph().map(Storage::Storage);
+                parts.serial = Some(product::Serial(state.serial()));
+                parts.entropy = state.entropy().map(product::Entropy);
+                parts.balloon = state.balloon().map(product::Balloon);
+                parts.memory_hotplug = state.memory_hotplug().map(product::MemoryHotplug);
+                parts.network = state.network().map(product::Network);
+            }
+            HvfNativeSnapshotDocumentState::V2Vsock(state) => {
+                parts.storage = state.device_graph().map(Storage::Storage);
+                parts.serial = Some(product::Serial(state.serial()));
+                parts.entropy = state.entropy().map(product::Entropy);
+                parts.balloon = state.balloon().map(product::Balloon);
+                parts.memory_hotplug = state.memory_hotplug().map(product::MemoryHotplug);
+                parts.network = state.network().map(product::Network);
+                parts.vsock = state.vsock().map(product::Vsock);
+            }
+            HvfNativeSnapshotDocumentState::V2Diff(state) => {
+                parts.storage = state.device_graph().map(Storage::Storage);
+                parts.serial = Some(product::Serial(state.serial()));
+                parts.entropy = state.entropy().map(product::Entropy);
+                parts.balloon = state.balloon().map(product::Balloon);
+                parts.memory_hotplug = state.memory_hotplug().map(product::MemoryHotplug);
+                parts.network = state.network().map(product::Network);
+                parts.vsock = state.vsock().map(product::Vsock);
+            }
+        }
+        parts
+    }
+}
+
+enum Storage<'a> {
+    MultiBlock(&'a bangbang_runtime::snapshot_device_v2_5::SnapshotV2MultiBlockDeviceGraph),
+    Storage(&'a bangbang_runtime::snapshot_device_v2_6::SnapshotV2StorageDeviceGraph),
+}
+
+impl Serialize for Storage<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::MultiBlock(graph) => storage::MultiBlockGraph(graph).serialize(serializer),
+            Self::Storage(graph) => storage::StorageGraph(graph).serialize(serializer),
+        }
+    }
+}
+
+pub(super) struct Diff<'a>(pub(super) &'a HvfNativeSnapshotDocument);
+
+impl Serialize for Diff<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match &self.0.state {
+            HvfNativeSnapshotDocumentState::V2Diff(state) => {
+                diff::DiffLayer(state.layer()).serialize(serializer)
+            }
+            HvfNativeSnapshotDocumentState::V1(_)
+            | HvfNativeSnapshotDocumentState::V2LegacyPlatform(_)
+            | HvfNativeSnapshotDocumentState::V2DeviceGraph(_)
+            | HvfNativeSnapshotDocumentState::V2MultiBlock(_)
+            | HvfNativeSnapshotDocumentState::V2Storage(_)
+            | HvfNativeSnapshotDocumentState::V2Serial(_)
+            | HvfNativeSnapshotDocumentState::V2Entropy(_)
+            | HvfNativeSnapshotDocumentState::V2Balloon(_)
+            | HvfNativeSnapshotDocumentState::V2MemoryHotplug(_)
+            | HvfNativeSnapshotDocumentState::V2Network(_)
+            | HvfNativeSnapshotDocumentState::V2Vsock(_) => serializer.serialize_none(),
+        }
+    }
+}

--- a/crates/hvf/src/snapshot_document/inspection/devices/diff.rs
+++ b/crates/hvf/src/snapshot_document/inspection/devices/diff.rs
@@ -1,0 +1,109 @@
+use bangbang_runtime::snapshot_diff_v2_13::{
+    SnapshotV2DiffBase, SnapshotV2DiffDataExtent, SnapshotV2DiffLayerBinding,
+};
+use serde::Serialize;
+use serde::ser::{SerializeSeq, SerializeStruct};
+
+use super::super::common::{GuestRange, V2Memory, Version};
+use super::super::fingerprint::FingerprintBuilder;
+
+pub(super) struct DiffLayer<'a>(pub(super) &'a SnapshotV2DiffLayerBinding);
+
+impl Serialize for DiffLayer<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut integrity = FingerprintBuilder::new("diff.layer.metadata-integrity");
+        integrity.u64(value.metadata_checksum());
+
+        let mut state = serializer.serialize_struct("DiffLayer", 11)?;
+        state.serialize_field("compatibility", "v2.13")?;
+        state.serialize_field("version", &Version(value.version()))?;
+        state.serialize_field("base", &DiffBase(value.base()))?;
+        state.serialize_field("result", &V2Memory(value.result()))?;
+        state.serialize_field("extent_count", &value.data_extents().len())?;
+        state.serialize_field("data_extents", &DiffExtents(value.data_extents()))?;
+        state.serialize_field("metadata_length", &value.metadata_length())?;
+        state.serialize_field("data_offset", &value.data_offset())?;
+        state.serialize_field("file_length", &value.file_length())?;
+        state.serialize_field("metadata_integrity", &integrity.finish())?;
+        state.serialize_field(
+            "relationship",
+            &DiffRelationship {
+                base_is_image: value.base().binding().is_some(),
+            },
+        )?;
+        state.end()
+    }
+}
+
+struct DiffBase<'a>(&'a SnapshotV2DiffBase);
+
+impl Serialize for DiffBase<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("DiffBase", 2)?;
+        match self.0 {
+            SnapshotV2DiffBase::Zero => {
+                state.serialize_field("kind", "zero")?;
+                state.serialize_field("binding", &Option::<u8>::None)?;
+            }
+            SnapshotV2DiffBase::Image(binding) => {
+                state.serialize_field("kind", "image")?;
+                state.serialize_field("binding", &V2Memory(binding))?;
+            }
+        }
+        state.end()
+    }
+}
+
+struct DiffExtents<'a>(&'a [SnapshotV2DiffDataExtent]);
+
+impl Serialize for DiffExtents<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for extent in self.0 {
+            sequence.serialize_element(&DiffExtent(*extent))?;
+        }
+        sequence.end()
+    }
+}
+
+struct DiffExtent(SnapshotV2DiffDataExtent);
+
+impl Serialize for DiffExtent {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("DiffExtent", 2)?;
+        state.serialize_field("range", &GuestRange(self.0.range()))?;
+        state.serialize_field("file_offset", &self.0.file_offset())?;
+        state.end()
+    }
+}
+
+struct DiffRelationship {
+    base_is_image: bool,
+}
+
+impl Serialize for DiffRelationship {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("DiffRelationship", 4)?;
+        state.serialize_field("base_is_image", &self.base_is_image)?;
+        state.serialize_field("base_and_result_are_distinct", &true)?;
+        state.serialize_field("result_matches_vm_memory", &true)?;
+        state.serialize_field("omitted_bytes_inherit_base", &true)?;
+        state.end()
+    }
+}

--- a/crates/hvf/src/snapshot_document/inspection/devices/product.rs
+++ b/crates/hvf/src/snapshot_document/inspection/devices/product.rs
@@ -1,0 +1,984 @@
+use std::fmt;
+
+use bangbang_runtime::entropy::EntropyConfig;
+use bangbang_runtime::network::{
+    GuestMacAddress, NetworkDeviceProfile, VirtioNetworkFeatureCapabilities,
+    VirtioNetworkPacketEnvelope,
+};
+use bangbang_runtime::serial::SerialMmioCaptureState;
+use bangbang_runtime::snapshot_balloon_v2_9::{
+    SnapshotV2BalloonAccountingState, SnapshotV2BalloonActiveQueuesState,
+    SnapshotV2BalloonContinuationState, SnapshotV2BalloonHintState, SnapshotV2BalloonPfnRange,
+    SnapshotV2BalloonQueueState, SnapshotV2BalloonState, SnapshotV2BalloonStatistics,
+};
+use bangbang_runtime::snapshot_entropy_v2_8::{
+    SnapshotV2EntropyBucketState, SnapshotV2EntropyLimiterState, SnapshotV2EntropyQueueState,
+    SnapshotV2EntropyRetryState, SnapshotV2EntropyState,
+};
+use bangbang_runtime::snapshot_memory_hotplug_v2_10::{
+    SnapshotV2MemoryHotplugPluggedRange, SnapshotV2MemoryHotplugQueueState,
+    SnapshotV2MemoryHotplugState,
+};
+use bangbang_runtime::snapshot_network_v2_11::{
+    SnapshotV2MmdsInterfaceState, SnapshotV2MmdsState, SnapshotV2NetworkBackendClass,
+    SnapshotV2NetworkInterfaceState, SnapshotV2NetworkLimiterState, SnapshotV2NetworkLocalState,
+    SnapshotV2NetworkQueueState, SnapshotV2NetworkRetryState, SnapshotV2NetworkState,
+    SnapshotV2NetworkTokenBucketState,
+};
+use bangbang_runtime::snapshot_serial_v2_7::{
+    SnapshotV2SerialEndpointIntent, SnapshotV2SerialState,
+};
+use bangbang_runtime::snapshot_vsock_v2_12::{
+    SnapshotV2VsockActiveQueuesState, SnapshotV2VsockQueueState, SnapshotV2VsockState,
+};
+use serde::Serialize;
+use serde::ser::{SerializeSeq, SerializeStruct};
+
+use super::super::fingerprint::{HexU8, HexU64, Redacted, RedactedOption, confidential_bytes};
+use super::shared::{EntropyRateConfig, SerialRateConfig, SerialRegisters, Transport, Virtio};
+
+pub(super) struct Serial<'a>(pub(super) &'a SnapshotV2SerialState);
+
+impl Serialize for Serial<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("SerialState", 4)?;
+        state.serialize_field("compatibility", "v2.7")?;
+        state.serialize_field("endpoint", &SerialEndpoint(value.endpoint_intent()))?;
+        state.serialize_field("rate_limiter", &SerialRateConfig(value.rate_limiter()))?;
+        state.serialize_field("device", &SerialDevice(value.device()))?;
+        state.end()
+    }
+}
+
+struct SerialEndpoint<'a>(&'a SnapshotV2SerialEndpointIntent);
+
+impl Serialize for SerialEndpoint<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let configured = self.0.configured_selector().is_some();
+        let kind = if configured {
+            "configured-output"
+        } else {
+            "default-process-stdio"
+        };
+        let mut state = serializer.serialize_struct("SerialEndpointIntent", 3)?;
+        state.serialize_field("kind", kind)?;
+        state.serialize_field("selector", &RedactedOption(configured))?;
+        state.serialize_field("process_authority", &RedactedOption(!configured))?;
+        state.end()
+    }
+}
+
+struct SerialDevice<'a>(&'a SerialMmioCaptureState);
+
+impl Serialize for SerialDevice<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let receive = value.receive_bytes();
+        let mut state = serializer.serialize_struct("SerialDevice", 8)?;
+        state.serialize_field("registers", &SerialRegisters(value.legacy_state()))?;
+        state.serialize_field(
+            "interrupt_identification",
+            &HexU8(value.interrupt_identification()),
+        )?;
+        state.serialize_field("line_status", &HexU8(value.line_status()))?;
+        state.serialize_field("modem_status", &HexU8(value.modem_status()))?;
+        state.serialize_field("receive_byte_count", &receive.len())?;
+        state.serialize_field(
+            "receive_bytes",
+            &confidential_bytes("devices.serial.receive-buffer", receive),
+        )?;
+        state.serialize_field(
+            "receive_interrupt_intent_pending",
+            &value.receive_interrupt_intent_pending(),
+        )?;
+        state.serialize_field(
+            "input_ready_intent_pending",
+            &value.input_ready_intent_pending(),
+        )?;
+        state.end()
+    }
+}
+
+pub(super) struct Entropy<'a>(pub(super) &'a SnapshotV2EntropyState);
+
+impl Serialize for Entropy<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("EntropyState", 9)?;
+        state.serialize_field("compatibility", "v2.8")?;
+        state.serialize_field("config", &EntropyConfiguration(value.config()))?;
+        state.serialize_field("active_queue", &EntropyQueue(value.active_queue()))?;
+        state.serialize_field("limiter", &EntropyLimiter(value.limiter()))?;
+        state.serialize_field("retry", &EntropyRetry(value.retry()))?;
+        state.serialize_field("pending_work", &value.has_pending_work())?;
+        state.serialize_field("virtio", &Virtio(value.virtio()))?;
+        state.serialize_field("transport", &Transport(value.transport()))?;
+        state.serialize_field("entropy_source_authority", &Redacted)?;
+        state.end()
+    }
+}
+
+struct EntropyConfiguration(EntropyConfig);
+
+impl Serialize for EntropyConfiguration {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("EntropyConfiguration", 1)?;
+        state.serialize_field("rate_limiter", &EntropyRateConfig(self.0.rate_limiter()))?;
+        state.end()
+    }
+}
+
+struct EntropyQueue(Option<SnapshotV2EntropyQueueState>);
+
+impl Serialize for EntropyQueue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(value) = self.0 else {
+            return serializer.serialize_none();
+        };
+        let mut state = serializer.serialize_struct("EntropyQueue", 3)?;
+        state.serialize_field("next_available", &value.next_available())?;
+        state.serialize_field("next_used", &value.next_used())?;
+        state.serialize_field("outstanding", &value.outstanding())?;
+        state.end()
+    }
+}
+
+struct EntropyLimiter(SnapshotV2EntropyLimiterState);
+
+impl Serialize for EntropyLimiter {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("EntropyLimiter", 2)?;
+        state.serialize_field("bandwidth", &EntropyBucket(self.0.bandwidth()))?;
+        state.serialize_field("ops", &EntropyBucket(self.0.ops()))?;
+        state.end()
+    }
+}
+
+struct EntropyBucket(Option<SnapshotV2EntropyBucketState>);
+
+impl Serialize for EntropyBucket {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(value) = self.0 else {
+            return serializer.serialize_none();
+        };
+        let mut state = serializer.serialize_struct("EntropyBucket", 3)?;
+        state.serialize_field("budget", &value.budget())?;
+        state.serialize_field("remaining_burst", &value.remaining_burst())?;
+        state.serialize_field("age_nanos", &value.age_nanos())?;
+        state.end()
+    }
+}
+
+struct EntropyRetry(SnapshotV2EntropyRetryState);
+
+impl Serialize for EntropyRetry {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let (disposition, remaining_nanos) = match self.0 {
+            SnapshotV2EntropyRetryState::None => ("none", None),
+            SnapshotV2EntropyRetryState::Immediate => ("immediate", None),
+            SnapshotV2EntropyRetryState::After { remaining_nanos } => {
+                ("after", Some(remaining_nanos))
+            }
+        };
+        let mut state = serializer.serialize_struct("EntropyRetry", 2)?;
+        state.serialize_field("disposition", disposition)?;
+        state.serialize_field("remaining_nanos", &remaining_nanos)?;
+        state.end()
+    }
+}
+
+pub(super) struct Balloon<'a>(pub(super) &'a SnapshotV2BalloonState);
+
+impl Serialize for Balloon<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let config = value.config();
+        let config_space = value.config_space();
+        let mut state = serializer.serialize_struct("BalloonState", 8)?;
+        state.serialize_field("compatibility", "v2.9")?;
+        state.serialize_field("config", &BalloonConfigView(config))?;
+        state.serialize_field("config_space", &BalloonConfigSpace(config_space))?;
+        state.serialize_field("continuation", &BalloonContinuation(value.continuation()))?;
+        state.serialize_field("accounting", &BalloonAccounting(value.accounting()))?;
+        state.serialize_field("virtio", &Virtio(value.virtio()))?;
+        state.serialize_field("transport", &Transport(value.transport()))?;
+        state.serialize_field("host_reclaim_authority", &Redacted)?;
+        state.end()
+    }
+}
+
+struct BalloonConfigView(bangbang_runtime::balloon::BalloonConfig);
+
+impl Serialize for BalloonConfigView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("BalloonConfig", 5)?;
+        state.serialize_field("amount_mib", &value.amount_mib())?;
+        state.serialize_field("deflate_on_oom", &value.deflate_on_oom())?;
+        state.serialize_field(
+            "stats_polling_interval_s",
+            &value.stats_polling_interval_s(),
+        )?;
+        state.serialize_field("free_page_hinting", &value.free_page_hinting())?;
+        state.serialize_field("free_page_reporting", &value.free_page_reporting())?;
+        state.end()
+    }
+}
+
+struct BalloonConfigSpace(bangbang_runtime::balloon::VirtioBalloonConfigSpace);
+
+impl Serialize for BalloonConfigSpace {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("BalloonConfigSpace", 3)?;
+        state.serialize_field("num_pages", &value.num_pages())?;
+        state.serialize_field("actual_pages", &value.actual_pages())?;
+        state.serialize_field("free_page_hint_cmd_id", &value.free_page_hint_cmd_id())?;
+        state.end()
+    }
+}
+
+struct BalloonContinuation<'a>(&'a SnapshotV2BalloonContinuationState);
+
+impl Serialize for BalloonContinuation<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("BalloonContinuation", 5)?;
+        state.serialize_field("active_queues", &BalloonActiveQueues(value.active_queues()))?;
+        state.serialize_field(
+            "stats_polling_interval_s",
+            &value.stats_polling_interval_s(),
+        )?;
+        state.serialize_field("statistics", &BalloonStatistics(value.statistics()))?;
+        state.serialize_field(
+            "statistics_pending_descriptor_head",
+            &value.statistics_pending_descriptor_head(),
+        )?;
+        state.serialize_field("hinting", &BalloonHint(value.hinting()))?;
+        state.end()
+    }
+}
+
+struct BalloonActiveQueues(Option<SnapshotV2BalloonActiveQueuesState>);
+
+impl Serialize for BalloonActiveQueues {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(value) = self.0 else {
+            return serializer.serialize_none();
+        };
+        let mut state = serializer.serialize_struct("BalloonActiveQueues", 5)?;
+        state.serialize_field("inflate", &BalloonQueue(value.inflate()))?;
+        state.serialize_field("deflate", &BalloonQueue(value.deflate()))?;
+        state.serialize_field("statistics", &OptionalBalloonQueue(value.statistics()))?;
+        state.serialize_field(
+            "free_page_hinting",
+            &OptionalBalloonQueue(value.free_page_hinting()),
+        )?;
+        state.serialize_field(
+            "free_page_reporting",
+            &OptionalBalloonQueue(value.free_page_reporting()),
+        )?;
+        state.end()
+    }
+}
+
+struct BalloonQueue(SnapshotV2BalloonQueueState);
+
+impl Serialize for BalloonQueue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("BalloonQueue", 3)?;
+        state.serialize_field("next_available", &self.0.next_available())?;
+        state.serialize_field("next_used", &self.0.next_used())?;
+        state.serialize_field("outstanding", &self.0.outstanding())?;
+        state.end()
+    }
+}
+
+struct OptionalBalloonQueue(Option<SnapshotV2BalloonQueueState>);
+
+impl Serialize for OptionalBalloonQueue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.0 {
+            Some(value) => BalloonQueue(value).serialize(serializer),
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+struct BalloonStatistics(SnapshotV2BalloonStatistics);
+
+impl Serialize for BalloonStatistics {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let values = self.0.values();
+        let mut state = serializer.serialize_struct("BalloonStatistics", 16)?;
+        state.serialize_field("swap_in", &values[0])?;
+        state.serialize_field("swap_out", &values[1])?;
+        state.serialize_field("major_faults", &values[2])?;
+        state.serialize_field("minor_faults", &values[3])?;
+        state.serialize_field("free_memory", &values[4])?;
+        state.serialize_field("total_memory", &values[5])?;
+        state.serialize_field("available_memory", &values[6])?;
+        state.serialize_field("disk_caches", &values[7])?;
+        state.serialize_field("hugetlb_allocations", &values[8])?;
+        state.serialize_field("hugetlb_failures", &values[9])?;
+        state.serialize_field("oom_kill", &values[10])?;
+        state.serialize_field("alloc_stall", &values[11])?;
+        state.serialize_field("async_scan", &values[12])?;
+        state.serialize_field("direct_scan", &values[13])?;
+        state.serialize_field("async_reclaim", &values[14])?;
+        state.serialize_field("direct_reclaim", &values[15])?;
+        state.end()
+    }
+}
+
+struct BalloonHint(SnapshotV2BalloonHintState);
+
+impl Serialize for BalloonHint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("BalloonHint", 4)?;
+        state.serialize_field("host_cmd", &self.0.host_cmd())?;
+        state.serialize_field("guest_cmd", &self.0.guest_cmd())?;
+        state.serialize_field("last_cmd", &self.0.last_cmd())?;
+        state.serialize_field("acknowledge_on_stop", &self.0.acknowledge_on_stop())?;
+        state.end()
+    }
+}
+
+struct BalloonAccounting<'a>(&'a SnapshotV2BalloonAccountingState);
+
+impl Serialize for BalloonAccounting<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("BalloonAccounting", 3)?;
+        state.serialize_field("inflated_page_count", &self.0.inflated_page_count())?;
+        state.serialize_field("range_count", &self.0.ranges().len())?;
+        state.serialize_field("ranges", &BalloonRanges(self.0.ranges()))?;
+        state.end()
+    }
+}
+
+struct BalloonRanges<'a>(&'a [SnapshotV2BalloonPfnRange]);
+
+impl Serialize for BalloonRanges<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for range in self.0 {
+            sequence.serialize_element(&BalloonRange(*range))?;
+        }
+        sequence.end()
+    }
+}
+
+struct BalloonRange(SnapshotV2BalloonPfnRange);
+
+impl Serialize for BalloonRange {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("BalloonRange", 2)?;
+        state.serialize_field("start_pfn", &self.0.start_pfn())?;
+        state.serialize_field("page_count", &self.0.page_count())?;
+        state.end()
+    }
+}
+
+pub(super) struct MemoryHotplug<'a>(pub(super) &'a SnapshotV2MemoryHotplugState);
+
+impl Serialize for MemoryHotplug<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let config = value.config();
+        let config_space = value.config_space();
+        let bitmap = value.plugged_bitmap();
+        let ranges = value.plugged_ranges();
+        let configured_block_count = config_space
+            .region_size()
+            .checked_div(config_space.block_size());
+        let mut state = serializer.serialize_struct("MemoryHotplugState", 11)?;
+        state.serialize_field("compatibility", "v2.10")?;
+        state.serialize_field("config", &MemoryHotplugConfig(config))?;
+        state.serialize_field("config_space", &MemoryHotplugConfigSpace(config_space))?;
+        state.serialize_field("active_queue", &MemoryHotplugQueue(value.active_queue()))?;
+        state.serialize_field("configured_block_count", &configured_block_count)?;
+        state.serialize_field("plugged_range_count", &ranges.len())?;
+        state.serialize_field(
+            "plugged_ranges",
+            &MemoryHotplugRanges(value.plugged_ranges()),
+        )?;
+        state.serialize_field("plugged_bitmap_byte_count", &bitmap.len())?;
+        state.serialize_field(
+            "plugged_bitmap",
+            &confidential_bytes("devices.memory-hotplug.plugged-bitmap", bitmap),
+        )?;
+        state.serialize_field("virtio", &Virtio(value.virtio()))?;
+        state.serialize_field("transport", &Transport(value.transport()))?;
+        state.end()
+    }
+}
+
+struct MemoryHotplugConfig(bangbang_runtime::memory_hotplug::MemoryHotplugConfig);
+
+impl Serialize for MemoryHotplugConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("MemoryHotplugConfig", 3)?;
+        state.serialize_field("total_size_mib", &value.total_size_mib())?;
+        state.serialize_field("block_size_mib", &value.block_size_mib())?;
+        state.serialize_field("slot_size_mib", &value.slot_size_mib())?;
+        state.end()
+    }
+}
+
+struct MemoryHotplugConfigSpace(bangbang_runtime::memory_hotplug::VirtioMemConfigSpace);
+
+impl Serialize for MemoryHotplugConfigSpace {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("MemoryHotplugConfigSpace", 7)?;
+        state.serialize_field("block_size", &value.block_size())?;
+        state.serialize_field("node_id", &value.node_id())?;
+        state.serialize_field("address", &HexU64(value.addr()))?;
+        state.serialize_field("region_size", &value.region_size())?;
+        state.serialize_field("usable_region_size", &value.usable_region_size())?;
+        state.serialize_field("plugged_size", &value.plugged_size())?;
+        state.serialize_field("requested_size", &value.requested_size())?;
+        state.end()
+    }
+}
+
+struct MemoryHotplugQueue(Option<SnapshotV2MemoryHotplugQueueState>);
+
+impl Serialize for MemoryHotplugQueue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(value) = self.0 else {
+            return serializer.serialize_none();
+        };
+        let mut state = serializer.serialize_struct("MemoryHotplugQueue", 2)?;
+        state.serialize_field("next_available", &value.next_available())?;
+        state.serialize_field("next_used", &value.next_used())?;
+        state.end()
+    }
+}
+
+struct MemoryHotplugRanges<'a>(
+    bangbang_runtime::snapshot_memory_hotplug_v2_10::SnapshotV2MemoryHotplugPluggedRanges<'a>,
+);
+
+impl Serialize for MemoryHotplugRanges<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let ranges = self.0.clone();
+        let mut sequence = serializer.serialize_seq(Some(ranges.len()))?;
+        for range in ranges {
+            sequence.serialize_element(&MemoryHotplugRange(range))?;
+        }
+        sequence.end()
+    }
+}
+
+struct MemoryHotplugRange(SnapshotV2MemoryHotplugPluggedRange);
+
+impl Serialize for MemoryHotplugRange {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("MemoryHotplugRange", 2)?;
+        state.serialize_field("start_block", &self.0.start_block())?;
+        state.serialize_field("block_count", &self.0.block_count())?;
+        state.end()
+    }
+}
+
+pub(super) struct Network<'a>(pub(super) &'a SnapshotV2NetworkState);
+
+impl Serialize for Network<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("NetworkState", 4)?;
+        state.serialize_field("compatibility", "v2.11")?;
+        state.serialize_field("interface_count", &value.interfaces().len())?;
+        state.serialize_field("interfaces", &NetworkInterfaces(value.interfaces()))?;
+        state.serialize_field("mmds", &OptionalMmds(value.mmds()))?;
+        state.end()
+    }
+}
+
+struct NetworkInterfaces<'a>(&'a [SnapshotV2NetworkInterfaceState]);
+
+impl Serialize for NetworkInterfaces<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for (index, interface) in self.0.iter().enumerate() {
+            sequence.serialize_element(&NetworkInterface { index, interface })?;
+        }
+        sequence.end()
+    }
+}
+
+struct NetworkInterface<'a> {
+    index: usize,
+    interface: &'a SnapshotV2NetworkInterfaceState,
+}
+
+impl Serialize for NetworkInterface<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.interface;
+        let mut state = serializer.serialize_struct("NetworkInterface", 13)?;
+        state.serialize_field("index", &self.index)?;
+        state.serialize_field("iface_id", value.iface_id())?;
+        state.serialize_field("captured_selector", &Redacted)?;
+        state.serialize_field(
+            "requested_guest_mac",
+            &OptionalGuestMac(value.requested_guest_mac()),
+        )?;
+        state.serialize_field("requested_mtu", &value.requested_mtu())?;
+        state.serialize_field("profile", &NetworkProfile(value.profile()))?;
+        state.serialize_field("backend", &NetworkBackend(value.backend()))?;
+        state.serialize_field("local", &NetworkLocal(value.local()))?;
+        state.serialize_field("virtio", &Virtio(value.virtio()))?;
+        state.serialize_field("rx_limiter", &NetworkLimiter(value.rx_limiter()))?;
+        state.serialize_field("tx_limiter", &NetworkLimiter(value.tx_limiter()))?;
+        state.serialize_field("transport", &Transport(value.transport()))?;
+        state.serialize_field("packet_io_authority", &Redacted)?;
+        state.end()
+    }
+}
+
+struct OptionalGuestMac(Option<GuestMacAddress>);
+
+impl Serialize for OptionalGuestMac {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.0 {
+            Some(value) => serializer.collect_str(&value),
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+struct NetworkProfile(NetworkDeviceProfile);
+
+impl Serialize for NetworkProfile {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("NetworkProfile", 4)?;
+        state.serialize_field("guest_mac", &OptionalGuestMac(value.guest_mac()))?;
+        state.serialize_field("mtu", &value.mtu())?;
+        state.serialize_field("packet_envelope", &PacketEnvelope(value.packet_envelope()))?;
+        state.serialize_field(
+            "feature_capabilities",
+            &NetworkFeatures(value.feature_capabilities()),
+        )?;
+        state.end()
+    }
+}
+
+struct PacketEnvelope(VirtioNetworkPacketEnvelope);
+
+impl Serialize for PacketEnvelope {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(match self.0 {
+            VirtioNetworkPacketEnvelope::RawEthernet => "raw-ethernet",
+            VirtioNetworkPacketEnvelope::DirectVirtioHeader => "direct-virtio-header",
+        })
+    }
+}
+
+struct NetworkFeatures(VirtioNetworkFeatureCapabilities);
+
+impl Serialize for NetworkFeatures {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("NetworkFeatures", 10)?;
+        state.serialize_field("checksum", &value.checksum())?;
+        state.serialize_field("guest_checksum", &value.guest_checksum())?;
+        state.serialize_field("guest_tso4", &value.guest_tso4())?;
+        state.serialize_field("guest_tso6", &value.guest_tso6())?;
+        state.serialize_field("guest_ufo", &value.guest_ufo())?;
+        state.serialize_field("host_tso4", &value.host_tso4())?;
+        state.serialize_field("host_tso6", &value.host_tso6())?;
+        state.serialize_field("host_ufo", &value.host_ufo())?;
+        state.serialize_field("merged_rx_buffers", &value.merged_rx_buffers())?;
+        state.serialize_field("feature_bits", &HexU64(value.feature_bits()))?;
+        state.end()
+    }
+}
+
+struct NetworkBackend(SnapshotV2NetworkBackendClass);
+
+impl Serialize for NetworkBackend {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(match self.0 {
+            SnapshotV2NetworkBackendClass::MmdsOnly => "mmds-only",
+            SnapshotV2NetworkBackendClass::Vmnet => "vmnet",
+        })
+    }
+}
+
+struct NetworkLocal<'a>(&'a SnapshotV2NetworkLocalState);
+
+impl Serialize for NetworkLocal<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("NetworkLocal", 3)?;
+        state.serialize_field("active_rx_queue", &NetworkQueue(self.0.active_rx_queue()))?;
+        state.serialize_field("active_tx_queue", &NetworkQueue(self.0.active_tx_queue()))?;
+        state.serialize_field("tx_retry", &NetworkRetry(self.0.tx_retry()))?;
+        state.end()
+    }
+}
+
+struct NetworkQueue(Option<SnapshotV2NetworkQueueState>);
+
+impl Serialize for NetworkQueue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(value) = self.0 else {
+            return serializer.serialize_none();
+        };
+        let mut state = serializer.serialize_struct("NetworkQueue", 2)?;
+        state.serialize_field("next_available", &value.next_available())?;
+        state.serialize_field("next_used", &value.next_used())?;
+        state.end()
+    }
+}
+
+struct NetworkRetry(SnapshotV2NetworkRetryState);
+
+impl Serialize for NetworkRetry {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let (disposition, remaining_nanos) = match self.0 {
+            SnapshotV2NetworkRetryState::None => ("none", None),
+            SnapshotV2NetworkRetryState::Immediate => ("immediate", None),
+            SnapshotV2NetworkRetryState::After { remaining_nanos } => {
+                ("after", Some(remaining_nanos))
+            }
+        };
+        let mut state = serializer.serialize_struct("NetworkRetry", 2)?;
+        state.serialize_field("disposition", disposition)?;
+        state.serialize_field("remaining_nanos", &remaining_nanos)?;
+        state.end()
+    }
+}
+
+struct NetworkLimiter(SnapshotV2NetworkLimiterState);
+
+impl Serialize for NetworkLimiter {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("NetworkLimiter", 2)?;
+        state.serialize_field("bandwidth", &NetworkBucket(self.0.bandwidth()))?;
+        state.serialize_field("ops", &NetworkBucket(self.0.ops()))?;
+        state.end()
+    }
+}
+
+struct NetworkBucket(Option<SnapshotV2NetworkTokenBucketState>);
+
+impl Serialize for NetworkBucket {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(value) = self.0 else {
+            return serializer.serialize_none();
+        };
+        let mut state = serializer.serialize_struct("NetworkBucket", 6)?;
+        state.serialize_field("size", &value.size())?;
+        state.serialize_field("configured_burst", &value.configured_burst())?;
+        state.serialize_field("refill_time_millis", &value.refill_time_millis())?;
+        state.serialize_field("budget", &value.budget())?;
+        state.serialize_field("remaining_burst", &value.remaining_burst())?;
+        state.serialize_field("age_nanos", &value.age_nanos())?;
+        state.end()
+    }
+}
+
+struct OptionalMmds<'a>(Option<&'a SnapshotV2MmdsState>);
+
+impl Serialize for OptionalMmds<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.0 {
+            Some(value) => Mmds(value).serialize(serializer),
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+struct Mmds<'a>(&'a SnapshotV2MmdsState);
+
+impl Serialize for Mmds<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("Mmds", 6)?;
+        state.serialize_field("version", &MmdsVersion(value.version()))?;
+        state.serialize_field("ipv4_address", &OptionalIpv4(value.ipv4_address()))?;
+        state.serialize_field(
+            "effective_ipv4_address",
+            &Ipv4(value.effective_ipv4_address()),
+        )?;
+        state.serialize_field("imds_compat", &value.imds_compat())?;
+        state.serialize_field("interface_count", &value.interfaces().len())?;
+        state.serialize_field("interfaces", &MmdsInterfaces(value.interfaces()))?;
+        state.end()
+    }
+}
+
+struct MmdsVersion(bangbang_runtime::mmds::MmdsVersion);
+
+impl Serialize for MmdsVersion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(match self.0 {
+            bangbang_runtime::mmds::MmdsVersion::V1 => "v1",
+            bangbang_runtime::mmds::MmdsVersion::V2 => "v2",
+        })
+    }
+}
+
+struct OptionalIpv4(Option<std::net::Ipv4Addr>);
+
+impl Serialize for OptionalIpv4 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.0 {
+            Some(value) => serializer.collect_str(&value),
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+struct Ipv4(std::net::Ipv4Addr);
+
+impl Serialize for Ipv4 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(&self.0)
+    }
+}
+
+struct MmdsInterfaces<'a>(&'a [SnapshotV2MmdsInterfaceState]);
+
+impl Serialize for MmdsInterfaces<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for value in self.0 {
+            sequence.serialize_element(&MmdsInterface(*value))?;
+        }
+        sequence.end()
+    }
+}
+
+struct MmdsInterface(SnapshotV2MmdsInterfaceState);
+
+impl Serialize for MmdsInterface {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("MmdsInterface", 4)?;
+        state.serialize_field("interface_index", &self.0.interface_index())?;
+        state.serialize_field(
+            "local_mac_address",
+            &Mac(self.0.local_mac_address().octets()),
+        )?;
+        state.serialize_field("ipv4_address", &Ipv4(self.0.ipv4_address()))?;
+        state.serialize_field("tcp_port", &self.0.tcp_port())?;
+        state.end()
+    }
+}
+
+struct Mac([u8; 6]);
+
+impl fmt::Display for Mac {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let [a, b, c, d, e, f] = self.0;
+        write!(formatter, "{a:02x}:{b:02x}:{c:02x}:{d:02x}:{e:02x}:{f:02x}")
+    }
+}
+
+impl Serialize for Mac {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+pub(super) struct Vsock<'a>(pub(super) &'a SnapshotV2VsockState);
+
+impl Serialize for Vsock<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("VsockState", 8)?;
+        state.serialize_field("compatibility", "v2.12")?;
+        state.serialize_field("guest_cid", &value.guest_cid())?;
+        state.serialize_field("backend_selector", &Redacted)?;
+        state.serialize_field("host_local_port_cursor", &Redacted)?;
+        state.serialize_field("active_queues", &VsockActiveQueues(value.active_queues()))?;
+        state.serialize_field("virtio", &Virtio(value.virtio()))?;
+        state.serialize_field("transport", &Transport(value.transport()))?;
+        state.serialize_field("socket_authority", &Redacted)?;
+        state.end()
+    }
+}
+
+struct VsockActiveQueues(Option<SnapshotV2VsockActiveQueuesState>);
+
+impl Serialize for VsockActiveQueues {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(value) = self.0 else {
+            return serializer.serialize_none();
+        };
+        let mut state = serializer.serialize_struct("VsockActiveQueues", 3)?;
+        state.serialize_field("rx", &VsockQueue(value.rx()))?;
+        state.serialize_field("tx", &VsockQueue(value.tx()))?;
+        state.serialize_field("event", &VsockQueue(value.event()))?;
+        state.end()
+    }
+}
+
+struct VsockQueue(SnapshotV2VsockQueueState);
+
+impl Serialize for VsockQueue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("VsockQueue", 3)?;
+        state.serialize_field("next_available", &self.0.next_available())?;
+        state.serialize_field("next_used", &self.0.next_used())?;
+        state.serialize_field("event_idx_enabled", &self.0.event_idx_enabled())?;
+        state.end()
+    }
+}

--- a/crates/hvf/src/snapshot_document/inspection/devices/shared.rs
+++ b/crates/hvf/src/snapshot_document/inspection/devices/shared.rs
@@ -1,0 +1,919 @@
+use bangbang_runtime::block::{
+    DriveCacheType, DriveIoEngine, DriveRateLimiterConfig, DriveTokenBucketConfig,
+    VirtioBlockQueueState, VirtioBlockRateLimiterState, VirtioBlockTokenBucketState,
+};
+use bangbang_runtime::entropy::{EntropyRateLimiterConfig, EntropyTokenBucketConfig};
+use bangbang_runtime::interrupt::DeviceInterruptStatus;
+use bangbang_runtime::mmio::MmioRegion;
+use bangbang_runtime::pci::{PciBarAddressSpace, PciBarPrefetchable, PciSbdf};
+use bangbang_runtime::pmem::{PmemRateLimiterConfig, PmemTokenBucketConfig, VirtioPmemQueueState};
+use bangbang_runtime::serial::{SerialMmioState, SerialRateLimiterConfig};
+use bangbang_runtime::snapshot_device_v2::{
+    SnapshotV2BlockBucketState, SnapshotV2BlockLimiterState, SnapshotV2DeviceKey,
+    SnapshotV2DeviceTransport, SnapshotV2DeviceTransportKind, SnapshotV2InterruptIntent,
+    SnapshotV2MmioDeviceState, SnapshotV2PciBarProbeState, SnapshotV2PciDeviceState,
+    SnapshotV2PciMsixState, SnapshotV2PciMsixTableEntry, SnapshotV2PciWritableByte,
+    SnapshotV2VirtioQueueState, SnapshotV2VirtioState,
+};
+use bangbang_runtime::snapshot_device_v2_6::{
+    SnapshotV2PmemBucketState, SnapshotV2PmemLimiterState,
+};
+use bangbang_runtime::storage_capture::{StorageDeviceOrigin, StorageRetryState};
+use bangbang_runtime::virtio_mmio::{
+    VirtioMmioDeviceRegisters, VirtioMmioQueueState, VirtioMmioTransportState,
+};
+use bangbang_runtime::virtio_pci::VirtioPciEndpointPhase;
+use serde::Serialize;
+use serde::ser::{SerializeSeq, SerializeStruct};
+
+use super::super::common::GuestRange;
+use super::super::fingerprint::{HexU8, HexU32, HexU64};
+
+pub(super) struct DeviceKey(pub(super) SnapshotV2DeviceKey);
+
+impl Serialize for DeviceKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("DeviceKey", 2)?;
+        state.serialize_field("kind", &self.0.kind())?;
+        state.serialize_field("instance", &self.0.instance())?;
+        state.end()
+    }
+}
+
+pub(super) struct OptionalDeviceKey(pub(super) Option<SnapshotV2DeviceKey>);
+
+impl Serialize for OptionalDeviceKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.0 {
+            Some(key) => DeviceKey(key).serialize(serializer),
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+pub(super) struct TransportKind(pub(super) SnapshotV2DeviceTransportKind);
+
+impl Serialize for TransportKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(match self.0 {
+            SnapshotV2DeviceTransportKind::Mmio => "mmio",
+            SnapshotV2DeviceTransportKind::Pci => "pci",
+        })
+    }
+}
+
+pub(super) struct MmioRegionView(pub(super) MmioRegion);
+
+impl Serialize for MmioRegionView {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("MmioRegion", 2)?;
+        state.serialize_field("id", &self.0.id().raw_value())?;
+        state.serialize_field("range", &GuestRange(self.0.range()))?;
+        state.end()
+    }
+}
+
+struct PciIdentity(PciSbdf);
+
+impl Serialize for PciIdentity {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("PciIdentity", 4)?;
+        state.serialize_field("segment", &self.0.segment())?;
+        state.serialize_field("bus", &self.0.bus())?;
+        state.serialize_field("device", &self.0.device())?;
+        state.serialize_field("function", &self.0.function())?;
+        state.end()
+    }
+}
+
+struct PciAddressSpace(PciBarAddressSpace);
+
+impl Serialize for PciAddressSpace {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(match self.0 {
+            PciBarAddressSpace::Memory32 => "memory-32",
+            PciBarAddressSpace::Memory64 => "memory-64",
+        })
+    }
+}
+
+struct PciPrefetchable(PciBarPrefetchable);
+
+impl Serialize for PciPrefetchable {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_bool(matches!(self.0, PciBarPrefetchable::Yes))
+    }
+}
+
+struct PciPhase(VirtioPciEndpointPhase);
+
+impl Serialize for PciPhase {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(match self.0 {
+            VirtioPciEndpointPhase::Active => "active",
+            VirtioPciEndpointPhase::Quiescing => "quiescing",
+            VirtioPciEndpointPhase::Released => "released",
+        })
+    }
+}
+
+struct Origin(StorageDeviceOrigin);
+
+impl Serialize for Origin {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(match self.0 {
+            StorageDeviceOrigin::Startup => "startup",
+            StorageDeviceOrigin::Runtime => "runtime",
+        })
+    }
+}
+
+pub(super) struct Retry(pub(super) StorageRetryState);
+
+impl Serialize for Retry {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let (disposition, remaining_nanos) = match self.0 {
+            StorageRetryState::None => ("none", None),
+            StorageRetryState::Immediate => ("immediate", None),
+            StorageRetryState::After { remaining_nanos } => ("after", Some(remaining_nanos)),
+        };
+        let mut state = serializer.serialize_struct("StorageRetry", 2)?;
+        state.serialize_field("disposition", disposition)?;
+        state.serialize_field("remaining_nanos", &remaining_nanos)?;
+        state.end()
+    }
+}
+
+pub(super) struct DriveCache(pub(super) DriveCacheType);
+
+impl Serialize for DriveCache {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(match self.0 {
+            DriveCacheType::Unsafe => "unsafe",
+            DriveCacheType::Writeback => "writeback",
+        })
+    }
+}
+
+pub(super) struct DriveEngine(pub(super) DriveIoEngine);
+
+impl Serialize for DriveEngine {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(match self.0 {
+            DriveIoEngine::Sync => "sync",
+            DriveIoEngine::Async => "async",
+        })
+    }
+}
+
+pub(super) struct Virtio<'a>(pub(super) &'a SnapshotV2VirtioState);
+
+impl Serialize for Virtio<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("VirtioState", 9)?;
+        state.serialize_field("available_features", &HexU64(value.available_features()))?;
+        state.serialize_field("driver_features", &HexU64(value.driver_features()))?;
+        state.serialize_field("config_generation", &value.config_generation())?;
+        state.serialize_field("status", &HexU32(value.status()))?;
+        state.serialize_field("activated", &value.is_activated())?;
+        state.serialize_field("queues", &VirtioQueues(value.queues()))?;
+        state.serialize_field("pending_notifications", &value.pending_notifications())?;
+        state.serialize_field(
+            "interrupt_intents",
+            &InterruptIntents(value.interrupt_intents()),
+        )?;
+        state.serialize_field("queue_count", &value.queues().len())?;
+        state.end()
+    }
+}
+
+struct VirtioQueues<'a>(&'a [SnapshotV2VirtioQueueState]);
+
+impl Serialize for VirtioQueues<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for (index, queue) in self.0.iter().enumerate() {
+            sequence.serialize_element(&VirtioQueue {
+                index,
+                queue: *queue,
+            })?;
+        }
+        sequence.end()
+    }
+}
+
+struct VirtioQueue {
+    index: usize,
+    queue: SnapshotV2VirtioQueueState,
+}
+
+impl Serialize for VirtioQueue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("VirtioQueue", 7)?;
+        state.serialize_field("index", &self.index)?;
+        state.serialize_field("max_size", &self.queue.max_size())?;
+        state.serialize_field("size", &self.queue.size())?;
+        state.serialize_field("ready", &self.queue.ready())?;
+        state.serialize_field(
+            "descriptor_table",
+            &HexU64(self.queue.descriptor_table().raw_value()),
+        )?;
+        state.serialize_field("driver_ring", &HexU64(self.queue.driver_ring().raw_value()))?;
+        state.serialize_field("device_ring", &HexU64(self.queue.device_ring().raw_value()))?;
+        state.end()
+    }
+}
+
+struct InterruptIntents<'a>(&'a [SnapshotV2InterruptIntent]);
+
+impl Serialize for InterruptIntents<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for intent in self.0 {
+            sequence.serialize_element(&InterruptIntent(*intent))?;
+        }
+        sequence.end()
+    }
+}
+
+struct InterruptIntent(SnapshotV2InterruptIntent);
+
+impl Serialize for InterruptIntent {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let (kind, queue_index) = match self.0 {
+            SnapshotV2InterruptIntent::Queue { queue_index } => ("queue", Some(queue_index)),
+            SnapshotV2InterruptIntent::Configuration => ("configuration", None),
+        };
+        let mut state = serializer.serialize_struct("InterruptIntent", 2)?;
+        state.serialize_field("kind", kind)?;
+        state.serialize_field("queue_index", &queue_index)?;
+        state.end()
+    }
+}
+
+pub(super) struct Transport<'a>(pub(super) &'a SnapshotV2DeviceTransport);
+
+impl Serialize for Transport<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.0 {
+            SnapshotV2DeviceTransport::Mmio(mmio) => MmioTransport(mmio).serialize(serializer),
+            SnapshotV2DeviceTransport::Pci(pci) => PciTransport(pci).serialize(serializer),
+        }
+    }
+}
+
+struct MmioTransport<'a>(&'a SnapshotV2MmioDeviceState);
+
+impl Serialize for MmioTransport<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("VirtioMmioTransport", 7)?;
+        state.serialize_field("kind", "mmio")?;
+        state.serialize_field("device_feature_select", &value.device_feature_select())?;
+        state.serialize_field("driver_feature_select", &value.driver_feature_select())?;
+        state.serialize_field("queue_select", &value.queue_select())?;
+        state.serialize_field("region", &MmioRegionView(value.region()))?;
+        state.serialize_field("interrupt_line", &value.interrupt_line().raw_value())?;
+        state.serialize_field("placement", "guest-visible")?;
+        state.end()
+    }
+}
+
+struct PciTransport<'a>(&'a SnapshotV2PciDeviceState);
+
+impl Serialize for PciTransport<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("VirtioPciTransport", 18)?;
+        state.serialize_field("kind", "pci")?;
+        state.serialize_field("phase", &PciPhase(value.phase()))?;
+        state.serialize_field("origin", &Origin(value.origin()))?;
+        state.serialize_field("sbdf", &PciIdentity(value.sbdf()))?;
+        state.serialize_field("bar_index", &value.bar_index())?;
+        state.serialize_field(
+            "bar_address_space",
+            &PciAddressSpace(value.bar_address_space()),
+        )?;
+        state.serialize_field(
+            "bar_prefetchable",
+            &PciPrefetchable(value.bar_prefetchable()),
+        )?;
+        state.serialize_field("bar_range", &GuestRange(value.bar_range()))?;
+        state.serialize_field("device_feature_select", &value.device_feature_select())?;
+        state.serialize_field("driver_feature_select", &value.driver_feature_select())?;
+        state.serialize_field("queue_select", &value.queue_select())?;
+        state.serialize_field("pci_cfg_bar", &value.pci_cfg_bar())?;
+        state.serialize_field("pci_cfg_offset", &value.pci_cfg_offset())?;
+        state.serialize_field("pci_cfg_length", &value.pci_cfg_length())?;
+        state.serialize_field("writable_bytes", &PciWritableBytes(value.writable_bytes()))?;
+        state.serialize_field("bar_probes", &PciBarProbes(value.bar_probes()))?;
+        state.serialize_field("msix", &PciMsix(value.msix()))?;
+        state.serialize_field("placement", "guest-visible")?;
+        state.end()
+    }
+}
+
+struct PciWritableBytes<'a>(&'a [SnapshotV2PciWritableByte]);
+
+impl Serialize for PciWritableBytes<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for byte in self.0 {
+            sequence.serialize_element(&PciWritableByte(*byte))?;
+        }
+        sequence.end()
+    }
+}
+
+struct PciWritableByte(SnapshotV2PciWritableByte);
+
+impl Serialize for PciWritableByte {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("PciWritableByte", 2)?;
+        state.serialize_field("offset", &self.0.offset())?;
+        state.serialize_field("value", &HexU8(self.0.value()))?;
+        state.end()
+    }
+}
+
+struct PciBarProbes<'a>(&'a [SnapshotV2PciBarProbeState]);
+
+impl Serialize for PciBarProbes<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for probe in self.0 {
+            sequence.serialize_element(&PciBarProbe(*probe))?;
+        }
+        sequence.end()
+    }
+}
+
+struct PciBarProbe(SnapshotV2PciBarProbeState);
+
+impl Serialize for PciBarProbe {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("PciBarProbe", 2)?;
+        state.serialize_field("index", &self.0.index())?;
+        state.serialize_field("pending", &self.0.pending())?;
+        state.end()
+    }
+}
+
+struct PciMsix<'a>(&'a SnapshotV2PciMsixState);
+
+impl Serialize for PciMsix<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("PciMsix", 8)?;
+        state.serialize_field("entries", &PciMsixEntries(value.entries()))?;
+        state.serialize_field("pending_words", &HexU64Values(value.pending_words()))?;
+        state.serialize_field("enabled", &value.enabled())?;
+        state.serialize_field("function_masked", &value.function_masked())?;
+        state.serialize_field("config_vector", &value.config_vector())?;
+        state.serialize_field("queue_vectors", &value.queue_vectors())?;
+        state.serialize_field(
+            "pending_transition_observed",
+            &value.pending_transition_observed(),
+        )?;
+        state.serialize_field("entry_count", &value.entries().len())?;
+        state.end()
+    }
+}
+
+struct PciMsixEntries<'a>(&'a [SnapshotV2PciMsixTableEntry]);
+
+impl Serialize for PciMsixEntries<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for entry in self.0 {
+            sequence.serialize_element(&PciMsixEntry(*entry))?;
+        }
+        sequence.end()
+    }
+}
+
+struct PciMsixEntry(SnapshotV2PciMsixTableEntry);
+
+impl Serialize for PciMsixEntry {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("PciMsixEntry", 4)?;
+        state.serialize_field("message_address_low", &HexU32(self.0.message_address_low()))?;
+        state.serialize_field(
+            "message_address_high",
+            &HexU32(self.0.message_address_high()),
+        )?;
+        state.serialize_field("message_data", &HexU32(self.0.message_data()))?;
+        state.serialize_field("vector_control", &HexU32(self.0.vector_control()))?;
+        state.end()
+    }
+}
+
+struct HexU64Values<'a>(&'a [u64]);
+
+impl Serialize for HexU64Values<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for value in self.0 {
+            sequence.serialize_element(&HexU64(*value))?;
+        }
+        sequence.end()
+    }
+}
+
+pub(super) struct LegacyVirtioMmio<'a>(pub(super) &'a VirtioMmioTransportState);
+
+impl Serialize for LegacyVirtioMmio<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("LegacyVirtioMmio", 8)?;
+        state.serialize_field("device", &LegacyVirtioDevice(*value.device_registers()))?;
+        state.serialize_field("queue_select", &value.queue_select())?;
+        state.serialize_field("queues", &LegacyVirtioQueues(value.queues()))?;
+        state.serialize_field("pending_notifications", &value.pending_notifications())?;
+        state.serialize_field(
+            "interrupt_status",
+            &InterruptStatus(value.interrupt_status()),
+        )?;
+        state.serialize_field("activated", &value.is_device_activated())?;
+        state.serialize_field(
+            "requires_device_config_write_status",
+            &value.requires_device_config_write_status(),
+        )?;
+        state.serialize_field("queue_count", &value.queues().len())?;
+        state.end()
+    }
+}
+
+struct LegacyVirtioDevice(VirtioMmioDeviceRegisters);
+
+impl Serialize for LegacyVirtioDevice {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("LegacyVirtioDevice", 8)?;
+        state.serialize_field("device_id", &value.device_id())?;
+        state.serialize_field("vendor_id", &HexU32(value.vendor_id()))?;
+        state.serialize_field("device_features", &HexU64(value.device_features()))?;
+        state.serialize_field("config_generation", &value.config_generation())?;
+        state.serialize_field("device_features_select", &value.device_features_select())?;
+        state.serialize_field("driver_features_select", &value.driver_features_select())?;
+        state.serialize_field("driver_features", &HexU64(value.driver_features()))?;
+        state.serialize_field("status", &HexU32(value.status()))?;
+        state.end()
+    }
+}
+
+struct LegacyVirtioQueues<'a>(&'a [VirtioMmioQueueState]);
+
+impl Serialize for LegacyVirtioQueues<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for (index, queue) in self.0.iter().enumerate() {
+            sequence.serialize_element(&LegacyVirtioQueue {
+                index,
+                queue: *queue,
+            })?;
+        }
+        sequence.end()
+    }
+}
+
+struct LegacyVirtioQueue {
+    index: usize,
+    queue: VirtioMmioQueueState,
+}
+
+impl Serialize for LegacyVirtioQueue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("LegacyVirtioQueue", 7)?;
+        state.serialize_field("index", &self.index)?;
+        state.serialize_field("max_size", &self.queue.max_size())?;
+        state.serialize_field("size", &self.queue.size())?;
+        state.serialize_field("ready", &self.queue.ready())?;
+        state.serialize_field(
+            "descriptor_table",
+            &HexU64(self.queue.descriptor_table().raw_value()),
+        )?;
+        state.serialize_field("driver_ring", &HexU64(self.queue.driver_ring().raw_value()))?;
+        state.serialize_field("device_ring", &HexU64(self.queue.device_ring().raw_value()))?;
+        state.end()
+    }
+}
+
+struct InterruptStatus(DeviceInterruptStatus);
+
+impl Serialize for InterruptStatus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_some(&HexU32(self.0.bits()))
+    }
+}
+
+pub(super) struct SerialRegisters(pub(super) SerialMmioState);
+
+impl Serialize for SerialRegisters {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("SerialRegisters", 6)?;
+        state.serialize_field("interrupt_enable", &HexU8(value.interrupt_enable()))?;
+        state.serialize_field("line_control", &HexU8(value.line_control()))?;
+        state.serialize_field("modem_control", &HexU8(value.modem_control()))?;
+        state.serialize_field("scratch", &HexU8(value.scratch()))?;
+        state.serialize_field("divisor_latch_low", &HexU8(value.divisor_latch_low()))?;
+        state.serialize_field("divisor_latch_high", &HexU8(value.divisor_latch_high()))?;
+        state.end()
+    }
+}
+
+pub(super) struct BlockQueue(pub(super) Option<VirtioBlockQueueState>);
+
+impl Serialize for BlockQueue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(queue) = self.0 else {
+            return serializer.serialize_none();
+        };
+        let mut state = serializer.serialize_struct("BlockQueue", 2)?;
+        state.serialize_field("next_available", &queue.next_available())?;
+        state.serialize_field("next_used", &queue.next_used())?;
+        state.end()
+    }
+}
+
+pub(super) struct PmemQueue(pub(super) Option<VirtioPmemQueueState>);
+
+impl Serialize for PmemQueue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(queue) = self.0 else {
+            return serializer.serialize_none();
+        };
+        let mut state = serializer.serialize_struct("PmemQueue", 2)?;
+        state.serialize_field("next_available", &queue.next_available())?;
+        state.serialize_field("next_used", &queue.next_used())?;
+        state.end()
+    }
+}
+
+pub(super) struct DriveRateConfig(pub(super) Option<DriveRateLimiterConfig>);
+
+impl Serialize for DriveRateConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(config) = self.0 else {
+            return serializer.serialize_none();
+        };
+        let mut state = serializer.serialize_struct("DriveRateLimiterConfig", 2)?;
+        state.serialize_field("bandwidth", &DriveTokenConfig(config.bandwidth()))?;
+        state.serialize_field("ops", &DriveTokenConfig(config.ops()))?;
+        state.end()
+    }
+}
+
+struct DriveTokenConfig(Option<DriveTokenBucketConfig>);
+
+impl Serialize for DriveTokenConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(config) = self.0 else {
+            return serializer.serialize_none();
+        };
+        serialize_token_config(
+            serializer,
+            config.size(),
+            config.one_time_burst(),
+            config.refill_time(),
+        )
+    }
+}
+
+pub(super) struct PmemRateConfig(pub(super) Option<PmemRateLimiterConfig>);
+
+impl Serialize for PmemRateConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(config) = self.0 else {
+            return serializer.serialize_none();
+        };
+        let mut state = serializer.serialize_struct("PmemRateLimiterConfig", 2)?;
+        state.serialize_field("bandwidth", &PmemTokenConfig(config.bandwidth()))?;
+        state.serialize_field("ops", &PmemTokenConfig(config.ops()))?;
+        state.end()
+    }
+}
+
+struct PmemTokenConfig(Option<PmemTokenBucketConfig>);
+
+impl Serialize for PmemTokenConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(config) = self.0 else {
+            return serializer.serialize_none();
+        };
+        serialize_token_config(
+            serializer,
+            config.size(),
+            config.one_time_burst(),
+            config.refill_time(),
+        )
+    }
+}
+
+pub(super) struct EntropyRateConfig(pub(super) Option<EntropyRateLimiterConfig>);
+
+impl Serialize for EntropyRateConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(config) = self.0 else {
+            return serializer.serialize_none();
+        };
+        let mut state = serializer.serialize_struct("EntropyRateLimiterConfig", 2)?;
+        state.serialize_field("bandwidth", &EntropyTokenConfig(config.bandwidth()))?;
+        state.serialize_field("ops", &EntropyTokenConfig(config.ops()))?;
+        state.end()
+    }
+}
+
+struct EntropyTokenConfig(Option<EntropyTokenBucketConfig>);
+
+impl Serialize for EntropyTokenConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(config) = self.0 else {
+            return serializer.serialize_none();
+        };
+        serialize_token_config(
+            serializer,
+            config.size(),
+            config.one_time_burst(),
+            config.refill_time(),
+        )
+    }
+}
+
+pub(super) struct SerialRateConfig(pub(super) Option<SerialRateLimiterConfig>);
+
+impl Serialize for SerialRateConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(config) = self.0 else {
+            return serializer.serialize_none();
+        };
+        serialize_token_config(
+            serializer,
+            config.size(),
+            config.one_time_burst(),
+            config.refill_time(),
+        )
+    }
+}
+
+fn serialize_token_config<S>(
+    serializer: S,
+    size: u64,
+    one_time_burst: Option<u64>,
+    refill_time: u64,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let mut state = serializer.serialize_struct("TokenBucketConfig", 3)?;
+    state.serialize_field("size", &size)?;
+    state.serialize_field("one_time_burst", &one_time_burst)?;
+    state.serialize_field("refill_time", &refill_time)?;
+    state.end()
+}
+
+pub(super) struct LegacyBlockLimiter(pub(super) VirtioBlockRateLimiterState);
+
+impl Serialize for LegacyBlockLimiter {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("LegacyBlockLimiter", 2)?;
+        state.serialize_field("bandwidth", &LegacyBlockBucket(self.0.bandwidth()))?;
+        state.serialize_field("ops", &LegacyBlockBucket(self.0.ops()))?;
+        state.end()
+    }
+}
+
+struct LegacyBlockBucket(Option<VirtioBlockTokenBucketState>);
+
+impl Serialize for LegacyBlockBucket {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(bucket) = self.0 else {
+            return serializer.serialize_none();
+        };
+        let mut state = serializer.serialize_struct("LegacyBlockBucket", 4)?;
+        state.serialize_field("config", &DriveTokenConfig(Some(bucket.config())))?;
+        state.serialize_field("budget", &bucket.budget())?;
+        state.serialize_field("remaining_burst", &bucket.remaining_burst())?;
+        state.serialize_field("age_nanos", &bucket.age_nanos())?;
+        state.end()
+    }
+}
+
+pub(super) struct BlockLimiter(pub(super) SnapshotV2BlockLimiterState);
+
+impl Serialize for BlockLimiter {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("BlockLimiter", 2)?;
+        state.serialize_field("bandwidth", &BlockBucket(self.0.bandwidth()))?;
+        state.serialize_field("ops", &BlockBucket(self.0.ops()))?;
+        state.end()
+    }
+}
+
+struct BlockBucket(Option<SnapshotV2BlockBucketState>);
+
+impl Serialize for BlockBucket {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(bucket) = self.0 else {
+            return serializer.serialize_none();
+        };
+        serialize_bucket_state(
+            serializer,
+            bucket.budget(),
+            bucket.remaining_burst(),
+            bucket.age_nanos(),
+        )
+    }
+}
+
+pub(super) struct PmemLimiter(pub(super) SnapshotV2PmemLimiterState);
+
+impl Serialize for PmemLimiter {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("PmemLimiter", 2)?;
+        state.serialize_field("bandwidth", &PmemBucket(self.0.bandwidth()))?;
+        state.serialize_field("ops", &PmemBucket(self.0.ops()))?;
+        state.end()
+    }
+}
+
+struct PmemBucket(Option<SnapshotV2PmemBucketState>);
+
+impl Serialize for PmemBucket {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(bucket) = self.0 else {
+            return serializer.serialize_none();
+        };
+        serialize_bucket_state(
+            serializer,
+            bucket.budget(),
+            bucket.remaining_burst(),
+            bucket.age_nanos(),
+        )
+    }
+}
+
+fn serialize_bucket_state<S>(
+    serializer: S,
+    budget: u64,
+    remaining_burst: u64,
+    age_nanos: u64,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let mut state = serializer.serialize_struct("TokenBucketState", 3)?;
+    state.serialize_field("budget", &budget)?;
+    state.serialize_field("remaining_burst", &remaining_burst)?;
+    state.serialize_field("age_nanos", &age_nanos)?;
+    state.end()
+}

--- a/crates/hvf/src/snapshot_document/inspection/devices/storage.rs
+++ b/crates/hvf/src/snapshot_document/inspection/devices/storage.rs
@@ -1,0 +1,437 @@
+use bangbang_runtime::block::DriveIoEngine;
+use bangbang_runtime::snapshot_device::{
+    SnapshotV1BlockRetryState, SnapshotV1DeviceState, SnapshotV1MmioDeviceMetadata,
+    SnapshotV1PlatformDeviceMetadata, SnapshotV1RootBlockState,
+};
+use bangbang_runtime::snapshot_device_v2::{
+    SnapshotV2BlockState, SnapshotV2DeviceGraph, SnapshotV2DeviceRecord,
+};
+use bangbang_runtime::snapshot_device_v2_5::{
+    SnapshotV2MultiBlockDeviceGraph, SnapshotV2MultiBlockDeviceRecord,
+};
+use bangbang_runtime::snapshot_device_v2_6::{
+    SnapshotV2PmemDeviceRecord, SnapshotV2StorageDeviceGraph,
+};
+use serde::Serialize;
+use serde::ser::{SerializeSeq, SerializeStruct};
+
+use super::super::common::GuestRange;
+use super::super::fingerprint::{HexU64, Redacted, confidential_bytes};
+use super::shared::{
+    BlockLimiter, BlockQueue, DeviceKey, DriveCache, DriveEngine, DriveRateConfig,
+    LegacyBlockLimiter, LegacyVirtioMmio, MmioRegionView, OptionalDeviceKey, PmemLimiter,
+    PmemQueue, PmemRateConfig, Retry, SerialRegisters, Transport, TransportKind, Virtio,
+};
+
+pub(super) struct LegacyDevices<'a>(pub(super) &'a SnapshotV1DeviceState);
+
+impl Serialize for LegacyDevices<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("LegacyDevices", 6)?;
+        state.serialize_field("root_block", &LegacyRootBlock(value.root_block()))?;
+        state.serialize_field("block_retry", &LegacyRetry(value.block_retry()))?;
+        state.serialize_field("serial", &LegacySerial(value))?;
+        state.serialize_field("vmgenid", &PlatformDevice(value.vmgenid()))?;
+        state.serialize_field("vmclock", &PlatformDevice(value.vmclock()))?;
+        state.serialize_field("vmclock_abi", &LegacyVmClockAbi(value.vmclock_abi()))?;
+        state.end()
+    }
+}
+
+struct LegacyRootBlock<'a>(&'a SnapshotV1RootBlockState);
+
+impl Serialize for LegacyRootBlock<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let runtime = value.runtime();
+        let backing_identity = value.backing_identity();
+        let mut state = serializer.serialize_struct("LegacyRootBlock", 16)?;
+        state.serialize_field("drive_id", value.drive_id())?;
+        state.serialize_field("path", &Redacted)?;
+        state.serialize_field("partuuid", &value.partuuid())?;
+        state.serialize_field("cache_type", &DriveCache(value.cache_type()))?;
+        state.serialize_field("io_engine", &DriveEngine(DriveIoEngine::Sync))?;
+        state.serialize_field(
+            "rate_limiter_config",
+            &DriveRateConfig(value.rate_limiter_config()),
+        )?;
+        // The guest-visible block ID may be derived from host dev/rdev/inode
+        // metadata, so even an equality fingerprint would expose host
+        // authority through a guessable oracle.
+        state.serialize_field("device_id", &Redacted)?;
+        state.serialize_field("capacity_sectors", &value.capacity_sectors())?;
+        state.serialize_field("backing_bytes", &backing_identity.len())?;
+        state.serialize_field("backing_identity", &Redacted)?;
+        state.serialize_field("mmio", &LegacyMmio(value.mmio()))?;
+        state.serialize_field("virtio", &LegacyVirtioMmio(runtime.transport()))?;
+        state.serialize_field("active_queue", &BlockQueue(runtime.active_queue()))?;
+        state.serialize_field("limiter", &LegacyBlockLimiter(runtime.rate_limiter()))?;
+        state.serialize_field("read_only", &true)?;
+        state.serialize_field("regular_file", &backing_identity.kind().is_regular_file())?;
+        state.end()
+    }
+}
+
+struct LegacyRetry(SnapshotV1BlockRetryState);
+
+impl Serialize for LegacyRetry {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let (disposition, remaining_nanos) = match self.0 {
+            SnapshotV1BlockRetryState::None => ("none", None),
+            SnapshotV1BlockRetryState::Immediate => ("immediate", None),
+            SnapshotV1BlockRetryState::After { remaining_nanos } => {
+                ("after", Some(remaining_nanos))
+            }
+        };
+        let mut state = serializer.serialize_struct("LegacyBlockRetry", 2)?;
+        state.serialize_field("disposition", disposition)?;
+        state.serialize_field("remaining_nanos", &remaining_nanos)?;
+        state.end()
+    }
+}
+
+struct LegacySerial<'a>(&'a SnapshotV1DeviceState);
+
+impl Serialize for LegacySerial<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("LegacySerial", 2)?;
+        state.serialize_field("mmio", &LegacyMmio(self.0.serial_mmio()))?;
+        state.serialize_field("registers", &SerialRegisters(self.0.serial_state()))?;
+        state.end()
+    }
+}
+
+struct LegacyMmio(SnapshotV1MmioDeviceMetadata);
+
+impl Serialize for LegacyMmio {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("LegacyMmio", 2)?;
+        state.serialize_field("region", &MmioRegionView(self.0.region()))?;
+        state.serialize_field("interrupt_line", &self.0.interrupt_line().raw_value())?;
+        state.end()
+    }
+}
+
+struct PlatformDevice(SnapshotV1PlatformDeviceMetadata);
+
+impl Serialize for PlatformDevice {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let fdt = self.0.fdt_region();
+        let mut state = serializer.serialize_struct("LegacyPlatformDevice", 4)?;
+        state.serialize_field("range", &GuestRange(self.0.range()))?;
+        state.serialize_field("fdt_base", &HexU64(fdt.base))?;
+        state.serialize_field("fdt_size", &fdt.size)?;
+        state.serialize_field("interrupt_line", &self.0.interrupt_line().raw_value())?;
+        state.end()
+    }
+}
+
+struct LegacyVmClockAbi(Option<bangbang_runtime::vmclock::VmClockAbi>);
+
+impl Serialize for LegacyVmClockAbi {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.0 {
+            Some(value) => confidential_bytes("devices.v1.vmclock-abi", &value.to_bytes())
+                .serialize(serializer),
+            None => serializer.serialize_none(),
+        }
+    }
+}
+
+pub(super) struct SingletonBlockGraph<'a>(pub(super) &'a SnapshotV2DeviceGraph);
+
+impl Serialize for SingletonBlockGraph<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("SingletonBlockGraph", 5)?;
+        state.serialize_field("compatibility", "v2.4")?;
+        state.serialize_field("root_key", &DeviceKey(value.root_key()))?;
+        state.serialize_field("transport_kind", &TransportKind(value.transport_kind()))?;
+        state.serialize_field("record_is_root", &value.record_is_root())?;
+        state.serialize_field("record", &SingletonBlockRecord(value.record()))?;
+        state.end()
+    }
+}
+
+struct SingletonBlockRecord<'a>(&'a SnapshotV2DeviceRecord);
+
+impl Serialize for SingletonBlockRecord<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let config = value.config();
+        let mut state = serializer.serialize_struct("SingletonBlockRecord", 5)?;
+        state.serialize_field("key", &DeviceKey(value.key()))?;
+        state.serialize_field("config", &SingletonBlockConfig(config))?;
+        state.serialize_field("block", &Block(value.block()))?;
+        state.serialize_field("virtio", &Virtio(value.virtio()))?;
+        state.serialize_field("transport", &Transport(value.transport()))?;
+        state.end()
+    }
+}
+
+struct SingletonBlockConfig<'a>(
+    &'a bangbang_runtime::snapshot_device_v2::SnapshotV2RootBlockConfig,
+);
+
+impl Serialize for SingletonBlockConfig<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("SingletonBlockConfig", 9)?;
+        state.serialize_field("drive_id", value.drive_id())?;
+        state.serialize_field("partuuid", &value.partuuid())?;
+        state.serialize_field("root", &true)?;
+        state.serialize_field("read_only", &value.is_read_only())?;
+        state.serialize_field("cache_type", &DriveCache(value.cache_type()))?;
+        state.serialize_field("io_engine", &DriveEngine(value.io_engine()))?;
+        state.serialize_field("rate_limiter", &DriveRateConfig(value.rate_limiter()))?;
+        state.serialize_field("regular_file", &true)?;
+        state.serialize_field("selector", &Redacted)?;
+        state.end()
+    }
+}
+
+struct Block<'a>(&'a SnapshotV2BlockState);
+
+impl Serialize for Block<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("BlockState", 5)?;
+        state.serialize_field("capacity_sectors", &value.capacity_sectors())?;
+        // See the native-v1 block-state note above. The same ID flows through
+        // every later block profile and must remain literally redacted.
+        state.serialize_field("device_id", &Redacted)?;
+        state.serialize_field("active_queue", &BlockQueue(value.active_queue()))?;
+        state.serialize_field("limiter", &BlockLimiter(value.limiter()))?;
+        state.serialize_field("retry", &Retry(value.retry()))?;
+        state.end()
+    }
+}
+
+pub(super) struct MultiBlockGraph<'a>(pub(super) &'a SnapshotV2MultiBlockDeviceGraph);
+
+impl Serialize for MultiBlockGraph<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("MultiBlockGraph", 5)?;
+        state.serialize_field("compatibility", "v2.5")?;
+        state.serialize_field("root_key", &OptionalDeviceKey(value.root_key()))?;
+        state.serialize_field("transport_kind", &TransportKind(value.transport_kind()))?;
+        state.serialize_field("record_count", &value.records().len())?;
+        state.serialize_field("block_records", &MultiBlockRecords(value.records()))?;
+        state.end()
+    }
+}
+
+struct MultiBlockRecords<'a>(&'a [SnapshotV2MultiBlockDeviceRecord]);
+
+impl Serialize for MultiBlockRecords<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for record in self.0 {
+            sequence.serialize_element(&MultiBlockRecord(record))?;
+        }
+        sequence.end()
+    }
+}
+
+struct MultiBlockRecord<'a>(&'a SnapshotV2MultiBlockDeviceRecord);
+
+impl Serialize for MultiBlockRecord<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let block = value.block();
+        let mut state = serializer.serialize_struct("MultiBlockRecord", 6)?;
+        state.serialize_field("key", &DeviceKey(value.key()))?;
+        state.serialize_field("config", &MultiBlockConfig(value.config()))?;
+        state.serialize_field("backing_bytes", &block.backing_bytes())?;
+        state.serialize_field("block", &Block(block.continuation()))?;
+        state.serialize_field("virtio", &Virtio(value.virtio()))?;
+        state.serialize_field("transport", &Transport(value.transport()))?;
+        state.end()
+    }
+}
+
+struct MultiBlockConfig<'a>(&'a bangbang_runtime::snapshot_device_v2_5::SnapshotV2MultiBlockConfig);
+
+impl Serialize for MultiBlockConfig<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("MultiBlockConfig", 9)?;
+        state.serialize_field("drive_id", value.drive_id())?;
+        state.serialize_field("partuuid", &value.partuuid())?;
+        state.serialize_field("root", &value.is_root())?;
+        state.serialize_field("read_only", &value.is_read_only())?;
+        state.serialize_field("cache_type", &DriveCache(value.cache_type()))?;
+        state.serialize_field("io_engine", &DriveEngine(value.io_engine()))?;
+        state.serialize_field("rate_limiter", &DriveRateConfig(value.rate_limiter()))?;
+        state.serialize_field("regular_file", &value.is_regular_file())?;
+        state.serialize_field("selector", &Redacted)?;
+        state.end()
+    }
+}
+
+pub(super) struct StorageGraph<'a>(pub(super) &'a SnapshotV2StorageDeviceGraph);
+
+impl Serialize for StorageGraph<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("StorageGraph", 7)?;
+        state.serialize_field("compatibility", "v2.6")?;
+        state.serialize_field("root_key", &OptionalDeviceKey(value.root_key()))?;
+        state.serialize_field("transport_kind", &TransportKind(value.transport_kind()))?;
+        state.serialize_field("record_count", &value.record_count())?;
+        state.serialize_field("block_record_count", &value.block_records().len())?;
+        state.serialize_field("pmem_record_count", &value.pmem_records().len())?;
+        state.serialize_field("records", &StorageRecords(value))?;
+        state.end()
+    }
+}
+
+struct StorageRecords<'a>(&'a SnapshotV2StorageDeviceGraph);
+
+impl Serialize for StorageRecords<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut sequence = serializer.serialize_seq(Some(value.record_count()))?;
+        for record in value.block_records() {
+            sequence.serialize_element(&StorageRecord::Block(record))?;
+        }
+        for record in value.pmem_records() {
+            sequence.serialize_element(&StorageRecord::Pmem(record))?;
+        }
+        sequence.end()
+    }
+}
+
+enum StorageRecord<'a> {
+    Block(&'a SnapshotV2MultiBlockDeviceRecord),
+    Pmem(&'a SnapshotV2PmemDeviceRecord),
+}
+
+impl Serialize for StorageRecord<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Block(record) => MultiBlockRecord(record).serialize(serializer),
+            Self::Pmem(record) => PmemRecord(record).serialize(serializer),
+        }
+    }
+}
+
+struct PmemRecord<'a>(&'a SnapshotV2PmemDeviceRecord);
+
+impl Serialize for PmemRecord<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let pmem = value.pmem();
+        let config_space = pmem.config_space();
+        let mut state = serializer.serialize_struct("PmemRecord", 12)?;
+        state.serialize_field("key", &DeviceKey(value.key()))?;
+        state.serialize_field("config", &PmemConfig(value.config()))?;
+        state.serialize_field("file_bytes", &pmem.file_bytes())?;
+        state.serialize_field("mapped_bytes", &pmem.mapped_bytes())?;
+        state.serialize_field("guest_range", &GuestRange(pmem.guest_range()))?;
+        state.serialize_field("config_start", &HexU64(config_space.start()))?;
+        state.serialize_field("config_size", &config_space.size())?;
+        state.serialize_field("active_queue", &PmemQueue(pmem.active_queue()))?;
+        state.serialize_field("limiter", &PmemLimiter(pmem.limiter()))?;
+        state.serialize_field(
+            "pending_rate_limited_queue",
+            &pmem.pending_rate_limited_queue(),
+        )?;
+        state.serialize_field("retry", &Retry(pmem.retry()))?;
+        state.serialize_field("virtio_and_transport", &PmemVirtioAndTransport(value))?;
+        state.end()
+    }
+}
+
+struct PmemVirtioAndTransport<'a>(&'a SnapshotV2PmemDeviceRecord);
+
+impl Serialize for PmemVirtioAndTransport<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("PmemVirtioAndTransport", 2)?;
+        state.serialize_field("virtio", &Virtio(self.0.virtio()))?;
+        state.serialize_field("transport", &Transport(self.0.transport()))?;
+        state.end()
+    }
+}
+
+struct PmemConfig<'a>(&'a bangbang_runtime::snapshot_device_v2_6::SnapshotV2PmemConfig);
+
+impl Serialize for PmemConfig<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.0;
+        let mut state = serializer.serialize_struct("PmemConfig", 7)?;
+        state.serialize_field("pmem_id", value.pmem_id())?;
+        state.serialize_field("root", &value.is_root())?;
+        state.serialize_field("read_only", &value.is_read_only())?;
+        state.serialize_field("rate_limiter", &PmemRateConfig(value.rate_limiter()))?;
+        state.serialize_field("regular_file", &value.is_regular_file())?;
+        state.serialize_field("selector", &Redacted)?;
+        state.serialize_field("device_kind", "pmem")?;
+        state.end()
+    }
+}

--- a/crates/hvf/src/snapshot_document/inspection/fingerprint.rs
+++ b/crates/hvf/src/snapshot_document/inspection/fingerprint.rs
@@ -1,0 +1,169 @@
+use std::fmt;
+
+use serde::Serialize;
+use serde::ser::SerializeStruct;
+use sha2::{Digest, Sha256};
+
+use super::SCHEMA;
+
+pub(super) const REDACTED: &str = "<redacted>";
+
+macro_rules! hex_scalar {
+    ($name:ident, $inner:ty, $width:literal) => {
+        pub(super) struct $name(pub(super) $inner);
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(formatter, concat!("0x{:0", $width, "x}"), self.0)
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                serializer.collect_str(self)
+            }
+        }
+    };
+}
+
+hex_scalar!(HexU8, u8, 2);
+hex_scalar!(HexU16, u16, 4);
+hex_scalar!(HexU32, u32, 8);
+hex_scalar!(HexU64, u64, 16);
+hex_scalar!(HexU128, u128, 32);
+
+pub(super) struct Redacted;
+
+impl Serialize for Redacted {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(REDACTED)
+    }
+}
+
+pub(super) struct RedactedOption(pub(super) bool);
+
+impl Serialize for RedactedOption {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if self.0 {
+            serializer.serialize_str(REDACTED)
+        } else {
+            serializer.serialize_none()
+        }
+    }
+}
+
+pub(super) struct Fingerprint {
+    content_bytes: usize,
+    digest: [u8; 32],
+}
+
+impl Serialize for Fingerprint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("ConfidentialFingerprint", 3)?;
+        state.serialize_field("algorithm", "sha256")?;
+        state.serialize_field("byte_length", &self.content_bytes)?;
+        state.serialize_field("digest", &HexDigest(&self.digest))?;
+        state.end()
+    }
+}
+
+struct HexDigest<'a>(&'a [u8; 32]);
+
+impl fmt::Display for HexDigest<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.0 {
+            write!(formatter, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl Serialize for HexDigest<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+pub(super) struct FingerprintBuilder {
+    hasher: Sha256,
+    content_bytes: usize,
+}
+
+impl FingerprintBuilder {
+    pub(super) fn new(domain: &'static str) -> Self {
+        let mut hasher = Sha256::new();
+        update_framed(&mut hasher, SCHEMA.as_bytes());
+        update_framed(&mut hasher, domain.as_bytes());
+        Self {
+            hasher,
+            content_bytes: 0,
+        }
+    }
+
+    pub(super) fn tag(&mut self, tag: u8) {
+        self.hasher.update([tag]);
+    }
+
+    pub(super) fn sequence_len(&mut self, length: usize) {
+        self.hasher.update((length as u64).to_be_bytes());
+    }
+
+    pub(super) fn bytes(&mut self, bytes: &[u8]) {
+        self.hasher.update((bytes.len() as u64).to_be_bytes());
+        self.hasher.update(bytes);
+        self.content_bytes = self.content_bytes.saturating_add(bytes.len());
+    }
+
+    pub(super) fn bool(&mut self, value: bool) {
+        self.hasher.update([u8::from(value)]);
+        self.content_bytes = self.content_bytes.saturating_add(1);
+    }
+
+    pub(super) fn u8(&mut self, value: u8) {
+        self.hasher.update([value]);
+        self.content_bytes = self.content_bytes.saturating_add(1);
+    }
+
+    pub(super) fn u64(&mut self, value: u64) {
+        self.hasher.update(value.to_be_bytes());
+        self.content_bytes = self.content_bytes.saturating_add(8);
+    }
+
+    pub(super) fn u128(&mut self, value: u128) {
+        self.hasher.update(value.to_be_bytes());
+        self.content_bytes = self.content_bytes.saturating_add(16);
+    }
+
+    pub(super) fn finish(self) -> Fingerprint {
+        Fingerprint {
+            content_bytes: self.content_bytes,
+            digest: self.hasher.finalize().into(),
+        }
+    }
+}
+
+pub(super) fn confidential_bytes(domain: &'static str, bytes: &[u8]) -> Fingerprint {
+    let mut builder = FingerprintBuilder::new(domain);
+    builder.bytes(bytes);
+    builder.finish()
+}
+
+fn update_framed(hasher: &mut Sha256, bytes: &[u8]) {
+    hasher.update((bytes.len() as u64).to_be_bytes());
+    hasher.update(bytes);
+}

--- a/crates/hvf/src/snapshot_document/inspection/tests.rs
+++ b/crates/hvf/src/snapshot_document/inspection/tests.rs
@@ -1,0 +1,661 @@
+use std::io::{self, Seek, SeekFrom, Write};
+
+use bangbang_runtime::memory::{
+    GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange, aarch64,
+};
+use bangbang_runtime::snapshot_diff_v2_13::{
+    NATIVE_V2_DIFF_MAX_EXTENTS, NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION, SnapshotV2DiffBase,
+    SnapshotV2DiffLayerBinding,
+};
+use bangbang_runtime::snapshot_memory_v2::{
+    NATIVE_V2_MEMORY_GUEST_GRANULE, NATIVE_V2_MEMORY_MAX_EXTENTS, SnapshotV2MemoryBinding,
+    write_snapshot_v2_memory_image_with_compatibility_version,
+};
+
+use super::*;
+use crate::snapshot_document::tests::{
+    inspection_document_fixtures, inspection_native_v1_document,
+    inspection_native_v1_document_with_pc,
+};
+use crate::snapshot_v2::tests::{
+    maximum_balloon_state_fixture, maximum_memory_hotplug_state_fixture,
+    maximum_network_state_fixture, maximum_storage_graph_fixture, platform_fixture,
+    platform_fixture_with_count, platform_fixture_with_cpu_template,
+};
+use serde_json::Value;
+
+#[test]
+fn maximum_vcpu_collection_serializes_within_the_public_ceiling() {
+    let document = HvfNativeSnapshotDocument {
+        state: HvfNativeSnapshotDocumentState::V2LegacyPlatform(platform_fixture_with_count(
+            MAX_SUPPORTED_VCPUS,
+            false,
+        )),
+    };
+    let json = document
+        .inspect_vcpu_states()
+        .to_pretty_json()
+        .expect("maximum vCPU inspection should serialize");
+    assert!(json.len() <= HVF_NATIVE_SNAPSHOT_INSPECTION_MAX_JSON_BYTES);
+    let value: Value = serde_json::from_str(&json).expect("maximum vCPU inspection should parse");
+    assert_eq!(
+        value["vcpus"]
+            .as_array()
+            .expect("maximum vCPU collection should be an array")
+            .len(),
+        usize::from(MAX_SUPPORTED_VCPUS)
+    );
+}
+
+#[test]
+fn maximum_memory_extent_collection_serializes_within_the_public_ceiling() {
+    // Four guest granules are also aligned to the largest supported host page
+    // size, so the same maximum-extent fixture allocates on macOS and Linux.
+    let extent_bytes = NATIVE_V2_MEMORY_GUEST_GRANULE * 4;
+    let ranges = (0..NATIVE_V2_MEMORY_MAX_EXTENTS)
+        .map(|index| {
+            GuestMemoryRange::new(
+                GuestAddress::new(
+                    aarch64::DRAM_MEM_START
+                        + u64::try_from(index).expect("memory extent index should fit")
+                            * extent_bytes,
+                ),
+                extent_bytes,
+            )
+            .expect("maximum memory extent should validate")
+        })
+        .collect::<Vec<_>>();
+    let binding = memory_binding_for_ranges(ranges);
+    let value = assert_serializes_within_public_ceiling(&common::V2Memory(&binding));
+    assert_eq!(
+        value["extent_count"].as_u64(),
+        Some(u64::try_from(NATIVE_V2_MEMORY_MAX_EXTENTS).expect("extent count should fit u64"))
+    );
+    assert_eq!(
+        value["extents"]
+            .as_array()
+            .expect("memory extents should be an array")
+            .len(),
+        NATIVE_V2_MEMORY_MAX_EXTENTS
+    );
+}
+
+#[test]
+fn maximum_storage_and_network_collections_serialize_within_the_public_ceiling() {
+    let storage = maximum_storage_graph_fixture();
+    let storage_value =
+        assert_serializes_within_public_ceiling(&devices::StorageGraphForTest(&storage));
+    assert_eq!(
+        storage_value["records"]
+            .as_array()
+            .expect("storage records should be an array")
+            .len(),
+        usize::from(NATIVE_V2_STORAGE_DEVICE_GRAPH_MAX_RECORDS)
+    );
+
+    let network = maximum_network_state_fixture();
+    let network_value = assert_serializes_within_public_ceiling(&devices::NetworkForTest(&network));
+    assert_eq!(
+        network_value["interfaces"]
+            .as_array()
+            .expect("network interfaces should be an array")
+            .len(),
+        NATIVE_V2_NETWORK_MAX_INTERFACES
+    );
+}
+
+#[test]
+fn maximum_balloon_accounting_serializes_within_the_public_ceiling() {
+    let balloon = maximum_balloon_state_fixture();
+    let value = assert_serializes_within_public_ceiling(&devices::BalloonForTest(&balloon));
+    assert_eq!(
+        value["accounting"]["ranges"]
+            .as_array()
+            .expect("balloon ranges should be an array")
+            .len(),
+        NATIVE_V2_BALLOON_STATE_MAX_ACCOUNTING_RANGES
+    );
+}
+
+#[test]
+fn maximum_valid_virtio_mem_bitmap_and_blocks_serialize_within_the_public_ceiling() {
+    let memory_hotplug = maximum_memory_hotplug_state_fixture();
+    let configured_blocks =
+        memory_hotplug.config_space().region_size() / memory_hotplug.config_space().block_size();
+    let plugged_ranges = memory_hotplug.plugged_ranges().len();
+    let bitmap_bytes = memory_hotplug.plugged_bitmap().len();
+    let value =
+        assert_serializes_within_public_ceiling(&devices::MemoryHotplugForTest(&memory_hotplug));
+    assert_eq!(
+        value["configured_block_count"].as_u64(),
+        Some(configured_blocks)
+    );
+    assert_eq!(
+        value["plugged_bitmap_byte_count"].as_u64(),
+        Some(u64::try_from(bitmap_bytes).expect("bitmap byte count should fit u64"))
+    );
+    assert_eq!(
+        value["plugged_ranges"]
+            .as_array()
+            .expect("virtio-mem ranges should be an array")
+            .len(),
+        plugged_ranges
+    );
+}
+
+#[test]
+fn maximum_diff_extent_collection_serializes_within_the_public_ceiling() {
+    let granule = NATIVE_V2_MEMORY_GUEST_GRANULE;
+    let stride = granule * 2;
+    let result_bytes = u64::try_from(NATIVE_V2_DIFF_MAX_EXTENTS)
+        .expect("Diff extent count should fit u64")
+        * stride;
+    let result = memory_binding_for_ranges(vec![
+        GuestMemoryRange::new(GuestAddress::new(aarch64::DRAM_MEM_START), result_bytes)
+            .expect("maximum Diff result range should validate"),
+    ]);
+    let ranges = (0..NATIVE_V2_DIFF_MAX_EXTENTS)
+        .map(|index| {
+            GuestMemoryRange::new(
+                GuestAddress::new(
+                    aarch64::DRAM_MEM_START
+                        + u64::try_from(index).expect("Diff extent index should fit") * stride,
+                ),
+                granule,
+            )
+            .expect("maximum Diff extent should validate")
+        })
+        .collect::<Vec<_>>();
+    let layer =
+        SnapshotV2DiffLayerBinding::try_from_ranges(SnapshotV2DiffBase::Zero, result, &ranges)
+            .expect("maximum Diff layer should validate");
+    let value = assert_serializes_within_public_ceiling(&devices::DiffLayerForTest(&layer));
+    assert_eq!(
+        value["data_extents"]
+            .as_array()
+            .expect("Diff extents should be an array")
+            .len(),
+        NATIVE_V2_DIFF_MAX_EXTENTS
+    );
+}
+
+#[test]
+fn injected_limit_rejects_before_returning_a_value() {
+    assert!(matches!(
+        format_pretty_json_with_limit(&"bounded", 1),
+        Err(HvfNativeSnapshotInspectionError::OutputTooLarge { maximum: 1 })
+    ));
+}
+
+#[test]
+fn every_exact_profile_has_deterministic_parseable_views() {
+    let expected_profiles = [
+        "v1",
+        "legacy-platform-v2.3",
+        "device-graph-v2.4",
+        "multi-block-device-graph-v2.5",
+        "storage-device-graph-v2.6",
+        "serial-state-v2.7",
+        "entropy-state-v2.8",
+        "balloon-state-v2.9",
+        "memory-hotplug-state-v2.10",
+        "network-state-v2.11",
+        "vsock-state-v2.12",
+        "diff-state-v2.13",
+    ];
+
+    let documents = inspection_document_fixtures();
+    assert_eq!(documents.len(), expected_profiles.len());
+    for (document, expected_profile) in documents.iter().zip(expected_profiles) {
+        let vcpus = document
+            .inspect_vcpu_states()
+            .to_pretty_json()
+            .expect("vCPU inspection should serialize");
+        let vm = document
+            .inspect_vm_state()
+            .to_pretty_json()
+            .expect("VM inspection should serialize");
+        assert_eq!(
+            document
+                .inspect_vcpu_states()
+                .to_pretty_json()
+                .expect("repeated vCPU inspection should serialize"),
+            vcpus
+        );
+        assert_eq!(
+            document
+                .inspect_vm_state()
+                .to_pretty_json()
+                .expect("repeated VM inspection should serialize"),
+            vm
+        );
+        assert!(vcpus.len() <= HVF_NATIVE_SNAPSHOT_INSPECTION_MAX_JSON_BYTES);
+        assert!(vm.len() <= HVF_NATIVE_SNAPSHOT_INSPECTION_MAX_JSON_BYTES);
+
+        let vcpu_value: Value =
+            serde_json::from_str(&vcpus).expect("vCPU inspection should be valid JSON");
+        let vm_value: Value =
+            serde_json::from_str(&vm).expect("VM inspection should be valid JSON");
+        assert_eq!(vcpu_value["schema"], SCHEMA);
+        assert_eq!(vm_value["schema"], SCHEMA);
+        assert_eq!(vcpu_value["view"], VCPU_VIEW);
+        assert_eq!(vm_value["view"], VM_VIEW);
+        assert_eq!(vcpu_value["profile"], expected_profile);
+        assert_eq!(vm_value["profile"], expected_profile);
+        assert_eq!(vcpu_value["version"], vm_value["version"]);
+        assert_eq!(vcpu_value["vcpus"], vm_value["vcpus"]);
+
+        let indexes = vm_value["vcpus"]
+            .as_array()
+            .expect("vCPU subtree should be an array")
+            .iter()
+            .map(|vcpu| {
+                vcpu["index"]
+                    .as_u64()
+                    .expect("vCPU index should be numeric")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(indexes, (0..indexes.len() as u64).collect::<Vec<_>>());
+        assert_fixed_lowercase_hex(&vcpu_value);
+        assert_fixed_lowercase_hex(&vm_value);
+
+        assert_root_field_order(
+            &vcpus,
+            &["schema", "view", "family", "profile", "version", "vcpus"],
+        );
+        assert_root_field_order(
+            &vm,
+            &[
+                "schema", "view", "family", "profile", "version", "memory", "machine", "global",
+                "topology", "time", "vcpus", "devices", "diff",
+            ],
+        );
+    }
+}
+
+#[test]
+fn ordinary_register_values_remain_explicit() {
+    let first: Value = serde_json::from_str(
+        &inspection_native_v1_document_with_pc(0x2000)
+            .inspect_vcpu_states()
+            .to_pretty_json()
+            .expect("first native-v1 inspection should serialize"),
+    )
+    .expect("first native-v1 inspection should parse");
+    let second: Value = serde_json::from_str(
+        &inspection_native_v1_document_with_pc(0x3000)
+            .inspect_vcpu_states()
+            .to_pretty_json()
+            .expect("second native-v1 inspection should serialize"),
+    )
+    .expect("second native-v1 inspection should parse");
+
+    assert_eq!(first["vcpus"][0]["general"]["pc"], "0x0000000000002000");
+    assert_eq!(second["vcpus"][0]["general"]["pc"], "0x0000000000003000");
+    assert_ne!(
+        first["vcpus"][0]["general"]["pc"],
+        second["vcpus"][0]["general"]["pc"]
+    );
+}
+
+#[test]
+fn ordinary_cpu_template_values_remain_explicit_at_their_exact_widths() {
+    let document = HvfNativeSnapshotDocument {
+        state: HvfNativeSnapshotDocumentState::V2LegacyPlatform(
+            platform_fixture_with_cpu_template(),
+        ),
+    };
+    let value: Value = serde_json::from_str(
+        &document
+            .inspect_vm_state()
+            .to_pretty_json()
+            .expect("CPU-template inspection should serialize"),
+    )
+    .expect("CPU-template inspection should parse");
+    let entries = value["machine"]["cpu_template_application"]["entries"]
+        .as_array()
+        .expect("CPU-template entries should be an array");
+    assert_eq!(entries.len(), 3);
+    assert_eq!(entries[0]["filter"], "0x000000ff");
+    assert_eq!(entries[1]["filter"], "0x000000000000ff00");
+    assert_eq!(
+        entries[2]["common_baseline"],
+        "0x0000001000000000000000000000abcd"
+    );
+    assert!(entries.iter().all(|entry| entry.get("values").is_none()));
+    assert!(
+        value["global"]["compatibility"]["cache_manifest"]["ctr_el0"]
+            .as_str()
+            .is_some()
+    );
+}
+
+#[test]
+fn sve_sme_identification_is_explicit_while_mutable_sme_state_is_fingerprinted() {
+    let document = HvfNativeSnapshotDocument {
+        state: HvfNativeSnapshotDocumentState::V2LegacyPlatform(platform_fixture(true)),
+    };
+    let value: Value = serde_json::from_str(
+        &document
+            .inspect_vm_state()
+            .to_pretty_json()
+            .expect("SME inspection should serialize"),
+    )
+    .expect("SME inspection should parse");
+    let identification = &value["global"]["compatibility"]["sve_sme_identification"];
+    assert_eq!(identification["id_aa64zfr0_el1"], "0x0000000000001234");
+    assert_eq!(identification["id_aa64smfr0_el1"], "0x0000000000005678");
+    assert_eq!(
+        value["vcpus"][0]["reviewed_sme"]["state"]["algorithm"],
+        "sha256"
+    );
+}
+
+#[test]
+fn fdt_checksum_is_literal_redaction_not_an_equality_oracle() {
+    for document in inspection_document_fixtures().into_iter().skip(1) {
+        let value: Value = serde_json::from_str(
+            &document
+                .inspect_vm_state()
+                .to_pretty_json()
+                .expect("native-v2 inspection should serialize"),
+        )
+        .expect("native-v2 inspection should parse");
+        assert_eq!(value["machine"]["fdt"]["checksum"], "<redacted>");
+    }
+}
+
+#[test]
+fn confidential_memory_identity_changes_only_its_fingerprint() {
+    let left_document = inspection_native_v1_document(1);
+    let right_document = inspection_native_v1_document(1);
+    let left_vcpus = left_document
+        .inspect_vcpu_states()
+        .to_pretty_json()
+        .expect("left vCPU inspection should serialize");
+    let right_vcpus = right_document
+        .inspect_vcpu_states()
+        .to_pretty_json()
+        .expect("right vCPU inspection should serialize");
+    assert_eq!(left_vcpus, right_vcpus);
+
+    let mut left: Value = serde_json::from_str(
+        &left_document
+            .inspect_vm_state()
+            .to_pretty_json()
+            .expect("left VM inspection should serialize"),
+    )
+    .expect("left VM inspection should parse");
+    let mut right: Value = serde_json::from_str(
+        &right_document
+            .inspect_vm_state()
+            .to_pretty_json()
+            .expect("right VM inspection should serialize"),
+    )
+    .expect("right VM inspection should parse");
+    assert_ne!(
+        left["memory"]["binding_identity"]["digest"],
+        right["memory"]["binding_identity"]["digest"]
+    );
+    assert_eq!(
+        left["memory"]["binding_identity"]["byte_length"],
+        right["memory"]["binding_identity"]["byte_length"]
+    );
+    left["memory"]["binding_identity"]["digest"] = Value::String("<digest>".to_owned());
+    right["memory"]["binding_identity"]["digest"] = Value::String("<digest>".to_owned());
+    assert_eq!(left, right);
+}
+
+#[test]
+fn authority_fields_are_literal_redactions_without_fingerprints() {
+    for document in inspection_document_fixtures() {
+        let json = document
+            .inspect_vm_state()
+            .to_pretty_json()
+            .expect("VM inspection should serialize");
+        let value: Value = serde_json::from_str(&json).expect("VM inspection should parse");
+        assert_authority_redaction(&value);
+    }
+}
+
+#[test]
+fn seeded_sensitive_values_are_absent_from_both_views() {
+    for document in inspection_document_fixtures() {
+        let vcpus = document
+            .inspect_vcpu_states()
+            .to_pretty_json()
+            .expect("vCPU inspection should serialize");
+        let vm = document
+            .inspect_vm_state()
+            .to_pretty_json()
+            .expect("VM inspection should serialize");
+
+        for marker in [
+            "sensitive-gic-state",
+            "/fixture/kernel",
+            "/fixture/initrd",
+            "secret=fixture",
+            "serial-log",
+            "vmnet:shared",
+            "/tmp/bangbang-vsock-inactive.sock",
+            "\"abc\"",
+        ] {
+            assert!(!vcpus.contains(marker), "vCPU view leaked {marker}");
+            assert!(!vm.contains(marker), "VM view leaked {marker}");
+        }
+
+        let (image_id, checksum) = raw_memory_identity_markers(&document);
+        assert!(!vcpus.contains(&image_id));
+        assert!(!vm.contains(&image_id));
+        assert!(!vcpus.contains(&checksum));
+        assert!(!vm.contains(&checksum));
+    }
+}
+
+#[test]
+fn fingerprints_are_algorithm_labelled_fixed_lowercase_sha256() {
+    let documents = inspection_document_fixtures();
+    let mut count = 0;
+    for document in &documents {
+        for json in [
+            document
+                .inspect_vcpu_states()
+                .to_pretty_json()
+                .expect("vCPU inspection should serialize"),
+            document
+                .inspect_vm_state()
+                .to_pretty_json()
+                .expect("VM inspection should serialize"),
+        ] {
+            let value: Value = serde_json::from_str(&json).expect("inspection should parse");
+            count += assert_fingerprint_shape(&value);
+        }
+    }
+    assert!(count > documents.len());
+}
+
+#[test]
+fn errors_and_view_debug_do_not_expose_values() {
+    let document = inspection_native_v1_document(1);
+    let error = format_pretty_json_with_limit(&"sensitive-output-marker", 1)
+        .expect_err("injected low limit should fail");
+    let display = error.to_string();
+    let debug = format!("{error:?}");
+    assert!(!display.contains("sensitive-output-marker"));
+    assert!(!debug.contains("sensitive-output-marker"));
+
+    let vcpu_debug = format!("{:?}", document.inspect_vcpu_states());
+    let vm_debug = format!("{:?}", document.inspect_vm_state());
+    for marker in ["sensitive-gic-state", "rootfs.img", "serial-log"] {
+        assert!(!vcpu_debug.contains(marker));
+        assert!(!vm_debug.contains(marker));
+    }
+}
+
+fn assert_fixed_lowercase_hex(value: &Value) {
+    match value {
+        Value::Array(values) => values.iter().for_each(assert_fixed_lowercase_hex),
+        Value::Object(values) => values.values().for_each(assert_fixed_lowercase_hex),
+        Value::String(value) if value.starts_with("0x") => {
+            assert!(matches!(value.len(), 4 | 6 | 10 | 18 | 34));
+            assert!(
+                value[2..]
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+            );
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+fn assert_authority_redaction(value: &Value) {
+    match value {
+        Value::Array(values) => values.iter().for_each(assert_authority_redaction),
+        Value::Object(values) => {
+            if values.contains_key("capacity_sectors") && values.contains_key("device_id") {
+                assert_eq!(
+                    values["device_id"], "<redacted>",
+                    "inode-derived block device ID was not literally redacted"
+                );
+            }
+            for (key, value) in values {
+                if key.contains("selector")
+                    || key.ends_with("_path")
+                    || key.ends_with("_authority")
+                    || matches!(
+                        key.as_str(),
+                        "path" | "backing_identity" | "host_local_port_cursor"
+                    )
+                    || (key == "arguments" && !value.is_array())
+                {
+                    assert!(
+                        value.is_null() || value.as_str() == Some("<redacted>"),
+                        "authority field {key} was not literally redacted: {value}"
+                    );
+                }
+                assert_authority_redaction(value);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+fn assert_fingerprint_shape(value: &Value) -> usize {
+    match value {
+        Value::Array(values) => values.iter().map(assert_fingerprint_shape).sum(),
+        Value::Object(values)
+            if values.get("algorithm") == Some(&Value::String("sha256".to_owned())) =>
+        {
+            assert_eq!(values.len(), 3);
+            assert!(values["byte_length"].as_u64().is_some());
+            let digest = values["digest"]
+                .as_str()
+                .expect("fingerprint digest should be a string");
+            assert_eq!(digest.len(), 64);
+            assert!(
+                digest
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+            );
+            1
+        }
+        Value::Object(values) => values.values().map(assert_fingerprint_shape).sum(),
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => 0,
+    }
+}
+
+fn raw_memory_identity_markers(document: &HvfNativeSnapshotDocument) -> (String, String) {
+    let (image_id, checksum) = match &document.state {
+        HvfNativeSnapshotDocumentState::V1(bundle) => {
+            let binding = bundle.commit_record().memory_binding();
+            (*binding.image_id().as_bytes(), binding.checksum())
+        }
+        state => {
+            let binding = platform_v2(state)
+                .expect("native-v2 fixture should retain a platform")
+                .memory();
+            (*binding.image_id().as_bytes(), binding.metadata_checksum())
+        }
+    };
+    let image_id = image_id
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    (image_id, format!("{checksum:016x}"))
+}
+
+fn assert_root_field_order(json: &str, fields: &[&str]) {
+    let mut previous = None;
+    for field in fields {
+        let position = json
+            .find(&format!("\"{field}\":"))
+            .expect("root field should be present");
+        if let Some(previous) = previous {
+            assert!(position > previous, "root field {field} is out of order");
+        }
+        previous = Some(position);
+    }
+}
+
+fn assert_serializes_within_public_ceiling<T: Serialize>(value: &T) -> Value {
+    let json = format_pretty_json(value, HVF_NATIVE_SNAPSHOT_INSPECTION_MAX_JSON_BYTES)
+        .expect("maximum inspection collection should serialize");
+    assert!(json.len() <= HVF_NATIVE_SNAPSHOT_INSPECTION_MAX_JSON_BYTES);
+    serde_json::from_str(&json).expect("maximum inspection collection should parse")
+}
+
+fn memory_binding_for_ranges(ranges: Vec<GuestMemoryRange>) -> SnapshotV2MemoryBinding {
+    let layout = GuestMemoryLayout::new(ranges).expect("maximum memory layout should validate");
+    let memory = GuestMemory::allocate(&layout).expect("maximum memory layout should allocate");
+    write_snapshot_v2_memory_image_with_compatibility_version(
+        &memory,
+        &mut DiscardSeek::default(),
+        NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION,
+    )
+    .expect("maximum memory binding should encode")
+}
+
+#[derive(Default)]
+struct DiscardSeek {
+    position: u64,
+    length: u64,
+}
+
+impl Write for DiscardSeek {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.position = self
+            .position
+            .checked_add(u64::try_from(bytes.len()).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidInput, "write length does not fit u64")
+            })?)
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "write position overflow")
+            })?;
+        self.length = self.length.max(self.position);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Seek for DiscardSeek {
+    fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
+        self.position = match position {
+            SeekFrom::Start(position) => position,
+            SeekFrom::End(offset) => checked_seek(self.length, offset)?,
+            SeekFrom::Current(offset) => checked_seek(self.position, offset)?,
+        };
+        Ok(self.position)
+    }
+}
+
+fn checked_seek(base: u64, offset: i64) -> io::Result<u64> {
+    if offset >= 0 {
+        base.checked_add(offset.unsigned_abs())
+    } else {
+        base.checked_sub(offset.unsigned_abs())
+    }
+    .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "seek position overflow"))
+}

--- a/crates/hvf/src/snapshot_document/tests.rs
+++ b/crates/hvf/src/snapshot_document/tests.rs
@@ -84,6 +84,132 @@ fn native_v1_document_fixture() -> (HvfSnapshotV1Bundle, Vec<u8>) {
     (bundle, bytes)
 }
 
+pub(crate) fn inspection_document_fixtures() -> Vec<HvfNativeSnapshotDocument> {
+    let (_, v1) = native_v1_document_fixture();
+    let legacy = encode_hvf_snapshot_v2_platform_state(&platform_fixture(false))
+        .expect("exact-2.3 inspection fixture should encode");
+    let device_graph =
+        encode_hvf_snapshot_v2_state(&complete_state_fixture(MMIO_GRAPH_FIXTURE_HEX))
+            .expect("exact-2.4 inspection fixture should encode");
+    let multi_block = encode_hvf_snapshot_v2_multi_block_state(
+        &complete_multi_block_state_fixture(MULTI_BLOCK_MMIO_GRAPH_FIXTURE_HEX),
+    )
+    .expect("exact-2.5 inspection fixture should encode");
+    let storage = encode_hvf_snapshot_v2_storage_state(&complete_storage_state_fixture(
+        STORAGE_MMIO_GRAPH_FIXTURE_HEX,
+    ))
+    .expect("exact-2.6 inspection fixture should encode");
+    let serial = encode_hvf_snapshot_v2_serial_state(&complete_serial_state_fixture(
+        Some(STORAGE_MMIO_GRAPH_FIXTURE_HEX),
+        SERIAL_CONFIGURED_FIXTURE_HEX,
+    ))
+    .expect("exact-2.7 inspection fixture should encode");
+    let entropy = encode_hvf_snapshot_v2_entropy_state(&complete_entropy_state_fixture(
+        None,
+        SERIAL_CONFIGURED_FIXTURE_HEX,
+        Some(ENTROPY_INACTIVE_MMIO_FIXTURE_HEX),
+        false,
+    ))
+    .expect("exact-2.8 inspection fixture should encode");
+    let balloon = encode_hvf_snapshot_v2_balloon_state(&complete_balloon_state_fixture(
+        SnapshotV2DeviceTransportKind::Mmio,
+        true,
+        true,
+        true,
+    ))
+    .expect("exact-2.9 inspection fixture should encode");
+    let memory_hotplug =
+        encode_hvf_snapshot_v2_memory_hotplug_state(&complete_memory_hotplug_state_fixture(
+            SnapshotV2DeviceTransportKind::Mmio,
+            true,
+            true,
+            true,
+            true,
+        ))
+        .expect("exact-2.10 inspection fixture should encode");
+    let network = encode_hvf_snapshot_v2_network_state(&complete_network_state_fixture(
+        SnapshotV2DeviceTransportKind::Mmio,
+        true,
+        true,
+        true,
+        true,
+        true,
+    ))
+    .expect("exact-2.11 inspection fixture should encode");
+    let vsock = encode_hvf_snapshot_v2_vsock_state(&complete_vsock_state_fixture(
+        SnapshotV2DeviceTransportKind::Mmio,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+    ))
+    .expect("exact-2.12 inspection fixture should encode");
+    let predecessor_memory_hotplug =
+        product_memory_hotplug_fixture(SnapshotV2DeviceTransportKind::Mmio);
+    let predecessor = exact_minor_twelve_memory_binding(Some(&predecessor_memory_hotplug));
+    let extent = GuestMemoryRange::new(GuestAddress::new(aarch64::DRAM_MEM_START), 4096)
+        .expect("Diff inspection fixture extent should validate");
+    let diff = encode_hvf_snapshot_v2_diff_state(&complete_diff_state_fixture(
+        SnapshotV2DeviceTransportKind::Mmio,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        SnapshotV2DiffBase::Image(predecessor),
+        &[extent],
+    ))
+    .expect("exact-2.13 inspection fixture should encode");
+
+    [
+        v1,
+        legacy,
+        device_graph,
+        multi_block,
+        storage,
+        serial,
+        entropy,
+        balloon,
+        memory_hotplug,
+        network,
+        vsock,
+        diff,
+    ]
+    .into_iter()
+    .map(|bytes| {
+        HvfNativeSnapshotDocument::decode(&bytes)
+            .expect("inspection fixture should decode as an exact document")
+    })
+    .collect()
+}
+
+pub(crate) fn inspection_native_v1_document(memory_mib: u64) -> HvfNativeSnapshotDocument {
+    let bundle = HvfSnapshotV1Bundle::try_new(memory_binding(memory_mib), native_v1_fixture())
+        .expect("native-v1 inspection fixture bundle should validate");
+    let bytes = encode_snapshot_commit_envelope(bundle.commit_record())
+        .expect("native-v1 inspection fixture should encode");
+    HvfNativeSnapshotDocument::decode(&bytes).expect("native-v1 inspection fixture should decode")
+}
+
+pub(crate) fn inspection_native_v1_document_with_pc(pc: u64) -> HvfNativeSnapshotDocument {
+    let (machine, compatibility, mut vcpu, interrupts, device) = native_v1_fixture().into_parts();
+    vcpu.general = crate::vcpu::HvfArm64VcpuGeneralRegisterState::new(
+        *vcpu.general.general_purpose_registers(),
+        pc,
+        vcpu.general.cpsr(),
+    );
+    let state = HvfSnapshotV1State::new(machine, compatibility, vcpu, interrupts, device);
+    let bundle = HvfSnapshotV1Bundle::try_new(memory_binding(1), state)
+        .expect("native-v1 inspection register fixture should validate");
+    let bytes = encode_snapshot_commit_envelope(bundle.commit_record())
+        .expect("native-v1 inspection register fixture should encode");
+    HvfNativeSnapshotDocument::decode(&bytes)
+        .expect("native-v1 inspection register fixture should decode")
+}
+
 #[test]
 fn native_v1_document_preserves_commit_memory_state_and_replacement() {
     let (bundle, bytes) = native_v1_document_fixture();

--- a/crates/hvf/src/snapshot_v2/tests.rs
+++ b/crates/hvf/src/snapshot_v2/tests.rs
@@ -1,10 +1,19 @@
 use std::io::Cursor;
 
+use bangbang_runtime::interrupt::GuestInterruptLine;
 use bangbang_runtime::machine::MachineConfigInput;
 use bangbang_runtime::memory::{
     GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange, aarch64,
 };
+use bangbang_runtime::memory_hotplug::{
+    MEMORY_HOTPLUG_DEFAULT_BLOCK_SIZE_MIB, MEMORY_HOTPLUG_DEFAULT_SLOT_SIZE_MIB,
+    MemoryHotplugConfig, MemoryHotplugConfigInput, VIRTIO_MEM_DEFAULT_REGION_ADDRESS,
+    VirtioMemConfigSpace,
+};
+use bangbang_runtime::mmio::{MmioRegion, MmioRegionId};
+use bangbang_runtime::network::{GuestMacAddress, NetworkDeviceProfile};
 use bangbang_runtime::pci::{PCI_BAR64_START, PCI_FIRST_ENDPOINT_DEVICE, PCI_LAST_ENDPOINT_DEVICE};
+use bangbang_runtime::pmem::{VIRTIO_PMEM_ALIGNMENT, VirtioPmemConfigSpace};
 use bangbang_runtime::snapshot_artifact::{
     NativeV2DiffSnapshotCandidateState, NativeV2DiffSnapshotCandidateStateError,
     NativeV2MemoryHotplugSnapshotCandidateState, NativeV2NetworkSnapshotCandidateState,
@@ -12,13 +21,18 @@ use bangbang_runtime::snapshot_artifact::{
 };
 use bangbang_runtime::snapshot_balloon_v2_9::{
     NATIVE_V2_BALLOON_STATE_COMPATIBILITY_VERSION, NATIVE_V2_BALLOON_STATE_HEADER_BYTES,
-    NATIVE_V2_BALLOON_STATE_SECTION_ENTRY_BYTES,
+    NATIVE_V2_BALLOON_STATE_MAX_ACCOUNTING_RANGES, NATIVE_V2_BALLOON_STATE_SECTION_ENTRY_BYTES,
+    SnapshotV2BalloonAccountingState, SnapshotV2BalloonPfnRange, SnapshotV2BalloonState,
 };
-use bangbang_runtime::snapshot_device_v2::SnapshotV2DeviceTransportKind;
+use bangbang_runtime::snapshot_device_v2::{
+    SnapshotV2DeviceTransport, SnapshotV2DeviceTransportKind, SnapshotV2MmioDeviceState,
+};
 use bangbang_runtime::snapshot_device_v2_5::NATIVE_V2_MULTI_BLOCK_DEVICE_GRAPH_MAX_BYTES;
 use bangbang_runtime::snapshot_device_v2_6::{
     NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
-    NATIVE_V2_STORAGE_DEVICE_GRAPH_SECTION_ENTRY_BYTES, SnapshotV2StorageDeviceGraph,
+    NATIVE_V2_STORAGE_DEVICE_GRAPH_MAX_RECORDS, NATIVE_V2_STORAGE_DEVICE_GRAPH_SECTION_ENTRY_BYTES,
+    SnapshotV2PmemConfig, SnapshotV2PmemDeviceRecord, SnapshotV2PmemState,
+    SnapshotV2StorageDeviceGraph,
 };
 use bangbang_runtime::snapshot_diff_v2_13::{
     NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION, SnapshotV2DiffBase, SnapshotV2DiffLayerBinding,
@@ -35,6 +49,7 @@ use bangbang_runtime::snapshot_format_v2::{
     encode_snapshot_v2_state_with_compatibility_version,
 };
 use bangbang_runtime::snapshot_memory_hotplug_v2_10::{
+    NATIVE_V2_MEMORY_HOTPLUG_MAX_BITMAP_BYTES, NATIVE_V2_MEMORY_HOTPLUG_MAX_BLOCKS,
     NATIVE_V2_MEMORY_HOTPLUG_STATE_COMPATIBILITY_VERSION,
     NATIVE_V2_MEMORY_HOTPLUG_STATE_HEADER_BYTES,
     NATIVE_V2_MEMORY_HOTPLUG_STATE_SECTION_ENTRY_BYTES, SnapshotV2MemoryHotplugState,
@@ -45,8 +60,9 @@ use bangbang_runtime::snapshot_memory_v2::{
 use bangbang_runtime::snapshot_network_v2_11::{
     NATIVE_V2_NETWORK_INTERFACE_DIRECTORY_ENTRY_BYTES,
     NATIVE_V2_NETWORK_INTERFACE_RECORD_HEADER_BYTES,
-    NATIVE_V2_NETWORK_INTERFACE_SECTION_ENTRY_BYTES, NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION,
-    NATIVE_V2_NETWORK_STATE_HEADER_BYTES, SnapshotV2NetworkState,
+    NATIVE_V2_NETWORK_INTERFACE_SECTION_ENTRY_BYTES, NATIVE_V2_NETWORK_MAX_INTERFACES,
+    NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION, NATIVE_V2_NETWORK_STATE_HEADER_BYTES,
+    SnapshotV2NetworkInterfaceState, SnapshotV2NetworkState,
 };
 use bangbang_runtime::snapshot_serial_v2_7::{
     NATIVE_V2_SERIAL_STATE_COMPATIBILITY_VERSION, SnapshotV2SerialState,
@@ -56,6 +72,7 @@ use bangbang_runtime::snapshot_vsock_v2_12::{
     NATIVE_V2_VSOCK_STATE_COMPATIBILITY_VERSION, NATIVE_V2_VSOCK_STATE_HEADER_BYTES,
     NATIVE_V2_VSOCK_STATE_SECTION_ENTRY_BYTES, SnapshotV2VsockState,
 };
+use bangbang_runtime::virtio_mmio::VIRTIO_MMIO_DEVICE_WINDOW_SIZE;
 use bangbang_runtime::virtio_pci::VIRTIO_PCI_CAPABILITY_BAR_SIZE;
 
 use super::*;
@@ -118,7 +135,48 @@ pub(crate) fn platform_fixture(with_sme: bool) -> HvfSnapshotV2PlatformState {
     platform_fixture_with_count(2, with_sme)
 }
 
-fn platform_fixture_with_count(vcpu_count: u8, with_sme: bool) -> HvfSnapshotV2PlatformState {
+pub(crate) fn platform_fixture_with_cpu_template() -> HvfSnapshotV2PlatformState {
+    let entries = [
+        (1, HvfArm64CpuTemplateValueWidth::U32, 0xff, 0x12, 0x1234),
+        (
+            3,
+            HvfArm64CpuTemplateValueWidth::U64,
+            0xff00,
+            0x3400,
+            0xabcd,
+        ),
+        (
+            52,
+            HvfArm64CpuTemplateValueWidth::U128,
+            0xffff,
+            0x5678,
+            (1_u128 << 100) | 0xabcd,
+        ),
+    ]
+    .into_iter()
+    .map(|(tag, width, filter, logical_value, baseline)| {
+        HvfArm64CpuTemplateApplicationEntry::try_from_stable_values(
+            tag,
+            width,
+            filter,
+            logical_value,
+            baseline,
+            (baseline & !filter) | logical_value,
+        )
+        .expect("inspection CPU-template entry should validate")
+    })
+    .collect();
+    let application = HvfArm64CpuTemplateApplicationState::try_new(entries)
+        .expect("inspection CPU-template application should validate");
+    let mut platform = platform_fixture(false);
+    platform.machine.cpu_template = Some(application);
+    platform
+}
+
+pub(crate) fn platform_fixture_with_count(
+    vcpu_count: u8,
+    with_sme: bool,
+) -> HvfSnapshotV2PlatformState {
     let (_, compatibility, mandatory, interrupts, devices) = native_v1_fixture().into_parts();
     let source_identification = compatibility.identification();
     let pfr0 = if with_sme {
@@ -935,6 +993,217 @@ pub(crate) fn product_memory_hotplug_fixture(
         &bytes,
     )
     .expect("relocated virtio-mem fixture should decode")
+}
+
+pub(crate) fn maximum_storage_graph_fixture() -> SnapshotV2StorageDeviceGraph {
+    let record_count = usize::from(NATIVE_V2_STORAGE_DEVICE_GRAPH_MAX_RECORDS);
+    let mut records = Vec::with_capacity(record_count);
+    for index in 0..record_count {
+        let mut bytes = fixture_bytes(STORAGE_MMIO_GRAPH_FIXTURE_HEX);
+        relocate_storage_product_fixture(&mut bytes, false);
+        let section_directory = usize::try_from(read_wire_u64(&bytes, 48))
+            .expect("storage section directory should fit usize");
+        let common_entry =
+            section_directory + 2 * NATIVE_V2_STORAGE_DEVICE_GRAPH_SECTION_ENTRY_BYTES;
+        let common_offset = storage_section_offset(&bytes, common_entry);
+        relocate_common_queues(
+            &mut bytes,
+            common_offset,
+            PRODUCT_STORAGE_QUEUE_BASE
+                + u64::try_from(index).expect("storage index should fit") * PRODUCT_QUEUE_STRIDE,
+        );
+        let template = SnapshotV2StorageDeviceGraph::decode(
+            NATIVE_V2_STORAGE_DEVICE_GRAPH_COMPATIBILITY_VERSION,
+            &bytes,
+        )
+        .expect("relocated pmem template should decode");
+        let template = template
+            .pmem_records()
+            .first()
+            .expect("pmem template should contain one record");
+
+        let instance = u32::try_from(index).expect("storage record index should fit u32");
+        let config = SnapshotV2PmemConfig::try_new(
+            format!("pmem_{instance}"),
+            index == 0,
+            instance.is_multiple_of(2),
+            template.config().rate_limiter(),
+            format!("pmem-selector-{instance}"),
+        )
+        .expect("maximum pmem configuration should validate");
+        let file_bytes = VIRTIO_PMEM_ALIGNMENT + 513 + u64::from(instance);
+        let mapped_bytes = VIRTIO_PMEM_ALIGNMENT * 2;
+        let guest_start = 0x4_0000_0000 + u64::from(instance) * 0x400_000;
+        let guest_range = GuestMemoryRange::new(GuestAddress::new(guest_start), mapped_bytes)
+            .expect("maximum pmem guest range should validate");
+        let pmem = SnapshotV2PmemState::try_new(
+            file_bytes,
+            mapped_bytes,
+            guest_range,
+            VirtioPmemConfigSpace::new(guest_start, mapped_bytes),
+            template.pmem().active_queue(),
+            template.pmem().limiter(),
+            template.pmem().pending_rate_limited_queue(),
+            template.pmem().retry(),
+        )
+        .expect("maximum pmem state should validate");
+        let region = MmioRegion::new(
+            MmioRegionId::new(100 + u64::from(instance)),
+            GuestAddress::new(0xd000_0000 + u64::from(instance) * VIRTIO_MMIO_DEVICE_WINDOW_SIZE),
+            VIRTIO_MMIO_DEVICE_WINDOW_SIZE,
+        )
+        .expect("maximum pmem MMIO region should validate");
+        let transport = SnapshotV2DeviceTransport::Mmio(SnapshotV2MmioDeviceState::from_parts(
+            instance % 2,
+            (instance + 1) % 2,
+            0,
+            region,
+            GuestInterruptLine::new(40 + instance)
+                .expect("maximum pmem interrupt line should validate"),
+        ));
+        records.push(
+            SnapshotV2PmemDeviceRecord::try_new(
+                instance,
+                config,
+                pmem,
+                template.virtio().clone(),
+                transport,
+            )
+            .expect("maximum pmem record should validate"),
+        );
+    }
+
+    let root_key = records
+        .first()
+        .map(SnapshotV2PmemDeviceRecord::key)
+        .expect("maximum storage graph should contain a root");
+    SnapshotV2StorageDeviceGraph::try_from_parts(
+        Some(root_key),
+        SnapshotV2DeviceTransportKind::Mmio,
+        Vec::new(),
+        records,
+    )
+    .expect("maximum storage graph should validate")
+}
+
+pub(crate) fn maximum_network_state_fixture() -> SnapshotV2NetworkState {
+    let mut interfaces = Vec::with_capacity(NATIVE_V2_NETWORK_MAX_INTERFACES);
+    for index in 0..NATIVE_V2_NETWORK_MAX_INTERFACES {
+        let mut bytes = fixture_bytes(NETWORK_INACTIVE_MMIO_FIXTURE_HEX);
+        let common_offset = network_record_section_offset(&bytes, 0, 2);
+        relocate_common_queues(
+            &mut bytes,
+            common_offset,
+            0x8014_0000
+                + u64::try_from(index).expect("network index should fit") * PRODUCT_QUEUE_STRIDE,
+        );
+        let transport_offset = network_record_section_offset(&bytes, 0, 4);
+        bytes[transport_offset + 12..transport_offset + 16].copy_from_slice(
+            &(43 + u32::try_from(index).expect("network interrupt index should fit")).to_le_bytes(),
+        );
+        write_wire_u64(
+            &mut bytes,
+            transport_offset + 16,
+            103 + u64::try_from(index).expect("network region index should fit"),
+        );
+        write_wire_u64(
+            &mut bytes,
+            transport_offset + 24,
+            0xd003_0000 + u64::try_from(index).expect("network MMIO index should fit") * 0x1000,
+        );
+        let (mut decoded, _) =
+            SnapshotV2NetworkState::decode(NATIVE_V2_NETWORK_STATE_COMPATIBILITY_VERSION, &bytes)
+                .expect("relocated network template should decode")
+                .into_parts();
+        let mut parts = decoded
+            .pop()
+            .expect("network template should contain one interface")
+            .into_parts();
+        let mac = GuestMacAddress::from_bytes([
+            0x02,
+            0,
+            0,
+            0,
+            0,
+            u8::try_from(index).expect("network index should fit u8"),
+        ]);
+        let template_profile = parts.profile;
+        parts.iface_id = format!("eth{index}");
+        parts.captured_selector = format!("vmnet:maximum-{index}");
+        parts.requested_guest_mac = Some(mac);
+        parts.profile = NetworkDeviceProfile::new(Some(mac), parts.requested_mtu)
+            .with_packet_envelope(template_profile.packet_envelope())
+            .with_feature_capabilities(template_profile.feature_capabilities());
+        interfaces.push(
+            SnapshotV2NetworkInterfaceState::try_from_parts(parts)
+                .expect("maximum network interface should validate"),
+        );
+    }
+    SnapshotV2NetworkState::try_new(interfaces, None)
+        .expect("maximum network state should validate")
+}
+
+pub(crate) fn maximum_balloon_state_fixture() -> SnapshotV2BalloonState {
+    let template = product_balloon_fixture(SnapshotV2DeviceTransportKind::Pci);
+    let ranges = (0..NATIVE_V2_BALLOON_STATE_MAX_ACCOUNTING_RANGES)
+        .map(|index| {
+            SnapshotV2BalloonPfnRange::try_new(
+                u32::try_from(index * 2).expect("balloon PFN should fit u32"),
+                1,
+            )
+            .expect("maximum balloon accounting range should validate")
+        })
+        .collect::<Vec<_>>();
+    let accounting = SnapshotV2BalloonAccountingState::try_new(
+        ranges,
+        u64::try_from(NATIVE_V2_BALLOON_STATE_MAX_ACCOUNTING_RANGES)
+            .expect("balloon range count should fit u64"),
+    )
+    .expect("maximum balloon accounting should validate");
+    SnapshotV2BalloonState::try_new(
+        template.config(),
+        template.config_space(),
+        *template.continuation(),
+        accounting,
+        template.virtio().clone(),
+        template.transport().clone(),
+    )
+    .expect("maximum balloon state should validate")
+}
+
+pub(crate) fn maximum_memory_hotplug_state_fixture() -> SnapshotV2MemoryHotplugState {
+    let template = product_memory_hotplug_fixture(SnapshotV2DeviceTransportKind::Mmio);
+    let block_size = MEMORY_HOTPLUG_DEFAULT_BLOCK_SIZE_MIB * MIB;
+    let address = VIRTIO_MEM_DEFAULT_REGION_ADDRESS.raw_value();
+    let address_space_end = aarch64::DRAM_MEM_START + aarch64::DRAM_MEM_MAX_SIZE;
+    let region_size = address_space_end - address;
+    let block_count = usize::try_from(region_size / block_size)
+        .expect("maximum virtio-mem block count should fit usize");
+    assert!(block_count <= NATIVE_V2_MEMORY_HOTPLUG_MAX_BLOCKS);
+    let bitmap_length = block_count.div_ceil(8);
+    assert!(bitmap_length <= NATIVE_V2_MEMORY_HOTPLUG_MAX_BITMAP_BYTES);
+    let bitmap = vec![0x55; bitmap_length];
+    let plugged_blocks = u64::try_from(block_count / 2)
+        .expect("maximum virtio-mem plugged block count should fit u64");
+    let config = MemoryHotplugConfig::try_from(MemoryHotplugConfigInput::new(
+        region_size / MIB,
+        MEMORY_HOTPLUG_DEFAULT_BLOCK_SIZE_MIB,
+        MEMORY_HOTPLUG_DEFAULT_SLOT_SIZE_MIB,
+    ))
+    .expect("maximum virtio-mem configuration should validate");
+    let config_space = VirtioMemConfigSpace::new(block_size, address, region_size)
+        .with_usable_region_size(region_size)
+        .with_plugged_size(plugged_blocks * block_size)
+        .with_requested_size(plugged_blocks * block_size);
+    SnapshotV2MemoryHotplugState::try_new(
+        config,
+        config_space,
+        None,
+        bitmap,
+        template.virtio().clone(),
+        template.transport().clone(),
+    )
+    .expect("maximum virtio-mem state should validate")
 }
 
 pub(crate) fn product_serial_fixture() -> SnapshotV2SerialState {

--- a/crates/runtime/src/snapshot_memory_v2.rs
+++ b/crates/runtime/src/snapshot_memory_v2.rs
@@ -85,6 +85,15 @@ impl SnapshotV2MemoryImageId {
     pub(crate) const fn to_bytes(self) -> [u8; IMAGE_ID_BYTES] {
         self.0
     }
+
+    /// Returns the opaque identity bytes to trusted persistence and inspection code.
+    ///
+    /// Diagnostics must not expose this random state/image pairing identity
+    /// directly. A public inspection surface should use only a cryptographic
+    /// equality fingerprint.
+    pub const fn as_bytes(&self) -> &[u8; IMAGE_ID_BYTES] {
+        &self.0
+    }
 }
 
 impl fmt::Debug for SnapshotV2MemoryImageId {


### PR DESCRIPTION
## Summary

- add borrowed canonical `vcpu-states` and `vm-state` inspection views for native-v1 and every exact native-v2 profile from 2.3 through 2.13
- serialize stable pretty JSON under `bangbang.snapshot-editor.info.v1` with exhaustive typed adapters, fixed-width hexadecimal values, canonical ordering, and a two-pass hard output ceiling
- keep ordinary portable state explicit, expose confidential state only through domain-separated SHA-256 equality fingerprints, and literally redact paths, selectors, process authority, inode-derived block IDs, and other host choices
- cover all profiles, deterministic output, privacy boundaries, failure behavior, and every maximum retained collection with checked fixtures
- raise the complete macOS CI job budget from 15 to 20 minutes after the original exact-head run reached the former limit with no product failure

## Scope exclusions

- no snapshot-editor CLI commands
- no path opening, restore-resource acquisition, state transformation, artifact publication, or KVM snapshot IDs
- no capability-ledger promotion or signed-process certification claim

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p bangbang --test executable_hvf_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang --test app_sandbox_process_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test hvf_lifecycle --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-hvf --test guest_boot --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `cargo clippy -p bangbang-launcher --test production_bundle_e2e --all-features --locked --target aarch64-apple-darwin -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

Closes #1772
Relates to #1542
