### PR TITLE
feat: add panic and terminal observability

### DIFF
--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -481,20 +481,14 @@ fn process_terminal_category(
     result: &Result<(), ProcessError>,
     contained: Option<&ContainedSession>,
 ) -> ProcessTerminalCategory {
-    match result {
-        Ok(()) if contained.is_some_and(ContainedSession::was_cancelled) => {
-            ProcessTerminalCategory::Cancelled
+    match terminal_result(result, contained).0 {
+        bangbang_session::TerminalCategory::Success => ProcessTerminalCategory::Success,
+        bangbang_session::TerminalCategory::Configuration => ProcessTerminalCategory::Configuration,
+        bangbang_session::TerminalCategory::ProcessFailure
+        | bangbang_session::TerminalCategory::Unstructured => {
+            ProcessTerminalCategory::ProcessFailure
         }
-        Ok(()) => ProcessTerminalCategory::Success,
-        Err(error)
-            if matches!(
-                error.exit_code(),
-                ProcessExitCode::ArgumentParsing | ProcessExitCode::BadConfiguration
-            ) =>
-        {
-            ProcessTerminalCategory::Configuration
-        }
-        Err(_) => ProcessTerminalCategory::ProcessFailure,
+        bangbang_session::TerminalCategory::Cancelled => ProcessTerminalCategory::Cancelled,
     }
 }
 

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -21,6 +21,7 @@ mod grant_integration_probe;
 #[doc(hidden)]
 #[cfg(target_os = "macos")]
 pub mod host_network;
+mod panic_bridge;
 mod periodic_metrics;
 #[cfg(target_os = "macos")]
 mod snapshot_restore_resources;
@@ -57,7 +58,7 @@ use vmm::{
     ProcessVmnetAuthority, VmmRequestHandler,
 };
 
-use bangbang_runtime::logger::{LoggerConfigInput, LoggerLevel};
+use bangbang_runtime::logger::{LoggerConfigInput, LoggerLevel, ProcessTerminalCategory};
 use bangbang_runtime::metrics::{MetricsConfigInput, MetricsDiagnostics, SharedSignalMetrics};
 use bangbang_runtime::mmds::MmdsContentInput;
 use bangbang_runtime::snapshot_format::{
@@ -95,29 +96,65 @@ fn main() -> ExitCode {
             ExitCode::FAILURE
         };
     }
-    let mut contained = match ContainedSession::bootstrap() {
+    let bridge = panic_bridge::PanicBridge::install();
+    let mut contained = None;
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        run_process_lifecycle(&bridge, &mut contained)
+    }));
+    match outcome {
+        Ok(exit_code) => {
+            bridge.restore();
+            exit_code
+        }
+        Err(payload) => {
+            bridge.nudge_fallback();
+            panic_bridge::isolate_secondary_panic(|| {
+                if let Some(session) = contained.as_mut() {
+                    let _ = session.finish(
+                        bangbang_session::TerminalCategory::ProcessFailure,
+                        ProcessExitCode::ProcessFailure.value(),
+                    );
+                }
+            });
+            panic_bridge::isolate_secondary_panic(|| drop(contained.take()));
+            bridge.restore();
+            panic_bridge::resume_original(payload)
+        }
+    }
+}
+
+fn run_process_lifecycle(
+    bridge: &panic_bridge::PanicBridge,
+    contained: &mut Option<ContainedSession>,
+) -> ExitCode {
+    *contained = match ContainedSession::bootstrap() {
         Ok(contained) => contained,
         Err(err) => {
             eprintln!("bangbang: {err}");
             return ProcessExitCode::ProcessFailure.into_exit_code();
         }
     };
-    let result = run(&mut contained);
+    let result = run(bridge, contained);
     let (category, exit_code) = terminal_result(&result, contained.as_ref());
     if let Some(session) = contained.as_mut() {
         let _ = session.finish(category, exit_code);
     }
-    match result {
+    let exit_code = match result {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
             let exit_code = err.exit_code().into_exit_code();
             eprintln!("bangbang: {err}");
             exit_code
         }
-    }
+    };
+    drop(contained.take());
+    exit_code
 }
 
-fn run(contained: &mut Option<ContainedSession>) -> Result<(), ProcessError> {
+fn run(
+    bridge: &panic_bridge::PanicBridge,
+    contained: &mut Option<ContainedSession>,
+) -> Result<(), ProcessError> {
     let snapshot_cancellation = NativeV1SnapshotCaptureCancellation::default();
     let mut contained_shutdown = if let Some(session) = contained.as_mut() {
         let (reader, writer) = session
@@ -280,117 +317,133 @@ fn run(contained: &mut Option<ContainedSession>) -> Result<(), ProcessError> {
                 .with_contained_restore_authority(contained_restore_authority);
             #[cfg(not(target_os = "macos"))]
             let mut vmm = vmm;
-            apply_startup_metrics_config(&mut vmm, metrics_config)?;
-            if contained_shutdown_requested(contained)? {
-                return Ok(());
-            }
-            apply_startup_logger_config(&mut vmm, logger_config)?;
-            if contained_shutdown_requested(contained)? {
-                return Ok(());
-            }
-            apply_startup_metadata_with_authority(
-                &mut vmm,
-                metadata.as_deref(),
-                grant_authority.as_ref(),
-            )?;
-            if contained_shutdown_requested(contained)? {
-                return Ok(());
-            }
-            let _fatal_signal_handlers = FatalSignalHandlers::install()?;
-            let _sigpipe_signal_handler = SigpipeSignalHandler::install(signal_metrics)?;
-            if apply_startup_config_file_with_cancel(
-                &mut vmm,
-                config_file.as_deref(),
-                grant_authority.as_ref(),
-                || contained_shutdown_requested(contained),
-            )? {
-                return finish_process_with_terminal_metrics(&mut vmm, Ok(()));
-            }
-            let result = (|| {
-                let mut shutdown_signal = match contained_shutdown.take() {
-                    Some(signal) => signal,
-                    None => ShutdownSignal::install(snapshot_cancellation.clone())?,
-                };
-                if contained_shutdown_requested(contained)? {
-                    return Ok(());
-                }
-                if no_api {
-                    if let Some(session) = contained.as_mut() {
-                        session
-                            .send_ready(bangbang_session::Readiness::NoApi)
-                            .map_err(|_| ProcessError::ContainedSession)?;
+            let _ = bridge.attach(vmm.emergency_logger());
+            let execution = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let result = (|| {
+                    apply_startup_metrics_config(&mut vmm, metrics_config)?;
+                    if contained_shutdown_requested(contained)? {
+                        return Ok(());
                     }
-                    println!("status: VM running without API");
-                    let result = wait_for_no_api_shutdown(&mut shutdown_signal, &mut vmm);
-                    return result.and_then(|()| contained_wakeup_result(contained));
-                }
-
-                #[cfg(target_os = "macos")]
-                let (_anchored_api_guard, server) = {
-                    let claim = contained
-                        .as_ref()
-                        .and_then(ContainedSession::directory_grant_authority)
-                        .map(|authority| {
-                            authority.claim_socket_directory(
-                                std::path::Path::new(&api_sock),
-                                ResourceRole::ApiSocketDirectory,
-                            )
-                        })
-                        .transpose()
-                        .map_err(|_| ProcessError::ContainedSession)?
-                        .flatten();
-                    match claim {
-                        Some(claim) => {
-                            let namespace = contained
-                                .as_ref()
-                                .ok_or(ProcessError::ContainedSession)?
-                                .socket_namespace()
-                                .map_err(|_| ProcessError::ContainedSession)?
-                                .ok_or(ProcessError::ContainedSession)?;
-                            let socket = bind_anchored_socket(
-                                namespace,
-                                claim,
-                                ResourceRole::ApiSocketDirectory,
-                                None,
-                            )
-                            .map_err(|error| {
-                                ProcessError::ApiServer(ApiServerError::Anchored(error))
-                            })?;
-                            let (server, guard) =
-                                ApiServer::from_anchored(socket, http_api_max_payload_size);
-                            (Some(guard), server)
+                    apply_startup_logger_config(&mut vmm, logger_config)?;
+                    if contained_shutdown_requested(contained)? {
+                        return Ok(());
+                    }
+                    apply_startup_metadata_with_authority(
+                        &mut vmm,
+                        metadata.as_deref(),
+                        grant_authority.as_ref(),
+                    )?;
+                    if contained_shutdown_requested(contained)? {
+                        return Ok(());
+                    }
+                    let _fatal_signal_handlers = FatalSignalHandlers::install()?;
+                    let _sigpipe_signal_handler = SigpipeSignalHandler::install(signal_metrics)?;
+                    if apply_startup_config_file_with_cancel(
+                        &mut vmm,
+                        config_file.as_deref(),
+                        grant_authority.as_ref(),
+                        || contained_shutdown_requested(contained),
+                    )? {
+                        return Ok(());
+                    }
+                    (|| {
+                        let mut shutdown_signal = match contained_shutdown.take() {
+                            Some(signal) => signal,
+                            None => ShutdownSignal::install(snapshot_cancellation.clone())?,
+                        };
+                        if contained_shutdown_requested(contained)? {
+                            return Ok(());
                         }
-                        None => (
-                            None,
-                            ApiServer::bind_with_max_payload_size(
-                                &api_sock,
-                                http_api_max_payload_size,
-                            )
-                            .map_err(ProcessError::ApiServer)?,
-                        ),
-                    }
-                };
-                #[cfg(not(target_os = "macos"))]
-                let server =
-                    ApiServer::bind_with_max_payload_size(&api_sock, http_api_max_payload_size)
-                        .map_err(ProcessError::ApiServer)?;
-                if contained_shutdown_requested(contained)? {
-                    return Ok(());
-                }
-                if let Some(session) = contained.as_mut() {
-                    session
-                        .send_ready(bangbang_session::Readiness::Api)
-                        .map_err(|_| ProcessError::ContainedSession)?;
-                }
-                println!("status: API server listening");
-                let shutdown_wakeup = shutdown_signal.wakeup_reader();
-                server
-                    .run_until(&mut vmm, shutdown_wakeup)
-                    .map_err(ProcessError::ApiServer)
-                    .and_then(|()| contained_wakeup_result(contained))
-            })();
+                        if no_api {
+                            if let Some(session) = contained.as_mut() {
+                                session
+                                    .send_ready(bangbang_session::Readiness::NoApi)
+                                    .map_err(|_| ProcessError::ContainedSession)?;
+                            }
+                            println!("status: VM running without API");
+                            let result = wait_for_no_api_shutdown(&mut shutdown_signal, &mut vmm);
+                            return result.and_then(|()| contained_wakeup_result(contained));
+                        }
 
-            finish_process_with_terminal_metrics(&mut vmm, result)
+                        #[cfg(target_os = "macos")]
+                        let (_anchored_api_guard, server) = {
+                            let claim = contained
+                                .as_ref()
+                                .and_then(ContainedSession::directory_grant_authority)
+                                .map(|authority| {
+                                    authority.claim_socket_directory(
+                                        std::path::Path::new(&api_sock),
+                                        ResourceRole::ApiSocketDirectory,
+                                    )
+                                })
+                                .transpose()
+                                .map_err(|_| ProcessError::ContainedSession)?
+                                .flatten();
+                            match claim {
+                                Some(claim) => {
+                                    let namespace = contained
+                                        .as_ref()
+                                        .ok_or(ProcessError::ContainedSession)?
+                                        .socket_namespace()
+                                        .map_err(|_| ProcessError::ContainedSession)?
+                                        .ok_or(ProcessError::ContainedSession)?;
+                                    let socket = bind_anchored_socket(
+                                        namespace,
+                                        claim,
+                                        ResourceRole::ApiSocketDirectory,
+                                        None,
+                                    )
+                                    .map_err(|error| {
+                                        ProcessError::ApiServer(ApiServerError::Anchored(error))
+                                    })?;
+                                    let (server, guard) =
+                                        ApiServer::from_anchored(socket, http_api_max_payload_size);
+                                    (Some(guard), server)
+                                }
+                                None => (
+                                    None,
+                                    ApiServer::bind_with_max_payload_size(
+                                        &api_sock,
+                                        http_api_max_payload_size,
+                                    )
+                                    .map_err(ProcessError::ApiServer)?,
+                                ),
+                            }
+                        };
+                        #[cfg(not(target_os = "macos"))]
+                        let server = ApiServer::bind_with_max_payload_size(
+                            &api_sock,
+                            http_api_max_payload_size,
+                        )
+                        .map_err(ProcessError::ApiServer)?;
+                        if contained_shutdown_requested(contained)? {
+                            return Ok(());
+                        }
+                        if let Some(session) = contained.as_mut() {
+                            session
+                                .send_ready(bangbang_session::Readiness::Api)
+                                .map_err(|_| ProcessError::ContainedSession)?;
+                        }
+                        println!("status: API server listening");
+                        let shutdown_wakeup = shutdown_signal.wakeup_reader();
+                        server
+                            .run_until(&mut vmm, shutdown_wakeup)
+                            .map_err(ProcessError::ApiServer)
+                            .and_then(|()| contained_wakeup_result(contained))
+                    })()
+                })();
+                let category = process_terminal_category(&result, contained.as_ref());
+                finish_process_with_terminal_observability(&mut vmm, result, category)
+            }));
+            match execution {
+                Ok(result) => result,
+                Err(payload) => {
+                    panic_bridge::isolate_secondary_panic(|| {
+                        vmm.handle_terminal_observability(ProcessTerminalCategory::Panic);
+                    });
+                    panic_bridge::resume_original(payload)
+                }
+            }
         }
     }
 }
@@ -422,6 +475,27 @@ fn terminal_result(
     }
 }
 
+fn process_terminal_category(
+    result: &Result<(), ProcessError>,
+    contained: Option<&ContainedSession>,
+) -> ProcessTerminalCategory {
+    match result {
+        Ok(()) if contained.is_some_and(ContainedSession::was_cancelled) => {
+            ProcessTerminalCategory::Cancelled
+        }
+        Ok(()) => ProcessTerminalCategory::Success,
+        Err(error)
+            if matches!(
+                error.exit_code(),
+                ProcessExitCode::ArgumentParsing | ProcessExitCode::BadConfiguration
+            ) =>
+        {
+            ProcessTerminalCategory::Configuration
+        }
+        Err(_) => ProcessTerminalCategory::ProcessFailure,
+    }
+}
+
 fn contained_shutdown_requested(
     contained: &Option<ContainedSession>,
 ) -> Result<bool, ProcessError> {
@@ -435,14 +509,15 @@ fn contained_wakeup_result(contained: &Option<ContainedSession>) -> Result<(), P
     contained_shutdown_requested(contained).map(|_| ())
 }
 
-fn finish_process_with_terminal_metrics<S>(
+fn finish_process_with_terminal_observability<S>(
     vmm: &mut ProcessVmm<S>,
     result: Result<(), ProcessError>,
+    category: ProcessTerminalCategory,
 ) -> Result<(), ProcessError>
 where
     S: vmm::InstanceStartExecutor,
 {
-    vmm.handle_terminal_metrics_flush();
+    vmm.handle_terminal_observability(category);
     result
 }
 
@@ -2598,6 +2673,7 @@ mod tests {
     use bangbang_runtime::boot::BootSourceConfigInput;
     use bangbang_runtime::logger::{
         LoggerApiRoute, LoggerConfigError, LoggerConfigInput, LoggerHttpMethod, LoggerLevel,
+        ProcessTerminalCategory,
     };
     use bangbang_runtime::machine::{MAX_MEM_SIZE_MIB, MachineConfigError};
     use bangbang_runtime::memory::{
@@ -5030,7 +5106,7 @@ mod tests {
     }
 
     #[test]
-    fn terminal_metrics_drain_initial_preserve_server_error_and_do_not_duplicate() {
+    fn terminal_observability_drains_initial_preserves_error_and_is_idempotent() {
         let metrics_path = unique_metrics_path("server-error-final");
         let mut vmm = ProcessVmm::with_starter(
             "demo-1",
@@ -5053,7 +5129,11 @@ mod tests {
             ErrorKind::BrokenPipe,
         )));
         assert_eq!(
-            super::finish_process_with_terminal_metrics(&mut vmm, result),
+            super::finish_process_with_terminal_observability(
+                &mut vmm,
+                result,
+                ProcessTerminalCategory::ProcessFailure,
+            ),
             Err(ProcessError::ApiServer(ApiServerError::Accept(
                 ErrorKind::BrokenPipe
             )))
@@ -5066,7 +5146,11 @@ mod tests {
         );
 
         assert_eq!(
-            super::finish_process_with_terminal_metrics(&mut vmm, Ok(())),
+            super::finish_process_with_terminal_observability(
+                &mut vmm,
+                Ok(()),
+                ProcessTerminalCategory::Success,
+            ),
             Ok(())
         );
         assert_eq!(
@@ -5103,7 +5187,11 @@ mod tests {
             ErrorKind::BrokenPipe,
         )));
         assert_eq!(
-            super::finish_process_with_terminal_metrics(&mut vmm, result),
+            super::finish_process_with_terminal_observability(
+                &mut vmm,
+                result,
+                ProcessTerminalCategory::ProcessFailure,
+            ),
             Err(ProcessError::ApiServer(ApiServerError::Accept(
                 ErrorKind::BrokenPipe
             )))
@@ -5111,10 +5199,65 @@ mod tests {
         let _failed_final = metrics_fifo.drain_available();
 
         assert_eq!(
-            super::finish_process_with_terminal_metrics(&mut vmm, Ok(())),
+            super::finish_process_with_terminal_observability(
+                &mut vmm,
+                Ok(()),
+                ProcessTerminalCategory::Success,
+            ),
             Ok(())
         );
         assert_eq!(metrics_fifo.drain_available(), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn terminal_logger_failure_is_counted_before_final_metrics_and_preserves_result() {
+        let metrics_path = unique_metrics_path("terminal-logger-failure");
+        let mut logger_fifo = MetricsFifo::create("terminal-logger-failure");
+        let mut vmm = ProcessVmm::with_starter(
+            "demo-1",
+            env!("CARGO_PKG_VERSION"),
+            "bangbang",
+            TestInstanceStarter,
+        );
+        vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+            &metrics_path,
+        )))
+        .expect("metrics should configure");
+        vmm.handle_action(VmmAction::PutLogger(
+            LoggerConfigInput::new().with_log_path(logger_fifo.path()),
+        ))
+        .expect("logger should configure");
+        vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            "/tmp/vmlinux",
+        )))
+        .expect("boot source should configure");
+        vmm.handle_action(VmmAction::InstanceStart)
+            .expect("instance should start");
+        vmm.handle_initial_metrics_flush();
+        assert_eq!(logger_fifo.drain_available(), b"action=InstanceStart\n");
+        logger_fifo.fill_to_capacity();
+
+        let result = Err(ProcessError::ApiServer(ApiServerError::Accept(
+            ErrorKind::BrokenPipe,
+        )));
+        assert_eq!(
+            super::finish_process_with_terminal_observability(
+                &mut vmm,
+                result,
+                ProcessTerminalCategory::ProcessFailure,
+            ),
+            Err(ProcessError::ApiServer(ApiServerError::Accept(
+                ErrorKind::BrokenPipe
+            )))
+        );
+        assert_eq!(
+            fs::read_to_string(&metrics_path).expect("metrics output should be readable"),
+            concat!(
+                "{\"vmm\":{\"metrics_flush_count\":1}}\n",
+                "{\"logger\":{\"missed_log_count\":1},\"vmm\":{\"metrics_flush_count\":1}}\n",
+            )
+        );
+        fs::remove_file(metrics_path).expect("metrics fixture should clean up");
     }
 
     #[test]
@@ -5147,7 +5290,11 @@ mod tests {
 
         let result = super::wait_for_no_api_shutdown(&mut shutdown_signal, &mut vmm);
         assert_eq!(
-            super::finish_process_with_terminal_metrics(&mut vmm, result),
+            super::finish_process_with_terminal_observability(
+                &mut vmm,
+                result,
+                ProcessTerminalCategory::Success,
+            ),
             Ok(())
         );
         assert_eq!(
@@ -5187,7 +5334,11 @@ mod tests {
 
         let result = super::wait_for_no_api_shutdown(&mut shutdown_signal, &mut vmm);
         assert_eq!(
-            super::finish_process_with_terminal_metrics(&mut vmm, result),
+            super::finish_process_with_terminal_observability(
+                &mut vmm,
+                result,
+                ProcessTerminalCategory::ProcessFailure,
+            ),
             Err(super::ProcessError::ProcessSessionTerminal)
         );
         assert_eq!(

--- a/crates/bangbang/src/main.rs
+++ b/crates/bangbang/src/main.rs
@@ -318,6 +318,8 @@ fn run(
             #[cfg(not(target_os = "macos"))]
             let mut vmm = vmm;
             let _ = bridge.attach(vmm.emergency_logger());
+            let mut fatal_signal_handlers = None;
+            let mut sigpipe_signal_handler = None;
             let execution = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 let result = (|| {
                     apply_startup_metrics_config(&mut vmm, metrics_config)?;
@@ -336,8 +338,8 @@ fn run(
                     if contained_shutdown_requested(contained)? {
                         return Ok(());
                     }
-                    let _fatal_signal_handlers = FatalSignalHandlers::install()?;
-                    let _sigpipe_signal_handler = SigpipeSignalHandler::install(signal_metrics)?;
+                    fatal_signal_handlers = Some(FatalSignalHandlers::install()?);
+                    sigpipe_signal_handler = Some(SigpipeSignalHandler::install(signal_metrics)?);
                     if apply_startup_config_file_with_cancel(
                         &mut vmm,
                         config_file.as_deref(),

--- a/crates/bangbang/src/panic_bridge.rs
+++ b/crates/bangbang/src/panic_bridge.rs
@@ -1,0 +1,807 @@
+use std::any::Any;
+use std::fmt;
+use std::io::{self, Write};
+use std::panic::{self, AssertUnwindSafe, PanicHookInfo};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::thread::{self, Thread};
+use std::time::Duration;
+
+use bangbang_runtime::logger::{EmergencyLogger, PanicLogRecords};
+
+const FALLBACK_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const FALLBACK_ARMED: u8 = 0;
+const FALLBACK_PENDING: u8 = 1;
+const FALLBACK_CLAIMED: u8 = 2;
+const FALLBACK_CLOSED: u8 = 3;
+
+type PanicPayload = Box<dyn Any + Send + 'static>;
+type PanicHook = Box<dyn Fn(&PanicHookInfo<'_>) + Send + Sync + 'static>;
+
+struct FallbackIngress {
+    state: AtomicU8,
+    shutdown: AtomicBool,
+    records: PanicLogRecords,
+}
+
+impl fmt::Debug for FallbackIngress {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FallbackIngress")
+            .field("state", &self.state.load(Ordering::Relaxed))
+            .field("shutdown", &self.shutdown.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
+    }
+}
+
+impl FallbackIngress {
+    fn new(records: PanicLogRecords) -> Self {
+        Self {
+            state: AtomicU8::new(FALLBACK_ARMED),
+            shutdown: AtomicBool::new(false),
+            records,
+        }
+    }
+
+    /// Makes one publication attempt and never retries.
+    fn publish_once(&self) -> bool {
+        self.state
+            .compare_exchange(
+                FALLBACK_ARMED,
+                FALLBACK_PENDING,
+                Ordering::Release,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+    }
+
+    fn claim(&self) -> Option<&[u8]> {
+        self.state
+            .compare_exchange(
+                FALLBACK_PENDING,
+                FALLBACK_CLAIMED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .ok()?;
+        Some(self.records.plain_bytes())
+    }
+
+    fn close_if_idle(&self) -> bool {
+        match self.state.compare_exchange(
+            FALLBACK_ARMED,
+            FALLBACK_CLOSED,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => true,
+            Err(FALLBACK_CLAIMED | FALLBACK_CLOSED) => true,
+            Err(_) => false,
+        }
+    }
+
+    fn request_shutdown(&self) {
+        self.shutdown.store(true, Ordering::Release);
+    }
+
+    fn shutdown_requested(&self) -> bool {
+        self.shutdown.load(Ordering::Acquire)
+    }
+
+    fn force_close(&self) {
+        self.state.store(FALLBACK_CLOSED, Ordering::Release);
+    }
+}
+
+struct FallbackWorkerGuard(Arc<FallbackIngress>);
+
+impl Drop for FallbackWorkerGuard {
+    fn drop(&mut self) {
+        self.0.force_close();
+    }
+}
+
+struct FallbackWorker {
+    ingress: Arc<FallbackIngress>,
+    thread: Thread,
+}
+
+impl fmt::Debug for FallbackWorker {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FallbackWorker")
+            .field("ingress", &self.ingress)
+            .finish_non_exhaustive()
+    }
+}
+
+impl FallbackWorker {
+    fn spawn(writer: impl Write + Send + 'static) -> Result<Self, std::io::ErrorKind> {
+        let ingress = Arc::new(FallbackIngress::new(PanicLogRecords::new()));
+        let worker_ingress = ingress.clone();
+        let handle = thread::Builder::new()
+            .name("bangbang-panic-stderr".to_owned())
+            .spawn(move || run_fallback_worker(worker_ingress, writer))
+            .map_err(|error| error.kind())?;
+        let worker_thread = handle.thread().clone();
+        drop(handle);
+        Ok(Self {
+            ingress,
+            thread: worker_thread,
+        })
+    }
+
+    fn publish_once(&self) -> bool {
+        self.ingress.publish_once()
+    }
+
+    fn nudge(&self) {
+        self.thread.unpark();
+    }
+
+    fn shutdown(&self) {
+        self.ingress.request_shutdown();
+        self.thread.unpark();
+    }
+}
+
+fn run_fallback_worker(ingress: Arc<FallbackIngress>, mut writer: impl Write) {
+    let _guard = FallbackWorkerGuard(ingress.clone());
+    loop {
+        deliver_fallback(&mut writer, &ingress);
+        if ingress.shutdown_requested() {
+            while !ingress.close_if_idle() {
+                deliver_fallback(&mut writer, &ingress);
+                thread::yield_now();
+            }
+            return;
+        }
+        thread::park_timeout(FALLBACK_POLL_INTERVAL);
+    }
+}
+
+fn deliver_fallback(writer: &mut impl Write, ingress: &FallbackIngress) {
+    let Some(record) = ingress.claim() else {
+        return;
+    };
+    match writer.write(record) {
+        Ok(written) if written == record.len() => {
+            let _ = writer.flush();
+        }
+        Ok(_) | Err(_) => {}
+    }
+}
+
+struct PanicBridgeState {
+    first_panic_seen: AtomicBool,
+    emergency_logger: OnceLock<EmergencyLogger>,
+    fallback: Option<FallbackWorker>,
+}
+
+impl fmt::Debug for PanicBridgeState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PanicBridgeState")
+            .field(
+                "first_panic_seen",
+                &self.first_panic_seen.load(Ordering::Relaxed),
+            )
+            .field(
+                "emergency_logger_attached",
+                &self.emergency_logger.get().is_some(),
+            )
+            .field("fallback", &self.fallback)
+            .finish()
+    }
+}
+
+impl PanicBridgeState {
+    fn invoke(&self) {
+        if self.first_panic_seen.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        if self
+            .emergency_logger
+            .get()
+            .is_some_and(EmergencyLogger::try_log_panic)
+        {
+            return;
+        }
+        if let Some(fallback) = &self.fallback {
+            let _ = fallback.publish_once();
+        }
+    }
+
+    fn nudge_fallback(&self) {
+        if let Some(fallback) = &self.fallback {
+            fallback.nudge();
+        }
+    }
+
+    fn shutdown_fallback(&self) {
+        if let Some(fallback) = &self.fallback {
+            fallback.shutdown();
+        }
+    }
+}
+
+/// Executable-owned exclusive panic-hook interval.
+#[must_use = "the prior hook must be restored explicitly"]
+pub(crate) struct PanicBridge {
+    state: Arc<PanicBridgeState>,
+    prior_hook: PanicHook,
+}
+
+impl fmt::Debug for PanicBridge {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PanicBridge")
+            .field("state", &self.state)
+            .field("prior_hook", &"<retained>")
+            .finish()
+    }
+}
+
+impl PanicBridge {
+    pub(crate) fn install() -> Self {
+        Self::install_with_writer(io::stderr())
+    }
+
+    fn install_with_writer(writer: impl Write + Send + 'static) -> Self {
+        let fallback = FallbackWorker::spawn(writer).ok();
+        let state = Arc::new(PanicBridgeState {
+            first_panic_seen: AtomicBool::new(false),
+            emergency_logger: OnceLock::new(),
+            fallback,
+        });
+        let hook_state = state.clone();
+        let hook: PanicHook = Box::new(move |_info| hook_state.invoke());
+        let prior_hook = panic::take_hook();
+        panic::set_hook(hook);
+        Self { state, prior_hook }
+    }
+
+    pub(crate) fn attach(&self, logger: EmergencyLogger) -> bool {
+        self.state.emergency_logger.set(logger).is_ok()
+    }
+
+    pub(crate) fn nudge_fallback(&self) {
+        self.state.nudge_fallback();
+    }
+
+    pub(crate) fn restore(self) {
+        self.state.shutdown_fallback();
+        panic::set_hook(self.prior_hook);
+    }
+}
+
+/// Runs suspect cleanup without allowing a secondary payload to replace the original.
+pub(crate) fn isolate_secondary_panic(operation: impl FnOnce()) {
+    if let Err(payload) = panic::catch_unwind(AssertUnwindSafe(operation)) {
+        std::mem::forget(payload);
+    }
+}
+
+pub(crate) fn resume_original(payload: PanicPayload) -> ! {
+    panic::resume_unwind(payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::io::{Error, ErrorKind, Write};
+    use std::path::PathBuf;
+    use std::process::{Command, Output, Stdio};
+    use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+    use std::sync::{Arc, Condvar, Mutex};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+    use bangbang_runtime::VmmController;
+    use bangbang_runtime::logger::{
+        LoggerConfigInput, LoggerLevel, PanicLogRecords, ProcessTerminalCategory,
+    };
+
+    use super::{
+        FallbackIngress, PanicBridge, PanicBridgeState, deliver_fallback, isolate_secondary_panic,
+        resume_original,
+    };
+
+    const CHILD_CASE_ENV: &str = "BANGBANG_PANIC_BRIDGE_CHILD_CASE";
+    static NEXT_PATH_ID: AtomicU64 = AtomicU64::new(0);
+
+    #[derive(Debug)]
+    struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("shared output lock should succeed")
+                .extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingWriter;
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _bytes: &[u8]) -> std::io::Result<usize> {
+            Err(Error::from(ErrorKind::BrokenPipe))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct WriterGateState {
+        entered: bool,
+        released: bool,
+    }
+
+    #[derive(Debug, Default)]
+    struct WriterGate {
+        state: Mutex<WriterGateState>,
+        changed: Condvar,
+    }
+
+    impl WriterGate {
+        fn wait_until_entered(&self) {
+            let deadline = Instant::now() + Duration::from_secs(2);
+            let mut state = self.state.lock().expect("gate lock should succeed");
+            while !state.entered {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                assert!(!remaining.is_zero(), "fallback writer should enter");
+                let (next, timeout) = self
+                    .changed
+                    .wait_timeout(state, remaining)
+                    .expect("gate wait should succeed");
+                state = next;
+                assert!(!timeout.timed_out() || state.entered);
+            }
+        }
+
+        fn release(&self) {
+            self.state
+                .lock()
+                .expect("gate lock should succeed")
+                .released = true;
+            self.changed.notify_all();
+        }
+    }
+
+    #[derive(Debug)]
+    struct HeldWriter(Arc<WriterGate>);
+
+    impl Write for HeldWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            let mut state = self.0.state.lock().expect("gate lock should succeed");
+            state.entered = true;
+            self.0.changed.notify_all();
+            while !state.released {
+                state = self
+                    .0
+                    .changed
+                    .wait(state)
+                    .expect("gate wait should succeed");
+            }
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct SecretPayload(&'static str);
+
+    struct PanicOnDropPayload(Arc<AtomicUsize>);
+
+    impl Drop for PanicOnDropPayload {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::AcqRel);
+            panic!("secondary-destructor-secret");
+        }
+    }
+
+    fn unique_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should follow epoch")
+            .as_nanos();
+        let id = NEXT_PATH_ID.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "bangbang-panic-bridge-{}-{nanos}-{id}-{name}",
+            std::process::id()
+        ))
+    }
+
+    fn wait_for_output(output: &Arc<Mutex<Vec<u8>>>) -> bool {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while output
+            .lock()
+            .expect("output lock should succeed")
+            .is_empty()
+            && Instant::now() < deadline
+        {
+            std::thread::yield_now();
+        }
+        !output
+            .lock()
+            .expect("output lock should succeed")
+            .is_empty()
+    }
+
+    fn run_default_redaction_case() {
+        let harness_hook = std::panic::take_hook();
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let bridge = PanicBridge::install_with_writer(SharedWriter(output.clone()));
+        let payload = std::panic::catch_unwind(|| panic!("ordinary-secret-payload"))
+            .expect_err("panic should be caught");
+        bridge.nudge_fallback();
+        let delivered = wait_for_output(&output);
+        bridge.restore();
+        std::panic::set_hook(harness_hook);
+
+        assert!(delivered);
+        assert_eq!(
+            *payload
+                .downcast::<&'static str>()
+                .expect("original string payload should resume"),
+            "ordinary-secret-payload"
+        );
+        assert_eq!(
+            *output.lock().expect("output lock should succeed"),
+            b"event=process-panic\n"
+        );
+    }
+
+    fn run_sentinel_restore_case() {
+        let harness_hook = std::panic::take_hook();
+        let sentinel_hits = Arc::new(AtomicUsize::new(0));
+        let hook_hits = sentinel_hits.clone();
+        std::panic::set_hook(Box::new(move |_info| {
+            hook_hits.fetch_add(1, Ordering::AcqRel);
+        }));
+        let bridge = PanicBridge::install_with_writer(std::io::sink());
+        let expected = Arc::new(SecretPayload("custom-secret-payload"));
+        let thrown = expected.clone();
+        let payload = std::panic::catch_unwind(move || std::panic::panic_any(thrown))
+            .expect_err("custom panic should be caught");
+        let owned_hits = sentinel_hits.load(Ordering::Acquire);
+        let payload =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| resume_original(payload)))
+                .expect_err("resumed payload should unwind to the harness catch");
+        bridge.restore();
+        let _ = std::panic::catch_unwind(|| panic!("sentinel-probe"));
+        let restored_hits = sentinel_hits.load(Ordering::Acquire);
+        std::panic::set_hook(harness_hook);
+
+        let resumed = payload
+            .downcast::<Arc<SecretPayload>>()
+            .expect("custom payload should retain its type");
+        assert!(Arc::ptr_eq(&expected, &resumed));
+        assert_eq!(resumed.0, "custom-secret-payload");
+        assert_eq!(owned_hits, 0);
+        assert_eq!(restored_hits, 1);
+    }
+
+    fn run_attached_logger_case() {
+        let fallback = Arc::new(Mutex::new(Vec::new()));
+        let bridge = PanicBridge::install_with_writer(SharedWriter(fallback.clone()));
+        let path = unique_path("attached");
+        let mut controller = VmmController::new("demo", "0.1.0", "bangbang");
+        assert!(bridge.attach(controller.emergency_logger()));
+        let config = controller
+            .prepare_logger_config(LoggerConfigInput::new().with_log_path(&path))
+            .expect("logger config should validate");
+        let prepared = controller
+            .prepare_logger_update(config, None)
+            .expect("logger update should prepare");
+        controller
+            .commit_logger_config(prepared)
+            .expect("logger should configure");
+
+        let payload = std::panic::catch_unwind(|| panic!("configured-secret"))
+            .expect_err("panic should be caught");
+        controller.settle_emergency_logger_loss();
+        assert!(controller.log_process_terminal(ProcessTerminalCategory::Panic));
+        drop(payload);
+        bridge.restore();
+        drop(controller);
+
+        assert_eq!(
+            fs::read_to_string(&path).expect("logger output should be readable"),
+            "event=process-panic\nevent=process-exit category=panic\n"
+        );
+        assert!(
+            fallback
+                .lock()
+                .expect("fallback lock should succeed")
+                .is_empty()
+        );
+        fs::remove_file(path).expect("logger fixture should clean up");
+    }
+
+    fn run_occupied_logger_fallback_case() {
+        let fallback = Arc::new(Mutex::new(Vec::new()));
+        let bridge = PanicBridge::install_with_writer(SharedWriter(fallback.clone()));
+        let path = unique_path("occupied");
+        let mut controller = VmmController::new("demo", "0.1.0", "bangbang");
+        let emergency = controller.emergency_logger();
+        assert!(bridge.attach(emergency.clone()));
+        let config = controller
+            .prepare_logger_config(LoggerConfigInput::new().with_log_path(&path))
+            .expect("logger config should validate");
+        let prepared = controller
+            .prepare_logger_update(config, None)
+            .expect("logger update should prepare");
+        controller
+            .commit_logger_config(prepared)
+            .expect("logger should configure");
+        assert!(emergency.try_log_panic());
+
+        let payload = std::panic::catch_unwind(|| panic!("occupied-logger-secret"))
+            .expect_err("panic should be caught");
+        bridge.nudge_fallback();
+        let delivered = wait_for_output(&fallback);
+        assert!(controller.log_process_terminal(ProcessTerminalCategory::Panic));
+        drop(payload);
+        bridge.restore();
+        drop(controller);
+
+        assert!(delivered);
+        assert_eq!(
+            *fallback.lock().expect("fallback lock should succeed"),
+            b"event=process-panic\n"
+        );
+        assert_eq!(
+            fs::read_to_string(&path).expect("logger output should be readable"),
+            "event=process-panic\nevent=process-exit category=panic\n"
+        );
+        fs::remove_file(path).expect("logger fixture should clean up");
+    }
+
+    fn run_filtered_fallback_case() {
+        let fallback = Arc::new(Mutex::new(Vec::new()));
+        let bridge = PanicBridge::install_with_writer(SharedWriter(fallback.clone()));
+        let path = unique_path("filtered");
+        let mut controller = VmmController::new("demo", "0.1.0", "bangbang");
+        assert!(bridge.attach(controller.emergency_logger()));
+        let config = controller
+            .prepare_logger_config(
+                LoggerConfigInput::new()
+                    .with_log_path(&path)
+                    .with_level(LoggerLevel::Off),
+            )
+            .expect("logger config should validate");
+        let prepared = controller
+            .prepare_logger_update(config, None)
+            .expect("logger update should prepare");
+        controller
+            .commit_logger_config(prepared)
+            .expect("logger should configure");
+
+        let payload = std::panic::catch_unwind(|| panic!("filtered-secret"))
+            .expect_err("panic should be caught");
+        bridge.nudge_fallback();
+        let delivered = wait_for_output(&fallback);
+        drop(payload);
+        bridge.restore();
+        drop(controller);
+
+        assert!(delivered);
+        assert_eq!(
+            *fallback.lock().expect("fallback lock should succeed"),
+            b"event=process-panic\n"
+        );
+        assert_eq!(
+            fs::read_to_string(&path).expect("logger output should be readable"),
+            ""
+        );
+        fs::remove_file(path).expect("logger fixture should clean up");
+    }
+
+    fn run_second_hook_silence_case() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let bridge = PanicBridge::install_with_writer(SharedWriter(output.clone()));
+        let first = std::panic::catch_unwind(|| panic!("first-secret"));
+        let second = std::panic::catch_unwind(|| panic!("second-secret"));
+        bridge.nudge_fallback();
+        let delivered = wait_for_output(&output);
+        drop(first);
+        drop(second);
+        bridge.restore();
+
+        assert!(delivered);
+        assert_eq!(
+            *output.lock().expect("output lock should succeed"),
+            b"event=process-panic\n"
+        );
+    }
+
+    fn run_stalled_fallback_case() {
+        let gate = Arc::new(WriterGate::default());
+        let bridge = PanicBridge::install_with_writer(HeldWriter(gate.clone()));
+        let caught = std::panic::catch_unwind(|| panic!("stalled-secret"));
+        assert!(
+            caught.is_err(),
+            "hook must return before fallback writer runs"
+        );
+        bridge.nudge_fallback();
+        gate.wait_until_entered();
+        gate.release();
+        drop(caught);
+        bridge.restore();
+    }
+
+    fn run_secondary_isolation_case() {
+        let bridge = PanicBridge::install_with_writer(std::io::sink());
+        let payload_drops = Arc::new(AtomicUsize::new(0));
+        let thrown = payload_drops.clone();
+
+        isolate_secondary_panic(|| std::panic::panic_any(PanicOnDropPayload(thrown)));
+
+        assert_eq!(payload_drops.load(Ordering::Acquire), 0);
+        bridge.restore();
+    }
+
+    struct DoublePanicGuard;
+
+    impl Drop for DoublePanicGuard {
+        fn drop(&mut self) {
+            panic!("secondary-double-panic-secret");
+        }
+    }
+
+    fn run_double_panic_case() -> ! {
+        let _bridge = PanicBridge::install_with_writer(std::io::sink());
+        let _guard = DoublePanicGuard;
+        panic!("primary-double-panic-secret");
+    }
+
+    #[test]
+    fn panic_bridge_child() {
+        let Ok(case) = std::env::var(CHILD_CASE_ENV) else {
+            return;
+        };
+        match case.as_str() {
+            "default-redaction" => run_default_redaction_case(),
+            "sentinel-restore" => run_sentinel_restore_case(),
+            "attached-logger" => run_attached_logger_case(),
+            "filtered-fallback" => run_filtered_fallback_case(),
+            "occupied-logger-fallback" => run_occupied_logger_fallback_case(),
+            "second-hook-silence" => run_second_hook_silence_case(),
+            "stalled-fallback" => run_stalled_fallback_case(),
+            "secondary-isolation" => run_secondary_isolation_case(),
+            "double-panic" => run_double_panic_case(),
+            _ => panic!("unknown panic bridge child case"),
+        }
+    }
+
+    fn spawn_child(case: &str) -> Output {
+        let mut child =
+            Command::new(std::env::current_exe().expect("test executable should exist"))
+                .args([
+                    "--exact",
+                    "panic_bridge::tests::panic_bridge_child",
+                    "--nocapture",
+                    "--test-threads=1",
+                ])
+                .env(CHILD_CASE_ENV, case)
+                .env("RUST_BACKTRACE", "0")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .expect("panic bridge child should spawn");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if child
+                .try_wait()
+                .expect("child status should be observable")
+                .is_some()
+            {
+                return child
+                    .wait_with_output()
+                    .expect("child output should be collected");
+            }
+            if Instant::now() >= deadline {
+                child.kill().expect("timed-out child should be killed");
+                let output = child
+                    .wait_with_output()
+                    .expect("timed-out child output should be collected");
+                panic!(
+                    "panic bridge child {case} timed out: stdout={:?} stderr={:?}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            std::thread::yield_now();
+        }
+    }
+
+    fn assert_success_without_secrets(case: &str, secrets: &[&str]) {
+        let output = spawn_child(case);
+        assert!(
+            output.status.success(),
+            "case {case} failed: stdout={:?} stderr={:?}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        for secret in secrets {
+            assert!(!stderr.contains(secret), "stderr exposed {secret:?}");
+        }
+    }
+
+    #[test]
+    fn subprocess_redacts_payloads_and_restores_prior_hooks() {
+        assert_success_without_secrets("default-redaction", &["ordinary-secret-payload"]);
+        assert_success_without_secrets("sentinel-restore", &["custom-secret-payload"]);
+    }
+
+    #[test]
+    fn subprocess_routes_logger_then_fixed_fallback() {
+        assert_success_without_secrets("attached-logger", &["configured-secret"]);
+        assert_success_without_secrets("filtered-fallback", &["filtered-secret"]);
+        assert_success_without_secrets("occupied-logger-fallback", &["occupied-logger-secret"]);
+    }
+
+    #[test]
+    fn subprocess_bounds_second_hook_and_stalled_fallback() {
+        assert_success_without_secrets("second-hook-silence", &["first-secret", "second-secret"]);
+        assert_success_without_secrets("stalled-fallback", &["stalled-secret"]);
+        assert_success_without_secrets("secondary-isolation", &["secondary-destructor-secret"]);
+    }
+
+    #[test]
+    fn fallback_ingress_has_one_attempt_and_closes_after_all_outcomes() {
+        let admitted = FallbackIngress::new(PanicLogRecords::new());
+        assert!(admitted.publish_once());
+        assert!(!admitted.publish_once());
+        let mut output = Vec::new();
+        deliver_fallback(&mut output, &admitted);
+        assert_eq!(output, b"event=process-panic\n");
+        assert!(admitted.close_if_idle());
+
+        let failed = FallbackIngress::new(PanicLogRecords::new());
+        assert!(failed.publish_once());
+        deliver_fallback(&mut FailingWriter, &failed);
+        assert!(failed.close_if_idle());
+
+        let closed = FallbackIngress::new(PanicLogRecords::new());
+        closed.force_close();
+        assert!(!closed.publish_once());
+        assert!(closed.close_if_idle());
+    }
+
+    #[test]
+    fn unavailable_fallback_returns_after_the_first_attempt() {
+        let state = PanicBridgeState {
+            first_panic_seen: AtomicBool::new(false),
+            emergency_logger: std::sync::OnceLock::new(),
+            fallback: None,
+        };
+
+        state.invoke();
+        state.invoke();
+
+        assert!(state.first_panic_seen.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn subprocess_double_panic_is_bounded_and_redacted() {
+        let output = spawn_child("double-panic");
+        assert!(!output.status.success(), "double panic must terminate");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(!stderr.contains("primary-double-panic-secret"));
+        assert!(!stderr.contains("secondary-double-panic-secret"));
+    }
+}

--- a/crates/bangbang/src/vmm.rs
+++ b/crates/bangbang/src/vmm.rs
@@ -128,7 +128,9 @@ use bangbang_runtime::boot_timer::BootTimerMmioLayout;
 use bangbang_runtime::cpu::CpuConfigInput;
 use bangbang_runtime::entropy::{EntropyConfig, EntropyMmioLayout};
 use bangbang_runtime::lazy_memory::LazyGuestMemoryConsumerProfile;
-use bangbang_runtime::logger::{LoggerApiRoute, LoggerConfigInput, LoggerHttpMethod};
+use bangbang_runtime::logger::{
+    EmergencyLogger, LoggerApiRoute, LoggerConfigInput, LoggerHttpMethod, ProcessTerminalCategory,
+};
 use bangbang_runtime::machine::{MachineConfigInput, MachineConfigPatchInput};
 use bangbang_runtime::memory::{GuestAddress, GuestMemory, GuestMemoryRange};
 use bangbang_runtime::memory_hotplug::{
@@ -5472,6 +5474,7 @@ where
     started_session: Option<S::Session>,
     metrics_session_epoch: Option<Instant>,
     initial_metrics_attempted: bool,
+    terminal_logger_attempted: bool,
     terminal_metrics_attempted: bool,
     process_metrics_diagnostics: MetricsDiagnostics,
     process_signal_metrics: Option<SharedSignalMetrics>,
@@ -5580,6 +5583,7 @@ where
             started_session: None,
             metrics_session_epoch: None,
             initial_metrics_attempted: false,
+            terminal_logger_attempted: false,
             terminal_metrics_attempted: false,
             process_metrics_diagnostics: MetricsDiagnostics::default(),
             process_signal_metrics: None,
@@ -7214,6 +7218,20 @@ where
 
         self.initial_metrics_attempted = true;
         let _ = self.flush_automatic_metrics();
+    }
+
+    pub(crate) fn emergency_logger(&self) -> EmergencyLogger {
+        self.controller.emergency_logger()
+    }
+
+    pub(crate) fn handle_terminal_observability(&mut self, category: ProcessTerminalCategory) {
+        self.handle_initial_metrics_flush();
+        self.controller.settle_emergency_logger_loss();
+        if !self.terminal_logger_attempted {
+            self.terminal_logger_attempted = true;
+            let _ = self.controller.log_process_terminal(category);
+        }
+        self.handle_terminal_metrics_flush();
     }
 
     fn handle_periodic_metrics_flush(&mut self) {
@@ -35680,7 +35698,7 @@ mod tests {
     use bangbang_runtime::entropy::{EntropyConfig, EntropyConfigInput};
     use bangbang_runtime::fdt::{Arm64FdtRegion, Arm64FdtVirtioMmioDevice};
     use bangbang_runtime::interrupt::GuestInterruptLine;
-    use bangbang_runtime::logger::LoggerConfigInput;
+    use bangbang_runtime::logger::{LoggerConfigInput, ProcessTerminalCategory};
     use bangbang_runtime::machine::{MachineConfig, MachineConfigInput, MachineConfigPatchInput};
     use bangbang_runtime::memory::{
         GuestAddress, GuestMemory, GuestMemoryLayout, GuestMemoryRange,
@@ -63838,6 +63856,105 @@ mod tests {
         assert_eq!(
             fs::read_to_string(logger.path()).expect("logger output should read"),
             "action=InstanceStart\n"
+        );
+    }
+
+    #[test]
+    fn terminal_observability_logs_once_between_initial_and_final_metrics() {
+        let output = TempFilePath::create("terminal-observability-order");
+        let mut vmm =
+            ProcessVmm::with_starter("demo-1", "0.1.0", "bangbang", FakeStarter::success(18));
+        vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+            output.path(),
+        )))
+        .expect("metrics should configure");
+        vmm.handle_action(VmmAction::PutLogger(
+            LoggerConfigInput::new().with_log_path(output.path()),
+        ))
+        .expect("logger should configure");
+        vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            "/tmp/vmlinux",
+        )))
+        .expect("boot source should configure");
+        vmm.handle_action(VmmAction::InstanceStart)
+            .expect("startup should succeed");
+
+        vmm.handle_terminal_observability(ProcessTerminalCategory::Success);
+        vmm.handle_terminal_observability(ProcessTerminalCategory::Panic);
+
+        assert_eq!(
+            fs::read_to_string(output.path()).expect("combined output should read"),
+            concat!(
+                "action=InstanceStart\n",
+                "{\"vmm\":{\"metrics_flush_count\":1}}\n",
+                "event=process-exit category=success\n",
+                "{\"vmm\":{\"metrics_flush_count\":1}}\n",
+            )
+        );
+    }
+
+    #[test]
+    fn terminal_observability_logs_pre_session_without_flushing_metrics() {
+        let output = TempFilePath::create("terminal-observability-pre-session");
+        let mut vmm =
+            ProcessVmm::with_starter("demo-1", "0.1.0", "bangbang", FakeStarter::success(18));
+        vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+            output.path(),
+        )))
+        .expect("metrics should configure");
+        vmm.handle_action(VmmAction::PutLogger(
+            LoggerConfigInput::new().with_log_path(output.path()),
+        ))
+        .expect("logger should configure");
+
+        vmm.handle_terminal_observability(ProcessTerminalCategory::Configuration);
+
+        assert_eq!(
+            fs::read_to_string(output.path()).expect("combined output should read"),
+            "event=process-exit category=configuration\n"
+        );
+    }
+
+    #[test]
+    fn terminal_observability_settles_emergency_loss_before_metrics_snapshot() {
+        let metrics = TempFilePath::create("terminal-emergency-loss-metrics");
+        let logger = TempFilePath::create("terminal-emergency-loss-logger");
+        let mut vmm =
+            ProcessVmm::with_starter("demo-1", "0.1.0", "bangbang", FakeStarter::success(18));
+        vmm.handle_action(VmmAction::PutMetrics(MetricsConfigInput::new(
+            metrics.path(),
+        )))
+        .expect("metrics should configure");
+        vmm.handle_action(VmmAction::PutLogger(
+            LoggerConfigInput::new().with_log_path(logger.path()),
+        ))
+        .expect("logger should configure");
+        vmm.handle_action(VmmAction::PutBootSource(BootSourceConfigInput::new(
+            "/tmp/vmlinux",
+        )))
+        .expect("boot source should configure");
+        vmm.handle_action(VmmAction::InstanceStart)
+            .expect("startup should succeed");
+        let emergency = vmm.emergency_logger();
+        assert!(emergency.try_log_panic());
+        assert!(!emergency.try_log_panic());
+
+        vmm.handle_terminal_observability(ProcessTerminalCategory::Panic);
+
+        assert_eq!(
+            fs::read_to_string(logger.path()).expect("logger output should read"),
+            concat!(
+                "action=InstanceStart\n",
+                "event=process-panic\n",
+                "event=process-exit category=panic\n",
+            )
+        );
+        assert_eq!(
+            fs::read_to_string(metrics.path()).expect("metrics output should read"),
+            concat!(
+                "{\"vmm\":{\"metrics_flush_count\":1}}\n",
+                "{\"logger\":{\"missed_log_count\":1},\"vmm\":{\"metrics_flush_count\":1}}\n",
+            )
         );
     }
 

--- a/crates/bangbang/tests/executable_hvf_e2e.rs
+++ b/crates/bangbang/tests/executable_hvf_e2e.rs
@@ -1318,6 +1318,11 @@ mod macos_arm64 {
 
         let output = bangbang.terminate();
         assert_clean_shutdown(output, &socket_path, "bangbang");
+        assert_terminal_logger_output(
+            &logger_path,
+            LoggerPrefixExpectation::LevelOrigin,
+            "success",
+        );
         assert_normal_terminal_metrics_output(&metrics_path);
         assert!(
             !uds_path.exists(),
@@ -1724,6 +1729,7 @@ mod macos_arm64 {
 
         let output = bangbang.terminate();
         assert_clean_shutdown(output, &socket_path, "bangbang config file");
+        assert_terminal_logger_output(&logger_path, LoggerPrefixExpectation::None, "success");
         assert_normal_terminal_metrics_output(&metrics_path);
         assert!(
             !uds_path.exists(),
@@ -1819,6 +1825,7 @@ mod macos_arm64 {
             &socket_path,
             "bangbang no-api config file",
         );
+        assert_terminal_logger_output(&logger_path, LoggerPrefixExpectation::None, "success");
         assert!(
             !uds_path.exists(),
             "bangbang no-api config-file shutdown should remove its owned vsock listener path"
@@ -18147,19 +18154,35 @@ mod macos_arm64 {
     fn assert_logger_output_lines(output: &str, prefix: LoggerPrefixExpectation) {
         let mut action_lines = Vec::new();
         let mut saw_api_request_line = false;
+        let mut terminal_lines = 0usize;
         for line in output.lines() {
             let record = logger_record_without_prefix(line, prefix, output);
             if record.starts_with("action=") {
                 action_lines.push(record);
                 continue;
             }
+            if let Some(category) = record.strip_prefix("event=process-exit category=") {
+                assert!(
+                    matches!(
+                        category,
+                        "success" | "configuration" | "process-failure" | "cancelled" | "panic"
+                    ),
+                    "terminal logger category should be fixed; output:\n{output}\nline: {line}"
+                );
+                terminal_lines += 1;
+                continue;
+            }
 
             assert!(
                 is_api_request_logger_line(record),
-                "logger output line should be an action record or API request record; output:\n{output}\nline: {line}"
+                "logger output line should be an action, API request, or terminal record; output:\n{output}\nline: {line}"
             );
             saw_api_request_line = true;
         }
+        assert!(
+            terminal_lines <= 1,
+            "logger output should include at most one terminal record; output:\n{output}"
+        );
 
         const EXPECTED_ACTION_LINES: &[&str] = &["action=InstanceStart", "action=FlushMetrics"];
         assert_eq!(
@@ -18234,6 +18257,21 @@ mod macos_arm64 {
         );
     }
 
+    fn assert_terminal_logger_output(path: &Path, prefix: LoggerPrefixExpectation, category: &str) {
+        let output = fs::read_to_string(path).unwrap_or_else(|err| {
+            panic!("logger output {} should be readable: {err}", path.display())
+        });
+        let line = output
+            .lines()
+            .next_back()
+            .expect("post-exit logger output should not be empty");
+        assert_eq!(
+            logger_record_without_prefix(line, prefix, &output),
+            format!("event=process-exit category={category}"),
+            "the terminal logger record should be the last completed record"
+        );
+    }
+
     #[test]
     fn logger_output_accepts_action_records_with_api_request_lines() {
         assert_logger_output_lines(
@@ -18257,7 +18295,9 @@ mod macos_arm64 {
     }
 
     #[test]
-    #[should_panic(expected = "logger output line should be an action record")]
+    #[should_panic(
+        expected = "logger output line should be an action, API request, or terminal record"
+    )]
     fn logger_output_rejects_unexpected_non_action_line() {
         assert_logger_output_lines(
             "action=InstanceStart\nunexpected\n",

--- a/crates/bangbang/tests/process_e2e.rs
+++ b/crates/bangbang/tests/process_e2e.rs
@@ -9,6 +9,7 @@
 
 mod support;
 
+use std::ffi::OsStr;
 use std::fs;
 use std::os::unix::fs::{MetadataExt, symlink};
 
@@ -179,6 +180,76 @@ fn executable_short_version_alias_exits_before_socket_publication() {
     assert!(
         !socket_path.exists(),
         "short version must not publish the API socket"
+    );
+}
+
+#[test]
+fn executable_logs_success_terminal_record_after_api_shutdown() {
+    let test_dir = TestDir::new();
+    let socket_path = test_dir.path().join("terminal-success.socket");
+    let logger_path = test_dir.path().join("terminal-success.log");
+    let instance_id = test_dir.instance_id();
+    let bangbang = BangbangProcess::start_with_extra_args(
+        &socket_path,
+        &instance_id,
+        &["--log-path", path_text(&logger_path)],
+    );
+
+    let output = bangbang.terminate();
+    assert_clean_shutdown(output, &socket_path, "API terminal logger");
+    assert_eq!(
+        fs::read_to_string(&logger_path).expect("terminal logger output should be readable"),
+        "event=process-exit category=success\n"
+    );
+}
+
+#[test]
+fn executable_logs_configuration_terminal_record_after_logger_setup() {
+    let test_dir = TestDir::new();
+    let socket_path = test_dir.path().join("terminal-configuration.socket");
+    let logger_path = test_dir.path().join("terminal-configuration.log");
+    let missing_metadata = test_dir.path().join("missing-metadata.json");
+    let instance_id = test_dir.instance_id();
+
+    let output = BangbangProcess::start_with_extra_args_expect_failure(
+        &socket_path,
+        &instance_id,
+        &[
+            "--log-path",
+            path_text(&logger_path),
+            "--metadata",
+            path_text(&missing_metadata),
+        ],
+    );
+
+    assert_eq!(output.status.code(), Some(BAD_CONFIGURATION_EXIT_CODE));
+    assert_eq!(
+        fs::read_to_string(&logger_path).expect("terminal logger output should be readable"),
+        "event=process-exit category=configuration\n"
+    );
+}
+
+#[test]
+fn executable_logs_process_failure_terminal_record_after_logger_setup() {
+    let test_dir = TestDir::new();
+    let logger_path = test_dir.path().join("terminal-process-failure.log");
+    let unavailable_socket = test_dir.path().join("missing").join("api.socket");
+    let instance_id = test_dir.instance_id();
+    let args = [
+        OsStr::new("--api-sock"),
+        unavailable_socket.as_os_str(),
+        OsStr::new("--id"),
+        OsStr::new(&instance_id),
+        OsStr::new("--log-path"),
+        logger_path.as_os_str(),
+    ];
+
+    let output = BangbangProcess::run_with_args_expect_exit(&args, "API bind failure");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        fs::read_to_string(&logger_path).expect("terminal logger output should be readable"),
+        "event=process-exit category=process-failure\n"
     );
 }
 

--- a/crates/launcher/tests/production_bundle_e2e.rs
+++ b/crates/launcher/tests/production_bundle_e2e.rs
@@ -16262,7 +16262,14 @@ impl OutputGrantFixture {
     }
 
     fn assert_original_outputs(&self) {
-        self.assert_original_outputs_with_logger_expectations(true, true);
+        Self::assert_outputs_at(
+            &self.opened_logger,
+            &self.opened_metrics,
+            &self.opened_serial,
+            true,
+            true,
+            true,
+        );
     }
 
     fn assert_original_outputs_with_logger_expectations(&self, api: bool, action: bool) {
@@ -16272,11 +16279,12 @@ impl OutputGrantFixture {
             &self.opened_serial,
             api,
             action,
+            false,
         );
     }
 
     fn assert_current_outputs(&self) {
-        Self::assert_outputs_at(&self.logger, &self.metrics, &self.serial, false, true);
+        Self::assert_outputs_at(&self.logger, &self.metrics, &self.serial, false, true, true);
     }
 
     fn assert_outputs_at(
@@ -16285,6 +16293,7 @@ impl OutputGrantFixture {
         serial_path: &Path,
         api: bool,
         action: bool,
+        terminal: bool,
     ) {
         let logger = fs::read(logger_path).expect("granted logger output should read");
         assert!(logger.starts_with(OUTPUT_LOGGER_SEED));
@@ -16302,6 +16311,13 @@ impl OutputGrantFixture {
                     .any(|window| window == b"action=InstanceStart\n")
             );
         }
+        let has_terminal = logger
+            .windows(b"event=process-exit category=success\n".len())
+            .any(|window| window == b"event=process-exit category=success\n");
+        assert_eq!(
+            has_terminal, terminal,
+            "terminal logger output should follow the configured module filter"
+        );
 
         let metrics = fs::read_to_string(metrics_path).expect("granted metrics output should read");
         let seed = std::str::from_utf8(OUTPUT_METRICS_SEED).expect("metrics seed should be UTF-8");

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -725,6 +725,22 @@ impl VmmController {
         self.logger_state.boot_timer_logger()
     }
 
+    /// Returns the narrow panic-record admission handle for this controller.
+    pub fn emergency_logger(&self) -> logger::EmergencyLogger {
+        self.logger_state.emergency_logger()
+    }
+
+    /// Settles the single possible deferred hook-side logger admission loss.
+    pub fn settle_emergency_logger_loss(&self) {
+        self.logger_state.settle_emergency_loss();
+    }
+
+    /// Emits one fixed process terminal record through the configured logger.
+    #[track_caller]
+    pub fn log_process_terminal(&self, category: logger::ProcessTerminalCategory) -> bool {
+        self.logger_state.log_process_terminal(category)
+    }
+
     pub fn vm_config(&self) -> Result<VmConfiguration, mmds::MmdsStateLockError> {
         Ok(VmConfiguration::new(
             self.machine_config,

--- a/crates/runtime/src/logger.rs
+++ b/crates/runtime/src/logger.rs
@@ -10,22 +10,27 @@ use std::os::unix::fs::OpenOptionsExt;
 use std::panic::Location;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, TryLockError};
 
 use delivery::{
-    LoggerDelivery, LoggerDeliveryConfig, LoggerProducer, PreparedLoggerWriter, ReplaceWriterError,
+    LoggerDelivery, LoggerDeliveryConfig, LoggerEmergencyIngress, LoggerProducer,
+    PanicRecordPrefix, PreparedLoggerWriter, ReplaceWriterError,
 };
 use event::{LogBatch, LogOrigin, LogRecord, LoggerEvent};
 #[cfg(test)]
 use rate_limiter::LogRateLimiterClock;
 use rate_limiter::{LogRateLimitDecision, LoggerRateLimitIdentity, LoggerRateLimiters};
 
-pub use event::{LoggerAction, LoggerApiRoute, LoggerHttpMethod};
+pub use event::{
+    LoggerAction, LoggerApiRoute, LoggerHttpMethod, PanicLogRecords, ProcessTerminalCategory,
+};
 
 const BOOT_TIMER_LOG_MODULE: &str = "bangbang_runtime::boot_timer";
 const API_REQUEST_LOG_MODULE: &str = "bangbang_runtime::api_server";
 const MINIMAL_ACTION_LOG_MODULE: &str = "bangbang_runtime::vmm_action";
+const PROCESS_LOG_MODULE: &str = "bangbang::process";
+const PANIC_LOG_MODULE: &str = "bangbang::panic";
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum LoggerLevel {
@@ -297,6 +302,112 @@ impl SharedLoggerMetrics {
     }
 }
 
+#[derive(Debug)]
+struct EmergencyLoggerTarget {
+    ingress: Option<Arc<LoggerEmergencyIngress>>,
+    prefix: PanicRecordPrefix,
+    enabled: bool,
+}
+
+impl Default for EmergencyLoggerTarget {
+    fn default() -> Self {
+        Self {
+            ingress: None,
+            prefix: PanicRecordPrefix::Plain,
+            enabled: false,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct EmergencyLoggerInner {
+    target: Mutex<EmergencyLoggerTarget>,
+    enabled: AtomicBool,
+    pending_loss: AtomicBool,
+    metrics: SharedLoggerMetrics,
+}
+
+/// Narrow, cloneable panic-record admission capability for an executable hook.
+#[derive(Clone)]
+pub struct EmergencyLogger {
+    inner: Arc<EmergencyLoggerInner>,
+}
+
+impl fmt::Debug for EmergencyLogger {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EmergencyLogger")
+            .finish_non_exhaustive()
+    }
+}
+
+impl EmergencyLogger {
+    fn new(metrics: SharedLoggerMetrics) -> Self {
+        let target = Mutex::new(EmergencyLoggerTarget::default());
+        // macOS lazily allocates the pthread-backed mutex on its first lock.
+        // Initialize it on this ordinary construction path, never in the hook.
+        drop(
+            target
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        );
+        Self {
+            inner: Arc::new(EmergencyLoggerInner {
+                target,
+                enabled: AtomicBool::new(false),
+                pending_loss: AtomicBool::new(false),
+                metrics,
+            }),
+        }
+    }
+
+    /// Attempts one preencoded panic-record publication without waiting or retrying.
+    pub fn try_log_panic(&self) -> bool {
+        match self.inner.target.try_lock() {
+            Ok(target) => {
+                if !target.enabled {
+                    return false;
+                }
+                let Some(ingress) = target.ingress.as_deref() else {
+                    return false;
+                };
+                if ingress.publish_once(target.prefix) {
+                    true
+                } else {
+                    self.inner.pending_loss.store(true, Ordering::Release);
+                    false
+                }
+            }
+            Err(TryLockError::WouldBlock | TryLockError::Poisoned(_)) => {
+                if self.inner.enabled.load(Ordering::Acquire) {
+                    self.inner.pending_loss.store(true, Ordering::Release);
+                }
+                false
+            }
+        }
+    }
+
+    fn update(&self, target: EmergencyLoggerTarget) {
+        let enabled = target.enabled;
+        let mut current = self
+            .inner
+            .target
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *current = target;
+        drop(current);
+        // A contended hook may conservatively linearize before this completed
+        // publication; a successful lock always observes the full snapshot.
+        self.inner.enabled.store(enabled, Ordering::Release);
+    }
+
+    fn settle_pending_loss(&self) {
+        if self.inner.pending_loss.swap(false, Ordering::AcqRel) {
+            self.inner.metrics.record_missed_logs(1);
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 struct BootTimerLogRateLimiter {
     inner: LoggerRateLimiters,
@@ -389,6 +500,8 @@ pub struct LoggerState {
     show_log_origin: bool,
     module: Option<String>,
     metrics: SharedLoggerMetrics,
+    panic_records: Arc<PanicLogRecords>,
+    emergency_logger: EmergencyLogger,
     boot_timer_rate_limiter: BootTimerLogRateLimiter,
     delivery_config: LoggerDeliveryConfig,
 }
@@ -427,24 +540,25 @@ impl fmt::Debug for PreparedLoggerConfig {
 
 impl Default for LoggerState {
     fn default() -> Self {
+        Self::with_shared_metrics(SharedLoggerMetrics::default())
+    }
+}
+
+impl LoggerState {
+    pub(crate) fn with_shared_metrics(metrics: SharedLoggerMetrics) -> Self {
+        let panic_records = Arc::new(PanicLogRecords::new());
+        let emergency_logger = EmergencyLogger::new(metrics.clone());
         Self {
             delivery: None,
             level: LoggerLevel::Info,
             show_level: false,
             show_log_origin: false,
             module: None,
-            metrics: SharedLoggerMetrics::default(),
+            metrics,
+            panic_records,
+            emergency_logger,
             boot_timer_rate_limiter: BootTimerLogRateLimiter::default(),
             delivery_config: LoggerDeliveryConfig::default(),
-        }
-    }
-}
-
-impl LoggerState {
-    pub(crate) fn with_shared_metrics(metrics: SharedLoggerMetrics) -> Self {
-        Self {
-            metrics,
-            ..Self::default()
         }
     }
 
@@ -497,14 +611,19 @@ impl LoggerState {
             self.commit_writer(writer)?;
         }
         self.apply_config(config);
+        self.publish_emergency_target();
         Ok(())
     }
 
     fn commit_writer(&mut self, writer: PreparedLoggerWriter) -> Result<(), LoggerConfigError> {
         let Some(delivery) = &self.delivery else {
-            let delivery =
-                LoggerDelivery::spawn(writer, self.metrics.clone(), self.delivery_config.clone())
-                    .map_err(LoggerConfigError::SpawnWorker)?;
+            let delivery = LoggerDelivery::spawn(
+                writer,
+                self.metrics.clone(),
+                self.panic_records.clone(),
+                self.delivery_config.clone(),
+            )
+            .map_err(LoggerConfigError::SpawnWorker)?;
             self.delivery = Some(delivery);
             return Ok(());
         };
@@ -517,6 +636,7 @@ impl LoggerState {
                 let successor = LoggerDelivery::spawn(
                     writer,
                     self.metrics.clone(),
+                    self.panic_records.clone(),
                     self.delivery_config.clone(),
                 )
                 .map_err(LoggerConfigError::SpawnWorker)?;
@@ -539,6 +659,49 @@ impl LoggerState {
         if let Some(module) = config.module {
             self.module = Some(module);
         }
+    }
+
+    fn publish_emergency_target(&self) {
+        let enabled = self.delivery.is_some()
+            && self.level.allows(LoggerLevel::Error)
+            && module_filter_allows(self.module.as_deref(), PANIC_LOG_MODULE);
+        self.emergency_logger.update(EmergencyLoggerTarget {
+            ingress: self
+                .delivery
+                .as_ref()
+                .map(LoggerDelivery::emergency_ingress),
+            prefix: PanicRecordPrefix::from_flags(self.show_level, self.show_log_origin),
+            enabled,
+        });
+    }
+
+    pub(crate) fn emergency_logger(&self) -> EmergencyLogger {
+        self.emergency_logger.clone()
+    }
+
+    pub(crate) fn settle_emergency_loss(&self) {
+        self.emergency_logger.settle_pending_loss();
+    }
+
+    #[track_caller]
+    pub(crate) fn log_process_terminal(&self, category: ProcessTerminalCategory) -> bool {
+        let level = category.level();
+        if !self.level.allows(level)
+            || !module_filter_allows(self.module.as_deref(), PROCESS_LOG_MODULE)
+        {
+            return false;
+        }
+        let Some(delivery) = &self.delivery else {
+            return false;
+        };
+        let record = LogRecord::encode(
+            self.show_level,
+            self.show_log_origin,
+            LogOrigin::from(Location::caller()),
+            level,
+            LoggerEvent::ProcessExit(category),
+        );
+        delivery.producer().deliver_host(LogBatch::one(record))
     }
 
     #[track_caller]
@@ -628,6 +791,7 @@ impl LoggerState {
     pub(crate) fn configure_test_writer(&mut self, writer: impl Write + Send + 'static) {
         self.commit_writer(PreparedLoggerWriter::new(writer))
             .expect("test logger writer should configure");
+        self.publish_emergency_target();
     }
 
     #[cfg(test)]
@@ -663,7 +827,7 @@ mod tests {
     use super::{
         BootTimerLogRateLimiter, LogRateLimitDecision, LogRateLimiterClock, LoggerAction,
         LoggerApiRoute, LoggerConfigError, LoggerConfigInput, LoggerDeliveryConfig,
-        LoggerHttpMethod, LoggerLevel, LoggerState, SharedLoggerMetrics,
+        LoggerHttpMethod, LoggerLevel, LoggerState, ProcessTerminalCategory, SharedLoggerMetrics,
     };
 
     static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
@@ -975,6 +1139,7 @@ mod tests {
             output: old_output.clone(),
         });
         let stale = state.boot_timer_logger();
+        let emergency = state.emergency_logger();
         assert!(stale.log_boot_time(1_000, 200));
         gate.wait_until_entered();
 
@@ -996,6 +1161,7 @@ mod tests {
 
         gate.release();
         assert!(stale.wait_for_delivery_for_test());
+        assert!(emergency.try_log_panic());
         assert!(state.log_action(LoggerAction::InstanceStart));
         assert_eq!(
             String::from_utf8(
@@ -1005,7 +1171,11 @@ mod tests {
                     .clone()
             )
             .expect("old output should be UTF-8"),
-            "Guest-boot-time =   1000 us 1 ms,    200 CPU us 0 CPU ms\naction=InstanceStart\n"
+            concat!(
+                "Guest-boot-time =   1000 us 1 ms,    200 CPU us 0 CPU ms\n",
+                "event=process-panic\n",
+                "action=InstanceStart\n",
+            )
         );
         assert_eq!(
             fs::metadata(&candidate_path)
@@ -1081,6 +1251,7 @@ mod tests {
         );
         state.configure_test_writer(SharedWriter(Arc::new(Mutex::new(Vec::new()))));
         let stale = state.boot_timer_logger();
+        let emergency = state.emergency_logger();
 
         assert!(state.disconnect_delivery_for_test());
         wait_for(|| observer.active() == 0);
@@ -1090,11 +1261,12 @@ mod tests {
         assert_eq!(observer.started(), 2);
 
         assert!(!stale.log_boot_time(1_000, 200));
+        assert!(emergency.try_log_panic());
         assert!(state.log_action(LoggerAction::FlushMetrics));
         assert_eq!(metrics.missed_log_count(), 1);
         assert_eq!(
             *output.lock().expect("successor output lock should succeed"),
-            b"action=FlushMetrics\n"
+            b"event=process-panic\naction=FlushMetrics\n"
         );
     }
 
@@ -1158,6 +1330,130 @@ mod tests {
             "level=Info action=FlushMetrics\n"
         );
         fs::remove_file(path).expect("fixture should clean up");
+    }
+
+    #[test]
+    fn process_terminal_records_use_fixed_categories_and_filters() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let mut state = LoggerState::default();
+        state.configure_test_writer(SharedWriter(output.clone()));
+
+        assert!(state.log_process_terminal(ProcessTerminalCategory::Success));
+        assert!(state.log_process_terminal(ProcessTerminalCategory::ProcessFailure));
+        state
+            .configure(LoggerConfigInput::new().with_module("other"))
+            .expect("module update should succeed");
+        assert!(!state.log_process_terminal(ProcessTerminalCategory::Panic));
+
+        assert_eq!(
+            *output.lock().expect("output lock should succeed"),
+            b"event=process-exit category=success\nevent=process-exit category=process-failure\n"
+        );
+    }
+
+    #[test]
+    fn emergency_logger_observes_late_configuration_and_prefix_update() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let mut state = LoggerState::default();
+        let emergency = state.emergency_logger();
+        assert!(!emergency.try_log_panic());
+
+        state.configure_test_writer(SharedWriter(output.clone()));
+        state
+            .configure(LoggerConfigInput::new().with_show_level(true))
+            .expect("prefix update should succeed");
+        assert!(emergency.try_log_panic());
+        assert!(state.boot_timer_logger().wait_for_delivery_for_test());
+
+        assert_eq!(
+            *output.lock().expect("output lock should succeed"),
+            b"level=Error event=process-panic\n"
+        );
+    }
+
+    #[test]
+    fn filtered_emergency_logger_does_not_record_a_loss() {
+        let metrics = SharedLoggerMetrics::default();
+        let mut state = LoggerState::with_shared_metrics(metrics.clone());
+        state.configure_test_writer(SharedWriter(Arc::new(Mutex::new(Vec::new()))));
+        state
+            .configure(LoggerConfigInput::new().with_level(LoggerLevel::Off))
+            .expect("filter update should succeed");
+
+        assert!(!state.emergency_logger().try_log_panic());
+        state.settle_emergency_loss();
+        assert_eq!(metrics.missed_log_count(), 0);
+    }
+
+    #[test]
+    fn occupied_emergency_ingress_coalesces_one_deferred_loss() {
+        let metrics = SharedLoggerMetrics::default();
+        let mut state = LoggerState::with_shared_metrics(metrics.clone());
+        state.configure_test_writer(SharedWriter(Arc::new(Mutex::new(Vec::new()))));
+        let emergency = state.emergency_logger();
+
+        assert!(emergency.try_log_panic());
+        assert!(!emergency.try_log_panic());
+        assert!(!emergency.try_log_panic());
+        state.settle_emergency_loss();
+        state.settle_emergency_loss();
+        assert_eq!(metrics.missed_log_count(), 1);
+    }
+
+    #[test]
+    fn contended_emergency_snapshot_returns_without_locking_and_defers_loss() {
+        let metrics = SharedLoggerMetrics::default();
+        let mut state = LoggerState::with_shared_metrics(metrics.clone());
+        state.configure_test_writer(SharedWriter(Arc::new(Mutex::new(Vec::new()))));
+        let emergency = state.emergency_logger();
+        let held = emergency.clone();
+        let (entered_sender, entered_receiver) = std::sync::mpsc::sync_channel(1);
+        let (release_sender, release_receiver) = std::sync::mpsc::sync_channel(1);
+        let holder = std::thread::spawn(move || {
+            let _guard = held
+                .inner
+                .target
+                .lock()
+                .expect("target lock should succeed");
+            entered_sender.send(()).expect("holder should signal entry");
+            release_receiver
+                .recv()
+                .expect("holder should receive release");
+        });
+        entered_receiver
+            .recv_timeout(Duration::from_secs(2))
+            .expect("holder should enter");
+
+        assert!(!emergency.try_log_panic());
+        release_sender
+            .send(())
+            .expect("holder should receive release signal");
+        holder.join().expect("holder should exit");
+        state.settle_emergency_loss();
+        assert_eq!(metrics.missed_log_count(), 1);
+    }
+
+    #[test]
+    fn poisoned_emergency_snapshot_returns_without_locking_and_defers_loss() {
+        let metrics = SharedLoggerMetrics::default();
+        let mut state = LoggerState::with_shared_metrics(metrics.clone());
+        state.configure_test_writer(SharedWriter(Arc::new(Mutex::new(Vec::new()))));
+        let emergency = state.emergency_logger();
+        let poisoned = emergency.clone();
+        let poisoner = std::thread::spawn(move || {
+            let _guard = poisoned
+                .inner
+                .target
+                .lock()
+                .expect("target lock should initially succeed");
+            panic!("poison emergency target fixture");
+        });
+        assert!(poisoner.join().is_err());
+
+        assert!(!emergency.try_log_panic());
+        state.settle_emergency_loss();
+        state.settle_emergency_loss();
+        assert_eq!(metrics.missed_log_count(), 1);
     }
 
     #[test]

--- a/crates/runtime/src/logger/delivery.rs
+++ b/crates/runtime/src/logger/delivery.rs
@@ -11,10 +11,19 @@ use std::time::Duration;
 use std::time::Instant;
 
 use super::SharedLoggerMetrics;
-use super::event::LogBatch;
+use super::event::{LogBatch, LogRecord, PanicLogRecords};
 
 const LOGGER_DELIVERY_QUEUE_CAPACITY: usize = 256;
 const LOGGER_DELIVERY_TIMEOUT: Duration = Duration::from_secs(1);
+const LOGGER_EMERGENCY_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+const EMERGENCY_ARMED: u8 = 0;
+const EMERGENCY_PLAIN_PENDING: u8 = 1;
+const EMERGENCY_LEVEL_PENDING: u8 = 2;
+const EMERGENCY_ORIGIN_PENDING: u8 = 3;
+const EMERGENCY_LEVEL_ORIGIN_PENDING: u8 = 4;
+const EMERGENCY_CLAIMED: u8 = 5;
+const EMERGENCY_CLOSED: u8 = 6;
 
 const RECEIPT_PENDING: u8 = 0;
 const RECEIPT_WRITING: u8 = 1;
@@ -26,6 +35,128 @@ const REPLACEMENT_COMMITTED: u8 = 1;
 const REPLACEMENT_CANCELLED: u8 = 2;
 
 pub(super) struct PreparedLoggerWriter(Box<dyn Write + Send>);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PanicRecordPrefix {
+    Plain,
+    Level,
+    Origin,
+    LevelAndOrigin,
+}
+
+impl PanicRecordPrefix {
+    pub(super) const fn from_flags(show_level: bool, show_log_origin: bool) -> Self {
+        match (show_level, show_log_origin) {
+            (false, false) => Self::Plain,
+            (true, false) => Self::Level,
+            (false, true) => Self::Origin,
+            (true, true) => Self::LevelAndOrigin,
+        }
+    }
+
+    const fn state(self) -> u8 {
+        match self {
+            Self::Plain => EMERGENCY_PLAIN_PENDING,
+            Self::Level => EMERGENCY_LEVEL_PENDING,
+            Self::Origin => EMERGENCY_ORIGIN_PENDING,
+            Self::LevelAndOrigin => EMERGENCY_LEVEL_ORIGIN_PENDING,
+        }
+    }
+
+    const fn from_state(state: u8) -> Option<Self> {
+        match state {
+            EMERGENCY_PLAIN_PENDING => Some(Self::Plain),
+            EMERGENCY_LEVEL_PENDING => Some(Self::Level),
+            EMERGENCY_ORIGIN_PENDING => Some(Self::Origin),
+            EMERGENCY_LEVEL_ORIGIN_PENDING => Some(Self::LevelAndOrigin),
+            _ => None,
+        }
+    }
+}
+
+pub(super) struct LoggerEmergencyIngress {
+    state: AtomicU8,
+    records: Arc<PanicLogRecords>,
+}
+
+impl fmt::Debug for LoggerEmergencyIngress {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LoggerEmergencyIngress")
+            .field("state", &self.state.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
+    }
+}
+
+impl LoggerEmergencyIngress {
+    pub(super) const fn new(records: Arc<PanicLogRecords>) -> Self {
+        Self {
+            state: AtomicU8::new(EMERGENCY_ARMED),
+            records,
+        }
+    }
+
+    /// Makes exactly one compare-exchange attempt and never retries.
+    pub(super) fn publish_once(&self, prefix: PanicRecordPrefix) -> bool {
+        self.state
+            .compare_exchange(
+                EMERGENCY_ARMED,
+                prefix.state(),
+                Ordering::Release,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+    }
+
+    fn claim(&self) -> Option<&LogRecord> {
+        let state = self.state.load(Ordering::Acquire);
+        let prefix = PanicRecordPrefix::from_state(state)?;
+        self.state
+            .compare_exchange(
+                state,
+                EMERGENCY_CLAIMED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .ok()?;
+        Some(match prefix {
+            PanicRecordPrefix::Plain => self.records.select(false, false),
+            PanicRecordPrefix::Level => self.records.select(true, false),
+            PanicRecordPrefix::Origin => self.records.select(false, true),
+            PanicRecordPrefix::LevelAndOrigin => self.records.select(true, true),
+        })
+    }
+
+    fn close_if_idle(&self) -> bool {
+        match self.state.compare_exchange(
+            EMERGENCY_ARMED,
+            EMERGENCY_CLOSED,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => true,
+            Err(EMERGENCY_CLAIMED | EMERGENCY_CLOSED) => true,
+            Err(_) => false,
+        }
+    }
+
+    fn force_close(&self) {
+        self.state.store(EMERGENCY_CLOSED, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    pub(super) fn state_for_test(&self) -> u8 {
+        self.state.load(Ordering::Acquire)
+    }
+}
+
+struct EmergencyWorkerGuard(Arc<LoggerEmergencyIngress>);
+
+impl Drop for EmergencyWorkerGuard {
+    fn drop(&mut self) {
+        self.0.force_close();
+    }
+}
 
 impl fmt::Debug for PreparedLoggerWriter {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -53,6 +184,7 @@ pub(super) struct LoggerDeliveryConfig {
     queue_capacity: usize,
     receipt_timeout: Duration,
     replacement_timeout: Duration,
+    emergency_poll_interval: Duration,
     #[cfg(test)]
     fail_spawn: bool,
     #[cfg(test)]
@@ -65,6 +197,7 @@ impl Default for LoggerDeliveryConfig {
             queue_capacity: LOGGER_DELIVERY_QUEUE_CAPACITY,
             receipt_timeout: LOGGER_DELIVERY_TIMEOUT,
             replacement_timeout: LOGGER_DELIVERY_TIMEOUT,
+            emergency_poll_interval: LOGGER_EMERGENCY_POLL_INTERVAL,
             #[cfg(test)]
             fail_spawn: false,
             #[cfg(test)]
@@ -80,6 +213,7 @@ impl LoggerDeliveryConfig {
             queue_capacity,
             receipt_timeout: timeout,
             replacement_timeout: timeout,
+            emergency_poll_interval: timeout,
             fail_spawn: false,
             worker_observer: None,
         }
@@ -202,6 +336,7 @@ impl LoggerProducer {
 
 pub(super) struct LoggerDelivery {
     producer: LoggerProducer,
+    emergency: Arc<LoggerEmergencyIngress>,
     replacement_timeout: Duration,
 }
 
@@ -210,6 +345,7 @@ impl fmt::Debug for LoggerDelivery {
         formatter
             .debug_struct("LoggerDelivery")
             .field("producer", &self.producer)
+            .field("emergency", &self.emergency)
             .field("replacement_timeout", &self.replacement_timeout)
             .finish_non_exhaustive()
     }
@@ -219,6 +355,7 @@ impl LoggerDelivery {
     pub(super) fn spawn(
         writer: PreparedLoggerWriter,
         metrics: SharedLoggerMetrics,
+        panic_records: Arc<PanicLogRecords>,
         config: LoggerDeliveryConfig,
     ) -> Result<Self, std::io::ErrorKind> {
         #[cfg(test)]
@@ -228,6 +365,9 @@ impl LoggerDelivery {
 
         let (sender, receiver) = mpsc::sync_channel(config.queue_capacity);
         let worker_metrics = metrics.clone();
+        let emergency = Arc::new(LoggerEmergencyIngress::new(panic_records));
+        let worker_emergency = emergency.clone();
+        let emergency_poll_interval = config.emergency_poll_interval;
         #[cfg(test)]
         let worker_observer = config.worker_observer.clone();
         thread::Builder::new()
@@ -235,7 +375,13 @@ impl LoggerDelivery {
             .spawn(move || {
                 #[cfg(test)]
                 let _worker_guard = worker_observer.map(WorkerGuard::start);
-                run_worker(receiver, writer, worker_metrics);
+                run_worker(
+                    receiver,
+                    writer,
+                    worker_metrics,
+                    worker_emergency,
+                    emergency_poll_interval,
+                );
             })
             .map_err(|error| error.kind())?;
 
@@ -245,12 +391,17 @@ impl LoggerDelivery {
                 metrics,
                 receipt_timeout: config.receipt_timeout,
             },
+            emergency,
             replacement_timeout: config.replacement_timeout,
         })
     }
 
     pub(super) fn producer(&self) -> LoggerProducer {
         self.producer.clone()
+    }
+
+    pub(super) fn emergency_ingress(&self) -> Arc<LoggerEmergencyIngress> {
+        self.emergency.clone()
     }
 
     pub(super) fn replace_writer(
@@ -398,38 +549,87 @@ fn run_worker(
     receiver: Receiver<WorkerMessage>,
     mut writer: PreparedLoggerWriter,
     metrics: SharedLoggerMetrics,
+    emergency: Arc<LoggerEmergencyIngress>,
+    emergency_poll_interval: Duration,
 ) {
-    while let Ok(mut message) = receiver.recv() {
-        match message.kind {
-            WorkerMessageKind::Batch => {
-                if let Some(batch) = message.batch.take() {
-                    deliver_batch(&mut writer, &batch, message.receipt.take(), &metrics);
+    let _emergency_guard = EmergencyWorkerGuard(emergency.clone());
+    loop {
+        deliver_emergency(&mut writer, &emergency, &metrics);
+        match receiver.recv_timeout(emergency_poll_interval) {
+            Ok(mut message) => {
+                deliver_emergency(&mut writer, &emergency, &metrics);
+                if !handle_worker_message(&mut writer, &metrics, &mut message) {
+                    close_emergency(&mut writer, &emergency, &metrics);
+                    return;
                 }
             }
-            WorkerMessageKind::Replace => {
-                if let (Some(replacement), Some(token)) =
-                    (message.writer.take(), message.replacement.take())
-                    && token.commit()
-                {
-                    let previous = std::mem::replace(&mut writer, replacement);
-                    token.notify();
-                    drop(previous);
-                }
-            }
-            #[cfg(test)]
-            WorkerMessageKind::Barrier => {
-                if let Some(sender) = message.signal.take() {
-                    let _ = sender.try_send(());
-                }
-            }
-            #[cfg(test)]
-            WorkerMessageKind::Disconnect => {
-                if let Some(sender) = message.signal.take() {
-                    let _ = sender.try_send(());
-                }
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => {
+                close_emergency(&mut writer, &emergency, &metrics);
                 return;
             }
         }
+    }
+}
+
+fn handle_worker_message(
+    writer: &mut PreparedLoggerWriter,
+    metrics: &SharedLoggerMetrics,
+    message: &mut WorkerMessage,
+) -> bool {
+    match message.kind {
+        WorkerMessageKind::Batch => {
+            if let Some(batch) = message.batch.take() {
+                deliver_batch(writer, &batch, message.receipt.take(), metrics);
+            }
+        }
+        WorkerMessageKind::Replace => {
+            if let (Some(replacement), Some(token)) =
+                (message.writer.take(), message.replacement.take())
+                && token.commit()
+            {
+                let previous = std::mem::replace(writer, replacement);
+                token.notify();
+                drop(previous);
+            }
+        }
+        #[cfg(test)]
+        WorkerMessageKind::Barrier => {
+            if let Some(sender) = message.signal.take() {
+                let _ = sender.try_send(());
+            }
+        }
+        #[cfg(test)]
+        WorkerMessageKind::Disconnect => {
+            if let Some(sender) = message.signal.take() {
+                let _ = sender.try_send(());
+            }
+            return false;
+        }
+    }
+    true
+}
+
+fn deliver_emergency(
+    writer: &mut PreparedLoggerWriter,
+    emergency: &LoggerEmergencyIngress,
+    metrics: &SharedLoggerMetrics,
+) {
+    if let Some(record) = emergency.claim()
+        && !writer.write(record.as_bytes())
+    {
+        metrics.record_missed_logs(1);
+    }
+}
+
+fn close_emergency(
+    writer: &mut PreparedLoggerWriter,
+    emergency: &LoggerEmergencyIngress,
+    metrics: &SharedLoggerMetrics,
+) {
+    while !emergency.close_if_idle() {
+        deliver_emergency(writer, emergency, metrics);
+        thread::yield_now();
     }
 }
 
@@ -660,7 +860,13 @@ mod tests {
     };
     use crate::logger::LoggerLevel;
     use crate::logger::SharedLoggerMetrics;
-    use crate::logger::event::{LogBatch, LogOrigin, LogRecord, LoggerAction, LoggerEvent};
+    use crate::logger::event::{
+        LogBatch, LogOrigin, LogRecord, LoggerAction, LoggerEvent, PanicLogRecords,
+    };
+
+    fn panic_records() -> Arc<PanicLogRecords> {
+        Arc::new(PanicLogRecords::new())
+    }
 
     fn record(action: LoggerAction) -> LogRecord {
         LogRecord::encode(
@@ -738,6 +944,19 @@ mod tests {
 
         fn flush(&mut self) -> std::io::Result<()> {
             Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct PanicWriter;
+
+    impl Write for PanicWriter {
+        fn write(&mut self, _bytes: &[u8]) -> std::io::Result<usize> {
+            panic!("panic writer fixture");
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            panic!("panic writer must not flush");
         }
     }
 
@@ -873,6 +1092,7 @@ mod tests {
         let delivery = LoggerDelivery::spawn(
             PreparedLoggerWriter::new(DropSignalWriter(Some(drop_sender))),
             SharedLoggerMetrics::default(),
+            panic_records(),
             LoggerDeliveryConfig::for_test(1, Duration::from_millis(100)),
         )
         .expect("worker should spawn");
@@ -890,6 +1110,7 @@ mod tests {
         let delivery = LoggerDelivery::spawn(
             PreparedLoggerWriter::new(SharedWriter(output.clone())),
             metrics.clone(),
+            panic_records(),
             LoggerDeliveryConfig::for_test(2, Duration::from_millis(100)),
         )
         .expect("worker should spawn");
@@ -907,6 +1128,151 @@ mod tests {
     }
 
     #[test]
+    fn emergency_ingress_publishes_once_before_waking_host_message() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let delivery = LoggerDelivery::spawn(
+            PreparedLoggerWriter::new(SharedWriter(output.clone())),
+            SharedLoggerMetrics::default(),
+            panic_records(),
+            LoggerDeliveryConfig::for_test(2, Duration::from_millis(100)),
+        )
+        .expect("worker should spawn");
+        let emergency = delivery.emergency_ingress();
+
+        assert!(emergency.publish_once(super::PanicRecordPrefix::Plain));
+        assert!(!emergency.publish_once(super::PanicRecordPrefix::Level));
+        assert!(
+            delivery
+                .producer()
+                .deliver_host(LogBatch::one(record(LoggerAction::InstanceStart)))
+        );
+
+        assert_eq!(emergency.state_for_test(), super::EMERGENCY_CLAIMED);
+        assert_eq!(
+            *output.lock().expect("output lock should succeed"),
+            b"event=process-panic\naction=InstanceStart\n"
+        );
+    }
+
+    #[test]
+    fn emergency_ingress_is_polled_without_an_ordinary_message() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let delivery = LoggerDelivery::spawn(
+            PreparedLoggerWriter::new(SharedWriter(output.clone())),
+            SharedLoggerMetrics::default(),
+            panic_records(),
+            LoggerDeliveryConfig::for_test(2, Duration::from_millis(5)),
+        )
+        .expect("worker should spawn");
+        let emergency = delivery.emergency_ingress();
+
+        assert!(emergency.publish_once(super::PanicRecordPrefix::Level));
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while output
+            .lock()
+            .expect("output lock should succeed")
+            .is_empty()
+            && std::time::Instant::now() < deadline
+        {
+            thread::yield_now();
+        }
+
+        assert_eq!(emergency.state_for_test(), super::EMERGENCY_CLAIMED);
+        assert_eq!(
+            *output.lock().expect("output lock should succeed"),
+            b"level=Error event=process-panic\n"
+        );
+    }
+
+    #[test]
+    fn emergency_ingress_is_independent_of_a_full_ordinary_queue() {
+        let gate = Arc::new(WriterGate::default());
+        let metrics = SharedLoggerMetrics::default();
+        let delivery = LoggerDelivery::spawn(
+            PreparedLoggerWriter::new(HeldWriter { gate: gate.clone() }),
+            metrics.clone(),
+            panic_records(),
+            LoggerDeliveryConfig::for_test(1, Duration::from_millis(10)),
+        )
+        .expect("worker should spawn");
+        let producer = delivery.producer();
+        let emergency = delivery.emergency_ingress();
+
+        assert!(producer.deliver_guest(LogBatch::one(record(LoggerAction::InstanceStart))));
+        gate.wait_until_entered();
+        assert!(producer.deliver_guest(LogBatch::one(record(LoggerAction::FlushMetrics))));
+        assert!(!producer.deliver_guest(LogBatch::one(record(LoggerAction::InstanceStart))));
+        assert!(emergency.publish_once(super::PanicRecordPrefix::Plain));
+        assert_eq!(metrics.missed_log_count(), 1);
+
+        gate.release();
+        assert!(producer.wait_for_idle_for_test());
+        assert_eq!(emergency.state_for_test(), super::EMERGENCY_CLAIMED);
+        assert_eq!(metrics.missed_log_count(), 1);
+    }
+
+    #[test]
+    fn emergency_write_failure_is_accounted_by_the_worker() {
+        let metrics = SharedLoggerMetrics::default();
+        let delivery = LoggerDelivery::spawn(
+            PreparedLoggerWriter::new(FailingWriter),
+            metrics.clone(),
+            panic_records(),
+            LoggerDeliveryConfig::for_test(1, Duration::from_millis(5)),
+        )
+        .expect("worker should spawn");
+        let emergency = delivery.emergency_ingress();
+
+        assert!(emergency.publish_once(super::PanicRecordPrefix::Plain));
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while metrics.missed_log_count() == 0 && std::time::Instant::now() < deadline {
+            thread::yield_now();
+        }
+
+        assert_eq!(emergency.state_for_test(), super::EMERGENCY_CLAIMED);
+        assert_eq!(metrics.missed_log_count(), 1);
+    }
+
+    #[test]
+    fn worker_unwind_closes_the_emergency_ingress() {
+        let delivery = LoggerDelivery::spawn(
+            PreparedLoggerWriter::new(PanicWriter),
+            SharedLoggerMetrics::default(),
+            panic_records(),
+            LoggerDeliveryConfig::for_test(1, Duration::from_millis(5)),
+        )
+        .expect("worker should spawn");
+        let emergency = delivery.emergency_ingress();
+
+        assert!(emergency.publish_once(super::PanicRecordPrefix::Plain));
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while emergency.state_for_test() != super::EMERGENCY_CLOSED
+            && std::time::Instant::now() < deadline
+        {
+            thread::yield_now();
+        }
+
+        assert_eq!(emergency.state_for_test(), super::EMERGENCY_CLOSED);
+        assert!(!emergency.publish_once(super::PanicRecordPrefix::Plain));
+    }
+
+    #[test]
+    fn disconnected_worker_closes_emergency_ingress() {
+        let delivery = LoggerDelivery::spawn(
+            PreparedLoggerWriter::new(SharedWriter(Arc::new(Mutex::new(Vec::new())))),
+            SharedLoggerMetrics::default(),
+            panic_records(),
+            LoggerDeliveryConfig::for_test(2, Duration::from_millis(10)),
+        )
+        .expect("worker should spawn");
+        let emergency = delivery.emergency_ingress();
+
+        assert!(delivery.disconnect_for_test());
+        assert_eq!(emergency.state_for_test(), super::EMERGENCY_CLOSED);
+        assert!(!emergency.publish_once(super::PanicRecordPrefix::Plain));
+    }
+
+    #[test]
     fn zero_short_error_and_flush_failures_are_single_accounted() {
         for writer in [
             PreparedLoggerWriter::new(ZeroWriter),
@@ -918,6 +1284,7 @@ mod tests {
             let delivery = LoggerDelivery::spawn(
                 writer,
                 metrics.clone(),
+                panic_records(),
                 LoggerDeliveryConfig::for_test(2, Duration::from_millis(100)),
             )
             .expect("worker should spawn");
@@ -937,6 +1304,7 @@ mod tests {
         let delivery = LoggerDelivery::spawn(
             PreparedLoggerWriter::new(HeldWriter { gate: gate.clone() }),
             metrics.clone(),
+            panic_records(),
             LoggerDeliveryConfig::for_test(2, Duration::from_millis(10)),
         )
         .expect("worker should spawn");
@@ -959,6 +1327,7 @@ mod tests {
         let delivery = LoggerDelivery::spawn(
             PreparedLoggerWriter::new(HeldWriter { gate: gate.clone() }),
             metrics.clone(),
+            panic_records(),
             LoggerDeliveryConfig::for_test(2, Duration::from_millis(10)),
         )
         .expect("worker should spawn");
@@ -983,6 +1352,7 @@ mod tests {
         let delivery = LoggerDelivery::spawn(
             PreparedLoggerWriter::new(HeldWriter { gate: gate.clone() }),
             metrics.clone(),
+            panic_records(),
             LoggerDeliveryConfig::for_test(1, Duration::from_millis(10)),
         )
         .expect("worker should spawn");
@@ -1009,6 +1379,7 @@ mod tests {
         let delivery = LoggerDelivery::spawn(
             PreparedLoggerWriter::new(SharedWriter(output)),
             metrics.clone(),
+            panic_records(),
             LoggerDeliveryConfig::for_test(2, Duration::from_millis(10)),
         )
         .expect("worker should spawn");

--- a/crates/runtime/src/logger/event.rs
+++ b/crates/runtime/src/logger/event.rs
@@ -95,6 +95,35 @@ pub enum LoggerAction {
     FlushMetrics,
 }
 
+/// Stable process termination categories emitted by the executable lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessTerminalCategory {
+    Success,
+    Configuration,
+    ProcessFailure,
+    Cancelled,
+    Panic,
+}
+
+impl ProcessTerminalCategory {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Configuration => "configuration",
+            Self::ProcessFailure => "process-failure",
+            Self::Cancelled => "cancelled",
+            Self::Panic => "panic",
+        }
+    }
+
+    pub(super) const fn level(self) -> LoggerLevel {
+        match self {
+            Self::Success | Self::Cancelled => LoggerLevel::Info,
+            Self::Configuration | Self::ProcessFailure | Self::Panic => LoggerLevel::Error,
+        }
+    }
+}
+
 impl LoggerAction {
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -118,6 +147,8 @@ pub(super) enum LoggerEvent {
     RateLimitRecovery {
         suppressed: u64,
     },
+    ProcessPanic,
+    ProcessExit(ProcessTerminalCategory),
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -210,6 +241,11 @@ impl LogRecord {
                 encoder.push_u64(suppressed);
                 encoder.push_str(" messages were suppressed due to rate limiting");
             }
+            LoggerEvent::ProcessPanic => encoder.push_str("event=process-panic"),
+            LoggerEvent::ProcessExit(category) => {
+                encoder.push_str("event=process-exit category=");
+                encoder.push_str(category.as_str());
+            }
         }
 
         encoder.finish()
@@ -225,6 +261,82 @@ impl LogRecord {
     #[cfg(test)]
     pub(super) fn as_str(&self) -> &str {
         std::str::from_utf8(self.as_bytes()).unwrap_or("")
+    }
+}
+
+/// Opaque, fixed panic records prepared before a panic hook can use them.
+#[derive(Clone)]
+pub struct PanicLogRecords {
+    plain: LogRecord,
+    level: LogRecord,
+    origin: LogRecord,
+    level_and_origin: LogRecord,
+}
+
+impl fmt::Debug for PanicLogRecords {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PanicLogRecords")
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for PanicLogRecords {
+    #[track_caller]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PanicLogRecords {
+    /// Preencodes every permitted prefix form using only caller metadata.
+    #[track_caller]
+    pub fn new() -> Self {
+        let origin = LogOrigin::from(Location::caller());
+        Self {
+            plain: LogRecord::encode(
+                false,
+                false,
+                origin,
+                LoggerLevel::Error,
+                LoggerEvent::ProcessPanic,
+            ),
+            level: LogRecord::encode(
+                true,
+                false,
+                origin,
+                LoggerLevel::Error,
+                LoggerEvent::ProcessPanic,
+            ),
+            origin: LogRecord::encode(
+                false,
+                true,
+                origin,
+                LoggerLevel::Error,
+                LoggerEvent::ProcessPanic,
+            ),
+            level_and_origin: LogRecord::encode(
+                true,
+                true,
+                origin,
+                LoggerLevel::Error,
+                LoggerEvent::ProcessPanic,
+            ),
+        }
+    }
+
+    /// Returns the fixed unprefixed fallback record.
+    pub fn plain_bytes(&self) -> &[u8] {
+        self.plain.as_bytes()
+    }
+
+    pub(super) const fn select(&self, show_level: bool, show_log_origin: bool) -> &LogRecord {
+        match (show_level, show_log_origin) {
+            (false, false) => &self.plain,
+            (true, false) => &self.level,
+            (false, true) => &self.origin,
+            (true, true) => &self.level_and_origin,
+        }
     }
 }
 
@@ -420,7 +532,7 @@ fn utf8_prefix_len(value: &str, maximum: usize) -> usize {
 mod tests {
     use super::{
         LogOrigin, LogRecord, LoggerAction, LoggerApiRoute, LoggerEvent, LoggerHttpMethod,
-        MAX_LOG_RECORD_BYTES, normalize_origin,
+        MAX_LOG_RECORD_BYTES, PanicLogRecords, ProcessTerminalCategory, normalize_origin,
     };
     use crate::logger::LoggerLevel;
 
@@ -475,6 +587,83 @@ mod tests {
             recovery.as_str(),
             "3 messages were suppressed due to rate limiting\n"
         );
+    }
+
+    #[test]
+    fn encodes_fixed_process_records_and_levels() {
+        let origin = LogOrigin::new("crates/bangbang/src/process.rs", 17);
+        let cases = [
+            (
+                ProcessTerminalCategory::Success,
+                LoggerLevel::Info,
+                "success",
+            ),
+            (
+                ProcessTerminalCategory::Configuration,
+                LoggerLevel::Error,
+                "configuration",
+            ),
+            (
+                ProcessTerminalCategory::ProcessFailure,
+                LoggerLevel::Error,
+                "process-failure",
+            ),
+            (
+                ProcessTerminalCategory::Cancelled,
+                LoggerLevel::Info,
+                "cancelled",
+            ),
+            (ProcessTerminalCategory::Panic, LoggerLevel::Error, "panic"),
+        ];
+
+        for (category, level, text) in cases {
+            let record = LogRecord::encode(
+                true,
+                false,
+                origin,
+                category.level(),
+                LoggerEvent::ProcessExit(category),
+            );
+            assert_eq!(category.level(), level);
+            assert_eq!(
+                record.as_str(),
+                format!(
+                    "level={} event=process-exit category={text}\n",
+                    level.as_str()
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn panic_record_set_preencodes_every_prefix_without_payload_input() {
+        let records = PanicLogRecords::new();
+        assert_eq!(records.plain.as_str(), "event=process-panic\n");
+        assert_eq!(records.level.as_str(), "level=Error event=process-panic\n");
+        assert!(records.origin.as_str().starts_with("origin="));
+        assert!(records.origin.as_str().ends_with(" event=process-panic\n"));
+        assert!(
+            records
+                .level_and_origin
+                .as_str()
+                .starts_with("level=Error origin=")
+        );
+        assert!(
+            records
+                .level_and_origin
+                .as_str()
+                .ends_with(" event=process-panic\n")
+        );
+        assert_eq!(records.plain_bytes(), b"event=process-panic\n");
+        for record in [
+            &records.plain,
+            &records.level,
+            &records.origin,
+            &records.level_and_origin,
+        ] {
+            assert!(record.as_bytes().len() <= MAX_LOG_RECORD_BYTES);
+            assert!(std::str::from_utf8(record.as_bytes()).is_ok());
+        }
     }
 
     #[test]

--- a/docs/firecracker-compatibility.md
+++ b/docs/firecracker-compatibility.md
@@ -81,8 +81,8 @@ general HVF runner-loop notification scheduling, public host-driven serial
 injection/streaming beyond process stdin,
 broader device-backed feature negotiation,
 device-backed runner-loop MMIO scheduling, complete device emulation,
-production log rotation/syslog/journald/tracing/remote telemetry, process-global
-panic/fatal observability durability,
+production log rotation/syslog/journald/tracing/remote telemetry, durable
+catch-all panic/fatal observability,
 non-timer CPU-suspend wake and broader PSCI power management, or successful actions beyond owned `InstanceStart`
 startup with an internal boot run loop across bounded step windows and runtime
 `FlushMetrics` yet. The implemented logger, interval metrics, serial, and
@@ -529,6 +529,52 @@ worker generations. Only a proven disconnected receiver licenses one successor
 worker; old clones remain attached to the disconnected generation. Path-free
 updates retain the active delivery object.
 
+### Terminal and panic process records
+
+A configured logger can append one fixed terminal record at process
+convergence. The exact bodies are `event=process-exit category=success`,
+`configuration`, `process-failure`, `cancelled`, or `panic`, followed by one
+newline. Success and cancellation use `Info`; the other categories use `Error`.
+These records use the stable `bangbang::process` module and retain the active
+level, module, `show_level`, and `show_log_origin` policy. They contain no error
+text, path, selector, descriptor, credential, guest/register value, or request
+data. The record is attempted once with the existing bounded host receipt
+before the final metrics snapshot; a confirmed failure or timeout is therefore
+reflected in that snapshot when a session owns one. Filtering or an
+unconfigured sink remains a no-op. The original process result and exit code
+always win.
+
+The executable also owns one redacting panic-hook interval after private binder
+dispatch and before contained bootstrap. Runtime installs no hook and exposes
+only a cloneable per-controller emergency producer. The executable retains the
+exact prior hook, never calls it while Bangbang owns the process, ignores
+`PanicHookInfo`, and restores the retained box directly after normal or caught
+teardown. The first hook invocation may publish only the preencoded
+`event=process-panic` record. An enabled `bangbang::panic` logger receives its
+configured prefix variant through a destination-owned one-shot atomic ingress;
+otherwise a prestarted worker owns the same plain fixed record for stderr.
+Both workers poll their slots at a bounded 100-ms interval. An ordinary logger
+message wakes the logger worker, and caught main-thread teardown nudges the
+fallback outside the hook.
+
+The hook itself performs no encoding, allocation, channel send, worker wake,
+sink/stderr I/O, wait, receipt, retry, or shared-counter update. Its attachment
+mutex is initialized before installation and only `try_lock` is used; each
+destination publication is one compare-exchange attempt. Enabled attachment
+contention, poison, or an occupied/closed logger ingress latches one deferred
+miss which the minimal finalizer settles outside the hook. A catchable
+main-runtime panic then attempts the panic terminal record and final metrics
+under a second catch, isolates contained cleanup, restores the prior hook, and
+resumes the original payload. All fixed panic and terminal variants are valid
+UTF-8 and at most 512 bytes.
+
+This is best-effort observability, not persistence. A logger or fallback worker
+can be stalled or lose a write after admission, and process exit can race its
+poll. A worker-thread-only panic has at most the fixed hook attempt and no main
+finalizer. A second hook invocation is silent; double panic, `panic=abort`, an
+explicit abort, fatal `_exit`, and uncatchable signals have no terminal metrics
+or delivery guarantee.
+
 ### Metrics field and transaction model
 
 Every implemented event total is an interval increment: deprecated, GET, PUT,
@@ -582,8 +628,9 @@ failure to its caller. While the process still owns the retained session and
 live diagnostics, every normal API or no-api convergence path makes one
 best-effort terminal attempt and then returns the original success or error.
 This includes handled shutdown, guest terminal outcomes, worker terminal
-errors, and ordinary bind/wait/server errors; it does not add process-global
-panic-hook or fatal-signal durability.
+errors, and ordinary bind/wait/server errors; it adds no fatal-signal
+durability. A catchable main-runtime panic uses only the protected
+minimal convergence described above and does not continue VMM/API execution.
 
 ### Serial output, input, and native snapshots
 
@@ -639,10 +686,11 @@ broad cross-host portability.
 
 The ordinary CLI has no production rotation, syslog, journald, tracing, remote
 telemetry, or resource-broker policy. Logger and metrics state remains
-process-owned rather than global, so there is no panic/fatal-signal durability
-claim. These named product and architecture boundaries, the sparse metrics
-schema, and the exact native-v1 plus 2.7-or-newer serial limits replace an
-open-ended “full logging and metrics” placeholder.
+per-controller; only the executable's bounded ownership interval uses the
+process-global panic hook. It carries no worker/double-panic/abort/fatal-signal
+durability claim. These named product and architecture boundaries, the sparse
+metrics schema, and the exact native-v1 plus 2.7-or-newer serial limits replace
+an open-ended “full logging and metrics” placeholder.
 
 The ordinary `bangbang` CLI remains the direct, uncontained process entry point.
 The separate production `Bangbang.app` entry point has a fixed unsandboxed
@@ -1772,8 +1820,9 @@ against `bangbang_runtime::api_server`, action logs against
 boot-timer records use the ten-per-five-second limiter and recovery warning.
 Queue pressure, receipt timeout, disconnect, or sink failure increments
 `missed_log_count` exactly once per affected record and never changes the
-functional outcome. No global process logging, panic/fatal writer, rotation, or
-external telemetry backend is claimed.
+functional outcome. The fixed process terminal and catchable-main panic
+boundary is defined above; no general global process logging, durable
+panic/fatal writer, rotation, or external telemetry backend is claimed.
 The API and VMM state path implement the `PUT /vsock` field policy above as a
 pre-boot-only guest configuration section. Valid requests replace the stored
 vsock config and return `204 No Content`; invalid requests fail without
@@ -4203,7 +4252,7 @@ Their eventual support level should follow the endpoint matrix:
   retains only its legacy six UART bytes, rejects nonrepresentable RX state,
   and excludes host endpoints, the output buffer, path, limiter state, and
   counters
-- process-global panic/fatal observability durability and production rotation,
+- durable catch-all worker/double-panic/abort/fatal observability and production rotation,
   syslog, journald, tracing, or remote telemetry; the implemented logger and
   sparse interval metrics schema do not fabricate absent records or devices
 - memory hotplug beyond the implemented block-granular selected MMIO-or-PCI

--- a/docs/security.md
+++ b/docs/security.md
@@ -2869,6 +2869,43 @@ delivery recovers. Logger filtering, queue pressure, timeout ambiguity, and
 sink failures never change the API, action, or guest outcome; rate-limited
 records and exact per-record delivery failures are observable only through
 process-local counters.
+
+Process convergence adds only fixed, non-user-derived logger records. Normal
+records are `event=process-exit category=<fixed-category>` under the
+`bangbang::process` filter; a catchable main-runtime panic can first emit
+`event=process-panic` under `bangbang::panic` and then the fixed `panic`
+terminal category. The five terminal categories, levels, optional
+level/origin prefixes, 512-byte ceiling, and callsites are compiled in. These
+records never incorporate `PanicHookInfo`, panic payloads, error strings,
+paths, selectors, descriptors, credentials, guest/register data, or API
+bodies. A filtered or unconfigured panic path uses only the plain fixed record
+through a precreated stderr worker.
+
+The ordinary executable exclusively owns the process-global Rust panic hook
+after private binder dispatch and before contained bootstrap. It retains the
+exact prior hook, suppresses it throughout that interval, restores it only
+after owned VMM/contained teardown, and then resumes the original payload. This
+prevents the default hook or a caller-supplied prior hook from rendering secret
+payload data while Bangbang owns the process. Runtime logger/metrics state
+remains per-controller and does not install a hook or expose mutable global
+state.
+
+The first hook invocation performs only a preinitialized attachment
+`try_lock`, fixed atomics, and at most one compare-exchange per destination. It
+does no allocation, formatting, channel operation, wake, I/O, wait, receipt,
+retry, or counter update; a second invocation performs no logger work. Logger
+and stderr workers own all writes and poll their one-shot slots every 100 ms.
+Configured-sink contention/poison/occupied loss is latched once and settled by
+the protected main finalizer before final metrics sampling. Normal terminal
+delivery uses the bounded host receipt before final metrics, so its confirmed
+failure or timeout is included without replacing the original process result.
+
+This boundary protects confidentiality and bounds work on a catchable main
+panic; it is not a durability mechanism. Admission can race process exit, and
+a worker can stall or fail after admission. Worker-only panic, panic during
+unwind, abort, fatal `_exit`, and uncatchable signals have no final metrics or
+record-persistence guarantee. Operators must not treat the presence or absence
+of these best-effort records as an audit log or security decision input.
 Current session-initial, periodic, explicit, and normal-terminal metrics lines
 can expose selected API request counters, startup timing fields, logger and
 serial counters, a terse boot run-loop status summary, and minimal device
@@ -3040,8 +3077,9 @@ The current scaffold does not implement:
   unconstrained cross-host portability remain non-goals. The exact snapshot
   boundary is in
   [Snapshot Feasibility](snapshot-feasibility.md#native-v2-212-vsock-activation-and-certification).
-- log rotation, syslog, journald, tracing, remote telemetry, or process-global
-  panic/fatal observability durability
+- log rotation, syslog, journald, tracing, remote telemetry, or durable
+  catch-all worker/double-panic/abort/fatal observability beyond the fixed
+  catchable-main boundary above
 - a public serial streaming API or serial behavior beyond the implemented
   exact native-v2 2.7–2.13 destination-authorized endpoint reconstruction
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2350,6 +2350,26 @@ timer MMIO outcomes do not change. API socket tests cover level/origin/module
 filters and verify that request bodies and dynamic selectors never reach logger
 output.
 
+Emergency logger tests separately prove one compare-exchange publication,
+priority before an ordinary wake message, bounded idle polling, independence
+from a full ordinary queue, held and failed writers, disconnect and worker
+unwind closure, failure-atomic replacement, a fresh disconnected successor,
+late prefix/filter publication, and immediate contended or poisoned attachment
+fallback with one deferred loss. Fixed panic and terminal variants are checked
+for exact text, level, UTF-8 validity, and the 512-byte ceiling.
+
+Every test that changes the global panic hook self-spawns the exact unit-test
+child with one case marker and `--test-threads=1`; the parent pipes output,
+enforces a five-second deadline, and kills only a timeout failure. These cases
+cover default and sentinel prior-hook suppression/restoration, string and
+custom payload redaction, resumed payload identity, pre-attachment and filtered
+fallback, an occupied logger ingress, first/second invocation behavior, a
+stalled fallback writer, secondary-payload isolation, and true panic-on-drop
+double panic. Direct ingress tests add unavailable, occupied, claimed, closed,
+and failed fallback outcomes without mutating a hook. The double-panic case
+requires only bounded non-success and absence of both secrets; it deliberately
+makes no persistence claim.
+
 Metrics transaction tests use injected outputs to cover every implemented
 increment family and persistent store, first/no-new/new-event lines, lower/new
 producer generations, keyed disappearance and reappearance, independent
@@ -2364,9 +2384,21 @@ preboot scheduler dormancy, a session-epoch deadline, Running and Paused
 periodic output, due work that is not starved by ready API clients, periodic
 failure/rearm/recovery, explicit failure propagation, initial/final sink
 failure, guest stop, worker terminal error, ordinary server error, exact result
-preservation, idempotent finalization, and independent process ownership. The
+preservation, terminal logger-before-final-metrics ordering, terminal logger
+failure accounting, all fixed categories, idempotent finalization, and
+independent process ownership. Ordinary real-binary tests cover successful API
+shutdown plus configuration and process failures after logger setup. The
 60-second rule is checked with injected `Instant` values and due schedulers;
 tests do not sleep for a production interval.
+
+Run the focused process-observability evidence with:
+
+```sh
+cargo test -p bangbang-runtime logger --all-features --locked
+cargo test -p bangbang --bin bangbang panic_bridge::tests --all-features --locked -- --test-threads=1
+cargo test -p bangbang --bin bangbang terminal_observability --all-features --locked
+cargo test -p bangbang --test process_e2e terminal_record --all-features --locked
+```
 
 Serial unit tests cover nullable output, the bounded 64-KiB internal TX buffer,
 nonblocking file/FIFO behavior, path redaction, exact token-bucket refill/drop
@@ -2399,7 +2431,10 @@ redaction. Direct create/FIFO/open timing remains covered by the original tests.
 Production reachability is intentionally narrower than those normative tests.
 The existing API-driven and config-file-driven signed executable scenarios each
 observe session-initial plus explicit output before shutdown and one additional
-normal-terminal line after exit. The signed boot-timer scenario proves a guest
+normal-terminal metrics line and final fixed success logger record after exit.
+The normal production-bundle output-grant cases check the same terminal logger
+record, while module-filtered concurrent cases prove it is suppressed. The
+signed boot-timer scenario proves a guest
 magic write reaches the configured logger; signed initrd/direct-rootfs serial
 scenarios prove configured public TX output and clear behavior. Dedicated
 signed serial-stdio cases use a raw `/dev/ttyS0` guest protocol and an exact


### PR DESCRIPTION
## Summary

- add fixed, typed `process-panic` and `process-exit` records plus a bounded one-shot emergency delivery path
- install an executable-owned, redacting panic hook and protected catchable-main teardown that preserves the original panic payload
- emit an idempotent terminal record before final metrics and extend process, signed-HVF, production-bundle, security, compatibility, and testing coverage

## Scope

- no broad promotion of ordinary logger call sites and no metrics-schema change
- no durability guarantee for worker-only panics, double panics, aborts, fatal signals, or process-exit races

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p bangbang-firecracker-capability-audit --locked -- validate`
- capability-audit comparison against the sibling Firecracker v1.16.0 checkout
- `cargo check --workspace --all-targets --all-features --locked`
- Linux musl target checks for `bangbang-launcher` and `bangbang-snapshot-tools`
- `cargo test --workspace --all-targets --all-features --locked --exclude bangbang-hvf`
- `cargo test -p bangbang-hvf --lib --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- all five Apple-target signed-test Clippy commands documented in `AGENTS.md`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `scripts/run-signed-process-tests.sh`
- `scripts/run-integration-tests.sh` on Apple Silicon without `--allow-unsupported`

Closes #1803

Parent: #1785
