### PR TITLE
test: certify Wave 7 core API ledger

### DIFF
--- a/compat/firecracker/v1.16.0/README.md
+++ b/compat/firecracker/v1.16.0/README.md
@@ -57,6 +57,7 @@ reviewed delta.
 | [Snapshot Diff and rebase](snapshot-diff-rebase-contract.md) | Native-v2 2.13 differential create/load, public rebase commands, stronger no-clobber transaction, and terminal Wave 6 composition |
 | [Snapshot editor state](snapshot-editor-contract.md) | Native-state version/vCPU/VM inspection, finite reviewed-register editing, no-clobber publication, signed Full/Diff product restore, and the exact twelve-row closure |
 | [Snapshot Wave 6](snapshot-wave6-contract.md) | Exact 70-row load, artifact, version, device, tool, time/identity, portability, and downstream-owner certification |
+| [Observability, tools, and specification](observability-tools-specification-contract.md) | Exact Wave 7 ownership, core API certification, x86 CPUID/MSR platform exclusions, and retained downstream handoffs |
 
 ## Dispositions
 

--- a/compat/firecracker/v1.16.0/capabilities.json
+++ b/compat/firecracker/v1.16.0/capabilities.json
@@ -30,11 +30,55 @@
     {
       "id": "api-operation:GET /",
       "family": "api-contract",
-      "summary": "Audit the observable Firecracker v1.16 API operation GET /.",
+      "summary": "Return deterministic Firecracker-shaped instance information with the process-owned id, exact Not started/Running/Paused state, immutable VMM version, and application name over the owner-only Unix API socket.",
       "source_refs": [
         "api-operation:GET /"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-operation:GET /balloon",
@@ -267,20 +311,108 @@
     {
       "id": "api-operation:GET /version",
       "family": "api-contract",
-      "summary": "Audit the observable Firecracker v1.16 API operation GET /version.",
+      "summary": "Return the running Bangbang build version in FirecrackerVersion JSON through the exact bodyless GET operation without mutating VM state.",
       "source_refs": [
         "api-operation:GET /version"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-operation:GET /vm/config",
       "family": "api-contract",
-      "summary": "Audit the observable Firecracker v1.16 API operation GET /vm/config.",
+      "summary": "Return deterministic supported VM configuration state through the optional Firecracker FullVmConfiguration schema; separately owned logger and metrics properties remain omitted and nonterminal.",
       "source_refs": [
         "api-operation:GET /vm/config"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-operation:PATCH /balloon",
@@ -747,11 +879,55 @@
     {
       "id": "api-operation:PUT /actions",
       "family": "api-contract",
-      "summary": "Audit the observable Firecracker v1.16 API operation PUT /actions.",
+      "summary": "Execute strict synchronous InstanceStart and FlushMetrics actions with state-aware failure atomicity, while rejecting SendCtrlAltDel on aarch64 before VMM mutation.",
       "source_refs": [
         "api-operation:PUT /actions"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-operation:PUT /balloon",
@@ -1524,20 +1700,108 @@
     {
       "id": "api-path:/",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API path /.",
+      "summary": "Expose only bodyless GET at the exact instance-information path and reject every other method, body, or nonexact route with a stable value-free fault.",
       "source_refs": [
         "api-path:/"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-path:/actions",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API path /actions.",
+      "summary": "Expose only strict body-bearing PUT at the exact synchronous-action path with fixed empty, malformed, unsupported-action, and state faults.",
       "source_refs": [
         "api-path:/actions"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-path:/balloon",
@@ -2304,11 +2568,55 @@
     {
       "id": "api-path:/version",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API path /version.",
+      "summary": "Expose only bodyless GET at the exact version path and reject every other method, body, or nonexact route without stopping the API process.",
       "source_refs": [
         "api-path:/version"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-path:/vm",
@@ -2371,11 +2679,55 @@
     {
       "id": "api-path:/vm/config",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API path /vm/config.",
+      "summary": "Expose only bodyless GET at the exact full-configuration path with deterministic supported-field serialization and stable invalid-route handling.",
       "source_refs": [
         "api-path:/vm/config"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-path:/vsock",
@@ -3658,11 +4010,93 @@
     {
       "id": "api-property:CpuConfig.cpuid_modifiers",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API property CpuConfig.cpuid_modifiers.",
+      "summary": "Reject the x86_64-only cpuid_modifiers collection as a fixed value-free malformed arm64 request because public Apple Silicon HVF has no identity-preserving CPUID leaf namespace.",
       "source_refs": [
         "api-property:CpuConfig.cpuid_modifiers"
       ],
-      "disposition": "audit-required"
+      "disposition": "proven-platform-impossible",
+      "exclusion": {
+        "upstream_contract": [
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/firecracker/swagger/firecracker.yaml#L1092-L1113"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs#L29-L48"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs#L70-L159"
+        }
+        ],
+        "platform_evidence": [
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_config_get_feature_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_sys_reg%28_%3A_%3A_%3A%29"
+        }
+        ],
+        "alternatives": [
+          "Accepting and silently ignoring CPUID or MSR input would report success without enforcing the requested guest CPU contract.",
+          "Mapping x86 CPUID leaves or model-specific registers into ARM system registers would change architecture, selector, width, and bitmap semantics.",
+          "Running an x86 emulator, Linux KVM sidecar, or different host backend would leave Bangbang's native macOS arm64/HVF target and one-process VM boundary."
+        ],
+        "stable_behavior": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "validate_cpu_config_json_shape and RequestError::MalformedRequest"
+        }
+        ],
+        "focused_tests": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "rejects_complete_x86_cpu_config_shapes_without_retaining_values"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable_configures_vm_before_start x86 shape cases"
+        }
+        ],
+        "compatibility_docs": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/cpu-template-contract.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "X86 CPUID/MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "docs/firecracker-compatibility.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        }
+        ],
+        "security_docs": [
+        {
+          "kind": "local",
+          "path": "docs/security.md",
+          "anchor": "X86 CPUID and MSR request values"
+        }
+        ],
+        "challenge": {
+          "kind": "github",
+          "url": "https://github.com/seven332/bangbang/issues/1784#issuecomment-5161129449"
+        }
+      }
     },
     {
       "id": "api-property:CpuConfig.kvm_capabilities",
@@ -3754,11 +4188,93 @@
     {
       "id": "api-property:CpuConfig.msr_modifiers",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API property CpuConfig.msr_modifiers.",
+      "summary": "Reject the x86_64-only msr_modifiers collection as a fixed value-free malformed arm64 request because public Apple Silicon HVF has no identity-preserving model-specific-register namespace.",
       "source_refs": [
         "api-property:CpuConfig.msr_modifiers"
       ],
-      "disposition": "audit-required"
+      "disposition": "proven-platform-impossible",
+      "exclusion": {
+        "upstream_contract": [
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/firecracker/swagger/firecracker.yaml#L1092-L1113"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs#L29-L48"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs#L70-L159"
+        }
+        ],
+        "platform_evidence": [
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_config_get_feature_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_sys_reg%28_%3A_%3A_%3A%29"
+        }
+        ],
+        "alternatives": [
+          "Accepting and silently ignoring CPUID or MSR input would report success without enforcing the requested guest CPU contract.",
+          "Mapping x86 CPUID leaves or model-specific registers into ARM system registers would change architecture, selector, width, and bitmap semantics.",
+          "Running an x86 emulator, Linux KVM sidecar, or different host backend would leave Bangbang's native macOS arm64/HVF target and one-process VM boundary."
+        ],
+        "stable_behavior": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "validate_cpu_config_json_shape and RequestError::MalformedRequest"
+        }
+        ],
+        "focused_tests": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "rejects_complete_x86_cpu_config_shapes_without_retaining_values"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable_configures_vm_before_start x86 shape cases"
+        }
+        ],
+        "compatibility_docs": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/cpu-template-contract.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "X86 CPUID/MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "docs/firecracker-compatibility.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        }
+        ],
+        "security_docs": [
+        {
+          "kind": "local",
+          "path": "docs/security.md",
+          "anchor": "X86 CPUID and MSR request values"
+        }
+        ],
+        "challenge": {
+          "kind": "github",
+          "url": "https://github.com/seven332/bangbang/issues/1784#issuecomment-5161129449"
+        }
+      }
     },
     {
       "id": "api-property:CpuConfig.reg_modifiers",
@@ -3908,56 +4424,548 @@
     {
       "id": "api-property:CpuidLeafModifier.flags",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API property CpuidLeafModifier.flags.",
+      "summary": "Reject the x86_64-only KVM CPUID leaf flags field inside a fixed value-free malformed arm64 request; HVF has no equivalent CPUID leaf/subleaf flag identity.",
       "source_refs": [
         "api-property:CpuidLeafModifier.flags"
       ],
-      "disposition": "audit-required"
+      "disposition": "proven-platform-impossible",
+      "exclusion": {
+        "upstream_contract": [
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/firecracker/swagger/firecracker.yaml#L1125-L1148"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs#L29-L48"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs#L70-L159"
+        }
+        ],
+        "platform_evidence": [
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_config_get_feature_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_sys_reg%28_%3A_%3A_%3A%29"
+        }
+        ],
+        "alternatives": [
+          "Accepting and silently ignoring CPUID or MSR input would report success without enforcing the requested guest CPU contract.",
+          "Mapping x86 CPUID leaves or model-specific registers into ARM system registers would change architecture, selector, width, and bitmap semantics.",
+          "Running an x86 emulator, Linux KVM sidecar, or different host backend would leave Bangbang's native macOS arm64/HVF target and one-process VM boundary."
+        ],
+        "stable_behavior": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "validate_cpu_config_json_shape and RequestError::MalformedRequest"
+        }
+        ],
+        "focused_tests": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "rejects_complete_x86_cpu_config_shapes_without_retaining_values"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable_configures_vm_before_start x86 shape cases"
+        }
+        ],
+        "compatibility_docs": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/cpu-template-contract.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "X86 CPUID/MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "docs/firecracker-compatibility.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        }
+        ],
+        "security_docs": [
+        {
+          "kind": "local",
+          "path": "docs/security.md",
+          "anchor": "X86 CPUID and MSR request values"
+        }
+        ],
+        "challenge": {
+          "kind": "github",
+          "url": "https://github.com/seven332/bangbang/issues/1784#issuecomment-5161129449"
+        }
+      }
     },
     {
       "id": "api-property:CpuidLeafModifier.leaf",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API property CpuidLeafModifier.leaf.",
+      "summary": "Reject the x86_64-only CPUID leaf index inside a fixed value-free malformed arm64 request; ARM system-register identifiers cannot preserve its meaning.",
       "source_refs": [
         "api-property:CpuidLeafModifier.leaf"
       ],
-      "disposition": "audit-required"
+      "disposition": "proven-platform-impossible",
+      "exclusion": {
+        "upstream_contract": [
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/firecracker/swagger/firecracker.yaml#L1125-L1148"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs#L29-L48"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs#L70-L159"
+        }
+        ],
+        "platform_evidence": [
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_config_get_feature_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_sys_reg%28_%3A_%3A_%3A%29"
+        }
+        ],
+        "alternatives": [
+          "Accepting and silently ignoring CPUID or MSR input would report success without enforcing the requested guest CPU contract.",
+          "Mapping x86 CPUID leaves or model-specific registers into ARM system registers would change architecture, selector, width, and bitmap semantics.",
+          "Running an x86 emulator, Linux KVM sidecar, or different host backend would leave Bangbang's native macOS arm64/HVF target and one-process VM boundary."
+        ],
+        "stable_behavior": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "validate_cpu_config_json_shape and RequestError::MalformedRequest"
+        }
+        ],
+        "focused_tests": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "rejects_complete_x86_cpu_config_shapes_without_retaining_values"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable_configures_vm_before_start x86 shape cases"
+        }
+        ],
+        "compatibility_docs": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/cpu-template-contract.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "X86 CPUID/MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "docs/firecracker-compatibility.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        }
+        ],
+        "security_docs": [
+        {
+          "kind": "local",
+          "path": "docs/security.md",
+          "anchor": "X86 CPUID and MSR request values"
+        }
+        ],
+        "challenge": {
+          "kind": "github",
+          "url": "https://github.com/seven332/bangbang/issues/1784#issuecomment-5161129449"
+        }
+      }
     },
     {
       "id": "api-property:CpuidLeafModifier.modifiers",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API property CpuidLeafModifier.modifiers.",
+      "summary": "Reject the x86_64-only CPUID register-modifier collection inside a fixed value-free malformed arm64 request; HVF exposes no CPUID table to modify.",
       "source_refs": [
         "api-property:CpuidLeafModifier.modifiers"
       ],
-      "disposition": "audit-required"
+      "disposition": "proven-platform-impossible",
+      "exclusion": {
+        "upstream_contract": [
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/firecracker/swagger/firecracker.yaml#L1125-L1148"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs#L29-L48"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs#L70-L159"
+        }
+        ],
+        "platform_evidence": [
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_config_get_feature_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_sys_reg%28_%3A_%3A_%3A%29"
+        }
+        ],
+        "alternatives": [
+          "Accepting and silently ignoring CPUID or MSR input would report success without enforcing the requested guest CPU contract.",
+          "Mapping x86 CPUID leaves or model-specific registers into ARM system registers would change architecture, selector, width, and bitmap semantics.",
+          "Running an x86 emulator, Linux KVM sidecar, or different host backend would leave Bangbang's native macOS arm64/HVF target and one-process VM boundary."
+        ],
+        "stable_behavior": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "validate_cpu_config_json_shape and RequestError::MalformedRequest"
+        }
+        ],
+        "focused_tests": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "rejects_complete_x86_cpu_config_shapes_without_retaining_values"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable_configures_vm_before_start x86 shape cases"
+        }
+        ],
+        "compatibility_docs": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/cpu-template-contract.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "X86 CPUID/MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "docs/firecracker-compatibility.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        }
+        ],
+        "security_docs": [
+        {
+          "kind": "local",
+          "path": "docs/security.md",
+          "anchor": "X86 CPUID and MSR request values"
+        }
+        ],
+        "challenge": {
+          "kind": "github",
+          "url": "https://github.com/seven332/bangbang/issues/1784#issuecomment-5161129449"
+        }
+      }
     },
     {
       "id": "api-property:CpuidLeafModifier.subleaf",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API property CpuidLeafModifier.subleaf.",
+      "summary": "Reject the x86_64-only CPUID subleaf index inside a fixed value-free malformed arm64 request; ARM register selection cannot preserve its meaning.",
       "source_refs": [
         "api-property:CpuidLeafModifier.subleaf"
       ],
-      "disposition": "audit-required"
+      "disposition": "proven-platform-impossible",
+      "exclusion": {
+        "upstream_contract": [
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/firecracker/swagger/firecracker.yaml#L1125-L1148"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs#L29-L48"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs#L70-L159"
+        }
+        ],
+        "platform_evidence": [
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_config_get_feature_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_sys_reg%28_%3A_%3A_%3A%29"
+        }
+        ],
+        "alternatives": [
+          "Accepting and silently ignoring CPUID or MSR input would report success without enforcing the requested guest CPU contract.",
+          "Mapping x86 CPUID leaves or model-specific registers into ARM system registers would change architecture, selector, width, and bitmap semantics.",
+          "Running an x86 emulator, Linux KVM sidecar, or different host backend would leave Bangbang's native macOS arm64/HVF target and one-process VM boundary."
+        ],
+        "stable_behavior": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "validate_cpu_config_json_shape and RequestError::MalformedRequest"
+        }
+        ],
+        "focused_tests": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "rejects_complete_x86_cpu_config_shapes_without_retaining_values"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable_configures_vm_before_start x86 shape cases"
+        }
+        ],
+        "compatibility_docs": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/cpu-template-contract.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "X86 CPUID/MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "docs/firecracker-compatibility.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        }
+        ],
+        "security_docs": [
+        {
+          "kind": "local",
+          "path": "docs/security.md",
+          "anchor": "X86 CPUID and MSR request values"
+        }
+        ],
+        "challenge": {
+          "kind": "github",
+          "url": "https://github.com/seven332/bangbang/issues/1784#issuecomment-5161129449"
+        }
+      }
     },
     {
       "id": "api-property:CpuidRegisterModifier.bitmap",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API property CpuidRegisterModifier.bitmap.",
+      "summary": "Reject the x86_64-only 32-bit CPUID register bitmap inside a fixed value-free malformed arm64 request rather than reinterpret it as an ARM register mask.",
       "source_refs": [
         "api-property:CpuidRegisterModifier.bitmap"
       ],
-      "disposition": "audit-required"
+      "disposition": "proven-platform-impossible",
+      "exclusion": {
+        "upstream_contract": [
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/firecracker/swagger/firecracker.yaml#L1150-L1167"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs#L29-L48"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs#L70-L159"
+        }
+        ],
+        "platform_evidence": [
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_config_get_feature_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_sys_reg%28_%3A_%3A_%3A%29"
+        }
+        ],
+        "alternatives": [
+          "Accepting and silently ignoring CPUID or MSR input would report success without enforcing the requested guest CPU contract.",
+          "Mapping x86 CPUID leaves or model-specific registers into ARM system registers would change architecture, selector, width, and bitmap semantics.",
+          "Running an x86 emulator, Linux KVM sidecar, or different host backend would leave Bangbang's native macOS arm64/HVF target and one-process VM boundary."
+        ],
+        "stable_behavior": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "validate_cpu_config_json_shape and RequestError::MalformedRequest"
+        }
+        ],
+        "focused_tests": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "rejects_complete_x86_cpu_config_shapes_without_retaining_values"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable_configures_vm_before_start x86 shape cases"
+        }
+        ],
+        "compatibility_docs": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/cpu-template-contract.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "X86 CPUID/MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "docs/firecracker-compatibility.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        }
+        ],
+        "security_docs": [
+        {
+          "kind": "local",
+          "path": "docs/security.md",
+          "anchor": "X86 CPUID and MSR request values"
+        }
+        ],
+        "challenge": {
+          "kind": "github",
+          "url": "https://github.com/seven332/bangbang/issues/1784#issuecomment-5161129449"
+        }
+      }
     },
     {
       "id": "api-property:CpuidRegisterModifier.register",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API property CpuidRegisterModifier.register.",
+      "summary": "Reject the x86_64-only eax/ebx/ecx/edx CPUID register selector inside a fixed value-free malformed arm64 request because no identity-preserving HVF target exists.",
       "source_refs": [
         "api-property:CpuidRegisterModifier.register"
       ],
-      "disposition": "audit-required"
+      "disposition": "proven-platform-impossible",
+      "exclusion": {
+        "upstream_contract": [
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/firecracker/swagger/firecracker.yaml#L1150-L1167"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs#L29-L48"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs#L70-L159"
+        }
+        ],
+        "platform_evidence": [
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_config_get_feature_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_sys_reg%28_%3A_%3A_%3A%29"
+        }
+        ],
+        "alternatives": [
+          "Accepting and silently ignoring CPUID or MSR input would report success without enforcing the requested guest CPU contract.",
+          "Mapping x86 CPUID leaves or model-specific registers into ARM system registers would change architecture, selector, width, and bitmap semantics.",
+          "Running an x86 emulator, Linux KVM sidecar, or different host backend would leave Bangbang's native macOS arm64/HVF target and one-process VM boundary."
+        ],
+        "stable_behavior": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "validate_cpu_config_json_shape and RequestError::MalformedRequest"
+        }
+        ],
+        "focused_tests": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "rejects_complete_x86_cpu_config_shapes_without_retaining_values"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable_configures_vm_before_start x86 shape cases"
+        }
+        ],
+        "compatibility_docs": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/cpu-template-contract.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "X86 CPUID/MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "docs/firecracker-compatibility.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        }
+        ],
+        "security_docs": [
+        {
+          "kind": "local",
+          "path": "docs/security.md",
+          "anchor": "X86 CPUID and MSR request values"
+        }
+        ],
+        "challenge": {
+          "kind": "github",
+          "url": "https://github.com/seven332/bangbang/issues/1784#issuecomment-5161129449"
+        }
+      }
     },
     {
       "id": "api-property:Drive.cache_type",
@@ -4347,20 +5355,108 @@
     {
       "id": "api-property:Error.fault_message",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API property Error.fault_message.",
+      "summary": "Serialize every public API failure as one fixed or value-redacted fault_message string without echoing untrusted request, resource, CPU, or host values.",
       "source_refs": [
         "api-property:Error.fault_message"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-property:FirecrackerVersion.firecracker_version",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API property FirecrackerVersion.firecracker_version.",
+      "summary": "Serialize the immutable running Bangbang package version under the exact required firecracker_version field.",
       "source_refs": [
         "api-property:FirecrackerVersion.firecracker_version"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-property:FullVmConfiguration.balloon",
@@ -4816,47 +5912,267 @@
     {
       "id": "api-property:InstanceActionInfo.action_type",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API property InstanceActionInfo.action_type.",
+      "summary": "Require exactly one action_type and accept Firecracker's InstanceStart and FlushMetrics values while returning the pinned aarch64 rejection for SendCtrlAltDel.",
       "source_refs": [
         "api-property:InstanceActionInfo.action_type"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-property:InstanceInfo.app_name",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API property InstanceInfo.app_name.",
+      "summary": "Serialize the immutable process application name under the exact required app_name field.",
       "source_refs": [
         "api-property:InstanceInfo.app_name"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-property:InstanceInfo.id",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API property InstanceInfo.id.",
+      "summary": "Serialize the validated process-owned microVM identity under the exact required id field without altering its Unicode byte-bound contract.",
       "source_refs": [
         "api-property:InstanceInfo.id"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-property:InstanceInfo.state",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API property InstanceInfo.state.",
+      "summary": "Serialize exactly Not started, Running, or Paused from committed process-owned VM state, preserving the prior state after rejected or failed actions.",
       "source_refs": [
         "api-property:InstanceInfo.state"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-property:InstanceInfo.vmm_version",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API property InstanceInfo.vmm_version.",
+      "summary": "Serialize the immutable running Bangbang package version under the exact required vmm_version field.",
       "source_refs": [
         "api-property:InstanceInfo.vmm_version"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-property:Logger.level",
@@ -5892,20 +7208,184 @@
     {
       "id": "api-property:MsrModifier.addr",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API property MsrModifier.addr.",
+      "summary": "Reject the x86_64-only 32-bit model-specific-register address inside a fixed value-free malformed arm64 request rather than alias it to an ARM system-register identifier.",
       "source_refs": [
         "api-property:MsrModifier.addr"
       ],
-      "disposition": "audit-required"
+      "disposition": "proven-platform-impossible",
+      "exclusion": {
+        "upstream_contract": [
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/firecracker/swagger/firecracker.yaml#L1169-L1185"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs#L29-L48"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs#L70-L159"
+        }
+        ],
+        "platform_evidence": [
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_config_get_feature_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_sys_reg%28_%3A_%3A_%3A%29"
+        }
+        ],
+        "alternatives": [
+          "Accepting and silently ignoring CPUID or MSR input would report success without enforcing the requested guest CPU contract.",
+          "Mapping x86 CPUID leaves or model-specific registers into ARM system registers would change architecture, selector, width, and bitmap semantics.",
+          "Running an x86 emulator, Linux KVM sidecar, or different host backend would leave Bangbang's native macOS arm64/HVF target and one-process VM boundary."
+        ],
+        "stable_behavior": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "validate_cpu_config_json_shape and RequestError::MalformedRequest"
+        }
+        ],
+        "focused_tests": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "rejects_complete_x86_cpu_config_shapes_without_retaining_values"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable_configures_vm_before_start x86 shape cases"
+        }
+        ],
+        "compatibility_docs": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/cpu-template-contract.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "X86 CPUID/MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "docs/firecracker-compatibility.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        }
+        ],
+        "security_docs": [
+        {
+          "kind": "local",
+          "path": "docs/security.md",
+          "anchor": "X86 CPUID and MSR request values"
+        }
+        ],
+        "challenge": {
+          "kind": "github",
+          "url": "https://github.com/seven332/bangbang/issues/1784#issuecomment-5161129449"
+        }
+      }
     },
     {
       "id": "api-property:MsrModifier.bitmap",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API property MsrModifier.bitmap.",
+      "summary": "Reject the x86_64-only 64-bit model-specific-register bitmap inside a fixed value-free malformed arm64 request because public HVF has no corresponding MSR target.",
       "source_refs": [
         "api-property:MsrModifier.bitmap"
       ],
-      "disposition": "audit-required"
+      "disposition": "proven-platform-impossible",
+      "exclusion": {
+        "upstream_contract": [
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/firecracker/swagger/firecracker.yaml#L1169-L1185"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs#L29-L48"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs#L70-L159"
+        }
+        ],
+        "platform_evidence": [
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_config_get_feature_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_sys_reg%28_%3A_%3A_%3A%29"
+        }
+        ],
+        "alternatives": [
+          "Accepting and silently ignoring CPUID or MSR input would report success without enforcing the requested guest CPU contract.",
+          "Mapping x86 CPUID leaves or model-specific registers into ARM system registers would change architecture, selector, width, and bitmap semantics.",
+          "Running an x86 emulator, Linux KVM sidecar, or different host backend would leave Bangbang's native macOS arm64/HVF target and one-process VM boundary."
+        ],
+        "stable_behavior": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "validate_cpu_config_json_shape and RequestError::MalformedRequest"
+        }
+        ],
+        "focused_tests": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "rejects_complete_x86_cpu_config_shapes_without_retaining_values"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable_configures_vm_before_start x86 shape cases"
+        }
+        ],
+        "compatibility_docs": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/cpu-template-contract.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "X86 CPUID/MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "docs/firecracker-compatibility.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        }
+        ],
+        "security_docs": [
+        {
+          "kind": "local",
+          "path": "docs/security.md",
+          "anchor": "X86 CPUID and MSR request values"
+        }
+        ],
+        "challenge": {
+          "kind": "github",
+          "url": "https://github.com/seven332/bangbang/issues/1784#issuecomment-5161129449"
+        }
+      }
     },
     {
       "id": "api-property:NetworkInterface.guest_mac",
@@ -8254,20 +9734,184 @@
     {
       "id": "api-schema:CpuidLeafModifier",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API schema CpuidLeafModifier.",
+      "summary": "Reject the complete x86_64-only CPUID leaf/subleaf/flags/modifiers schema as a fixed value-free malformed arm64 request before runtime state or backend construction.",
       "source_refs": [
         "api-schema:CpuidLeafModifier"
       ],
-      "disposition": "audit-required"
+      "disposition": "proven-platform-impossible",
+      "exclusion": {
+        "upstream_contract": [
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/firecracker/swagger/firecracker.yaml#L1125-L1148"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs#L29-L48"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs#L70-L159"
+        }
+        ],
+        "platform_evidence": [
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_config_get_feature_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_sys_reg%28_%3A_%3A_%3A%29"
+        }
+        ],
+        "alternatives": [
+          "Accepting and silently ignoring CPUID or MSR input would report success without enforcing the requested guest CPU contract.",
+          "Mapping x86 CPUID leaves or model-specific registers into ARM system registers would change architecture, selector, width, and bitmap semantics.",
+          "Running an x86 emulator, Linux KVM sidecar, or different host backend would leave Bangbang's native macOS arm64/HVF target and one-process VM boundary."
+        ],
+        "stable_behavior": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "validate_cpu_config_json_shape and RequestError::MalformedRequest"
+        }
+        ],
+        "focused_tests": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "rejects_complete_x86_cpu_config_shapes_without_retaining_values"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable_configures_vm_before_start x86 shape cases"
+        }
+        ],
+        "compatibility_docs": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/cpu-template-contract.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "X86 CPUID/MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "docs/firecracker-compatibility.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        }
+        ],
+        "security_docs": [
+        {
+          "kind": "local",
+          "path": "docs/security.md",
+          "anchor": "X86 CPUID and MSR request values"
+        }
+        ],
+        "challenge": {
+          "kind": "github",
+          "url": "https://github.com/seven332/bangbang/issues/1784#issuecomment-5161129449"
+        }
+      }
     },
     {
       "id": "api-schema:CpuidRegisterModifier",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API schema CpuidRegisterModifier.",
+      "summary": "Reject the complete x86_64-only CPUID register/bitmap schema as a fixed value-free malformed arm64 request before runtime state or backend construction.",
       "source_refs": [
         "api-schema:CpuidRegisterModifier"
       ],
-      "disposition": "audit-required"
+      "disposition": "proven-platform-impossible",
+      "exclusion": {
+        "upstream_contract": [
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/firecracker/swagger/firecracker.yaml#L1150-L1167"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs#L29-L48"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs#L70-L159"
+        }
+        ],
+        "platform_evidence": [
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_config_get_feature_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_sys_reg%28_%3A_%3A_%3A%29"
+        }
+        ],
+        "alternatives": [
+          "Accepting and silently ignoring CPUID or MSR input would report success without enforcing the requested guest CPU contract.",
+          "Mapping x86 CPUID leaves or model-specific registers into ARM system registers would change architecture, selector, width, and bitmap semantics.",
+          "Running an x86 emulator, Linux KVM sidecar, or different host backend would leave Bangbang's native macOS arm64/HVF target and one-process VM boundary."
+        ],
+        "stable_behavior": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "validate_cpu_config_json_shape and RequestError::MalformedRequest"
+        }
+        ],
+        "focused_tests": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "rejects_complete_x86_cpu_config_shapes_without_retaining_values"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable_configures_vm_before_start x86 shape cases"
+        }
+        ],
+        "compatibility_docs": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/cpu-template-contract.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "X86 CPUID/MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "docs/firecracker-compatibility.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        }
+        ],
+        "security_docs": [
+        {
+          "kind": "local",
+          "path": "docs/security.md",
+          "anchor": "X86 CPUID and MSR request values"
+        }
+        ],
+        "challenge": {
+          "kind": "github",
+          "url": "https://github.com/seven332/bangbang/issues/1784#issuecomment-5161129449"
+        }
+      }
     },
     {
       "id": "api-schema:Drive",
@@ -8343,47 +9987,267 @@
     {
       "id": "api-schema:Error",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API schema Error.",
+      "summary": "Emit deterministic JSON error objects containing the Firecracker-shaped fault_message property for parser, route, state, resource, backend, and payload-limit failures.",
       "source_refs": [
         "api-schema:Error"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-schema:FirecrackerVersion",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API schema FirecrackerVersion.",
+      "summary": "Emit the exact required firecracker_version JSON object for the running Bangbang build.",
       "source_refs": [
         "api-schema:FirecrackerVersion"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-schema:FullVmConfiguration",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API schema FullVmConfiguration.",
+      "summary": "Emit deterministic supported optional sections of Firecracker's no-required-property FullVmConfiguration schema; logger and metrics properties retain their separate Wave 7 owners.",
       "source_refs": [
         "api-schema:FullVmConfiguration"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-schema:InstanceActionInfo",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API schema InstanceActionInfo.",
+      "summary": "Parse a strict deny-unknown-fields object containing the required Firecracker action_type and preserve action/state failure atomicity.",
       "source_refs": [
         "api-schema:InstanceActionInfo"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-schema:InstanceInfo",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API schema InstanceInfo.",
+      "summary": "Emit all four required Firecracker instance-information fields from immutable identity/version inputs and committed process-owned state.",
       "source_refs": [
         "api-schema:InstanceInfo"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "api-schema:Logger",
@@ -8697,11 +10561,93 @@
     {
       "id": "api-schema:MsrModifier",
       "family": "api-contract",
-      "summary": "Audit the Firecracker v1.16 API schema MsrModifier.",
+      "summary": "Reject the complete x86_64-only model-specific-register address/bitmap schema as a fixed value-free malformed arm64 request before runtime state or backend construction.",
       "source_refs": [
         "api-schema:MsrModifier"
       ],
-      "disposition": "audit-required"
+      "disposition": "proven-platform-impossible",
+      "exclusion": {
+        "upstream_contract": [
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/firecracker/swagger/firecracker.yaml#L1169-L1185"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs#L29-L48"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs#L70-L159"
+        }
+        ],
+        "platform_evidence": [
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_config_get_feature_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_reg%28_%3A_%3A_%3A%29"
+        },
+        {
+          "kind": "authoritative",
+          "url": "https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_sys_reg%28_%3A_%3A_%3A%29"
+        }
+        ],
+        "alternatives": [
+          "Accepting and silently ignoring CPUID or MSR input would report success without enforcing the requested guest CPU contract.",
+          "Mapping x86 CPUID leaves or model-specific registers into ARM system registers would change architecture, selector, width, and bitmap semantics.",
+          "Running an x86 emulator, Linux KVM sidecar, or different host backend would leave Bangbang's native macOS arm64/HVF target and one-process VM boundary."
+        ],
+        "stable_behavior": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "validate_cpu_config_json_shape and RequestError::MalformedRequest"
+        }
+        ],
+        "focused_tests": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "rejects_complete_x86_cpu_config_shapes_without_retaining_values"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable_configures_vm_before_start x86 shape cases"
+        }
+        ],
+        "compatibility_docs": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/cpu-template-contract.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "X86 CPUID/MSR platform boundary"
+        },
+        {
+          "kind": "local",
+          "path": "docs/firecracker-compatibility.md",
+          "anchor": "X86 CPUID and MSR platform boundary"
+        }
+        ],
+        "security_docs": [
+        {
+          "kind": "local",
+          "path": "docs/security.md",
+          "anchor": "X86 CPUID and MSR request values"
+        }
+        ],
+        "challenge": {
+          "kind": "github",
+          "url": "https://github.com/seven332/bangbang/issues/1784#issuecomment-5161129449"
+        }
+      }
     },
     {
       "id": "api-schema:NetworkInterface",
@@ -9352,11 +11298,55 @@
     {
       "id": "corpus:actions-api",
       "family": "api-contract",
-      "summary": "Audit all applicable capability claims owned by the pinned actions-api source corpus.",
+      "summary": "Implement and verify the applicable pinned actions API: strict action schema, synchronous InstanceStart and FlushMetrics, aarch64 SendCtrlAltDel rejection, state admission, fixed faults, and failure atomicity.",
       "source_refs": [
         "corpus:actions-api"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "corpus:ballooning",
@@ -13016,12 +15006,56 @@
     {
       "id": "semantic.specification:api-availability-stability-and-failure-information",
       "family": "specifications",
-      "summary": "Audit applicable API availability, stability, request/failure information, startup, and operational specification outcomes.",
+      "summary": "Keep the owner-only API socket available while the control loop lives; provide strict request, response, state, survival, and value-safe failure behavior with signed lifecycle evidence, while logger, formal, performance, telemetry, and Wave 8 interaction claims retain their exact downstream owners.",
       "source_refs": [
         "corpus:formal-verification",
         "corpus:specification"
       ],
-      "disposition": "audit-required"
+      "disposition": "implemented-and-verified",
+      "implementation": [
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core Firecracker API request and response model"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API dispatch and state-aware response handling"
+        },
+        {
+          "kind": "local",
+          "path": "crates/runtime/src/lib.rs",
+          "anchor": "InstanceInfo, VmmAction, and full configuration state"
+        }
+      ],
+      "validation": [
+        {
+          "kind": "local",
+          "path": "compat/firecracker/v1.16.0/observability-tools-specification-contract.md",
+          "anchor": "Core API certification"
+        },
+        {
+          "kind": "local",
+          "path": "crates/api/src/http.rs",
+          "anchor": "core instance, version, configuration, action, route, and fault tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/src/api_server.rs",
+          "anchor": "core API controller and Unix socket tests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/executable_hvf_e2e.rs",
+          "anchor": "signed_executable_runs_and_pauses_two_isolated_public_smp_guests"
+        },
+        {
+          "kind": "local",
+          "path": "crates/bangbang/tests/process_e2e.rs",
+          "anchor": "executable API success, malformed input, method/path, state, and redaction tests"
+        }
+      ]
     },
     {
       "id": "semantic.specification:performance-resource-and-telemetry-outcomes",

--- a/compat/firecracker/v1.16.0/cpu-template-contract.md
+++ b/compat/firecracker/v1.16.0/cpu-template-contract.md
@@ -19,9 +19,10 @@ The implementation deliberately separates three outcomes:
 
 The Firecracker-shaped arm64 `CpuConfig` schema, PUT operation/path, startup
 property, and ARM modifier properties now have a complete finite policy. The
-x86 CPUID/MSR leaves, whole CPU-template corpora, heterogeneous-fleet outcomes,
-and public dump/strip/verify/fingerprint helper remain nonterminal Wave 7 work;
-terminal arm64 request handling does not claim those independent contracts.
+x86 CPUID/MSR leaves have a separate terminal platform-exclusion policy. Whole
+CPU-template corpora, heterogeneous-fleet outcomes, and the public
+dump/strip/verify/fingerprint helper remain nonterminal Wave 7 work; neither
+terminal architecture boundary claims those independent contracts.
 
 ## Request model and bounds
 
@@ -52,6 +53,27 @@ All input and executable aggregates have manual value-redacted `Debug`
 implementations. Structurally valid but unavailable KVM-only categories cross
 the runtime action boundary only long enough to return their fixed platform
 classification; they are never installed as effective controller state.
+
+## X86 CPUID and MSR platform boundary
+
+Firecracker's `cpuid_modifiers`, `msr_modifiers`, `CpuidLeafModifier`,
+`CpuidRegisterModifier`, and `MsrModifier` identities describe executable
+x86_64 CPU state. The pinned arm64 model rejects those fields as foreign
+architecture input, while public Apple Silicon Hypervisor.framework exposes
+ARM general, system, and feature registers rather than an identity-preserving
+x86 CPUID-leaf or model-specific-register namespace.
+
+Bangbang therefore rejects every complete x86 CPUID or MSR request shape as a
+fixed malformed request before conversion, controller mutation, backend
+construction, or guest start. The response does not retain or expose a leaf,
+subleaf, flag, register, address, or bitmap value, and a rejected replacement
+leaves the prior CPU and VM configuration unchanged. Mapping x86 selectors to
+ARM registers would change the architecture and bitmap semantics; silently
+accepting them would falsely report enforcement; and an x86 emulator or
+Linux/KVM sidecar would leave the supported native macOS arm64/HVF process
+boundary. The exact 13-record proof, authoritative sources, rejected
+alternatives, and focused tests are checked by the
+[Wave 7 contract](observability-tools-specification-contract.md).
 
 ## Executable custom subset
 

--- a/compat/firecracker/v1.16.0/machine-lifecycle-audit.md
+++ b/compat/firecracker/v1.16.0/machine-lifecycle-audit.md
@@ -62,7 +62,7 @@ validation. They move from `audit-required` to
 | --- | --- | --- |
 | Boot source (7) | `api-operation:PUT /boot-source`; `api-path:/boot-source`; `api-schema:BootSource`; `api-property:BootSource.boot_args`; `api-property:BootSource.initrd_path`; `api-property:BootSource.kernel_image_path`; `api-property:FullVmConfiguration.boot-source` | Strict API/config parsing, transactional retained authority, value-redacted faults, kernel/initrd/rootfs/argument loading, FDT publication, GET serialization, and signed public startup. |
 | Machine configuration (6) | `api-operation:GET /machine-config`; `api-operation:PUT /machine-config`; `api-operation:PATCH /machine-config`; `api-path:/machine-config`; `api-schema:MachineConfiguration`; `api-property:FullVmConfiguration.machine-config` | Defaults, replacement/partial update, target vCPU and configured-equals-realized memory bounds, SMT/static-template/dirty/exact-2M policy, state admission, serialization, and failure-atomic balloon compatibility. |
-| CPU configuration (2) | `api-operation:PUT /cpu-config`; `api-path:/cpu-config` | The already-terminal `CpuConfig` arm64 schema, finite reviewed modifier execution on every vCPU, transactional replacement, value redaction, and stable outcomes for KVM/static/non-executable categories. X86 CPUID/MSR leaves remain separate Wave 7 audit work. |
+| CPU configuration (2) | `api-operation:PUT /cpu-config`; `api-path:/cpu-config` | The already-terminal `CpuConfig` arm64 schema, finite reviewed modifier execution on every vCPU, transactional replacement, value redaction, and stable outcomes for KVM/static/non-executable categories. The 13 x86 CPUID/MSR identities now have separate checked platform exclusions. |
 | VM state (3) | `api-path:/vm`; `api-schema:Vm`; `api-property:Vm.state` | The already-terminal PATCH operation is the path's only operation; Paused/Resumed parsing, idempotent process-owned topology-wide transitions, errors, latency, and signed SMP isolation are covered. |
 
 The public boot-source configuration is not an internal placeholder: the same
@@ -77,7 +77,7 @@ The directly reviewed identities and their current downstream boundaries are:
 
 | Boundary | Exact identities | Final disposition or owner |
 | --- | --- | --- |
-| Exported configuration | `api-operation:GET /vm/config`; `api-path:/vm/config`; `api-schema:FullVmConfiguration` | `audit-required`; Wave 8 owns final cross-capability certification after every exported device field has a terminal result. |
+| Exported configuration | `api-operation:GET /vm/config`; `api-path:/vm/config`; `api-schema:FullVmConfiguration` | `implemented-and-verified`; strict bodyless routing and deterministic serialization of the supported optional configuration are terminal under the [Wave 7 contract](observability-tools-specification-contract.md). The optional `.logger` and `.metrics` properties retain their #1786/#1787 owners, and Wave 8 retains only the final cross-capability interaction semantic. |
 | Snapshot create API leaves | `api-operation:PUT /snapshot/create`; `api-path:/snapshot/create`; `api-schema:SnapshotCreateParams`; `api-property:SnapshotCreateParams.snapshot_type`; `api-property:SnapshotCreateParams.snapshot_path`; `api-property:SnapshotCreateParams.mem_file_path` | `implemented-and-verified`; strict paused-only Full/Diff parsing and the two-output public transaction have portable, signed real-HVF, ordinary-production, and App Sandbox evidence. |
 | Snapshot load aggregates | `api-operation:PUT /snapshot/load`; `api-path:/snapshot/load`; `api-schema:SnapshotLoadParams` | `implemented-and-verified`; the strict schema, frozen native-v1 File/Uffd and native-v2 2.3–2.13 File/COW dispatch, Paused-first lifecycle, authority, failure, and mechanism boundaries are closed by the [Wave 6 snapshot contract](snapshot-wave6-contract.md). |
 | Snapshot semantics | `semantic.snapshot:full-create-load-and-public-lifecycle` | `implemented-and-verified`; the public lineage advances from device-free native-v2 2.3 through exact 2.12 Full with all 64 optional-device products, while exact 2.13 Diff adds mandatory base/selection/result kind 14 and retains all earlier readers. Zero-root and matching rebased results load through direct, contained, ordinary-production, and App Sandbox boundaries. |
@@ -87,7 +87,8 @@ The directly reviewed identities and their current downstream boundaries are:
 | Mixed snapshot aggregates | `semantic.snapshot:diff-dirty-tracking-and-memory-backends`; `corpus:snapshot-versioning` | `implemented-and-verified`; the exact Diff/rebase, frozen external-pager, version ladder, mechanism exclusions, and bounded portability evidence compose in the Wave 6 ledger. |
 | Snapshot composition | `semantic.snapshot:multi-vcpu-drives-devices-and-mmds` | `implemented-and-verified`; Full 2.12 and Diff 2.13 close all 64 optional-device MMIO/PCI products, exact complete-set external drive restoration, tools, recapture, and direct/contained production evidence. Firecracker v1.16 has no per-drive load-override field. |
 | Snapshot tracking leaves | `api-property:SnapshotLoadParams.enable_diff_snapshots`; `api-property:SnapshotLoadParams.track_dirty_pages` | Already `implemented-and-verified`; they select complete destination dirty tracking and compose with the separately certified exact-2.13 create/rebase boundary. |
-| Broad specifications | `corpus:specification`; `semantic.specification:api-availability-stability-and-failure-information`; `semantic.specification:performance-resource-and-telemetry-outcomes` | `audit-required`; applicable repository-wide outcomes remain Wave 7 work after their producers stabilize. |
+| Core API specification | `semantic.specification:api-availability-stability-and-failure-information` | `implemented-and-verified`; socket/control-loop availability, strict request/response/state behavior, process survival, value-safe failures, and the signed lifecycle are terminal under the [Wave 7 contract](observability-tools-specification-contract.md). Comprehensive failure logging, formal proof, numeric performance/telemetry outcomes, and final cross-capability interactions remain explicitly separate. |
+| Broad specifications | `corpus:specification`; `semantic.specification:performance-resource-and-telemetry-outcomes` | `audit-required`; #1798 owns the applicable numeric startup, resource, performance, and telemetry outcomes after their producers stabilize. |
 | Cross-capability certification | `semantic.cross-capability:state-errors-metrics-security-and-snapshots` | `audit-required`; Wave 8 owns the final interaction audit after the individual lifecycle, error, telemetry, security, device, network, and snapshot producers stabilize. |
 | External isolation gates | `semantic.isolation:host-resource-authority-and-brokerage`; `semantic.isolation:jailer-seccomp-and-macos-containment-outcomes`; `semantic.isolation:multiprocess-concurrency-redaction-and-failure-atomicity` | Unchanged `missing-platform-feasible`; #1351 retains its independent external root, vmnet, credential, and deployment evidence gates. |
 
@@ -103,13 +104,15 @@ Those exact identities establish the following non-overlapping handoffs:
   distinct-host success pair remain explicit nonclaims rather than pending
   implementations; #1491 owns explicit future CPU/host/fleet pairs.
 - Wave 7 owns `cpu-template-helper`, host-side kernel/rootfs construction,
-  heterogeneous-fleet CPU-template outcomes, and applicable repository-wide
-  specification outcomes after producers stabilize.
-- Wave 8 owns final cross-capability certification of `GET /vm/config`,
-  `api-path:/vm/config`, and `api-schema:FullVmConfiguration`. Their terminal
-  boot, machine, and CPU properties do not certify unrelated device fields;
-  `semantic.cross-capability:state-errors-metrics-security-and-snapshots`
-  remains part of the same final interaction gate.
+  heterogeneous-fleet CPU-template outcomes, and the remaining applicable
+  repository-wide performance, resource, telemetry, and corpus outcomes after
+  producers stabilize. The core API and architecture-specific x86 boundary
+  are closed by the checked Wave 7 contract.
+- Wave 8 owns only
+  `semantic.cross-capability:state-errors-metrics-security-and-snapshots`, the
+  final interaction audit. Terminal `GET /vm/config`, path, and schema claims
+  remain bounded to deterministic export of supported optional fields and do
+  not certify unrelated logger, metrics, device, or cross-capability behavior.
 - #1351 retains only its independent external root/vmnet evidence gates. This
   audit does not change those records or their public behavior.
 

--- a/compat/firecracker/v1.16.0/observability-tools-specification-contract.md
+++ b/compat/firecracker/v1.16.0/observability-tools-specification-contract.md
@@ -1,0 +1,216 @@
+# Firecracker v1.16.0 observability, tools, and specification contract
+
+This is the checked ownership and evidence ledger for Wave 7 parent
+[#1491](https://github.com/seven332/bangbang/issues/1491). It is pinned to
+Firecracker v1.16.0 commit
+`d83d72b710361a10294480131377b1b00b163af8` and Bangbang's supported macOS
+arm64/Hypervisor.framework target.
+
+The starting boundary is exact: 93 records belong to #1491 and nine records
+remain named #1373, #1378, or Wave 8 handoffs. Ownership is stable even as an
+owning child changes its rows from `audit-required` to a supported terminal
+disposition. Producer-only children #1785, #1788, and #1789 intentionally own
+no early disposition; their work feeds #1786, #1790, and #1799 respectively.
+
+## Evidence keys
+
+- **FC-API**: pinned
+  [`firecracker.yaml`](https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/firecracker/swagger/firecracker.yaml)
+  operations and schemas.
+- **FC-ACTIONS**: pinned strict
+  [action parser](https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/firecracker/src/api_server/request/actions.rs)
+  including the aarch64 `SendCtrlAltDel` rejection.
+- **FC-X86**: pinned
+  [x86 custom CPU-template implementation](https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/x86_64/custom_cpu_template.rs)
+  and Swagger's explicit x86-only CPUID/MSR descriptions.
+- **FC-ARM**: pinned arm64
+  [`CustomCpuTemplate`](https://github.com/firecracker-microvm/firecracker/blob/d83d72b710361a10294480131377b1b00b163af8/src/vmm/src/cpu_config/aarch64/custom_cpu_template.rs#L29-L48)
+  accepts only the arm64 fields and denies unknown architecture fields.
+- **APPLE-HVF**: public arm64 HVF exposes typed
+  [general-register](https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_reg%28_%3A_%3A_%3A%29),
+  [system-register](https://developer.apple.com/documentation/hypervisor/hv_vcpu_get_sys_reg%28_%3A_%3A_%3A%29),
+  and
+  [feature-register](https://developer.apple.com/documentation/hypervisor/hv_vcpu_config_get_feature_reg%28_%3A_%3A_%3A%29)
+  interfaces, not an x86 CPUID leaf/MSR namespace.
+- **LOCAL-API**: strict request/response types and routes in
+  `crates/api/src/{http,route}.rs`.
+- **LOCAL-DISPATCH**: Unix-socket handling and controller dispatch in
+  `crates/bangbang/src/api_server.rs`.
+- **LOCAL-STATE**: process-owned instance/action/configuration behavior in
+  `crates/runtime/src/lib.rs` and `crates/bangbang/src/vmm.rs`.
+- **FOCUSED**: API parser/response and controller tests in
+  `crates/api/src/http.rs` and `crates/bangbang/src/api_server.rs`.
+- **PROCESS**: real executable socket, malformed-route survival,
+  configuration, action, state, and redaction tests in
+  `crates/bangbang/tests/process_e2e.rs`.
+- **SIGNED**: signed real-HVF lifecycle in
+  `crates/bangbang/tests/executable_hvf_e2e.rs`, plus App Sandbox and production
+  API boundaries in the owning signed targets.
+
+## Core API certification
+
+The four operations expose Firecracker-shaped instance, version, optional
+full-configuration, and synchronous-action behavior. Bodyless GETs, exact
+method/path matching, strict action JSON, deterministic 200/204/400/413
+responses, fixed `fault_message` JSON, state admission, failure atomicity, and
+process survival are covered at the appropriate library/process/signed layers.
+The instance states are exactly `Not started`, `Running`, and `Paused`.
+
+`FullVmConfiguration` has no required properties in the pinned schema.
+Bangbang therefore implements deterministic supported-field export and
+optional omission while the separately tracked optional `.logger` and
+`.metrics` properties remain owned by #1786 and #1787. This schema result does
+not close the Wave 8 interaction semantic.
+
+The terminal API specification semantic is similarly bounded. It covers API
+socket availability while the process control loop is alive, strict
+request/response/state behavior, survival of malformed or external failures,
+value-safe failure information, and current signed lifecycle evidence. It does
+not claim comprehensive failure logging (#1786), formal proofs (#1797),
+numeric startup/resource/performance or telemetry outcomes (#1798), or final
+cross-capability interactions (Wave 8).
+
+## X86 CPUID/MSR platform boundary
+
+All 13 CPUID/MSR identities are executable x86_64 contracts. ARM register
+reinterpretation would change their architecture and bitmap semantics; an x86
+emulator or Linux/KVM sidecar would change the native backend and one-process
+boundary; silently accepting them would report success without enforcing the
+requested CPU state. None is an identity-preserving implementation on macOS
+arm64/HVF.
+
+Bangbang retains Firecracker's architecture-strict behavior: complete
+`cpuid_modifiers` or `msr_modifiers` shapes are rejected before conversion,
+runtime mutation, backend construction, or start. The response is the fixed
+malformed-request fault and contains no leaf, subleaf, flags, register,
+address, or bitmap value. The focused tests are
+`rejects_complete_x86_cpu_config_shapes_without_retaining_values` and the x86
+cases in `executable_configures_vm_before_start`.
+
+The current platform decision is the #1784
+[Plan Challenge](https://github.com/seven332/bangbang/issues/1784#issuecomment-5161129449).
+The existing arm64 `kvm_capabilities`, `vcpu_features`, and reviewed
+`reg_modifiers` behavior is unchanged; its own exact platform/safety outcomes
+remain in the CPU-template contract.
+
+## Exact #1491-owned ledger
+
+| Identity | Owner | Result after #1784 |
+| --- | --- | --- |
+| `api-operation:GET /` | #1784 | `implemented-and-verified` |
+| `api-operation:GET /version` | #1784 | `implemented-and-verified` |
+| `api-operation:GET /vm/config` | #1784 | `implemented-and-verified` |
+| `api-operation:PUT /actions` | #1784 | `implemented-and-verified` |
+| `api-path:/` | #1784 | `implemented-and-verified` |
+| `api-path:/actions` | #1784 | `implemented-and-verified` |
+| `api-path:/version` | #1784 | `implemented-and-verified` |
+| `api-path:/vm/config` | #1784 | `implemented-and-verified` |
+| `api-property:CpuConfig.cpuid_modifiers` | #1784 | `proven-platform-impossible` |
+| `api-property:CpuConfig.msr_modifiers` | #1784 | `proven-platform-impossible` |
+| `api-property:CpuidLeafModifier.flags` | #1784 | `proven-platform-impossible` |
+| `api-property:CpuidLeafModifier.leaf` | #1784 | `proven-platform-impossible` |
+| `api-property:CpuidLeafModifier.modifiers` | #1784 | `proven-platform-impossible` |
+| `api-property:CpuidLeafModifier.subleaf` | #1784 | `proven-platform-impossible` |
+| `api-property:CpuidRegisterModifier.bitmap` | #1784 | `proven-platform-impossible` |
+| `api-property:CpuidRegisterModifier.register` | #1784 | `proven-platform-impossible` |
+| `api-property:Error.fault_message` | #1784 | `implemented-and-verified` |
+| `api-property:FirecrackerVersion.firecracker_version` | #1784 | `implemented-and-verified` |
+| `api-property:InstanceActionInfo.action_type` | #1784 | `implemented-and-verified` |
+| `api-property:InstanceInfo.app_name` | #1784 | `implemented-and-verified` |
+| `api-property:InstanceInfo.id` | #1784 | `implemented-and-verified` |
+| `api-property:InstanceInfo.state` | #1784 | `implemented-and-verified` |
+| `api-property:InstanceInfo.vmm_version` | #1784 | `implemented-and-verified` |
+| `api-property:MsrModifier.addr` | #1784 | `proven-platform-impossible` |
+| `api-property:MsrModifier.bitmap` | #1784 | `proven-platform-impossible` |
+| `api-schema:CpuidLeafModifier` | #1784 | `proven-platform-impossible` |
+| `api-schema:CpuidRegisterModifier` | #1784 | `proven-platform-impossible` |
+| `api-schema:Error` | #1784 | `implemented-and-verified` |
+| `api-schema:FirecrackerVersion` | #1784 | `implemented-and-verified` |
+| `api-schema:FullVmConfiguration` | #1784 | `implemented-and-verified` |
+| `api-schema:InstanceActionInfo` | #1784 | `implemented-and-verified` |
+| `api-schema:InstanceInfo` | #1784 | `implemented-and-verified` |
+| `api-schema:MsrModifier` | #1784 | `proven-platform-impossible` |
+| `corpus:actions-api` | #1784 | `implemented-and-verified` |
+| `semantic.specification:api-availability-stability-and-failure-information` | #1784 | `implemented-and-verified` |
+| `api-operation:PUT /logger` | #1786 | `audit-required` |
+| `api-path:/logger` | #1786 | `audit-required` |
+| `api-property:FullVmConfiguration.logger` | #1786 | `audit-required` |
+| `api-property:Logger.level` | #1786 | `audit-required` |
+| `api-property:Logger.log_path` | #1786 | `audit-required` |
+| `api-property:Logger.module` | #1786 | `audit-required` |
+| `api-property:Logger.show_level` | #1786 | `audit-required` |
+| `api-property:Logger.show_log_origin` | #1786 | `audit-required` |
+| `api-schema:Logger` | #1786 | `audit-required` |
+| `corpus:logger` | #1786 | `audit-required` |
+| `semantic.observability:logger-delivery-filtering-loss-and-redaction` | #1786 | `audit-required` |
+| `api-operation:PUT /metrics` | #1787 | `audit-required` |
+| `api-path:/metrics` | #1787 | `audit-required` |
+| `api-property:FullVmConfiguration.metrics` | #1787 | `audit-required` |
+| `api-property:Metrics.metrics_path` | #1787 | `audit-required` |
+| `api-property:RateLimiter.bandwidth` | #1787 | `audit-required` |
+| `api-property:RateLimiter.ops` | #1787 | `audit-required` |
+| `api-property:TokenBucket.one_time_burst` | #1787 | `audit-required` |
+| `api-property:TokenBucket.refill_time` | #1787 | `audit-required` |
+| `api-property:TokenBucket.size` | #1787 | `audit-required` |
+| `api-schema:Metrics` | #1787 | `audit-required` |
+| `api-schema:RateLimiter` | #1787 | `audit-required` |
+| `api-schema:TokenBucket` | #1787 | `audit-required` |
+| `corpus:metrics` | #1790 | `audit-required` |
+| `semantic.observability:metrics-schema-producers-flush-and-lifecycle` | #1790 | `audit-required` |
+| `corpus:tracing` | #1791 | `audit-required` |
+| `tool-argument:cpu-template-helper/template/dump/config` | #1792 | `audit-required` |
+| `tool-argument:cpu-template-helper/template/dump/output` | #1792 | `audit-required` |
+| `tool-argument:cpu-template-helper/template/dump/template` | #1792 | `audit-required` |
+| `tool-argument:cpu-template-helper/template/verify/config` | #1792 | `audit-required` |
+| `tool-argument:cpu-template-helper/template/verify/template` | #1792 | `audit-required` |
+| `tool-operation:cpu-template-helper/template/dump` | #1792 | `audit-required` |
+| `tool-operation:cpu-template-helper/template/verify` | #1792 | `audit-required` |
+| `tool-argument:cpu-template-helper/template/strip/paths` | #1793 | `audit-required` |
+| `tool-argument:cpu-template-helper/template/strip/suffix` | #1793 | `audit-required` |
+| `tool-operation:cpu-template-helper/template/strip` | #1793 | `audit-required` |
+| `tool-argument:cpu-template-helper/fingerprint/compare/curr` | #1794 | `audit-required` |
+| `tool-argument:cpu-template-helper/fingerprint/compare/filters` | #1794 | `audit-required` |
+| `tool-argument:cpu-template-helper/fingerprint/compare/prev` | #1794 | `audit-required` |
+| `tool-argument:cpu-template-helper/fingerprint/dump/config` | #1794 | `audit-required` |
+| `tool-argument:cpu-template-helper/fingerprint/dump/output` | #1794 | `audit-required` |
+| `tool-argument:cpu-template-helper/fingerprint/dump/template` | #1794 | `audit-required` |
+| `tool-operation:cpu-template-helper/fingerprint/compare` | #1794 | `audit-required` |
+| `tool-operation:cpu-template-helper/fingerprint/dump` | #1794 | `audit-required` |
+| `corpus:cpu-template-helper` | #1795 | `audit-required` |
+| `corpus:cpu-templates` | #1795 | `audit-required` |
+| `semantic.cpu:configuration-templates-and-feature-state` | #1795 | `audit-required` |
+| `corpus:getting-started` | #1796 | `audit-required` |
+| `corpus:rootfs-and-kernel` | #1796 | `audit-required` |
+| `corpus:formal-verification` | #1797 | `audit-required` |
+| `corpus:network-performance` | #1798 | `audit-required` |
+| `corpus:specification` | #1798 | `audit-required` |
+| `semantic.specification:performance-resource-and-telemetry-outcomes` | #1798 | `audit-required` |
+| `corpus:design` | #1799 | `audit-required` |
+| `corpus:device-api` | #1799 | `audit-required` |
+| `corpus:release-changelog` | #1799 | `audit-required` |
+| `semantic.tools:packaging-help-errors-and-applicable-operations` | #1799 | `audit-required` |
+| `semantic.transport:virtio-mmio-activation` | #1799 | `audit-required` |
+
+## Exact retained handoffs
+
+| Identity | Retained owner | Current disposition |
+| --- | --- | --- |
+| `corpus:jailer` | #1373 | `audit-required` |
+| `corpus:production-host` | #1373 | `audit-required` |
+| `tool-argument:jailer/chroot-base-dir` | #1373 | `audit-required` |
+| `tool-argument:jailer/gid` | #1373 | `audit-required` |
+| `tool-argument:jailer/uid` | #1373 | `audit-required` |
+| `tool-operation:jailer/run` | #1373 | `audit-required` |
+| `corpus:network-setup` | #1378 | `audit-required` |
+| `semantic.network:virtio-net-vmnet-policy-and-connectivity` | #1378 | `audit-required` |
+| `semantic.cross-capability:state-errors-metrics-security-and-snapshots` | Wave 8 | `audit-required` |
+
+## Disposition accounting
+
+#1784 moves 22 rows to `implemented-and-verified` and 13 rows to
+`proven-platform-impossible`. The post-#1784 inventory is therefore exactly
+318 implemented, 67 audit-required, three missing-platform-feasible, and 30
+proven-platform-impossible. If every other #1491-owned row later becomes
+implemented while the nine handoffs remain, the prospective Wave 7 endpoint
+is 376/9/3/30. These are exact consequences of the current row set, not quotas;
+the authoritative current totals remain derived from `capabilities.json`.

--- a/crates/api/src/http.rs
+++ b/crates/api/src/http.rs
@@ -7476,6 +7476,33 @@ mod tests {
     }
 
     #[test]
+    fn rejects_complete_x86_cpu_config_shapes_without_retaining_values() {
+        const CPUID: &str = r#"{"cpuid_modifiers":[{"leaf":"0x4a11cafe","subleaf":"0x1badb002","flags":1432778632,"modifiers":[{"register":"edx","bitmap":"0b10100101101001011010010110100101"}]}]}"#;
+        const MSR: &str = r#"{"msr_modifiers":[{"addr":"0x5eedc0de","bitmap":"0b1010010110100101101001011010010110100101101001011010010110100101"}]}"#;
+        const COMBINED: &str = r#"{"cpuid_modifiers":[{"leaf":"0x4a11cafe","subleaf":"0x1badb002","flags":1432778632,"modifiers":[{"register":"edx","bitmap":"0b10100101101001011010010110100101"}]}],"msr_modifiers":[{"addr":"0x5eedc0de","bitmap":"0b1010010110100101101001011010010110100101101001011010010110100101"}]}"#;
+
+        for body in [CPUID, MSR, COMBINED] {
+            let result = parse_request(&request_with_body("PUT", "/cpu-config", body));
+
+            assert_eq!(result, Err(RequestError::MalformedRequest));
+            let diagnostic = format!("{:?}", result.expect_err("x86 shape must fail"));
+            for value in [
+                "4a11cafe",
+                "1badb002",
+                "1432778632",
+                "edx",
+                "5eedc0de",
+                "1010010110100101",
+            ] {
+                assert!(
+                    !diagnostic.contains(value),
+                    "fixed parser error must not retain x86 input values"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn rejects_duplicate_cpu_config_fields() {
         for body in [
             r#"{"kvm_capabilities":[],"kvm_capabilities":[]}"#,

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -2360,6 +2360,50 @@ fn executable_configures_vm_before_start() {
         "GET / after custom PUT /cpu-config",
     );
 
+    let vm_config_before_x86_requests = http_get(&socket_path, "/vm/config");
+    for (request_name, body) in [
+        (
+            "PUT /cpu-config x86 CPUID shape",
+            r#"{"cpuid_modifiers":[{"leaf":"0x4a11cafe","subleaf":"0x1badb002","flags":1432778632,"modifiers":[{"register":"edx","bitmap":"0b10100101101001011010010110100101"}]}]}"#,
+        ),
+        (
+            "PUT /cpu-config x86 MSR shape",
+            r#"{"msr_modifiers":[{"addr":"0x5eedc0de","bitmap":"0b1010010110100101101001011010010110100101101001011010010110100101"}]}"#,
+        ),
+    ] {
+        let response = http_put_json(&socket_path, "/cpu-config", body);
+        assert_bad_request_response(&response, request_name);
+        assert_response_contains(
+            &response,
+            r#"{"fault_message":"Malformed HTTP request."}"#,
+            request_name,
+        );
+        for value in [
+            "4a11cafe",
+            "1badb002",
+            "1432778632",
+            "edx",
+            "5eedc0de",
+            "1010010110100101",
+        ] {
+            assert!(
+                !response.contains(value),
+                "{request_name} response must not retain x86 input values"
+            );
+        }
+        let instance_info = http_get(&socket_path, "/");
+        assert_response_contains(
+            &instance_info,
+            r#""state":"Not started""#,
+            &format!("GET / after {request_name}"),
+        );
+        assert_eq!(
+            http_get(&socket_path, "/vm/config"),
+            vm_config_before_x86_requests,
+            "{request_name} must not mutate the exported VM configuration"
+        );
+    }
+
     let malformed_cpu_config_response = http_put_json(&socket_path, "/cpu-config", "not-json");
     assert_bad_request_response(&malformed_cpu_config_response, "PUT /cpu-config malformed");
     assert_response_contains(

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -313,6 +313,24 @@ Exact bounds, replacement/GET/snapshot behavior, expert-risk limits, signed
 evidence, and remaining Wave 7 helper/portability ownership are in the checked
 [CPU-template contract](../compat/firecracker/v1.16.0/cpu-template-contract.md).
 
+## X86 CPUID and MSR platform boundary
+
+Firecracker's CPUID leaf/register and MSR modifier schemas are executable
+x86_64 contracts, not architecture-neutral names for ARM state. The pinned
+arm64 implementation rejects those fields, and public Apple Silicon
+Hypervisor.framework has ARM general, system, and feature-register interfaces
+but no identity-preserving x86 CPUID-leaf or model-specific-register namespace.
+
+Complete `cpuid_modifiers` and `msr_modifiers` request shapes therefore receive
+the fixed malformed-request response before conversion, retained configuration,
+backend construction, or start. The response is value-free, the prior
+configuration and `Not started` state are unchanged, and no x86 selector is
+aliased to an ARM register. Silent acceptance would claim CPU state that was
+not enforced; emulation or a Linux/KVM sidecar would change Bangbang's native
+macOS arm64/HVF and one-process boundary. The checked
+[Wave 7 ownership and specification contract](../compat/firecracker/v1.16.0/observability-tools-specification-contract.md)
+records the exact 13 exclusions, evidence, alternatives, and focused tests.
+
 ## Internal Concurrent vCPU Run Coordination
 
 The ordered HVF topology is consumed by an internal concurrent
@@ -725,6 +743,14 @@ subjects; current API/CLI behavior remains here, snapshot format behavior
 remains in [Snapshot Feasibility](snapshot-feasibility.md), security and
 authority remain in [macOS Host Security Model](security.md), and validation
 commands remain in [Testing Guide](testing.md).
+
+The checked
+[Wave 7 ownership and specification contract](../compat/firecracker/v1.16.0/observability-tools-specification-contract.md)
+certifies the core API operation/path/schema set and its bounded API
+availability, stability, state, survival, and value-safe failure semantic. It
+also preserves the independent logger, metrics, tools, corpus, performance,
+formal-verification, and final cross-capability owners rather than promoting
+them through that aggregate result.
 
 Current global disposition totals are derived from `capabilities.json` and
 checked by the capability-audit tests. Human-readable documents deliberately

--- a/docs/security.md
+++ b/docs/security.md
@@ -2127,6 +2127,24 @@ Error messages for host file open failures should not echo configured host
 paths. Tests already cover this for several path surfaces, and new host path
 features should add resource-specific redaction and file-type tests.
 
+## X86 CPUID and MSR request values
+
+CPUID leaves, subleaves, flags, register names, MSR addresses, and modifier
+bitmaps are untrusted CPU-control values. On the supported macOS arm64/HVF
+target they have no identity-preserving execution namespace. Complete x86_64
+request shapes are rejected as malformed before conversion, retained
+configuration, backend construction, or start; the prior CPU configuration and
+VM state remain unchanged.
+
+The fixed failure response, product diagnostics, logs, metrics, and serial
+output must not include any submitted selector, address, or bitmap value.
+Mapping these values to ARM registers would create different architecture and
+bitmap semantics, silently ignoring them would falsely report enforcement, and
+delegating them to an emulator or Linux/KVM sidecar would cross the native
+backend and one-process trust boundary. The exact exclusion evidence and tests
+are recorded in the checked
+[Wave 7 contract](../compat/firecracker/v1.16.0/observability-tools-specification-contract.md).
+
 ## Aggregate Storage Trust and Capacity Boundary
 
 The #1471 direct and normal-production signed profiles compose Sync, portable

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1428,6 +1428,28 @@ documents may retain selected-family counts only when a focused test uses them
 as a closure invariant; do not copy global totals or delivery chronology into
 prose.
 
+### Wave 7 core API and ownership evidence
+
+The checked
+[Wave 7 ownership and specification contract](../compat/firecracker/v1.16.0/observability-tools-specification-contract.md)
+pins the exact #1491-owned set, retained handoffs, core API terminal set, and
+x86 CPUID/MSR exclusions. Changes to that boundary must run the focused ledger,
+strict full-shape request, and real-process nonmutation tests:
+
+```sh
+cargo test -p bangbang-firecracker-capability-audit --test checked_inventory wave_7_ownership_and_core_api_policy_is_stable --locked
+cargo test -p bangbang-api rejects_complete_x86_cpu_config_shapes_without_retaining_values --locked
+cargo test -p bangbang --test process_e2e executable_configures_vm_before_start --locked
+```
+
+The API test submits complete CPUID-only, MSR-only, and combined x86 shapes and
+requires one fixed value-free malformed result. The process case sends the same
+classes through the real Unix socket and proves the process survives, the
+instance remains `Not started`, and `GET /vm/config` is unchanged. The ledger
+test mechanically prevents dropped or double-owned rows and prevents the core
+API schema from absorbing the independently owned logger, metrics, performance,
+formal-verification, or Wave 8 interaction results.
+
 ### Snapshot Paging Evidence
 
 Changes to the frozen native-v1 Uffd reader, pager protocol, lazy-memory

--- a/tools/firecracker-capability-audit/tests/checked_inventory.rs
+++ b/tools/firecracker-capability-audit/tests/checked_inventory.rs
@@ -56,6 +56,396 @@ fn local_reference_paths(references: &[Reference]) -> Option<BTreeSet<&str>> {
 }
 
 #[test]
+fn wave_7_ownership_and_core_api_policy_is_stable() {
+    const CONTRACT_PATH: &str =
+        "compat/firecracker/v1.16.0/observability-tools-specification-contract.md";
+    const CHALLENGE_URL: &str =
+        "https://github.com/seven332/bangbang/issues/1784#issuecomment-5161129449";
+    const WAVE_7_OWNED: [(&str, &str); 93] = [
+        ("api-operation:GET /", "#1784"),
+        ("api-operation:GET /version", "#1784"),
+        ("api-operation:GET /vm/config", "#1784"),
+        ("api-operation:PUT /actions", "#1784"),
+        ("api-path:/", "#1784"),
+        ("api-path:/actions", "#1784"),
+        ("api-path:/version", "#1784"),
+        ("api-path:/vm/config", "#1784"),
+        ("api-property:CpuConfig.cpuid_modifiers", "#1784"),
+        ("api-property:CpuConfig.msr_modifiers", "#1784"),
+        ("api-property:CpuidLeafModifier.flags", "#1784"),
+        ("api-property:CpuidLeafModifier.leaf", "#1784"),
+        ("api-property:CpuidLeafModifier.modifiers", "#1784"),
+        ("api-property:CpuidLeafModifier.subleaf", "#1784"),
+        ("api-property:CpuidRegisterModifier.bitmap", "#1784"),
+        ("api-property:CpuidRegisterModifier.register", "#1784"),
+        ("api-property:Error.fault_message", "#1784"),
+        (
+            "api-property:FirecrackerVersion.firecracker_version",
+            "#1784",
+        ),
+        ("api-property:InstanceActionInfo.action_type", "#1784"),
+        ("api-property:InstanceInfo.app_name", "#1784"),
+        ("api-property:InstanceInfo.id", "#1784"),
+        ("api-property:InstanceInfo.state", "#1784"),
+        ("api-property:InstanceInfo.vmm_version", "#1784"),
+        ("api-property:MsrModifier.addr", "#1784"),
+        ("api-property:MsrModifier.bitmap", "#1784"),
+        ("api-schema:CpuidLeafModifier", "#1784"),
+        ("api-schema:CpuidRegisterModifier", "#1784"),
+        ("api-schema:Error", "#1784"),
+        ("api-schema:FirecrackerVersion", "#1784"),
+        ("api-schema:FullVmConfiguration", "#1784"),
+        ("api-schema:InstanceActionInfo", "#1784"),
+        ("api-schema:InstanceInfo", "#1784"),
+        ("api-schema:MsrModifier", "#1784"),
+        ("corpus:actions-api", "#1784"),
+        (
+            "semantic.specification:api-availability-stability-and-failure-information",
+            "#1784",
+        ),
+        ("api-operation:PUT /logger", "#1786"),
+        ("api-path:/logger", "#1786"),
+        ("api-property:FullVmConfiguration.logger", "#1786"),
+        ("api-property:Logger.level", "#1786"),
+        ("api-property:Logger.log_path", "#1786"),
+        ("api-property:Logger.module", "#1786"),
+        ("api-property:Logger.show_level", "#1786"),
+        ("api-property:Logger.show_log_origin", "#1786"),
+        ("api-schema:Logger", "#1786"),
+        ("corpus:logger", "#1786"),
+        (
+            "semantic.observability:logger-delivery-filtering-loss-and-redaction",
+            "#1786",
+        ),
+        ("api-operation:PUT /metrics", "#1787"),
+        ("api-path:/metrics", "#1787"),
+        ("api-property:FullVmConfiguration.metrics", "#1787"),
+        ("api-property:Metrics.metrics_path", "#1787"),
+        ("api-property:RateLimiter.bandwidth", "#1787"),
+        ("api-property:RateLimiter.ops", "#1787"),
+        ("api-property:TokenBucket.one_time_burst", "#1787"),
+        ("api-property:TokenBucket.refill_time", "#1787"),
+        ("api-property:TokenBucket.size", "#1787"),
+        ("api-schema:Metrics", "#1787"),
+        ("api-schema:RateLimiter", "#1787"),
+        ("api-schema:TokenBucket", "#1787"),
+        ("corpus:metrics", "#1790"),
+        (
+            "semantic.observability:metrics-schema-producers-flush-and-lifecycle",
+            "#1790",
+        ),
+        ("corpus:tracing", "#1791"),
+        (
+            "tool-argument:cpu-template-helper/template/dump/config",
+            "#1792",
+        ),
+        (
+            "tool-argument:cpu-template-helper/template/dump/output",
+            "#1792",
+        ),
+        (
+            "tool-argument:cpu-template-helper/template/dump/template",
+            "#1792",
+        ),
+        (
+            "tool-argument:cpu-template-helper/template/verify/config",
+            "#1792",
+        ),
+        (
+            "tool-argument:cpu-template-helper/template/verify/template",
+            "#1792",
+        ),
+        ("tool-operation:cpu-template-helper/template/dump", "#1792"),
+        (
+            "tool-operation:cpu-template-helper/template/verify",
+            "#1792",
+        ),
+        (
+            "tool-argument:cpu-template-helper/template/strip/paths",
+            "#1793",
+        ),
+        (
+            "tool-argument:cpu-template-helper/template/strip/suffix",
+            "#1793",
+        ),
+        ("tool-operation:cpu-template-helper/template/strip", "#1793"),
+        (
+            "tool-argument:cpu-template-helper/fingerprint/compare/curr",
+            "#1794",
+        ),
+        (
+            "tool-argument:cpu-template-helper/fingerprint/compare/filters",
+            "#1794",
+        ),
+        (
+            "tool-argument:cpu-template-helper/fingerprint/compare/prev",
+            "#1794",
+        ),
+        (
+            "tool-argument:cpu-template-helper/fingerprint/dump/config",
+            "#1794",
+        ),
+        (
+            "tool-argument:cpu-template-helper/fingerprint/dump/output",
+            "#1794",
+        ),
+        (
+            "tool-argument:cpu-template-helper/fingerprint/dump/template",
+            "#1794",
+        ),
+        (
+            "tool-operation:cpu-template-helper/fingerprint/compare",
+            "#1794",
+        ),
+        (
+            "tool-operation:cpu-template-helper/fingerprint/dump",
+            "#1794",
+        ),
+        ("corpus:cpu-template-helper", "#1795"),
+        ("corpus:cpu-templates", "#1795"),
+        (
+            "semantic.cpu:configuration-templates-and-feature-state",
+            "#1795",
+        ),
+        ("corpus:getting-started", "#1796"),
+        ("corpus:rootfs-and-kernel", "#1796"),
+        ("corpus:formal-verification", "#1797"),
+        ("corpus:network-performance", "#1798"),
+        ("corpus:specification", "#1798"),
+        (
+            "semantic.specification:performance-resource-and-telemetry-outcomes",
+            "#1798",
+        ),
+        ("corpus:design", "#1799"),
+        ("corpus:device-api", "#1799"),
+        ("corpus:release-changelog", "#1799"),
+        (
+            "semantic.tools:packaging-help-errors-and-applicable-operations",
+            "#1799",
+        ),
+        ("semantic.transport:virtio-mmio-activation", "#1799"),
+    ];
+    const RETAINED_HANDOFFS: [(&str, &str); 9] = [
+        ("corpus:jailer", "#1373"),
+        ("corpus:production-host", "#1373"),
+        ("tool-argument:jailer/chroot-base-dir", "#1373"),
+        ("tool-argument:jailer/gid", "#1373"),
+        ("tool-argument:jailer/uid", "#1373"),
+        ("tool-operation:jailer/run", "#1373"),
+        ("corpus:network-setup", "#1378"),
+        (
+            "semantic.network:virtio-net-vmnet-policy-and-connectivity",
+            "#1378",
+        ),
+        (
+            "semantic.cross-capability:state-errors-metrics-security-and-snapshots",
+            "Wave 8",
+        ),
+    ];
+    const CORE_IMPLEMENTED: [&str; 22] = [
+        "api-operation:GET /",
+        "api-operation:GET /version",
+        "api-operation:GET /vm/config",
+        "api-operation:PUT /actions",
+        "api-path:/",
+        "api-path:/actions",
+        "api-path:/version",
+        "api-path:/vm/config",
+        "api-property:Error.fault_message",
+        "api-property:FirecrackerVersion.firecracker_version",
+        "api-property:InstanceActionInfo.action_type",
+        "api-property:InstanceInfo.app_name",
+        "api-property:InstanceInfo.id",
+        "api-property:InstanceInfo.state",
+        "api-property:InstanceInfo.vmm_version",
+        "api-schema:Error",
+        "api-schema:FirecrackerVersion",
+        "api-schema:FullVmConfiguration",
+        "api-schema:InstanceActionInfo",
+        "api-schema:InstanceInfo",
+        "corpus:actions-api",
+        "semantic.specification:api-availability-stability-and-failure-information",
+    ];
+    const X86_IMPOSSIBLE: [&str; 13] = [
+        "api-property:CpuConfig.cpuid_modifiers",
+        "api-property:CpuConfig.msr_modifiers",
+        "api-property:CpuidLeafModifier.flags",
+        "api-property:CpuidLeafModifier.leaf",
+        "api-property:CpuidLeafModifier.modifiers",
+        "api-property:CpuidLeafModifier.subleaf",
+        "api-property:CpuidRegisterModifier.bitmap",
+        "api-property:CpuidRegisterModifier.register",
+        "api-property:MsrModifier.addr",
+        "api-property:MsrModifier.bitmap",
+        "api-schema:CpuidLeafModifier",
+        "api-schema:CpuidRegisterModifier",
+        "api-schema:MsrModifier",
+    ];
+
+    let repository_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|tools| tools.parent())
+        .expect("tool package must be nested under the repository tools directory")
+        .to_path_buf();
+    let inventory = read_capability_inventory(&repository_root.join(CAPABILITY_INVENTORY_PATH))
+        .expect("checked capability inventory must parse");
+    let by_id = inventory
+        .capabilities
+        .iter()
+        .map(|capability| (capability.id.as_str(), capability))
+        .collect::<BTreeMap<_, _>>();
+    let contract = std::fs::read_to_string(repository_root.join(CONTRACT_PATH))
+        .expect("Wave 7 contract must be readable");
+    let normalized_contract = contract.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    let owned = WAVE_7_OWNED
+        .iter()
+        .map(|(id, _)| *id)
+        .collect::<BTreeSet<_>>();
+    let handoffs = RETAINED_HANDOFFS
+        .iter()
+        .map(|(id, _)| *id)
+        .collect::<BTreeSet<_>>();
+    let implemented = CORE_IMPLEMENTED.into_iter().collect::<BTreeSet<_>>();
+    let impossible = X86_IMPOSSIBLE.into_iter().collect::<BTreeSet<_>>();
+
+    assert_eq!(owned.len(), 93, "Wave 7 owner identities must be unique");
+    assert_eq!(handoffs.len(), 9, "retained handoffs must be unique");
+    assert!(owned.is_disjoint(&handoffs));
+    assert_eq!(implemented.len(), 22);
+    assert_eq!(impossible.len(), 13);
+    assert!(implemented.is_disjoint(&impossible));
+    assert!(implemented.union(&impossible).all(|id| owned.contains(id)));
+
+    for (id, owner) in WAVE_7_OWNED.into_iter().chain(RETAINED_HANDOFFS) {
+        assert!(
+            by_id.contains_key(id),
+            "Wave 7 ledger identity must exist: {id}"
+        );
+        let prefix = format!("| `{id}` | {owner} |");
+        assert_eq!(
+            contract.matches(&prefix).count(),
+            1,
+            "Wave 7 contract must contain one exact owner row: {id}"
+        );
+    }
+
+    for id in &implemented {
+        let capability = by_id.get(id).expect("core API identity must exist");
+        assert_eq!(
+            capability.disposition,
+            Disposition::ImplementedAndVerified,
+            "core API identity must be terminal: {id}"
+        );
+        assert!(!capability.implementation.is_empty());
+        assert!(!capability.validation.is_empty());
+        assert!(capability.exclusion.is_none());
+        assert!(
+            contract.contains(&format!("| `{id}` | #1784 | `implemented-and-verified` |")),
+            "contract must record implemented result: {id}"
+        );
+    }
+
+    for id in &impossible {
+        let capability = by_id.get(id).expect("x86 identity must exist");
+        assert_eq!(capability.source_refs, [*id]);
+        assert_eq!(
+            capability.disposition,
+            Disposition::ProvenPlatformImpossible,
+            "x86 identity must retain terminal platform evidence: {id}"
+        );
+        let exclusion = capability
+            .exclusion
+            .as_ref()
+            .expect("x86 identity must retain exclusion evidence");
+        assert!(exclusion.upstream_contract.iter().any(|reference| matches!(
+            reference,
+            Reference::Authoritative { url } if url.contains("firecracker.yaml#L")
+        )));
+        assert!(exclusion.upstream_contract.iter().any(|reference| matches!(
+            reference,
+            Reference::Authoritative { url }
+                if url.contains("cpu_config/x86_64/custom_cpu_template.rs#L")
+        )));
+        assert!(
+            exclusion.platform_evidence.iter().all(|reference| matches!(
+                reference,
+                Reference::Authoritative { url } if url.starts_with("https://developer.apple.com/documentation/hypervisor/")
+            ))
+        );
+        assert!(exclusion.alternatives.len() >= 3);
+        assert_eq!(
+            local_reference_paths(&exclusion.stable_behavior),
+            Some(BTreeSet::from(["crates/api/src/http.rs"]))
+        );
+        assert_eq!(
+            local_reference_paths(&exclusion.focused_tests),
+            Some(BTreeSet::from([
+                "crates/api/src/http.rs",
+                "crates/bangbang/tests/process_e2e.rs",
+            ]))
+        );
+        assert!(
+            local_reference_paths(&exclusion.compatibility_docs)
+                .expect("x86 compatibility evidence must be local")
+                .contains(CONTRACT_PATH)
+        );
+        assert_eq!(
+            local_reference_paths(&exclusion.security_docs),
+            Some(BTreeSet::from(["docs/security.md"]))
+        );
+        assert_eq!(
+            exclusion.challenge,
+            Reference::Github {
+                url: CHALLENGE_URL.to_string()
+            }
+        );
+        assert!(capability.summary.contains("x86_64"));
+        assert!(capability.summary.contains("malformed"));
+        assert!(
+            contract.contains(&format!(
+                "| `{id}` | #1784 | `proven-platform-impossible` |"
+            )),
+            "contract must record platform result: {id}"
+        );
+    }
+
+    let selected = implemented
+        .union(&impossible)
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let expected_audit = owned
+        .difference(&selected)
+        .copied()
+        .chain(handoffs.iter().copied())
+        .collect::<BTreeSet<_>>();
+    let actual_audit = inventory
+        .capabilities
+        .iter()
+        .filter(|capability| capability.disposition == Disposition::AuditRequired)
+        .map(|capability| capability.id.as_str())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(actual_audit, expected_audit);
+    for id in &handoffs {
+        assert_eq!(
+            by_id.get(id).expect("handoff must exist").disposition,
+            Disposition::AuditRequired,
+            "external or Wave 8 handoff must not move: {id}"
+        );
+    }
+
+    assert!(normalized_contract.contains("Producer-only children #1785, #1788, and #1789"));
+    assert!(normalized_contract.contains("does not claim comprehensive failure logging (#1786)"));
+    assert!(
+        normalized_contract
+            .contains("numeric startup/resource/performance or telemetry outcomes (#1798)")
+    );
+    assert!(normalized_contract.contains("final cross-capability interactions (Wave 8)"));
+    assert!(normalized_contract.contains("318 implemented, 67 audit-required"));
+    assert!(normalized_contract.contains("376/9/3/30"));
+}
+
+#[test]
 fn snapshot_paging_terminal_policy_is_stable() {
     const CAPABILITY_ID: &str = "corpus:snapshot-page-faults";
 
@@ -516,10 +906,10 @@ fn snapshot_paging_terminal_policy_is_stable() {
             .filter(|capability| capability.disposition == disposition)
             .count()
     };
-    assert_eq!(count(Disposition::ImplementedAndVerified), 296);
-    assert_eq!(count(Disposition::AuditRequired), 102);
+    assert_eq!(count(Disposition::ImplementedAndVerified), 318);
+    assert_eq!(count(Disposition::AuditRequired), 67);
     assert_eq!(count(Disposition::MissingPlatformFeasible), 3);
-    assert_eq!(count(Disposition::ProvenPlatformImpossible), 17);
+    assert_eq!(count(Disposition::ProvenPlatformImpossible), 30);
 }
 
 #[test]
@@ -1246,10 +1636,10 @@ fn snapshot_wave6_terminal_policy_is_stable() {
             .filter(|capability| capability.disposition == disposition)
             .count()
     };
-    assert_eq!(count(Disposition::ImplementedAndVerified), 296);
-    assert_eq!(count(Disposition::AuditRequired), 102);
+    assert_eq!(count(Disposition::ImplementedAndVerified), 318);
+    assert_eq!(count(Disposition::AuditRequired), 67);
     assert_eq!(count(Disposition::MissingPlatformFeasible), 3);
-    assert_eq!(count(Disposition::ProvenPlatformImpossible), 17);
+    assert_eq!(count(Disposition::ProvenPlatformImpossible), 30);
 }
 
 #[test]
@@ -1543,10 +1933,10 @@ fn network_mmds_closure_policy_is_stable() {
             .filter(|capability| capability.disposition == disposition)
             .count()
     };
-    assert_eq!(count(Disposition::ImplementedAndVerified), 296);
-    assert_eq!(count(Disposition::AuditRequired), 102);
+    assert_eq!(count(Disposition::ImplementedAndVerified), 318);
+    assert_eq!(count(Disposition::AuditRequired), 67);
     assert_eq!(count(Disposition::MissingPlatformFeasible), 3);
-    assert_eq!(count(Disposition::ProvenPlatformImpossible), 17);
+    assert_eq!(count(Disposition::ProvenPlatformImpossible), 30);
 }
 
 #[test]
@@ -1692,10 +2082,10 @@ fn vsock_closure_policy_is_stable() {
             .filter(|capability| capability.disposition == disposition)
             .count()
     };
-    assert_eq!(count(Disposition::ImplementedAndVerified), 296);
-    assert_eq!(count(Disposition::AuditRequired), 102);
+    assert_eq!(count(Disposition::ImplementedAndVerified), 318);
+    assert_eq!(count(Disposition::AuditRequired), 67);
     assert_eq!(count(Disposition::MissingPlatformFeasible), 3);
-    assert_eq!(count(Disposition::ProvenPlatformImpossible), 17);
+    assert_eq!(count(Disposition::ProvenPlatformImpossible), 30);
 }
 
 #[test]
@@ -1962,10 +2352,10 @@ fn delivery_closure_policy_is_stable() {
             .filter(|capability| capability.disposition == disposition)
             .count()
     };
-    assert_eq!(count(Disposition::ImplementedAndVerified), 296);
-    assert_eq!(count(Disposition::AuditRequired), 102);
+    assert_eq!(count(Disposition::ImplementedAndVerified), 318);
+    assert_eq!(count(Disposition::AuditRequired), 67);
     assert_eq!(count(Disposition::MissingPlatformFeasible), 3);
-    assert_eq!(count(Disposition::ProvenPlatformImpossible), 17);
+    assert_eq!(count(Disposition::ProvenPlatformImpossible), 30);
 
     for id in IMPLEMENTED_ORIGINAL {
         assert_eq!(


### PR DESCRIPTION
## Summary

- add the checked 93-owned/9-handoff Wave 7 ledger and certify 22 core API records
- close 13 x86_64 CPUID/MSR identities as proven platform-impossible with authoritative upstream/HVF evidence and value-redacted full-shape tests
- preserve logger, metrics, tools, corpus, performance, formal-verification, and Wave 8 ownership while updating the exact inventory totals

## Scope

This PR changes evidence, tests, and compatibility documentation only. It does not change the production parser, runtime, or HVF backend. `FullVmConfiguration` is terminal only for its optional supported-field schema/export behavior; `.logger`, `.metrics`, and final cross-capability interactions remain with their named owners.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p bangbang-firecracker-capability-audit --all-targets --locked`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- compare --firecracker /Users/liangyou/github/firecracker`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo check -p bangbang-launcher --all-targets --all-features --locked --target aarch64-unknown-linux-musl`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five documented `aarch64-apple-darwin` signed-target Clippy gates with `-D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-integration-tests.sh`

Closes #1784
