### PR TITLE
feat: publish edited snapshot state atomically

### DIFF
--- a/crates/hvf/src/lib.rs
+++ b/crates/hvf/src/lib.rs
@@ -142,9 +142,9 @@ pub use snapshot_document::{
     HvfNativeSnapshotDocumentReplaceError, HvfNativeSnapshotInspectionError,
     HvfNativeSnapshotPlatformRef, HvfNativeSnapshotRegisterRemovalError,
     HvfNativeSnapshotRegisterRemovalOutcome, HvfNativeSnapshotRegisterRemovalReport,
-    HvfNativeSnapshotRegisterRemovalStatus, HvfNativeSnapshotVcpuRef,
-    HvfNativeSnapshotVcpuRegisterRemovalReport, HvfNativeSnapshotVcpuState,
-    HvfNativeSnapshotVcpuStatesInspection, HvfNativeSnapshotVcpus,
+    HvfNativeSnapshotRegisterRemovalRequest, HvfNativeSnapshotRegisterRemovalStatus,
+    HvfNativeSnapshotVcpuRef, HvfNativeSnapshotVcpuRegisterRemovalReport,
+    HvfNativeSnapshotVcpuState, HvfNativeSnapshotVcpuStatesInspection, HvfNativeSnapshotVcpus,
     HvfNativeSnapshotVmStateInspection,
 };
 pub use snapshot_restore::{

--- a/crates/hvf/src/snapshot_document.rs
+++ b/crates/hvf/src/snapshot_document.rs
@@ -62,7 +62,8 @@ pub use inspection::{
 pub use register_removal::{
     HVF_NATIVE_SNAPSHOT_REVIEWED_KVM_REGISTER_COUNT, HvfNativeSnapshotRegisterRemovalError,
     HvfNativeSnapshotRegisterRemovalOutcome, HvfNativeSnapshotRegisterRemovalReport,
-    HvfNativeSnapshotRegisterRemovalStatus, HvfNativeSnapshotVcpuRegisterRemovalReport,
+    HvfNativeSnapshotRegisterRemovalRequest, HvfNativeSnapshotRegisterRemovalStatus,
+    HvfNativeSnapshotVcpuRegisterRemovalReport,
 };
 
 /// Exact semantic profile owned by one native HVF snapshot document.

--- a/crates/hvf/src/snapshot_document/register_removal.rs
+++ b/crates/hvf/src/snapshot_document/register_removal.rs
@@ -523,14 +523,20 @@ const REVIEWED_KVM_REGISTERS: [ReviewedKvmRegister;
     },
 ];
 
-#[derive(Debug)]
-struct ReviewedRequest {
+/// Opaque, value-free validated request for reviewed KVM register removal.
+///
+/// Construction performs exact registry, empty, and duplicate validation. The
+/// resulting value retains only semantic targets and their count, so a caller
+/// can validate before any path access without retaining submitted IDs.
+#[derive(Clone)]
+pub struct HvfNativeSnapshotRegisterRemovalRequest {
     targets: [Target; HVF_NATIVE_SNAPSHOT_REVIEWED_KVM_REGISTER_COUNT],
     len: usize,
 }
 
-impl ReviewedRequest {
-    fn try_new(ids: &[u64]) -> Result<Self, HvfNativeSnapshotRegisterRemovalError> {
+impl HvfNativeSnapshotRegisterRemovalRequest {
+    /// Validates one nonempty ordered request against the exact reviewed table.
+    pub fn try_new(ids: &[u64]) -> Result<Self, HvfNativeSnapshotRegisterRemovalError> {
         if ids.is_empty() {
             return Err(HvfNativeSnapshotRegisterRemovalError::EmptyRequest);
         }
@@ -566,8 +572,23 @@ impl ReviewedRequest {
         Ok(request)
     }
 
+    /// Returns the validated number of requested registers.
+    pub const fn request_count(&self) -> usize {
+        self.len
+    }
+
     fn targets(&self) -> &[Target] {
         self.targets.get(..self.len).unwrap_or_default()
+    }
+}
+
+impl fmt::Debug for HvfNativeSnapshotRegisterRemovalRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HvfNativeSnapshotRegisterRemovalRequest")
+            .field("request_count", &self.len)
+            .field("targets", &"<redacted>")
+            .finish()
     }
 }
 
@@ -579,7 +600,19 @@ impl HvfNativeSnapshotDocument {
         register_ids: &[u64],
     ) -> Result<HvfNativeSnapshotRegisterRemovalOutcome, HvfNativeSnapshotRegisterRemovalError>
     {
-        let request = ReviewedRequest::try_new(register_ids)?;
+        let request = HvfNativeSnapshotRegisterRemovalRequest::try_new(register_ids)?;
+        self.try_remove_reviewed_kvm_register_request(&request)
+    }
+
+    /// Applies one already-validated reviewed KVM register-removal request.
+    ///
+    /// This seam lets path-based callers complete value-free request admission
+    /// before opening or inspecting the snapshot state input.
+    pub fn try_remove_reviewed_kvm_register_request(
+        self,
+        request: &HvfNativeSnapshotRegisterRemovalRequest,
+    ) -> Result<HvfNativeSnapshotRegisterRemovalOutcome, HvfNativeSnapshotRegisterRemovalError>
+    {
         let vcpu_count = self.vcpu_count();
         let mut replacements = Vec::new();
         replacements
@@ -594,7 +627,7 @@ impl HvfNativeSnapshotDocument {
         let mut not_present_count = 0_usize;
         for state in self.vcpus() {
             let state = HvfNativeSnapshotVcpuState::from(state);
-            let (replacement, vcpu_report) = transform_vcpu(state, &request)?;
+            let (replacement, vcpu_report) = transform_vcpu(state, request)?;
             removed_count += vcpu_report.removed_count();
             not_present_count += vcpu_report.not_present_count();
             replacements.push(replacement);
@@ -617,7 +650,7 @@ impl HvfNativeSnapshotDocument {
 
 fn transform_vcpu(
     state: HvfNativeSnapshotVcpuState,
-    request: &ReviewedRequest,
+    request: &HvfNativeSnapshotRegisterRemovalRequest,
 ) -> Result<
     (
         HvfNativeSnapshotVcpuState,

--- a/crates/hvf/src/snapshot_document/register_removal/tests.rs
+++ b/crates/hvf/src/snapshot_document/register_removal/tests.rs
@@ -115,14 +115,15 @@ fn registry_is_exact_unique_and_pinned_to_firecracker_v1_16() {
         .iter()
         .map(|register| register.id)
         .collect::<Vec<_>>();
-    let request = ReviewedRequest::try_new(&ids).expect("all 67 exact IDs should be accepted");
+    let request = HvfNativeSnapshotRegisterRemovalRequest::try_new(&ids)
+        .expect("all 67 exact IDs should be accepted");
     assert_eq!(request.targets(), request.targets.as_slice());
 }
 
 #[test]
 fn request_validation_rejects_empty_unknown_and_duplicate_ids_without_values() {
     assert!(matches!(
-        ReviewedRequest::try_new(&[]),
+        HvfNativeSnapshotRegisterRemovalRequest::try_new(&[]),
         Err(HvfNativeSnapshotRegisterRemovalError::EmptyRequest)
     ));
 
@@ -152,6 +153,24 @@ fn request_validation_rejects_empty_unknown_and_duplicate_ids_without_values() {
         assert!(!rendered.contains(&TPIDR2_EL0.to_string()));
         assert!(!rendered.contains("6030"));
     }
+
+    let request = HvfNativeSnapshotRegisterRemovalRequest::try_new(&[DBGBVR0, TPIDR2_EL0])
+        .expect("reviewed request should validate");
+    assert_eq!(request.request_count(), 2);
+    let rendered = format!("{request:?}");
+    assert!(!rendered.contains("6030"));
+    assert!(!rendered.contains(&DBGBVR0.to_string()));
+    assert!(!rendered.contains(&TPIDR2_EL0.to_string()));
+
+    let document = legacy_document(true);
+    let convenience = document
+        .clone()
+        .try_remove_reviewed_kvm_registers(&[DBGBVR0, TPIDR2_EL0])
+        .expect("slice convenience should transform");
+    let prevalidated = document
+        .try_remove_reviewed_kvm_register_request(&request)
+        .expect("prevalidated request should transform");
+    assert_eq!(prevalidated, convenience);
 }
 
 #[test]
@@ -560,7 +579,7 @@ fn outcome_debug_is_value_free() {
 }
 
 fn request_error(ids: &[u64]) -> HvfNativeSnapshotRegisterRemovalError {
-    match ReviewedRequest::try_new(ids) {
+    match HvfNativeSnapshotRegisterRemovalRequest::try_new(ids) {
         Ok(_) => panic!("request should have been rejected"),
         Err(error) => error,
     }
@@ -691,4 +710,172 @@ fn assert_non_optional_vcpu_state_preserved(
         after.reviewed_optional().simd_fp(),
         before.reviewed_optional().simd_fp()
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn portable_state_transaction_publishes_exact_v1_v2_and_diff_documents() {
+    use std::fs;
+    use std::os::unix::fs::MetadataExt;
+
+    use bangbang_runtime::snapshot_state_edit::{
+        SnapshotStateEditCommit, SnapshotStateEditPaths, publish_edited_snapshot_state_with,
+    };
+
+    let mut documents = vec![inspection_native_v1_document(1), legacy_document(true)];
+    documents.push(
+        inspection_document_fixtures()
+            .into_iter()
+            .find(|document| matches!(document.state, HvfNativeSnapshotDocumentState::V2Diff(_)))
+            .expect("profile matrix should contain exact 2.13 Diff"),
+    );
+
+    for (index, document) in documents.into_iter().enumerate() {
+        let directory = RegisterEditTestDirectory::new(index);
+        let input = directory.path.join("input.state");
+        let output = directory.path.join("output.state");
+        let source_bytes = document.encode().expect("source document should encode");
+        fs::write(&input, &source_bytes).expect("source should write");
+        let source_facts = fs::metadata(&input).expect("source facts should read");
+        let source_facts = (
+            source_facts.dev(),
+            source_facts.ino(),
+            source_facts.mode(),
+            source_facts.size(),
+            source_facts.mtime(),
+            source_facts.mtime_nsec(),
+            source_facts.ctime(),
+            source_facts.ctime_nsec(),
+        );
+        let request = HvfNativeSnapshotRegisterRemovalRequest::try_new(&[DBGBVR0, TPIDR2_EL0])
+            .expect("request should validate before path access");
+        let paths = SnapshotStateEditPaths::new(&input, &output);
+
+        let outcome = publish_edited_snapshot_state_with(
+            &paths,
+            |bytes| {
+                let document = HvfNativeSnapshotDocument::decode(bytes)
+                    .map_err(RegisterEditPublicationTestError::Decode)?;
+                document
+                    .try_remove_reviewed_kvm_register_request(&request)
+                    .map_err(RegisterEditPublicationTestError::Transform)
+            },
+            |outcome| {
+                outcome
+                    .document()
+                    .encode()
+                    .map_err(RegisterEditPublicationTestError::Encode)
+            },
+            |bytes, outcome| {
+                let decoded = HvfNativeSnapshotDocument::decode(bytes)
+                    .map_err(RegisterEditPublicationTestError::Decode)?;
+                if &decoded == outcome.document() {
+                    Ok(())
+                } else {
+                    Err(RegisterEditPublicationTestError::Mismatch)
+                }
+            },
+        )
+        .expect("exact edited state should publish");
+
+        assert_eq!(outcome.commit(), SnapshotStateEditCommit::Durable);
+        assert_eq!(outcome.product().report().request_count(), 2);
+        let published_bytes = fs::read(&output).expect("published output should read");
+        let published = HvfNativeSnapshotDocument::decode(&published_bytes)
+            .expect("published document should decode");
+        assert_eq!(&published, outcome.product().document());
+        assert_eq!(
+            fs::metadata(&output)
+                .expect("published mode should read")
+                .mode()
+                & 0o7777,
+            0o600
+        );
+        assert_eq!(fs::read(&input).expect("source should read"), source_bytes);
+        let after = fs::metadata(&input).expect("source facts should reread");
+        assert_eq!(
+            (
+                after.dev(),
+                after.ino(),
+                after.mode(),
+                after.size(),
+                after.mtime(),
+                after.mtime_nsec(),
+                after.ctime(),
+                after.ctime_nsec(),
+            ),
+            source_facts
+        );
+        assert!(
+            fs::read_dir(&directory.path)
+                .expect("directory should enumerate")
+                .map(|entry| entry.expect("entry should read"))
+                .all(|entry| !entry
+                    .file_name()
+                    .as_encoded_bytes()
+                    .starts_with(b".bangbang-snapshot-edit-"))
+        );
+    }
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+enum RegisterEditPublicationTestError {
+    Decode(crate::snapshot_document::HvfNativeSnapshotDocumentDecodeError),
+    Transform(HvfNativeSnapshotRegisterRemovalError),
+    Encode(crate::snapshot_document::HvfNativeSnapshotDocumentEncodeError),
+    Mismatch,
+}
+
+#[cfg(unix)]
+impl fmt::Display for RegisterEditPublicationTestError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Decode(_) => "test decode failure",
+            Self::Transform(_) => "test transform failure",
+            Self::Encode(_) => "test encode failure",
+            Self::Mismatch => "test exact-document mismatch",
+        })
+    }
+}
+
+#[cfg(unix)]
+impl std::error::Error for RegisterEditPublicationTestError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Decode(source) => Some(source),
+            Self::Transform(source) => Some(source),
+            Self::Encode(source) => Some(source),
+            Self::Mismatch => None,
+        }
+    }
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+struct RegisterEditTestDirectory {
+    path: std::path::PathBuf,
+}
+
+#[cfg(unix)]
+impl RegisterEditTestDirectory {
+    fn new(index: usize) -> Self {
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        static NEXT_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+        let sequence = NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "bb-hvf-state-edit-{}-{index}-{sequence}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&path).expect("test directory should create");
+        Self { path }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for RegisterEditTestDirectory {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -54,6 +54,7 @@ pub mod snapshot_network_v2_11;
 pub mod snapshot_rebase;
 pub mod snapshot_restore;
 pub mod snapshot_serial_v2_7;
+pub mod snapshot_state_edit;
 pub mod snapshot_vsock_restore_v2_12;
 pub mod snapshot_vsock_v2_12;
 pub mod startup;

--- a/crates/runtime/src/snapshot_artifact.rs
+++ b/crates/runtime/src/snapshot_artifact.rs
@@ -35,13 +35,13 @@ use crate::snapshot_device_v2_6::{
 };
 #[cfg(target_os = "macos")]
 use crate::snapshot_diff_v2_13::{
-    NATIVE_V2_DIFF_MAGIC, SnapshotV2DiffBase, SnapshotV2DiffMaterializationError,
-    promote_snapshot_v2_diff_zero_root_file_with_cancel, verify_snapshot_v2_diff_layer_output,
-    verify_snapshot_v2_diff_layer_output_with_cancel,
+    NATIVE_V2_DIFF_MAGIC, SnapshotV2DiffBase, promote_snapshot_v2_diff_zero_root_file_with_cancel,
+    verify_snapshot_v2_diff_layer_output, verify_snapshot_v2_diff_layer_output_with_cancel,
 };
 use crate::snapshot_diff_v2_13::{
     NATIVE_V2_DIFF_STATE_COMPATIBILITY_VERSION, SnapshotV2DiffLayerBinding,
-    SnapshotV2DiffStateError, SnapshotV2DiffVerifyError, decode_snapshot_v2_diff_layer_binding,
+    SnapshotV2DiffMaterializationError, SnapshotV2DiffStateError, SnapshotV2DiffVerifyError,
+    decode_snapshot_v2_diff_layer_binding,
 };
 use crate::snapshot_entropy_v2_8::{
     NATIVE_V2_ENTROPY_STATE_COMPATIBILITY_VERSION, SnapshotV2EntropyState,
@@ -50,10 +50,11 @@ use crate::snapshot_entropy_v2_8::{
 #[cfg(target_os = "macos")]
 use crate::snapshot_format::NATIVE_V1_SNAPSHOT_MAX_FILE_BYTES;
 use crate::snapshot_format::{
-    NATIVE_V1_SNAPSHOT_VERSION, NativeSnapshotFormatError, NativeSnapshotState,
-    SnapshotFormatVersion, decode_native_snapshot_state,
+    NATIVE_V1_SNAPSHOT_VERSION, NativeSnapshotFormatError, SnapshotFormatVersion,
 };
-#[cfg(test)]
+#[cfg(target_os = "macos")]
+use crate::snapshot_format::{NativeSnapshotState, decode_native_snapshot_state};
+#[cfg(all(test, target_os = "macos"))]
 use crate::snapshot_format_v2::NATIVE_V2_SNAPSHOT_VERSION;
 use crate::snapshot_format_v2::{
     NATIVE_V2_BALLOON_COMPONENT_KEY, NATIVE_V2_DEVICE_GRAPH_COMPONENT_KEY,
@@ -3850,6 +3851,18 @@ impl SnapshotArtifactOutput {
 
 impl fmt::Debug for SnapshotArtifactOutput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.location {
+            SnapshotArtifactOutputLocation::Path(path) => {
+                let _ = path;
+            }
+            SnapshotArtifactOutputLocation::Anchored {
+                directory,
+                child,
+                tracker,
+            } => {
+                let _ = (directory, child, tracker);
+            }
+        }
         f.debug_struct("SnapshotArtifactOutput")
             .field("destination", &REDACTED)
             .finish()
@@ -3875,10 +3888,12 @@ impl SnapshotArtifactOutputs {
         )
     }
 
+    #[cfg(target_os = "macos")]
     fn state(&self) -> &SnapshotArtifactOutput {
         &self.state
     }
 
+    #[cfg(target_os = "macos")]
     fn memory(&self) -> &SnapshotArtifactOutput {
         &self.memory
     }
@@ -3886,6 +3901,7 @@ impl SnapshotArtifactOutputs {
 
 impl fmt::Debug for SnapshotArtifactOutputs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let _ = (&self.state, &self.memory);
         f.debug_struct("SnapshotArtifactOutputs")
             .field("state", &REDACTED)
             .field("memory", &REDACTED)
@@ -3904,6 +3920,7 @@ pub struct SnapshotMemoryStagingWriter {
 }
 
 impl SnapshotMemoryStagingWriter {
+    #[cfg(target_os = "macos")]
     fn new(file: File, closed: Arc<AtomicBool>) -> Self {
         Self {
             file: Some(file),
@@ -4008,6 +4025,7 @@ pub struct SnapshotStagingOwnership {
 }
 
 impl SnapshotStagingOwnership {
+    #[cfg(target_os = "macos")]
     fn new(
         artifact: SnapshotArtifactKind,
         directory_identity: SnapshotArtifactIdentity,
@@ -5431,13 +5449,14 @@ pub fn load_prepared_native_snapshot_memory_file(
 pub fn load_prepared_native_snapshot_memory_file_with_cancel<C>(
     prepared: PreparedNativeSnapshotState,
     file: File,
-    mut is_cancelled: C,
+    is_cancelled: C,
 ) -> Result<LoadedNativeSnapshotArtifacts, SnapshotArtifactLoadError>
 where
     C: FnMut() -> bool,
 {
     #[cfg(target_os = "macos")]
     {
+        let mut is_cancelled = is_cancelled;
         load_prepared_native_snapshot_memory_file_macos(prepared, file, &mut is_cancelled)
     }
     #[cfg(not(target_os = "macos"))]
@@ -5481,13 +5500,14 @@ pub fn load_prepared_native_snapshot_memory_path(
 pub fn load_prepared_native_snapshot_memory_path_with_cancel<C>(
     prepared: PreparedNativeSnapshotState,
     path: &Path,
-    mut is_cancelled: C,
+    is_cancelled: C,
 ) -> Result<LoadedNativeSnapshotArtifacts, SnapshotArtifactLoadError>
 where
     C: FnMut() -> bool,
 {
     #[cfg(target_os = "macos")]
     {
+        let mut is_cancelled = is_cancelled;
         load_prepared_native_snapshot_memory_path_macos(prepared, path, &mut is_cancelled)
     }
     #[cfg(not(target_os = "macos"))]

--- a/crates/runtime/src/snapshot_memory.rs
+++ b/crates/runtime/src/snapshot_memory.rs
@@ -891,6 +891,7 @@ pub fn load_snapshot_memory_image_with_backing<R: Read + Seek>(
 /// integrity trailer without allocating guest memory or re-reading the data.
 /// Full CRC and GPA-range validation remains the responsibility of
 /// [`load_snapshot_memory_image`].
+#[cfg(target_os = "macos")]
 pub(crate) fn verify_snapshot_memory_image_output<R: Read + Seek>(
     binding: &SnapshotMemoryBinding,
     reader: &mut R,

--- a/crates/runtime/src/snapshot_memory_v2.rs
+++ b/crates/runtime/src/snapshot_memory_v2.rs
@@ -1062,7 +1062,6 @@ impl FileFacts {
         self.mode & libc::S_IFMT as u32 == libc::S_IFREG as u32
     }
 
-    #[cfg(target_os = "macos")]
     pub(crate) const fn permissions(self) -> u32 {
         self.mode & 0o7777
     }

--- a/crates/runtime/src/snapshot_state_edit.rs
+++ b/crates/runtime/src/snapshot_state_edit.rs
@@ -1,0 +1,662 @@
+//! Failure-atomic publication for one edited native snapshot state document.
+//!
+//! The transaction retains one immutable input and publishes one distinct,
+//! absent output from private same-directory staging. A successful `linkat` is
+//! the commit point. Before that point, `Err` guarantees that no final output
+//! was created; after it, cleanup or durability uncertainty is returned only as
+//! a committed outcome.
+//!
+//! Retained descriptors and repeated identity/fact checks are detection
+//! boundaries. POSIX has no inode-conditioned `linkat` or `unlinkat`, so callers
+//! must retain trusted mutation authority over both directories and prevent
+//! concurrent mutation of the opened input inode.
+
+use std::collections::TryReserveError;
+use std::fmt;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::snapshot_format::NATIVE_V1_SNAPSHOT_MAX_FILE_BYTES;
+use crate::snapshot_format_v2::NATIVE_V2_SNAPSHOT_MAX_FILE_BYTES;
+
+const REDACTED: &str = "<redacted>";
+
+/// Maximum accepted input or encoded output bytes for one native state edit.
+pub const SNAPSHOT_STATE_EDIT_MAX_FILE_BYTES: usize =
+    if NATIVE_V1_SNAPSHOT_MAX_FILE_BYTES > NATIVE_V2_SNAPSHOT_MAX_FILE_BYTES {
+        NATIVE_V1_SNAPSHOT_MAX_FILE_BYTES
+    } else {
+        NATIVE_V2_SNAPSHOT_MAX_FILE_BYTES
+    };
+
+/// The immutable input and distinct absent output of one state edit.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SnapshotStateEditPaths {
+    input: PathBuf,
+    output: PathBuf,
+}
+
+impl SnapshotStateEditPaths {
+    /// Creates one input/output path request without opening either path.
+    pub fn new(input: impl Into<PathBuf>, output: impl Into<PathBuf>) -> Self {
+        Self {
+            input: input.into(),
+            output: output.into(),
+        }
+    }
+
+    /// Returns the immutable input path to a trusted caller.
+    pub fn input(&self) -> &Path {
+        &self.input
+    }
+
+    /// Returns the final output path to a trusted caller.
+    pub fn output(&self) -> &Path {
+        &self.output
+    }
+}
+
+impl fmt::Debug for SnapshotStateEditPaths {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotStateEditPaths")
+            .field("input", &REDACTED)
+            .field("output", &REDACTED)
+            .finish()
+    }
+}
+
+/// Stable role of one submitted state-edit path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotStateEditPathRole {
+    /// Immutable source state.
+    Input,
+    /// Distinct no-clobber final destination.
+    Output,
+}
+
+impl fmt::Display for SnapshotStateEditPathRole {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Input => "input",
+            Self::Output => "output",
+        })
+    }
+}
+
+/// Stable checkpoint in one state-edit transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotStateEditStage {
+    /// Reject unsupported compile targets before path or callback access.
+    PlatformCheck,
+    /// Validate input path syntax.
+    InputPathValidation,
+    /// Open and retain the input parent directory.
+    InputDirectoryOpen,
+    /// Open the final input component without following it.
+    InputFileOpen,
+    /// Validate and retain immutable input descriptor facts.
+    InputValidation,
+    /// Validate output path syntax.
+    OutputPathValidation,
+    /// Open and retain the output parent directory.
+    OutputDirectoryOpen,
+    /// Reject input/output path or object aliases.
+    AliasCheck,
+    /// Require an absent final output.
+    OutputPreflight,
+    /// Read the bounded immutable input bytes.
+    InputRead,
+    /// Transform input bytes into a typed edited product.
+    Transform,
+    /// Encode the typed product into canonical bounded bytes.
+    Encode,
+    /// Create and validate private output-directory staging.
+    StagingCreate,
+    /// Write the complete canonical bytes.
+    StagingWrite,
+    /// Flush the staging writer.
+    StagingFlush,
+    /// Synchronize the staging file.
+    StagingFileSync,
+    /// Seek staging back to its first byte.
+    StagingSeek,
+    /// Reread the complete staged bytes and EOF.
+    StagingRead,
+    /// Semantically verify the reread staged document.
+    StagingVerify,
+    /// Recheck the immutable input descriptor facts.
+    SourceStability,
+    /// Recheck retained and path-resolved directory identities.
+    DirectoryStability,
+    /// Recheck input, absent output, and private staging entries.
+    EntryStability,
+    /// Perform final checks and atomically hard-link the absent output.
+    Commit,
+    /// Verify identities after the hard-link commit point.
+    CommitVerification,
+    /// Remove only the identity-matching private staging entry.
+    StagingCleanup,
+    /// Synchronize the committed output directory.
+    OutputDirectorySync,
+    /// Finish without another fallible transition.
+    Complete,
+}
+
+impl fmt::Display for SnapshotStateEditStage {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::PlatformCheck => "platform check",
+            Self::InputPathValidation => "input path validation",
+            Self::InputDirectoryOpen => "input directory open",
+            Self::InputFileOpen => "input file open",
+            Self::InputValidation => "input validation",
+            Self::OutputPathValidation => "output path validation",
+            Self::OutputDirectoryOpen => "output directory open",
+            Self::AliasCheck => "input/output alias check",
+            Self::OutputPreflight => "output preflight",
+            Self::InputRead => "input read",
+            Self::Transform => "typed transformation",
+            Self::Encode => "state encoding",
+            Self::StagingCreate => "staging creation",
+            Self::StagingWrite => "staging write",
+            Self::StagingFlush => "staging flush",
+            Self::StagingFileSync => "staging file synchronization",
+            Self::StagingSeek => "staging seek",
+            Self::StagingRead => "staging reread",
+            Self::StagingVerify => "staging semantic verification",
+            Self::SourceStability => "source stability check",
+            Self::DirectoryStability => "directory stability check",
+            Self::EntryStability => "entry stability check",
+            Self::Commit => "hard-link commit",
+            Self::CommitVerification => "committed identity verification",
+            Self::StagingCleanup => "staging cleanup",
+            Self::OutputDirectorySync => "output directory synchronization",
+            Self::Complete => "completion",
+        })
+    }
+}
+
+/// Disposition of one private staging name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotStateEditCleanup {
+    /// The exact owned staging entry was removed.
+    Removed,
+    /// The owned staging entry was already absent.
+    AlreadyAbsent,
+    /// A replacement entry was deliberately retained.
+    ChangedRefused,
+    /// Inspection or removal failed.
+    Failed(io::ErrorKind),
+}
+
+/// Value-redacted infrastructure failure before the hard-link commit point.
+pub enum SnapshotStateEditFailure {
+    /// The compile target cannot provide the required Unix transaction.
+    UnsupportedPlatform,
+    /// The caller cancelled at a stable precommit checkpoint.
+    Cancelled,
+    /// One submitted path has no valid exact final component.
+    InvalidPath {
+        /// Path role, without its value.
+        path: SnapshotStateEditPathRole,
+    },
+    /// The opened input descriptor is not one valid immutable regular file.
+    InvalidInput,
+    /// Input length exceeds the fixed native-state ceiling.
+    InputTooLarge {
+        /// Public fixed maximum; the submitted length is not retained.
+        maximum: usize,
+    },
+    /// Encoded state is empty or exceeds the fixed native-state ceiling.
+    InvalidEncodedStateLength {
+        /// Public fixed maximum; the observed length is not retained.
+        maximum: usize,
+    },
+    /// Input and output name the same path or filesystem object.
+    InputOutputAlias,
+    /// The no-clobber final output already exists.
+    OutputAlreadyExists,
+    /// Private staging-name randomness is unavailable.
+    RandomnessUnavailable,
+    /// Every fixed staging-name creation attempt collided.
+    StagingNameExhausted,
+    /// The fresh staging descriptor did not retain its required facts.
+    InvalidStaging,
+    /// The retained input descriptor facts changed.
+    SourceChanged,
+    /// A parent path no longer resolves to its retained directory.
+    DirectoryChanged {
+        /// Changed path's role.
+        path: SnapshotStateEditPathRole,
+    },
+    /// A final component no longer has its required identity.
+    EntryChanged {
+        /// Changed path's role.
+        path: SnapshotStateEditPathRole,
+    },
+    /// The private staging name, descriptor, or facts changed.
+    StagingChanged,
+    /// Staging bytes differ from the canonical encoded state.
+    StagingContentMismatch,
+    /// The filesystem rejected the required no-clobber hard-link commit.
+    HardLinkUnavailable {
+        /// Stable OS error class.
+        kind: io::ErrorKind,
+    },
+    /// A bounded buffer reservation failed.
+    Allocation(TryReserveError),
+    /// Another filesystem operation failed.
+    Io {
+        /// Stable OS error class.
+        kind: io::ErrorKind,
+    },
+}
+
+impl fmt::Debug for SnapshotStateEditFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (kind, path) = match self {
+            Self::UnsupportedPlatform => ("unsupported platform", None),
+            Self::Cancelled => ("cancelled", None),
+            Self::InvalidPath { path } => ("invalid path", Some(*path)),
+            Self::InvalidInput => ("invalid input", Some(SnapshotStateEditPathRole::Input)),
+            Self::InputTooLarge { .. } => {
+                ("input too large", Some(SnapshotStateEditPathRole::Input))
+            }
+            Self::InvalidEncodedStateLength { .. } => ("encoded state length", None),
+            Self::InputOutputAlias => ("input/output alias", None),
+            Self::OutputAlreadyExists => ("output exists", Some(SnapshotStateEditPathRole::Output)),
+            Self::RandomnessUnavailable => ("randomness unavailable", None),
+            Self::StagingNameExhausted => ("staging names exhausted", None),
+            Self::InvalidStaging => ("invalid staging", None),
+            Self::SourceChanged => ("source changed", Some(SnapshotStateEditPathRole::Input)),
+            Self::DirectoryChanged { path } => ("directory changed", Some(*path)),
+            Self::EntryChanged { path } => ("entry changed", Some(*path)),
+            Self::StagingChanged => ("staging changed", None),
+            Self::StagingContentMismatch => ("staging content mismatch", None),
+            Self::HardLinkUnavailable { .. } => ("hard link unavailable", None),
+            Self::Allocation(_) => ("allocation", None),
+            Self::Io { .. } => ("I/O", None),
+        };
+        formatter
+            .debug_struct("SnapshotStateEditFailure")
+            .field("kind", &kind)
+            .field("path", &path)
+            .field("details", &REDACTED)
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotStateEditFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedPlatform => {
+                formatter.write_str("edited state publication requires a Unix target")
+            }
+            Self::Cancelled => formatter.write_str("the caller cancelled before commit"),
+            Self::InvalidPath { path } => write!(formatter, "the {path} path is invalid"),
+            Self::InvalidInput => formatter.write_str("the input descriptor is invalid"),
+            Self::InputTooLarge { maximum } => {
+                write!(
+                    formatter,
+                    "the input exceeds the {maximum}-byte state limit"
+                )
+            }
+            Self::InvalidEncodedStateLength { maximum } => write!(
+                formatter,
+                "the encoded state length is outside the 1..={maximum} byte limit"
+            ),
+            Self::InputOutputAlias => formatter.write_str("input and output alias"),
+            Self::OutputAlreadyExists => formatter.write_str("the output already exists"),
+            Self::RandomnessUnavailable => {
+                formatter.write_str("private staging-name randomness is unavailable")
+            }
+            Self::StagingNameExhausted => {
+                formatter.write_str("private staging-name attempts were exhausted")
+            }
+            Self::InvalidStaging => formatter.write_str("the private staging file is invalid"),
+            Self::SourceChanged => formatter.write_str("the immutable input changed"),
+            Self::DirectoryChanged { path } => write!(formatter, "the {path} directory changed"),
+            Self::EntryChanged { path } => write!(formatter, "the {path} entry changed"),
+            Self::StagingChanged => formatter.write_str("the private staging entry changed"),
+            Self::StagingContentMismatch => formatter.write_str("private staging content changed"),
+            Self::HardLinkUnavailable { kind } => {
+                write!(
+                    formatter,
+                    "no-clobber hard-link commit failed with {kind:?}"
+                )
+            }
+            Self::Allocation(_) => formatter.write_str("bounded state allocation failed"),
+            Self::Io { kind } => write!(formatter, "filesystem operation failed with {kind:?}"),
+        }
+    }
+}
+
+impl std::error::Error for SnapshotStateEditFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Allocation(source) => Some(source),
+            Self::UnsupportedPlatform
+            | Self::Cancelled
+            | Self::InvalidPath { .. }
+            | Self::InvalidInput
+            | Self::InputTooLarge { .. }
+            | Self::InvalidEncodedStateLength { .. }
+            | Self::InputOutputAlias
+            | Self::OutputAlreadyExists
+            | Self::RandomnessUnavailable
+            | Self::StagingNameExhausted
+            | Self::InvalidStaging
+            | Self::SourceChanged
+            | Self::DirectoryChanged { .. }
+            | Self::EntryChanged { .. }
+            | Self::StagingChanged
+            | Self::StagingContentMismatch
+            | Self::HardLinkUnavailable { .. }
+            | Self::Io { .. } => None,
+        }
+    }
+}
+
+/// Infrastructure failure whose `Err` contract proves no final output committed.
+pub struct SnapshotStateEditError {
+    stage: SnapshotStateEditStage,
+    failure: SnapshotStateEditFailure,
+    staging_cleanup: Option<SnapshotStateEditCleanup>,
+}
+
+impl SnapshotStateEditError {
+    /// Returns the precommit stage that failed.
+    pub const fn stage(&self) -> SnapshotStateEditStage {
+        self.stage
+    }
+
+    /// Returns the value-redacted primary failure.
+    pub const fn failure(&self) -> &SnapshotStateEditFailure {
+        &self.failure
+    }
+
+    /// Returns the explicit private-staging cleanup disposition, when present.
+    pub const fn staging_cleanup(&self) -> Option<SnapshotStateEditCleanup> {
+        self.staging_cleanup
+    }
+}
+
+impl fmt::Debug for SnapshotStateEditError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotStateEditError")
+            .field("stage", &self.stage)
+            .field("failure", &self.failure)
+            .field("staging_cleanup", &self.staging_cleanup)
+            .finish()
+    }
+}
+
+impl fmt::Display for SnapshotStateEditError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "edited snapshot state publication failed during {}: {}",
+            self.stage, self.failure
+        )
+    }
+}
+
+impl std::error::Error for SnapshotStateEditError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.failure)
+    }
+}
+
+/// Typed caller-operation failure before the hard-link commit point.
+pub struct SnapshotStateEditOperationError<E> {
+    stage: SnapshotStateEditStage,
+    source: E,
+    staging_cleanup: Option<SnapshotStateEditCleanup>,
+}
+
+impl<E> SnapshotStateEditOperationError<E> {
+    /// Returns the transform, encode, or semantic-verification stage.
+    pub const fn stage(&self) -> SnapshotStateEditStage {
+        self.stage
+    }
+
+    /// Returns the typed operation failure to a trusted caller.
+    pub const fn source(&self) -> &E {
+        &self.source
+    }
+
+    /// Returns the explicit private-staging cleanup disposition, when present.
+    pub const fn staging_cleanup(&self) -> Option<SnapshotStateEditCleanup> {
+        self.staging_cleanup
+    }
+}
+
+impl<E> fmt::Debug for SnapshotStateEditOperationError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotStateEditOperationError")
+            .field("stage", &self.stage)
+            .field("source", &REDACTED)
+            .field("staging_cleanup", &self.staging_cleanup)
+            .finish()
+    }
+}
+
+impl<E> fmt::Display for SnapshotStateEditOperationError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "edited snapshot state operation failed during {}",
+            self.stage
+        )
+    }
+}
+
+impl<E> std::error::Error for SnapshotStateEditOperationError<E> {}
+
+/// Failure from publication infrastructure or a typed caller operation.
+pub enum SnapshotStateEditTransactionError<E> {
+    /// Path, descriptor, staging, commit, or cancellation failure.
+    Publication(SnapshotStateEditError),
+    /// Typed transform, encode, or semantic-verification failure.
+    Operation(SnapshotStateEditOperationError<E>),
+}
+
+impl<E> SnapshotStateEditTransactionError<E> {
+    /// Returns the infrastructure failure, when present.
+    pub const fn publication(&self) -> Option<&SnapshotStateEditError> {
+        match self {
+            Self::Publication(error) => Some(error),
+            Self::Operation(_) => None,
+        }
+    }
+
+    /// Returns the typed operation failure, when present.
+    pub const fn operation(&self) -> Option<&SnapshotStateEditOperationError<E>> {
+        match self {
+            Self::Publication(_) => None,
+            Self::Operation(error) => Some(error),
+        }
+    }
+}
+
+impl<E> From<SnapshotStateEditError> for SnapshotStateEditTransactionError<E> {
+    fn from(error: SnapshotStateEditError) -> Self {
+        Self::Publication(error)
+    }
+}
+
+impl<E> fmt::Debug for SnapshotStateEditTransactionError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Publication(error) => formatter.debug_tuple("Publication").field(error).finish(),
+            Self::Operation(error) => formatter.debug_tuple("Operation").field(error).finish(),
+        }
+    }
+}
+
+impl<E> fmt::Display for SnapshotStateEditTransactionError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Publication(error) => error.fmt(formatter),
+            Self::Operation(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl<E> std::error::Error for SnapshotStateEditTransactionError<E> {}
+
+/// Value-redacted reason that a committed edit is not proven durable and clean.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotStateEditCommitFailure {
+    /// A retained or path-resolved parent directory changed.
+    DirectoryChanged {
+        /// Changed path's role.
+        path: SnapshotStateEditPathRole,
+    },
+    /// The immutable input facts or name changed after commit.
+    InputChanged,
+    /// The final output no longer names the committed inode.
+    OutputEntryChanged,
+    /// The staging name no longer names the committed inode.
+    StagingEntryChanged,
+    /// Staging cleanup was not conclusive.
+    Cleanup,
+    /// Another postcommit filesystem operation failed.
+    Io(io::ErrorKind),
+}
+
+/// Durability and cleanup classification after successful hard-link commit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotStateEditCommit {
+    /// Output identity, staging cleanup, and directory synchronization succeeded.
+    Durable,
+    /// The output link committed, but later proof is incomplete.
+    Uncertain {
+        /// First postcommit stage that became uncertain.
+        stage: SnapshotStateEditStage,
+        /// Stable first uncertainty.
+        failure: SnapshotStateEditCommitFailure,
+        /// Best-effort staging cleanup disposition.
+        staging_cleanup: SnapshotStateEditCleanup,
+        /// Output-directory synchronization failure, if any.
+        directory_sync: Option<io::ErrorKind>,
+    },
+}
+
+/// Typed edited product and classification returned after hard-link commit.
+pub struct SnapshotStateEditOutcome<T> {
+    product: T,
+    commit: SnapshotStateEditCommit,
+}
+
+impl<T> SnapshotStateEditOutcome<T> {
+    /// Returns the caller's typed transformed product.
+    pub const fn product(&self) -> &T {
+        &self.product
+    }
+
+    /// Returns the durable or committed-uncertain classification.
+    pub const fn commit(&self) -> SnapshotStateEditCommit {
+        self.commit
+    }
+
+    /// Consumes the outcome into its typed product and commit classification.
+    pub fn into_parts(self) -> (T, SnapshotStateEditCommit) {
+        (self.product, self.commit)
+    }
+}
+
+impl<T> fmt::Debug for SnapshotStateEditOutcome<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SnapshotStateEditOutcome")
+            .field("product", &REDACTED)
+            .field("commit", &self.commit)
+            .finish()
+    }
+}
+
+/// Publishes one synchronously transformed, encoded, and verified state document.
+pub fn publish_edited_snapshot_state_with<T, E, Transform, Encode, Verify>(
+    paths: &SnapshotStateEditPaths,
+    transform: Transform,
+    encode: Encode,
+    verify: Verify,
+) -> Result<SnapshotStateEditOutcome<T>, SnapshotStateEditTransactionError<E>>
+where
+    Transform: FnOnce(&[u8]) -> Result<T, E>,
+    Encode: FnOnce(&T) -> Result<Vec<u8>, E>,
+    Verify: FnOnce(&[u8], &T) -> Result<(), E>,
+{
+    publish_edited_snapshot_state_with_cancel(paths, transform, encode, verify, |_| false)
+}
+
+/// Publishes one edited state document with stable precommit cancellation.
+///
+/// Transform, encode, semantic verification, and the cancellation callback all
+/// finish before final repeated checks. After those checks, the implementation
+/// calls `linkat` directly without invoking caller code or allocating.
+pub fn publish_edited_snapshot_state_with_cancel<T, E, Transform, Encode, Verify, Cancel>(
+    paths: &SnapshotStateEditPaths,
+    transform: Transform,
+    encode: Encode,
+    verify: Verify,
+    is_cancelled: Cancel,
+) -> Result<SnapshotStateEditOutcome<T>, SnapshotStateEditTransactionError<E>>
+where
+    Transform: FnOnce(&[u8]) -> Result<T, E>,
+    Encode: FnOnce(&T) -> Result<Vec<u8>, E>,
+    Verify: FnOnce(&[u8], &T) -> Result<(), E>,
+    Cancel: FnMut(SnapshotStateEditStage) -> bool,
+{
+    #[cfg(unix)]
+    {
+        unix::publish_edited_snapshot_state_unix_with_cancel(
+            paths,
+            transform,
+            encode,
+            verify,
+            is_cancelled,
+        )
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (paths, transform, encode, verify, is_cancelled);
+        Err(precommit_error(
+            SnapshotStateEditStage::PlatformCheck,
+            SnapshotStateEditFailure::UnsupportedPlatform,
+        )
+        .into())
+    }
+}
+
+fn precommit_error(
+    stage: SnapshotStateEditStage,
+    failure: SnapshotStateEditFailure,
+) -> SnapshotStateEditError {
+    SnapshotStateEditError {
+        stage,
+        failure,
+        staging_cleanup: None,
+    }
+}
+
+fn operation_error<E>(
+    stage: SnapshotStateEditStage,
+    source: E,
+) -> SnapshotStateEditOperationError<E> {
+    SnapshotStateEditOperationError {
+        stage,
+        source,
+        staging_cleanup: None,
+    }
+}
+
+#[cfg(unix)]
+mod unix;
+
+#[cfg(test)]
+mod tests;

--- a/crates/runtime/src/snapshot_state_edit/tests.rs
+++ b/crates/runtime/src/snapshot_state_edit/tests.rs
@@ -1,0 +1,1467 @@
+use super::*;
+
+#[test]
+fn paths_debug_redacts_both_values() {
+    let paths = SnapshotStateEditPaths::new("sensitive-input", "sensitive-output");
+    let debug = format!("{paths:?}");
+    assert!(!debug.contains("sensitive-input"));
+    assert!(!debug.contains("sensitive-output"));
+    assert_eq!(paths.input(), Path::new("sensitive-input"));
+    assert_eq!(paths.output(), Path::new("sensitive-output"));
+}
+
+#[cfg(not(unix))]
+#[test]
+fn unsupported_platform_rejects_before_callbacks() {
+    let paths = SnapshotStateEditPaths::new("", "");
+    let mut callbacks = 0;
+    let error = publish_edited_snapshot_state_with_cancel(
+        &paths,
+        |_| {
+            callbacks += 1;
+            Ok::<_, ()>(())
+        },
+        |_| {
+            callbacks += 1;
+            Ok(Vec::new())
+        },
+        |_, _| {
+            callbacks += 1;
+            Ok(())
+        },
+        |_| {
+            callbacks += 1;
+            false
+        },
+    )
+    .expect_err("unsupported target should reject");
+    assert_eq!(callbacks, 0);
+    let publication = error
+        .publication()
+        .expect("failure should be infrastructure");
+    assert_eq!(publication.stage(), SnapshotStateEditStage::PlatformCheck);
+    assert!(matches!(
+        publication.failure(),
+        SnapshotStateEditFailure::UnsupportedPlatform
+    ));
+}
+
+#[cfg(unix)]
+mod unix_tests {
+    use std::ffi::CString;
+    use std::fs::{self, File, OpenOptions};
+    use std::io::{self, Write};
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+    use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
+    use std::os::unix::net::UnixListener;
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Barrier};
+
+    use super::super::unix::{
+        with_state_edit_action, with_state_edit_action_and_cleanup_failure,
+        with_state_edit_cleanup_failure, with_state_edit_failure_and_cleanup_failure,
+        with_state_edit_failures, with_state_edit_hard_link_failure,
+        with_state_edit_random_failure, with_state_edit_random_names, with_state_edit_staging_mode,
+    };
+    use super::*;
+
+    const SOURCE: &[u8] = b"bounded-source-state";
+    const SUFFIX: &[u8] = b"-edited";
+    const PRECOMMIT_STAGES: [SnapshotStateEditStage; 23] = [
+        SnapshotStateEditStage::PlatformCheck,
+        SnapshotStateEditStage::InputPathValidation,
+        SnapshotStateEditStage::InputDirectoryOpen,
+        SnapshotStateEditStage::InputFileOpen,
+        SnapshotStateEditStage::InputValidation,
+        SnapshotStateEditStage::OutputPathValidation,
+        SnapshotStateEditStage::OutputDirectoryOpen,
+        SnapshotStateEditStage::AliasCheck,
+        SnapshotStateEditStage::OutputPreflight,
+        SnapshotStateEditStage::InputRead,
+        SnapshotStateEditStage::Transform,
+        SnapshotStateEditStage::Encode,
+        SnapshotStateEditStage::StagingCreate,
+        SnapshotStateEditStage::StagingWrite,
+        SnapshotStateEditStage::StagingFlush,
+        SnapshotStateEditStage::StagingFileSync,
+        SnapshotStateEditStage::StagingSeek,
+        SnapshotStateEditStage::StagingRead,
+        SnapshotStateEditStage::StagingVerify,
+        SnapshotStateEditStage::SourceStability,
+        SnapshotStateEditStage::DirectoryStability,
+        SnapshotStateEditStage::EntryStability,
+        SnapshotStateEditStage::Commit,
+    ];
+
+    static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+
+    #[derive(Debug)]
+    struct TestDirectory {
+        path: PathBuf,
+    }
+
+    impl TestDirectory {
+        fn new(label: &str) -> Self {
+            let sequence = NEXT_TEST_DIRECTORY.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "bb-state-edit-{label}-{}-{sequence}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).expect("test directory should create");
+            Self { path }
+        }
+
+        fn child(&self, name: &str) -> PathBuf {
+            self.path.join(name)
+        }
+
+        fn staging_entries(&self) -> Vec<PathBuf> {
+            staging_entries(&self.path)
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct ToyProduct {
+        bytes: Vec<u8>,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct ToyError(&'static str);
+
+    impl fmt::Display for ToyError {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str(self.0)
+        }
+    }
+
+    impl std::error::Error for ToyError {}
+
+    type TestFileFacts = (u64, u64, u32, u64, i64, i64, i64, i64);
+
+    struct EditFixture {
+        directory: TestDirectory,
+        paths: SnapshotStateEditPaths,
+        source_facts: TestFileFacts,
+    }
+
+    impl EditFixture {
+        fn new(label: &str) -> Self {
+            let directory = TestDirectory::new(label);
+            let input = directory.child("input.state");
+            let output = directory.child("output.state");
+            fs::write(&input, SOURCE).expect("source should write");
+            let source_facts = test_file_facts(&input);
+            Self {
+                directory,
+                paths: SnapshotStateEditPaths::new(input, output),
+                source_facts,
+            }
+        }
+
+        fn expected(&self) -> Vec<u8> {
+            let mut expected = SOURCE.to_vec();
+            expected.extend_from_slice(SUFFIX);
+            expected
+        }
+
+        fn assert_source_unchanged(&self) {
+            assert_eq!(
+                fs::read(self.paths.input()).expect("source should read"),
+                SOURCE
+            );
+            assert_eq!(test_file_facts(self.paths.input()), self.source_facts);
+        }
+
+        fn assert_uncommitted_and_clean(&self) {
+            self.assert_source_unchanged();
+            assert!(!self.paths.output().exists());
+            assert!(self.directory.staging_entries().is_empty());
+        }
+
+        fn assert_durable(&self, outcome: &SnapshotStateEditOutcome<ToyProduct>) {
+            assert_eq!(outcome.commit(), SnapshotStateEditCommit::Durable);
+            assert_eq!(outcome.product().bytes, self.expected());
+            assert_eq!(
+                fs::read(self.paths.output()).expect("output should read"),
+                self.expected()
+            );
+            assert_eq!(
+                fs::metadata(self.paths.output())
+                    .expect("output metadata should read")
+                    .mode()
+                    & 0o7777,
+                0o600
+            );
+            self.assert_source_unchanged();
+            assert!(self.directory.staging_entries().is_empty());
+        }
+    }
+
+    fn test_file_facts(path: &Path) -> TestFileFacts {
+        let metadata = fs::metadata(path).expect("file facts should read");
+        (
+            metadata.dev(),
+            metadata.ino(),
+            metadata.mode(),
+            metadata.size(),
+            metadata.mtime(),
+            metadata.mtime_nsec(),
+            metadata.ctime(),
+            metadata.ctime_nsec(),
+        )
+    }
+
+    fn publish_toy(
+        paths: &SnapshotStateEditPaths,
+    ) -> Result<SnapshotStateEditOutcome<ToyProduct>, SnapshotStateEditTransactionError<ToyError>>
+    {
+        publish_edited_snapshot_state_with(
+            paths,
+            |input| {
+                let mut bytes = Vec::new();
+                bytes
+                    .try_reserve_exact(input.len() + SUFFIX.len())
+                    .map_err(|_| ToyError("secret transform allocation"))?;
+                bytes.extend_from_slice(input);
+                bytes.extend_from_slice(SUFFIX);
+                Ok(ToyProduct { bytes })
+            },
+            |product| Ok(product.bytes.clone()),
+            |staged, product| {
+                if staged == product.bytes {
+                    Ok(())
+                } else {
+                    Err(ToyError("secret semantic mismatch"))
+                }
+            },
+        )
+    }
+
+    fn staging_entries(directory: &Path) -> Vec<PathBuf> {
+        fs::read_dir(directory)
+            .expect("directory should enumerate")
+            .map(|entry| entry.expect("entry should read"))
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .as_encoded_bytes()
+                    .starts_with(b".bangbang-snapshot-edit-")
+            })
+            .map(|entry| entry.path())
+            .collect()
+    }
+
+    fn one_staging(directory: &Path) -> PathBuf {
+        let entries = staging_entries(directory);
+        assert_eq!(entries.len(), 1);
+        entries
+            .into_iter()
+            .next()
+            .expect("one staging entry should exist")
+    }
+
+    fn create_fifo(path: &Path) {
+        let path = CString::new(path.as_os_str().as_bytes()).expect("FIFO path should encode");
+        // SAFETY: the CString is NUL-terminated and the test owns the absent path.
+        let result = unsafe { libc::mkfifo(path.as_ptr(), 0o600) };
+        assert_eq!(result, 0, "FIFO fixture should create");
+    }
+
+    fn staging_name(random: [u8; 16]) -> String {
+        let mut name = String::from(".bangbang-snapshot-edit-");
+        for byte in random {
+            use std::fmt::Write as _;
+            write!(&mut name, "{byte:02x}").expect("staging name should format");
+        }
+        name
+    }
+
+    #[test]
+    fn same_and_cross_directory_edits_commit_durably_after_all_callbacks() {
+        for cross_directory in [false, true] {
+            let source = TestDirectory::new(if cross_directory {
+                "cross-source"
+            } else {
+                "same"
+            });
+            let destination = cross_directory.then(|| TestDirectory::new("cross-output"));
+            let input = source.child("input.state");
+            fs::write(&input, SOURCE).expect("source should write");
+            let source_facts = test_file_facts(&input);
+            let output = destination.as_ref().map_or_else(
+                || source.child("output.state"),
+                |root| root.child("output.state"),
+            );
+            let paths = SnapshotStateEditPaths::new(input, output);
+            let order = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+            let transform_order = std::rc::Rc::clone(&order);
+            let encode_order = std::rc::Rc::clone(&order);
+            let verify_order = std::rc::Rc::clone(&order);
+            let commit_order = std::rc::Rc::clone(&order);
+            let outcome = publish_edited_snapshot_state_with_cancel(
+                &paths,
+                move |input| {
+                    transform_order.borrow_mut().push("transform");
+                    let mut bytes = input.to_vec();
+                    bytes.extend_from_slice(SUFFIX);
+                    Ok::<_, ToyError>(ToyProduct { bytes })
+                },
+                move |product| {
+                    encode_order.borrow_mut().push("encode");
+                    Ok(product.bytes.clone())
+                },
+                move |staged, product| {
+                    verify_order.borrow_mut().push("verify");
+                    assert_eq!(staged, product.bytes);
+                    Ok(())
+                },
+                move |stage| {
+                    if stage == SnapshotStateEditStage::Commit {
+                        assert_eq!(&*commit_order.borrow(), &["transform", "encode", "verify"]);
+                    }
+                    false
+                },
+            )
+            .expect("edit should commit");
+            assert_eq!(outcome.commit(), SnapshotStateEditCommit::Durable);
+            assert_eq!(fs::read(paths.input()).expect("input should read"), SOURCE);
+            assert_eq!(test_file_facts(paths.input()), source_facts);
+            assert_eq!(
+                fs::read(paths.output()).expect("output should read"),
+                outcome.product().bytes
+            );
+            assert_eq!(
+                fs::metadata(paths.output())
+                    .expect("output mode should read")
+                    .mode()
+                    & 0o7777,
+                0o600
+            );
+            let output_directory = paths.output().parent().expect("output should have parent");
+            assert!(staging_entries(output_directory).is_empty());
+        }
+    }
+
+    #[test]
+    fn every_precommit_stage_can_cancel_without_output() {
+        for target in PRECOMMIT_STAGES {
+            let fixture = EditFixture::new(&format!("cancel-{target:?}"));
+            let error = publish_edited_snapshot_state_with_cancel(
+                &fixture.paths,
+                |input| {
+                    let mut bytes = input.to_vec();
+                    bytes.extend_from_slice(SUFFIX);
+                    Ok::<_, ToyError>(ToyProduct { bytes })
+                },
+                |product| Ok(product.bytes.clone()),
+                |staged, product| {
+                    assert_eq!(staged, product.bytes);
+                    Ok(())
+                },
+                |stage| stage == target,
+            )
+            .expect_err("target checkpoint should cancel");
+            let publication = error
+                .publication()
+                .expect("cancel should be infrastructure");
+            assert_eq!(publication.stage(), target);
+            assert!(matches!(
+                publication.failure(),
+                SnapshotStateEditFailure::Cancelled
+            ));
+            if PRECOMMIT_STAGES
+                .iter()
+                .position(|stage| *stage == target)
+                .expect("stage should be listed")
+                > PRECOMMIT_STAGES
+                    .iter()
+                    .position(|stage| *stage == SnapshotStateEditStage::StagingCreate)
+                    .expect("staging stage should be listed")
+            {
+                assert_eq!(
+                    publication.staging_cleanup(),
+                    Some(SnapshotStateEditCleanup::Removed)
+                );
+            } else {
+                assert_eq!(publication.staging_cleanup(), None);
+            }
+            fixture.assert_uncommitted_and_clean();
+        }
+    }
+
+    #[test]
+    fn every_precommit_stage_failure_preserves_primary_error_and_input() {
+        for target in PRECOMMIT_STAGES {
+            let fixture = EditFixture::new(&format!("failure-{target:?}"));
+            let error = with_state_edit_failures([(target, io::ErrorKind::Other)], || {
+                publish_toy(&fixture.paths).expect_err("target stage should fail")
+            });
+            let publication = error
+                .publication()
+                .expect("failure should be infrastructure");
+            assert_eq!(publication.stage(), target);
+            assert!(matches!(
+                publication.failure(),
+                SnapshotStateEditFailure::Io {
+                    kind: io::ErrorKind::Other
+                }
+            ));
+            fixture.assert_uncommitted_and_clean();
+        }
+    }
+
+    #[test]
+    fn typed_callback_failures_are_redacted_and_clean_staging() {
+        let fixture = EditFixture::new("typed-errors");
+        for (target, expected_cleanup) in [
+            (SnapshotStateEditStage::Transform, None),
+            (SnapshotStateEditStage::Encode, None),
+            (
+                SnapshotStateEditStage::StagingVerify,
+                Some(SnapshotStateEditCleanup::Removed),
+            ),
+        ] {
+            let error = publish_edited_snapshot_state_with(
+                &fixture.paths,
+                |input| {
+                    if target == SnapshotStateEditStage::Transform {
+                        return Err(ToyError("sensitive-transform-value"));
+                    }
+                    Ok(ToyProduct {
+                        bytes: input.to_vec(),
+                    })
+                },
+                |product| {
+                    if target == SnapshotStateEditStage::Encode {
+                        return Err(ToyError("sensitive-encode-value"));
+                    }
+                    Ok(product.bytes.clone())
+                },
+                |_, _| {
+                    if target == SnapshotStateEditStage::StagingVerify {
+                        return Err(ToyError("sensitive-verify-value"));
+                    }
+                    Ok(())
+                },
+            )
+            .expect_err("selected callback should fail");
+            let operation = error.operation().expect("failure should remain typed");
+            assert_eq!(operation.stage(), target);
+            assert_eq!(operation.staging_cleanup(), expected_cleanup);
+            assert!(operation.source().0.starts_with("sensitive-"));
+            let rendered = format!("{error:?} / {error}");
+            assert!(!rendered.contains("sensitive"));
+            fixture.assert_uncommitted_and_clean();
+        }
+    }
+
+    #[test]
+    fn verifier_panic_unwinds_only_owned_staging() {
+        let fixture = EditFixture::new("panic");
+        let unwind = catch_unwind(AssertUnwindSafe(|| {
+            let _ = publish_edited_snapshot_state_with(
+                &fixture.paths,
+                |input| {
+                    Ok::<_, ToyError>(ToyProduct {
+                        bytes: input.to_vec(),
+                    })
+                },
+                |product| Ok(product.bytes.clone()),
+                |_, _| -> Result<(), ToyError> { panic!("sensitive verifier panic") },
+            );
+        }));
+        assert!(unwind.is_err());
+        fixture.assert_uncommitted_and_clean();
+    }
+
+    #[test]
+    fn invalid_special_and_oversized_inputs_fail_without_blocking_or_staging() {
+        enum InputKind {
+            Missing,
+            Oversized,
+            Directory,
+            Symlink,
+            Fifo,
+            Socket,
+            Unreadable,
+        }
+
+        for (label, kind) in [
+            ("missing", InputKind::Missing),
+            ("oversized", InputKind::Oversized),
+            ("directory", InputKind::Directory),
+            ("symlink", InputKind::Symlink),
+            ("fifo", InputKind::Fifo),
+            ("socket", InputKind::Socket),
+            ("unreadable", InputKind::Unreadable),
+        ] {
+            let directory = TestDirectory::new(label);
+            let input = directory.child("input");
+            let output = directory.child("output");
+            let mut listener = None;
+            match kind {
+                InputKind::Missing => {}
+                InputKind::Oversized => {
+                    let file = File::create(&input).expect("oversized fixture should create");
+                    file.set_len(
+                        u64::try_from(SNAPSHOT_STATE_EDIT_MAX_FILE_BYTES)
+                            .expect("limit should fit")
+                            + 1,
+                    )
+                    .expect("oversized sparse fixture should extend");
+                }
+                InputKind::Directory => fs::create_dir(&input).expect("directory should create"),
+                InputKind::Symlink => {
+                    let target = directory.child("target");
+                    fs::write(&target, SOURCE).expect("target should write");
+                    symlink(&target, &input).expect("symlink should create");
+                }
+                InputKind::Fifo => create_fifo(&input),
+                InputKind::Socket => {
+                    listener = Some(UnixListener::bind(&input).expect("socket should bind"));
+                }
+                InputKind::Unreadable => {
+                    fs::write(&input, SOURCE).expect("unreadable input should write");
+                    fs::set_permissions(&input, fs::Permissions::from_mode(0o000))
+                        .expect("permissions should change");
+                }
+            }
+            let paths = SnapshotStateEditPaths::new(&input, &output);
+            let error = publish_toy(&paths).expect_err("invalid input should fail");
+            assert!(error.publication().is_some());
+            assert!(!output.exists());
+            assert!(directory.staging_entries().is_empty());
+            if matches!(kind, InputKind::Unreadable) {
+                fs::set_permissions(&input, fs::Permissions::from_mode(0o600))
+                    .expect("permissions should restore");
+            }
+            drop(listener);
+        }
+    }
+
+    #[test]
+    fn invalid_components_and_special_output_collisions_are_rejected() {
+        let directory = TestDirectory::new("paths");
+        let input = directory.child("input");
+        fs::write(&input, SOURCE).expect("input should write");
+        let invalid = [
+            PathBuf::new(),
+            PathBuf::from("."),
+            PathBuf::from(".."),
+            directory.path.join("trailing/"),
+            PathBuf::from(std::ffi::OsString::from_vec(b"bad\0component".to_vec())),
+        ];
+        for output in invalid {
+            let paths = SnapshotStateEditPaths::new(&input, output);
+            let error = publish_toy(&paths).expect_err("invalid output should fail");
+            let publication = error
+                .publication()
+                .expect("failure should be infrastructure");
+            assert_eq!(
+                publication.stage(),
+                SnapshotStateEditStage::OutputPathValidation
+            );
+            assert!(matches!(
+                publication.failure(),
+                SnapshotStateEditFailure::InvalidPath {
+                    path: SnapshotStateEditPathRole::Output
+                }
+            ));
+        }
+
+        enum OutputKind {
+            Regular,
+            Directory,
+            Symlink,
+            Fifo,
+            Socket,
+        }
+        for (label, kind) in [
+            ("regular", OutputKind::Regular),
+            ("directory", OutputKind::Directory),
+            ("symlink", OutputKind::Symlink),
+            ("fifo", OutputKind::Fifo),
+            ("socket", OutputKind::Socket),
+        ] {
+            let root = TestDirectory::new(&format!("output-{label}"));
+            let source = root.child("input");
+            let output = root.child("output");
+            fs::write(&source, SOURCE).expect("source should write");
+            let mut listener = None;
+            match kind {
+                OutputKind::Regular => fs::write(&output, b"foreign").expect("output should write"),
+                OutputKind::Directory => fs::create_dir(&output).expect("output dir should create"),
+                OutputKind::Symlink => {
+                    symlink(&source, &output).expect("output symlink should create")
+                }
+                OutputKind::Fifo => create_fifo(&output),
+                OutputKind::Socket => {
+                    listener =
+                        Some(UnixListener::bind(&output).expect("output socket should bind"));
+                }
+            }
+            let paths = SnapshotStateEditPaths::new(&source, &output);
+            let error = publish_toy(&paths).expect_err("existing output should fail");
+            let publication = error
+                .publication()
+                .expect("failure should be infrastructure");
+            assert!(matches!(
+                publication.failure(),
+                SnapshotStateEditFailure::OutputAlreadyExists
+                    | SnapshotStateEditFailure::InputOutputAlias
+            ));
+            assert!(root.staging_entries().is_empty());
+            drop(listener);
+        }
+    }
+
+    #[test]
+    fn exact_resolved_and_hard_link_aliases_fail_before_staging() {
+        let fixture = EditFixture::new("aliases");
+        for paths in [
+            SnapshotStateEditPaths::new(fixture.paths.input(), fixture.paths.input()),
+            {
+                let alias_parent = fixture.directory.child("alias-parent");
+                symlink(&fixture.directory.path, &alias_parent)
+                    .expect("parent alias should create");
+                SnapshotStateEditPaths::new(fixture.paths.input(), alias_parent.join("input.state"))
+            },
+            {
+                let output = fixture.directory.child("hard-link-output");
+                fs::hard_link(fixture.paths.input(), &output).expect("hard link should create");
+                SnapshotStateEditPaths::new(fixture.paths.input(), output)
+            },
+        ] {
+            let error = publish_toy(&paths).expect_err("alias should reject");
+            let publication = error
+                .publication()
+                .expect("failure should be infrastructure");
+            assert!(matches!(
+                publication.failure(),
+                SnapshotStateEditFailure::InputOutputAlias
+            ));
+        }
+        assert!(fixture.directory.staging_entries().is_empty());
+    }
+
+    #[test]
+    fn random_failure_collision_retry_exhaustion_and_mode_fixup_are_bounded() {
+        let failure_fixture = EditFixture::new("random-failure");
+        let error = with_state_edit_random_failure(|| {
+            publish_toy(&failure_fixture.paths).expect_err("random failure should reject")
+        });
+        let publication = error
+            .publication()
+            .expect("failure should be infrastructure");
+        assert!(matches!(
+            publication.failure(),
+            SnapshotStateEditFailure::RandomnessUnavailable
+        ));
+        failure_fixture.assert_uncommitted_and_clean();
+
+        let retry_fixture = EditFixture::new("random-retry");
+        let collision = [0x11; 16];
+        let winner = [0x22; 16];
+        let collision_path = retry_fixture.directory.child(&staging_name(collision));
+        fs::write(&collision_path, b"foreign").expect("collision should create");
+        let outcome = with_state_edit_random_names([collision, winner], || {
+            publish_toy(&retry_fixture.paths).expect("second random name should win")
+        });
+        assert_eq!(outcome.commit(), SnapshotStateEditCommit::Durable);
+        assert_eq!(
+            fs::read(&collision_path).expect("collision should remain"),
+            b"foreign"
+        );
+
+        let exhausted_fixture = EditFixture::new("random-exhausted");
+        let repeated = [0x33; 16];
+        fs::write(
+            exhausted_fixture.directory.child(&staging_name(repeated)),
+            b"foreign",
+        )
+        .expect("collision should create");
+        let error = with_state_edit_random_names(std::iter::repeat_n(repeated, 16), || {
+            publish_toy(&exhausted_fixture.paths).expect_err("collisions should exhaust")
+        });
+        assert!(matches!(
+            error
+                .publication()
+                .expect("failure should be infrastructure")
+                .failure(),
+            SnapshotStateEditFailure::StagingNameExhausted
+        ));
+        assert!(!exhausted_fixture.paths.output().exists());
+
+        let mode_fixture = EditFixture::new("mode-fixup");
+        let outcome = with_state_edit_staging_mode(0o000, || {
+            publish_toy(&mode_fixture.paths).expect("explicit chmod should normalize mode")
+        });
+        mode_fixture.assert_durable(&outcome);
+    }
+
+    #[test]
+    fn write_flush_sync_seek_read_and_verify_failures_clean_staging() {
+        for stage in [
+            SnapshotStateEditStage::StagingWrite,
+            SnapshotStateEditStage::StagingFlush,
+            SnapshotStateEditStage::StagingFileSync,
+            SnapshotStateEditStage::StagingSeek,
+            SnapshotStateEditStage::StagingRead,
+            SnapshotStateEditStage::StagingVerify,
+        ] {
+            let fixture = EditFixture::new(&format!("staging-{stage:?}"));
+            let error = with_state_edit_failures([(stage, io::ErrorKind::Other)], || {
+                publish_toy(&fixture.paths).expect_err("injected staging stage should fail")
+            });
+            let publication = error
+                .publication()
+                .expect("failure should be infrastructure");
+            assert_eq!(publication.stage(), stage);
+            assert_eq!(
+                publication.staging_cleanup(),
+                Some(SnapshotStateEditCleanup::Removed)
+            );
+            fixture.assert_uncommitted_and_clean();
+        }
+
+        let mismatch_fixture = EditFixture::new("staging-mismatch");
+        let directory = mismatch_fixture.directory.path.clone();
+        let error = with_state_edit_action(
+            SnapshotStateEditStage::StagingRead,
+            move || {
+                let staging = one_staging(&directory);
+                fs::write(staging, b"changed").expect("staging should corrupt");
+            },
+            || publish_toy(&mismatch_fixture.paths).expect_err("corruption should reject"),
+        );
+        let publication = error
+            .publication()
+            .expect("failure should be infrastructure");
+        assert_eq!(publication.stage(), SnapshotStateEditStage::StagingRead);
+        assert!(matches!(
+            publication.failure(),
+            SnapshotStateEditFailure::StagingContentMismatch | SnapshotStateEditFailure::Io { .. }
+        ));
+        mismatch_fixture.assert_uncommitted_and_clean();
+    }
+
+    #[test]
+    fn final_callback_detects_source_output_parent_and_staging_mutations() {
+        let source_fixture = EditFixture::new("source-mutation");
+        let source = source_fixture.paths.input().to_path_buf();
+        let error = publish_edited_snapshot_state_with_cancel(
+            &source_fixture.paths,
+            |input| {
+                let mut bytes = input.to_vec();
+                bytes.extend_from_slice(SUFFIX);
+                Ok::<_, ToyError>(ToyProduct { bytes })
+            },
+            |product| Ok(product.bytes.clone()),
+            |_, _| Ok(()),
+            move |stage| {
+                if stage == SnapshotStateEditStage::Commit {
+                    fs::write(&source, b"changed-source-state").expect("source should mutate");
+                }
+                false
+            },
+        )
+        .expect_err("source mutation should reject");
+        assert!(matches!(
+            error
+                .publication()
+                .expect("failure should be infrastructure")
+                .failure(),
+            SnapshotStateEditFailure::SourceChanged
+        ));
+        assert!(!source_fixture.paths.output().exists());
+        assert!(source_fixture.directory.staging_entries().is_empty());
+
+        let output_fixture = EditFixture::new("output-race");
+        let output = output_fixture.paths.output().to_path_buf();
+        let error = publish_edited_snapshot_state_with_cancel(
+            &output_fixture.paths,
+            |input| {
+                Ok::<_, ToyError>(ToyProduct {
+                    bytes: input.to_vec(),
+                })
+            },
+            |product| Ok(product.bytes.clone()),
+            |_, _| Ok(()),
+            move |stage| {
+                if stage == SnapshotStateEditStage::Commit {
+                    fs::write(&output, b"foreign-winner").expect("foreign output should win");
+                }
+                false
+            },
+        )
+        .expect_err("late output should reject");
+        assert!(matches!(
+            error
+                .publication()
+                .expect("failure should be infrastructure")
+                .failure(),
+            SnapshotStateEditFailure::OutputAlreadyExists
+        ));
+        assert_eq!(
+            fs::read(output_fixture.paths.output()).expect("foreign output should remain"),
+            b"foreign-winner"
+        );
+        assert!(output_fixture.directory.staging_entries().is_empty());
+
+        let staging_fixture = EditFixture::new("staging-replacement");
+        let directory = staging_fixture.directory.path.clone();
+        let error = publish_edited_snapshot_state_with_cancel(
+            &staging_fixture.paths,
+            |input| {
+                Ok::<_, ToyError>(ToyProduct {
+                    bytes: input.to_vec(),
+                })
+            },
+            |product| Ok(product.bytes.clone()),
+            |_, _| Ok(()),
+            move |stage| {
+                if stage == SnapshotStateEditStage::Commit {
+                    let staging = one_staging(&directory);
+                    fs::remove_file(&staging).expect("owned staging should remove");
+                    fs::write(&staging, b"foreign-staging")
+                        .expect("foreign staging should replace");
+                }
+                false
+            },
+        )
+        .expect_err("staging replacement should reject");
+        let publication = error
+            .publication()
+            .expect("failure should be infrastructure");
+        assert!(matches!(
+            publication.failure(),
+            SnapshotStateEditFailure::StagingChanged
+        ));
+        assert_eq!(
+            publication.staging_cleanup(),
+            Some(SnapshotStateEditCleanup::ChangedRefused)
+        );
+        assert!(!staging_fixture.paths.output().exists());
+        assert_eq!(staging_fixture.directory.staging_entries().len(), 1);
+
+        let parent_root = TestDirectory::new("parent-replacement");
+        let input_parent = parent_root.child("input-parent");
+        fs::create_dir(&input_parent).expect("input parent should create");
+        let input = input_parent.join("input.state");
+        fs::write(&input, SOURCE).expect("input should write");
+        let output = parent_root.child("output.state");
+        let moved = parent_root.child("moved-parent");
+        let input_parent_for_action = input_parent.clone();
+        let paths = SnapshotStateEditPaths::new(&input, &output);
+        let error = publish_edited_snapshot_state_with_cancel(
+            &paths,
+            |input| {
+                Ok::<_, ToyError>(ToyProduct {
+                    bytes: input.to_vec(),
+                })
+            },
+            |product| Ok(product.bytes.clone()),
+            |_, _| Ok(()),
+            move |stage| {
+                if stage == SnapshotStateEditStage::Commit {
+                    fs::rename(&input_parent_for_action, &moved).expect("input parent should move");
+                    fs::create_dir(&input_parent_for_action)
+                        .expect("replacement parent should create");
+                }
+                false
+            },
+        )
+        .expect_err("parent replacement should reject");
+        assert!(matches!(
+            error
+                .publication()
+                .expect("failure should be infrastructure")
+                .failure(),
+            SnapshotStateEditFailure::DirectoryChanged {
+                path: SnapshotStateEditPathRole::Input
+            }
+        ));
+        assert!(!output.exists());
+        assert!(staging_entries(&parent_root.path).is_empty());
+    }
+
+    #[test]
+    fn final_callback_detects_input_name_output_parent_and_staging_removal() {
+        let input_fixture = EditFixture::new("input-name-replacement");
+        let input = input_fixture.paths.input().to_path_buf();
+        let displaced = input_fixture.directory.child("displaced-input");
+        let error = publish_edited_snapshot_state_with_cancel(
+            &input_fixture.paths,
+            |bytes| {
+                Ok::<_, ToyError>(ToyProduct {
+                    bytes: bytes.to_vec(),
+                })
+            },
+            |product| Ok(product.bytes.clone()),
+            |_, _| Ok(()),
+            move |stage| {
+                if stage == SnapshotStateEditStage::Commit {
+                    fs::rename(&input, &displaced).expect("input name should move");
+                    fs::write(&input, b"foreign-input-name")
+                        .expect("foreign input name should replace");
+                }
+                false
+            },
+        )
+        .expect_err("input-name replacement should reject");
+        let publication = error
+            .publication()
+            .expect("failure should be infrastructure");
+        assert!(matches!(
+            publication.failure(),
+            SnapshotStateEditFailure::EntryChanged {
+                path: SnapshotStateEditPathRole::Input
+            } | SnapshotStateEditFailure::SourceChanged
+        ));
+        assert_eq!(
+            publication.staging_cleanup(),
+            Some(SnapshotStateEditCleanup::Removed)
+        );
+        assert!(!input_fixture.paths.output().exists());
+        assert!(input_fixture.directory.staging_entries().is_empty());
+
+        let parent_root = TestDirectory::new("output-parent-replacement");
+        let input = parent_root.child("input.state");
+        fs::write(&input, SOURCE).expect("input should write");
+        let output_parent = parent_root.child("output-parent");
+        fs::create_dir(&output_parent).expect("output parent should create");
+        let output = output_parent.join("output.state");
+        let moved = parent_root.child("moved-output-parent");
+        let output_parent_for_action = output_parent.clone();
+        let paths = SnapshotStateEditPaths::new(&input, &output);
+        let error = publish_edited_snapshot_state_with_cancel(
+            &paths,
+            |bytes| {
+                Ok::<_, ToyError>(ToyProduct {
+                    bytes: bytes.to_vec(),
+                })
+            },
+            |product| Ok(product.bytes.clone()),
+            |_, _| Ok(()),
+            move |stage| {
+                if stage == SnapshotStateEditStage::Commit {
+                    fs::rename(&output_parent_for_action, &moved)
+                        .expect("output parent should move");
+                    fs::create_dir(&output_parent_for_action)
+                        .expect("replacement output parent should create");
+                }
+                false
+            },
+        )
+        .expect_err("output-parent replacement should reject");
+        let publication = error
+            .publication()
+            .expect("failure should be infrastructure");
+        assert!(matches!(
+            publication.failure(),
+            SnapshotStateEditFailure::DirectoryChanged {
+                path: SnapshotStateEditPathRole::Output
+            }
+        ));
+        assert_eq!(
+            publication.staging_cleanup(),
+            Some(SnapshotStateEditCleanup::Removed)
+        );
+        assert!(!output.exists());
+        assert!(staging_entries(&parent_root.path).is_empty());
+        assert!(staging_entries(&parent_root.child("moved-output-parent")).is_empty());
+
+        let staging_fixture = EditFixture::new("staging-removal");
+        let staging_directory = staging_fixture.directory.path.clone();
+        let error = publish_edited_snapshot_state_with_cancel(
+            &staging_fixture.paths,
+            |bytes| {
+                Ok::<_, ToyError>(ToyProduct {
+                    bytes: bytes.to_vec(),
+                })
+            },
+            |product| Ok(product.bytes.clone()),
+            |_, _| Ok(()),
+            move |stage| {
+                if stage == SnapshotStateEditStage::Commit {
+                    fs::remove_file(one_staging(&staging_directory))
+                        .expect("staging should remove");
+                }
+                false
+            },
+        )
+        .expect_err("staging removal should reject");
+        let publication = error
+            .publication()
+            .expect("failure should be infrastructure");
+        assert!(matches!(
+            publication.failure(),
+            SnapshotStateEditFailure::StagingChanged
+        ));
+        assert_eq!(
+            publication.staging_cleanup(),
+            Some(SnapshotStateEditCleanup::AlreadyAbsent)
+        );
+        assert!(!staging_fixture.paths.output().exists());
+        assert!(staging_fixture.directory.staging_entries().is_empty());
+    }
+
+    #[test]
+    fn cleanup_failure_preserves_primary_error_and_foreign_names() {
+        let failure_fixture = EditFixture::new("cleanup-failure");
+        let error = with_state_edit_failure_and_cleanup_failure(
+            SnapshotStateEditStage::StagingWrite,
+            io::ErrorKind::WriteZero,
+            io::ErrorKind::PermissionDenied,
+            || publish_toy(&failure_fixture.paths).expect_err("write should fail"),
+        );
+        let publication = error
+            .publication()
+            .expect("failure should be infrastructure");
+        assert_eq!(publication.stage(), SnapshotStateEditStage::StagingWrite);
+        assert!(matches!(
+            publication.failure(),
+            SnapshotStateEditFailure::Io {
+                kind: io::ErrorKind::WriteZero
+            }
+        ));
+        assert_eq!(
+            publication.staging_cleanup(),
+            Some(SnapshotStateEditCleanup::Failed(
+                io::ErrorKind::PermissionDenied
+            ))
+        );
+        assert!(!failure_fixture.paths.output().exists());
+        assert_eq!(failure_fixture.directory.staging_entries().len(), 1);
+    }
+
+    #[test]
+    fn hard_link_failure_is_precommit_and_fresh_retry_succeeds() {
+        let fixture = EditFixture::new("link-failure");
+        let error = with_state_edit_hard_link_failure(io::ErrorKind::Unsupported, || {
+            publish_toy(&fixture.paths).expect_err("unsupported hard link should reject")
+        });
+        let publication = error
+            .publication()
+            .expect("failure should be infrastructure");
+        assert_eq!(publication.stage(), SnapshotStateEditStage::Commit);
+        assert!(matches!(
+            publication.failure(),
+            SnapshotStateEditFailure::HardLinkUnavailable {
+                kind: io::ErrorKind::Unsupported
+            }
+        ));
+        assert_eq!(
+            publication.staging_cleanup(),
+            Some(SnapshotStateEditCleanup::Removed)
+        );
+        fixture.assert_uncommitted_and_clean();
+
+        let outcome = publish_toy(&fixture.paths).expect("fresh retry should commit");
+        fixture.assert_durable(&outcome);
+    }
+
+    #[test]
+    fn committed_cleanup_and_directory_sync_failures_never_rollback_output() {
+        let cleanup_fixture = EditFixture::new("postcommit-cleanup");
+        let outcome = with_state_edit_cleanup_failure(io::ErrorKind::PermissionDenied, || {
+            publish_toy(&cleanup_fixture.paths).expect("commit should return an outcome")
+        });
+        assert!(matches!(
+            outcome.commit(),
+            SnapshotStateEditCommit::Uncertain {
+                stage: SnapshotStateEditStage::StagingCleanup,
+                failure: SnapshotStateEditCommitFailure::Cleanup,
+                staging_cleanup: SnapshotStateEditCleanup::Failed(io::ErrorKind::PermissionDenied),
+                directory_sync: None,
+            }
+        ));
+        assert_eq!(
+            fs::read(cleanup_fixture.paths.output()).expect("committed output should remain"),
+            cleanup_fixture.expected()
+        );
+        assert_eq!(cleanup_fixture.directory.staging_entries().len(), 1);
+
+        let sync_fixture = EditFixture::new("postcommit-sync");
+        let outcome = with_state_edit_failures(
+            [(
+                SnapshotStateEditStage::OutputDirectorySync,
+                io::ErrorKind::Other,
+            )],
+            || publish_toy(&sync_fixture.paths).expect("commit should return an outcome"),
+        );
+        assert!(matches!(
+            outcome.commit(),
+            SnapshotStateEditCommit::Uncertain {
+                stage: SnapshotStateEditStage::OutputDirectorySync,
+                failure: SnapshotStateEditCommitFailure::Io(io::ErrorKind::Other),
+                staging_cleanup: SnapshotStateEditCleanup::Removed,
+                directory_sync: Some(io::ErrorKind::Other),
+            }
+        ));
+        assert_eq!(
+            fs::read(sync_fixture.paths.output()).expect("committed output should remain"),
+            sync_fixture.expected()
+        );
+        assert!(sync_fixture.directory.staging_entries().is_empty());
+
+        let precedence_fixture = EditFixture::new("postcommit-precedence");
+        let outcome = with_state_edit_failures(
+            [
+                (
+                    SnapshotStateEditStage::CommitVerification,
+                    io::ErrorKind::InvalidData,
+                ),
+                (
+                    SnapshotStateEditStage::OutputDirectorySync,
+                    io::ErrorKind::Other,
+                ),
+            ],
+            || publish_toy(&precedence_fixture.paths).expect("commit should return outcome"),
+        );
+        assert!(matches!(
+            outcome.commit(),
+            SnapshotStateEditCommit::Uncertain {
+                stage: SnapshotStateEditStage::CommitVerification,
+                failure: SnapshotStateEditCommitFailure::Io(io::ErrorKind::InvalidData),
+                staging_cleanup: SnapshotStateEditCleanup::Removed,
+                directory_sync: Some(io::ErrorKind::Other),
+            }
+        ));
+        assert!(precedence_fixture.paths.output().exists());
+    }
+
+    #[test]
+    fn committed_identity_changes_are_uncertain_without_final_rollback() {
+        let output_fixture = EditFixture::new("postcommit-output-change");
+        let output = output_fixture.paths.output().to_path_buf();
+        let outcome = with_state_edit_action(
+            SnapshotStateEditStage::CommitVerification,
+            move || {
+                fs::remove_file(&output).expect("committed output should remove");
+                fs::write(&output, b"foreign-after-commit").expect("foreign output should replace");
+            },
+            || publish_toy(&output_fixture.paths).expect("commit should return outcome"),
+        );
+        assert!(matches!(
+            outcome.commit(),
+            SnapshotStateEditCommit::Uncertain {
+                failure: SnapshotStateEditCommitFailure::OutputEntryChanged,
+                ..
+            }
+        ));
+        assert_eq!(
+            fs::read(output_fixture.paths.output()).expect("foreign output should remain"),
+            b"foreign-after-commit"
+        );
+
+        let staging_fixture = EditFixture::new("postcommit-staging-change");
+        let directory = staging_fixture.directory.path.clone();
+        let outcome = with_state_edit_action(
+            SnapshotStateEditStage::CommitVerification,
+            move || {
+                let staging = one_staging(&directory);
+                fs::remove_file(&staging).expect("committed staging should remove");
+                fs::write(&staging, b"foreign-staging").expect("foreign staging should replace");
+            },
+            || publish_toy(&staging_fixture.paths).expect("commit should return outcome"),
+        );
+        assert!(matches!(
+            outcome.commit(),
+            SnapshotStateEditCommit::Uncertain {
+                failure: SnapshotStateEditCommitFailure::StagingEntryChanged,
+                staging_cleanup: SnapshotStateEditCleanup::ChangedRefused,
+                ..
+            }
+        ));
+        assert_eq!(
+            fs::read(staging_fixture.paths.output()).expect("committed output should remain"),
+            staging_fixture.expected()
+        );
+        assert_eq!(staging_fixture.directory.staging_entries().len(), 1);
+    }
+
+    #[test]
+    fn concurrent_publishers_have_exactly_one_no_clobber_winner() {
+        let fixture = EditFixture::new("concurrent");
+        let paths = Arc::new(fixture.paths.clone());
+        let barrier = Arc::new(Barrier::new(3));
+        let mut threads = Vec::new();
+        for _ in 0..2 {
+            let paths = Arc::clone(&paths);
+            let barrier = Arc::clone(&barrier);
+            threads.push(std::thread::spawn(move || {
+                barrier.wait();
+                publish_toy(&paths)
+            }));
+        }
+        barrier.wait();
+        let results = threads
+            .into_iter()
+            .map(|thread| thread.join().expect("publisher should not panic"))
+            .collect::<Vec<_>>();
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(results.iter().filter(|result| result.is_err()).count(), 1);
+        let loser = results
+            .iter()
+            .find_map(|result| result.as_ref().err())
+            .expect("one publisher should lose");
+        assert!(matches!(
+            loser
+                .publication()
+                .expect("loser should be infrastructure")
+                .failure(),
+            SnapshotStateEditFailure::OutputAlreadyExists
+        ));
+        assert_eq!(
+            fs::read(fixture.paths.output()).expect("winner output should read"),
+            fixture.expected()
+        );
+        fixture.assert_source_unchanged();
+        assert!(fixture.directory.staging_entries().is_empty());
+    }
+
+    #[test]
+    fn generic_debug_and_errors_do_not_expose_products_paths_or_operation_values() {
+        let fixture = EditFixture::new("redaction");
+        let outcome = publish_toy(&fixture.paths).expect("edit should succeed");
+        let rendered = format!("{outcome:?}");
+        assert!(!rendered.contains("bounded-source-state"));
+        assert!(!rendered.contains("edited"));
+        assert!(
+            !rendered.contains(
+                fixture
+                    .paths
+                    .output()
+                    .to_str()
+                    .expect("test output should be UTF-8")
+            )
+        );
+
+        let collision = publish_toy(&fixture.paths).expect_err("second edit should collide");
+        let rendered = format!("{collision:?} / {collision}");
+        assert!(
+            !rendered.contains(
+                fixture
+                    .paths
+                    .input()
+                    .to_str()
+                    .expect("test input should be UTF-8")
+            )
+        );
+        assert!(
+            !rendered.contains(
+                fixture
+                    .paths
+                    .output()
+                    .to_str()
+                    .expect("test output should be UTF-8")
+            )
+        );
+    }
+
+    #[test]
+    fn unwritable_output_parent_fails_before_private_staging() {
+        let source = TestDirectory::new("unwritable-source");
+        let destination = TestDirectory::new("unwritable-output");
+        let input = source.child("input");
+        fs::write(&input, SOURCE).expect("source should write");
+        fs::set_permissions(&destination.path, fs::Permissions::from_mode(0o500))
+            .expect("output parent should become unwritable");
+        let paths = SnapshotStateEditPaths::new(&input, destination.child("output"));
+        let result = publish_toy(&paths);
+        fs::set_permissions(&destination.path, fs::Permissions::from_mode(0o700))
+            .expect("output parent should restore");
+        let error = result.expect_err("unwritable parent should fail");
+        assert!(error.publication().is_some());
+        assert!(!paths.output().exists());
+        assert!(destination.staging_entries().is_empty());
+    }
+
+    #[test]
+    fn encoded_length_bounds_reject_empty_and_oversized_results_before_staging() {
+        for oversized in [false, true] {
+            let fixture = EditFixture::new(if oversized {
+                "encoded-large"
+            } else {
+                "encoded-empty"
+            });
+            let error = publish_edited_snapshot_state_with(
+                &fixture.paths,
+                |input| {
+                    Ok::<_, ToyError>(ToyProduct {
+                        bytes: input.to_vec(),
+                    })
+                },
+                move |_| {
+                    Ok(if oversized {
+                        vec![0_u8; SNAPSHOT_STATE_EDIT_MAX_FILE_BYTES + 1]
+                    } else {
+                        Vec::new()
+                    })
+                },
+                |_, _| Ok(()),
+            )
+            .expect_err("invalid encoded length should reject");
+            let publication = error
+                .publication()
+                .expect("failure should be infrastructure");
+            assert_eq!(publication.stage(), SnapshotStateEditStage::Encode);
+            assert!(matches!(
+                publication.failure(),
+                SnapshotStateEditFailure::InvalidEncodedStateLength { .. }
+            ));
+            fixture.assert_uncommitted_and_clean();
+        }
+    }
+
+    #[test]
+    fn explicit_cleanup_failure_after_verify_is_not_retried_on_drop() {
+        let fixture = EditFixture::new("cleanup-once");
+        let error = with_state_edit_failure_and_cleanup_failure(
+            SnapshotStateEditStage::EntryStability,
+            io::ErrorKind::Other,
+            io::ErrorKind::PermissionDenied,
+            || publish_toy(&fixture.paths).expect_err("entry stage should fail"),
+        );
+        assert_eq!(
+            error
+                .publication()
+                .expect("failure should be infrastructure")
+                .staging_cleanup(),
+            Some(SnapshotStateEditCleanup::Failed(
+                io::ErrorKind::PermissionDenied
+            ))
+        );
+        assert_eq!(fixture.directory.staging_entries().len(), 1);
+        assert!(!fixture.paths.output().exists());
+    }
+
+    #[test]
+    fn committed_cleanup_failure_still_attempts_directory_sync() {
+        let fixture = EditFixture::new("cleanup-plus-sync");
+        let directory = fixture.directory.path.clone();
+        let observed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let observed_action = Arc::clone(&observed);
+        let outcome = with_state_edit_action_and_cleanup_failure(
+            SnapshotStateEditStage::OutputDirectorySync,
+            move || {
+                assert!(one_staging(&directory).exists());
+                observed_action.store(true, Ordering::Release);
+            },
+            io::ErrorKind::PermissionDenied,
+            || publish_toy(&fixture.paths).expect("commit should return outcome"),
+        );
+        assert!(observed.load(Ordering::Acquire));
+        assert!(fixture.paths.output().exists());
+        assert!(matches!(
+            outcome.commit(),
+            SnapshotStateEditCommit::Uncertain { .. }
+        ));
+    }
+
+    #[test]
+    fn input_and_output_parent_symlinks_stay_anchored_when_stable() {
+        let root = TestDirectory::new("stable-parent-links");
+        let actual_input = root.child("actual-input");
+        let actual_output = root.child("actual-output");
+        fs::create_dir(&actual_input).expect("input dir should create");
+        fs::create_dir(&actual_output).expect("output dir should create");
+        let input_link = root.child("input-link");
+        let output_link = root.child("output-link");
+        symlink(&actual_input, &input_link).expect("input parent symlink should create");
+        symlink(&actual_output, &output_link).expect("output parent symlink should create");
+        let input = input_link.join("state");
+        let output = output_link.join("edited");
+        fs::write(actual_input.join("state"), SOURCE).expect("source should write");
+        let paths = SnapshotStateEditPaths::new(input, output);
+        let outcome = publish_toy(&paths).expect("stable parent links should commit");
+        assert_eq!(outcome.commit(), SnapshotStateEditCommit::Durable);
+        assert_eq!(
+            fs::read(actual_output.join("edited")).expect("output should read"),
+            outcome.product().bytes
+        );
+    }
+
+    #[test]
+    fn output_parent_that_is_not_a_directory_fails_closed() {
+        let root = TestDirectory::new("special-parent");
+        let input = root.child("input");
+        let parent = root.child("not-a-directory");
+        fs::write(&input, SOURCE).expect("input should write");
+        fs::write(&parent, b"ordinary").expect("special parent should write");
+        let paths = SnapshotStateEditPaths::new(&input, parent.join("output"));
+        let error = publish_toy(&paths).expect_err("special parent should reject");
+        let publication = error
+            .publication()
+            .expect("failure should be infrastructure");
+        assert_eq!(
+            publication.stage(),
+            SnapshotStateEditStage::OutputDirectoryOpen
+        );
+        assert!(!paths.output().exists());
+    }
+
+    #[test]
+    fn staging_same_inode_mode_and_content_drift_abort_before_commit() {
+        for mode_drift in [false, true] {
+            let fixture = EditFixture::new(if mode_drift {
+                "staging-mode-drift"
+            } else {
+                "staging-content-drift"
+            });
+            let directory = fixture.directory.path.clone();
+            let error = publish_edited_snapshot_state_with_cancel(
+                &fixture.paths,
+                |input| {
+                    Ok::<_, ToyError>(ToyProduct {
+                        bytes: input.to_vec(),
+                    })
+                },
+                |product| Ok(product.bytes.clone()),
+                |_, _| Ok(()),
+                move |stage| {
+                    if stage == SnapshotStateEditStage::Commit {
+                        let staging = one_staging(&directory);
+                        if mode_drift {
+                            fs::set_permissions(&staging, fs::Permissions::from_mode(0o640))
+                                .expect("staging mode should change");
+                        } else {
+                            let mut file = OpenOptions::new()
+                                .write(true)
+                                .truncate(true)
+                                .open(&staging)
+                                .expect("staging should reopen");
+                            file.write_all(b"changed-staging-state")
+                                .expect("staging should change");
+                        }
+                    }
+                    false
+                },
+            )
+            .expect_err("same-inode staging drift should reject");
+            let publication = error
+                .publication()
+                .expect("failure should be infrastructure");
+            assert!(matches!(
+                publication.failure(),
+                SnapshotStateEditFailure::StagingChanged
+                    | SnapshotStateEditFailure::StagingContentMismatch
+            ));
+            assert_eq!(
+                publication.staging_cleanup(),
+                Some(SnapshotStateEditCleanup::Removed)
+            );
+            assert!(!fixture.paths.output().exists());
+            assert!(fixture.directory.staging_entries().is_empty());
+        }
+    }
+}

--- a/crates/runtime/src/snapshot_state_edit/unix.rs
+++ b/crates/runtime/src/snapshot_state_edit/unix.rs
@@ -1,0 +1,1431 @@
+#[cfg(test)]
+use std::cell::RefCell;
+#[cfg(test)]
+use std::collections::VecDeque;
+use std::ffi::CString;
+use std::fs::{File, OpenOptions, Permissions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::mem::MaybeUninit;
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::{FileExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Component, Path, PathBuf};
+
+use crate::snapshot_memory_v2::{FileFacts, inspect_file, inspect_file_facts};
+
+use super::*;
+
+const STAGING_PREFIX: &[u8] = b".bangbang-snapshot-edit-";
+const STAGING_RANDOM_BYTES: usize = 16;
+const STAGING_CREATE_ATTEMPTS: usize = 16;
+const CONTENT_COMPARE_BYTES: usize = 8192;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct FileIdentity {
+    device: libc::dev_t,
+    inode: libc::ino_t,
+}
+
+impl fmt::Debug for FileIdentity {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("FileIdentity(<redacted>)")
+    }
+}
+
+struct SplitPath {
+    parent: PathBuf,
+    component: CString,
+}
+
+impl fmt::Debug for SplitPath {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SplitPath")
+            .field("parent", &REDACTED)
+            .field("component", &REDACTED)
+            .finish()
+    }
+}
+
+struct OpenedPath {
+    role: SnapshotStateEditPathRole,
+    parent: PathBuf,
+    directory: File,
+    directory_identity: FileIdentity,
+    component: CString,
+}
+
+impl fmt::Debug for OpenedPath {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("OpenedPath")
+            .field("role", &self.role)
+            .field("parent", &REDACTED)
+            .field("component", &REDACTED)
+            .field("directory_identity", &REDACTED)
+            .finish()
+    }
+}
+
+struct AdoptedInput {
+    path: OpenedPath,
+    file: File,
+    identity: FileIdentity,
+    facts: FileFacts,
+}
+
+impl fmt::Debug for AdoptedInput {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AdoptedInput")
+            .field("path", &self.path)
+            .field("file", &REDACTED)
+            .field("identity", &REDACTED)
+            .field("facts", &REDACTED)
+            .finish()
+    }
+}
+
+struct StagingFile<'directory> {
+    directory: &'directory File,
+    name: CString,
+    file: File,
+    identity: FileIdentity,
+    verified_facts: Option<FileFacts>,
+    active: bool,
+    cleanup_on_drop: bool,
+}
+
+impl fmt::Debug for StagingFile<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StagingFile")
+            .field("name", &REDACTED)
+            .field("identity", &REDACTED)
+            .field("active", &self.active)
+            .finish()
+    }
+}
+
+impl StagingFile<'_> {
+    fn cleanup(&mut self) -> Option<SnapshotStateEditCleanup> {
+        if !self.active {
+            return None;
+        }
+        self.cleanup_on_drop = false;
+        let cleanup = clean_owned_entry(self.directory, &self.name, self.identity);
+        self.active = false;
+        Some(cleanup)
+    }
+
+    fn abandon_cleanup(&mut self) {
+        self.cleanup_on_drop = false;
+        self.active = false;
+    }
+}
+
+impl Drop for StagingFile<'_> {
+    fn drop(&mut self) {
+        if self.active && self.cleanup_on_drop {
+            let _ = clean_owned_entry(self.directory, &self.name, self.identity);
+        }
+    }
+}
+
+struct SystemEditPolicy<C> {
+    is_cancelled: C,
+}
+
+impl<C> SystemEditPolicy<C>
+where
+    C: FnMut(SnapshotStateEditStage) -> bool,
+{
+    fn checkpoint(&mut self, stage: SnapshotStateEditStage) -> Result<(), SnapshotStateEditError> {
+        enter_state_edit_stage(stage)
+            .map_err(|kind| precommit_error(stage, SnapshotStateEditFailure::Io { kind }))?;
+        if (self.is_cancelled)(stage) {
+            Err(precommit_error(stage, SnapshotStateEditFailure::Cancelled))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+pub(super) fn publish_edited_snapshot_state_unix_with_cancel<
+    T,
+    E,
+    Transform,
+    Encode,
+    Verify,
+    Cancel,
+>(
+    paths: &SnapshotStateEditPaths,
+    transform: Transform,
+    encode: Encode,
+    verify: Verify,
+    is_cancelled: Cancel,
+) -> Result<SnapshotStateEditOutcome<T>, SnapshotStateEditTransactionError<E>>
+where
+    Transform: FnOnce(&[u8]) -> Result<T, E>,
+    Encode: FnOnce(&T) -> Result<Vec<u8>, E>,
+    Verify: FnOnce(&[u8], &T) -> Result<(), E>,
+    Cancel: FnMut(SnapshotStateEditStage) -> bool,
+{
+    let mut policy = SystemEditPolicy { is_cancelled };
+    policy.checkpoint(SnapshotStateEditStage::PlatformCheck)?;
+
+    let input = adopt_input(paths.input(), &mut policy)?;
+    let output = open_output(paths.output(), &mut policy)?;
+
+    policy.checkpoint(SnapshotStateEditStage::AliasCheck)?;
+    if same_named_path(&input.path, &output) {
+        return Err(precommit_error(
+            SnapshotStateEditStage::AliasCheck,
+            SnapshotStateEditFailure::InputOutputAlias,
+        )
+        .into());
+    }
+
+    policy.checkpoint(SnapshotStateEditStage::OutputPreflight)?;
+    verify_output_absent(&input, &output, SnapshotStateEditStage::OutputPreflight)?;
+
+    policy.checkpoint(SnapshotStateEditStage::InputRead)?;
+    let input_bytes = read_input(&input)?;
+
+    policy.checkpoint(SnapshotStateEditStage::Transform)?;
+    let product = transform(&input_bytes).map_err(|source| {
+        SnapshotStateEditTransactionError::Operation(operation_error(
+            SnapshotStateEditStage::Transform,
+            source,
+        ))
+    })?;
+
+    policy.checkpoint(SnapshotStateEditStage::Encode)?;
+    let encoded = encode(&product).map_err(|source| {
+        SnapshotStateEditTransactionError::Operation(operation_error(
+            SnapshotStateEditStage::Encode,
+            source,
+        ))
+    })?;
+    if encoded.is_empty() || encoded.len() > SNAPSHOT_STATE_EDIT_MAX_FILE_BYTES {
+        return Err(precommit_error(
+            SnapshotStateEditStage::Encode,
+            SnapshotStateEditFailure::InvalidEncodedStateLength {
+                maximum: SNAPSHOT_STATE_EDIT_MAX_FILE_BYTES,
+            },
+        )
+        .into());
+    }
+
+    policy.checkpoint(SnapshotStateEditStage::StagingCreate)?;
+    let mut staging = create_staging(&output.directory)?;
+
+    if let Err(error) =
+        write_and_verify_staging(&encoded, &product, &mut staging, verify, &mut policy)
+    {
+        return Err(cleanup_transaction_error(&mut staging, error));
+    }
+
+    for (stage, check) in [
+        (
+            SnapshotStateEditStage::SourceStability,
+            verify_source as fn(&AdoptedInput, &OpenedPath, &StagingFile<'_>, &[u8]) -> _,
+        ),
+        (
+            SnapshotStateEditStage::DirectoryStability,
+            verify_directories,
+        ),
+        (SnapshotStateEditStage::EntryStability, verify_entries),
+    ] {
+        if let Err(error) = policy
+            .checkpoint(stage)
+            .and_then(|()| check(&input, &output, &staging, &encoded))
+        {
+            return Err(cleanup_publication_error(&mut staging, error).into());
+        }
+    }
+
+    // This is the final caller-controlled checkpoint. Every fact, directory,
+    // entry, and byte check is repeated after it. No callback, allocator, or
+    // test action runs between those checks and the hard-link syscall.
+    if let Err(error) = policy.checkpoint(SnapshotStateEditStage::Commit) {
+        return Err(cleanup_publication_error(&mut staging, error).into());
+    }
+    if let Err(error) = verify_source(&input, &output, &staging, &encoded)
+        .and_then(|()| verify_directories(&input, &output, &staging, &encoded))
+        .and_then(|()| verify_entries(&input, &output, &staging, &encoded))
+    {
+        return Err(cleanup_publication_error(&mut staging, error).into());
+    }
+
+    if let Err(kind) = hard_link_no_clobber(&output.directory, &staging.name, &output.component) {
+        let failure = if kind == io::ErrorKind::AlreadyExists {
+            SnapshotStateEditFailure::OutputAlreadyExists
+        } else {
+            SnapshotStateEditFailure::HardLinkUnavailable { kind }
+        };
+        let error = precommit_error(SnapshotStateEditStage::Commit, failure);
+        return Err(cleanup_publication_error(&mut staging, error).into());
+    }
+
+    // `linkat` is the commit point. From here onward this function cannot
+    // return `Err`, invoke caller/cancellation code, or remove the final name.
+    Ok(finish_committed_edit(
+        product,
+        &input,
+        &output,
+        &mut staging,
+    ))
+}
+
+fn adopt_input<C>(
+    path: &Path,
+    policy: &mut SystemEditPolicy<C>,
+) -> Result<AdoptedInput, SnapshotStateEditError>
+where
+    C: FnMut(SnapshotStateEditStage) -> bool,
+{
+    policy.checkpoint(SnapshotStateEditStage::InputPathValidation)?;
+    let split = split_path(path).ok_or_else(|| {
+        precommit_error(
+            SnapshotStateEditStage::InputPathValidation,
+            SnapshotStateEditFailure::InvalidPath {
+                path: SnapshotStateEditPathRole::Input,
+            },
+        )
+    })?;
+
+    policy.checkpoint(SnapshotStateEditStage::InputDirectoryOpen)?;
+    let directory = open_directory(&split.parent).map_err(|kind| {
+        precommit_error(
+            SnapshotStateEditStage::InputDirectoryOpen,
+            SnapshotStateEditFailure::Io { kind },
+        )
+    })?;
+    let directory_identity = file_identity(&directory).map_err(|kind| {
+        precommit_error(
+            SnapshotStateEditStage::InputDirectoryOpen,
+            SnapshotStateEditFailure::Io { kind },
+        )
+    })?;
+
+    policy.checkpoint(SnapshotStateEditStage::InputFileOpen)?;
+    let file = open_input(&directory, &split.component).map_err(|kind| {
+        precommit_error(
+            SnapshotStateEditStage::InputFileOpen,
+            SnapshotStateEditFailure::Io { kind },
+        )
+    })?;
+    let identity = file_identity(&file).map_err(|kind| {
+        precommit_error(
+            SnapshotStateEditStage::InputFileOpen,
+            SnapshotStateEditFailure::Io { kind },
+        )
+    })?;
+
+    policy.checkpoint(SnapshotStateEditStage::InputValidation)?;
+    let facts = inspect_file(&file).map_err(|_| {
+        precommit_error(
+            SnapshotStateEditStage::InputValidation,
+            SnapshotStateEditFailure::InvalidInput,
+        )
+    })?;
+    if facts.length() > u64::try_from(SNAPSHOT_STATE_EDIT_MAX_FILE_BYTES).unwrap_or(u64::MAX) {
+        return Err(precommit_error(
+            SnapshotStateEditStage::InputValidation,
+            SnapshotStateEditFailure::InputTooLarge {
+                maximum: SNAPSHOT_STATE_EDIT_MAX_FILE_BYTES,
+            },
+        ));
+    }
+    if entry_identity(&directory, &split.component).map_err(|kind| {
+        precommit_error(
+            SnapshotStateEditStage::InputValidation,
+            SnapshotStateEditFailure::Io { kind },
+        )
+    })? != Some(identity)
+        || inspect_file(&file).ok() != Some(facts)
+    {
+        return Err(precommit_error(
+            SnapshotStateEditStage::InputValidation,
+            SnapshotStateEditFailure::SourceChanged,
+        ));
+    }
+
+    Ok(AdoptedInput {
+        path: OpenedPath {
+            role: SnapshotStateEditPathRole::Input,
+            parent: split.parent,
+            directory,
+            directory_identity,
+            component: split.component,
+        },
+        file,
+        identity,
+        facts,
+    })
+}
+
+fn open_output<C>(
+    path: &Path,
+    policy: &mut SystemEditPolicy<C>,
+) -> Result<OpenedPath, SnapshotStateEditError>
+where
+    C: FnMut(SnapshotStateEditStage) -> bool,
+{
+    policy.checkpoint(SnapshotStateEditStage::OutputPathValidation)?;
+    let split = split_path(path).ok_or_else(|| {
+        precommit_error(
+            SnapshotStateEditStage::OutputPathValidation,
+            SnapshotStateEditFailure::InvalidPath {
+                path: SnapshotStateEditPathRole::Output,
+            },
+        )
+    })?;
+
+    policy.checkpoint(SnapshotStateEditStage::OutputDirectoryOpen)?;
+    let directory = open_directory(&split.parent).map_err(|kind| {
+        precommit_error(
+            SnapshotStateEditStage::OutputDirectoryOpen,
+            SnapshotStateEditFailure::Io { kind },
+        )
+    })?;
+    let directory_identity = file_identity(&directory).map_err(|kind| {
+        precommit_error(
+            SnapshotStateEditStage::OutputDirectoryOpen,
+            SnapshotStateEditFailure::Io { kind },
+        )
+    })?;
+    Ok(OpenedPath {
+        role: SnapshotStateEditPathRole::Output,
+        parent: split.parent,
+        directory,
+        directory_identity,
+        component: split.component,
+    })
+}
+
+fn same_named_path(input: &OpenedPath, output: &OpenedPath) -> bool {
+    input.directory_identity == output.directory_identity
+        && input.component.as_bytes() == output.component.as_bytes()
+}
+
+fn verify_output_absent(
+    input: &AdoptedInput,
+    output: &OpenedPath,
+    stage: SnapshotStateEditStage,
+) -> Result<(), SnapshotStateEditError> {
+    match entry_identity(&output.directory, &output.component) {
+        Ok(None) => Ok(()),
+        Ok(Some(identity)) if identity == input.identity => Err(precommit_error(
+            stage,
+            SnapshotStateEditFailure::InputOutputAlias,
+        )),
+        Ok(Some(_)) => Err(precommit_error(
+            stage,
+            SnapshotStateEditFailure::OutputAlreadyExists,
+        )),
+        Err(kind) => Err(precommit_error(
+            stage,
+            SnapshotStateEditFailure::Io { kind },
+        )),
+    }
+}
+
+fn read_input(input: &AdoptedInput) -> Result<Vec<u8>, SnapshotStateEditError> {
+    let stage = SnapshotStateEditStage::InputRead;
+    let length = usize::try_from(input.facts.length()).map_err(|_| {
+        precommit_error(
+            stage,
+            SnapshotStateEditFailure::InputTooLarge {
+                maximum: SNAPSHOT_STATE_EDIT_MAX_FILE_BYTES,
+            },
+        )
+    })?;
+    let mut bytes = Vec::new();
+    bytes
+        .try_reserve_exact(length)
+        .map_err(|source| precommit_error(stage, SnapshotStateEditFailure::Allocation(source)))?;
+    bytes.resize(length, 0);
+    read_exact_at(&input.file, &mut bytes, 0).map_err(|source| {
+        precommit_error(
+            stage,
+            SnapshotStateEditFailure::Io {
+                kind: source.kind(),
+            },
+        )
+    })?;
+    let mut extra = [0_u8; 1];
+    let offset = u64::try_from(length)
+        .map_err(|_| precommit_error(stage, SnapshotStateEditFailure::SourceChanged))?;
+    let trailing = input.file.read_at(&mut extra, offset).map_err(|source| {
+        precommit_error(
+            stage,
+            SnapshotStateEditFailure::Io {
+                kind: source.kind(),
+            },
+        )
+    })?;
+    if trailing != 0 || inspect_file(&input.file).ok() != Some(input.facts) {
+        return Err(precommit_error(
+            stage,
+            SnapshotStateEditFailure::SourceChanged,
+        ));
+    }
+    Ok(bytes)
+}
+
+fn create_staging(directory: &File) -> Result<StagingFile<'_>, SnapshotStateEditError> {
+    let stage = SnapshotStateEditStage::StagingCreate;
+    for _ in 0..STAGING_CREATE_ATTEMPTS {
+        let name = staging_name()?;
+        match open_staging(directory, &name) {
+            Ok(file) => {
+                let identity = match file_identity(&file) {
+                    Ok(identity) => identity,
+                    Err(kind) => {
+                        let mut error =
+                            precommit_error(stage, SnapshotStateEditFailure::Io { kind });
+                        error.staging_cleanup = Some(SnapshotStateEditCleanup::Failed(kind));
+                        return Err(error);
+                    }
+                };
+                let mut staging = StagingFile {
+                    directory,
+                    name,
+                    file,
+                    identity,
+                    verified_facts: None,
+                    active: true,
+                    cleanup_on_drop: true,
+                };
+                if let Err(source) = staging.file.set_permissions(Permissions::from_mode(0o600)) {
+                    let error = precommit_error(
+                        stage,
+                        SnapshotStateEditFailure::Io {
+                            kind: source.kind(),
+                        },
+                    );
+                    return Err(cleanup_publication_error(&mut staging, error));
+                }
+                let position = staging.file.stream_position().map_err(|source| {
+                    cleanup_publication_error(
+                        &mut staging,
+                        precommit_error(
+                            stage,
+                            SnapshotStateEditFailure::Io {
+                                kind: source.kind(),
+                            },
+                        ),
+                    )
+                })?;
+                let facts = inspect_file_facts(&staging.file).map_err(|_| {
+                    cleanup_publication_error(
+                        &mut staging,
+                        precommit_error(stage, SnapshotStateEditFailure::InvalidStaging),
+                    )
+                })?;
+                if !valid_staging_facts(facts, 0)
+                    || position != 0
+                    || file_identity(&staging.file).ok() != Some(staging.identity)
+                    || entry_identity(staging.directory, &staging.name)
+                        .ok()
+                        .flatten()
+                        != Some(staging.identity)
+                {
+                    let error = precommit_error(stage, SnapshotStateEditFailure::InvalidStaging);
+                    return Err(cleanup_publication_error(&mut staging, error));
+                }
+                return Ok(staging);
+            }
+            Err(io::ErrorKind::AlreadyExists) => {}
+            Err(kind) => {
+                return Err(precommit_error(
+                    stage,
+                    SnapshotStateEditFailure::Io { kind },
+                ));
+            }
+        }
+    }
+    Err(precommit_error(
+        stage,
+        SnapshotStateEditFailure::StagingNameExhausted,
+    ))
+}
+
+fn write_and_verify_staging<T, E, Verify, C>(
+    encoded: &[u8],
+    product: &T,
+    staging: &mut StagingFile<'_>,
+    verify: Verify,
+    policy: &mut SystemEditPolicy<C>,
+) -> Result<(), SnapshotStateEditTransactionError<E>>
+where
+    Verify: FnOnce(&[u8], &T) -> Result<(), E>,
+    C: FnMut(SnapshotStateEditStage) -> bool,
+{
+    policy.checkpoint(SnapshotStateEditStage::StagingWrite)?;
+    staging.file.write_all(encoded).map_err(|source| {
+        precommit_error(
+            SnapshotStateEditStage::StagingWrite,
+            SnapshotStateEditFailure::Io {
+                kind: source.kind(),
+            },
+        )
+    })?;
+    let expected_length = u64::try_from(encoded.len()).map_err(|_| {
+        precommit_error(
+            SnapshotStateEditStage::StagingWrite,
+            SnapshotStateEditFailure::InvalidEncodedStateLength {
+                maximum: SNAPSHOT_STATE_EDIT_MAX_FILE_BYTES,
+            },
+        )
+    })?;
+    if staging.file.stream_position().ok() != Some(expected_length)
+        || staging.file.metadata().ok().map(|metadata| metadata.len()) != Some(expected_length)
+    {
+        return Err(precommit_error(
+            SnapshotStateEditStage::StagingWrite,
+            SnapshotStateEditFailure::StagingChanged,
+        )
+        .into());
+    }
+
+    policy.checkpoint(SnapshotStateEditStage::StagingFlush)?;
+    staging.file.flush().map_err(|source| {
+        precommit_error(
+            SnapshotStateEditStage::StagingFlush,
+            SnapshotStateEditFailure::Io {
+                kind: source.kind(),
+            },
+        )
+    })?;
+
+    policy.checkpoint(SnapshotStateEditStage::StagingFileSync)?;
+    staging.file.sync_all().map_err(|source| {
+        precommit_error(
+            SnapshotStateEditStage::StagingFileSync,
+            SnapshotStateEditFailure::Io {
+                kind: source.kind(),
+            },
+        )
+    })?;
+
+    policy.checkpoint(SnapshotStateEditStage::StagingSeek)?;
+    if staging.file.seek(SeekFrom::Start(0)).map_err(|source| {
+        precommit_error(
+            SnapshotStateEditStage::StagingSeek,
+            SnapshotStateEditFailure::Io {
+                kind: source.kind(),
+            },
+        )
+    })? != 0
+    {
+        return Err(precommit_error(
+            SnapshotStateEditStage::StagingSeek,
+            SnapshotStateEditFailure::StagingChanged,
+        )
+        .into());
+    }
+
+    policy.checkpoint(SnapshotStateEditStage::StagingRead)?;
+    let mut reread = Vec::new();
+    reread.try_reserve_exact(encoded.len()).map_err(|source| {
+        precommit_error(
+            SnapshotStateEditStage::StagingRead,
+            SnapshotStateEditFailure::Allocation(source),
+        )
+    })?;
+    reread.resize(encoded.len(), 0);
+    staging.file.read_exact(&mut reread).map_err(|source| {
+        precommit_error(
+            SnapshotStateEditStage::StagingRead,
+            SnapshotStateEditFailure::Io {
+                kind: source.kind(),
+            },
+        )
+    })?;
+    let mut extra = [0_u8; 1];
+    if staging.file.read(&mut extra).map_err(|source| {
+        precommit_error(
+            SnapshotStateEditStage::StagingRead,
+            SnapshotStateEditFailure::Io {
+                kind: source.kind(),
+            },
+        )
+    })? != 0
+        || reread != encoded
+    {
+        return Err(precommit_error(
+            SnapshotStateEditStage::StagingRead,
+            SnapshotStateEditFailure::StagingContentMismatch,
+        )
+        .into());
+    }
+
+    policy.checkpoint(SnapshotStateEditStage::StagingVerify)?;
+    verify(&reread, product).map_err(|source| {
+        SnapshotStateEditTransactionError::Operation(operation_error(
+            SnapshotStateEditStage::StagingVerify,
+            source,
+        ))
+    })?;
+
+    let facts = inspect_file_facts(&staging.file).map_err(|_| {
+        precommit_error(
+            SnapshotStateEditStage::StagingVerify,
+            SnapshotStateEditFailure::InvalidStaging,
+        )
+    })?;
+    if !valid_staging_facts(facts, expected_length)
+        || file_identity(&staging.file).ok() != Some(staging.identity)
+        || entry_identity(staging.directory, &staging.name)
+            .ok()
+            .flatten()
+            != Some(staging.identity)
+    {
+        return Err(precommit_error(
+            SnapshotStateEditStage::StagingVerify,
+            SnapshotStateEditFailure::StagingChanged,
+        )
+        .into());
+    }
+    staging.verified_facts = Some(facts);
+    Ok(())
+}
+
+fn valid_staging_facts(facts: FileFacts, expected_length: u64) -> bool {
+    facts.permissions() == 0o600
+        && facts.is_regular()
+        && facts.is_read_write()
+        && facts.is_close_on_exec()
+        && !facts.is_append()
+        && facts.length() == expected_length
+}
+
+fn verify_source(
+    input: &AdoptedInput,
+    _output: &OpenedPath,
+    _staging: &StagingFile<'_>,
+    _encoded: &[u8],
+) -> Result<(), SnapshotStateEditError> {
+    if inspect_file(&input.file).ok() == Some(input.facts)
+        && file_identity(&input.file).ok() == Some(input.identity)
+    {
+        Ok(())
+    } else {
+        Err(precommit_error(
+            SnapshotStateEditStage::SourceStability,
+            SnapshotStateEditFailure::SourceChanged,
+        ))
+    }
+}
+
+fn verify_directories(
+    input: &AdoptedInput,
+    output: &OpenedPath,
+    _staging: &StagingFile<'_>,
+    _encoded: &[u8],
+) -> Result<(), SnapshotStateEditError> {
+    for path in [&input.path, output] {
+        let retained = file_identity(&path.directory).ok();
+        let reopened = open_directory(&path.parent)
+            .ok()
+            .and_then(|directory| file_identity(&directory).ok());
+        if retained != Some(path.directory_identity) || reopened != Some(path.directory_identity) {
+            return Err(precommit_error(
+                SnapshotStateEditStage::DirectoryStability,
+                SnapshotStateEditFailure::DirectoryChanged { path: path.role },
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn verify_entries(
+    input: &AdoptedInput,
+    output: &OpenedPath,
+    staging: &StagingFile<'_>,
+    encoded: &[u8],
+) -> Result<(), SnapshotStateEditError> {
+    let stage = SnapshotStateEditStage::EntryStability;
+    if entry_identity(&input.path.directory, &input.path.component)
+        .ok()
+        .flatten()
+        != Some(input.identity)
+    {
+        return Err(precommit_error(
+            stage,
+            SnapshotStateEditFailure::EntryChanged {
+                path: SnapshotStateEditPathRole::Input,
+            },
+        ));
+    }
+    verify_output_absent(input, output, stage)?;
+    if entry_identity(staging.directory, &staging.name)
+        .ok()
+        .flatten()
+        != Some(staging.identity)
+        || file_identity(&staging.file).ok() != Some(staging.identity)
+        || staging.verified_facts.is_none()
+        || inspect_file_facts(&staging.file).ok() != staging.verified_facts
+    {
+        return Err(precommit_error(
+            stage,
+            SnapshotStateEditFailure::StagingChanged,
+        ));
+    }
+    verify_staging_content(&staging.file, encoded, stage)
+}
+
+fn verify_staging_content(
+    file: &File,
+    expected: &[u8],
+    stage: SnapshotStateEditStage,
+) -> Result<(), SnapshotStateEditError> {
+    let mut buffer = [0_u8; CONTENT_COMPARE_BYTES];
+    let mut offset = 0_usize;
+    while offset < expected.len() {
+        let count = (expected.len() - offset).min(buffer.len());
+        let Some(chunk) = buffer.get_mut(..count) else {
+            return Err(precommit_error(
+                stage,
+                SnapshotStateEditFailure::StagingContentMismatch,
+            ));
+        };
+        let file_offset = u64::try_from(offset).map_err(|_| {
+            precommit_error(stage, SnapshotStateEditFailure::StagingContentMismatch)
+        })?;
+        read_exact_at(file, chunk, file_offset).map_err(|source| {
+            precommit_error(
+                stage,
+                SnapshotStateEditFailure::Io {
+                    kind: source.kind(),
+                },
+            )
+        })?;
+        let end = offset.checked_add(count).ok_or_else(|| {
+            precommit_error(stage, SnapshotStateEditFailure::StagingContentMismatch)
+        })?;
+        if expected.get(offset..end) != Some(chunk) {
+            return Err(precommit_error(
+                stage,
+                SnapshotStateEditFailure::StagingContentMismatch,
+            ));
+        }
+        offset = end;
+    }
+    let mut extra = [0_u8; 1];
+    let file_offset = u64::try_from(offset)
+        .map_err(|_| precommit_error(stage, SnapshotStateEditFailure::StagingContentMismatch))?;
+    if file.read_at(&mut extra, file_offset).map_err(|source| {
+        precommit_error(
+            stage,
+            SnapshotStateEditFailure::Io {
+                kind: source.kind(),
+            },
+        )
+    })? != 0
+    {
+        return Err(precommit_error(
+            stage,
+            SnapshotStateEditFailure::StagingContentMismatch,
+        ));
+    }
+    Ok(())
+}
+
+fn finish_committed_edit<T>(
+    product: T,
+    input: &AdoptedInput,
+    output: &OpenedPath,
+    staging: &mut StagingFile<'_>,
+) -> SnapshotStateEditOutcome<T> {
+    let mut first_uncertainty = None;
+
+    if let Err(kind) = enter_state_edit_stage(SnapshotStateEditStage::CommitVerification) {
+        record_uncertainty(
+            &mut first_uncertainty,
+            SnapshotStateEditStage::CommitVerification,
+            SnapshotStateEditCommitFailure::Io(kind),
+        );
+    }
+    for path in [&input.path, output] {
+        let retained = file_identity(&path.directory).ok();
+        let reopened = open_directory(&path.parent)
+            .ok()
+            .and_then(|directory| file_identity(&directory).ok());
+        if retained != Some(path.directory_identity) || reopened != Some(path.directory_identity) {
+            record_uncertainty(
+                &mut first_uncertainty,
+                SnapshotStateEditStage::CommitVerification,
+                SnapshotStateEditCommitFailure::DirectoryChanged { path: path.role },
+            );
+        }
+    }
+    if inspect_file(&input.file).ok() != Some(input.facts)
+        || entry_identity(&input.path.directory, &input.path.component)
+            .ok()
+            .flatten()
+            != Some(input.identity)
+    {
+        record_uncertainty(
+            &mut first_uncertainty,
+            SnapshotStateEditStage::CommitVerification,
+            SnapshotStateEditCommitFailure::InputChanged,
+        );
+    }
+    if entry_identity(&output.directory, &output.component)
+        .ok()
+        .flatten()
+        != Some(staging.identity)
+    {
+        record_uncertainty(
+            &mut first_uncertainty,
+            SnapshotStateEditStage::CommitVerification,
+            SnapshotStateEditCommitFailure::OutputEntryChanged,
+        );
+    }
+    if entry_identity(staging.directory, &staging.name)
+        .ok()
+        .flatten()
+        != Some(staging.identity)
+    {
+        record_uncertainty(
+            &mut first_uncertainty,
+            SnapshotStateEditStage::CommitVerification,
+            SnapshotStateEditCommitFailure::StagingEntryChanged,
+        );
+    }
+
+    let staging_cleanup = match enter_state_edit_stage(SnapshotStateEditStage::StagingCleanup) {
+        Ok(()) => staging
+            .cleanup()
+            .unwrap_or(SnapshotStateEditCleanup::AlreadyAbsent),
+        Err(kind) => {
+            staging.abandon_cleanup();
+            SnapshotStateEditCleanup::Failed(kind)
+        }
+    };
+    if matches!(
+        staging_cleanup,
+        SnapshotStateEditCleanup::ChangedRefused | SnapshotStateEditCleanup::Failed(_)
+    ) {
+        record_uncertainty(
+            &mut first_uncertainty,
+            SnapshotStateEditStage::StagingCleanup,
+            SnapshotStateEditCommitFailure::Cleanup,
+        );
+    }
+
+    let directory_sync = match enter_state_edit_stage(SnapshotStateEditStage::OutputDirectorySync) {
+        Ok(()) => output
+            .directory
+            .sync_all()
+            .err()
+            .map(|source| source.kind()),
+        Err(kind) => Some(kind),
+    };
+    if let Some(kind) = directory_sync {
+        record_uncertainty(
+            &mut first_uncertainty,
+            SnapshotStateEditStage::OutputDirectorySync,
+            SnapshotStateEditCommitFailure::Io(kind),
+        );
+    }
+
+    let _ = enter_state_edit_stage(SnapshotStateEditStage::Complete);
+    let commit = match first_uncertainty {
+        None => SnapshotStateEditCommit::Durable,
+        Some((stage, failure)) => SnapshotStateEditCommit::Uncertain {
+            stage,
+            failure,
+            staging_cleanup,
+            directory_sync,
+        },
+    };
+    SnapshotStateEditOutcome { product, commit }
+}
+
+fn cleanup_transaction_error<E>(
+    staging: &mut StagingFile<'_>,
+    error: SnapshotStateEditTransactionError<E>,
+) -> SnapshotStateEditTransactionError<E> {
+    match error {
+        SnapshotStateEditTransactionError::Publication(error) => {
+            cleanup_publication_error(staging, error).into()
+        }
+        SnapshotStateEditTransactionError::Operation(mut error) => {
+            error.staging_cleanup = staging.cleanup();
+            SnapshotStateEditTransactionError::Operation(error)
+        }
+    }
+}
+
+fn cleanup_publication_error(
+    staging: &mut StagingFile<'_>,
+    mut error: SnapshotStateEditError,
+) -> SnapshotStateEditError {
+    error.staging_cleanup = staging.cleanup();
+    error
+}
+
+fn record_uncertainty(
+    first: &mut Option<(SnapshotStateEditStage, SnapshotStateEditCommitFailure)>,
+    stage: SnapshotStateEditStage,
+    failure: SnapshotStateEditCommitFailure,
+) {
+    if first.is_none() {
+        *first = Some((stage, failure));
+    }
+}
+
+fn split_path(path: &Path) -> Option<SplitPath> {
+    let raw_path = path.as_os_str().as_bytes();
+    if raw_path.contains(&0) {
+        return None;
+    }
+    let raw_component = raw_path.rsplit(|byte| *byte == b'/').next()?;
+    if raw_component.is_empty() || raw_component == b"." || raw_component == b".." {
+        return None;
+    }
+    let Component::Normal(component) = path.components().next_back()? else {
+        return None;
+    };
+    if component.as_bytes() != raw_component {
+        return None;
+    }
+    let component = CString::new(raw_component).ok()?;
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf();
+    Some(SplitPath { parent, component })
+}
+
+fn open_directory(path: &Path) -> Result<File, io::ErrorKind> {
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY)
+        .open(path)
+        .map_err(|source| source.kind())
+}
+
+fn open_input(directory: &File, component: &CString) -> Result<File, io::ErrorKind> {
+    // SAFETY: `directory` is live and `component` is one NUL-terminated final
+    // component. No-follow/nonblocking reject final-symlink traversal and avoid
+    // blocking on special files before descriptor validation. Success returns
+    // one fresh descriptor owned by this function.
+    let descriptor = unsafe {
+        libc::openat(
+            directory.as_raw_fd(),
+            component.as_ptr(),
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
+        )
+    };
+    if descriptor < 0 {
+        Err(io::Error::last_os_error().kind())
+    } else {
+        // SAFETY: successful `openat` returned one fresh owned descriptor.
+        Ok(unsafe { File::from_raw_fd(descriptor) })
+    }
+}
+
+fn open_staging(directory: &File, name: &CString) -> Result<File, io::ErrorKind> {
+    #[cfg(test)]
+    let mode = STATE_EDIT_TEST_HOOK.with(|hook| hook.borrow().staging_mode.unwrap_or(0o600));
+    #[cfg(not(test))]
+    let mode: libc::c_int = 0o600;
+    // SAFETY: `directory` is live and `name` is one generated NUL-terminated
+    // component. Exclusive no-follow creation returns one fresh descriptor;
+    // the promoted mode argument has the variadic ABI's integer type.
+    let descriptor = unsafe {
+        libc::openat(
+            directory.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDWR | libc::O_CREAT | libc::O_EXCL | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            mode,
+        )
+    };
+    if descriptor < 0 {
+        Err(io::Error::last_os_error().kind())
+    } else {
+        // SAFETY: successful `openat` returned one fresh owned descriptor.
+        Ok(unsafe { File::from_raw_fd(descriptor) })
+    }
+}
+
+fn staging_name() -> Result<CString, SnapshotStateEditError> {
+    let stage = SnapshotStateEditStage::StagingCreate;
+    let mut random = [0_u8; STAGING_RANDOM_BYTES];
+    fill_staging_random(&mut random)
+        .map_err(|()| precommit_error(stage, SnapshotStateEditFailure::RandomnessUnavailable))?;
+    let mut bytes = Vec::new();
+    bytes
+        .try_reserve_exact(STAGING_PREFIX.len() + STAGING_RANDOM_BYTES * 2)
+        .map_err(|source| precommit_error(stage, SnapshotStateEditFailure::Allocation(source)))?;
+    bytes.extend_from_slice(STAGING_PREFIX);
+    for byte in random {
+        bytes.push(hex_digit(byte >> 4));
+        bytes.push(hex_digit(byte & 0x0f));
+    }
+    CString::new(bytes)
+        .map_err(|_| precommit_error(stage, SnapshotStateEditFailure::RandomnessUnavailable))
+}
+
+fn fill_staging_random(destination: &mut [u8; STAGING_RANDOM_BYTES]) -> Result<(), ()> {
+    #[cfg(test)]
+    if STATE_EDIT_TEST_HOOK.with(|hook| hook.borrow().random_failure) {
+        return Err(());
+    }
+    #[cfg(test)]
+    if let Some(random) =
+        STATE_EDIT_TEST_HOOK.with(|hook| hook.borrow_mut().random_names.pop_front())
+    {
+        *destination = random;
+        return Ok(());
+    }
+    getrandom::fill(destination).map_err(|_| ())
+}
+
+const fn hex_digit(nibble: u8) -> u8 {
+    match nibble {
+        0..=9 => b'0' + nibble,
+        _ => b'a' + (nibble - 10),
+    }
+}
+
+fn file_identity(file: &File) -> Result<FileIdentity, io::ErrorKind> {
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `file` owns a live descriptor and `stat` points to writable
+    // storage for the complete result.
+    if unsafe { libc::fstat(file.as_raw_fd(), stat.as_mut_ptr()) } != 0 {
+        return Err(io::Error::last_os_error().kind());
+    }
+    // SAFETY: successful `fstat` initialized the complete structure.
+    let stat = unsafe { stat.assume_init() };
+    Ok(FileIdentity {
+        device: stat.st_dev,
+        inode: stat.st_ino,
+    })
+}
+
+fn entry_identity(
+    directory: &File,
+    component: &CString,
+) -> Result<Option<FileIdentity>, io::ErrorKind> {
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `directory` is live, `component` is NUL-terminated, and `stat`
+    // points to writable storage. No-follow inspects the final entry itself.
+    let result = unsafe {
+        libc::fstatat(
+            directory.as_raw_fd(),
+            component.as_ptr(),
+            stat.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    if result == 0 {
+        // SAFETY: successful `fstatat` initialized the complete structure.
+        let stat = unsafe { stat.assume_init() };
+        return Ok(Some(FileIdentity {
+            device: stat.st_dev,
+            inode: stat.st_ino,
+        }));
+    }
+    let error = io::Error::last_os_error();
+    if error.kind() == io::ErrorKind::NotFound {
+        Ok(None)
+    } else {
+        Err(error.kind())
+    }
+}
+
+fn hard_link_no_clobber(
+    directory: &File,
+    staging: &CString,
+    output: &CString,
+) -> Result<(), io::ErrorKind> {
+    #[cfg(test)]
+    if let Some(kind) = STATE_EDIT_TEST_HOOK.with(|hook| hook.borrow().hard_link_failure) {
+        return Err(kind);
+    }
+    // SAFETY: both names are NUL-terminated single components and both
+    // descriptors are the retained output directory. `linkat` never replaces
+    // an existing destination; flags zero never requests source-symlink follow.
+    let result = unsafe {
+        libc::linkat(
+            directory.as_raw_fd(),
+            staging.as_ptr(),
+            directory.as_raw_fd(),
+            output.as_ptr(),
+            0,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error().kind())
+    }
+}
+
+fn clean_owned_entry(
+    directory: &File,
+    name: &CString,
+    expected: FileIdentity,
+) -> SnapshotStateEditCleanup {
+    #[cfg(test)]
+    if let Some(kind) = STATE_EDIT_TEST_HOOK.with(|hook| hook.borrow().cleanup_failure) {
+        return SnapshotStateEditCleanup::Failed(kind);
+    }
+    match entry_identity(directory, name) {
+        Ok(None) => SnapshotStateEditCleanup::AlreadyAbsent,
+        Ok(Some(actual)) if actual != expected => SnapshotStateEditCleanup::ChangedRefused,
+        Ok(Some(_)) => {
+            // SAFETY: `directory` is live and `name` is one NUL-terminated
+            // generated component. The immediate identity check is best effort;
+            // trusted directory mutation authority remains required because
+            // POSIX has no conditional unlink by expected inode.
+            let result = unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) };
+            if result == 0 {
+                SnapshotStateEditCleanup::Removed
+            } else {
+                let kind = io::Error::last_os_error().kind();
+                if kind == io::ErrorKind::NotFound {
+                    SnapshotStateEditCleanup::AlreadyAbsent
+                } else {
+                    SnapshotStateEditCleanup::Failed(kind)
+                }
+            }
+        }
+        Err(kind) => SnapshotStateEditCleanup::Failed(kind),
+    }
+}
+
+fn read_exact_at(file: &File, mut bytes: &mut [u8], mut offset: u64) -> io::Result<()> {
+    while !bytes.is_empty() {
+        match file.read_at(bytes, offset) {
+            Ok(0) => return Err(io::Error::from(io::ErrorKind::UnexpectedEof)),
+            Ok(count) => {
+                let Some(remaining) = bytes.get_mut(count..) else {
+                    return Err(io::Error::from(io::ErrorKind::InvalidData));
+                };
+                bytes = remaining;
+                offset = offset
+                    .checked_add(
+                        u64::try_from(count)
+                            .map_err(|_| io::Error::from(io::ErrorKind::InvalidData))?,
+                    )
+                    .ok_or_else(|| io::Error::from(io::ErrorKind::InvalidData))?;
+            }
+            Err(source) if source.kind() == io::ErrorKind::Interrupted => {}
+            Err(source) => return Err(source),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(test))]
+fn enter_state_edit_stage(_stage: SnapshotStateEditStage) -> Result<(), io::ErrorKind> {
+    Ok(())
+}
+
+#[cfg(test)]
+type StageAction = Box<dyn FnOnce()>;
+
+#[cfg(test)]
+#[derive(Default)]
+struct StateEditTestHook {
+    failures: VecDeque<(SnapshotStateEditStage, io::ErrorKind)>,
+    actions: VecDeque<(SnapshotStateEditStage, StageAction)>,
+    random_failure: bool,
+    random_names: VecDeque<[u8; STAGING_RANDOM_BYTES]>,
+    hard_link_failure: Option<io::ErrorKind>,
+    cleanup_failure: Option<io::ErrorKind>,
+    staging_mode: Option<libc::c_int>,
+}
+
+#[cfg(test)]
+thread_local! {
+    static STATE_EDIT_TEST_HOOK: RefCell<StateEditTestHook> =
+        RefCell::new(StateEditTestHook::default());
+}
+
+#[cfg(test)]
+fn enter_state_edit_stage(stage: SnapshotStateEditStage) -> Result<(), io::ErrorKind> {
+    let action = STATE_EDIT_TEST_HOOK.with(|hook| {
+        let mut hook = hook.borrow_mut();
+        hook.actions
+            .iter()
+            .position(|(candidate, _)| *candidate == stage)
+            .and_then(|position| hook.actions.remove(position))
+            .map(|(_, action)| action)
+    });
+    if let Some(action) = action {
+        action();
+    }
+    STATE_EDIT_TEST_HOOK.with(|hook| {
+        let mut hook = hook.borrow_mut();
+        hook.failures
+            .iter()
+            .position(|(candidate, _)| *candidate == stage)
+            .and_then(|position| hook.failures.remove(position))
+            .map_or(Ok(()), |(_, kind)| Err(kind))
+    })
+}
+
+#[cfg(test)]
+pub(super) fn with_state_edit_failures<T>(
+    failures: impl IntoIterator<Item = (SnapshotStateEditStage, io::ErrorKind)>,
+    operation: impl FnOnce() -> T,
+) -> T {
+    with_test_hook(
+        StateEditTestHook {
+            failures: failures.into_iter().collect(),
+            ..StateEditTestHook::default()
+        },
+        operation,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn with_state_edit_action<T>(
+    stage: SnapshotStateEditStage,
+    action: impl FnOnce() + 'static,
+    operation: impl FnOnce() -> T,
+) -> T {
+    let mut actions = VecDeque::new();
+    actions.push_back((stage, Box::new(action) as StageAction));
+    with_test_hook(
+        StateEditTestHook {
+            actions,
+            ..StateEditTestHook::default()
+        },
+        operation,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn with_state_edit_random_failure<T>(operation: impl FnOnce() -> T) -> T {
+    with_test_hook(
+        StateEditTestHook {
+            random_failure: true,
+            ..StateEditTestHook::default()
+        },
+        operation,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn with_state_edit_random_names<T>(
+    names: impl IntoIterator<Item = [u8; STAGING_RANDOM_BYTES]>,
+    operation: impl FnOnce() -> T,
+) -> T {
+    with_test_hook(
+        StateEditTestHook {
+            random_names: names.into_iter().collect(),
+            ..StateEditTestHook::default()
+        },
+        operation,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn with_state_edit_hard_link_failure<T>(
+    kind: io::ErrorKind,
+    operation: impl FnOnce() -> T,
+) -> T {
+    with_test_hook(
+        StateEditTestHook {
+            hard_link_failure: Some(kind),
+            ..StateEditTestHook::default()
+        },
+        operation,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn with_state_edit_cleanup_failure<T>(
+    kind: io::ErrorKind,
+    operation: impl FnOnce() -> T,
+) -> T {
+    with_test_hook(
+        StateEditTestHook {
+            cleanup_failure: Some(kind),
+            ..StateEditTestHook::default()
+        },
+        operation,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn with_state_edit_failure_and_cleanup_failure<T>(
+    stage: SnapshotStateEditStage,
+    primary: io::ErrorKind,
+    cleanup: io::ErrorKind,
+    operation: impl FnOnce() -> T,
+) -> T {
+    with_test_hook(
+        StateEditTestHook {
+            failures: [(stage, primary)].into_iter().collect(),
+            cleanup_failure: Some(cleanup),
+            ..StateEditTestHook::default()
+        },
+        operation,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn with_state_edit_action_and_cleanup_failure<T>(
+    stage: SnapshotStateEditStage,
+    action: impl FnOnce() + 'static,
+    cleanup: io::ErrorKind,
+    operation: impl FnOnce() -> T,
+) -> T {
+    let mut actions = VecDeque::new();
+    actions.push_back((stage, Box::new(action) as StageAction));
+    with_test_hook(
+        StateEditTestHook {
+            actions,
+            cleanup_failure: Some(cleanup),
+            ..StateEditTestHook::default()
+        },
+        operation,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn with_state_edit_staging_mode<T>(
+    mode: libc::c_int,
+    operation: impl FnOnce() -> T,
+) -> T {
+    with_test_hook(
+        StateEditTestHook {
+            staging_mode: Some(mode),
+            ..StateEditTestHook::default()
+        },
+        operation,
+    )
+}
+
+#[cfg(test)]
+fn with_test_hook<T>(hook: StateEditTestHook, operation: impl FnOnce() -> T) -> T {
+    struct Reset;
+
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            STATE_EDIT_TEST_HOOK.with(|current| {
+                *current.borrow_mut() = StateEditTestHook::default();
+            });
+        }
+    }
+
+    STATE_EDIT_TEST_HOOK.with(|current| {
+        *current.borrow_mut() = hook;
+    });
+    let reset = Reset;
+    let result = operation();
+    drop(reset);
+    result
+}

--- a/crates/runtime/src/vsock/direct_restore.rs
+++ b/crates/runtime/src/vsock/direct_restore.rs
@@ -579,7 +579,9 @@ fn path_to_cstring(path: &Path) -> io::Result<CString> {
 
 #[cfg(test)]
 mod tests {
-    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _, symlink};
+    #[cfg(target_os = "macos")]
+    use std::os::unix::fs::MetadataExt as _;
+    use std::os::unix::fs::{PermissionsExt as _, symlink};
     use std::sync::atomic::{AtomicU64, Ordering};
 
     use crate::snapshot::{SnapshotVsockOverride, resolve_snapshot_vsock_selectors};


### PR DESCRIPTION
## Summary

- add a backend-neutral Unix transaction for bounded edited snapshot state with retained descriptors, private mode-0600 staging, repeated stability checks, and no-clobber `linkat` commit
- distinguish precommit errors from committed cleanup or durability uncertainty while keeping paths, operation values, products, and filesystem identities redacted
- expose an opaque prevalidated reviewed-register removal request and prove exact native-v1, native-v2, and 2.13 Diff composition
- close the Linux-musl cfg gaps needed to compile the portable runtime path with warnings denied

## Scope exclusions

- no public snapshot-editor command activation
- no memory rebase, capability inventory, or product documentation changes

## Verification

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-runtime --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo check -p bangbang-snapshot-tools --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented Apple-target integration-test Clippy commands
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`
- `git diff --check`

Closes #1774
Parent: #1542
