### PR TITLE
feat: add reviewed KVM register removal

### DIFF
--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -136,11 +136,15 @@ pub use snapshot_bundle::{
     decode_hvf_snapshot_v1_state, encode_hvf_snapshot_v1_state,
 };
 pub use snapshot_document::{
-    HVF_NATIVE_SNAPSHOT_INSPECTION_MAX_JSON_BYTES, HvfNativeSnapshotDocument,
-    HvfNativeSnapshotDocumentDecodeError, HvfNativeSnapshotDocumentEncodeError,
-    HvfNativeSnapshotDocumentProfile, HvfNativeSnapshotDocumentReplaceError,
-    HvfNativeSnapshotInspectionError, HvfNativeSnapshotPlatformRef, HvfNativeSnapshotVcpuRef,
-    HvfNativeSnapshotVcpuState, HvfNativeSnapshotVcpuStatesInspection, HvfNativeSnapshotVcpus,
+    HVF_NATIVE_SNAPSHOT_INSPECTION_MAX_JSON_BYTES, HVF_NATIVE_SNAPSHOT_REVIEWED_KVM_REGISTER_COUNT,
+    HvfNativeSnapshotDocument, HvfNativeSnapshotDocumentDecodeError,
+    HvfNativeSnapshotDocumentEncodeError, HvfNativeSnapshotDocumentProfile,
+    HvfNativeSnapshotDocumentReplaceError, HvfNativeSnapshotInspectionError,
+    HvfNativeSnapshotPlatformRef, HvfNativeSnapshotRegisterRemovalError,
+    HvfNativeSnapshotRegisterRemovalOutcome, HvfNativeSnapshotRegisterRemovalReport,
+    HvfNativeSnapshotRegisterRemovalStatus, HvfNativeSnapshotVcpuRef,
+    HvfNativeSnapshotVcpuRegisterRemovalReport, HvfNativeSnapshotVcpuState,
+    HvfNativeSnapshotVcpuStatesInspection, HvfNativeSnapshotVcpus,
     HvfNativeSnapshotVmStateInspection,
 };
 pub use snapshot_restore::{

--- a/crates/hvf/src/optional_state.rs
+++ b/crates/hvf/src/optional_state.rs
@@ -46,6 +46,27 @@ impl<T: Copy> HvfArm64OptionalStateValue<T> {
     }
 }
 
+/// One reviewed optional register slot addressable by snapshot tooling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HvfArm64ReviewedOptionalStateTarget {
+    /// One debug breakpoint value register.
+    BreakpointValue(u8),
+    /// One debug breakpoint control register.
+    BreakpointControl(u8),
+    /// One debug watchpoint value register.
+    WatchpointValue(u8),
+    /// One debug watchpoint control register.
+    WatchpointControl(u8),
+    /// One of `SMCR_EL1`, `SMPRI_EL1`, or `TPIDR2_EL0` in restore order.
+    SmeSystemRegister(u8),
+}
+
+fn replace_with_destination_default(value: &mut HvfArm64OptionalStateValue<u64>) -> bool {
+    let removed = matches!(value, HvfArm64OptionalStateValue::Explicit(_));
+    *value = HvfArm64OptionalStateValue::DestinationDefault;
+    removed
+}
+
 /// Value-free rejection while constructing reviewed optional restore state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HvfArm64ReviewedOptionalStateBuildError {
@@ -554,6 +575,145 @@ impl HvfArm64ReviewedOptionalStateRestore {
     pub const fn simd_fp(&self) -> &HvfArm64VcpuSimdFpState {
         &self.simd_fp
     }
+
+    /// Reset requested, present register values and rebuild all checked
+    /// optional-state layers.
+    pub(crate) fn try_with_destination_defaults(
+        self,
+        targets: &[HvfArm64ReviewedOptionalStateTarget],
+        removed: &mut [bool],
+    ) -> Result<Self, HvfArm64ReviewedOptionalStateBuildError> {
+        if targets.len() != removed.len() {
+            return Err(HvfArm64ReviewedOptionalStateBuildError::DebugRegisterInventory);
+        }
+
+        let Self {
+            expected_id_aa64dfr0_el1,
+            expected_sme_version,
+            breakpoints,
+            watchpoints,
+            mut sme,
+            simd_fp,
+        } = self;
+        let HvfArm64DebugRegisterRestoreState {
+            implemented_count: breakpoint_count,
+            values: mut breakpoint_values,
+            controls: mut breakpoint_controls,
+        } = breakpoints;
+        let HvfArm64DebugRegisterRestoreState {
+            implemented_count: watchpoint_count,
+            values: mut watchpoint_values,
+            controls: mut watchpoint_controls,
+        } = watchpoints;
+
+        for (target, was_removed) in targets.iter().zip(removed) {
+            *was_removed = match *target {
+                HvfArm64ReviewedOptionalStateTarget::BreakpointValue(index) => {
+                    replace_debug_slot(&mut breakpoint_values, breakpoint_count, index)?
+                }
+                HvfArm64ReviewedOptionalStateTarget::BreakpointControl(index) => {
+                    replace_debug_slot(&mut breakpoint_controls, breakpoint_count, index)?
+                }
+                HvfArm64ReviewedOptionalStateTarget::WatchpointValue(index) => {
+                    replace_debug_slot(&mut watchpoint_values, watchpoint_count, index)?
+                }
+                HvfArm64ReviewedOptionalStateTarget::WatchpointControl(index) => {
+                    replace_debug_slot(&mut watchpoint_controls, watchpoint_count, index)?
+                }
+                HvfArm64ReviewedOptionalStateTarget::SmeSystemRegister(index) => {
+                    match sme.as_mut() {
+                        Some(state) => {
+                            let value = state.system_registers.get_mut(usize::from(index)).ok_or(
+                                HvfArm64ReviewedOptionalStateBuildError::SmeConditionalInventory,
+                            )?;
+                            replace_with_destination_default(value)
+                        }
+                        None => false,
+                    }
+                }
+            };
+        }
+
+        let breakpoints = HvfArm64DebugRegisterRestoreState::try_new(
+            breakpoint_count,
+            breakpoint_values,
+            breakpoint_controls,
+        )?;
+        let watchpoints = HvfArm64DebugRegisterRestoreState::try_new(
+            watchpoint_count,
+            watchpoint_values,
+            watchpoint_controls,
+        )?;
+        let sme = sme
+            .map(|state| rebuild_sme_restore_state(state, &simd_fp))
+            .transpose()?;
+        Self::try_new(
+            expected_id_aa64dfr0_el1,
+            expected_sme_version,
+            breakpoints,
+            watchpoints,
+            sme,
+            simd_fp,
+        )
+    }
+}
+
+fn replace_debug_slot(
+    values: &mut [HvfArm64OptionalStateValue<u64>; DEBUG_REGISTER_CAPACITY],
+    implemented_count: u8,
+    index: u8,
+) -> Result<bool, HvfArm64ReviewedOptionalStateBuildError> {
+    if index >= DEBUG_REGISTER_CAPACITY as u8 {
+        return Err(HvfArm64ReviewedOptionalStateBuildError::DebugRegisterInventory);
+    }
+    if index >= implemented_count {
+        return Ok(false);
+    }
+    let value = values
+        .get_mut(usize::from(index))
+        .ok_or(HvfArm64ReviewedOptionalStateBuildError::DebugRegisterInventory)?;
+    Ok(replace_with_destination_default(value))
+}
+
+fn rebuild_sme_restore_state(
+    state: HvfArm64SmeRestoreState,
+    simd_fp: &HvfArm64VcpuSimdFpState,
+) -> Result<HvfArm64SmeRestoreState, HvfArm64ReviewedOptionalStateBuildError> {
+    let HvfArm64SmeRestoreState {
+        version,
+        identification,
+        maximum_svl_bytes,
+        pstate,
+        system_registers,
+        z_registers,
+        p_registers,
+        za_register,
+        zt0_register,
+    } = state;
+    let mut input = HvfArm64SmeRestoreStateInput::new(
+        version,
+        identification,
+        maximum_svl_bytes,
+        pstate,
+        system_registers,
+    );
+    input = match (z_registers, p_registers) {
+        (Some(z_registers), Some(p_registers)) => {
+            input.with_streaming_registers(z_registers.into_vec(), p_registers.into_vec())
+        }
+        (None, None) => input,
+        _ => {
+            return Err(HvfArm64ReviewedOptionalStateBuildError::SmeConditionalInventory);
+        }
+    };
+    input = match (za_register, zt0_register) {
+        (Some(za_register), zt0_register) => input.with_za_register(za_register, zt0_register),
+        (None, None) => input,
+        (None, Some(_)) => {
+            return Err(HvfArm64ReviewedOptionalStateBuildError::SmeConditionalInventory);
+        }
+    };
+    HvfArm64SmeRestoreState::try_new(input, simd_fp)
 }
 
 const fn breakpoint_count(id_aa64dfr0_el1: u64) -> u8 {

--- a/crates/hvf/src/snapshot_document.rs
+++ b/crates/hvf/src/snapshot_document.rs
@@ -53,10 +53,16 @@ use crate::snapshot_v2::{
 const REDACTED: &str = "<redacted>";
 
 mod inspection;
+mod register_removal;
 
 pub use inspection::{
     HVF_NATIVE_SNAPSHOT_INSPECTION_MAX_JSON_BYTES, HvfNativeSnapshotInspectionError,
     HvfNativeSnapshotVcpuStatesInspection, HvfNativeSnapshotVmStateInspection,
+};
+pub use register_removal::{
+    HVF_NATIVE_SNAPSHOT_REVIEWED_KVM_REGISTER_COUNT, HvfNativeSnapshotRegisterRemovalError,
+    HvfNativeSnapshotRegisterRemovalOutcome, HvfNativeSnapshotRegisterRemovalReport,
+    HvfNativeSnapshotRegisterRemovalStatus, HvfNativeSnapshotVcpuRegisterRemovalReport,
 };
 
 /// Exact semantic profile owned by one native HVF snapshot document.

--- a/crates/hvf/src/snapshot_document/register_removal.rs
+++ b/crates/hvf/src/snapshot_document/register_removal.rs
@@ -1,0 +1,677 @@
+//! Reviewed Firecracker KVM register removal for owned snapshot documents.
+
+use std::collections::TryReserveError;
+use std::fmt;
+
+use crate::optional_state::{
+    HvfArm64ReviewedOptionalStateBuildError, HvfArm64ReviewedOptionalStateTarget as Target,
+};
+use crate::snapshot_v2::{HvfSnapshotV2BuildError, HvfSnapshotV2VcpuState};
+
+use super::{
+    HvfNativeSnapshotDocument, HvfNativeSnapshotDocumentReplaceError, HvfNativeSnapshotVcpuState,
+};
+
+/// Number of exact Firecracker v1.16.0 aarch64 KVM U64 register identifiers
+/// accepted by the reviewed removal operation.
+pub const HVF_NATIVE_SNAPSHOT_REVIEWED_KVM_REGISTER_COUNT: usize = 67;
+
+/// Result for one requested register on one vCPU.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HvfNativeSnapshotRegisterRemovalStatus {
+    /// An explicitly persisted value was reset to its destination default.
+    Removed,
+    /// The register was already defaulted or is not implemented by this vCPU.
+    NotPresent,
+}
+
+impl fmt::Display for HvfNativeSnapshotRegisterRemovalStatus {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Removed => formatter.write_str("removed"),
+            Self::NotPresent => formatter.write_str("not present"),
+        }
+    }
+}
+
+/// Ordered removal results for one vCPU.
+#[derive(Clone, PartialEq, Eq)]
+pub struct HvfNativeSnapshotVcpuRegisterRemovalReport {
+    vcpu_index: u32,
+    statuses:
+        [HvfNativeSnapshotRegisterRemovalStatus; HVF_NATIVE_SNAPSHOT_REVIEWED_KVM_REGISTER_COUNT],
+    request_count: usize,
+    removed_count: usize,
+}
+
+impl HvfNativeSnapshotVcpuRegisterRemovalReport {
+    /// Return the canonical vCPU index.
+    pub const fn vcpu_index(&self) -> u32 {
+        self.vcpu_index
+    }
+
+    /// Return statuses in the caller's request order.
+    pub fn statuses(&self) -> &[HvfNativeSnapshotRegisterRemovalStatus] {
+        self.statuses.get(..self.request_count).unwrap_or_default()
+    }
+
+    /// Return the number of explicitly persisted values removed on this vCPU.
+    pub const fn removed_count(&self) -> usize {
+        self.removed_count
+    }
+
+    /// Return the number of requested values that were not present.
+    pub const fn not_present_count(&self) -> usize {
+        self.request_count - self.removed_count
+    }
+}
+
+impl fmt::Debug for HvfNativeSnapshotVcpuRegisterRemovalReport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfNativeSnapshotVcpuRegisterRemovalReport")
+            .field("vcpu_index", &self.vcpu_index)
+            .field("request_count", &self.request_count)
+            .field("removed_count", &self.removed_count)
+            .field("not_present_count", &self.not_present_count())
+            .finish()
+    }
+}
+
+/// Aggregate ordered report for one reviewed register-removal operation.
+#[derive(Clone, PartialEq, Eq)]
+pub struct HvfNativeSnapshotRegisterRemovalReport {
+    vcpus: Vec<HvfNativeSnapshotVcpuRegisterRemovalReport>,
+    request_count: usize,
+    removed_count: usize,
+    not_present_count: usize,
+}
+
+impl HvfNativeSnapshotRegisterRemovalReport {
+    /// Return the number of requested register identifiers.
+    pub const fn request_count(&self) -> usize {
+        self.request_count
+    }
+
+    /// Return ordered per-vCPU results.
+    pub fn vcpus(&self) -> &[HvfNativeSnapshotVcpuRegisterRemovalReport] {
+        &self.vcpus
+    }
+
+    /// Return the total number of explicitly persisted values removed.
+    pub const fn removed_count(&self) -> usize {
+        self.removed_count
+    }
+
+    /// Return the total number of requested values that were not present.
+    pub const fn not_present_count(&self) -> usize {
+        self.not_present_count
+    }
+}
+
+impl fmt::Debug for HvfNativeSnapshotRegisterRemovalReport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfNativeSnapshotRegisterRemovalReport")
+            .field("vcpu_count", &self.vcpus.len())
+            .field("request_count", &self.request_count)
+            .field("removed_count", &self.removed_count)
+            .field("not_present_count", &self.not_present_count)
+            .finish()
+    }
+}
+
+/// Successfully rebuilt document and its value-free removal report.
+#[derive(Clone, PartialEq, Eq)]
+pub struct HvfNativeSnapshotRegisterRemovalOutcome {
+    document: HvfNativeSnapshotDocument,
+    report: HvfNativeSnapshotRegisterRemovalReport,
+}
+
+impl HvfNativeSnapshotRegisterRemovalOutcome {
+    /// Return the rebuilt document.
+    pub const fn document(&self) -> &HvfNativeSnapshotDocument {
+        &self.document
+    }
+
+    /// Return the value-free removal report.
+    pub const fn report(&self) -> &HvfNativeSnapshotRegisterRemovalReport {
+        &self.report
+    }
+
+    /// Consume the outcome into its rebuilt document and report.
+    pub fn into_parts(
+        self,
+    ) -> (
+        HvfNativeSnapshotDocument,
+        HvfNativeSnapshotRegisterRemovalReport,
+    ) {
+        (self.document, self.report)
+    }
+}
+
+impl fmt::Debug for HvfNativeSnapshotRegisterRemovalOutcome {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfNativeSnapshotRegisterRemovalOutcome")
+            .field("profile", &self.document.profile())
+            .field("report", &self.report)
+            .field("document", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Value-free failure to remove reviewed Firecracker KVM register state.
+pub enum HvfNativeSnapshotRegisterRemovalError {
+    /// The request contained no register identifiers.
+    EmptyRequest,
+    /// One register identifier is not in the exact reviewed registry.
+    UnsupportedRegister {
+        /// Zero-based position in the submitted request.
+        request_index: usize,
+    },
+    /// One reviewed register appeared more than once.
+    DuplicateRegister {
+        /// Position of the first occurrence.
+        first_request_index: usize,
+        /// Position of the duplicate occurrence.
+        duplicate_request_index: usize,
+    },
+    /// Checked result storage could not be allocated.
+    Allocation(TryReserveError),
+    /// Rebuilding checked optional state failed.
+    OptionalState(HvfArm64ReviewedOptionalStateBuildError),
+    /// Rebuilding one native-v2 vCPU failed.
+    Vcpu(HvfSnapshotV2BuildError),
+    /// Rebuilding the exact outer document profile failed.
+    Document(HvfNativeSnapshotDocumentReplaceError),
+}
+
+impl fmt::Display for HvfNativeSnapshotRegisterRemovalError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyRequest => formatter.write_str("reviewed register-removal request is empty"),
+            Self::UnsupportedRegister { request_index } => write!(
+                formatter,
+                "register-removal request position {request_index} is not reviewed"
+            ),
+            Self::DuplicateRegister {
+                first_request_index,
+                duplicate_request_index,
+            } => write!(
+                formatter,
+                "register-removal request position {duplicate_request_index} duplicates position {first_request_index}"
+            ),
+            Self::Allocation(_) => {
+                formatter.write_str("failed to allocate checked register-removal results")
+            }
+            Self::OptionalState(source) => {
+                write!(
+                    formatter,
+                    "failed to rebuild reviewed optional state: {source}"
+                )
+            }
+            Self::Vcpu(source) => write!(formatter, "failed to rebuild native-v2 vCPU: {source}"),
+            Self::Document(source) => {
+                write!(
+                    formatter,
+                    "failed to rebuild native snapshot document: {source}"
+                )
+            }
+        }
+    }
+}
+
+impl fmt::Debug for HvfNativeSnapshotRegisterRemovalError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "HvfNativeSnapshotRegisterRemovalError({self})")
+    }
+}
+
+impl std::error::Error for HvfNativeSnapshotRegisterRemovalError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Allocation(source) => Some(source),
+            Self::OptionalState(source) => Some(source),
+            Self::Vcpu(source) => Some(source),
+            Self::Document(source) => Some(source),
+            Self::EmptyRequest
+            | Self::UnsupportedRegister { .. }
+            | Self::DuplicateRegister { .. } => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ReviewedKvmRegister {
+    id: u64,
+    target: Target,
+}
+
+// Pinned to Firecracker v1.16.0 commit d83d72b710361a10294480131377b1b00b163af8.
+// These are literal KVM U64 system-register IDs by design: this registry must
+// not accept neighboring encodings through a family or range decoder.
+const REVIEWED_KVM_REGISTERS: [ReviewedKvmRegister;
+    HVF_NATIVE_SNAPSHOT_REVIEWED_KVM_REGISTER_COUNT] = [
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8004,
+        target: Target::BreakpointValue(0),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_800c,
+        target: Target::BreakpointValue(1),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8014,
+        target: Target::BreakpointValue(2),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_801c,
+        target: Target::BreakpointValue(3),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8024,
+        target: Target::BreakpointValue(4),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_802c,
+        target: Target::BreakpointValue(5),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8034,
+        target: Target::BreakpointValue(6),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_803c,
+        target: Target::BreakpointValue(7),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8044,
+        target: Target::BreakpointValue(8),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_804c,
+        target: Target::BreakpointValue(9),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8054,
+        target: Target::BreakpointValue(10),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_805c,
+        target: Target::BreakpointValue(11),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8064,
+        target: Target::BreakpointValue(12),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_806c,
+        target: Target::BreakpointValue(13),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8074,
+        target: Target::BreakpointValue(14),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_807c,
+        target: Target::BreakpointValue(15),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8005,
+        target: Target::BreakpointControl(0),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_800d,
+        target: Target::BreakpointControl(1),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8015,
+        target: Target::BreakpointControl(2),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_801d,
+        target: Target::BreakpointControl(3),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8025,
+        target: Target::BreakpointControl(4),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_802d,
+        target: Target::BreakpointControl(5),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8035,
+        target: Target::BreakpointControl(6),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_803d,
+        target: Target::BreakpointControl(7),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8045,
+        target: Target::BreakpointControl(8),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_804d,
+        target: Target::BreakpointControl(9),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8055,
+        target: Target::BreakpointControl(10),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_805d,
+        target: Target::BreakpointControl(11),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8065,
+        target: Target::BreakpointControl(12),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_806d,
+        target: Target::BreakpointControl(13),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8075,
+        target: Target::BreakpointControl(14),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_807d,
+        target: Target::BreakpointControl(15),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8006,
+        target: Target::WatchpointValue(0),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_800e,
+        target: Target::WatchpointValue(1),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8016,
+        target: Target::WatchpointValue(2),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_801e,
+        target: Target::WatchpointValue(3),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8026,
+        target: Target::WatchpointValue(4),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_802e,
+        target: Target::WatchpointValue(5),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8036,
+        target: Target::WatchpointValue(6),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_803e,
+        target: Target::WatchpointValue(7),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8046,
+        target: Target::WatchpointValue(8),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_804e,
+        target: Target::WatchpointValue(9),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8056,
+        target: Target::WatchpointValue(10),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_805e,
+        target: Target::WatchpointValue(11),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8066,
+        target: Target::WatchpointValue(12),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_806e,
+        target: Target::WatchpointValue(13),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8076,
+        target: Target::WatchpointValue(14),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_807e,
+        target: Target::WatchpointValue(15),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8007,
+        target: Target::WatchpointControl(0),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_800f,
+        target: Target::WatchpointControl(1),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8017,
+        target: Target::WatchpointControl(2),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_801f,
+        target: Target::WatchpointControl(3),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8027,
+        target: Target::WatchpointControl(4),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_802f,
+        target: Target::WatchpointControl(5),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8037,
+        target: Target::WatchpointControl(6),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_803f,
+        target: Target::WatchpointControl(7),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8047,
+        target: Target::WatchpointControl(8),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_804f,
+        target: Target::WatchpointControl(9),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8057,
+        target: Target::WatchpointControl(10),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_805f,
+        target: Target::WatchpointControl(11),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8067,
+        target: Target::WatchpointControl(12),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_806f,
+        target: Target::WatchpointControl(13),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_8077,
+        target: Target::WatchpointControl(14),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_807f,
+        target: Target::WatchpointControl(15),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_c096,
+        target: Target::SmeSystemRegister(0),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_c094,
+        target: Target::SmeSystemRegister(1),
+    },
+    ReviewedKvmRegister {
+        id: 0x6030_0000_0013_de85,
+        target: Target::SmeSystemRegister(2),
+    },
+];
+
+#[derive(Debug)]
+struct ReviewedRequest {
+    targets: [Target; HVF_NATIVE_SNAPSHOT_REVIEWED_KVM_REGISTER_COUNT],
+    len: usize,
+}
+
+impl ReviewedRequest {
+    fn try_new(ids: &[u64]) -> Result<Self, HvfNativeSnapshotRegisterRemovalError> {
+        if ids.is_empty() {
+            return Err(HvfNativeSnapshotRegisterRemovalError::EmptyRequest);
+        }
+
+        let mut request = Self {
+            targets: [Target::BreakpointValue(0); HVF_NATIVE_SNAPSHOT_REVIEWED_KVM_REGISTER_COUNT],
+            len: 0,
+        };
+        for (request_index, id) in ids.iter().enumerate() {
+            let target = REVIEWED_KVM_REGISTERS
+                .iter()
+                .find(|register| register.id == *id)
+                .map(|register| register.target)
+                .ok_or(HvfNativeSnapshotRegisterRemovalError::UnsupportedRegister {
+                    request_index,
+                })?;
+            if let Some(first_request_index) = request
+                .targets
+                .get(..request.len)
+                .and_then(|targets| targets.iter().position(|candidate| *candidate == target))
+            {
+                return Err(HvfNativeSnapshotRegisterRemovalError::DuplicateRegister {
+                    first_request_index,
+                    duplicate_request_index: request_index,
+                });
+            }
+            let slot = request.targets.get_mut(request.len).ok_or(
+                HvfNativeSnapshotRegisterRemovalError::UnsupportedRegister { request_index },
+            )?;
+            *slot = target;
+            request.len += 1;
+        }
+        Ok(request)
+    }
+
+    fn targets(&self) -> &[Target] {
+        self.targets.get(..self.len).unwrap_or_default()
+    }
+}
+
+impl HvfNativeSnapshotDocument {
+    /// Reset exact reviewed Firecracker aarch64 KVM U64 register values to
+    /// destination defaults while preserving the document's exact profile.
+    pub fn try_remove_reviewed_kvm_registers(
+        self,
+        register_ids: &[u64],
+    ) -> Result<HvfNativeSnapshotRegisterRemovalOutcome, HvfNativeSnapshotRegisterRemovalError>
+    {
+        let request = ReviewedRequest::try_new(register_ids)?;
+        let vcpu_count = self.vcpu_count();
+        let mut replacements = Vec::new();
+        replacements
+            .try_reserve_exact(vcpu_count)
+            .map_err(HvfNativeSnapshotRegisterRemovalError::Allocation)?;
+        let mut vcpu_reports = Vec::new();
+        vcpu_reports
+            .try_reserve_exact(vcpu_count)
+            .map_err(HvfNativeSnapshotRegisterRemovalError::Allocation)?;
+
+        let mut removed_count = 0_usize;
+        let mut not_present_count = 0_usize;
+        for state in self.vcpus() {
+            let state = HvfNativeSnapshotVcpuState::from(state);
+            let (replacement, vcpu_report) = transform_vcpu(state, &request)?;
+            removed_count += vcpu_report.removed_count();
+            not_present_count += vcpu_report.not_present_count();
+            replacements.push(replacement);
+            vcpu_reports.push(vcpu_report);
+        }
+        let document = self
+            .try_replace_vcpus(replacements)
+            .map_err(HvfNativeSnapshotRegisterRemovalError::Document)?;
+        Ok(HvfNativeSnapshotRegisterRemovalOutcome {
+            document,
+            report: HvfNativeSnapshotRegisterRemovalReport {
+                vcpus: vcpu_reports,
+                request_count: request.len,
+                removed_count,
+                not_present_count,
+            },
+        })
+    }
+}
+
+fn transform_vcpu(
+    state: HvfNativeSnapshotVcpuState,
+    request: &ReviewedRequest,
+) -> Result<
+    (
+        HvfNativeSnapshotVcpuState,
+        HvfNativeSnapshotVcpuRegisterRemovalReport,
+    ),
+    HvfNativeSnapshotRegisterRemovalError,
+> {
+    let mut removed = [false; HVF_NATIVE_SNAPSHOT_REVIEWED_KVM_REGISTER_COUNT];
+    let (replacement, vcpu_index) = match state {
+        HvfNativeSnapshotVcpuState::V1(state) => (HvfNativeSnapshotVcpuState::V1(state), 0),
+        HvfNativeSnapshotVcpuState::V2(state) => {
+            let (index, mpidr, mandatory, timer, pending_interrupts, gic_icc, reviewed_optional) =
+                (*state).into_parts();
+            let removed = removed.get_mut(..request.len).unwrap_or_default();
+            let reviewed_optional = reviewed_optional
+                .try_with_destination_defaults(request.targets(), removed)
+                .map_err(HvfNativeSnapshotRegisterRemovalError::OptionalState)?;
+            let state = HvfSnapshotV2VcpuState::try_new(
+                index,
+                mpidr,
+                mandatory,
+                timer,
+                pending_interrupts,
+                gic_icc,
+                reviewed_optional,
+            )
+            .map_err(HvfNativeSnapshotRegisterRemovalError::Vcpu)?;
+            (HvfNativeSnapshotVcpuState::V2(Box::new(state)), index)
+        }
+    };
+    Ok((replacement, report_vcpu(vcpu_index, &removed, request.len)))
+}
+
+fn report_vcpu(
+    vcpu_index: u32,
+    removed: &[bool; HVF_NATIVE_SNAPSHOT_REVIEWED_KVM_REGISTER_COUNT],
+    request_count: usize,
+) -> HvfNativeSnapshotVcpuRegisterRemovalReport {
+    let mut statuses = [HvfNativeSnapshotRegisterRemovalStatus::NotPresent;
+        HVF_NATIVE_SNAPSHOT_REVIEWED_KVM_REGISTER_COUNT];
+    let mut removed_count = 0;
+    for (status, was_removed) in statuses.iter_mut().zip(removed).take(request_count) {
+        if *was_removed {
+            *status = HvfNativeSnapshotRegisterRemovalStatus::Removed;
+            removed_count += 1;
+        }
+    }
+    HvfNativeSnapshotVcpuRegisterRemovalReport {
+        vcpu_index,
+        statuses,
+        request_count,
+        removed_count,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/hvf/src/snapshot_document/register_removal/tests.rs
+++ b/crates/hvf/src/snapshot_document/register_removal/tests.rs
@@ -1,0 +1,694 @@
+use super::*;
+use bangbang_runtime::cpu::{
+    KVM_REG_ARM64_ACTLR_EL1, KVM_REG_ARM64_CORE_PC, KVM_REG_ARM64_CORE_PSTATE,
+    KVM_REG_ARM64_ID_AA64DFR0_EL1, KVM_REG_ARM64_ID_AA64PFR0_EL1, kvm_reg_arm64_core_q,
+};
+
+use crate::optional_state::{
+    HvfArm64DebugRegisterRestoreState, HvfArm64OptionalStateValue,
+    HvfArm64ReviewedOptionalStateRestore, HvfArm64SmeRestoreState, HvfArm64SmeRestoreStateInput,
+};
+use crate::snapshot_document::tests::{
+    inspection_document_fixtures, inspection_native_v1_document,
+};
+use crate::snapshot_v2::tests::{platform_fixture, platform_fixture_with_count};
+
+use super::super::{HvfNativeSnapshotDocumentState, HvfNativeSnapshotVcpuRef};
+
+const DBGBVR0: u64 = 0x6030_0000_0013_8004;
+const DBGBVR1: u64 = 0x6030_0000_0013_800c;
+const DBGBCR0: u64 = 0x6030_0000_0013_8005;
+const SMCR_EL1: u64 = 0x6030_0000_0013_c096;
+const SMPRI_EL1: u64 = 0x6030_0000_0013_c094;
+const TPIDR2_EL0: u64 = 0x6030_0000_0013_de85;
+const KVM_SVE_Z0: u64 = 0x6080_0000_0015_0000;
+const KVM_SVE_P0: u64 = 0x6050_0000_0015_0400;
+const KVM_SVE_FFR: u64 = 0x6050_0000_0015_0600;
+const KVM_SVE_VLS: u64 = 0x6060_0000_0015_ffff;
+const KVM_CNTV_CVAL_EL0: u64 = 0x6030_0000_0013_df1a;
+const KVM_CNTPCT_EL0_OR_PTIMER_CNT: u64 = 0x6030_0000_0013_df01;
+const KVM_ICC_PMR_EL1: u64 = 0x6030_0000_0013_c230;
+
+fn legacy_document(with_sme: bool) -> HvfNativeSnapshotDocument {
+    HvfNativeSnapshotDocument {
+        state: HvfNativeSnapshotDocumentState::V2LegacyPlatform(platform_fixture(with_sme)),
+    }
+}
+
+fn kvm_u64_sysreg(op0: u64, op1: u64, crn: u64, crm: u64, op2: u64) -> u64 {
+    0x6000_0000_0000_0000
+        | 0x0030_0000_0000_0000
+        | 0x0013_0000
+        | (op0 << 14)
+        | (op1 << 11)
+        | (crn << 7)
+        | (crm << 3)
+        | op2
+}
+
+#[test]
+fn registry_is_exact_unique_and_pinned_to_firecracker_v1_16() {
+    assert_eq!(
+        REVIEWED_KVM_REGISTERS.len(),
+        HVF_NATIVE_SNAPSHOT_REVIEWED_KVM_REGISTER_COUNT
+    );
+    for (index, register) in REVIEWED_KVM_REGISTERS.iter().enumerate() {
+        assert!(
+            REVIEWED_KVM_REGISTERS[..index]
+                .iter()
+                .all(|previous| previous.id != register.id && previous.target != register.target)
+        );
+    }
+
+    for index in 0..16_u64 {
+        assert_eq!(
+            REVIEWED_KVM_REGISTERS[index as usize].id,
+            kvm_u64_sysreg(2, 0, 0, index, 4)
+        );
+        assert_eq!(
+            REVIEWED_KVM_REGISTERS[16 + index as usize].id,
+            kvm_u64_sysreg(2, 0, 0, index, 5)
+        );
+        assert_eq!(
+            REVIEWED_KVM_REGISTERS[32 + index as usize].id,
+            kvm_u64_sysreg(2, 0, 0, index, 6)
+        );
+        assert_eq!(
+            REVIEWED_KVM_REGISTERS[48 + index as usize].id,
+            kvm_u64_sysreg(2, 0, 0, index, 7)
+        );
+    }
+    assert_eq!(
+        [
+            REVIEWED_KVM_REGISTERS[0].id,
+            REVIEWED_KVM_REGISTERS[15].id,
+            REVIEWED_KVM_REGISTERS[16].id,
+            REVIEWED_KVM_REGISTERS[31].id,
+            REVIEWED_KVM_REGISTERS[32].id,
+            REVIEWED_KVM_REGISTERS[47].id,
+            REVIEWED_KVM_REGISTERS[48].id,
+            REVIEWED_KVM_REGISTERS[63].id,
+        ],
+        [
+            0x6030_0000_0013_8004,
+            0x6030_0000_0013_807c,
+            0x6030_0000_0013_8005,
+            0x6030_0000_0013_807d,
+            0x6030_0000_0013_8006,
+            0x6030_0000_0013_807e,
+            0x6030_0000_0013_8007,
+            0x6030_0000_0013_807f,
+        ]
+    );
+    assert_eq!(
+        REVIEWED_KVM_REGISTERS[64..]
+            .iter()
+            .map(|register| register.id)
+            .collect::<Vec<_>>(),
+        [SMCR_EL1, SMPRI_EL1, TPIDR2_EL0]
+    );
+    assert_eq!(SMCR_EL1, kvm_u64_sysreg(3, 0, 1, 2, 6));
+    assert_eq!(SMPRI_EL1, kvm_u64_sysreg(3, 0, 1, 2, 4));
+    assert_eq!(TPIDR2_EL0, kvm_u64_sysreg(3, 3, 13, 0, 5));
+
+    let ids = REVIEWED_KVM_REGISTERS
+        .iter()
+        .map(|register| register.id)
+        .collect::<Vec<_>>();
+    let request = ReviewedRequest::try_new(&ids).expect("all 67 exact IDs should be accepted");
+    assert_eq!(request.targets(), request.targets.as_slice());
+}
+
+#[test]
+fn request_validation_rejects_empty_unknown_and_duplicate_ids_without_values() {
+    assert!(matches!(
+        ReviewedRequest::try_new(&[]),
+        Err(HvfNativeSnapshotRegisterRemovalError::EmptyRequest)
+    ));
+
+    let unsupported = 0xdead_beef_cafe_babe;
+    let error = request_error(&[DBGBVR0, unsupported]);
+    assert!(matches!(
+        &error,
+        HvfNativeSnapshotRegisterRemovalError::UnsupportedRegister { request_index: 1 }
+    ));
+    let rendered = format!("{error:?} / {error}");
+    assert!(!rendered.contains("dead"));
+    assert!(!rendered.contains(&unsupported.to_string()));
+
+    for (ids, duplicate_request_index) in [
+        ([TPIDR2_EL0, TPIDR2_EL0, DBGBVR0], 1),
+        ([TPIDR2_EL0, DBGBVR0, TPIDR2_EL0], 2),
+    ] {
+        let error = request_error(&ids);
+        assert!(matches!(
+            &error,
+            HvfNativeSnapshotRegisterRemovalError::DuplicateRegister {
+                first_request_index: 0,
+                duplicate_request_index: actual,
+            } if *actual == duplicate_request_index
+        ));
+        let rendered = format!("{error:?} / {error}");
+        assert!(!rendered.contains(&TPIDR2_EL0.to_string()));
+        assert!(!rendered.contains("6030"));
+    }
+}
+
+#[test]
+fn exact_lookup_rejects_other_kvm_families_sizes_and_neighbors() {
+    let rejected = [
+        0x5030_0000_0013_8004,
+        0x6020_0000_0013_8004,
+        0x6040_0000_0013_8004,
+        KVM_REG_ARM64_CORE_PC,
+        KVM_REG_ARM64_CORE_PSTATE,
+        kvm_reg_arm64_core_q(0).expect("Q0 should have a KVM identity"),
+        KVM_REG_ARM64_ID_AA64PFR0_EL1,
+        KVM_REG_ARM64_ID_AA64DFR0_EL1,
+        KVM_REG_ARM64_ACTLR_EL1,
+        KVM_SVE_Z0,
+        KVM_SVE_P0,
+        KVM_SVE_FFR,
+        KVM_SVE_VLS,
+        KVM_CNTV_CVAL_EL0,
+        KVM_CNTPCT_EL0_OR_PTIMER_CNT,
+        KVM_ICC_PMR_EL1,
+        DBGBVR0 ^ 0x100,
+        0x6030_0000_0013_8084,
+        SMCR_EL1 ^ 1,
+        TPIDR2_EL0 ^ 0x8,
+        0,
+        u64::MAX,
+    ];
+    for (request_index, id) in rejected.into_iter().enumerate() {
+        let error = request_error(&[id]);
+        assert!(matches!(
+            &error,
+            HvfNativeSnapshotRegisterRemovalError::UnsupportedRegister { request_index: 0 }
+        ));
+        assert_eq!(
+            error.to_string(),
+            "register-removal request position 0 is not reviewed",
+            "case {request_index}"
+        );
+    }
+}
+
+#[test]
+fn all_67_semantic_targets_remove_fully_explicit_optional_state() {
+    let original = fully_explicit_optional_state();
+    let targets = REVIEWED_KVM_REGISTERS
+        .iter()
+        .map(|register| register.target)
+        .collect::<Vec<_>>();
+    let mut removed = [false; HVF_NATIVE_SNAPSHOT_REVIEWED_KVM_REGISTER_COUNT];
+    let transformed = original
+        .clone()
+        .try_with_destination_defaults(&targets, &mut removed)
+        .expect("every exact semantic target should rebuild");
+
+    assert!(removed.into_iter().all(|removed| removed));
+    assert!(
+        transformed
+            .breakpoints()
+            .values()
+            .iter()
+            .all(|value| { *value == HvfArm64OptionalStateValue::DestinationDefault })
+    );
+    assert!(
+        transformed
+            .breakpoints()
+            .controls()
+            .iter()
+            .all(|value| { *value == HvfArm64OptionalStateValue::DestinationDefault })
+    );
+    assert!(
+        transformed
+            .watchpoints()
+            .values()
+            .iter()
+            .all(|value| { *value == HvfArm64OptionalStateValue::DestinationDefault })
+    );
+    assert!(
+        transformed
+            .watchpoints()
+            .controls()
+            .iter()
+            .all(|value| { *value == HvfArm64OptionalStateValue::DestinationDefault })
+    );
+    let before_sme = original.sme().expect("fixture should contain SME state");
+    let after_sme = transformed
+        .sme()
+        .expect("transformed fixture should retain SME state");
+    assert_eq!(
+        after_sme.system_registers(),
+        &[HvfArm64OptionalStateValue::DestinationDefault; 3]
+    );
+    assert_eq!(after_sme.version(), before_sme.version());
+    assert_eq!(after_sme.identification(), before_sme.identification());
+    assert_eq!(
+        after_sme.maximum_svl_bytes(),
+        before_sme.maximum_svl_bytes()
+    );
+    assert_eq!(after_sme.pstate(), before_sme.pstate());
+    assert_eq!(after_sme.z_registers(), before_sme.z_registers());
+    assert_eq!(after_sme.p_registers(), before_sme.p_registers());
+    assert_eq!(after_sme.za_register(), before_sme.za_register());
+    assert_eq!(after_sme.zt0_register(), before_sme.zt0_register());
+    assert_eq!(
+        transformed.expected_id_aa64dfr0_el1(),
+        original.expected_id_aa64dfr0_el1()
+    );
+    assert_eq!(
+        transformed.expected_sme_version(),
+        original.expected_sme_version()
+    );
+    assert_eq!(transformed.simd_fp(), original.simd_fp());
+}
+
+#[test]
+fn native_v1_is_unchanged_and_reports_every_request_not_present() {
+    let document = inspection_native_v1_document(1);
+    let original = document.clone();
+    let original_bytes = original
+        .encode()
+        .expect("native-v1 fixture should encode canonically");
+    let outcome = document
+        .try_remove_reviewed_kvm_registers(&[DBGBVR0, SMCR_EL1])
+        .expect("native-v1 should accept a reviewed no-op request");
+
+    assert_eq!(outcome.document(), &original);
+    assert_eq!(
+        outcome
+            .document()
+            .encode()
+            .expect("native-v1 no-op should encode canonically"),
+        original_bytes
+    );
+    assert_eq!(outcome.report().request_count(), 2);
+    assert_eq!(outcome.report().removed_count(), 0);
+    assert_eq!(outcome.report().not_present_count(), 2);
+    assert_eq!(outcome.report().vcpus().len(), 1);
+    assert_eq!(outcome.report().vcpus()[0].vcpu_index(), 0);
+    assert_eq!(
+        outcome.report().vcpus()[0].statuses(),
+        [
+            HvfNativeSnapshotRegisterRemovalStatus::NotPresent,
+            HvfNativeSnapshotRegisterRemovalStatus::NotPresent,
+        ]
+    );
+}
+
+#[test]
+fn debug_removal_is_ordered_per_vcpu_and_idempotent() {
+    let original = mixed_debug_presence_document();
+    let outcome = original
+        .clone()
+        .try_remove_reviewed_kvm_registers(&[DBGBVR1, DBGBCR0, SMCR_EL1, DBGBVR0])
+        .expect("reviewed debug registers should transform");
+
+    assert_eq!(outcome.document().profile(), original.profile());
+    assert_eq!(outcome.report().request_count(), 4);
+    assert_eq!(outcome.report().removed_count(), 2);
+    assert_eq!(outcome.report().not_present_count(), 6);
+    for (expected_index, report) in outcome.report().vcpus().iter().enumerate() {
+        assert_eq!(report.vcpu_index(), expected_index as u32);
+        assert_eq!(
+            report.statuses(),
+            [
+                HvfNativeSnapshotRegisterRemovalStatus::NotPresent,
+                if expected_index == 0 {
+                    HvfNativeSnapshotRegisterRemovalStatus::Removed
+                } else {
+                    HvfNativeSnapshotRegisterRemovalStatus::NotPresent
+                },
+                HvfNativeSnapshotRegisterRemovalStatus::NotPresent,
+                if expected_index == 0 {
+                    HvfNativeSnapshotRegisterRemovalStatus::Removed
+                } else {
+                    HvfNativeSnapshotRegisterRemovalStatus::NotPresent
+                },
+            ]
+        );
+    }
+
+    for (before, after) in original.vcpus().zip(outcome.document().vcpus()) {
+        let (HvfNativeSnapshotVcpuRef::V2(before), HvfNativeSnapshotVcpuRef::V2(after)) =
+            (before, after)
+        else {
+            panic!("legacy native-v2 fixture should expose native-v2 vCPUs");
+        };
+        assert_non_optional_vcpu_state_preserved(before, after);
+        assert_eq!(
+            after.reviewed_optional().breakpoints().values()[0],
+            HvfArm64OptionalStateValue::DestinationDefault
+        );
+        assert_eq!(
+            after.reviewed_optional().breakpoints().controls()[0],
+            HvfArm64OptionalStateValue::DestinationDefault
+        );
+        assert_eq!(
+            after.reviewed_optional().breakpoints().values()[1..],
+            before.reviewed_optional().breakpoints().values()[1..]
+        );
+        assert_eq!(
+            after.reviewed_optional().breakpoints().controls()[1..],
+            before.reviewed_optional().breakpoints().controls()[1..]
+        );
+        assert_eq!(
+            after.reviewed_optional().watchpoints(),
+            before.reviewed_optional().watchpoints()
+        );
+        assert_eq!(after.reviewed_optional().sme(), None);
+    }
+
+    let transformed = outcome.document().clone();
+    let second = transformed
+        .clone()
+        .try_remove_reviewed_kvm_registers(&[DBGBVR1, DBGBCR0, SMCR_EL1, DBGBVR0])
+        .expect("repeating a reviewed request should be a successful no-op");
+    assert_eq!(second.document(), &transformed);
+    assert_eq!(second.report().removed_count(), 0);
+    assert_eq!(second.report().not_present_count(), 8);
+    assert!(second.report().vcpus().iter().all(|report| {
+        report
+            .statuses()
+            .iter()
+            .all(|status| *status == HvfNativeSnapshotRegisterRemovalStatus::NotPresent)
+    }));
+}
+
+#[test]
+fn sme_removal_preserves_conditional_state_and_reports_absent_values() {
+    let original = legacy_document(true);
+    let outcome = original
+        .clone()
+        .try_remove_reviewed_kvm_registers(&[TPIDR2_EL0, SMPRI_EL1, SMCR_EL1])
+        .expect("reviewed SME system registers should transform");
+
+    assert_eq!(outcome.report().removed_count(), 4);
+    assert_eq!(outcome.report().not_present_count(), 2);
+    for report in outcome.report().vcpus() {
+        assert_eq!(
+            report.statuses(),
+            [
+                HvfNativeSnapshotRegisterRemovalStatus::Removed,
+                HvfNativeSnapshotRegisterRemovalStatus::NotPresent,
+                HvfNativeSnapshotRegisterRemovalStatus::Removed,
+            ]
+        );
+    }
+
+    for (before, after) in original.vcpus().zip(outcome.document().vcpus()) {
+        let (HvfNativeSnapshotVcpuRef::V2(before), HvfNativeSnapshotVcpuRef::V2(after)) =
+            (before, after)
+        else {
+            panic!("SME fixture should expose native-v2 vCPUs");
+        };
+        assert_non_optional_vcpu_state_preserved(before, after);
+        assert_eq!(
+            after.reviewed_optional().breakpoints(),
+            before.reviewed_optional().breakpoints()
+        );
+        assert_eq!(
+            after.reviewed_optional().watchpoints(),
+            before.reviewed_optional().watchpoints()
+        );
+        let before = before
+            .reviewed_optional()
+            .sme()
+            .expect("fixture should carry SME state");
+        let after = after
+            .reviewed_optional()
+            .sme()
+            .expect("transformed fixture should retain SME state");
+        assert_eq!(
+            after.system_registers(),
+            &[HvfArm64OptionalStateValue::DestinationDefault; 3]
+        );
+        assert_eq!(after.version(), before.version());
+        assert_eq!(after.identification(), before.identification());
+        assert_eq!(after.maximum_svl_bytes(), before.maximum_svl_bytes());
+        assert_eq!(after.pstate(), before.pstate());
+        assert_eq!(after.z_registers(), before.z_registers());
+        assert_eq!(after.p_registers(), before.p_registers());
+        assert_eq!(after.za_register(), before.za_register());
+        assert_eq!(after.zt0_register(), before.zt0_register());
+    }
+}
+
+#[test]
+fn every_exact_profile_rebuilds_and_round_trips_without_outer_profile_drift() {
+    for document in inspection_document_fixtures() {
+        let family = document.family();
+        let version = document.version();
+        let profile = document.profile();
+        let vcpu_count = document.vcpu_count();
+        let outcome = document
+            .try_remove_reviewed_kvm_registers(&[DBGBVR0])
+            .expect("every exact native profile should rebuild");
+        assert_eq!(outcome.document().family(), family);
+        assert_eq!(outcome.document().version(), version);
+        assert_eq!(outcome.document().profile(), profile);
+        assert_eq!(outcome.document().vcpu_count(), vcpu_count);
+
+        let bytes = outcome
+            .document()
+            .encode()
+            .expect("transformed profile should encode");
+        let decoded =
+            HvfNativeSnapshotDocument::decode(&bytes).expect("transformed profile should decode");
+        assert_eq!(&decoded, outcome.document());
+    }
+}
+
+#[test]
+fn diff_rebuild_preserves_layer_memory_devices_and_non_target_vcpu_state() {
+    let original = inspection_document_fixtures()
+        .into_iter()
+        .find(|document| matches!(&document.state, HvfNativeSnapshotDocumentState::V2Diff(_)))
+        .expect("profile matrix should contain exact 2.13 Diff");
+    let outcome = original
+        .clone()
+        .try_remove_reviewed_kvm_registers(&[DBGBVR0])
+        .expect("Diff breakpoint removal should rebuild");
+    let (
+        HvfNativeSnapshotDocumentState::V2Diff(before),
+        HvfNativeSnapshotDocumentState::V2Diff(after),
+    ) = (&original.state, &outcome.document().state)
+    else {
+        panic!("Diff transform must retain its exact state variant");
+    };
+
+    assert_eq!(after.device_graph(), before.device_graph());
+    assert_eq!(after.serial(), before.serial());
+    assert_eq!(after.entropy(), before.entropy());
+    assert_eq!(after.balloon(), before.balloon());
+    assert_eq!(after.memory_hotplug(), before.memory_hotplug());
+    assert_eq!(after.network(), before.network());
+    assert_eq!(after.vsock(), before.vsock());
+    assert_eq!(after.layer(), before.layer());
+    assert_eq!(after.platform().memory(), before.platform().memory());
+    assert_eq!(after.platform().machine(), before.platform().machine());
+    assert_eq!(after.platform().global(), before.platform().global());
+    assert_eq!(after.platform().topology(), before.platform().topology());
+    assert_eq!(after.platform().time(), before.platform().time());
+    for (before, after) in before
+        .platform()
+        .vcpus()
+        .iter()
+        .zip(after.platform().vcpus())
+    {
+        assert_non_optional_vcpu_state_preserved(before, after);
+        assert_eq!(
+            after.reviewed_optional().breakpoints().values()[0],
+            HvfArm64OptionalStateValue::DestinationDefault
+        );
+        assert_eq!(
+            after.reviewed_optional().breakpoints().values()[1..],
+            before.reviewed_optional().breakpoints().values()[1..]
+        );
+        assert_eq!(
+            after.reviewed_optional().breakpoints().controls(),
+            before.reviewed_optional().breakpoints().controls()
+        );
+        assert_eq!(
+            after.reviewed_optional().watchpoints(),
+            before.reviewed_optional().watchpoints()
+        );
+        assert_eq!(
+            after.reviewed_optional().sme(),
+            before.reviewed_optional().sme()
+        );
+    }
+}
+
+#[test]
+fn maximum_vcpu_report_is_bounded_canonical_and_complete() {
+    let document = HvfNativeSnapshotDocument {
+        state: HvfNativeSnapshotDocumentState::V2LegacyPlatform(platform_fixture_with_count(
+            32, false,
+        )),
+    };
+    let outcome = document
+        .try_remove_reviewed_kvm_registers(&[DBGBVR0])
+        .expect("maximum checked vCPU inventory should transform");
+    assert_eq!(outcome.report().vcpus().len(), 32);
+    assert_eq!(outcome.report().removed_count(), 32);
+    assert_eq!(outcome.report().not_present_count(), 0);
+    for (expected_index, report) in outcome.report().vcpus().iter().enumerate() {
+        assert_eq!(report.vcpu_index(), expected_index as u32);
+        assert_eq!(
+            report.statuses(),
+            [HvfNativeSnapshotRegisterRemovalStatus::Removed]
+        );
+        assert_eq!(report.removed_count(), 1);
+        assert_eq!(report.not_present_count(), 0);
+    }
+}
+
+#[test]
+fn outcome_debug_is_value_free() {
+    let outcome = legacy_document(true)
+        .try_remove_reviewed_kvm_registers(&[DBGBVR0, TPIDR2_EL0])
+        .expect("reviewed request should transform");
+    let debug = format!("{outcome:?}");
+    assert!(debug.contains("<redacted>"));
+    assert!(!debug.contains("1111"));
+    assert!(!debug.contains("fixture"));
+    assert!(!debug.contains("6030"));
+}
+
+fn request_error(ids: &[u64]) -> HvfNativeSnapshotRegisterRemovalError {
+    match ReviewedRequest::try_new(ids) {
+        Ok(_) => panic!("request should have been rejected"),
+        Err(error) => error,
+    }
+}
+
+fn fully_explicit_optional_state() -> HvfArm64ReviewedOptionalStateRestore {
+    let platform = platform_fixture(true);
+    let vcpu = &platform.vcpus()[0];
+    let source = vcpu.reviewed_optional();
+    let simd_fp = vcpu.mandatory().simd_fp.clone();
+    let expected_dfr0 = (source.expected_id_aa64dfr0_el1() & !((0xf << 12) | (0xf << 20)))
+        | (0xf << 12)
+        | (0xf << 20);
+    let breakpoints = HvfArm64DebugRegisterRestoreState::try_new(
+        16,
+        std::array::from_fn(|index| HvfArm64OptionalStateValue::Explicit(index as u64 + 1)),
+        std::array::from_fn(|index| HvfArm64OptionalStateValue::Explicit(index as u64 + 101)),
+    )
+    .expect("fully explicit breakpoint state should validate");
+    let watchpoints = HvfArm64DebugRegisterRestoreState::try_new(
+        16,
+        std::array::from_fn(|index| HvfArm64OptionalStateValue::Explicit(index as u64 + 201)),
+        std::array::from_fn(|index| HvfArm64OptionalStateValue::Explicit(index as u64 + 301)),
+    )
+    .expect("fully explicit watchpoint state should validate");
+    let source_sme = source
+        .sme()
+        .expect("source fixture should contain SME state");
+    let input = HvfArm64SmeRestoreStateInput::new(
+        source_sme.version(),
+        source_sme.identification(),
+        source_sme.maximum_svl_bytes(),
+        source_sme.pstate(),
+        [
+            HvfArm64OptionalStateValue::Explicit(401),
+            HvfArm64OptionalStateValue::Explicit(402),
+            HvfArm64OptionalStateValue::Explicit(403),
+        ],
+    );
+    let input = match (source_sme.z_registers(), source_sme.p_registers()) {
+        (Some(z_registers), Some(p_registers)) => {
+            input.with_streaming_registers(z_registers.to_vec(), p_registers.to_vec())
+        }
+        (None, None) => input,
+        _ => panic!("checked SME fixture must pair streaming inventories"),
+    };
+    let input = match (source_sme.za_register(), source_sme.zt0_register()) {
+        (Some(za_register), zt0_register) => {
+            input.with_za_register(za_register.clone(), zt0_register.copied())
+        }
+        (None, None) => input,
+        (None, Some(_)) => panic!("checked SME fixture must pair ZA and ZT0"),
+    };
+    let sme = HvfArm64SmeRestoreState::try_new(input, &simd_fp)
+        .expect("fully explicit SME state should validate");
+    HvfArm64ReviewedOptionalStateRestore::try_new(
+        expected_dfr0,
+        source.expected_sme_version(),
+        breakpoints,
+        watchpoints,
+        Some(sme),
+        simd_fp,
+    )
+    .expect("fully explicit reviewed state should validate")
+}
+
+fn mixed_debug_presence_document() -> HvfNativeSnapshotDocument {
+    let platform = platform_fixture(false);
+    let mut vcpus = platform.vcpus().to_vec();
+    let (index, mpidr, mandatory, timer, pending_interrupts, gic_icc, optional) =
+        vcpus[1].clone().into_parts();
+    let mut breakpoint_values = *optional.breakpoints().values();
+    let mut breakpoint_controls = *optional.breakpoints().controls();
+    breakpoint_values[0] = HvfArm64OptionalStateValue::DestinationDefault;
+    breakpoint_controls[0] = HvfArm64OptionalStateValue::DestinationDefault;
+    let breakpoints = HvfArm64DebugRegisterRestoreState::try_new(
+        optional.breakpoints().implemented_count(),
+        breakpoint_values,
+        breakpoint_controls,
+    )
+    .expect("mixed-presence breakpoint fixture should validate");
+    let optional = HvfArm64ReviewedOptionalStateRestore::try_new(
+        optional.expected_id_aa64dfr0_el1(),
+        optional.expected_sme_version(),
+        breakpoints,
+        optional.watchpoints().clone(),
+        optional.sme().cloned(),
+        optional.simd_fp().clone(),
+    )
+    .expect("mixed-presence reviewed state should validate");
+    vcpus[1] = HvfSnapshotV2VcpuState::try_new(
+        index,
+        mpidr,
+        mandatory,
+        timer,
+        pending_interrupts,
+        gic_icc,
+        optional,
+    )
+    .expect("mixed-presence vCPU should validate");
+    let platform = platform
+        .try_replace_vcpus(vcpus)
+        .expect("mixed-presence platform should validate");
+    HvfNativeSnapshotDocument {
+        state: HvfNativeSnapshotDocumentState::V2LegacyPlatform(platform),
+    }
+}
+
+fn assert_non_optional_vcpu_state_preserved(
+    before: &HvfSnapshotV2VcpuState,
+    after: &HvfSnapshotV2VcpuState,
+) {
+    assert_eq!(after.index(), before.index());
+    assert_eq!(after.mpidr(), before.mpidr());
+    assert_eq!(after.mandatory(), before.mandatory());
+    assert_eq!(after.timer(), before.timer());
+    assert_eq!(after.pending_interrupts(), before.pending_interrupts());
+    assert_eq!(after.gic_icc(), before.gic_icc());
+    assert_eq!(
+        after.reviewed_optional().expected_id_aa64dfr0_el1(),
+        before.reviewed_optional().expected_id_aa64dfr0_el1()
+    );
+    assert_eq!(
+        after.reviewed_optional().expected_sme_version(),
+        before.reviewed_optional().expected_sme_version()
+    );
+    assert_eq!(
+        after.reviewed_optional().simd_fp(),
+        before.reviewed_optional().simd_fp()
+    );
+}


### PR DESCRIPTION
## Summary

- add an exact 67-entry Firecracker v1.16.0 aarch64 KVM register registry for reviewed breakpoint, watchpoint, and SME system state
- add a consuming native snapshot document transform with ordered, value-free per-vCPU removal results
- rebuild optional state, each native-v2 vCPU, and the original exact native profile through existing validators while treating native-v1 as a canonical no-op
- cover all accepted targets, rejected KVM families and neighbors, mixed presence, 32 vCPUs, native-v1, every v2.3-v2.13 profile, and exact Diff preservation

## Scope

This PR is pure in-memory transformation only. It does not add path handling, output publication, command activation, signed capability evidence, documentation claims, or inventory promotion.

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo check -p bangbang-snapshot-tools --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked` (1523 passed)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented Apple-target integration-test Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh` without `--allow-unsupported`
- `git diff --check`

Closes #1773

Related to #1542
